### PR TITLE
feat: prototype HostFrame snapshot

### DIFF
--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -682,6 +682,17 @@ public sealed class ModuleLowerer
         return (fn, fnType);
     }
 
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisHostGetFrame(LlvmModuleBuilder builder)
+    {
+        var fn = builder.Module.GetNamedFunction("stasis_host_get_frame");
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new[] { i8Ptr, i8Ptr }, false);
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("stasis_host_get_frame", fnType);
+        return (fn, fnType);
+    }
+
     private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisGfxPollReload(LlvmModuleBuilder builder)
     {
         var fn = builder.Module.GetNamedFunction("stasis_gfx_poll_reload");
@@ -1252,6 +1263,7 @@ public sealed class ModuleLowerer
             "gfx_draw_sprite",
             "gfx_draw_sprites_i32",
             "gfx_poll_reload",
+            "host_get_frame",
             "gfx_window_width",
             "gfx_window_height",
             "gfx_window_resized",
@@ -3084,6 +3096,36 @@ public sealed class ModuleLowerer
                         var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
                         var cast = builder.BuildBitCast(cmds, i8Ptr, "gfx_draw_sprites_i32.ptr");
                         builder.BuildCall2(fnType, fn, new[] { cast, count }, "");
+                        return ConstI32(0);
+                    }
+                case "host_get_frame":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("host_get_frame expects (out_i32, out_f32).", span);
+                            return ConstI32(0);
+                        }
+
+                        var outI32 = LowerArrayPointer(builder, args[0], locals);
+                        if (outI32.Handle == IntPtr.Zero)
+                            outI32 = LowerExpression(builder, args[0], locals);
+
+                        var outF32 = LowerArrayPointer(builder, args[1], locals);
+                        if (outF32.Handle == IntPtr.Zero)
+                            outF32 = LowerExpression(builder, args[1], locals);
+
+                        if (outI32.TypeOf.Kind != LLVMTypeKind.LLVMPointerTypeKind ||
+                            outF32.TypeOf.Kind != LLVMTypeKind.LLVMPointerTypeKind)
+                        {
+                            AddDiagnostic("host_get_frame expects array/pointer arguments.", span);
+                            return ConstI32(0);
+                        }
+
+                        var (fn, fnType) = GetOrDeclareStasisHostGetFrame(_moduleBuilder);
+                        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+                        var castI32 = builder.BuildBitCast(outI32, i8Ptr, "host_get_frame.i32.ptr");
+                        var castF32 = builder.BuildBitCast(outF32, i8Ptr, "host_get_frame.f32.ptr");
+                        builder.BuildCall2(fnType, fn, new[] { castI32, castF32 }, "");
                         return ConstI32(0);
                     }
                 case "gfx_poll_reload":

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -120,6 +120,9 @@ static float g_prev_y_px[STASIS_MAX_POINTERS];
 static SDL_FingerID g_finger_ids[STASIS_MAX_POINTERS - 1];
 static int g_finger_active[STASIS_MAX_POINTERS - 1];
 
+/* Forward decls for exported functions used before their definitions (MSVC C mode does not allow implicit declarations). */
+STASIS_EXPORT int stasis_get_time_ms(void);
+
 /* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
 static void setup_ortho(void);
@@ -486,6 +489,51 @@ STASIS_EXPORT int stasis_input_viewport_w_px(void) {
 
 STASIS_EXPORT int stasis_input_viewport_h_px(void) {
     return g_window ? g_input_frame.viewport_h_px : 0;
+}
+
+/*
+ * Host snapshot: fill caller-provided buffers with a deterministic view of host state.
+ *
+ * Layout is defined in src/stdlib/host_frame.stasis. This is intentionally a simple
+ * "copy out" ABI for native now, and a good fit for WASM later (one import to get a snapshot).
+ */
+STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
+    if (!out_i32 || !out_f32) return;
+
+    /* i32 header */
+    out_i32[0] = stasis_get_time_ms();
+    out_i32[1] = g_window_width;
+    out_i32[2] = g_window_height;
+    out_i32[3] = g_input_frame.viewport_x_px;
+    out_i32[4] = g_input_frame.viewport_y_px;
+    out_i32[5] = g_input_frame.viewport_w_px;
+    out_i32[6] = g_input_frame.viewport_h_px;
+    out_i32[7] = g_input_frame.pointer_count;
+    out_i32[8] = g_input_frame.dropped_pointers;
+
+    for (int i = 9; i < 16; i++) out_i32[i] = 0;
+
+    const int i32_base = 16;
+    const int i32_stride = 4;
+    const int f32_base = 0;
+    const int f32_stride = 6;
+    for (int i = 0; i < STASIS_MAX_POINTERS; i++) {
+        const StasisPointer* p = &g_input_frame.pointers[i];
+        out_i32[i32_base + i * i32_stride + 0] = p->id;
+        out_i32[i32_base + i * i32_stride + 1] = p->is_down;
+        out_i32[i32_base + i * i32_stride + 2] = p->went_down;
+        out_i32[i32_base + i * i32_stride + 3] = p->went_up;
+
+        out_f32[f32_base + i * f32_stride + 0] = p->x_px;
+        out_f32[f32_base + i * f32_stride + 1] = p->y_px;
+        out_f32[f32_base + i * f32_stride + 2] = p->dx_px;
+        out_f32[f32_base + i * f32_stride + 3] = p->dy_px;
+        out_f32[f32_base + i * f32_stride + 4] = p->x_n;
+        out_f32[f32_base + i * f32_stride + 5] = p->y_n;
+    }
+
+    for (int i = i32_base + STASIS_MAX_POINTERS * i32_stride; i < 64; i++) out_i32[i] = 0;
+    for (int i = f32_base + STASIS_MAX_POINTERS * f32_stride; i < 64; i++) out_f32[i] = 0.0f;
 }
 
 /* ============================================================

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -46,6 +46,8 @@ EXPORTS
     stasis_gfx_debug_bake_hash
     stasis_gfx_debug_enable_hash
     stasis_gfx_debug_get_frame_hash
+    stasis_host_get_frame
+    host_get_frame=stasis_host_get_frame
     stasis_load_font
     stasis_draw_text
     stasis_measure_text

--- a/samples/host_frame_demo.stasis
+++ b/samples/host_frame_demo.stasis
@@ -1,0 +1,42 @@
+import "../src/stdlib/stdlib.stasis";
+import "../src/stdlib/graphics.stasis";
+import "../src/stdlib/host_frame.stasis";
+
+// Host Frame Demo (prototype)
+// Shows the "one snapshot per tick" read model.
+
+global host_i32: i32[64];
+global host_f32: f32[64];
+
+function main(): i32 {
+    let ok: bool = init_window(800, 600, "Stasis HostFrame Demo");
+    if (!ok) { return 1; }
+
+    let running: i32 = 1;
+    for (; running == 1;) {
+        begin_frame();
+
+        // Refresh snapshot AFTER begin_frame so the snapshot reflects the event pump for this frame.
+        host_frame_refresh(host_i32, host_f32);
+
+        clear(0.05, 0.05, 0.08, 1.0);
+
+        let w: f32 = i32_to_f32(host_window_w_px(host_i32));
+        let h: f32 = i32_to_f32(host_window_h_px(host_i32));
+        draw_line(0.0, 0.0, w, h, 0.2, 0.9, 0.9, 1.0);
+        draw_line(0.0, h, w, 0.0, 0.2, 0.9, 0.9, 1.0);
+
+        // Mouse is pointer slot 0 in the current runtime.
+        let mx: f32 = host_pointer_x_px(host_f32, 0);
+        let my: f32 = host_pointer_y_px(host_f32, 0);
+        draw_line(mx - 10.0, my, mx + 10.0, my, 1.0, 0.3, 0.3, 1.0);
+        draw_line(mx, my - 10.0, mx, my + 10.0, 1.0, 0.3, 0.3, 1.0);
+
+        end_frame();
+
+        if (should_quit()) { running = 0; }
+        sleep_ms(16);
+    }
+
+    return 0;
+}

--- a/src/stdlib/host_frame.stasis
+++ b/src/stdlib/host_frame.stasis
@@ -1,0 +1,91 @@
+import "graphics.stasis";
+
+// Host frame snapshot (prototype)
+//
+// Practical hybrid approach:
+// - Reads: host writes a single deterministic snapshot once per tick via `host_get_frame`.
+// - Writes/effects: rendering/audio remain explicit command calls (draw_line/gfx_draw_sprite/etc).
+//
+// Usage:
+// - In your program, define `global host_i32: i32[64];` and `global host_f32: f32[64];`
+// - Call `host_frame_refresh(host_i32, host_f32)` once at the start of your tick.
+// - Read everything using the accessors below for the rest of the tick.
+
+// NOTE: This is a prototype layout. Treat all unused indices as reserved.
+
+const HOST_MAX_POINTERS: i32 = 8;
+
+// i32 layout
+const HOST_I_TIME_MS: i32 = 0;
+const HOST_I_WINDOW_W_PX: i32 = 1;
+const HOST_I_WINDOW_H_PX: i32 = 2;
+const HOST_I_VIEWPORT_X_PX: i32 = 3;
+const HOST_I_VIEWPORT_Y_PX: i32 = 4;
+const HOST_I_VIEWPORT_W_PX: i32 = 5;
+const HOST_I_VIEWPORT_H_PX: i32 = 6;
+const HOST_I_POINTER_COUNT: i32 = 7;
+const HOST_I_DROPPED_POINTERS: i32 = 8;
+const HOST_I_POINTER_BASE: i32 = 16; // reserve space for future fields before pointers
+const HOST_I_POINTER_STRIDE: i32 = 4; // id, is_down, went_down, went_up
+const HOST_I32_COUNT: i32 = 64;
+
+// f32 layout
+const HOST_F_POINTER_BASE: i32 = 0;
+const HOST_F_POINTER_STRIDE: i32 = 6; // x_px, y_px, dx_px, dy_px, x_n, y_n
+const HOST_F32_COUNT: i32 = 64;
+
+extern function host_get_frame(out_i32: i32[], out_f32: f32[]): void;
+
+function host_frame_refresh(out_i32: i32[], out_f32: f32[]): void {
+    host_get_frame(out_i32, out_f32);
+}
+
+function host_time_ms(i32s: i32[]): i32 { return i32s[HOST_I_TIME_MS]; }
+function host_window_w_px(i32s: i32[]): i32 { return i32s[HOST_I_WINDOW_W_PX]; }
+function host_window_h_px(i32s: i32[]): i32 { return i32s[HOST_I_WINDOW_H_PX]; }
+function host_viewport_x_px(i32s: i32[]): i32 { return i32s[HOST_I_VIEWPORT_X_PX]; }
+function host_viewport_y_px(i32s: i32[]): i32 { return i32s[HOST_I_VIEWPORT_Y_PX]; }
+function host_viewport_w_px(i32s: i32[]): i32 { return i32s[HOST_I_VIEWPORT_W_PX]; }
+function host_viewport_h_px(i32s: i32[]): i32 { return i32s[HOST_I_VIEWPORT_H_PX]; }
+function host_pointer_count(i32s: i32[]): i32 { return i32s[HOST_I_POINTER_COUNT]; }
+function host_dropped_pointers(i32s: i32[]): i32 { return i32s[HOST_I_DROPPED_POINTERS]; }
+
+function host_pointer_id(i32s: i32[], index: i32): i32 {
+    return i32s[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 0];
+}
+
+function host_pointer_is_down(i32s: i32[], index: i32): i32 {
+    return i32s[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 1];
+}
+
+function host_pointer_went_down(i32s: i32[], index: i32): i32 {
+    return i32s[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 2];
+}
+
+function host_pointer_went_up(i32s: i32[], index: i32): i32 {
+    return i32s[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3];
+}
+
+function host_pointer_x_px(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0];
+}
+
+function host_pointer_y_px(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1];
+}
+
+function host_pointer_dx_px(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 2];
+}
+
+function host_pointer_dy_px(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 3];
+}
+
+function host_pointer_x_n(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4];
+}
+
+function host_pointer_y_n(f32s: f32[], index: i32): f32 {
+    return f32s[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5];
+}

--- a/vscode-stasis/.gitignore
+++ b/vscode-stasis/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 out/
+dist/
 .vscode-test/
 *.vsix
 npm-debug.log*


### PR DESCRIPTION
Adds a prototype host snapshot API (single call per tick) and stdlib helpers, as a baseline for replacing many small host query externs.\n\n- Runtime: exports stasis_host_get_frame(host_i32*, host_f32*)\n- Compiler: lowers extern host_get_frame(...) to stasis_host_get_frame\n- Stdlib: src/stdlib/host_frame.stasis defines layout + accessors (no globals)\n- Sample: samples/host_frame_demo.stasis demonstrates usage\n\nNotes:\n- This is intentionally a minimal hybrid: reads via snapshot, writes remain explicit render commands.\n- Layout is reserved/extendable; indices beyond current fields are zeroed.