### PR TITLE
LSP: hover for locals and struct fields

### DIFF
--- a/Stasis.LanguageServer.Tests/HoverHandlerTests.cs
+++ b/Stasis.LanguageServer.Tests/HoverHandlerTests.cs
@@ -3,6 +3,7 @@ namespace Stasis.LanguageServer.Tests;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Stasis.LanguageServer.Handlers;
 using Stasis.LanguageServer.Services;
+using Stasis.LanguageServer.Models;
 using Xunit;
 
 public class HoverHandlerTests
@@ -56,16 +57,25 @@ public class HoverHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_ReturnsHoverWhenDocumentIsValid()
+    public async Task HandleAsync_ReturnsHoverForLocalSymbol()
     {
         // Arrange
         var manager = new DocumentManager();
         var handler = new HoverHandler(manager);
         var uri = "file:///test.stasis";
-        var content = "let x: i32 = 5;";
+        var content = """
+                      function main(): void {
+                          let x: i32;
+                          x = 5;
+                      }
+                      """;
 
         manager.GetOrCreateDocument(uri, content);
         manager.UpdateDocument(uri, content, 1);
+
+        var xOffset = content.IndexOf("x = 5", StringComparison.Ordinal);
+        Assert.True(xOffset >= 0, "Test content should contain x assignment.");
+        var xPos = TextPositionConverter.OffsetToPosition(content, xOffset);
 
         var request = new HoverParams
         {
@@ -73,16 +83,129 @@ public class HoverHandlerTests
             {
                 Uri = new Uri(uri)
             },
-            Position = new Position(0, 0)
+            Position = xPos
         };
 
         // Act
         var result = await handler.Handle(request, CancellationToken.None);
 
         // Assert
-        // Note: Current implementation returns null for unimplemented AST traversal
-        // but doesn't crash - this verifies basic handler stability
-        Assert.True(result == null || result != null); // Handler works without crashing
+        Assert.NotNull(result);
+        var markdown = GetHoverMarkdown(result!);
+        Assert.NotNull(markdown);
+        Assert.Contains("x", markdown!, StringComparison.Ordinal);
+        Assert.Contains("i32", markdown!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ReturnsHoverForNestedStructField()
+    {
+        var manager = new DocumentManager();
+        var handler = new HoverHandler(manager);
+        var uri = "file:///test.stasis";
+        var content = """
+                      struct Inner {
+                          a: i32;
+                      }
+
+                      struct Outer {
+                          inner: Inner;
+                      }
+
+                      function main(): void {
+                          let s: Outer;
+                          s.inner.a = 1;
+                      }
+                      """;
+
+        manager.GetOrCreateDocument(uri, content);
+        manager.UpdateDocument(uri, content, 1);
+
+        var aOffset = content.IndexOf("a = 1", StringComparison.Ordinal);
+        Assert.True(aOffset >= 0, "Test content should contain a assignment.");
+        var aPos = TextPositionConverter.OffsetToPosition(content, aOffset);
+
+        var request = new HoverParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(uri) },
+            Position = aPos
+        };
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        Assert.NotNull(result);
+        var markdown = GetHoverMarkdown(result!);
+        Assert.NotNull(markdown);
+        Assert.Contains("(field)", markdown!, StringComparison.Ordinal);
+        Assert.Contains("a: i32", markdown!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ReturnsHoverForImportedStructField()
+    {
+        var manager = new DocumentManager();
+        var handler = new HoverHandler(manager);
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"stasis-hover-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var importedPath = Path.Combine(tempRoot, "defs.stasis");
+            var entryPath = Path.Combine(tempRoot, "entry.stasis");
+
+            File.WriteAllText(importedPath, """
+                                            struct Inner {
+                                                a: i32;
+                                            }
+
+                                            struct Outer {
+                                                inner: Inner;
+                                            }
+                                            """);
+
+            File.WriteAllText(entryPath, """
+                                         import "./defs.stasis";
+
+                                         function main(): void {
+                                             let s: Outer;
+                                             s.inner.a = 1;
+                                         }
+                                         """);
+
+            var docId = new TextDocumentIdentifier { Uri = new Uri(entryPath) };
+            var uri = docId.Uri.ToString();
+            var content = File.ReadAllText(entryPath);
+
+            manager.GetOrCreateDocument(uri, content);
+            manager.UpdateDocument(uri, content, 1);
+
+            var aOffset = content.IndexOf("a = 1", StringComparison.Ordinal);
+            Assert.True(aOffset >= 0, "Test content should contain a assignment.");
+            var aPos = TextPositionConverter.OffsetToPosition(content, aOffset);
+
+            var request = new HoverParams
+            {
+                TextDocument = docId,
+                Position = aPos
+            };
+
+            var result = await handler.Handle(request, CancellationToken.None);
+            Assert.NotNull(result);
+            var markdown = GetHoverMarkdown(result!);
+            Assert.NotNull(markdown);
+            Assert.Contains("(field)", markdown!, StringComparison.Ordinal);
+            Assert.Contains("a: i32", markdown!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
     }
 
     [Fact]
@@ -100,5 +223,21 @@ public class HoverHandlerTests
 
         // Assert
         Assert.NotNull(options);
+    }
+
+    private static string? GetHoverMarkdown(Hover hover)
+    {
+        // OmniSharp exposes hover contents as a discriminated union. Use reflection so tests stay stable
+        // across minor protocol type changes.
+        var contents = hover.Contents;
+        var contentsType = contents.GetType();
+
+        var valueProp = contentsType.GetProperty("Value");
+        if (valueProp?.GetValue(contents) is MarkupContent markup)
+        {
+            return markup.Value;
+        }
+
+        return contents.ToString();
     }
 }

--- a/Stasis.LanguageServer.Tests/HoverHandlerTests.cs
+++ b/Stasis.LanguageServer.Tests/HoverHandlerTests.cs
@@ -98,6 +98,40 @@ public class HoverHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_PrefersLocalWhenShadowingGlobal()
+    {
+        var manager = new DocumentManager();
+        var handler = new HoverHandler(manager);
+        var uri = "file:///test.stasis";
+        var content = """
+                      function main(): void {
+                          let print: i32;
+                          print = 1;
+                      }
+                      """;
+
+        manager.GetOrCreateDocument(uri, content);
+        manager.UpdateDocument(uri, content, 1);
+
+        var offset = content.IndexOf("print = 1", StringComparison.Ordinal);
+        Assert.True(offset >= 0, "Test content should contain print assignment.");
+        var pos = TextPositionConverter.OffsetToPosition(content, offset);
+
+        var request = new HoverParams
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(uri) },
+            Position = pos
+        };
+
+        var result = await handler.Handle(request, CancellationToken.None);
+        Assert.NotNull(result);
+        var markdown = GetHoverMarkdown(result!);
+        Assert.NotNull(markdown);
+        Assert.Contains("(local variable)", markdown!, StringComparison.Ordinal);
+        Assert.Contains("print: i32", markdown!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task HandleAsync_ReturnsHoverForNestedStructField()
     {
         var manager = new DocumentManager();

--- a/Stasis.LanguageServer.Tests/LspCompletionTests.cs
+++ b/Stasis.LanguageServer.Tests/LspCompletionTests.cs
@@ -700,6 +700,9 @@ internal sealed class LspTestHarness : IAsyncDisposable
         PropertyNameCaseInsensitive = true
     };
 
+    private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
     private readonly CancellationTokenSource _shutdownCts = new();
     private Task _readerTask;
     private readonly Stream _clientIn;
@@ -835,8 +838,9 @@ internal sealed class LspTestHarness : IAsyncDisposable
 #pragma warning disable VSTHRD003, VSTHRD103
         try
         {
-            await SendRequestAsync("shutdown", new { }, CancellationToken.None);
-            await SendNotificationAsync("exit", new { }, CancellationToken.None);
+            using var cts = new CancellationTokenSource(ShutdownTimeout);
+            await SendRequestAsync("shutdown", new { }, cts.Token);
+            await SendNotificationAsync("exit", new { }, cts.Token);
         }
         catch
         {
@@ -872,7 +876,17 @@ internal sealed class LspTestHarness : IAsyncDisposable
         await WriteMessageAsync(payload, cancellationToken);
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
-        await using var _ = linked.Token.Register(() => tcs.TrySetCanceled(linked.Token));
+        if (!cancellationToken.CanBeCanceled)
+        {
+            linked.CancelAfter(DefaultRequestTimeout);
+        }
+
+        await using var registration = linked.Token.Register(() =>
+        {
+            _pending.TryRemove(id, out _);
+            tcs.TrySetCanceled(linked.Token);
+        });
+
         return await tcs.Task;
     }
 

--- a/Stasis.LanguageServer/Handlers/HoverHandler.cs
+++ b/Stasis.LanguageServer/Handlers/HoverHandler.cs
@@ -55,15 +55,17 @@ public class HoverHandler : HoverHandlerBase
         if (identifierChain.Count == 1)
         {
             var name = identifierChain[0];
+
+            // Prefer in-scope locals/parameters over globals/builtins when names collide.
+            if (TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, name, out var kindLabel, out var typeText))
+            {
+                return CreateHover(FormatLocalSymbolInfo(kindLabel, name, typeText));
+            }
+
             if (doc.SemanticResult?.Symbols is not null &&
                 doc.SemanticResult.Symbols.TryGetValue(name, out var symbol))
             {
                 return CreateHover(FormatSymbolInfo(symbol));
-            }
-
-            if (TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, name, out var kindLabel, out var typeText))
-            {
-                return CreateHover(FormatLocalSymbolInfo(kindLabel, name, typeText));
             }
 
             return null;
@@ -85,21 +87,19 @@ public class HoverHandler : HoverHandlerBase
             }
         }
 
+        // Prefer in-scope locals/parameters over globals/builtins when names collide.
         string? receiverTypeName = null;
-
-        if (doc.SemanticResult?.Symbols is not null &&
-            doc.SemanticResult.Symbols.TryGetValue(baseName, out var receiverSymbol))
+        if (TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, baseName, out _, out var receiverTypeText) &&
+            !string.IsNullOrEmpty(receiverTypeText))
         {
-            receiverTypeName = receiverSymbol.Type is NamedTypeSymbol named ? named.TypeName : null;
+            receiverTypeName = ExtractNamedTypeName(receiverTypeText);
         }
 
         if (string.IsNullOrEmpty(receiverTypeName) &&
-            TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, baseName, out _, out var receiverTypeText))
+            doc.SemanticResult?.Symbols is not null &&
+            doc.SemanticResult.Symbols.TryGetValue(baseName, out var receiverSymbol))
         {
-            if (!string.IsNullOrEmpty(receiverTypeText))
-            {
-                receiverTypeName = ExtractNamedTypeName(receiverTypeText);
-            }
+            receiverTypeName = receiverSymbol.Type is NamedTypeSymbol named ? named.TypeName : null;
         }
 
         if (string.IsNullOrEmpty(receiverTypeName))

--- a/Stasis.LanguageServer/Handlers/HoverHandler.cs
+++ b/Stasis.LanguageServer/Handlers/HoverHandler.cs
@@ -24,21 +24,17 @@ public class HoverHandler : HoverHandlerBase
         var uri = request.TextDocument.Uri.ToString();
         var doc = _documentManager.GetDocument(uri);
 
-        if (doc?.SemanticResult == null || doc.ParseResult == null)
-            return Task.FromResult<Hover?>(null);
-
-        var compilationUnit = doc.ParseResult.CompilationUnit;
-        if (compilationUnit == null)
+        if (doc?.ParseResult?.CompilationUnit == null)
             return Task.FromResult<Hover?>(null);
 
         var offset = TextPositionConverter.PositionToOffset(doc.Content, request.Position);
-        var node = FindNodeAtPosition(compilationUnit, offset);
-
-        if (node == null)
+        if (!TryGetIdentifierChainAtOffset(doc.Content, offset, out var identifierChain))
+        {
             return Task.FromResult<Hover?>(null);
+        }
 
-        var hover = GetHoverInfo(node, doc.SemanticResult, offset);
-        return Task.FromResult(hover);
+        var hover = GetHoverInfo(identifierChain, doc, offset);
+        return Task.FromResult<Hover?>(hover);
     }
 
     protected override HoverRegistrationOptions CreateRegistrationOptions(HoverCapability? capability, ClientCapabilities clientCapabilities)
@@ -47,150 +43,97 @@ public class HoverHandler : HoverHandlerBase
     }
 
     /// <summary>
-    /// Recursively finds the most specific syntax node at the given offset.
+    /// Extracts hover information using semantic analysis + the import-expanded symbol index.
     /// </summary>
-    private static SyntaxNode? FindNodeAtPosition(SyntaxNode node, int offset)
+    private static Hover? GetHoverInfo(IReadOnlyList<string> identifierChain, DocumentState doc, int cursorOffset)
     {
-        // Check if offset is within this node's span
-        if (node.Span.Start > offset || offset >= node.Span.Start + node.Span.Length)
+        if (identifierChain.Count == 0)
+        {
             return null;
-
-        return node switch
-        {
-            CompilationUnitSyntax cu => FindInCompilationUnit(cu, offset),
-            DeclarationSyntax decl => FindInDeclaration(decl, offset),
-            StatementSyntax stmt => FindInStatement(stmt, offset),
-            ExpressionSyntax expr => FindInExpression(expr, offset),
-            _ => node
-        };
-    }
-
-    private static SyntaxNode? FindInCompilationUnit(CompilationUnitSyntax cu, int offset)
-    {
-        foreach (var decl in cu.Declarations)
-        {
-            var found = FindNodeAtPosition(decl, offset);
-            if (found != null)
-                return found;
         }
-        return null;
-    }
 
-    private static SyntaxNode? FindInDeclaration(DeclarationSyntax decl, int offset)
-    {
-        return decl switch
+        if (identifierChain.Count == 1)
         {
-            FunctionDeclarationSyntax func when func.Body != null =>
-                FindNodeAtPosition(func.Body, offset) ?? decl,
-            _ => decl
-        };
-    }
+            var name = identifierChain[0];
+            if (doc.SemanticResult?.Symbols is not null &&
+                doc.SemanticResult.Symbols.TryGetValue(name, out var symbol))
+            {
+                return CreateHover(FormatSymbolInfo(symbol));
+            }
 
-    private static SyntaxNode? FindInStatement(StatementSyntax stmt, int offset)
-    {
-        return stmt switch
-        {
-            BlockStatementSyntax block => FindInBlock(block, offset) ?? stmt,
-            VariableDeclarationSyntax varDecl when varDecl.Initializer != null =>
-                FindNodeAtPosition(varDecl.Initializer, offset) ?? stmt,
-            ExpressionStatementSyntax exprStmt =>
-                FindNodeAtPosition(exprStmt.Expression, offset) ?? stmt,
-            IfStatementSyntax ifStmt =>
-                FindNodeAtPosition(ifStmt.Condition, offset) ??
-                FindNodeAtPosition(ifStmt.ThenBlock, offset) ??
-                (ifStmt.ElseBlock != null ? FindNodeAtPosition(ifStmt.ElseBlock, offset) : null) ??
-                stmt,
-            ForStatementSyntax forStmt =>
-                (forStmt.Condition != null ? FindNodeAtPosition(forStmt.Condition, offset) : null) ??
-                FindNodeAtPosition(forStmt.Body, offset) ??
-                stmt,
-            ForeachStatementSyntax foreachStmt =>
-                FindNodeAtPosition(foreachStmt.Iterable, offset) ??
-                FindNodeAtPosition(foreachStmt.Body, offset) ??
-                stmt,
-            ReturnStatementSyntax retStmt when retStmt.Expression != null =>
-                FindNodeAtPosition(retStmt.Expression, offset) ?? stmt,
-            _ => stmt
-        };
-    }
+            if (TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, name, out var kindLabel, out var typeText))
+            {
+                return CreateHover(FormatLocalSymbolInfo(kindLabel, name, typeText));
+            }
 
-    private static SyntaxNode? FindInBlock(BlockStatementSyntax block, int offset)
-    {
-        foreach (var statement in block.Statements)
-        {
-            var found = FindNodeAtPosition(statement, offset);
-            if (found != null)
-                return found;
-        }
-        return null;
-    }
-
-    private static SyntaxNode? FindInExpression(ExpressionSyntax expr, int offset)
-    {
-        return expr switch
-        {
-            IdentifierExpressionSyntax => expr, // Found an identifier - this is what we want!
-            BinaryExpressionSyntax bin =>
-                FindNodeAtPosition(bin.Left, offset) ??
-                FindNodeAtPosition(bin.Right, offset) ??
-                expr,
-            UnaryExpressionSyntax unary =>
-                FindNodeAtPosition(unary.Operand, offset) ?? expr,
-            CallExpressionSyntax call =>
-                FindNodeAtPosition(call.Callee, offset) ??
-                FindInArguments(call.Arguments, offset) ??
-                expr,
-            MemberAccessExpressionSyntax member =>
-                FindNodeAtPosition(member.Receiver, offset) ?? expr,
-            ArrayAccessExpressionSyntax arrayAccess =>
-                FindNodeAtPosition(arrayAccess.Receiver, offset) ??
-                FindNodeAtPosition(arrayAccess.Index, offset) ??
-                expr,
-            ParenthesizedExpressionSyntax paren =>
-                FindNodeAtPosition(paren.Expression, offset) ?? expr,
-            AssignmentExpressionSyntax assign =>
-                FindNodeAtPosition(assign.Left, offset) ??
-                FindNodeAtPosition(assign.Right, offset) ??
-                expr,
-            _ => expr
-        };
-    }
-
-    private static SyntaxNode? FindInArguments(IReadOnlyList<ExpressionSyntax> arguments, int offset)
-    {
-        foreach (var arg in arguments)
-        {
-            var found = FindNodeAtPosition(arg, offset);
-            if (found != null)
-                return found;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// Extracts hover information from a syntax node using semantic analysis.
-    /// </summary>
-    private static Hover? GetHoverInfo(SyntaxNode node, SemanticResult semanticResult, int offset)
-    {
-        // Extract identifier name from the node
-        var identifierName = node switch
-        {
-            IdentifierExpressionSyntax ident => ident.Identifier.Text,
-            FunctionDeclarationSyntax func => func.Name.Text,
-            _ => null
-        };
-
-        if (string.IsNullOrEmpty(identifierName))
             return null;
+        }
 
-        // Look up symbol in semantic result
-        if (!semanticResult.Symbols.TryGetValue(identifierName, out var symbol))
+        if (doc.SymbolIndex == null)
+        {
             return null;
+        }
 
-        // Format hover content as markdown
-        var markdown = FormatSymbolInfo(symbol);
+        var baseName = identifierChain[0];
+        var memberName = identifierChain[^1];
 
-        return new Hover
+        if (doc.SymbolIndex.GetEnum(baseName) is { } enumSymbol)
+        {
+            if (enumSymbol.Members.Any(m => string.Equals(m, memberName, StringComparison.Ordinal)))
+            {
+                return CreateHover(FormatEnumMemberInfo(baseName, memberName));
+            }
+        }
+
+        string? receiverTypeName = null;
+
+        if (doc.SemanticResult?.Symbols is not null &&
+            doc.SemanticResult.Symbols.TryGetValue(baseName, out var receiverSymbol))
+        {
+            receiverTypeName = receiverSymbol.Type is NamedTypeSymbol named ? named.TypeName : null;
+        }
+
+        if (string.IsNullOrEmpty(receiverTypeName) &&
+            TryResolveLocalOrDeclarationSymbol(doc.ParseResult!.CompilationUnit!, cursorOffset, baseName, out _, out var receiverTypeText))
+        {
+            if (!string.IsNullOrEmpty(receiverTypeText))
+            {
+                receiverTypeName = ExtractNamedTypeName(receiverTypeText);
+            }
+        }
+
+        if (string.IsNullOrEmpty(receiverTypeName))
+        {
+            return null;
+        }
+
+        if (!TryResolveMemberReceiverType(receiverTypeName, identifierChain, doc.SymbolIndex, out var memberReceiverType))
+        {
+            return null;
+        }
+
+        if (doc.SymbolIndex.GetStruct(memberReceiverType) is not { } structSymbol)
+        {
+            if (doc.SymbolIndex.GetEnum(memberReceiverType) is { } enumReceiver &&
+                enumReceiver.Members.Any(m => string.Equals(m, memberName, StringComparison.Ordinal)))
+            {
+                return CreateHover(FormatEnumMemberInfo(memberReceiverType, memberName));
+            }
+
+            return null;
+        }
+
+        var field = structSymbol.Fields.FirstOrDefault(f => string.Equals(f.Name, memberName, StringComparison.Ordinal));
+        if (field == null)
+        {
+            return null;
+        }
+
+        return CreateHover(FormatFieldInfo(field));
+    }
+
+    private static Hover CreateHover(string markdown) =>
+        new()
         {
             Contents = new MarkedStringsOrMarkupContent(new MarkupContent
             {
@@ -198,7 +141,6 @@ public class HoverHandler : HoverHandlerBase
                 Value = markdown
             })
         };
-    }
 
     /// <summary>
     /// Formats symbol information as markdown for hover display.
@@ -222,4 +164,330 @@ public class HoverHandler : HoverHandlerBase
 
         return $"```stasis\n({kindLabel}) {symbol.Name}{typeInfo}\n```";
     }
+
+    private static string FormatLocalSymbolInfo(string kindLabel, string name, string? typeText)
+    {
+        var typeInfo = string.IsNullOrWhiteSpace(typeText) ? "" : $": {typeText}";
+        return $"```stasis\n({kindLabel}) {name}{typeInfo}\n```";
+    }
+
+    private static string FormatFieldInfo(StructFieldSymbol field) =>
+        $"```stasis\n(field) {field.Name}: {field.TypeText}\n```";
+
+    private static string FormatEnumMemberInfo(string enumName, string memberName) =>
+        $"```stasis\n(enum member) {enumName}.{memberName}\n```";
+
+    private static bool TryResolveMemberReceiverType(
+        string baseTypeName,
+        IReadOnlyList<string> identifierChain,
+        SymbolIndex index,
+        out string memberReceiverTypeName)
+    {
+        memberReceiverTypeName = baseTypeName;
+
+        if (identifierChain.Count <= 1)
+        {
+            return true;
+        }
+
+        // Walk through chain excluding the last member name; we want the receiver type for the hovered member.
+        for (var i = 1; i < identifierChain.Count - 1; i++)
+        {
+            var member = identifierChain[i];
+            if (index.GetStruct(memberReceiverTypeName) is not { } structSymbol)
+            {
+                return false;
+            }
+
+            var field = structSymbol.Fields.FirstOrDefault(f => string.Equals(f.Name, member, StringComparison.Ordinal));
+            if (field == null)
+            {
+                return false;
+            }
+
+            var nextType = ExtractNamedTypeName(field.TypeText);
+            if (string.IsNullOrEmpty(nextType))
+            {
+                return false;
+            }
+
+            memberReceiverTypeName = nextType;
+        }
+
+        return true;
+    }
+
+    private static string? ExtractNamedTypeName(string typeText)
+    {
+        if (string.IsNullOrEmpty(typeText))
+        {
+            return null;
+        }
+
+        typeText = typeText.Trim();
+
+        var bracketIndex = typeText.IndexOf('[');
+        if (bracketIndex >= 0)
+        {
+            return null;
+        }
+
+        return typeText;
+    }
+
+    private static bool TryResolveLocalOrDeclarationSymbol(
+        CompilationUnitSyntax compilationUnit,
+        int cursorOffset,
+        string name,
+        out string kindLabel,
+        out string? typeText)
+    {
+        kindLabel = "symbol";
+        typeText = null;
+
+        foreach (var decl in compilationUnit.Declarations)
+        {
+            switch (decl)
+            {
+                case StructDeclarationSyntax s when string.Equals(s.Name.Text, name, StringComparison.Ordinal):
+                    kindLabel = "struct";
+                    typeText = null;
+                    return true;
+                case EnumDeclarationSyntax e when string.Equals(e.Name.Text, name, StringComparison.Ordinal):
+                    kindLabel = "enum";
+                    typeText = null;
+                    return true;
+                case GlobalDeclarationSyntax g when string.Equals(g.Name.Text, name, StringComparison.Ordinal):
+                    kindLabel = "global variable";
+                    typeText = TypeSyntaxToString(g.Type);
+                    return true;
+                case ConstDeclarationSyntax c when string.Equals(c.Name.Text, name, StringComparison.Ordinal):
+                    kindLabel = "constant";
+                    typeText = TypeSyntaxToString(c.Type);
+                    return true;
+            }
+        }
+
+        if (!TryGetEnclosingCallable(compilationUnit, cursorOffset, out var parameters, out var body))
+        {
+            return false;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            if (string.Equals(parameter.Name.Text, name, StringComparison.Ordinal))
+            {
+                kindLabel = "parameter";
+                typeText = TypeSyntaxToString(parameter.Type);
+                return true;
+            }
+        }
+
+        VariableDeclarationSyntax? best = null;
+        foreach (var decl in EnumerateVariableDeclarations(body))
+        {
+            if (!string.Equals(decl.Name.Text, name, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (decl.Span.Start > cursorOffset)
+            {
+                continue;
+            }
+
+            if (best == null || decl.Span.Start >= best.Span.Start)
+            {
+                best = decl;
+            }
+        }
+
+        if (best == null)
+        {
+            return false;
+        }
+
+        kindLabel = "local variable";
+        typeText = best.Type == null ? null : TypeSyntaxToString(best.Type);
+        return true;
+    }
+
+    private static bool TryGetEnclosingCallable(
+        CompilationUnitSyntax compilationUnit,
+        int cursorOffset,
+        out IReadOnlyList<ParameterSyntax> parameters,
+        out BlockStatementSyntax body)
+    {
+        foreach (var decl in compilationUnit.Declarations)
+        {
+            switch (decl)
+            {
+                case FunctionDeclarationSyntax fn when ContainsOffset(fn.Span, cursorOffset):
+                    if (fn.Body == null)
+                    {
+                        break;
+                    }
+                    parameters = fn.Parameters;
+                    body = fn.Body;
+                    return true;
+                case TestDeclarationSyntax test when ContainsOffset(test.Span, cursorOffset):
+                    parameters = test.Parameters;
+                    body = test.Body;
+                    return true;
+            }
+        }
+
+        parameters = Array.Empty<ParameterSyntax>();
+        body = null!;
+        return false;
+    }
+
+    private static IEnumerable<VariableDeclarationSyntax> EnumerateVariableDeclarations(StatementSyntax stmt)
+    {
+        switch (stmt)
+        {
+            case VariableDeclarationSyntax v:
+                yield return v;
+                yield break;
+            case BlockStatementSyntax block:
+                foreach (var s in block.Statements)
+                {
+                    foreach (var v in EnumerateVariableDeclarations(s))
+                    {
+                        yield return v;
+                    }
+                }
+                yield break;
+            case IfStatementSyntax ifStmt:
+                foreach (var v in EnumerateVariableDeclarations(ifStmt.ThenBlock))
+                {
+                    yield return v;
+                }
+                if (ifStmt.ElseBlock != null)
+                {
+                    foreach (var v in EnumerateVariableDeclarations(ifStmt.ElseBlock))
+                    {
+                        yield return v;
+                    }
+                }
+                yield break;
+            case ForStatementSyntax forStmt:
+                foreach (var v in EnumerateVariableDeclarations(forStmt.Body))
+                {
+                    yield return v;
+                }
+                yield break;
+            case ForeachStatementSyntax foreachStmt:
+                foreach (var v in EnumerateVariableDeclarations(foreachStmt.Body))
+                {
+                    yield return v;
+                }
+                yield break;
+            default:
+                yield break;
+        }
+    }
+
+    private static bool ContainsOffset(SourceSpan span, int cursorOffset) =>
+        span.Start <= cursorOffset && cursorOffset < span.Start + span.Length;
+
+    private static string TypeSyntaxToString(TypeSyntax type) =>
+        type switch
+        {
+            NamedTypeSyntax named => named.Name,
+            ArrayTypeSyntax arr when string.IsNullOrEmpty(arr.SizeText) => $"{TypeSyntaxToString(arr.ElementType)}[]",
+            ArrayTypeSyntax arr => $"{TypeSyntaxToString(arr.ElementType)}[{arr.SizeText}]",
+            _ => "unknown"
+        };
+
+    private static bool TryGetIdentifierChainAtOffset(string content, int offset, out IReadOnlyList<string> chain)
+    {
+        chain = Array.Empty<string>();
+
+        if (offset < 0)
+        {
+            offset = 0;
+        }
+        if (offset > content.Length)
+        {
+            offset = content.Length;
+        }
+
+        // Prefer the character under the cursor; if it's not an identifier, fall back to the previous character.
+        var scanIndex = offset;
+        if (scanIndex == content.Length || (scanIndex < content.Length && !IsIdentifierChar(content[scanIndex])))
+        {
+            scanIndex = Math.Max(0, offset - 1);
+        }
+
+        if (scanIndex < 0 || scanIndex >= content.Length || !IsIdentifierChar(content[scanIndex]))
+        {
+            return false;
+        }
+
+        var end = scanIndex + 1;
+        while (end < content.Length && IsIdentifierChar(content[end]))
+        {
+            end++;
+        }
+
+        var start = scanIndex;
+        while (start - 1 >= 0 && IsIdentifierChar(content[start - 1]))
+        {
+            start--;
+        }
+
+        var names = new List<string>(8)
+        {
+            content.Substring(start, end - start)
+        };
+
+        var i = start - 1;
+        while (TrySkipInlineWhitespaceLeft(content, ref i) && i >= 0 && content[i] == '.')
+        {
+            i--; // skip '.'
+            if (!TrySkipInlineWhitespaceLeft(content, ref i))
+            {
+                break;
+            }
+
+            var prevEnd = i + 1;
+            while (i >= 0 && IsIdentifierChar(content[i]))
+            {
+                i--;
+            }
+
+            var prevStart = i + 1;
+            if (prevStart >= prevEnd)
+            {
+                break;
+            }
+
+            names.Add(content.Substring(prevStart, prevEnd - prevStart));
+        }
+
+        names.Reverse();
+        chain = names;
+        return true;
+    }
+
+    private static bool TrySkipInlineWhitespaceLeft(string content, ref int index)
+    {
+        while (index >= 0 && char.IsWhiteSpace(content[index]))
+        {
+            if (content[index] == '\n' || content[index] == '\r')
+            {
+                return false;
+            }
+            index--;
+        }
+
+        return true;
+    }
+
+    private static bool IsIdentifierChar(char ch) =>
+        (ch >= 'a' && ch <= 'z') ||
+        (ch >= 'A' && ch <= 'Z') ||
+        (ch >= '0' && ch <= '9') ||
+        ch == '_';
 }


### PR DESCRIPTION
Improves hover to work on locals/parameters and on member-access chains (including nested + imported structs/enums) by using parse-tree fallback plus the import-expanded SymbolIndex.

Tests:
- dotnet test -c Release Stasis.LanguageServer.Tests/Stasis.LanguageServer.Tests.csproj