### PR TITLE
docs: complete audio plan

### DIFF
--- a/docs/audio-plan.md
+++ b/docs/audio-plan.md
@@ -2,6 +2,16 @@
 
 This document describes a practical, low-latency, cross-platform plan for sound output in Stasis, inspired by the Handmade Hero "game generates samples; platform plays them" model.
 
+## Status (desktop MVP)
+
+Implemented for desktop via SDL2:
+
+- Runtime ring buffer + audio callback: `runtime/stasis_graphics.c`
+- Stasis-facing builtins: `audio_is_available`, `audio_get_sample_rate`, `audio_get_channels`, `audio_get_queued_frames`, `audio_get_underruns`, `audio_push_f32_interleaved`
+- Example program: `samples/audio_sine.stasis` (prints queued frames + underruns)
+
+WASM/WebAudio remains planned work.
+
 ## Goals
 
 - Cross-platform sound output suitable for games (desktop first, then WASM/mobile).
@@ -200,4 +210,3 @@ CI sanity:
 - M2: SDL2 backend wired into the runner (desktop audio output).
 - M3: Stasis sample: sine wave + underrun stats (`samples/audio_sine.stasis`).
 - M4: WebAudio design + first worklet prototype (feature-flagged).
-

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -8,7 +8,7 @@ This file is a lightweight, persistent checklist of upcoming work. It complement
 - [x] Game dev readiness: P0 stdlib modules (`game_math`, `game_draw`, `game_collision`) + canonical UTF-8 buffer helpers (remove samples writing string headers directly).
 - [x] Game dev readiness: P1 input helpers (went_down/up, mapping), viewport/camera helpers, and draw batching helpers.
 - [x] Game dev readiness: P2 audio mixer layer (one-shots + loops) and more templates/examples.
-- [ ] Follow through: implement `docs/audio-plan.md` (desktop SDL2 audio MVP first).
+- [x] Follow through: implement `docs/audio-plan.md` (desktop SDL2 audio MVP first).
 - [ ] Follow through: implement `docs/input-plan.md` (pointer snapshot, mouse + touch/taps).
 - [ ] Follow through: implement `docs/aquarium-sample-plan.md` (add `samples/aquarium.stasis`).
 - [ ] Follow through: execute `docs/data-hot-reload-plan.md` (end-to-end dev workflow + tests).


### PR DESCRIPTION
Cascading PR off #50.

- Documents that the desktop SDL2 audio MVP is implemented.
- Marks docs/audio-plan.md follow-through task complete in docs/tasks.md.

Refs:
- Runtime audio: runtime/stasis_graphics.c
- Sample: samples/audio_sine.stasis

Tests:
- test.bat