### PR TITLE
feat: game dev P1 helpers

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -6,7 +6,7 @@ This file is a lightweight, persistent checklist of upcoming work. It complement
 
 - [x] Fix PR `#24` (enum explicit values + SDL scancodes): resolve conflicts and restore CI green.
 - [ ] Game dev readiness: P0 stdlib modules (`game_math`, `game_draw`, `game_collision`) + canonical UTF-8 buffer helpers (remove samples writing string headers directly).
-- [ ] Game dev readiness: P1 input helpers (went_down/up, mapping), viewport/camera helpers, and draw batching helpers.
+- [x] Game dev readiness: P1 input helpers (went_down/up, mapping), viewport/camera helpers, and draw batching helpers.
 - [ ] Game dev readiness: P2 audio mixer layer (one-shots + loops) and more templates/examples.
 - [ ] Follow through: implement `docs/audio-plan.md` (desktop SDL2 audio MVP first).
 - [ ] Follow through: implement `docs/input-plan.md` (pointer snapshot, mouse + touch/taps).

--- a/samples/input_pointers.stasis
+++ b/samples/input_pointers.stasis
@@ -1,4 +1,5 @@
 import "../src/stdlib/stdlib.stasis";
+import "../src/stdlib/game_viewport.stasis";
 
 // Input pointers sample: draws a crosshair at each active pointer (mouse + touch).
 // Uses the input snapshot builtins:
@@ -16,15 +17,10 @@ function draw_cross(x: f32, y: f32, r: f32, g: f32, b: f32): void {
 }
 
 function draw_viewport_outline(): void {
-    let vx_i: i32 = input_viewport_x_px();
-    let vy_i: i32 = input_viewport_y_px();
-    let vw_i: i32 = input_viewport_w_px();
-    let vh_i: i32 = input_viewport_h_px();
-
-    let vx: f32 = vx_i;
-    let vy: f32 = vy_i;
-    let vw: f32 = vw_i;
-    let vh: f32 = vh_i;
+    let vx: f32 = game_viewport_x_px();
+    let vy: f32 = game_viewport_y_px();
+    let vw: f32 = game_viewport_w_px();
+    let vh: f32 = game_viewport_h_px();
 
     let x0: f32 = vx;
     let y0: f32 = vy;

--- a/samples/interactive_showcase.stasis
+++ b/samples/interactive_showcase.stasis
@@ -1,5 +1,6 @@
 import "../src/stdlib/stdlib.stasis";
 import "../src/stdlib/game_draw.stasis";
+import "../src/stdlib/game_input.stasis";
 import "../src/stdlib/game_math.stasis";
 
 // Interactive showcase sample:
@@ -99,23 +100,6 @@ function text_backspace(): void {
     text_sync_header();
 }
 
-function key_went_down(sc: i32): bool {
-    if (sc < 0 || sc >= 128) {
-        return false;
-    }
-    let down: bool = is_key_down(sc);
-    let prev: i32 = key_prev[sc];
-    let went: bool = down && prev == 0;
-
-    let next: i32 = 0;
-    if (down) {
-        next = 1;
-    }
-    key_prev[sc] = next;
-
-    return went;
-}
-
 function update_text_input(): void {
     if (!text_focused) {
         return;
@@ -125,18 +109,18 @@ function update_text_input(): void {
     // A..Z = 4..29, 1..0 = 30..39, Return=40, Backspace=42, Space=44
     let sc: i32 = 0;
 
-    if (key_went_down(42)) {
+    if (game_key_went_down(game_key_update(key_prev, 42))) {
         text_backspace();
     }
-    if (key_went_down(44)) {
+    if (game_key_went_down(game_key_update(key_prev, 44))) {
         text_append_byte(32);
     }
-    if (key_went_down(40)) {
+    if (game_key_went_down(game_key_update(key_prev, 40))) {
         text_append_byte(10);
     }
 
     for (sc = 4; sc <= 29; sc = sc + 1) {
-        if (key_went_down(sc)) {
+        if (game_key_went_down(game_key_update(key_prev, sc))) {
             // lower-case ASCII
             let ch: i32 = 97 + (sc - 4);
             text_append_byte(ch);
@@ -144,7 +128,7 @@ function update_text_input(): void {
     }
 
     for (sc = 30; sc <= 39; sc = sc + 1) {
-        if (key_went_down(sc)) {
+        if (game_key_went_down(game_key_update(key_prev, sc))) {
             let ch: i32 = 48;
             if (sc == 39) {
                 ch = 48;

--- a/src/stdlib/game_draw_batch.stasis
+++ b/src/stdlib/game_draw_batch.stasis
@@ -1,0 +1,64 @@
+// Draw batching helpers (not loaded by default).
+//
+// These helpers build a line command buffer compatible with:
+// - draw_lines_f32(lines: f32[], count: i32)
+//
+// Layout: 8 floats per line:
+//   x0, y0, x1, y1, r, g, b, a
+
+const GAME_LINE_STRIDE_F32: i32 = 8;
+
+function game_lines_clear(count: i32[]): void {
+    count[0] = 0;
+}
+
+function game_lines_push(
+    lines: f32[],
+    max_lines: i32,
+    count: i32[],
+    x0: f32, y0: f32, x1: f32, y1: f32,
+    r: f32, g: f32, b: f32, a: f32
+): bool {
+    if (count[0] >= max_lines) {
+        return false;
+    }
+    let base: i32 = count[0] * GAME_LINE_STRIDE_F32;
+    lines[base + 0] = x0;
+    lines[base + 1] = y0;
+    lines[base + 2] = x1;
+    lines[base + 3] = y1;
+    lines[base + 4] = r;
+    lines[base + 5] = g;
+    lines[base + 6] = b;
+    lines[base + 7] = a;
+    count[0] = count[0] + 1;
+    return true;
+}
+
+function game_lines_flush(lines: f32[], count: i32[]): void {
+    if (count[0] <= 0) {
+        return;
+    }
+    draw_lines_f32(lines, count[0]);
+}
+
+function game_lines_push_rect(
+    lines: f32[],
+    max_lines: i32,
+    count: i32[],
+    cx: f32, cy: f32,
+    half: f32,
+    r: f32, g: f32, b: f32, a: f32
+): bool {
+    let x0: f32 = cx - half;
+    let y0: f32 = cy - half;
+    let x1: f32 = cx + half;
+    let y1: f32 = cy + half;
+
+    if (!game_lines_push(lines, max_lines, count, x0, y0, x1, y0, r, g, b, a)) { return false; }
+    if (!game_lines_push(lines, max_lines, count, x1, y0, x1, y1, r, g, b, a)) { return false; }
+    if (!game_lines_push(lines, max_lines, count, x1, y1, x0, y1, r, g, b, a)) { return false; }
+    if (!game_lines_push(lines, max_lines, count, x0, y1, x0, y0, r, g, b, a)) { return false; }
+    return true;
+}
+

--- a/src/stdlib/game_input.stasis
+++ b/src/stdlib/game_input.stasis
@@ -1,0 +1,73 @@
+// Game input helpers (not loaded by default).
+//
+// These helpers are deterministic and explicit; they do not allocate or hide casts.
+//
+// Keyboard:
+// - Host provides `is_key_down(scancode: i32) -> bool`.
+// - To detect edges, pass an `i32[SC_MAX]` array of prior states (0/1).
+//
+// Pointers:
+// - Host provides `input_pointer_*` snapshot queries for the current frame.
+
+// Updates `key_prev[sc]` (0/1) and returns a small state code:
+// - 0: up
+// - 1: down (held)
+// - 2: went_down (down this frame, was up last frame)
+// - 3: went_up (up this frame, was down last frame)
+//
+// Notes:
+// - If `sc` is out of range, returns 0 and does not touch `key_prev`.
+function game_key_update(key_prev: i32[], sc: i32): i32 {
+    if (sc < 0 || sc >= 128) {
+        return 0;
+    }
+
+    let down: bool = is_key_down(sc);
+    let prev: i32 = key_prev[sc];
+    let next: i32 = 0;
+    if (down) {
+        next = 1;
+    }
+    key_prev[sc] = next;
+
+    if (next == 1 && prev == 0) {
+        return 2;
+    }
+    if (next == 0 && prev == 1) {
+        return 3;
+    }
+    return next;
+}
+
+function game_key_is_down(code: i32): bool {
+    return code == 1 || code == 2;
+}
+
+function game_key_went_down(code: i32): bool {
+    return code == 2;
+}
+
+function game_key_went_up(code: i32): bool {
+    return code == 3;
+}
+
+function game_pointer_any_went_down(): bool {
+    let count: i32 = input_pointer_count();
+    let i: i32 = 0;
+    for (i = 0; i < count; i = i + 1) {
+        if (input_pointer_went_down(i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function game_pointer_hit_aabb_px(idx: i32, x0: f32, y0: f32, x1: f32, y1: f32): bool {
+    let count: i32 = input_pointer_count();
+    if (idx < 0 || idx >= count) {
+        return false;
+    }
+    let px: f32 = input_pointer_x_px(idx);
+    let py: f32 = input_pointer_y_px(idx);
+    return px >= x0 && px <= x1 && py >= y0 && py <= y1;
+}

--- a/src/stdlib/game_viewport.stasis
+++ b/src/stdlib/game_viewport.stasis
@@ -1,0 +1,64 @@
+// Viewport and coordinate helpers (not loaded by default).
+//
+// Host provides:
+// - input_viewport_*_px() -> i32
+// - input_pointer_x_n/y_n() -> f32 (normalized)
+//
+// Viewport is currently the full window, but treating it as a first-class rect
+// keeps UI/game coordinate conversions explicit.
+
+function game_viewport_x_px_i32(): i32 { return input_viewport_x_px(); }
+function game_viewport_y_px_i32(): i32 { return input_viewport_y_px(); }
+function game_viewport_w_px_i32(): i32 { return input_viewport_w_px(); }
+function game_viewport_h_px_i32(): i32 { return input_viewport_h_px(); }
+
+function game_viewport_x_px(): f32 { return i32_to_f32(input_viewport_x_px()); }
+function game_viewport_y_px(): f32 { return i32_to_f32(input_viewport_y_px()); }
+function game_viewport_w_px(): f32 { return i32_to_f32(input_viewport_w_px()); }
+function game_viewport_h_px(): f32 { return i32_to_f32(input_viewport_h_px()); }
+
+// Convert viewport-local normalized coords (0..1) to pixel space.
+// - `nx/ny` are in viewport-local normalized space.
+function game_viewport_n_to_px(nx: f32, ny: f32, out_x_px: f32[], out_y_px: f32[]): void {
+    out_x_px[0] = game_viewport_x_px() + nx * game_viewport_w_px();
+    out_y_px[0] = game_viewport_y_px() + ny * game_viewport_h_px();
+}
+
+// Convert pixel coords to viewport-local normalized space (0..1).
+function game_viewport_px_to_n(x_px: f32, y_px: f32, out_nx: f32[], out_ny: f32[]): void {
+    let vw: f32 = game_viewport_w_px();
+    let vh: f32 = game_viewport_h_px();
+    if (vw <= 0.0 || vh <= 0.0) {
+        out_nx[0] = 0.0;
+        out_ny[0] = 0.0;
+        return;
+    }
+    out_nx[0] = (x_px - game_viewport_x_px()) / vw;
+    out_ny[0] = (y_px - game_viewport_y_px()) / vh;
+}
+
+// Simple 2D camera (screen pixels <-> world units).
+//
+// Convention:
+// - world -> screen: screen = viewport_origin + ((world - cam_pos) * zoom)
+// - screen -> world: world = cam_pos + ((screen - viewport_origin) / zoom)
+struct GameCamera2D {
+    x: f32;
+    y: f32;
+    zoom: f32;
+}
+
+function game_camera2d_world_to_screen(cam: GameCamera2D[], wx: f32, wy: f32, out_sx: f32[], out_sy: f32[]): void {
+    let z: f32 = cam[0].zoom;
+    if (z == 0.0) { z = 1.0; }
+    out_sx[0] = game_viewport_x_px() + (wx - cam[0].x) * z;
+    out_sy[0] = game_viewport_y_px() + (wy - cam[0].y) * z;
+}
+
+function game_camera2d_screen_to_world(cam: GameCamera2D[], sx: f32, sy: f32, out_wx: f32[], out_wy: f32[]): void {
+    let z: f32 = cam[0].zoom;
+    if (z == 0.0) { z = 1.0; }
+    out_wx[0] = cam[0].x + (sx - game_viewport_x_px()) / z;
+    out_wy[0] = cam[0].y + (sy - game_viewport_y_px()) / z;
+}
+

--- a/tests/stdlib_game_draw_batch.stasis
+++ b/tests/stdlib_game_draw_batch.stasis
@@ -1,0 +1,18 @@
+import "../src/stdlib/game_draw_batch.stasis";
+
+global lines: f32[64];
+global count: i32[1];
+
+test `game_lines_push respects max_lines`(): bool {
+    game_lines_clear(count);
+    let ok0: bool = game_lines_push(lines, 1, count, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0);
+    let ok1: bool = game_lines_push(lines, 1, count, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0);
+    return ok0 && !ok1 && count[0] == 1;
+}
+
+test `game_lines_push_rect pushes four lines`(): bool {
+    game_lines_clear(count);
+    let ok: bool = game_lines_push_rect(lines, 16, count, 10.0, 10.0, 2.0, 0.1, 0.2, 0.3, 1.0);
+    return ok && count[0] == 4;
+}
+

--- a/tests/stdlib_game_input.stasis
+++ b/tests/stdlib_game_input.stasis
@@ -1,0 +1,8 @@
+import "../src/stdlib/game_input.stasis";
+
+global key_prev: i32[128];
+
+test `game_key_update returns up for invalid scancode`(): bool {
+    return game_key_update(key_prev, -1) == 0 && game_key_update(key_prev, 128) == 0;
+}
+


### PR DESCRIPTION
Cascading PR off #48.

Implements the next task in docs/tasks.md (P1):
- Input helpers: src/stdlib/game_input.stasis (keyboard edge tracking + pointer helpers)
- Viewport/camera helpers: src/stdlib/game_viewport.stasis (explicit pixel<->normalized conversions + GameCamera2D)
- Draw batching helpers: src/stdlib/game_draw_batch.stasis (build a draw_lines_f32 buffer)
- Refactors samples to use helpers:
  - samples/interactive_showcase.stasis uses game_input
  - samples/input_pointers.stasis uses game_viewport
- Adds deterministic tests that don't depend on graphics linking:
  - tests/stdlib_game_input.stasis
  - tests/stdlib_game_draw_batch.stasis

Tests:
- build.bat
- test.bat