### PR TITLE
docs: Unity vs Stasis tradeoffs for Brickout Revenge

### DIFF
--- a/docs/brickout-revenge-unity-vs-stasis.md
+++ b/docs/brickout-revenge-unity-vs-stasis.md
@@ -1,0 +1,254 @@
+# Brickout Revenge: Unity vs Stasis (Honest Pros/Cons)
+
+This document is intentionally blunt and decision-oriented. It assumes Brickout Revenge is a 2D game with:
+
+- A menu / level select
+- A main game loop with collisions, spawns, upgrades, and UI
+- Data-driven levels (JSON or similar)
+- A desire for fast iteration during design
+
+## Summary (when each is the obvious choice)
+
+Choose **Unity** if you want:
+
+- A mature editor and asset pipeline (UI layout, sprites, animations, audio, input)
+- A fast path to shipping on multiple platforms
+- A large ecosystem for UI, tooling, localization, analytics, and deployment
+- A team workflow where designers can iterate without touching code much
+
+Choose **Stasis** if you want:
+
+- Tight control over determinism and memory layout (no hidden allocations)
+- A custom engine where you own every subsystem and can keep it minimal
+- A "game as a program" workflow with strong reproducibility goals
+- To explore language/runtime design alongside building the game
+
+For a "production game" with typical scope pressures, **Unity is usually the lower-risk path**. For a language/toolchain project that also happens to include a game, **Stasis makes sense**, but you pay in tooling and content velocity.
+
+## Unity: Pros for Brickout Revenge
+
+### 1) Editor-driven iteration (biggest win)
+
+- Build and tweak the menu + shop + HUD visually.
+- Iterate layout for different aspect ratios and safe areas.
+- Prefabs for towers, balls, bricks, FX.
+- You can hand off content creation to non-programmers.
+
+### 2) UI stack and text rendering are solved
+
+- Unity UI Toolkit / UGUI handles text, fonts, localization, anchoring, accessibility, scaling.
+- No custom font rendering integration work.
+- Easy to build a shop UI with buttons, scroll views, tooltips, and animations.
+
+### 3) Asset pipeline + importers
+
+- Sprite import, slicing, packing, atlases, compression.
+- Audio import, mixers, volume groups, spatialization (if needed).
+- Build settings per platform are standard.
+
+### 4) Debugging and profiling tooling
+
+- Step-through debugging, scene inspection, live object state.
+- Profiler, frame debugger, memory profiler.
+- Much easier to diagnose "blank screen" issues.
+
+### 5) Ecosystem + libraries
+
+- Tweening, save systems, JSON, addressables, input system, controller support.
+- Tons of prior art for tower defense + breakout-like mechanics.
+
+## Unity: Cons (and how they show up)
+
+### 1) Determinism is not the default
+
+If you want deterministic replays, lockstep simulation, or strict "same input => same output":
+
+- Floating point + physics + variable timestep can diverge across machines.
+- You can mitigate with fixed timestep, custom physics, careful RNG, and avoiding nondeterministic APIs, but it becomes a discipline and a tax.
+
+### 2) Hidden allocations / GC spikes
+
+Unity is much better than it used to be, but:
+
+- C# + engine APIs can allocate unexpectedly.
+- UI and strings can allocate a lot if not careful.
+- You can manage it (pooling, Burst/Jobs/ECS for hot loops), but it adds complexity.
+
+### 3) Engine overhead and constraints
+
+- You inherit engine behavior and sometimes fight it.
+- Performance is usually fine for 2D, but "minimal engine" is not what Unity is.
+
+### 4) Dependency and version churn
+
+- Unity upgrades, package changes, deprecated APIs.
+- The cost is real over multi-year development.
+
+### 5) Build size and platform quirks
+
+- The smallest possible build is still larger than a custom runtime.
+- Some platforms require extra work (cert, store constraints, etc.).
+
+## Stasis: Pros for Brickout Revenge
+
+### 1) Determinism is a first-class design goal
+
+Stasis is explicitly oriented around:
+
+- Static global memory
+- Predictable layouts
+- Minimal hidden behavior
+
+That maps well to:
+
+- Replays and exact simulation
+- Deterministic level scripts ("spawn ball preset X at tick T")
+- Debugging by recording inputs and replaying
+
+### 2) Memory/layout transparency
+
+If Brickout becomes a "systems game" (economy, upgrade trees, lots of entities), Stasis makes it easy to:
+
+- Control representation (SoA vs AoS lowering)
+- Avoid accidental allocations/copies
+- Keep data in cache-friendly structures
+
+### 3) Fast iteration for programmers (tick hot-swap)
+
+For a code-heavy workflow:
+
+- Hot reload and data binding can make tuning quick.
+- You can keep the whole game as one deterministic program.
+
+### 4) You own the entire stack
+
+That is both a pro and a con. The pro side:
+
+- If you want a bespoke rendering approach, fixed simulation, or custom export pipeline, you can do it exactly.
+
+## Stasis: Cons (the real costs)
+
+### 1) Content velocity: you are building an engine while making a game
+
+Even if the runtime exists, you will repeatedly hit issues that Unity simply avoids:
+
+- UI layout and polish (menus, hover states, animations, accessibility)
+- Text rendering + font fallback + localization
+- Editor tooling to author levels and tune content
+
+### 2) Tooling and diagnostics are still maturing
+
+Compared to Unity:
+
+- Debugging blank screens is slower.
+- You may need to add one-off diagnostics features to unblock yourself.
+- You will build internal tools you never planned to build.
+
+### 3) Platform and distribution surface area
+
+Unity gives you a well-known shipping path. With Stasis:
+
+- You own packaging, platform quirks, controllers, windowing behavior, etc.
+- If you want consoles or mobile stores, the slope gets steep.
+
+### 4) Missing "standard game features"
+
+You will likely need to implement or integrate:
+
+- Save/load + persistence
+- Settings UI, resolution handling, input remapping
+- Audio mixing and options
+- Localization
+- Analytics/telemetry (if desired)
+
+### 5) Team scalability
+
+Unity scales better to a team with different roles.
+Stasis will tend to bottleneck on the people who can modify engine/runtime/game code.
+
+## Brickout-specific considerations
+
+### Menu, shop, HUD, and polish
+
+Unity is dramatically easier for:
+
+- Interactive UI flows
+- Transitions, animations, layout across resolutions
+
+Stasis can do it, but each UI feature is closer to "engine work".
+
+### Level authoring workflow
+
+Unity:
+
+- ScriptableObjects, JSON importers, editor windows, timeline-like tools.
+- Designers can tweak spawn timing visually.
+
+Stasis:
+
+- JSON data binding can work, but you still need authoring tools.
+- Without a dedicated editor, levels become spreadsheets/JSON, which is workable but slower and easier to break.
+
+### Deterministic gameplay and replays
+
+If deterministic replays are important:
+
+- Stasis is aligned by design.
+- Unity can do it, but you will fight nondeterminism unless you avoid Unity physics and treat the game as a pure simulation.
+
+### Performance needs
+
+For typical 2D brickout + towers:
+
+- Unity performance will be fine.
+- Stasis can be faster or simpler, but performance is unlikely to be the deciding factor.
+
+## Recommendation patterns (practical)
+
+### Pattern 1: Unity for the game, Stasis for experiments
+
+Use Unity to ship the game, and keep Stasis as:
+
+- A sandbox for deterministic simulation experiments
+- A testbed for language features (like your overloading research)
+
+Pros: ship faster, keep Stasis focused.
+Cons: you lose the "game proves the language" narrative.
+
+### Pattern 2: Unity for authoring, Stasis for runtime (high effort)
+
+Use Unity as a level/editor tool and export data to Stasis (JSON/binary).
+
+Pros: best-of-both-worlds in theory.
+Cons: two-engine complexity, tool glue, more moving parts than either approach alone.
+
+### Pattern 3: Stasis-only (language-first)
+
+If the primary goal is Stasis as a platform:
+
+- Brickout is a showcase and stress test.
+- Accept that you will spend time on tooling.
+
+Pros: aligned with Stasis goals.
+Cons: slower to reach "polished game".
+
+## A frank decision checklist
+
+Choose Unity if you answer "yes" to any of these:
+
+- Do you want to ship on Steam/mobile with conventional workflows?
+- Do you want UI polish and responsiveness quickly?
+- Do you want to iterate with a visual editor and prefabs?
+- Do you want to reduce risk and unknown unknowns?
+
+Choose Stasis if you answer "yes" to these:
+
+- Is determinism/replayability a core identity requirement?
+- Is the Stasis toolchain itself a first-order product goal?
+- Are you okay building missing tooling as you go?
+
+## Bottom line
+
+For Brickout Revenge as a *game product*, Unity is the pragmatic choice.
+For Brickout Revenge as a *Stasis showcase and development driver*, Stasis is justified, but treat the game as part of the toolchain R&D cost.
+


### PR DESCRIPTION
Adds docs/brickout-revenge-unity-vs-stasis.md with a candid pros/cons analysis to help decide whether Brickout Revenge should be built in Unity or Stasis.