### PR TITLE
chore: ignore stasis_graphics.lib build byproducts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _ReSharper.Caches/
 *.exe
 *.so
 *.dylib
+**/stasis_graphics.lib
 runtime/build/
 codevcpkg/
 build/hotstate/


### PR DESCRIPTION
Running stasisc build can drop stasis_graphics.lib next to sample/example outputs; ignore it so smoke-running samples doesn't dirty the working tree.