### PR TITLE
feat: HostFrame snapshot (host_get_frame)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Backends:
 - Game-dev iteration workflow: `docs/game-dev-workflow.md`
 - Language spec (semantics, memory rules): `docs/spec.md`
 - Parser/grammar notes (LL(1)): `docs/compilation.md`
+- Host ABI direction (snapshot + command buffer): `docs/host-snapshot-command-buffer.md`
 
 ## Repo layout
 

--- a/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
@@ -345,6 +345,13 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
                 CraneliftTypeMapper.ClifType.I32);
         }
 
+        if (builtins.Contains("host_get_frame"))
+        {
+            builder.DeclareExternal("stasis_host_get_frame", CraneliftTypeMapper.ClifType.Void,
+                CraneliftTypeMapper.ClifType.R64,
+                CraneliftTypeMapper.ClifType.R64);
+        }
+
         if (builtins.Contains("gfx_load_sprite"))
         {
             builder.DeclareExternal("stasis_gfx_load_sprite", CraneliftTypeMapper.ClifType.I32,

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -1014,6 +1014,7 @@ public sealed class CraneliftFunctionBuilder
             "clear" => true,
             "draw_line" => true,
             "draw_lines_f32" => true,
+            "host_get_frame" => true,
             "gfx_load_sprite" => true,
             "gfx_draw_sprite" => true,
             "gfx_draw_sprites_i32" => true,
@@ -1438,6 +1439,8 @@ public sealed class CraneliftFunctionBuilder
                 return LowerDrawLine(arguments);
             case "draw_lines_f32":
                 return LowerDrawLinesF32(arguments);
+            case "host_get_frame":
+                return LowerHostGetFrame(arguments);
             case "gfx_load_sprite":
                 return LowerGfxLoadSprite(arguments);
             case "gfx_draw_sprite":
@@ -2214,6 +2217,9 @@ public sealed class CraneliftFunctionBuilder
 
     private string LowerDrawLinesF32(IReadOnlyList<ExpressionSyntax> arguments) =>
         LowerExternalCallVoid("stasis_draw_lines_f32", "draw_lines_f32 expects (lines: f32[], count: i32).", arguments, 2);
+
+    private string LowerHostGetFrame(IReadOnlyList<ExpressionSyntax> arguments) =>
+        LowerExternalCallVoid("stasis_host_get_frame", "host_get_frame expects (out_i32: i32[], out_f32: f32[]).", arguments, 2);
 
     private string LowerGfxLoadSprite(IReadOnlyList<ExpressionSyntax> arguments) =>
         LowerExternalCallValue("stasis_gfx_load_sprite", "gfx_load_sprite expects (path, max_w, max_h).", arguments, 3);

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -641,6 +641,17 @@ public sealed class ModuleLowerer
         return (fn, fnType);
     }
 
+    private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisHostGetFrame(LlvmModuleBuilder builder)
+    {
+        var fn = builder.Module.GetNamedFunction("stasis_host_get_frame");
+        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new[] { i8Ptr, i8Ptr }, false);
+        if (fn.Handle != IntPtr.Zero)
+            return (fn, fnType);
+        fn = builder.Module.AddFunction("stasis_host_get_frame", fnType);
+        return (fn, fnType);
+    }
+
     private static (LLVMValueRef Fn, LLVMTypeRef Type) GetOrDeclareStasisGfxLoadSprite(LlvmModuleBuilder builder)
     {
         var fn = builder.Module.GetNamedFunction("stasis_gfx_load_sprite");
@@ -1238,6 +1249,7 @@ public sealed class ModuleLowerer
             "clear",
             "draw_line",
             "draw_lines_f32",
+            "host_get_frame",
             "gfx_load_sprite",
             "gfx_draw_sprite",
             "gfx_draw_sprites_i32",
@@ -3012,6 +3024,34 @@ public sealed class ModuleLowerer
                         var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
                         var cast = builder.BuildBitCast(lines, i8Ptr, "draw_lines_f32.ptr");
                         builder.BuildCall2(fnType, fn, new[] { cast, count }, "");
+                        return ConstI32(0);
+                    }
+                case "host_get_frame":
+                    {
+                        if (args.Count != 2)
+                        {
+                            AddDiagnostic("host_get_frame expects (out_i32: i32[], out_f32: f32[]).", span);
+                            return ConstI32(0);
+                        }
+
+                        var outI32 = LowerArrayPointer(builder, args[0], locals);
+                        if (outI32.Handle == IntPtr.Zero)
+                            outI32 = LowerExpression(builder, args[0], locals);
+                        var outF32 = LowerArrayPointer(builder, args[1], locals);
+                        if (outF32.Handle == IntPtr.Zero)
+                            outF32 = LowerExpression(builder, args[1], locals);
+
+                        if (outI32.TypeOf.Kind != LLVMTypeKind.LLVMPointerTypeKind || outF32.TypeOf.Kind != LLVMTypeKind.LLVMPointerTypeKind)
+                        {
+                            AddDiagnostic("host_get_frame expects array/pointer arguments.", span);
+                            return ConstI32(0);
+                        }
+
+                        var (fn, fnType) = GetOrDeclareStasisHostGetFrame(_moduleBuilder);
+                        var i8Ptr = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+                        var castI32 = builder.BuildBitCast(outI32, i8Ptr, "host_get_frame.i32");
+                        var castF32 = builder.BuildBitCast(outF32, i8Ptr, "host_get_frame.f32");
+                        builder.BuildCall2(fnType, fn, new[] { castI32, castF32 }, "");
                         return ConstI32(0);
                     }
                 case "gfx_load_sprite":

--- a/docs/asset_hot_reload.md
+++ b/docs/asset_hot_reload.md
@@ -1,0 +1,42 @@
+## Asset Hot Reload (Long-Term Plan)
+
+### Goal
+Make asset hot reload (sprites, data files) smooth and deterministic without per-frame filesystem polling.
+
+### Current State
+- The runtime can watch asset directories in dev and mark sprites dirty when their backing file changes.
+- For older/legacy patterns, polling-based reload can be expensive on Windows (AV, NTFS metadata, path resolution), causing frame-time spikes.
+
+### Proposed Long-Term Architecture (Hybrid)
+Reads (events) are host-driven; rendering stays command-based.
+
+1. Event-driven file watching
+   - The host/runtime watches asset directories using native file notifications.
+   - When a file changes, the runtime marks the corresponding sprite entries as dirty (e.g. `needs_reraster=1`).
+   - The next draw of that sprite triggers re-bake/re-upload.
+
+2. No per-frame polling
+   - Polling becomes optional (debug/legacy) and is not required for correctness.
+   - Hot reload latency is driven by the OS notification (typically < 1 frame).
+
+3. Deterministic point of application
+   - Changed assets are applied at a predictable point:
+     - either at frame boundaries (after event pump, before draw),
+     - or at the next draw call for that handle.
+   - This keeps behavior deterministic and avoids "mid-frame" partial updates.
+
+### Implementation Notes
+- Windows: directory notifications via `FindFirstChangeNotification` (simple) or `ReadDirectoryChangesW` (precise file names).
+- Linux/macOS: inotify / FSEvents equivalents.
+- WASM: the watcher becomes a browser-host responsibility; changes can arrive via a host API and the runtime marks dirty.
+
+### ABI Surface (minimal)
+- A "mark dirty" hook is enough for correctness:
+  - `stasis_gfx_notify_file_changed(path)` (path-based)
+  - or `stasis_gfx_mark_sprite_dirty(handle)` (handle-based)
+
+### Why this is better
+- Eliminates per-frame filesystem stats.
+- Avoids frame-time spikes and scales to many assets.
+- Fits future WASM hosting (events come from JS, not local disk polling).
+

--- a/docs/host-snapshot-command-buffer.md
+++ b/docs/host-snapshot-command-buffer.md
@@ -1,0 +1,215 @@
+# Host Snapshot + Command Buffer (host ABI direction)
+
+This document proposes a practical path from today's "many small extern calls" host API to a hybrid:
+
+- Snapshot in: one call per tick to read host state (time, viewport, input, flags).
+- Command buffer out: one call per tick to submit rendering/audio/etc commands in bulk.
+
+The goal is smoother resize behavior, fewer host boundary calls (important for WASM), easier headless testing, and a clearer host/runtime layering.
+
+## Current situation (today)
+
+The host boundary is effectively split across:
+
+- `runtime/stasis_graphics.c`: SDL window ownership, event pumping, input snapshot (`g_input_frame`), plus rendering backend (OpenGL or SDL renderer). Exposes many extern-style functions (`begin_frame`, `draw_line`, `gfx_draw_sprite`, `gfx_window_width`, `input_pointer_x_px`, etc.).
+- `stasis_runner.exe`: native launcher/loop that loads the compiled program and calls into it.
+- `Stasis.Cli`: builds/links programs, runs the runner, and manages hot reload.
+
+This works, but has two recurring problems:
+
+1) Boundary call churn: lots of "query" calls and lots of tiny draw calls.
+2) Resize smoothness: state derived from window size can get baked into pipeline state (e.g., shader source), and the update paths are not always centralized.
+
+## Immediate fix (short term, no rewrite)
+
+The current "maximize makes sprites disappear" class of bugs strongly suggests stale transforms or stale pipeline state during resize.
+
+Do these first:
+
+1) Stop baking window size into shaders
+   - Use uniforms (or a single ortho matrix) for `window_w/window_h` in both line + sprite programs.
+   - Resize becomes "update uniform/matrix", not "delete program + recompile shader".
+   - Result: fewer resize hitch points and fewer "missed one pipeline" bugs.
+
+2) Centralize resize handling
+   - Add a single "apply resize" function that updates *all* window/viewport/projection state:
+     - `g_window_width/g_window_height`
+     - viewport (`glViewport` / renderer viewport)
+     - ortho/projection matrix
+     - any renderer/backend state that depends on size
+   - Call it from every resize entry point:
+     - SDL window events
+     - `set_window_size`
+     - `set_fullscreen`
+     - any platform-specific "drawable size changed" hooks
+
+These are independent of (and compatible with) the medium-term ABI direction below.
+
+## Recommended direction (medium term): snapshot-in + command-buffer-out
+
+### Tick model
+
+Per tick:
+
+1) Host pumps events and updates its internal state.
+2) Host fills a HostFrame snapshot (in guest memory) via one call: `host_get_frame(...)`.
+3) Program reads HostFrame for the full tick (read-only), then writes a command buffer.
+4) Program submits the command buffer once: `host_submit_*(...)`.
+5) Host executes commands and presents.
+
+Key property: resize/viewport/DPI changes become *just fields in the HostFrame*, so every pipeline sees the same authoritative values.
+
+### Why this matches Stasis
+
+- Deterministic: HostFrame is a single snapshot (not time-varying queries mid-tick).
+- Static memory: both HostFrame and command buffers are fixed-size global arrays (no hidden allocation).
+- AoS -> SoA: command buffers can be SoA-friendly (separate streams per command type).
+- WASM friendly: reduces imports/exports to a small stable surface.
+
+## ABI pieces
+
+This section describes a v1-shaped ABI. It is intentionally conservative: fixed-size buffers, versioning, and "copy out" semantics.
+
+### 1) HostFrame snapshot (already prototyped)
+
+There is already a prototype in `src/stdlib/host_frame.stasis`, and a native implementation in `runtime/stasis_graphics.c`:
+
+- `extern function host_get_frame(out_i32: i32[], out_f32: f32[]): void;`
+- `STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32)`
+
+Proposed changes to make it "production-shaped":
+
+- Add a small header for versioning and per-tick flags.
+- Add `dt` and a monotonic `frame_index` so systems can be written without relying on wall-clock deltas.
+- Treat any unused indices as reserved for forward compatibility.
+
+Suggested i32 header (example):
+
+- `HOST_I_MAGIC`: constant (helps detect uninitialized buffers in debug)
+- `HOST_I_VERSION`: increments when layout changes
+- `HOST_I_FRAME_INDEX`: increments once per tick
+- `HOST_I_TIME_MS`: monotonic ms since start (or since epoch; but monotonic is preferred)
+- `HOST_I_DT_MS`: delta in ms since last tick (clamped, deterministic policy)
+- `HOST_I_WINDOW_W_PX`, `HOST_I_WINDOW_H_PX`
+- `HOST_I_VIEWPORT_X_PX`, `HOST_I_VIEWPORT_Y_PX`, `HOST_I_VIEWPORT_W_PX`, `HOST_I_VIEWPORT_H_PX`
+- `HOST_I_FLAGS`: bitfield (resized, focus, etc.)
+- `HOST_I_POINTER_COUNT`, `HOST_I_DROPPED_POINTERS`
+
+Suggested f32 header (example):
+
+- `HOST_F_DT_S`: `dt` in seconds for convenience (or omit if redundant)
+- `HOST_F_DPI_SCALE_X`, `HOST_F_DPI_SCALE_Y` (if/when needed)
+
+Pointer layout can stay as-is (id/buttons in i32, positions/deltas in f32).
+
+### 2) Command buffers (new)
+
+We want to move "high-churn outputs" to bulk submission, starting with graphics and (later) audio.
+
+Two common encodings:
+
+1) Generic opcode stream (byte/i32 stream with tags + payload sizes).
+2) Fixed SoA streams per subsystem (lines stream, sprites stream, text stream, etc.).
+
+For Stasis v1, prefer (2). Reasons:
+
+- No variable-length parsing logic required in the host.
+- Fixed layouts remain easy to version.
+- Fast to validate (counts + bounds checks).
+- Matches existing "batched" APIs (`draw_lines_f32`, `gfx_draw_sprites_i32`).
+
+#### Graphics command buffer v1 (SoA)
+
+Define a "gfx command buffer" as:
+
+- Header i32 fields (version + counts)
+- Payload arrays for each stream
+
+Example layout (one possible split):
+
+- `gfx_i32[]` header:
+  - version
+  - flags (e.g., "clear requested")
+  - `line_count`
+  - `sprite_count`
+  - reserved
+- `gfx_f32[]` payload for `lines`:
+  - `line_count * 8` floats: `x1,y1,x2,y2,r,g,b,a`
+- `gfx_i32[]` payload for `sprites` (if keeping `gfx_draw_sprites_i32`-style packing)
+  - `sprite_count * SPRITE_STRIDE_I32`
+
+Alternatively, make sprites a `gfx_f32[]` stream (handle as i32 + six f32, or all f32 with handle converted) if you want a single float stream.
+
+Host-side API shape:
+
+- `extern function gfx_submit(cmd_i32: i32[], cmd_f32: f32[]): void;`
+
+Runtime implementation:
+
+- Parse header, clamp counts, then execute:
+  - for each line: enqueue like `stasis_draw_line` does today
+  - for each sprite: enqueue like `stasis_gfx_draw_sprite` does today
+
+Program-side stdlib shape:
+
+- `gfx_cmd_begin()` resets write cursors.
+- `gfx_cmd_line(...)` appends to the line stream (bounds checked; drop counter increments on overflow).
+- `gfx_cmd_sprite(...)` appends to sprite stream.
+- `gfx_cmd_submit()` calls `gfx_submit(...)`.
+
+This preserves static memory and avoids per-call overhead.
+
+#### Audio command buffer v1 (later)
+
+The runtime already uses an f32 stereo ring buffer. A "command buffer" layer can standardize:
+
+- A shared "producer writes N frames" protocol per tick.
+- A single `audio_submit(frames_f32, frame_count)` import (or direct ring mapping).
+
+The design should mirror graphics: fixed-size, deterministic overflow behavior, versioned header.
+
+## Versioning and compatibility
+
+The host boundary needs explicit versioning so older binaries can fail with a clear diagnostic instead of silently misinterpreting memory.
+
+Recommended policy:
+
+- Each snapshot/buffer has a `VERSION` integer in index 0/1.
+- A mismatch is a hard error unless the host explicitly supports a known compat path.
+- Reserve unused indices for forward expansion.
+
+## Debugging and testing wins
+
+Snapshot + command buffer unlocks cheap headless validation:
+
+- Record HostFrame + command buffers for a tick range and replay them deterministically.
+- Hash the command buffer to validate two code paths produce identical output streams (like the existing line benchmark does).
+- A "null host" can accept commands and only validate bounds and invariants, enabling CI tests without SDL/GL.
+
+## Migration plan (incremental, minimal disruption)
+
+Phase 0: Fix resize smoothness in current runtime
+- Refactor shaders to use uniforms/matrices (no window-size baked shader source).
+- Centralize resize handling in `runtime/stasis_graphics.c`.
+
+Phase 1: Make HostFrame v1 real
+- Extend `src/stdlib/host_frame.stasis` with version/flags/dt/frame_index.
+- Update `runtime/stasis_graphics.c` `stasis_host_get_frame` to fill them.
+- Add a small sample that prints HostFrame fields and validates invariants.
+
+Phase 2: Add graphics command buffer v1 (parallel to existing extern calls)
+- Add `gfx_submit(cmd_i32, cmd_f32)` as a new extern import.
+- Add stdlib helpers that write to global command buffers.
+- Add a sample that draws using the command buffer and compares to per-call drawing (hash-based).
+
+Phase 3: Port high-churn drawing call sites
+- Keep `draw_line` / `gfx_draw_sprite` for simplicity and compatibility.
+- Prefer command buffers for "many draws per tick" code paths (particles, UI, tilemaps).
+
+Phase 4: Fold more host queries into HostFrame
+- Deprecate many `input_*` and `gfx_window_*` query calls in favor of HostFrame reads.
+
+Phase 5: Prepare for a WASM host
+- HostFrame becomes one import from JS, command buffers become one export or one import call.
+- The native runner becomes "a host implementation", not the canonical execution model.
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -16,6 +16,7 @@ This file is a lightweight, persistent checklist of upcoming work. It complement
 - [ ] Follow through: execute `docs/data-hot-reload-plan.md` (end-to-end dev workflow + tests).
 - [ ] Follow through: execute `docs/cranelift-backend-plan.md` (close remaining backend gaps).
 - [ ] Follow through: execute `docs/hosts-first-class-plan.md` (host APIs, packaging, and ergonomics).
+- [ ] Follow through: execute `docs/host-snapshot-command-buffer.md` (HostFrame snapshot + per-tick command buffers).
 - [ ] Follow through: execute `docs/android-plan.md` (Android runtime build + host proof-of-concept).
 - [ ] Follow through: execute `docs/brickout-android-debug-plan.md` (debug APK + adb asset push workflow).
 - [ ] Follow through: review `docs/self-hosted-compiler-plan.md` (background; superseded by `docs/self-host-gap-closure.md`).

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -500,6 +500,51 @@ STASIS_EXPORT int stasis_input_viewport_h_px(void) {
     return g_window ? g_input_frame.viewport_h_px : 0;
 }
 
+/*
+ * Host snapshot: fill caller-provided buffers with a deterministic view of host state.
+ *
+ * Layout is defined in src/stdlib/host_frame.stasis. This is intentionally a simple
+ * "copy out" ABI for native now, and a good fit for WASM later (one import to get a snapshot).
+ */
+STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
+    if (!out_i32 || !out_f32) return;
+
+    /* i32 header */
+    out_i32[0] = stasis_get_time_ms();
+    out_i32[1] = g_window_width;
+    out_i32[2] = g_window_height;
+    out_i32[3] = g_input_frame.viewport_x_px;
+    out_i32[4] = g_input_frame.viewport_y_px;
+    out_i32[5] = g_input_frame.viewport_w_px;
+    out_i32[6] = g_input_frame.viewport_h_px;
+    out_i32[7] = g_input_frame.pointer_count;
+    out_i32[8] = g_input_frame.dropped_pointers;
+
+    for (int i = 9; i < 16; i++) out_i32[i] = 0;
+
+    const int i32_base = 16;
+    const int i32_stride = 4;
+    const int f32_base = 0;
+    const int f32_stride = 6;
+    for (int i = 0; i < STASIS_MAX_POINTERS; i++) {
+        const StasisPointer* p = &g_input_frame.pointers[i];
+        out_i32[i32_base + i * i32_stride + 0] = p->id;
+        out_i32[i32_base + i * i32_stride + 1] = p->is_down;
+        out_i32[i32_base + i * i32_stride + 2] = p->went_down;
+        out_i32[i32_base + i * i32_stride + 3] = p->went_up;
+
+        out_f32[f32_base + i * f32_stride + 0] = p->x_px;
+        out_f32[f32_base + i * f32_stride + 1] = p->y_px;
+        out_f32[f32_base + i * f32_stride + 2] = p->dx_px;
+        out_f32[f32_base + i * f32_stride + 3] = p->dy_px;
+        out_f32[f32_base + i * f32_stride + 4] = p->x_n;
+        out_f32[f32_base + i * f32_stride + 5] = p->y_n;
+    }
+
+    for (int i = i32_base + STASIS_MAX_POINTERS * i32_stride; i < 64; i++) out_i32[i] = 0;
+    for (int i = f32_base + STASIS_MAX_POINTERS * f32_stride; i < 64; i++) out_f32[i] = 0.0f;
+}
+
 /* ============================================================
  * Audio output (SDL2) - f32 stereo ring buffer
  * ============================================================ */

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -43,6 +43,8 @@ EXPORTS
     stasis_input_viewport_y_px
     stasis_input_viewport_w_px
     stasis_input_viewport_h_px
+    stasis_host_get_frame
+    host_get_frame=stasis_host_get_frame
     stasis_gfx_notify_file_changed
     gfx_notify_file_changed=stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite

--- a/src/stdlib/host_frame.stasis
+++ b/src/stdlib/host_frame.stasis
@@ -1,0 +1,94 @@
+import "graphics.stasis";
+
+// Host frame snapshot (prototype)
+//
+// Practical hybrid approach:
+// - Reads: host writes a single deterministic snapshot once per tick via `host_get_frame`.
+// - Writes/effects: rendering/audio remain explicit command calls (draw_line/gfx_draw_sprite/etc).
+//
+// Usage:
+// - Call `host_frame_refresh()` once at the start of your tick.
+// - Read everything from `host_i32[]` / `host_f32[]` accessors below for the rest of the tick.
+
+// NOTE: This is a prototype layout. Treat all unused indices as reserved.
+
+const HOST_MAX_POINTERS: i32 = 8;
+
+// i32 layout
+const HOST_I_TIME_MS: i32 = 0;
+const HOST_I_WINDOW_W_PX: i32 = 1;
+const HOST_I_WINDOW_H_PX: i32 = 2;
+const HOST_I_VIEWPORT_X_PX: i32 = 3;
+const HOST_I_VIEWPORT_Y_PX: i32 = 4;
+const HOST_I_VIEWPORT_W_PX: i32 = 5;
+const HOST_I_VIEWPORT_H_PX: i32 = 6;
+const HOST_I_POINTER_COUNT: i32 = 7;
+const HOST_I_DROPPED_POINTERS: i32 = 8;
+const HOST_I_POINTER_BASE: i32 = 16; // reserve space for future fields before pointers
+const HOST_I_POINTER_STRIDE: i32 = 4; // id, is_down, went_down, went_up
+const HOST_I32_COUNT: i32 = 64;
+
+// f32 layout
+const HOST_F_POINTER_BASE: i32 = 0;
+const HOST_F_POINTER_STRIDE: i32 = 6; // x_px, y_px, dx_px, dy_px, x_n, y_n
+const HOST_F32_COUNT: i32 = 64;
+
+global host_i32: i32[HOST_I32_COUNT];
+global host_f32: f32[HOST_F32_COUNT];
+
+extern function host_get_frame(out_i32: i32[], out_f32: f32[]): void;
+
+function host_frame_refresh(): void {
+    host_get_frame(host_i32, host_f32);
+}
+
+function host_time_ms(): i32 { return host_i32[HOST_I_TIME_MS]; }
+function host_window_w_px(): i32 { return host_i32[HOST_I_WINDOW_W_PX]; }
+function host_window_h_px(): i32 { return host_i32[HOST_I_WINDOW_H_PX]; }
+function host_viewport_x_px(): i32 { return host_i32[HOST_I_VIEWPORT_X_PX]; }
+function host_viewport_y_px(): i32 { return host_i32[HOST_I_VIEWPORT_Y_PX]; }
+function host_viewport_w_px(): i32 { return host_i32[HOST_I_VIEWPORT_W_PX]; }
+function host_viewport_h_px(): i32 { return host_i32[HOST_I_VIEWPORT_H_PX]; }
+function host_pointer_count(): i32 { return host_i32[HOST_I_POINTER_COUNT]; }
+function host_dropped_pointers(): i32 { return host_i32[HOST_I_DROPPED_POINTERS]; }
+
+function host_pointer_id(index: i32): i32 {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 0];
+}
+
+function host_pointer_is_down(index: i32): i32 {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 1];
+}
+
+function host_pointer_went_down(index: i32): i32 {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 2];
+}
+
+function host_pointer_went_up(index: i32): i32 {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3];
+}
+
+function host_pointer_x_px(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0];
+}
+
+function host_pointer_y_px(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1];
+}
+
+function host_pointer_dx_px(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 2];
+}
+
+function host_pointer_dy_px(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 3];
+}
+
+function host_pointer_x_n(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4];
+}
+
+function host_pointer_y_n(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5];
+}
+


### PR DESCRIPTION
Adds a deterministic HostFrame snapshot API (one call per tick) and docs for the snapshot + command-buffer direction.

Changes:
- Runtime: stasis_host_get_frame copies window/viewport/pointer state into caller-provided buffers; exported as host_get_frame.
- Stdlib: src/stdlib/host_frame.stasis helper wrappers and fixed buffer layout.
- Compiler: LLVM + Cranelift lowering for host_get_frame -> stasis_host_get_frame.
- Docs: docs/host-snapshot-command-buffer.md and docs/asset_hot_reload.md; linked from README and tasks.

Motivation: reduce query-call churn and make host state propagation (resize/input/etc) deterministic and WASM-friendly.