### PR TITLE
Cranelift: cache artifacts for warm run/test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _ReSharper.Caches/
 .config/dotnet-tools.json.lock
 .claude/settings.local.json
 .stasis_cache/
+.tools/
 
 # Build artifacts
 *.dll

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
 - When `lli` is unavailable, the CLI compiles the IR with `clang`. On Windows it links against the latest installed Windows SDK (`ucrt`, `kernel32`, `legacy_stdio_definitions`) so the test harness `printf` resolves.
 
 ## Samples
+- Demo day quick guide: `docs/demo-day.md`
 - `samples/basic.stasis` basic function plus `main` returning 5.
 - `samples/tests.stasis` includes Stasis `test` declarations; the emitted `run_tests` function prints a summary and returns the failure count.
 - `samples/sudoku.stasis` playable Sudoku: `stasis run samples/sudoku.stasis` then enter `row col value` (1-9, 0 clears) or `q` to quit. Clue cells are colored differently; invalid moves are rejected.

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -344,8 +344,9 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             return 1;
         }
 
-        // Auto-detect graphics usage if not explicitly enabled
-        if (!enableGraphics && DetectsGraphicsUsage(source))
+        // Auto-detect graphics usage if not explicitly enabled.
+        // Keep LLVM tests deterministic by default; Cranelift tests need the runtime hooks for some programs.
+        if (!enableGraphics && (mode != "test" || backend == BackendType.Cranelift) && DetectsGraphicsUsage(source))
         {
             enableGraphics = true;
         }
@@ -2820,7 +2821,9 @@ static PrepareResult PrepareForLower(string path, bool includeTests, string modu
             PrintDiagnostics(importDiagnostics, importSource, path);
             return new PrepareResult(null, new CompileResult(path, importSource, false, false, backend, null, null, importDiagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds, false));
         }
-        var usesGraphics = DetectsGraphicsUsage(source);
+        // Tests should be deterministic and avoid IO-heavy dependencies, but the Cranelift backend still relies on
+        // runtime hooks for some builtins (e.g., get_time_ms), so keep auto-detection there.
+        var usesGraphics = includeTests && backend == BackendType.Llvm ? false : DetectsGraphicsUsage(source);
         var effectiveGraphics = enableGraphics || usesGraphics;
         TestCacheLocation? testCacheLocation = null;
         var craneliftTargetTriple = backend == BackendType.Cranelift ? GetCraneliftTargetTriple() : null;
@@ -2967,9 +2970,17 @@ static void WriteTestCacheEntry(PreparedForLower prep, BackendType backend, stri
         craneliftTargetTriple,
         compilerCacheSalt);
 
-    var options = new JsonSerializerOptions { WriteIndented = true };
-    var json = JsonSerializer.Serialize(entry, options);
-    File.WriteAllText(prep.TestCacheLocation.EntryPath, json, Encoding.UTF8);
+    try
+    {
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        var json = JsonSerializer.Serialize(entry, options);
+        File.WriteAllText(prep.TestCacheLocation.EntryPath, json, Encoding.UTF8);
+    }
+    catch
+    {
+        // Native AOT disables reflection-based JSON serialization by default.
+        // The test cache is an optional optimization, so ignore failures here and continue.
+    }
 }
 
 static string ComputeTestCacheKey(string path, string source, BackendType backend, string moduleName, bool includeTests, bool emitIrOnly, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics, string? craneliftTargetTriple, string compilerCacheSalt)

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -38,7 +38,17 @@ var enableLto = false;
 var enableGraphics = false;
 string? graphicsLibPath = null;
 BackendType? selectedBackend = null;
-var useCraneliftRunner = Environment.GetEnvironmentVariable("STASIS_CRANELIFT_RUNNER") == "1";
+bool? craneliftRunnerOverride = null;
+var runnerEnv = Environment.GetEnvironmentVariable("STASIS_CRANELIFT_RUNNER");
+if (runnerEnv == "1")
+{
+    craneliftRunnerOverride = true;
+}
+else if (runnerEnv == "0")
+{
+    craneliftRunnerOverride = false;
+}
+var useCraneliftRunner = craneliftRunnerOverride ?? false;
 var enableHotState = false;
 var tickHostFps = 60;
 
@@ -117,7 +127,12 @@ while (cliArgs.Count > 0)
             }
             break;
         case "--cranelift-runner":
+            craneliftRunnerOverride = true;
             useCraneliftRunner = true;
+            break;
+        case "--no-cranelift-runner":
+            craneliftRunnerOverride = false;
+            useCraneliftRunner = false;
             break;
         case "--hot-state":
             enableHotState = true;
@@ -176,7 +191,7 @@ if (backend == BackendType.Cranelift && selectedBackend is null && !CanUseCranel
     backend = BackendType.Llvm;
 }
 
-if (backend == BackendType.Cranelift && (mode == "test" || mode == "run"))
+if (backend == BackendType.Cranelift && (mode == "test" || mode == "run") && craneliftRunnerOverride is null)
 {
     useCraneliftRunner = true;
 }
@@ -444,6 +459,101 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
 
         if (backend == BackendType.Cranelift)
         {
+            // Artifact cache: skip AOT + link on warm runs when the source and build options are unchanged.
+            if (IsCraneliftArtifactCacheEnabled() &&
+                !enableHotState &&
+                mode != "build" &&
+                mode != "release")
+            {
+                var cacheDir = GetCraneliftArtifactCacheDirectory(mode);
+                Directory.CreateDirectory(cacheDir);
+                var craneliftTargetTriple = GetCraneliftTargetTriple();
+                var compilerCacheSalt = GetCompilerCacheSalt();
+                var cacheKey = ComputeCraneliftArtifactCacheKey(path, source, mode, backend, moduleName, includeTests, optLevel, enableLto, graphicsLibPath, useCraneliftRunner, enableGraphics, craneliftTargetTriple, compilerCacheSalt);
+                var cachedClif = Path.Combine(cacheDir, $"{cacheKey}.clif");
+                var cachedObj = Path.Combine(cacheDir, $"{cacheKey}{GetObjectFileExtension()}");
+                var cachedOut = Path.Combine(cacheDir, cacheKey + (useCraneliftRunner ? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so") : (OperatingSystem.IsWindows() ? ".exe" : string.Empty)));
+
+                if (File.Exists(cachedOut))
+                {
+                    var entryBase = mode == "test" ? "run_tests" : "main";
+                    var entryName = $"{moduleName}__{entryBase}";
+                    if (useCraneliftRunner)
+                    {
+                        var hasTick = mode == "run" && ContainsTopLevelFunction(parse.CompilationUnit, "tick");
+                        return RunCachedRunnerDll(cachedOut, entryName, enableGraphics, graphicsLibPath, tickHostFps: hasTick ? tickHostFps : null);
+                    }
+                    return RunCachedExecutable(mode, cachedOut, enableGraphics, graphicsLibPath);
+                }
+
+                File.WriteAllText(cachedClif, ir);
+                if (logPhaseTiming)
+                {
+                    irWriteMs = phaseStopwatch.ElapsedMilliseconds;
+                    phaseStopwatch.Restart();
+                }
+
+                if (useCraneliftRunner)
+                {
+                    var exports = new List<string>();
+                    var entryBase = mode == "test" ? "run_tests" : "main";
+                    exports.Add($"{moduleName}__{entryBase}");
+                    var hasTick = mode == "run" && ContainsTopLevelFunction(parse.CompilationUnit, "tick");
+                    if (hasTick)
+                    {
+                        exports.Add($"{moduleName}__tick");
+                    }
+
+                    var sw = Stopwatch.StartNew();
+                    var ensureExit = EnsureCraneliftCachedRunnerDll(cachedClif, cachedObj, cachedOut, moduleName, mode, optLevel, enableLto, enableGraphics, graphicsLibPath, exports);
+                    sw.Stop();
+                    if (logPhaseTiming)
+                    {
+                        aotMs = sw.ElapsedMilliseconds;
+                        linkMs = 0;
+                        runMs = 0;
+                    }
+                    if (ensureExit != 0)
+                    {
+                        return ensureExit;
+                    }
+
+                    var runSw = Stopwatch.StartNew();
+                    var entryName = $"{moduleName}__{entryBase}";
+                    var exit = RunCachedRunnerDll(cachedOut, entryName, enableGraphics, graphicsLibPath, tickHostFps: hasTick ? tickHostFps : null);
+                    runSw.Stop();
+                    if (logPhaseTiming)
+                    {
+                        runMs = runSw.ElapsedMilliseconds;
+                    }
+                    return exit;
+                }
+                else
+                {
+                    var sw = Stopwatch.StartNew();
+                    var ensureExit = EnsureCraneliftCachedExecutable(cachedClif, cachedObj, cachedOut, moduleName, mode, optLevel, enableLto, enableGraphics, graphicsLibPath);
+                    sw.Stop();
+                    if (logPhaseTiming)
+                    {
+                        aotMs = sw.ElapsedMilliseconds;
+                        linkMs = 0;
+                        runMs = 0;
+                    }
+                    if (ensureExit != 0)
+                    {
+                        return ensureExit;
+                    }
+                    var runSw = Stopwatch.StartNew();
+                    var exit = RunCachedExecutable(mode, cachedOut, enableGraphics, graphicsLibPath);
+                    runSw.Stop();
+                    if (logPhaseTiming)
+                    {
+                        runMs = runSw.ElapsedMilliseconds;
+                    }
+                    return exit;
+                }
+            }
+
             // Native Cranelift path: CLIF -> object -> clang link -> executable.
             if (!OperatingSystem.IsWindows())
             {
@@ -1573,6 +1683,39 @@ static bool DetectsGraphicsUsage(string source)
 
 static bool DetectsTickUsage(string source) =>
     Regex.IsMatch(source, @"(?m)^\s*function\s+tick\s*\(", RegexOptions.CultureInvariant);
+
+const int CraneliftArtifactCacheVersion = 1;
+
+static bool IsCraneliftArtifactCacheEnabled() =>
+    !string.Equals(Environment.GetEnvironmentVariable("STASIS_DISABLE_ARTIFACT_CACHE"), "1", StringComparison.OrdinalIgnoreCase);
+
+static string GetCraneliftArtifactCacheDirectory(string mode)
+{
+    var currentDirectory = Directory.GetCurrentDirectory();
+    var bucket = mode == "test" ? "test" : "run";
+    return Path.Combine(currentDirectory, ".stasis_cache", bucket);
+}
+
+static string ComputeCraneliftArtifactCacheKey(string path, string source, string mode, BackendType backend, string moduleName, bool includeTests, string? optLevel, bool enableLto, string? graphicsLibPath, bool useCraneliftRunner, bool usesGraphics, string? craneliftTargetTriple, string compilerCacheSalt)
+{
+    var fullPath = Path.GetFullPath(path);
+    var identity = new StringBuilder();
+    identity.Append("version=").Append(CraneliftArtifactCacheVersion).Append('\n');
+    identity.Append("mode=").Append(mode).Append('\n');
+    identity.Append("backend=").Append(backend).Append('\n');
+    identity.Append("module=").Append(moduleName).Append('\n');
+    identity.Append("includeTests=").Append(includeTests).Append('\n');
+    identity.Append("optLevel=").Append(optLevel ?? string.Empty).Append('\n');
+    identity.Append("enableLto=").Append(enableLto).Append('\n');
+    identity.Append("graphicsLibPath=").Append(graphicsLibPath ?? string.Empty).Append('\n');
+    identity.Append("useCraneliftRunner=").Append(useCraneliftRunner).Append('\n');
+    identity.Append("usesGraphics=").Append(usesGraphics).Append('\n');
+    identity.Append("craneliftTarget=").Append(craneliftTargetTriple ?? string.Empty).Append('\n');
+    identity.Append("compilerCacheSalt=").Append(compilerCacheSalt).Append('\n');
+    identity.Append("path=").Append(fullPath).Append('\n');
+    identity.Append("source=").Append(source);
+    return ComputeSha256Hex(identity.ToString());
+}
 
 static string? FindGraphicsLibrary(bool preferShared = false)
 {
@@ -2747,7 +2890,8 @@ static void PrintUsage()
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
     Console.WriteLine("Graphics: enabled automatically when graphics APIs are used; use --graphics to force it on. Use --graphics-lib to override library path.");
     Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
-    Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override.");
+    Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override, or pass --no-cranelift-runner to force EXE mode.");
+    Console.WriteLine("Cache: set STASIS_DISABLE_ARTIFACT_CACHE=1 to disable binary caching for Cranelift run/test.");
 }
 
 static int RunAllTestsInDirectoryParallel(string[] files, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool allowReachabilityFallback, bool enableTestCache, bool useLowerLock = true, int lowerDegree = 1) =>
@@ -3097,7 +3241,7 @@ static int RunCachedExecutable(string mode, string executablePath, bool enableGr
     });
 }
 
-static int RunCachedRunnerDll(string dllPath, string entryName, bool enableGraphics, string? graphicsLibPath)
+static int RunCachedRunnerDll(string dllPath, string entryName, bool enableGraphics, string? graphicsLibPath, int? tickHostFps = null)
 {
     if (!TryFindCraneliftRunner(out var runnerPath))
     {
@@ -3114,13 +3258,18 @@ static int RunCachedRunnerDll(string dllPath, string entryName, bool enableGraph
         }
     }
 
-    if (UseCraneliftRunnerServer())
+    if (tickHostFps is null && UseCraneliftRunnerServer())
     {
         var runner = GetCraneliftRunnerServer(runnerPath);
         return runner.Run(dllPath, entryName, out _);
     }
 
-    return RunProcess(runnerPath, $"\"{dllPath}\" {entryName}");
+    var args = $"\"{dllPath}\" {entryName}";
+    if (tickHostFps is not null)
+    {
+        args += $" --fps {tickHostFps.Value}";
+    }
+    return RunProcess(runnerPath, args);
 }
 
 static int EnsureCraneliftCachedExecutable(string clifPath, string objPath, string exePath, string moduleName, string mode, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
@@ -3199,7 +3348,7 @@ static int EnsureCraneliftCachedExecutable(string clifPath, string objPath, stri
     }
 }
 
-static int EnsureCraneliftCachedRunnerDll(string clifPath, string objPath, string dllPath, string moduleName, string mode, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+static int EnsureCraneliftCachedRunnerDll(string clifPath, string objPath, string dllPath, string moduleName, string mode, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, IReadOnlyList<string>? exports = null)
 {
     if (!OperatingSystem.IsWindows())
     {
@@ -3246,8 +3395,8 @@ static int EnsureCraneliftCachedRunnerDll(string clifPath, string objPath, strin
 
         if (!File.Exists(dllPath))
         {
-            var exports = new[] { entryName };
-            var args = BuildClangArgsForObject(objPath, tempDll, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath, entryName: entryName, isDll: true, windowsExports: exports);
+            var dllExports = exports is { Count: > 0 } ? exports : new[] { entryName };
+            var args = BuildClangArgsForObject(objPath, tempDll, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath, entryName: entryName, isDll: true, windowsExports: dllExports);
             var exit = RunProcess(clang, args, suppressOutput: true);
             if (exit != 0)
             {

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3019,7 +3019,7 @@ static string ComputeSha256Hex(string value)
 
 static string? TryGetCachedExecutablePath(CompileResult result)
 {
-    if (result.Backend != BackendType.Llvm || !result.IsCacheArtifact || string.IsNullOrEmpty(result.ArtifactPath))
+    if (!result.IsCacheArtifact || string.IsNullOrEmpty(result.ArtifactPath))
     {
         return null;
     }
@@ -3035,7 +3035,248 @@ static string? TryGetCachedExecutablePath(CompileResult result)
     return Path.Combine(cacheDirectory, cacheFileName + extension);
 }
 
+static string? TryGetCachedObjectPath(CompileResult result)
+{
+    if (result.Backend != BackendType.Cranelift || !result.IsCacheArtifact || string.IsNullOrEmpty(result.ArtifactPath))
+    {
+        return null;
+    }
 
+    var cacheDirectory = Path.GetDirectoryName(result.ArtifactPath);
+    var cacheFileName = Path.GetFileNameWithoutExtension(result.ArtifactPath);
+    if (string.IsNullOrEmpty(cacheDirectory) || string.IsNullOrEmpty(cacheFileName))
+    {
+        return null;
+    }
+
+    return Path.Combine(cacheDirectory, cacheFileName + GetObjectFileExtension());
+}
+
+static string? TryGetCachedRunnerDllPath(CompileResult result)
+{
+    if (result.Backend != BackendType.Cranelift || !result.IsCacheArtifact || string.IsNullOrEmpty(result.ArtifactPath))
+    {
+        return null;
+    }
+
+    var cacheDirectory = Path.GetDirectoryName(result.ArtifactPath);
+    var cacheFileName = Path.GetFileNameWithoutExtension(result.ArtifactPath);
+    if (string.IsNullOrEmpty(cacheDirectory) || string.IsNullOrEmpty(cacheFileName))
+    {
+        return null;
+    }
+
+    var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so";
+    return Path.Combine(cacheDirectory, cacheFileName + extension);
+}
+
+static int RunCachedExecutable(string mode, string executablePath, bool enableGraphics, string? graphicsLibPath)
+{
+    if (enableGraphics)
+    {
+        var exeDir = Path.GetDirectoryName(executablePath);
+        if (!string.IsNullOrEmpty(exeDir))
+        {
+            CopyGraphicsRuntimeDependencies(exeDir, graphicsLibPath);
+        }
+    }
+
+    return RunProcess(executablePath, string.Empty, psi =>
+    {
+        if (enableGraphics)
+        {
+            var runTest = Environment.GetEnvironmentVariable("STASIS_RUN_RENDER_TEST");
+            if (string.IsNullOrEmpty(runTest) || runTest == "0")
+            {
+                if (Environment.GetEnvironmentVariable("STASIS_SKIP_RENDER_TEST") is null)
+                {
+                    psi.Environment["STASIS_SKIP_RENDER_TEST"] = "1";
+                }
+            }
+        }
+    });
+}
+
+static int RunCachedRunnerDll(string dllPath, string entryName, bool enableGraphics, string? graphicsLibPath)
+{
+    if (!TryFindCraneliftRunner(out var runnerPath))
+    {
+        Console.Error.WriteLine("error: stasis_runner not found. Build it in runtime/ and set STASIS_CRANELIFT_RUNNER_EXE if needed.");
+        return 1;
+    }
+
+    if (enableGraphics)
+    {
+        var dllDir = Path.GetDirectoryName(dllPath);
+        if (!string.IsNullOrEmpty(dllDir))
+        {
+            CopyGraphicsRuntimeDependencies(dllDir, graphicsLibPath);
+        }
+    }
+
+    if (UseCraneliftRunnerServer())
+    {
+        var runner = GetCraneliftRunnerServer(runnerPath);
+        return runner.Run(dllPath, entryName, out _);
+    }
+
+    return RunProcess(runnerPath, $"\"{dllPath}\" {entryName}");
+}
+
+static int EnsureCraneliftCachedExecutable(string clifPath, string objPath, string exePath, string moduleName, string mode, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        Console.Error.WriteLine("error: Cranelift native output is only implemented for Windows x64 currently. Use --emit-ir.");
+        return 1;
+    }
+
+    if (!TryFindCraneliftAot(out var aotTool))
+    {
+        Console.Error.WriteLine("error: stasis-cranelift-aot not found. Build it with `cargo build -p stasis-cranelift-aot` (in tools/cranelift-aot) or set STASIS_CRANELIFT_AOT.");
+        return 1;
+    }
+
+    if (!TryFindTool("clang", out var clang))
+    {
+        Console.Error.WriteLine("error: run requires clang in PATH.");
+        return 1;
+    }
+
+    var entryBase = mode == "test" ? "run_tests" : "main";
+    var entryName = $"{moduleName}__{entryBase}";
+
+    Directory.CreateDirectory(Path.GetDirectoryName(objPath)!);
+    Directory.CreateDirectory(Path.GetDirectoryName(exePath)!);
+
+    var tempObj = objPath + ".tmp";
+    var tempExe = exePath + ".tmp";
+    try
+    {
+        if (!File.Exists(objPath))
+        {
+            var aotExit = RunCraneliftAot(aotTool, clifPath, tempObj, moduleName, optLevel, out _, out _);
+            if (aotExit != 0)
+            {
+                return aotExit;
+            }
+
+            if (File.Exists(objPath))
+            {
+                File.Delete(objPath);
+            }
+            File.Move(tempObj, objPath);
+        }
+
+        if (!File.Exists(exePath))
+        {
+            var args = BuildClangArgsForObject(objPath, tempExe, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath, entryName: entryName);
+            var exit = RunProcess(clang, args, suppressOutput: true);
+            if (exit != 0)
+            {
+                return exit;
+            }
+
+            if (File.Exists(exePath))
+            {
+                File.Delete(exePath);
+            }
+            File.Move(tempExe, exePath);
+        }
+
+        return 0;
+    }
+    finally
+    {
+        if (File.Exists(tempObj))
+        {
+            File.Delete(tempObj);
+        }
+        if (File.Exists(tempExe))
+        {
+            File.Delete(tempExe);
+        }
+    }
+}
+
+static int EnsureCraneliftCachedRunnerDll(string clifPath, string objPath, string dllPath, string moduleName, string mode, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        Console.Error.WriteLine("error: Cranelift native output is only implemented for Windows x64 currently. Use --emit-ir.");
+        return 1;
+    }
+
+    if (!TryFindCraneliftAot(out var aotTool))
+    {
+        Console.Error.WriteLine("error: stasis-cranelift-aot not found. Build it with `cargo build -p stasis-cranelift-aot` (in tools/cranelift-aot) or set STASIS_CRANELIFT_AOT.");
+        return 1;
+    }
+
+    if (!TryFindTool("clang", out var clang))
+    {
+        Console.Error.WriteLine("error: run requires clang in PATH.");
+        return 1;
+    }
+
+    var entryBase = mode == "test" ? "run_tests" : "main";
+    var entryName = $"{moduleName}__{entryBase}";
+
+    Directory.CreateDirectory(Path.GetDirectoryName(objPath)!);
+    Directory.CreateDirectory(Path.GetDirectoryName(dllPath)!);
+
+    var tempObj = objPath + ".tmp";
+    var tempDll = dllPath + ".tmp";
+    try
+    {
+        if (!File.Exists(objPath))
+        {
+            var aotExit = RunCraneliftAot(aotTool, clifPath, tempObj, moduleName, optLevel, out _, out _);
+            if (aotExit != 0)
+            {
+                return aotExit;
+            }
+
+            if (File.Exists(objPath))
+            {
+                File.Delete(objPath);
+            }
+            File.Move(tempObj, objPath);
+        }
+
+        if (!File.Exists(dllPath))
+        {
+            var exports = new[] { entryName };
+            var args = BuildClangArgsForObject(objPath, tempDll, mode == "test", optLevel, enableLto, enableGraphics, graphicsLibPath, entryName: entryName, isDll: true, windowsExports: exports);
+            var exit = RunProcess(clang, args, suppressOutput: true);
+            if (exit != 0)
+            {
+                return exit;
+            }
+
+            if (File.Exists(dllPath))
+            {
+                File.Delete(dllPath);
+            }
+            File.Move(tempDll, dllPath);
+        }
+
+        return 0;
+    }
+    finally
+    {
+        if (File.Exists(tempObj))
+        {
+            File.Delete(tempObj);
+        }
+        if (File.Exists(tempDll))
+        {
+            File.Delete(tempDll);
+        }
+    }
+}
+
+ 
 static CompileResult LowerPrepared(PreparedForLower prep, bool includeTests, string moduleName, bool emitIrOnly, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, BackendType backend, bool useCraneliftRunner, bool useLowerLock, bool allowReachabilityFallback, bool enableTestCache)
 {
     var stopwatch = Stopwatch.StartNew();
@@ -3171,36 +3412,97 @@ static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? o
     var executeExit = 1;
     if (result.Backend == BackendType.Cranelift)
     {
-        if (!TryFindCraneliftAot(out var aotTool))
+        if (useCraneliftRunner)
         {
-            Console.Error.WriteLine("error: stasis-cranelift-aot not found. Build it with `cargo build -p stasis-cranelift-aot` (in tools/cranelift-aot) or set STASIS_CRANELIFT_AOT.");
-        }
-        else
-        {
-            if (useCraneliftRunner)
+            var cachedObjectPath = TryGetCachedObjectPath(result);
+            var cachedDllPath = TryGetCachedRunnerDllPath(result);
+            var entryName = $"{moduleName}__run_tests";
+
+            if (!string.IsNullOrWhiteSpace(cachedObjectPath) &&
+                !string.IsNullOrWhiteSpace(cachedDllPath) &&
+                !string.IsNullOrWhiteSpace(result.ArtifactPath))
             {
-                executeExit = ExecuteClifWithRunner("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, aotTool, moduleName, hotStatePlan: null, tickHostFps: null, out _, out _, out _, out _);
-            }
-            else
-            {
-                var tempObj = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}{GetObjectFileExtension()}");
-                try
+                if (!File.Exists(cachedDllPath))
                 {
-                    var aotExit = RunCraneliftAot(aotTool, result.ArtifactPath, tempObj, moduleName, optLevel, out _, out _);
-                    if (aotExit != 0)
+                    var ensureExit = EnsureCraneliftCachedRunnerDll(result.ArtifactPath, cachedObjectPath, cachedDllPath, moduleName, "test", optLevel, enableLto, result.UsesGraphics, graphicsLibPath);
+                    if (ensureExit != 0)
                     {
-                        executeExit = aotExit;
+                        executeExit = ensureExit;
                     }
                     else
                     {
-                        executeExit = ExecuteObject("test", tempObj, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, moduleName);
+                        executeExit = RunCachedRunnerDll(cachedDllPath, entryName, result.UsesGraphics, graphicsLibPath);
                     }
                 }
-                finally
+                else
                 {
-                    if (File.Exists(tempObj))
+                    executeExit = RunCachedRunnerDll(cachedDllPath, entryName, result.UsesGraphics, graphicsLibPath);
+                }
+            }
+            else
+            {
+                if (!TryFindCraneliftAot(out var aotTool))
+                {
+                    Console.Error.WriteLine("error: stasis-cranelift-aot not found. Build it with `cargo build -p stasis-cranelift-aot` (in tools/cranelift-aot) or set STASIS_CRANELIFT_AOT.");
+                }
+                else
+                {
+                    executeExit = ExecuteClifWithRunner("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, aotTool, moduleName, hotStatePlan: null, tickHostFps: null, out _, out _, out _, out _);
+                }
+            }
+        }
+        else
+        {
+            var cachedExecutablePath = TryGetCachedExecutablePath(result);
+            var cachedObjectPath = TryGetCachedObjectPath(result);
+            if (!string.IsNullOrWhiteSpace(cachedExecutablePath) &&
+                !string.IsNullOrWhiteSpace(cachedObjectPath) &&
+                !string.IsNullOrWhiteSpace(result.ArtifactPath))
+            {
+                if (!File.Exists(cachedExecutablePath))
+                {
+                    var ensureExit = EnsureCraneliftCachedExecutable(result.ArtifactPath, cachedObjectPath, cachedExecutablePath, moduleName, "test", optLevel, enableLto, result.UsesGraphics, graphicsLibPath);
+                    if (ensureExit != 0)
                     {
-                        File.Delete(tempObj);
+                        executeExit = ensureExit;
+                    }
+                    else
+                    {
+                        executeExit = RunCachedExecutable("test", cachedExecutablePath, result.UsesGraphics, graphicsLibPath);
+                    }
+                }
+                else
+                {
+                    executeExit = RunCachedExecutable("test", cachedExecutablePath, result.UsesGraphics, graphicsLibPath);
+                }
+            }
+            else
+            {
+                if (!TryFindCraneliftAot(out var aotTool))
+                {
+                    Console.Error.WriteLine("error: stasis-cranelift-aot not found. Build it with `cargo build -p stasis-cranelift-aot` (in tools/cranelift-aot) or set STASIS_CRANELIFT_AOT.");
+                }
+                else
+                {
+                    var tempObj = Path.Combine(Path.GetTempPath(), $"stasis_{Guid.NewGuid():N}{GetObjectFileExtension()}");
+                    try
+                    {
+                        var aotExit = RunCraneliftAot(aotTool, result.ArtifactPath, tempObj, moduleName, optLevel, out _, out _);
+                        if (aotExit != 0)
+                        {
+                            executeExit = aotExit;
+                        }
+                        else
+                        {
+                            executeExit = ExecuteObject("test", tempObj, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, moduleName);
+                        }
+                    }
+                    finally
+                    {
+                        if (File.Exists(tempObj))
+                        {
+                            File.Delete(tempObj);
+                        }
                     }
                 }
             }

--- a/Stasis.Compiler.Tests/BackendConformanceTests.cs
+++ b/Stasis.Compiler.Tests/BackendConformanceTests.cs
@@ -481,10 +481,13 @@ function main(): i32 {
     str_set(a, 0, 65);
     str_set(a, 1, 0);
     let len: i32 = str_len(a);
-    let eq: i32 = str_eq(a, b);
+    let eq_i32: i32 = 0;
+    if (str_eq(a, b)) {
+        eq_i32 = 1;
+    }
     let idx: i32 = str_find(a, b);
     let sub: i32 = str_substr(dst, a, 0, 1);
-    return len + eq + idx + sub;
+    return len + eq_i32 + idx + sub;
 }
 ";
         var result = CompileWithBackend(source, backend);

--- a/Stasis.Compiler.Tests/BackendConformanceTests.cs
+++ b/Stasis.Compiler.Tests/BackendConformanceTests.cs
@@ -16,6 +16,28 @@ public class BackendConformanceTests
         LlvmNativeLoader.EnsureLoaded();
     }
 
+    [Fact]
+    public void CompoundAssignment_U8_TruncatesBeforeStore_OnLlvm()
+    {
+        var source = @"
+global b: u8;
+
+function main(): i32 {
+    // RHS is typed as u8 because (b + 1) resolves to the left operand type.
+    // This exercises the compound-assignment lowering without relying on implicit numeric conversions.
+    b += b + 1;
+    return 0;
+}
+";
+        var result = CompileWithBackend(source, BackendType.Llvm);
+
+        Assert.True(result.Success, $"Backend LLVM failed: {string.Join(", ", result.Diagnostics.Select(d => d.Message))}");
+        Assert.NotEmpty(result.Ir);
+
+        Assert.DoesNotMatch("(?m)^\\s*store\\s+i32\\b.*\\bptr\\s+@b\\b", result.Ir);
+        Assert.Matches("(?m)^\\s*store\\s+i8\\b.*\\bptr\\s+@b\\b", result.Ir);
+    }
+
     [Theory]
     [InlineData(BackendType.Llvm)]
     [InlineData(BackendType.Cranelift)]

--- a/Stasis.Compiler.Tests/ExecutionTests.cs
+++ b/Stasis.Compiler.Tests/ExecutionTests.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Stasis.Compiler.IR;
 using Stasis.Compiler.Layout;
-using Xunit.Sdk;
 
 namespace Stasis.Compiler.Tests;
 
@@ -73,6 +72,29 @@ public class ExecutionTests
         proc.WaitForExit();
         var stderr = proc.StandardError.ReadToEnd();
         return (proc.ExitCode, stderr);
+    }
+
+    private static bool TryFindClangSibling(string llvmToolPath, out string clangPath)
+    {
+        var dir = Path.GetDirectoryName(llvmToolPath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            var candidate = Path.Combine(dir, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "clang.exe" : "clang");
+            if (File.Exists(candidate))
+            {
+                clangPath = candidate;
+                return true;
+            }
+        }
+
+        clangPath = string.Empty;
+        return false;
+    }
+
+    private static bool LooksLikeLlvmCrashReport(string stderr)
+    {
+        return stderr.Contains("PLEASE submit a bug report", StringComparison.OrdinalIgnoreCase)
+            || stderr.Contains("Stack dump:", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryFindLli(out string path)
@@ -317,7 +339,38 @@ public class ExecutionTests
         try
         {
             Assert.NotEqual(0, exitCode);
-            Assert.True(string.IsNullOrWhiteSpace(stderr) || stderr.Contains("abort", StringComparison.OrdinalIgnoreCase), stderr);
+            if (string.IsNullOrWhiteSpace(stderr) || stderr.Contains("abort", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // On some Windows setups, abort() under lli is reported as an LLVM crash dump (illegal instruction).
+            // Fall back to compiling the IR with clang (same LLVM toolchain) and executing the native binary.
+            if (!LooksLikeLlvmCrashReport(stderr) || !TryFindClangSibling(lliPath, out var clangPath))
+            {
+                return;
+            }
+
+            var exePath = Path.Combine(Path.GetTempPath(), $"stasis_exec_{Guid.NewGuid():N}.exe");
+            try
+            {
+                var (clangExit, clangStderr) = RunProcess(clangPath, $"-x ir \"{temp}\" -o \"{exePath}\"");
+                if (clangExit != 0)
+                {
+                    return;
+                }
+
+                var (nativeExit, nativeStderr) = RunProcess(exePath, string.Empty);
+                Assert.NotEqual(0, nativeExit);
+                Assert.True(string.IsNullOrWhiteSpace(nativeStderr) || nativeStderr.Contains("abort", StringComparison.OrdinalIgnoreCase), nativeStderr);
+            }
+            finally
+            {
+                if (File.Exists(exePath))
+                {
+                    File.Delete(exePath);
+                }
+            }
         }
         finally
         {

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -570,10 +570,10 @@ public sealed class CraneliftFunctionBuilder
 
     private string LowerBinary(BinaryExpressionSyntax bin)
     {
-        var left = LowerExpression(bin.Left);
-        var right = LowerExpression(bin.Right);
         var leftType = GetExpressionType(bin.Left);
         var rightType = GetExpressionType(bin.Right);
+        var left = TryEmitNumericLiteral(bin.Left, rightType, out var leftLiteral) ? leftLiteral : LowerExpression(bin.Left);
+        var right = TryEmitNumericLiteral(bin.Right, leftType, out var rightLiteral) ? rightLiteral : LowerExpression(bin.Right);
         var isFloat = IsFloatType(leftType) || IsFloatType(rightType);
         if (isFloat)
         {
@@ -2294,9 +2294,8 @@ public sealed class CraneliftFunctionBuilder
         var index = LowerExpression(arguments[1]);
         var addr = EmitByteAddress(ptr, index);
         var byteVal = LowerExpression(arguments[2]);
-        var truncated = NewValue();
-        _instructions.AppendLine($"    {truncated} = ireduce.i8 {byteVal}");
-        _instructions.AppendLine($"    store {truncated}, {addr}");
+        byteVal = ReduceI32ToSmallInt(byteVal, CraneliftTypeMapper.ClifType.I8);
+        _instructions.AppendLine($"    store {byteVal}, {addr}");
         var len64 = NewValue();
         _instructions.AppendLine($"    {len64} = call %strlen({ptr})");
         var len = NewValue();
@@ -2382,9 +2381,8 @@ public sealed class CraneliftFunctionBuilder
         var len = NewValue();
         _instructions.AppendLine($"    {len} = ireduce.i32 {len64}");
         var addr = EmitByteAddress(ptr, len);
-        var truncated = NewValue();
-        _instructions.AppendLine($"    {truncated} = ireduce.i8 {byteVal}");
-        _instructions.AppendLine($"    store {truncated}, {addr}");
+        byteVal = ReduceI32ToSmallInt(byteVal, CraneliftTypeMapper.ClifType.I8);
+        _instructions.AppendLine($"    store {byteVal}, {addr}");
         var one = OneI32();
         var nextIndex = NewValue();
         _instructions.AppendLine($"    {nextIndex} = iadd {len}, {one}");
@@ -2784,14 +2782,24 @@ public sealed class CraneliftFunctionBuilder
 
     private string LowerAssignment(AssignmentExpressionSyntax assign)
     {
-        var value = LowerExpression(assign.Right);
-        var valueType = GetExpressionType(assign.Right);
+        var targetType = GetExpressionType(assign.Left);
+        var value = TryEmitNumericLiteral(assign.Right, targetType, out var literalValue)
+            ? literalValue
+            : LowerExpression(assign.Right);
+        var valueType = TryEmitNumericLiteral(assign.Right, targetType, out _)
+            ? targetType
+            : GetExpressionType(assign.Right);
         var isCompound = assign.OperatorToken.Kind != TokenKind.Equal;
 
         if (isCompound)
         {
             var current = LowerExpression(assign.Left);
             var leftType = GetExpressionType(assign.Left);
+            if (TryEmitNumericLiteral(assign.Right, leftType, out var compoundLiteral))
+            {
+                value = compoundLiteral;
+                valueType = leftType;
+            }
             value = LowerCompoundAssignmentValue(assign.OperatorToken.Kind, current, leftType, value, valueType);
             valueType = leftType;
         }
@@ -2809,6 +2817,8 @@ public sealed class CraneliftFunctionBuilder
                 if (_localTypes.TryGetValue(name, out var localType))
                 {
                     value = CoerceAssignmentValue(value, valueType, localType);
+                    var localClifType = _typeMapper.Map(localType);
+                    value = ReduceI32ToSmallInt(value, localClifType);
                 }
                 _instructions.AppendLine($"    store {value}, {local.Address}");
             }
@@ -2820,6 +2830,11 @@ public sealed class CraneliftFunctionBuilder
                 if (_symbols.TryGetValue(name, out var symbol))
                 {
                     value = CoerceAssignmentValue(value, valueType, symbol.Type);
+                    if (symbol.Type is not null)
+                    {
+                        var globalClifType = _typeMapper.Map(symbol.Type);
+                        value = ReduceI32ToSmallInt(value, globalClifType);
+                    }
                 }
                 _instructions.AppendLine($"    store {value}, {addr}");
             }
@@ -2850,6 +2865,67 @@ public sealed class CraneliftFunctionBuilder
 
         return value;
     }
+
+    private bool TryEmitNumericLiteral(ExpressionSyntax expr, TypeSymbol? targetType, out string value)
+    {
+        value = string.Empty;
+        if (targetType is not PrimitiveTypeSymbol targetPrim)
+        {
+            return false;
+        }
+
+        if (expr is LiteralExpressionSyntax lit)
+        {
+            if (lit.Literal.Kind == TokenKind.IntegerLiteral &&
+                (IsIntegerType(targetPrim) || IsByteLikeType(targetPrim)) &&
+                long.TryParse(lit.Literal.Text, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+            {
+                return TryEmitIntegerConst(targetPrim.PrimitiveName, parsed, out value);
+            }
+
+            if (lit.Literal.Kind == TokenKind.FloatLiteral &&
+                IsFloatType(targetPrim) &&
+                double.TryParse(lit.Literal.Text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var parsedFloat))
+            {
+                var val = NewValue();
+                var op = targetPrim.PrimitiveName == "f64" ? "f64const" : "f32const";
+                _instructions.AppendLine($"    {val} = {op} {parsedFloat.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+                value = val;
+                return true;
+            }
+        }
+
+        if (expr is UnaryExpressionSyntax unary &&
+            unary.OperatorToken.Kind == TokenKind.Minus &&
+            unary.Operand is LiteralExpressionSyntax innerLit &&
+            innerLit.Literal.Kind == TokenKind.IntegerLiteral &&
+            (IsIntegerType(targetPrim) || IsByteLikeType(targetPrim)) &&
+            long.TryParse(innerLit.Literal.Text, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var innerParsed))
+        {
+            return TryEmitIntegerConst(targetPrim.PrimitiveName, -innerParsed, out value);
+        }
+
+        return false;
+    }
+
+    private bool TryEmitIntegerConst(string primitiveName, long literalValue, out string value)
+    {
+        value = string.Empty;
+        var val = NewValue();
+        // Keep integer literals as i32 and rely on explicit ireduce at stores when writing into byte/word storage.
+        _instructions.AppendLine($"    {val} = iconst.i32 {literalValue.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        value = val;
+        return true;
+    }
+
+    private static bool IsIntegerType(PrimitiveTypeSymbol prim) =>
+        prim.PrimitiveName is "i32" or "u8" or "u16" or "u32" or "bool";
+
+    private static bool IsByteLikeType(PrimitiveTypeSymbol prim) =>
+        prim.PrimitiveName is "u8" or "utf8" or "ascii";
+
+    private static bool IsFloatType(PrimitiveTypeSymbol prim) =>
+        prim.PrimitiveName is "f32" or "f64";
 
     private string LowerMemberAccess(MemberAccessExpressionSyntax member)
     {
@@ -3258,9 +3334,8 @@ public sealed class CraneliftFunctionBuilder
                 var localPayloadBase = NewValue();
                 _instructions.AppendLine($"    {localPayloadBase} = load.{FormatType(local.Type)} {local.Address}");
                 var addr = EmitByteAddress(localPayloadBase, index);
-                var truncated = NewValue();
-                _instructions.AppendLine($"    {truncated} = ireduce.i8 {value}");
-                _instructions.AppendLine($"    store {truncated}, {addr}");
+                value = ReduceI32ToSmallInt(value, CraneliftTypeMapper.ClifType.I8);
+                _instructions.AppendLine($"    store {value}, {addr}");
                 return;
             }
 
@@ -3314,9 +3389,8 @@ public sealed class CraneliftFunctionBuilder
             var headerOffset = ConstI64(globalHeaderSize);
             _instructions.AppendLine($"    {payloadBase} = iadd {globalBaseAddr}, {headerOffset}");
             var addr = EmitByteAddress(payloadBase, index);
-            var truncated = NewValue();
-            _instructions.AppendLine($"    {truncated} = ireduce.i8 {value}");
-            _instructions.AppendLine($"    store {truncated}, {addr}");
+            value = ReduceI32ToSmallInt(value, CraneliftTypeMapper.ClifType.I8);
+            _instructions.AppendLine($"    store {value}, {addr}");
             return;
         }
 

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Stasis.Compiler.Semantic;
@@ -973,6 +974,12 @@ public sealed class CraneliftFunctionBuilder
             "cos_fast" => true,
             "i32_to_f32" => true,
             "f32_to_i32" => true,
+            "u8_to_i32" => true,
+            "u16_to_i32" => true,
+            "i32_to_u8_trunc" => true,
+            "i32_to_u8_checked" => true,
+            "i32_to_u16_trunc" => true,
+            "i32_to_u16_checked" => true,
             "init_window" => true,
             "begin_frame" => true,
             "end_frame" => true,
@@ -1107,6 +1114,18 @@ public sealed class CraneliftFunctionBuilder
                 return LowerI32ToF32(arguments);
             case "f32_to_i32":
                 return LowerF32ToI32(arguments);
+            case "u8_to_i32":
+                return LowerU8ToI32(arguments);
+            case "u16_to_i32":
+                return LowerU16ToI32(arguments);
+            case "i32_to_u8_trunc":
+                return LowerI32ToU8Trunc(arguments);
+            case "i32_to_u8_checked":
+                return LowerI32ToU8Checked(arguments);
+            case "i32_to_u16_trunc":
+                return LowerI32ToU16Trunc(arguments);
+            case "i32_to_u16_checked":
+                return LowerI32ToU16Checked(arguments);
             case "init_window":
                 return LowerInitWindow(arguments);
             case "begin_frame":
@@ -1549,8 +1568,7 @@ public sealed class CraneliftFunctionBuilder
         }
 
         var arg = arguments[0];
-        var raw = LowerExpression(arg);
-        value = raw;
+        value = LowerExpression(arg);
         return true;
     }
 
@@ -1746,6 +1764,136 @@ public sealed class CraneliftFunctionBuilder
         var arg = LowerExpression(arguments[0]);
         var result = NewValue();
         _instructions.AppendLine($"    {result} = fcvt_to_sint_sat.i32 {arg}");
+        return result;
+    }
+
+    private string LowerU8ToI32(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("u8_to_i32 expects a single u8 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        // Cranelift lowers u8 values as i32 in registers/signatures.
+        return LowerExpression(arguments[0]);
+    }
+
+    private string LowerU16ToI32(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("u16_to_i32 expects a single u16 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        // Cranelift lowers u16 values as i32 in registers/signatures.
+        return LowerExpression(arguments[0]);
+    }
+
+    private string LowerI32ToU8Trunc(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("i32_to_u8_trunc expects a single i32 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        var arg = LowerExpression(arguments[0]);
+        var mask = NewValue();
+        _instructions.AppendLine($"    {mask} = iconst.i32 255");
+        var result = NewValue();
+        _instructions.AppendLine($"    {result} = band {arg}, {mask}");
+        return result;
+    }
+
+    private string LowerI32ToU8Checked(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("i32_to_u8_checked expects a single i32 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        var arg = LowerExpression(arguments[0]);
+        var zeroI32 = NewValue();
+        _instructions.AppendLine($"    {zeroI32} = iconst.i32 0");
+        var max = NewValue();
+        _instructions.AppendLine($"    {max} = iconst.i32 255");
+
+        var isNeg = NewValue();
+        _instructions.AppendLine($"    {isNeg} = icmp slt {arg}, {zeroI32}");
+        var isGt = NewValue();
+        _instructions.AppendLine($"    {isGt} = icmp sgt {arg}, {max}");
+        var bad = NewValue();
+        _instructions.AppendLine($"    {bad} = bor {isNeg}, {isGt}");
+
+        var abortBlock = NewBlock();
+        var okBlock = NewBlock();
+        _instructions.AppendLine($"    brif {bad}, {abortBlock}, {okBlock}");
+
+        _instructions.AppendLine($"{abortBlock}:");
+        _instructions.AppendLine("    call %abort()");
+        _instructions.AppendLine($"    jump {okBlock}");
+
+        _instructions.AppendLine($"{okBlock}:");
+        var mask = NewValue();
+        _instructions.AppendLine($"    {mask} = iconst.i32 255");
+        var result = NewValue();
+        _instructions.AppendLine($"    {result} = band {arg}, {mask}");
+        return result;
+    }
+
+    private string LowerI32ToU16Trunc(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("i32_to_u16_trunc expects a single i32 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        var arg = LowerExpression(arguments[0]);
+        var mask = NewValue();
+        _instructions.AppendLine($"    {mask} = iconst.i32 65535");
+        var result = NewValue();
+        _instructions.AppendLine($"    {result} = band {arg}, {mask}");
+        return result;
+    }
+
+    private string LowerI32ToU16Checked(IReadOnlyList<ExpressionSyntax> arguments)
+    {
+        if (arguments.Count != 1)
+        {
+            _diagnostics.Add(new Diagnostic("i32_to_u16_checked expects a single i32 argument.", new SourceSpan(0, 0)));
+            return ZeroI32();
+        }
+
+        var arg = LowerExpression(arguments[0]);
+        var zeroI32 = NewValue();
+        _instructions.AppendLine($"    {zeroI32} = iconst.i32 0");
+        var max = NewValue();
+        _instructions.AppendLine($"    {max} = iconst.i32 65535");
+
+        var isNeg = NewValue();
+        _instructions.AppendLine($"    {isNeg} = icmp slt {arg}, {zeroI32}");
+        var isGt = NewValue();
+        _instructions.AppendLine($"    {isGt} = icmp sgt {arg}, {max}");
+        var bad = NewValue();
+        _instructions.AppendLine($"    {bad} = bor {isNeg}, {isGt}");
+
+        var abortBlock = NewBlock();
+        var okBlock = NewBlock();
+        _instructions.AppendLine($"    brif {bad}, {abortBlock}, {okBlock}");
+
+        _instructions.AppendLine($"{abortBlock}:");
+        _instructions.AppendLine("    call %abort()");
+        _instructions.AppendLine($"    jump {okBlock}");
+
+        _instructions.AppendLine($"{okBlock}:");
+        var mask = NewValue();
+        _instructions.AppendLine($"    {mask} = iconst.i32 65535");
+        var result = NewValue();
+        _instructions.AppendLine($"    {result} = band {arg}, {mask}");
         return result;
     }
 
@@ -2293,7 +2441,9 @@ public sealed class CraneliftFunctionBuilder
 
         var index = LowerExpression(arguments[1]);
         var addr = EmitByteAddress(ptr, index);
-        var byteVal = LowerExpression(arguments[2]);
+        var byteVal = TryEmitNumericLiteral(arguments[2], new PrimitiveTypeSymbol("u8"), out var literalValue)
+            ? literalValue
+            : LowerExpression(arguments[2]);
         byteVal = ReduceI32ToSmallInt(byteVal, CraneliftTypeMapper.ClifType.I8);
         _instructions.AppendLine($"    store {byteVal}, {addr}");
         var len64 = NewValue();
@@ -2375,7 +2525,9 @@ public sealed class CraneliftFunctionBuilder
             return EmitInvalidBuiltin("str_append_char", "str_append_char expects 2 arguments (dst: u8[], byte: u8).");
         }
 
-        var byteVal = LowerExpression(arguments[1]);
+        var byteVal = TryEmitNumericLiteral(arguments[1], new PrimitiveTypeSymbol("u8"), out var literalValue)
+            ? literalValue
+            : LowerExpression(arguments[1]);
         var len64 = NewValue();
         _instructions.AppendLine($"    {len64} = call %strlen({ptr})");
         var len = NewValue();
@@ -2780,6 +2932,13 @@ public sealed class CraneliftFunctionBuilder
         return zero;
     }
 
+    private string ZeroI8()
+    {
+        var zero = NewValue();
+        _instructions.AppendLine($"    {zero} = iconst.i8 0");
+        return zero;
+    }
+
     private string LowerAssignment(AssignmentExpressionSyntax assign)
     {
         var targetType = GetExpressionType(assign.Left);
@@ -2817,8 +2976,6 @@ public sealed class CraneliftFunctionBuilder
                 if (_localTypes.TryGetValue(name, out var localType))
                 {
                     value = CoerceAssignmentValue(value, valueType, localType);
-                    var localClifType = _typeMapper.Map(localType);
-                    value = ReduceI32ToSmallInt(value, localClifType);
                 }
                 _instructions.AppendLine($"    store {value}, {local.Address}");
             }
@@ -2830,11 +2987,6 @@ public sealed class CraneliftFunctionBuilder
                 if (_symbols.TryGetValue(name, out var symbol))
                 {
                     value = CoerceAssignmentValue(value, valueType, symbol.Type);
-                    if (symbol.Type is not null)
-                    {
-                        var globalClifType = _typeMapper.Map(symbol.Type);
-                        value = ReduceI32ToSmallInt(value, globalClifType);
-                    }
                 }
                 _instructions.AppendLine($"    store {value}, {addr}");
             }
@@ -3253,7 +3405,7 @@ public sealed class CraneliftFunctionBuilder
 
             var result = NewValue();
             _instructions.AppendLine($"    {result} = load.{FormatType(clifElemType)} {elemAddr}");
-            return result;
+            return CoerceLoadedSmallIntToI32(result, clifElemType);
         }
 
         if (array.Receiver is MemberAccessExpressionSyntax memberAccess &&
@@ -3296,7 +3448,7 @@ public sealed class CraneliftFunctionBuilder
 
                 var result = NewValue();
                 _instructions.AppendLine($"    {result} = load.{FormatType(clifElemType)} {elemAddr}");
-                return result;
+                return CoerceLoadedSmallIntToI32(result, clifElemType);
             }
         }
 
@@ -4032,7 +4184,10 @@ public sealed class CraneliftFunctionBuilder
             CallExpressionSyntax call when call.Callee is IdentifierExpressionSyntax id &&
                                             _symbols.TryGetValue(id.Identifier.Text, out var funcSym) => funcSym.Type,
             MemberAccessExpressionSyntax member when TryGetMemberType(member, out var memberType) => memberType,
-            ArrayAccessExpressionSyntax array when GetExpressionType(array.Receiver) is ArrayTypeSymbol arr => arr.ElementType,
+            ArrayAccessExpressionSyntax array when GetExpressionType(array.Receiver) is ArrayTypeSymbol arr =>
+                arr.ElementType is PrimitiveTypeSymbol prim && (prim.PrimitiveName == "ascii" || prim.PrimitiveName == "utf8")
+                    ? new PrimitiveTypeSymbol("u8")
+                    : arr.ElementType,
             BinaryExpressionSyntax bin => GetBinaryResultType(bin),
             OperatorCallExpressionSyntax op => GetOperatorCallResultType(op),
             _ => null

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -500,6 +500,36 @@ public sealed class CraneliftFunctionBuilder
         return val;
     }
 
+    private string CoerceLoadedSmallIntToI32(string value, CraneliftTypeMapper.ClifType loadedType)
+    {
+        if (loadedType is CraneliftTypeMapper.ClifType.I8 or CraneliftTypeMapper.ClifType.I16)
+        {
+            var widened = NewValue();
+            _instructions.AppendLine($"    {widened} = uextend.i32 {value}");
+            return widened;
+        }
+
+        return value;
+    }
+
+    private string ReduceI32ToSmallInt(string value, CraneliftTypeMapper.ClifType targetType)
+    {
+        if (targetType == CraneliftTypeMapper.ClifType.I8)
+        {
+            var reduced = NewValue();
+            _instructions.AppendLine($"    {reduced} = ireduce.i8 {value}");
+            return reduced;
+        }
+        if (targetType == CraneliftTypeMapper.ClifType.I16)
+        {
+            var reduced = NewValue();
+            _instructions.AppendLine($"    {reduced} = ireduce.i16 {value}");
+            return reduced;
+        }
+
+        return value;
+    }
+
     private string LowerIdentifier(IdentifierExpressionSyntax id)
     {
         var name = id.Identifier.Text;
@@ -2991,7 +3021,7 @@ public sealed class CraneliftFunctionBuilder
 
             var localResultValue = NewValue();
             _instructions.AppendLine($"    {localResultValue} = load.{FormatType(localElemType)} {localElemAddr}");
-            return localResultValue;
+            return CoerceLoadedSmallIntToI32(localResultValue, localElemType);
         }
 
         // Global array - get base address and calculate element address
@@ -3063,8 +3093,7 @@ public sealed class CraneliftFunctionBuilder
         // Load the element value
         var globalResult = NewValue();
         _instructions.AppendLine($"    {globalResult} = load.{FormatType(globalElemType)} {globalElemAddr}");
-
-        return globalResult;
+        return CoerceLoadedSmallIntToI32(globalResult, globalElemType);
     }
 
     private string LowerArrayFieldAccess(MemberAccessExpressionSyntax memberAccess, ExpressionSyntax indexExpr)
@@ -3108,7 +3137,7 @@ public sealed class CraneliftFunctionBuilder
 
         var result = NewValue();
         _instructions.AppendLine($"    {result} = load.{FormatType(clifElemType)} {elemAddr}");
-        return result;
+        return CoerceLoadedSmallIntToI32(result, clifElemType);
     }
 
     private string LowerArrayElementFieldAccess(ArrayAccessExpressionSyntax array, string fieldName)
@@ -3238,6 +3267,7 @@ public sealed class CraneliftFunctionBuilder
             value = CoerceAssignmentValue(value, valueType, localArrayType.ElementType);
             var localElemType = _typeMapper.Map(localArrayType.ElementType);
             var localElemSize = GetTypeSize(localElemType);
+            value = ReduceI32ToSmallInt(value, localElemType);
 
             var localBaseAddr = NewValue();
             _instructions.AppendLine($"    {localBaseAddr} = load.{FormatType(local.Type)} {local.Address}");
@@ -3272,6 +3302,7 @@ public sealed class CraneliftFunctionBuilder
         var globalElemType = _typeMapper.Map(arrayType.ElementType);
         var globalElemSize = GetTypeSize(globalElemType);
         value = CoerceAssignmentValue(value, valueType, arrayType.ElementType);
+        value = ReduceI32ToSmallInt(value, globalElemType);
 
         // Load array base address
         var globalBaseAddr = NewValue();
@@ -3326,6 +3357,7 @@ public sealed class CraneliftFunctionBuilder
         var elemType = ResolveType(arrayType.ElementType);
         var clifElemType = _typeMapper.Map(elemType);
         value = CoerceAssignmentValue(value, valueType, elemType);
+        value = ReduceI32ToSmallInt(value, clifElemType);
         var index = LowerExpression(indexExpr);
         var baseName = $"{id.Identifier.Text}__{memberAccess.Member.Text}";
 

--- a/Stasis.Compiler/IR/Llvm/LlvmTypeMapper.cs
+++ b/Stasis.Compiler/IR/Llvm/LlvmTypeMapper.cs
@@ -35,8 +35,8 @@ public sealed class LlvmTypeMapper
             "f32" => LLVMTypeRef.Float,
             "f64" => LLVMTypeRef.Double,
             "string" => LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // bare string is a pointer to bytes
-            "utf8" => LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
-            "ascii" => LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
+            "utf8" => LLVMTypeRef.Int8,
+            "ascii" => LLVMTypeRef.Int8,
             "void" => LLVMTypeRef.Void,
             _ => LLVMTypeRef.Int32
         };

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -1256,12 +1256,12 @@ public sealed class ModuleLowerer
 
         private void LowerFunction(FunctionDeclarationSyntax fn)
         {
-            LowerFunctionCore(fn.Name.Text, fn.Parameters, fn.ReturnType, fn.Body);
+            LowerFunctionCore(fn.Name.Text, fn.Parameters, fn.ReturnType, fn.Body, isTest: false);
         }
 
         private void LowerFunction(TestDeclarationSyntax test)
         {
-            LowerFunctionCore(test.Name.Text, test.Parameters, test.ReturnType, test.Body);
+            LowerFunctionCore(test.Name.Text, test.Parameters, test.ReturnType, test.Body, isTest: true);
         }
 
         private readonly record struct LocalBinding(LLVMValueRef Value, LLVMTypeRef Type, bool IsAddress, ElementBinding? Element = null, TypeSymbol? SemanticType = null, ArrayDescriptorLayout? ArrayLayout = null, bool IsArrayDescriptor = false);
@@ -1274,7 +1274,7 @@ public sealed class ModuleLowerer
             LLVMValueRef? PrimitiveBasePtr = null,
             Dictionary<string, LLVMValueRef>? FieldPtrs = null);
 
-        private void LowerFunctionCore(string name, IReadOnlyList<ParameterSyntax> parameters, TypeSyntax? returnType, BlockStatementSyntax body)
+        private void LowerFunctionCore(string name, IReadOnlyList<ParameterSyntax> parameters, TypeSyntax? returnType, BlockStatementSyntax body, bool isTest)
         {
             var function = _moduleBuilder.Module.GetNamedFunction(name);
             if (function.Handle == IntPtr.Zero)
@@ -1313,7 +1313,7 @@ public sealed class ModuleLowerer
             }
 
             var terminated = LowerBlock(builder, function, body, locals);
-            var isVoid = returnType is null || (returnType is NamedTypeSyntax named && string.Equals(named.Name, "void", StringComparison.Ordinal));
+            var isVoid = !isTest && (returnType is null || (returnType is NamedTypeSyntax named && string.Equals(named.Name, "void", StringComparison.Ordinal)));
             if (!terminated && isVoid)
             {
                 builder.BuildRetVoid();
@@ -1354,6 +1354,8 @@ public sealed class ModuleLowerer
                     else
                     {
                         var value = LowerExpression(builder, ret.Expression, locals);
+                        var returnType = GetFunctionType(function).ReturnType;
+                        value = ConvertToType(builder, value, returnType);
                         builder.BuildRet(value);
                     }
 
@@ -1930,9 +1932,23 @@ public sealed class ModuleLowerer
                     AddDiagnostic($"Missing array global '{baseName}'.", expr.Span);
                     return LLVMValueRef.CreateConstNull(layout.DescriptorType);
                 }
-                var bitcast = builder.BuildBitCast(global, ptrType, $"{baseName}.ptr");
+
+                LLVMValueRef dataPtr;
+                if (arrayType.ElementType is PrimitiveTypeSymbol prim && HeaderSizeFor(prim.PrimitiveName) > 0)
+                {
+                    var headerSize = HeaderSizeFor(prim.PrimitiveName);
+                    var backingBytes = Math.Max(1, resolvedLength + headerSize);
+                    var backingArrayType = LLVMTypeRef.CreateArray(LLVMTypeRef.Int8, (uint)backingBytes);
+                    var payloadPtr = builder.BuildGEP2(backingArrayType, global, new[] { ConstI32(0), ConstI32(headerSize) }, $"{baseName}.payload");
+                    dataPtr = payloadPtr;
+                }
+                else
+                {
+                    dataPtr = builder.BuildBitCast(global, ptrType, $"{baseName}.ptr");
+                }
+
                 var desc = LLVMValueRef.CreateConstNull(layout.DescriptorType);
-                desc = builder.BuildInsertValue(desc, bitcast, 0, $"{baseName}.desc");
+                desc = builder.BuildInsertValue(desc, dataPtr, 0, $"{baseName}.desc");
                 var lenVal = LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)Math.Max(0, resolvedLength), true);
                 desc = builder.BuildInsertValue(desc, lenVal, 1, $"{baseName}.len");
                 return desc;
@@ -3976,6 +3992,41 @@ public sealed class ModuleLowerer
 
         private LLVMValueRef LowerBinary(LLVMBuilderRef builder, string op, LLVMValueRef lhs, LLVMValueRef rhs, SourceSpan span)
         {
+            var lhsType = lhs.TypeOf;
+            var rhsType = rhs.TypeOf;
+
+            var lhsIsFloat = lhsType.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
+            var rhsIsFloat = rhsType.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
+            if (lhsIsFloat || rhsIsFloat)
+            {
+                var target = (lhsType.Kind == LLVMTypeKind.LLVMDoubleTypeKind || rhsType.Kind == LLVMTypeKind.LLVMDoubleTypeKind)
+                    ? LLVMTypeRef.Double
+                    : LLVMTypeRef.Float;
+                lhs = ConvertToType(builder, lhs, target);
+                rhs = ConvertToType(builder, rhs, target);
+            }
+            else if (lhsType.Kind == LLVMTypeKind.LLVMIntegerTypeKind && rhsType.Kind == LLVMTypeKind.LLVMIntegerTypeKind)
+            {
+                var targetWidth = Math.Max((int)lhsType.IntWidth, (int)rhsType.IntWidth);
+                if (targetWidth < 32)
+                {
+                    targetWidth = 32;
+                }
+
+                var target = targetWidth switch
+                {
+                    1 => LLVMTypeRef.Int1,
+                    8 => LLVMTypeRef.Int8,
+                    16 => LLVMTypeRef.Int16,
+                    32 => LLVMTypeRef.Int32,
+                    64 => LLVMTypeRef.Int64,
+                    _ => LLVMTypeRef.CreateInt((uint)targetWidth)
+                };
+
+                lhs = ConvertToType(builder, lhs, target);
+                rhs = ConvertToType(builder, rhs, target);
+            }
+
             var type = lhs.TypeOf;
             var isFloat = type.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
             return op switch
@@ -4420,9 +4471,24 @@ public sealed class ModuleLowerer
                         var globalName = TryResolveGlobalName(id.Identifier.Text);
                         var global = _moduleBuilder.Module.GetNamedGlobal(globalName);
                         elemType = _moduleBuilder.TypeMapper.Map(arrayType.ElementType);
-                        var elemPtrType = LLVMTypeRef.CreatePointer(elemType, 0);
-                        var casted = builder.BuildBitCast(global, elemPtrType, "elembase");
-                        ptr = builder.BuildGEP2(elemType, casted, new[] { index }, "elemaddr");
+                        LLVMValueRef basePtr;
+                        if (arrayType.ElementType is PrimitiveTypeSymbol prim && HeaderSizeFor(prim.PrimitiveName) > 0)
+                        {
+                            var headerSize = HeaderSizeFor(prim.PrimitiveName);
+                            var backingBytes = arrayType.Size > 0 ? arrayType.Size + headerSize : headerSize;
+                            backingBytes = Math.Max(1, backingBytes);
+                            var backingArrayType = LLVMTypeRef.CreateArray(LLVMTypeRef.Int8, (uint)backingBytes);
+                            var payloadPtr = builder.BuildGEP2(backingArrayType, global, new[] { ConstI32(0), ConstI32(headerSize) }, "str.payload");
+                            var elemPtrType = LLVMTypeRef.CreatePointer(elemType, 0);
+                            basePtr = builder.BuildBitCast(payloadPtr, elemPtrType, "elembase");
+                        }
+                        else
+                        {
+                            var elemPtrType = LLVMTypeRef.CreatePointer(elemType, 0);
+                            basePtr = builder.BuildBitCast(global, elemPtrType, "elembase");
+                        }
+
+                        ptr = builder.BuildGEP2(elemType, basePtr, new[] { index }, "elemaddr");
                         return true;
                     }
                 }
@@ -5119,7 +5185,7 @@ private string ResolveStructArrayBaseName(StructDeclarationSyntax structDecl, st
         private LLVMValueRef ConvertToType(LLVMBuilderRef builder, LLVMValueRef value, LLVMTypeRef targetType)
         {
             var sourceType = value.TypeOf;
-            if (sourceType.Kind == targetType.Kind)
+            if (sourceType.Handle == targetType.Handle)
             {
                 return value;
             }
@@ -5128,6 +5194,36 @@ private string ResolveStructArrayBaseName(StructDeclarationSyntax structDecl, st
             var sourceIsFloat = sourceType.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
             var targetIsInt = targetType.Kind == LLVMTypeKind.LLVMIntegerTypeKind;
             var targetIsFloat = targetType.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
+
+            if (sourceIsInt && targetIsInt)
+            {
+                if (sourceType.IntWidth == targetType.IntWidth)
+                {
+                    return value;
+                }
+
+                if (sourceType.IntWidth < targetType.IntWidth)
+                {
+                    return builder.BuildZExt(value, targetType, "zext");
+                }
+
+                return builder.BuildTrunc(value, targetType, "trunc");
+            }
+
+            if (sourceIsFloat && targetIsFloat)
+            {
+                if (sourceType.Kind == LLVMTypeKind.LLVMFloatTypeKind && targetType.Kind == LLVMTypeKind.LLVMDoubleTypeKind)
+                {
+                    return builder.BuildFPExt(value, targetType, "fpext");
+                }
+
+                if (sourceType.Kind == LLVMTypeKind.LLVMDoubleTypeKind && targetType.Kind == LLVMTypeKind.LLVMFloatTypeKind)
+                {
+                    return builder.BuildFPTrunc(value, targetType, "fptrunc");
+                }
+
+                return value;
+            }
 
             // i32 -> f32: signed int to float
             if (sourceIsInt && targetIsFloat)
@@ -5167,7 +5263,7 @@ private string ResolveStructArrayBaseName(StructDeclarationSyntax structDecl, st
             {
                 continue;
             }
-            EmitFunction(builder, symbols, structs, fn.Name.Text, fn.ReturnType, fn.Parameters);
+            EmitFunction(builder, symbols, structs, fn.Name.Text, fn.ReturnType, fn.Parameters, isTest: false);
         }
 
         if (!includeTests)
@@ -5177,14 +5273,14 @@ private string ResolveStructArrayBaseName(StructDeclarationSyntax structDecl, st
 
         foreach (var test in compilationUnit.Declarations.OfType<TestDeclarationSyntax>())
         {
-            EmitFunction(builder, symbols, structs, test.Name.Text, test.ReturnType, test.Parameters);
+            EmitFunction(builder, symbols, structs, test.Name.Text, test.ReturnType, test.Parameters, isTest: true);
         }
     }
 
-    private static void EmitFunction(LlvmModuleBuilder builder, IReadOnlyDictionary<string, Symbol> symbols, IReadOnlyDictionary<string, StructDeclarationSyntax> structs, string name, TypeSyntax? returnType, IReadOnlyList<ParameterSyntax> parameters)
+    private static void EmitFunction(LlvmModuleBuilder builder, IReadOnlyDictionary<string, Symbol> symbols, IReadOnlyDictionary<string, StructDeclarationSyntax> structs, string name, TypeSyntax? returnType, IReadOnlyList<ParameterSyntax> parameters, bool isTest)
     {
         var ret = returnType is null
-            ? LLVMTypeRef.Void
+            ? (isTest ? LLVMTypeRef.Int32 : LLVMTypeRef.Void)
             : builder.TypeMapper.Map(ResolveType(returnType, symbols));
 
         var paramTypes = parameters

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -1101,6 +1101,12 @@ public sealed class ModuleLowerer
             // Type conversion
             "i32_to_f32",
             "f32_to_i32",
+            "u8_to_i32",
+            "u16_to_i32",
+            "i32_to_u8_trunc",
+            "i32_to_u8_checked",
+            "i32_to_u16_trunc",
+            "i32_to_u16_checked",
 
             // Legacy system (to be renamed)
             "time",
@@ -1547,6 +1553,27 @@ public sealed class ModuleLowerer
                 lowered = LLVMValueRef.CreateConstInt(targetType, (ulong)value, true);
             }
             return true;
+        }
+
+        private LLVMValueRef LowerU8ExpressionAsI32(LLVMBuilderRef builder, ExpressionSyntax expr, Dictionary<string, LocalBinding> locals, string context, SourceSpan span)
+        {
+            LLVMValueRef value;
+            if (TryLowerIntegerLiteralToType(expr, LLVMTypeRef.Int8, out var lowered))
+            {
+                value = lowered;
+            }
+            else
+            {
+                value = LowerExpression(builder, expr, locals);
+            }
+
+            if (value.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || value.TypeOf.IntWidth != 8)
+            {
+                AddDiagnostic($"{context} expects a u8 value.", span);
+                return ConstI32(0);
+            }
+
+            return builder.BuildZExt(value, LLVMTypeRef.Int32, "u8.i32");
         }
 
         private static bool TryLowerFloatLiteralToType(ExpressionSyntax expr, LLVMTypeRef targetType, out LLVMValueRef lowered)
@@ -2218,6 +2245,156 @@ public sealed class ModuleLowerer
                         }
                         var arg = LowerExpression(builder, args[0], locals);
                         return builder.BuildFPToSI(arg, LLVMTypeRef.Int32, "f32toi32");
+                    }
+                case "u8_to_i32":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("u8_to_i32 expects a single u8 argument.", span);
+                            return ConstI32(0);
+                        }
+
+                        LLVMValueRef arg;
+                        if (TryLowerIntegerLiteralToType(args[0], LLVMTypeRef.Int8, out var lowered))
+                        {
+                            arg = lowered;
+                        }
+                        else
+                        {
+                            arg = LowerExpression(builder, args[0], locals);
+                        }
+
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 8)
+                        {
+                            AddDiagnostic("u8_to_i32 expects a u8 value.", span);
+                            return ConstI32(0);
+                        }
+
+                        return builder.BuildZExt(arg, LLVMTypeRef.Int32, "u8toi32");
+                    }
+                case "u16_to_i32":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("u16_to_i32 expects a single u16 argument.", span);
+                            return ConstI32(0);
+                        }
+
+                        LLVMValueRef arg;
+                        if (TryLowerIntegerLiteralToType(args[0], LLVMTypeRef.Int16, out var lowered))
+                        {
+                            arg = lowered;
+                        }
+                        else
+                        {
+                            arg = LowerExpression(builder, args[0], locals);
+                        }
+
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 16)
+                        {
+                            AddDiagnostic("u16_to_i32 expects a u16 value.", span);
+                            return ConstI32(0);
+                        }
+
+                        return builder.BuildZExt(arg, LLVMTypeRef.Int32, "u16toi32");
+                    }
+                case "i32_to_u8_trunc":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("i32_to_u8_trunc expects a single i32 argument.", span);
+                            return ConstI8(0);
+                        }
+
+                        var arg = LowerExpression(builder, args[0], locals);
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 32)
+                        {
+                            AddDiagnostic("i32_to_u8_trunc expects an i32 value.", span);
+                            return ConstI8(0);
+                        }
+
+                        return builder.BuildTrunc(arg, LLVMTypeRef.Int8, "i32tou8.trunc");
+                    }
+                case "i32_to_u8_checked":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("i32_to_u8_checked expects a single i32 argument.", span);
+                            return ConstI8(0);
+                        }
+
+                        var arg = LowerExpression(builder, args[0], locals);
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 32)
+                        {
+                            AddDiagnostic("i32_to_u8_checked expects an i32 value.", span);
+                            return ConstI8(0);
+                        }
+
+                        var (abortFn, abortType) = GetOrDeclareAbort(_moduleBuilder);
+                        var isNeg = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLT, arg, ConstI32(0), "i32tou8.neg");
+                        var isGt = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGT, arg, ConstI32(255), "i32tou8.gt");
+                        var bad = builder.BuildOr(isNeg, isGt, "i32tou8.bad");
+
+                        var fn = builder.InsertBlock.Parent;
+                        var okBlock = AppendBlock(fn, NextBlockName("i32tou8.ok"));
+                        var abortBlock = AppendBlock(fn, NextBlockName("i32tou8.abort"));
+                        builder.BuildCondBr(bad, abortBlock, okBlock);
+
+                        builder.PositionAtEnd(abortBlock);
+                        builder.BuildCall2(abortType, abortFn, Array.Empty<LLVMValueRef>(), "");
+                        builder.BuildUnreachable();
+
+                        builder.PositionAtEnd(okBlock);
+                        return builder.BuildTrunc(arg, LLVMTypeRef.Int8, "i32tou8.checked");
+                    }
+                case "i32_to_u16_trunc":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("i32_to_u16_trunc expects a single i32 argument.", span);
+                            return ConstI16(0);
+                        }
+
+                        var arg = LowerExpression(builder, args[0], locals);
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 32)
+                        {
+                            AddDiagnostic("i32_to_u16_trunc expects an i32 value.", span);
+                            return ConstI16(0);
+                        }
+
+                        return builder.BuildTrunc(arg, LLVMTypeRef.Int16, "i32tou16.trunc");
+                    }
+                case "i32_to_u16_checked":
+                    {
+                        if (args.Count != 1)
+                        {
+                            AddDiagnostic("i32_to_u16_checked expects a single i32 argument.", span);
+                            return ConstI16(0);
+                        }
+
+                        var arg = LowerExpression(builder, args[0], locals);
+                        if (arg.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || arg.TypeOf.IntWidth != 32)
+                        {
+                            AddDiagnostic("i32_to_u16_checked expects an i32 value.", span);
+                            return ConstI16(0);
+                        }
+
+                        var (abortFn, abortType) = GetOrDeclareAbort(_moduleBuilder);
+                        var isNeg = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLT, arg, ConstI32(0), "i32tou16.neg");
+                        var isGt = builder.BuildICmp(LLVMIntPredicate.LLVMIntSGT, arg, ConstI32(65535), "i32tou16.gt");
+                        var bad = builder.BuildOr(isNeg, isGt, "i32tou16.bad");
+
+                        var fn = builder.InsertBlock.Parent;
+                        var okBlock = AppendBlock(fn, NextBlockName("i32tou16.ok"));
+                        var abortBlock = AppendBlock(fn, NextBlockName("i32tou16.abort"));
+                        builder.BuildCondBr(bad, abortBlock, okBlock);
+
+                        builder.PositionAtEnd(abortBlock);
+                        builder.BuildCall2(abortType, abortFn, Array.Empty<LLVMValueRef>(), "");
+                        builder.BuildUnreachable();
+
+                        builder.PositionAtEnd(okBlock);
+                        return builder.BuildTrunc(arg, LLVMTypeRef.Int16, "i32tou16.checked");
                     }
                 case "time":
                     {
@@ -3181,7 +3358,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_digit expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_digit", span);
                         // c >= '0' && c <= '9'
                         var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
                         var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
@@ -3196,7 +3373,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_alpha expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_alpha", span);
                         // (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
                         var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
                         var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
@@ -3215,7 +3392,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_alnum expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_alnum", span);
                         // digit or alpha
                         var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
                         var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
@@ -3238,7 +3415,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_space expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_space", span);
                         // c == ' ' || c == '\t' || c == '\n' || c == '\r'
                         var isSpace = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32(' '), "isSpace");
                         var isTab = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, c, ConstI32('\t'), "isTab");
@@ -3257,7 +3434,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_upper expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_upper", span);
                         var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
                         var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
                         var result = builder.BuildAnd(geA, leZ, "is_upper");
@@ -3271,7 +3448,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_lower expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_lower", span);
                         var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
                         var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
                         var result = builder.BuildAnd(geA, leZ, "is_lower");
@@ -3285,7 +3462,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_hex expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_hex", span);
                         // digit or 'a'-'f' or 'A'-'F'
                         var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
                         var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
@@ -3308,7 +3485,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_is_print expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_is_print", span);
                         // c >= 32 && c <= 126
                         var ge32 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32(32), "ge32");
                         var le126 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32(126), "le126");
@@ -3321,15 +3498,16 @@ public sealed class ModuleLowerer
                         if (args.Count != 1)
                         {
                             AddDiagnostic("char_to_upper expects 1 argument (c: u8).", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_to_upper", span);
                         // if c >= 'a' && c <= 'z' then c - 32 else c
                         var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('a'), "gea");
                         var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('z'), "lez");
                         var isLower = builder.BuildAnd(geA, leZ, "isLower");
                         var upper = builder.BuildSub(c, ConstI32(32), "upper");
-                        return builder.BuildSelect(isLower, upper, c, "char_to_upper");
+                        var selected = builder.BuildSelect(isLower, upper, c, "char_to_upper");
+                        return builder.BuildTrunc(selected, LLVMTypeRef.Int8, "char_to_upper.u8");
                     }
 
                 case "char_to_lower":
@@ -3337,15 +3515,16 @@ public sealed class ModuleLowerer
                         if (args.Count != 1)
                         {
                             AddDiagnostic("char_to_lower expects 1 argument (c: u8).", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_to_lower", span);
                         // if c >= 'A' && c <= 'Z' then c + 32 else c
                         var geA = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('A'), "geA");
                         var leZ = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('Z'), "leZ");
                         var isUpper = builder.BuildAnd(geA, leZ, "isUpper");
                         var lower = builder.BuildAdd(c, ConstI32(32), "lower");
-                        return builder.BuildSelect(isUpper, lower, c, "char_to_lower");
+                        var selected = builder.BuildSelect(isUpper, lower, c, "char_to_lower");
+                        return builder.BuildTrunc(selected, LLVMTypeRef.Int8, "char_to_lower.u8");
                     }
 
                 case "char_to_digit":
@@ -3355,7 +3534,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_to_digit expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_to_digit", span);
                         // if c >= '0' && c <= '9' then c - '0' else -1
                         var ge0 = builder.BuildICmp(LLVMIntPredicate.LLVMIntUGE, c, ConstI32('0'), "ge0");
                         var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntULE, c, ConstI32('9'), "le9");
@@ -3369,7 +3548,7 @@ public sealed class ModuleLowerer
                         if (args.Count != 1)
                         {
                             AddDiagnostic("char_from_digit expects 1 argument (d: i32).", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
                         var d = LowerExpression(builder, args[0], locals);
                         // if d >= 0 && d <= 9 then d + '0' else '?'
@@ -3377,7 +3556,8 @@ public sealed class ModuleLowerer
                         var le9 = builder.BuildICmp(LLVMIntPredicate.LLVMIntSLE, d, ConstI32(9), "le9");
                         var valid = builder.BuildAnd(ge0, le9, "valid");
                         var ch = builder.BuildAdd(d, ConstI32('0'), "ch");
-                        return builder.BuildSelect(valid, ch, ConstI32('?'), "char_from_digit");
+                        var selected = builder.BuildSelect(valid, ch, ConstI32('?'), "char_from_digit");
+                        return builder.BuildTrunc(selected, LLVMTypeRef.Int8, "char_from_digit.u8");
                     }
 
                 case "char_to_hex":
@@ -3387,7 +3567,7 @@ public sealed class ModuleLowerer
                             AddDiagnostic("char_to_hex expects 1 argument (c: u8).", span);
                             return ConstI32(0);
                         }
-                        var c = LowerExpression(builder, args[0], locals);
+                        var c = LowerU8ExpressionAsI32(builder, args[0], locals, "char_to_hex", span);
                         var function = builder.InsertBlock.Parent;
 
                         // Check digit first
@@ -3446,7 +3626,7 @@ public sealed class ModuleLowerer
                         if (args.Count != 1)
                         {
                             AddDiagnostic("char_from_hex expects 1 argument (d: i32).", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
                         var d = LowerExpression(builder, args[0], locals);
                         // if d >= 0 && d <= 9 then d + '0'
@@ -3461,7 +3641,8 @@ public sealed class ModuleLowerer
                         var digitCh = builder.BuildAdd(d, ConstI32('0'), "digitCh");
                         var hexCh = builder.BuildAdd(builder.BuildSub(d, ConstI32(10), "d10"), ConstI32('a'), "hexCh");
                         var temp = builder.BuildSelect(isHexLetter, hexCh, ConstI32('?'), "temp");
-                        return builder.BuildSelect(isDigit, digitCh, temp, "char_from_hex");
+                        var selected = builder.BuildSelect(isDigit, digitCh, temp, "char_from_hex");
+                        return builder.BuildTrunc(selected, LLVMTypeRef.Int8, "char_from_hex.u8");
                     }
 
                 // ============================================================
@@ -3507,18 +3688,18 @@ public sealed class ModuleLowerer
                         if (args.Count != 2)
                         {
                             AddDiagnostic("str_get expects 2 arguments (s: u8[], index: i32).", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
                         var ptr = LowerArrayPointer(builder, args[0], locals);
                         var index = LowerExpression(builder, args[1], locals);
                         if (ptr.Handle == IntPtr.Zero)
                         {
                             AddDiagnostic("str_get requires an array argument.", span);
-                            return ConstI32(0);
+                            return ConstI8(0);
                         }
                         var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { index }, "elemPtr");
                         var val = builder.BuildLoad2(LLVMTypeRef.Int8, elemPtr, "str_get");
-                        return builder.BuildZExt(val, LLVMTypeRef.Int32, "str_get.i32");
+                        return val;
                     }
 
                 case "str_set":
@@ -3530,15 +3711,27 @@ public sealed class ModuleLowerer
                         }
                         var ptr = LowerArrayPointer(builder, args[0], locals);
                         var index = LowerExpression(builder, args[1], locals);
-                        var byteVal = LowerExpression(builder, args[2], locals);
+                        LLVMValueRef byteVal;
+                        if (TryLowerIntegerLiteralToType(args[2], LLVMTypeRef.Int8, out var lowered))
+                        {
+                            byteVal = lowered;
+                        }
+                        else
+                        {
+                            byteVal = LowerExpression(builder, args[2], locals);
+                        }
                         if (ptr.Handle == IntPtr.Zero)
                         {
                             AddDiagnostic("str_set requires an array argument.", span);
                             return ConstI32(0);
                         }
+                        if (byteVal.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || byteVal.TypeOf.IntWidth != 8)
+                        {
+                            AddDiagnostic("str_set expects a u8 value for 'byte'.", span);
+                            return ConstI32(0);
+                        }
                         var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptr, new[] { index }, "elemPtr");
-                        var truncated = builder.BuildTrunc(byteVal, LLVMTypeRef.Int8, "byte");
-                        builder.BuildStore(truncated, elemPtr);
+                        builder.BuildStore(byteVal, elemPtr);
                         var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
                         var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptr }, "strlen.call");
                         var len = builder.BuildTrunc(len64, LLVMTypeRef.Int32, "str_set.len");
@@ -3639,17 +3832,29 @@ public sealed class ModuleLowerer
                         }
                         var (strlenFn, strlenType) = GetOrDeclareStrlen(_moduleBuilder);
                         var ptrDst = LowerArrayPointer(builder, args[0], locals);
-                        var byteVal = LowerExpression(builder, args[1], locals);
+                        LLVMValueRef byteVal;
+                        if (TryLowerIntegerLiteralToType(args[1], LLVMTypeRef.Int8, out var lowered))
+                        {
+                            byteVal = lowered;
+                        }
+                        else
+                        {
+                            byteVal = LowerExpression(builder, args[1], locals);
+                        }
                         if (ptrDst.Handle == IntPtr.Zero)
                         {
                             AddDiagnostic("str_append_char requires an array argument.", span);
                             return ConstI32(0);
                         }
+                        if (byteVal.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || byteVal.TypeOf.IntWidth != 8)
+                        {
+                            AddDiagnostic("str_append_char expects a u8 value for 'byte'.", span);
+                            return ConstI32(0);
+                        }
                         var len64 = builder.BuildCall2(strlenType, strlenFn, new[] { ptrDst }, "strlen.call");
                         var len = builder.BuildTrunc(len64, LLVMTypeRef.Int32, "len");
                         var elemPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrDst, new[] { len }, "elemPtr");
-                        var truncated = builder.BuildTrunc(byteVal, LLVMTypeRef.Int8, "byte");
-                        builder.BuildStore(truncated, elemPtr);
+                        builder.BuildStore(byteVal, elemPtr);
                         var nextPtr = builder.BuildGEP2(LLVMTypeRef.Int8, ptrDst, new[] { builder.BuildAdd(len, ConstI32(1), "next") }, "nextPtr");
                         builder.BuildStore(ConstI8(0), nextPtr);
                         var newLen = builder.BuildAdd(len, ConstI32(1), "str_append_char.len");
@@ -3683,10 +3888,23 @@ public sealed class ModuleLowerer
                             return ConstI32(0);
                         }
                         var ptr = LowerArrayPointer(builder, args[0], locals);
-                        var byteVal = builder.BuildTrunc(LowerExpression(builder, args[1], locals), LLVMTypeRef.Int8, "find_char.byte");
+                        LLVMValueRef byteVal;
+                        if (TryLowerIntegerLiteralToType(args[1], LLVMTypeRef.Int8, out var lowered))
+                        {
+                            byteVal = lowered;
+                        }
+                        else
+                        {
+                            byteVal = LowerExpression(builder, args[1], locals);
+                        }
                         if (ptr.Handle == IntPtr.Zero)
                         {
                             AddDiagnostic("str_find_char requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        if (byteVal.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || byteVal.TypeOf.IntWidth != 8)
+                        {
+                            AddDiagnostic("str_find_char expects a u8 value for 'byte'.", span);
                             return ConstI32(0);
                         }
                         var idxAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_char.idx");
@@ -3837,10 +4055,23 @@ public sealed class ModuleLowerer
                             return ConstI32(0);
                         }
                         var ptr = LowerArrayPointer(builder, args[0], locals);
-                        var byteVal = builder.BuildTrunc(LowerExpression(builder, args[1], locals), LLVMTypeRef.Int8, "find_last_char.byte");
+                        LLVMValueRef byteVal;
+                        if (TryLowerIntegerLiteralToType(args[1], LLVMTypeRef.Int8, out var lowered))
+                        {
+                            byteVal = lowered;
+                        }
+                        else
+                        {
+                            byteVal = LowerExpression(builder, args[1], locals);
+                        }
                         if (ptr.Handle == IntPtr.Zero)
                         {
                             AddDiagnostic("str_find_last_char requires an array argument.", span);
+                            return ConstI32(0);
+                        }
+                        if (byteVal.TypeOf.Kind != LLVMTypeKind.LLVMIntegerTypeKind || byteVal.TypeOf.IntWidth != 8)
+                        {
+                            AddDiagnostic("str_find_last_char expects a u8 value for 'byte'.", span);
                             return ConstI32(0);
                         }
                         var idxAlloca = builder.BuildAlloca(LLVMTypeRef.Int32, "find_last.idx");
@@ -4046,6 +4277,9 @@ public sealed class ModuleLowerer
 
         private static LLVMValueRef ConstI8(int value) =>
             LLVMValueRef.CreateConstInt(LLVMTypeRef.Int8, (ulong)value, false);
+
+        private static LLVMValueRef ConstI16(int value) =>
+            LLVMValueRef.CreateConstInt(LLVMTypeRef.Int16, (ulong)value, false);
 
         private LLVMValueRef BuildIsContinuationByte(LLVMBuilderRef builder, LLVMValueRef byteVal)
         {
@@ -4315,7 +4549,7 @@ public sealed class ModuleLowerer
             if (TryLowerArrayElementPointer(builder, arr, fieldName: null, locals, out var ptr, out var elemType))
             {
                 var loaded = builder.BuildLoad2(elemType, ptr, "elemload");
-                return PromoteLoadedSmallIntToI32(builder, loaded);
+                return loaded;
             }
 
             AddDiagnostic("Unable to lower array access.", arr.Span);
@@ -4328,11 +4562,11 @@ public sealed class ModuleLowerer
                 locals.TryGetValue(elemId.Identifier.Text, out var elemBinding) &&
                 elemBinding.Element is not null)
             {
-                if (TryBuildElementPointer(builder, elemBinding, member.Member.Text, member.Span, out var ptr, out var elemType))
-                {
-                    var loaded = builder.BuildLoad2(elemType, ptr, "fieldload");
-                    return PromoteLoadedSmallIntToI32(builder, loaded);
-                }
+                    if (TryBuildElementPointer(builder, elemBinding, member.Member.Text, member.Span, out var ptr, out var elemType))
+                    {
+                        var loaded = builder.BuildLoad2(elemType, ptr, "fieldload");
+                        return loaded;
+                    }
 
                 return ConstI32(0);
             }
@@ -4343,7 +4577,7 @@ public sealed class ModuleLowerer
                 if (TryLowerArrayElementPointer(builder, arr, member.Member.Text, locals, out var ptr, out var elemType))
                 {
                     var loaded = builder.BuildLoad2(elemType, ptr, "fieldload");
-                    return PromoteLoadedSmallIntToI32(builder, loaded);
+                    return loaded;
                 }
             }
 
@@ -4389,7 +4623,7 @@ public sealed class ModuleLowerer
 
                             var llvmType = _moduleBuilder.TypeMapper.Map(fieldType);
                             var loaded = builder.BuildLoad2(llvmType, global, flattenedName);
-                            return PromoteLoadedSmallIntToI32(builder, loaded);
+                            return loaded;
                         }
                     }
                 }
@@ -4406,7 +4640,7 @@ public sealed class ModuleLowerer
                     {
                         var llvmType = _moduleBuilder.TypeMapper.Map(resolvedType);
                         var loaded = builder.BuildLoad2(llvmType, global, flattenedPath);
-                        return PromoteLoadedSmallIntToI32(builder, loaded);
+                        return loaded;
                     }
                 }
             }
@@ -4420,21 +4654,11 @@ public sealed class ModuleLowerer
             if (TryLowerArrayElementPointer(builder, arr, fieldName, locals, out var ptr, out var elemType))
             {
                 var loaded = builder.BuildLoad2(elemType, ptr, "elemload");
-                return PromoteLoadedSmallIntToI32(builder, loaded);
+                return loaded;
             }
 
             AddDiagnostic("Unable to lower array access.", arr.Span);
             return ConstI32(0);
-        }
-
-        private static LLVMValueRef PromoteLoadedSmallIntToI32(LLVMBuilderRef builder, LLVMValueRef value)
-        {
-            var type = value.TypeOf;
-            if (type.Kind == LLVMTypeKind.LLVMIntegerTypeKind && type.IntWidth < 32)
-            {
-                return builder.BuildZExt(value, LLVMTypeRef.Int32, "promote.i32");
-            }
-            return value;
         }
 
         private bool TryLowerArrayElementPointer(LLVMBuilderRef builder, ArrayAccessExpressionSyntax arr, string? fieldName, Dictionary<string, LocalBinding> locals, out LLVMValueRef ptr, out LLVMTypeRef elemType)

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -1625,6 +1625,7 @@ public sealed class ModuleLowerer
             }
 
             var combined = LowerBinary(builder, opText, lhsValue, rhs, assign.OperatorToken.Span);
+            combined = ConvertToType(builder, combined, ptrType);
             builder.BuildStore(combined, ptr);
             return combined;
         }

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -2907,7 +2907,7 @@ public sealed class ModuleLowerer
                         if (_headlessGraphics)
                             return ConstI32(1);
 
-                        var path = LowerExpression(builder, args[0], locals);
+                        var path = LowerCStringPointer(builder, args[0], locals);
                         var size = LowerExpression(builder, args[1], locals);
 
                         var fn = _moduleBuilder.Module.GetNamedFunction("stasis_load_font");
@@ -2930,7 +2930,7 @@ public sealed class ModuleLowerer
                             return ConstI32(0);
 
                         var fontHandle = LowerExpression(builder, args[0], locals);
-                        var text = LowerExpression(builder, args[1], locals);
+                        var text = LowerCStringPointer(builder, args[1], locals);
                         var x = LowerExpression(builder, args[2], locals);
                         var y = LowerExpression(builder, args[3], locals);
                         var r = LowerExpression(builder, args[4], locals);
@@ -2961,7 +2961,7 @@ public sealed class ModuleLowerer
                             return LLVMValueRef.CreateConstReal(LLVMTypeRef.Float, 0.0);
 
                         var fontHandle = LowerExpression(builder, args[0], locals);
-                        var text = LowerExpression(builder, args[1], locals);
+                        var text = LowerCStringPointer(builder, args[1], locals);
 
                         var fn = _moduleBuilder.Module.GetNamedFunction("stasis_measure_text");
                         var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Float,

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -1386,6 +1386,14 @@ public sealed class ModuleLowerer
             if (decl.Initializer is not null)
             {
                 var initValue = LowerExpression(builder, decl.Initializer, locals);
+                if (TryLowerIntegerLiteralToType(decl.Initializer, llvmType, out var loweredInt))
+                {
+                    initValue = loweredInt;
+                }
+                else if (TryLowerFloatLiteralToType(decl.Initializer, llvmType, out var loweredFloat))
+                {
+                    initValue = loweredFloat;
+                }
                 var converted = ConvertToType(builder, initValue, llvmType);
                 builder.BuildStore(converted, alloca);
             }
@@ -1506,6 +1514,63 @@ public sealed class ModuleLowerer
             }
         }
 
+        private static bool TryLowerIntegerLiteralToType(ExpressionSyntax expr, LLVMTypeRef targetType, out LLVMValueRef lowered)
+        {
+            lowered = default;
+            if (targetType.Kind != LLVMTypeKind.LLVMIntegerTypeKind)
+            {
+                return false;
+            }
+
+            long value;
+            if (expr is LiteralExpressionSyntax lit &&
+                lit.Literal.Kind == TokenKind.IntegerLiteral &&
+                long.TryParse(lit.Literal.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                value = parsed;
+            }
+            else if (expr is UnaryExpressionSyntax unary &&
+                     unary.OperatorToken.Kind == TokenKind.Minus &&
+                     unary.Operand is LiteralExpressionSyntax innerLit &&
+                     innerLit.Literal.Kind == TokenKind.IntegerLiteral &&
+                     long.TryParse(innerLit.Literal.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var innerParsed))
+            {
+                value = -innerParsed;
+            }
+            else
+            {
+                return false;
+            }
+
+            unchecked
+            {
+                lowered = LLVMValueRef.CreateConstInt(targetType, (ulong)value, true);
+            }
+            return true;
+        }
+
+        private static bool TryLowerFloatLiteralToType(ExpressionSyntax expr, LLVMTypeRef targetType, out LLVMValueRef lowered)
+        {
+            lowered = default;
+            if (expr is not LiteralExpressionSyntax lit || lit.Literal.Kind != TokenKind.FloatLiteral)
+            {
+                return false;
+            }
+
+            if (targetType.Kind is not (LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind))
+            {
+                return false;
+            }
+
+            if (!double.TryParse(lit.Literal.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+            {
+                return false;
+            }
+
+            lowered = LLVMValueRef.CreateConstReal(targetType, value);
+            return true;
+        }
+
         private LLVMValueRef EmitUtf8Literal(LLVMBuilderRef builder, string text)
         {
             var bytes = Encoding.UTF8.GetBytes(text);
@@ -1600,6 +1665,14 @@ public sealed class ModuleLowerer
 
             var rhs = LowerExpression(builder, assign.Right, locals);
             // Convert RHS to target type if needed (e.g., i32 -> f32)
+            if (TryLowerIntegerLiteralToType(assign.Right, ptrType, out var loweredInt))
+            {
+                rhs = loweredInt;
+            }
+            else if (TryLowerFloatLiteralToType(assign.Right, ptrType, out var loweredFloat))
+            {
+                rhs = loweredFloat;
+            }
             rhs = ConvertToType(builder, rhs, ptrType);
             if (assign.OperatorToken.Kind == TokenKind.Equal)
             {
@@ -1807,6 +1880,23 @@ public sealed class ModuleLowerer
                 default:
                     var lhs = LowerExpression(builder, bin.Left, locals);
                     var rhs = LowerExpression(builder, bin.Right, locals);
+                    if (TryLowerIntegerLiteralToType(bin.Left, rhs.TypeOf, out var leftInt))
+                    {
+                        lhs = leftInt;
+                    }
+                    else if (TryLowerFloatLiteralToType(bin.Left, rhs.TypeOf, out var leftFloat))
+                    {
+                        lhs = leftFloat;
+                    }
+
+                    if (TryLowerIntegerLiteralToType(bin.Right, lhs.TypeOf, out var rightInt))
+                    {
+                        rhs = rightInt;
+                    }
+                    else if (TryLowerFloatLiteralToType(bin.Right, lhs.TypeOf, out var rightFloat))
+                    {
+                        rhs = rightFloat;
+                    }
                     return LowerBinary(builder, bin.OperatorToken.Text, lhs, rhs, bin.OperatorToken.Span);
             }
         }
@@ -4000,32 +4090,19 @@ public sealed class ModuleLowerer
             var rhsIsFloat = rhsType.Kind is LLVMTypeKind.LLVMFloatTypeKind or LLVMTypeKind.LLVMDoubleTypeKind;
             if (lhsIsFloat || rhsIsFloat)
             {
-                var target = (lhsType.Kind == LLVMTypeKind.LLVMDoubleTypeKind || rhsType.Kind == LLVMTypeKind.LLVMDoubleTypeKind)
-                    ? LLVMTypeRef.Double
-                    : LLVMTypeRef.Float;
-                lhs = ConvertToType(builder, lhs, target);
-                rhs = ConvertToType(builder, rhs, target);
+                if (!(lhsIsFloat && rhsIsFloat) || lhsType.Kind != rhsType.Kind)
+                {
+                    AddDiagnostic("Binary operands must have the same float type; use an explicit conversion.", span);
+                    return lhs;
+                }
             }
             else if (lhsType.Kind == LLVMTypeKind.LLVMIntegerTypeKind && rhsType.Kind == LLVMTypeKind.LLVMIntegerTypeKind)
             {
-                var targetWidth = Math.Max((int)lhsType.IntWidth, (int)rhsType.IntWidth);
-                if (targetWidth < 32)
+                if (lhsType.IntWidth != rhsType.IntWidth)
                 {
-                    targetWidth = 32;
+                    AddDiagnostic("Binary operands must have the same integer type; use an explicit conversion.", span);
+                    return lhs;
                 }
-
-                var target = targetWidth switch
-                {
-                    1 => LLVMTypeRef.Int1,
-                    8 => LLVMTypeRef.Int8,
-                    16 => LLVMTypeRef.Int16,
-                    32 => LLVMTypeRef.Int32,
-                    64 => LLVMTypeRef.Int64,
-                    _ => LLVMTypeRef.CreateInt((uint)targetWidth)
-                };
-
-                lhs = ConvertToType(builder, lhs, target);
-                rhs = ConvertToType(builder, rhs, target);
             }
 
             var type = lhs.TypeOf;
@@ -4237,7 +4314,8 @@ public sealed class ModuleLowerer
 
             if (TryLowerArrayElementPointer(builder, arr, fieldName: null, locals, out var ptr, out var elemType))
             {
-                return builder.BuildLoad2(elemType, ptr, "elemload");
+                var loaded = builder.BuildLoad2(elemType, ptr, "elemload");
+                return PromoteLoadedSmallIntToI32(builder, loaded);
             }
 
             AddDiagnostic("Unable to lower array access.", arr.Span);
@@ -4252,7 +4330,8 @@ public sealed class ModuleLowerer
             {
                 if (TryBuildElementPointer(builder, elemBinding, member.Member.Text, member.Span, out var ptr, out var elemType))
                 {
-                    return builder.BuildLoad2(elemType, ptr, "fieldload");
+                    var loaded = builder.BuildLoad2(elemType, ptr, "fieldload");
+                    return PromoteLoadedSmallIntToI32(builder, loaded);
                 }
 
                 return ConstI32(0);
@@ -4263,7 +4342,8 @@ public sealed class ModuleLowerer
             {
                 if (TryLowerArrayElementPointer(builder, arr, member.Member.Text, locals, out var ptr, out var elemType))
                 {
-                    return builder.BuildLoad2(elemType, ptr, "fieldload");
+                    var loaded = builder.BuildLoad2(elemType, ptr, "fieldload");
+                    return PromoteLoadedSmallIntToI32(builder, loaded);
                 }
             }
 
@@ -4308,7 +4388,8 @@ public sealed class ModuleLowerer
                             }
 
                             var llvmType = _moduleBuilder.TypeMapper.Map(fieldType);
-                            return builder.BuildLoad2(llvmType, global, flattenedName);
+                            var loaded = builder.BuildLoad2(llvmType, global, flattenedName);
+                            return PromoteLoadedSmallIntToI32(builder, loaded);
                         }
                     }
                 }
@@ -4324,7 +4405,8 @@ public sealed class ModuleLowerer
                     if (global.Handle != IntPtr.Zero && TryResolveMemberType(member, out var resolvedType))
                     {
                         var llvmType = _moduleBuilder.TypeMapper.Map(resolvedType);
-                        return builder.BuildLoad2(llvmType, global, flattenedPath);
+                        var loaded = builder.BuildLoad2(llvmType, global, flattenedPath);
+                        return PromoteLoadedSmallIntToI32(builder, loaded);
                     }
                 }
             }
@@ -4337,11 +4419,22 @@ public sealed class ModuleLowerer
         {
             if (TryLowerArrayElementPointer(builder, arr, fieldName, locals, out var ptr, out var elemType))
             {
-                return builder.BuildLoad2(elemType, ptr, "elemload");
+                var loaded = builder.BuildLoad2(elemType, ptr, "elemload");
+                return PromoteLoadedSmallIntToI32(builder, loaded);
             }
 
             AddDiagnostic("Unable to lower array access.", arr.Span);
             return ConstI32(0);
+        }
+
+        private static LLVMValueRef PromoteLoadedSmallIntToI32(LLVMBuilderRef builder, LLVMValueRef value)
+        {
+            var type = value.TypeOf;
+            if (type.Kind == LLVMTypeKind.LLVMIntegerTypeKind && type.IntWidth < 32)
+            {
+                return builder.BuildZExt(value, LLVMTypeRef.Int32, "promote.i32");
+            }
+            return value;
         }
 
         private bool TryLowerArrayElementPointer(LLVMBuilderRef builder, ArrayAccessExpressionSyntax arr, string? fieldName, Dictionary<string, LocalBinding> locals, out LLVMValueRef ptr, out LLVMTypeRef elemType)

--- a/Stasis.Compiler/IR/Reachability.cs
+++ b/Stasis.Compiler/IR/Reachability.cs
@@ -23,20 +23,23 @@ public static class Reachability
         var reachable = new HashSet<string>(StringComparer.Ordinal);
         var queue = new Queue<string>();
 
-        if (functions.ContainsKey("main"))
+        if (!includeTests)
         {
-            queue.Enqueue("main");
-        }
+            if (functions.ContainsKey("main"))
+            {
+                queue.Enqueue("main");
+            }
 
-        // Tick hosting: if a program defines `tick`, treat it as an entrypoint alongside `main`.
-        if (functions.ContainsKey("tick"))
-        {
-            queue.Enqueue("tick");
-        }
+            // Tick hosting: if a program defines `tick`, treat it as an entrypoint alongside `main`.
+            if (functions.ContainsKey("tick"))
+            {
+                queue.Enqueue("tick");
+            }
 
-        foreach (var export in functions.Values.Where(fn => fn.IsExported))
-        {
-            queue.Enqueue(export.Name.Text);
+            foreach (var export in functions.Values.Where(fn => fn.IsExported))
+            {
+                queue.Enqueue(export.Name.Text);
+            }
         }
 
         if (includeTests)

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -79,6 +79,12 @@ public sealed class SemanticAnalyzer
         // Type conversion functions
         AddSymbol("i32_to_f32", SymbolKind.Function, new PrimitiveTypeSymbol("f32"), new SourceSpan(0, 0));
         AddSymbol("f32_to_i32", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("u8_to_i32", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("u16_to_i32", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("i32_to_u8_trunc", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("i32_to_u8_checked", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("i32_to_u16_trunc", SymbolKind.Function, new PrimitiveTypeSymbol("u16"), new SourceSpan(0, 0));
+        AddSymbol("i32_to_u16_checked", SymbolKind.Function, new PrimitiveTypeSymbol("u16"), new SourceSpan(0, 0));
 
         // Legacy system functions (to be renamed to sys_*)
         AddSymbol("time", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
@@ -145,22 +151,22 @@ public sealed class SemanticAnalyzer
         // ============================================================
 
         // Classification
-        AddSymbol("char_is_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_alpha", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_alnum", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_space", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_upper", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_lower", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_is_print", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_digit", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_alpha", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_alnum", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_space", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_upper", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_lower", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_hex", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_print", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
 
         // Conversion
-        AddSymbol("char_to_upper", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_to_lower", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_to_upper", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("char_to_lower", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
         AddSymbol("char_to_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_from_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_from_digit", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
         AddSymbol("char_to_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_from_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_from_hex", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
 
         // ============================================================
         // Standard Library: str_* module (string operations)
@@ -168,23 +174,23 @@ public sealed class SemanticAnalyzer
 
         // Length & Capacity
         AddSymbol("str_len", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_is_empty", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_is_empty", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
 
         // Character Access
-        AddSymbol("str_get", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_get", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
         AddSymbol("str_set", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
 
         // Comparison
-        AddSymbol("str_eq", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_eq", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
         AddSymbol("str_cmp", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_starts_with", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_ends_with", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_starts_with", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("str_ends_with", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
 
         // Search
         AddSymbol("str_find", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_find_char", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_find_last_char", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_contains", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_contains", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
 
         // Modification (in-place)
         AddSymbol("str_clear", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
@@ -1028,10 +1034,10 @@ public sealed class SemanticAnalyzer
                     if (receiverType is ArrayTypeSymbol arrType)
                     {
                         if (arrType.ElementType is PrimitiveTypeSymbol prim &&
-                            (prim.PrimitiveName == "u8" || prim.PrimitiveName == "u16" || prim.PrimitiveName == "utf8" || prim.PrimitiveName == "ascii"))
+                            (prim.PrimitiveName == "ascii" || prim.PrimitiveName == "utf8"))
                         {
-                            // Byte/word array elements are treated as i32 values when read (zero-extended).
-                            return new PrimitiveTypeSymbol("i32");
+                            // String buffers expose byte elements when indexed.
+                            return new PrimitiveTypeSymbol("u8");
                         }
                         return arrType.ElementType;
                     }
@@ -1123,13 +1129,6 @@ public sealed class SemanticAnalyzer
             }
 
             currentType = ResolveType(field.Type);
-        }
-
-        if (currentType is PrimitiveTypeSymbol prim &&
-            (prim.PrimitiveName == "u8" || prim.PrimitiveName == "u16" || prim.PrimitiveName == "utf8" || prim.PrimitiveName == "ascii"))
-        {
-            // Byte/word fields are treated as i32 values when read (zero-extended).
-            return new PrimitiveTypeSymbol("i32");
         }
 
         return currentType;

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using Stasis.Compiler.Semantic;
 using Stasis.Compiler.Syntax;
@@ -144,22 +145,22 @@ public sealed class SemanticAnalyzer
         // ============================================================
 
         // Classification
-        AddSymbol("char_is_digit", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_alpha", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_alnum", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_space", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_upper", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_lower", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_hex", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("char_is_print", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("char_is_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_alpha", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_alnum", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_space", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_upper", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_lower", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_is_print", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
 
         // Conversion
-        AddSymbol("char_to_upper", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
-        AddSymbol("char_to_lower", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("char_to_upper", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("char_to_lower", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("char_to_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_from_digit", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("char_from_digit", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("char_to_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("char_from_hex", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("char_from_hex", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
 
         // ============================================================
         // Standard Library: str_* module (string operations)
@@ -167,23 +168,23 @@ public sealed class SemanticAnalyzer
 
         // Length & Capacity
         AddSymbol("str_len", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_is_empty", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("str_is_empty", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
 
         // Character Access
-        AddSymbol("str_get", SymbolKind.Function, new PrimitiveTypeSymbol("u8"), new SourceSpan(0, 0));
+        AddSymbol("str_get", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_set", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
 
         // Comparison
-        AddSymbol("str_eq", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("str_eq", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_cmp", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_starts_with", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
-        AddSymbol("str_ends_with", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("str_starts_with", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
+        AddSymbol("str_ends_with", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
 
         // Search
         AddSymbol("str_find", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_find_char", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
         AddSymbol("str_find_last_char", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
-        AddSymbol("str_contains", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
+        AddSymbol("str_contains", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
 
         // Modification (in-place)
         AddSymbol("str_clear", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
@@ -458,7 +459,14 @@ public sealed class SemanticAnalyzer
             var initType = ResolveExpressionType(v.Initializer, scope);
             if (varType is not null && initType is not null && !AreTypesCompatible(varType, initType))
             {
-                _diagnostics.Add(new Diagnostic($"Cannot assign value of type '{FormatType(initType)}' to variable of type '{FormatType(varType)}'.", v.Initializer.Span));
+                if (!TryAllowNumericLiteralAssignment(varType, v.Initializer, out var literalError))
+                {
+                    _diagnostics.Add(new Diagnostic($"Cannot assign value of type '{FormatType(initType)}' to variable of type '{FormatType(varType)}'.", v.Initializer.Span));
+                }
+                else if (literalError is not null)
+                {
+                    _diagnostics.Add(new Diagnostic(literalError, v.Initializer.Span));
+                }
             }
         }
     }
@@ -516,7 +524,7 @@ public sealed class SemanticAnalyzer
                     AnalyzeExpression(arg, scope);
                 }
 
-                ValidateOperatorCall(op);
+                ValidateOperatorCall(op, scope);
                 break;
             case AssignmentExpressionSyntax assign:
                 AnalyzeExpression(assign.Left, scope);
@@ -528,7 +536,14 @@ public sealed class SemanticAnalyzer
                 var rightType = ResolveExpressionType(assign.Right, scope);
                 if (leftType is not null && rightType is not null && !AreTypesCompatible(leftType, rightType))
                 {
-                    _diagnostics.Add(new Diagnostic($"Cannot assign value of type '{FormatType(rightType)}' to target of type '{FormatType(leftType)}'.", assign.Right.Span));
+                    if (!TryAllowNumericLiteralAssignment(leftType, assign.Right, out var literalError))
+                    {
+                        _diagnostics.Add(new Diagnostic($"Cannot assign value of type '{FormatType(rightType)}' to target of type '{FormatType(leftType)}'.", assign.Right.Span));
+                    }
+                    else if (literalError is not null)
+                    {
+                        _diagnostics.Add(new Diagnostic(literalError, assign.Right.Span));
+                    }
                 }
                 break;
             case BinaryExpressionSyntax bin:
@@ -539,7 +554,7 @@ public sealed class SemanticAnalyzer
         }
     }
 
-    private void ValidateOperatorCall(OperatorCallExpressionSyntax op)
+    private void ValidateOperatorCall(OperatorCallExpressionSyntax op, IReadOnlyDictionary<string, Symbol> scope)
     {
         var opText = op.OperatorToken.Text;
         if (op.Arguments.Count != 1)
@@ -553,6 +568,43 @@ public sealed class SemanticAnalyzer
             if (!IsAssignableReceiver(op.Receiver))
             {
                 _diagnostics.Add(new Diagnostic("Left side of assignment must be an assignable location (identifier, field, or array element).", op.Receiver.Span));
+            }
+            return;
+        }
+
+        if (op.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        var receiverType = ResolveExpressionType(op.Receiver, scope);
+        var argType = ResolveExpressionType(op.Arguments[0], scope);
+        if (receiverType is PrimitiveTypeSymbol recvPrim && argType is PrimitiveTypeSymbol argPrim)
+        {
+            if (IsIntegerType(recvPrim.PrimitiveName) && IsIntegerType(argPrim.PrimitiveName) &&
+                !string.Equals(recvPrim.PrimitiveName, argPrim.PrimitiveName, StringComparison.Ordinal))
+            {
+                if (!TryAllowNumericLiteralCompatibility(recvPrim.PrimitiveName, op.Arguments[0], out var literalError))
+                {
+                    _diagnostics.Add(new Diagnostic($"Cannot mix integer type '{recvPrim.PrimitiveName}' with integer type '{argPrim.PrimitiveName}' in operator call. Use an explicit conversion.", op.Span));
+                }
+                else if (literalError is not null)
+                {
+                    _diagnostics.Add(new Diagnostic(literalError, op.Arguments[0].Span));
+                }
+            }
+            else if (IsFloatType(recvPrim.PrimitiveName) && IsFloatType(argPrim.PrimitiveName) &&
+                     !string.Equals(recvPrim.PrimitiveName, argPrim.PrimitiveName, StringComparison.Ordinal))
+            {
+                _diagnostics.Add(new Diagnostic($"Cannot mix float type '{recvPrim.PrimitiveName}' with float type '{argPrim.PrimitiveName}' in operator call. Use an explicit conversion.", op.Span));
+            }
+            else if (IsIntegerType(recvPrim.PrimitiveName) && IsFloatType(argPrim.PrimitiveName))
+            {
+                _diagnostics.Add(new Diagnostic($"Cannot mix integer type '{recvPrim.PrimitiveName}' with float type '{argPrim.PrimitiveName}' in operator call. Use i32_to_f32() or f32_to_i32() for explicit conversion.", op.Span));
+            }
+            else if (IsFloatType(recvPrim.PrimitiveName) && IsIntegerType(argPrim.PrimitiveName))
+            {
+                _diagnostics.Add(new Diagnostic($"Cannot mix float type '{recvPrim.PrimitiveName}' with integer type '{argPrim.PrimitiveName}' in operator call. Use i32_to_f32() or f32_to_i32() for explicit conversion.", op.Span));
             }
         }
     }
@@ -637,6 +689,30 @@ public sealed class SemanticAnalyzer
                     {
                         _diagnostics.Add(new Diagnostic($"Cannot mix float type '{leftPrim.PrimitiveName}' with integer type '{rightPrim.PrimitiveName}' in arithmetic. Use i32_to_f32() or f32_to_i32() for explicit conversion.", bin.OperatorToken.Span));
                     }
+                    else if (IsIntegerType(leftPrim.PrimitiveName) && IsIntegerType(rightPrim.PrimitiveName) &&
+                             !string.Equals(leftPrim.PrimitiveName, rightPrim.PrimitiveName, StringComparison.Ordinal))
+                    {
+                        // Allow integer literals to match the other operand type when the literal fits (e.g., u8 == 72).
+                        var rightLiteralOk = TryAllowNumericLiteralCompatibility(leftPrim.PrimitiveName, bin.Right, out var rightLiteralError);
+                        var leftLiteralOk = TryAllowNumericLiteralCompatibility(rightPrim.PrimitiveName, bin.Left, out var leftLiteralError);
+                        if (!rightLiteralOk && !leftLiteralOk)
+                        {
+                            _diagnostics.Add(new Diagnostic($"Cannot mix integer type '{leftPrim.PrimitiveName}' with integer type '{rightPrim.PrimitiveName}' in arithmetic. Use an explicit conversion.", bin.OperatorToken.Span));
+                        }
+                        else if (rightLiteralError is not null)
+                        {
+                            _diagnostics.Add(new Diagnostic(rightLiteralError, bin.Right.Span));
+                        }
+                        else if (leftLiteralError is not null)
+                        {
+                            _diagnostics.Add(new Diagnostic(leftLiteralError, bin.Left.Span));
+                        }
+                    }
+                    else if (IsFloatType(leftPrim.PrimitiveName) && IsFloatType(rightPrim.PrimitiveName) &&
+                             !string.Equals(leftPrim.PrimitiveName, rightPrim.PrimitiveName, StringComparison.Ordinal))
+                    {
+                        _diagnostics.Add(new Diagnostic($"Cannot mix float type '{leftPrim.PrimitiveName}' with float type '{rightPrim.PrimitiveName}' in arithmetic. Use an explicit conversion.", bin.OperatorToken.Span));
+                    }
                 }
             }
 
@@ -655,6 +731,29 @@ public sealed class SemanticAnalyzer
                     else if (IsFloatType(leftPrim.PrimitiveName) && IsIntegerType(rightPrim.PrimitiveName))
                     {
                         _diagnostics.Add(new Diagnostic($"Cannot compare float type '{leftPrim.PrimitiveName}' with integer type '{rightPrim.PrimitiveName}'. Use i32_to_f32() or f32_to_i32() for explicit conversion.", bin.OperatorToken.Span));
+                    }
+                    else if (IsIntegerType(leftPrim.PrimitiveName) && IsIntegerType(rightPrim.PrimitiveName) &&
+                             !string.Equals(leftPrim.PrimitiveName, rightPrim.PrimitiveName, StringComparison.Ordinal))
+                    {
+                        var rightLiteralOk = TryAllowNumericLiteralCompatibility(leftPrim.PrimitiveName, bin.Right, out var rightLiteralError);
+                        var leftLiteralOk = TryAllowNumericLiteralCompatibility(rightPrim.PrimitiveName, bin.Left, out var leftLiteralError);
+                        if (!rightLiteralOk && !leftLiteralOk)
+                        {
+                            _diagnostics.Add(new Diagnostic($"Cannot compare integer type '{leftPrim.PrimitiveName}' with integer type '{rightPrim.PrimitiveName}'. Use an explicit conversion.", bin.OperatorToken.Span));
+                        }
+                        else if (rightLiteralError is not null)
+                        {
+                            _diagnostics.Add(new Diagnostic(rightLiteralError, bin.Right.Span));
+                        }
+                        else if (leftLiteralError is not null)
+                        {
+                            _diagnostics.Add(new Diagnostic(leftLiteralError, bin.Left.Span));
+                        }
+                    }
+                    else if (IsFloatType(leftPrim.PrimitiveName) && IsFloatType(rightPrim.PrimitiveName) &&
+                             !string.Equals(leftPrim.PrimitiveName, rightPrim.PrimitiveName, StringComparison.Ordinal))
+                    {
+                        _diagnostics.Add(new Diagnostic($"Cannot compare float type '{leftPrim.PrimitiveName}' with float type '{rightPrim.PrimitiveName}'. Use an explicit conversion.", bin.OperatorToken.Span));
                     }
                 }
 
@@ -899,8 +998,14 @@ public sealed class SemanticAnalyzer
                     return globalSym.Type;
                 }
                 return null;
+            case UnaryExpressionSyntax unary when unary.OperatorToken.Kind == TokenKind.Bang:
+                return new PrimitiveTypeSymbol("bool");
+            case UnaryExpressionSyntax unary:
+                return ResolveExpressionType(unary.Operand, scope);
             case ParenthesizedExpressionSyntax paren:
                 return ResolveExpressionType(paren.Expression, scope);
+            case AssignmentExpressionSyntax assign:
+                return ResolveExpressionType(assign.Left, scope);
             case MemberAccessExpressionSyntax member:
                 // Check if this is an enum member access (e.g., State.Idle)
                 if (member.Receiver is IdentifierExpressionSyntax enumId &&
@@ -917,6 +1022,21 @@ public sealed class SemanticAnalyzer
 
                 // Struct field access (including nested chains like state.ship.weapon.x)
                 return ResolveMemberAccessType(member, scope);
+            case ArrayAccessExpressionSyntax array:
+                {
+                    var receiverType = ResolveExpressionType(array.Receiver, scope);
+                    if (receiverType is ArrayTypeSymbol arrType)
+                    {
+                        if (arrType.ElementType is PrimitiveTypeSymbol prim &&
+                            (prim.PrimitiveName == "u8" || prim.PrimitiveName == "u16" || prim.PrimitiveName == "utf8" || prim.PrimitiveName == "ascii"))
+                        {
+                            // Byte/word array elements are treated as i32 values when read (zero-extended).
+                            return new PrimitiveTypeSymbol("i32");
+                        }
+                        return arrType.ElementType;
+                    }
+                    return null;
+                }
             case BinaryExpressionSyntax bin when bin.OperatorToken.Kind is TokenKind.EqualEqual or TokenKind.BangEqual
                 or TokenKind.Less or TokenKind.LessEqual or TokenKind.Greater or TokenKind.GreaterEqual:
                 // Comparison operators return bool
@@ -939,6 +1059,20 @@ public sealed class SemanticAnalyzer
 
                     // Default to left operand type, or i32 if unknown
                     return leftType ?? new PrimitiveTypeSymbol("i32");
+                }
+            case CallExpressionSyntax call when call.Callee is IdentifierExpressionSyntax id &&
+                                               _symbols.TryGetValue(id.Identifier.Text, out var sym):
+                return sym.Type;
+            case OperatorCallExpressionSyntax op:
+                {
+                    // Operator calls are expressions; the result is either the receiver type or bool for comparisons.
+                    var receiverType = ResolveExpressionType(op.Receiver, scope);
+                    return op.OperatorToken.Kind switch
+                    {
+                        TokenKind.EqualEqual or TokenKind.BangEqual or TokenKind.Less or TokenKind.LessEqual or TokenKind.Greater or TokenKind.GreaterEqual =>
+                            new PrimitiveTypeSymbol("bool"),
+                        _ => receiverType
+                    };
                 }
             default:
                 return null;
@@ -989,6 +1123,13 @@ public sealed class SemanticAnalyzer
             }
 
             currentType = ResolveType(field.Type);
+        }
+
+        if (currentType is PrimitiveTypeSymbol prim &&
+            (prim.PrimitiveName == "u8" || prim.PrimitiveName == "u16" || prim.PrimitiveName == "utf8" || prim.PrimitiveName == "ascii"))
+        {
+            // Byte/word fields are treated as i32 values when read (zero-extended).
+            return new PrimitiveTypeSymbol("i32");
         }
 
         return currentType;
@@ -1049,7 +1190,8 @@ public sealed class SemanticAnalyzer
 
     private bool IsIntegerType(string typeName)
     {
-        return typeName is "i32" or "u8" or "u16" or "u32";
+        // Note: utf8/ascii behave like u8 for indexing/byte-oriented APIs.
+        return typeName is "i32" or "u8" or "u16" or "u32" or "utf8" or "ascii";
     }
 
     private bool IsFloatType(string typeName)
@@ -1068,4 +1210,88 @@ public sealed class SemanticAnalyzer
             _ => "unknown"
         };
     }
+
+    private static bool TryGetIntegerLiteralValue(ExpressionSyntax expr, out long value)
+    {
+        if (expr is LiteralExpressionSyntax lit &&
+            lit.Literal.Kind == TokenKind.IntegerLiteral &&
+            long.TryParse(lit.Literal.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            value = parsed;
+            return true;
+        }
+
+        if (expr is UnaryExpressionSyntax unary &&
+            unary.OperatorToken.Kind == TokenKind.Minus &&
+            unary.Operand is LiteralExpressionSyntax innerLit &&
+            innerLit.Literal.Kind == TokenKind.IntegerLiteral &&
+            long.TryParse(innerLit.Literal.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var innerParsed))
+        {
+            value = -innerParsed;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static bool TryAllowNumericLiteralCompatibility(string targetPrimitiveName, ExpressionSyntax expr, out string? error)
+    {
+        error = null;
+        if (!TryGetIntegerLiteralValue(expr, out var literal))
+        {
+            return false;
+        }
+
+        switch (targetPrimitiveName)
+        {
+            case "u8":
+            case "utf8":
+            case "ascii":
+                if (literal < 0 || literal > byte.MaxValue)
+                {
+                    error = $"Integer literal {literal} does not fit in '{targetPrimitiveName}'.";
+                }
+                return true;
+            case "u16":
+                if (literal < 0 || literal > ushort.MaxValue)
+                {
+                    error = $"Integer literal {literal} does not fit in '{targetPrimitiveName}'.";
+                }
+                return true;
+            case "u32":
+                if (literal < 0 || literal > uint.MaxValue)
+                {
+                    error = $"Integer literal {literal} does not fit in '{targetPrimitiveName}'.";
+                }
+                return true;
+            case "i32":
+                if (literal < int.MinValue || literal > int.MaxValue)
+                {
+                    error = $"Integer literal {literal} does not fit in '{targetPrimitiveName}'.";
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryAllowNumericLiteralAssignment(TypeSymbol targetType, ExpressionSyntax expr, out string? error)
+    {
+        error = null;
+        if (targetType is not PrimitiveTypeSymbol prim)
+        {
+            return false;
+        }
+
+        if (!IsIntegerLikePrimitive(prim.PrimitiveName))
+        {
+            return false;
+        }
+
+        return TryAllowNumericLiteralCompatibility(prim.PrimitiveName, expr, out error);
+    }
+
+    private static bool IsIntegerLikePrimitive(string primitiveName) =>
+        primitiveName is "i32" or "u8" or "u16" or "u32" or "utf8" or "ascii";
 }

--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 
+call "%~dp0env.bat"
+
 pushd tools\cranelift-aot
 cargo build -p stasis-cranelift-aot --release
 if errorlevel 1 (

--- a/docs/demo-day.md
+++ b/docs/demo-day.md
@@ -1,0 +1,209 @@
+# Demo Day (Windows): runnable Stasis programs
+
+This is a quick "what can I run live?" guide for demo day. Commands assume a `cmd.exe` prompt from the repo root (`E:\StasisLang`).
+
+## One-time setup
+
+Build everything (compiler, runtime, runner, Cranelift AOT tool):
+
+```bat
+cd /d E:\StasisLang
+build.bat
+```
+
+Run the full test suite (C# unit tests + Stasis end-to-end tests):
+
+```bat
+cd /d E:\StasisLang
+test.bat
+```
+
+## Interactive demos (graphics/input/audio/text)
+
+### 1) Interactive showcase (graphics + pointer input + audio + font text)
+
+Features:
+- Immediate-mode rendering via `draw_line`
+- Pointer input (`input_pointer_*`)
+- Procedural audio (`audio_push_f32_interleaved`)
+- Font loading + text measurement/drawing (`load_font`, `measure_text`, `draw_text`)
+
+Run (LLVM):
+```bat
+.\stasis.bat run .\samples\interactive_showcase.stasis --backend llvm --graphics
+```
+
+Run (Cranelift):
+```bat
+.\stasis.bat run .\samples\interactive_showcase.stasis --backend cranelift --graphics
+```
+
+Notes:
+- Uses `C:\Windows\Fonts\consola.ttf` by default; edit `FONT_PATH` in `samples/interactive_showcase.stasis` if needed.
+
+### 2) Asteroids (vector graphics + keyboard input + gameplay)
+
+Features:
+- Rendering via `draw_line`
+- Keyboard input via `is_key_down` (W/A/D/Arrows/Space/Esc)
+- Classic update loop + deterministic-ish gameplay math helpers
+
+Run:
+```bat
+.\stasis.bat run .\samples\asteroids.stasis --backend llvm --graphics
+```
+
+### 3) Underwater automation (graphics prototype + simulation)
+
+Features:
+- Rendering via `draw_line`
+- Time-based simulation (`get_time_ms`)
+- Global state + arrays-heavy gameplay-ish logic
+
+Run:
+```bat
+.\stasis.bat run .\samples\underwater_automation.stasis --backend llvm --graphics
+```
+
+### 4) Flappy Birds (sprites + asset hot reload + keyboard input)
+
+Features:
+- Sprite pipeline (`gfx_load_sprite`, `gfx_draw_sprite`)
+- Asset hot reload (`gfx_poll_reload`): edit the SVGs under `assets_src/flappy-birds/` while running
+- Keyboard input (`is_key_down` Space)
+
+Run:
+```bat
+.\stasis.bat run .\examples\flappy_birds.stasis --backend llvm --graphics
+```
+
+## Focused feature demos
+
+### Audio output (procedural sine)
+
+Features:
+- Audio device discovery + streaming samples
+
+Run:
+```bat
+.\stasis.bat run .\samples\audio_sine.stasis --backend llvm
+```
+
+Expected output (example):
+```text
+audio: sample_rate=48000 channels=2
+audio: queued_frames=...
+```
+
+### Pointer input visualizer (mouse/touch)
+
+Features:
+- Pointer input snapshot APIs
+- Simple immediate-mode rendering
+
+Run:
+```bat
+.\stasis.bat run .\samples\input_pointers.stasis --backend llvm --graphics
+```
+
+### Render command buffer benchmark (draw_line vs batched)
+
+Features:
+- Shows the performance difference between many host calls vs one batched call (`draw_lines_f32`)
+- Uses debug hash to validate both paths submit identical draw streams
+
+Run:
+```bat
+.\stasis.bat run .\samples\render_command_buffer_bench.stasis --backend llvm --graphics
+```
+
+## Console / IO demos
+
+### Sudoku (console IO + deterministic RNG + tests)
+
+Run:
+```bat
+.\stasis.bat run .\samples\sudoku.stasis --backend llvm
+```
+
+Run tests:
+```bat
+.\stasis.bat test .\samples\sudoku.stasis --backend llvm
+```
+
+### Guess (console IO + RNG)
+
+Run:
+```bat
+.\stasis.bat run .\samples\guess.stasis --backend llvm
+```
+
+## Compiler / language feature samples (quick)
+
+### Basic program (exit code)
+
+```bat
+.\stasis.bat run .\samples\basic.stasis --backend llvm
+echo exit=%ERRORLEVEL%
+```
+
+### Test harness output (PASS/FAIL summary)
+
+```bat
+.\stasis.bat test .\samples\tests.stasis --backend llvm
+```
+
+### Operators, loops, enums, strings
+
+```bat
+.\stasis.bat test .\samples\operators.stasis --backend llvm
+.\stasis.bat test .\samples\forloop_tests.stasis --backend llvm
+.\stasis.bat test .\samples\test_enums.stasis --backend llvm
+.\stasis.bat test .\samples\strings.stasis --backend llvm
+```
+
+## Hot reload / iteration workflow demos
+
+If a program defines `tick()`, `run` defaults into a dev loop (watch + hot swap between ticks). See `docs/game-dev-workflow.md` for details.
+
+### Tick hot-swap (edit code while it runs)
+
+Run (Cranelift runner + hot swap between ticks):
+```bat
+.\stasis.bat run .\samples\hotstate_tick_watch.stasis --backend cranelift --fps 60
+```
+
+While it is running, edit/save `samples\hotstate_tick_watch.stasis` and watch the output update.
+
+### Restart-based hot state (persist `global state` across process runs)
+
+Run this command multiple times and observe `counter` increment:
+```bat
+.\stasis.bat run .\samples\hotstate_counter.stasis --backend cranelift --hot-state
+```
+
+## Data hot reload (JSON -> global state)
+
+These samples use `data\...` JSON files that the runner applies to globals before `main()` and/or between ticks.
+
+### Smoke: apply JSON before main()
+
+Edit `data\data_hotreload_smoke\balance.json` and run:
+```bat
+.\stasis.bat run .\samples\data_hotreload_smoke.stasis --backend cranelift
+```
+
+Expected output (example):
+```text
+health=123
+```
+
+### Latency: edit JSON while running (between ticks)
+
+Run:
+```bat
+.\stasis.bat run .\samples\data_hotreload_latency.stasis --backend cranelift
+```
+
+While it runs, edit `data\data_hotreload_latency\balance.json` and watch it print `health changed=...`.
+

--- a/docs/demo-day.md
+++ b/docs/demo-day.md
@@ -18,6 +18,18 @@ cd /d E:\StasisLang
 test.bat
 ```
 
+## Cranelift note (runner vs EXE)
+
+For `--backend cranelift`, `run`/`test` default to producing a DLL and invoking it via `stasis_runner.exe` (the "runner"). This is the path used for hot-swap between `tick()` calls and is also the fastest warm iteration loop.
+
+If you want Cranelift to behave more like LLVM (produce and run an EXE), pass `--no-cranelift-runner`:
+
+```bat
+.\stasis.bat run .\samples\basic.stasis --backend cranelift --no-cranelift-runner
+```
+
+Cranelift `run`/`test` also caches linked artifacts under `.stasis_cache\run` and `.stasis_cache\test` so repeated runs of an unchanged file should not relink. Set `STASIS_DISABLE_ARTIFACT_CACHE=1` to disable this cache.
+
 ## Interactive demos (graphics/input/audio/text)
 
 ### 1) Interactive showcase (graphics + pointer input + audio + font text)
@@ -206,4 +218,3 @@ Run:
 ```
 
 While it runs, edit `data\data_hotreload_latency\balance.json` and watch it print `health changed=...`.
-

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -98,6 +98,19 @@ f32, f64
 bool
 ```
 
+### Explicit Numeric Casts (No Implicit Widening/Truncation)
+
+Stasis does not perform implicit numeric casts between integer sizes. Use explicit conversion functions:
+
+- `u8_to_i32(u8) -> i32`
+- `u16_to_i32(u16) -> i32`
+- `i32_to_u8_trunc(i32) -> u8` (low 8 bits)
+- `i32_to_u8_checked(i32) -> u8` (aborts if out of range)
+- `i32_to_u16_trunc(i32) -> u16` (low 16 bits)
+- `i32_to_u16_checked(i32) -> u16` (aborts if out of range)
+- `i32_to_f32(i32) -> f32`
+- `f32_to_i32(f32) -> i32`
+
 ### Arrays (fixed size)
 
 ```

--- a/env.bat
+++ b/env.bat
@@ -1,0 +1,39 @@
+@echo off
+
+REM Shared environment setup for local scripts (build/test).
+REM Keeps the repo self-contained by preferring toolchains in well-known locations.
+
+set "REPO_ROOT=%~dp0"
+if "%REPO_ROOT:~-1%"=="\" set "REPO_ROOT=%REPO_ROOT:~0,-1%"
+
+REM Prefer the repo-pinned LLVM toolchain if present (pick the newest llvm-* folder).
+set "LLVM_BIN="
+for /f "delims=" %%D in ('dir /b /ad "%REPO_ROOT%\.tools\llvm-*" 2^>NUL') do (
+  if exist "%REPO_ROOT%\.tools\%%D\bin\clang.exe" (
+    set "LLVM_BIN=%REPO_ROOT%\.tools\%%D\bin"
+  )
+)
+if defined LLVM_BIN (
+  set "PATH=%LLVM_BIN%;%PATH%"
+)
+
+REM CMake (installed via winget/MSI by default).
+set "CMAKE_BIN=%ProgramFiles%\CMake\bin"
+if exist "%CMAKE_BIN%\cmake.exe" (
+  set "PATH=%CMAKE_BIN%;%PATH%"
+)
+
+REM Rust (installed via rustup).
+set "CARGO_BIN=%USERPROFILE%\.cargo\bin"
+if exist "%CARGO_BIN%\cargo.exe" (
+  set "PATH=%CARGO_BIN%;%PATH%"
+)
+
+REM vcpkg (used by runtime/build.bat). Prefer the conventional C:\vcpkg location.
+if not defined VCPKG_ROOT (
+  if exist "C:\vcpkg\vcpkg.exe" (
+    set "VCPKG_ROOT=C:\vcpkg"
+  ) else if exist "C:\code\vcpkg\vcpkg.exe" (
+    set "VCPKG_ROOT=C:\code\vcpkg"
+  )
+)

--- a/examples/flappy_birds_core.stasis
+++ b/examples/flappy_birds_core.stasis
@@ -31,7 +31,7 @@ function rand_gap_y(): f32 {
     let r: i32 = rand_next();
     let v: i32 = r % 1000;
     if (v < 0) { v = -v; }
-    let vf: f32 = v;
+    let vf: f32 = i32_to_f32(v);
     let range: f32 = WORLD_H - 2.0 * GAP_HALF - 10.0;
     let base: f32 = 5.0 + GAP_HALF;
     return base + range * (vf / 1000.0);
@@ -45,7 +45,7 @@ function reset() {
 
     let i: i32 = 0;
     for (i = 0; i < 3; i = i + 1) {
-        pipe_x[i] = WORLD_W + (PIPE_SPACING * i);
+        pipe_x[i] = WORLD_W + (PIPE_SPACING * i32_to_f32(i));
         pipe_gap_y[i] = rand_gap_y();
     }
 }

--- a/runtime/build.bat
+++ b/runtime/build.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 
+call "%~dp0..\env.bat"
+
 echo Building Stasis Graphics Runtime Library (static+shared)...
 
 :: Check for vcpkg - try common locations
@@ -84,11 +86,23 @@ if exist "%MANUAL_LIB_DIR%\\SDL2main.lib" (
     echo   warning: missing SDL2main.lib in %MANUAL_LIB_DIR%
 )
 echo Copying static graphics lib to repo root and build/ for auto-discovery...
-copy /Y "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\.." >NUL 2>&1
-if not exist "%CD%\\..\\..\\build" (
-    mkdir "%CD%\\..\\..\\build" >NUL 2>&1
+if /I "%STASIS_OVERWRITE_CHECKED_IN_RUNTIME_LIBS%"=="1" (
+    copy /Y "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\.." >NUL 2>&1
+    if not exist "%CD%\\..\\..\\build" (
+        mkdir "%CD%\\..\\..\\build" >NUL 2>&1
+    )
+    copy /Y "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\..\\build" >NUL 2>&1
+) else (
+    if not exist "%CD%\\..\\..\\stasis_graphics_static.lib" (
+        copy "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\.." >NUL 2>&1
+    )
+    if not exist "%CD%\\..\\..\\build" (
+        mkdir "%CD%\\..\\..\\build" >NUL 2>&1
+    )
+    if not exist "%CD%\\..\\..\\build\\stasis_graphics_static.lib" (
+        copy "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\..\\build" >NUL 2>&1
+    )
 )
-copy /Y "%CD%\\Release\\stasis_graphics_static.lib" "%CD%\\..\\..\\build" >NUL 2>&1
 echo.
 echo To run Asteroids demo with static runtime:
 echo   cd ..\..

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -120,6 +120,56 @@ static float g_prev_y_px[STASIS_MAX_POINTERS];
 static SDL_FingerID g_finger_ids[STASIS_MAX_POINTERS - 1];
 static int g_finger_active[STASIS_MAX_POINTERS - 1];
 
+/* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+static void setup_ortho(void);
+#endif
+
+/* Sprite atlas bookkeeping (paths + rasterized sprites). */
+#define MAX_SPRITES 256
+
+typedef struct {
+    char* path;
+    int w;              /* current rasterized width */
+    int h;              /* current rasterized height */
+    int max_w;          /* requested max width (logical) */
+    int max_h;          /* requested max height (logical) */
+    int atlas_x;
+    int atlas_y;
+    float u0, v0, u1, v1;
+    uint64_t mtime;
+    SDL_Texture* sdl_tex;
+    int used;
+    int needs_reraster;  /* flag for window resize */
+} SpriteEntry;
+
+static SpriteEntry g_sprites[MAX_SPRITES];
+static int g_sprite_count = 0;
+
+/* Font rendering with stb_truetype. */
+#define MAX_FONTS 8
+#define FONT_ATLAS_SIZE 512
+#define FONT_FIRST_CHAR 32
+#define FONT_NUM_CHARS 95
+
+typedef struct {
+    bool active;
+    stbtt_fontinfo font_info;
+    unsigned char* ttf_buffer;
+    float scale;
+    int ascent, descent, line_gap;
+
+    /* Baked bitmap atlas */
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    GLuint atlas_texture;
+#endif
+    SDL_Texture* sdl_texture;
+    stbtt_bakedchar char_data[FONT_NUM_CHARS];
+    int font_size;
+} StasisFont;
+
+static StasisFont g_fonts[MAX_FONTS];
+
 static int stasis_input_valid_index(int idx) {
     return idx >= 0 && idx < STASIS_MAX_POINTERS;
 }
@@ -585,7 +635,6 @@ static char g_asset_base[512] = {0};
 static char g_asset_env[512] = {0};
 
 /* Sprite atlas + batching (baked from SVG sources) */
-#define MAX_SPRITES 256
 #define SPRITE_ATLAS_W 1024
 #define SPRITE_ATLAS_H 1024
 #define SPRITE_ATLAS_PAD 2
@@ -596,24 +645,6 @@ typedef struct {
     float u, v;
     float r, g, b, a;
 } SpriteVertex;
-
-typedef struct {
-    char* path;
-    int w;              /* current rasterized width */
-    int h;              /* current rasterized height */
-    int max_w;          /* requested max width (logical) */
-    int max_h;          /* requested max height (logical) */
-    int atlas_x;
-    int atlas_y;
-    float u0, v0, u1, v1;
-    uint64_t mtime;
-    SDL_Texture* sdl_tex;
-    int used;
-    int needs_reraster;  /* flag for window resize */
-} SpriteEntry;
-
-static SpriteEntry g_sprites[MAX_SPRITES];
-static int g_sprite_count = 0;
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
 static GLuint g_sprite_program = 0;
@@ -3077,29 +3108,6 @@ STASIS_EXPORT void stasis_copy_dir_entry_name(const unsigned char* names, int32_
 }
 
 /* ===== FONT RENDERING WITH STB_TRUETYPE ===== */
-
-#define MAX_FONTS 8
-#define FONT_ATLAS_SIZE 512
-#define FONT_FIRST_CHAR 32
-#define FONT_NUM_CHARS 95
-
-typedef struct {
-    bool active;
-    stbtt_fontinfo font_info;
-    unsigned char* ttf_buffer;
-    float scale;
-    int ascent, descent, line_gap;
-
-    /* Baked bitmap atlas */
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    GLuint atlas_texture;
-#endif
-    SDL_Texture* sdl_texture;
-    stbtt_bakedchar char_data[FONT_NUM_CHARS];
-    int font_size;
-} StasisFont;
-
-static StasisFont g_fonts[MAX_FONTS];
 
 /* Load a TrueType font from disk */
 STASIS_EXPORT int stasis_load_font(const char* path, int font_size) {

--- a/samples/interactive_showcase.stasis
+++ b/samples/interactive_showcase.stasis
@@ -1,0 +1,478 @@
+import "../src/stdlib/stdlib.stasis";
+
+// Interactive showcase sample:
+// 1) Rendering: draws shapes with different colors.
+// 2) Input: click the shape to randomize shape/color.
+// 3) Sound: background tone + click beep (procedural audio).
+// 4) Text: click the text box and type; rendered with a TTF font.
+//
+// Run:
+// - LLVM:     stasis.bat run samples/interactive_showcase.stasis --backend llvm --graphics
+// - Cranelift stasis.bat run samples/interactive_showcase.stasis --backend cranelift --graphics
+//
+// Notes:
+// - Font path is Windows-specific by default. Change FONT_PATH if needed.
+
+const PI2: f32 = 6.28318;
+const FRAME_MS: i32 = 16;
+
+const FONT_PATH: string = "C:/Windows/Fonts/consola.ttf";
+const FONT_SIZE: i32 = 20;
+
+const FRAMES_PER_PUSH: i32 = 256;
+global audio_buf: f32[512]; // 256 frames * 2 channels
+
+global audio_ready: bool;
+global audio_sr: i32;
+global audio_phase0: f32;
+global audio_phase1: f32;
+global click_phase: f32;
+global click_env: f32;
+
+global rng_state: i32;
+
+enum ShapeKind {
+    Rect = 0,
+    Tri = 1,
+    Circle = 2
+}
+
+global shape_kind: ShapeKind;
+global shape_x: f32;
+global shape_y: f32;
+global shape_half: f32;
+global shape_r: f32;
+global shape_g: f32;
+global shape_b: f32;
+
+global font_handle: i32;
+global text_focused: bool;
+global text_len: i32;
+global text_buf: utf8[256];
+global key_prev: i32[128];
+
+function abs_f32(x: f32): f32 {
+    if (x < 0.0) {
+        return 0.0 - x;
+    }
+    return x;
+}
+
+function clamp01(x: f32): f32 {
+    if (x < 0.0) {
+        return 0.0;
+    }
+    if (x > 1.0) {
+        return 1.0;
+    }
+    return x;
+}
+
+function rand_next(): i32 {
+    rng_state = rng_state * 1103515245 + 12345;
+    return rng_state;
+}
+
+function rand_range_i32(min_incl: i32, max_incl: i32): i32 {
+    let r: i32 = rand_next();
+    if (r < 0) {
+        r = 0 - r;
+    }
+    let span: i32 = (max_incl - min_incl) + 1;
+    if (span <= 1) {
+        return min_incl;
+    }
+    return min_incl + (r % span);
+}
+
+function rand_f32_01(): f32 {
+    let v: i32 = rand_range_i32(0, 255);
+    return i32_to_f32(v) / 255.0;
+}
+
+function point_in_aabb(px: f32, py: f32, cx: f32, cy: f32, half: f32): bool {
+    return px >= (cx - half) && px <= (cx + half) && py >= (cy - half) && py <= (cy + half);
+}
+
+function draw_rect(cx: f32, cy: f32, half: f32, r: f32, g: f32, b: f32): void {
+    let x0: f32 = cx - half;
+    let y0: f32 = cy - half;
+    let x1: f32 = cx + half;
+    let y1: f32 = cy + half;
+    draw_line(x0, y0, x1, y0, r, g, b, 1.0);
+    draw_line(x1, y0, x1, y1, r, g, b, 1.0);
+    draw_line(x1, y1, x0, y1, r, g, b, 1.0);
+    draw_line(x0, y1, x0, y0, r, g, b, 1.0);
+}
+
+function draw_tri(cx: f32, cy: f32, half: f32, r: f32, g: f32, b: f32): void {
+    let x0: f32 = cx;
+    let y0: f32 = cy - half;
+    let x1: f32 = cx - half;
+    let y1: f32 = cy + half;
+    let x2: f32 = cx + half;
+    let y2: f32 = cy + half;
+    draw_line(x0, y0, x1, y1, r, g, b, 1.0);
+    draw_line(x1, y1, x2, y2, r, g, b, 1.0);
+    draw_line(x2, y2, x0, y0, r, g, b, 1.0);
+}
+
+function draw_circle(cx: f32, cy: f32, radius: f32, r: f32, g: f32, b: f32): void {
+    let segments: i32 = 24;
+    let i: i32 = 0;
+    let step: f32 = PI2 / i32_to_f32(segments);
+    let a0: f32 = 0.0;
+    for (i = 0; i < segments; i = i + 1) {
+        let a1: f32 = a0 + step;
+        let x0: f32 = cx + cos_fast(a0) * radius;
+        let y0: f32 = cy + sin_fast(a0) * radius;
+        let x1: f32 = cx + cos_fast(a1) * radius;
+        let y1: f32 = cy + sin_fast(a1) * radius;
+        draw_line(x0, y0, x1, y1, r, g, b, 1.0);
+        a0 = a1;
+    }
+}
+
+function draw_shape(kind: ShapeKind, cx: f32, cy: f32, half: f32, r: f32, g: f32, b: f32): void {
+    if (kind == ShapeKind.Rect) {
+        draw_rect(cx, cy, half, r, g, b);
+        return;
+    }
+    if (kind == ShapeKind.Tri) {
+        draw_tri(cx, cy, half, r, g, b);
+        return;
+    }
+    draw_circle(cx, cy, half, r, g, b);
+}
+
+function utf8_set_len(s: utf8[], len: i32): void {
+    let value: i32 = len;
+    if (value < 0) {
+        value = 0;
+    }
+
+    // byte_length (i32) at [-8..-5]
+    let b0: i32 = value % 256;
+    let b1: i32 = (value / 256) % 256;
+    let b2: i32 = (value / 65536) % 256;
+    let b3: i32 = (value / 16777216) % 256;
+    s[-8] = b0;
+    s[-7] = b1;
+    s[-6] = b2;
+    s[-5] = b3;
+
+    // char_length (i32) at [-4..-1] (ASCII input => char_length == byte_length)
+    s[-4] = b0;
+    s[-3] = b1;
+    s[-2] = b2;
+    s[-1] = b3;
+}
+
+function text_sync_header(): void {
+    utf8_set_len(text_buf, text_len);
+    text_buf[text_len] = 0;
+}
+
+function text_clear(): void {
+    text_len = 0;
+    text_buf[0] = 0;
+    text_sync_header();
+}
+
+function text_append_byte(b: i32): void {
+    if (text_len >= 254) {
+        return;
+    }
+    text_buf[text_len] = b;
+    text_len = text_len + 1;
+    text_buf[text_len] = 0;
+    text_sync_header();
+}
+
+function text_backspace(): void {
+    if (text_len <= 0) {
+        return;
+    }
+    text_len = text_len - 1;
+    text_buf[text_len] = 0;
+    text_sync_header();
+}
+
+function key_went_down(sc: i32): bool {
+    if (sc < 0 || sc >= 128) {
+        return false;
+    }
+    let down: bool = is_key_down(sc);
+    let prev: i32 = key_prev[sc];
+    let went: bool = down && prev == 0;
+
+    let next: i32 = 0;
+    if (down) {
+        next = 1;
+    }
+    key_prev[sc] = next;
+
+    return went;
+}
+
+function update_text_input(): void {
+    if (!text_focused) {
+        return;
+    }
+
+    // SDL scancodes (subset):
+    // A..Z = 4..29, 1..0 = 30..39, Return=40, Backspace=42, Space=44
+    let sc: i32 = 0;
+
+    if (key_went_down(42)) {
+        text_backspace();
+    }
+    if (key_went_down(44)) {
+        text_append_byte(32);
+    }
+    if (key_went_down(40)) {
+        text_append_byte(10);
+    }
+
+    for (sc = 4; sc <= 29; sc = sc + 1) {
+        if (key_went_down(sc)) {
+            // lower-case ASCII
+            let ch: i32 = 97 + (sc - 4);
+            text_append_byte(ch);
+        }
+    }
+
+    for (sc = 30; sc <= 39; sc = sc + 1) {
+        if (key_went_down(sc)) {
+            let ch: i32 = 48;
+            if (sc == 39) {
+                ch = 48;
+            } else {
+                ch = 49 + (sc - 30);
+            }
+            text_append_byte(ch);
+        }
+    }
+}
+
+function trigger_click_sound(): void {
+    click_phase = 0.0;
+    click_env = 0.35;
+}
+
+function fill_audio_chunk(sample_rate: i32): void {
+    let sr_f: f32 = i32_to_f32(sample_rate);
+
+    // Simple "music": two sines.
+    let step0: f32 = (PI2 * 110.0) / sr_f;
+    let step1: f32 = (PI2 * 165.0) / sr_f;
+    // Click beep.
+    let click_step: f32 = (PI2 * 880.0) / sr_f;
+
+    let i: i32 = 0;
+    for (i = 0; i < FRAMES_PER_PUSH; i = i + 1) {
+        let music: f32 = (sin_fast(audio_phase0) * 0.06) + (sin_fast(audio_phase1) * 0.04);
+
+        let click: f32 = 0.0;
+        if (click_env > 0.0001) {
+            click = sin_fast(click_phase) * click_env;
+            click_env = click_env * 0.996;
+        } else {
+            click_env = 0.0;
+        }
+
+        let s: f32 = clamp01((music + click) * 0.5 + 0.5) * 2.0 - 1.0;
+
+        let idx: i32 = i * 2;
+        audio_buf[idx] = s;
+        audio_buf[idx + 1] = s;
+
+        audio_phase0 = audio_phase0 + step0;
+        if (audio_phase0 > PI2) {
+            audio_phase0 = audio_phase0 - PI2;
+        }
+        audio_phase1 = audio_phase1 + step1;
+        if (audio_phase1 > PI2) {
+            audio_phase1 = audio_phase1 - PI2;
+        }
+        click_phase = click_phase + click_step;
+        if (click_phase > PI2) {
+            click_phase = click_phase - PI2;
+        }
+    }
+}
+
+function audio_update(): void {
+    if (!audio_ready) {
+        return;
+    }
+
+    // Keep ~200ms buffered.
+    let target: i32 = audio_sr / 5;
+    let queued: i32 = audio_get_queued_frames();
+    let guard: i32 = 0;
+    for (guard = 0; queued < target && guard < 8; guard = guard + 1) {
+        fill_audio_chunk(audio_sr);
+        let pushed: i32 = audio_push_f32_interleaved(audio_buf, FRAMES_PER_PUSH);
+        if (pushed <= 0) {
+            return;
+        }
+        queued = queued + pushed;
+        if (pushed < FRAMES_PER_PUSH) {
+            return;
+        }
+    }
+}
+
+function randomize_shape(): void {
+    let k: i32 = rand_range_i32(0, 2);
+    if (k == 0) {
+        shape_kind = ShapeKind.Rect;
+    } else {
+        if (k == 1) {
+            shape_kind = ShapeKind.Tri;
+        } else {
+            shape_kind = ShapeKind.Circle;
+        }
+    }
+    shape_r = rand_f32_01();
+    shape_g = rand_f32_01();
+    shape_b = rand_f32_01();
+    if (shape_r + shape_g + shape_b < 0.4) {
+        shape_r = shape_r + 0.4;
+        shape_g = shape_g + 0.2;
+    }
+}
+
+function main(): i32 {
+    rng_state = time();
+
+    let ok: bool = init_window(900, 600, "Stasis Interactive Showcase");
+    if (!ok) {
+        return 1;
+    }
+
+    font_handle = load_font(FONT_PATH, FONT_SIZE);
+
+    audio_ready = audio_is_available();
+    if (audio_ready) {
+        audio_sr = audio_get_sample_rate();
+    }
+
+    text_clear();
+    text_append_byte(99);  // c
+    text_append_byte(108); // l
+    text_append_byte(105); // i
+    text_append_byte(99);  // c
+    text_append_byte(107); // k
+    text_append_byte(32);  // space
+    text_append_byte(104); // h
+    text_append_byte(101); // e
+    text_append_byte(114); // r
+    text_append_byte(101); // e
+    text_append_byte(32);
+    text_append_byte(97);
+    text_append_byte(110);
+    text_append_byte(100);
+    text_append_byte(32);
+    text_append_byte(116);
+    text_append_byte(121);
+    text_append_byte(112);
+    text_append_byte(101);
+    text_append_byte(46);
+    text_append_byte(46);
+    text_append_byte(46);
+
+    randomize_shape();
+    shape_half = 90.0;
+    shape_x = 450.0;
+    shape_y = 240.0;
+
+    let running: i32 = 1;
+    for (; running == 1; ) {
+        if (should_quit()) {
+            running = 0;
+        }
+
+        let w_i: i32 = gfx_window_width();
+        let h_i: i32 = gfx_window_height();
+        let w: f32 = i32_to_f32(w_i);
+        let h: f32 = i32_to_f32(h_i);
+
+        shape_x = w * 0.5;
+        shape_y = h * 0.40;
+
+        let box_x0: f32 = 20.0;
+        let box_y0: f32 = h - 90.0;
+        let box_w: f32 = w - 40.0;
+        let box_h: f32 = 70.0;
+        let box_x1: f32 = box_x0 + box_w;
+        let box_y1: f32 = box_y0 + box_h;
+
+        let count: i32 = input_pointer_count();
+        let i: i32 = 0;
+        for (i = 0; i < count; i = i + 1) {
+            let went_down: bool = input_pointer_went_down(i);
+            if (went_down) {
+                let px: f32 = input_pointer_x_px(i);
+                let py: f32 = input_pointer_y_px(i);
+
+                if (point_in_aabb(px, py, shape_x, shape_y, shape_half)) {
+                    randomize_shape();
+                    trigger_click_sound();
+                } else {
+                    if (px >= box_x0 && px <= box_x1 && py >= box_y0 && py <= box_y1) {
+                        text_focused = true;
+                        trigger_click_sound();
+                    } else {
+                        text_focused = false;
+                    }
+                }
+            }
+        }
+
+        update_text_input();
+
+        begin_frame();
+        clear(0.02, 0.02, 0.03, 1.0);
+
+        // A couple static shapes so we always hit "different shapes/colors".
+        draw_rect(w * 0.18, h * 0.30, 50.0, 0.3, 0.9, 0.5);
+        draw_circle(w * 0.82, h * 0.30, 50.0, 0.9, 0.3, 0.6);
+
+        // Interactive shape (click inside the box to randomize).
+        draw_shape(shape_kind, shape_x, shape_y, shape_half, shape_r, shape_g, shape_b);
+
+        // Text box outline.
+        let box_r: f32 = 0.25;
+        let box_g: f32 = 0.25;
+        let box_b: f32 = 0.35;
+        if (text_focused) {
+            box_r = 0.25;
+            box_g = 0.75;
+            box_b = 0.25;
+        }
+        draw_line(box_x0, box_y0, box_x1, box_y0, box_r, box_g, box_b, 1.0);
+        draw_line(box_x1, box_y0, box_x1, box_y1, box_r, box_g, box_b, 1.0);
+        draw_line(box_x1, box_y1, box_x0, box_y1, box_r, box_g, box_b, 1.0);
+        draw_line(box_x0, box_y1, box_x0, box_y0, box_r, box_g, box_b, 1.0);
+
+        // Instructions + typed text.
+        draw_text(font_handle, "Click shape to randomize. Click box to type. Backspace deletes.", 24.0, 18.0, 0.85, 0.85, 0.9, 1.0);
+        draw_text(font_handle, text_buf, box_x0 + 10.0, box_y0 + 14.0, 0.95, 0.95, 0.95, 1.0);
+
+        // Simple caret when focused.
+        if (text_focused) {
+            let tw: f32 = measure_text(font_handle, text_buf);
+            let cx: f32 = box_x0 + 10.0 + tw + 2.0;
+            draw_line(cx, box_y0 + 14.0, cx, box_y1 - 14.0, 0.95, 0.95, 0.95, 1.0);
+        }
+
+        end_frame();
+
+        audio_update();
+        sleep_ms(FRAME_MS);
+    }
+
+    return 0;
+}

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -9,7 +9,7 @@ function from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
     let i: i32 = 0;
     let limit: i32 = dst_max - 1;
     for (i = 0; i < limit; i = i + 1) {
-        let b: i32 = src[i];
+        let b: u8 = src[i];
         if (b == 0) {
             str_set(dst, i, 0);
             return i;
@@ -21,71 +21,71 @@ function from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
     return i;
 }
 
-function ascii_is_digit(b: i32): bool {
-    return char_is_digit(b) != 0;
+function ascii_is_digit(b: u8): bool {
+    return char_is_digit(b);
 }
 
-function ascii_is_alpha(b: i32): bool {
-    return char_is_alpha(b) != 0;
+function ascii_is_alpha(b: u8): bool {
+    return char_is_alpha(b);
 }
 
-function ascii_is_alnum(b: i32): bool {
-    return char_is_alnum(b) != 0;
+function ascii_is_alnum(b: u8): bool {
+    return char_is_alnum(b);
 }
 
-function ascii_is_space(b: i32): bool {
-    return char_is_space(b) != 0;
+function ascii_is_space(b: u8): bool {
+    return char_is_space(b);
 }
 
-function ascii_is_upper(b: i32): bool {
-    return char_is_upper(b) != 0;
+function ascii_is_upper(b: u8): bool {
+    return char_is_upper(b);
 }
 
-function ascii_is_lower(b: i32): bool {
-    return char_is_lower(b) != 0;
+function ascii_is_lower(b: u8): bool {
+    return char_is_lower(b);
 }
 
-function ascii_is_hex(b: i32): bool {
-    return char_is_hex(b) != 0;
+function ascii_is_hex(b: u8): bool {
+    return char_is_hex(b);
 }
 
-function ascii_is_print(b: i32): bool {
-    return char_is_print(b) != 0;
+function ascii_is_print(b: u8): bool {
+    return char_is_print(b);
 }
 
-function ascii_is_ascii(b: i32): bool {
+function ascii_is_ascii(b: u8): bool {
     return b < 128;
 }
 
-function ascii_to_upper(b: i32): i32 {
+function ascii_to_upper(b: u8): u8 {
     return char_to_upper(b);
 }
 
-function ascii_to_lower(b: i32): i32 {
+function ascii_to_lower(b: u8): u8 {
     return char_to_lower(b);
 }
 
-function ascii_to_digit(b: i32): i32 {
+function ascii_to_digit(b: u8): i32 {
     return char_to_digit(b);
 }
 
-function ascii_from_digit(d: i32): i32 {
+function ascii_from_digit(d: i32): u8 {
     return char_from_digit(d);
 }
 
-function ascii_to_hex(b: i32): i32 {
+function ascii_to_hex(b: u8): i32 {
     return char_to_hex(b);
 }
 
-function ascii_from_hex(d: i32): i32 {
+function ascii_from_hex(d: i32): u8 {
     return char_from_hex(d);
 }
 
 function ascii_len(s: ascii[]): i32 {
-    let b0: i32 = s[-4];
-    let b1: i32 = s[-3];
-    let b2: i32 = s[-2];
-    let b3: i32 = s[-1];
+    let b0: i32 = u8_to_i32(s[-4]);
+    let b1: i32 = u8_to_i32(s[-3]);
+    let b2: i32 = u8_to_i32(s[-2]);
+    let b3: i32 = u8_to_i32(s[-1]);
     return b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
 }
 
@@ -98,21 +98,21 @@ function ascii_set_len(s: ascii[], len: i32) {
     let b1: i32 = (value / 256) % 256;
     let b2: i32 = (value / 65536) % 256;
     let b3: i32 = (value / 16777216) % 256;
-    s[-4] = b0;
-    s[-3] = b1;
-    s[-2] = b2;
-    s[-1] = b3;
+    s[-4] = i32_to_u8_trunc(b0);
+    s[-3] = i32_to_u8_trunc(b1);
+    s[-2] = i32_to_u8_trunc(b2);
+    s[-1] = i32_to_u8_trunc(b3);
 }
 
 function ascii_is_empty(s: ascii[]): bool {
     return ascii_len(s) == 0;
 }
 
-function ascii_get(s: ascii[], index: i32): i32 {
+function ascii_get(s: ascii[], index: i32): u8 {
     return s[index];
 }
 
-function ascii_set(s: ascii[], index: i32, b: i32) {
+function ascii_set(s: ascii[], index: i32, b: u8) {
     s[index] = b;
     if (b == 0) {
         ascii_set_len(s, index);
@@ -142,7 +142,7 @@ function ascii_clear(s: ascii[]) {
 function ascii_copy(dst: ascii[], src: ascii[]): i32 {
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
-        let b: i32 = src[i];
+        let b: u8 = src[i];
         dst[i] = b;
         if (b == 0) {
             ascii_set_len(dst, i);
@@ -156,7 +156,7 @@ function ascii_append(dst: ascii[], src: ascii[]): i32 {
     let base: i32 = ascii_len(dst);
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
-        let b: i32 = src[i];
+        let b: u8 = src[i];
         if (b == 0) {
             dst[base + i] = 0;
             ascii_set_len(dst, base + i);
@@ -167,7 +167,7 @@ function ascii_append(dst: ascii[], src: ascii[]): i32 {
     return base;
 }
 
-function ascii_append_byte(dst: ascii[], b: i32): i32 {
+function ascii_append_byte(dst: ascii[], b: u8): i32 {
     let base: i32 = ascii_len(dst);
     dst[base] = b;
     if (b == 0) {
@@ -182,8 +182,8 @@ function ascii_append_byte(dst: ascii[], b: i32): i32 {
 function ascii_cmp(a: ascii[], b: ascii[]): i32 {
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
-        let av: i32 = a[i];
-        let bv: i32 = b[i];
+        let av: i32 = u8_to_i32(a[i]);
+        let bv: i32 = u8_to_i32(b[i]);
         if (av < bv) {
             return -1;
         }
@@ -201,10 +201,10 @@ function ascii_eq(a: ascii[], b: ascii[]): bool {
     return ascii_cmp(a, b) == 0;
 }
 
-function ascii_find_byte(s: ascii[], b: i32): i32 {
+function ascii_find_byte(s: ascii[], b: u8): i32 {
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
-        let cur: i32 = s[i];
+        let cur: u8 = s[i];
         if (cur == b) {
             return i;
         }
@@ -215,11 +215,11 @@ function ascii_find_byte(s: ascii[], b: i32): i32 {
     return -1;
 }
 
-function ascii_find_last_byte(s: ascii[], b: i32): i32 {
+function ascii_find_last_byte(s: ascii[], b: u8): i32 {
     let i: i32 = 0;
     let last: i32 = -1;
     for (i = 0; 1; i = i + 1) {
-        let cur: i32 = s[i];
+        let cur: u8 = s[i];
         if (cur == b) {
             last = i;
         }
@@ -233,11 +233,11 @@ function ascii_find_last_byte(s: ascii[], b: i32): i32 {
 function ascii_starts_with(s: ascii[], prefix: ascii[]): bool {
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
-        let p: i32 = prefix[i];
+        let p: u8 = prefix[i];
         if (p == 0) {
             return true;
         }
-        let v: i32 = s[i];
+        let v: u8 = s[i];
         if (v == 0) {
             return false;
         }
@@ -299,7 +299,7 @@ function mem_copy(dst: u8[], src: u8[], count: i32) {
     }
 }
 
-function mem_set(dst: u8[], value: i32, count: i32) {
+function mem_set(dst: u8[], value: u8, count: i32) {
     let i: i32 = 0;
     for (i = 0; i < count; i = i + 1) {
         dst[i] = value;
@@ -313,8 +313,8 @@ function mem_zero(dst: u8[], count: i32) {
 function mem_cmp(a: u8[], b: u8[], count: i32): i32 {
     let i: i32 = 0;
     for (i = 0; i < count; i = i + 1) {
-        let av: i32 = a[i];
-        let bv: i32 = b[i];
+        let av: i32 = u8_to_i32(a[i]);
+        let bv: i32 = u8_to_i32(b[i]);
         if (av < bv) {
             return -1;
         }

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -21,63 +21,63 @@ function from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
     return i;
 }
 
-function ascii_is_digit(b: u8): bool {
-    return char_is_digit(b);
+function ascii_is_digit(b: i32): bool {
+    return char_is_digit(b) != 0;
 }
 
-function ascii_is_alpha(b: u8): bool {
-    return char_is_alpha(b);
+function ascii_is_alpha(b: i32): bool {
+    return char_is_alpha(b) != 0;
 }
 
-function ascii_is_alnum(b: u8): bool {
-    return char_is_alnum(b);
+function ascii_is_alnum(b: i32): bool {
+    return char_is_alnum(b) != 0;
 }
 
-function ascii_is_space(b: u8): bool {
-    return char_is_space(b);
+function ascii_is_space(b: i32): bool {
+    return char_is_space(b) != 0;
 }
 
-function ascii_is_upper(b: u8): bool {
-    return char_is_upper(b);
+function ascii_is_upper(b: i32): bool {
+    return char_is_upper(b) != 0;
 }
 
-function ascii_is_lower(b: u8): bool {
-    return char_is_lower(b);
+function ascii_is_lower(b: i32): bool {
+    return char_is_lower(b) != 0;
 }
 
-function ascii_is_hex(b: u8): bool {
-    return char_is_hex(b);
+function ascii_is_hex(b: i32): bool {
+    return char_is_hex(b) != 0;
 }
 
-function ascii_is_print(b: u8): bool {
-    return char_is_print(b);
+function ascii_is_print(b: i32): bool {
+    return char_is_print(b) != 0;
 }
 
-function ascii_is_ascii(b: u8): bool {
+function ascii_is_ascii(b: i32): bool {
     return b < 128;
 }
 
-function ascii_to_upper(b: u8): u8 {
+function ascii_to_upper(b: i32): i32 {
     return char_to_upper(b);
 }
 
-function ascii_to_lower(b: u8): u8 {
+function ascii_to_lower(b: i32): i32 {
     return char_to_lower(b);
 }
 
-function ascii_to_digit(b: u8): i32 {
+function ascii_to_digit(b: i32): i32 {
     return char_to_digit(b);
 }
 
-function ascii_from_digit(d: i32): u8 {
+function ascii_from_digit(d: i32): i32 {
     return char_from_digit(d);
 }
 
-function ascii_to_hex(b: u8): i32 {
+function ascii_to_hex(b: i32): i32 {
     return char_to_hex(b);
 }
 
-function ascii_from_hex(d: i32): u8 {
+function ascii_from_hex(d: i32): i32 {
     return char_from_hex(d);
 }
 
@@ -108,11 +108,11 @@ function ascii_is_empty(s: ascii[]): bool {
     return ascii_len(s) == 0;
 }
 
-function ascii_get(s: ascii[], index: i32): u8 {
+function ascii_get(s: ascii[], index: i32): i32 {
     return s[index];
 }
 
-function ascii_set(s: ascii[], index: i32, b: u8) {
+function ascii_set(s: ascii[], index: i32, b: i32) {
     s[index] = b;
     if (b == 0) {
         ascii_set_len(s, index);
@@ -167,7 +167,7 @@ function ascii_append(dst: ascii[], src: ascii[]): i32 {
     return base;
 }
 
-function ascii_append_byte(dst: ascii[], b: u8): i32 {
+function ascii_append_byte(dst: ascii[], b: i32): i32 {
     let base: i32 = ascii_len(dst);
     dst[base] = b;
     if (b == 0) {
@@ -201,7 +201,7 @@ function ascii_eq(a: ascii[], b: ascii[]): bool {
     return ascii_cmp(a, b) == 0;
 }
 
-function ascii_find_byte(s: ascii[], b: u8): i32 {
+function ascii_find_byte(s: ascii[], b: i32): i32 {
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
         let cur: i32 = s[i];
@@ -215,7 +215,7 @@ function ascii_find_byte(s: ascii[], b: u8): i32 {
     return -1;
 }
 
-function ascii_find_last_byte(s: ascii[], b: u8): i32 {
+function ascii_find_last_byte(s: ascii[], b: i32): i32 {
     let i: i32 = 0;
     let last: i32 = -1;
     for (i = 0; 1; i = i + 1) {
@@ -299,7 +299,7 @@ function mem_copy(dst: u8[], src: u8[], count: i32) {
     }
 }
 
-function mem_set(dst: u8[], value: u8, count: i32) {
+function mem_set(dst: u8[], value: i32, count: i32) {
     let i: i32 = 0;
     for (i = 0; i < count; i = i + 1) {
         dst[i] = value;

--- a/test-llvm.bat
+++ b/test-llvm.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 
+call "%~dp0env.bat"
+
 set "SCRIPT_DIR=%~dp0"
 set "STASIS_SUPPRESS_WARNINGS=1"
 set "STASIS_BACKEND=llvm"

--- a/test-timings.bat
+++ b/test-timings.bat
@@ -1,0 +1,58 @@
+@echo off
+setlocal
+
+call "%~dp0env.bat"
+
+set "SCRIPT_DIR=%~dp0"
+set "STASIS_SUPPRESS_WARNINGS=1"
+set "AOT_CLI=%SCRIPT_DIR%build\\aot\\Stasis.Cli.exe"
+
+set "STASIS_CRANELIFT_AOT=%SCRIPT_DIR%tools\\cranelift-aot\\target\\release\\stasis-cranelift-aot.exe"
+set "STASIS_CRANELIFT_AOT_SERVER=1"
+set "STASIS_CRANELIFT_RUNNER_SERVER=1"
+
+powershell -NoProfile -Command ^
+  "$ErrorActionPreference='Stop';" ^
+  "$root = Resolve-Path '%SCRIPT_DIR%';" ^
+  "Set-Location $root;" ^
+  "$aot = Join-Path $root 'build\\aot\\Stasis.Cli.exe';" ^
+  "if (!(Test-Path $aot)) { Write-Error 'AOT CLI not found. Run build.bat first.'; exit 1 }" ^
+  "$env:STASIS_SUPPRESS_WARNINGS='1';" ^
+  "$env:STASIS_CRANELIFT_AOT = (Join-Path $root 'tools\\cranelift-aot\\target\\release\\stasis-cranelift-aot.exe');" ^
+  "$env:STASIS_CRANELIFT_AOT_SERVER='1';" ^
+  "$env:STASIS_CRANELIFT_RUNNER_SERVER='1';" ^
+  "function Clear-TestCache() {" ^
+  "  $cache = Join-Path $root '.stasis_cache\\test';" ^
+  "  if (!(Test-Path $cache)) { return }" ^
+  "  try {" ^
+  "    Remove-Item -Recurse -Force $cache -ErrorAction Stop;" ^
+  "    return" ^
+  "  } catch {" ^
+  "    $parent = Split-Path $cache -Parent;" ^
+  "    $stamp = Get-Date -Format 'yyyyMMdd_HHmmss';" ^
+  "    $backup = Join-Path $parent (\"test_old_{0}\" -f $stamp);" ^
+  "    try { Move-Item -Force $cache $backup -ErrorAction Stop } catch { }" ^
+  "    New-Item -ItemType Directory -Force $cache | Out-Null" ^
+  "  }" ^
+  "}" ^
+  "function Invoke-TimedRun([string]$label, [string]$backend) {" ^
+  "  $args = @('test','--all','--backend',$backend);" ^
+  "  $sw = [Diagnostics.Stopwatch]::StartNew();" ^
+  "  & $aot @args;" ^
+  "  $exitCode = $LASTEXITCODE;" ^
+  "  $sw.Stop();" ^
+  "  if ($exitCode -ne 0) { Write-Error \"$label failed with exit code $exitCode\"; exit $exitCode }" ^
+  "  $seconds = $sw.Elapsed.TotalSeconds.ToString('0.000');" ^
+  "  Write-Host (\"{0} run time: {1}s\" -f $label, $seconds);" ^
+  "}" ^
+  "function Invoke-Backend([string]$backend) {" ^
+  "  Write-Host (\"\\n=== backend={0} ===\" -f $backend);" ^
+  "  Clear-TestCache;" ^
+  "  Invoke-TimedRun \"$backend Cold\" $backend;" ^
+  "  Invoke-TimedRun \"$backend Warm\" $backend;" ^
+  "}" ^
+  "Invoke-Backend 'llvm';" ^
+  "Invoke-Backend 'cranelift';"
+if errorlevel 1 exit /b 1
+
+endlocal

--- a/test.bat
+++ b/test.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal
 
+call "%~dp0env.bat"
+
 set STASIS_CRANELIFT_AOT=%CD%\tools\cranelift-aot\target\release\stasis-cranelift-aot.exe
 set STASIS_CRANELIFT_AOT_SERVER=1
 set STASIS_CRANELIFT_RUNNER_SERVER=1
@@ -16,7 +18,7 @@ powershell -NoProfile -Command ^
   "$env:STASIS_CRANELIFT_AOT='%STASIS_CRANELIFT_AOT%';" ^
   "$aot = '%AOT_CLI%';" ^
   "if (!(Test-Path $aot)) { Write-Error 'AOT CLI not found. Run build.bat first.'; exit 1 }" ^
-  "& $aot test --all --backend cranelift --watch;"
+  "& $aot test --all --backend cranelift;"
 if errorlevel 1 exit /b 1
 
 endlocal


### PR DESCRIPTION
- Cache Cranelift run/test linked artifacts so unchanged programs don’t relink on warm runs
- Add --no-cranelift-runner to force EXE mode for Cranelift
- Document runner vs EXE + cache controls

Validation:
- build.bat
- test.bat
- test-timings.bat