### PR TITLE
feat: cached glyph runs for text

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,7 +12,7 @@ This file is a lightweight, persistent checklist of remaining work. It complemen
 
 ### Graphics Command Buffers
 
-- [ ] Command buffers: keep persistent prebuilt streams (only rewrite dirty ranges; avoid rebuilding every tick).
+- [x] Command buffers: keep persistent prebuilt streams (only rewrite dirty ranges; avoid rebuilding every tick).
 - [ ] Command buffers: optimize runtime submit fast paths (avoid per-sprite overhead when debug hashing is off; build VBOs directly from streams).
 - [ ] Command buffers: evolve text output toward cached glyph runs (avoid per-frame UTF-8 copies + parsing).
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,7 +14,7 @@ This file is a lightweight, persistent checklist of remaining work. It complemen
 
 - [x] Command buffers: keep persistent prebuilt streams (only rewrite dirty ranges; avoid rebuilding every tick).
 - [ ] Command buffers: optimize runtime submit fast paths (avoid per-sprite overhead when debug hashing is off; build VBOs directly from streams).
-- [ ] Command buffers: evolve text output toward cached glyph runs (avoid per-frame UTF-8 copies + parsing).
+- [x] Command buffers: evolve text output toward cached glyph runs (avoid per-frame UTF-8 copies + parsing).
 
 ### Sys / Stdlib
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -66,6 +66,9 @@ static void stasis_sdl_log_output(void* userdata, int category, SDL_LogPriority 
 
 STASIS_EXPORT void stasis_set_window_size(int width, int height);
 STASIS_EXPORT int stasis_get_time_us(void);
+STASIS_EXPORT int stasis_gfx_cache_text(int font_handle, const char* text);
+STASIS_EXPORT void stasis_gfx_draw_text_cached(int run_handle, float x, float y, float r, float g, float b, float a);
+STASIS_EXPORT float stasis_gfx_measure_text_cached(int run_handle);
 
 /* Global state */
 static SDL_Window* g_window = NULL;
@@ -3010,7 +3013,8 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     }
 
     /* text: payload is split between i32 metadata + u8 bytes + f32 color/pos */
-    if (cmd_u8 && text_count > 0 && text_bytes_used > 0) {
+    /* byte_off < 0 encodes cached text run handle (no cmd_u8 access). */
+    if (text_count > 0) {
         const int32_t text_i32_base = 32 + gfx_cmd_max_sprites * 7;
         const int32_t text_f32_base = 4 + gfx_cmd_max_lines * 8;
         const int32_t* text_meta = cmd_i32 + text_i32_base;
@@ -3022,7 +3026,20 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
             const int byte_len = text_meta[base_i + 2];
 
             if (font <= 0) continue;
-            if (byte_off < 0 || byte_off >= text_bytes_used) continue;
+            if (byte_off < 0) {
+                const int run = -byte_off;
+                const int base_f = text_f32_base + i * 6;
+                const float x = cmd_f32[base_f + 0];
+                const float y = cmd_f32[base_f + 1];
+                const float r = cmd_f32[base_f + 2];
+                const float g = cmd_f32[base_f + 3];
+                const float b = cmd_f32[base_f + 4];
+                const float a = cmd_f32[base_f + 5];
+                stasis_gfx_draw_text_cached(run, x, y, r, g, b, a);
+                continue;
+            }
+            if (!cmd_u8 || text_bytes_used <= 0) continue;
+            if (byte_off >= text_bytes_used) continue;
             if (byte_len < 0) continue;
             if (byte_off + byte_len >= text_bytes_used) continue;
 
@@ -3041,7 +3058,8 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     }
 
     /* text: payload is split between i32 metadata + u8 bytes + f32 color/pos */
-    if (cmd_u8 && text_count > 0 && text_bytes_used > 0) {
+    /* byte_off < 0 encodes cached text run handle (no cmd_u8 access). */
+    if (text_count > 0) {
         const int32_t text_i32_base = 32 + gfx_cmd_max_sprites * 7;
         const int32_t text_f32_base = 4 + gfx_cmd_max_lines * 8;
         const int32_t* text_meta = cmd_i32 + text_i32_base;
@@ -3053,7 +3071,20 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
             const int byte_len = text_meta[base_i + 2];
 
             if (font <= 0) continue;
-            if (byte_off < 0 || byte_off >= text_bytes_used) continue;
+            if (byte_off < 0) {
+                const int run = -byte_off;
+                const int base_f = text_f32_base + i * 6;
+                const float x = cmd_f32[base_f + 0];
+                const float y = cmd_f32[base_f + 1];
+                const float r = cmd_f32[base_f + 2];
+                const float g = cmd_f32[base_f + 3];
+                const float b = cmd_f32[base_f + 4];
+                const float a = cmd_f32[base_f + 5];
+                stasis_gfx_draw_text_cached(run, x, y, r, g, b, a);
+                continue;
+            }
+            if (!cmd_u8 || text_bytes_used <= 0) continue;
+            if (byte_off >= text_bytes_used) continue;
             if (byte_len < 0) continue;
             if (byte_off + byte_len >= text_bytes_used) continue;
 
@@ -4019,6 +4050,223 @@ STASIS_EXPORT void stasis_copy_dir_entry_name(const unsigned char* names, int32_
 }
 
 /* ===== FONT RENDERING WITH STB_TRUETYPE ===== */
+
+/* ===== CACHED TEXT RUNS (glyph quads) ===== */
+
+typedef struct {
+    float x0, y0, x1, y1;
+    float s0, t0, s1, t1;
+} StasisTextQuad;
+
+typedef struct {
+    int active;
+    int font_handle;
+    uint32_t hash;
+    int text_off;
+    int text_len;
+    int quad_off;
+    int quad_count;
+    float width;
+    float height;
+} StasisTextRun;
+
+#define STASIS_MAX_TEXT_RUNS 1024
+#define STASIS_TEXT_RUN_MAX_BYTES 262144
+#define STASIS_TEXT_RUN_MAX_QUADS 65536
+
+static StasisTextRun g_text_runs[STASIS_MAX_TEXT_RUNS];
+static unsigned char g_text_run_bytes[STASIS_TEXT_RUN_MAX_BYTES];
+static int g_text_run_bytes_used = 0;
+static StasisTextQuad g_text_run_quads[STASIS_TEXT_RUN_MAX_QUADS];
+static int g_text_run_quads_used = 0;
+
+static uint32_t fnv1a_u32(const unsigned char* data, int len) {
+    uint32_t h = 2166136261u;
+    for (int i = 0; i < len; i++) {
+        h ^= (uint32_t)data[i];
+        h *= 16777619u;
+    }
+    return h;
+}
+
+static int stasis_find_or_alloc_text_run_slot(int font_handle, uint32_t hash, const char* text, int len) {
+    int free_slot = -1;
+    for (int i = 0; i < STASIS_MAX_TEXT_RUNS; i++) {
+        if (!g_text_runs[i].active) {
+            if (free_slot < 0) free_slot = i;
+            continue;
+        }
+        if (g_text_runs[i].font_handle != font_handle) continue;
+        if (g_text_runs[i].hash != hash) continue;
+        if (g_text_runs[i].text_len != len) continue;
+        if (g_text_runs[i].text_off < 0 || g_text_runs[i].text_off + len >= STASIS_TEXT_RUN_MAX_BYTES) continue;
+        if (memcmp(g_text_run_bytes + g_text_runs[i].text_off, text, (size_t)len) == 0) {
+            return i;
+        }
+    }
+    return free_slot;
+}
+
+/* Cache a text run and return a 1-based handle (0 on failure). */
+STASIS_EXPORT int stasis_gfx_cache_text(int font_handle, const char* text) {
+    if (font_handle <= 0 || font_handle > MAX_FONTS) return 0;
+    if (!text) return 0;
+    StasisFont* font = &g_fonts[font_handle - 1];
+    if (!font->active) return 0;
+
+    const int len = (int)strlen(text);
+    if (len <= 0) return 0;
+    if (len > 8192) return 0; /* hard cap per cached run */
+
+    const uint32_t hash = fnv1a_u32((const unsigned char*)text, len);
+    const int slot = stasis_find_or_alloc_text_run_slot(font_handle, hash, text, len);
+    if (slot < 0) return 0;
+    if (g_text_runs[slot].active) {
+        return slot + 1;
+    }
+
+    const int bytes_needed = len + 1;
+    if (g_text_run_bytes_used + bytes_needed > STASIS_TEXT_RUN_MAX_BYTES) return 0;
+
+    const int text_off = g_text_run_bytes_used;
+    memcpy(g_text_run_bytes + text_off, text, (size_t)len);
+    g_text_run_bytes[text_off + len] = 0;
+    g_text_run_bytes_used += bytes_needed;
+
+    const int quad_off = g_text_run_quads_used;
+    int quad_count = 0;
+
+    float pos_x = 0.0f;
+    float pos_y = 0.0f;
+    float max_x = 0.0f;
+    float max_y = 0.0f;
+    const float start_x = 0.0f;
+
+    for (int i = 0; i < len; i++) {
+        unsigned char ch = (unsigned char)text[i];
+        if (ch == '\r') continue;
+        if (ch == '\n') {
+            pos_x = start_x;
+            pos_y += (float)font->font_size;
+            continue;
+        }
+        if (ch < FONT_FIRST_CHAR || ch >= FONT_FIRST_CHAR + FONT_NUM_CHARS) continue;
+
+        if (quad_off + quad_count >= STASIS_TEXT_RUN_MAX_QUADS) {
+            return 0;
+        }
+
+        stbtt_aligned_quad quad;
+        stbtt_GetBakedQuad(font->char_data, FONT_ATLAS_SIZE, FONT_ATLAS_SIZE,
+            (int)ch - FONT_FIRST_CHAR, &pos_x, &pos_y, &quad, g_use_sdl_renderer ? 0 : 1);
+
+        StasisTextQuad* out = &g_text_run_quads[quad_off + quad_count];
+        out->x0 = quad.x0;
+        out->y0 = quad.y0;
+        out->x1 = quad.x1;
+        out->y1 = quad.y1;
+        out->s0 = quad.s0;
+        out->t0 = quad.t0;
+        out->s1 = quad.s1;
+        out->t1 = quad.t1;
+
+        if (quad.x1 > max_x) max_x = quad.x1;
+        if (quad.y1 > max_y) max_y = quad.y1;
+        quad_count++;
+    }
+
+    g_text_run_quads_used += quad_count;
+
+    StasisTextRun* run = &g_text_runs[slot];
+    run->active = 1;
+    run->font_handle = font_handle;
+    run->hash = hash;
+    run->text_off = text_off;
+    run->text_len = len;
+    run->quad_off = quad_off;
+    run->quad_count = quad_count;
+    run->width = max_x;
+    run->height = max_y;
+
+    return slot + 1;
+}
+
+static void stasis_draw_text_cached_internal(int run_handle, float x, float y, float r, float g, float b, float a) {
+    if (run_handle <= 0 || run_handle > STASIS_MAX_TEXT_RUNS) return;
+    StasisTextRun* run = &g_text_runs[run_handle - 1];
+    if (!run->active) return;
+    if (run->font_handle <= 0 || run->font_handle > MAX_FONTS) return;
+
+    StasisFont* font = &g_fonts[run->font_handle - 1];
+    if (!font->active) return;
+
+    if (g_use_sdl_renderer) {
+        if (!font->sdl_texture || !g_renderer) return;
+
+        SDL_SetTextureBlendMode(font->sdl_texture, SDL_BLENDMODE_BLEND);
+        SDL_SetTextureColorMod(font->sdl_texture,
+            (Uint8)(r < 0.0f ? 0 : (r > 1.0f ? 255 : (int)(r * 255.0f))),
+            (Uint8)(g < 0.0f ? 0 : (g > 1.0f ? 255 : (int)(g * 255.0f))),
+            (Uint8)(b < 0.0f ? 0 : (b > 1.0f ? 255 : (int)(b * 255.0f))));
+        SDL_SetTextureAlphaMod(font->sdl_texture,
+            (Uint8)(a < 0.0f ? 0 : (a > 1.0f ? 255 : (int)(a * 255.0f))));
+
+        for (int i = 0; i < run->quad_count; i++) {
+            StasisTextQuad* q = &g_text_run_quads[run->quad_off + i];
+            SDL_Rect src;
+            src.x = (int)(q->s0 * (float)FONT_ATLAS_SIZE);
+            src.y = (int)(q->t0 * (float)FONT_ATLAS_SIZE);
+            src.w = (int)((q->s1 - q->s0) * (float)FONT_ATLAS_SIZE);
+            src.h = (int)((q->t1 - q->t0) * (float)FONT_ATLAS_SIZE);
+
+            SDL_FRect dst;
+            dst.x = x + q->x0;
+            dst.y = y + q->y0;
+            dst.w = q->x1 - q->x0;
+            dst.h = q->y1 - q->y0;
+
+            if (src.w > 0 && src.h > 0 && dst.w > 0.0f && dst.h > 0.0f) {
+                SDL_RenderCopyF(g_renderer, font->sdl_texture, &src, &dst);
+            }
+        }
+        return;
+    }
+
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, font->atlas_texture);
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+    glColor4f(r, g, b, a);
+
+    glBegin(GL_QUADS);
+    for (int i = 0; i < run->quad_count; i++) {
+        StasisTextQuad* q = &g_text_run_quads[run->quad_off + i];
+        glTexCoord2f(q->s0, q->t0); glVertex2f(x + q->x0, y + q->y0);
+        glTexCoord2f(q->s1, q->t0); glVertex2f(x + q->x1, y + q->y0);
+        glTexCoord2f(q->s1, q->t1); glVertex2f(x + q->x1, y + q->y1);
+        glTexCoord2f(q->s0, q->t1); glVertex2f(x + q->x0, y + q->y1);
+    }
+    glEnd();
+
+    glDisable(GL_TEXTURE_2D);
+    glColor4f(1, 1, 1, 1);
+#endif
+}
+
+STASIS_EXPORT void stasis_gfx_draw_text_cached(int run_handle, float x, float y, float r, float g, float b, float a) {
+    stasis_draw_text_cached_internal(run_handle, x, y, r, g, b, a);
+}
+
+STASIS_EXPORT float stasis_gfx_measure_text_cached(int run_handle) {
+    if (run_handle <= 0 || run_handle > STASIS_MAX_TEXT_RUNS) return 0.0f;
+    StasisTextRun* run = &g_text_runs[run_handle - 1];
+    if (!run->active) return 0.0f;
+    return run->width;
+}
 
 /* Load a TrueType font from disk */
 STASIS_EXPORT int stasis_load_font(const char* path, int font_size) {

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -69,6 +69,9 @@ EXPORTS
     stasis_load_font
     stasis_draw_text
     stasis_measure_text
+    stasis_gfx_cache_text
+    stasis_gfx_draw_text_cached
+    stasis_gfx_measure_text_cached
     stasis_list_directory
     stasis_list_directory_struct
     stasis_copy_dir_entry_name

--- a/src/gfx_cmd.stasis
+++ b/src/gfx_cmd.stasis
@@ -243,6 +243,35 @@ function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b
     gfx_cmd_i32[GFX_I_TEXT_COUNT] = i + 1;
 }
 
+// Write a text draw referencing a cached glyph run (no per-frame UTF-8 bytes copied).
+// The runtime interprets `byte_offset < 0` as a cached text handle.
+function gfx_cmd_text_cached(font: i32, run_handle: i32, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_TEXT_COUNT];
+    if (i >= GFX_MAX_TEXT) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+    if (run_handle <= 0) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+
+    let base_i: i32 = GFX_I_TEXT_BASE + i * GFX_TEXT_STRIDE_I32;
+    gfx_cmd_i32[base_i + 0] = font;
+    gfx_cmd_i32[base_i + 1] = 0 - run_handle; // negative => cached run handle
+    gfx_cmd_i32[base_i + 2] = 0;
+
+    let base_f: i32 = GFX_F_TEXT_BASE + i * GFX_TEXT_STRIDE_F32;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = r;
+    gfx_cmd_f32[base_f + 3] = g;
+    gfx_cmd_f32[base_f + 4] = b;
+    gfx_cmd_f32[base_f + 5] = a;
+
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = i + 1;
+}
+
 function gfx_cmd_set_line_count(count: i32): void {
     if (count < 0) { count = 0; }
     if (count > GFX_MAX_LINES) { count = GFX_MAX_LINES; }

--- a/src/gfx_cmd.stasis
+++ b/src/gfx_cmd.stasis
@@ -56,6 +56,7 @@ global gfx_cmd_i32: i32[34848];
 global gfx_cmd_f32: f32[92292];
 global gfx_cmd_u8: u8[65536];
 
+// Begin a new frame, resetting all counts (typical immediate-mode usage).
 function @inline gfx_cmd_begin(): void {
     gfx_cmd_i32[GFX_I_MAGIC] = GFX_CMD_MAGIC;
     gfx_cmd_i32[GFX_I_VERSION] = GFX_CMD_VERSION;
@@ -67,6 +68,20 @@ function @inline gfx_cmd_begin(): void {
     gfx_cmd_i32[GFX_I_TEXT_COUNT] = 0;
     gfx_cmd_i32[GFX_I_DROPPED_TEXT] = 0;
     gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = 0;
+}
+
+// Begin a new frame without clearing counts/streams (persistent-mode usage).
+//
+// Intended usage:
+// - Prebuild streams once (set counts + write entries).
+// - Each tick call `gfx_cmd_begin_persistent()`, patch only changed entries, and `gfx_cmd_mark_present()`.
+function @inline gfx_cmd_begin_persistent(): void {
+    gfx_cmd_i32[GFX_I_MAGIC] = GFX_CMD_MAGIC;
+    gfx_cmd_i32[GFX_I_VERSION] = GFX_CMD_VERSION;
+    gfx_cmd_i32[GFX_I_FLAGS] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_LINES] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_TEXT] = 0;
 }
 
 function @inline gfx_cmd_clear(r: f32, g: f32, b: f32, a: f32): void {
@@ -116,6 +131,20 @@ function gfx_cmd_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i3
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = i + 1;
 }
 
+function gfx_cmd_set_sprite_at(index: i32, handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
+    if (index < 0 || index >= GFX_MAX_SPRITES) {
+        return;
+    }
+    let base: i32 = GFX_I_SPRITE_BASE + index * GFX_SPRITE_STRIDE_I32;
+    gfx_cmd_i32[base + 0] = handle;
+    gfx_cmd_i32[base + 1] = x;
+    gfx_cmd_i32[base + 2] = y;
+    gfx_cmd_i32[base + 3] = w;
+    gfx_cmd_i32[base + 4] = h;
+    gfx_cmd_i32[base + 5] = rot_deg;
+    gfx_cmd_i32[base + 6] = a;
+}
+
 function gfx_cmd_lines_from_f32(lines: f32[], count: i32): void {
     if (count <= 0) {
         return;
@@ -160,6 +189,22 @@ function gfx_cmd_sprites_from_i32(cmds: i32[], count: i32): void {
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = start + n;
 }
 
+function gfx_cmd_set_line_at(index: i32, x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32): void {
+    if (index < 0 || index >= GFX_MAX_LINES) {
+        return;
+    }
+
+    let base: i32 = GFX_F_LINE_BASE + index * GFX_LINE_STRIDE_F32;
+    gfx_cmd_f32[base + 0] = x1;
+    gfx_cmd_f32[base + 1] = y1;
+    gfx_cmd_f32[base + 2] = x2;
+    gfx_cmd_f32[base + 3] = y2;
+    gfx_cmd_f32[base + 4] = r;
+    gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b;
+    gfx_cmd_f32[base + 7] = a;
+}
+
 function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     let i: i32 = gfx_cmd_i32[GFX_I_TEXT_COUNT];
     if (i >= GFX_MAX_TEXT) {
@@ -196,6 +241,30 @@ function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b
 
     gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = used + byte_len + 1;
     gfx_cmd_i32[GFX_I_TEXT_COUNT] = i + 1;
+}
+
+function gfx_cmd_set_line_count(count: i32): void {
+    if (count < 0) { count = 0; }
+    if (count > GFX_MAX_LINES) { count = GFX_MAX_LINES; }
+    gfx_cmd_i32[GFX_I_LINE_COUNT] = count;
+}
+
+function gfx_cmd_set_sprite_count(count: i32): void {
+    if (count < 0) { count = 0; }
+    if (count > GFX_MAX_SPRITES) { count = GFX_MAX_SPRITES; }
+    gfx_cmd_i32[GFX_I_SPRITE_COUNT] = count;
+}
+
+function gfx_cmd_set_text_count(count: i32): void {
+    if (count < 0) { count = 0; }
+    if (count > GFX_MAX_TEXT) { count = GFX_MAX_TEXT; }
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = count;
+}
+
+function gfx_cmd_set_text_bytes_used(bytes_used: i32): void {
+    if (bytes_used < 0) { bytes_used = 0; }
+    if (bytes_used > GFX_TEXT_MAX_BYTES) { bytes_used = GFX_TEXT_MAX_BYTES; }
+    gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = bytes_used;
 }
 
 function @inline gfx_cmd_submit(): void {

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -25,6 +25,10 @@ extern function gfx_dump_bmp(path: string): i32;
 extern function load_font(path: string, size: i32): i32;
 extern function measure_text(font: i32, text: string): f32;
 
+// Cache text into a host-side glyph run; intended for startup/init, not per-tick.
+function @extern("stasis_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
+function @extern("stasis_gfx_measure_text_cached") gfx_measure_text_cached(run_handle: i32): f32;
+
 // Deprecated controls/debug: kept as stubs so older samples compile; host-owned behavior should move to snapshot/commands.
 function set_postfx(strength: f32, phase: f32, speed: f32, r: f32, g: f32, b: f32): void {
 }
@@ -94,6 +98,10 @@ function gfx_draw_sprites_i32(cmds: i32[], count: i32): void {
 
 function draw_text(font: i32, text: string, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     gfx_cmd_text(font, text, x, y, r, g, b, a);
+}
+
+function draw_text_cached(font: i32, run_handle: i32, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
+    gfx_cmd_text_cached(font, run_handle, x, y, r, g, b, a);
 }
 
 function gfx_window_width(): i32 { return host_window_w_px(); }

--- a/tests/gfx_cmd_persistent.stasis
+++ b/tests/gfx_cmd_persistent.stasis
@@ -1,0 +1,50 @@
+import "../src/gfx_cmd.stasis";
+import "../src/stdlib/stdlib.stasis";
+
+test `persistent begin preserves sprite entries`(): bool {
+    gfx_cmd_begin();
+    gfx_cmd_set_sprite_count(2);
+
+    gfx_cmd_set_sprite_at(0, 11, 1, 2, 3, 4, 5, 6);
+    gfx_cmd_set_sprite_at(1, 22, 7, 8, 9, 10, 11, 12);
+
+    // Simulate next tick without rebuilding the full stream.
+    gfx_cmd_begin_persistent();
+    gfx_cmd_set_sprite_at(0, 33, 100, 200, 3, 4, 5, 6);
+
+    let base0: i32 = GFX_I_SPRITE_BASE + 0 * GFX_SPRITE_STRIDE_I32;
+    let base1: i32 = GFX_I_SPRITE_BASE + 1 * GFX_SPRITE_STRIDE_I32;
+
+    // Sprite 0 updated.
+    if (gfx_cmd_i32[base0 + 0] != 33) { return false; }
+    if (gfx_cmd_i32[base0 + 1] != 100) { return false; }
+    if (gfx_cmd_i32[base0 + 2] != 200) { return false; }
+
+    // Sprite 1 preserved.
+    if (gfx_cmd_i32[base1 + 0] != 22) { return false; }
+    if (gfx_cmd_i32[base1 + 1] != 7) { return false; }
+    if (gfx_cmd_i32[base1 + 2] != 8) { return false; }
+
+    return true;
+}
+
+test `persistent begin preserves line entries`(): bool {
+    gfx_cmd_begin();
+    gfx_cmd_set_line_count(1);
+    gfx_cmd_set_line_at(0, 1.0, 2.0, 3.0, 4.0, 0.1, 0.2, 0.3, 0.4);
+
+    gfx_cmd_begin_persistent();
+
+    let base: i32 = GFX_F_LINE_BASE + 0 * GFX_LINE_STRIDE_F32;
+    if (gfx_cmd_f32[base + 0] != 1.0) { return false; }
+    if (gfx_cmd_f32[base + 1] != 2.0) { return false; }
+    if (gfx_cmd_f32[base + 2] != 3.0) { return false; }
+    if (gfx_cmd_f32[base + 3] != 4.0) { return false; }
+    if (gfx_cmd_f32[base + 4] != 0.1) { return false; }
+    if (gfx_cmd_f32[base + 5] != 0.2) { return false; }
+    if (gfx_cmd_f32[base + 6] != 0.3) { return false; }
+    if (gfx_cmd_f32[base + 7] != 0.4) { return false; }
+
+    return true;
+}
+

--- a/tests/gfx_cmd_text_cached.stasis
+++ b/tests/gfx_cmd_text_cached.stasis
@@ -1,0 +1,18 @@
+import "../src/gfx_cmd.stasis";
+import "../src/stdlib/stdlib.stasis";
+
+test `cached text does not consume text bytes`(): bool {
+    gfx_cmd_begin();
+    gfx_cmd_text_cached(1, 7, 10.0, 20.0, 1.0, 1.0, 1.0, 1.0);
+
+    if (gfx_cmd_text_count() != 1) { return false; }
+    if (gfx_cmd_text_bytes_used() != 0) { return false; }
+
+    let base_i: i32 = GFX_I_TEXT_BASE + 0 * GFX_TEXT_STRIDE_I32;
+    if (gfx_cmd_i32[base_i + 0] != 1) { return false; }
+    if (gfx_cmd_i32[base_i + 1] != -7) { return false; }
+    if (gfx_cmd_i32[base_i + 2] != 0) { return false; }
+
+    return true;
+}
+


### PR DESCRIPTION
Implements cached glyph runs for command-buffer text to avoid per-frame UTF-8 copying and per-character `stbtt_GetBakedQuad` work.

- Runtime text cache: `stasis_gfx_cache_text`, `stasis_gfx_draw_text_cached`, `stasis_gfx_measure_text_cached`.
- Command buffer: `byte_off < 0` in text meta encodes cached run handle; adds `gfx_cmd_text_cached(...)`.
- Stdlib: adds `gfx_cache_text(...)` + `draw_text_cached(...)`.
- Tests: `tests/gfx_cmd_text_cached.stasis`.
- Marks the cached glyph run todo complete in `docs/tasks.md`.