### PR TITLE
WASM prototype: run brickout_revenge_v1 in browser (main-based)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ build/test_perf_compare_optimized.csv
 build/sample_test_compare_optimized.csv
 stasis_sys_static.lib
 build/stasis_sys_static.lib
+build/wasm/
+
+# WASM prototype outputs
+examples/wasm/**/*.wasm
 
 # Android local build outputs
 android/out/

--- a/examples/wasm/brickout_revenge_v1/README.md
+++ b/examples/wasm/brickout_revenge_v1/README.md
@@ -1,0 +1,22 @@
+# Brickout Revenge v1 - WASM prototype
+
+This is a minimal prototype to compile and run `samples/brickout_revenge/brickout_revenge_v1.stasis` in a browser via `wasm32`.
+
+Status: proof-of-concept host shims (Canvas2D, no input, no audio).
+
+## Build
+
+From repo root:
+
+- `powershell -ExecutionPolicy Bypass -File scripts/build-wasm-brickout.ps1`
+
+Outputs `examples/wasm/brickout_revenge_v1/brickout_revenge_v1.wasm`.
+
+## Run
+
+You need a local HTTP server (file:// won't load WASM).
+
+- `powershell -ExecutionPolicy Bypass -File scripts/serve-wasm.ps1 -Root examples/wasm/brickout_revenge_v1`
+
+Then open `http://127.0.0.1:5173/` in a browser.
+

--- a/examples/wasm/brickout_revenge_v1/README.md
+++ b/examples/wasm/brickout_revenge_v1/README.md
@@ -2,7 +2,7 @@
 
 This is a minimal prototype to compile and run `samples/brickout_revenge/brickout_revenge_v1.stasis` in a browser via `wasm32`.
 
-Status: proof-of-concept host shims (Canvas2D, pointer input, no audio).
+Status: proof-of-concept host shims (Canvas2D, pointer input, virtual resolution scaling, no audio).
 
 ## Build
 

--- a/examples/wasm/brickout_revenge_v1/README.md
+++ b/examples/wasm/brickout_revenge_v1/README.md
@@ -2,7 +2,7 @@
 
 This is a minimal prototype to compile and run `samples/brickout_revenge/brickout_revenge_v1.stasis` in a browser via `wasm32`.
 
-Status: proof-of-concept host shims (Canvas2D, no input, no audio).
+Status: proof-of-concept host shims (Canvas2D, pointer input, no audio).
 
 ## Build
 
@@ -16,7 +16,6 @@ Outputs `examples/wasm/brickout_revenge_v1/brickout_revenge_v1.wasm`.
 
 You need a local HTTP server (file:// won't load WASM).
 
-- `powershell -ExecutionPolicy Bypass -File scripts/serve-wasm.ps1 -Root examples/wasm/brickout_revenge_v1`
+- `powershell -ExecutionPolicy Bypass -File scripts/serve-wasm.ps1`
 
-Then open `http://127.0.0.1:5173/` in a browser.
-
+Then open `http://127.0.0.1:5173/examples/wasm/brickout_revenge_v1/` in a browser.

--- a/examples/wasm/brickout_revenge_v1/index.html
+++ b/examples/wasm/brickout_revenge_v1/index.html
@@ -53,12 +53,17 @@
         padding: 12px;
         box-sizing: border-box;
       }
-      canvas {
-        width: 100%;
-        height: 100%;
+      #canvasWrap {
+        display: flex;
+        align-items: center;
+        justify-content: center;
         border-radius: 10px;
         background: #090b12;
         box-shadow: 0 0 0 1px rgba(255,255,255,0.06) inset;
+        overflow: hidden;
+      }
+      canvas {
+        display: block;
       }
       #log {
         white-space: pre-wrap;
@@ -85,7 +90,9 @@
         <div class="note">Prototype: wasm32 via LLVM IR; JS host shims for graphics/input (pointer), no audio.</div>
       </header>
       <div id="content">
-        <canvas id="canvas"></canvas>
+        <div id="canvasWrap">
+          <canvas id="canvas"></canvas>
+        </div>
         <div id="log"></div>
       </div>
     </div>

--- a/examples/wasm/brickout_revenge_v1/index.html
+++ b/examples/wasm/brickout_revenge_v1/index.html
@@ -82,7 +82,7 @@
       <header>
         <div class="title">Brickout Revenge v1 (WASM prototype)</div>
         <button id="start">Start</button>
-        <div class="note">Prototype: LLVM IR → wasm32, JS host shims for graphics/input/audio.</div>
+        <div class="note">Prototype: wasm32 via LLVM IR; JS host shims for graphics/input (pointer), no audio.</div>
       </header>
       <div id="content">
         <canvas id="canvas"></canvas>
@@ -92,4 +92,3 @@
     <script type="module" src="./main.js"></script>
   </body>
 </html>
-

--- a/examples/wasm/brickout_revenge_v1/index.html
+++ b/examples/wasm/brickout_revenge_v1/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stasis - Brickout Revenge v1 (WASM prototype)</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0b0d14;
+        color: #e9eefc;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      }
+      #wrap {
+        display: grid;
+        grid-template-rows: auto 1fr;
+        height: 100%;
+      }
+      header {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        padding: 10px 12px;
+        border-bottom: 1px solid rgba(255,255,255,0.08);
+        background: rgba(255,255,255,0.02);
+      }
+      header .title {
+        font-weight: 600;
+      }
+      header button {
+        padding: 8px 10px;
+        background: #2b64ff;
+        border: 0;
+        border-radius: 6px;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      header button:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+      header .note {
+        opacity: 0.8;
+        font-size: 12px;
+      }
+      #content {
+        display: grid;
+        grid-template-columns: 1fr 340px;
+        gap: 12px;
+        padding: 12px;
+        box-sizing: border-box;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+        border-radius: 10px;
+        background: #090b12;
+        box-shadow: 0 0 0 1px rgba(255,255,255,0.06) inset;
+      }
+      #log {
+        white-space: pre-wrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        padding: 10px;
+        border-radius: 10px;
+        background: rgba(255,255,255,0.03);
+        box-shadow: 0 0 0 1px rgba(255,255,255,0.06) inset;
+        overflow: auto;
+      }
+      @media (max-width: 900px) {
+        #content { grid-template-columns: 1fr; }
+        #log { height: 220px; }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wrap">
+      <header>
+        <div class="title">Brickout Revenge v1 (WASM prototype)</div>
+        <button id="start">Start</button>
+        <div class="note">Prototype: LLVM IR → wasm32, JS host shims for graphics/input/audio.</div>
+      </header>
+      <div id="content">
+        <canvas id="canvas"></canvas>
+        <div id="log"></div>
+      </div>
+    </div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>
+

--- a/examples/wasm/brickout_revenge_v1/main.js
+++ b/examples/wasm/brickout_revenge_v1/main.js
@@ -20,10 +20,11 @@ function resizeCanvas(w, h) {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
-function readCString(memU8, ptr) {
+function readCString(memU8, ptr, cap = 4096) {
   ptr = ptr >>> 0;
   let s = "";
-  for (let i = ptr; i < memU8.length; i++) {
+  const end = Math.min(memU8.length, ptr + cap);
+  for (let i = ptr; i < end; i++) {
     const b = memU8[i];
     if (b === 0) break;
     s += String.fromCharCode(b);
@@ -34,6 +35,36 @@ function readCString(memU8, ptr) {
 function i32ToSigned(x) {
   x = x | 0;
   return x;
+}
+
+function scorePrintableAscii(s) {
+  let score = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 9 || c === 10 || c === 13) score += 1;
+    else if (c >= 32 && c <= 126) score += 2;
+    else score -= 5;
+  }
+  return score;
+}
+
+function readMaybeStasisString(memU8, ptr) {
+  const candidates = [
+    readCString(memU8, ptr, 4096),
+    readCString(memU8, (ptr + 4) | 0, 4096), // ascii[N] payload
+    readCString(memU8, (ptr + 8) | 0, 4096), // utf8[N] payload
+  ];
+  let best = candidates[0];
+  let bestScore = scorePrintableAscii(best);
+  for (let i = 1; i < candidates.length; i++) {
+    const s = candidates[i];
+    const sc = scorePrintableAscii(s);
+    if (sc > bestScore) {
+      bestScore = sc;
+      best = s;
+    }
+  }
+  return best;
 }
 
 async function start() {
@@ -53,6 +84,104 @@ async function start() {
   let canvasW = 600;
   let canvasH = 1200;
   resizeCanvas(canvasW, canvasH);
+
+  const pointerState = new Map(); // pointerId -> { id, x, y, down, wentDown, wentUp }
+  let pointerSnapshot = [];
+
+  function snapPointers() {
+    const arr = [];
+    for (const p of pointerState.values()) {
+      if (p.down || p.wentDown || p.wentUp) arr.push(p);
+    }
+    arr.sort((a, b) => a.id - b.id);
+    pointerSnapshot = arr;
+  }
+
+  function clearPointerEdges() {
+    for (const p of pointerState.values()) {
+      p.wentDown = false;
+      p.wentUp = false;
+    }
+    for (const [id, p] of pointerState.entries()) {
+      if (!p.down) pointerState.delete(id);
+    }
+  }
+
+  function canvasToGamePx(clientX, clientY) {
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return { x: 0, y: 0 };
+    const x = ((clientX - rect.left) / rect.width) * canvasW;
+    const y = ((clientY - rect.top) / rect.height) * canvasH;
+    return { x, y };
+  }
+
+  canvas.tabIndex = 0;
+  canvas.style.touchAction = "none";
+
+  canvas.addEventListener("pointerdown", (e) => {
+    canvas.focus();
+    const pos = canvasToGamePx(e.clientX, e.clientY);
+    const id = e.pointerId | 0;
+    let p = pointerState.get(id);
+    if (!p) {
+      p = { id, x: pos.x, y: pos.y, down: true, wentDown: true, wentUp: false };
+      pointerState.set(id, p);
+    } else {
+      p.x = pos.x;
+      p.y = pos.y;
+      p.down = true;
+      p.wentDown = true;
+    }
+    try {
+      canvas.setPointerCapture(e.pointerId);
+    } catch {
+      // ignore
+    }
+    e.preventDefault();
+  });
+
+  canvas.addEventListener("pointermove", (e) => {
+    const id = e.pointerId | 0;
+    const p = pointerState.get(id);
+    if (!p) return;
+    const pos = canvasToGamePx(e.clientX, e.clientY);
+    p.x = pos.x;
+    p.y = pos.y;
+    e.preventDefault();
+  });
+
+  function pointerUpLike(e) {
+    const id = e.pointerId | 0;
+    const p = pointerState.get(id);
+    if (!p) return;
+    const pos = canvasToGamePx(e.clientX, e.clientY);
+    p.x = pos.x;
+    p.y = pos.y;
+    p.down = false;
+    p.wentUp = true;
+    e.preventDefault();
+  }
+
+  canvas.addEventListener("pointerup", pointerUpLike);
+  canvas.addEventListener("pointercancel", pointerUpLike);
+
+  let escapeDown = false;
+  let quitRequested = false;
+
+  window.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") {
+      escapeDown = true;
+      quitRequested = true;
+      e.preventDefault();
+    }
+  });
+
+  window.addEventListener("keyup", (e) => {
+    if (e.code === "Escape") {
+      escapeDown = false;
+      e.preventDefault();
+    }
+  });
 
   function getSpriteHandleForPath(path) {
     const existing = sprites.get(path);
@@ -149,16 +278,45 @@ async function start() {
       stasis_input_viewport_w_px: () => canvasW | 0,
       stasis_input_viewport_h_px: () => canvasH | 0,
 
-      stasis_input_pointer_count: () => 0,
-      stasis_input_pointer_id: (_index) => 0,
-      stasis_input_pointer_went_down: (_index) => 0,
-      stasis_input_pointer_went_up: (_index) => 0,
-      stasis_input_pointer_is_down: (_index) => 0,
-      stasis_input_pointer_x_px: (_index) => 0.0,
-      stasis_input_pointer_y_px: (_index) => 0.0,
+      stasis_input_pointer_count: () => pointerSnapshot.length | 0,
+      stasis_input_pointer_id: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0;
+        return pointerSnapshot[index].id | 0;
+      },
+      stasis_input_pointer_went_down: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0;
+        return pointerSnapshot[index].wentDown ? 1 : 0;
+      },
+      stasis_input_pointer_went_up: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0;
+        return pointerSnapshot[index].wentUp ? 1 : 0;
+      },
+      stasis_input_pointer_is_down: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0;
+        return pointerSnapshot[index].down ? 1 : 0;
+      },
+      stasis_input_pointer_x_px: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0.0;
+        return +pointerSnapshot[index].x;
+      },
+      stasis_input_pointer_y_px: (index) => {
+        index = index | 0;
+        if (index < 0 || index >= pointerSnapshot.length) return 0.0;
+        return +pointerSnapshot[index].y;
+      },
 
-      stasis_should_quit: () => 0,
-      stasis_is_key_down: (_scancode) => 0,
+      stasis_should_quit: () => (quitRequested ? 1 : 0),
+      stasis_is_key_down: (scancode) => {
+        scancode = scancode | 0;
+        // SDL scancode 41 is Escape.
+        if (scancode === 41) return escapeDown ? 1 : 0;
+        return 0;
+      },
 
       stasis_get_time_ms: () => (performance.now() | 0),
 
@@ -168,16 +326,20 @@ async function start() {
       stasis_audio_push_f32_interleaved: (_samplesPtr, _frames) => 0,
 
       printf: (fmtPtr, arg0) => {
-        const fmt = readCString(memU8, fmtPtr);
+        const fmt = readMaybeStasisString(memU8, fmtPtr);
         const arg = arg0 | 0;
+
         let out = fmt;
         if (fmt.includes("%s")) {
-          out = fmt.replace("%s", readCString(memU8, arg));
+          out = fmt.replace("%s", readMaybeStasisString(memU8, arg));
         } else if (fmt.includes("%d") || fmt.includes("%i")) {
           out = fmt.replace(/%[di]/, String(i32ToSigned(arg)));
         } else if (fmt.includes("%c")) {
           out = fmt.replace("%c", String.fromCharCode(arg & 0xff));
+        } else if (fmt.includes("%%")) {
+          out = fmt.replace("%%", "%");
         }
+
         out = out.replace(/\r?\n$/, "");
         if (out.length > 0) log(out);
         return 0;
@@ -212,7 +374,10 @@ async function start() {
 
     let steps = 0;
     while (acc >= tickMs && steps < 5) {
+      snapPointers();
       const t = exports.tick() | 0;
+      clearPointerEdges();
+      quitRequested = false;
       if (t !== 0) {
         log(`tick() -> ${t} (stop)`);
         startBtn.disabled = false;
@@ -235,4 +400,3 @@ startBtn.addEventListener("click", () => {
     startBtn.disabled = false;
   });
 });
-

--- a/examples/wasm/brickout_revenge_v1/main.js
+++ b/examples/wasm/brickout_revenge_v1/main.js
@@ -1,6 +1,7 @@
 const wasmPath = "./brickout_revenge_v1.wasm";
 
 const canvas = document.getElementById("canvas");
+const canvasWrap = document.getElementById("canvasWrap");
 const ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
 const logEl = document.getElementById("log");
 const startBtn = document.getElementById("start");
@@ -9,6 +10,11 @@ window.__stasisWasmHost = {
   started: false,
   tickCount: 0,
   lastTickResult: 0,
+  virtualW: 0,
+  virtualH: 0,
+  displayW: 0,
+  displayH: 0,
+  scale: 1,
 };
 
 function log(line) {
@@ -17,13 +23,37 @@ function log(line) {
   logEl.scrollTop = logEl.scrollHeight;
 }
 
-function resizeCanvas(w, h) {
+function updateCanvasLayout(virtualW, virtualH, onResize) {
+  const rect = canvasWrap.getBoundingClientRect();
+  const availW = rect.width;
+  const availH = rect.height;
+
+  if (availW <= 0 || availH <= 0 || virtualW <= 0 || virtualH <= 0) return;
+
+  const fitScale = Math.max(0.05, Math.min(availW / virtualW, availH / virtualH));
+  const displayW = Math.max(1, Math.floor(virtualW * fitScale));
+  const displayH = Math.max(1, Math.floor(virtualH * fitScale));
+
   const dpr = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
-  canvas.width = Math.max(1, Math.floor(w * dpr));
-  canvas.height = Math.max(1, Math.floor(h * dpr));
-  canvas.style.width = `${w}px`;
-  canvas.style.height = `${h}px`;
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  canvas.width = Math.max(1, Math.floor(displayW * dpr));
+  canvas.height = Math.max(1, Math.floor(displayH * dpr));
+  canvas.style.width = `${displayW}px`;
+  canvas.style.height = `${displayH}px`;
+  ctx.setTransform(dpr * fitScale, 0, 0, dpr * fitScale, 0, 0);
+
+  const changed =
+    window.__stasisWasmHost.displayW !== displayW ||
+    window.__stasisWasmHost.displayH !== displayH ||
+    window.__stasisWasmHost.virtualW !== virtualW ||
+    window.__stasisWasmHost.virtualH !== virtualH;
+
+  window.__stasisWasmHost.virtualW = virtualW;
+  window.__stasisWasmHost.virtualH = virtualH;
+  window.__stasisWasmHost.displayW = displayW;
+  window.__stasisWasmHost.displayH = displayH;
+  window.__stasisWasmHost.scale = fitScale;
+
+  if (changed && typeof onResize === "function") onResize();
 }
 
 function readCString(memU8, ptr, cap = 4096) {
@@ -87,9 +117,28 @@ async function start() {
   let nextSpriteId = 1;
 
   let resizedFlag = 1;
-  let canvasW = 600;
-  let canvasH = 1200;
-  resizeCanvas(canvasW, canvasH);
+  let virtualW = 600;
+  let virtualH = 1200;
+  updateCanvasLayout(virtualW, virtualH, () => {
+    resizedFlag = 1;
+  });
+
+  const resizeObserver = new ResizeObserver(() => {
+    updateCanvasLayout(virtualW, virtualH, () => {
+      resizedFlag = 1;
+    });
+  });
+  resizeObserver.observe(canvasWrap);
+  window.addEventListener("resize", () => {
+    updateCanvasLayout(virtualW, virtualH, () => {
+      resizedFlag = 1;
+    });
+  });
+  window.addEventListener("orientationchange", () => {
+    updateCanvasLayout(virtualW, virtualH, () => {
+      resizedFlag = 1;
+    });
+  });
 
   const pointerState = new Map(); // pointerId -> { id, x, y, down, wentDown, wentUp }
   let pointerSnapshot = [];
@@ -116,8 +165,8 @@ async function start() {
   function canvasToGamePx(clientX, clientY) {
     const rect = canvas.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) return { x: 0, y: 0 };
-    const x = ((clientX - rect.left) / rect.width) * canvasW;
-    const y = ((clientY - rect.top) / rect.height) * canvasH;
+    const x = ((clientX - rect.left) / rect.width) * virtualW;
+    const y = ((clientY - rect.top) / rect.height) * virtualH;
     return { x, y };
   }
 
@@ -209,13 +258,14 @@ async function start() {
       cosf: (x) => Math.cos(x),
 
       stasis_init_window: (w, h, titlePtr) => {
-        canvasW = w | 0;
-        canvasH = h | 0;
-        resizedFlag = 1;
-        resizeCanvas(canvasW, canvasH);
+        virtualW = w | 0;
+        virtualH = h | 0;
+        updateCanvasLayout(virtualW, virtualH, () => {
+          resizedFlag = 1;
+        });
         const title = memU8 ? readCString(memU8, titlePtr) : "Stasis";
         document.title = title;
-        log(`init_window(${canvasW}x${canvasH}, "${title}")`);
+        log(`init_window(${virtualW}x${virtualH}, "${title}")`);
         return 1;
       },
 
@@ -233,7 +283,7 @@ async function start() {
         const bb = Math.max(0, Math.min(255, Math.floor(b * 255)));
         const aa = Math.max(0, Math.min(1, a));
         ctx.fillStyle = `rgba(${rr},${gg},${bb},${aa})`;
-        ctx.fillRect(0, 0, canvasW, canvasH);
+        ctx.fillRect(0, 0, virtualW, virtualH);
       },
 
       stasis_draw_line: (x1, y1, x2, y2, r, g, b, a) => {
@@ -271,8 +321,8 @@ async function start() {
 
       stasis_gfx_poll_reload: (_handle) => 0,
 
-      stasis_gfx_window_width: () => canvasW | 0,
-      stasis_gfx_window_height: () => canvasH | 0,
+      stasis_gfx_window_width: () => virtualW | 0,
+      stasis_gfx_window_height: () => virtualH | 0,
       stasis_gfx_window_resized: () => {
         const v = resizedFlag;
         resizedFlag = 0;
@@ -281,8 +331,8 @@ async function start() {
 
       stasis_input_viewport_x_px: () => 0,
       stasis_input_viewport_y_px: () => 0,
-      stasis_input_viewport_w_px: () => canvasW | 0,
-      stasis_input_viewport_h_px: () => canvasH | 0,
+      stasis_input_viewport_w_px: () => virtualW | 0,
+      stasis_input_viewport_h_px: () => virtualH | 0,
 
       stasis_input_pointer_count: () => pointerSnapshot.length | 0,
       stasis_input_pointer_id: (index) => {

--- a/examples/wasm/brickout_revenge_v1/main.js
+++ b/examples/wasm/brickout_revenge_v1/main.js
@@ -5,6 +5,12 @@ const ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
 const logEl = document.getElementById("log");
 const startBtn = document.getElementById("start");
 
+window.__stasisWasmHost = {
+  started: false,
+  tickCount: 0,
+  lastTickResult: 0,
+};
+
 function log(line) {
   console.log(line);
   logEl.textContent += line + "\n";
@@ -362,6 +368,8 @@ async function start() {
     return;
   }
 
+  window.__stasisWasmHost.started = true;
+
   const tickHz = 60;
   const tickMs = 1000 / tickHz;
   let last = performance.now();
@@ -376,6 +384,8 @@ async function start() {
     while (acc >= tickMs && steps < 5) {
       snapPointers();
       const t = exports.tick() | 0;
+      window.__stasisWasmHost.tickCount++;
+      window.__stasisWasmHost.lastTickResult = t;
       clearPointerEdges();
       quitRequested = false;
       if (t !== 0) {

--- a/examples/wasm/brickout_revenge_v1/main.js
+++ b/examples/wasm/brickout_revenge_v1/main.js
@@ -1,0 +1,238 @@
+const wasmPath = "./brickout_revenge_v1.wasm";
+
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
+const logEl = document.getElementById("log");
+const startBtn = document.getElementById("start");
+
+function log(line) {
+  console.log(line);
+  logEl.textContent += line + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function resizeCanvas(w, h) {
+  const dpr = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
+  canvas.width = Math.max(1, Math.floor(w * dpr));
+  canvas.height = Math.max(1, Math.floor(h * dpr));
+  canvas.style.width = `${w}px`;
+  canvas.style.height = `${h}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function readCString(memU8, ptr) {
+  ptr = ptr >>> 0;
+  let s = "";
+  for (let i = ptr; i < memU8.length; i++) {
+    const b = memU8[i];
+    if (b === 0) break;
+    s += String.fromCharCode(b);
+  }
+  return s;
+}
+
+function i32ToSigned(x) {
+  x = x | 0;
+  return x;
+}
+
+async function start() {
+  startBtn.disabled = true;
+  logEl.textContent = "";
+
+  const wasmBytes = await fetch(wasmPath).then((r) => r.arrayBuffer());
+
+  let exports = null;
+  let memU8 = null;
+
+  const sprites = new Map(); // path -> { id, img }
+  const spriteById = new Map(); // id -> { path, img }
+  let nextSpriteId = 1;
+
+  let resizedFlag = 1;
+  let canvasW = 600;
+  let canvasH = 1200;
+  resizeCanvas(canvasW, canvasH);
+
+  function getSpriteHandleForPath(path) {
+    const existing = sprites.get(path);
+    if (existing) return existing.id;
+    const id = nextSpriteId++;
+    const img = new Image();
+    img.decoding = "async";
+    img.src = path.startsWith("/") ? path : `/${path}`;
+    sprites.set(path, { id, img });
+    spriteById.set(id, { path, img });
+    return id;
+  }
+
+  const imports = {
+    env: {
+      memory: undefined,
+
+      sinf: (x) => Math.sin(x),
+      cosf: (x) => Math.cos(x),
+
+      stasis_init_window: (w, h, titlePtr) => {
+        canvasW = w | 0;
+        canvasH = h | 0;
+        resizedFlag = 1;
+        resizeCanvas(canvasW, canvasH);
+        const title = memU8 ? readCString(memU8, titlePtr) : "Stasis";
+        document.title = title;
+        log(`init_window(${canvasW}x${canvasH}, "${title}")`);
+        return 1;
+      },
+
+      stasis_begin_frame: () => {
+        // no-op
+      },
+
+      stasis_end_frame: () => {
+        // no-op
+      },
+
+      stasis_clear: (r, g, b, a) => {
+        const rr = Math.max(0, Math.min(255, Math.floor(r * 255)));
+        const gg = Math.max(0, Math.min(255, Math.floor(g * 255)));
+        const bb = Math.max(0, Math.min(255, Math.floor(b * 255)));
+        const aa = Math.max(0, Math.min(1, a));
+        ctx.fillStyle = `rgba(${rr},${gg},${bb},${aa})`;
+        ctx.fillRect(0, 0, canvasW, canvasH);
+      },
+
+      stasis_draw_line: (x1, y1, x2, y2, r, g, b, a) => {
+        const rr = Math.max(0, Math.min(255, Math.floor(r * 255)));
+        const gg = Math.max(0, Math.min(255, Math.floor(g * 255)));
+        const bb = Math.max(0, Math.min(255, Math.floor(b * 255)));
+        ctx.strokeStyle = `rgba(${rr},${gg},${bb},${a})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(x1, y1);
+        ctx.lineTo(x2, y2);
+        ctx.stroke();
+      },
+
+      stasis_gfx_load_sprite: (pathPtr, _maxW, _maxH) => {
+        const path = readCString(memU8, pathPtr);
+        return getSpriteHandleForPath(path);
+      },
+
+      stasis_gfx_draw_sprite: (handle, x, y, w, h, rotDeg, a) => {
+        handle = handle | 0;
+        const entry = spriteById.get(handle);
+        if (!entry || !entry.img || !entry.img.complete) return;
+        const alpha = Math.max(0, Math.min(1, (a | 0) / 255));
+        const rot = ((rotDeg | 0) * Math.PI) / 180;
+        ctx.save();
+        ctx.translate(x | 0, y | 0);
+        if (rot !== 0) ctx.rotate(rot);
+        ctx.globalAlpha = alpha;
+        const ww = w | 0;
+        const hh = h | 0;
+        ctx.drawImage(entry.img, -ww / 2, -hh / 2, ww, hh);
+        ctx.restore();
+      },
+
+      stasis_gfx_poll_reload: (_handle) => 0,
+
+      stasis_gfx_window_width: () => canvasW | 0,
+      stasis_gfx_window_height: () => canvasH | 0,
+      stasis_gfx_window_resized: () => {
+        const v = resizedFlag;
+        resizedFlag = 0;
+        return v;
+      },
+
+      stasis_input_viewport_x_px: () => 0,
+      stasis_input_viewport_y_px: () => 0,
+      stasis_input_viewport_w_px: () => canvasW | 0,
+      stasis_input_viewport_h_px: () => canvasH | 0,
+
+      stasis_input_pointer_count: () => 0,
+      stasis_input_pointer_id: (_index) => 0,
+      stasis_input_pointer_went_down: (_index) => 0,
+      stasis_input_pointer_went_up: (_index) => 0,
+      stasis_input_pointer_is_down: (_index) => 0,
+      stasis_input_pointer_x_px: (_index) => 0.0,
+      stasis_input_pointer_y_px: (_index) => 0.0,
+
+      stasis_should_quit: () => 0,
+      stasis_is_key_down: (_scancode) => 0,
+
+      stasis_get_time_ms: () => (performance.now() | 0),
+
+      stasis_audio_is_available: () => 0,
+      stasis_audio_get_sample_rate: () => 0,
+      stasis_audio_get_queued_frames: () => 0,
+      stasis_audio_push_f32_interleaved: (_samplesPtr, _frames) => 0,
+
+      printf: (fmtPtr, arg0) => {
+        const fmt = readCString(memU8, fmtPtr);
+        const arg = arg0 | 0;
+        let out = fmt;
+        if (fmt.includes("%s")) {
+          out = fmt.replace("%s", readCString(memU8, arg));
+        } else if (fmt.includes("%d") || fmt.includes("%i")) {
+          out = fmt.replace(/%[di]/, String(i32ToSigned(arg)));
+        } else if (fmt.includes("%c")) {
+          out = fmt.replace("%c", String.fromCharCode(arg & 0xff));
+        }
+        out = out.replace(/\r?\n$/, "");
+        if (out.length > 0) log(out);
+        return 0;
+      },
+    },
+  };
+
+  const { instance } = await WebAssembly.instantiate(wasmBytes, imports);
+  exports = instance.exports;
+  memU8 = new Uint8Array(exports.memory.buffer);
+
+  if (typeof exports.main !== "function" || typeof exports.tick !== "function") {
+    throw new Error("wasm exports missing main/tick");
+  }
+
+  const rc = exports.main();
+  log(`main() -> ${rc | 0}`);
+  if ((rc | 0) !== 0) {
+    startBtn.disabled = false;
+    return;
+  }
+
+  const tickHz = 60;
+  const tickMs = 1000 / tickHz;
+  let last = performance.now();
+  let acc = 0;
+
+  function frame(now) {
+    const dt = now - last;
+    last = now;
+    acc += dt;
+
+    let steps = 0;
+    while (acc >= tickMs && steps < 5) {
+      const t = exports.tick() | 0;
+      if (t !== 0) {
+        log(`tick() -> ${t} (stop)`);
+        startBtn.disabled = false;
+        return;
+      }
+      acc -= tickMs;
+      steps++;
+    }
+
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+}
+
+startBtn.addEventListener("click", () => {
+  start().catch((e) => {
+    console.error(e);
+    log(`error: ${e && e.stack ? e.stack : String(e)}`);
+    startBtn.disabled = false;
+  });
+});
+

--- a/samples/brickout_revenge/brickout_revenge_v1.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1.stasis
@@ -367,6 +367,77 @@ function apply_config_live(): void {
     }
 }
 
+function ensure_config_loaded(): void {
+    if (state.config.magic == 1337) {
+        return;
+    }
+
+    // Fallback defaults for hosts that don't provide JSON data binding (e.g. WASM prototype).
+    state.config.magic = 1337;
+
+    state.config.screen.w = 600;
+    state.config.screen.h = 1200;
+
+    state.config.grid.origin_x = 50.0;
+    state.config.grid.margin_bottom = 50.0;
+    state.config.grid.spacing = 5.0;
+
+    state.config.brick.width = 60.0;
+    state.config.brick.height = 20.0;
+
+    state.config.paddle.y = 30.0;
+    state.config.paddle.width = 100.0;
+    state.config.paddle.height = 10.0;
+    state.config.paddle.speed = 400.0;
+
+    state.config.ball.radius = 6.0;
+    state.config.ball.spawn_jitter_x = 30.0;
+    state.config.ball.clamp_margin_x = 100.0;
+    state.config.ball.vx_rand = 100.0;
+    state.config.ball.speed_min_base = 150.0;
+    state.config.ball.speed_min_per_wave = 10.0;
+    state.config.ball.speed_max_base = 250.0;
+    state.config.ball.speed_max_per_wave = 12.0;
+    state.config.ball.damage_base = 1;
+    state.config.ball.damage_wave_div = 4;
+    state.config.ball.hp_base = 20;
+    state.config.ball.hp_wave_div = 2;
+    state.config.ball.hp_scale = 10;
+
+    state.config.wave.start_wave = 1;
+    state.config.wave.start_max_balls_wave = 5;
+    state.config.wave.max_balls_wave_add = 2;
+    state.config.wave.start_spawn_balls = 90;
+
+    state.config.timing.ball_spawn_cd_ms = 1000;
+    state.config.timing.end_phase_restart_ms = 3000;
+
+    state.config.fx.jiggle_threshold = 10;
+    state.config.fx.jiggle_degrees = 5.0;
+    state.config.fx.paddle_aim_degrees = 15.0;
+    state.config.fx.paddle_bounce_vx_scale = 200.0;
+
+    state.config.tower_basic.range = 140.0;
+    state.config.tower_basic.cooldown_ms = 220;
+    state.config.tower_basic.damage = 1;
+    state.config.tower_basic.shot_fx_ms = 90;
+
+    state.config.tower_armored.range = 160.0;
+    state.config.tower_armored.cooldown_ms = 320;
+    state.config.tower_armored.damage = 2;
+    state.config.tower_armored.shot_fx_ms = 90;
+
+    state.config.tower_reflector.range = 190.0;
+    state.config.tower_reflector.cooldown_ms = 180;
+    state.config.tower_reflector.damage = 1;
+    state.config.tower_reflector.shot_fx_ms = 90;
+
+    state.config.score.ball_kill = 1;
+    state.config.score.brick_kill = 10;
+
+    print_string("warning: config.json not bound; using fallback defaults\n");
+}
+
 function sfx_reset(): void {
     let i: i32 = 0;
     for (i = 0; i < SFX_MAX_VOICES; i = i + 1) {
@@ -2201,13 +2272,7 @@ function draw_drag_preview(): void {
 }
 
 function main(): i32 {
-    // Require JSON data binding: this sample expects to be run under the native runner so
-    // `samples/brickout_revenge/data/config.json` is applied to `state.config` before main().
-    if (state.config.magic != 1337) {
-        print_string("error: brickout config.json not bound (expected state.config.magic == 1337)\n");
-        print_string("run: .\\stasis.bat run samples/brickout_revenge/brickout_revenge.stasis --backend cranelift --graphics\n");
-        return 1;
-    }
+    ensure_config_loaded();
 
     print_string("Brickout config loaded (magic=1337)\n");
     print_string("screen.w=");
@@ -2257,7 +2322,8 @@ function main(): i32 {
     state.sprites.brick_reflector_fx = gfx_load_sprite("samples/brickout_revenge/assets/brick_reflector_fx.svg", 160, 64);
 
     if (state.initialized == 0) {
-        seed_rng(time());
+        // Use get_time_ms() so non-libc hosts (e.g. wasm) don't need C's time().
+        seed_rng(get_time_ms());
         init_game(true);
         setup_default_bricks();
         start_wave();

--- a/scripts/build-wasm-brickout.ps1
+++ b/scripts/build-wasm-brickout.ps1
@@ -1,0 +1,79 @@
+param(
+  [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+$cli = Join-Path $repoRoot "Stasis.Cli\bin\$Configuration\net9.0\Stasis.Cli.exe"
+if (!(Test-Path $cli)) {
+  Write-Host "Building CLI ($Configuration)..."
+  dotnet build -c $Configuration .\Stasis.sln | Out-Host
+}
+
+$clang = Join-Path $repoRoot ".tools\llvm-18.1.8\bin\clang.exe"
+if (!(Test-Path $clang)) {
+  throw "clang not found: $clang"
+}
+
+$source = Join-Path $repoRoot "samples\brickout_revenge\brickout_revenge_v1.stasis"
+if (!(Test-Path $source)) {
+  throw "source not found: $source"
+}
+
+$outDir = Join-Path $repoRoot "examples\wasm\brickout_revenge_v1"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+$tmpDir = Join-Path $repoRoot "build\wasm"
+New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+
+$irPath = Join-Path $tmpDir "brickout_revenge_v1.ll"
+$wasmPath = Join-Path $outDir "brickout_revenge_v1.wasm"
+
+Write-Host "Emitting LLVM IR..."
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $cli
+$psi.Arguments = "run `"$source`" --backend llvm --emit-ir --llvm-target wasm32-unknown-unknown"
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+
+$proc = [System.Diagnostics.Process]::Start($psi)
+$irText = $proc.StandardOutput.ReadToEnd()
+$errText = $proc.StandardError.ReadToEnd()
+$proc.WaitForExit()
+
+if ($proc.ExitCode -ne 0) {
+  throw "stasisc failed ($($proc.ExitCode)):`n$errText"
+}
+
+# The CLI prints a timing footer on stdout; strip it so clang can parse the IR.
+$irLines = $irText -split "`r?`n"
+$irLines = $irLines | Where-Object { $_ -notmatch '^Total time=' }
+$irTextClean = ($irLines -join "`n")
+
+$utf8NoBom = New-Object System.Text.UTF8Encoding -ArgumentList @($false)
+[System.IO.File]::WriteAllText($irPath, $irTextClean, $utf8NoBom)
+
+Write-Host "Compiling to wasm32..."
+& $clang @(
+  "--target=wasm32-unknown-unknown",
+  "-O0",
+  "-nostdlib",
+  "-Wl,--no-entry",
+  "-Wl,--export=main",
+  "-Wl,--export=tick",
+  "-Wl,--export=memory",
+  "-Wl,--allow-undefined",
+  "-Wl,--initial-memory=67108864",
+  "-Wl,--max-memory=67108864",
+  "-Wl,-z,stack-size=8388608",
+  $irPath,
+  "-o",
+  $wasmPath
+) | Out-Host
+
+Write-Host "Wrote: $wasmPath"

--- a/scripts/serve-wasm.ps1
+++ b/scripts/serve-wasm.ps1
@@ -1,0 +1,54 @@
+param(
+  [string]$Root = ".",
+  [int]$Port = 5173
+)
+
+$ErrorActionPreference = "Stop"
+
+$rootPath = Resolve-Path $Root
+
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+  throw "node not found in PATH"
+}
+
+Write-Host "Serving $rootPath on http://127.0.0.1:$Port/"
+
+node -e @"
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = process.argv[1];
+const port = Number(process.argv[2]);
+
+function contentType(p) {
+  if (p.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (p.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (p.endsWith('.wasm')) return 'application/wasm';
+  if (p.endsWith('.svg')) return 'image/svg+xml';
+  if (p.endsWith('.json')) return 'application/json; charset=utf-8';
+  if (p.endsWith('.css')) return 'text/css; charset=utf-8';
+  return 'application/octet-stream';
+}
+
+const server = http.createServer((req, res) => {
+  let urlPath = req.url.split('?')[0];
+  if (urlPath === '/') urlPath = '/index.html';
+  const fsPath = path.join(root, urlPath);
+  if (!fsPath.startsWith(root)) {
+    res.writeHead(403); res.end('forbidden'); return;
+  }
+  fs.readFile(fsPath, (err, data) => {
+    if (err) {
+      res.writeHead(404); res.end('not found'); return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType(fsPath) });
+    res.end(data);
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  console.log('listening on http://127.0.0.1:' + port + '/');
+});
+"@ $rootPath $Port

--- a/scripts/serve-wasm.ps1
+++ b/scripts/serve-wasm.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$Root = ".",
+  [string]$Root = (Join-Path $PSScriptRoot ".."),
   [int]$Port = 5173
 )
 
@@ -21,6 +21,7 @@ const path = require('path');
 
 const root = process.argv[1];
 const port = Number(process.argv[2]);
+const rootResolved = path.resolve(root);
 
 function contentType(p) {
   if (p.endsWith('.html')) return 'text/html; charset=utf-8';
@@ -34,9 +35,11 @@ function contentType(p) {
 
 const server = http.createServer((req, res) => {
   let urlPath = req.url.split('?')[0];
-  if (urlPath === '/') urlPath = '/index.html';
-  const fsPath = path.join(root, urlPath);
-  if (!fsPath.startsWith(root)) {
+  try { urlPath = decodeURIComponent(urlPath); } catch { /* ignore */ }
+  if (urlPath.endsWith('/')) urlPath += 'index.html';
+
+  const fsPath = path.resolve(path.join(rootResolved, '.' + urlPath));
+  if (!fsPath.startsWith(rootResolved)) {
     res.writeHead(403); res.end('forbidden'); return;
   }
   fs.readFile(fsPath, (err, data) => {

--- a/tests/browser/.gitignore
+++ b/tests/browser/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -1,0 +1,15 @@
+# Browser tests (Playwright)
+
+This folder contains end-to-end browser tests for Stasis web/WASM prototypes.
+
+## Setup
+
+From `tests/browser`:
+
+- `npm install`
+- `npx playwright install chromium`
+
+## Run
+
+- `npm test`
+

--- a/tests/browser/package-lock.json
+++ b/tests/browser/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "stasis-browser-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stasis-browser-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.57.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/browser/package.json
+++ b/tests/browser/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "stasis-browser-tests",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": {
+    "@playwright/test": "1.57.0"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/tests/browser/playwright.config.js
+++ b/tests/browser/playwright.config.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  testDir: ".",
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    browserName: "chromium",
+    headless: true,
+    viewport: { width: 1100, height: 800 }
+  }
+};
+
+module.exports = config;
+

--- a/tests/browser/wasm_brickout.spec.js
+++ b/tests/browser/wasm_brickout.spec.js
@@ -1,0 +1,101 @@
+const { test, expect } = require("@playwright/test");
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+function repoRoot() {
+  return path.resolve(__dirname, "..", "..");
+}
+
+function contentType(p) {
+  if (p.endsWith(".html")) return "text/html; charset=utf-8";
+  if (p.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (p.endsWith(".wasm")) return "application/wasm";
+  if (p.endsWith(".svg")) return "image/svg+xml";
+  if (p.endsWith(".json")) return "application/json; charset=utf-8";
+  if (p.endsWith(".css")) return "text/css; charset=utf-8";
+  return "application/octet-stream";
+}
+
+function startStaticServer(root) {
+  const rootResolved = path.resolve(root);
+  const server = http.createServer((req, res) => {
+    let urlPath = String(req.url || "/").split("?")[0];
+    try {
+      urlPath = decodeURIComponent(urlPath);
+    } catch {
+      // ignore
+    }
+    if (urlPath.endsWith("/")) urlPath += "index.html";
+
+    const fsPath = path.resolve(path.join(rootResolved, "." + urlPath));
+    if (!fsPath.startsWith(rootResolved)) {
+      res.writeHead(403);
+      res.end("forbidden");
+      return;
+    }
+
+    fs.readFile(fsPath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end("not found");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": contentType(fsPath) });
+      res.end(data);
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      resolve({ server, port: addr.port });
+    });
+  });
+}
+
+test("brickout wasm starts and ticks without errors", async ({ page }) => {
+  const root = repoRoot();
+
+  const build = spawnSync(
+    "powershell",
+    ["-ExecutionPolicy", "Bypass", "-File", path.join(root, "scripts", "build-wasm-brickout.ps1")],
+    { cwd: root, encoding: "utf8" }
+  );
+  expect(build.status, `build failed:\n${build.stdout}\n${build.stderr}`).toBe(0);
+
+  const wasmPath = path.join(
+    root,
+    "examples",
+    "wasm",
+    "brickout_revenge_v1",
+    "brickout_revenge_v1.wasm"
+  );
+  expect(fs.existsSync(wasmPath), "wasm output missing").toBeTruthy();
+
+  const { server, port } = await startStaticServer(root);
+  const baseURL = `http://127.0.0.1:${port}`;
+
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(`pageerror: ${String(e && e.stack ? e.stack : e)}`));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+  });
+
+  try {
+    await page.goto(`${baseURL}/examples/wasm/brickout_revenge_v1/`, { waitUntil: "load" });
+    await page.getByRole("button", { name: "Start" }).click();
+
+    await expect(page.locator("#log")).toContainText("main() -> 0", { timeout: 20_000 });
+    await page.waitForFunction(() => window.__stasisWasmHost && window.__stasisWasmHost.tickCount >= 20, null, {
+      timeout: 20_000
+    });
+
+    expect(errors, `browser errors:\n${errors.join("\n")}`).toEqual([]);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+


### PR DESCRIPTION
Supersedes #73 by rebasing the WASM brickout prototype onto main.

Includes:
- wasm32 build script (scripts/build-wasm-brickout.ps1) and simple dev server (scripts/serve-wasm.ps1).
- Browser host shims (examples/wasm/brickout_revenge_v1/) with virtual-resolution scaling (fits/zooms to the available viewport) and pointer input.
- Playwright E2E test (	ests/browser/wasm_brickout.spec.js) that builds + starts the page and asserts it ticks without JS/page errors.

Run locally:
- powershell -ExecutionPolicy Bypass -File scripts/build-wasm-brickout.ps1
- powershell -ExecutionPolicy Bypass -File scripts/serve-wasm.ps1
- Open http://127.0.0.1:5173/examples/wasm/brickout_revenge_v1/

Playwright:
- cd tests/browser; npm install; npx playwright install chromium; npm test
