### PR TITLE
fix: frame_timer foreach without underscore var

### DIFF
--- a/samples/brickout_revenge.stasis
+++ b/samples/brickout_revenge.stasis
@@ -267,7 +267,7 @@ function init_game(reset_progress: bool): void {
     state.timers.tick_time_ms = 0;
 
     frame_timer_init(state.frame_timer.samples_ms);
-    state.frame_timer.sample_index = frame_timer_reset_index();
+    state.frame_timer.sample_index = 0;
 
     // Game state
     // Start immediately in battle; no setup pause.
@@ -278,7 +278,7 @@ function init_game(reset_progress: bool): void {
     // Initialize frame time tracking
     // Note: Frame times will be filled with first actual measurement
     // to provide accurate average from the start
-    state.frame_timer.sample_index = frame_timer_reset_index();
+    state.frame_timer.sample_index = 0;
 
     if (reset_progress) {
         state.wave = 1;
@@ -1321,7 +1321,7 @@ function main(): i32 {
 
     // Initialize frame time buffer with baseline value
     frame_timer_init(state.frame_timer.samples_ms);
-    state.frame_timer.sample_index = frame_timer_reset_index();
+    state.frame_timer.sample_index = 0;
 
     let frame: i32 = 0;
     for (frame = 0; state.running == 1; frame = frame + 1) {

--- a/src/stdlib/frame_timer.stasis
+++ b/src/stdlib/frame_timer.stasis
@@ -13,15 +13,10 @@ struct FrameTimer {
 }
 
 function frame_timer_init(samples_ms: i32[]): void {
-    foreach (let v, i in samples_ms) {
-        if (i < FRAME_TIMER_SAMPLES) {
-            samples_ms[i] = 1;
-        }
+    let i: i32 = 0;
+    for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
+        samples_ms[i] = 1;
     }
-}
-
-function frame_timer_reset_index(): i32 {
-    return 0;
 }
 
 function frame_timer_push(samples_ms: i32[], sample_index: i32, value_ms: i32): i32 {
@@ -38,10 +33,9 @@ function frame_timer_push(samples_ms: i32[], sample_index: i32, value_ms: i32): 
 function frame_timer_avg_tenths(samples_ms: i32[]): i32 {
     // Fixed-point average in 0.1ms units to avoid f32->i32 cast issues in some backends.
     let sum: i32 = 0;
-    foreach (let v, i in samples_ms) {
-        if (i < FRAME_TIMER_SAMPLES) {
-            sum = sum + v;
-        }
+    let i: i32 = 0;
+    for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
+        sum = sum + samples_ms[i];
     }
     return (sum * 10) / FRAME_TIMER_SAMPLES;
 }
@@ -49,10 +43,10 @@ function frame_timer_avg_tenths(samples_ms: i32[]): i32 {
 function frame_timer_max(samples_ms: i32[]): i32 {
     // Returns the max sample value across the full sample window.
     let max_v: i32 = 0;
-    foreach (let v, i in samples_ms) {
-        if (i < FRAME_TIMER_SAMPLES) {
-            if (v > max_v) { max_v = v; }
-        }
+    let i: i32 = 0;
+    for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
+        let v: i32 = samples_ms[i];
+        if (v > max_v) { max_v = v; }
     }
     return max_v;
 }

--- a/src/stdlib/frame_timer.stasis
+++ b/src/stdlib/frame_timer.stasis
@@ -13,7 +13,7 @@ struct FrameTimer {
 }
 
 function frame_timer_init(samples_ms: i32[]): void {
-    foreach (let _v, i in samples_ms) {
+    foreach (let v, i in samples_ms) {
         if (i < FRAME_TIMER_SAMPLES) {
             samples_ms[i] = 1;
         }


### PR DESCRIPTION
Follow-up after #18: removes let _v from frame_timer_init foreach since underscore-prefixed variable names aren’t supported.