### PR TITLE
feat: add headless game templates

### DIFF
--- a/Stasis.Compiler.Tests/TemplateOutputTests.cs
+++ b/Stasis.Compiler.Tests/TemplateOutputTests.cs
@@ -1,0 +1,224 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Stasis.Compiler.Tests;
+
+public class TemplateOutputTests
+{
+    private const string CliProject = "Stasis.Cli";
+    private static readonly object CliBuildLock = new();
+    private static string? BuiltCliConfiguration;
+
+    private static string GetRepoRoot()
+    {
+        var current = FindRepoRoot(Directory.GetCurrentDirectory());
+        if (!string.IsNullOrEmpty(current))
+        {
+            return current;
+        }
+
+        var assemblyDir = Path.GetDirectoryName(typeof(TemplateOutputTests).Assembly.Location);
+        current = FindRepoRoot(assemblyDir);
+        if (!string.IsNullOrEmpty(current))
+        {
+            return current;
+        }
+
+        throw new InvalidOperationException("Could not find repo root");
+    }
+
+    private static string? FindRepoRoot(string? start)
+    {
+        var current = start;
+        while (current != null && !File.Exists(Path.Combine(current, "Stasis.sln")))
+        {
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        return current;
+    }
+
+    private static string GetBuildConfiguration()
+    {
+        var assemblyPath = typeof(TemplateOutputTests).Assembly.Location;
+        if (assemblyPath.Contains("Release", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Release";
+        }
+        return "Debug";
+    }
+
+    private static void EnsureCliBuilt(string cliProj, string root, string configuration)
+    {
+        lock (CliBuildLock)
+        {
+            if (string.Equals(BuiltCliConfiguration, configuration, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"build --nologo --configuration {configuration} \"{cliProj}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = root
+            };
+
+            using var process = Process.Start(psi)!;
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                var stdout = process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                throw new InvalidOperationException($"Failed to build CLI ({process.ExitCode}).\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            }
+
+            BuiltCliConfiguration = configuration;
+        }
+    }
+
+    private static (int exitCode, string stdout, string stderr) RunCli(params string[] args)
+    {
+        var root = GetRepoRoot();
+        var cliProj = Path.Combine(root, CliProject, $"{CliProject}.csproj");
+        var config = GetBuildConfiguration();
+
+        EnsureCliBuilt(cliProj, root, config);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"run --no-build --configuration {config} --project \"{cliProj}\" -- {string.Join(" ", args)}",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = root
+        };
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null) stdout.AppendLine(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null) stderr.AppendLine(e.Data);
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return (process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    private static bool TryFindLli()
+    {
+        var search = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? Array.Empty<string>();
+        foreach (var dir in search)
+        {
+            var candidate = Path.Combine(dir, OperatingSystem.IsWindows() ? "lli.exe" : "lli");
+            if (File.Exists(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void FactorioLite_ProducesSvgSnapshots()
+    {
+        if (!TryFindLli())
+        {
+            return;
+        }
+
+        var root = GetRepoRoot();
+        var outPath = Path.Combine(root, "build", "factorio_lite_200.svg");
+
+        if (File.Exists(outPath)) File.Delete(outPath);
+
+        try
+        {
+            var (exitCode, stdout, stderr) = RunCli("run", "examples/templates/factorio_lite.stasis", "--backend", "llvm");
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(outPath), $"Expected '{outPath}' to be created.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            var svg = File.ReadAllText(outPath);
+            Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<circle", svg, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
+
+    [Fact]
+    public void BreakoutDefense_ProducesSvgSnapshots()
+    {
+        if (!TryFindLli())
+        {
+            return;
+        }
+
+        var root = GetRepoRoot();
+        var outPath = Path.Combine(root, "build", "breakout_defense_200.svg");
+
+        if (File.Exists(outPath)) File.Delete(outPath);
+
+        try
+        {
+            var (exitCode, stdout, stderr) = RunCli("run", "examples/templates/breakout_defense.stasis", "--backend", "llvm");
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(outPath), $"Expected '{outPath}' to be created.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            var svg = File.ReadAllText(outPath);
+            Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<circle", svg, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
+
+    [Fact]
+    public void Match3Overlay_ProducesCsvHistogram()
+    {
+        if (!TryFindLli())
+        {
+            return;
+        }
+
+        var root = GetRepoRoot();
+        var outPath = Path.Combine(root, "build", "match3_combo_hist.csv");
+
+        if (File.Exists(outPath)) File.Delete(outPath);
+
+        try
+        {
+            var (exitCode, stdout, stderr) = RunCli("run", "examples/templates/match3_overlay.stasis", "--backend", "llvm");
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(outPath), $"Expected '{outPath}' to be created.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            var csv = File.ReadAllText(outPath);
+            Assert.Contains("combo,count", csv, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\n0,", csv, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
+}
+

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -1,0 +1,27 @@
+# Stasis game templates (headless)
+
+These are small, deterministic templates meant to exercise Stasis' static global memory + SoA style.
+They do not require the graphics runtime; they emit snapshots (SVG/CSV) into `build/`.
+
+## Run
+
+From the repo root:
+
+- `.\stasis.bat run .\examples\templates\factorio_lite.stasis --backend llvm`
+  - Writes `build/factorio_lite_<tick>.svg`
+- `.\stasis.bat run .\examples\templates\breakout_defense.stasis --backend llvm`
+  - Writes `build/breakout_defense_<tick>.svg`
+- `.\stasis.bat run .\examples\templates\match3_overlay.stasis --backend llvm`
+  - Writes `build/match3_combo_hist.csv`
+
+If you want to validate compilation only (no execution), add `--emit-ir`:
+
+- `.\stasis.bat run .\examples\templates\factorio_lite.stasis --emit-ir > $null`
+
+## Files
+
+- `examples/templates/template_io.stasis`: ASCII int formatting + file writing + snapshot naming helpers
+- `examples/templates/template_svg.stasis`: tiny SVG builder used by the templates
+- `examples/templates/factorio_lite.stasis`: belt simulation + one assembler + SVG snapshots
+- `examples/templates/breakout_defense.stasis`: bouncing balls + one tower + projectiles + SVG snapshots
+- `examples/templates/match3_overlay.stasis`: match detection + deterministic cascades + CSV histogram

--- a/examples/templates/breakout_defense.stasis
+++ b/examples/templates/breakout_defense.stasis
@@ -1,0 +1,310 @@
+import "../../src/stdlib/stdlib.stasis";
+import "template_io.stasis";
+import "template_svg.stasis";
+
+// Breakout-defense template (headless):
+// - integer ball physics (deterministic)
+// - one tower that fires projectiles at nearest ball in range
+// - emits SVG snapshots to build/ every N ticks
+
+const SCREEN_W: i32 = 320;
+const SCREEN_H: i32 = 240;
+
+const BALL_MAX: i32 = 6;
+const PROJ_MAX: i32 = 32;
+
+const BALL_R: i32 = 5;
+const PROJ_R: i32 = 2;
+
+const TICKS_TOTAL: i32 = 200;
+const SNAP_EVERY: i32 = 5;
+
+global tick: i32;
+
+// Balls (SoA).
+global ball_active: u8[6];
+global ball_x: i32[6];
+global ball_y: i32[6];
+global ball_vx: i32[6];
+global ball_vy: i32[6];
+global ball_hp: i32[6];
+
+// Single tower.
+global tower_x: i32;
+global tower_y: i32;
+global tower_range2: i32;
+global tower_cooldown: i32;
+const TOWER_COOLDOWN_TICKS: i32 = 12;
+
+// Projectiles (SoA).
+global proj_active: u8[32];
+global proj_x: i32[32];
+global proj_y: i32[32];
+global proj_vx: i32[32];
+global proj_vy: i32[32];
+global proj_target: i32[32];
+
+// Snapshot buffers.
+global svg: ascii[65536];
+global path: ascii[256];
+global label: ascii[64];
+
+function iabs(x: i32): i32 {
+    if (x < 0) { return 0 - x; }
+    return x;
+}
+
+function isign(x: i32): i32 {
+    if (x < 0) { return -1; }
+    if (x > 0) { return 1; }
+    return 0;
+}
+
+function clamp_i32(v: i32, lo: i32, hi: i32): i32 {
+    if (v < lo) { return lo; }
+    if (v > hi) { return hi; }
+    return v;
+}
+
+function dist2(ax: i32, ay: i32, bx: i32, by: i32): i32 {
+    let dx: i32 = ax - bx;
+    let dy: i32 = ay - by;
+    return dx * dx + dy * dy;
+}
+
+function init_world(): void {
+    tick = 0;
+
+    tower_x = SCREEN_W / 2;
+    tower_y = SCREEN_H - 40;
+    tower_range2 = 90 * 90;
+    tower_cooldown = 0;
+
+    let i: i32 = 0;
+    for (i = 0; i < BALL_MAX; i = i + 1) {
+        ball_active[i] = 1;
+        ball_hp[i] = 3;
+        ball_x[i] = 40 + i * 30;
+        ball_y[i] = 40 + (i % 2) * 18;
+        ball_vx[i] = 2 + (i % 3);
+        ball_vy[i] = 2 + ((i + 1) % 3);
+        if ((i % 2) == 1) {
+            ball_vx[i] = 0 - ball_vx[i];
+        }
+    }
+
+    for (i = 0; i < PROJ_MAX; i = i + 1) {
+        proj_active[i] = 0;
+        proj_x[i] = 0;
+        proj_y[i] = 0;
+        proj_vx[i] = 0;
+        proj_vy[i] = 0;
+        proj_target[i] = -1;
+    }
+}
+
+function step_balls(): void {
+    let i: i32 = 0;
+    for (i = 0; i < BALL_MAX; i = i + 1) {
+        if (ball_active[i] != 0) {
+            ball_x[i] = ball_x[i] + ball_vx[i];
+            ball_y[i] = ball_y[i] + ball_vy[i];
+
+            if (ball_x[i] < BALL_R) {
+                ball_x[i] = BALL_R;
+                ball_vx[i] = 0 - ball_vx[i];
+            }
+            if (ball_x[i] > (SCREEN_W - BALL_R)) {
+                ball_x[i] = SCREEN_W - BALL_R;
+                ball_vx[i] = 0 - ball_vx[i];
+            }
+            if (ball_y[i] < BALL_R) {
+                ball_y[i] = BALL_R;
+                ball_vy[i] = 0 - ball_vy[i];
+            }
+            if (ball_y[i] > (SCREEN_H - BALL_R)) {
+                ball_y[i] = SCREEN_H - BALL_R;
+                ball_vy[i] = 0 - ball_vy[i];
+            }
+        }
+    }
+}
+
+function find_nearest_ball_in_range(): i32 {
+    let best_i: i32 = -1;
+    let best_d2: i32 = 0;
+
+    let i: i32 = 0;
+    for (i = 0; i < BALL_MAX; i = i + 1) {
+        if (ball_active[i] != 0) {
+            let d2: i32 = dist2(tower_x, tower_y, ball_x[i], ball_y[i]);
+            if (d2 <= tower_range2) {
+                if (best_i == -1) {
+                    best_i = i;
+                    best_d2 = d2;
+                } else {
+                    if (d2 < best_d2) {
+                        best_i = i;
+                        best_d2 = d2;
+                    }
+                }
+            }
+        }
+    }
+
+    return best_i;
+}
+
+function spawn_projectile(target_idx: i32): void {
+    // Find a free slot.
+    let slot: i32 = -1;
+    let i: i32 = 0;
+    for (i = 0; i < PROJ_MAX; i = i + 1) {
+        if (proj_active[i] == 0) {
+            slot = i;
+            i = PROJ_MAX;
+        }
+    }
+    if (slot == -1) { return; }
+
+    proj_active[slot] = 1;
+    proj_x[slot] = tower_x;
+    proj_y[slot] = tower_y;
+    proj_target[slot] = target_idx;
+
+    let dx: i32 = ball_x[target_idx] - tower_x;
+    let dy: i32 = ball_y[target_idx] - tower_y;
+    let adx: i32 = iabs(dx);
+    let ady: i32 = iabs(dy);
+
+    // Integer "normalize" by dominant axis.
+    let speed: i32 = 6;
+    if (adx >= ady) {
+        let denom: i32 = adx;
+        if (denom == 0) { denom = 1; }
+        proj_vx[slot] = isign(dx) * speed;
+        proj_vy[slot] = (dy * speed) / denom;
+    } else {
+        let denom2: i32 = ady;
+        if (denom2 == 0) { denom2 = 1; }
+        proj_vy[slot] = isign(dy) * speed;
+        proj_vx[slot] = (dx * speed) / denom2;
+    }
+
+    proj_vx[slot] = clamp_i32(proj_vx[slot], -speed, speed);
+    proj_vy[slot] = clamp_i32(proj_vy[slot], -speed, speed);
+
+    if (proj_vx[slot] == 0 && proj_vy[slot] == 0) {
+        proj_vy[slot] = -speed;
+    }
+}
+
+function step_tower(): void {
+    if (tower_cooldown > 0) {
+        tower_cooldown = tower_cooldown - 1;
+    }
+
+    if (tower_cooldown == 0) {
+        let target: i32 = find_nearest_ball_in_range();
+        if (target != -1) {
+            spawn_projectile(target);
+            tower_cooldown = TOWER_COOLDOWN_TICKS;
+        }
+    }
+}
+
+function step_projectiles(): void {
+    let i: i32 = 0;
+    for (i = 0; i < PROJ_MAX; i = i + 1) {
+        if (proj_active[i] != 0) {
+            proj_x[i] = proj_x[i] + proj_vx[i];
+            proj_y[i] = proj_y[i] + proj_vy[i];
+
+            // Despawn if out of bounds.
+            if (proj_x[i] < -10 || proj_x[i] > (SCREEN_W + 10) || proj_y[i] < -10 || proj_y[i] > (SCREEN_H + 10)) {
+                proj_active[i] = 0;
+                proj_target[i] = -1;
+            } else {
+                // Hit check vs target (if still alive).
+                let t: i32 = proj_target[i];
+                if (t >= 0 && t < BALL_MAX) {
+                    if (ball_active[t] != 0) {
+                        let hit_d2: i32 = dist2(proj_x[i], proj_y[i], ball_x[t], ball_y[t]);
+                        let hit_r: i32 = BALL_R + PROJ_R + 1;
+                        if (hit_d2 <= (hit_r * hit_r)) {
+                            ball_hp[t] = ball_hp[t] - 1;
+                            if (ball_hp[t] <= 0) {
+                                ball_active[t] = 0;
+                            } else {
+                                ball_vx[t] = 0 - ball_vx[t];
+                                ball_vy[t] = 0 - ball_vy[t];
+                            }
+                            proj_active[i] = 0;
+                            proj_target[i] = -1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+function draw_frame_svg(): void {
+    svg_begin(svg, SCREEN_W, SCREEN_H);
+
+    // Borders.
+    svg_rect(svg, 6, 6, SCREEN_W - 12, SCREEN_H - 12, "#131b2a");
+    svg_rect(svg, 8, 8, SCREEN_W - 16, SCREEN_H - 16, "#0b0e16");
+
+    // Tower.
+    svg_rect(svg, tower_x - 8, tower_y - 8, 16, 16, "#ff8f3a");
+    svg_circle(svg, tower_x, tower_y, 3, "#ffd2aa");
+
+    // Balls.
+    let i: i32 = 0;
+    for (i = 0; i < BALL_MAX; i = i + 1) {
+        if (ball_active[i] != 0) {
+            svg_circle(svg, ball_x[i], ball_y[i], BALL_R, "#4bd37b");
+        }
+    }
+
+    // Projectiles.
+    for (i = 0; i < PROJ_MAX; i = i + 1) {
+        if (proj_active[i] != 0) {
+            svg_circle(svg, proj_x[i], proj_y[i], PROJ_R, "#4ba3d3");
+        }
+    }
+
+    ascii_clear(label);
+    ascii_append(label, "tick=");
+    t_append_i32(label, tick);
+    svg_text(svg, 10, 20, label, "#dfe7ff", 14);
+
+    svg_end(svg);
+}
+
+function dump_svg_every(n: i32): void {
+    if (n <= 0) { return; }
+    if ((tick % n) == 0) {
+        draw_frame_svg();
+        t_path_set_svg(path, "build/breakout_defense_", tick);
+        t_write_ascii_file(path, svg);
+    }
+}
+
+function step(): void {
+    tick = tick + 1;
+    step_balls();
+    step_tower();
+    step_projectiles();
+    dump_svg_every(SNAP_EVERY);
+}
+
+function main(): i32 {
+    init_world();
+    let i: i32 = 0;
+    for (i = 0; i < TICKS_TOTAL; i = i + 1) {
+        step();
+    }
+    return 0;
+}

--- a/examples/templates/factorio_lite.stasis
+++ b/examples/templates/factorio_lite.stasis
@@ -1,0 +1,251 @@
+import "../../src/stdlib/stdlib.stasis";
+import "template_io.stasis";
+import "template_svg.stasis";
+
+// Factorio-lite template:
+// - 8x8 tile grid
+// - belt moves one item per cell per tick (double-buffered)
+// - one assembler consumes A+B => C
+// - emits SVG snapshots to build/ every N ticks
+
+const W: i32 = 8;
+const H: i32 = 8;
+const N: i32 = 64;
+
+// Tile types (u16)
+const TILE_EMPTY: u16 = 0;
+const TILE_BELT: u16 = 1;
+const TILE_ASSEMBLER: u16 = 2;
+
+// Belt directions (u8): 0=E, 1=S, 2=W, 3=N
+const DIR_E: u8 = 0;
+const DIR_S: u8 = 1;
+const DIR_W: u8 = 2;
+const DIR_N: u8 = 3;
+
+// Items (u32): 0=none
+const ITEM_A: u32 = 1;
+const ITEM_B: u32 = 2;
+const ITEM_C: u32 = 3;
+
+global tick: i32;
+global tile_type: u16[64];
+global belt_dir: u8[64];
+global belt_item: u32[64];
+global belt_item_next: u32[64];
+
+// One assembler at a fixed cell.
+global asm_idx: i32;
+global asm_in_a: i32;
+global asm_in_b: i32;
+global asm_progress: i32;
+const ASM_TICKS: i32 = 12;
+
+global svg: ascii[65536];
+global path: ascii[256];
+global label: ascii[64];
+
+function idx(x: i32, y: i32): i32 {
+    return y * W + x;
+}
+
+function in_bounds(x: i32, y: i32): bool {
+    if (x < 0 || y < 0) { return false; }
+    if (x >= W || y >= H) { return false; }
+    return true;
+}
+
+function dir_dx(d: u8): i32 {
+    if (d == DIR_E) { return 1; }
+    if (d == DIR_W) { return -1; }
+    return 0;
+}
+
+function dir_dy(d: u8): i32 {
+    if (d == DIR_S) { return 1; }
+    if (d == DIR_N) { return -1; }
+    return 0;
+}
+
+function init_world(): void {
+    tick = 0;
+    asm_in_a = 0;
+    asm_in_b = 0;
+    asm_progress = 0;
+
+    let i: i32 = 0;
+    for (i = 0; i < N; i = i + 1) {
+        tile_type[i] = TILE_EMPTY;
+        belt_dir[i] = DIR_E;
+        belt_item[i] = 0;
+        belt_item_next[i] = 0;
+    }
+
+    // Build a simple loop of belts around the border.
+    let x: i32 = 0;
+    let y: i32 = 0;
+    for (x = 0; x < W; x = x + 1) {
+        tile_type[idx(x, 0)] = TILE_BELT; belt_dir[idx(x, 0)] = DIR_E;
+        tile_type[idx(x, H - 1)] = TILE_BELT; belt_dir[idx(x, H - 1)] = DIR_W;
+    }
+    for (y = 0; y < H; y = y + 1) {
+        tile_type[idx(0, y)] = TILE_BELT; belt_dir[idx(0, y)] = DIR_S;
+        tile_type[idx(W - 1, y)] = TILE_BELT; belt_dir[idx(W - 1, y)] = DIR_N;
+    }
+
+    // Place assembler in center.
+    asm_idx = idx(3, 3);
+    tile_type[asm_idx] = TILE_ASSEMBLER;
+
+    // Seed a couple items.
+    belt_item[idx(1, 0)] = ITEM_A;
+    belt_item[idx(2, 0)] = ITEM_B;
+}
+
+function step_belts(): void {
+    // Start with next = current.
+    let i: i32 = 0;
+    for (i = 0; i < N; i = i + 1) {
+        belt_item_next[i] = belt_item[i];
+    }
+
+    // Move items deterministically; first mover wins.
+    for (i = 0; i < N; i = i + 1) {
+        if (tile_type[i] == TILE_BELT) {
+            let item: u32 = belt_item[i];
+            if (item != 0) {
+                let x: i32 = i % W;
+                let y: i32 = i / W;
+                let d: u8 = belt_dir[i];
+                let nx: i32 = x + dir_dx(d);
+                let ny: i32 = y + dir_dy(d);
+                if (in_bounds(nx, ny)) {
+                    let ni: i32 = idx(nx, ny);
+                    if (tile_type[ni] == TILE_BELT) {
+                        if (belt_item_next[ni] == 0) {
+                            belt_item_next[ni] = item;
+                            belt_item_next[i] = 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Commit.
+    for (i = 0; i < N; i = i + 1) {
+        belt_item[i] = belt_item_next[i];
+    }
+}
+
+function assembler_pull_inputs(): void {
+    // Pull from left/right belts into assembler input bins.
+    let ax: i32 = asm_idx % W;
+    let ay: i32 = asm_idx / W;
+    let li: i32 = idx(ax - 1, ay);
+    let ri: i32 = idx(ax + 1, ay);
+
+    if (in_bounds(ax - 1, ay)) {
+        if (tile_type[li] == TILE_BELT) {
+            let it: u32 = belt_item[li];
+            if (it == ITEM_A && asm_in_a == 0) { belt_item[li] = 0; asm_in_a = 1; }
+            if (it == ITEM_B && asm_in_b == 0) { belt_item[li] = 0; asm_in_b = 1; }
+        }
+    }
+    if (in_bounds(ax + 1, ay)) {
+        if (tile_type[ri] == TILE_BELT) {
+            let it2: u32 = belt_item[ri];
+            if (it2 == ITEM_A && asm_in_a == 0) { belt_item[ri] = 0; asm_in_a = 1; }
+            if (it2 == ITEM_B && asm_in_b == 0) { belt_item[ri] = 0; asm_in_b = 1; }
+        }
+    }
+}
+
+function assembler_try_output(): void {
+    // Output to belt above assembler if empty.
+    let ax: i32 = asm_idx % W;
+    let ay: i32 = asm_idx / W;
+    let oi: i32 = idx(ax, ay - 1);
+    if (in_bounds(ax, ay - 1)) {
+        if (tile_type[oi] == TILE_BELT && belt_item[oi] == 0) {
+            belt_item[oi] = ITEM_C;
+        }
+    }
+}
+
+function step_assembler(): void {
+    assembler_pull_inputs();
+
+    if (asm_in_a != 0 && asm_in_b != 0) {
+        asm_progress = asm_progress + 1;
+        if (asm_progress >= ASM_TICKS) {
+            asm_in_a = 0;
+            asm_in_b = 0;
+            asm_progress = 0;
+            assembler_try_output();
+        }
+    } else {
+        asm_progress = 0;
+    }
+}
+
+function draw_world_svg(): void {
+    svg_begin(svg, 256, 256);
+    let cell: i32 = 28;
+    let pad: i32 = 8;
+    let x: i32 = 0;
+    let y: i32 = 0;
+    for (y = 0; y < H; y = y + 1) {
+        for (x = 0; x < W; x = x + 1) {
+            let i: i32 = idx(x, y);
+            let px: i32 = pad + x * cell;
+            let py: i32 = pad + y * cell;
+            if (tile_type[i] == TILE_BELT) {
+                svg_rect(svg, px, py, cell - 2, cell - 2, "#1b2a44");
+            }
+            if (tile_type[i] == TILE_ASSEMBLER) {
+                svg_rect(svg, px, py, cell - 2, cell - 2, "#3a2b1f");
+            }
+            if (belt_item[i] != 0) {
+                if (belt_item[i] == ITEM_A) { svg_circle(svg, px + (cell / 2), py + (cell / 2), 6, "#4bd37b"); }
+                if (belt_item[i] == ITEM_B) { svg_circle(svg, px + (cell / 2), py + (cell / 2), 6, "#4ba3d3"); }
+                if (belt_item[i] == ITEM_C) { svg_circle(svg, px + (cell / 2), py + (cell / 2), 6, "#d3b64b"); }
+                if (belt_item[i] != ITEM_A && belt_item[i] != ITEM_B && belt_item[i] != ITEM_C) {
+                    svg_circle(svg, px + (cell / 2), py + (cell / 2), 6, "#d6d6d6");
+                }
+            }
+        }
+    }
+
+    ascii_clear(label);
+    ascii_append(label, "tick=");
+    t_append_i32(label, tick);
+    svg_text(svg, 10, 20, label, "#dfe7ff", 14);
+
+    svg_end(svg);
+}
+
+function dump_svg_every(n: i32): void {
+    if (n <= 0) { return; }
+    if ((tick % n) == 0) {
+        draw_world_svg();
+        t_path_set_svg(path, "build/factorio_lite_", tick);
+        t_write_ascii_file(path, svg);
+    }
+}
+
+function step(): void {
+    tick = tick + 1;
+    step_belts();
+    step_assembler();
+    dump_svg_every(20);
+}
+
+function main(): i32 {
+    init_world();
+    let i: i32 = 0;
+    for (i = 0; i < 200; i = i + 1) {
+        step();
+    }
+    return 0;
+}

--- a/examples/templates/match3_overlay.stasis
+++ b/examples/templates/match3_overlay.stasis
@@ -1,0 +1,259 @@
+import "../../src/stdlib/stdlib.stasis";
+import "template_io.stasis";
+
+// Match-3 overlay template (headless):
+// - deterministic match detection + cascade resolution (no recursion)
+// - logs cascade ("combo") length distribution to CSV in build/
+
+const W: i32 = 8;
+const H: i32 = 10;
+const N: i32 = 80;
+
+const TILE_TYPES: i32 = 5; // 1..5; 0 = empty
+
+const SEEDS: i32 = 1000;
+const COMBO_MAX: i32 = 20;
+
+global rng_state: i32;
+global cell_type: u8[80];
+global mark: u8[80];
+
+global hist: i32[21];
+
+global csv: ascii[32768];
+global path: ascii[256];
+
+function idx(x: i32, y: i32): i32 {
+    return y * W + x;
+}
+
+function rng_seed(seed: i32): void {
+    rng_state = seed;
+    if (rng_state == 0) { rng_state = 1; }
+}
+
+function rng_next_u32(): i32 {
+    rng_state = rng_state * 1103515245 + 12345;
+    if (rng_state < 0) {
+        rng_state = 0 - rng_state;
+    }
+    return rng_state;
+}
+
+function rng_tile(): u8 {
+    let r: i32 = rng_next_u32() % TILE_TYPES;
+    return i32_to_u8_trunc(r + 1);
+}
+
+function clear_marks(): void {
+    let i: i32 = 0;
+    for (i = 0; i < N; i = i + 1) {
+        mark[i] = 0;
+    }
+}
+
+function fill_board(): void {
+    let i: i32 = 0;
+    for (i = 0; i < N; i = i + 1) {
+        cell_type[i] = rng_tile();
+    }
+}
+
+function swap_cells(a: i32, b: i32): void {
+    let t: u8 = cell_type[a];
+    cell_type[a] = cell_type[b];
+    cell_type[b] = t;
+}
+
+function mark_matches(): i32 {
+    clear_marks();
+    let found: i32 = 0;
+
+    // Horizontal runs.
+    let y: i32 = 0;
+    for (y = 0; y < H; y = y + 1) {
+        let run_val: u8 = 0;
+        let run_len: i32 = 0;
+        let run_start_x: i32 = 0;
+
+        let x: i32 = 0;
+        for (x = 0; x < W; x = x + 1) {
+            let v: u8 = cell_type[idx(x, y)];
+            if (x == 0) {
+                run_val = v;
+                run_len = 1;
+                run_start_x = 0;
+            } else {
+                if (v != 0 && v == run_val) {
+                    run_len = run_len + 1;
+                } else {
+                    if (run_val != 0 && run_len >= 3) {
+                        let mx: i32 = 0;
+                        for (mx = 0; mx < run_len; mx = mx + 1) {
+                            mark[idx(run_start_x + mx, y)] = 1;
+                        }
+                        found = 1;
+                    }
+                    run_val = v;
+                    run_len = 1;
+                    run_start_x = x;
+                }
+            }
+        }
+        if (run_val != 0 && run_len >= 3) {
+            let mx2: i32 = 0;
+            for (mx2 = 0; mx2 < run_len; mx2 = mx2 + 1) {
+                mark[idx(run_start_x + mx2, y)] = 1;
+            }
+            found = 1;
+        }
+    }
+
+    // Vertical runs.
+    let x2: i32 = 0;
+    for (x2 = 0; x2 < W; x2 = x2 + 1) {
+        let run_val2: u8 = 0;
+        let run_len2: i32 = 0;
+        let run_start_y: i32 = 0;
+
+        let y2: i32 = 0;
+        for (y2 = 0; y2 < H; y2 = y2 + 1) {
+            let v2: u8 = cell_type[idx(x2, y2)];
+            if (y2 == 0) {
+                run_val2 = v2;
+                run_len2 = 1;
+                run_start_y = 0;
+            } else {
+                if (v2 != 0 && v2 == run_val2) {
+                    run_len2 = run_len2 + 1;
+                } else {
+                    if (run_val2 != 0 && run_len2 >= 3) {
+                        let my: i32 = 0;
+                        for (my = 0; my < run_len2; my = my + 1) {
+                            mark[idx(x2, run_start_y + my)] = 1;
+                        }
+                        found = 1;
+                    }
+                    run_val2 = v2;
+                    run_len2 = 1;
+                    run_start_y = y2;
+                }
+            }
+        }
+        if (run_val2 != 0 && run_len2 >= 3) {
+            let my2: i32 = 0;
+            for (my2 = 0; my2 < run_len2; my2 = my2 + 1) {
+                mark[idx(x2, run_start_y + my2)] = 1;
+            }
+            found = 1;
+        }
+    }
+
+    return found;
+}
+
+function clear_marked(): void {
+    let i: i32 = 0;
+    for (i = 0; i < N; i = i + 1) {
+        if (mark[i] != 0) {
+            cell_type[i] = 0;
+        }
+    }
+}
+
+function collapse_and_refill(): void {
+    let x: i32 = 0;
+    for (x = 0; x < W; x = x + 1) {
+        let write_y: i32 = H - 1;
+
+        let y: i32 = 0;
+        for (y = H - 1; y >= 0; y = y - 1) {
+            let v: u8 = cell_type[idx(x, y)];
+            if (v != 0) {
+                cell_type[idx(x, write_y)] = v;
+                if (write_y != y) {
+                    cell_type[idx(x, y)] = 0;
+                }
+                write_y = write_y - 1;
+            }
+        }
+
+        let y2: i32 = 0;
+        for (y2 = write_y; y2 >= 0; y2 = y2 - 1) {
+            cell_type[idx(x, y2)] = rng_tile();
+        }
+    }
+}
+
+function resolve_cascades(): i32 {
+    let combos: i32 = 0;
+    let iter: i32 = 0;
+    for (iter = 0; iter < COMBO_MAX; iter = iter + 1) {
+        if (mark_matches() == 0) {
+            return combos;
+        }
+        combos = combos + 1;
+        clear_marked();
+        collapse_and_refill();
+    }
+    return combos;
+}
+
+function simulate_one_seed(seed: i32): i32 {
+    rng_seed(seed);
+    fill_board();
+
+    // Deterministic swap choice per seed (adjacent, clamped).
+    let ax: i32 = rng_next_u32() % W;
+    let ay: i32 = rng_next_u32() % H;
+    let dir: i32 = rng_next_u32() % 2; // 0=right, 1=down
+
+    let bx: i32 = ax;
+    let by: i32 = ay;
+    if (dir == 0) { bx = ax + 1; by = ay; }
+    if (dir == 1) { bx = ax; by = ay + 1; }
+    if (bx >= W) { bx = ax - 1; }
+    if (by >= H) { by = ay - 1; }
+    if (bx < 0) { bx = ax; }
+    if (by < 0) { by = ay; }
+
+    swap_cells(idx(ax, ay), idx(bx, by));
+    return resolve_cascades();
+}
+
+function append_csv_line(combo: i32, count: i32): void {
+    t_append_i32(csv, combo);
+    ascii_append(csv, ",");
+    t_append_i32(csv, count);
+    ascii_append(csv, "\n");
+}
+
+function write_hist_csv(): void {
+    ascii_clear(csv);
+    ascii_append(csv, "combo,count\n");
+
+    let c: i32 = 0;
+    for (c = 0; c <= COMBO_MAX; c = c + 1) {
+        append_csv_line(c, hist[c]);
+    }
+
+    t_path_set_csv(path, "build/match3_combo_hist");
+    t_write_ascii_file(path, csv);
+}
+
+function main(): i32 {
+    let i: i32 = 0;
+    for (i = 0; i <= COMBO_MAX; i = i + 1) {
+        hist[i] = 0;
+    }
+
+    for (i = 1; i <= SEEDS; i = i + 1) {
+        let combos: i32 = simulate_one_seed(i);
+        if (combos < 0) { combos = 0; }
+        if (combos > COMBO_MAX) { combos = COMBO_MAX; }
+        hist[combos] = hist[combos] + 1;
+    }
+
+    write_hist_csv();
+    return 0;
+}

--- a/examples/templates/template_io.stasis
+++ b/examples/templates/template_io.stasis
@@ -1,0 +1,39 @@
+import "../../src/stdlib/stdlib.stasis";
+
+// Minimal file + naming helpers (ASCII paths).
+
+function t_append_i32(dst: ascii[], value: i32): void {
+    let v: i32 = value;
+    if (v == 0) {
+        ascii_append_byte(dst, 48);
+        return;
+    }
+    if (v < 0) {
+        ascii_append_byte(dst, 45);
+        v = 0 - v;
+    }
+    let pow10: i32 = 1;
+    for (; pow10 <= v / 10; pow10 = pow10 * 10) {
+    }
+    for (; pow10 > 0; pow10 = pow10 / 10) {
+        let digit: i32 = (v / pow10) % 10;
+        ascii_append_byte(dst, i32_to_u8_trunc(48 + digit));
+    }
+}
+
+function t_path_set_svg(out_path: ascii[], base: ascii[], tick: i32): void {
+    ascii_clear(out_path);
+    ascii_append(out_path, base);
+    t_append_i32(out_path, tick);
+    ascii_append(out_path, ".svg");
+}
+
+function t_path_set_csv(out_path: ascii[], base: ascii[]): void {
+    ascii_clear(out_path);
+    ascii_append(out_path, base);
+    ascii_append(out_path, ".csv");
+}
+
+function t_write_ascii_file(path: ascii[], text: ascii[]): bool {
+    return sys_write_file(path, text, ascii_len(text)) == 1;
+}

--- a/examples/templates/template_svg.stasis
+++ b/examples/templates/template_svg.stasis
@@ -1,0 +1,63 @@
+import "../../src/stdlib/stdlib.stasis";
+import "template_io.stasis";
+
+// Minimal SVG writer (ASCII).
+// Intended for deterministic snapshots you can diff in git or by hash.
+
+function svg_begin(out: ascii[], w: i32, h: i32): void {
+    ascii_clear(out);
+    ascii_append(out, "<svg xmlns='http://www.w3.org/2000/svg' width='");
+    t_append_i32(out, w);
+    ascii_append(out, "' height='");
+    t_append_i32(out, h);
+    ascii_append(out, "' viewBox='0 0 ");
+    t_append_i32(out, w);
+    ascii_append(out, " ");
+    t_append_i32(out, h);
+    ascii_append(out, "'>");
+    ascii_append(out, "<rect width='100%' height='100%' fill='#0b0e16'/>");
+}
+
+function svg_end(out: ascii[]): void {
+    ascii_append(out, "</svg>");
+}
+
+function svg_rect(out: ascii[], x: i32, y: i32, w: i32, h: i32, fill: ascii[]): void {
+    ascii_append(out, "<rect x='");
+    t_append_i32(out, x);
+    ascii_append(out, "' y='");
+    t_append_i32(out, y);
+    ascii_append(out, "' width='");
+    t_append_i32(out, w);
+    ascii_append(out, "' height='");
+    t_append_i32(out, h);
+    ascii_append(out, "' fill='");
+    ascii_append(out, fill);
+    ascii_append(out, "'/>");
+}
+
+function svg_circle(out: ascii[], cx: i32, cy: i32, r: i32, fill: ascii[]): void {
+    ascii_append(out, "<circle cx='");
+    t_append_i32(out, cx);
+    ascii_append(out, "' cy='");
+    t_append_i32(out, cy);
+    ascii_append(out, "' r='");
+    t_append_i32(out, r);
+    ascii_append(out, "' fill='");
+    ascii_append(out, fill);
+    ascii_append(out, "'/>");
+}
+
+function svg_text(out: ascii[], x: i32, y: i32, text: ascii[], fill: ascii[], size: i32): void {
+    ascii_append(out, "<text x='");
+    t_append_i32(out, x);
+    ascii_append(out, "' y='");
+    t_append_i32(out, y);
+    ascii_append(out, "' fill='");
+    ascii_append(out, fill);
+    ascii_append(out, "' font-family='monospace' font-size='");
+    t_append_i32(out, size);
+    ascii_append(out, "'>");
+    ascii_append(out, text);
+    ascii_append(out, "</text>");
+}


### PR DESCRIPTION
Adds three small deterministic templates under examples/templates: factorio-lite belts+assembler (SVG snapshots), breakout-defense balls+tower projectiles (SVG snapshots), and match-3 cascades (CSV histogram). Includes tiny shared ASCII SVG/file helpers and a compiler test that runs each template via the CLI and asserts snapshots are generated.