### PR TITLE
Runner hot-swap: swap hook + tick pacing + tests

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -2838,7 +2838,13 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
             }
             phase.Restart();
 
-            var exported = new[] { $"{moduleName}__main", $"{moduleName}__tick" };
+            var exports = new List<string> { $"{moduleName}__main", $"{moduleName}__tick" };
+            if (sema.Symbols.TryGetValue("swap", out var swapSymbol) &&
+                swapSymbol.Kind == SymbolKind.Function)
+            {
+                exports.Add($"{moduleName}__swap");
+            }
+            var exported = exports.ToArray();
             if (!TryCreateHotStatePlan(sourcePath, layout, moduleName, exported, excludeSpriteFields: false, out var plan))
             {
                 return 1;

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -2838,12 +2838,19 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
             }
             phase.Restart();
 
-            if (!TryCreateHotStatePlan(sourcePath, layout, moduleName, new[] { $"{moduleName}__main", $"{moduleName}__tick" }, excludeSpriteFields: false, out var plan))
+            var exported = new[] { $"{moduleName}__main", $"{moduleName}__tick" };
+            if (!TryCreateHotStatePlan(sourcePath, layout, moduleName, exported, excludeSpriteFields: false, out var plan))
             {
                 return 1;
             }
             planMs = phase.ElapsedMilliseconds;
             phase.Restart();
+
+            DataBindingPlan? dataBindingPlan = null;
+            if (!TryGetDataBindingPlan(sourcePath, layout, moduleName, exported, out dataBindingPlan))
+            {
+                return 1;
+            }
 
             var linkArgs = BuildClangArgsForObject(hotObjPath, hotDll, isTest: false, optLevel, enableLto, usesGraphics, graphicsLibPath, linkLibraries, entryName: $"{moduleName}__main", isDll: true, windowsDefFilePath: plan.DefPath);
             if (OperatingSystem.IsWindows())
@@ -2872,11 +2879,10 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
                 var entry = $"{moduleName}__main";
                 var runnerArgs = $"\"{hotDll}\" {entry} --state-map \"{plan.MapPath}\" --swap-file \"{swapFile}\" --fps {fps}";
 
-                var dataFile = FindDataBindingJson(sourcePath, repoRoot);
-                if (!string.IsNullOrEmpty(dataFile))
+                if (dataBindingPlan is not null)
                 {
-                    runnerArgs += $" --data-bind \"{dataFile}\" \"{plan.StructMetaPath}\"";
-                    Console.WriteLine($"Data binding: {dataFile}");
+                    runnerArgs += $" --data-bind \"{dataBindingPlan.JsonPath}\" \"{dataBindingPlan.StructMetaPath}\"";
+                    Console.WriteLine($"Data binding: {dataBindingPlan.JsonPath}");
                 }
 
                 var psi = new ProcessStartInfo
@@ -3074,7 +3080,10 @@ static bool TryCreateHotStatePlan(string sourcePath, LayoutPlan layout, string m
     var hotExitPath = Path.Combine(hotDir, $"{baseName}.{moduleName}.hot-exit");
 
     // Emit map/exports/metadata only when missing to keep hot-reload fast.
-    var structMetaPath = Path.Combine(hotDir, $"{baseName}.{moduleName}.struct-meta.json");
+    var structMetaFileName = excludeSpriteFields
+        ? $"{baseName}.{moduleName}.databind.struct-meta.json"
+        : $"{baseName}.{moduleName}.struct-meta.json";
+    var structMetaPath = Path.Combine(hotDir, structMetaFileName);
     if (!File.Exists(mapPath) || !File.Exists(defPath) || !File.Exists(structMetaPath))
     {
         var map = new StringBuilder();

--- a/Stasis.Compiler.Tests/HotSwapRunnerTests.cs
+++ b/Stasis.Compiler.Tests/HotSwapRunnerTests.cs
@@ -13,6 +13,25 @@ namespace Stasis.Compiler.Tests;
 public sealed class HotSwapRunnerTests
 {
     [Fact]
+    public void Reachability_includes_swap_entrypoint_when_defined()
+    {
+        var source = """
+            struct S { x: i32; }
+            global state: S;
+
+            function main(): i32 { return 0; }
+            function tick(): i32 { return 0; }
+            function swap(): i32 { return 0; }
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+
+        var reachable = Stasis.Compiler.IR.Reachability.CollectReachableFunctions(parse.CompilationUnit, includeTests: false, allowFallback: false);
+        Assert.Contains("swap", reachable);
+    }
+
+    [Fact]
     public void Runner_ticks_at_60_fps()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Stasis.Compiler.Tests/HotSwapRunnerTests.cs
+++ b/Stasis.Compiler.Tests/HotSwapRunnerTests.cs
@@ -1,0 +1,373 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stasis.Compiler.Tests;
+
+public sealed class HotSwapRunnerTests
+{
+    [Fact]
+    public void Runner_ticks_at_60_fps()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        if (!TryFindRepoRoot(out var repoRoot) || !TryFindRunner(repoRoot, out var runnerExe) || !TryFindClang(out var clangExe))
+        {
+            return;
+        }
+
+        var tempDir = CreateTempDir();
+        try
+        {
+            var dllPath = Path.Combine(tempDir, "tickrate.dll");
+            var cPath = Path.Combine(tempDir, "tickrate.c");
+            File.WriteAllText(cPath, TickRateDllSource, System.Text.Encoding.ASCII);
+
+            CompileDll(clangExe, cPath, dllPath, tempDir);
+
+            var stderr = RunRunnerAndCaptureStderr(runnerExe, $"\"{dllPath}\" tickrate__main --fps 60", timeoutMs: 10000);
+
+            var match = Regex.Match(stderr, @"TICKRATE ticks=(\d+) elapsed_ms=(\d+)");
+            Assert.True(match.Success, $"missing TICKRATE line in stderr:\n{stderr}");
+
+            var ticks = int.Parse(match.Groups[1].Value);
+            var elapsedMs = int.Parse(match.Groups[2].Value);
+            Assert.True(elapsedMs > 0, $"invalid elapsed_ms={elapsedMs}\n{stderr}");
+
+            var ticksPerSecond = (double)ticks / (elapsedMs / 1000.0);
+            Assert.InRange(ticksPerSecond, 52.0, 68.0);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task Runner_processes_one_swap_per_swap_file_write()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        if (!TryFindRepoRoot(out var repoRoot) || !TryFindRunner(repoRoot, out var runnerExe) || !TryFindClang(out var clangExe))
+        {
+            return;
+        }
+
+        var tempDir = CreateTempDir();
+        try
+        {
+            var dllV1 = Path.Combine(tempDir, "swap_v1.dll");
+            var dllV2 = Path.Combine(tempDir, "swap_v2.dll");
+            var cV1 = Path.Combine(tempDir, "swap_v1.c");
+            var cV2 = Path.Combine(tempDir, "swap_v2.c");
+            File.WriteAllText(cV1, SwapDllSource("TICK_V1"), System.Text.Encoding.ASCII);
+            File.WriteAllText(cV2, SwapDllSource("TICK_V2"), System.Text.Encoding.ASCII);
+
+            CompileDll(clangExe, cV1, dllV1, tempDir);
+            CompileDll(clangExe, cV2, dllV2, tempDir);
+
+            var swapFile = Path.Combine(tempDir, "swap_file.txt");
+
+            using var proc = StartRunner(runnerExe, $"\"{dllV1}\" swap__main --swap-file \"{swapFile}\" --fps 60");
+
+            var stderrLines = new List<string>();
+            var stderrDone = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            proc.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is null)
+                {
+                    stderrDone.TrySetResult(true);
+                    return;
+                }
+                lock (stderrLines)
+                {
+                    stderrLines.Add(e.Data);
+                }
+            };
+            proc.BeginErrorReadLine();
+
+            Assert.True(WaitForLine(stderrLines, l => l.Contains("TICK_V1 first", StringComparison.Ordinal), timeoutMs: 5000), "did not observe v1 tick start");
+
+            WriteSwapFileAndWaitConsumed(swapFile, dllV2, timeoutMs: 5000);
+            Assert.True(WaitForHotSwapCount(stderrLines, 1, timeoutMs: 5000), "expected 1 hot-swap");
+            Assert.True(WaitForLine(stderrLines, l => l.Contains("TICK_V2 first", StringComparison.Ordinal), timeoutMs: 5000), "did not observe v2 tick start");
+            Assert.True(WaitForLine(stderrLines, l => l.Contains("SWAP TICK_V2 count=1", StringComparison.Ordinal), timeoutMs: 5000), "did not observe v2 swap hook");
+
+            WriteSwapFileAndWaitConsumed(swapFile, dllV1, timeoutMs: 5000);
+            Assert.True(WaitForHotSwapCount(stderrLines, 2, timeoutMs: 5000), "expected 2 hot-swaps");
+            Assert.True(WaitForLine(stderrLines, l => l.Contains("SWAP TICK_V1 count=1", StringComparison.Ordinal), timeoutMs: 5000), "did not observe v1 swap hook");
+
+            proc.Kill(entireProcessTree: true);
+            proc.WaitForExit(5000);
+            try
+            {
+                await stderrDone.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            }
+            catch
+            {
+                // best-effort
+            }
+
+            var all = string.Join("\n", stderrLines);
+            Assert.Equal(2, Regex.Matches(all, @"^\[.*\]: HOTSWAP \d+ ms$", RegexOptions.Multiline).Count);
+            Assert.Equal(2, Regex.Matches(all, @"^HOTSWAP loading:", RegexOptions.Multiline).Count);
+            Assert.Equal(2, Regex.Matches(all, @"^HOTSWAP ok:", RegexOptions.Multiline).Count);
+            Assert.Equal(2, Regex.Matches(all, @"^SWAP TICK_V[12] count=1$", RegexOptions.Multiline).Count);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    private static Process StartRunner(string runnerExe, string args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = runnerExe,
+            Arguments = args,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        return Process.Start(psi)!;
+    }
+
+    private static string RunRunnerAndCaptureStderr(string runnerExe, string args, int timeoutMs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = runnerExe,
+            Arguments = args,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        if (!proc.WaitForExit(timeoutMs))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"runner timed out after {timeoutMs}ms");
+        }
+        return proc.StandardError.ReadToEnd();
+    }
+
+    private static void CompileDll(string clangExe, string cPath, string dllOut, string workingDir)
+    {
+        var args = $"-shared \"{cPath}\" -o \"{dllOut}\"";
+        var psi = new ProcessStartInfo
+        {
+            FileName = clangExe,
+            Arguments = args,
+            WorkingDirectory = workingDir,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+        var stderr = proc.StandardError.ReadToEnd();
+        if (proc.ExitCode != 0 || !File.Exists(dllOut))
+        {
+            throw new InvalidOperationException($"clang failed (exit {proc.ExitCode}):\n{stderr}");
+        }
+    }
+
+    private static void WriteSwapFileAndWaitConsumed(string swapFile, string nextDllPath, int timeoutMs)
+    {
+        File.WriteAllText(swapFile, nextDllPath + "\n", System.Text.Encoding.ASCII);
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (!File.Exists(swapFile))
+            {
+                return;
+            }
+            Thread.Sleep(10);
+        }
+        throw new TimeoutException("swap file was not consumed (deleted) by runner");
+    }
+
+    private static bool WaitForHotSwapCount(List<string> stderrLines, int expected, int timeoutMs)
+    {
+        return WaitForCondition(() =>
+        {
+            lock (stderrLines)
+            {
+                var all = string.Join("\n", stderrLines);
+                return Regex.Matches(all, @"^\[.*\]: HOTSWAP \d+ ms$", RegexOptions.Multiline).Count >= expected;
+            }
+        }, timeoutMs);
+    }
+
+    private static bool WaitForLine(List<string> stderrLines, Func<string, bool> predicate, int timeoutMs)
+    {
+        return WaitForCondition(() =>
+        {
+            lock (stderrLines)
+            {
+                return stderrLines.Any(predicate);
+            }
+        }, timeoutMs);
+    }
+
+    private static bool WaitForCondition(Func<bool> condition, int timeoutMs)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            Thread.Sleep(10);
+        }
+        return false;
+    }
+
+    private static string CreateTempDir()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "stasis_hotswap_test_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    private static bool TryFindRepoRoot(out string root)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var sln = Path.Combine(dir.FullName, "Stasis.sln");
+            if (File.Exists(sln))
+            {
+                root = dir.FullName;
+                return true;
+            }
+            dir = dir.Parent;
+        }
+        root = string.Empty;
+        return false;
+    }
+
+    private static bool TryFindRunner(string repoRoot, out string runnerExe)
+    {
+        var candidates = new[]
+        {
+            Path.Combine(repoRoot, "runtime", "build", "bin", "Release", "stasis_runner.exe"),
+            Path.Combine(repoRoot, "stasis_runner.exe"),
+            Path.Combine(repoRoot, "build", "stasis_runner.exe")
+        };
+
+        runnerExe = candidates.FirstOrDefault(File.Exists) ?? string.Empty;
+        return !string.IsNullOrEmpty(runnerExe);
+    }
+
+    private static bool TryFindClang(out string clangExe)
+    {
+        var search = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? Array.Empty<string>();
+        foreach (var dir in search)
+        {
+            var candidate = Path.Combine(dir, "clang.exe");
+            if (File.Exists(candidate))
+            {
+                clangExe = candidate;
+                return true;
+            }
+        }
+
+        clangExe = string.Empty;
+        return false;
+    }
+
+    private const string TickRateDllSource = """
+        #include <windows.h>
+        #include <stdint.h>
+        #include <stdio.h>
+
+        static int g_ticks = 0;
+        static LARGE_INTEGER g_t0;
+        static LARGE_INTEGER g_freq;
+        static int g_started = 0;
+
+        __declspec(dllexport) int tickrate__main(void) {
+            return 0;
+        }
+
+        __declspec(dllexport) int tickrate__tick(void) {
+            if (!g_started) {
+                QueryPerformanceFrequency(&g_freq);
+                QueryPerformanceCounter(&g_t0);
+                g_started = 1;
+            }
+
+            g_ticks++;
+            if (g_ticks >= 120) {
+                LARGE_INTEGER t1;
+                QueryPerformanceCounter(&t1);
+                long long elapsed_ms = (t1.QuadPart - g_t0.QuadPart) * 1000LL / g_freq.QuadPart;
+                if (elapsed_ms < 1) elapsed_ms = 1;
+                fprintf(stderr, "TICKRATE ticks=%d elapsed_ms=%lld\n", g_ticks, elapsed_ms);
+                return 1;
+            }
+
+            return 0;
+        }
+        """;
+
+    private static string SwapDllSource(string tag)
+    {
+        return $$"""
+            #include <windows.h>
+            #include <stdio.h>
+
+            static int g_once = 0;
+            static int g_swap_count = 0;
+
+            __declspec(dllexport) int swap__main(void) {
+                return 0;
+            }
+
+            __declspec(dllexport) int swap__swap(void) {
+                g_swap_count++;
+                fprintf(stderr, "SWAP %s count=%d\n", "{{tag}}", g_swap_count);
+                return 0;
+            }
+
+            __declspec(dllexport) int swap__tick(void) {
+                if (!g_once) {
+                    fprintf(stderr, "%s first\n", "{{tag}}");
+                    g_once = 1;
+                }
+                return 0;
+            }
+            """;
+    }
+}

--- a/Stasis.Compiler/IR/Reachability.cs
+++ b/Stasis.Compiler/IR/Reachability.cs
@@ -42,6 +42,12 @@ public static class Reachability
                 queue.Enqueue("tick");
             }
 
+            // Hot-swap hook: if a program defines `swap`, treat it as an entrypoint so it can be invoked after a DLL swap.
+            if (functions.ContainsKey("swap"))
+            {
+                queue.Enqueue("swap");
+            }
+
             foreach (var export in functions.Values.Where(fn => fn.IsExported))
             {
                 queue.Enqueue(export.Name.Text);

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>
+#include <time.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -400,6 +401,53 @@ static void free_state_map(stasis_state_symbol **syms, uint32_t *sym_count)
     free(*syms);
     *syms = NULL;
     *sym_count = 0;
+}
+
+static uint64_t stasis_epoch_ms(void)
+{
+#ifdef _WIN32
+    FILETIME ft;
+    GetSystemTimeAsFileTime(&ft);
+    ULARGE_INTEGER uli;
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    /* 100ns ticks since 1601-01-01 -> ms since 1970-01-01 */
+    const uint64_t EPOCH_DIFFERENCE_100NS = 116444736000000000ULL;
+    if (uli.QuadPart < EPOCH_DIFFERENCE_100NS)
+    {
+        return 0;
+    }
+    return (uli.QuadPart - EPOCH_DIFFERENCE_100NS) / 10000ULL;
+#else
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+    {
+        return 0;
+    }
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000ULL);
+#endif
+}
+
+static void stasis_format_local_time(char *out, size_t out_cap)
+{
+    if (!out || out_cap == 0)
+    {
+        return;
+    }
+
+#ifdef _WIN32
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    _snprintf_s(out, out_cap, _TRUNCATE, "%04u-%02u-%02u %02u:%02u:%02u.%03u",
+                (unsigned)st.wYear, (unsigned)st.wMonth, (unsigned)st.wDay,
+                (unsigned)st.wHour, (unsigned)st.wMinute, (unsigned)st.wSecond,
+                (unsigned)st.wMilliseconds);
+#else
+    time_t now = time(NULL);
+    struct tm tm_now;
+    localtime_r(&now, &tm_now);
+    strftime(out, out_cap, "%Y-%m-%d %H:%M:%S", &tm_now);
+#endif
 }
 
 static int copy_state_to_buffer(HMODULE lib, stasis_state_symbol *syms, uint32_t sym_count, uint8_t *buffer, uint32_t total_bytes, int allow_missing, uint32_t *missing_count)
@@ -878,6 +926,8 @@ int main(int argc, char **argv)
     /* Optional tick loop: if `<module>__tick` is exported, call init once then tick at target FPS. */
     char tick_name[512];
     tick_name[0] = '\0';
+    char swap_name[512];
+    swap_name[0] = '\0';
     const char *sep = strstr(entry_name, "__");
     if (sep)
     {
@@ -886,6 +936,11 @@ int main(int argc, char **argv)
         {
             memcpy(tick_name, entry_name, prefix_len);
             memcpy(tick_name + prefix_len, "tick", 5);
+        }
+        if (prefix_len + 4 < sizeof(swap_name))
+        {
+            memcpy(swap_name, entry_name, prefix_len);
+            memcpy(swap_name + prefix_len, "swap", 5);
         }
     }
 
@@ -903,16 +958,24 @@ int main(int argc, char **argv)
         stasis_tick_fn tick = (stasis_tick_fn)tick_sym;
         LARGE_INTEGER freq;
         QueryPerformanceFrequency(&freq);
-        long long target_us = 1000000LL / (long long)fps;
+        LONGLONG tick_step = freq.QuadPart / (LONGLONG)fps;
+        if (tick_step < 1)
+        {
+            tick_step = 1;
+        }
 
-        LARGE_INTEGER last;
-        QueryPerformanceCounter(&last);
+        LARGE_INTEGER next;
+        QueryPerformanceCounter(&next);
 
         for (;;)
         {
             /* Swap between ticks if requested. */
                     if (swap_file_path && file_exists(swap_file_path))
                     {
+                        LARGE_INTEGER swap_latency_t0;
+                        LARGE_INTEGER swap_latency_t1;
+                        QueryPerformanceCounter(&swap_latency_t0);
+
                         char new_path[2048];
                         char map_path[2048];
                         map_path[0] = '\0';
@@ -1016,6 +1079,12 @@ int main(int argc, char **argv)
                                 break;
                             }
 
+                            FARPROC new_swap_sym = NULL;
+                            if (swap_name[0] != '\0')
+                            {
+                                new_swap_sym = GetProcAddress(new_lib, swap_name);
+                            }
+
                             if (buffer)
                             {
                                 QueryPerformanceCounter(&sw_t0);
@@ -1049,6 +1118,26 @@ int main(int argc, char **argv)
 
                             /* Update DLL handle for data binding system */
                             stasis_data_set_dll(new_lib);
+
+                            /* Optional post-swap hook: call `<module>__swap` once after each swap. */
+                            if (new_swap_sym)
+                            {
+                                int (*swap_fn)(void) = (int (*)(void))new_swap_sym;
+                                int swap_result = swap_fn();
+                                if (swap_result != 0)
+                                {
+                                    result = swap_result == 1 ? 0 : swap_result;
+                                    break;
+                                }
+                            }
+
+                            QueryPerformanceCounter(&swap_latency_t1);
+                            long long swap_latency_us = (swap_latency_t1.QuadPart - swap_latency_t0.QuadPart) * 1000000LL / sw_freq.QuadPart;
+                            long long swap_latency_ms = (swap_latency_us + 500LL) / 1000LL;
+                            char local_time[64];
+                            stasis_format_local_time(local_time, sizeof(local_time));
+                            uint64_t epoch_ms = stasis_epoch_ms();
+                            fprintf(stderr, "[%" PRIu64 ", %s]: HOTSWAP %lld ms\n", epoch_ms, local_time, swap_latency_ms);
                         }
                     }
 
@@ -1062,30 +1151,34 @@ int main(int argc, char **argv)
                 break;
             }
 
-            LARGE_INTEGER now;
-            QueryPerformanceCounter(&now);
-            long long elapsed_us = (now.QuadPart - last.QuadPart) * 1000000LL / freq.QuadPart;
-            last = now;
+            next.QuadPart += tick_step;
 
-            long long sleep_us = target_us - elapsed_us;
-            while (sleep_us > 0)
+            for (;;)
             {
                 /* Break host sleep if a swap is pending. */
                 if (swap_file_path && file_exists(swap_file_path))
                 {
                     break;
                 }
-                DWORD ms = (DWORD)(sleep_us / 1000LL);
-                if (ms == 0)
+
+                LARGE_INTEGER now;
+                QueryPerformanceCounter(&now);
+                LONGLONG remaining = next.QuadPart - now.QuadPart;
+                if (remaining <= 0)
                 {
-                    ms = 1;
+                    break;
                 }
-                if (ms > 5)
+
+                /* Sleep most of the remaining time, then yield/spin to land closer to the target. */
+                DWORD ms = (DWORD)((remaining * 1000LL) / freq.QuadPart);
+                if (ms > 1)
                 {
-                    ms = 5;
+                    Sleep(ms - 1);
                 }
-                Sleep(ms);
-                sleep_us -= (long long)ms * 1000LL;
+                else
+                {
+                    SwitchToThread();
+                }
             }
         }
     }

--- a/samples/brickout_revenge/brickout_revenge_v1.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1.stasis
@@ -613,6 +613,24 @@ function point_in_rect(px: f32, py: f32, rx: f32, ry: f32, rw: f32, rh: f32): bo
     return true;
 }
 
+function rect_fully_in_level(x: f32, y: f32, w: f32, h: f32): bool {
+    let sw: f32 = i32_to_f32(state.config.screen.w);
+    let sh: f32 = i32_to_f32(state.config.screen.h);
+    if (x < 0.0) { return false; }
+    if (y < 0.0) { return false; }
+    if (x + w > sw) { return false; }
+    if (y + h > sh) { return false; }
+    return true;
+}
+
+function brick_fully_in_level(gx: i32, gy: i32): bool {
+    let x: f32 = grid_to_world_x(gx);
+    let y: f32 = grid_to_world_y(gy);
+    let w: f32 = state.config.brick.width;
+    let h: f32 = state.config.brick.height;
+    return rect_fully_in_level(x, y, w, h);
+}
+
 // Grid helpers - bricks are placed on a grid in the lower portion
 function grid_to_world_x(gx: i32): f32 {
     let gxf: f32 = i32_to_f32(gx);
@@ -675,6 +693,7 @@ function find_free_brick_slot(): i32 {
 
 function place_brick_at_grid(gx: i32, gy: i32, brick_type: BrickType): bool {
     if (!grid_in_bounds(gx, gy)) { return false; }
+    if (!brick_fully_in_level(gx, gy)) { return false; }
     if (grid_is_occupied(gx, gy)) { return false; }
     let slot: i32 = find_free_brick_slot();
     if (slot < 0) { return false; }
@@ -784,46 +803,18 @@ function init_game(reset_progress: bool): void {
 
 function setup_default_bricks(): void {
     // Stress test: Fill the bottom of the screen with bricks
-    let brick_idx: i32 = 0;
     let row: i32 = 0;
     let col: i32 = 0;
 
     // Fill grid rows/cols for the starting layout.
     for (row = 0; row < GRID_ROWS; row = row + 1) {
         for (col = 0; col < GRID_COLS; col = col + 1) {
-            if (brick_idx < MAX_BRICKS) {
-                state.bricks[brick_idx].active = true;
-                state.bricks[brick_idx].x = grid_to_world_x(col);
-                state.bricks[brick_idx].y = grid_to_world_y(row);
-                state.bricks[brick_idx].grid_x = col;
-                state.bricks[brick_idx].grid_y = row;
-                state.bricks[brick_idx].attack_cd_ms = 0;
-                state.bricks[brick_idx].shot_fx_ms = 0;
-
-                // Mix brick types for variety
-                let type_selector: i32 = (row + col) % 3;
-
-                // Stress test: bricks have 10-30 HP
-                let brick_hp: i32 = 10 + (next_rand() % 21);
-
-                if (type_selector == 0) {
-                    state.bricks[brick_idx].brick_type = BrickType.Basic;
-                    state.bricks[brick_idx].hp = brick_hp;
-                    state.bricks[brick_idx].max_hp = brick_hp;
-                }
-                if (type_selector == 1) {
-                    state.bricks[brick_idx].brick_type = BrickType.Armored;
-                    state.bricks[brick_idx].hp = brick_hp;
-                    state.bricks[brick_idx].max_hp = brick_hp;
-                }
-                if (type_selector == 2) {
-                    state.bricks[brick_idx].brick_type = BrickType.Reflector;
-                    state.bricks[brick_idx].hp = brick_hp;
-                    state.bricks[brick_idx].max_hp = brick_hp;
-                }
-
-                brick_idx = brick_idx + 1;
-            }
+            // Mix brick types for variety
+            let type_selector: i32 = (row + col) % 3;
+            let brick_type: BrickType = BrickType.Basic;
+            if (type_selector == 1) { brick_type = BrickType.Armored; }
+            if (type_selector == 2) { brick_type = BrickType.Reflector; }
+            place_brick_at_grid(col, row, brick_type);
         }
     }
 }
@@ -2040,6 +2031,11 @@ function update_drag_from_screen(screen_x: f32, screen_y: f32): void {
 
     let in_play: bool = point_in_rect(screen_x, screen_y, state.layout.play_x, state.layout.play_y, state.layout.play_w, state.layout.play_h);
     let valid: bool = in_play && grid_in_bounds(state.drag_grid_x, state.drag_grid_y);
+    if (valid) {
+        if (!brick_fully_in_level(state.drag_grid_x, state.drag_grid_y)) {
+            valid = false;
+        }
+    }
     if (valid) {
         if (grid_is_occupied(state.drag_grid_x, state.drag_grid_y)) {
             valid = false;


### PR DESCRIPTION
- Runner: call optional <module>__swap() exactly once after each DLL hot-swap (after state restore).
- Runner: improve --fps pacing and emit timestamped hot-swap latency lines.
- Tests: add integration tests that compile tiny DLLs with clang to verify 60fps tick pacing and 1 swap hook call per swap-file write.
- Sample: enforce brick placement fully within level bounds (brickout_revenge_v1).

Notes:
- Built/verified locally: untime/build.bat, dotnet test -c Release .\\Stasis.Compiler.Tests\\Stasis.Compiler.Tests.csproj.