### PR TITLE
docs: WSL toolchains + global mem top30

### DIFF
--- a/docs/timings.md
+++ b/docs/timings.md
@@ -94,3 +94,38 @@ Command:
 Result:
 - total globals: 626180 bytes (611.50 KiB)
 - state: 44562 bytes (43.52 KiB)
+
+Top 30 globals by size (bytes):
+- 369168 gfx_cmd_f32
+- 139392 gfx_cmd_i32
+- 65536 gfx_cmd_u8
+- 44562 state
+- 3072 host_i32
+- 2048 audio_buf
+- 768 brickout_level_event_preset
+- 768 brickout_level_event_tick
+- 288 sfx_voices
+- 256 host_f32
+- 68 brickout_level_name_tmp
+- 40 brickout_level_name_0
+- 40 brickout_level_name_1
+- 40 brickout_level_name_2
+- 12 brickout_digits_tmp
+- 12 brickout_level_event_count
+- 12 brickout_level_event_offset
+- 12 brickout_level_initial_power_cap
+- 12 brickout_level_initial_scraps
+- 4 audio_sr
+- 4 bench_count
+- 4 bench_frame
+- 4 bench_sum_ms
+- 4 bench_sum_us
+- 4 brickout_level_done
+- 4 brickout_level_next_event_index
+- 4 brickout_level_tick
+- 4 brickout_levels_magic
+- 4 brickout_ui_font
+- 4 desktop_size_h
+
+Note:
+- `total globals` includes graphics/audio/input buffers and other globals (e.g. `gfx_cmd_*`, `host_*`) in addition to the game `state` struct.

--- a/docs/wsl-dev.md
+++ b/docs/wsl-dev.md
@@ -16,78 +16,11 @@ Install toolchains if you don't already have them.
 
 ### .NET SDK (Ubuntu)
 
-This repo targets .NET 9.x. On Ubuntu in WSL, the most reliable approach is to install the Microsoft package feed for your Ubuntu version and then install `dotnet-sdk-9.0`.
+This repo targets .NET 9.x.
 
-First, check your Ubuntu version (pick the matching install block below):
+#### Copy/paste (recommended): install .NET 9 SDK via `dotnet-install.sh`
 
-```bash
-cat /etc/os-release
-# Look for: VERSION_ID="24.04" (or "22.04", etc.)
-```
-
-#### Ubuntu 24.04 (VERSION_ID="24.04")
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ca-certificates wget apt-transport-https
-
-wget "https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb" \
-  -O /tmp/packages-microsoft-prod.deb
-sudo dpkg -i /tmp/packages-microsoft-prod.deb
-rm -f /tmp/packages-microsoft-prod.deb
-
-sudo apt-get update
-sudo apt-get install -y dotnet-sdk-9.0
-
-dotnet --info
-```
-
-#### Ubuntu 22.04 (VERSION_ID="22.04")
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ca-certificates wget apt-transport-https
-
-wget "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" \
-  -O /tmp/packages-microsoft-prod.deb
-sudo dpkg -i /tmp/packages-microsoft-prod.deb
-rm -f /tmp/packages-microsoft-prod.deb
-
-sudo apt-get update
-sudo apt-get install -y dotnet-sdk-9.0
-
-dotnet --info
-```
-
-#### Auto-detect (works if Microsoft publishes a config for your VERSION_ID)
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ca-certificates wget apt-transport-https
-
-source /etc/os-release
-wget "https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb" \
-  -O /tmp/packages-microsoft-prod.deb
-sudo dpkg -i /tmp/packages-microsoft-prod.deb
-rm -f /tmp/packages-microsoft-prod.deb
-
-sudo apt-get update
-sudo apt-get install -y dotnet-sdk-9.0
-
-dotnet --info
-```
-
-#### If apt can't find `dotnet-sdk-9.0` (common on new Ubuntu releases)
-
-If you see `E: Unable to locate package dotnet-sdk-9.0`, first sanity-check what packages the repo is exposing:
-
-```bash
-grep -R "packages.microsoft.com" /etc/apt/sources.list /etc/apt/sources.list.d || true
-sudo apt-get update
-apt-cache search dotnet-sdk | head -n 20
-```
-
-If `dotnet-sdk-9.0` still doesn't appear, use the official installer script (installs into your home dir; no apt repo required):
+This works even when `apt` can't find `dotnet-sdk-9.0` (a common issue on some Ubuntu/WSL combinations):
 
 ```bash
 sudo apt-get update
@@ -106,7 +39,31 @@ dotnet --info
 dotnet --list-sdks
 ```
 
-If you prefer to manage multiple SDKs, install `dotnet` via `asdf` or `dotnet-install.sh`, but the apt-based install above tends to be the least surprising for WSL dev.
+#### Optional: install via `apt` (Microsoft feed)
+
+If you prefer `apt`, you can install the Microsoft package feed for your Ubuntu version and then install `dotnet-sdk-9.0`.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates wget apt-transport-https
+
+source /etc/os-release
+wget "https://packages.microsoft.com/config/ubuntu/$VERSION_ID/packages-microsoft-prod.deb" \
+  -O /tmp/packages-microsoft-prod.deb
+sudo dpkg -i /tmp/packages-microsoft-prod.deb
+rm -f /tmp/packages-microsoft-prod.deb
+
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-9.0
+
+dotnet --info
+```
+
+If you hit `E: Unable to locate package dotnet-sdk-9.0`, double-check what packages are available:
+
+```bash
+apt-cache search dotnet-sdk | head -n 20
+```
 
 ### Rust (rustup + stable toolchain)
 


### PR DESCRIPTION
- Update docs/wsl-dev.md with a copy/paste .NET 9 install block (dotnet-install.sh), plus optional apt-based install and WSL gh auth notes.
- Extend docs/timings.md with Brickout Revenge v1 global memory top-30 list and a short note explaining total-vs-state.