### PR TITLE
Remove gfx_poll_reload; auto sprite hot-reload in dev

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3497,6 +3497,7 @@ static Process StartWatchChild(string exePath, string[] args)
         UseShellExecute = false
     };
     psi.EnvironmentVariables["STASIS_ASSET_ROOT"] = Directory.GetCurrentDirectory();
+    psi.EnvironmentVariables["STASIS_DEV"] = "1";
     return Process.Start(psi)!;
 }
 

--- a/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
@@ -387,12 +387,6 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
             builder.DeclareExternal("stasis_gfx_window_resized", CraneliftTypeMapper.ClifType.I32);
         }
 
-        if (builtins.Contains("gfx_poll_reload"))
-        {
-            builder.DeclareExternal("stasis_gfx_poll_reload", CraneliftTypeMapper.ClifType.I32,
-                CraneliftTypeMapper.ClifType.I32);
-        }
-
         if (builtins.Contains("gfx_debug_bake_hash"))
         {
             builder.DeclareExternal("stasis_gfx_debug_bake_hash", CraneliftTypeMapper.ClifType.I32,
@@ -1288,7 +1282,7 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
             or "init_window" or "begin_frame" or "end_frame" or "clear" or "draw_line" or "draw_lines_f32"
             or "gfx_load_sprite" or "gfx_draw_sprite" or "gfx_draw_sprites_i32"
             or "gfx_window_width" or "gfx_window_height" or "gfx_window_resized"
-            or "gfx_poll_reload" or "gfx_debug_bake_hash" or "gfx_debug_enable_hash" or "gfx_debug_get_frame_hash"
+            or "gfx_debug_bake_hash" or "gfx_debug_enable_hash" or "gfx_debug_get_frame_hash"
             or "is_key_down" or "should_quit" or "get_window_size" or "set_fullscreen"
             or "load_font" or "draw_text" or "measure_text" or "set_postfx"
             or "list_directory" or "dir_list_entry_is_dir" or "dir_list_entry_copy_name"

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -1017,7 +1017,6 @@ public sealed class CraneliftFunctionBuilder
             "gfx_load_sprite" => true,
             "gfx_draw_sprite" => true,
             "gfx_draw_sprites_i32" => true,
-            "gfx_poll_reload" => true,
             "gfx_window_width" => true,
             "gfx_window_height" => true,
             "gfx_window_resized" => true,
@@ -1445,8 +1444,6 @@ public sealed class CraneliftFunctionBuilder
                 return LowerGfxDrawSprite(arguments);
             case "gfx_draw_sprites_i32":
                 return LowerGfxDrawSpritesI32(arguments);
-            case "gfx_poll_reload":
-                return LowerGfxPollReload(arguments);
             case "gfx_window_width":
                 return LowerGfxWindowWidth(arguments);
             case "gfx_window_height":
@@ -2226,9 +2223,6 @@ public sealed class CraneliftFunctionBuilder
 
     private string LowerGfxDrawSpritesI32(IReadOnlyList<ExpressionSyntax> arguments) =>
         LowerExternalCallVoid("stasis_gfx_draw_sprites_i32", "gfx_draw_sprites_i32 expects (cmds: i32[], count: i32).", arguments, 2);
-
-    private string LowerGfxPollReload(IReadOnlyList<ExpressionSyntax> arguments) =>
-        LowerExternalCallValue("stasis_gfx_poll_reload", "gfx_poll_reload expects (handle: i32).", arguments, 1);
 
     private string LowerGfxWindowWidth(IReadOnlyList<ExpressionSyntax> arguments) =>
         LowerExternalCallValue("stasis_gfx_window_width", "gfx_window_width expects no arguments.", arguments, 0);

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -682,16 +682,6 @@ public sealed class ModuleLowerer
         return (fn, fnType);
     }
 
-    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisGfxPollReload(LlvmModuleBuilder builder)
-    {
-        var fn = builder.Module.GetNamedFunction("stasis_gfx_poll_reload");
-        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new[] { LLVMTypeRef.Int32 }, false);
-        if (fn.Handle != IntPtr.Zero)
-            return (fn, fnType);
-        fn = builder.Module.AddFunction("stasis_gfx_poll_reload", fnType);
-        return (fn, fnType);
-    }
-
     private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisGfxWindowWidth(LlvmModuleBuilder builder)
     {
         var fn = builder.Module.GetNamedFunction("stasis_gfx_window_width");
@@ -1251,7 +1241,6 @@ public sealed class ModuleLowerer
             "gfx_load_sprite",
             "gfx_draw_sprite",
             "gfx_draw_sprites_i32",
-            "gfx_poll_reload",
             "gfx_window_width",
             "gfx_window_height",
             "gfx_window_resized",
@@ -3085,22 +3074,6 @@ public sealed class ModuleLowerer
                         var cast = builder.BuildBitCast(cmds, i8Ptr, "gfx_draw_sprites_i32.ptr");
                         builder.BuildCall2(fnType, fn, new[] { cast, count }, "");
                         return ConstI32(0);
-                    }
-                case "gfx_poll_reload":
-                    {
-                        if (args.Count != 1)
-                        {
-                            AddDiagnostic("gfx_poll_reload expects a sprite handle.", span);
-                            return ConstI32(0);
-                        }
-
-                        var handle = LowerExpression(builder, args[0], locals);
-
-                        if (_headlessGraphics)
-                            return ConstI32(0);
-
-                        var (fn, fnType) = GetOrDeclareStasisGfxPollReload(_moduleBuilder);
-                        return builder.BuildCall2(fnType, fn, new[] { handle }, "gfx_poll_reload.call");
                     }
                 case "gfx_window_width":
                     {

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -128,7 +128,6 @@ public sealed class SemanticAnalyzer
             AddSymbol("gfx_load_sprite", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
             AddSymbol("gfx_draw_sprite", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
             AddSymbol("gfx_draw_sprites_i32", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
-            AddSymbol("gfx_poll_reload", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));
             AddSymbol("gfx_window_width", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
             AddSymbol("gfx_window_height", SymbolKind.Function, new PrimitiveTypeSymbol("i32"), new SourceSpan(0, 0));
             AddSymbol("gfx_window_resized", SymbolKind.Function, new PrimitiveTypeSymbol("bool"), new SourceSpan(0, 0));

--- a/docs/brickout-revenge-assets.md
+++ b/docs/brickout-revenge-assets.md
@@ -36,11 +36,6 @@ These functions are treated as built-ins by the compiler and lowered to external
   - `rot` is radians, rotating around the sprite's center.
   - `(r,g,b,a)` multiplies/tints the sprite output.
 
-- `gfx_poll_reload(handle: i32) -> bool`
-  - Checks whether the sprite source changed on disk and, if so, rebuilds it and updates the atlas region.
-  - Handle remains stable; subsequent draws use the new pixels.
-  - Intended to be called once per frame for a small set of sprites.
-
 Notes:
 - Stasis stores the returned `i32` handles in globals/struct fields (static memory friendly).
 - The runtime owns all allocations and GL resources; Stasis never sees pointers or variable-sized arrays.
@@ -57,14 +52,7 @@ Rasterization:
 
 ## Hot Reload Model
 
-Hot reload is always enabled for now (no flags):
-- `gfx_poll_reload(handle)` checks the on-disk modified time.
-- If modified, the runtime reloads and rebakes the sprite and updates the atlas region via `glTexSubImage2D`.
-- Mipmaps are regenerated for the atlas after updates (acceptable for dev; can be optimized later).
-
-Recommended usage pattern:
-- Load once during initialization (store handles in globals).
-- Call `gfx_poll_reload` once per frame for the small set of sprites you are actively using.
+In dev watch mode, sprite source SVGs are watched and hot-reloaded automatically (no explicit polling).
 
 ## Breakout Revenge - Sprite Set
 

--- a/docs/data-hot-reload-plan.md
+++ b/docs/data-hot-reload-plan.md
@@ -9,7 +9,7 @@ Current hot reload timings:
 | Change Type | Time | Bottleneck |
 |-------------|------|------------|
 | Code (.stasis) | 50-250ms | Cranelift AOT + linking |
-| SVG assets | ~5-10ms | `gfx_poll_reload()` |
+| SVG assets | ~5-10ms | runtime sprite hot-reload |
 | Data files | N/A | Not implemented |
 
 Code changes require compilation. Data changes (level layouts, entity definitions, balance parameters) don't need compilation - they should reload in <50ms.
@@ -36,7 +36,7 @@ Examples of data that should hot-reload fast:
 Not data (handled by existing systems):
 
 - Code logic (hot-swap workflow)
-- SVG sprites (`gfx_poll_reload()`)
+- SVG sprites (runtime sprite hot-reload)
 - Audio assets (future work)
 
 ## Design Options
@@ -59,7 +59,7 @@ if (data_changed("data/levels.json")) {
 **Pros:**
 - No language changes required
 - Fast C implementation in runtime
-- Matches existing `gfx_poll_reload()` pattern
+- Matches existing sprite hot-reload model
 - Clear separation: code is compiled, data is interpreted
 
 **Cons:**
@@ -99,7 +99,7 @@ Runner memory-maps data files directly. File changes are visible immediately.
 
 ## Recommended Approach: Option A (Runtime Facilities)
 
-Matches the existing pattern (`gfx_load_sprite` / `gfx_poll_reload`) and keeps the runtime self-contained.
+Matches the existing pattern (load once, hot-reload on save) and keeps the runtime self-contained.
 
 ## Data Format
 
@@ -337,7 +337,7 @@ data/
 
 assets_src/
   my_game/
-    player.svg         # Art (gfx_poll_reload on change)
+    player.svg         # Art (hot-reload on save)
     enemy.svg
 ```
 

--- a/docs/demo-day.md
+++ b/docs/demo-day.md
@@ -81,7 +81,7 @@ Run:
 
 Features:
 - Sprite pipeline (`gfx_load_sprite`, `gfx_draw_sprite`)
-- Asset hot reload (`gfx_poll_reload`): edit the SVGs under `assets_src/flappy-birds/` while running
+- Asset hot reload: edit the SVGs under `assets_src/flappy-birds/` while running in dev watch mode
 - Keyboard input (`is_key_down` Space)
 
 Run:

--- a/docs/flappy-birds-tutorial.md
+++ b/docs/flappy-birds-tutorial.md
@@ -271,9 +271,6 @@ function draw_frame() {
     begin_frame();
     clear(0.05, 0.07, 0.12, 1.0);
 
-    gfx_poll_reload(spr_bird);
-    gfx_poll_reload(spr_pipe);
-
     let i: i32 = 0;
     for (i = 0; i < 3; i = i + 1) {
         draw_pipe(pipe_x[i], pipe_gap_y[i]);
@@ -314,7 +311,7 @@ runtime\build.bat
 dotnet run --project Stasis.Cli -- run examples/flappy_birds.stasis --backend cranelift --graphics --graphics-lib runtime\build\Release\stasis_graphics.dll
 ```
 
-**Why:** This mirrors the classic game loop—poll input, advance physics, draw—while keeping data in globals for deterministic behavior. Hot reload via `gfx_poll_reload` means you can tweak art without restarting.
+**Why:** This mirrors the classic game loop—poll input, advance physics, draw—while keeping data in globals for deterministic behavior. In dev watch mode, sprites hot-reload when you save SVGs.
 
 ---
 

--- a/docs/game-dev-workflow.md
+++ b/docs/game-dev-workflow.md
@@ -67,7 +67,7 @@ With `tick()` hosting, the runner targets `--fps` and sleeps between ticks.
 
 - Store source art in `assets_src/<game-name>/.../*.svg`.
 - Load with `gfx_load_sprite(...)` once and store the returned handle in `state`.
-- For rapid art iteration, call `gfx_poll_reload(handle)` periodically (often once per tick is fine).
+- For rapid art iteration, run in dev watch mode and edit the SVGs; sprites reload automatically (no explicit polling).
 
 The runtime bakes SVG -> RGBA -> atlas and can update atlas regions on change.
 Keep SVGs within the supported subset described in `docs/svg-migration-plan.md`.
@@ -80,7 +80,7 @@ Goal: change something, feel it immediately, keep the game running.
 
 - Keep `.\stasis.bat run ... --fps ...` running.
 - Make a small code change (movement, cooldown, damage, camera), save, and keep playing.
-- Change SVGs and rely on `gfx_poll_reload(...)` to refresh art without recompiling.
+- Change SVGs and the running game will pick them up automatically in dev watch mode.
 - When a change makes the game less fun, revert immediately and try a different direction.
 
 ### The medium loop (30-60 minutes)
@@ -102,7 +102,7 @@ Tips:
 
 - Use `--fps 10` while debugging input/logic.
 - Keep the game running; save the `.stasis` file to hot-swap code between ticks.
-- Edit SVGs and rely on `gfx_poll_reload` to see art changes without recompiling.
+- Edit SVGs; sprites reload automatically in dev watch mode.
 
 ### What hot-swap actually does
 
@@ -231,7 +231,7 @@ These are not impossible forever, but they are high friction given the current m
 - [ ] Assets live under `assets_src/<game>/`
 - [ ] Only supported SVG features (no filters/SMIL; animate via layering + transforms in code)
 - [ ] Sprite handles live under `state` and are not recomputed every tick
-- [ ] Call `gfx_poll_reload(handle)` when you want live updates
+- [ ] Run in dev watch mode to get live sprite updates
 
 ### Performance instrumentation
 

--- a/examples/flappy_birds.stasis
+++ b/examples/flappy_birds.stasis
@@ -49,9 +49,6 @@ function draw_frame() {
     begin_frame();
     clear(0.05, 0.07, 0.12, 1.0);
 
-    gfx_poll_reload(spr_bird);
-    gfx_poll_reload(spr_pipe);
-
     let i: i32 = 0;
     for (i = 0; i < 3; i = i + 1) {
         draw_pipe(pipe_x[i], pipe_gap_y[i]);

--- a/examples/wasm/brickout_revenge_v1/main.js
+++ b/examples/wasm/brickout_revenge_v1/main.js
@@ -319,8 +319,6 @@ async function start() {
         ctx.restore();
       },
 
-      stasis_gfx_poll_reload: (_handle) => 0,
-
       stasis_gfx_window_width: () => virtualW | 0,
       stasis_gfx_window_height: () => virtualH | 0,
       stasis_gfx_window_resized: () => {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -74,7 +74,6 @@ The library exports these functions for Stasis programs:
 | `stasis_gfx_load_sprite(path)` | Load and bake an SVG sprite into an atlas; returns handle |
 | `stasis_gfx_draw_sprite(handle, x, y, sx, sy, rot, r, g, b, a)` | Draw baked sprite (centered) with scale/rotation/tint |
 | `stasis_gfx_draw_sprites_i32(cmds, count)` | Batch: draw `count` sprites from an `i32` array (7 ints per sprite) |
-| `stasis_gfx_poll_reload(handle)` | Hot reload baked sprite if source file changed |
 | `stasis_gfx_debug_bake_hash(path)` | Debug: bake SVG on CPU and return a pixel hash |
 | `stasis_gfx_debug_enable_hash(enabled)` | Debug: enable per-frame draw-call hash (for verifying batch equivalence) |
 | `stasis_gfx_debug_get_frame_hash()` | Debug: get current frame hash (0 if disabled) |

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <direct.h>
+#include <windows.h>
 #else
 #include <sys/stat.h>
 #include <unistd.h>
@@ -146,7 +147,6 @@ typedef struct {
     SDL_Texture* sdl_tex;
     int used;
     int needs_reraster;  /* flag for window resize */
-    int last_poll_ms;    /* throttle gfx_poll_reload disk stats */
 } SpriteEntry;
 
 static SpriteEntry g_sprites[MAX_SPRITES];
@@ -891,6 +891,10 @@ static void ensure_asset_base(void) {
 #endif
 }
 
+static void gfx_asset_watch_init(void);
+static void gfx_asset_watch_apply_pending_changes(void);
+static void gfx_asset_watch_shutdown(void);
+
 static int is_absolute_path(const char* path) {
     if (!path || !*path) return 0;
 #if defined(_WIN32)
@@ -916,6 +920,119 @@ static int resolve_asset_path(const char* path, char* out, size_t out_size) {
         if (*p == '\\') *p = '/';
     }
     return 1;
+}
+
+#if defined(_WIN32)
+static volatile LONG g_asset_watch_dirty = 0;
+static HANDLE g_asset_watch_stop_event = NULL;
+static HANDLE g_asset_watch_change_handle = NULL;
+static HANDLE g_asset_watch_thread = NULL;
+
+static int gfx_asset_watch_enabled(void) {
+    static int cached = -1;
+    if (cached != -1) return cached;
+
+    /* Explicit override (applies to both dev and non-dev runs). */
+    const char* env = getenv("STASIS_GFX_WATCH_ASSETS");
+    if (env && *env) {
+        cached = (env[0] == '1') ? 1 : 0;
+        return cached;
+    }
+
+    /* Default: enable only in dev (e.g. `stasis run --watch`). */
+    const char* dev = getenv("STASIS_DEV");
+    cached = (dev && dev[0] == '1') ? 1 : 0;
+    return cached;
+}
+
+static DWORD WINAPI gfx_asset_watch_thread_proc(LPVOID userdata) {
+    (void)userdata;
+
+    HANDLE handles[2];
+    handles[0] = g_asset_watch_stop_event;
+    handles[1] = g_asset_watch_change_handle;
+
+    for (;;) {
+        DWORD wait = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+        if (wait == WAIT_OBJECT_0) {
+            break;
+        }
+        if (wait == WAIT_OBJECT_0 + 1) {
+            InterlockedExchange(&g_asset_watch_dirty, 1);
+            if (!FindNextChangeNotification(g_asset_watch_change_handle)) {
+                break;
+            }
+            continue;
+        }
+        break;
+    }
+
+    return 0;
+}
+#endif
+
+static void gfx_asset_watch_init(void) {
+#if defined(_WIN32)
+    if (!gfx_asset_watch_enabled()) return;
+    if (g_asset_watch_thread) return;
+
+    ensure_asset_base();
+
+    g_asset_watch_stop_event = CreateEventA(NULL, TRUE, FALSE, NULL);
+    if (!g_asset_watch_stop_event) {
+        return;
+    }
+
+    DWORD flags = FILE_NOTIFY_CHANGE_FILE_NAME |
+                  FILE_NOTIFY_CHANGE_DIR_NAME |
+                  FILE_NOTIFY_CHANGE_LAST_WRITE |
+                  FILE_NOTIFY_CHANGE_SIZE;
+    g_asset_watch_change_handle = FindFirstChangeNotificationA(g_asset_base, TRUE, flags);
+    if (g_asset_watch_change_handle == INVALID_HANDLE_VALUE) {
+        g_asset_watch_change_handle = NULL;
+        CloseHandle(g_asset_watch_stop_event);
+        g_asset_watch_stop_event = NULL;
+        return;
+    }
+
+    g_asset_watch_thread = CreateThread(NULL, 0, gfx_asset_watch_thread_proc, NULL, 0, NULL);
+    if (!g_asset_watch_thread) {
+        FindCloseChangeNotification(g_asset_watch_change_handle);
+        g_asset_watch_change_handle = NULL;
+        CloseHandle(g_asset_watch_stop_event);
+        g_asset_watch_stop_event = NULL;
+        return;
+    }
+#endif
+}
+
+static void gfx_asset_watch_shutdown(void) {
+#if defined(_WIN32)
+    if (g_asset_watch_stop_event) {
+        SetEvent(g_asset_watch_stop_event);
+    }
+    if (g_asset_watch_thread) {
+        WaitForSingleObject(g_asset_watch_thread, 5000);
+        CloseHandle(g_asset_watch_thread);
+        g_asset_watch_thread = NULL;
+    }
+    if (g_asset_watch_change_handle) {
+        FindCloseChangeNotification(g_asset_watch_change_handle);
+        g_asset_watch_change_handle = NULL;
+    }
+    if (g_asset_watch_stop_event) {
+        CloseHandle(g_asset_watch_stop_event);
+        g_asset_watch_stop_event = NULL;
+    }
+#endif
+}
+
+STASIS_EXPORT void stasis_gfx_notify_file_changed(const char* path) {
+    (void)path;
+#if defined(_WIN32)
+    if (!gfx_asset_watch_enabled()) return;
+    InterlockedExchange(&g_asset_watch_dirty, 1);
+#endif
 }
 
 static char* read_text_file(const char* path) {
@@ -2117,6 +2234,7 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
 #endif
     }
 
+    gfx_asset_watch_init();
     return 1;
 }
 
@@ -2238,6 +2356,7 @@ STASIS_EXPORT int stasis_set_fullscreen(int fullscreen) {
  */
 STASIS_EXPORT void stasis_begin_frame(void) {
     gfx_debug_hash_reset_if_enabled();
+    gfx_asset_watch_apply_pending_changes();
     if (!g_events_pumped_this_frame) {
         stasis_pump_events();
         g_events_pumped_this_frame = 1;
@@ -2397,22 +2516,6 @@ static int gfx_should_log_sprite_loads(void) {
     if (cached != -1) return cached;
     const char* env = getenv("STASIS_GFX_LOG_SPRITES");
     cached = (env && env[0] == '1') ? 1 : 0;
-    return cached;
-}
-
-static int gfx_sprite_poll_min_interval_ms(void) {
-    static int cached = -1;
-    if (cached != -1) return cached;
-
-    const char* env = getenv("STASIS_GFX_POLL_RELOAD_MIN_MS");
-    if (!env || !*env) {
-        cached = 200; /* default: 5Hz polling per sprite handle */
-        return cached;
-    }
-
-    int v = atoi(env);
-    if (v < 0) v = 0;
-    cached = v;
     return cached;
 }
 
@@ -2641,6 +2744,28 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
 #endif
 }
 
+static void gfx_asset_watch_apply_pending_changes(void) {
+#if defined(_WIN32)
+    if (!gfx_asset_watch_enabled()) return;
+
+    if (InterlockedExchange(&g_asset_watch_dirty, 0) == 0) {
+        return;
+    }
+
+    for (int i = 0; i < MAX_SPRITES; i++) {
+        SpriteEntry* e = &g_sprites[i];
+        if (!e->used || !e->path) continue;
+
+        uint64_t mt = get_file_mtime(e->path);
+        if (!mt || mt <= e->mtime) continue;
+
+        if (!sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h, 1)) {
+            SDL_Log("gfx_watch: reload failed for %s", e->path);
+        }
+    }
+#endif
+}
+
 /*
  * Load and bake a sprite from an SVG file at a specified max size.
  * The sprite will be rasterized to fit within max_w x max_h while preserving aspect ratio.
@@ -2686,35 +2811,6 @@ STASIS_EXPORT int stasis_gfx_load_sprite(const char* path, int max_w, int max_h)
 
     SDL_Log("gfx_load_sprite: MAX_SPRITES reached");
     return 0;
-}
-
-/*
- * Poll and reload a sprite if its source changed on disk.
- * Returns 1 if reloaded, 0 otherwise.
- */
-STASIS_EXPORT int stasis_gfx_poll_reload(int handle) {
-    SpriteEntry* e = sprite_get(handle);
-    if (!e || !e->path) return 0;
-
-    int min_interval_ms = gfx_sprite_poll_min_interval_ms();
-    if (min_interval_ms > 0) {
-        int now_ms = stasis_get_time_ms();
-        if (e->last_poll_ms != 0) {
-            int delta = now_ms - e->last_poll_ms;
-            if (delta >= 0 && delta < min_interval_ms) {
-                return 0;
-            }
-        }
-        e->last_poll_ms = now_ms;
-    }
-
-    uint64_t mt = get_file_mtime(e->path);
-    if (!mt || mt <= e->mtime) return 0;
-    /* Use sized version if max dimensions are set */
-    if (e->max_w > 0 && e->max_h > 0) {
-        return sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h, 1) ? 1 : 0;
-    }
-    return sprite_build_into_entry(e, e->path, 1) ? 1 : 0;
 }
 
 /*
@@ -3034,6 +3130,7 @@ STASIS_EXPORT int stasis_gfx_window_resized(void) {
  */
 STASIS_EXPORT void stasis_shutdown(void) {
     stasis_audio_shutdown_internal();
+    gfx_asset_watch_shutdown();
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
     if (g_postfx_program) {
@@ -3102,7 +3199,6 @@ STASIS_EXPORT void stasis_shutdown(void) {
 /* ===== DIRECTORY LISTING ===== */
 
 #ifdef _WIN32
-#include <windows.h>
 #else
 #include <dirent.h>
 #endif

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -43,13 +43,13 @@ EXPORTS
     stasis_input_viewport_y_px
     stasis_input_viewport_w_px
     stasis_input_viewport_h_px
+    stasis_gfx_notify_file_changed
+    gfx_notify_file_changed=stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite
     gfx_load_sprite=stasis_gfx_load_sprite
     stasis_gfx_draw_sprite
     gfx_draw_sprite=stasis_gfx_draw_sprite
     stasis_gfx_draw_sprites_i32
-    stasis_gfx_poll_reload
-    gfx_poll_reload=stasis_gfx_poll_reload
     stasis_gfx_debug_bake_hash
     stasis_gfx_debug_enable_hash
     stasis_gfx_debug_get_frame_hash

--- a/samples/brickout_revenge/brickout_revenge.stasis
+++ b/samples/brickout_revenge/brickout_revenge.stasis
@@ -126,16 +126,7 @@ function tick(): i32 {
 
 function draw_frame(): void {
     // Hot reload during development (no flags for now)
-    // if (state.sprites.paddle == 0) { } else { gfx_poll_reload(state.sprites.paddle); }
-    // if (state.sprites.ball == 0) { } else { gfx_poll_reload(state.sprites.ball); }
-    // if (state.sprites.brick_basic_base == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_base); }
-    // if (state.sprites.brick_basic_turret == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_turret); }
-    // if (state.sprites.brick_basic_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_fx); }
-    // if (state.sprites.brick_armored_base == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_base); }
-    // if (state.sprites.brick_armored_turret == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_turret); }    
-    // if (state.sprites.brick_armored_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_fx); }
-    // if (state.sprites.brick_reflector_base == 0) { } else { gfx_poll_reload(state.sprites.brick_reflector_base); }
-    // if (state.sprites.brick_reflector_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_reflector_fx); }
+    // Asset hot reload is automatic in dev (`stasis run --watch`).
 
     // draw_bricks();
     // draw_balls();

--- a/samples/brickout_revenge/brickout_revenge_v1.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1.stasis
@@ -21,7 +21,6 @@ import "../../src/stdlib/audio.stasis";
 // - draw_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32)
 // - gfx_load_sprite(path: string, max_w: i32, max_h: i32) -> i32
 // - gfx_draw_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): top-left
-// - gfx_poll_reload(handle: i32) -> bool
 // - gfx_window_width() -> i32
 // - gfx_window_height() -> i32
 // - gfx_window_resized() -> bool
@@ -2161,18 +2160,6 @@ function draw_ui(): void {
 }
 
 function draw_frame(): void {
-    // Hot reload during development (no flags for now)
-    if (state.sprites.paddle == 0) { } else { gfx_poll_reload(state.sprites.paddle); }
-    if (state.sprites.ball == 0) { } else { gfx_poll_reload(state.sprites.ball); }
-    if (state.sprites.brick_basic_base == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_base); }
-    if (state.sprites.brick_basic_turret == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_turret); }
-    if (state.sprites.brick_basic_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_basic_fx); }
-    if (state.sprites.brick_armored_base == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_base); }
-    if (state.sprites.brick_armored_turret == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_turret); }
-    if (state.sprites.brick_armored_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_armored_fx); }
-    if (state.sprites.brick_reflector_base == 0) { } else { gfx_poll_reload(state.sprites.brick_reflector_base); }
-    if (state.sprites.brick_reflector_fx == 0) { } else { gfx_poll_reload(state.sprites.brick_reflector_fx); }
-
     draw_bricks();
     draw_balls();
     draw_paddle();

--- a/src/stasis/cli_linking.stasis
+++ b/src/stasis/cli_linking.stasis
@@ -22,7 +22,6 @@ function ir_needs_graphics_runtime(): bool {
     if (ascii_contains(stasis.ir_out, "call float @stasis_measure_text")) { return true; }
 
     if (ascii_contains(stasis.ir_out, "call i32 @stasis_gfx_load_sprite")) { return true; }
-    if (ascii_contains(stasis.ir_out, "call i32 @stasis_gfx_poll_reload")) { return true; }
     if (ascii_contains(stasis.ir_out, "call void @stasis_gfx_draw_sprite")) { return true; }
     if (ascii_contains(stasis.ir_out, "call void @stasis_gfx_draw_sprites_i32")) { return true; }
 

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -15,7 +15,6 @@ extern function draw_lines_f32(lines: f32[], count: i32): void;
 extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 extern function gfx_draw_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void;
 extern function gfx_draw_sprites_i32(cmds: i32[], count: i32): void;
-extern function gfx_poll_reload(handle: i32): bool;
 extern function gfx_window_width(): i32;
 extern function gfx_window_height(): i32;
 extern function gfx_window_resized(): bool;


### PR DESCRIPTION
- Removes gfx_poll_reload from runtime exports, stdlib, compiler lowering, and docs/samples.
- Adds a Windows asset watcher that marks sprites dirty on file changes and reloads them on the next begin_frame().
- stasis run --watch now sets STASIS_DEV=1, enabling sprite hot-reload automatically in dev (override with STASIS_GFX_WATCH_ASSETS=0/1).

Build: build.bat