### PR TITLE
feat: warn on unused struct fields

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -433,16 +433,16 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             parseMs = phaseStopwatch.ElapsedMilliseconds;
             phaseStopwatch.Restart();
         }
-        if (parse.Diagnostics.Count > 0)
+        if (HasErrors(parse.Diagnostics))
         {
-            
+             
             PrintDiagnostics(parse.Diagnostics, source, path);
             return 1;
         }
 
         var linkLibraries = CollectLinkDirectives(parse.CompilationUnit);
         var linkDiagnostics = ValidateLinkDirectives(linkLibraries, parse.CompilationUnit);
-        if (linkDiagnostics.Count > 0)
+        if (HasErrors(linkDiagnostics))
         {
             PrintDiagnostics(linkDiagnostics, source, path);
             return 1;
@@ -465,7 +465,10 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         if (sema.Diagnostics.Count > 0)
         {
             PrintDiagnostics(sema.Diagnostics, source, path);
-            return 1;
+            if (HasErrors(sema.Diagnostics))
+            {
+                return 1;
+            }
         }
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
@@ -531,13 +534,13 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             {
                 WriteIrOutput(ir, outputPath);
             }
-            return 1;
+            return HasErrors(lowerDiagnostics) ? 1 : 0;
         }
 
         if (emitIrOnly)
         {
             WriteIrOutput(ir, outputPath);
-            return lowerDiagnostics.Count > 0 ? 1 : 0;
+            return HasErrors(lowerDiagnostics) ? 1 : 0;
         }
 
         if (backend == BackendType.Cranelift)
@@ -3168,14 +3171,14 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
         var parse = Parser.Parse(source);
         parseMs = phase.ElapsedMilliseconds;
         phase.Restart();
-        if (parse.Diagnostics.Count > 0)
+        if (HasErrors(parse.Diagnostics))
         {
             PrintDiagnostics(parse.Diagnostics, source, sourcePath);
             return 1;
         }
         var linkLibraries = CollectLinkDirectives(parse.CompilationUnit);
         var linkDiagnostics = ValidateLinkDirectives(linkLibraries, parse.CompilationUnit);
-        if (linkDiagnostics.Count > 0)
+        if (HasErrors(linkDiagnostics))
         {
             PrintDiagnostics(linkDiagnostics, source, sourcePath);
             return 1;
@@ -3188,7 +3191,10 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
         if (sema.Diagnostics.Count > 0)
         {
             PrintDiagnostics(sema.Diagnostics, source, sourcePath);
-            return 1;
+            if (HasErrors(sema.Diagnostics))
+            {
+                return 1;
+            }
         }
 
         if (!ContainsTopLevelFunction(parse.CompilationUnit, "tick"))
@@ -3216,7 +3222,7 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
         {
             PrintDiagnostics(result.Diagnostics, source, sourcePath);
             Console.WriteLine(result.Ir);
-            return 1;
+            return HasErrors(result.Diagnostics) ? 1 : 0;
         }
 
         // On Windows, loaded DLLs stay file-locked even after swap, so alternating between swapA/swapB
@@ -3815,7 +3821,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         }
 
         var parse = Parser.Parse(source);
-        if (parse.Diagnostics.Count > 0)
+        if (HasErrors(parse.Diagnostics))
         {
             PrintDiagnostics(parse.Diagnostics, source, sourcePath);
             clif = string.Empty;
@@ -3825,7 +3831,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
 
         var linkLibraries = CollectLinkDirectives(parse.CompilationUnit);
         var linkDiagnostics = ValidateLinkDirectives(linkLibraries, parse.CompilationUnit);
-        if (linkDiagnostics.Count > 0)
+        if (HasErrors(linkDiagnostics))
         {
             PrintDiagnostics(linkDiagnostics, source, sourcePath);
             clif = string.Empty;
@@ -3841,7 +3847,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
             PrintDiagnostics(sema.Diagnostics, source, sourcePath);
             clif = string.Empty;
             lowerMs = 0;
-            return 1;
+            return HasErrors(sema.Diagnostics) ? 1 : 0;
         }
 
         if (!ContainsTopLevelFunction(parse.CompilationUnit, "tick"))
@@ -4849,7 +4855,7 @@ static PrepareResult PrepareForLower(string path, bool includeTests, string modu
         var runtimeImports = GetRuntimeImportFlags(path);
         var sema = new SemanticAnalyzer(new SemanticAnalyzerOptions(EnableGraphicsBuiltins: false, EnableAudioBuiltins: false)).Analyze(parse.CompilationUnit);
         diagnostics.AddRange(sema.Diagnostics);
-        if (sema.Diagnostics.Count > 0)
+        if (HasErrors(sema.Diagnostics))
         {
             return new PrepareResult(null, new CompileResult(path, source, hasTests, usesGraphics, linkLibraries, backend, null, null, diagnostics, emitIrOnly, stopwatch.ElapsedMilliseconds, false));
         }
@@ -5392,7 +5398,7 @@ static int ConsumeCompileResult(CompileResult result, bool emitIrOnly, string? o
         }
 
         Console.WriteLine($"Total time={result.CompileMilliseconds}ms");
-        return 1;
+        return HasErrors(result.Diagnostics) ? 1 : 0;
     }
 
     if (emitIrOnly)
@@ -5543,15 +5549,33 @@ static void PrintDiagnostics(IEnumerable<Diagnostic> diagnostics, string source,
 {
     foreach (var d in diagnostics)
     {
+        if (d.Severity == DiagnosticSeverity.Warning && ShouldSuppressWarnings())
+        {
+            continue;
+        }
+
         var (line, column, lineText) = GetLineInfo(source, d.Span.Start);
         var length = Math.Max(1, d.Span.Length);
         var markerLen = Math.Min(length, Math.Max(1, Math.Max(0, lineText.Length - (column - 1))));
         var marker = new string(' ', Math.Max(0, column - 1)) + new string('^', markerLen);
         var location = filePath is null ? $"line {line}, column {column}" : $"{filePath}:{line}:{column}";
-        Console.Error.WriteLine($"error: {d.Message} ({location})");
+        var prefix = d.Severity == DiagnosticSeverity.Warning ? "warning" : "error";
+        Console.Error.WriteLine($"{prefix}: {d.Message} ({location})");
         Console.Error.WriteLine(lineText);
         Console.Error.WriteLine(marker);
     }
+}
+
+static bool HasErrors(IEnumerable<Diagnostic> diagnostics)
+{
+    foreach (var d in diagnostics)
+    {
+        if (d.Severity == DiagnosticSeverity.Error)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 static (int line, int column, string lineText) GetLineInfo(string source, int offset)

--- a/Stasis.Compiler.Tests/BackendConformanceTests.cs
+++ b/Stasis.Compiler.Tests/BackendConformanceTests.cs
@@ -547,7 +547,7 @@ function add(a: i32, b: i32): i32 {
         }
 
         var semantic = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        if (semantic.Diagnostics.Count > 0)
+        if (semantic.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
         {
             return new CodeGenerationResult(string.Empty, semantic.Diagnostics);
         }

--- a/Stasis.Compiler.Tests/CraneliftBackendConfirmationTests.cs
+++ b/Stasis.Compiler.Tests/CraneliftBackendConfirmationTests.cs
@@ -155,7 +155,7 @@ public class CraneliftBackendConfirmationTests
         Assert.Empty(parse.Diagnostics);
 
         var semantic = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(semantic.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(semantic.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, semantic.Symbols).Plan();
         var options = new CodeGenerationOptions(ModuleName: "cranelift_confirm", IncludeTests: false, EmitTestHarness: false);
@@ -533,7 +533,7 @@ public class CraneliftBackendConfirmationTests
         Assert.Empty(parse.Diagnostics);
 
         var semantic = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(semantic.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(semantic.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, semantic.Symbols).Plan();
 

--- a/Stasis.Compiler.Tests/DiagnosticAsserts.cs
+++ b/Stasis.Compiler.Tests/DiagnosticAsserts.cs
@@ -1,0 +1,11 @@
+using Stasis.Compiler;
+
+namespace Stasis.Compiler.Tests;
+
+internal static class DiagnosticAsserts
+{
+    public static void AssertNoErrors(IEnumerable<Diagnostic> diagnostics)
+    {
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+}

--- a/Stasis.Compiler.Tests/ExecutionTests.cs
+++ b/Stasis.Compiler.Tests/ExecutionTests.cs
@@ -62,7 +62,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "execmodule", LowerOptions.Production);
@@ -219,7 +219,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "testmodule", LowerOptions.Default);
@@ -258,7 +258,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "execops", LowerOptions.Production);
@@ -301,7 +301,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "gfxmodule", LowerOptions.Production);
@@ -347,7 +347,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "substr_ok", LowerOptions.Production);
@@ -392,7 +392,7 @@ public class ExecutionTests
         Assert.Empty(parse.Diagnostics);
 
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         var lower = new ModuleLowerer().LowerToIr(parse.CompilationUnit, sema, layout, "substr_abort", LowerOptions.Production);

--- a/Stasis.Compiler.Tests/LoweringTests.cs
+++ b/Stasis.Compiler.Tests/LoweringTests.cs
@@ -26,7 +26,7 @@ public class LoweringTests
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
         if (!allowSemanticDiagnostics)
         {
-            Assert.Empty(sema.Diagnostics);
+            DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
         }
 
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();

--- a/Stasis.Compiler.Tests/ParserTests.cs
+++ b/Stasis.Compiler.Tests/ParserTests.cs
@@ -83,7 +83,7 @@ public class ParserTests
         var func = Assert.IsType<FunctionDeclarationSyntax>(Assert.Single(result.CompilationUnit.Declarations));
         Assert.IsType<VariableDeclarationSyntax>(Assert.Single(func.Body!.Statements));
         var sema = new SemanticAnalyzer().Analyze(result.CompilationUnit);
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]

--- a/Stasis.Compiler.Tests/SemanticTests.cs
+++ b/Stasis.Compiler.Tests/SemanticTests.cs
@@ -47,7 +47,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -127,6 +127,28 @@ public class SemanticTests
     }
 
     [Fact]
+    public void Warns_on_struct_fields_that_are_never_used()
+    {
+        var source = """
+            struct S { used: i32; unused: i32; }
+            global state: S;
+            function f(): void {
+                state.used = 1;
+            }
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
+        Assert.Contains(sema.Diagnostics, d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("S.unused", StringComparison.Ordinal) &&
+            d.Message.Contains("never assigned or referenced", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Flags_calling_non_function_symbol()
     {
         var source = """
@@ -174,7 +196,7 @@ public class SemanticTests
         Assert.Empty(parse.Diagnostics);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -206,7 +228,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -253,7 +275,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -293,7 +315,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -308,7 +330,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -322,7 +344,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
         Assert.Contains("players", sema.Symbols.Keys);
     }
 
@@ -437,7 +459,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
         Assert.Contains("State", sema.Symbols.Keys);
         Assert.Equal(SymbolKind.Enum, sema.Symbols["State"].Kind);
     }
@@ -452,7 +474,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
         Assert.Contains("State.Idle", sema.Symbols.Keys);
         Assert.Contains("State.Jump", sema.Symbols.Keys);
         Assert.Contains("State.Run", sema.Symbols.Keys);
@@ -473,7 +495,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -505,7 +527,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -521,7 +543,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -571,7 +593,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -587,7 +609,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]
@@ -640,7 +662,7 @@ public class SemanticTests
         var parse = Parser.Parse(source);
         var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
 
-        Assert.Empty(sema.Diagnostics);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
     }
 
     [Fact]

--- a/Stasis.Compiler/Diagnostic.cs
+++ b/Stasis.Compiler/Diagnostic.cs
@@ -1,3 +1,3 @@
 namespace Stasis.Compiler;
 
-public sealed record Diagnostic(string Message, SourceSpan Span, string? FilePath = null);
+public sealed record Diagnostic(string Message, SourceSpan Span, string? FilePath = null, DiagnosticSeverity Severity = DiagnosticSeverity.Error);

--- a/Stasis.Compiler/DiagnosticSeverity.cs
+++ b/Stasis.Compiler/DiagnosticSeverity.cs
@@ -1,0 +1,7 @@
+namespace Stasis.Compiler;
+
+public enum DiagnosticSeverity
+{
+    Warning,
+    Error
+}

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -29,7 +29,10 @@ public sealed class SemanticAnalyzer
     private readonly List<Diagnostic> _diagnostics = new();
     private readonly Dictionary<string, StructDeclarationSyntax> _structs = new(StringComparer.Ordinal);
 
-    private bool AtDiagnosticLimit => _diagnostics.Count >= DiagnosticPolicy.MaxErrors;
+    private int _errorCount;
+    private bool AtDiagnosticLimit => _errorCount >= DiagnosticPolicy.MaxErrors;
+
+    private readonly HashSet<string> _usedStructFields = new(StringComparer.Ordinal);
 
     private static IEnumerable<string> GetClosestMatches(string target, IEnumerable<string> candidates, int maxCount = 3)
     {
@@ -158,6 +161,11 @@ public sealed class SemanticAnalyzer
             }
         }
 
+        if (!AtDiagnosticLimit)
+        {
+            EmitUnusedStructFieldWarnings();
+        }
+
         return new SemanticResult(_diagnostics, new Dictionary<string, Symbol>(_symbols));
     }
 
@@ -179,7 +187,25 @@ public sealed class SemanticAnalyzer
             }
         }
 
-        _diagnostics.Add(new Diagnostic(message, span));
+        _diagnostics.Add(new Diagnostic(message, span, Severity: DiagnosticSeverity.Error));
+        _errorCount++;
+    }
+
+    private void AddWarning(string message, SourceSpan span)
+    {
+        for (var i = 0; i < _diagnostics.Count; i++)
+        {
+            var d = _diagnostics[i];
+            if (d.Span.Start == span.Start &&
+                d.Span.Length == span.Length &&
+                string.Equals(d.Message, message, StringComparison.Ordinal) &&
+                d.Severity == DiagnosticSeverity.Warning)
+            {
+                return;
+            }
+        }
+
+        _diagnostics.Add(new Diagnostic(message, span, Severity: DiagnosticSeverity.Warning));
     }
 
     private void ValidateFunctionDeclarations(CompilationUnitSyntax compilationUnit)
@@ -1785,10 +1811,69 @@ public sealed class SemanticAnalyzer
                 return new PrimitiveTypeSymbol("i32");
             }
 
+            _usedStructFields.Add($"{named.TypeName}.{field.Identifier.Text}");
             currentType = ResolveType(field.Type);
         }
 
         return currentType;
+    }
+
+    private void EmitUnusedStructFieldWarnings()
+    {
+        var usedStructs = new HashSet<string>(StringComparer.Ordinal);
+
+        void AddType(TypeSymbol? type)
+        {
+            if (type is null)
+            {
+                return;
+            }
+
+            switch (type)
+            {
+                case NamedTypeSymbol named:
+                    if (_symbols.TryGetValue(named.TypeName, out var sym) && sym.Kind == SymbolKind.Struct)
+                    {
+                        if (usedStructs.Add(named.TypeName) && _structs.TryGetValue(named.TypeName, out var decl))
+                        {
+                            foreach (var field in decl.Fields)
+                            {
+                                AddType(ResolveType(field.Type));
+                            }
+                        }
+                    }
+                    break;
+                case ArrayTypeSymbol arr:
+                    AddType(arr.ElementType);
+                    break;
+            }
+        }
+
+        foreach (var sym in _symbols.Values)
+        {
+            AddType(sym.Type);
+        }
+
+        foreach (var (structName, structDecl) in _structs)
+        {
+            if (!usedStructs.Contains(structName))
+            {
+                continue;
+            }
+
+            foreach (var field in structDecl.Fields)
+            {
+                var key = $"{structName}.{field.Identifier.Text}";
+                if (_usedStructFields.Contains(key))
+                {
+                    continue;
+                }
+
+                AddWarning(
+                    $"Struct field '{key}' is never assigned or referenced. Hint: remove it, or add a use so the intent is explicit.",
+                    field.Identifier.Span);
+            }
+        }
     }
 
     private bool AreTypesCompatible(TypeSymbol target, TypeSymbol source)

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -1851,6 +1851,12 @@ public sealed class SemanticAnalyzer
 
         foreach (var sym in _symbols.Values)
         {
+            // Only consider value-bearing symbols as evidence that a struct is "used".
+            // Otherwise, we'd warn on fields for structs that are declared but never referenced anywhere.
+            if (sym.Kind is SymbolKind.Struct or SymbolKind.Enum)
+            {
+                continue;
+            }
             AddType(sym.Type);
         }
 

--- a/Stasis.LanguageServer/Services/DiagnosticsPublisher.cs
+++ b/Stasis.LanguageServer/Services/DiagnosticsPublisher.cs
@@ -6,6 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using Stasis.LanguageServer.Models;
 using CompilerDiagnostic = Stasis.Compiler.Diagnostic;
 using CompilerSourceSpan = Stasis.Compiler.SourceSpan;
+using CompilerSeverity = Stasis.Compiler.DiagnosticSeverity;
 
 /// <summary>
 /// Service responsible for converting Stasis diagnostics to LSP format and publishing them to the client.
@@ -50,7 +51,7 @@ public class DiagnosticsPublisher
             {
                 Range = range,
                 Message = diag.Message,
-                Severity = DiagnosticSeverity.Error,
+                Severity = diag.Severity == CompilerSeverity.Warning ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error,
                 Source = "Stasis"
             });
         }


### PR DESCRIPTION
- Add warning diagnostics (severity) and print warning: vs error: in CLI.
- Emit a warning when a used struct has fields that are never assigned or referenced.
- Language server maps compiler warnings to LSP warnings.
- Tests updated to ignore warnings when asserting successful compiles.