### PR TITLE
fix: normalize i32→f32 casts in samples and improve Linux clang linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _ReSharper.Caches/
 !vscode-stasis/.vscode/**
 .config/dotnet-tools.json.lock
 .claude/settings.local.json
+.stasis_cache/
 
 # Build artifacts
 *.dll

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -2641,7 +2641,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
         await gate.WaitAsync();
         try
         {
-            var prep = PrepareForLower(file, includeTests, moduleName, emitIrOnly, backend, enableTestCache, enableGraphics);
+            var prep = PrepareForLower(file, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, backend, useCraneliftRunner, enableTestCache);
             if (prep.Prepared is not null)
             {
                 await prepChannel.Writer.WriteAsync(prep.Prepared);
@@ -2663,7 +2663,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
         await foreach (var item in prepChannel.Reader.ReadAllAsync())
         {
             var effectiveGraphics = enableGraphics || item.UsesGraphics;
-            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, effectiveGraphics, backend, useLowerLock, allowReachabilityFallback, enableTestCache);
+            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, optLevel, enableLto, effectiveGraphics, graphicsLibPath, backend, useCraneliftRunner, useLowerLock, allowReachabilityFallback, enableTestCache);
             await resultChannel.Writer.WriteAsync(result);
         }
     })).ToArray();
@@ -2685,7 +2685,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
     return exitCode;
 }
 
-static PrepareResult PrepareForLower(string path, bool includeTests, string moduleName, bool emitIrOnly, BackendType backend, bool enableTestCache, bool enableGraphics)
+static PrepareResult PrepareForLower(string path, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool enableTestCache)
 {
     var stopwatch = Stopwatch.StartNew();
     var diagnostics = new List<Diagnostic>();
@@ -2702,8 +2702,8 @@ static PrepareResult PrepareForLower(string path, bool includeTests, string modu
         TestCacheLocation? testCacheLocation = null;
         if (enableTestCache)
         {
-            testCacheLocation = CreateTestCacheLocation(path, source, backend, moduleName, includeTests, emitIrOnly, effectiveGraphics);
-            var cachedResult = TryLoadTestCache(testCacheLocation, source, backend, moduleName, includeTests, emitIrOnly, effectiveGraphics);
+            testCacheLocation = CreateTestCacheLocation(path, source, backend, moduleName, includeTests, emitIrOnly, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, effectiveGraphics);
+            var cachedResult = TryLoadTestCache(testCacheLocation, source, backend, moduleName, includeTests, emitIrOnly, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, effectiveGraphics);
             if (cachedResult is not null)
             {
                 return new PrepareResult(null, cachedResult);
@@ -2753,11 +2753,11 @@ static string GetTestCacheDirectory()
     return Path.Combine(currentDirectory, ".stasis_cache", "test");
 }
 
-static TestCacheLocation CreateTestCacheLocation(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+static TestCacheLocation CreateTestCacheLocation(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics)
 {
     var cacheDirectory = GetTestCacheDirectory();
     Directory.CreateDirectory(cacheDirectory);
-    var cacheKey = ComputeTestCacheKey(path, source, backend, moduleName, includeTests, emitIrOnly, usesGraphics);
+    var cacheKey = ComputeTestCacheKey(path, source, backend, moduleName, includeTests, emitIrOnly, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, usesGraphics);
     var extension = backend == BackendType.Cranelift ? "clif" : "ll";
     var artifactPath = Path.Combine(cacheDirectory, $"{cacheKey}.{extension}");
     var entryPath = Path.Combine(cacheDirectory, $"{cacheKey}.json");
@@ -2765,7 +2765,7 @@ static TestCacheLocation CreateTestCacheLocation(string path, string source, Bac
     return new TestCacheLocation(cacheKey, artifactPath, entryPath, sourceHash);
 }
 
-static CompileResult? TryLoadTestCache(TestCacheLocation cacheLocation, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+static CompileResult? TryLoadTestCache(TestCacheLocation cacheLocation, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics)
 {
     if (!File.Exists(cacheLocation.EntryPath))
     {
@@ -2791,6 +2791,10 @@ static CompileResult? TryLoadTestCache(TestCacheLocation cacheLocation, string s
         !string.Equals(entry.ModuleName, moduleName, StringComparison.Ordinal) ||
         entry.IncludeTests != includeTests ||
         entry.EmitIrOnly != emitIrOnly ||
+        entry.EnableLto != enableLto ||
+        !string.Equals(entry.OptLevel, optLevel, StringComparison.Ordinal) ||
+        !string.Equals(entry.GraphicsLibPath, graphicsLibPath, StringComparison.Ordinal) ||
+        entry.UseCraneliftRunner != useCraneliftRunner ||
         entry.UsesGraphics != usesGraphics)
     {
         return null;
@@ -2804,7 +2808,7 @@ static CompileResult? TryLoadTestCache(TestCacheLocation cacheLocation, string s
     return new CompileResult(entry.FilePath, source, entry.HasTests, entry.UsesGraphics, backend, entry.ArtifactPath, null, new List<Diagnostic>(), emitIrOnly, 0, true);
 }
 
-static void WriteTestCacheEntry(PreparedForLower prep, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+static void WriteTestCacheEntry(PreparedForLower prep, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics)
 {
     if (prep.TestCacheLocation is null)
     {
@@ -2828,14 +2832,18 @@ static void WriteTestCacheEntry(PreparedForLower prep, BackendType backend, stri
         backend,
         moduleName,
         includeTests,
-        emitIrOnly);
+        emitIrOnly,
+        optLevel,
+        enableLto,
+        graphicsLibPath,
+        useCraneliftRunner);
 
     var options = new JsonSerializerOptions { WriteIndented = true };
     var json = JsonSerializer.Serialize(entry, options);
     File.WriteAllText(prep.TestCacheLocation.EntryPath, json, Encoding.UTF8);
 }
 
-static string ComputeTestCacheKey(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+static string ComputeTestCacheKey(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics)
 {
     var fullPath = Path.GetFullPath(path);
     var identity = new StringBuilder();
@@ -2844,6 +2852,10 @@ static string ComputeTestCacheKey(string path, string source, BackendType backen
     identity.Append("module=").Append(moduleName).Append('\n');
     identity.Append("includeTests=").Append(includeTests).Append('\n');
     identity.Append("emitIrOnly=").Append(emitIrOnly).Append('\n');
+    identity.Append("optLevel=").Append(optLevel ?? string.Empty).Append('\n');
+    identity.Append("enableLto=").Append(enableLto).Append('\n');
+    identity.Append("graphicsLibPath=").Append(graphicsLibPath ?? string.Empty).Append('\n');
+    identity.Append("useCraneliftRunner=").Append(useCraneliftRunner).Append('\n');
     identity.Append("usesGraphics=").Append(usesGraphics).Append('\n');
     identity.Append("path=").Append(fullPath).Append('\n');
     identity.Append("source=").Append(source);
@@ -2864,7 +2876,7 @@ static string ComputeSha256Hex(string value)
 }
 
 
-static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics, BackendType backend, bool useLowerLock, bool allowReachabilityFallback, bool enableTestCache)
+static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool useLowerLock, bool allowReachabilityFallback, bool enableTestCache)
 {
     var stopwatch = Stopwatch.StartNew();
     var diagnostics = new List<Diagnostic>();
@@ -2905,7 +2917,7 @@ static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, str
             File.WriteAllText(tempArtifact, result.Ir);
             if (isCacheArtifact && prep.TestCacheLocation is not null)
             {
-                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, enableGraphics);
+                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, enableGraphics);
             }
 
             return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, isCacheArtifact);
@@ -2948,7 +2960,7 @@ static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, str
             File.WriteAllText(tempArtifact, lower.Ir);
             if (isCacheArtifact && prep.TestCacheLocation is not null)
             {
-                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, enableGraphics);
+                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, enableGraphics);
             }
 
             return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, isCacheArtifact);
@@ -3415,4 +3427,8 @@ sealed record TestCacheEntry(
     BackendType Backend,
     string ModuleName,
     bool IncludeTests,
-    bool EmitIrOnly);
+    bool EmitIrOnly,
+    string? OptLevel,
+    bool EnableLto,
+    string? GraphicsLibPath,
+    bool UseCraneliftRunner);

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -339,7 +339,7 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         }
 
         // Auto-detect graphics usage if not explicitly enabled
-        if (!enableGraphics && mode != "test" && DetectsGraphicsUsage(source))
+        if (!enableGraphics && DetectsGraphicsUsage(source))
         {
             enableGraphics = true;
         }
@@ -1123,39 +1123,9 @@ static string? FindRepoRoot()
 static int Execute(string mode, string llPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
 {
     // lli doesn't support external libraries easily, so use clang when graphics is enabled
-    if (!enableGraphics && TryFindTool("lli", out var lli))
+    if (!enableGraphics && TryFindTool("lli", out var llvmInterpreter))
     {
-        var lliExit = RunProcess(lli, mode == "test" ? $"-entry-function=run_tests \"{llPath}\"" : $"\"{llPath}\"");
-        if (lliExit == 0)
-        {
-            return 0;
-        }
-
-        // Retry with clang for stability if lli fails (e.g., SIGSEGV on some inputs).
-        if (TryFindTool("clang", out var clangPath))
-        {
-            var exePath = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty));
-            try
-            {
-                var args = BuildClangArgs(llPath, exePath, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath);
-                var clangExit = RunProcess(clangPath, args, suppressOutput: true);
-                if (clangExit != 0)
-                {
-                    return clangExit;
-                }
-
-                return RunProcess(exePath, string.Empty);
-            }
-            finally
-            {
-                if (File.Exists(exePath))
-                {
-                    File.Delete(exePath);
-                }
-            }
-        }
-
-        return lliExit;
+        return ExecuteWithLlvmInterpreter(llvmInterpreter, mode, llPath, optLevel, enableLto, enableGraphics, graphicsLibPath);
     }
 
     if (TryFindTool("clang", out var clang))
@@ -1345,6 +1315,57 @@ static string BuildClangArgs(string llPath, string exePath, bool isTest, string?
     }
 
     return string.Join(" ", args);
+}
+
+static int ExecuteWithLlvmInterpreter(string llvmInterpreter, string mode, string llvmIrPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+{
+    var interpreterArguments = mode == "test"
+        ? $"-entry-function=run_tests \"{llvmIrPath}\""
+        : $"\"{llvmIrPath}\"";
+    var interpreterExitCode = RunProcess(llvmInterpreter, interpreterArguments);
+    if (interpreterExitCode == 0)
+    {
+        return 0;
+    }
+
+    // Retry with clang for stability if the interpreter fails (e.g., SIGSEGV on some inputs).
+    if (TryExecuteWithClangFallback(mode, llvmIrPath, optLevel, enableLto, enableGraphics, graphicsLibPath, out var clangExitCode))
+    {
+        return clangExitCode;
+    }
+
+    return interpreterExitCode;
+}
+
+static bool TryExecuteWithClangFallback(string mode, string llvmIrPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, out int exitCode)
+{
+    if (!TryFindTool("clang", out var clangPath))
+    {
+        exitCode = 1;
+        return false;
+    }
+
+    var executablePath = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty));
+    try
+    {
+        var clangArguments = BuildClangArgs(llvmIrPath, executablePath, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath);
+        var clangExitCode = RunProcess(clangPath, clangArguments, suppressOutput: true);
+        if (clangExitCode != 0)
+        {
+            exitCode = clangExitCode;
+            return true;
+        }
+
+        exitCode = RunProcess(executablePath, string.Empty);
+        return true;
+    }
+    finally
+    {
+        if (File.Exists(executablePath))
+        {
+            File.Delete(executablePath);
+        }
+    }
 }
 
 static void CopyGraphicsRuntimeDependencies(string targetDir, string? graphicsLibPath)
@@ -2639,7 +2660,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
     {
         await foreach (var item in prepChannel.Reader.ReadAllAsync())
         {
-            var effectiveGraphics = enableGraphics;
+            var effectiveGraphics = enableGraphics || item.UsesGraphics;
             var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, effectiveGraphics, backend, useLowerLock, allowReachabilityFallback);
             await resultChannel.Writer.WriteAsync(result);
         }

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -339,7 +339,7 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         }
 
         // Auto-detect graphics usage if not explicitly enabled
-        if (!enableGraphics && DetectsGraphicsUsage(source))
+        if (!enableGraphics && mode != "test" && DetectsGraphicsUsage(source))
         {
             enableGraphics = true;
         }
@@ -1125,7 +1125,37 @@ static int Execute(string mode, string llPath, string? optLevel, bool enableLto,
     // lli doesn't support external libraries easily, so use clang when graphics is enabled
     if (!enableGraphics && TryFindTool("lli", out var lli))
     {
-        return RunProcess(lli, mode == "test" ? $"-entry-function=run_tests \"{llPath}\"" : $"\"{llPath}\"");
+        var lliExit = RunProcess(lli, mode == "test" ? $"-entry-function=run_tests \"{llPath}\"" : $"\"{llPath}\"");
+        if (lliExit == 0)
+        {
+            return 0;
+        }
+
+        // Retry with clang for stability if lli fails (e.g., SIGSEGV on some inputs).
+        if (TryFindTool("clang", out var clangPath))
+        {
+            var exePath = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty));
+            try
+            {
+                var args = BuildClangArgs(llPath, exePath, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath);
+                var clangExit = RunProcess(clangPath, args, suppressOutput: true);
+                if (clangExit != 0)
+                {
+                    return clangExit;
+                }
+
+                return RunProcess(exePath, string.Empty);
+            }
+            finally
+            {
+                if (File.Exists(exePath))
+                {
+                    File.Delete(exePath);
+                }
+            }
+        }
+
+        return lliExit;
     }
 
     if (TryFindTool("clang", out var clang))
@@ -1419,8 +1449,8 @@ static string? FindGraphicsSharedLibrary()
     // Prefer workspace runtime outputs before falling back to cwd root
     var cwd = Directory.GetCurrentDirectory();
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin", "Release"));
-    searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Release"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin"));
+    searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Release"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin", "Debug"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Debug"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build"));
@@ -1464,7 +1494,7 @@ static bool DetectsGraphicsUsage(string source)
     return Regex.IsMatch(
         source,
         @"(?<![A-Za-z0-9_])" +
-        @"(init_window|begin_frame|end_frame|draw_line|clear|gfx_load_sprite|gfx_draw_sprite|gfx_poll_reload|gfx_debug_bake_hash|should_quit|is_key_down|get_mouse_x|get_mouse_y|is_mouse_down|audio_is_available|audio_get_sample_rate|audio_get_channels|audio_get_queued_frames|audio_get_underruns|audio_push_f32_interleaved|time|get_time_ms|sleep_ms)" +
+        @"(init_window|begin_frame|end_frame|draw_line|clear|gfx_load_sprite|gfx_draw_sprite|gfx_poll_reload|gfx_debug_bake_hash|should_quit|is_key_down|get_mouse_x|get_mouse_y|is_mouse_down|audio_is_available|audio_get_sample_rate|audio_get_channels|audio_get_queued_frames|audio_get_underruns|audio_push_f32_interleaved|get_time_ms|sleep_ms)" +
         @"\s*\(",
         RegexOptions.CultureInvariant);
 }
@@ -1485,8 +1515,8 @@ static string? FindGraphicsLibrary(bool preferShared = false)
     // Prefer workspace runtime outputs before falling back to cwd root
     var cwd = Directory.GetCurrentDirectory();
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin", "Release"));
-    searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Release"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin"));
+    searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Release"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "bin", "Debug"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build", "Debug"));
     searchPaths.Add(Path.Combine(cwd, "runtime", "build"));
@@ -1538,8 +1568,8 @@ static string? FindGraphicsLibrary(bool preferShared = false)
         {
             candidates = new[]
             {
-                "libstasis_graphics_static.a",
-                "libstasis_graphics.dylib"
+                "libstasis_graphics.dylib",
+                "libstasis_graphics_static.a"
             };
         }
     }
@@ -1561,8 +1591,8 @@ static string? FindGraphicsLibrary(bool preferShared = false)
         {
             candidates = new[]
             {
-                "libstasis_graphics_static.a",
-                "libstasis_graphics.so"
+                "libstasis_graphics.so",
+                "libstasis_graphics_static.a"
             };
         }
     }
@@ -2609,7 +2639,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
     {
         await foreach (var item in prepChannel.Reader.ReadAllAsync())
         {
-            var effectiveGraphics = enableGraphics || item.UsesGraphics;
+            var effectiveGraphics = enableGraphics;
             var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, effectiveGraphics, backend, useLowerLock, allowReachabilityFallback);
             await resultChannel.Writer.WriteAsync(result);
         }
@@ -2892,7 +2922,13 @@ static bool LikelyContainsTestBlock(string path)
 {
     foreach (var line in File.ReadLines(path))
     {
-        if (line.Contains("test", StringComparison.Ordinal))
+        var trimmed = line.AsSpan().TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        if (Regex.IsMatch(line, @"^\s*test\b", RegexOptions.CultureInvariant))
         {
             return true;
         }

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -895,21 +895,28 @@ static string BuildClangArgsForObject(string objPath, string outputPath, bool is
         var libPath = graphicsLibPath ?? FindGraphicsLibrary(preferShared: isDll);
         if (!string.IsNullOrEmpty(libPath))
         {
-            var libFile = Path.GetFileName(libPath);
-            var isStaticLib = libFile != null && libFile.Contains("static", StringComparison.OrdinalIgnoreCase);
-            if (isStaticLib)
+            var libraryFile = Path.GetFileName(libPath);
+            var isStaticLibrary = libraryFile != null && libraryFile.Contains("static", StringComparison.OrdinalIgnoreCase);
+            if (isStaticLibrary)
             {
                 linkingStaticGraphics = true;
             }
 
             args.Add($"\"{libPath}\"");
-            var libDir = Path.GetDirectoryName(libPath);
-            if (!string.IsNullOrEmpty(libDir))
+            var libraryDirectory = Path.GetDirectoryName(libPath);
+            if (!string.IsNullOrEmpty(libraryDirectory))
             {
-                args.Add($"-L\"{libDir}\"");
+                args.Add($"-L\"{libraryDirectory}\"");
             }
 
-            if (isStaticLib)
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                !isStaticLibrary &&
+                !string.IsNullOrEmpty(libraryDirectory))
+            {
+                args.Add($"-Wl,-rpath,\"{libraryDirectory}\"");
+            }
+
+            if (isStaticLibrary)
             {
                 args.Add("-lSDL2main");
                 args.Add("-lSDL2-static");
@@ -998,6 +1005,11 @@ static string BuildClangArgsForObject(string objPath, string outputPath, bool is
         args.Add("-lucrt");
         args.Add("-lvcruntime");
         args.Add("-loldnames");
+    }
+
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+        args.Add("-lm");
     }
 
     return string.Join(" ", args);
@@ -1195,18 +1207,18 @@ static string BuildClangArgs(string llPath, string exePath, bool isTest, string?
         var libPath = graphicsLibPath ?? FindGraphicsLibrary();
         if (!string.IsNullOrEmpty(libPath))
         {
-            var libDir = Path.GetDirectoryName(libPath);
-            var libFile = Path.GetFileName(libPath);
-            var isStaticLib = libFile != null && libFile.Contains("static", StringComparison.OrdinalIgnoreCase);
-            linkingStaticGraphics = isStaticLib;
+            var libraryDirectory = Path.GetDirectoryName(libPath);
+            var libraryFile = Path.GetFileName(libPath);
+            var isStaticLibrary = libraryFile != null && libraryFile.Contains("static", StringComparison.OrdinalIgnoreCase);
+            linkingStaticGraphics = isStaticLibrary;
 
-            if (!string.IsNullOrEmpty(libDir))
+            if (!string.IsNullOrEmpty(libraryDirectory))
             {
-                args.Add($"-L\"{libDir}\"");
+                args.Add($"-L\"{libraryDirectory}\"");
             }
 
             // When a full path is known, pass it directly so clang doesn't guess the name
-            if (!string.IsNullOrEmpty(libFile))
+            if (!string.IsNullOrEmpty(libraryFile))
             {
                 args.Add($"\"{libPath}\"");
             }
@@ -1215,8 +1227,15 @@ static string BuildClangArgs(string llPath, string exePath, bool isTest, string?
                 args.Add("-lstasis_graphics");
             }
 
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                !isStaticLibrary &&
+                !string.IsNullOrEmpty(libraryDirectory))
+            {
+                args.Add($"-Wl,-rpath,\"{libraryDirectory}\"");
+            }
+
             // If we are linking the static runtime, pull in its static deps for a single EXE.
-            if (isStaticLib && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (isStaticLibrary && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 args.Add("-lSDL2main");
                 args.Add("-lSDL2-static");
@@ -1288,6 +1307,11 @@ static string BuildClangArgs(string llPath, string exePath, bool isTest, string?
     else if (isTest)
     {
         args.Add("-Wl,-e,run_tests");
+    }
+
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+        args.Add("-lm");
     }
 
     return string.Join(" ", args);

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -283,7 +284,8 @@ if (runAllInDirectory && mode == "test")
     }
 
     var allowReachabilityFallback = mode != "release";
-    var overallExit = RunAllTestsInDirectoryParallel(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, backend, useCraneliftRunner, allowReachabilityFallback);
+    var enableTestCache = true;
+    var overallExit = RunAllTestsInDirectoryParallel(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, backend, useCraneliftRunner, allowReachabilityFallback, enableTestCache);
     Environment.Exit(overallExit);
 }
 
@@ -2624,10 +2626,10 @@ static void PrintUsage()
     Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override.");
 }
 
-static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool allowReachabilityFallback, bool useLowerLock = true, int lowerDegree = 1) =>
-    RunAllTestsInDirectoryParallelAsync(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, backend, useCraneliftRunner, allowReachabilityFallback, useLowerLock, lowerDegree).GetAwaiter().GetResult();
+static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool allowReachabilityFallback, bool enableTestCache, bool useLowerLock = true, int lowerDegree = 1) =>
+    RunAllTestsInDirectoryParallelAsync(files, includeTests, moduleName, emitIrOnly, optLevel, enableLto, enableGraphics, graphicsLibPath, backend, useCraneliftRunner, allowReachabilityFallback, enableTestCache, useLowerLock, lowerDegree).GetAwaiter().GetResult();
 
-static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool allowReachabilityFallback, bool useLowerLock, int lowerDegree)
+static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool allowReachabilityFallback, bool enableTestCache, bool useLowerLock, int lowerDegree)
 {
     var prepChannel = Channel.CreateUnbounded<PreparedForLower>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
     var resultChannel = Channel.CreateUnbounded<CompileResult>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false });
@@ -2639,7 +2641,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
         await gate.WaitAsync();
         try
         {
-            var prep = PrepareForLower(file, emitIrOnly, backend);
+            var prep = PrepareForLower(file, includeTests, moduleName, emitIrOnly, backend, enableTestCache, enableGraphics);
             if (prep.Prepared is not null)
             {
                 await prepChannel.Writer.WriteAsync(prep.Prepared);
@@ -2661,7 +2663,7 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
         await foreach (var item in prepChannel.Reader.ReadAllAsync())
         {
             var effectiveGraphics = enableGraphics || item.UsesGraphics;
-            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, effectiveGraphics, backend, useLowerLock, allowReachabilityFallback);
+            var result = LowerPrepared(item, includeTests, moduleName, emitIrOnly, effectiveGraphics, backend, useLowerLock, allowReachabilityFallback, enableTestCache);
             await resultChannel.Writer.WriteAsync(result);
         }
     })).ToArray();
@@ -2683,38 +2685,49 @@ static async Task<int> RunAllTestsInDirectoryParallelAsync(string[] files, bool 
     return exitCode;
 }
 
-static PrepareResult PrepareForLower(string path, bool emitIrOnly, BackendType backend)
+static PrepareResult PrepareForLower(string path, bool includeTests, string moduleName, bool emitIrOnly, BackendType backend, bool enableTestCache, bool enableGraphics)
 {
     var stopwatch = Stopwatch.StartNew();
     var diagnostics = new List<Diagnostic>();
     try
     {
-    var source = LoadSourceWithImports(path, out var importDiagnostics, out var importSource);
-    if (importDiagnostics.Count > 0)
-    {
-        PrintDiagnostics(importDiagnostics, importSource, path);
-        return new PrepareResult(null, new CompileResult(path, importSource, false, false, backend, null, null, importDiagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds));
-    }
+        var source = LoadSourceWithImports(path, out var importDiagnostics, out var importSource);
+        if (importDiagnostics.Count > 0)
+        {
+            PrintDiagnostics(importDiagnostics, importSource, path);
+            return new PrepareResult(null, new CompileResult(path, importSource, false, false, backend, null, null, importDiagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds, false));
+        }
         var usesGraphics = DetectsGraphicsUsage(source);
+        var effectiveGraphics = enableGraphics || usesGraphics;
+        TestCacheLocation? testCacheLocation = null;
+        if (enableTestCache)
+        {
+            testCacheLocation = CreateTestCacheLocation(path, source, backend, moduleName, includeTests, emitIrOnly, effectiveGraphics);
+            var cachedResult = TryLoadTestCache(testCacheLocation, source, backend, moduleName, includeTests, emitIrOnly, effectiveGraphics);
+            if (cachedResult is not null)
+            {
+                return new PrepareResult(null, cachedResult);
+            }
+        }
         var parse = Parser.Parse(source);
         diagnostics.AddRange(parse.Diagnostics);
         var hasTests = parse.CompilationUnit.Declarations.OfType<TestDeclarationSyntax>().Any();
 
         if (parse.Diagnostics.Count > 0 || (!hasTests && !emitIrOnly))
         {
-            return new PrepareResult(null, new CompileResult(path, source, hasTests, usesGraphics, backend, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds));
+            return new PrepareResult(null, new CompileResult(path, source, hasTests, usesGraphics, backend, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds, false));
         }
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
         diagnostics.AddRange(sema.Diagnostics);
         if (sema.Diagnostics.Count > 0)
         {
-            return new PrepareResult(null, new CompileResult(path, source, hasTests, usesGraphics, backend, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds));
+            return new PrepareResult(null, new CompileResult(path, source, hasTests, usesGraphics, backend, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds, false));
         }
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         stopwatch.Stop();
-        return new PrepareResult(new PreparedForLower(path, source, parse.CompilationUnit, sema, layout, hasTests, usesGraphics, stopwatch.ElapsedMilliseconds), null);
+        return new PrepareResult(new PreparedForLower(path, source, parse.CompilationUnit, sema, layout, hasTests, usesGraphics, stopwatch.ElapsedMilliseconds, testCacheLocation), null);
     }
     finally
     {
@@ -2732,13 +2745,132 @@ static string LoadSourceWithImports(string path, out List<Diagnostic> importDiag
     return result.ExpandedSource;
 }
 
+const int TestCacheVersion = 1;
 
-static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics, BackendType backend, bool useLowerLock, bool allowReachabilityFallback)
+static string GetTestCacheDirectory()
+{
+    var currentDirectory = Directory.GetCurrentDirectory();
+    return Path.Combine(currentDirectory, ".stasis_cache", "test");
+}
+
+static TestCacheLocation CreateTestCacheLocation(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+{
+    var cacheDirectory = GetTestCacheDirectory();
+    Directory.CreateDirectory(cacheDirectory);
+    var cacheKey = ComputeTestCacheKey(path, source, backend, moduleName, includeTests, emitIrOnly, usesGraphics);
+    var extension = backend == BackendType.Cranelift ? "clif" : "ll";
+    var artifactPath = Path.Combine(cacheDirectory, $"{cacheKey}.{extension}");
+    var entryPath = Path.Combine(cacheDirectory, $"{cacheKey}.json");
+    var sourceHash = ComputeSha256Hex(source);
+    return new TestCacheLocation(cacheKey, artifactPath, entryPath, sourceHash);
+}
+
+static CompileResult? TryLoadTestCache(TestCacheLocation cacheLocation, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+{
+    if (!File.Exists(cacheLocation.EntryPath))
+    {
+        return null;
+    }
+
+    TestCacheEntry? entry;
+    try
+    {
+        var json = File.ReadAllText(cacheLocation.EntryPath);
+        entry = JsonSerializer.Deserialize<TestCacheEntry>(json);
+    }
+    catch
+    {
+        return null;
+    }
+
+    if (entry is null ||
+        entry.Version != TestCacheVersion ||
+        !string.Equals(entry.CacheKey, cacheLocation.CacheKey, StringComparison.Ordinal) ||
+        !string.Equals(entry.SourceHash, cacheLocation.SourceHash, StringComparison.Ordinal) ||
+        entry.Backend != backend ||
+        !string.Equals(entry.ModuleName, moduleName, StringComparison.Ordinal) ||
+        entry.IncludeTests != includeTests ||
+        entry.EmitIrOnly != emitIrOnly ||
+        entry.UsesGraphics != usesGraphics)
+    {
+        return null;
+    }
+
+    if (!File.Exists(entry.ArtifactPath))
+    {
+        return null;
+    }
+
+    return new CompileResult(entry.FilePath, source, entry.HasTests, entry.UsesGraphics, backend, entry.ArtifactPath, null, new List<Diagnostic>(), emitIrOnly, 0, true);
+}
+
+static void WriteTestCacheEntry(PreparedForLower prep, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+{
+    if (prep.TestCacheLocation is null)
+    {
+        return;
+    }
+
+    var cacheDirectory = Path.GetDirectoryName(prep.TestCacheLocation.EntryPath);
+    if (!string.IsNullOrEmpty(cacheDirectory))
+    {
+        Directory.CreateDirectory(cacheDirectory);
+    }
+
+    var entry = new TestCacheEntry(
+        TestCacheVersion,
+        prep.TestCacheLocation.CacheKey,
+        prep.FilePath,
+        prep.TestCacheLocation.ArtifactPath,
+        prep.TestCacheLocation.SourceHash,
+        prep.HasTests,
+        usesGraphics,
+        backend,
+        moduleName,
+        includeTests,
+        emitIrOnly);
+
+    var options = new JsonSerializerOptions { WriteIndented = true };
+    var json = JsonSerializer.Serialize(entry, options);
+    File.WriteAllText(prep.TestCacheLocation.EntryPath, json, Encoding.UTF8);
+}
+
+static string ComputeTestCacheKey(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, bool usesGraphics)
+{
+    var fullPath = Path.GetFullPath(path);
+    var identity = new StringBuilder();
+    identity.Append("version=").Append(TestCacheVersion).Append('\n');
+    identity.Append("backend=").Append(backend).Append('\n');
+    identity.Append("module=").Append(moduleName).Append('\n');
+    identity.Append("includeTests=").Append(includeTests).Append('\n');
+    identity.Append("emitIrOnly=").Append(emitIrOnly).Append('\n');
+    identity.Append("usesGraphics=").Append(usesGraphics).Append('\n');
+    identity.Append("path=").Append(fullPath).Append('\n');
+    identity.Append("source=").Append(source);
+    return ComputeSha256Hex(identity.ToString());
+}
+
+static string ComputeSha256Hex(string value)
+{
+    var bytes = Encoding.UTF8.GetBytes(value);
+    using var sha256 = SHA256.Create();
+    var hash = sha256.ComputeHash(bytes);
+    var builder = new StringBuilder(hash.Length * 2);
+    foreach (var hashByte in hash)
+    {
+        builder.Append(hashByte.ToString("x2"));
+    }
+    return builder.ToString();
+}
+
+
+static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, bool enableGraphics, BackendType backend, bool useLowerLock, bool allowReachabilityFallback, bool enableTestCache)
 {
     var stopwatch = Stopwatch.StartNew();
     var diagnostics = new List<Diagnostic>();
     string? tempArtifact = null;
     string? irForOutput = null;
+    var isCacheArtifact = false;
 
     try
     {
@@ -2758,13 +2890,25 @@ static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, str
 
             if (emitIrOnly || result.Diagnostics.Count > 0)
             {
-                return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+                return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, false);
             }
 
-            tempArtifact = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}.clif");
+            if (enableTestCache && prep.TestCacheLocation is not null)
+            {
+                tempArtifact = prep.TestCacheLocation.ArtifactPath;
+                isCacheArtifact = true;
+            }
+            else
+            {
+                tempArtifact = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}.clif");
+            }
             File.WriteAllText(tempArtifact, result.Ir);
+            if (isCacheArtifact && prep.TestCacheLocation is not null)
+            {
+                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, enableGraphics);
+            }
 
-            return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+            return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, isCacheArtifact);
         }
         else
         {
@@ -2789,13 +2933,25 @@ static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, str
 
             if (emitIrOnly || lower.Diagnostics.Count > 0)
             {
-                return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+                return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, false);
             }
 
-            tempArtifact = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}.ll");
+            if (enableTestCache && prep.TestCacheLocation is not null)
+            {
+                tempArtifact = prep.TestCacheLocation.ArtifactPath;
+                isCacheArtifact = true;
+            }
+            else
+            {
+                tempArtifact = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}.ll");
+            }
             File.WriteAllText(tempArtifact, lower.Ir);
+            if (isCacheArtifact && prep.TestCacheLocation is not null)
+            {
+                WriteTestCacheEntry(prep, backend, moduleName, includeTests, emitIrOnly, enableGraphics);
+            }
 
-            return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds);
+            return new CompileResult(prep.FilePath, prep.Source, prep.HasTests, enableGraphics, backend, tempArtifact, irForOutput, diagnostics, emitIrOnly, prep.PrepMilliseconds + stopwatch.ElapsedMilliseconds, isCacheArtifact);
         }
     }
     finally
@@ -2884,16 +3040,19 @@ static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? o
     var total = result.CompileMilliseconds + testStopwatch.ElapsedMilliseconds;
     Console.WriteLine($"Total time={total}ms");
 
-    try
+    if (!result.IsCacheArtifact)
     {
-        if (File.Exists(result.ArtifactPath))
+        try
         {
-            File.Delete(result.ArtifactPath);
+            if (File.Exists(result.ArtifactPath))
+            {
+                File.Delete(result.ArtifactPath);
+            }
         }
-    }
-    catch
-    {
-        // Best-effort cleanup
+        catch
+        {
+            // Best-effort cleanup
+        }
     }
 
     return executeExit;
@@ -3223,7 +3382,8 @@ sealed record CompileResult(
     string? IrForOutput,
     List<Diagnostic> Diagnostics,
     bool EmitIrOnly,
-    long CompileMilliseconds);
+    long CompileMilliseconds,
+    bool IsCacheArtifact);
 
 sealed record PreparedForLower(
     string FilePath,
@@ -3233,6 +3393,26 @@ sealed record PreparedForLower(
     LayoutPlan Layout,
     bool HasTests,
     bool UsesGraphics,
-    long PrepMilliseconds);
+    long PrepMilliseconds,
+    TestCacheLocation? TestCacheLocation);
 
 sealed record PrepareResult(PreparedForLower? Prepared, CompileResult? Result);
+
+sealed record TestCacheLocation(
+    string CacheKey,
+    string ArtifactPath,
+    string EntryPath,
+    string SourceHash);
+
+sealed record TestCacheEntry(
+    int Version,
+    string CacheKey,
+    string FilePath,
+    string ArtifactPath,
+    string SourceHash,
+    bool HasTests,
+    bool UsesGraphics,
+    BackendType Backend,
+    string ModuleName,
+    bool IncludeTests,
+    bool EmitIrOnly);

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1122,8 +1122,52 @@ static string? FindRepoRoot()
     return null;
 }
 
-static int Execute(string mode, string llPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+static int Execute(string mode, string llPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, string? cachedExecutablePath = null, bool keepExecutable = false)
 {
+    var cachedExecutableUsed = false;
+    if (!string.IsNullOrWhiteSpace(cachedExecutablePath))
+    {
+        if (File.Exists(cachedExecutablePath))
+        {
+            cachedExecutableUsed = true;
+        }
+        else if (TryFindTool("clang", out var clangForCache))
+        {
+            var args = BuildClangArgs(llPath, cachedExecutablePath, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath);
+            var exit = RunProcess(clangForCache, args, suppressOutput: true);
+            if (exit != 0)
+            {
+                return exit;
+            }
+
+            cachedExecutableUsed = true;
+        }
+    }
+
+    if (cachedExecutableUsed)
+    {
+        var cachedExecutableDirectory = Path.GetDirectoryName(cachedExecutablePath);
+        if (enableGraphics && !string.IsNullOrEmpty(cachedExecutableDirectory))
+        {
+            CopyGraphicsRuntimeDependencies(cachedExecutableDirectory, graphicsLibPath);
+        }
+
+        return RunProcess(cachedExecutablePath!, string.Empty, psi =>
+        {
+            if (enableGraphics)
+            {
+                var runTest = Environment.GetEnvironmentVariable("STASIS_RUN_RENDER_TEST");
+                if (string.IsNullOrEmpty(runTest) || runTest == "0")
+                {
+                    if (Environment.GetEnvironmentVariable("STASIS_SKIP_RENDER_TEST") is null)
+                    {
+                        psi.Environment["STASIS_SKIP_RENDER_TEST"] = "1";
+                    }
+                }
+            }
+        });
+    }
+
     // lli doesn't support external libraries easily, so use clang when graphics is enabled
     if (!enableGraphics && TryFindTool("lli", out var llvmInterpreter))
     {
@@ -1168,7 +1212,7 @@ static int Execute(string mode, string llPath, string? optLevel, bool enableLto,
         }
         finally
         {
-            if (File.Exists(exePath))
+            if (!keepExecutable && File.Exists(exePath))
             {
                 File.Delete(exePath);
             }
@@ -2875,6 +2919,24 @@ static string ComputeSha256Hex(string value)
     return builder.ToString();
 }
 
+static string? TryGetCachedExecutablePath(CompileResult result)
+{
+    if (result.Backend != BackendType.Llvm || !result.IsCacheArtifact || string.IsNullOrEmpty(result.ArtifactPath))
+    {
+        return null;
+    }
+
+    var cacheDirectory = Path.GetDirectoryName(result.ArtifactPath);
+    var cacheFileName = Path.GetFileNameWithoutExtension(result.ArtifactPath);
+    if (string.IsNullOrEmpty(cacheDirectory) || string.IsNullOrEmpty(cacheFileName))
+    {
+        return null;
+    }
+
+    var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
+    return Path.Combine(cacheDirectory, cacheFileName + extension);
+}
+
 
 static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool useLowerLock, bool allowReachabilityFallback, bool enableTestCache)
 {
@@ -3046,7 +3108,9 @@ static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? o
     }
     else
     {
-        executeExit = Execute("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath);
+        var cachedExecutablePath = TryGetCachedExecutablePath(result);
+        var keepExecutable = !string.IsNullOrEmpty(cachedExecutablePath);
+        executeExit = Execute("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, cachedExecutablePath, keepExecutable);
     }
     testStopwatch.Stop();
     var total = result.CompileMilliseconds + testStopwatch.ElapsedMilliseconds;

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <ctype.h>
+#include <time.h>
 #if defined(_WIN32)
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -2193,7 +2194,23 @@ STASIS_EXPORT int stasis_is_key_down(int scancode) {
  * Get current time in milliseconds
  */
 STASIS_EXPORT int stasis_get_time_ms(void) {
+#if defined(_WIN32)
+    if (SDL_WasInit(SDL_INIT_TIMER) == 0) {
+        if (SDL_Init(SDL_INIT_TIMER) != 0) {
+            return 0;
+        }
+    }
     return (int)SDL_GetTicks();
+#else
+    if (SDL_WasInit(SDL_INIT_TIMER) != 0) {
+        return (int)SDL_GetTicks();
+    }
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return 0;
+    }
+    return (int)((now.tv_sec * 1000) + (now.tv_nsec / 1000000));
+#endif
 }
 
 /*
@@ -2201,7 +2218,21 @@ STASIS_EXPORT int stasis_get_time_ms(void) {
  */
 STASIS_EXPORT void stasis_sleep_ms(int ms) {
     if (ms > 0) {
+        if (SDL_WasInit(SDL_INIT_TIMER) != 0) {
+            SDL_Delay((Uint32)ms);
+            return;
+        }
+#if defined(_WIN32)
+        if (SDL_Init(SDL_INIT_TIMER) != 0) {
+            return;
+        }
         SDL_Delay((Uint32)ms);
+#else
+        struct timespec delay;
+        delay.tv_sec = ms / 1000;
+        delay.tv_nsec = (ms % 1000) * 1000000;
+        nanosleep(&delay, NULL);
+#endif
     }
 }
 

--- a/samples/forloop_tests.stasis
+++ b/samples/forloop_tests.stasis
@@ -73,7 +73,7 @@ test assign_f32_in_loop(): bool {
     let i: i32 = 0;
     let value: f32 = 0.0;
     for (i = 0; i < 5; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         value = if32;
     }
     // After loop, value should be 4.0
@@ -84,7 +84,7 @@ test i32_to_f32_conversion_in_loop(): bool {
     let i: i32 = 0;
     let sum: f32 = 0.0;
     for (i = 0; i < 5; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         sum = sum + if32;
     }
     // 0+1+2+3+4 = 10
@@ -95,7 +95,7 @@ test calculation_with_converted_value(): bool {
     let i: i32 = 0;
     let result: f32 = 0.0;
     for (i = 0; i < 3; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         result = 100.0 + if32 * 50.0;
     }
     // After i=0: result = 100
@@ -127,7 +127,7 @@ test accumulator_f32(): bool {
     let curr: f32 = 0.0;
     prev = 0.0;
     for (i = 1; i < 5; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         curr = prev + if32;
         prev = curr;
     }
@@ -141,7 +141,7 @@ test prev_curr_pattern_like_asteroids(): bool {
     let last_prev: f32 = 0.0;
     prev_x = 100.0;
     for (i = 1; i < 4; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         curr_x = 100.0 + if32 * 30.0;
         last_prev = prev_x;
         prev_x = curr_x;
@@ -176,7 +176,7 @@ test division_in_loop(): bool {
     let i: i32 = 0;
     let result: f32 = 0.0;
     for (i = 0; i < 4; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         result = if32 / 4.0;
     }
     // After i=3: result = 3/4 = 0.75
@@ -189,7 +189,7 @@ test angle_calculation_like_asteroids(): bool {
     let PI: f32 = 3.14159;
     angle = 0.0;
     for (i = 1; i < 5; i = i + 1) {
-        let if32: f32 = i32_to_f32(i);
+        let if32: f32 = i;
         angle = (if32 / 8.0) * 2.0 * PI;
     }
     // After i=4: angle = (4/8) * 2 * PI = PI

--- a/samples/forloop_tests.stasis
+++ b/samples/forloop_tests.stasis
@@ -73,7 +73,7 @@ test assign_f32_in_loop(): bool {
     let i: i32 = 0;
     let value: f32 = 0.0;
     for (i = 0; i < 5; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         value = if32;
     }
     // After loop, value should be 4.0
@@ -84,7 +84,7 @@ test i32_to_f32_conversion_in_loop(): bool {
     let i: i32 = 0;
     let sum: f32 = 0.0;
     for (i = 0; i < 5; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         sum = sum + if32;
     }
     // 0+1+2+3+4 = 10
@@ -95,7 +95,7 @@ test calculation_with_converted_value(): bool {
     let i: i32 = 0;
     let result: f32 = 0.0;
     for (i = 0; i < 3; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         result = 100.0 + if32 * 50.0;
     }
     // After i=0: result = 100
@@ -127,7 +127,7 @@ test accumulator_f32(): bool {
     let curr: f32 = 0.0;
     prev = 0.0;
     for (i = 1; i < 5; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         curr = prev + if32;
         prev = curr;
     }
@@ -141,7 +141,7 @@ test prev_curr_pattern_like_asteroids(): bool {
     let last_prev: f32 = 0.0;
     prev_x = 100.0;
     for (i = 1; i < 4; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         curr_x = 100.0 + if32 * 30.0;
         last_prev = prev_x;
         prev_x = curr_x;
@@ -176,7 +176,7 @@ test division_in_loop(): bool {
     let i: i32 = 0;
     let result: f32 = 0.0;
     for (i = 0; i < 4; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         result = if32 / 4.0;
     }
     // After i=3: result = 3/4 = 0.75
@@ -189,7 +189,7 @@ test angle_calculation_like_asteroids(): bool {
     let PI: f32 = 3.14159;
     angle = 0.0;
     for (i = 1; i < 5; i = i + 1) {
-        let if32: f32 = i;
+        let if32: f32 = i32_to_f32(i);
         angle = (if32 / 8.0) * 2.0 * PI;
     }
     // After i=4: angle = (4/8) * 2 * PI = PI

--- a/samples/underwater_automation.stasis
+++ b/samples/underwater_automation.stasis
@@ -208,8 +208,8 @@ function setup_depth_bands(): void {
         for (x = 0; x < MAP_W; x = x + 1) {
             let idx: i32 = tile_index(x, y);
             state.tiles[idx].depth = depth;
-            let depth_ratio: f32 = i32_to_f32(y);
-            let map_height: f32 = i32_to_f32(MAP_H);
+            let depth_ratio: f32 = y;
+            let map_height: f32 = MAP_H;
             state.tiles[idx].light = 0.15 + (depth_ratio / map_height) * 0.35;
         }
     }
@@ -409,7 +409,7 @@ function apply_module(i: i32, module_type: i32, depth: i32): void {
 }
 
 function update_units(delta_ms: i32): void {
-    let dt: f32 = i32_to_f32(delta_ms);
+    let dt: f32 = delta_ms;
     dt = dt / 1000.0;
 
     let i: i32 = 0;
@@ -468,7 +468,7 @@ function update_lighting(delta_ms: i32): void {
                 noise_seed = 0 - noise_seed;
             }
             noise_seed = noise_seed % 97;
-            let flicker: f32 = i32_to_f32(noise_seed);
+            let flicker: f32 = noise_seed;
             flicker = flicker / 97.0;
             flicker = 0.04 + flicker * 0.08;
 
@@ -482,7 +482,7 @@ function update_lighting(delta_ms: i32): void {
         }
     }
 
-    let dt_seconds: f32 = i32_to_f32(delta_ms);
+    let dt_seconds: f32 = delta_ms;
     dt_seconds = dt_seconds / 1000.0;
     state.postfx_phase = state.postfx_phase + dt_seconds * state.postfx_speed;
     if (state.postfx_phase > 100000.0) {
@@ -506,12 +506,12 @@ function step_sim(delta_ms: i32): void {
 }
 
 function to_screen_x(grid_x: i32): f32 {
-    let gx: f32 = i32_to_f32(grid_x);
+    let gx: f32 = grid_x;
     return gx * CELL + 40.0;
 }
 
 function to_screen_y(grid_y: i32): f32 {
-    let gy: f32 = i32_to_f32(grid_y);
+    let gy: f32 = grid_y;
     return SCREEN_H - (gy * CELL + 80.0);
 }
 
@@ -605,7 +605,7 @@ function draw_units(): void {
                 if (state.units[i].kind == UNIT_PAYLOAD) {
                     r = 0.94; g = 0.82; b = 0.42;
                 }
-                let depth_as_float: f32 = i32_to_f32(depth);
+                let depth_as_float: f32 = depth;
                 let depth_mix: f32 = depth_as_float / 2.0;
                 r = r * (0.8 + 0.2 * depth_mix);
                 g = g * (0.8 + 0.2 * depth_mix);
@@ -617,7 +617,7 @@ function draw_units(): void {
 
                 let sx: f32 = to_screen_x(state.units[i].x);
                 let sy: f32 = to_screen_y(y_row);
-                let y_row_float: f32 = i32_to_f32(y_row);
+                let y_row_float: f32 = y_row;
                 let frac: f32 = state.units[i].y - y_row_float;
                 let offset: f32 = frac * CELL;
 
@@ -641,7 +641,7 @@ function draw_overlay(): void {
     }
     let i: i32 = 0;
     for (i = 0; i < delivered; i = i + 1) {
-        let payload_index: f32 = i32_to_f32(i);
+        let payload_index: f32 = i;
         let payload_bar_x: f32 = 40.0 + payload_index * 10.0;
         draw_line(payload_bar_x, SCREEN_H - 30.0, payload_bar_x + 6.0, SCREEN_H - 30.0, 0.95, 0.85, 0.45, 1.0);
     }

--- a/samples/underwater_automation.stasis
+++ b/samples/underwater_automation.stasis
@@ -208,8 +208,8 @@ function setup_depth_bands(): void {
         for (x = 0; x < MAP_W; x = x + 1) {
             let idx: i32 = tile_index(x, y);
             state.tiles[idx].depth = depth;
-            let depth_ratio: f32 = y;
-            let map_height: f32 = MAP_H;
+            let depth_ratio: f32 = i32_to_f32(y);
+            let map_height: f32 = i32_to_f32(MAP_H);
             state.tiles[idx].light = 0.15 + (depth_ratio / map_height) * 0.35;
         }
     }
@@ -409,7 +409,7 @@ function apply_module(i: i32, module_type: i32, depth: i32): void {
 }
 
 function update_units(delta_ms: i32): void {
-    let dt: f32 = delta_ms;
+    let dt: f32 = i32_to_f32(delta_ms);
     dt = dt / 1000.0;
 
     let i: i32 = 0;
@@ -468,7 +468,7 @@ function update_lighting(delta_ms: i32): void {
                 noise_seed = 0 - noise_seed;
             }
             noise_seed = noise_seed % 97;
-            let flicker: f32 = noise_seed;
+            let flicker: f32 = i32_to_f32(noise_seed);
             flicker = flicker / 97.0;
             flicker = 0.04 + flicker * 0.08;
 
@@ -482,7 +482,7 @@ function update_lighting(delta_ms: i32): void {
         }
     }
 
-    let dt_seconds: f32 = delta_ms;
+    let dt_seconds: f32 = i32_to_f32(delta_ms);
     dt_seconds = dt_seconds / 1000.0;
     state.postfx_phase = state.postfx_phase + dt_seconds * state.postfx_speed;
     if (state.postfx_phase > 100000.0) {
@@ -506,12 +506,12 @@ function step_sim(delta_ms: i32): void {
 }
 
 function to_screen_x(grid_x: i32): f32 {
-    let gx: f32 = grid_x;
+    let gx: f32 = i32_to_f32(grid_x);
     return gx * CELL + 40.0;
 }
 
 function to_screen_y(grid_y: i32): f32 {
-    let gy: f32 = grid_y;
+    let gy: f32 = i32_to_f32(grid_y);
     return SCREEN_H - (gy * CELL + 80.0);
 }
 
@@ -605,7 +605,7 @@ function draw_units(): void {
                 if (state.units[i].kind == UNIT_PAYLOAD) {
                     r = 0.94; g = 0.82; b = 0.42;
                 }
-                let depth_as_float: f32 = depth;
+                let depth_as_float: f32 = i32_to_f32(depth);
                 let depth_mix: f32 = depth_as_float / 2.0;
                 r = r * (0.8 + 0.2 * depth_mix);
                 g = g * (0.8 + 0.2 * depth_mix);
@@ -617,7 +617,7 @@ function draw_units(): void {
 
                 let sx: f32 = to_screen_x(state.units[i].x);
                 let sy: f32 = to_screen_y(y_row);
-                let y_row_float: f32 = y_row;
+                let y_row_float: f32 = i32_to_f32(y_row);
                 let frac: f32 = state.units[i].y - y_row_float;
                 let offset: f32 = frac * CELL;
 
@@ -641,7 +641,7 @@ function draw_overlay(): void {
     }
     let i: i32 = 0;
     for (i = 0; i < delivered; i = i + 1) {
-        let payload_index: f32 = i;
+        let payload_index: f32 = i32_to_f32(i);
         let payload_bar_x: f32 = 40.0 + payload_index * 10.0;
         draw_line(payload_bar_x, SCREEN_H - 30.0, payload_bar_x + 6.0, SCREEN_H - 30.0, 0.95, 0.85, 0.45, 1.0);
     }

--- a/test-llvm.bat
+++ b/test-llvm.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "STASIS_SUPPRESS_WARNINGS=1"
+set "STASIS_BACKEND=llvm"
+set "STASIS_COMMAND=%SCRIPT_DIR%stasis.bat"
+
+powershell -NoProfile -Command ^
+  "$ErrorActionPreference='Stop';" ^
+  "$stasisCommand = '%STASIS_COMMAND%';" ^
+  "$arguments = @('test','samples','--all','--backend','%STASIS_BACKEND%');" ^
+  "function Invoke-TimedRun([string]$label) {" ^
+  "  $stopwatch = [Diagnostics.Stopwatch]::StartNew();" ^
+  "  & $stasisCommand @arguments;" ^
+  "  $exitCode = $LASTEXITCODE;" ^
+  "  $stopwatch.Stop();" ^
+  "  if ($exitCode -ne 0) { Write-Error \"$label run failed with exit code $exitCode\"; exit $exitCode }" ^
+  "  $seconds = $stopwatch.Elapsed.TotalSeconds.ToString('0.000');" ^
+  "  Write-Host (\"{0} run time: {1}s\" -f $label, $seconds);" ^
+  "}" ^
+  "Invoke-TimedRun 'Cold';" ^
+  "Invoke-TimedRun 'Warm';"
+if errorlevel 1 exit /b 1
+
+endlocal

--- a/tools/install-dotnet-9.sh
+++ b/tools/install-dotnet-9.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTNET_CHANNEL="9.0"
+DOTNET_INSTALL_DIR="${DOTNET_INSTALL_DIR:-$HOME/.dotnet}"
+DOTNET_INSTALL_SCRIPT_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_INSTALL_SCRIPT_PATH="${TMPDIR:-/tmp}/dotnet-install.sh"
+
+if command -v dotnet >/dev/null 2>&1; then
+    CURRENT_DOTNET_VERSION="$(dotnet --version)"
+    if [[ "${CURRENT_DOTNET_VERSION}" == 9.* ]]; then
+        echo "dotnet ${CURRENT_DOTNET_VERSION} already installed."
+        exit 0
+    fi
+fi
+
+echo "Installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_INSTALL_DIR}"
+
+mkdir -p "${DOTNET_INSTALL_DIR}"
+
+curl -fsSL "${DOTNET_INSTALL_SCRIPT_URL}" -o "${DOTNET_INSTALL_SCRIPT_PATH}"
+
+bash "${DOTNET_INSTALL_SCRIPT_PATH}" \
+    --channel "${DOTNET_CHANNEL}" \
+    --install-dir "${DOTNET_INSTALL_DIR}"
+
+echo ""
+echo "Add .NET to your PATH for this shell:"
+echo "  export PATH=\"${DOTNET_INSTALL_DIR}:\$PATH\""
+
+echo ""
+echo "Verify the install:"
+echo "  dotnet --version"


### PR DESCRIPTION
### Motivation
- Sample code contained implicit `i32`→`f32` assignments that triggered type errors during compilation and execution. 
- The native toolchain and linker flags on Linux prevented graphics-linked binaries from resolving shared libraries at runtime. 
- Tests that build and run samples with LLVM/clang need a stable link setup and runtime graphics library available. 

### Description
- Replaced implicit integer-to-float assignments in `samples/forloop_tests.stasis` and `samples/underwater_automation.stasis` with explicit `i32_to_f32(...)` calls to fix type errors. 
- Updated `Stasis.Cli/Program.cs` to normalize naming, add rpath support when a shared `libstasis_graphics.so` is provided, and add `-lm` to non-Windows clang link invocations so math symbols resolve on Linux. 
- Added logic to pass library directories to `-L` and emit `-Wl,-rpath` for non-static shared graphics libs to ensure runtime resolution. 
- Installed and built native tools/dependencies (`llvm/clang`, `libsdl2-dev`, `libglew-dev`) and built the `stasis_graphics` runtime so graphics-linked tests can be run locally. 

### Testing
- Ran `stasis.sh test samples --all --backend cranelift` (cold and warm); the run completed successfully (warnings about Cranelift native AOT are expected on non-Windows). 
- Ran `stasis.sh test samples --all --backend llvm` with the native graphics runtime built and `SDL_VIDEODRIVER=dummy`; the majority of sample tests passed, and graphics tests were exercised with the SDL fallback. 
- Exercised the `underwater_automation.stasis` tests individually under LLVM and observed they passed. 
- Observed an intermittent `exit 139` when running the entire LLVM suite end-to-end in this CI-like environment (appears tied to `samples/sudoku.stasis` in this environment), so full-suite LLVM instability remains under investigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695278e0f150832fbbede97817ab2c71)