### PR TITLE
feat: compile stasis fenced blocks in markdown

### DIFF
--- a/Stasis.Compiler.Tests/MarkdownStasisExtractorTests.cs
+++ b/Stasis.Compiler.Tests/MarkdownStasisExtractorTests.cs
@@ -1,0 +1,73 @@
+using Stasis.Compiler;
+
+namespace Stasis.Compiler.Tests;
+
+public class MarkdownStasisExtractorTests
+{
+    [Fact]
+    public void Preserves_line_numbers_and_extracts_only_stasis_blocks()
+    {
+        var md = string.Join('\n',
+            "# Title",
+            "",
+            "Not code.",
+            "",
+            "```stasis",
+            "function a(): i32 { return 1; }",
+            "```",
+            "",
+            "```notstasis",
+            "function b(): i32 { return 2; }",
+            "```",
+            "",
+            "More text.",
+            "",
+            "```stasis",
+            "function c(): i32 { return 3; }",
+            "```",
+            "");
+
+        var extracted = MarkdownStasisExtractor.Extract(md);
+
+        // Same number of lines so diagnostics can reference the markdown line numbers.
+        Assert.Equal(CountLines(md), CountLines(extracted));
+
+        Assert.Contains("function a()", extracted);
+        Assert.Contains("function c()", extracted);
+        Assert.DoesNotContain("function b()", extracted);
+
+        // Ensure function a() appears on the same line number in both strings.
+        var mdLineA = LineNumberOf(md, "function a(): i32 { return 1; }");
+        var exLineA = LineNumberOf(extracted, "function a(): i32 { return 1; }");
+        Assert.Equal(mdLineA, exLineA);
+    }
+
+    private static int CountLines(string s)
+    {
+        var count = 1;
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (s[i] == '\n')
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int LineNumberOf(string s, string needle)
+    {
+        var idx = s.IndexOf(needle, StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"needle not found: {needle}");
+
+        var line = 1;
+        for (var i = 0; i < idx; i++)
+        {
+            if (s[i] == '\n')
+            {
+                line++;
+            }
+        }
+        return line;
+    }
+}

--- a/Stasis.Compiler/MarkdownStasisExtractor.cs
+++ b/Stasis.Compiler/MarkdownStasisExtractor.cs
@@ -1,0 +1,73 @@
+using System.Text;
+
+namespace Stasis.Compiler;
+
+public static class MarkdownStasisExtractor
+{
+    // Extracts ```stasis fenced code blocks from a markdown document.
+    // Preserves line numbers by replacing non-stasis lines with blank lines.
+    public static string Extract(string markdown)
+    {
+        if (string.IsNullOrEmpty(markdown))
+        {
+            return string.Empty;
+        }
+
+        // Normalize newlines so line/column mapping is stable across platforms.
+        var normalized = markdown.Replace("\r\n", "\n").Replace("\r", "\n");
+        var lines = normalized.Split('\n', StringSplitOptions.None);
+
+        var sb = new StringBuilder(normalized.Length);
+        var inStasis = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmed = line.TrimStart();
+
+            if (!inStasis)
+            {
+                if (IsFenceStart(trimmed))
+                {
+                    inStasis = true;
+                }
+
+                // Blank line to preserve line numbers.
+                sb.Append(string.Empty);
+            }
+            else
+            {
+                if (IsFenceEnd(trimmed))
+                {
+                    inStasis = false;
+                    sb.Append(string.Empty);
+                }
+                else
+                {
+                    sb.Append(line);
+                }
+            }
+
+            if (i < lines.Length - 1)
+            {
+                sb.Append('\n');
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static bool IsFenceStart(string trimmedLine)
+    {
+        if (!trimmedLine.StartsWith("```", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var lang = trimmedLine.Substring(3).Trim();
+        return string.Equals(lang, "stasis", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsFenceEnd(string trimmedLine) =>
+        trimmedLine.StartsWith("```", StringComparison.Ordinal);
+}

--- a/Stasis.Compiler/SourceImporter.cs
+++ b/Stasis.Compiler/SourceImporter.cs
@@ -34,6 +34,11 @@ public static class SourceImporter
             return new SourceImportResultWithMap(source, string.Empty, Array.Empty<SourceImportSegment>());
         }
 
+        if (string.Equals(Path.GetExtension(fullPath), ".md", StringComparison.OrdinalIgnoreCase))
+        {
+            source = MarkdownStasisExtractor.Extract(source);
+        }
+
         if (IsStdlibPath(fullPath))
         {
             EnsureStdlibHasNoGlobals(fullPath, source, diagnostics);

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -41,5 +41,5 @@ This file is a lightweight, persistent checklist of remaining work. It complemen
 
 ### Tooling / DX
 
-- [ ] Support compiling Markdown code blocks: allow `stasis build/test` on `.md` by extracting ```stasis fenced blocks so docs stay valid.
+- [x] Support compiling Markdown code blocks: allow `stasis build/test` on `.md` by extracting ```stasis fenced blocks so docs stay valid.
 - [ ] Maintenance: regularly scan open PRs for conflicts and keep them mergeable (merge `main` into branches or rebase).


### PR DESCRIPTION
Replaces closed #106 (base branch was deleted).\n\n- Allows stasis build/test on .md files by extracting `stasis fenced blocks while preserving line numbers.\n- Adds Stasis.Compiler.Tests/MarkdownStasisExtractorTests.cs.