### PR TITLE
feat: @extern no-body function declarations

### DIFF
--- a/Stasis.Compiler.Tests/ParserTests.cs
+++ b/Stasis.Compiler.Tests/ParserTests.cs
@@ -103,6 +103,41 @@ public class ParserTests
     }
 
     [Fact]
+    public void Parses_extern_attribute_no_body_declaration()
+    {
+        var source = """
+            function @extern foo(x: i32): i32;
+            """;
+
+        var result = Parser.Parse(source);
+
+        Assert.Empty(result.Diagnostics);
+        var func = Assert.IsType<FunctionDeclarationSyntax>(Assert.Single(result.CompilationUnit.Declarations));
+        Assert.False(func.IsExtern);
+        Assert.Null(func.Body);
+        Assert.NotNull(func.Semicolon);
+        var attr = Assert.Single(func.Attributes);
+        Assert.Equal("extern", attr.Text);
+        Assert.Null(attr.StringValue);
+    }
+
+    [Fact]
+    public void Parses_extern_attribute_with_link_name()
+    {
+        var source = """
+            function @extern("stasis_custom_name") foo(): i32;
+            """;
+
+        var result = Parser.Parse(source);
+
+        Assert.Empty(result.Diagnostics);
+        var func = Assert.IsType<FunctionDeclarationSyntax>(Assert.Single(result.CompilationUnit.Declarations));
+        var attr = Assert.Single(func.Attributes);
+        Assert.Equal("extern", attr.Text);
+        Assert.Equal("\"stasis_custom_name\"", attr.StringValue);
+    }
+
+    [Fact]
     public void Parses_link_directive()
     {
         var source = """

--- a/Stasis.Compiler.Tests/SemanticTests.cs
+++ b/Stasis.Compiler.Tests/SemanticTests.cs
@@ -97,6 +97,20 @@ public class SemanticTests
     }
 
     [Fact]
+    public void Flags_non_extern_function_declaration_without_body()
+    {
+        var source = """
+            function f(): i32;
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+
+        Assert.Contains(sema.Diagnostics, d => d.Message.Contains("missing a body", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Flags_read_of_uninitialized_local()
     {
         var source = """

--- a/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
@@ -758,7 +758,7 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
     {
         foreach (var func in compilationUnit.Declarations.OfType<FunctionDeclarationSyntax>())
         {
-            if (!func.IsExtern)
+            if (!func.IsExtern && !HasExternAttribute(func))
             {
                 continue;
             }
@@ -778,6 +778,7 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
                 continue;
             }
 
+            var externName = GetExternLinkName(func) ?? func.Name.Text;
             var returnTypeSymbol = func.ReturnType is null
                 ? new VoidTypeSymbol()
                 : ResolveType(func.ReturnType, symbols);
@@ -786,8 +787,30 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
                 .Select(p => NormalizeFunctionType(builder.TypeMapper.Map(ResolveType(p.Type, symbols))))
                 .ToArray();
 
-            builder.DeclareExternal(func.Name.Text, returnType, paramTypes);
+            builder.DeclareExternal(externName, returnType, paramTypes);
         }
+    }
+
+    private static bool HasExternAttribute(FunctionDeclarationSyntax func) =>
+        func.Attributes.Any(attr => string.Equals(attr.Text, "extern", StringComparison.Ordinal));
+
+    private static string? GetExternLinkName(FunctionDeclarationSyntax func)
+    {
+        var raw = func.Attributes
+            .FirstOrDefault(a => string.Equals(a.Text, "extern", StringComparison.Ordinal))?
+            .StringValue;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
+        {
+            return raw.Substring(1, raw.Length - 2);
+        }
+
+        return raw;
     }
 
     private static void EmitGlobals(

--- a/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftFunctionBuilder.cs
@@ -713,7 +713,9 @@ public sealed class CraneliftFunctionBuilder
         }
 
         var isExtern = IsExternFunction(funcName);
-        var callName = IsBuiltinFunction(funcName) ? funcName : (isExtern ? funcName : MangleFunctionName(funcName));
+        var callName = IsBuiltinFunction(funcName)
+            ? funcName
+            : (isExtern ? GetExternCallName(funcName) : MangleFunctionName(funcName));
         var argList = string.Join(", ", args);
         if (IsVoidFunction(funcName))
         {
@@ -1663,7 +1665,39 @@ public sealed class CraneliftFunctionBuilder
         return call;
     }
     private bool IsExternFunction(string name) =>
-        _functions.TryGetValue(name, out var func) && func.IsExtern;
+        _functions.TryGetValue(name, out var func) && (func.IsExtern || HasExternAttribute(func));
+
+    private string GetExternCallName(string name)
+    {
+        if (!_functions.TryGetValue(name, out var func))
+        {
+            return name;
+        }
+
+        var linkName = func.Attributes
+            .FirstOrDefault(a => string.Equals(a.Text, "extern", StringComparison.Ordinal))?
+            .StringValue;
+
+        if (!string.IsNullOrWhiteSpace(linkName))
+        {
+            return UnquoteStringLiteral(linkName);
+        }
+
+        return name;
+    }
+
+    private static string UnquoteStringLiteral(string text)
+    {
+        if (text.Length >= 2 && text[0] == '"' && text[^1] == '"')
+        {
+            return text.Substring(1, text.Length - 2);
+        }
+
+        return text;
+    }
+
+    private static bool HasExternAttribute(FunctionDeclarationSyntax func) =>
+        func.Attributes.Any(attr => string.Equals(attr.Text, "extern", StringComparison.Ordinal));
 
     private string MangleFunctionName(string name) => $"{_moduleName}__{name}";
 

--- a/Stasis.Compiler/Parser.cs
+++ b/Stasis.Compiler/Parser.cs
@@ -179,17 +179,27 @@ public sealed class Parser
         }
 
         var functionKeyword = Consume(TokenKind.FunctionKeyword, "Expected 'function'.");
-        var attributes = new List<Token>();
+        var attributes = new List<FunctionAttributeSyntax>();
         while (Match(TokenKind.At))
         {
-            var attr = Consume(TokenKind.Identifier, "Expected attribute name after '@'.");
+            var attrName = ConsumeOneOf("Expected attribute name after '@'.", TokenKind.Identifier, TokenKind.ExternKeyword);
+            Token? openParen = null;
+            Token? value = null;
+            Token? closeParen = null;
+            if (Match(TokenKind.LParen))
+            {
+                openParen = Previous;
+                value = Consume(TokenKind.StringLiteral, "Expected string literal attribute value.");
+                closeParen = Consume(TokenKind.RParen, "Expected ')' after attribute value.");
+            }
+
             if (attributes.Count < 10)
             {
-                attributes.Add(attr);
+                attributes.Add(new FunctionAttributeSyntax(attrName, openParen, value, closeParen));
             }
             else
             {
-                _diagnostics.Add(new Diagnostic("Functions may have at most 10 attributes.", attr.Span));
+                _diagnostics.Add(new Diagnostic("Functions may have at most 10 attributes.", attrName.Span));
             }
         }
         var name = Consume(TokenKind.Identifier, "Expected function name.");
@@ -206,6 +216,11 @@ public sealed class Parser
         {
             var semicolon = Consume(TokenKind.Semicolon, "Expected ';' after extern function declaration.");
             return new FunctionDeclarationSyntax(exportKeyword, externKeyword, functionKeyword, attributes, name, parameters, returnType, Body: null, Semicolon: semicolon);
+        }
+
+        if (Match(TokenKind.Semicolon))
+        {
+            return new FunctionDeclarationSyntax(exportKeyword, externKeyword, functionKeyword, attributes, name, parameters, returnType, Body: null, Semicolon: Previous);
         }
 
         var body = ParseBlock();

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -41,6 +41,7 @@ public sealed class SemanticAnalyzer
         DeclareGlobals(compilationUnit);
         DeclareConstants(compilationUnit);
         DeclareFunctions(compilationUnit);
+        ValidateFunctionDeclarations(compilationUnit);
 
         foreach (var decl in compilationUnit.Declarations)
         {
@@ -56,6 +57,29 @@ public sealed class SemanticAnalyzer
         }
 
         return new SemanticResult(_diagnostics, new Dictionary<string, Symbol>(_symbols));
+    }
+
+    private void ValidateFunctionDeclarations(CompilationUnitSyntax compilationUnit)
+    {
+        foreach (var fn in compilationUnit.Declarations.OfType<FunctionDeclarationSyntax>())
+        {
+            var hasExternAttr = fn.Attributes.Any(a => string.Equals(a.Text, "extern", StringComparison.Ordinal));
+
+            if (fn.Body is null)
+            {
+                if (!fn.IsExtern && !hasExternAttr)
+                {
+                    _diagnostics.Add(new Diagnostic($"Function '{fn.Name.Text}' is missing a body. Add a body or mark it as extern.", fn.Name.Span));
+                }
+            }
+            else
+            {
+                if (hasExternAttr)
+                {
+                    _diagnostics.Add(new Diagnostic($"Function '{fn.Name.Text}' has a body and cannot be marked @extern.", fn.Name.Span));
+                }
+            }
+        }
     }
 
     private void DeclareBuiltIns()

--- a/Stasis.Compiler/Syntax/FunctionAttributeSyntax.cs
+++ b/Stasis.Compiler/Syntax/FunctionAttributeSyntax.cs
@@ -1,0 +1,17 @@
+using Stasis.Compiler;
+
+namespace Stasis.Compiler.Syntax;
+
+public sealed record FunctionAttributeSyntax(
+    Token Name,
+    Token? OpenParen,
+    Token? Value,
+    Token? CloseParen)
+    : SyntaxNode(new SourceSpan(
+        Name.Span.Start,
+        ((CloseParen ?? Value ?? OpenParen ?? Name).Span.End) - Name.Span.Start))
+{
+    public string Text => Name.Text;
+    public string? StringValue => Value?.Text;
+}
+

--- a/Stasis.Compiler/Syntax/FunctionSyntax.cs
+++ b/Stasis.Compiler/Syntax/FunctionSyntax.cs
@@ -9,7 +9,7 @@ public sealed record FunctionDeclarationSyntax(
     Token? ExportKeyword,
     Token? ExternKeyword,
     Token FunctionKeyword,
-    IReadOnlyList<Token> Attributes,
+    IReadOnlyList<FunctionAttributeSyntax> Attributes,
     Token Name,
     IReadOnlyList<ParameterSyntax> Parameters,
     TypeSyntax? ReturnType,

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -125,7 +125,9 @@ FunctionDecl     -> ExportOpt ExternOpt
 ```
 AttributeListOpt -> Attribute AttributeListOpt
                   | <empty>
-Attribute        -> "@" Identifier
+Attribute        -> "@" Identifier AttributeValueOpt
+AttributeValueOpt -> "(" StringLiteral ")"
+                   | <empty>
 ```
 
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -476,6 +476,26 @@ function @inline name(param: Type): ReturnType { ... }
 - Parameters are primitive or references (struct indices, slices, etc.).
 - All struct/array data resides in global memory.
 
+### Extern declarations
+
+Functions declared without a body must be explicitly marked as extern:
+
+```
+extern function sleep_ms(ms: i32): void;
+```
+
+The attribute form is also supported:
+
+```
+function @extern sleep_ms(ms: i32): void;
+```
+
+To call a different underlying symbol name, provide a link name:
+
+```
+function @extern("stasis_sleep_ms") sleep_ms(ms: i32): void;
+```
+
 ---
 
 # **10. Globals**

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -19,8 +19,9 @@ This file is a lightweight, persistent checklist of remaining work. It complemen
 ### Sys / Stdlib
 
 - [x] Sys/memory: bulk move + safe wrappers (`mem_copy_*`, `mem_set_*`) exist.
-- [ ] Sys/memory: keep bulk clears (`memset`) as a compiler/runtime detail (avoid exposing `sys_memset_*` to user code).
-- [ ] Stdlib/platform externs: support `@extern` no-body declarations and implement per-platform so APIs are visible in source.
+- [x] Sys/memory: keep bulk clears (`memset`) as a compiler/runtime detail (avoid exposing `sys_memset_*` to user code).
+- [x] Stdlib/platform externs: support `@extern` no-body declarations (and optional link name) so APIs are visible in source.
+- [ ] Stdlib/platform externs: wire up per-platform stdlib selection (so extern-backed APIs can vary by platform).
 
 ### Game Dev Readiness
 


### PR DESCRIPTION
- Allow declaration-only functions via `;` when marked `extern` or `@extern` (optional link name: `@extern(native_symbol)`).
- Validate bodyless non-extern functions as a semantic error.
- Treat `@extern` as extern during lowering (and call mapped link names).
- Docs: update `docs/spec.md`, `docs/compilation.md`, and `docs/tasks.md`.