### PR TITLE
Bucket Catcher: drop sprite color config

### DIFF
--- a/samples/bucket_catcher.stasis
+++ b/samples/bucket_catcher.stasis
@@ -53,12 +53,6 @@ struct BucketConfig {
     background_red: f32;
     background_green: f32;
     background_blue: f32;
-    bucket_red: f32;
-    bucket_green: f32;
-    bucket_blue: f32;
-    ball_red: f32;
-    ball_green: f32;
-    ball_blue: f32;
     ui_red: f32;
     ui_green: f32;
     ui_blue: f32;

--- a/samples/bucket_catcher/data/config.json
+++ b/samples/bucket_catcher/data/config.json
@@ -18,12 +18,6 @@
     "background_red": 0.05,
     "background_green": 0.07,
     "background_blue": 0.10,
-    "bucket_red": 0.2,
-    "bucket_green": 0.8,
-    "bucket_blue": 1.0,
-    "ball_red": 1.0,
-    "ball_green": 0.7,
-    "ball_blue": 0.2,
     "ui_red": 0.9,
     "ui_green": 0.9,
     "ui_blue": 0.9


### PR DESCRIPTION
Bucket/ball colors are controlled by SVG sprites, so remove the unused ucket_* and all_* color fields from samples/bucket_catcher config.