### PR TITLE
fix: VS Code LSP install + WSL guidance

### DIFF
--- a/Stasis.LanguageServer.Tests/LspCompletionTests.cs
+++ b/Stasis.LanguageServer.Tests/LspCompletionTests.cs
@@ -17,6 +17,47 @@ namespace Stasis.LanguageServer.Tests;
 public sealed class LspCompletionTests
 {
     [Fact]
+    public async Task CompletesGlobalStateMembersAfterDot()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var tempDir = Directory.CreateTempSubdirectory("stasis_lsp_state_completion_");
+        try
+        {
+            var entryPath = Path.Combine(tempDir.FullName, "main.stasis");
+            var document = string.Join("\n", new[]
+            {
+                "struct GameState {",
+                "    score: i32;",
+                "    misses: i32;",
+                "}",
+                "",
+                "global state: GameState;",
+                "",
+                "function main(): i32 {",
+                "    state.",
+                "    return 0;",
+                "}"
+            });
+
+            var uri = new Uri(entryPath).AbsoluteUri;
+            var position = GetPositionAfter(document, "state.");
+
+            await using var harness = await LspTestHarness.StartAsync(cts.Token);
+            await harness.InitializeAsync(cts.Token);
+            await harness.DidOpenAsync(uri, document, cts.Token);
+
+            var labels = await harness.RequestCompletionLabelsAsync(uri, position.Line, position.Character, cts.Token);
+            Assert.Contains("score", labels);
+            Assert.Contains("misses", labels);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task CompletesBrickoutStateMembersAfterDot()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/Stasis.LanguageServer/Stasis.LanguageServer.csproj
+++ b/Stasis.LanguageServer/Stasis.LanguageServer.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
-    <ProjectReference Include="..\Stasis.Compiler\Stasis.Compiler.csproj" />
+    <ProjectReference Include="..\Stasis.Compiler\Stasis.Compiler.csproj" Properties="StasisIncludeLibLLVM=false" />
   </ItemGroup>
 
 </Project>

--- a/docs/wsl-dev.md
+++ b/docs/wsl-dev.md
@@ -143,6 +143,20 @@ cd StasisLang
 
 If you prefer to keep a single working copy, open `\\\\wsl$\\<distro>\\home\\<user>\\src\\StasisLang` in your editor (or use VS Code Remote - WSL).
 
+## VS Code: LSP/autocomplete in Remote - WSL
+
+If you're using VS Code Remote - WSL, make sure you install the Stasis extension into the WSL environment (extensions are installed per-remote).
+
+From the repo root (inside WSL), build + install the full extension (syntax + LSP):
+
+```bash
+# In WSL, "code" should be available when using VS Code Remote - WSL.
+code --version
+
+# Build/publish server, package VSIX, and install (force-reinstall)
+./scripts/install_vscode_stasis_lsp_wsl.sh --force
+```
+
 ### Optional: SSH clone instead of HTTPS
 
 If you prefer SSH (no HTTPS tokens), create an SSH key in WSL and add it to GitHub:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,7 @@ param(
   [switch]$BrowserTests,
   [switch]$CheckOnly,
   [switch]$Force,
-  [string]$LspRuntime = "win-x64",
+  [string]$LspRuntime = "",
   [string]$LspConfiguration = "Release"
 )
 

--- a/scripts/install_vscode_stasis_lsp.ps1
+++ b/scripts/install_vscode_stasis_lsp.ps1
@@ -40,13 +40,11 @@ if (-not $code) {
   throw "VS Code CLI (code) not found in PATH. Enable it from the VS Code command palette."
 }
 
-if (Test-Path $serverOut) {
-  Remove-Item -Recurse -Force $serverOut
-}
 New-Item -ItemType Directory -Force -Path $serverOut | Out-Null
 New-Item -ItemType File -Force -Path (Join-Path $serverOut ".gitkeep") | Out-Null
 
 $publishArgs = @("publish", $serverProject, "-c", $Configuration, "-o", $serverOut,
+  "-p:StasisIncludeLibLLVM=false",
   "-p:SelfContained=false",
   "-p:PublishSingleFile=false",
   "-p:PublishReadyToRun=false",

--- a/scripts/install_vscode_stasis_lsp_wsl.sh
+++ b/scripts/install_vscode_stasis_lsp_wsl.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+force=0
+skip_install=0
+configuration="Release"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force|-f)
+      force=1
+      shift
+      ;;
+    --skip-install)
+      skip_install=1
+      shift
+      ;;
+    --configuration|-c)
+      configuration="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [--force] [--skip-install] [--configuration <Debug|Release>]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+server_project="$repo_root/Stasis.LanguageServer/Stasis.LanguageServer.csproj"
+extension_dir="$repo_root/vscode-stasis"
+server_out="$extension_dir/server"
+vsix_dir="$extension_dir/.vsix"
+vsix_path="$vsix_dir/stasislang.stasis.vsix"
+
+command -v dotnet >/dev/null || { echo "error: dotnet not found in PATH" >&2; exit 1; }
+command -v npm >/dev/null || { echo "error: npm not found in PATH" >&2; exit 1; }
+command -v npx >/dev/null || { echo "error: npx not found in PATH" >&2; exit 1; }
+command -v code >/dev/null || { echo "error: code (VS Code CLI) not found in PATH" >&2; exit 1; }
+
+mkdir -p "$server_out"
+dotnet publish "$server_project" -c "$configuration" -o "$server_out" \
+  -p:StasisIncludeLibLLVM=false \
+  -p:SelfContained=false \
+  -p:PublishSingleFile=false \
+  -p:PublishReadyToRun=false \
+  -p:UseAppHost=false
+
+pushd "$extension_dir" >/dev/null
+if [[ ! -d node_modules ]]; then
+  npm install
+fi
+
+npm run build
+
+mkdir -p "$vsix_dir"
+npx @vscode/vsce package --out "$vsix_path"
+
+if [[ $skip_install -eq 1 ]]; then
+  echo "Built VSIX: $vsix_path"
+  popd >/dev/null
+  exit 0
+fi
+
+install_args=(--install-extension "$vsix_path")
+if [[ $force -eq 1 ]]; then
+  install_args+=(--force)
+fi
+code "${install_args[@]}"
+echo "Installed VSIX: $vsix_path"
+
+popd >/dev/null
+

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -17,6 +17,11 @@ This builds/publishes the language server, packages the VSIX, and installs it vi
 
 - `powershell -ExecutionPolicy Bypass -File .\\scripts\\install_vscode_stasis_lsp.ps1 -Force`
 
+Notes:
+
+- If you're using VS Code Remote - WSL, install the extension into the WSL environment (not Windows). In WSL, use `./scripts/install_vscode_stasis_lsp_wsl.sh --force`.
+- If you pass `-Runtime linux-x64` you may pull in large native artifacts; prefer omitting `-Runtime` unless you specifically need a RID-specific publish.
+
 ## Development
 
 1. Build the language server:

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -44,6 +44,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const output = vscode.window.createOutputChannel("Stasis");
   const server = tryServerCommand(context.extensionPath);
   if (!server) {
+    void vscode.window.showWarningMessage(
+      "Stasis LSP server binary not found; autocomplete/hover/diagnostics are disabled (syntax highlighting still works). See vscode-stasis/README.md for install steps."
+    );
     output.appendLine(
       "Stasis Language Server binary not found. LSP features are disabled; syntax highlighting still works."
     );


### PR DESCRIPTION
Fixes common reasons the VS Code extension shows no autocomplete (LSP not installed in the right environment / server not published).\n\n- Adds WSL install script: scripts/install_vscode_stasis_lsp_wsl.sh\n- Makes scripts/install.ps1 default to a RID-less publish (smaller, avoids pulling large native LLVM artifacts)\n- Makes scripts/install_vscode_stasis_lsp.ps1 pass -p:StasisIncludeLibLLVM=false and avoids deleting server/ (safer + more reproducible)\n- VS Code extension now shows a warning toast when the LSP server is missing\n- Docs: adds Remote-WSL extension install section (docs/wsl-dev.md)\n\nVerification:\n- dotnet test Stasis.sln (Release)\n- npm run build (vscode-stasis)\n