### PR TITLE
feat: incremental hotswap via split objects

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -1040,9 +1040,20 @@ static int BuildExecutableFromObject(string objPath, string outputPath, bool isT
 
 static string BuildClangArgsForObject(string objPath, string outputPath, bool isTest, string? optLevel, bool enableLto, bool enableGraphics = false, string? graphicsLibPath = null, IReadOnlyList<string>? linkLibraries = null, string? entryName = null, bool isDll = false, string? windowsDefFilePath = null, IReadOnlyList<string>? windowsExports = null)
 {
-    // Link the object file into a normal executable (use CRT defaults).
+    return BuildClangArgsForLinkInputs(new[] { $"\"{objPath}\"" }, outputPath, isTest, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, entryName, isDll, windowsDefFilePath, windowsExports);
+}
+
+static string BuildClangArgsForResponseFile(string rspPath, string outputPath, bool isTest, string? optLevel, bool enableLto, bool enableGraphics = false, string? graphicsLibPath = null, IReadOnlyList<string>? linkLibraries = null, string? entryName = null, bool isDll = false, string? windowsDefFilePath = null, IReadOnlyList<string>? windowsExports = null)
+{
+    return BuildClangArgsForLinkInputs(new[] { $"@\"{rspPath}\"" }, outputPath, isTest, optLevel, enableLto, enableGraphics, graphicsLibPath, linkLibraries, entryName, isDll, windowsDefFilePath, windowsExports);
+}
+
+static string BuildClangArgsForLinkInputs(IEnumerable<string> inputs, string outputPath, bool isTest, string? optLevel, bool enableLto, bool enableGraphics = false, string? graphicsLibPath = null, IReadOnlyList<string>? linkLibraries = null, string? entryName = null, bool isDll = false, string? windowsDefFilePath = null, IReadOnlyList<string>? windowsExports = null)
+{
+    // Link the object file(s) into a normal executable (use CRT defaults).
     var effectiveLinkLibraries = PrepareLinkLibraries(linkLibraries, enableGraphics, ref graphicsLibPath);
-    var args = new List<string> { $"\"{objPath}\"" };
+    var args = new List<string>();
+    args.AddRange(inputs);
     if (isDll)
     {
         args.Add("-shared");
@@ -3237,13 +3248,122 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
 
         try
         {
-            var aotExit = RunCraneliftAot(aotTool, hotClifPath, hotObjPath, moduleName, optLevel, out var spawnFallback, out var compileFallback);
-            aotSpawnMs = spawnFallback ?? 0;
-            aotCompileMs = compileFallback;
-            if (aotExit != 0)
+            var clifHashSw = Stopwatch.StartNew();
+            if (!TryComputeClifSplitHashes(result.Ir, out var globalsHash, out var functionHashes, out var functionOrder))
             {
-                return aotExit;
+                Console.Error.WriteLine("error: failed to compute CLIF split hashes.");
+                return 1;
             }
+            clifHashSw.Stop();
+
+            var objCacheDir = Path.Combine(swapDir, $"{baseName}.{moduleName}.objcache");
+            Directory.CreateDirectory(objCacheDir);
+            var manifestPath = Path.Combine(objCacheDir, "manifest.json");
+            var globalsObjPath = Path.Combine(objCacheDir, "globals" + GetObjectFileExtension());
+
+            CraneliftSplitManifest? prev = null;
+            if (File.Exists(manifestPath) && TryReadTextShared(manifestPath, out var prevJson))
+            {
+                try
+                {
+                    prev = JsonSerializer.Deserialize<CraneliftSplitManifest>(prevJson);
+                }
+                catch
+                {
+                    prev = null;
+                }
+            }
+
+            var needsGlobals = prev is null ||
+                               !string.Equals(prev.GlobalsHash, globalsHash, StringComparison.Ordinal) ||
+                               !File.Exists(globalsObjPath);
+
+            var toCompile = new List<string>();
+            var currentFns = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var name in functionOrder)
+            {
+                currentFns.Add(name);
+                var objPath = Path.Combine(objCacheDir, "fn_" + SanitizeSymbolForFileName(name) + GetObjectFileExtension());
+
+                var prevHashOk = prev is not null &&
+                                 prev.FunctionHashes is not null &&
+                                 prev.FunctionHashes.TryGetValue(name, out var prevHash) &&
+                                 string.Equals(prevHash, functionHashes[name], StringComparison.Ordinal);
+
+                if (!prevHashOk || !File.Exists(objPath))
+                {
+                    toCompile.Add(name);
+                }
+            }
+
+            // Best-effort cleanup for removed functions (keeps link inputs small).
+            if (prev is not null && prev.FunctionHashes is not null)
+            {
+                foreach (var oldName in prev.FunctionHashes.Keys)
+                {
+                    if (currentFns.Contains(oldName))
+                    {
+                        continue;
+                    }
+
+                    var oldObjPath = Path.Combine(objCacheDir, "fn_" + SanitizeSymbolForFileName(oldName) + GetObjectFileExtension());
+                    try
+                    {
+                        if (File.Exists(oldObjPath))
+                        {
+                            File.Delete(oldObjPath);
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+            }
+
+            // Compile only what changed.
+            var aotSw = Stopwatch.StartNew();
+            aotSpawnMs = 0;
+            aotCompileMs = 0;
+
+            var target = GetCraneliftTargetTriple();
+            if (string.IsNullOrEmpty(target))
+            {
+                Console.Error.WriteLine("error: unable to determine Cranelift target triple for this host. Set STASIS_CRANELIFT_TARGET to override.");
+                return 1;
+            }
+            var normalizedOpt = NormalizeCraneliftOptLevel(optLevel);
+
+            if (needsGlobals)
+            {
+                var args = $"--input \"{hotClifPath}\" --out-dir \"{objCacheDir}\" --globals-only --target {target} --module-name \"{moduleName}\" --opt-level {normalizedOpt}";
+                var exit = RunProcess(aotTool, args, suppressOutput: true);
+                if (exit != 0)
+                {
+                    return exit;
+                }
+            }
+
+            if (toCompile.Count > 0)
+            {
+                var sb = new StringBuilder();
+                sb.Append($"--input \"{hotClifPath}\" --out-dir \"{objCacheDir}\" --functions-only --target {target} --module-name \"{moduleName}\" --opt-level {normalizedOpt}");
+                foreach (var fn in toCompile)
+                {
+                    sb.Append(" --function \"");
+                    sb.Append(fn);
+                    sb.Append('"');
+                }
+
+                var exit = RunProcess(aotTool, sb.ToString(), suppressOutput: true);
+                if (exit != 0)
+                {
+                    return exit;
+                }
+            }
+
+            aotSw.Stop();
+            aotCompileMs = aotSw.ElapsedMilliseconds + clifHashSw.ElapsedMilliseconds;
             phase.Restart();
 
             if (!TryCreateHotStatePlan(sourcePath, layout, moduleName, new[] { $"{moduleName}__main", $"{moduleName}__tick" }, excludeSpriteFields: false, out var plan))
@@ -3253,7 +3373,29 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
             planMs = phase.ElapsedMilliseconds;
             phase.Restart();
 
-            var linkArgs = BuildClangArgsForObject(hotObjPath, hotDll, isTest: false, optLevel, enableLto, usesGraphics, graphicsLibPath, linkLibraries, entryName: $"{moduleName}__main", isDll: true, windowsDefFilePath: plan.DefPath);
+            var rspPath = Path.Combine(objCacheDir, $"link.{pid}.rsp");
+            {
+                var rsp = new StringBuilder();
+                static string ToRspPath(string path) => path.Replace('\\', '/');
+
+                void AddObj(string path)
+                {
+                    rsp.Append('"');
+                    rsp.Append(ToRspPath(path));
+                    rsp.Append('"');
+                    rsp.Append('\n');
+                }
+
+                AddObj(globalsObjPath);
+                foreach (var fn in functionOrder)
+                {
+                    var obj = Path.Combine(objCacheDir, "fn_" + SanitizeSymbolForFileName(fn) + GetObjectFileExtension());
+                    AddObj(obj);
+                }
+                WriteAllTextAtomic(rspPath, rsp.ToString(), Encoding.ASCII);
+            }
+
+            var linkArgs = BuildClangArgsForResponseFile(rspPath, hotDll, isTest: false, optLevel, enableLto, usesGraphics, graphicsLibPath, linkLibraries, entryName: $"{moduleName}__main", isDll: true, windowsDefFilePath: plan.DefPath);
             if (OperatingSystem.IsWindows())
             {
                 if (Environment.GetEnvironmentVariable("STASIS_HOTSWAP_USE_LLD") == "1")
@@ -3270,6 +3412,14 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
             {
                 return linkExit;
             }
+
+            var newManifest = new CraneliftSplitManifest
+            {
+                Version = 1,
+                GlobalsHash = globalsHash,
+                FunctionHashes = functionHashes
+            };
+            WriteAllTextAtomic(manifestPath, JsonSerializer.Serialize(newManifest), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var dllDir = Path.GetDirectoryName(hotDll);
             if (usesGraphics && !string.IsNullOrEmpty(dllDir))
@@ -3401,10 +3551,6 @@ static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int f
                 if (File.Exists(hotClifPath))
                 {
                     File.Delete(hotClifPath);
-                }
-                if (File.Exists(hotObjPath))
-                {
-                    File.Delete(hotObjPath);
                 }
             }
             catch
@@ -5622,6 +5768,115 @@ static bool LikelyContainsTestBlock(string path)
     return false;
 }
 
+static bool TryComputeClifSplitHashes(string clif, out string globalsHash, out Dictionary<string, string> functionHashes, out List<string> functionOrder)
+{
+    globalsHash = string.Empty;
+    functionHashes = new Dictionary<string, string>(StringComparer.Ordinal);
+    functionOrder = new List<string>();
+
+    try
+    {
+        var normalized = clif.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+
+        var globals = new StringBuilder();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd();
+            var t = line.Trim();
+            if (t.Length == 0 || t.StartsWith(';'))
+            {
+                continue;
+            }
+
+            if (t.StartsWith("global ", StringComparison.Ordinal) || t.StartsWith("external ", StringComparison.Ordinal))
+            {
+                globals.Append(t);
+                globals.Append('\n');
+                continue;
+            }
+
+            if (!t.StartsWith("function %", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var rest = t.Substring("function %".Length);
+            var paren = rest.IndexOf('(');
+            if (paren <= 0)
+            {
+                return false;
+            }
+            var name = rest.Substring(0, paren).Trim();
+            if (name.Length == 0)
+            {
+                return false;
+            }
+
+            functionOrder.Add(name);
+
+            var fnText = new StringBuilder();
+            fnText.Append(t);
+            fnText.Append('\n');
+
+            while (i + 1 < lines.Length)
+            {
+                i++;
+                var bodyLine = lines[i].TrimEnd();
+                fnText.Append(bodyLine);
+                fnText.Append('\n');
+                if (bodyLine.Trim() == "}")
+                {
+                    break;
+                }
+            }
+
+            functionHashes[name] = HashSha256Hex(fnText.ToString());
+        }
+
+        if (functionOrder.Count == 0)
+        {
+            return false;
+        }
+
+        globalsHash = HashSha256Hex(globals.ToString());
+        return true;
+    }
+    catch
+    {
+        return false;
+    }
+}
+
+static string SanitizeSymbolForFileName(string sym)
+{
+    var sb = new StringBuilder(sym.Length);
+    foreach (var ch in sym)
+    {
+        if ((ch >= 'a' && ch <= 'z') ||
+            (ch >= 'A' && ch <= 'Z') ||
+            (ch >= '0' && ch <= '9') ||
+            ch == '_' ||
+            ch == '-')
+        {
+            sb.Append(ch);
+        }
+        else
+        {
+            sb.Append('_');
+        }
+    }
+    return sb.ToString();
+}
+
+static string HashSha256Hex(string text)
+{
+    var bytes = Encoding.UTF8.GetBytes(text);
+    var hash = SHA256.HashData(bytes);
+    return Convert.ToHexString(hash).ToLowerInvariant();
+}
+
 static class LlvmLock
 {
     public static readonly object Lower = new();
@@ -5976,6 +6231,13 @@ sealed record CompileResult(
     bool EmitIrOnly,
     long CompileMilliseconds,
     bool IsCacheArtifact);
+
+sealed class CraneliftSplitManifest
+{
+    public int Version { get; init; }
+    public string GlobalsHash { get; init; } = string.Empty;
+    public Dictionary<string, string> FunctionHashes { get; init; } = new(StringComparer.Ordinal);
+}
 
 sealed record PreparedForLower(
     string FilePath,

--- a/tools/cranelift-aot/src/main.rs
+++ b/tools/cranelift-aot/src/main.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::collections::HashSet;
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
@@ -27,8 +28,28 @@ struct Args
     input: Option<PathBuf>,
 
     /// Output object file path.
-    #[arg(long, value_name = "PATH", required_unless_present = "server")]
+    #[arg(long, value_name = "PATH", required_unless_present_any = ["server", "out_dir"])]
     output: Option<PathBuf>,
+
+    /// Output directory for split-object mode.
+    /// Writes:
+    /// - globals.{obj|o} (unless --functions-only)
+    /// - fn_<symbol>.{obj|o} for each selected function (unless --globals-only)
+    #[arg(long, value_name = "DIR")]
+    out_dir: Option<PathBuf>,
+
+    /// In split-object mode, emit only the globals object.
+    #[arg(long)]
+    globals_only: bool,
+
+    /// In split-object mode, emit only selected function objects (no globals object).
+    #[arg(long)]
+    functions_only: bool,
+
+    /// In split-object mode, emit only these functions (repeatable).
+    /// If omitted (and not --globals-only), all functions are emitted.
+    #[arg(long = "function", value_name = "NAME")]
+    functions: Vec<String>,
 
     /// Target triple (default: x86_64-pc-windows-msvc).
     #[arg(long, value_name = "TRIPLE", default_value = "x86_64-pc-windows-msvc")]
@@ -57,10 +78,19 @@ fn main() -> Result<()>
     }
 
     let input = args.input.context("missing --input")?;
-    let output = args.output.context("missing --output")?;
     let clif = fs::read_to_string(&input)
         .with_context(|| format!("failed to read input file: {}", input.display()))?;
 
+    if let Some(out_dir) = args.out_dir
+    {
+        if args.globals_only && args.functions_only
+        {
+            bail!("--globals-only and --functions-only are mutually exclusive");
+        }
+        return compile_split(&clif, &out_dir, &args.target, &args.module_name, &args.opt_level, args.globals_only, args.functions_only, &args.functions);
+    }
+
+    let output = args.output.context("missing --output")?;
     compile_clif(&clif, &output, &args.target, &args.module_name, &args.opt_level)
 }
 
@@ -158,6 +188,236 @@ fn compile_clif(clif: &str, output: &PathBuf, target: &str, module_name: &str, o
     fs::write(output, obj_bytes)
         .with_context(|| format!("failed to write object file: {}", output.display()))?;
 
+    Ok(())
+}
+
+fn compile_split(
+    clif: &str,
+    out_dir: &PathBuf,
+    target: &str,
+    module_name: &str,
+    opt_level: &str,
+    globals_only: bool,
+    functions_only: bool,
+    selected_functions: &[String],
+) -> Result<()>
+{
+    let triple = Triple::from_str(target)
+        .map_err(|_| anyhow::anyhow!("invalid target triple: {target}"))?;
+    let target_is_windows = matches!(triple.operating_system, OperatingSystem::Windows);
+    let ext = object_extension_for_target(&triple);
+
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("failed to create output dir: {}", out_dir.display()))?;
+
+    let flags = build_flags(opt_level, &triple)?;
+    let isa_for_parse = isa::lookup(triple.clone())
+        .context("failed to look up ISA for target")?
+        .finish(flags)
+        .context("failed to finalize ISA")?;
+    let default_cc = isa_for_parse.default_call_conv();
+
+    let parsed = parse_stasis_clif(clif, default_cc).context("failed to parse stasis CLIF")?;
+
+    if !functions_only
+    {
+        let globals_path = out_dir.join(format!("globals.{ext}"));
+        emit_globals_object(&parsed, &globals_path, &triple, module_name, opt_level)?;
+    }
+
+    if globals_only
+    {
+        return Ok(());
+    }
+
+    let mut requested: Vec<&ParsedFunction> = Vec::new();
+    if selected_functions.is_empty()
+    {
+        requested.extend(parsed.functions.iter());
+    }
+    else
+    {
+        let set: HashSet<&str> = selected_functions.iter().map(|s| s.as_str()).collect();
+        for f in &parsed.functions
+        {
+            if set.contains(f.name.as_str())
+            {
+                requested.push(f);
+            }
+        }
+        for name in selected_functions
+        {
+            if parsed.functions.iter().all(|f| f.name != *name)
+            {
+                bail!("unknown function requested via --function: {name}");
+            }
+        }
+    }
+
+    for f in requested
+    {
+        let file_name = format!("fn_{}.{}", sanitize_symbol_for_filename(&f.name), ext);
+        let out_path = out_dir.join(file_name);
+        emit_function_object(&parsed, f, &out_path, &triple, module_name, opt_level, target_is_windows)?;
+    }
+
+    Ok(())
+}
+
+fn object_extension_for_target(triple: &Triple) -> &'static str
+{
+    match triple.operating_system
+    {
+        OperatingSystem::Windows => "obj",
+        _ => "o",
+    }
+}
+
+fn sanitize_symbol_for_filename(sym: &str) -> String
+{
+    let mut out = String::with_capacity(sym.len());
+    for ch in sym.chars()
+    {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'
+        {
+            out.push(ch);
+        }
+        else
+        {
+            out.push('_');
+        }
+    }
+    out
+}
+
+fn write_atomic(path: &PathBuf, bytes: &[u8]) -> Result<()>
+{
+    let tmp = PathBuf::from(format!("{}.tmp", path.display()));
+    fs::write(&tmp, bytes)
+        .with_context(|| format!("failed to write temp output: {}", tmp.display()))?;
+    if path.exists()
+    {
+        fs::remove_file(path).ok();
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("failed to move output into place: {}", path.display()))?;
+    Ok(())
+}
+
+fn emit_globals_object(parsed: &ParsedModule, output: &PathBuf, triple: &Triple, module_name: &str, opt_level: &str) -> Result<()>
+{
+    let flags = build_flags(opt_level, triple)?;
+    let isa = isa::lookup(triple.clone())
+        .context("failed to look up ISA for target")?
+        .finish(flags)
+        .context("failed to finalize ISA")?;
+    let builder = ObjectBuilder::new(isa, module_name.to_string(), default_libcall_names())
+        .context("failed to create ObjectBuilder")?;
+    let mut module = ObjectModule::new(builder);
+
+    // Define all globals in exactly one object to avoid duplicate definitions.
+    for g in &parsed.globals
+    {
+        let id = module
+            .declare_data(&g.name, Linkage::Export, true, false)
+            .with_context(|| format!("declare_data failed for {}", g.name))?;
+
+        let mut data_desc = DataDescription::new();
+        match &g.init_data
+        {
+            GlobalInitData::Zero => {
+                data_desc.define_zeroinit(g.size_bytes);
+            }
+            GlobalInitData::String(bytes) => {
+                data_desc.define(bytes.clone().into_boxed_slice());
+            }
+        }
+        module
+            .define_data(id, &data_desc)
+            .with_context(|| format!("define_data failed for {}", g.name))?;
+    }
+
+    let product = module.finish();
+    let obj_bytes = product.emit().context("failed to emit object")?;
+    write_atomic(output, &obj_bytes)
+        .with_context(|| format!("failed to write object file: {}", output.display()))?;
+    Ok(())
+}
+
+fn emit_function_object(
+    parsed: &ParsedModule,
+    function: &ParsedFunction,
+    output: &PathBuf,
+    triple: &Triple,
+    module_name: &str,
+    opt_level: &str,
+    target_is_windows: bool,
+) -> Result<()>
+{
+    let flags = build_flags(opt_level, triple)?;
+    let isa = isa::lookup(triple.clone())
+        .context("failed to look up ISA for target")?
+        .finish(flags)
+        .context("failed to finalize ISA")?;
+
+    let builder = ObjectBuilder::new(isa, module_name.to_string(), default_libcall_names())
+        .context("failed to create ObjectBuilder")?;
+    let mut module = ObjectModule::new(builder);
+
+    // Declare globals as imports (they are defined in globals.obj).
+    let mut data_ids = std::collections::HashMap::new();
+    for g in &parsed.globals
+    {
+        let id = module
+            .declare_data(&g.name, Linkage::Import, true, false)
+            .with_context(|| format!("declare_data failed for {}", g.name))?;
+        data_ids.insert(g.name.clone(), id);
+    }
+
+    // Declare external functions.
+    let mut function_ids = std::collections::HashMap::new();
+    for ext in &parsed.externals
+    {
+        let link_name =
+            if ext.name == "printf_str" || ext.name == "printf3"
+            {
+                if target_is_windows { "printf" } else { "stasis_printf3" }
+            }
+            else
+            {
+                &ext.name
+            };
+
+        let id = module
+            .declare_function(link_name, Linkage::Import, &ext.signature)
+            .with_context(|| format!("declare external function failed for {}", ext.name))?;
+        function_ids.insert(ext.name.clone(), id);
+    }
+
+    // Declare all stasis functions so calls can resolve. Import everything except the one we define.
+    for f in &parsed.functions
+    {
+        let linkage = if f.name == function.name { Linkage::Export } else { Linkage::Import };
+        let id = module
+            .declare_function(&f.name, linkage, &f.signature)
+            .with_context(|| format!("declare function failed for {}", f.name))?;
+        function_ids.insert(f.name.clone(), id);
+    }
+
+    let func = build_function_ir(&mut module, &function_ids, &data_ids, function)?;
+
+    let mut ctx = module.make_context();
+    ctx.func = func;
+
+    let func_id = *function_ids.get(&function.name).context("missing function id")?;
+    module
+        .define_function(func_id, &mut ctx)
+        .with_context(|| format!("define_function failed for {}", function.name))?;
+
+    let product = module.finish();
+    let obj_bytes = product.emit().context("failed to emit object")?;
+    write_atomic(output, &obj_bytes)
+        .with_context(|| format!("failed to write object file: {}", output.display()))?;
     Ok(())
 }
 


### PR DESCRIPTION
Implements an incremental object-cache + fast-link pipeline for Cranelift tick hot-swap builds (Windows/COFF and non-Windows/ELF/Mach-O).\n\nCore idea (dev watch, tick hot-swap):\n- Emit globals once into globals.{obj|o}\n- Emit each function into its own fn_<symbol>.{obj|o}\n- On rebuild, only recompile functions whose CLIF text changed\n- Relink the DLL from globals + all cached function objects\n\nChanges:\n- tools/cranelift-aot: adds split-object mode (globals-only / functions-only, select functions via --function)\n- Stasis.Cli: tick --watch now uses split-object cache in build/hotstate/<name>.<module>.objcache/\n\nHow to test timing:\n- Ensure clang is on PATH (or add .tools/llvm-*/bin to PATH)\n- Run a tick-watch loop and make a small edit in a single function\n- Compare HOTSWAP(ms): total=... between main and this branch\n\nValidation:\n- cargo build --release (tools/cranelift-aot)\n- dotnet build Stasis.Cli (Release)\n- dotnet test Stasis.Compiler.Tests (HotSwapIntegrationTests.WatchTickHotSwap*)\n