### PR TITLE
fix: restore deps and mute audio in wsl dev

### DIFF
--- a/dev_brickout_revenge_v1_wsl.sh
+++ b/dev_brickout_revenge_v1_wsl.sh
@@ -18,6 +18,8 @@ fi
 
 export STASIS_ASSET_ROOT="${script_dir}"
 export STASIS_USE_SDL=1
+: "${STASIS_DISABLE_AUDIO:=1}"
+: "${SDL_AUDIODRIVER:=dummy}"
 
 : "${STASIS_CRANELIFT_JIT_RUNNER:=0}"
 : "${STASIS_JIT_WATCHDOG_MS:=15000}"
@@ -25,4 +27,3 @@ export STASIS_USE_SDL=1
 exec ./stasis.sh run "samples/brickout_revenge/brickout_revenge_v1.stasis" \
   --watch --backend cranelift --graphics --module brick --fps 60 \
   "$@"
-

--- a/docs/timings.md
+++ b/docs/timings.md
@@ -53,3 +53,26 @@ Summary:
 
 Notes:
 - Script defaults `STASIS_HOTSWAP_DELAY_MS=500` and retries when the runner restarts.
+
+## WSL data-binding reload timing (brickout_revenge_v1 config.json)
+
+Date: 2026-01-26
+
+Repo:
+- Branch: fix/wsl-llvmsharp-restore
+- Commit: eccb2af
+
+Command:
+
+```bash
+STASIS_DISABLE_AUDIO=1 SDL_AUDIODRIVER=dummy ./stasis.sh run samples/brickout_revenge/brickout_revenge_v1.stasis --watch --backend cranelift --graphics --module brick --fps 60
+```
+
+Metric:
+- Parse `DATABIND: reloaded ... apply_ms=...` from `build/hotstate/brickout_revenge_v1.brick.runner.err.log` after editing `samples/brickout_revenge/data/config.json`.
+
+Samples (ms):
+- 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1
+
+Summary:
+- count=10 min=0.100ms avg=0.100ms max=0.100ms

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -2143,6 +2143,14 @@ int main(int argc, char **argv)
     }
 
     stasis_data_set_dll(lib);
+    if (data_bind_json && data_bind_meta)
+    {
+        int handle = stasis_data_bind(data_bind_json, data_bind_meta);
+        if (handle == 0)
+        {
+            fprintf(stderr, "warning: failed to register data binding\n");
+        }
+    }
     stasis_try_set_sys_args(lib, argc, argv);
 
     stasis_entry_fn entry = (stasis_entry_fn)symbol;

--- a/stasis.sh
+++ b/stasis.sh
@@ -2,4 +2,24 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+need_restore=0
+assets_path="${SCRIPT_DIR}/Stasis.Cli/obj/project.assets.json"
+if [[ ! -f "${assets_path}" ]]; then
+  need_restore=1
+else
+  llvmsharp_version="$(
+    grep -o 'PackageReference Include="LLVMSharp" Version="[^"]*"' "${SCRIPT_DIR}/Stasis.Compiler/Stasis.Compiler.csproj" \
+      | sed 's/.*Version="\\([^"]*\\)".*/\\1/' \
+      | head -n 1
+  )"
+  nuget_root="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+  if [[ -n "${llvmsharp_version}" && ! -d "${nuget_root}/llvmsharp/${llvmsharp_version}" ]]; then
+    need_restore=1
+  fi
+fi
+
+if [[ "${need_restore}" == "1" ]]; then
+  dotnet restore "${SCRIPT_DIR}/Stasis.sln"
+fi
+
 dotnet run --no-restore --project "${SCRIPT_DIR}/Stasis.Cli/Stasis.Cli.csproj" -- "$@"


### PR DESCRIPTION
## Summary
- auto-restore NuGet deps in stasis.sh when required
- default WSL dev script to disable audio (avoids runner crashes)

## Testing
- `bash dev_brickout_revenge_v1_wsl.sh` (WSL)
- `scripts/hotswap_timing_brickout_v1.sh` (WSL)
