### PR TITLE
fix: improve LSP completion sync

### DIFF
--- a/Stasis.LanguageServer.Tests/LspCompletionTests.cs
+++ b/Stasis.LanguageServer.Tests/LspCompletionTests.cs
@@ -9,6 +9,8 @@ using Stasis.LanguageServer.Services;
 using Stasis.Compiler;
 using Xunit;
 using System.Reflection;
+using System.IO;
+using LspRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Stasis.LanguageServer.Tests;
 
@@ -135,6 +137,187 @@ public sealed class LspCompletionTests
     }
 
     [Fact]
+    public async Task CompletesDeepNestedStructMembersAfterDot()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "struct ScreenConfig {",
+            "    width: i32;",
+            "    height: i32;",
+            "}",
+            "",
+            "struct BrickConfig {",
+            "    width: f32;",
+            "    height: f32;",
+            "}",
+            "",
+            "struct Config {",
+            "    screen: ScreenConfig;",
+            "    brick: BrickConfig;",
+            "}",
+            "",
+            "struct GameState {",
+            "    config: Config;",
+            "}",
+            "",
+            "global state: GameState;",
+            "",
+            "function main(): i32 {",
+            "    state.config.brick.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_deep.stasis";
+        var position = GetPositionAfter(document, "state.config.brick.");
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("width", labels);
+        Assert.Contains("height", labels);
+    }
+
+    [Fact]
+    public async Task CompletesParameterStructMembersAfterDot()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "struct Vec2 {",
+            "    x: f32;",
+            "    y: f32;",
+            "}",
+            "",
+            "function move(pos: Vec2): i32 {",
+            "    pos.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_param.stasis";
+        var position = GetPositionAfter(document, "pos.");
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("x", labels);
+        Assert.Contains("y", labels);
+    }
+
+    [Fact]
+    public async Task CompletesLocalStructMembersAfterDot()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "struct Vec2 {",
+            "    x: f32;",
+            "    y: f32;",
+            "}",
+            "",
+            "function main(): i32 {",
+            "    let pos: Vec2 = 0;",
+            "    pos.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_local.stasis";
+        var position = GetPositionAfter(document, "pos.");
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("x", labels);
+        Assert.Contains("y", labels);
+    }
+
+    [Fact]
+    public async Task CompletesEnumMembersAfterDot()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "enum Phase {",
+            "    Idle,",
+            "    Running,",
+            "}",
+            "",
+            "function main(): i32 {",
+            "    Phase.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_enum.stasis";
+        var position = GetPositionAfter(document, "Phase.");
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("Idle", labels);
+        Assert.Contains("Running", labels);
+    }
+
+    [Fact]
+    public async Task CompletesNestedMembersWithOtherStateUsesInFile()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "struct Config {",
+            "    screen: ScreenConfig;",
+            "}",
+            "",
+            "struct ScreenConfig {",
+            "    w: i32;",
+            "    h: i32;",
+            "}",
+            "",
+            "struct GameState {",
+            "    config: Config;",
+            "    game: i32;",
+            "}",
+            "",
+            "global state: GameState;",
+            "",
+            "function foo(): void {",
+            "    state.game = 1;",
+            "}",
+            "",
+            "function main(): i32 {",
+            "    state.config.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_state_variants.stasis";
+        var position = GetPositionAfter(document, "state.config.");
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("screen", labels);
+    }
+
+    [Fact]
     public void BuildsSymbolIndexForNestedStructs()
     {
         var document = string.Join("\n", new[]
@@ -196,6 +379,7 @@ public sealed class LspCompletionTests
 
         var screenOffset = TextPositionConverter.PositionToOffset(document, new Position(screenPos.Line, screenPos.Character));
         var spritesOffset = TextPositionConverter.PositionToOffset(document, new Position(spritesPos.Line, spritesPos.Character));
+        var spritesDotOffset = TextPositionConverter.PositionToOffset(document, new Position(spritesPos.Line, Math.Max(0, spritesPos.Character - 1)));
 
         var method = typeof(CompletionHandler).GetMethod(
             "TryGetMemberAccessReceiverChain",
@@ -213,6 +397,123 @@ public sealed class LspCompletionTests
         Assert.True(spritesOk);
         var spritesChain = (IReadOnlyList<string>)spritesArgs[2]!;
         Assert.Equal(new[] { "state", "sprites" }, spritesChain);
+
+        var spritesDotArgs = new object?[] { document, spritesDotOffset, null };
+        var spritesDotOk = (bool)method!.Invoke(null, spritesDotArgs)!;
+        Assert.True(spritesDotOk);
+        var spritesDotChain = (IReadOnlyList<string>)spritesDotArgs[2]!;
+        Assert.Equal(new[] { "state", "sprites" }, spritesDotChain);
+    }
+
+    [Fact]
+    public void ExtractsReceiverChainsForDeepMemberAccess()
+    {
+        var document = string.Join("\n", new[]
+        {
+            "struct ScreenConfig { width: i32; }",
+            "struct BrickConfig { width: f32; }",
+            "struct Config { screen: ScreenConfig; brick: BrickConfig; }",
+            "struct GameState { config: Config; }",
+            "global state: GameState;",
+            "function main(): i32 {",
+            "    state.config.brick.",
+            "    return 0;",
+            "}"
+        });
+
+        var pos = GetPositionAfter(document, "state.config.brick.");
+        var offset = TextPositionConverter.PositionToOffset(document, new Position(pos.Line, pos.Character));
+
+        var method = typeof(CompletionHandler).GetMethod(
+            "TryGetMemberAccessReceiverChain",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var args = new object?[] { document, offset, null };
+        var ok = (bool)method!.Invoke(null, args)!;
+        Assert.True(ok);
+        var chain = (IReadOnlyList<string>)args[2]!;
+        Assert.Equal(new[] { "state", "config", "brick" }, chain);
+    }
+
+    [Fact]
+    public async Task CompletesAfterIncrementalChange()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var document = string.Join("\n", new[]
+        {
+            "struct Config {",
+            "    screen: ScreenConfig;",
+            "}",
+            "",
+            "struct ScreenConfig {",
+            "    w: i32;",
+            "    h: i32;",
+            "}",
+            "",
+            "struct GameState {",
+            "    config: Config;",
+            "}",
+            "",
+            "global state: GameState;",
+            "",
+            "function main(): i32 {",
+            "    state.",
+            "    return 0;",
+            "}"
+        });
+
+        var uri = "file:///test/test_incremental.stasis";
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var replacement = "    state.config.";
+        var editOffset = document.IndexOf("    state.", StringComparison.Ordinal);
+        Assert.True(editOffset >= 0, "Expected to find state line for incremental update.");
+        var editStart = GetPositionAt(document, editOffset);
+        var editEnd = new Position(editStart.Line, editStart.Character + "    state.".Length);
+        await harness.DidChangeAsync(uri, new[]
+        {
+            new TextDocumentContentChangeEvent
+            {
+                Range = new LspRange(editStart, editEnd),
+                Text = replacement
+            }
+        }, 2, cts.Token);
+
+        var updatedDocument = document.Replace("    state.", replacement);
+        var position = GetPositionAfter(updatedDocument, "state.config.");
+        var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+        Assert.Contains("screen", labels);
+    }
+
+    [Fact]
+    public async Task CompletesNestedMembersInBrickoutSample()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        var samplePath = Path.Combine(repoRoot, "samples", "brickout_revenge", "brickout_revenge.stasis");
+        Assert.True(File.Exists(samplePath), $"Missing sample file: {samplePath}");
+
+        var document = await File.ReadAllTextAsync(samplePath, cts.Token);
+        var uri = "file:///samples/brickout_revenge/brickout_revenge.stasis";
+
+        await using var harness = await LspTestHarness.StartAsync(cts.Token);
+        await harness.InitializeAsync(cts.Token);
+        await harness.DidOpenAsync(uri, document, cts.Token);
+
+        var configPos = GetPositionAfter(document, "state.config.");
+        var configLabels = await harness.RequestCompletionLabelsAsync(uri, configPos.Line, configPos.Character, cts.Token);
+        Assert.Contains("screen", configLabels);
+        Assert.Contains("brick", configLabels);
+
+        var brickPos = GetPositionAfter(document, "state.config.brick.");
+        var brickLabels = await harness.RequestCompletionLabelsAsync(uri, brickPos.Line, brickPos.Character, cts.Token);
+        Assert.Contains("width", brickLabels);
+        Assert.Contains("height", brickLabels);
     }
 
     private static (int Line, int Character) GetPositionAfter(string content, string marker)
@@ -224,9 +525,15 @@ public sealed class LspCompletionTests
         }
 
         var offset = index + marker.Length;
+        var position = GetPositionAt(content, offset);
+        return (position.Line, position.Character);
+    }
+
+    private static Position GetPositionAt(string content, int offset)
+    {
         var line = 0;
         var column = 0;
-        for (var i = 0; i < offset; i++)
+        for (var i = 0; i < offset && i < content.Length; i++)
         {
             if (content[i] == '\n')
             {
@@ -239,7 +546,7 @@ public sealed class LspCompletionTests
             }
         }
 
-        return (line, column);
+        return new Position(line, column);
     }
 }
 
@@ -327,6 +634,30 @@ internal sealed class LspTestHarness : IAsyncDisposable
             }
         };
         return SendNotificationAsync("textDocument/didOpen", @params, cancellationToken);
+    }
+
+    public Task DidChangeAsync(
+        string uri,
+        IReadOnlyList<TextDocumentContentChangeEvent> changes,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        var @params = new
+        {
+            textDocument = new
+            {
+                uri,
+                version
+            },
+            contentChanges = changes.Select(c => new
+            {
+                range = c.Range,
+                rangeLength = c.RangeLength,
+                text = c.Text
+            })
+        };
+
+        return SendNotificationAsync("textDocument/didChange", @params, cancellationToken);
     }
 
     public async Task<IReadOnlyList<string>> RequestCompletionLabelsAsync(

--- a/Stasis.LanguageServer.Tests/TextPositionConverterTests.cs
+++ b/Stasis.LanguageServer.Tests/TextPositionConverterTests.cs
@@ -27,5 +27,22 @@ public class TextPositionConverterTests
         Assert.Equal(3, TextPositionConverter.PositionToOffset(text, new Position(1, 0)));
         Assert.Equal(4, TextPositionConverter.PositionToOffset(text, new Position(1, 1)));
     }
-}
 
+    [Fact]
+    public void PositionToOffset_ClampsBeyondLineLength()
+    {
+        var text = "abc\ndef";
+
+        Assert.Equal(3, TextPositionConverter.PositionToOffset(text, new Position(0, 10)));
+        Assert.Equal(7, TextPositionConverter.PositionToOffset(text, new Position(1, 99)));
+    }
+
+    [Fact]
+    public void PositionToOffset_ClampsBeyondLineLengthWithCrLf()
+    {
+        var text = "abc\r\ndef";
+
+        Assert.Equal(3, TextPositionConverter.PositionToOffset(text, new Position(0, 10)));
+        Assert.Equal(8, TextPositionConverter.PositionToOffset(text, new Position(1, 99)));
+    }
+}

--- a/Stasis.LanguageServer/Handlers/CompletionHandler.cs
+++ b/Stasis.LanguageServer/Handlers/CompletionHandler.cs
@@ -17,28 +17,49 @@ public class CompletionHandler : CompletionHandlerBase
         _documentManager = documentManager;
     }
 
-    public override Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
+    public override async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
     {
         var uri = request.TextDocument.Uri.ToString();
         var doc = _documentManager.GetDocument(uri);
 
         if (doc?.ParseResult == null || doc.SymbolIndex == null)
-            return Task.FromResult(new CompletionList());
-
-        var offset = TextPositionConverter.PositionToOffset(doc.Content, request.Position);
-        if (!TryGetMemberAccessReceiverChain(doc.Content, offset, out var receiverChain))
         {
-            return Task.FromResult(new CompletionList());
+            await Console.Error.WriteLineAsync($"[completion] {uri} missing parse/symbol data");
+            return new CompletionList();
+        }
+
+        var lineSpan = GetLineSpan(doc.Content, request.Position.Line);
+        var lineOffset = lineSpan.Start + Math.Min(request.Position.Character, lineSpan.Text.Length);
+        var offset = lineOffset;
+        var triggerChar = request.Context?.TriggerCharacter;
+        if (!TryGetMemberAccessReceiverChainFromLinePrefix(lineSpan.Text, request.Position.Character, out var receiverChain) &&
+            !TryGetMemberAccessReceiverChain(doc.Content, offset, out receiverChain))
+        {
+            if (triggerChar == "." && TryGetMemberAccessReceiverChainFromPosition(doc.Content, offset, out receiverChain))
+            {
+                await Console.Error.WriteLineAsync($"[completion] {uri} fallback chain {string.Join(".", receiverChain)}");
+            }
+            else
+            {
+                var posInfo = $"{request.Position.Line}:{request.Position.Character}";
+                var snippet = GetSnippet(doc.Content, offset, 40);
+                await Console.Error.WriteLineAsync($"[completion] {uri} no member access at offset {offset} (len {doc.Content.Length}, pos {posInfo}, trigger {triggerChar ?? "null"}, lines {lineSpan.LineCount}) :: {snippet} :: line[{request.Position.Line}]={EscapeLine(lineSpan.Text)}");
+                return new CompletionList();
+            }
         }
 
         var receiverTypeName = ResolveReceiverTypeName(receiverChain, doc, offset);
         if (string.IsNullOrEmpty(receiverTypeName))
         {
-            return Task.FromResult(new CompletionList());
+            await Console.Error.WriteLineAsync($"[completion] {uri} unresolved chain {string.Join(".", receiverChain)}");
+            return new CompletionList();
         }
 
         var items = GetMemberCompletions(receiverTypeName, doc.SymbolIndex);
-        return Task.FromResult(new CompletionList(items));
+        var preview = string.Join(", ", items.Take(10).Select(i => i.Label));
+        var posInfoOk = $"{request.Position.Line}:{request.Position.Character}";
+        await Console.Error.WriteLineAsync($"[completion] {uri} {string.Join(".", receiverChain)} -> {receiverTypeName} ({items.Count}) [{preview}] pos {posInfoOk} line[{request.Position.Line}]={EscapeLine(lineSpan.Text)}");
+        return new CompletionList(items);
     }
 
     public override Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
@@ -261,28 +282,36 @@ public class CompletionHandler : CompletionHandlerBase
         }
 
         // Find the dot token for the member access immediately before the cursor.
-        var dotIndex = cursorOffset - 1;
-        if (!TrySkipInlineWhitespaceLeft(content, ref dotIndex))
+        var dotIndex = cursorOffset;
+        if (dotIndex < content.Length && content[dotIndex] == '.')
         {
-            return false;
+            // dotIndex already points at the dot
         }
-
-        // If we're in the middle of typing an identifier, walk backwards to find the dot.
-        var identStart = dotIndex;
-        while (identStart >= 0 && IsIdentifierChar(content[identStart]))
+        else
         {
-            identStart--;
-        }
+            dotIndex = cursorOffset - 1;
+            if (!TrySkipInlineWhitespaceLeft(content, ref dotIndex))
+            {
+                return false;
+            }
 
-        dotIndex = identStart;
-        if (!TrySkipInlineWhitespaceLeft(content, ref dotIndex))
-        {
-            return false;
-        }
+            // If we're in the middle of typing an identifier, walk backwards to find the dot.
+            var identStart = dotIndex;
+            while (identStart >= 0 && IsIdentifierChar(content[identStart]))
+            {
+                identStart--;
+            }
 
-        if (dotIndex < 0 || content[dotIndex] != '.')
-        {
-            return false;
+            dotIndex = identStart;
+            if (!TrySkipInlineWhitespaceLeft(content, ref dotIndex))
+            {
+                return false;
+            }
+
+            if (dotIndex < 0 || content[dotIndex] != '.')
+            {
+                return false;
+            }
         }
 
         // Extract receiver chain to the left of '.'.
@@ -338,6 +367,149 @@ public class CompletionHandler : CompletionHandlerBase
     }
 
     private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private static bool TryGetMemberAccessReceiverChainFromPosition(string content, int cursorOffset, out IReadOnlyList<string> receiverChain)
+    {
+        receiverChain = Array.Empty<string>();
+        if (cursorOffset <= 0 || cursorOffset > content.Length)
+        {
+            return false;
+        }
+
+        var names = new Stack<string>();
+        var i = cursorOffset - 1;
+
+        if (!TrySkipInlineWhitespaceLeft(content, ref i) || i < 0)
+        {
+            return false;
+        }
+
+        while (true)
+        {
+            var end = i;
+            while (i >= 0 && IsIdentifierChar(content[i]))
+            {
+                i--;
+            }
+
+            var start = i + 1;
+            if (start > end)
+            {
+                break;
+            }
+
+            names.Push(content.Substring(start, end - start + 1));
+
+            if (!TrySkipInlineWhitespaceLeft(content, ref i))
+            {
+                break;
+            }
+
+            if (i >= 0 && content[i] == '.')
+            {
+                i--;
+                if (!TrySkipInlineWhitespaceLeft(content, ref i))
+                {
+                    break;
+                }
+                continue;
+            }
+
+            break;
+        }
+
+        if (names.Count == 0)
+        {
+            return false;
+        }
+
+        receiverChain = names.ToArray();
+        return true;
+    }
+
+    private static bool TryGetMemberAccessReceiverChainFromLinePrefix(string lineText, int character, out IReadOnlyList<string> receiverChain)
+    {
+        receiverChain = Array.Empty<string>();
+        if (character < 0)
+        {
+            return false;
+        }
+
+        var names = new Stack<string>();
+        var endIndex = Math.Min(character, lineText.Length) - 1;
+        while (endIndex >= 0 && char.IsWhiteSpace(lineText[endIndex]))
+        {
+            endIndex--;
+        }
+
+        if (endIndex < 0)
+        {
+            return false;
+        }
+
+        if (lineText[endIndex] == '.')
+        {
+            endIndex--;
+            while (endIndex >= 0 && char.IsWhiteSpace(lineText[endIndex]))
+            {
+                endIndex--;
+            }
+        }
+
+        if (endIndex < 0 || lineText.LastIndexOf('.', endIndex) < 0)
+        {
+            return false;
+        }
+
+        var i = endIndex;
+        while (true)
+        {
+            if (!TrySkipInlineWhitespaceLeft(lineText, ref i))
+            {
+                break;
+            }
+
+            if (i < 0)
+            {
+                break;
+            }
+
+            var end = i;
+            while (i >= 0 && IsIdentifierChar(lineText[i]))
+            {
+                i--;
+            }
+
+            var start = i + 1;
+            if (start > end)
+            {
+                break;
+            }
+
+            names.Push(lineText.Substring(start, end - start + 1));
+
+            if (!TrySkipInlineWhitespaceLeft(lineText, ref i))
+            {
+                break;
+            }
+
+            if (i >= 0 && lineText[i] == '.')
+            {
+                i--;
+                continue;
+            }
+
+            break;
+        }
+
+        if (names.Count == 0)
+        {
+            return false;
+        }
+
+        receiverChain = names.ToArray();
+        return true;
+    }
 
     private static bool TrySkipInlineWhitespaceLeft(string content, ref int index)
     {
@@ -412,4 +584,67 @@ public class CompletionHandler : CompletionHandlerBase
 
         return typeText;
     }
+
+    private static string GetSnippet(string content, int offset, int radius)
+    {
+        if (offset < 0)
+        {
+            offset = 0;
+        }
+        if (offset > content.Length)
+        {
+            offset = content.Length;
+        }
+
+        var start = Math.Max(0, offset - radius);
+        var length = Math.Min(content.Length - start, radius * 2);
+        var snippet = content.Substring(start, length);
+        return snippet.Replace("\r", "\\r").Replace("\n", "\\n");
+    }
+
+    private static (string Text, int Start, int LineCount) GetLineSpan(string content, int lineIndex)
+    {
+        var line = 0;
+        var lineStart = 0;
+        var offset = 0;
+
+        while (offset < content.Length)
+        {
+            var ch = content[offset];
+            if (ch == '\r' || ch == '\n')
+            {
+                if (line == lineIndex)
+                {
+                    var lineText = content.Substring(lineStart, offset - lineStart);
+                    return (lineText, lineStart, line + 1);
+                }
+
+                if (ch == '\r' && offset + 1 < content.Length && content[offset + 1] == '\n')
+                {
+                    offset += 2;
+                }
+                else
+                {
+                    offset += 1;
+                }
+
+                line++;
+                lineStart = offset;
+                continue;
+            }
+
+            offset += 1;
+        }
+
+        if (line == lineIndex)
+        {
+            var lineText = content.Substring(lineStart, offset - lineStart);
+            return (lineText, lineStart, line + 1);
+        }
+
+        return (string.Empty, lineStart, line + 1);
+    }
+
+    private static string EscapeLine(string lineText) =>
+        lineText.Replace("\r", "\\r").Replace("\n", "\\n");
 }

--- a/Stasis.LanguageServer/Services/TextPositionConverter.cs
+++ b/Stasis.LanguageServer/Services/TextPositionConverter.cs
@@ -6,21 +6,28 @@ public static class TextPositionConverter
 {
     public static int PositionToOffset(string text, Position position)
     {
+        if (position.Line < 0 || position.Character < 0)
+        {
+            return 0;
+        }
+
         int offset = 0;
         int line = 0;
-        int character = 0;
+        int lineStart = 0;
 
         while (offset < text.Length)
         {
-            if (line == position.Line && character == position.Character)
-            {
-                return offset;
-            }
-
             var ch = text[offset];
-            if (ch == '\r')
+            if (ch == '\r' || ch == '\n')
             {
-                if (offset + 1 < text.Length && text[offset + 1] == '\n')
+                if (line == position.Line)
+                {
+                    var lineLength = offset - lineStart;
+                    var clamped = Math.Min(position.Character, lineLength);
+                    return lineStart + clamped;
+                }
+
+                if (ch == '\r' && offset + 1 < text.Length && text[offset + 1] == '\n')
                 {
                     offset += 2;
                 }
@@ -30,20 +37,18 @@ public static class TextPositionConverter
                 }
 
                 line++;
-                character = 0;
-                continue;
-            }
-
-            if (ch == '\n')
-            {
-                offset += 1;
-                line++;
-                character = 0;
+                lineStart = offset;
                 continue;
             }
 
             offset += 1;
-            character++;
+        }
+
+        if (line == position.Line)
+        {
+            var lineLength = offset - lineStart;
+            var clamped = Math.Min(position.Character, lineLength);
+            return lineStart + clamped;
         }
 
         return text.Length;
@@ -98,4 +103,3 @@ public static class TextPositionConverter
         return new Position(line, character);
     }
 }
-

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -64,6 +64,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     documentSelector: [{ scheme: "file", language: "stasis" }],
     outputChannel: output,
     traceOutputChannel: output,
+    middleware: {
+      didChange: async (event, next) => {
+        // Force full-text sync to keep the server document in sync for large files.
+        const doc = event.document;
+        const end = doc.lineAt(doc.lineCount - 1).range.end;
+        const fullText = doc.getText();
+        output.appendLine(`[didChange] ${doc.uri.toString()} len=${fullText.length} lines=${doc.lineCount}`);
+        const fullEvent = {
+          document: doc,
+          contentChanges: [
+            {
+              range: new vscode.Range(0, 0, end.line, end.character),
+              rangeOffset: 0,
+              rangeLength: fullText.length,
+              text: fullText,
+            },
+          ],
+          reason: event.reason,
+        };
+        return next(fullEvent);
+      },
+    },
   };
 
   output.appendLine(`Starting Stasis LSP: ${server.command} ${server.args.join(" ")}`.trim());


### PR DESCRIPTION
## Summary
- add completion coverage for params, locals, enums, deep/nested chains
- fix completion range handling and cursor clamping
- force full-text LSP change sync with logging for large files

## Testing
- dotnet test .\\Stasis.LanguageServer.Tests\\Stasis.LanguageServer.Tests.csproj -c Release