### PR TITLE
fix: keep memset as compiler/runtime detail

### DIFF
--- a/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
@@ -303,35 +303,7 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
             );
         }
 
-        if (builtins.Contains("sys_memset_u8"))
-        {
-            builder.DeclareExternal("stasis_sys_memset_u8", CraneliftTypeMapper.ClifType.Void,
-                CraneliftTypeMapper.ClifType.R64, // dst
-                CraneliftTypeMapper.ClifType.I32, // dst_index
-                CraneliftTypeMapper.ClifType.I32, // value (byte)
-                CraneliftTypeMapper.ClifType.I32  // count
-            );
-        }
-
-        if (builtins.Contains("sys_memset_i32"))
-        {
-            builder.DeclareExternal("stasis_sys_memset_i32", CraneliftTypeMapper.ClifType.Void,
-                CraneliftTypeMapper.ClifType.R64, // dst
-                CraneliftTypeMapper.ClifType.I32, // dst_index
-                CraneliftTypeMapper.ClifType.I32, // value
-                CraneliftTypeMapper.ClifType.I32  // count
-            );
-        }
-
-        if (builtins.Contains("sys_memset_f32"))
-        {
-            builder.DeclareExternal("stasis_sys_memset_f32", CraneliftTypeMapper.ClifType.Void,
-                CraneliftTypeMapper.ClifType.R64, // dst
-                CraneliftTypeMapper.ClifType.I32, // dst_index
-                CraneliftTypeMapper.ClifType.F32, // value
-                CraneliftTypeMapper.ClifType.I32  // count
-            );
-        }
+        // sys_memset_* is intentionally not exposed as a Stasis builtin; treat bulk clears as a compiler/runtime detail.
 
         if (builtins.Contains("time"))
         {
@@ -1405,13 +1377,12 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
             or "sys_argc" or "sys_argv"
             or "sys_read_file" or "sys_list_dir" or "sys_write_file" or "sys_file_exists" or "sys_file_size" or "sys_file_mtime_ms"
             or "sys_exec" or "sys_spawn" or "sys_sleep_ms"
-            or "sys_memcpy_u8" or "sys_memcpy_i32" or "sys_memcpy_f32"
-            or "sys_memmove_u8" or "sys_memmove_i32" or "sys_memmove_f32"
-            or "sys_memset_u8" or "sys_memset_i32" or "sys_memset_f32"
-            or "time" or "get_time_ms" or "get_time_us" or "sleep_ms"
-            or "audio_is_available" or "audio_get_sample_rate" or "audio_get_channels"
-            or "audio_get_queued_frames" or "audio_get_underruns" or "audio_push_f32_interleaved"
-            or "sin" or "cos" or "sin_fast" or "cos_fast"
+             or "sys_memcpy_u8" or "sys_memcpy_i32" or "sys_memcpy_f32"
+             or "sys_memmove_u8" or "sys_memmove_i32" or "sys_memmove_f32"
+             or "time" or "get_time_ms" or "get_time_us" or "sleep_ms"
+             or "audio_is_available" or "audio_get_sample_rate" or "audio_get_channels"
+             or "audio_get_queued_frames" or "audio_get_underruns" or "audio_push_f32_interleaved"
+             or "sin" or "cos" or "sin_fast" or "cos_fast"
             or "init_window" or "gfx_load_sprite" or "gfx_poll_reload" or "load_font" or "measure_text"
             or "char_is_digit" or "char_is_alpha" or "char_is_alnum" or "char_is_space"
             or "char_is_upper" or "char_is_lower" or "char_is_hex" or "char_is_print"

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -1063,9 +1063,6 @@ public sealed class CraneliftFunctionBuilder
             "sys_memmove_u8" => true,
             "sys_memmove_i32" => true,
             "sys_memmove_f32" => true,
-            "sys_memset_u8" => true,
-            "sys_memset_i32" => true,
-            "sys_memset_f32" => true,
             "time" => true,
             "get_time_ms" => true,
             "get_time_us" => true,
@@ -1439,12 +1436,6 @@ public sealed class CraneliftFunctionBuilder
                 return LowerExternalCallVoid("stasis_sys_memmove_i32", "sys_memmove_i32 expects (dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32).", arguments, 5);
             case "sys_memmove_f32":
                 return LowerExternalCallVoid("stasis_sys_memmove_f32", "sys_memmove_f32 expects (dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32).", arguments, 5);
-            case "sys_memset_u8":
-                return LowerExternalCallVoid("stasis_sys_memset_u8", "sys_memset_u8 expects (dst: u8[], dst_index: i32, value: i32, count: i32).", arguments, 4);
-            case "sys_memset_i32":
-                return LowerExternalCallVoid("stasis_sys_memset_i32", "sys_memset_i32 expects (dst: i32[], dst_index: i32, value: i32, count: i32).", arguments, 4);
-            case "sys_memset_f32":
-                return LowerExternalCallVoid("stasis_sys_memset_f32", "sys_memset_f32 expects (dst: f32[], dst_index: i32, value: f32, count: i32).", arguments, 4);
             case "time":
                 return LowerTime(arguments);
             case "get_time_ms":

--- a/Stasis.Compiler/IR/ModuleLowerer.cs
+++ b/Stasis.Compiler/IR/ModuleLowerer.cs
@@ -1272,9 +1272,6 @@ public sealed class ModuleLowerer
             "sys_memmove_u8",
             "sys_memmove_i32",
             "sys_memmove_f32",
-            "sys_memset_u8",
-            "sys_memset_i32",
-            "sys_memset_f32",
 
             // Legacy math (to be renamed)
             "sin",
@@ -2948,7 +2945,7 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "sys_memcpy_u8.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "sys_memcpy_u8.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memcpy_u8.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
@@ -2987,7 +2984,7 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0), "sys_memcpy_i32.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0), "sys_memcpy_i32.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memcpy_i32.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
@@ -3026,7 +3023,7 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0), "sys_memcpy_f32.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0), "sys_memcpy_f32.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memcpy_f32.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
@@ -3065,7 +3062,7 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "sys_memmove_u8.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "sys_memmove_u8.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memmove_u8.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
@@ -3104,7 +3101,7 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0), "sys_memmove_i32.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0), "sys_memmove_i32.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memmove_i32.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
@@ -3143,117 +3140,10 @@ public sealed class ModuleLowerer
 
                         var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0), "sys_memmove_f32.dst");
                         var srcCast = builder.BuildBitCast(srcPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0), "sys_memmove_f32.src");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, "sys_memmove_f32.call");
+                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, srcCast, srcIndex, count }, string.Empty);
                         return ConstI32(0);
                     }
 
-                case "sys_memset_u8":
-                    {
-                        if (args.Count != 4)
-                        {
-                            AddDiagnostic("sys_memset_u8 expects (dst: u8[], dst_index: i32, value: i32, count: i32).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstPtr = LowerArrayPointer(builder, args[0], locals);
-                        if (dstPtr.Handle == IntPtr.Zero)
-                        {
-                            AddDiagnostic("sys_memset_u8 expects array argument (dst).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstIndex = LowerExpression(builder, args[1], locals);
-                        var value = LowerExpression(builder, args[2], locals);
-                        var count = LowerExpression(builder, args[3], locals);
-
-                        var fn = _moduleBuilder.Module.GetNamedFunction("stasis_sys_memset_u8");
-                        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void,
-                            new[]
-                            {
-                                LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
-                                LLVMTypeRef.Int32,
-                                LLVMTypeRef.Int32,
-                                LLVMTypeRef.Int32
-                            }, false);
-                        if (fn.Handle == IntPtr.Zero)
-                            fn = _moduleBuilder.Module.AddFunction("stasis_sys_memset_u8", fnType);
-
-                        var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "sys_memset_u8.dst");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, value, count }, "sys_memset_u8.call");
-                        return ConstI32(0);
-                    }
-
-                case "sys_memset_i32":
-                    {
-                        if (args.Count != 4)
-                        {
-                            AddDiagnostic("sys_memset_i32 expects (dst: i32[], dst_index: i32, value: i32, count: i32).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstPtr = LowerArrayPointer(builder, args[0], locals);
-                        if (dstPtr.Handle == IntPtr.Zero)
-                        {
-                            AddDiagnostic("sys_memset_i32 expects array argument (dst).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstIndex = LowerExpression(builder, args[1], locals);
-                        var value = LowerExpression(builder, args[2], locals);
-                        var count = LowerExpression(builder, args[3], locals);
-
-                        var fn = _moduleBuilder.Module.GetNamedFunction("stasis_sys_memset_i32");
-                        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void,
-                            new[]
-                            {
-                                LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0),
-                                LLVMTypeRef.Int32,
-                                LLVMTypeRef.Int32,
-                                LLVMTypeRef.Int32
-                            }, false);
-                        if (fn.Handle == IntPtr.Zero)
-                            fn = _moduleBuilder.Module.AddFunction("stasis_sys_memset_i32", fnType);
-
-                        var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0), "sys_memset_i32.dst");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, value, count }, "sys_memset_i32.call");
-                        return ConstI32(0);
-                    }
-
-                case "sys_memset_f32":
-                    {
-                        if (args.Count != 4)
-                        {
-                            AddDiagnostic("sys_memset_f32 expects (dst: f32[], dst_index: i32, value: f32, count: i32).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstPtr = LowerArrayPointer(builder, args[0], locals);
-                        if (dstPtr.Handle == IntPtr.Zero)
-                        {
-                            AddDiagnostic("sys_memset_f32 expects array argument (dst).", span);
-                            return ConstI32(0);
-                        }
-
-                        var dstIndex = LowerExpression(builder, args[1], locals);
-                        var value = LowerExpression(builder, args[2], locals);
-                        var count = LowerExpression(builder, args[3], locals);
-
-                        var fn = _moduleBuilder.Module.GetNamedFunction("stasis_sys_memset_f32");
-                        var fnType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void,
-                            new[]
-                            {
-                                LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0),
-                                LLVMTypeRef.Int32,
-                                LLVMTypeRef.Float,
-                                LLVMTypeRef.Int32
-                            }, false);
-                        if (fn.Handle == IntPtr.Zero)
-                            fn = _moduleBuilder.Module.AddFunction("stasis_sys_memset_f32", fnType);
-
-                        var dstCast = builder.BuildBitCast(dstPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Float, 0), "sys_memset_f32.dst");
-                        builder.BuildCall2(fnType, fn, new[] { dstCast, dstIndex, value, count }, "sys_memset_f32.call");
-                        return ConstI32(0);
-                    }
                 case "sin":
                 case "cos":
                 case "sin_fast":

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -100,9 +100,6 @@ public sealed class SemanticAnalyzer
         AddSymbol("sys_memmove_u8", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
         AddSymbol("sys_memmove_i32", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
         AddSymbol("sys_memmove_f32", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
-        AddSymbol("sys_memset_u8", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
-        AddSymbol("sys_memset_i32", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
-        AddSymbol("sys_memset_f32", SymbolKind.Function, new VoidTypeSymbol(), new SourceSpan(0, 0));
 
         // Legacy math functions (to be renamed to math_*)
         AddSymbol("sin", SymbolKind.Function, new PrimitiveTypeSymbol("f32"), new SourceSpan(0, 0));
@@ -404,9 +401,17 @@ public sealed class SemanticAnalyzer
 
         void NoteWriteTarget(ExpressionSyntax target, HashSet<int> assignedInScope)
         {
-            if (target is IdentifierExpressionSyntax id && TryResolveLocalId(id.Identifier.Text, out var localId))
+            switch (target)
             {
-                assignedInScope.Add(localId);
+                case IdentifierExpressionSyntax id when TryResolveLocalId(id.Identifier.Text, out var localId):
+                    assignedInScope.Add(localId);
+                    return;
+                case MemberAccessExpressionSyntax member:
+                    NoteWriteTarget(member.Receiver, assignedInScope);
+                    return;
+                case ArrayAccessExpressionSyntax array:
+                    NoteWriteTarget(array.Receiver, assignedInScope);
+                    return;
             }
         }
 
@@ -417,10 +422,13 @@ public sealed class SemanticAnalyzer
                 case IdentifierExpressionSyntax:
                     return;
                 case MemberAccessExpressionSyntax member:
-                    AnalyzeExpr(member.Receiver, assignedInScope);
+                    // Writing through a receiver does not require the receiver local to be "definitely assigned"
+                    // (e.g. `buf[i] = ...`, `s.field = ...`). Treat the receiver as an lvalue base.
+                    AnalyzeLValue(member.Receiver, assignedInScope);
                     return;
                 case ArrayAccessExpressionSyntax array:
-                    AnalyzeExpr(array.Receiver, assignedInScope);
+                    // Same rule as member access: the receiver is an lvalue base.
+                    AnalyzeLValue(array.Receiver, assignedInScope);
                     AnalyzeExpr(array.Index, assignedInScope);
                     return;
                 default:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -156,9 +156,9 @@ These are host-provided helpers intended for tooling (compilers, asset pipelines
 - `sys_memmove_u8(dst: u8[M], dst_index: i32, src: u8[N], src_index: i32, count: i32) -> void` (copies `count` bytes; overlap-safe)
 - `sys_memmove_i32(dst: i32[M], dst_index: i32, src: i32[N], src_index: i32, count: i32) -> void` (copies `count` elements; overlap-safe)
 - `sys_memmove_f32(dst: f32[M], dst_index: i32, src: f32[N], src_index: i32, count: i32) -> void` (copies `count` elements; overlap-safe)
-- `sys_memset_u8(dst: u8[M], dst_index: i32, value: i32, count: i32) -> void` (sets `count` bytes to `(value & 255)`)
-- `sys_memset_i32(dst: i32[M], dst_index: i32, value: i32, count: i32) -> void` (sets `count` elements)
-- `sys_memset_f32(dst: f32[M], dst_index: i32, value: f32, count: i32) -> void` (sets `count` elements)
+- `sys_memset_u8(dst: u8[M], dst_index: i32, value: i32, count: i32) -> void` (runtime internal; compiler/runtime may use for bulk clears; not callable from Stasis source)
+- `sys_memset_i32(dst: i32[M], dst_index: i32, value: i32, count: i32) -> void` (runtime internal; compiler/runtime may use for bulk clears; not callable from Stasis source)
+- `sys_memset_f32(dst: f32[M], dst_index: i32, value: f32, count: i32) -> void` (runtime internal; compiler/runtime may use for bulk clears; not callable from Stasis source)
 
 ### Imports
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -18,7 +18,8 @@ This file is a lightweight, persistent checklist of remaining work. It complemen
 
 ### Sys / Stdlib
 
-- [ ] Sys: add bulk set/move helpers (`sys_memset_*`, `sys_memmove_*`) and safe stdlib wrappers (`mem_copy_*`, `mem_set_*`).
+- [x] Sys/memory: bulk move + safe wrappers (`mem_copy_*`, `mem_set_*`) exist.
+- [ ] Sys/memory: keep bulk clears (`memset`) as a compiler/runtime detail (avoid exposing `sys_memset_*` to user code).
 - [ ] Stdlib/platform externs: support `@extern` no-body declarations and implement per-platform so APIs are visible in source.
 
 ### Game Dev Readiness

--- a/src/stdlib/memory.stasis
+++ b/src/stdlib/memory.stasis
@@ -39,7 +39,10 @@ function mem_set_u8(dst: u8[], dst_cap: i32, dst_index: i32, value: u8, count: i
     let n: i32 = count;
     if (n > rem) { n = rem; }
     if (n <= 0) { return 0; }
-    sys_memset_u8(dst, dst_index, u8_to_i32(value), n);
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
     return n;
 }
 
@@ -80,7 +83,10 @@ function mem_set_i32(dst: i32[], dst_cap: i32, dst_index: i32, value: i32, count
     let n: i32 = count;
     if (n > rem) { n = rem; }
     if (n <= 0) { return 0; }
-    sys_memset_i32(dst, dst_index, value, n);
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
     return n;
 }
 
@@ -121,7 +127,10 @@ function mem_set_f32(dst: f32[], dst_cap: i32, dst_index: i32, value: f32, count
     let n: i32 = count;
     if (n > rem) { n = rem; }
     if (n <= 0) { return 0; }
-    sys_memset_f32(dst, dst_index, value, n);
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
     return n;
 }
 

--- a/tests/stdlib_mem.stasis
+++ b/tests/stdlib_mem.stasis
@@ -4,6 +4,8 @@ global mem_src: u8[8];
 global mem_dst: u8[8];
 global mem_a: u8[4];
 global mem_b: u8[4];
+global mem_overlap: u8[8];
+global mem_i32: i32[4];
 
 test `mem_copy copies bytes`() {
     mem_src[0] = 1;
@@ -31,6 +33,30 @@ test `mem_set writes value`() {
         && mem_dst[1] == 7
         && mem_dst[2] == 7
         && mem_dst[3] == 7;
+}
+
+test `mem_copy handles overlap`() {
+    mem_overlap[0] = 1;
+    mem_overlap[1] = 2;
+    mem_overlap[2] = 3;
+    mem_overlap[3] = 4;
+    mem_overlap[4] = 5;
+    mem_overlap[5] = 6;
+    mem_overlap[6] = 7;
+    mem_overlap[7] = 8;
+
+    // Copy right by one (overlap).
+    mem_copy_u8(mem_overlap, 8, 1, mem_overlap, 8, 0, 7);
+    return mem_overlap[1] == 1
+        && mem_overlap[2] == 2
+        && mem_overlap[3] == 3
+        && mem_overlap[7] == 7;
+}
+
+test `mem_set_i32 writes values`() {
+    mem_set_i32(mem_i32, 4, 0, 42, 4);
+    return mem_i32[0] == 42
+        && mem_i32[3] == 42;
 }
 
 test `mem_zero clears bytes`() {


### PR DESCRIPTION
﻿- Remove `sys_memset_*` from Stasis surface builtins (compiler no longer resolves/lowers them from user code).
- Implement `mem_set_u8/i32/f32` in `src/stdlib/memory.stasis` via simple loops.
- Fix LLVM IR emission for void syscalls (`sys_memcpy_*`/`sys_memmove_*`) so calls aren’t named.
- Add/adjust `tests/stdlib_mem.stasis` coverage (overlap-safe memmove + i32 set behavior).
- Update `docs/spec.md` to mark `sys_memset_*` as runtime-internal (not callable from Stasis source).

Local verification: `build.bat` + `test.bat`.
