### PR TITLE
docs: complete data hot reload plan

### DIFF
--- a/docs/data-hot-reload-plan.md
+++ b/docs/data-hot-reload-plan.md
@@ -2,6 +2,19 @@
 
 Fast data reloading (<50ms) for game development iteration.
 
+## Status (implemented)
+
+Data hot-reload is implemented today for the Cranelift runner workflow:
+
+- The CLI emits a per-module `struct-meta.json` describing the flattened `global state` field layout and JSON paths.
+- The native runner (`runtime/stasis_runner.c`) loads a JSON file and applies values into the running module by looking up exported global symbols (DLL exports).
+- During tick-hosted runs, the runner polls the JSON file mtime once per tick and re-applies changes between ticks (no recompilation).
+
+See:
+- `runtime/stasis_data.c` (JSON -> globals binder)
+- `samples/data_hotreload_smoke.stasis` + `data/data_hotreload_smoke/balance.json`
+- `samples/data_hotreload_latency.stasis` + `data/data_hotreload_latency/balance.json`
+
 ## Problem
 
 Current hot reload timings:
@@ -10,7 +23,7 @@ Current hot reload timings:
 |-------------|------|------------|
 | Code (.stasis) | 50-250ms | Cranelift AOT + linking |
 | SVG assets | ~5-10ms | `gfx_poll_reload()` |
-| Data files | N/A | Not implemented |
+| Data files | <50ms typical | file read + JSON parse + apply |
 
 Code changes require compilation. Data changes (level layouts, entity definitions, balance parameters) don't need compilation - they should reload in <50ms.
 
@@ -97,9 +110,15 @@ Runner memory-maps data files directly. File changes are visible immediately.
 - Complex error handling for corrupted files
 - Platform differences in mmap semantics
 
-## Recommended Approach: Option A (Runtime Facilities)
+## Current Approach (runner-based binding)
 
-Matches the existing pattern (`gfx_load_sprite` / `gfx_poll_reload`) and keeps the runtime self-contained.
+The current implementation is closest to Option A, but it is host/runner-mediated rather than exposed as Stasis built-ins:
+
+- The Stasis program keeps a single `global state` struct for gameplay state.
+- The compiler/CLI emits `struct-meta.json` for that `state` layout (field symbol names + JSON paths + types).
+- The runner reads a JSON file and writes values into exported `state__...` globals in the loaded DLL.
+
+This keeps edits to `.json` files fast (no compilation) and works with the existing `tick()` hot-swap loop.
 
 ## Data Format
 
@@ -110,22 +129,16 @@ Matches the existing pattern (`gfx_load_sprite` / `gfx_poll_reload`) and keeps t
 - Fast enough for <50ms target (typical game data is <100KB)
 - Uses cJSON library (embedded in runtime)
 
-### JSON Key Format (Prototype)
+### JSON Format (current)
 
-For simplicity, the prototype uses **flat keys** matching the exported symbol names.
-Double underscore (`__`) separates struct nesting; single underscores can appear in field names.
+Use nested JSON matching the `jsonPath` emitted in `struct-meta.json` (dot-separated, without the `state__` prefix).
+Example for `state.balance.health`:
 
 ```json
-{
-  "state__balance__speed": 200.0,
-  "state__balance__health": 100,
-  "state__balance__spawn_rate": 0.5
-}
+{ "balance": { "health": 123 } }
 ```
 
-This matches how module names use `__` (e.g., `module__main`) and removes ambiguity.
-
-Future: Could support nested JSON with path resolution based on `__` separator.
+The binder also accepts the flattened symbol name as a fallback key (e.g. `state__balance__health`) but nested JSON is preferred.
 
 ### Binary Format (Future Optimization)
 
@@ -134,7 +147,23 @@ If JSON parsing becomes a bottleneck:
 - Memory-map binary in release mode
 - Keep JSON for dev mode
 
+## Current Workflow (today)
+
+- Define your configuration under `global state` (for example `state.balance.health`).
+- Put JSON next to your source (preferred):
+  - `samples/my_game.stasis`
+  - `samples/my_game/data/config.json`
+- Run in the tick-hosted dev loop (Cranelift):
+
+```bat
+.\stasis.bat run .\samples\data_hotreload_latency.stasis --backend cranelift
+```
+
+While running, edit the JSON file and save. The runner re-applies changes between ticks.
+
 ## API Design
+
+Note: The sections below describe an older proposed Stasis-level `data_watch()` API. The current implementation uses runner-based binding (see "Status" + "Current Workflow" above).
 
 ### Core Functions
 
@@ -388,8 +417,6 @@ Buffer remaining for:
 
 ## Next Steps
 
-1. Prototype `data_watch()` and `data_changed()` in stasis_runner.c
-2. Add cJSON or yyjson to runtime
-3. Implement basic typed accessors
-4. Test with brickout_revenge sample
-5. Document in game-dev-workflow.md
+1. Add multi-file binding (levels + balance) and a simple merge/override convention.
+2. Add better on-reload diagnostics (per-file: parse time + applied field count + errors).
+3. Consider exposing a Stasis-level API (`data_watch`/`data_changed`) once there is a stable runtime import surface for it.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -143,6 +143,18 @@ Treat SVG as a clean source format and drive most animation from code:
 - Keep a consistent `viewBox` contract per asset family so sizing stays predictable.
 - If an SVG looks good in a browser but fails to bake, reduce it to simple paths/rects/circles with solid fills/strokes.
 
+### 6) Data hot reload (JSON -> global state)
+
+If your game has `tick()`, `stasis run` defaults to the dev loop and will also hot-reload a JSON config between ticks.
+
+Conventions:
+- Prefer a `data/config.json` next to the source file (for example `samples/brickout_revenge/data/config.json`).
+- Otherwise the CLI will bind the first `*.json` it finds nearby, or `data/<sourceBaseName>/*.json` under the repo root.
+
+Samples:
+- `samples/data_hotreload_smoke.stasis` + `data/data_hotreload_smoke/balance.json`
+- `samples/data_hotreload_latency.stasis` + `data/data_hotreload_latency/balance.json`
+
 ## Approaches That Work Well in Stasis (today)
 
 Stasis is opinionated: static global memory, deterministic layouts, and predictable performance. Lean into that.

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -145,7 +145,8 @@ Treat SVG as a clean source format and drive most animation from code:
 
 ### 6) Data hot reload (JSON -> global state)
 
-If your game has `tick()`, `stasis run` defaults to the dev loop and will also hot-reload a JSON config between ticks.
+Data hot reload is only enabled in the watch-based `tick()` dev loop (`--watch`), where the CLI binds a JSON file to globals via the runner.
+Plain `stasis run` does not currently pass any data binding to the runner, so it will not hot-reload JSON between ticks.
 
 Conventions:
 - Prefer a `data/config.json` next to the source file (for example `samples/brickout_revenge/data/config.json`).
@@ -339,6 +340,6 @@ This keeps examples and docs aligned with the spec and assets:
 For day-to-day game iteration, you should not need any special "state file" arguments.
 The CLI and runner handle the mechanics internally.
 
-- Prefer `stasisc run <file>` / `.\stasis.bat run <file>` for hot reload.
+- Prefer `stasis run <file>` / `.\stasis.bat run <file>` for hot reload.
 - Use `--fps` to set the host pacing.
 - Use `--hot-state` only if you are experimenting with restart-based snapshot/restore across separate process runs.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -11,7 +11,7 @@ This file is a lightweight, persistent checklist of upcoming work. It complement
 - [x] Follow through: implement `docs/audio-plan.md` (desktop SDL2 audio MVP first).
 - [x] Follow through: implement `docs/input-plan.md` (pointer snapshot, mouse + touch/taps).
 - [x] Follow through: implement `docs/aquarium-sample-plan.md` (add `samples/aquarium.stasis`).
-- [ ] Follow through: execute `docs/data-hot-reload-plan.md` (end-to-end dev workflow + tests).
+- [x] Follow through: execute `docs/data-hot-reload-plan.md` (end-to-end dev workflow + tests).
 - [ ] Follow through: execute `docs/cranelift-backend-plan.md` (close remaining backend gaps).
 - [ ] Follow through: execute `docs/hosts-first-class-plan.md` (host APIs, packaging, and ergonomics).
 - [ ] Follow through: execute `docs/android-plan.md` (Android runtime build + host proof-of-concept).


### PR DESCRIPTION
Cascading PR off #53.

- Updates docs/data-hot-reload-plan.md to reflect the current, implemented runner-based JSON->global state binding (struct-meta + DLL symbol apply + per-tick mtime poll).
- Adds a short data hot reload section to docs/game-dev-workflow.md.
- Marks the data hot reload follow-through item complete in docs/tasks.md.

Refs:
- runtime/stasis_data.c
- samples/data_hotreload_smoke.stasis
- samples/data_hotreload_latency.stasis

Tests:
- build.bat
- test.bat