### PR TITLE
fix: do not rerun main() on tick hot reload

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -2162,7 +2162,6 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     var hotExitPath = enableHotState && mode == "run" ? GetHotExitFilePath(fullPath, moduleName) : null;
 
     if (mode == "run" &&
-        enableHotState &&
         backend == BackendType.Cranelift &&
         useCraneliftRunner &&
         OperatingSystem.IsWindows() &&
@@ -2332,8 +2331,8 @@ static void PrintUsage()
     Console.WriteLine("  stasisc format <file>");
     Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout. With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
     Console.WriteLine("Watch: use --watch to re-run on file changes (run/test only).");
-    Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across runs, enabling simple stateful restart experiments.");
-    Console.WriteLine("Tick hosting: if your program defines `function tick()`, the runner will call `main()` once then call `tick()` at `--fps` (host paced); hot swaps between ticks do not call `main()` again.");
+    Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
+    Console.WriteLine("Tick hosting: if your program defines `function tick()` and you run with --watch, the host will hot-swap between ticks and preserve the global 'state' automatically (main() is not called again on swaps).");
     Console.WriteLine("Graphics: use --graphics to enable SDL2/OpenGL graphics runtime. Specify --graphics-lib to override library path.");
     Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
     Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override.");

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -29,6 +29,7 @@ var emitIrOnly = false;
 string? outputPath = null;
 var runAllInDirectory = false;
 var watch = false;
+var watchExplicit = false;
 string? optLevel = null;
 var enableLto = false;
 var enableGraphics = false;
@@ -44,10 +45,8 @@ while (cliArgs.Count > 0)
     switch (arg)
     {
         case "dev":
-            // Dev mode: optimized for iteration (watch + tick hot-swap when available).
-            devMode = true;
+            // Back-compat alias for the run dev workflow.
             mode = "run";
-            watch = true;
             break;
         case "build":
             mode = arg;
@@ -82,6 +81,7 @@ while (cliArgs.Count > 0)
             break;
         case "--watch":
             watch = true;
+            watchExplicit = true;
             break;
         case "--opt-level" when cliArgs.Count > 0:
             optLevel = cliArgs.Dequeue();
@@ -163,10 +163,7 @@ if (optLevel is not null && !IsValidOptLevel(optLevel))
     Environment.Exit(1);
 }
 
-if (devMode)
-{
-    Environment.SetEnvironmentVariable("STASIS_PHASE_TIMING", "1");
-}
+devMode = mode == "run";
 
 // Set default backend based on mode if not explicitly specified
 var backend = selectedBackend ?? CodeGeneratorFactory.GetDefaultBackend(mode == "release");
@@ -240,6 +237,22 @@ if (mode == "format")
 }
 
 LlvmNativeLoader.EnsureLoaded();
+
+// Dev defaults: in run mode, auto-enable watch for tick-hosted games (or likely graphics programs),
+// and enable phase timing output when watching. (Explicit --watch always wins.)
+if (devMode && !watchExplicit && File.Exists(path))
+{
+    var sourceForDetect = File.ReadAllText(path);
+    if (DetectsTickUsage(sourceForDetect) || DetectsGraphicsUsage(sourceForDetect))
+    {
+        watch = true;
+    }
+}
+
+if (devMode && watch)
+{
+    Environment.SetEnvironmentVariable("STASIS_PHASE_TIMING", "1");
+}
 
 if (watch)
 {
@@ -2026,8 +2039,13 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
     {
         if (runner is not null && runner.HasExited)
         {
+            if (runner.ExitCode == 0)
+            {
+                return 0;
+            }
+
             Console.Error.WriteLine($"error: runner exited with code {runner.ExitCode}");
-            break;
+            return 1;
         }
 
         try
@@ -2336,17 +2354,16 @@ static string QuoteArg(string arg) =>
 static void PrintUsage()
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  stasisc dev <file> [--fps <1..240>] [--module <name>]");
+    Console.WriteLine("  stasisc run <file> [--fps <1..240>] [--module <name>]");
     Console.WriteLine("  stasisc release <file> [--out <path>] [--module <name>]");
     Console.WriteLine();
     Console.WriteLine("Other commands:");
-    Console.WriteLine("  stasisc run <file> [--watch] [--fps <1..240>] [--module <name>] [--with-tests] [--emit-ir] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
     Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift>]");
     Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
     Console.WriteLine("  stasisc format <file>");
     Console.WriteLine();
     Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout. With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
-    Console.WriteLine("Dev: 'dev' implies --watch and enables per-phase timing output; if your program defines `function tick()`, the host will hot-swap between ticks and preserve the global 'state' automatically (main() is not called again on swaps).");
+    Console.WriteLine("Run: for games that define `function tick()`, 'run' defaults to a dev loop (auto-watch + tick hot-swap + phase timings) with state preserved between swaps and no re-running main().");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
     Console.WriteLine("Graphics: enabled automatically when graphics APIs are used; use --graphics to force it on. Use --graphics-lib to override library path.");
     Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1932,7 +1932,7 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
             if (startRunner)
             {
                 var entry = $"{moduleName}__main";
-                var runnerArgs = $"\"{hotDll}\" {entry} --state \"{plan.SnapshotPath}\" --state-map \"{plan.MapPath}\" --swap-file \"{swapFile}\" --fps {fps}";
+                var runnerArgs = $"\"{hotDll}\" {entry} --state-map \"{plan.MapPath}\" --swap-file \"{swapFile}\" --fps {fps}";
                 var psi = new ProcessStartInfo
                 {
                     FileName = runnerPath,
@@ -2333,7 +2333,7 @@ static void PrintUsage()
     Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout. With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
     Console.WriteLine("Watch: use --watch to re-run on file changes (run/test only).");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across runs, enabling simple stateful restart experiments.");
-    Console.WriteLine("Tick hosting: if your program defines `function tick()`, the runner will call `main()` once then call `tick()` at `--fps` (host paced) and can hot-swap between ticks in --watch + --hot-state mode.");
+    Console.WriteLine("Tick hosting: if your program defines `function tick()`, the runner will call `main()` once then call `tick()` at `--fps` (host paced); hot swaps between ticks do not call `main()` again.");
     Console.WriteLine("Graphics: use --graphics to enable SDL2/OpenGL graphics runtime. Specify --graphics-lib to override library path.");
     Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
     Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override.");

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -21,6 +21,7 @@ if (cliArgs.Count == 0 || cliArgs.Contains("--help"))
 }
 
 var mode = "run";
+var devMode = false;
 string? path = null;
 var includeTests = false;
 var moduleName = "module";
@@ -42,6 +43,12 @@ while (cliArgs.Count > 0)
     var arg = cliArgs.Dequeue();
     switch (arg)
     {
+        case "dev":
+            // Dev mode: optimized for iteration (watch + tick hot-swap when available).
+            devMode = true;
+            mode = "run";
+            watch = true;
+            break;
         case "build":
             mode = arg;
             break;
@@ -154,6 +161,11 @@ if (optLevel is not null && !IsValidOptLevel(optLevel))
 {
     Console.Error.WriteLine($"error: invalid --opt-level '{optLevel}'. Use 0,1,2,3,s,z.");
     Environment.Exit(1);
+}
+
+if (devMode)
+{
+    Environment.SetEnvironmentVariable("STASIS_PHASE_TIMING", "1");
 }
 
 // Set default backend based on mode if not explicitly specified
@@ -2324,16 +2336,19 @@ static string QuoteArg(string arg) =>
 static void PrintUsage()
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  stasisc run <file> [--watch] [--hot-state] [--fps <1..240>] [--module <name>] [--with-tests] [--emit-ir] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
+    Console.WriteLine("  stasisc dev <file> [--fps <1..240>] [--module <name>]");
+    Console.WriteLine("  stasisc release <file> [--out <path>] [--module <name>]");
+    Console.WriteLine();
+    Console.WriteLine("Other commands:");
+    Console.WriteLine("  stasisc run <file> [--watch] [--fps <1..240>] [--module <name>] [--with-tests] [--emit-ir] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
     Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift>]");
     Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
-    Console.WriteLine("  stasisc release <file> [--module <name>] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
     Console.WriteLine("  stasisc format <file>");
+    Console.WriteLine();
     Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout. With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
-    Console.WriteLine("Watch: use --watch to re-run on file changes (run/test only).");
+    Console.WriteLine("Dev: 'dev' implies --watch and enables per-phase timing output; if your program defines `function tick()`, the host will hot-swap between ticks and preserve the global 'state' automatically (main() is not called again on swaps).");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
-    Console.WriteLine("Tick hosting: if your program defines `function tick()` and you run with --watch, the host will hot-swap between ticks and preserve the global 'state' automatically (main() is not called again on swaps).");
-    Console.WriteLine("Graphics: use --graphics to enable SDL2/OpenGL graphics runtime. Specify --graphics-lib to override library path.");
+    Console.WriteLine("Graphics: enabled automatically when graphics APIs are used; use --graphics to force it on. Use --graphics-lib to override library path.");
     Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
     Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override.");
 }

--- a/docs/brickout-revenge-economy.md
+++ b/docs/brickout-revenge-economy.md
@@ -1,0 +1,366 @@
+# Brickout Revenge: Economic System Design
+
+## Overview
+
+This document explores adding an Age of Empires 2-inspired economic layer to Brickout Revenge. The core tension: **you can't just build defenses**. You must balance resource generation, defensive structures, and offensive capabilities to survive escalating waves.
+
+---
+
+## Current State
+
+- 50 bricks spawn automatically in a grid
+- 3 brick types: Basic (balanced), Armored (slow/strong), Reflector (fast/disruptive)
+- No resource management - everything is free
+- Waves scale in ball HP, damage, and count
+- Win condition: survive (currently undefined)
+
+---
+
+## Design Philosophy
+
+### The AoE2 Triangle
+
+```
+        ECONOMY
+          /\
+         /  \
+        /    \
+       /      \
+    DEFENSE--OFFENSE
+```
+
+In AoE2:
+- **Economy** (villagers, farms, trade) enables everything
+- **Defense** (walls, towers, castles) protects economy
+- **Offense** (military) threatens enemy economy and ends games
+
+### Translated to Brickout Revenge
+
+| AoE2 Concept | Brickout Equivalent |
+|--------------|---------------------|
+| Villagers gathering | Harvester bricks extracting from resource balls |
+| Farms/mines | Resource-generating brick types |
+| Walls/towers | Defensive bricks (current implementation) |
+| Military units | Special attack bricks, ball modifiers |
+| Trade | Risk/reward mechanics with special bricks |
+
+---
+
+## Resource System
+
+### Option A: Single Currency (Simpler)
+
+**Energy** - Universal resource from destroyed balls and harvester bricks.
+
+Pros:
+- Easy to understand
+- Single economy to balance
+- Faster decision-making
+
+Cons:
+- Less strategic depth
+- No meaningful trade-offs between resource types
+
+### Option B: Dual Currency (Recommended)
+
+**Scrap** - Raw materials from ball destruction
+- Gained when any brick destroys a ball
+- Base amount: 1 scrap per ball kill
+- Bonus: +1 if overkill (ball HP was low)
+
+**Power** - Energy from special sources
+- Generated passively by Generator bricks
+- Gained from Power Orb balls (special spawn)
+- Required for advanced brick abilities
+
+**The Balance:**
+- Basic structures cost only Scrap
+- Advanced structures cost Scrap + Power
+- Upgrades require accumulated Power
+- Power generation takes brick slots away from combat
+
+### Option C: Triple Resource (Complex)
+
+**Scrap** (materials), **Power** (energy), **Tech** (research points)
+
+Only recommended if adding a tech tree with unlockable brick types.
+
+---
+
+## New Brick Types for Economy
+
+### Tier 1: Economic Foundation
+
+#### Harvester Brick
+```
+Cost: 50 Scrap
+HP: 15 (low)
+Range: 100 (short)
+Ability: Extracts 3 Scrap per ball hit (doesn't damage balls)
+Weakness: Cannot attack - purely economic
+```
+**Strategic Role:** Early game economy. Vulnerable, must be protected.
+
+#### Generator Brick
+```
+Cost: 80 Scrap
+HP: 20
+Range: 0 (no attack)
+Ability: +1 Power per 5 seconds passively
+Weakness: Takes a slot, produces nothing in combat
+```
+**Strategic Role:** Late game scaling. Invest now, benefit later.
+
+### Tier 2: Hybrid Units
+
+#### Salvager Brick
+```
+Cost: 100 Scrap, 20 Power
+HP: 25
+Range: 130
+Ability: Normal attack + 50% bonus Scrap from kills
+```
+**Strategic Role:** Bridges economy and defense.
+
+#### Reactor Brick
+```
+Cost: 120 Scrap, 40 Power
+HP: 30
+Range: 150
+Ability: Attacks deal splash damage; killed balls explode for +2 Scrap each
+Weakness: Slow cooldown (400ms)
+```
+**Strategic Role:** Area control with economic bonus.
+
+### Tier 3: Specialists
+
+#### Trade Post Brick
+```
+Cost: 150 Scrap
+HP: 35
+Ability: Convert 10 Scrap → 3 Power (manual activation during setup)
+```
+**Strategic Role:** Resource conversion for late game pivots.
+
+#### Vault Brick
+```
+Cost: 200 Scrap, 30 Power
+HP: 50 (very high)
+Range: 0
+Ability: Stores up to 100 bonus Scrap; if destroyed, lose stored resources
+```
+**Strategic Role:** Risk/reward banking. Protects surplus but vulnerable.
+
+---
+
+## New Ball Types (Resource-Related)
+
+### Resource Balls (Spawn Naturally)
+
+| Ball Type | Appearance | Behavior | Reward |
+|-----------|-----------|----------|--------|
+| Standard | White | Normal | 1 Scrap |
+| Rich | Gold shimmer | Slower, more HP | 5 Scrap |
+| Power Orb | Blue glow | Fast, low HP | 3 Power |
+| Volatile | Red pulse | Explodes on death (damages adjacent bricks) | 8 Scrap |
+| Armored | Steel texture | High HP, low damage | 2 Scrap |
+
+### Threat Balls (Punish Greed)
+
+| Ball Type | Appearance | Behavior | Threat |
+|-----------|-----------|----------|--------|
+| Thief | Dark purple | Steals 5 Scrap if hits paddle | -5 Scrap |
+| Drainer | Cyan | Damages Generator bricks 2x | Anti-economy |
+| Swarm Leader | Glowing core | Spawns 2 mini-balls on bounce | Overwhelm |
+
+---
+
+## Wave Economy Scaling
+
+### Early Game (Waves 1-5)
+- Mostly Standard balls
+- Occasional Rich ball (10% chance)
+- Player establishes economy
+- Recommended: 2-3 Harvesters, rest Basic bricks
+
+### Mid Game (Waves 6-15)
+- Power Orbs begin spawning (15% chance)
+- Thief balls introduced (5% chance)
+- Volatile balls appear (10% chance)
+- Pressure to build advanced structures
+
+### Late Game (Waves 16+)
+- Swarm Leaders appear
+- Drainers target economy
+- Rich balls more common but so are threats
+- Economy must sustain constant rebuilding
+
+---
+
+## Setup Phase Economy
+
+### Between-Wave Budget
+
+After each wave:
+1. **Income Phase:** Collect accumulated resources
+2. **Damage Report:** See which bricks were destroyed
+3. **Build Phase:** Place new bricks, upgrade existing
+4. **Ready Check:** Confirm to start next wave
+
+### Building Costs (Recommended Starting Values)
+
+| Brick | Scrap Cost | Power Cost | Notes |
+|-------|------------|------------|-------|
+| Basic | 30 | 0 | Starter unit |
+| Armored | 60 | 0 | Tank |
+| Reflector | 45 | 10 | Utility |
+| Harvester | 50 | 0 | Economy |
+| Generator | 80 | 0 | Investment |
+| Salvager | 100 | 20 | Hybrid |
+| Reactor | 120 | 40 | AOE |
+| Trade Post | 150 | 0 | Conversion |
+| Vault | 200 | 30 | Banking |
+
+### Upgrade System
+
+Each brick can be upgraded once (level 2):
+- +50% HP
+- +25% range
+- -20% cooldown
+- Upgrade cost: 50% of original Scrap cost + 10 Power
+
+---
+
+## Balance Considerations
+
+### The "Turtle Problem"
+
+**Risk:** Players build only economy + defense, never progress.
+
+**Solutions:**
+1. Wave timer - limited time before balls auto-spawn
+2. Escalating ball HP outpaces pure defense
+3. Generator cap (max 5) prevents infinite scaling
+4. Threat balls specifically counter passive play
+
+### The "All-In Problem"
+
+**Risk:** Players spend everything immediately, lose to attrition.
+
+**Solutions:**
+1. Starting resources are limited (100 Scrap, 0 Power)
+2. Brick repair costs resources (can't just rebuild for free)
+3. Vault mechanic rewards saving
+4. Power gates advanced content
+
+### Economic Breakpoints
+
+Target resource curves per wave:
+
+| Wave | Expected Income | Recommended Spend | Reserve |
+|------|-----------------|-------------------|---------|
+| 1-3 | 50-80 Scrap | 40-60 | 20+ |
+| 4-6 | 100-150 | 80-120 | 30+ |
+| 7-10 | 150-250 | 120-200 | 50+ |
+| 11-15 | 250-400 | 200-350 | 80+ |
+| 16+ | 400+ | Variable | 100+ |
+
+### The AoE2 "Boom" vs "Rush" Decision
+
+Create two viable strategies:
+
+**Economic Boom:**
+- Heavy Harvester/Generator investment early
+- Minimal combat bricks
+- Survive waves 1-5 with less defense
+- Dominant mid-game economy
+- Risk: Lose to early aggression (tough waves)
+
+**Combat Rush:**
+- All Basic/Armored bricks
+- No economic structures
+- Strong early defense
+- Struggles late game without income
+- Risk: Lose to attrition
+
+**Balanced:**
+- 60% combat, 40% economy
+- Steady progression
+- Never dominant but never weak
+- The "safe" option
+
+---
+
+## Fun Factor Analysis
+
+### What Makes AoE2 Economy Fun?
+
+1. **Meaningful choices** - Every villager placed is a unit not trained
+2. **Visible accumulation** - Watch numbers grow
+3. **Risk of loss** - Raids threaten economy
+4. **Comeback potential** - Strong eco can recover from losses
+5. **Multiple viable strategies** - Boom, rush, timing attacks
+
+### Applying to Brickout Revenge
+
+1. **Every brick slot matters** - 50 max means real trade-offs
+2. **Resource counters on screen** - Satisfying to see Scrap pile up
+3. **Threat balls can steal resources** - Creates tension
+4. **Harvesters can rebuild after losses** - Economy enables comebacks
+5. **Rush vs Boom paths** - Multiple ways to win
+
+### "Juice" Suggestions
+
+- **Scrap collection VFX:** Particles fly to counter when balls die
+- **Power pulse:** Generator bricks glow when producing
+- **Income summary:** End-of-wave screen shows resource breakdown
+- **Upgrade fanfare:** Visual/audio feedback for leveling bricks
+- **Low resource warning:** Screen edge flashes when below 20 Scrap
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Economy
+- Add Scrap resource
+- Bricks cost Scrap to place
+- Balls drop Scrap on death
+- Setup phase with simple UI
+
+### Phase 2: Economic Bricks
+- Harvester brick
+- Generator brick
+- Power resource
+- Upgrade system (level 2 only)
+
+### Phase 3: Risk/Reward
+- Threat balls (Thief, Drainer)
+- Volatile balls
+- Rich balls and Power Orbs
+- Vault brick
+
+### Phase 4: Polish
+- Visual feedback for all economy actions
+- Balance tuning based on playtest
+- Additional brick types if needed
+- Win condition (survive wave X, reach Y resources)
+
+---
+
+## Open Questions
+
+1. **Brick placement grid:** Keep fixed grid or allow free placement?
+2. **Repair mechanic:** Can damaged bricks be healed, or only replaced?
+3. **Carry-over:** Do resources persist between games (meta-progression)?
+4. **Difficulty modes:** Scale starting resources or wave intensity?
+5. **Multiplayer potential:** Competitive economy racing?
+
+---
+
+## Summary
+
+The economic layer transforms Brickout Revenge from a pure defense game into a strategic resource management experience. By forcing players to balance between income generation (Harvesters/Generators), defense (combat bricks), and investment (upgrades/Vaults), we create meaningful decisions every wave.
+
+The key insight from AoE2: **economy is interesting because it competes for the same resources as military**. In Brickout Revenge, brick slots are the limiting factor. You can't have 50 Generators AND 50 combat bricks. That tension is where strategy lives.
+
+**Recommended starting point:** Implement Phase 1 with just Scrap, test the setup phase flow, then layer in complexity.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -78,8 +78,7 @@ Keep SVGs within the supported subset described in `docs/svg-migration-plan.md`.
 
 Goal: change something, feel it immediately, keep the game running.
 
-- Keep `.\stasis.bat run ... --watch --hot-state --fps ...` running.
-- Keep `.\stasis.bat dev ... --fps ...` running.
+- Keep `.\stasis.bat run ... --fps ...` running.
 - Make a small code change (movement, cooldown, damage, camera), save, and keep playing.
 - Change SVGs and rely on `gfx_poll_reload(...)` to refresh art without recompiling.
 - When a change makes the game less fun, revert immediately and try a different direction.
@@ -97,7 +96,7 @@ Goal: converge on one "fun slice" and validate it is stable.
 
 Run with hot reload (Windows + Cranelift + `tick()`):
 
-`.\stasis.bat dev .\samples\your_game.stasis --fps 60`
+`.\stasis.bat run .\samples\your_game.stasis --fps 60`
 
 Tips:
 
@@ -328,6 +327,6 @@ This keeps examples and docs aligned with the spec and assets:
 For day-to-day game iteration, you should not need any special "state file" arguments.
 The CLI and runner handle the mechanics internally.
 
-- Prefer `stasisc dev <file>` / `.\stasis.bat dev <file>` for hot reload.
+- Prefer `stasisc run <file>` / `.\stasis.bat run <file>` for hot reload.
 - Use `--fps` to set the host pacing.
 - Use `--hot-state` only if you are experimenting with restart-based snapshot/restore across separate process runs.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -94,9 +94,9 @@ Goal: converge on one "fun slice" and validate it is stable.
 
 ### Recommended commands
 
-Run with hot-swap (Windows + Cranelift):
+Run with hot reload (Windows + Cranelift + `tick()`):
 
-`.\stasis.bat run .\samples\your_game.stasis --backend cranelift --hot-state --watch --fps 60`
+`.\stasis.bat run .\samples\your_game.stasis --watch --fps 60`
 
 Tips:
 
@@ -110,8 +110,7 @@ On each code edit:
 
 1) CLI compiles to CLIF and AOTs to `.obj`.
 2) CLI links a new `.dll`.
-3) CLI writes a "swap file" containing the new DLL path.
-4) Runner sees the swap request between ticks:
+3) Runner hot-swaps between ticks:
    - copies `state` out of the old DLL
    - `LoadLibraryA()` the new DLL
    - restores `state` into the new DLL
@@ -322,3 +321,12 @@ This keeps examples and docs aligned with the spec and assets:
 - Hot swapping assumes compatible `state` layout between swaps.
 - If you change struct layout often, expect occasional "restart required" moments; design your `state` so core gameplay stays stable and experimental data stays in a separate sub-struct.
 - When in doubt: keep the hot-swap loop for *gameplay iteration*, and occasionally do a full restart when you change fundamentals.
+
+## Flags You Should (and Should Not) Care About
+
+For day-to-day game iteration, you should not need any special "state file" arguments.
+The CLI and runner handle the mechanics internally.
+
+- Use `--watch` to enable hot reload.
+- Use `--fps` to set the host pacing.
+- Use `--hot-state` only if you are experimenting with restart-based snapshot/restore across separate process runs.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -79,6 +79,7 @@ Keep SVGs within the supported subset described in `docs/svg-migration-plan.md`.
 Goal: change something, feel it immediately, keep the game running.
 
 - Keep `.\stasis.bat run ... --watch --hot-state --fps ...` running.
+- Keep `.\stasis.bat dev ... --fps ...` running.
 - Make a small code change (movement, cooldown, damage, camera), save, and keep playing.
 - Change SVGs and rely on `gfx_poll_reload(...)` to refresh art without recompiling.
 - When a change makes the game less fun, revert immediately and try a different direction.
@@ -96,7 +97,7 @@ Goal: converge on one "fun slice" and validate it is stable.
 
 Run with hot reload (Windows + Cranelift + `tick()`):
 
-`.\stasis.bat run .\samples\your_game.stasis --watch --fps 60`
+`.\stasis.bat dev .\samples\your_game.stasis --fps 60`
 
 Tips:
 
@@ -327,6 +328,6 @@ This keeps examples and docs aligned with the spec and assets:
 For day-to-day game iteration, you should not need any special "state file" arguments.
 The CLI and runner handle the mechanics internally.
 
-- Use `--watch` to enable hot reload.
+- Prefer `stasisc dev <file>` / `.\stasis.bat dev <file>` for hot reload.
 - Use `--fps` to set the host pacing.
 - Use `--hot-state` only if you are experimenting with restart-based snapshot/restore across separate process runs.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -43,8 +43,10 @@ Reason: the hot-swap workflow copies `state` from the old module into the new mo
 
 ### 3) Use a sentinel to avoid clobbering restored state
 
-When using hot-swap, the host restores `state` *before* calling `main()`/`tick()`.
-If you always run `init_game(true)` unconditionally, you will overwrite the restored data.
+In the tick hot-swap workflow, `main()` is called once at process start, and hot swaps do not call `main()` again.
+That means swaps between ticks will not re-run your init code.
+
+However, if you use a workflow that restores `state` and then calls `main()` (eg. restart-based restore), `main()` can clobber restored data.
 
 Use a sentinel like:
 
@@ -113,7 +115,9 @@ On each code edit:
    - copies `state` out of the old DLL
    - `LoadLibraryA()` the new DLL
    - restores `state` into the new DLL
-   - continues calling `tick()`
+   - continues calling `tick()` (does not call `main()` on swap)
+
+This is a same-process swap: your game keeps running, and state stays in memory.
 
 ### Reading the timing logs
 

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -52,7 +52,7 @@ static void print_usage(void)
     fprintf(stderr, "usage: stasis_runner <dll_path> [entry]\n");
     fprintf(stderr, "  entry defaults to run_tests (use main for run mode)\n");
     fprintf(stderr, "usage: stasis_runner --server\n");
-    fprintf(stderr, "usage: stasis_runner <dll_path> [entry] --state <snapshot_path> --state-map <map_path> [--hot-exit-file <path>]\n");
+    fprintf(stderr, "usage: stasis_runner <dll_path> [entry] --state-map <map_path> [--state <snapshot_path>] [--hot-exit-file <path>]\n");
 }
 
 #ifdef _WIN32
@@ -608,9 +608,9 @@ int main(int argc, char **argv)
         }
     }
 
-    if ((state_path != NULL) != (state_map_path != NULL))
+    if (state_path != NULL && state_map_path == NULL)
     {
-        fprintf(stderr, "error: --state and --state-map must be provided together.\n");
+        fprintf(stderr, "error: --state requires --state-map.\n");
         return 1;
     }
 
@@ -638,7 +638,7 @@ int main(int argc, char **argv)
     uint64_t map_hash = 0;
     uint8_t *restore_data = NULL;
     stasis_hot_exit_args hot_exit_args = {0};
-    if (state_path && state_map_path)
+    if (state_map_path)
     {
         if (read_state_map(state_map_path, &map_hash, &syms, &sym_count, &total_bytes) != 0)
         {
@@ -658,40 +658,43 @@ int main(int argc, char **argv)
             return 1;
         }
 
-        LARGE_INTEGER freq;
-        LARGE_INTEGER t0;
-        LARGE_INTEGER t1;
-        QueryPerformanceFrequency(&freq);
-        QueryPerformanceCounter(&t0);
-        int load_result = load_state_snapshot(state_path, map_hash, total_bytes, &restore_data);
-        QueryPerformanceCounter(&t1);
-        long long restore_io_us = (t1.QuadPart - t0.QuadPart) * 1000000LL / freq.QuadPart;
-        if (load_result == 1)
+        if (state_path)
         {
-            FreeLibrary(lib);
-            return 1;
-        }
-        if (load_result == 0)
-        {
+            LARGE_INTEGER freq;
+            LARGE_INTEGER t0;
+            LARGE_INTEGER t1;
+            QueryPerformanceFrequency(&freq);
             QueryPerformanceCounter(&t0);
-            for (uint32_t i = 0; i < sym_count; i++)
-            {
-                FARPROC addr = GetProcAddress(lib, syms[i].name);
-                if (!addr)
-                {
-                    fprintf(stderr, "error: state symbol not exported: %s\n", syms[i].name);
-                    FreeLibrary(lib);
-                    return 1;
-                }
-                memcpy((void *)addr, restore_data + syms[i].offset, syms[i].size);
-            }
+            int load_result = load_state_snapshot(state_path, map_hash, total_bytes, &restore_data);
             QueryPerformanceCounter(&t1);
-            long long restore_copy_us = (t1.QuadPart - t0.QuadPart) * 1000000LL / freq.QuadPart;
-            fprintf(stderr, "HOTSTATE restore: io=%lldus copy=%lldus bytes=%u symbols=%u\n", restore_io_us, restore_copy_us, total_bytes, sym_count);
-        }
-        else
-        {
-            fprintf(stderr, "HOTSTATE restore: none\n");
+            long long restore_io_us = (t1.QuadPart - t0.QuadPart) * 1000000LL / freq.QuadPart;
+            if (load_result == 1)
+            {
+                FreeLibrary(lib);
+                return 1;
+            }
+            if (load_result == 0)
+            {
+                QueryPerformanceCounter(&t0);
+                for (uint32_t i = 0; i < sym_count; i++)
+                {
+                    FARPROC addr = GetProcAddress(lib, syms[i].name);
+                    if (!addr)
+                    {
+                        fprintf(stderr, "error: state symbol not exported: %s\n", syms[i].name);
+                        FreeLibrary(lib);
+                        return 1;
+                    }
+                    memcpy((void *)addr, restore_data + syms[i].offset, syms[i].size);
+                }
+                QueryPerformanceCounter(&t1);
+                long long restore_copy_us = (t1.QuadPart - t0.QuadPart) * 1000000LL / freq.QuadPart;
+                fprintf(stderr, "HOTSTATE restore: io=%lldus copy=%lldus bytes=%u symbols=%u\n", restore_io_us, restore_copy_us, total_bytes, sym_count);
+            }
+            else
+            {
+                fprintf(stderr, "HOTSTATE restore: none\n");
+            }
         }
     }
 
@@ -760,7 +763,7 @@ int main(int argc, char **argv)
                             long long save_us = 0;
                             long long load_us = 0;
                             long long restore_us = 0;
-                            if (state_path && state_map_path)
+                            if (state_map_path)
                             {
                                 buffer = (uint8_t *)malloc(total_bytes);
                                 if (!buffer)
@@ -910,6 +913,10 @@ int main(int argc, char **argv)
 
         fprintf(stderr, "HOTSTATE save: io=%lldus copy=%lldus bytes=%u symbols=%u\n", save_io_us, save_copy_us, total_bytes, sym_count);
         free(save_data);
+    }
+
+    if (state_map_path)
+    {
         free(restore_data);
         for (uint32_t i = 0; i < sym_count; i++)
         {

--- a/samples/brickout_revenge.stasis
+++ b/samples/brickout_revenge.stasis
@@ -1331,6 +1331,14 @@ function main(): i32 {
 }
 
 function tick(): i32 {
+    //////////////////////////////////////////////
+    // Data transform area
+    // Kind of like a repl to change data on each subsequent loop
+   
+   
+
+    ////////////////////////////////////////////////
+
     if (state.running != 1) {
         return 1;
     }


### PR DESCRIPTION
Tick hot-swap between frames should not re-run main().

- runner: allow --state-map without --state; hot swaps still copy state, but disk snapshot restore/save remains opt-in via --state.
- CLI: tick hot-swap watch uses --state-map only.
- docs/help: clarify that hot swaps call tick only (main() is not called again).