### PR TITLE
feat: utf8 substring safety

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -159,7 +159,7 @@ if (runAllInDirectory && mode == "test")
 var singleExit = ProcessFile(path, mode, includeTests, moduleName, emitIrOnly, outputPath, optLevel, enableLto, enableGraphics, graphicsLibPath);
 Environment.Exit(singleExit);
 
-static int ProcessFile(string path, string mode, bool includeTests, string moduleName, bool emitIrOnly, string? outputPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+static int ProcessFile(string path, string mode, bool includeTests, string moduleName, bool emitIrOnly, string? outputPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, bool useLowerLock = true)
 {
     var fileStopwatch = System.Diagnostics.Stopwatch.StartNew();
     var tempLl = string.Empty;
@@ -187,7 +187,14 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             ? new LowerOptions(IncludeTests: includeTests, EmitTestHarness: includeTests, HeadlessGraphics: false)
             : (includeTests ? LowerOptions.Default : LowerOptions.Production);
         LowerResult lower;
-        lock (LlvmLock.Lower)
+        if (useLowerLock)
+        {
+            lock (LlvmLock.Lower)
+            {
+                lower = lowerer.LowerToIr(parse.CompilationUnit, sema, layout, moduleName, lowerOptions);
+            }
+        }
+        else
         {
             lower = lowerer.LowerToIr(parse.CompilationUnit, sema, layout, moduleName, lowerOptions);
         }
@@ -465,10 +472,10 @@ static void PrintUsage()
     Console.WriteLine("Graphics: use --graphics to enable SDL2/OpenGL graphics runtime. Specify --graphics-lib to override library path.");
 }
 
-static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath) =>
-    RunAllTestsInDirectoryParallelAsync(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath).GetAwaiter().GetResult();
+static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, bool useLowerLock = true, int lowerDegree = 1) =>
+    RunAllTestsInDirectoryParallelAsync(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, useLowerLock, lowerDegree).GetAwaiter().GetResult();
 
-static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, bool useLowerLock, int lowerDegree)
 {
     var prepChannel = Channel.CreateUnbounded<PreparedForLower>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
     var resultChannel = Channel.CreateUnbounded<CompileResult>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
@@ -497,14 +504,14 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
         }
     })).ToArray();
 
-    var lowerer = Task.Run(async () =>
+    var lowerWorkers = Enumerable.Range(0, Math.Max(1, lowerDegree)).Select(_ => Task.Run(async () =>
     {
         await foreach (var item in prepChannel.Reader.ReadAllAsync())
         {
-            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, enableGraphics);
+            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, enableGraphics, useLowerLock);
             await resultChannel.Writer.WriteAsync(result);
         }
-    });
+    })).ToArray();
 
     var exitCode = 0;
     var consumer = Task.Run(async () =>
@@ -517,7 +524,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
 
     await Task.WhenAll(producers);
     prepChannel.Writer.Complete();
-    await lowerer;
+    await Task.WhenAll(lowerWorkers);
     resultChannel.Writer.Complete();
     await consumer;
     return exitCode;
@@ -556,7 +563,7 @@ static PrepareResult PrepareForLower(string path, bool emitIrOnly)
     }
 }
 
-static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics)
+static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics, bool useLowerLock)
 {
     var stopwatch = Stopwatch.StartNew();
     var diagnostics = new List<Diagnostic>();
@@ -570,7 +577,14 @@ static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, str
             ? new LowerOptions(IncludeTests: includeTests, EmitTestHarness: includeTests, HeadlessGraphics: false)
             : (includeTests ? LowerOptions.Default : LowerOptions.Production);
         LowerResult lower;
-        lock (LlvmLock.Lower)
+        if (useLowerLock)
+        {
+            lock (LlvmLock.Lower)
+            {
+                lower = lowerer.LowerToIr(prep.CompilationUnit, prep.Sema, prep.Layout, moduleName, lowerOptions);
+            }
+        }
+        else
         {
             lower = lowerer.LowerToIr(prep.CompilationUnit, prep.Sema, prep.Layout, moduleName, lowerOptions);
         }

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1,9 +1,13 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Stasis.Compiler;
 using Stasis.Compiler.IR;
 using Stasis.Compiler.Layout;
+using Stasis.Compiler.Semantic;
 using Stasis.Compiler.Syntax;
 using Stasis.Cli;
 
@@ -133,38 +137,22 @@ if (mode == "format")
     return;
 }
 
+LlvmNativeLoader.EnsureLoaded();
+
 if (runAllInDirectory && mode == "test")
 {
     var root = Directory.Exists(path) ? path : Path.GetDirectoryName(path)!;
-    var files = Directory.GetFiles(root, "*.stasis", SearchOption.AllDirectories).OrderBy(p => p).ToArray();
+    var files = Directory.GetFiles(root, "*.stasis", SearchOption.AllDirectories)
+        .Where(LikelyContainsTestBlock)
+        .OrderBy(p => p)
+        .ToArray();
     if (files.Length == 0)
     {
         Console.Error.WriteLine($"error: no .stasis files found under {root}");
         Environment.Exit(1);
     }
 
-    var overallExit = 0;
-    foreach (var file in files)
-    {
-        var source = File.ReadAllText(file);
-        var parse = Parser.Parse(source);
-        if (parse.Diagnostics.Count > 0)
-        {
-            Console.WriteLine($"=== {file} ===");
-            PrintDiagnostics(parse.Diagnostics, source, file);
-            overallExit = 1;
-            continue;
-        }
-
-        var hasTests = parse.CompilationUnit.Declarations.OfType<TestDeclarationSyntax>().Any();
-        if (!hasTests)
-        {
-            continue;
-        }
-
-        Console.WriteLine($"=== {file} ===");
-        overallExit = Math.Max(overallExit, ProcessFile(file, mode, includeTests, moduleName, emitIrOnly, outputPath, optLevel, enableLto, enableGraphics, graphicsLibPath));
-    }
+    var overallExit = RunAllTestsInDirectoryParallel(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath);
     Environment.Exit(overallExit);
 }
 
@@ -186,8 +174,6 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             return 1;
         }
 
-        LlvmNativeLoader.EnsureLoaded();
-
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
         if (sema.Diagnostics.Count > 0)
         {
@@ -200,7 +186,11 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         var lowerOptions = enableGraphics
             ? new LowerOptions(IncludeTests: includeTests, EmitTestHarness: includeTests, HeadlessGraphics: false)
             : (includeTests ? LowerOptions.Default : LowerOptions.Production);
-        var lower = lowerer.LowerToIr(parse.CompilationUnit, sema, layout, moduleName, lowerOptions);
+        LowerResult lower;
+        lock (LlvmLock.Lower)
+        {
+            lower = lowerer.LowerToIr(parse.CompilationUnit, sema, layout, moduleName, lowerOptions);
+        }
         if (lower.Diagnostics.Count > 0)
         {
             PrintDiagnostics(lower.Diagnostics, source, path);
@@ -475,6 +465,188 @@ static void PrintUsage()
     Console.WriteLine("Graphics: use --graphics to enable SDL2/OpenGL graphics runtime. Specify --graphics-lib to override library path.");
 }
 
+static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath) =>
+    RunAllTestsInDirectoryParallelAsync(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath).GetAwaiter().GetResult();
+
+static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+{
+    var prepChannel = Channel.CreateUnbounded<PreparedForLower>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    var resultChannel = Channel.CreateUnbounded<CompileResult>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
+    var concurrency = Math.Max(1, Environment.ProcessorCount);
+    var gate = new SemaphoreSlim(concurrency);
+
+    var producers = files.Select(file => Task.Run(async () =>
+    {
+        await gate.WaitAsync();
+        try
+        {
+            var prep = PrepareForLower(file, emitIrOnly);
+            if (prep.Prepared is not null)
+            {
+                await prepChannel.Writer.WriteAsync(prep.Prepared);
+            }
+
+            if (prep.Result is not null)
+            {
+                await resultChannel.Writer.WriteAsync(prep.Result);
+            }
+        }
+        finally
+        {
+            gate.Release();
+        }
+    })).ToArray();
+
+    var lowerer = Task.Run(async () =>
+    {
+        await foreach (var item in prepChannel.Reader.ReadAllAsync())
+        {
+            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, enableGraphics);
+            await resultChannel.Writer.WriteAsync(result);
+        }
+    });
+
+    var exitCode = 0;
+    var consumer = Task.Run(async () =>
+    {
+        await foreach (var result in resultChannel.Reader.ReadAllAsync())
+        {
+            exitCode = Math.Max(exitCode, ConsumeCompileResult(result, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath));
+        }
+    });
+
+    await Task.WhenAll(producers);
+    prepChannel.Writer.Complete();
+    await lowerer;
+    resultChannel.Writer.Complete();
+    await consumer;
+    return exitCode;
+}
+
+static PrepareResult PrepareForLower(string path, bool emitIrOnly)
+{
+    var stopwatch = Stopwatch.StartNew();
+    var diagnostics = new List<Diagnostic>();
+    try
+    {
+        var source = File.ReadAllText(path);
+        var parse = Parser.Parse(source);
+        diagnostics.AddRange(parse.Diagnostics);
+        var hasTests = parse.CompilationUnit.Declarations.OfType<TestDeclarationSyntax>().Any();
+
+        if (parse.Diagnostics.Count > 0 || (!hasTests && !emitIrOnly))
+        {
+            return new PrepareResult(null, new CompileResult(path, source, hasTests, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds));
+        }
+
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+        diagnostics.AddRange(sema.Diagnostics);
+        if (sema.Diagnostics.Count > 0)
+        {
+            return new PrepareResult(null, new CompileResult(path, source, hasTests, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds));
+        }
+
+        var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
+        stopwatch.Stop();
+        return new PrepareResult(new PreparedForLower(path, source, parse.CompilationUnit, sema, layout, hasTests, stopwatch.ElapsedMilliseconds), null);
+    }
+    finally
+    {
+        stopwatch.Stop();
+    }
+}
+
+static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics)
+{
+    var stopwatch = Stopwatch.StartNew();
+    var diagnostics = new List<Diagnostic>();
+    string? tempLl = null;
+    string? irForOutput = null;
+
+    try
+    {
+        var lowerer = new ModuleLowerer();
+        var lowerOptions = enableGraphics
+            ? new LowerOptions(IncludeTests: includeTests, EmitTestHarness: includeTests, HeadlessGraphics: false)
+            : (includeTests ? LowerOptions.Default : LowerOptions.Production);
+        LowerResult lower;
+        lock (LlvmLock.Lower)
+        {
+            lower = lowerer.LowerToIr(prep.CompilationUnit, prep.Sema, prep.Layout, moduleName, lowerOptions);
+        }
+        diagnostics.AddRange(lower.Diagnostics);
+        irForOutput = emitIrOnly || lower.Diagnostics.Count > 0 ? lower.Ir : null;
+
+        if (emitIrOnly || lower.Diagnostics.Count > 0)
+        {
+            return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, tempLl, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+        }
+
+        tempLl = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}.ll");
+        File.WriteAllText(tempLl, lower.Ir);
+
+        return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, tempLl, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+    }
+    finally
+    {
+        stopwatch.Stop();
+    }
+}
+
+static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+{
+    var testStopwatch = Stopwatch.StartNew();
+
+    if (result.Diagnostics.Count > 0)
+    {
+        Console.WriteLine($"=== {result.FilePath} ===");
+        PrintDiagnostics(result.Diagnostics, result.Source, result.FilePath);
+        if (!string.IsNullOrEmpty(result.IrForOutput))
+        {
+            Console.WriteLine(result.IrForOutput);
+        }
+
+        Console.WriteLine($"Total time={result.CompileMilliseconds}ms");
+        return 1;
+    }
+
+    if (emitIrOnly)
+    {
+        if (!string.IsNullOrEmpty(result.IrForOutput))
+        {
+            Console.WriteLine(result.IrForOutput);
+        }
+
+        Console.WriteLine($"Total time={result.CompileMilliseconds}ms");
+        return 0;
+    }
+
+    if (!result.HasTests || string.IsNullOrEmpty(result.LlPath))
+    {
+        return 0;
+    }
+
+    Console.WriteLine($"=== {result.FilePath} ===");
+    var executeExit = Execute("test", result.LlPath, optLevel, enableLto, enableGraphics, graphicsLibPath);
+    testStopwatch.Stop();
+    var total = result.CompileMilliseconds + testStopwatch.ElapsedMilliseconds;
+    Console.WriteLine($"Total time={total}ms");
+
+    try
+    {
+        if (File.Exists(result.LlPath))
+        {
+            File.Delete(result.LlPath);
+        }
+    }
+    catch
+    {
+        // Best-effort cleanup
+    }
+
+    return executeExit;
+}
+
 static void PrintDiagnostics(IEnumerable<Diagnostic> diagnostics, string source, string? filePath = null)
 {
     foreach (var d in diagnostics)
@@ -514,3 +686,42 @@ static (int line, int column, string lineText) GetLineInfo(string source, int of
     var lineText = source.Substring(lineStart, Math.Max(0, lineEnd - lineStart));
     return (line, column, lineText);
 }
+
+static bool LikelyContainsTestBlock(string path)
+{
+    foreach (var line in File.ReadLines(path))
+    {
+        if (line.Contains("test", StringComparison.Ordinal))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static class LlvmLock
+{
+    public static readonly object Lower = new();
+}
+
+sealed record CompileResult(
+    string FilePath,
+    string Source,
+    bool HasTests,
+    string? LlPath,
+    string? IrForOutput,
+    List<Diagnostic> Diagnostics,
+    bool EmitIrOnly,
+    long CompileMilliseconds);
+
+sealed record PreparedForLower(
+    string FilePath,
+    string Source,
+    CompilationUnitSyntax CompilationUnit,
+    SemanticResult Sema,
+    LayoutPlan Layout,
+    bool HasTests,
+    long PrepMilliseconds);
+
+sealed record PrepareResult(PreparedForLower? Prepared, CompileResult? Result);

--- a/Stasis.Compiler.Tests/ExecutionTests.cs
+++ b/Stasis.Compiler.Tests/ExecutionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Stasis.Compiler.IR;
@@ -220,6 +221,103 @@ public class ExecutionTests
         {
             Assert.Equal(0, exitCode);
             Assert.True(string.IsNullOrWhiteSpace(stderr), stderr);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void StrSubstr_copies_full_codepoint()
+    {
+        if (!TryFindLli(out var lliPath))
+        {
+            return;
+        }
+
+        var source = """
+            global src: u8[16];
+            global dst: u8[16];
+
+            function main(): i32 {
+                // src = 0xE2 0x82 0xAC 'A' '\0'
+                src[0] = 226;
+                src[1] = 130;
+                src[2] = 172;
+                src[3] = 65;
+                src[4] = 0;
+                let len: i32 = str_substr(dst, src, 0, 3);
+                return len.==(3).&&(dst[0].==(226)).&&(dst[1].==(130)).&&(dst[2].==(172)).&&(dst[3].==(0));
+            }
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+        Assert.Empty(sema.Diagnostics);
+
+        var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
+        var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "substr_ok", LowerOptions.Production);
+        Assert.Empty(lower.Diagnostics);
+
+        var temp = Path.GetTempFileName();
+        File.WriteAllText(temp, lower.Ir);
+
+        var (exitCode, stderr) = RunProcess(lliPath, temp);
+        try
+        {
+            Assert.Equal(1, exitCode);
+            Assert.True(string.IsNullOrWhiteSpace(stderr), stderr);
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Fact]
+    public void StrSubstr_aborts_on_misaligned_boundary()
+    {
+        if (!TryFindLli(out var lliPath))
+        {
+            return;
+        }
+
+        var source = """
+            global src: u8[16];
+            global dst: u8[16];
+
+            function main(): i32 {
+                // src = 0xE2 0x82 0xAC 'A' '\0'
+                src[0] = 226;
+                src[1] = 130;
+                src[2] = 172;
+                src[3] = 65;
+                src[4] = 0;
+                return str_substr(dst, src, 1, 2); // mid-codepoint start should abort
+            }
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+        Assert.Empty(sema.Diagnostics);
+
+        var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
+        var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "substr_abort", LowerOptions.Production);
+        Assert.Empty(lower.Diagnostics);
+
+        var temp = Path.GetTempFileName();
+        File.WriteAllText(temp, lower.Ir);
+
+        var (exitCode, stderr) = RunProcess(lliPath, temp);
+        try
+        {
+            Assert.NotEqual(0, exitCode);
+            Assert.True(string.IsNullOrWhiteSpace(stderr) || stderr.Contains("abort", StringComparison.OrdinalIgnoreCase), stderr);
         }
         finally
         {

--- a/Stasis.Compiler.Tests/Stasis.Compiler.Tests.csproj
+++ b/Stasis.Compiler.Tests/Stasis.Compiler.Tests.csproj
@@ -13,8 +13,9 @@
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Verify.Xunit" Version="31.8.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="libLLVM" Version="20.1.2" />
   </ItemGroup>

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -511,6 +511,119 @@ public sealed class ModuleLowerer
         return (fn, fnType);
     }
 
+    // ============================================================
+    // Standard Library: C library string function declarations
+    // ============================================================
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrlen(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Int64, new[] { i8Ptr }, false);
+        var fn = builder.Module.GetNamedFunction("strlen");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strlen", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrcmp(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new[] { i8Ptr, i8Ptr }, false);
+        var fn = builder.Module.GetNamedFunction("strcmp");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strcmp", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrncmp(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new[] { i8Ptr, i8Ptr, LLVMTypeRef.Int64 }, false);
+        var fn = builder.Module.GetNamedFunction("strncmp");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strncmp", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrcpy(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, i8Ptr }, false);
+        var fn = builder.Module.GetNamedFunction("strcpy");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strcpy", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrcat(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, i8Ptr }, false);
+        var fn = builder.Module.GetNamedFunction("strcat");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strcat", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrchr(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, LLVMTypeRef.Int32 }, false);
+        var fn = builder.Module.GetNamedFunction("strchr");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strchr", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrrchr(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, LLVMTypeRef.Int32 }, false);
+        var fn = builder.Module.GetNamedFunction("strrchr");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strrchr", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStrstr(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, i8Ptr }, false);
+        var fn = builder.Module.GetNamedFunction("strstr");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("strstr", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareMemcpy(LlvmModuleBuilder builder)
+    {
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(i8Ptr, new[] { i8Ptr, i8Ptr, LLVMTypeRef.Int64 }, false);
+        var fn = builder.Module.GetNamedFunction("memcpy");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("memcpy", fnType);
+        return (fn, fnType);
+    }
+
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareAbort(LlvmModuleBuilder builder)
+    {
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, Array.Empty<LLVMTypeRef>(), false);
+        var fn = builder.Module.GetNamedFunction("abort");
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("abort", fnType);
+        return (fn, fnType);
+    }
+
     private static LLVMTypeRef GetFunctionType(LLVMValueRef fn)
     {
         var type = fn.TypeOf;
@@ -534,6 +647,7 @@ public sealed class ModuleLowerer
         private Dictionary<string, TestDeclarationSyntax> _tests = new(StringComparer.Ordinal);
         private readonly HashSet<string> _builtIns = new(StringComparer.Ordinal)
         {
+            // Legacy I/O (to be deprecated)
             "print_string",
             "print",
             "print_int",
@@ -545,20 +659,70 @@ public sealed class ModuleLowerer
             "print_solved",
             "read_char",
             "read_int",
+
+            // Legacy math (to be renamed)
             "sin",
             "cos",
             "sin_fast",
             "cos_fast",
+
+            // Legacy system (to be renamed)
             "time",
+            "get_time_ms",
+            "sleep_ms",
+
+            // Legacy graphics (external runtime)
             "init_window",
             "begin_frame",
             "end_frame",
             "clear",
             "draw_line",
             "is_key_down",
-            "get_time_ms",
-            "sleep_ms",
-            "should_quit"
+            "should_quit",
+
+            // Standard Library: char_* module
+            "char_is_digit",
+            "char_is_alpha",
+            "char_is_alnum",
+            "char_is_space",
+            "char_is_upper",
+            "char_is_lower",
+            "char_is_hex",
+            "char_is_print",
+            "char_to_upper",
+            "char_to_lower",
+            "char_to_digit",
+            "char_from_digit",
+            "char_to_hex",
+            "char_from_hex",
+
+            // Standard Library: str_* module
+            "str_len",
+            "str_is_empty",
+            "str_get",
+            "str_set",
+            "str_eq",
+            "str_cmp",
+            "str_starts_with",
+            "str_ends_with",
+            "str_find",
+            "str_find_char",
+            "str_find_last_char",
+            "str_contains",
+            "str_clear",
+            "str_copy",
+            "str_append",
+            "str_append_char",
+            "str_substr",
+            "str_trim_start",
+            "str_trim_end",
+            "str_trim",
+            "str_to_upper",
+            "str_to_lower",
+            "str_from_i32",
+            "str_from_f32",
+            "str_to_i32",
+            "str_to_f32"
         };
         private int _blockId;
         private readonly bool _headlessGraphics;
@@ -1481,10 +1645,842 @@ public sealed class ModuleLowerer
                         var (fn, fnType) = GetOrDeclareStasisShouldQuit(_moduleBuilder);
                         return builder.BuildCall2(fnType, fn, Array.Empty<LLVMValueRef>(), "should_quit.call");
                     }
+
+                // ============================================================
+                // Standard Library: char_* module (character/byte utilities)
+                // ============================================================
+
+                case "char_is_digit":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_digit expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // c >= '0' && c <= '9'
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
+                        var result = builder.BuildAnd(ge0, le9, "is_digit");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_digit.i32");
+                    }
+
+                case "char_is_alpha":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_alpha expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
+                        var lower = builder.BuildAnd(geA, leZ, "lower");
+                        var geAU = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leZU = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
+                        var upper = builder.BuildAnd(geAU, leZU, "upper");
+                        var result = builder.BuildOr(lower, upper, "is_alpha");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_alpha.i32");
+                    }
+
+                case "char_is_alnum":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_alnum expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // digit or alpha
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
+                        var digit = builder.BuildAnd(ge0, le9, "digit");
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
+                        var lower = builder.BuildAnd(geA, leZ, "lower");
+                        var geAU = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leZU = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
+                        var upper = builder.BuildAnd(geAU, leZU, "upper");
+                        var alpha = builder.BuildOr(lower, upper, "alpha");
+                        var result = builder.BuildOr(digit, alpha, "is_alnum");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_alnum.i32");
+                    }
+
+                case "char_is_space":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_space expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // c == ' ' || c == '\t' || c == '\n' || c == '\r'
+                        var isSpace = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32(' '), "isSpace");
+                        var isTab = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32('\t'), "isTab");
+                        var isNewline = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32('\n'), "isNewline");
+                        var isCr = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32('\r'), "isCr");
+                        var r1 = builder.BuildOr(isSpace, isTab, "r1");
+                        var r2 = builder.BuildOr(r1, isNewline, "r2");
+                        var result = builder.BuildOr(r2, isCr, "is_space");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_space.i32");
+                    }
+
+                case "char_is_upper":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_upper expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
+                        var result = builder.BuildAnd(geA, leZ, "is_upper");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_upper.i32");
+                    }
+
+                case "char_is_lower":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_lower expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
+                        var result = builder.BuildAnd(geA, leZ, "is_lower");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_lower.i32");
+                    }
+
+                case "char_is_hex":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_hex expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // digit or 'a'-'f' or 'A'-'F'
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
+                        var digit = builder.BuildAnd(ge0, le9, "digit");
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leF = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('f'), "lef");
+                        var lowerHex = builder.BuildAnd(geA, leF, "lowerHex");
+                        var geAU = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leFU = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('F'), "leF");
+                        var upperHex = builder.BuildAnd(geAU, leFU, "upperHex");
+                        var hex = builder.BuildOr(lowerHex, upperHex, "hex");
+                        var result = builder.BuildOr(digit, hex, "is_hex");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_hex.i32");
+                    }
+
+                case "char_is_print":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_is_print expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // c >= 32 && c <= 126
+                        var ge32 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32(32), "ge32");
+                        var le126 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32(126), "le126");
+                        var result = builder.BuildAnd(ge32, le126, "is_print");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "is_print.i32");
+                    }
+
+                case "char_to_upper":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_to_upper expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // if c >= 'a' && c <= 'z' then c - 32 else c
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
+                        var isLower = builder.BuildAnd(geA, leZ, "isLower");
+                        var upper = builder.BuildSub(c, ConstI32(32), "upper");
+                        return builder.BuildSelect(isLower, upper, c, "char_to_upper");
+                    }
+
+                case "char_to_lower":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_to_lower expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // if c >= 'A' && c <= 'Z' then c + 32 else c
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
+                        var isUpper = builder.BuildAnd(geA, leZ, "isUpper");
+                        var lower = builder.BuildAdd(c, ConstI32(32), "lower");
+                        return builder.BuildSelect(isUpper, lower, c, "char_to_lower");
+                    }
+
+                case "char_to_digit":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_to_digit expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        // if c >= '0' && c <= '9' then c - '0' else -1
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
+                        var isDigit = builder.BuildAnd(ge0, le9, "isDigit");
+                        var digit = builder.BuildSub(c, ConstI32('0'), "digit");
+                        return builder.BuildSelect(isDigit, digit, ConstI32(-1), "char_to_digit");
+                    }
+
+                case "char_from_digit":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_from_digit expects 1 argument (d: i32).", span);
+                            return ConstI32(0);
+                        }
+                        var d = LowerExpression(builder, args[0], locals);
+                        // if d >= 0 && d <= 9 then d + '0' else '?'
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGE, d, ConstI32(0), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLE, d, ConstI32(9), "le9");
+                        var valid = builder.BuildAnd(ge0, le9, "valid");
+                        var ch = builder.BuildAdd(d, ConstI32('0'), "ch");
+                        return builder.BuildSelect(valid, ch, ConstI32('?'), "char_from_digit");
+                    }
+
+                case "char_to_hex":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_to_hex expects 1 argument (c: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var c = LowerExpression(builder, args[0], locals);
+                        var function = builder.InsertBlock.Parent;
+
+                        // Check digit first
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
+                        var isDigit = builder.BuildAnd(ge0, le9, "isDigit");
+
+                        var digitBlock = AppendBlock(function, NextBlockName("hex.digit"));
+                        var lowerBlock = AppendBlock(function, NextBlockName("hex.lower"));
+                        var upperBlock = AppendBlock(function, NextBlockName("hex.upper"));
+                        var invalidBlock = AppendBlock(function, NextBlockName("hex.invalid"));
+                        var mergeBlock = AppendBlock(function, NextBlockName("hex.merge"));
+
+                        builder.BuildCondBr(isDigit, digitBlock, lowerBlock);
+
+                        builder.PositionAtEnd(digitBlock);
+                        var digitVal = builder.BuildSub(c, ConstI32('0'), "digitVal");
+                        builder.BuildBr(mergeBlock);
+
+                        builder.PositionAtEnd(lowerBlock);
+                        var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
+                        var leF = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('f'), "lef");
+                        var isLower = builder.BuildAnd(geA, leF, "isLower");
+                        builder.BuildCondBr(isLower, AppendBlock(function, NextBlockName("hex.lowerVal")), upperBlock);
+
+                        var lowerValBlock = function.LastBasicBlock;
+                        builder.PositionAtEnd(lowerValBlock);
+                        var lowerVal = builder.BuildSub(c, ConstI32('a' - 10), "lowerVal");
+                        builder.BuildBr(mergeBlock);
+
+                        builder.PositionAtEnd(upperBlock);
+                        var geAU = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
+                        var leFU = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('F'), "leF");
+                        var isUpper = builder.BuildAnd(geAU, leFU, "isUpper");
+                        builder.BuildCondBr(isUpper, AppendBlock(function, NextBlockName("hex.upperVal")), invalidBlock);
+
+                        var upperValBlock = function.LastBasicBlock;
+                        builder.PositionAtEnd(upperValBlock);
+                        var upperVal = builder.BuildSub(c, ConstI32('A' - 10), "upperVal");
+                        builder.BuildBr(mergeBlock);
+
+                        builder.PositionAtEnd(invalidBlock);
+                        builder.BuildBr(mergeBlock);
+
+                        builder.PositionAtEnd(mergeBlock);
+                        var phi = builder.BuildPhi(LLVMTypeRef.Int32, "hex.result");
+                        phi.AddIncoming(new[] { digitVal }, new[] { digitBlock }, 1);
+                        phi.AddIncoming(new[] { lowerVal }, new[] { lowerValBlock }, 1);
+                        phi.AddIncoming(new[] { upperVal }, new[] { upperValBlock }, 1);
+                        phi.AddIncoming(new[] { ConstI32(-1) }, new[] { invalidBlock }, 1);
+                        return phi;
+                    }
+
+                case "char_from_hex":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("char_from_hex expects 1 argument (d: i32).", span);
+                            return ConstI32(0);
+                        }
+                        var d = LowerExpression(builder, args[0], locals);
+                        // if d >= 0 && d <= 9 then d + '0'
+                        // else if d >= 10 && d <= 15 then d - 10 + 'a'
+                        // else '?'
+                        var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGE, d, ConstI32(0), "ge0");
+                        var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLE, d, ConstI32(9), "le9");
+                        var isDigit = builder.BuildAnd(ge0, le9, "isDigit");
+                        var ge10 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGE, d, ConstI32(10), "ge10");
+                        var le15 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLE, d, ConstI32(15), "le15");
+                        var isHexLetter = builder.BuildAnd(ge10, le15, "isHexLetter");
+                        var digitCh = builder.BuildAdd(d, ConstI32('0'), "digitCh");
+                        var hexCh = builder.BuildAdd(builder.BuildSub(d, ConstI32(10), "d10"), ConstI32('a'), "hexCh");
+                        var temp = builder.BuildSelect(isHexLetter, hexCh, ConstI32('?'), "temp");
+                        return builder.BuildSelect(isDigit, digitCh, temp, "char_from_hex");
+                    }
+
+                // ============================================================
+                // Standard Library: str_* module (string operations)
+                // ============================================================
+
+                case "str_len":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("str_len expects 1 argument (s: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        // Get pointer to the array and call strlen
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_len requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptr }, "strlen.call");
+                        return builder.BuildTrunc(len64, LLVMTypeRef.Int32, "str_len");
+                    }
+
+                case "str_is_empty":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("str_is_empty expects 1 argument (s: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_is_empty requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var firstByte = builder.BuildLoad2(LLVMTypeRef.Int8, ptr, "firstByte");
+                        var isZero = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, firstByte, ConstI8(0), "isZero");
+                        return builder.BuildZExt(isZero, LLVMTypeRef.Int32, "str_is_empty");
+                    }
+
+                case "str_get":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_get expects 2 arguments (s: u8[], index: i32).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        var index = LowerExpression(builder, args[1], locals);
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_get requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { index }, "elemPtr");
+                        var val = builder.BuildLoad2(LLVMTypeRef.Int8, elemPtr, "str_get");
+                        return builder.BuildZExt(val, LLVMTypeRef.Int32, "str_get.i32");
+                    }
+
+                case "str_set":
+                    {
+                        if (args.Count != 3)
+                        {
+                            AddDiagnostic("str_set expects 3 arguments (s: u8[], index: i32, byte: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        var index = LowerExpression(builder, args[1], locals);
+                        var byteVal = LowerExpression(builder, args[2], locals);
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_set requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { index }, "elemPtr");
+                        var truncated = builder.BuildTrunc(byteVal, LLVMTypeRef.Int8, "byte");
+                        builder.BuildStore(truncated, elemPtr);
+                        return ConstI32(0);
+                    }
+
+                case "str_eq":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_eq expects 2 arguments (a: u8[], b: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strcmpFn, strcmpType) = GetOrDeclareStrcmp(_moduleBuilder);
+                        var ptrA = LowerArrayPointer(builder, args[0], locals);
+                        var ptrB = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrA.Handle == IntPtr.Zero || ptrB.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_eq requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        var cmp = builder.BuildCall2(strcmpType, strcmpFn, new[] { ptrA, ptrB }, "strcmp.call");
+                        var isEqual = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cmp, ConstI32(0), "isEqual");
+                        return builder.BuildZExt(isEqual, LLVMTypeRef.Int32, "str_eq");
+                    }
+
+                case "str_cmp":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_cmp expects 2 arguments (a: u8[], b: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strcmpFn, strcmpType) = GetOrDeclareStrcmp(_moduleBuilder);
+                        var ptrA = LowerArrayPointer(builder, args[0], locals);
+                        var ptrB = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrA.Handle == IntPtr.Zero || ptrB.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_cmp requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        return builder.BuildCall2(strcmpType, strcmpFn, new[] { ptrA, ptrB }, "str_cmp");
+                    }
+
+                case "str_copy":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_copy expects 2 arguments (dst: u8[], src: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strcpyFn, strcpyType) = GetOrDeclareStrcpy(_moduleBuilder);
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptrDst = LowerArrayPointer(builder, args[0], locals);
+                        var ptrSrc = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrDst.Handle == IntPtr.Zero || ptrSrc.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_copy requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        builder.BuildCall2(strcpyType, strcpyFn, new[] { ptrDst, ptrSrc }, "");
+                        var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptrDst }, "strlen.call");
+                        return builder.BuildTrunc(len64, LLVMTypeRef.Int32, "str_copy.len");
+                    }
+
+                case "str_append":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_append expects 2 arguments (dst: u8[], src: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strcatFn, strcatType) = GetOrDeclareStrcat(_moduleBuilder);
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptrDst = LowerArrayPointer(builder, args[0], locals);
+                        var ptrSrc = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrDst.Handle == IntPtr.Zero || ptrSrc.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_append requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        builder.BuildCall2(strcatType, strcatFn, new[] { ptrDst, ptrSrc }, "");
+                        var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptrDst }, "strlen.call");
+                        return builder.BuildTrunc(len64, LLVMTypeRef.Int32, "str_append.len");
+                    }
+
+                case "str_append_char":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_append_char expects 2 arguments (dst: u8[], byte: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptrDst = LowerArrayPointer(builder, args[0], locals);
+                        var byteVal = LowerExpression(builder, args[1], locals);
+                        if (ptrDst.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_append_char requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptrDst }, "strlen.call");
+                        var len = builder.BuildTrunc(len64, LLVMTypeRef.Int32, "len");
+                        var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrDst, new[] { len }, "elemPtr");
+                        var truncated = builder.BuildTrunc(byteVal, LLVMTypeRef.Int8, "byte");
+                        builder.BuildStore(truncated, elemPtr);
+                        var nextPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrDst, new[] { builder.BuildAdd(len, ConstI32(1), "next") }, "nextPtr");
+                        builder.BuildStore(ConstI8(0), nextPtr);
+                        return builder.BuildAdd(len, ConstI32(1), "str_append_char.len");
+                    }
+
+                case "str_clear":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("str_clear expects 1 argument (s: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_clear requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        builder.BuildStore(ConstI8(0), ptr);
+                        return ConstI32(0);
+                    }
+
+                case "str_find_char":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_find_char expects 2 arguments (s: u8[], byte: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        var byteVal = builder.BuildTrunc(LowerExpression(builder, args[1], locals), LLVMTypeRef.Int8, "find_char.byte");
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_find_char requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var idxAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_char.idx");
+                        var resultAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_char.result");
+                        builder.BuildStore(ConstI32(0), idxAlloca);
+                        builder.BuildStore(ConstI32(-1), resultAlloca);
+
+                        var fn = builder.InsertBlock.Parent;
+                        var loopBlock = AppendBlock(fn, NextBlockName("find_char.loop"));
+                        var checkZeroBlock = AppendBlock(fn, NextBlockName("find_char.zero"));
+                        var incBlock = AppendBlock(fn, NextBlockName("find_char.inc"));
+                        var hitBlock = AppendBlock(fn, NextBlockName("find_char.hit"));
+                        var missBlock = AppendBlock(fn, NextBlockName("find_char.miss"));
+                        var exitBlock = AppendBlock(fn, NextBlockName("find_char.exit"));
+
+                        builder.BuildBr(loopBlock);
+
+                        builder.PositionAtEnd(loopBlock);
+                        var idx = builder.BuildLoad2(LLVMTypeRef.Int32, idxAlloca, "find_char.idx.cur");
+                        var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { idx }, "find_char.ptr");
+                        var cur = builder.BuildLoad2(LLVMTypeRef.Int8, elemPtr, "find_char.cur");
+                        var isMatch = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cur, byteVal, "find_char.match");
+                        var isZero = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cur, ConstI8(0), "find_char.zero");
+                        builder.BuildCondBr(isMatch, hitBlock, checkZeroBlock);
+
+                        builder.PositionAtEnd(checkZeroBlock);
+                        builder.BuildCondBr(isZero, missBlock, incBlock);
+
+                        builder.PositionAtEnd(incBlock);
+                        var next = builder.BuildAdd(idx, ConstI32(1), "find_char.next");
+                        builder.BuildStore(next, idxAlloca);
+                        builder.BuildBr(loopBlock);
+
+                        builder.PositionAtEnd(hitBlock);
+                        builder.BuildStore(idx, resultAlloca);
+                        builder.BuildBr(exitBlock);
+
+                        builder.PositionAtEnd(missBlock);
+                        builder.BuildStore(ConstI32(-1), resultAlloca);
+                        builder.BuildBr(exitBlock);
+
+                        builder.PositionAtEnd(exitBlock);
+                        var result = builder.BuildLoad2(LLVMTypeRef.Int32, resultAlloca, "find_char.result.val");
+                        return result;
+                    }
+
+                case "str_contains":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_contains expects 2 arguments (s: u8[], needle: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strstrFn, strstrType) = GetOrDeclareStrstr(_moduleBuilder);
+                        var ptrS = LowerArrayPointer(builder, args[0], locals);
+                        var ptrNeedle = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrS.Handle == IntPtr.Zero || ptrNeedle.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_contains requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        var found = builder.BuildCall2(strstrType, strstrFn, new[] { ptrS, ptrNeedle }, "strstr.call");
+                        var isNotNull = builder.BuildICmp(LLVMIntPredicate.LLVMIntNE, found, LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), "isNotNull");
+                        return builder.BuildZExt(isNotNull, LLVMTypeRef.Int32, "str_contains");
+                    }
+
+                case "str_find":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_find expects 2 arguments (s: u8[], needle: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strstrFn, strstrType) = GetOrDeclareStrstr(_moduleBuilder);
+                        var ptrS = LowerArrayPointer(builder, args[0], locals);
+                        var ptrNeedle = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrS.Handle == IntPtr.Zero || ptrNeedle.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_find requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        var found = builder.BuildCall2(strstrType, strstrFn, new[] { ptrS, ptrNeedle }, "strstr.call");
+                        var isNull = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, found, LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), "isNull");
+                        // Manual pointer diff: convert both pointers to int64, subtract, then truncate to i32
+                        var foundInt = builder.BuildPtrToInt(found, LLVMTypeRef.Int64, "found.int");
+                        var ptrSInt = builder.BuildPtrToInt(ptrS, LLVMTypeRef.Int64, "ptrS.int");
+                        var diff = builder.BuildSub(foundInt, ptrSInt, "diff");
+                        var idx = builder.BuildTrunc(diff, LLVMTypeRef.Int32, "idx");
+                        return builder.BuildSelect(isNull, ConstI32(-1), idx, "str_find");
+                    }
+
+                case "str_starts_with":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_starts_with expects 2 arguments (s: u8[], prefix: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strncmpFn, strncmpType) = GetOrDeclareStrncmp(_moduleBuilder);
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptrS = LowerArrayPointer(builder, args[0], locals);
+                        var ptrPrefix = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrS.Handle == IntPtr.Zero || ptrPrefix.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_starts_with requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        var prefixLen = builder.BuildCall2(strlenType, strlenFn, new[] { ptrPrefix }, "prefixLen");
+                        var cmp = builder.BuildCall2(strncmpType, strncmpFn, new[] { ptrS, ptrPrefix, prefixLen }, "strncmp.call");
+                        var isZero = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cmp, ConstI32(0), "isZero");
+                        return builder.BuildZExt(isZero, LLVMTypeRef.Int32, "str_starts_with");
+                    }
+
+                case "str_ends_with":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_ends_with expects 2 arguments (s: u8[], suffix: u8[]).", span);
+                            return ConstI32(0);
+                        }
+                        var (strncmpFn, strncmpType) = GetOrDeclareStrncmp(_moduleBuilder);
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var ptrS = LowerArrayPointer(builder, args[0], locals);
+                        var ptrSuffix = LowerArrayPointer(builder, args[1], locals);
+                        if (ptrS.Handle == IntPtr.Zero || ptrSuffix.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_ends_with requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+                        var sLen = builder.BuildCall2(strlenType, strlenFn, new[] { ptrS }, "sLen");
+                        var suffixLen = builder.BuildCall2(strlenType, strlenFn, new[] { ptrSuffix }, "suffixLen");
+                        var offset = builder.BuildSub(sLen, suffixLen, "offset");
+                        var offset32 = builder.BuildTrunc(offset, LLVMTypeRef.Int32, "offset32");
+                        var endPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrS, new[] { offset32 }, "endPtr");
+                        var cmp = builder.BuildCall2(strncmpType, strncmpFn, new[] { endPtr, ptrSuffix, suffixLen }, "strncmp.call");
+                        // Also check that sLen >= suffixLen
+                        var lenOk = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGE, sLen, suffixLen, "lenOk");
+                        var isZero = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cmp, ConstI32(0), "isZero");
+                        var result = builder.BuildAnd(lenOk, isZero, "ends_with");
+                        return builder.BuildZExt(result, LLVMTypeRef.Int32, "str_ends_with");
+                    }
+
+                case "str_find_last_char":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("str_find_last_char expects 2 arguments (s: u8[], byte: u8).", span);
+                            return ConstI32(0);
+                        }
+                        var ptr = LowerArrayPointer(builder, args[0], locals);
+                        var byteVal = builder.BuildTrunc(LowerExpression(builder, args[1], locals), LLVMTypeRef.Int8, "find_last_char.byte");
+                        if (ptr.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_find_last_char requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        var idxAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_last.idx");
+                        var lastAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_last.last");
+                        builder.BuildStore(ConstI32(0), idxAlloca);
+                        builder.BuildStore(ConstI32(-1), lastAlloca);
+
+                        var fn = builder.InsertBlock.Parent;
+                        var loopBlock = AppendBlock(fn, NextBlockName("find_last.loop"));
+                        var afterMatchBlock = AppendBlock(fn, NextBlockName("find_last.after"));
+                        var endBlock = AppendBlock(fn, NextBlockName("find_last.end"));
+
+                        builder.BuildBr(loopBlock);
+
+                        builder.PositionAtEnd(loopBlock);
+                        var idx = builder.BuildLoad2(LLVMTypeRef.Int32, idxAlloca, "find_last.idx.cur");
+                        var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { idx }, "find_last.ptr");
+                        var cur = builder.BuildLoad2(LLVMTypeRef.Int8, elemPtr, "find_last.cur");
+                        var isZero = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cur, ConstI8(0), "find_last.zero");
+                        var isMatch = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, cur, byteVal, "find_last.match");
+                        builder.BuildCondBr(isZero, endBlock, afterMatchBlock);
+
+                        builder.PositionAtEnd(afterMatchBlock);
+                        var lastCur = builder.BuildLoad2(LLVMTypeRef.Int32, lastAlloca, "find_last.last.cur");
+                        var newLast = builder.BuildSelect(isMatch, idx, lastCur, "find_last.last.next");
+                        builder.BuildStore(newLast, lastAlloca);
+                        var nextIdx = builder.BuildAdd(idx, ConstI32(1), "find_last.next");
+                        builder.BuildStore(nextIdx, idxAlloca);
+                        builder.BuildBr(loopBlock);
+
+                        builder.PositionAtEnd(endBlock);
+                        return builder.BuildLoad2(LLVMTypeRef.Int32, lastAlloca, "find_last.result");
+                    }
+
+                case "str_substr":
+                    {
+                        if (args.Count != 4)
+                        {
+                            AddDiagnostic("str_substr expects 4 arguments (dst: u8[], src: u8[], start: i32, byte_len: i32).", span);
+                            return ConstI32(0);
+                        }
+
+                        var ptrDst = LowerArrayPointer(builder, args[0], locals);
+                        var ptrSrc = LowerArrayPointer(builder, args[1], locals);
+                        var start = LowerExpression(builder, args[2], locals);
+                        var byteLen = LowerExpression(builder, args[3], locals);
+                        if (ptrDst.Handle == IntPtr.Zero || ptrSrc.Handle == IntPtr.Zero)
+                        {
+                            AddDiagnostic("str_substr requires array arguments.", span);
+                            return ConstI32(0);
+                        }
+
+                        var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
+                        var (memcpyFn, memcpyType) = GetOrDeclareMemcpy(_moduleBuilder);
+                        var (abortFn, abortType) = GetOrDeclareAbort(_moduleBuilder);
+
+                        var srcLen64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptrSrc }, "substr.srclen64");
+                        var srcLen = builder.BuildTrunc(srcLen64, LLVMTypeRef.Int32, "substr.srclen");
+                        var end = builder.BuildAdd(start, byteLen, "substr.end");
+
+                        // Validate start/end ranges: start >= 0, byteLen >= 0, end <= srcLen
+                        var startNeg = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLT, start, ConstI32(0), "substr.startNeg");
+                        var lenNeg = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLT, byteLen, ConstI32(0), "substr.lenNeg");
+                        var endGt = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGT, end, srcLen, "substr.endGt");
+                        var badRange = builder.BuildOr(builder.BuildOr(startNeg, lenNeg, "substr.badRange1"), endGt, "substr.badRange");
+
+                        var fn = builder.InsertBlock.Parent;
+                        var rangeOkBlock = AppendBlock(fn, NextBlockName("substr.range_ok"));
+                        var abortBlock = AppendBlock(fn, NextBlockName("substr.abort"));
+                        builder.BuildCondBr(badRange, abortBlock, rangeOkBlock);
+
+                        builder.PositionAtEnd(abortBlock);
+                        builder.BuildCall2(abortType, abortFn, Array.Empty<LLVMValueRef>(), "substr.abort");
+                        builder.BuildUnreachable();
+
+                        builder.PositionAtEnd(rangeOkBlock);
+                        // Boundary validation: bytes at start and end must not be UTF-8 continuation bytes
+                        var startPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrSrc, new[] { start }, "substr.startPtr");
+                        var startByte = builder.BuildLoad2(LLVMTypeRef.Int8, startPtr, "substr.startByte");
+                        var startCont = BuildIsContinuationByte(builder, startByte);
+
+                        var endPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrSrc, new[] { end }, "substr.endPtr");
+                        var endByte = builder.BuildLoad2(LLVMTypeRef.Int8, endPtr, "substr.endByte");
+                        var endCont = BuildIsContinuationByte(builder, endByte);
+
+                        var misaligned = builder.BuildOr(startCont, endCont, "substr.misaligned");
+
+                        var okBlock = AppendBlock(fn, NextBlockName("substr.ok"));
+                        builder.BuildCondBr(misaligned, abortBlock, okBlock);
+
+                        builder.PositionAtEnd(okBlock);
+                        var len64 = builder.BuildZExt(byteLen, LLVMTypeRef.Int64, "substr.len64");
+                        builder.BuildCall2(memcpyType, memcpyFn, new[] { ptrDst, startPtr, len64 }, "substr.copy");
+                        var terminatorPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrDst, new[] { byteLen }, "substr.term");
+                        builder.BuildStore(ConstI8(0), terminatorPtr);
+                        return byteLen;
+                    }
+
+                case "str_trim_start":
+                case "str_trim_end":
+                case "str_trim":
+                case "str_to_upper":
+                case "str_to_lower":
+                case "str_from_i32":
+                case "str_from_f32":
+                case "str_to_i32":
+                case "str_to_f32":
+                    AddDiagnostic($"Built-in '{name}' is not yet implemented.", span);
+                    return ConstI32(0);
+
                 default:
                     AddDiagnostic($"Unknown built-in '{name}'.", span);
                     return ConstI32(0);
             }
+        }
+
+        private LLVMValueRef LowerArrayPointer(LLVMBuilderRef builder, ExpressionSyntax expr, Dictionary<string, LocalBinding> locals)
+        {
+            // Get a pointer to the first element of an array
+            if (expr is IdentifierExpressionSyntax id)
+            {
+                // Check if it's a global array
+                if (_symbols.TryGetValue(id.Identifier.Text, out var sym) && sym.Kind == SymbolKind.Global && sym.Type is ArrayTypeSymbol arrayTypeSym)
+                {
+                    var global = _moduleBuilder.Module.GetNamedGlobal(id.Identifier.Text);
+                    if (global.Handle != IntPtr.Zero)
+                    {
+                        // Get element type from the semantic type symbol
+                        var elemType = _moduleBuilder.TypeMapper.Map(arrayTypeSym.ElementType);
+                        var size = arrayTypeSym.Size;
+                        var llvmArrayType = LLVMTypeRef.CreateArray(elemType, (uint)Math.Max(1, size));
+                        // GEP to get pointer to first element
+                        return builder.BuildGEP2(llvmArrayType, global, new[] { ConstI32(0), ConstI32(0) }, $"{id.Identifier.Text}.ptr");
+                    }
+                }
+                // Check for local array binding
+                if (locals.TryGetValue(id.Identifier.Text, out var local) && local.IsAddress)
+                {
+                    return local.Value;
+                }
+            }
+            else if (expr is MemberAccessExpressionSyntax member)
+            {
+                // Handle struct field arrays like state.buffer
+                var flattenedPath = BuildFlattenedMemberPath(member);
+                if (flattenedPath is not null)
+                {
+                    // Try to resolve the type from member access
+                    if (TryResolveMemberType(member, out var memberType) && memberType is ArrayTypeSymbol memberArrayType)
+                    {
+                        var global = _moduleBuilder.Module.GetNamedGlobal(flattenedPath);
+                        if (global.Handle != IntPtr.Zero)
+                        {
+                            var elemType = _moduleBuilder.TypeMapper.Map(memberArrayType.ElementType);
+                            var size = memberArrayType.Size;
+                            var llvmArrayType = LLVMTypeRef.CreateArray(elemType, (uint)Math.Max(1, size));
+                            return builder.BuildGEP2(llvmArrayType, global, new[] { ConstI32(0), ConstI32(0) }, $"{flattenedPath}.ptr");
+                        }
+                    }
+                }
+            }
+            return default;
+        }
+
+        private static LLVMValueRef ConstI8(int value) =>
+            LLVMValueRef.CreateConstInt(LLVMTypeRef.Int8, (ulong)value, false);
+
+        private LLVMValueRef BuildIsContinuationByte(LLVMBuilderRef builder, LLVMValueRef byteVal)
+        {
+            var byteI32 = builder.BuildZExt(byteVal, LLVMTypeRef.Int32, "byte.i32");
+            var masked = builder.BuildAnd(byteI32, ConstI32(0xC0), "byte.mask");
+            return builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, masked, ConstI32(0x80), "byte.is_cont");
         }
 
         private LLVMValueRef LowerOperatorCall(LLVMBuilderRef builder, OperatorCallExpressionSyntax op, Dictionary<string, LocalBinding> locals)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -104,15 +104,28 @@ bool
 Type[IntegerLiteral]
 ```
 
-### Strings
+### String Types
 
 ```
-string[N]   // sugar for u8[N]
+ascii[N]   // fixed-byte ASCII strings (single-byte code units)
+utf8[N]    // UTF-8 strings with tracked byte and codepoint lengths
+string[N]  // alias for utf8[N] (backward compatibility)
 ```
+
+**ascii[N] layout and invariants**
+- Layout: `[len: i32][data: u8[N]]`
+- Invariant: all bytes are `< 128`; `len` is the used byte count.
+- `data[len]` is set to `0` as a sentinel; sentinel is not counted in `N`.
+
+**utf8[N] layout and invariants**
+- Layout: `[byte_length: i32][char_length: i32][data: u8[N]]`
+- Invariant: `data[0..byte_length)` is valid UTF-8; `char_length` matches decoded codepoints.
+- `data[byte_length]` is set to `0` as a sentinel; sentinel is not counted in `N`.
 
 ### Built-in I/O helpers
 
-- `print_string(string[N])` prints a string literal that the compiler lowers to a null-terminated `u8` array in global memory; the runtime maps it to an LLVM `i8*`.
+- `print_string(utf8[N])` prints a UTF-8 string literal; the compiler lowers it to global static storage with headers and a null sentinel, and the runtime maps the payload to an LLVM `i8*`.
+- ASCII literals may be typed as `ascii[N]` and widen to `utf8[N]` when passed to UTF-8 APIs.
 - Helpers like `print(i32)`, `print_int(i32)`, and `print_char(i32)` cover common prompt cases, while `print_cell(i32)` renders Sudoku grid cells with coloring metadata.
 - Input helpers include `read_char()` and `read_int()`; higher-level readers such as `read_line()` and `parse_seed_input()` can be implemented in Stasis using these primitives, which is how `samples/sudoku.stasis` parses seeds and user moves.
 - `time()` returns the current wall-clock epoch truncated to `i32`, so samples can seed deterministic generators from the clock when the user does not supply a value.

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -27,6 +27,7 @@ Stasis exposes two text types; `string[N]` remains an alias for `utf8[N]` for co
   - Invariants: `data[0..byte_length)` is valid UTF-8; `char_length` matches decoded codepoints; `data[byte_length]` is `0` as a sentinel (not counted in `N`).
   - Indexing: byte-indexed by default; codepoint helpers available.
   - Header-driven ops: `str_*` functions read/write headers; raw byte helpers require a recount if they change payload bytes.
+  - Boundary checks: UTF-8 mutators that take byte indices validate codepoint boundaries; invalid ranges are rejected without mutation.
 
 ### UTF-8 Encoding Basics
 
@@ -55,8 +56,8 @@ Stasis exposes two text types; `string[N]` remains an alias for `utf8[N]` for co
 - Iterating from start to end, respecting codepoint boundaries
 
 **Unsafe without care:**
-- Truncating at arbitrary byte positions (may split a codepoint)
-- Extracting substrings by byte index (may start/end mid-codepoint)
+- Truncating at arbitrary byte positions (may split a codepoint; validated mutators will reject)
+- Extracting substrings by byte index (validated mutators will reject mid-codepoint ranges)
 - Case conversion (only reliable for ASCII a-z/A-Z)
 
 ---
@@ -95,6 +96,7 @@ ascii_from_hex(d: i32): u8       // 0->'0', 10->'a', else '?'
 ## Module: `str_` (String Operations)
 
 All string functions operate on `utf8[N]` values (`string[N]` alias). Unless noted, mutating functions update both `byte_length` and `char_length` and maintain the null sentinel. For ASCII-only payloads, prefer `ascii[N]` and the `ascii_` helpers; ASCII inputs widen to UTF-8 when passed here.
+All operations that accept byte indices validate UTF-8 codepoint boundaries before mutating; invalid ranges leave the destination unchanged and return `-1` or `0` as noted.
 
 ### Length
 
@@ -164,12 +166,12 @@ str_append_codepoint(dst: utf8[], cp: i32): i32     // Append UTF-8 encoded code
 
 ### Substring (Byte-Based)
 
-These use byte indices. Caller must ensure indices don't split UTF-8 codepoints.
+These use byte indices and validate UTF-8 boundaries before copying.
 
 ```stasis
 str_substr(dst: utf8[], src: utf8[], start: i32, byte_len: i32): i32
     // Extract byte_len bytes starting at byte index start
-    // Returns bytes copied
+    // Returns bytes copied, or -1 if start/length are not on codepoint boundaries or out of range
 ```
 
 ### Trimming (In-Place, ASCII Whitespace)

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -5,7 +5,7 @@ This document defines the standard library for the Stasis programming language.
 ## Design Principles
 
 1. **Prefix by module**: `str_`, `io_`, `sys_`, `math_`, `ascii_`, `mem_`, `gfx_`
-2. **UTF-8 everywhere**: All strings use the `string[N]` type (UTF-8 payload + length headers)
+2. **Text types**: `ascii[N]` for single-byte text, `utf8[N]` (aka `string[N]`) for full UTF-8
 3. **In-place operations**: Modify destination buffer, return length or success
 4. **Consistent naming**: `module_verb_noun` pattern
 5. **No app-specific functions**: Generic primitives only
@@ -15,15 +15,18 @@ This document defines the standard library for the Stasis programming language.
 
 ## String Model
 
-Stasis strings use a dedicated `string[N]` type with UTF-8 payload and tracked lengths.
+Stasis exposes two text types; `string[N]` remains an alias for `utf8[N]` for compatibility.
 
-- **Type**: `string[N]` where `N` is the maximum payload size in bytes (not counting headers)
-- **Layout (in memory)**: `[byte_length: i32][char_length: i32][data: u8[N]]`
-- **UTF-8 encoded payload**: `data` holds the UTF-8 bytes; `byte_length` is the used byte count
-- **Codepoint-aware**: `char_length` tracks the decoded codepoint count for the current payload
-- **Byte-indexed by default**: APIs accept byte indices for performance, but maintain codepoint counts
-- **Null sentinel**: `data[byte_length]` is always set to `0` for interop; the sentinel is not counted in `N`
-- **Header-driven ops**: `str_*` functions read and write the headers; raw byte helpers require a recount if they change payload bytes
+- **ASCII strings**: `ascii[N]`
+  - Layout: `[len: i32][data: u8[N]]`
+  - Invariants: `data[0..len)` are `< 128`; `len` is the used byte count; `data[len]` is `0` as a sentinel (not counted in `N`).
+  - Indexing: byte-indexed; O(1) access.
+
+- **UTF-8 strings**: `utf8[N]` (and `string[N]`)
+  - Layout: `[byte_length: i32][char_length: i32][data: u8[N]]`
+  - Invariants: `data[0..byte_length)` is valid UTF-8; `char_length` matches decoded codepoints; `data[byte_length]` is `0` as a sentinel (not counted in `N`).
+  - Indexing: byte-indexed by default; codepoint helpers available.
+  - Header-driven ops: `str_*` functions read/write headers; raw byte helpers require a recount if they change payload bytes.
 
 ### UTF-8 Encoding Basics
 
@@ -91,15 +94,15 @@ ascii_from_hex(d: i32): u8       // 0->'0', 10->'a', else '?'
 
 ## Module: `str_` (String Operations)
 
-All string functions operate on `string[N]` values (UTF-8 payload + length headers). Unless noted, mutating functions update both `byte_length` and `char_length` and maintain the null sentinel.
+All string functions operate on `utf8[N]` values (`string[N]` alias). Unless noted, mutating functions update both `byte_length` and `char_length` and maintain the null sentinel. For ASCII-only payloads, prefer `ascii[N]` and the `ascii_` helpers; ASCII inputs widen to UTF-8 when passed here.
 
 ### Length
 
 ```stasis
-str_len(s: string[]): i32              // Byte length from header (fast)
-str_len_utf8(s: string[]): i32         // Codepoint count from header
-str_is_empty(s: string[]): bool        // Returns byte_length == 0
-str_recount_utf8(s: string[]): i32     // Recompute lengths from payload, fix headers
+str_len(s: utf8[]): i32              // Byte length from header (fast)
+str_len_utf8(s: utf8[]): i32         // Codepoint count from header
+str_is_empty(s: utf8[]): bool        // Returns byte_length == 0
+str_recount_utf8(s: utf8[]): i32     // Recompute lengths from payload, fix headers
 ```
 
 ### Byte Access (Low-Level)
@@ -107,22 +110,22 @@ str_recount_utf8(s: string[]): i32     // Recompute lengths from payload, fix he
 These operate on raw bytes and do not adjust headers. Call `str_recount_utf8` after manual edits to resync lengths.
 
 ```stasis
-str_get_byte(s: string[], index: i32): u8       // Get byte at index (0 if out of bounds)
-str_set_byte(s: string[], index: i32, b: u8)    // Set byte at index (no-op if out of bounds)
+str_get_byte(s: utf8[], index: i32): u8       // Get byte at index (0 if out of bounds)
+str_set_byte(s: utf8[], index: i32, b: u8)    // Set byte at index (no-op if out of bounds)
 ```
 
 ### UTF-8 Iteration
 
 ```stasis
-str_next_codepoint(s: string[], byte_index: i32): i32
+str_next_codepoint(s: utf8[], byte_index: i32): i32
     // Returns byte index of next codepoint start, or -1 if at end
     // Usage: iterate codepoints without decoding
 
-str_decode_codepoint(s: string[], byte_index: i32): i32
+str_decode_codepoint(s: utf8[], byte_index: i32): i32
     // Decode codepoint at byte_index, return Unicode codepoint value
     // Returns -1 if invalid UTF-8 or out of bounds
 
-str_encode_codepoint(dst: string[], codepoint: i32): i32
+str_encode_codepoint(dst: utf8[], codepoint: i32): i32
     // Encode codepoint into dst payload, update lengths, return bytes written (1-4)
     // Returns 0 if invalid codepoint or no capacity
 ```
@@ -132,10 +135,10 @@ str_encode_codepoint(dst: string[], codepoint: i32): i32
 All comparisons are byte-wise, which preserves UTF-8 lexicographic order.
 
 ```stasis
-str_eq(a: string[], b: string[]): bool                 // Byte-wise equality
-str_cmp(a: string[], b: string[]): i32                 // -1, 0, 1 (lexicographic)
-str_starts_with(s: string[], prefix: string[]): bool   // Check prefix match
-str_ends_with(s: string[], suffix: string[]): bool     // Check suffix match
+str_eq(a: utf8[], b: utf8[]): bool                 // Byte-wise equality
+str_cmp(a: utf8[], b: utf8[]): i32                 // -1, 0, 1 (lexicographic)
+str_starts_with(s: utf8[], prefix: utf8[]): bool   // Check prefix match
+str_ends_with(s: utf8[], suffix: utf8[]): bool     // Check suffix match
 ```
 
 ### Search (Returns Byte Index)
@@ -143,20 +146,20 @@ str_ends_with(s: string[], suffix: string[]): bool     // Check suffix match
 These return **byte indices**. When searching for ASCII characters, results are always safe to use for splitting.
 
 ```stasis
-str_find(s: string[], needle: string[]): i32           // First byte index of needle, or -1
-str_find_byte(s: string[], b: u8): i32                 // First byte index of byte, or -1
-str_find_last_byte(s: string[], b: u8): i32            // Last byte index of byte, or -1
-str_contains(s: string[], needle: string[]): bool      // True if s contains needle
+str_find(s: utf8[], needle: utf8[]): i32           // First byte index of needle, or -1
+str_find_byte(s: utf8[], b: u8): i32                 // First byte index of byte, or -1
+str_find_last_byte(s: utf8[], b: u8): i32            // Last byte index of byte, or -1
+str_contains(s: utf8[], needle: utf8[]): bool      // True if s contains needle
 ```
 
 ### Modification (In-Place)
 
 ```stasis
-str_clear(s: string[])                                // Reset lengths to 0 and write null sentinel
-str_copy(dst: string[], src: string[]): i32           // Copy src to dst, return bytes copied
-str_append(dst: string[], src: string[]): i32         // Append src to dst, return new byte length
-str_append_byte(dst: string[], b: u8): i32            // Append single byte (must be ASCII), return new length
-str_append_codepoint(dst: string[], cp: i32): i32     // Append UTF-8 encoded codepoint, return bytes written
+str_clear(s: utf8[])                                // Reset lengths to 0 and write null sentinel
+str_copy(dst: utf8[], src: utf8[]): i32           // Copy src to dst, return bytes copied
+str_append(dst: utf8[], src: utf8[]): i32         // Append src to dst, return new byte length
+str_append_byte(dst: utf8[], b: u8): i32            // Append single byte (must be ASCII), return new length
+str_append_codepoint(dst: utf8[], cp: i32): i32     // Append UTF-8 encoded codepoint, return bytes written
 ```
 
 ### Substring (Byte-Based)
@@ -164,7 +167,7 @@ str_append_codepoint(dst: string[], cp: i32): i32     // Append UTF-8 encoded co
 These use byte indices. Caller must ensure indices don't split UTF-8 codepoints.
 
 ```stasis
-str_substr(dst: string[], src: string[], start: i32, byte_len: i32): i32
+str_substr(dst: utf8[], src: utf8[], start: i32, byte_len: i32): i32
     // Extract byte_len bytes starting at byte index start
     // Returns bytes copied
 ```
@@ -174,9 +177,9 @@ str_substr(dst: string[], src: string[], start: i32, byte_len: i32): i32
 Trims ASCII whitespace (space, tab, newline, carriage return). Safe for UTF-8 since these are all single-byte. Length headers are updated.
 
 ```stasis
-str_trim_start(s: string[]): i32    // Remove leading ASCII whitespace
-str_trim_end(s: string[]): i32      // Remove trailing ASCII whitespace
-str_trim(s: string[]): i32          // Remove both, return new byte length
+str_trim_start(s: utf8[]): i32    // Remove leading ASCII whitespace
+str_trim_end(s: utf8[]): i32      // Remove trailing ASCII whitespace
+str_trim(s: utf8[]): i32          // Remove both, return new byte length
 ```
 
 ### Case Conversion (ASCII Only, In-Place)
@@ -184,24 +187,24 @@ str_trim(s: string[]): i32          // Remove both, return new byte length
 Only converts ASCII letters (a-z, A-Z). Non-ASCII UTF-8 bytes are unchanged. Length headers are preserved.
 
 ```stasis
-str_to_upper(s: string[])           // Convert ASCII lowercase to uppercase
-str_to_lower(s: string[])           // Convert ASCII uppercase to lowercase
+str_to_upper(s: utf8[])           // Convert ASCII lowercase to uppercase
+str_to_lower(s: utf8[])           // Convert ASCII uppercase to lowercase
 ```
 
 ### Number Conversion
 
 ```stasis
-str_from_i32(dst: string[], value: i32): i32                   // Int to string, return byte length
-str_from_f32(dst: string[], value: f32, decimals: i32): i32    // Float to string
-str_to_i32(s: string[]): i32                                   // Parse int (0 on failure)
-str_to_f32(s: string[]): f32                                   // Parse float (0.0 on failure)
+str_from_i32(dst: utf8[], value: i32): i32                   // Int to string, return byte length
+str_from_f32(dst: utf8[], value: f32, decimals: i32): i32    // Float to string
+str_to_i32(s: utf8[]): i32                                   // Parse int (0 on failure)
+str_to_f32(s: utf8[]): f32                                   // Parse float (0.0 on failure)
 ```
 
 ### Validation
 
 ```stasis
-str_is_valid_utf8(s: string[]): bool              // Check if string is valid UTF-8
-str_sanitize_utf8(s: string[]): i32               // Replace invalid sequences with U+FFFD and fix headers
+str_is_valid_utf8(s: utf8[]): bool              // Check if string is valid UTF-8
+str_sanitize_utf8(s: utf8[]): i32               // Replace invalid sequences with U+FFFD and fix headers
 ```
 
 ---
@@ -211,8 +214,8 @@ str_sanitize_utf8(s: string[]): i32               // Replace invalid sequences w
 ### Console Output
 
 ```stasis
-io_print(s: string[])             // Print UTF-8 string (no newline)
-io_println(s: string[])           // Print UTF-8 string + newline
+io_print(s: utf8[])             // Print UTF-8 string (no newline)
+io_println(s: utf8[])           // Print UTF-8 string + newline
 io_print_i32(value: i32)          // Print integer
 io_print_f32(value: f32)          // Print float
 io_print_codepoint(cp: i32)       // Print single Unicode codepoint (UTF-8 encoded)
@@ -224,7 +227,7 @@ io_newline()                      // Print newline
 
 ```stasis
 io_read_byte(): i32               // Read single byte (blocking), -1 on EOF
-io_read_line(dst: string[]): i32  // Read UTF-8 line into buffer, return byte length
+io_read_line(dst: utf8[]): i32  // Read UTF-8 line into buffer, return byte length
 io_read_i32(): i32                // Read and parse integer
 ```
 
@@ -345,7 +348,7 @@ mem_cmp(a: u8[], b: u8[], count: i32): i32     // Compare bytes, return -1/0/1
 These are implemented in `runtime/stasis_graphics.c`, not as compiler built-ins.
 
 ```stasis
-gfx_init(width: i32, height: i32, title: string[]): bool
+gfx_init(width: i32, height: i32, title: utf8[]): bool
 gfx_begin_frame()
 gfx_end_frame()
 gfx_clear(r: f32, g: f32, b: f32, a: f32)
@@ -448,7 +451,7 @@ let t: i32 = sys_time_sec();
 ### Iterating Over Codepoints
 
 ```stasis
-global text: string[256];
+global text: utf8[256];
 global i: i32;
 global cp: i32;
 
@@ -468,8 +471,8 @@ function print_codepoints() {
 ### Safe String Splitting on ASCII Delimiter
 
 ```stasis
-global path: string[256];
-global filename: string[64];
+global path: utf8[256];
+global filename: utf8[64];
 
 function extract_filename() {
     // Find last '/' - safe because '/' is ASCII

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -27,7 +27,7 @@ Stasis exposes two text types; `string[N]` remains an alias for `utf8[N]` for co
   - Invariants: `data[0..byte_length)` is valid UTF-8; `char_length` matches decoded codepoints; `data[byte_length]` is `0` as a sentinel (not counted in `N`).
   - Indexing: byte-indexed by default; codepoint helpers available.
   - Header-driven ops: `str_*` functions read/write headers; raw byte helpers require a recount if they change payload bytes.
-  - Boundary checks: UTF-8 mutators that take byte indices validate codepoint boundaries; invalid ranges are rejected without mutation.
+  - Boundary checks: UTF-8 mutators that take byte indices validate codepoint boundaries; invalid ranges trigger a fatal exit (coding error).
 
 ### UTF-8 Encoding Basics
 
@@ -56,8 +56,8 @@ Stasis exposes two text types; `string[N]` remains an alias for `utf8[N]` for co
 - Iterating from start to end, respecting codepoint boundaries
 
 **Unsafe without care:**
-- Truncating at arbitrary byte positions (may split a codepoint; validated mutators will reject)
-- Extracting substrings by byte index (validated mutators will reject mid-codepoint ranges)
+- Truncating at arbitrary byte positions (validated mutators will abort on mid-codepoint splits)
+- Extracting substrings by byte index (validated mutators will abort on mid-codepoint ranges)
 - Case conversion (only reliable for ASCII a-z/A-Z)
 
 ---
@@ -96,7 +96,7 @@ ascii_from_hex(d: i32): u8       // 0->'0', 10->'a', else '?'
 ## Module: `str_` (String Operations)
 
 All string functions operate on `utf8[N]` values (`string[N]` alias). Unless noted, mutating functions update both `byte_length` and `char_length` and maintain the null sentinel. For ASCII-only payloads, prefer `ascii[N]` and the `ascii_` helpers; ASCII inputs widen to UTF-8 when passed here.
-All operations that accept byte indices validate UTF-8 codepoint boundaries before mutating; invalid ranges leave the destination unchanged and return `-1` or `0` as noted.
+All operations that accept byte indices validate UTF-8 codepoint boundaries before mutating; invalid ranges are treated as coding errors and trigger a fatal exit rather than continuing with partial writes.
 
 ### Length
 
@@ -166,12 +166,12 @@ str_append_codepoint(dst: utf8[], cp: i32): i32     // Append UTF-8 encoded code
 
 ### Substring (Byte-Based)
 
-These use byte indices and validate UTF-8 boundaries before copying.
+These use byte indices and validate UTF-8 boundaries before copying. Misaligned ranges abort.
 
 ```stasis
 str_substr(dst: utf8[], src: utf8[], start: i32, byte_len: i32): i32
     // Extract byte_len bytes starting at byte index start
-    // Returns bytes copied, or -1 if start/length are not on codepoint boundaries or out of range
+    // Returns bytes copied; aborts if start/length are not on codepoint boundaries or out of range
 ```
 
 ### Trimming (In-Place, ASCII Whitespace)

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1,0 +1,483 @@
+﻿# Stasis Standard Library Design
+
+This document defines the standard library for the Stasis programming language.
+
+## Design Principles
+
+1. **Prefix by module**: `str_`, `io_`, `sys_`, `math_`, `ascii_`, `mem_`, `gfx_`
+2. **UTF-8 everywhere**: All strings use the `string[N]` type (UTF-8 payload + length headers)
+3. **In-place operations**: Modify destination buffer, return length or success
+4. **Consistent naming**: `module_verb_noun` pattern
+5. **No app-specific functions**: Generic primitives only
+6. **Explicit about bytes vs codepoints**: Function names and docs clearly indicate which unit they operate on
+
+---
+
+## String Model
+
+Stasis strings use a dedicated `string[N]` type with UTF-8 payload and tracked lengths.
+
+- **Type**: `string[N]` where `N` is the maximum payload size in bytes (not counting headers)
+- **Layout (in memory)**: `[byte_length: i32][char_length: i32][data: u8[N]]`
+- **UTF-8 encoded payload**: `data` holds the UTF-8 bytes; `byte_length` is the used byte count
+- **Codepoint-aware**: `char_length` tracks the decoded codepoint count for the current payload
+- **Byte-indexed by default**: APIs accept byte indices for performance, but maintain codepoint counts
+- **Null sentinel**: `data[byte_length]` is always set to `0` for interop; the sentinel is not counted in `N`
+- **Header-driven ops**: `str_*` functions read and write the headers; raw byte helpers require a recount if they change payload bytes
+
+### UTF-8 Encoding Basics
+
+| Codepoint Range | Bytes | First Byte Pattern | Continuation Bytes |
+|-----------------|-------|--------------------|--------------------|
+| U+0000 - U+007F | 1 | `0xxxxxxx` | none |
+| U+0080 - U+07FF | 2 | `110xxxxx` | 1 (`10xxxxxx`) |
+| U+0800 - U+FFFF | 3 | `1110xxxx` | 2 |
+| U+10000 - U+10FFFF | 4 | `11110xxx` | 3 |
+
+### Key Implications
+
+1. **ASCII is a subset**: Bytes 0-127 are identical to ASCII and always single-byte
+2. **Byte length differs from character count**: "h\xe2\x82\xacllo" is 7 bytes but 6 characters
+3. **Random byte access can split characters**: Indexing into the middle of a multi-byte sequence produces invalid UTF-8
+4. **Searching for ASCII is safe**: ASCII bytes (0-127) never appear as continuation bytes
+5. **Headers must stay in sync**: Any change to payload bytes must update `byte_length` and `char_length`
+
+### Safety Guidelines
+
+**Safe operations on UTF-8 strings:**
+- Searching for ASCII characters (`,`, `\n`, `/`, etc.)
+- Comparing strings byte-by-byte (UTF-8 maintains sort order)
+- Copying/appending entire strings
+- Measuring byte length
+- Iterating from start to end, respecting codepoint boundaries
+
+**Unsafe without care:**
+- Truncating at arbitrary byte positions (may split a codepoint)
+- Extracting substrings by byte index (may start/end mid-codepoint)
+- Case conversion (only reliable for ASCII a-z/A-Z)
+
+---
+
+## Module: `ascii_` (ASCII Byte Utilities)
+
+Classification and conversion for **ASCII bytes only** (0-127). These functions operate on single bytes and are only meaningful for ASCII characters. For UTF-8 strings, use these only on bytes you know to be ASCII.
+
+### Classification
+
+```stasis
+ascii_is_digit(b: u8): bool      // '0'-'9' (48-57)
+ascii_is_alpha(b: u8): bool      // 'a'-'z', 'A'-'Z'
+ascii_is_alnum(b: u8): bool      // digit or alpha
+ascii_is_space(b: u8): bool      // ' ', '\t', '\n', '\r' (32, 9, 10, 13)
+ascii_is_upper(b: u8): bool      // 'A'-'Z' (65-90)
+ascii_is_lower(b: u8): bool      // 'a'-'z' (97-122)
+ascii_is_hex(b: u8): bool        // '0'-'9', 'a'-'f', 'A'-'F'
+ascii_is_print(b: u8): bool      // printable ASCII (32-126)
+ascii_is_ascii(b: u8): bool      // true if b < 128
+```
+
+### Conversion
+
+```stasis
+ascii_to_upper(b: u8): u8        // 'a'->'A', others unchanged
+ascii_to_lower(b: u8): u8        // 'A'->'a', others unchanged
+ascii_to_digit(b: u8): i32       // '0'->0, '9'->9, else -1
+ascii_from_digit(d: i32): u8     // 0->'0', 9->'9', else '?'
+ascii_to_hex(b: u8): i32         // '0'->0, 'a'->10, 'F'->15, else -1
+ascii_from_hex(d: i32): u8       // 0->'0', 10->'a', else '?'
+```
+
+---
+
+## Module: `str_` (String Operations)
+
+All string functions operate on `string[N]` values (UTF-8 payload + length headers). Unless noted, mutating functions update both `byte_length` and `char_length` and maintain the null sentinel.
+
+### Length
+
+```stasis
+str_len(s: string[]): i32              // Byte length from header (fast)
+str_len_utf8(s: string[]): i32         // Codepoint count from header
+str_is_empty(s: string[]): bool        // Returns byte_length == 0
+str_recount_utf8(s: string[]): i32     // Recompute lengths from payload, fix headers
+```
+
+### Byte Access (Low-Level)
+
+These operate on raw bytes and do not adjust headers. Call `str_recount_utf8` after manual edits to resync lengths.
+
+```stasis
+str_get_byte(s: string[], index: i32): u8       // Get byte at index (0 if out of bounds)
+str_set_byte(s: string[], index: i32, b: u8)    // Set byte at index (no-op if out of bounds)
+```
+
+### UTF-8 Iteration
+
+```stasis
+str_next_codepoint(s: string[], byte_index: i32): i32
+    // Returns byte index of next codepoint start, or -1 if at end
+    // Usage: iterate codepoints without decoding
+
+str_decode_codepoint(s: string[], byte_index: i32): i32
+    // Decode codepoint at byte_index, return Unicode codepoint value
+    // Returns -1 if invalid UTF-8 or out of bounds
+
+str_encode_codepoint(dst: string[], codepoint: i32): i32
+    // Encode codepoint into dst payload, update lengths, return bytes written (1-4)
+    // Returns 0 if invalid codepoint or no capacity
+```
+
+### Comparison
+
+All comparisons are byte-wise, which preserves UTF-8 lexicographic order.
+
+```stasis
+str_eq(a: string[], b: string[]): bool                 // Byte-wise equality
+str_cmp(a: string[], b: string[]): i32                 // -1, 0, 1 (lexicographic)
+str_starts_with(s: string[], prefix: string[]): bool   // Check prefix match
+str_ends_with(s: string[], suffix: string[]): bool     // Check suffix match
+```
+
+### Search (Returns Byte Index)
+
+These return **byte indices**. When searching for ASCII characters, results are always safe to use for splitting.
+
+```stasis
+str_find(s: string[], needle: string[]): i32           // First byte index of needle, or -1
+str_find_byte(s: string[], b: u8): i32                 // First byte index of byte, or -1
+str_find_last_byte(s: string[], b: u8): i32            // Last byte index of byte, or -1
+str_contains(s: string[], needle: string[]): bool      // True if s contains needle
+```
+
+### Modification (In-Place)
+
+```stasis
+str_clear(s: string[])                                // Reset lengths to 0 and write null sentinel
+str_copy(dst: string[], src: string[]): i32           // Copy src to dst, return bytes copied
+str_append(dst: string[], src: string[]): i32         // Append src to dst, return new byte length
+str_append_byte(dst: string[], b: u8): i32            // Append single byte (must be ASCII), return new length
+str_append_codepoint(dst: string[], cp: i32): i32     // Append UTF-8 encoded codepoint, return bytes written
+```
+
+### Substring (Byte-Based)
+
+These use byte indices. Caller must ensure indices don't split UTF-8 codepoints.
+
+```stasis
+str_substr(dst: string[], src: string[], start: i32, byte_len: i32): i32
+    // Extract byte_len bytes starting at byte index start
+    // Returns bytes copied
+```
+
+### Trimming (In-Place, ASCII Whitespace)
+
+Trims ASCII whitespace (space, tab, newline, carriage return). Safe for UTF-8 since these are all single-byte. Length headers are updated.
+
+```stasis
+str_trim_start(s: string[]): i32    // Remove leading ASCII whitespace
+str_trim_end(s: string[]): i32      // Remove trailing ASCII whitespace
+str_trim(s: string[]): i32          // Remove both, return new byte length
+```
+
+### Case Conversion (ASCII Only, In-Place)
+
+Only converts ASCII letters (a-z, A-Z). Non-ASCII UTF-8 bytes are unchanged. Length headers are preserved.
+
+```stasis
+str_to_upper(s: string[])           // Convert ASCII lowercase to uppercase
+str_to_lower(s: string[])           // Convert ASCII uppercase to lowercase
+```
+
+### Number Conversion
+
+```stasis
+str_from_i32(dst: string[], value: i32): i32                   // Int to string, return byte length
+str_from_f32(dst: string[], value: f32, decimals: i32): i32    // Float to string
+str_to_i32(s: string[]): i32                                   // Parse int (0 on failure)
+str_to_f32(s: string[]): f32                                   // Parse float (0.0 on failure)
+```
+
+### Validation
+
+```stasis
+str_is_valid_utf8(s: string[]): bool              // Check if string is valid UTF-8
+str_sanitize_utf8(s: string[]): i32               // Replace invalid sequences with U+FFFD and fix headers
+```
+
+---
+
+## Module: `io_` (Input/Output)
+
+### Console Output
+
+```stasis
+io_print(s: string[])             // Print UTF-8 string (no newline)
+io_println(s: string[])           // Print UTF-8 string + newline
+io_print_i32(value: i32)          // Print integer
+io_print_f32(value: f32)          // Print float
+io_print_codepoint(cp: i32)       // Print single Unicode codepoint (UTF-8 encoded)
+io_print_bool(value: bool)        // Print "true" or "false"
+io_newline()                      // Print newline
+```
+
+### Console Input
+
+```stasis
+io_read_byte(): i32               // Read single byte (blocking), -1 on EOF
+io_read_line(dst: string[]): i32  // Read UTF-8 line into buffer, return byte length
+io_read_i32(): i32                // Read and parse integer
+```
+
+---
+
+## Module: `sys_` (System)
+
+### Time
+
+```stasis
+sys_time_sec(): i32             // Unix timestamp in seconds
+sys_time_ms(): i32              // Milliseconds since program start
+sys_sleep_ms(ms: i32)           // Sleep for milliseconds
+```
+
+### Platform Info
+
+```stasis
+sys_platform(): i32             // 0=unknown, 1=windows, 2=linux, 3=macos
+sys_arch(): i32                 // 0=unknown, 1=x86_64, 2=arm64, 3=wasm32
+sys_pointer_size(): i32         // 4 or 8 bytes
+```
+
+### Program Control
+
+```stasis
+sys_exit(code: i32)             // Exit program with code
+sys_abort()                     // Abort immediately
+```
+
+### Random Numbers
+
+```stasis
+sys_random_seed(seed: i32)              // Seed the PRNG
+sys_random(): i32                       // Next random i32
+sys_random_range(min: i32, max: i32): i32  // Random in [min, max)
+```
+
+---
+
+## Module: `math_` (Mathematics)
+
+### Trigonometry
+
+```stasis
+math_sin(x: f32): f32           // Precise sine
+math_cos(x: f32): f32           // Precise cosine
+math_tan(x: f32): f32           // Tangent
+math_sin_fast(x: f32): f32      // Fast sine (less precise)
+math_cos_fast(x: f32): f32      // Fast cosine (less precise)
+math_atan2(y: f32, x: f32): f32 // Arc tangent of y/x
+```
+
+### Exponential / Logarithm
+
+```stasis
+math_sqrt(x: f32): f32          // Square root
+math_pow(base: f32, exp: f32): f32  // Power
+math_exp(x: f32): f32           // e^x
+math_log(x: f32): f32           // Natural log
+math_log10(x: f32): f32         // Base-10 log
+```
+
+### Rounding
+
+```stasis
+math_floor(x: f32): f32         // Round down
+math_ceil(x: f32): f32          // Round up
+math_round(x: f32): f32         // Round to nearest
+math_trunc(x: f32): f32         // Truncate toward zero
+```
+
+### Absolute Value / Min / Max
+
+```stasis
+math_abs_i32(x: i32): i32
+math_abs_f32(x: f32): f32
+math_min_i32(a: i32, b: i32): i32
+math_max_i32(a: i32, b: i32): i32
+math_min_f32(a: f32, b: f32): f32
+math_max_f32(a: f32, b: f32): f32
+math_clamp_i32(x: i32, min: i32, max: i32): i32
+math_clamp_f32(x: f32, min: f32, max: f32): f32
+```
+
+### Sign
+
+```stasis
+math_sign_i32(x: i32): i32      // -1, 0, or 1
+math_sign_f32(x: f32): f32      // -1.0, 0.0, or 1.0
+```
+
+### Constants
+
+```stasis
+const MATH_PI: f32 = 3.14159265;
+const MATH_TAU: f32 = 6.28318530;
+const MATH_E: f32 = 2.71828182;
+```
+
+---
+
+## Module: `mem_` (Memory Operations)
+
+Raw byte operations on buffers.
+
+```stasis
+mem_copy(dst: u8[], src: u8[], count: i32)     // Copy count bytes
+mem_set(dst: u8[], value: u8, count: i32)      // Fill with value
+mem_zero(dst: u8[], count: i32)                // Fill with zeros
+mem_cmp(a: u8[], b: u8[], count: i32): i32     // Compare bytes, return -1/0/1
+```
+
+---
+
+## Module: `gfx_` (Graphics - External Runtime)
+
+These are implemented in `runtime/stasis_graphics.c`, not as compiler built-ins.
+
+```stasis
+gfx_init(width: i32, height: i32, title: string[]): bool
+gfx_begin_frame()
+gfx_end_frame()
+gfx_clear(r: f32, g: f32, b: f32, a: f32)
+gfx_draw_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32)
+gfx_is_key_down(scancode: i32): bool
+gfx_should_quit(): bool
+```
+
+---
+
+## Implementation Priority
+
+### Phase 1: Essential (Self-Hosting Foundation)
+
+- [ ] `ascii_*` module (all functions)
+- [ ] `str_*` module (core: len, copy, append, compare, find)
+- [ ] `sys_exit`, `sys_abort`
+
+### Phase 2: UTF-8 Support
+
+- [ ] `str_len_utf8` - codepoint counting and header sync
+- [ ] `str_next_codepoint`, `str_decode_codepoint`, `str_encode_codepoint`
+- [ ] `str_is_valid_utf8`, `str_sanitize_utf8`
+- [ ] `str_append_codepoint`
+
+### Phase 3: Utilities
+
+- [ ] `math_sqrt`, `math_abs_*`, `math_min_*`, `math_max_*`, `math_clamp_*`
+- [ ] `io_println`, `io_read_line`, `io_newline`
+- [ ] `mem_*` functions
+- [ ] `sys_random*`
+- [ ] Number conversion functions
+
+### Phase 4: Extended Math
+
+- [ ] `math_atan2`, `math_pow`, `math_floor`, `math_ceil`, `math_round`
+- [ ] `math_tan`, `math_exp`, `math_log`, `math_log10`
+
+### Phase 5: Cleanup
+
+- [ ] Remove legacy Sudoku functions
+- [ ] Rename legacy functions to new naming convention
+- [ ] Deprecation warnings for old names
+
+---
+
+## Current Built-in Functions (Legacy)
+
+### To Remove (App-Specific)
+
+| Function           | Reason                    |
+| ------------------ | ------------------------- |
+| `print_cell`       | Sudoku-specific rendering |
+| `print_prompt`     | Sudoku-specific prompt    |
+| `print_invalid`    | Sudoku-specific error     |
+| `print_clue_error` | Sudoku-specific error     |
+| `print_solved`     | Sudoku-specific message   |
+
+### To Rename (Consistency)
+
+| Old Name       | New Name       |
+| -------------- | -------------- |
+| `print_string` | `io_print`     |
+| `print_int`    | `io_print_i32` |
+| `print_char`   | `io_print_codepoint` |
+| `read_char`    | `io_read_byte` |
+| `read_int`     | `io_read_i32`  |
+| `time`         | `sys_time_sec` |
+| `get_time_ms`  | `sys_time_ms`  |
+| `sleep_ms`     | `sys_sleep_ms` |
+| `sin`          | `math_sin`     |
+| `cos`          | `math_cos`     |
+| `sin_fast`     | `math_sin_fast`|
+| `cos_fast`     | `math_cos_fast`|
+
+---
+
+## Migration Guide
+
+For existing code using legacy function names:
+
+```stasis
+// Old way:
+print_string("Hello");
+print_int(42);
+let c: i32 = read_char();
+let t: i32 = time();
+
+// New way:
+io_print("Hello");
+io_print_i32(42);
+let c: i32 = io_read_byte();
+let t: i32 = sys_time_sec();
+```
+
+---
+
+## UTF-8 Usage Examples
+
+### Iterating Over Codepoints
+
+```stasis
+global text: string[256];
+global i: i32;
+global cp: i32;
+
+function print_codepoints() {
+    i = 0;
+    while (i >= 0) {
+        cp = str_decode_codepoint(text, i);
+        if (cp >= 0) {
+            io_print_codepoint(cp);
+            io_print(" ");
+        }
+        i = str_next_codepoint(text, i);
+    }
+}
+```
+
+### Safe String Splitting on ASCII Delimiter
+
+```stasis
+global path: string[256];
+global filename: string[64];
+
+function extract_filename() {
+    // Find last '/' - safe because '/' is ASCII
+    let slash_pos: i32 = str_find_last_byte(path, 47);  // 47 = '/'
+    if (slash_pos >= 0) {
+        str_substr(filename, path, slash_pos + 1, str_len(path) - slash_pos - 1);
+    } else {
+        str_copy(filename, path);
+    }
+}
+```


### PR DESCRIPTION
- implement boundary-checked str_substr with fatal misalignment handling
- replace libc find/last_find with inline scans
- add execution tests for valid copy and abort on misaligned start
- align with updated UTF-8 string model