### PR TITLE
feat: runner bulk HostFrame + command buffer submit

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -257,6 +257,32 @@ static IReadOnlyList<string> BuildRunnerExports(string moduleName, string mode, 
     return new[] { $"{moduleName}__main" };
 }
 
+static void AddHostAbiDataExports(LayoutPlan layout, List<string> exports)
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        return;
+    }
+
+    static void AddIfGlobalExists(LayoutPlan layout, List<string> exports, string globalName)
+    {
+        if (layout.Globals.Any(g => string.Equals(g.Name, globalName, StringComparison.Ordinal)))
+        {
+            exports.Add($"{globalName},DATA");
+        }
+    }
+
+    // Bulk host mode: runner pushes HostFrame snapshot into guest memory and reads out command buffers.
+    // Export these globals as DATA so the runner can GetProcAddress them.
+    AddIfGlobalExists(layout, exports, "host_i32");
+    AddIfGlobalExists(layout, exports, "host_f32");
+    AddIfGlobalExists(layout, exports, "host_keys");
+
+    AddIfGlobalExists(layout, exports, "gfx_cmd_i32");
+    AddIfGlobalExists(layout, exports, "gfx_cmd_f32");
+    AddIfGlobalExists(layout, exports, "gfx_cmd_u8");
+}
+
 if (mode == "format")
 {
     var input = File.ReadAllText(path);
@@ -501,15 +527,25 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
                 Directory.CreateDirectory(cacheDir);
                 var craneliftTargetTriple = GetCraneliftTargetTriple();
                 var compilerCacheSalt = GetCompilerCacheSalt();
-                var cacheKey = ComputeCraneliftArtifactCacheKey(path, source, mode, backend, moduleName, includeTests, optLevel, enableLto, graphicsLibPath, linkLibraries, useCraneliftRunner, enableGraphics, craneliftTargetTriple, compilerCacheSalt);
+                var hostAbiKey = string.Empty;
+                if (useCraneliftRunner && OperatingSystem.IsWindows())
+                {
+                    var tmp = new List<string>();
+                    AddHostAbiDataExports(layout, tmp);
+                    hostAbiKey = string.Join(';', tmp);
+                }
+                var cacheKey = ComputeCraneliftArtifactCacheKey(path, source, mode, backend, moduleName, includeTests, optLevel, enableLto, graphicsLibPath, linkLibraries, useCraneliftRunner, enableGraphics, craneliftTargetTriple, compilerCacheSalt, hostAbiKey);
                 var cachedClif = Path.Combine(cacheDir, $"{cacheKey}.clif");
                 var cachedObj = Path.Combine(cacheDir, $"{cacheKey}{GetObjectFileExtension()}");
                 var cachedOut = Path.Combine(cacheDir, cacheKey + (useCraneliftRunner ? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" : ".so") : (OperatingSystem.IsWindows() ? ".exe" : string.Empty)));
 
                 var hasTick = mode == "run" && ContainsTopLevelFunction(parse.CompilationUnit, "tick");
-                var runnerExports = useCraneliftRunner
+                var exportedFunctions = useCraneliftRunner
                     ? BuildRunnerExports(moduleName, mode, hasTick, includeTests)
                     : Array.Empty<string>();
+                var runnerExports = exportedFunctions;
+                var dllExports = exportedFunctions.ToList();
+                AddHostAbiDataExports(layout, dllExports);
                 DataBindingPlan? dataBindingPlan = null;
                 if (useCraneliftRunner)
                 {
@@ -539,9 +575,8 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
 
                 if (useCraneliftRunner)
                 {
-                    var exports = runnerExports;
                     var sw = Stopwatch.StartNew();
-                    var ensureExit = EnsureCraneliftCachedRunnerDll(cachedClif, cachedObj, cachedOut, moduleName, mode, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, dataBindingPlan?.DefPath, exports);
+                    var ensureExit = EnsureCraneliftCachedRunnerDll(cachedClif, cachedObj, cachedOut, moduleName, mode, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, dataBindingPlan?.DefPath, dllExports);
                     sw.Stop();
                     if (logPhaseTiming)
                     {
@@ -620,16 +655,18 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             {
                 HotStatePlan? hotStatePlan = null;
                 var hasTick = ContainsTopLevelFunction(parse.CompilationUnit, "tick");
-                var exports = BuildRunnerExports(moduleName, mode, hasTick, includeTests);
+                var exportedFunctions = BuildRunnerExports(moduleName, mode, hasTick, includeTests);
+                var dllExports = exportedFunctions.ToList();
+                AddHostAbiDataExports(layout, dllExports);
                 if (enableHotState)
                 {
-                    if (!TryCreateHotStatePlan(path, layout, moduleName, exports, excludeSpriteFields: true, out var createdPlan))
+                    if (!TryCreateHotStatePlan(path, layout, moduleName, exportedFunctions, excludeSpriteFields: true, out var createdPlan))
                     {
                         return 1;
                     }
                     hotStatePlan = createdPlan;
                 }
-                if (!TryGetDataBindingPlan(path, layout, moduleName, exports, out var dataBindingPlan))
+                if (!TryGetDataBindingPlan(path, layout, moduleName, exportedFunctions, out var dataBindingPlan))
                 {
                     return 1;
                 }
@@ -639,8 +676,8 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
                 long runLink;
                 long runRun;
                 var runExit = useInMemoryClif
-                    ? ExecuteClifWithRunnerFromString(mode, ir, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, aotTool, moduleName, hotStatePlan, dataBindingPlan, hasTick ? tickHostFps : (int?)null, out runAotSpawn, out runAotCompile, out runLink, out runRun)
-                    : ExecuteClifWithRunner(mode, tempClif, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, aotTool, moduleName, hotStatePlan, dataBindingPlan, hasTick ? tickHostFps : (int?)null, out runAotSpawn, out runAotCompile, out runLink, out runRun);
+                    ? ExecuteClifWithRunnerFromString(mode, ir, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, aotTool, moduleName, hotStatePlan, dataBindingPlan, dllExports, hasTick ? tickHostFps : (int?)null, out runAotSpawn, out runAotCompile, out runLink, out runRun)
+                    : ExecuteClifWithRunner(mode, tempClif, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, aotTool, moduleName, hotStatePlan, dataBindingPlan, dllExports, hasTick ? tickHostFps : (int?)null, out runAotSpawn, out runAotCompile, out runLink, out runRun);
                 if (logPhaseTiming)
                 {
                     aotSpawnMs = runAotSpawn ?? 0;
@@ -887,7 +924,7 @@ static int ExecuteObjectWithRunner(string mode, string objPath, string? optLevel
     }
 }
 
-static int ExecuteClifWithRunner(string mode, string clifPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, string aotTool, string moduleName, HotStatePlan? hotStatePlan, DataBindingPlan? dataBindingPlan, int? tickHostFps, out long? aotSpawnMs, out long aotCompileMs, out long linkMs, out long runMs)
+static int ExecuteClifWithRunner(string mode, string clifPath, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, string aotTool, string moduleName, HotStatePlan? hotStatePlan, DataBindingPlan? dataBindingPlan, IReadOnlyList<string> dllExports, int? tickHostFps, out long? aotSpawnMs, out long aotCompileMs, out long linkMs, out long runMs)
 {
     aotSpawnMs = null;
     aotCompileMs = 0;
@@ -902,20 +939,7 @@ static int ExecuteClifWithRunner(string mode, string clifPath, string? optLevel,
             return aotExit;
         }
 
-        IReadOnlyList<string> exports;
-        if (mode == "test")
-        {
-            exports = new[] { $"{moduleName}__run_tests" };
-        }
-        else if (tickHostFps is not null)
-        {
-            exports = new[] { $"{moduleName}__main", $"{moduleName}__tick" };
-        }
-        else
-        {
-            exports = new[] { $"{moduleName}__main" };
-        }
-        return ExecuteObjectWithRunner(mode, tempObj, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, moduleName, hotStatePlan, dataBindingPlan, exports, tickHostFps, out linkMs, out runMs);
+        return ExecuteObjectWithRunner(mode, tempObj, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, moduleName, hotStatePlan, dataBindingPlan, dllExports, tickHostFps, out linkMs, out runMs);
     }
     finally
     {
@@ -926,7 +950,7 @@ static int ExecuteClifWithRunner(string mode, string clifPath, string? optLevel,
     }
 }
 
-static int ExecuteClifWithRunnerFromString(string mode, string clif, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, string aotTool, string moduleName, HotStatePlan? hotStatePlan, DataBindingPlan? dataBindingPlan, int? tickHostFps, out long? aotSpawnMs, out long aotCompileMs, out long linkMs, out long runMs)
+static int ExecuteClifWithRunnerFromString(string mode, string clif, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, string aotTool, string moduleName, HotStatePlan? hotStatePlan, DataBindingPlan? dataBindingPlan, IReadOnlyList<string> dllExports, int? tickHostFps, out long? aotSpawnMs, out long aotCompileMs, out long linkMs, out long runMs)
 {
     aotSpawnMs = null;
     aotCompileMs = 0;
@@ -941,20 +965,7 @@ static int ExecuteClifWithRunnerFromString(string mode, string clif, string? opt
             return aotExit;
         }
 
-        IReadOnlyList<string> exports;
-        if (mode == "test")
-        {
-            exports = new[] { $"{moduleName}__run_tests" };
-        }
-        else if (tickHostFps is not null)
-        {
-            exports = new[] { $"{moduleName}__main", $"{moduleName}__tick" };
-        }
-        else
-        {
-            exports = new[] { $"{moduleName}__main" };
-        }
-        return ExecuteObjectWithRunner(mode, tempObj, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, moduleName, hotStatePlan, dataBindingPlan, exports, tickHostFps, out linkMs, out runMs);
+        return ExecuteObjectWithRunner(mode, tempObj, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, moduleName, hotStatePlan, dataBindingPlan, dllExports, tickHostFps, out linkMs, out runMs);
     }
     finally
     {
@@ -1112,6 +1123,13 @@ static string BuildClangArgsForObject(string objPath, string outputPath, bool is
             if (!string.IsNullOrEmpty(windowsDefFilePath))
             {
                 args.Add($"-Wl,/DEF:\"{windowsDefFilePath}\"");
+                if (windowsExports is { Count: > 0 })
+                {
+                    foreach (var ex in windowsExports)
+                    {
+                        args.Add($"-Wl,/EXPORT:{ex}");
+                    }
+                }
             }
             else
             {
@@ -2129,7 +2147,7 @@ static string GetCraneliftArtifactCacheDirectory(string mode)
     return Path.Combine(currentDirectory, ".stasis_cache", bucket);
 }
 
-static string ComputeCraneliftArtifactCacheKey(string path, string source, string mode, BackendType backend, string moduleName, bool includeTests, string? optLevel, bool enableLto, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, bool useCraneliftRunner, bool usesGraphics, string? craneliftTargetTriple, string compilerCacheSalt)
+static string ComputeCraneliftArtifactCacheKey(string path, string source, string mode, BackendType backend, string moduleName, bool includeTests, string? optLevel, bool enableLto, string? graphicsLibPath, IReadOnlyList<string> linkLibraries, bool useCraneliftRunner, bool usesGraphics, string? craneliftTargetTriple, string compilerCacheSalt, string hostAbiKey)
 {
     var fullPath = Path.GetFullPath(path);
     var identity = new StringBuilder();
@@ -2146,6 +2164,7 @@ static string ComputeCraneliftArtifactCacheKey(string path, string source, strin
     identity.Append("usesGraphics=").Append(usesGraphics).Append('\n');
     identity.Append("craneliftTarget=").Append(craneliftTargetTriple ?? string.Empty).Append('\n');
     identity.Append("compilerCacheSalt=").Append(compilerCacheSalt).Append('\n');
+    identity.Append("hostAbiKey=").Append(hostAbiKey).Append('\n');
     identity.Append("path=").Append(fullPath).Append('\n');
     identity.Append("source=").Append(source);
     return ComputeSha256Hex(identity.ToString());
@@ -4244,7 +4263,7 @@ static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? o
                 }
                 else
                 {
-                    executeExit = ExecuteClifWithRunner("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, result.LinkLibraries, aotTool, moduleName, hotStatePlan: null, dataBindingPlan: null, tickHostFps: null, out _, out _, out _, out _);
+                    executeExit = ExecuteClifWithRunner("test", result.ArtifactPath, optLevel, enableLto, result.UsesGraphics, graphicsLibPath, result.LinkLibraries, aotTool, moduleName, hotStatePlan: null, dataBindingPlan: null, dllExports: new[] { $"{moduleName}__run_tests" }, tickHostFps: null, out _, out _, out _, out _);
                 }
             }
         }

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1127,7 +1127,8 @@ static string BuildClangArgsForObject(string objPath, string outputPath, bool is
                 {
                     foreach (var ex in windowsExports)
                     {
-                        args.Add($"-Wl,/EXPORT:{ex}");
+                        args.Add("-Xlinker");
+                        args.Add($"/EXPORT:{ex}");
                     }
                 }
             }
@@ -1138,7 +1139,8 @@ static string BuildClangArgsForObject(string objPath, string outputPath, bool is
                     : new[] { exportName };
                 foreach (var ex in exports)
                 {
-                    args.Add($"-Wl,/EXPORT:{ex}");
+                    args.Add("-Xlinker");
+                    args.Add($"/EXPORT:{ex}");
                 }
             }
         }

--- a/docs/graphics-command-buffer-v1.md
+++ b/docs/graphics-command-buffer-v1.md
@@ -36,6 +36,7 @@ Stasis builtins:
 Helper module (recommended writer):
 
 - `src/gfx_cmd.stasis` (`gfx_cmd_begin`, `gfx_cmd_clear`, `gfx_cmd_line`, `gfx_cmd_sprite`, `gfx_cmd_text`, `gfx_cmd_submit`, `gfx_cmd_submit_no_present`)
+  - For bulk host mode: call `gfx_cmd_mark_present()` and let the host submit after `tick()`.
 
 ## Memory layout (v1)
 

--- a/docs/host-snapshot-command-buffer.md
+++ b/docs/host-snapshot-command-buffer.md
@@ -66,6 +66,18 @@ Key property: resize/viewport/DPI changes become *just fields in the HostFrame*,
 - AoS -> SoA: command buffers can be SoA-friendly (separate streams per command type).
 - WASM friendly: reduces imports/exports to a small stable surface.
 
+### Bulk host mode (no explicit calls from Stasis)
+
+In the "bulk host" model, the program does not call `host_get_frame` or `gfx_submit*` at all.
+
+Per tick:
+
+1) Host writes HostFrame directly into exported Stasis globals (`host_i32[]`, `host_f32[]`, `host_keys[]`).
+2) Host calls `tick()`.
+3) Host reads exported command buffers (`gfx_cmd_i32[]`, `gfx_cmd_f32[]`, `gfx_cmd_u8[]`) and submits/presents once.
+
+This is the direction that minimizes Stasis->host calls on hot paths (important for WASM).
+
 ## ABI pieces
 
 This section describes a v1-shaped ABI. It is intentionally conservative: fixed-size buffers, versioning, and "copy out" semantics.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -13,9 +13,11 @@ This file is a lightweight, persistent checklist of upcoming work. It complement
 - [ ] Command buffers: evolve text output toward glyph runs/caching (avoid per-frame UTF-8 copies + per-string parsing).
 - [x] Compiler: implement `function @inline ...` (parse + carry attribute + inline small functions in LLVM/Cranelift codegen).
 - [ ] HostFrame: add `version`, `flags`, `frame_index`, and `dt` so tick can be snapshot-only (no ad-hoc queries).
-- [ ] HostFrame: add keyboard state + quit/focus flags to snapshot to reduce per-tick host calls (esp. for WASM).
-- [ ] Host bulk mode: runner writes `host_i32[]`/`host_f32[]` directly and program never calls `host_get_frame`.
-- [ ] Host bulk mode: runner reads `gfx_cmd_*` globals and submits/presents (program never calls `gfx_submit*`/`end_frame`).
+- [ ] HostFrame: add keyboard state + quit/focus flags to snapshot so tick can avoid `is_key_down`/`should_quit` imports.
+- [ ] Host bulk mode: export `host_*` globals from program DLL for runner/hosts.
+- [ ] Host bulk mode: runner writes HostFrame globals before `tick()` (no `host_frame_refresh()` in hot paths).
+- [ ] Host bulk mode: export `gfx_cmd_*` globals from program DLL for runner/hosts.
+- [ ] Host bulk mode: runner submits `gfx_cmd_*` after `tick()` (no `gfx_submit*`/`end_frame` in hot paths).
 - [ ] Game dev readiness: P0 stdlib modules (`game_math`, `game_draw`, `game_collision`) + canonical UTF-8 buffer helpers (remove samples writing string headers directly).
 - [ ] Game dev readiness: P1 input helpers (went_down/up, mapping), viewport/camera helpers, and draw batching helpers.
 - [ ] Game dev readiness: P2 audio mixer layer (one-shots + loops) and more templates/examples.

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -123,6 +123,7 @@ static int g_finger_active[STASIS_MAX_POINTERS - 1];
 
 /* Forward decls for exported functions used before their definitions (MSVC C mode does not allow implicit declarations). */
 STASIS_EXPORT int stasis_get_time_ms(void);
+STASIS_EXPORT int stasis_should_quit(void);
 STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, int x, int y, int w, int h, int rot_degrees, int a);
 STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, float y, float r, float g, float b, float a);
 
@@ -525,8 +526,9 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     out_i32[6] = g_input_frame.viewport_h_px;
     out_i32[7] = g_input_frame.pointer_count;
     out_i32[8] = g_input_frame.dropped_pointers;
+    out_i32[9] = stasis_should_quit();
 
-    for (int i = 9; i < 16; i++) out_i32[i] = 0;
+    for (int i = 10; i < 16; i++) out_i32[i] = 0;
 
     const int i32_base = 16;
     const int i32_stride = 4;
@@ -3128,6 +3130,21 @@ STASIS_EXPORT int stasis_is_key_down(int scancode) {
     if (!g_keyboard_state) return 0;
     if (scancode < 0 || scancode >= SDL_NUM_SCANCODES) return 0;
     return g_keyboard_state[scancode] ? 1 : 0;
+}
+
+/*
+ * Bulk keyboard snapshot: copy SDL keyboard state into caller-provided buffer.
+ * Returns number of bytes written.
+ */
+STASIS_EXPORT int stasis_host_get_keyboard_state(uint8_t* out_u8, int max_bytes) {
+    if (!out_u8 || max_bytes <= 0) return 0;
+    SDL_PumpEvents();
+    int len = 0;
+    const uint8_t* state = SDL_GetKeyboardState(&len);
+    if (!state || len <= 0) return 0;
+    int n = len < max_bytes ? len : max_bytes;
+    memcpy(out_u8, state, (size_t)n);
+    return n;
 }
 
 /*

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -46,6 +46,8 @@ EXPORTS
     stasis_input_viewport_h_px
     stasis_host_get_frame
     host_get_frame=stasis_host_get_frame
+    stasis_host_get_keyboard_state
+    host_get_keyboard_state=stasis_host_get_keyboard_state
     stasis_gfx_notify_file_changed
     gfx_notify_file_changed=stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -18,6 +18,27 @@
 typedef int (*stasis_entry_fn)(void);
 typedef int (*stasis_tick_fn)(void);
 typedef void (*stasis_sys_set_args_fn)(int argc, const char *const *argv);
+typedef void (*stasis_host_get_frame_fn)(int32_t *out_i32, float *out_f32);
+typedef int (*stasis_host_get_keyboard_state_fn)(uint8_t *out_u8, int max_bytes);
+typedef void (*stasis_gfx_submit_u8_fn)(const int32_t *cmd_i32, const float *cmd_f32, const uint8_t *cmd_u8);
+
+static int stasis_env_flag(const char *name, int default_value)
+{
+    const char *v = getenv(name);
+    if (!v || !v[0])
+    {
+        return default_value;
+    }
+    if (v[0] == '0')
+    {
+        return 0;
+    }
+    if (v[0] == '1')
+    {
+        return 1;
+    }
+    return default_value;
+}
 
 #ifndef _WIN32
 static void stasis_sleep_us(long long usec)
@@ -1364,6 +1385,43 @@ int main(int argc, char **argv)
         QueryPerformanceFrequency(&freq);
         long long target_us = 1000000LL / (long long)fps;
 
+        /* Bulk host mode: host writes HostFrame globals and submits command buffers. */
+        const int bulk_enabled = stasis_env_flag("STASIS_HOST_BULK", 1);
+        int bulk_active = 0;
+        int32_t *host_i32 = NULL;
+        float *host_f32 = NULL;
+        uint8_t *host_keys = NULL;
+        int32_t *gfx_cmd_i32 = NULL;
+        float *gfx_cmd_f32 = NULL;
+        uint8_t *gfx_cmd_u8 = NULL;
+
+        stasis_host_get_frame_fn host_get_frame = NULL;
+        stasis_host_get_keyboard_state_fn host_get_keyboard_state = NULL;
+        stasis_gfx_submit_u8_fn gfx_submit_u8 = NULL;
+
+        if (bulk_enabled)
+        {
+            host_i32 = (int32_t *)GetProcAddress(lib, "host_i32");
+            host_f32 = (float *)GetProcAddress(lib, "host_f32");
+            host_keys = (uint8_t *)GetProcAddress(lib, "host_keys");
+            gfx_cmd_i32 = (int32_t *)GetProcAddress(lib, "gfx_cmd_i32");
+            gfx_cmd_f32 = (float *)GetProcAddress(lib, "gfx_cmd_f32");
+            gfx_cmd_u8 = (uint8_t *)GetProcAddress(lib, "gfx_cmd_u8");
+
+            HMODULE gfx = GetModuleHandleA("stasis_graphics.dll");
+            if (gfx)
+            {
+                host_get_frame = (stasis_host_get_frame_fn)GetProcAddress(gfx, "stasis_host_get_frame");
+                host_get_keyboard_state = (stasis_host_get_keyboard_state_fn)GetProcAddress(gfx, "stasis_host_get_keyboard_state");
+                gfx_submit_u8 = (stasis_gfx_submit_u8_fn)GetProcAddress(gfx, "stasis_gfx_submit_u8");
+            }
+
+            if (host_i32 && host_f32 && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8 && host_get_frame && gfx_submit_u8)
+            {
+                bulk_active = 1;
+            }
+        }
+
         LARGE_INTEGER last;
         QueryPerformanceCounter(&last);
 
@@ -1530,11 +1588,25 @@ int main(int argc, char **argv)
             /* Poll data bindings for changes (fast path: just checks mtimes) */
             stasis_data_poll_all();
 
+            if (bulk_active)
+            {
+                host_get_frame(host_i32, host_f32);
+                if (host_get_keyboard_state && host_keys)
+                {
+                    (void)host_get_keyboard_state(host_keys, 512);
+                }
+            }
+
             int tick_result = tick();
             if (tick_result != 0)
             {
                 result = tick_result == 1 ? 0 : tick_result;
                 break;
+            }
+
+            if (bulk_active)
+            {
+                gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
             }
 
             LARGE_INTEGER now;

--- a/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
@@ -2194,7 +2194,7 @@ function draw_frame(): void {
 
 // Timing
 function compute_delta_ms(): i32 {
-    let current_time: i32 = get_time_ms();
+    let current_time: i32 = host_time_ms();
     let delta_ms: i32 = current_time - state.timers.last_time;
     if (delta_ms < 1) { delta_ms = 1; }
     if (delta_ms > 100) { delta_ms = 100; }
@@ -2392,12 +2392,8 @@ function main(): i32 {
     if (!(BENCH_SKIP_MAXIMIZE == 1)) {
         maximize_window_for_desktop();
     }
-
-    // Ensure viewport/pointer state is up to date before querying HostFrame.
-    // (`should_quit` pumps SDL events and updates `g_input_frame`.)
-    should_quit();
-    host_frame_refresh();
-    sync_screen_size();
+    state.runtime_screen.w = state.config.screen.w;
+    state.runtime_screen.h = state.config.screen.h;
     print_string("window_px=");
     print_int(state.runtime_screen.w);
     print_string("x");
@@ -2411,8 +2407,6 @@ function main(): i32 {
         audio_sr = 0;
     }
 
-    state.runtime_screen.w = host_window_w_px();
-    state.runtime_screen.h = host_window_h_px();
     state.layout.viewport_x = 0.0;
     state.layout.viewport_y = 0.0;
     state.layout.viewport_w = i32_to_f32(state.runtime_screen.w);
@@ -2468,12 +2462,9 @@ function tick(): i32 {
         return 1;
     }
 
-    let quit: bool = should_quit();
-    if (quit) {
+    if (host_quit_requested()) {
         state.running = 0;
     }
-
-    host_frame_refresh();
     sync_screen_size();
     update_layout();
     apply_config_live();
@@ -2481,7 +2472,7 @@ function tick(): i32 {
     state.timers.frame_start = get_time_ms();
     let bench_start_us: i32 = get_time_us();
 
-    if (is_key_down(Scancode.Escape)) {
+    if (host_key_down(Scancode.Escape)) {
         state.running = 0;
     }
 
@@ -2503,7 +2494,7 @@ function tick(): i32 {
     update_game(dt, delta_ms);
     audio_update();
     draw_frame();
-    gfx_cmd_submit_no_present();
+    gfx_cmd_mark_present();
     // Measure frame time (logic + rendering prep, excluding vsync/swap/sleep)
     let frame_end: i32 = get_time_ms();
     state.timers.tick_time_ms = frame_end - state.timers.frame_start;
@@ -2514,8 +2505,6 @@ function tick(): i32 {
     // Store in circular buffer for averaging
     state.frame_timer.sample_index =
         frame_timer_push(state.frame_timer.samples_ms, state.frame_timer.sample_index, state.timers.tick_time_ms);
-
-    end_frame();
 
     if (BENCH_AUTO_EXIT == 1) {
         bench_frame = bench_frame + 1;

--- a/src/gfx_cmd.stasis
+++ b/src/gfx_cmd.stasis
@@ -216,6 +216,10 @@ function @inline gfx_cmd_submit_no_present(): void {
     gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
 }
 
+function @inline gfx_cmd_mark_present(): void {
+    gfx_cmd_i32[GFX_I_FLAGS] = gfx_cmd_i32[GFX_I_FLAGS] + GFX_FLAG_PRESENT;
+}
+
 function @inline gfx_cmd_line_count(): i32 { return gfx_cmd_i32[GFX_I_LINE_COUNT]; }
 function @inline gfx_cmd_sprite_count(): i32 { return gfx_cmd_i32[GFX_I_SPRITE_COUNT]; }
 function @inline gfx_cmd_text_count(): i32 { return gfx_cmd_i32[GFX_I_TEXT_COUNT]; }

--- a/src/host_frame.stasis
+++ b/src/host_frame.stasis
@@ -24,6 +24,7 @@ const HOST_I_VIEWPORT_W_PX: i32 = 5;
 const HOST_I_VIEWPORT_H_PX: i32 = 6;
 const HOST_I_POINTER_COUNT: i32 = 7;
 const HOST_I_DROPPED_POINTERS: i32 = 8;
+const HOST_I_QUIT_REQUESTED: i32 = 9;
 const HOST_I_POINTER_BASE: i32 = 16; // reserve space for future fields before pointers
 const HOST_I_POINTER_STRIDE: i32 = 4; // id, is_down, went_down, went_up
 const HOST_I32_COUNT: i32 = 64;
@@ -35,6 +36,7 @@ const HOST_F32_COUNT: i32 = 64;
 
 global host_i32: i32[64];
 global host_f32: f32[64];
+global host_keys: u8[512];
 
 extern function host_get_frame(out_i32: i32[], out_f32: f32[]): void;
 
@@ -51,6 +53,12 @@ function host_viewport_w_px(): i32 { return host_i32[HOST_I_VIEWPORT_W_PX]; }
 function host_viewport_h_px(): i32 { return host_i32[HOST_I_VIEWPORT_H_PX]; }
 function host_pointer_count(): i32 { return host_i32[HOST_I_POINTER_COUNT]; }
 function host_dropped_pointers(): i32 { return host_i32[HOST_I_DROPPED_POINTERS]; }
+function host_quit_requested(): bool { return host_i32[HOST_I_QUIT_REQUESTED] != 0; }
+
+function host_key_down(scancode: i32): bool {
+    if (scancode < 0 || scancode >= 512) { return false; }
+    return host_keys[scancode] != 0;
+}
 
 function host_pointer_id(index: i32): i32 {
     return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 0];


### PR DESCRIPTION
Stacks on #88.

Goal: eliminate Stasis->host calls on hot paths by having the native runner do bulk IO.

Changes:
- untime/stasis_runner.c: bulk mode writes HostFrame globals before 	ick() and submits gfx_cmd_* after 	ick() (toggle via STASIS_HOST_BULK, default on when buffers are present).
- Stasis.Cli/Program.cs: export host_* and gfx_cmd_* globals from the program DLL on Windows so the runner can GetProcAddress them (uses -Xlinker /EXPORT: so ,DATA works).
- untime/stasis_graphics.c/.def: add stasis_host_get_keyboard_state and include quit_requested in stasis_host_get_frame.
- src/host_frame.stasis: add host_keys[512] + host_key_down() + host_quit_requested().
- src/gfx_cmd.stasis: add gfx_cmd_mark_present() for bulk mode.
- samples/brickout_revenge/brickout_revenge_v1_cmd.stasis: remove should_quit/is_key_down and remove explicit submit/end_frame; runner submits.
- Docs/tasks updated to reflect the bulk-mode steps.

Sanity:
- dotnet test passes.
- untime/build.bat passes.
- Brickout cmd bench runs with STASIS_GFX_VSYNC=0 and shows lower vg_tick_us after removing submit from Stasis.