### PR TITLE
feat: bytecode interpreter backend for fast dev hot swap

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -11,6 +11,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Stasis.Compiler;
 using Stasis.Compiler.IR;
+using Stasis.Compiler.IR.Bytecode;
 using Stasis.Compiler.Layout;
 using Stasis.Compiler.Semantic;
 using Stasis.Compiler.Syntax;
@@ -117,11 +118,12 @@ while (cliArgs.Count > 0)
             {
                 "llvm" => BackendType.Llvm,
                 "cranelift" => BackendType.Cranelift,
+                "bytecode" => BackendType.Bytecode,
                 _ => null
             };
             if (selectedBackend is null)
             {
-                Console.Error.WriteLine($"error: invalid --backend '{backendArg}'. Use 'llvm' or 'cranelift'.");
+                Console.Error.WriteLine($"error: invalid --backend '{backendArg}'. Use 'llvm', 'cranelift', or 'bytecode'.");
                 Environment.Exit(1);
             }
             break;
@@ -484,6 +486,7 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         // Generate code using selected backend
         string ir;
         IReadOnlyList<Diagnostic> lowerDiagnostics;
+        BytecodeModule? bytecodeModule = null;
 
         if (backend == BackendType.Cranelift)
         {
@@ -499,6 +502,13 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
             var result = generator.Generate(parse.CompilationUnit, sema, layout, options);
             ir = result.Ir;
             lowerDiagnostics = result.Diagnostics;
+        }
+        else if (backend == BackendType.Bytecode)
+        {
+            var result = BytecodeCompiler.Compile(parse.CompilationUnit, moduleName);
+            ir = result.Disassembly;
+            lowerDiagnostics = result.Diagnostics;
+            bytecodeModule = result.Module;
         }
         else
         {
@@ -541,6 +551,29 @@ static int ProcessFile(string path, string mode, bool includeTests, string modul
         {
             WriteIrOutput(ir, outputPath);
             return HasErrors(lowerDiagnostics) ? 1 : 0;
+        }
+
+        if (backend == BackendType.Bytecode)
+        {
+            if (bytecodeModule is null)
+            {
+                Console.Error.WriteLine("error: bytecode backend internal error (no module produced).");
+                return 1;
+            }
+
+            if (!string.Equals(mode, "run", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine("error: bytecode backend currently supports only `run` or `--emit-ir`.");
+                return 1;
+            }
+
+            if (!ContainsTopLevelFunction(parse.CompilationUnit, "tick"))
+            {
+                Console.Error.WriteLine("error: bytecode backend currently requires a top-level `function tick()`.");
+                return 1;
+            }
+
+            return RunBytecodeTickVm(bytecodeModule, moduleName, tickHostFps);
         }
 
         if (backend == BackendType.Cranelift)
@@ -3040,6 +3073,279 @@ static IReadOnlyList<FieldLayout> BuildDataBindingFieldList(LayoutPlan layout, G
     return results;
 }
 
+static int RunBytecodeTickVm(BytecodeModule module, string moduleName, int fps)
+{
+    using var cts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        cts.Cancel();
+    };
+
+    var vm = new BytecodeVm(module);
+    var tickName = $"{moduleName}__tick";
+    return RunBytecodeTickLoop(vm, tickName, fps, gate: null, cts.Token);
+}
+
+static int WatchBytecodeTick(string sourcePath, string moduleName, int fps)
+{
+    var fullPath = Path.GetFullPath(sourcePath);
+    var dir = Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory();
+    var fileName = Path.GetFileName(fullPath);
+    var debounce = TimeSpan.FromMilliseconds(75);
+    var lastChange = DateTime.UtcNow;
+
+    using var cts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        cts.Cancel();
+    };
+
+    using var watcher = new FileSystemWatcher(dir, fileName)
+    {
+        NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName
+    };
+
+    using var changeSignal = new ManualResetEventSlim(false);
+    void OnChange(object? _, FileSystemEventArgs __)
+    {
+        lastChange = DateTime.UtcNow;
+        changeSignal.Set();
+    }
+
+    watcher.Changed += OnChange;
+    watcher.Created += OnChange;
+    watcher.Renamed += OnChange;
+    watcher.EnableRaisingEvents = true;
+
+    static bool TryCompile(string path, string moduleName, bool printDiagnostics, out BytecodeModule module, out string sourceText)
+    {
+        module = null!;
+        sourceText = string.Empty;
+
+        var source = LoadSourceWithImports(path, out var importDiagnostics, out var importSource);
+        if (importDiagnostics.Count > 0)
+        {
+            if (printDiagnostics)
+            {
+                PrintDiagnostics(importDiagnostics, importSource, path);
+            }
+            return false;
+        }
+
+        var parse = Parser.Parse(source);
+        if (HasErrors(parse.Diagnostics))
+        {
+            if (printDiagnostics)
+            {
+                PrintDiagnostics(parse.Diagnostics, source, path);
+            }
+            return false;
+        }
+
+        var sema = new SemanticAnalyzer(new SemanticAnalyzerOptions(EnableGraphicsBuiltins: false, EnableAudioBuiltins: false)).Analyze(parse.CompilationUnit);
+        if (HasErrors(sema.Diagnostics))
+        {
+            if (printDiagnostics)
+            {
+                PrintDiagnostics(sema.Diagnostics, source, path);
+            }
+            return false;
+        }
+
+        var bc = BytecodeCompiler.Compile(parse.CompilationUnit, moduleName);
+        if (!bc.Success || bc.Module is null)
+        {
+            if (printDiagnostics)
+            {
+                PrintDiagnostics(bc.Diagnostics, source, path);
+            }
+            return false;
+        }
+
+        module = bc.Module;
+        sourceText = source;
+        return true;
+    }
+
+    var swInitial = Stopwatch.StartNew();
+    if (!TryCompile(fullPath, moduleName, printDiagnostics: true, out var initialModule, out _))
+    {
+        return 1;
+    }
+    swInitial.Stop();
+    Console.WriteLine($"HOTSWAP(ms): total={swInitial.Elapsed.TotalMilliseconds.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} latency=-1 load=-1");
+
+    var vm = new BytecodeVm(initialModule);
+    var gate = new object();
+    var tickName = $"{moduleName}__tick";
+
+    var tickTask = Task.Run(() => RunBytecodeTickLoop(vm, tickName, fps, gate, cts.Token), cts.Token);
+
+    while (!cts.IsCancellationRequested)
+    {
+        try
+        {
+            changeSignal.Wait(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            break;
+        }
+
+        changeSignal.Reset();
+
+        while (!cts.IsCancellationRequested && DateTime.UtcNow - lastChange < debounce)
+        {
+            Thread.Sleep(10);
+        }
+
+        if (cts.IsCancellationRequested)
+        {
+            break;
+        }
+
+        var swTotal = Stopwatch.StartNew();
+        var swapLatencyMs = (int)Math.Max(0, (DateTime.UtcNow - lastChange).TotalMilliseconds);
+
+        BytecodeModule? nextModule = null;
+        var attempt = 0;
+        while (nextModule is null)
+        {
+            if (TryCompile(fullPath, moduleName, printDiagnostics: false, out var compiled, out _))
+            {
+                nextModule = compiled;
+                break;
+            }
+
+            attempt++;
+            if (attempt >= 10)
+            {
+                _ = TryCompile(fullPath, moduleName, printDiagnostics: true, out _, out _);
+                break;
+            }
+
+            Thread.Sleep(15);
+        }
+        if (nextModule is null)
+        {
+            continue;
+        }
+
+        var swLoad = Stopwatch.StartNew();
+        lock (gate)
+        {
+            vm.HotSwap(nextModule);
+        }
+        swLoad.Stop();
+
+        swTotal.Stop();
+        Console.WriteLine($"HOTSWAP(ms): total={swTotal.Elapsed.TotalMilliseconds.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} latency={swapLatencyMs} load={swLoad.Elapsed.TotalMilliseconds.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}");
+    }
+
+    try
+    {
+        cts.Cancel();
+        tickTask.Wait(TimeSpan.FromSeconds(1));
+    }
+    catch
+    {
+        // ignore
+    }
+
+    return 0;
+}
+
+static int RunBytecodeTickLoop(BytecodeVm vm, string tickName, int fps, object? gate, CancellationToken token)
+{
+    if (fps < 1 || fps > 240) fps = 60;
+
+    var frameTicks = Math.Max(1L, Stopwatch.Frequency / fps);
+    var next = Stopwatch.GetTimestamp();
+
+    while (!token.IsCancellationRequested)
+    {
+        next += frameTicks;
+
+        try
+        {
+            if (gate is null)
+            {
+                if (!TryCallTick(vm, tickName, out var exitCode, out var error))
+                {
+                    Console.Error.WriteLine($"error: bytecode tick failed: {error}");
+                    return 1;
+                }
+                if (exitCode != 0) return exitCode;
+            }
+            else
+            {
+                lock (gate)
+                {
+                    if (!TryCallTick(vm, tickName, out var exitCode, out var error))
+                    {
+                        Console.Error.WriteLine($"error: bytecode tick failed: {error}");
+                        return 1;
+                    }
+                    if (exitCode != 0) return exitCode;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"error: bytecode tick crashed: {ex.Message}");
+            return 1;
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        var remaining = next - now;
+        if (remaining <= 0)
+        {
+            next = now;
+            continue;
+        }
+
+        var sleepMs = (int)(remaining * 1000 / Stopwatch.Frequency);
+        if (sleepMs > 0)
+        {
+            Thread.Sleep(Math.Min(sleepMs, 50));
+        }
+    }
+
+    return 0;
+
+    static bool TryCallTick(BytecodeVm vm, string tickName, out int exitCode, out string? error)
+    {
+        exitCode = 0;
+        error = null;
+
+        var idx = vm.Module.FindFunctionIndex(tickName);
+        if (idx < 0)
+        {
+            error = $"function not found: {tickName}";
+            return false;
+        }
+
+        var fn = vm.Module.Functions[idx];
+        if (fn.ReturnKind == BytecodeValueKind.Void)
+        {
+            vm.CallVoid(tickName);
+            exitCode = 0;
+            return true;
+        }
+
+        if (fn.ReturnKind == BytecodeValueKind.I32)
+        {
+            exitCode = vm.CallI32(tickName);
+            return true;
+        }
+
+        error = $"unsupported tick return kind: {fn.ReturnKind}";
+        return false;
+    }
+}
+
 static int WatchCraneliftTickHotSwap(string sourcePath, string moduleName, int fps, string? optLevel, bool enableLto, bool enableGraphics, string? graphicsLibPath)
 {
     var entryAssetRoot = GetEntryAssetRoot(sourcePath);
@@ -4363,6 +4669,13 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     var hotExitPath = enableHotState && mode == "run" ? GetHotExitFilePath(fullPath, moduleName) : null;
 
     if (mode == "run" &&
+        backend == BackendType.Bytecode &&
+        DetectsTickUsage(File.ReadAllText(fullPath)))
+    {
+        return WatchBytecodeTick(fullPath, moduleName, tickHostFps);
+    }
+
+    if (mode == "run" &&
         backend == BackendType.Cranelift &&
         useCraneliftRunner &&
         (OperatingSystem.IsWindows() || OperatingSystem.IsLinux()) &&
@@ -4622,8 +4935,8 @@ static void PrintUsage()
     Console.WriteLine("  stasisc release <file> [--out <path>] [--module <name>]");
     Console.WriteLine();
     Console.WriteLine("Other commands:");
-    Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift>]");
-    Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
+    Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift|bytecode>]");
+    Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift|bytecode>] [--graphics] [--graphics-lib <path>]");
     Console.WriteLine("  stasisc format <file>");
     Console.WriteLine();
     Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
@@ -4631,7 +4944,7 @@ static void PrintUsage()
     Console.WriteLine("Run: use --watch for a dev loop (auto-rebuild + tick hot-swap + phase timings) with state preserved between swaps and no re-running main().");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
     Console.WriteLine("Graphics: enabled automatically when graphics APIs are used; use --graphics to force it on. Use --graphics-lib to override library path.");
-    Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
+    Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; bytecode is a dev-focused interpreter backend.");
     Console.WriteLine("LLVM: pass --llvm-target <triple> to set the LLVM module target triple (useful for cross-compiling emitted IR).");
     Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override, or pass --no-cranelift-runner to force EXE mode.");
     Console.WriteLine("Cache: set STASIS_DISABLE_ARTIFACT_CACHE=1 to disable binary caching for Cranelift run/test.");

--- a/Stasis.Compiler.Tests/BytecodeVmTests.cs
+++ b/Stasis.Compiler.Tests/BytecodeVmTests.cs
@@ -1,5 +1,6 @@
 using Stasis.Compiler.IR.Bytecode;
 using Xunit;
+using System.Collections.Immutable;
 
 namespace Stasis.Compiler.Tests;
 
@@ -10,7 +11,7 @@ public sealed class BytecodeVmTests
     {
         var b1 = new BytecodeBuilder();
         var gCounter = b1.DeclareGlobalI32("counter");
-        var f1 = b1.DefineFunction("tick", localCount: 0);
+        var f1 = b1.DefineFunction("tick", BytecodeValueKind.I32, ImmutableArray<BytecodeValueKind>.Empty, localCount: 0);
         f1.Emit(BytecodeOp.LoadGlobalI32, gCounter);
         f1.Emit(BytecodeOp.ConstI32, 1);
         f1.Emit(BytecodeOp.AddI32);
@@ -27,7 +28,7 @@ public sealed class BytecodeVmTests
 
         var b2 = new BytecodeBuilder();
         var gCounter2 = b2.DeclareGlobalI32("counter");
-        var f2 = b2.DefineFunction("tick", localCount: 0);
+        var f2 = b2.DefineFunction("tick", BytecodeValueKind.I32, ImmutableArray<BytecodeValueKind>.Empty, localCount: 0);
         f2.Emit(BytecodeOp.LoadGlobalI32, gCounter2);
         f2.Emit(BytecodeOp.ConstI32, 2);
         f2.Emit(BytecodeOp.AddI32);
@@ -47,7 +48,7 @@ public sealed class BytecodeVmTests
     public void JumpIfZero_SkipsAdd_WhenConditionIsZero()
     {
         var b = new BytecodeBuilder();
-        var f = b.DefineFunction("f", localCount: 0);
+        var f = b.DefineFunction("f", BytecodeValueKind.I32, ImmutableArray<BytecodeValueKind>.Empty, localCount: 0);
 
         // if (0) { return 123 } else { return 7 }
         f.Emit(BytecodeOp.ConstI32, 0);
@@ -64,4 +65,3 @@ public sealed class BytecodeVmTests
         Assert.Equal(7, vm.CallI32("f"));
     }
 }
-

--- a/Stasis.Compiler.Tests/BytecodeVmTests.cs
+++ b/Stasis.Compiler.Tests/BytecodeVmTests.cs
@@ -1,0 +1,67 @@
+using Stasis.Compiler.IR.Bytecode;
+using Xunit;
+
+namespace Stasis.Compiler.Tests;
+
+public sealed class BytecodeVmTests
+{
+    [Fact]
+    public void Tick_IncrementsGlobalCounter_AndHotSwapPreservesState()
+    {
+        var b1 = new BytecodeBuilder();
+        var gCounter = b1.DeclareGlobalI32("counter");
+        var f1 = b1.DefineFunction("tick", localCount: 0);
+        f1.Emit(BytecodeOp.LoadGlobalI32, gCounter);
+        f1.Emit(BytecodeOp.ConstI32, 1);
+        f1.Emit(BytecodeOp.AddI32);
+        f1.Emit(BytecodeOp.StoreGlobalI32, gCounter);
+        f1.Emit(BytecodeOp.LoadGlobalI32, gCounter);
+        f1.Emit(BytecodeOp.ReturnI32);
+        f1.Finish();
+        var m1 = b1.Build();
+
+        var vm = new BytecodeVm(m1);
+        Assert.Equal(0, vm.GetGlobalI32("counter"));
+        Assert.Equal(1, vm.CallI32("tick"));
+        Assert.Equal(1, vm.GetGlobalI32("counter"));
+
+        var b2 = new BytecodeBuilder();
+        var gCounter2 = b2.DeclareGlobalI32("counter");
+        var f2 = b2.DefineFunction("tick", localCount: 0);
+        f2.Emit(BytecodeOp.LoadGlobalI32, gCounter2);
+        f2.Emit(BytecodeOp.ConstI32, 2);
+        f2.Emit(BytecodeOp.AddI32);
+        f2.Emit(BytecodeOp.StoreGlobalI32, gCounter2);
+        f2.Emit(BytecodeOp.LoadGlobalI32, gCounter2);
+        f2.Emit(BytecodeOp.ReturnI32);
+        f2.Finish();
+        var m2 = b2.Build();
+
+        vm.HotSwap(m2);
+        Assert.Equal(1, vm.GetGlobalI32("counter"));
+        Assert.Equal(3, vm.CallI32("tick"));
+        Assert.Equal(3, vm.GetGlobalI32("counter"));
+    }
+
+    [Fact]
+    public void JumpIfZero_SkipsAdd_WhenConditionIsZero()
+    {
+        var b = new BytecodeBuilder();
+        var f = b.DefineFunction("f", localCount: 0);
+
+        // if (0) { return 123 } else { return 7 }
+        f.Emit(BytecodeOp.ConstI32, 0);
+        var jz = f.Emit(BytecodeOp.JumpIfZeroI32, a: 0);
+        f.Emit(BytecodeOp.ConstI32, 123);
+        f.Emit(BytecodeOp.ReturnI32);
+        var elseIp = f.CurrentIp;
+        f.PatchJump(jz, elseIp);
+        f.Emit(BytecodeOp.ConstI32, 7);
+        f.Emit(BytecodeOp.ReturnI32);
+        f.Finish();
+
+        var vm = new BytecodeVm(b.Build());
+        Assert.Equal(7, vm.CallI32("f"));
+    }
+}
+

--- a/Stasis.Compiler/IR/BackendType.cs
+++ b/Stasis.Compiler/IR/BackendType.cs
@@ -11,6 +11,11 @@ public enum BackendType
     Cranelift,
 
     /// <summary>
+    /// Bytecode backend - interpreter-friendly, intended for ultra-fast dev hot swaps.
+    /// </summary>
+    Bytecode,
+
+    /// <summary>
     /// LLVM backend - optimized compilation, suitable for release builds.
     /// </summary>
     Llvm

--- a/Stasis.Compiler/IR/Bytecode/BytecodeBuilder.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeBuilder.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeBuilder
+{
+    private readonly List<string> _globals = new();
+    private readonly List<BytecodeFunction> _functions = new();
+
+    public int DeclareGlobalI32(string name)
+    {
+        var idx = _globals.IndexOf(name);
+        if (idx >= 0) return idx;
+        _globals.Add(name);
+        return _globals.Count - 1;
+    }
+
+    public FunctionBuilder DefineFunction(string name, int localCount)
+    {
+        return new FunctionBuilder(this, name, localCount);
+    }
+
+    public BytecodeModule Build()
+    {
+        return new BytecodeModule
+        {
+            GlobalNames = _globals.ToImmutableArray(),
+            Functions = _functions.ToImmutableArray()
+        };
+    }
+
+    public sealed class FunctionBuilder
+    {
+        private readonly BytecodeBuilder _module;
+        private readonly string _name;
+        private readonly int _localCount;
+        private readonly List<BytecodeInst> _code = new();
+
+        internal FunctionBuilder(BytecodeBuilder module, string name, int localCount)
+        {
+            _module = module;
+            _name = name;
+            _localCount = localCount;
+        }
+
+        public int Emit(BytecodeOp op, int a = 0)
+        {
+            _code.Add(new BytecodeInst(op, a));
+            return _code.Count - 1;
+        }
+
+        public void PatchJump(int instIndex, int targetIp)
+        {
+            var inst = _code[instIndex];
+            if (inst.Op is not (BytecodeOp.Jump or BytecodeOp.JumpIfZeroI32))
+            {
+                throw new InvalidOperationException($"PatchJump expected Jump/JumpIfZeroI32, got {inst.Op}.");
+            }
+            _code[instIndex] = inst with { A = targetIp };
+        }
+
+        public int CurrentIp => _code.Count;
+
+        public void Finish()
+        {
+            _module._functions.Add(new BytecodeFunction
+            {
+                Name = _name,
+                LocalCount = _localCount,
+                Code = _code.ToImmutableArray()
+            });
+        }
+    }
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeBuilder.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeBuilder.cs
@@ -4,27 +4,47 @@ namespace Stasis.Compiler.IR.Bytecode;
 
 public sealed class BytecodeBuilder
 {
-    private readonly List<string> _globals = new();
+    private readonly List<BytecodeGlobal> _globals = new();
     private readonly List<BytecodeFunction> _functions = new();
 
     public int DeclareGlobalI32(string name)
     {
-        var idx = _globals.IndexOf(name);
-        if (idx >= 0) return idx;
-        _globals.Add(name);
+        return DeclareGlobal(name, BytecodeValueKind.I32);
+    }
+
+    public int DeclareGlobalF32(string name)
+    {
+        return DeclareGlobal(name, BytecodeValueKind.F32);
+    }
+
+    private int DeclareGlobal(string name, BytecodeValueKind kind)
+    {
+        for (var i = 0; i < _globals.Count; i++)
+        {
+            if (string.Equals(_globals[i].Name, name, StringComparison.Ordinal))
+            {
+                if (_globals[i].Kind != kind)
+                {
+                    throw new InvalidOperationException($"Global '{name}' kind mismatch: {_globals[i].Kind} vs {kind}.");
+                }
+                return i;
+            }
+        }
+
+        _globals.Add(new BytecodeGlobal { Name = name, Kind = kind });
         return _globals.Count - 1;
     }
 
-    public FunctionBuilder DefineFunction(string name, int localCount)
+    public FunctionBuilder DefineFunction(string name, BytecodeValueKind returnKind, ImmutableArray<BytecodeValueKind> paramKinds, int localCount)
     {
-        return new FunctionBuilder(this, name, localCount);
+        return new FunctionBuilder(this, name, returnKind, paramKinds, localCount);
     }
 
     public BytecodeModule Build()
     {
         return new BytecodeModule
         {
-            GlobalNames = _globals.ToImmutableArray(),
+            Globals = _globals.ToImmutableArray(),
             Functions = _functions.ToImmutableArray()
         };
     }
@@ -33,19 +53,23 @@ public sealed class BytecodeBuilder
     {
         private readonly BytecodeBuilder _module;
         private readonly string _name;
+        private readonly BytecodeValueKind _returnKind;
+        private readonly ImmutableArray<BytecodeValueKind> _paramKinds;
         private readonly int _localCount;
         private readonly List<BytecodeInst> _code = new();
 
-        internal FunctionBuilder(BytecodeBuilder module, string name, int localCount)
+        internal FunctionBuilder(BytecodeBuilder module, string name, BytecodeValueKind returnKind, ImmutableArray<BytecodeValueKind> paramKinds, int localCount)
         {
             _module = module;
             _name = name;
+            _returnKind = returnKind;
+            _paramKinds = paramKinds;
             _localCount = localCount;
         }
 
-        public int Emit(BytecodeOp op, int a = 0)
+        public int Emit(BytecodeOp op, int a = 0, int b = 0)
         {
-            _code.Add(new BytecodeInst(op, a));
+            _code.Add(new BytecodeInst(op, a, b));
             return _code.Count - 1;
         }
 
@@ -66,10 +90,11 @@ public sealed class BytecodeBuilder
             _module._functions.Add(new BytecodeFunction
             {
                 Name = _name,
+                ReturnKind = _returnKind,
+                ParamKinds = _paramKinds,
                 LocalCount = _localCount,
                 Code = _code.ToImmutableArray()
             });
         }
     }
 }
-

--- a/Stasis.Compiler/IR/Bytecode/BytecodeCompileResult.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeCompileResult.cs
@@ -1,0 +1,28 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeCompileResult
+{
+    public required bool Success { get; init; }
+    public required BytecodeModule? Module { get; init; }
+    public required string Disassembly { get; init; }
+    public required IReadOnlyList<Diagnostic> Diagnostics { get; init; }
+
+    public static BytecodeCompileResult Ok(BytecodeModule module, string disassembly) =>
+        new()
+        {
+            Success = true,
+            Module = module,
+            Disassembly = disassembly,
+            Diagnostics = Array.Empty<Diagnostic>()
+        };
+
+    public static BytecodeCompileResult Fail(IReadOnlyList<Diagnostic> diagnostics) =>
+        new()
+        {
+            Success = false,
+            Module = null,
+            Disassembly = string.Empty,
+            Diagnostics = diagnostics
+        };
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeCompiler.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeCompiler.cs
@@ -1,0 +1,719 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+using Stasis.Compiler.Syntax;
+
+namespace Stasis.Compiler.IR.Bytecode;
+
+public static class BytecodeCompiler
+{
+    public static BytecodeCompileResult Compile(CompilationUnitSyntax unit, string moduleName = "module")
+    {
+        var diagnostics = new List<Diagnostic>();
+
+        var builder = new BytecodeBuilder();
+        var globals = new Dictionary<string, (int index, BytecodeValueKind kind)>(StringComparer.Ordinal);
+        foreach (var g in unit.Declarations.OfType<GlobalDeclarationSyntax>())
+        {
+            if (!TryMapTypeToKind(g.Type, out var kind) || kind == BytecodeValueKind.Void)
+            {
+                diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported global type '{FormatType(g.Type)}'.", g.Type.Span));
+                continue;
+            }
+
+            var idx = kind == BytecodeValueKind.F32
+                ? builder.DeclareGlobalF32(g.Name.Text)
+                : builder.DeclareGlobalI32(g.Name.Text);
+
+            globals[g.Name.Text] = (idx, kind);
+        }
+
+        var functions = unit.Declarations
+            .OfType<FunctionDeclarationSyntax>()
+            .Where(f => !f.IsExtern && f.Body is not null)
+            .ToList();
+
+        foreach (var f in functions)
+        {
+            if (f.Body is null)
+            {
+                continue;
+            }
+
+            if (!TryMapTypeToKind(f.ReturnType, out var returnKind))
+            {
+                diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported return type for '{f.Name.Text}'.", f.ReturnType?.Span ?? f.Name.Span));
+                continue;
+            }
+
+            var locals = new Dictionary<string, (int index, BytecodeValueKind kind)>(StringComparer.Ordinal);
+            var paramKinds = ImmutableArray.CreateBuilder<BytecodeValueKind>(f.Parameters.Count);
+
+            var localIndex = 0;
+            foreach (var p in f.Parameters)
+            {
+                if (!TryMapTypeToKind(p.Type, out var pk) || pk == BytecodeValueKind.Void)
+                {
+                    diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported parameter type '{FormatType(p.Type)}' in '{f.Name.Text}'.", p.Type.Span));
+                    continue;
+                }
+                locals[p.Name.Text] = (localIndex++, pk);
+                paramKinds.Add(pk);
+            }
+
+            var letDecls = new List<VariableDeclarationSyntax>();
+            CollectLets(f.Body, letDecls);
+            foreach (var v in letDecls)
+            {
+                if (locals.ContainsKey(v.Name.Text))
+                {
+                    diagnostics.Add(new Diagnostic($"Bytecode backend: duplicate local '{v.Name.Text}' in '{f.Name.Text}'.", v.Name.Span));
+                    continue;
+                }
+
+                var kind = BytecodeValueKind.I32;
+                if (v.Type is not null)
+                {
+                    if (!TryMapTypeToKind(v.Type, out kind) || kind == BytecodeValueKind.Void)
+                    {
+                        diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported local type '{FormatType(v.Type)}' in '{f.Name.Text}'.", v.Type.Span));
+                        continue;
+                    }
+                }
+                else if (v.Initializer is LiteralExpressionSyntax lit && TryMapLiteralToKind(lit.Literal, out var lk))
+                {
+                    kind = lk;
+                }
+
+                locals[v.Name.Text] = (localIndex++, kind);
+            }
+
+            var fb = builder.DefineFunction(
+                $"{moduleName}__{f.Name.Text}",
+                returnKind,
+                paramKinds.ToImmutable(),
+                localIndex);
+
+            var emitter = new FunctionEmitter(fb, locals, globals, diagnostics);
+            emitter.LowerBlock(f.Body);
+            emitter.EnsureReturn(returnKind);
+            fb.Finish();
+        }
+
+        if (diagnostics.Count > 0)
+        {
+            return BytecodeCompileResult.Fail(diagnostics);
+        }
+
+        var module = builder.Build();
+        return BytecodeCompileResult.Ok(module, Disassemble(module));
+    }
+
+    private static void CollectLets(BlockStatementSyntax block, List<VariableDeclarationSyntax> lets)
+    {
+        foreach (var stmt in block.Statements)
+        {
+            if (stmt is VariableDeclarationSyntax v)
+            {
+                lets.Add(v);
+                continue;
+            }
+
+            if (stmt is IfStatementSyntax iff)
+            {
+                CollectLets(iff.ThenBlock, lets);
+                if (iff.ElseBlock is not null)
+                {
+                    CollectLets(iff.ElseBlock, lets);
+                }
+                continue;
+            }
+
+            if (stmt is ForStatementSyntax fr)
+            {
+                CollectLets(fr.Body, lets);
+                continue;
+            }
+
+            if (stmt is BlockStatementSyntax nested)
+            {
+                CollectLets(nested, lets);
+            }
+        }
+    }
+
+    private static string Disassemble(BytecodeModule module)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("; Bytecode module");
+        sb.AppendLine("; Globals:");
+        for (var i = 0; i < module.Globals.Length; i++)
+        {
+            var g = module.Globals[i];
+            sb.Append(i.ToString(CultureInfo.InvariantCulture)).Append(": ").Append(g.Name).Append(" : ").Append(g.Kind).AppendLine();
+        }
+        sb.AppendLine("; Functions:");
+        for (var i = 0; i < module.Functions.Length; i++)
+        {
+            var f = module.Functions[i];
+            sb.Append("fn[").Append(i.ToString(CultureInfo.InvariantCulture)).Append("] ").Append(f.Name);
+            sb.Append(" locals=").Append(f.LocalCount.ToString(CultureInfo.InvariantCulture));
+            sb.Append(" ret=").Append(f.ReturnKind);
+            sb.Append(" params=").Append(string.Join(",", f.ParamKinds));
+            sb.AppendLine();
+            for (var ip = 0; ip < f.Code.Length; ip++)
+            {
+                var inst = f.Code[ip];
+                sb.Append("  ").Append(ip.ToString(CultureInfo.InvariantCulture)).Append(": ").Append(inst.Op);
+                if (inst.A != 0 || inst.B != 0)
+                {
+                    sb.Append(' ').Append(inst.A.ToString(CultureInfo.InvariantCulture));
+                    if (inst.B != 0)
+                    {
+                        sb.Append(' ').Append(inst.B.ToString(CultureInfo.InvariantCulture));
+                    }
+                }
+                sb.AppendLine();
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    private static bool TryMapTypeToKind(TypeSyntax? type, out BytecodeValueKind kind)
+    {
+        if (type is null)
+        {
+            kind = BytecodeValueKind.Void;
+            return true;
+        }
+
+        if (type is not NamedTypeSyntax named)
+        {
+            kind = BytecodeValueKind.Void;
+            return false;
+        }
+
+        switch (named.Name)
+        {
+            case "i32":
+            case "bool":
+                kind = BytecodeValueKind.I32;
+                return true;
+            case "f32":
+                kind = BytecodeValueKind.F32;
+                return true;
+            default:
+                kind = BytecodeValueKind.Void;
+                return false;
+        }
+    }
+
+    private static bool TryMapLiteralToKind(Token lit, out BytecodeValueKind kind)
+    {
+        switch (lit.Kind)
+        {
+            case TokenKind.IntegerLiteral:
+            case TokenKind.TrueKeyword:
+            case TokenKind.FalseKeyword:
+                kind = BytecodeValueKind.I32;
+                return true;
+            case TokenKind.FloatLiteral:
+                kind = BytecodeValueKind.F32;
+                return true;
+            default:
+                kind = BytecodeValueKind.Void;
+                return false;
+        }
+    }
+
+    private static string FormatType(TypeSyntax type) =>
+        type switch
+        {
+            NamedTypeSyntax n => n.Name,
+            ArrayTypeSyntax a => $"{FormatType(a.ElementType)}[{a.SizeText}]",
+            _ => "?"
+        };
+
+    private sealed class FunctionEmitter
+    {
+        private readonly BytecodeBuilder.FunctionBuilder _fb;
+        private readonly Dictionary<string, (int index, BytecodeValueKind kind)> _locals;
+        private readonly Dictionary<string, (int index, BytecodeValueKind kind)> _globals;
+        private readonly List<Diagnostic> _diagnostics;
+
+        public FunctionEmitter(
+            BytecodeBuilder.FunctionBuilder fb,
+            Dictionary<string, (int index, BytecodeValueKind kind)> locals,
+            Dictionary<string, (int index, BytecodeValueKind kind)> globals,
+            List<Diagnostic> diagnostics)
+        {
+            _fb = fb;
+            _locals = locals;
+            _globals = globals;
+            _diagnostics = diagnostics;
+        }
+
+        public void LowerBlock(BlockStatementSyntax block)
+        {
+            foreach (var stmt in block.Statements)
+            {
+                LowerStatement(stmt);
+            }
+        }
+
+        public void EnsureReturn(BytecodeValueKind returnKind)
+        {
+            if (returnKind == BytecodeValueKind.Void)
+            {
+                _fb.Emit(BytecodeOp.ReturnVoid);
+            }
+            else if (returnKind == BytecodeValueKind.F32)
+            {
+                _fb.Emit(BytecodeOp.ConstF32, BitConverter.SingleToInt32Bits(0.0f));
+                _fb.Emit(BytecodeOp.ReturnF32);
+            }
+            else
+            {
+                _fb.Emit(BytecodeOp.ConstI32, 0);
+                _fb.Emit(BytecodeOp.ReturnI32);
+            }
+        }
+
+        private void LowerStatement(StatementSyntax stmt)
+        {
+            switch (stmt)
+            {
+                case VariableDeclarationSyntax v:
+                    LowerVar(v);
+                    break;
+                case ExpressionStatementSyntax es:
+                    LowerExpr(es.Expression);
+                    _fb.Emit(BytecodeOp.Pop);
+                    break;
+                case ReturnStatementSyntax r:
+                    LowerReturn(r);
+                    break;
+                case IfStatementSyntax iff:
+                    LowerIf(iff);
+                    break;
+                case ForStatementSyntax fr:
+                    LowerFor(fr);
+                    break;
+                case BlockStatementSyntax b:
+                    LowerBlock(b);
+                    break;
+                default:
+                    _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported statement {stmt.GetType().Name}.", stmt.Span));
+                    break;
+            }
+        }
+
+        private void LowerVar(VariableDeclarationSyntax v)
+        {
+            if (!_locals.TryGetValue(v.Name.Text, out var local))
+            {
+                _diagnostics.Add(new Diagnostic($"Bytecode backend: unknown local '{v.Name.Text}'.", v.Name.Span));
+                return;
+            }
+
+            if (v.Initializer is null)
+            {
+                EmitDefault(local.kind);
+                EmitStoreLocal(local.index, local.kind);
+                return;
+            }
+
+            var initKind = InferKind(v.Initializer);
+            LowerExpr(v.Initializer);
+            EmitCoerce(initKind, local.kind, v.Initializer.Span);
+            EmitStoreLocal(local.index, local.kind);
+        }
+
+        private void LowerReturn(ReturnStatementSyntax r)
+        {
+            if (r.Expression is null)
+            {
+                _fb.Emit(BytecodeOp.ReturnVoid);
+                return;
+            }
+
+            var k = InferKind(r.Expression);
+            LowerExpr(r.Expression);
+            _fb.Emit(k == BytecodeValueKind.F32 ? BytecodeOp.ReturnF32 : BytecodeOp.ReturnI32);
+        }
+
+        private void LowerIf(IfStatementSyntax iff)
+        {
+            LowerExpr(iff.Condition);
+            var jzToElse = _fb.Emit(BytecodeOp.JumpIfZeroI32, 0);
+            LowerBlock(iff.ThenBlock);
+            if (iff.ElseBlock is null)
+            {
+                _fb.PatchJump(jzToElse, _fb.CurrentIp);
+                return;
+            }
+            var jToMerge = _fb.Emit(BytecodeOp.Jump, 0);
+            var elseIp = _fb.CurrentIp;
+            _fb.PatchJump(jzToElse, elseIp);
+            LowerBlock(iff.ElseBlock);
+            _fb.PatchJump(jToMerge, _fb.CurrentIp);
+        }
+
+        private void LowerFor(ForStatementSyntax fr)
+        {
+            if (fr.Initializer is not null)
+            {
+                LowerExpr(fr.Initializer);
+                _fb.Emit(BytecodeOp.Pop);
+            }
+
+            var loopIp = _fb.CurrentIp;
+
+            if (fr.Condition is not null)
+            {
+                LowerExpr(fr.Condition);
+            }
+            else
+            {
+                _fb.Emit(BytecodeOp.ConstI32, 1);
+            }
+
+            var jzToEnd = _fb.Emit(BytecodeOp.JumpIfZeroI32, 0);
+            LowerBlock(fr.Body);
+            if (fr.Step is not null)
+            {
+                LowerExpr(fr.Step);
+                _fb.Emit(BytecodeOp.Pop);
+            }
+            _fb.Emit(BytecodeOp.Jump, loopIp);
+            _fb.PatchJump(jzToEnd, _fb.CurrentIp);
+        }
+
+        private void LowerExpr(ExpressionSyntax expr)
+        {
+            switch (expr)
+            {
+                case ParenthesizedExpressionSyntax p:
+                    LowerExpr(p.Expression);
+                    return;
+                case LiteralExpressionSyntax lit:
+                    LowerLiteral(lit);
+                    return;
+                case IdentifierExpressionSyntax id:
+                    LowerIdLoad(id);
+                    return;
+                case UnaryExpressionSyntax un:
+                    LowerUnary(un);
+                    return;
+                case AssignmentExpressionSyntax assign:
+                    LowerAssign(assign);
+                    return;
+                case BinaryExpressionSyntax bin:
+                    LowerBinary(bin);
+                    return;
+                default:
+                    _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported expression {expr.GetType().Name}.", expr.Span));
+                    _fb.Emit(BytecodeOp.ConstI32, 0);
+                    return;
+            }
+        }
+
+        private void LowerLiteral(LiteralExpressionSyntax lit)
+        {
+            switch (lit.Literal.Kind)
+            {
+                case TokenKind.IntegerLiteral:
+                    if (!int.TryParse(lit.Literal.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i))
+                    {
+                        _diagnostics.Add(new Diagnostic($"Bytecode backend: invalid integer literal '{lit.Literal.Text}'.", lit.Span));
+                        _fb.Emit(BytecodeOp.ConstI32, 0);
+                        return;
+                    }
+                    _fb.Emit(BytecodeOp.ConstI32, i);
+                    return;
+                case TokenKind.FloatLiteral:
+                    if (!float.TryParse(lit.Literal.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
+                    {
+                        _diagnostics.Add(new Diagnostic($"Bytecode backend: invalid float literal '{lit.Literal.Text}'.", lit.Span));
+                        _fb.Emit(BytecodeOp.ConstF32, BitConverter.SingleToInt32Bits(0.0f));
+                        return;
+                    }
+                    _fb.Emit(BytecodeOp.ConstF32, BitConverter.SingleToInt32Bits(f));
+                    return;
+                case TokenKind.TrueKeyword:
+                    _fb.Emit(BytecodeOp.ConstI32, 1);
+                    return;
+                case TokenKind.FalseKeyword:
+                    _fb.Emit(BytecodeOp.ConstI32, 0);
+                    return;
+                default:
+                    _diagnostics.Add(new Diagnostic("Bytecode backend: unsupported literal.", lit.Span));
+                    _fb.Emit(BytecodeOp.ConstI32, 0);
+                    return;
+            }
+        }
+
+        private void LowerIdLoad(IdentifierExpressionSyntax id)
+        {
+            var name = id.Identifier.Text;
+            if (_locals.TryGetValue(name, out var local))
+            {
+                EmitLoadLocal(local.index, local.kind);
+                return;
+            }
+            if (_globals.TryGetValue(name, out var g))
+            {
+                EmitLoadGlobal(g.index, g.kind);
+                return;
+            }
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unknown identifier '{name}'.", id.Identifier.Span));
+            _fb.Emit(BytecodeOp.ConstI32, 0);
+        }
+
+        private void LowerUnary(UnaryExpressionSyntax un)
+        {
+            var k = InferKind(un.Operand);
+            LowerExpr(un.Operand);
+            if (un.OperatorToken.Kind == TokenKind.Minus)
+            {
+                _fb.Emit(k == BytecodeValueKind.F32 ? BytecodeOp.NegF32 : BytecodeOp.NegI32);
+                return;
+            }
+            if (un.OperatorToken.Kind == TokenKind.Bang)
+            {
+                _fb.Emit(BytecodeOp.NotI32);
+                return;
+            }
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported unary operator '{un.OperatorToken.Text}'.", un.OperatorToken.Span));
+        }
+
+        private void LowerAssign(AssignmentExpressionSyntax assign)
+        {
+            if (assign.Left is not IdentifierExpressionSyntax id)
+            {
+                _diagnostics.Add(new Diagnostic("Bytecode backend: assignment target must be an identifier.", assign.Left.Span));
+                LowerExpr(assign.Right);
+                return;
+            }
+
+            var name = id.Identifier.Text;
+            if (_locals.TryGetValue(name, out var local))
+            {
+                LowerAssignToLocal(local, assign);
+                return;
+            }
+            if (_globals.TryGetValue(name, out var g))
+            {
+                LowerAssignToGlobal(g, assign);
+                return;
+            }
+
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unknown identifier '{name}'.", id.Identifier.Span));
+            LowerExpr(assign.Right);
+        }
+
+        private void LowerAssignToLocal((int index, BytecodeValueKind kind) local, AssignmentExpressionSyntax assign)
+        {
+            var rhsKind = InferKind(assign.Right);
+            if (assign.OperatorToken.Kind == TokenKind.Equal)
+            {
+                LowerExpr(assign.Right);
+                EmitCoerce(rhsKind, local.kind, assign.Right.Span);
+                _fb.Emit(BytecodeOp.Dup);
+                EmitStoreLocal(local.index, local.kind);
+                return;
+            }
+
+            if (assign.OperatorToken.Kind is TokenKind.PlusEqual or TokenKind.MinusEqual or TokenKind.StarEqual or TokenKind.SlashEqual)
+            {
+                EmitLoadLocal(local.index, local.kind);
+                LowerExpr(assign.Right);
+                EmitCoerce(rhsKind, local.kind, assign.Right.Span);
+                EmitBinaryOp(local.kind, assign.OperatorToken.Kind);
+                _fb.Emit(BytecodeOp.Dup);
+                EmitStoreLocal(local.index, local.kind);
+                return;
+            }
+
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported assignment operator '{assign.OperatorToken.Text}'.", assign.OperatorToken.Span));
+            LowerExpr(assign.Right);
+        }
+
+        private void LowerAssignToGlobal((int index, BytecodeValueKind kind) g, AssignmentExpressionSyntax assign)
+        {
+            var rhsKind = InferKind(assign.Right);
+            if (assign.OperatorToken.Kind == TokenKind.Equal)
+            {
+                LowerExpr(assign.Right);
+                EmitCoerce(rhsKind, g.kind, assign.Right.Span);
+                _fb.Emit(BytecodeOp.Dup);
+                EmitStoreGlobal(g.index, g.kind);
+                return;
+            }
+
+            if (assign.OperatorToken.Kind is TokenKind.PlusEqual or TokenKind.MinusEqual or TokenKind.StarEqual or TokenKind.SlashEqual)
+            {
+                EmitLoadGlobal(g.index, g.kind);
+                LowerExpr(assign.Right);
+                EmitCoerce(rhsKind, g.kind, assign.Right.Span);
+                EmitBinaryOp(g.kind, assign.OperatorToken.Kind);
+                _fb.Emit(BytecodeOp.Dup);
+                EmitStoreGlobal(g.index, g.kind);
+                return;
+            }
+
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported assignment operator '{assign.OperatorToken.Text}'.", assign.OperatorToken.Span));
+            LowerExpr(assign.Right);
+        }
+
+        private void LowerBinary(BinaryExpressionSyntax bin)
+        {
+            var lk = InferKind(bin.Left);
+            var rk = InferKind(bin.Right);
+            var arithKind = lk == BytecodeValueKind.F32 || rk == BytecodeValueKind.F32 ? BytecodeValueKind.F32 : BytecodeValueKind.I32;
+
+            if (bin.OperatorToken.Kind is TokenKind.Plus or TokenKind.Minus or TokenKind.Star or TokenKind.Slash)
+            {
+                LowerExpr(bin.Left);
+                EmitCoerce(lk, arithKind, bin.Left.Span);
+                LowerExpr(bin.Right);
+                EmitCoerce(rk, arithKind, bin.Right.Span);
+                EmitBinaryOp(arithKind, bin.OperatorToken.Kind);
+                return;
+            }
+
+            if (bin.OperatorToken.Kind is TokenKind.EqualEqual or TokenKind.BangEqual or TokenKind.Less or TokenKind.LessEqual or TokenKind.Greater or TokenKind.GreaterEqual)
+            {
+                LowerExpr(bin.Left);
+                EmitCoerce(lk, arithKind, bin.Left.Span);
+                LowerExpr(bin.Right);
+                EmitCoerce(rk, arithKind, bin.Right.Span);
+                EmitCompareOp(arithKind, bin.OperatorToken.Kind);
+                return;
+            }
+
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: unsupported binary operator '{bin.OperatorToken.Text}'.", bin.OperatorToken.Span));
+            _fb.Emit(BytecodeOp.ConstI32, 0);
+        }
+
+        private BytecodeValueKind InferKind(ExpressionSyntax expr)
+        {
+            switch (expr)
+            {
+                case ParenthesizedExpressionSyntax p:
+                    return InferKind(p.Expression);
+                case LiteralExpressionSyntax lit:
+                    return TryMapLiteralToKind(lit.Literal, out var k) ? k : BytecodeValueKind.I32;
+                case IdentifierExpressionSyntax id:
+                    {
+                        var name = id.Identifier.Text;
+                        if (_locals.TryGetValue(name, out var local)) return local.kind;
+                        if (_globals.TryGetValue(name, out var g)) return g.kind;
+                        return BytecodeValueKind.I32;
+                    }
+                case UnaryExpressionSyntax un:
+                    return un.OperatorToken.Kind == TokenKind.Bang ? BytecodeValueKind.I32 : InferKind(un.Operand);
+                case AssignmentExpressionSyntax assign:
+                    return InferKind(assign.Right);
+                case BinaryExpressionSyntax bin:
+                    if (bin.OperatorToken.Kind is TokenKind.EqualEqual or TokenKind.BangEqual or TokenKind.Less or TokenKind.LessEqual or TokenKind.Greater or TokenKind.GreaterEqual)
+                    {
+                        return BytecodeValueKind.I32;
+                    }
+                    var lk = InferKind(bin.Left);
+                    var rk = InferKind(bin.Right);
+                    return lk == BytecodeValueKind.F32 || rk == BytecodeValueKind.F32 ? BytecodeValueKind.F32 : BytecodeValueKind.I32;
+                default:
+                    return BytecodeValueKind.I32;
+            }
+        }
+
+        private void EmitDefault(BytecodeValueKind kind)
+        {
+            if (kind == BytecodeValueKind.F32)
+            {
+                _fb.Emit(BytecodeOp.ConstF32, BitConverter.SingleToInt32Bits(0.0f));
+            }
+            else
+            {
+                _fb.Emit(BytecodeOp.ConstI32, 0);
+            }
+        }
+
+        private void EmitCoerce(BytecodeValueKind from, BytecodeValueKind to, SourceSpan span)
+        {
+            if (from == to)
+            {
+                return;
+            }
+            _diagnostics.Add(new Diagnostic($"Bytecode backend: cannot coerce {from} to {to} yet.", span));
+        }
+
+        private void EmitLoadLocal(int idx, BytecodeValueKind kind) =>
+            _fb.Emit(kind == BytecodeValueKind.F32 ? BytecodeOp.LoadLocalF32 : BytecodeOp.LoadLocalI32, idx);
+
+        private void EmitStoreLocal(int idx, BytecodeValueKind kind) =>
+            _fb.Emit(kind == BytecodeValueKind.F32 ? BytecodeOp.StoreLocalF32 : BytecodeOp.StoreLocalI32, idx);
+
+        private void EmitLoadGlobal(int idx, BytecodeValueKind kind) =>
+            _fb.Emit(kind == BytecodeValueKind.F32 ? BytecodeOp.LoadGlobalF32 : BytecodeOp.LoadGlobalI32, idx);
+
+        private void EmitStoreGlobal(int idx, BytecodeValueKind kind) =>
+            _fb.Emit(kind == BytecodeValueKind.F32 ? BytecodeOp.StoreGlobalF32 : BytecodeOp.StoreGlobalI32, idx);
+
+        private void EmitBinaryOp(BytecodeValueKind kind, TokenKind op)
+        {
+            if (kind == BytecodeValueKind.F32)
+            {
+                _fb.Emit(op switch
+                {
+                    TokenKind.Plus or TokenKind.PlusEqual => BytecodeOp.AddF32,
+                    TokenKind.Minus or TokenKind.MinusEqual => BytecodeOp.SubF32,
+                    TokenKind.Star or TokenKind.StarEqual => BytecodeOp.MulF32,
+                    TokenKind.Slash or TokenKind.SlashEqual => BytecodeOp.DivF32,
+                    _ => BytecodeOp.Nop
+                });
+                return;
+            }
+
+            _fb.Emit(op switch
+            {
+                TokenKind.Plus or TokenKind.PlusEqual => BytecodeOp.AddI32,
+                TokenKind.Minus or TokenKind.MinusEqual => BytecodeOp.SubI32,
+                TokenKind.Star or TokenKind.StarEqual => BytecodeOp.MulI32,
+                TokenKind.Slash or TokenKind.SlashEqual => BytecodeOp.DivI32,
+                _ => BytecodeOp.Nop
+            });
+        }
+
+        private void EmitCompareOp(BytecodeValueKind kind, TokenKind op)
+        {
+            if (kind == BytecodeValueKind.F32)
+            {
+                _fb.Emit(op switch
+                {
+                    TokenKind.EqualEqual => BytecodeOp.CmpEqF32,
+                    TokenKind.BangEqual => BytecodeOp.CmpNeF32,
+                    TokenKind.Less => BytecodeOp.CmpLtF32,
+                    TokenKind.LessEqual => BytecodeOp.CmpLeF32,
+                    TokenKind.Greater => BytecodeOp.CmpGtF32,
+                    TokenKind.GreaterEqual => BytecodeOp.CmpGeF32,
+                    _ => BytecodeOp.Nop
+                });
+                return;
+            }
+
+            _fb.Emit(op switch
+            {
+                TokenKind.EqualEqual => BytecodeOp.CmpEqI32,
+                TokenKind.BangEqual => BytecodeOp.CmpNeI32,
+                TokenKind.Less => BytecodeOp.CmpLtI32,
+                TokenKind.LessEqual => BytecodeOp.CmpLeI32,
+                TokenKind.Greater => BytecodeOp.CmpGtI32,
+                TokenKind.GreaterEqual => BytecodeOp.CmpGeI32,
+                _ => BytecodeOp.Nop
+            });
+        }
+    }
+}

--- a/Stasis.Compiler/IR/Bytecode/BytecodeFunction.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeFunction.cs
@@ -1,0 +1,11 @@
+using System.Collections.Immutable;
+
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeFunction
+{
+    public required string Name { get; init; }
+    public required int LocalCount { get; init; }
+    public required ImmutableArray<BytecodeInst> Code { get; init; }
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeFunction.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeFunction.cs
@@ -5,7 +5,8 @@ namespace Stasis.Compiler.IR.Bytecode;
 public sealed class BytecodeFunction
 {
     public required string Name { get; init; }
+    public required BytecodeValueKind ReturnKind { get; init; }
+    public required ImmutableArray<BytecodeValueKind> ParamKinds { get; init; }
     public required int LocalCount { get; init; }
     public required ImmutableArray<BytecodeInst> Code { get; init; }
 }
-

--- a/Stasis.Compiler/IR/Bytecode/BytecodeGlobal.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeGlobal.cs
@@ -1,0 +1,8 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeGlobal
+{
+    public required string Name { get; init; }
+    public required BytecodeValueKind Kind { get; init; }
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeInst.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeInst.cs
@@ -1,4 +1,3 @@
 namespace Stasis.Compiler.IR.Bytecode;
 
-public readonly record struct BytecodeInst(BytecodeOp Op, int A = 0);
-
+public readonly record struct BytecodeInst(BytecodeOp Op, int A = 0, int B = 0);

--- a/Stasis.Compiler/IR/Bytecode/BytecodeInst.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeInst.cs
@@ -1,0 +1,4 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public readonly record struct BytecodeInst(BytecodeOp Op, int A = 0);
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeModule.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeModule.cs
@@ -4,14 +4,14 @@ namespace Stasis.Compiler.IR.Bytecode;
 
 public sealed class BytecodeModule
 {
-    public required ImmutableArray<string> GlobalNames { get; init; }
+    public required ImmutableArray<BytecodeGlobal> Globals { get; init; }
     public required ImmutableArray<BytecodeFunction> Functions { get; init; }
 
     public int FindGlobalIndex(string name)
     {
-        for (var i = 0; i < GlobalNames.Length; i++)
+        for (var i = 0; i < Globals.Length; i++)
         {
-            if (string.Equals(GlobalNames[i], name, StringComparison.Ordinal))
+            if (string.Equals(Globals[i].Name, name, StringComparison.Ordinal))
             {
                 return i;
             }

--- a/Stasis.Compiler/IR/Bytecode/BytecodeModule.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeModule.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeModule
+{
+    public required ImmutableArray<string> GlobalNames { get; init; }
+    public required ImmutableArray<BytecodeFunction> Functions { get; init; }
+
+    public int FindGlobalIndex(string name)
+    {
+        for (var i = 0; i < GlobalNames.Length; i++)
+        {
+            if (string.Equals(GlobalNames[i], name, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    public int FindFunctionIndex(string name)
+    {
+        for (var i = 0; i < Functions.Length; i++)
+        {
+            if (string.Equals(Functions[i].Name, name, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeOp.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeOp.cs
@@ -4,29 +4,63 @@ public enum BytecodeOp : byte
 {
     Nop = 0,
 
+    Pop = 2,
+    Dup = 3,
+
     // Stack constants
     ConstI32 = 1, // a = i32
+    ConstF32 = 4, // a = f32 bits (BitConverter.SingleToInt32Bits)
 
     // Locals
     LoadLocalI32 = 10,  // a = local index
     StoreLocalI32 = 11, // a = local index
+    LoadLocalF32 = 12,  // a = local index
+    StoreLocalF32 = 13, // a = local index
 
     // Globals
     LoadGlobalI32 = 20,  // a = global index
     StoreGlobalI32 = 21, // a = global index
+    LoadGlobalF32 = 22,  // a = global index
+    StoreGlobalF32 = 23, // a = global index
 
     // Arithmetic
     AddI32 = 30,
     SubI32 = 31,
     MulI32 = 32,
     DivI32 = 33,
+    NegI32 = 34,
+
+    AddF32 = 35,
+    SubF32 = 36,
+    MulF32 = 37,
+    DivF32 = 38,
+    NegF32 = 39,
+
+    // Comparisons (push i32 0/1)
+    CmpEqI32 = 70,
+    CmpNeI32 = 71,
+    CmpLtI32 = 72,
+    CmpLeI32 = 73,
+    CmpGtI32 = 74,
+    CmpGeI32 = 75,
+    CmpEqF32 = 76,
+    CmpNeF32 = 77,
+    CmpLtF32 = 78,
+    CmpLeF32 = 79,
+    CmpGtF32 = 80,
+    CmpGeF32 = 81,
+
+    NotI32 = 82,
 
     // Control flow
     Jump = 40,        // a = absolute instruction index
     JumpIfZeroI32 = 41, // pops i32; if == 0, jump to a
 
+    // Calls
+    Call = 45, // a = function index, b = arg count
+
     // Returns
     ReturnI32 = 50, // pops i32 and returns it
+    ReturnF32 = 52, // pops f32 bits and returns it (as i32 bits)
     ReturnVoid = 51
 }
-

--- a/Stasis.Compiler/IR/Bytecode/BytecodeOp.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeOp.cs
@@ -1,0 +1,32 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public enum BytecodeOp : byte
+{
+    Nop = 0,
+
+    // Stack constants
+    ConstI32 = 1, // a = i32
+
+    // Locals
+    LoadLocalI32 = 10,  // a = local index
+    StoreLocalI32 = 11, // a = local index
+
+    // Globals
+    LoadGlobalI32 = 20,  // a = global index
+    StoreGlobalI32 = 21, // a = global index
+
+    // Arithmetic
+    AddI32 = 30,
+    SubI32 = 31,
+    MulI32 = 32,
+    DivI32 = 33,
+
+    // Control flow
+    Jump = 40,        // a = absolute instruction index
+    JumpIfZeroI32 = 41, // pops i32; if == 0, jump to a
+
+    // Returns
+    ReturnI32 = 50, // pops i32 and returns it
+    ReturnVoid = 51
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeValueKind.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeValueKind.cs
@@ -1,0 +1,9 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public enum BytecodeValueKind : byte
+{
+    Void = 0,
+    I32 = 1,
+    F32 = 2
+}
+

--- a/Stasis.Compiler/IR/Bytecode/BytecodeVm.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeVm.cs
@@ -1,148 +1,435 @@
+using System.Collections.Immutable;
+
 namespace Stasis.Compiler.IR.Bytecode;
 
 public sealed class BytecodeVm
 {
-    private readonly int[] _globalsI32;
+    private ulong[] _globals;
 
     public BytecodeVm(BytecodeModule module)
     {
         Module = module;
-        _globalsI32 = new int[module.GlobalNames.Length];
+        _globals = new ulong[module.Globals.Length];
     }
 
     public BytecodeModule Module { get; private set; }
 
     public int GetGlobalI32(string name)
     {
-        var idx = Module.FindGlobalIndex(name);
-        if (idx < 0) throw new InvalidOperationException($"Global not found: {name}");
-        return _globalsI32[idx];
+        var (idx, kind) = RequireGlobal(name);
+        if (kind != BytecodeValueKind.I32) throw new InvalidOperationException($"Global '{name}' is not i32.");
+        return (int)(uint)_globals[idx];
     }
 
     public void SetGlobalI32(string name, int value)
     {
-        var idx = Module.FindGlobalIndex(name);
-        if (idx < 0) throw new InvalidOperationException($"Global not found: {name}");
-        _globalsI32[idx] = value;
+        var (idx, kind) = RequireGlobal(name);
+        if (kind != BytecodeValueKind.I32) throw new InvalidOperationException($"Global '{name}' is not i32.");
+        _globals[idx] = (uint)value;
+    }
+
+    public float GetGlobalF32(string name)
+    {
+        var (idx, kind) = RequireGlobal(name);
+        if (kind != BytecodeValueKind.F32) throw new InvalidOperationException($"Global '{name}' is not f32.");
+        return BitsToF32((int)(uint)_globals[idx]);
+    }
+
+    public void SetGlobalF32(string name, float value)
+    {
+        var (idx, kind) = RequireGlobal(name);
+        if (kind != BytecodeValueKind.F32) throw new InvalidOperationException($"Global '{name}' is not f32.");
+        _globals[idx] = (uint)F32ToBits(value);
     }
 
     public void HotSwap(BytecodeModule next)
     {
-        // Dev-friendly state migration: preserve globals by name (i32 only for now).
-        var nextGlobals = new int[next.GlobalNames.Length];
-        for (var i = 0; i < next.GlobalNames.Length; i++)
+        var nextGlobals = new ulong[next.Globals.Length];
+        for (var i = 0; i < next.Globals.Length; i++)
         {
-            var name = next.GlobalNames[i];
-            var oldIdx = Module.FindGlobalIndex(name);
-            if (oldIdx >= 0)
+            var nextG = next.Globals[i];
+            var oldIdx = Module.FindGlobalIndex(nextG.Name);
+            if (oldIdx < 0)
             {
-                nextGlobals[i] = _globalsI32[oldIdx];
+                continue;
             }
+            var oldG = Module.Globals[oldIdx];
+            if (oldG.Kind != nextG.Kind)
+            {
+                continue;
+            }
+            nextGlobals[i] = _globals[oldIdx];
         }
 
         Module = next;
-        Array.Clear(_globalsI32, 0, _globalsI32.Length);
-        Array.Copy(nextGlobals, _globalsI32, Math.Min(nextGlobals.Length, _globalsI32.Length));
+        _globals = nextGlobals;
     }
 
-    public int CallI32(string functionName)
+    public int CallI32(string functionName, params ulong[] args)
     {
-        var fnIdx = Module.FindFunctionIndex(functionName);
-        if (fnIdx < 0) throw new InvalidOperationException($"Function not found: {functionName}");
-        return ExecuteI32(Module.Functions[fnIdx]);
+        var fn = RequireFunction(functionName);
+        if (fn.ReturnKind != BytecodeValueKind.I32) throw new InvalidOperationException($"Function '{functionName}' does not return i32.");
+        return (int)(uint)Execute(fn, args);
     }
 
-    private int ExecuteI32(BytecodeFunction fn)
+    public void CallVoid(string functionName, params ulong[] args)
     {
-        var locals = new int[fn.LocalCount];
-        var stack = new int[Math.Max(64, fn.LocalCount * 2 + 16)];
+        var fn = RequireFunction(functionName);
+        if (fn.ReturnKind != BytecodeValueKind.Void) throw new InvalidOperationException($"Function '{functionName}' does not return void.");
+        _ = Execute(fn, args);
+    }
+
+    private static int F32ToBits(float v) => BitConverter.SingleToInt32Bits(v);
+    private static float BitsToF32(int bits) => BitConverter.Int32BitsToSingle(bits);
+
+    private (int idx, BytecodeValueKind kind) RequireGlobal(string name)
+    {
+        var idx = Module.FindGlobalIndex(name);
+        if (idx < 0) throw new InvalidOperationException($"Global not found: {name}");
+        return (idx, Module.Globals[idx].Kind);
+    }
+
+    private BytecodeFunction RequireFunction(string name)
+    {
+        var idx = Module.FindFunctionIndex(name);
+        if (idx < 0) throw new InvalidOperationException($"Function not found: {name}");
+        return Module.Functions[idx];
+    }
+
+    private sealed class Frame
+    {
+        public required BytecodeFunction Fn { get; init; }
+        public required int Ip { get; set; }
+        public required ulong[] Locals { get; init; }
+        public required int StackBase { get; init; }
+    }
+
+    private ulong Execute(BytecodeFunction entry, ulong[] args)
+    {
+        static void EnsureArgsMatch(BytecodeFunction fn, ulong[] a)
+        {
+            if (a.Length != fn.ParamKinds.Length)
+            {
+                throw new InvalidOperationException($"Call arg count mismatch for '{fn.Name}': expected {fn.ParamKinds.Length}, got {a.Length}.");
+            }
+        }
+
+        EnsureArgsMatch(entry, args);
+
+        var stack = new ulong[256];
         var sp = 0;
 
-        int Pop()
+        int I32(ulong v) => (int)(uint)v;
+        ulong U32(int v) => (uint)v;
+        float F32(ulong v) => BitsToF32((int)(uint)v);
+        ulong F32Bits(float v) => (uint)F32ToBits(v);
+
+        ulong Pop()
         {
             if (sp <= 0) throw new InvalidOperationException("Bytecode stack underflow.");
             return stack[--sp];
         }
 
-        void Push(int v)
+        void Push(ulong v)
         {
             if (sp >= stack.Length) Array.Resize(ref stack, stack.Length * 2);
             stack[sp++] = v;
         }
 
+        var callStack = new Stack<Frame>(64);
+        var fn = entry;
         var ip = 0;
-        while (ip >= 0 && ip < fn.Code.Length)
+        var locals = new ulong[fn.LocalCount];
+        for (var i = 0; i < args.Length; i++)
         {
+            locals[i] = args[i];
+        }
+
+        while (true)
+        {
+            if (ip < 0 || ip >= fn.Code.Length)
+            {
+                throw new InvalidOperationException($"Bytecode function '{fn.Name}' fell off end without return.");
+            }
+
             var inst = fn.Code[ip++];
             switch (inst.Op)
             {
                 case BytecodeOp.Nop:
                     break;
-                case BytecodeOp.ConstI32:
-                    Push(inst.A);
+                case BytecodeOp.Pop:
+                    _ = Pop();
                     break;
+                case BytecodeOp.Dup:
+                    {
+                        var v = Pop();
+                        Push(v);
+                        Push(v);
+                        break;
+                    }
+
+                case BytecodeOp.ConstI32:
+                    Push(U32(inst.A));
+                    break;
+                case BytecodeOp.ConstF32:
+                    Push(U32(inst.A));
+                    break;
+
                 case BytecodeOp.LoadLocalI32:
+                case BytecodeOp.LoadLocalF32:
                     Push(locals[inst.A]);
                     break;
                 case BytecodeOp.StoreLocalI32:
+                case BytecodeOp.StoreLocalF32:
                     locals[inst.A] = Pop();
                     break;
+
                 case BytecodeOp.LoadGlobalI32:
-                    Push(_globalsI32[inst.A]);
+                case BytecodeOp.LoadGlobalF32:
+                    Push(_globals[inst.A]);
                     break;
                 case BytecodeOp.StoreGlobalI32:
-                    _globalsI32[inst.A] = Pop();
+                case BytecodeOp.StoreGlobalF32:
+                    _globals[inst.A] = Pop();
                     break;
+
                 case BytecodeOp.AddI32:
                     {
-                        var b = Pop();
-                        var a = Pop();
-                        Push(a + b);
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a + b));
                         break;
                     }
                 case BytecodeOp.SubI32:
                     {
-                        var b = Pop();
-                        var a = Pop();
-                        Push(a - b);
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a - b));
                         break;
                     }
                 case BytecodeOp.MulI32:
                     {
-                        var b = Pop();
-                        var a = Pop();
-                        Push(a * b);
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a * b));
                         break;
                     }
                 case BytecodeOp.DivI32:
                     {
-                        var b = Pop();
-                        var a = Pop();
-                        Push(a / b);
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a / b));
                         break;
                     }
+                case BytecodeOp.NegI32:
+                    Push(U32(-I32(Pop())));
+                    break;
+
+                case BytecodeOp.AddF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(F32Bits(a + b));
+                        break;
+                    }
+                case BytecodeOp.SubF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(F32Bits(a - b));
+                        break;
+                    }
+                case BytecodeOp.MulF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(F32Bits(a * b));
+                        break;
+                    }
+                case BytecodeOp.DivF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(F32Bits(a / b));
+                        break;
+                    }
+                case BytecodeOp.NegF32:
+                    Push(F32Bits(-F32(Pop())));
+                    break;
+
+                case BytecodeOp.NotI32:
+                    {
+                        var v = I32(Pop());
+                        Push(U32(v == 0 ? 1 : 0));
+                        break;
+                    }
+
+                case BytecodeOp.CmpEqI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a == b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpNeI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a != b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpLtI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a < b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpLeI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a <= b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpGtI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a > b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpGeI32:
+                    {
+                        var b = I32(Pop());
+                        var a = I32(Pop());
+                        Push(U32(a >= b ? 1 : 0));
+                        break;
+                    }
+
+                case BytecodeOp.CmpEqF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a == b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpNeF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a != b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpLtF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a < b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpLeF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a <= b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpGtF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a > b ? 1 : 0));
+                        break;
+                    }
+                case BytecodeOp.CmpGeF32:
+                    {
+                        var b = F32(Pop());
+                        var a = F32(Pop());
+                        Push(U32(a >= b ? 1 : 0));
+                        break;
+                    }
+
                 case BytecodeOp.Jump:
                     ip = inst.A;
                     break;
                 case BytecodeOp.JumpIfZeroI32:
                     {
-                        var cond = Pop();
+                        var cond = I32(Pop());
                         if (cond == 0)
                         {
                             ip = inst.A;
                         }
                         break;
                     }
-                case BytecodeOp.ReturnI32:
-                    return Pop();
+
+                case BytecodeOp.Call:
+                    {
+                        var callee = Module.Functions[inst.A];
+                        var argc = inst.B;
+                        if (argc != callee.ParamKinds.Length)
+                        {
+                            throw new InvalidOperationException($"Call arg count mismatch for '{callee.Name}': expected {callee.ParamKinds.Length}, got {argc}.");
+                        }
+
+                        var callArgs = new ulong[argc];
+                        for (var i = argc - 1; i >= 0; i--)
+                        {
+                            callArgs[i] = Pop();
+                        }
+
+                        callStack.Push(new Frame
+                        {
+                            Fn = fn,
+                            Ip = ip,
+                            Locals = locals,
+                            StackBase = sp
+                        });
+
+                        fn = callee;
+                        ip = 0;
+                        locals = new ulong[fn.LocalCount];
+                        for (var i = 0; i < callArgs.Length; i++)
+                        {
+                            locals[i] = callArgs[i];
+                        }
+                        break;
+                    }
+
                 case BytecodeOp.ReturnVoid:
-                    return 0;
+                    {
+                        if (callStack.Count == 0)
+                        {
+                            return 0;
+                        }
+                        var caller = callStack.Pop();
+                        fn = caller.Fn;
+                        ip = caller.Ip;
+                        locals = caller.Locals;
+                        sp = caller.StackBase;
+                        break;
+                    }
+                case BytecodeOp.ReturnI32:
+                case BytecodeOp.ReturnF32:
+                    {
+                        var ret = Pop();
+                        if (callStack.Count == 0)
+                        {
+                            return ret;
+                        }
+                        var caller = callStack.Pop();
+                        fn = caller.Fn;
+                        ip = caller.Ip;
+                        locals = caller.Locals;
+                        sp = caller.StackBase;
+                        Push(ret);
+                        break;
+                    }
+
                 default:
                     throw new InvalidOperationException($"Unknown bytecode op: {inst.Op}.");
             }
         }
-
-        throw new InvalidOperationException($"Bytecode function '{fn.Name}' fell off end without return.");
     }
 }
 

--- a/Stasis.Compiler/IR/Bytecode/BytecodeVm.cs
+++ b/Stasis.Compiler/IR/Bytecode/BytecodeVm.cs
@@ -1,0 +1,148 @@
+namespace Stasis.Compiler.IR.Bytecode;
+
+public sealed class BytecodeVm
+{
+    private readonly int[] _globalsI32;
+
+    public BytecodeVm(BytecodeModule module)
+    {
+        Module = module;
+        _globalsI32 = new int[module.GlobalNames.Length];
+    }
+
+    public BytecodeModule Module { get; private set; }
+
+    public int GetGlobalI32(string name)
+    {
+        var idx = Module.FindGlobalIndex(name);
+        if (idx < 0) throw new InvalidOperationException($"Global not found: {name}");
+        return _globalsI32[idx];
+    }
+
+    public void SetGlobalI32(string name, int value)
+    {
+        var idx = Module.FindGlobalIndex(name);
+        if (idx < 0) throw new InvalidOperationException($"Global not found: {name}");
+        _globalsI32[idx] = value;
+    }
+
+    public void HotSwap(BytecodeModule next)
+    {
+        // Dev-friendly state migration: preserve globals by name (i32 only for now).
+        var nextGlobals = new int[next.GlobalNames.Length];
+        for (var i = 0; i < next.GlobalNames.Length; i++)
+        {
+            var name = next.GlobalNames[i];
+            var oldIdx = Module.FindGlobalIndex(name);
+            if (oldIdx >= 0)
+            {
+                nextGlobals[i] = _globalsI32[oldIdx];
+            }
+        }
+
+        Module = next;
+        Array.Clear(_globalsI32, 0, _globalsI32.Length);
+        Array.Copy(nextGlobals, _globalsI32, Math.Min(nextGlobals.Length, _globalsI32.Length));
+    }
+
+    public int CallI32(string functionName)
+    {
+        var fnIdx = Module.FindFunctionIndex(functionName);
+        if (fnIdx < 0) throw new InvalidOperationException($"Function not found: {functionName}");
+        return ExecuteI32(Module.Functions[fnIdx]);
+    }
+
+    private int ExecuteI32(BytecodeFunction fn)
+    {
+        var locals = new int[fn.LocalCount];
+        var stack = new int[Math.Max(64, fn.LocalCount * 2 + 16)];
+        var sp = 0;
+
+        int Pop()
+        {
+            if (sp <= 0) throw new InvalidOperationException("Bytecode stack underflow.");
+            return stack[--sp];
+        }
+
+        void Push(int v)
+        {
+            if (sp >= stack.Length) Array.Resize(ref stack, stack.Length * 2);
+            stack[sp++] = v;
+        }
+
+        var ip = 0;
+        while (ip >= 0 && ip < fn.Code.Length)
+        {
+            var inst = fn.Code[ip++];
+            switch (inst.Op)
+            {
+                case BytecodeOp.Nop:
+                    break;
+                case BytecodeOp.ConstI32:
+                    Push(inst.A);
+                    break;
+                case BytecodeOp.LoadLocalI32:
+                    Push(locals[inst.A]);
+                    break;
+                case BytecodeOp.StoreLocalI32:
+                    locals[inst.A] = Pop();
+                    break;
+                case BytecodeOp.LoadGlobalI32:
+                    Push(_globalsI32[inst.A]);
+                    break;
+                case BytecodeOp.StoreGlobalI32:
+                    _globalsI32[inst.A] = Pop();
+                    break;
+                case BytecodeOp.AddI32:
+                    {
+                        var b = Pop();
+                        var a = Pop();
+                        Push(a + b);
+                        break;
+                    }
+                case BytecodeOp.SubI32:
+                    {
+                        var b = Pop();
+                        var a = Pop();
+                        Push(a - b);
+                        break;
+                    }
+                case BytecodeOp.MulI32:
+                    {
+                        var b = Pop();
+                        var a = Pop();
+                        Push(a * b);
+                        break;
+                    }
+                case BytecodeOp.DivI32:
+                    {
+                        var b = Pop();
+                        var a = Pop();
+                        Push(a / b);
+                        break;
+                    }
+                case BytecodeOp.Jump:
+                    ip = inst.A;
+                    break;
+                case BytecodeOp.JumpIfZeroI32:
+                    {
+                        var cond = Pop();
+                        if (cond == 0)
+                        {
+                            ip = inst.A;
+                        }
+                        break;
+                    }
+                case BytecodeOp.ReturnI32:
+                    return Pop();
+                case BytecodeOp.ReturnVoid:
+                    return 0;
+                default:
+                    throw new InvalidOperationException($"Unknown bytecode op: {inst.Op}.");
+            }
+        }
+
+        throw new InvalidOperationException($"Bytecode function '{fn.Name}' fell off end without return.");
+    }
+}
+

--- a/Stasis.Compiler/IR/CodeGeneratorFactory.cs
+++ b/Stasis.Compiler/IR/CodeGeneratorFactory.cs
@@ -43,7 +43,7 @@ public static class CodeGeneratorFactory
         {
             BackendType.Llvm => true,
             BackendType.Cranelift => true,
-            BackendType.Bytecode => false,
+            BackendType.Bytecode => true,
             _ => false
         };
     }
@@ -59,7 +59,7 @@ public static class CodeGeneratorFactory
         {
             BackendType.Llvm => true,
             BackendType.Cranelift => true, // Can generate CLIF text
-            BackendType.Bytecode => false,
+            BackendType.Bytecode => true,
             _ => false
         };
     }

--- a/Stasis.Compiler/IR/CodeGeneratorFactory.cs
+++ b/Stasis.Compiler/IR/CodeGeneratorFactory.cs
@@ -17,6 +17,7 @@ public static class CodeGeneratorFactory
         {
             BackendType.Llvm => new Llvm.LlvmCodeGenerator(moduleName),
             BackendType.Cranelift => new Cranelift.CraneliftCodeGenerator(moduleName),
+            // Bytecode backend not wired into the CLI yet; VM + format lives under IR/Bytecode/.
             _ => throw new ArgumentException($"Unknown backend type: {backend}", nameof(backend))
         };
     }
@@ -42,6 +43,7 @@ public static class CodeGeneratorFactory
         {
             BackendType.Llvm => true,
             BackendType.Cranelift => true,
+            BackendType.Bytecode => false,
             _ => false
         };
     }
@@ -57,6 +59,7 @@ public static class CodeGeneratorFactory
         {
             BackendType.Llvm => true,
             BackendType.Cranelift => true, // Can generate CLIF text
+            BackendType.Bytecode => false,
             _ => false
         };
     }

--- a/docs/bytecode-dev.md
+++ b/docs/bytecode-dev.md
@@ -55,7 +55,8 @@ Planned extensions:
 ## Integration plan (incremental)
 
 Phase 0 (this branch):
-- implement VM + module model + hot-swap global migration (i32 only)
+- implement VM + module model + hot-swap global migration (i32/f32)
+- implement minimal compiler emitter for a headless subset (locals/globals, if/for, + - * /, comparisons, assignment)
 - tests for VM execution and hot swap
 
 Phase 1:
@@ -65,3 +66,38 @@ Phase 1:
 Phase 2:
 - move VM into the native runner (or add a stable host-import layer) so games can run with SDL/graphics and still hot swap in milliseconds.
 
+## Current status (prototype)
+
+- CLI supports `--backend bytecode` for `--emit-ir` (prints disassembly) and a dev-only `run` path that requires a top-level `function tick()`.
+- `--watch` + `tick()` runs an in-process C# VM and hot-swaps by recompiling + `vm.HotSwap(...)`.
+- No structs/arrays/member access, no externs, no function calls. This is intentionally minimal to measure "edit -> swap" overhead.
+
+## Benchmarking hot swap
+
+Run the headless timing harness:
+
+- `powershell -ExecutionPolicy Bypass -File scripts/hotswap_timing_bytecode_counter.ps1`
+
+It edits `examples/bytecode_counter.stasis` in a loop and summarizes:
+
+- `HOTSWAP(ms): total=... latency=... load=...`
+
+`load` is the in-memory swap time (no `LoadLibrary`), and should be near-zero.
+
+### Example results (Windows, Feb 4 2026)
+
+Command:
+
+- `powershell -ExecutionPolicy Bypass -File scripts/hotswap_timing_bytecode_counter.ps1 -Iterations 100 -SleepAfterEditMs 100`
+
+Observed:
+
+- Initial compile: ~24.57ms
+- HOTSWAP total (edit->recompile+swap): min~0.164ms avg~0.354ms max~4.365ms
+- HOTSWAP load (vm swap only): min~0.001ms avg~0.004ms max~0.313ms
+- HOTSWAP latency: ~75-90ms (dominated by the debounce window and filesystem notification timing, not compilation)
+
+## Windows Defender / Smart App Control notes
+
+- The bytecode watch loop avoids generating/loading new DLLs, so it should be far less sensitive to Windows Defender file scanning than the Cranelift hot-swap path.
+- If Smart App Control blocks execution of build outputs, prefer running via `dotnet` or ensure your build artifacts live in a trusted/excluded directory.

--- a/docs/bytecode-dev.md
+++ b/docs/bytecode-dev.md
@@ -1,0 +1,67 @@
+# Bytecode Interpreter Backend (Dev Hot Swap)
+
+Goal: make dev iteration much faster than Cranelift AOT (and avoid Windows `LoadLibrary` cost) by running Stasis in a bytecode VM and hot-swapping by replacing bytecode (no native link, no DLL load).
+
+## Why bytecode (vs Cranelift AOT)
+
+- Windows AOT hot swap is dominated by DLL load time (often ~400-700ms).
+- A bytecode VM can swap in milliseconds: write a small `.stbc` file (or in-memory), validate, then swap code pointers.
+- Runtime cost is higher than native, but acceptable for many dev loops.
+
+## Design constraints (Stasis-specific)
+
+- Stasis uses static global memory and deterministic layout rules.
+- Hot swap should preserve global state when structs/layout did not change.
+- AoS-to-SoA lowering must still happen (VM should operate on the lowered storage model).
+
+## Proposed architecture
+
+Build graph (dev):
+
+- parse + sema + layout -> bytecode emit -> runner interprets -> hot swap replaces bytecode
+
+Key property: the "runner" stays stable; only bytecode changes.
+
+## Swap strategy
+
+1) Compile new module to bytecode
+2) Validate compatibility:
+   - module ABI version
+   - global layout hash (or per-global size/type signature)
+3) Migrate state:
+   - preserve globals by name/type when compatible
+   - if incompatible, either reset incompatible globals or force restart
+4) Swap:
+   - atomically replace function table / bytecode buffers
+
+## Instruction set (initial)
+
+Start with a simple, typed, stack VM (i32 first; f32 and memory ops next).
+
+- `ConstI32 <imm>`
+- `LoadLocalI32 <idx>` / `StoreLocalI32 <idx>`
+- `LoadGlobalI32 <idx>` / `StoreGlobalI32 <idx>`
+- `AddI32/SubI32/MulI32/DivI32`
+- `Jump <ip>` / `JumpIfZeroI32 <ip>`
+- `ReturnI32` / `ReturnVoid`
+
+Planned extensions:
+
+- f32 ops (and i32<->f32 conversions)
+- comparisons + structured control flow
+- arrays/struct field addressing with explicit bounds rules
+- calls (direct call by function index; host imports for gfx/audio/sys)
+
+## Integration plan (incremental)
+
+Phase 0 (this branch):
+- implement VM + module model + hot-swap global migration (i32 only)
+- tests for VM execution and hot swap
+
+Phase 1:
+- add compiler backend to emit bytecode for a small subset (no graphics)
+- `stasisc run --backend bytecode` for headless programs
+
+Phase 2:
+- move VM into the native runner (or add a stable host-import layer) so games can run with SDL/graphics and still hot swap in milliseconds.
+

--- a/examples/bytecode_counter.stasis
+++ b/examples/bytecode_counter.stasis
@@ -1,0 +1,34 @@
+global counter: i32;
+
+function tick(): i32 {
+    counter = counter + 1;
+    return 0;
+}
+
+
+
+
+
+
+
+
+// test edit 2026-02-04T18:33:18.5030028-05:00
+
+// test edit2 2026-02-04T18:33:19.0195132-05:00
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/scripts/hotswap_timing_bytecode_counter.ps1
+++ b/scripts/hotswap_timing_bytecode_counter.ps1
@@ -1,0 +1,259 @@
+param(
+    [int]$Iterations = 25,
+    [int]$Fps = 60,
+    [int]$SleepAfterEditMs = 250,
+    [int]$SwapTimeoutMs = 5000
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $root
+
+$sample = Join-Path $root "examples\\bytecode_counter.stasis"
+if (-not (Test-Path $sample)) {
+    Write-Error "Sample not found: $sample"
+    exit 1
+}
+
+$originalSample = Get-Content -Raw -Path $sample
+$sampleTouched = $false
+
+$buildDir = Join-Path $root "build"
+New-Item -ItemType Directory -Force $buildDir | Out-Null
+
+$outLog = Join-Path $buildDir "hotswap_bytecode_counter.out.log"
+$errLog = Join-Path $buildDir "hotswap_bytecode_counter.err.log"
+Remove-Item $outLog, $errLog -ErrorAction SilentlyContinue
+
+function Read-TextFileShared {
+    param([string]$Path)
+    $fs = $null
+    $sr = $null
+    try {
+        $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        $sr = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8, $true)
+        return $sr.ReadToEnd()
+    }
+    finally {
+        if ($sr) { try { $sr.Dispose() } catch {} }
+        if ($fs) { try { $fs.Dispose() } catch {} }
+    }
+}
+
+function Wait-ForText {
+    param(
+        [string]$Path,
+        [string]$Needle,
+        [int]$TimeoutMs
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if (Test-Path $Path) {
+            try {
+                $text = Read-TextFileShared -Path $Path
+                if ($text.IndexOf($Needle, [System.StringComparison]::Ordinal) -ge 0) { return $true }
+            } catch {
+                # ignore
+            }
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    return $false
+}
+
+function Wait-ForSwapCountIncrease {
+    param(
+        [string]$Path,
+        [string]$Pattern,
+        [int]$PrevCount,
+        [int]$TimeoutMs
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if (Test-Path $Path) {
+            try {
+                $text = Read-TextFileShared -Path $Path
+                $count = ([regex]::Matches($text, $Pattern)).Count
+                if ($count -gt $PrevCount) { return $count }
+            } catch {
+                # ignore
+            }
+        }
+        Start-Sleep -Milliseconds 25
+    }
+    return -1
+}
+
+function Parse-HotSwapSummary([string[]]$lines) {
+    $swaps = @()
+    foreach ($line in $lines) {
+        if ($line -like "*HOTSWAP(ms):*") {
+            $fields = @{}
+            foreach ($m in [regex]::Matches($line, "([A-Za-z_]+)=(-?[0-9]+(?:\.[0-9]+)?)")) {
+                $fields[$m.Groups[1].Value] = [double]$m.Groups[2].Value
+            }
+            if ($fields.ContainsKey("load")) { $swaps += $fields }
+        }
+    }
+    return $swaps
+}
+
+function Touch-Sample([string]$Path, [string]$Tag) {
+    $text = "`n// hotswap timing bytecode_counter $Tag $([DateTime]::UtcNow.Ticks)`n"
+    Add-Content -Path $Path -Value $text -Encoding ascii
+}
+
+Write-Host ("Sample: {0}" -f $sample)
+
+$cliArgs = @("run", $sample, "--watch", "--backend", "bytecode", "--module", "bc", "--fps", [string]$Fps)
+
+$cliExe = Join-Path $root "Stasis.Cli\\bin\\Release\\net9.0\\Stasis.Cli.exe"
+Write-Host "Building CLI (Release)..."
+dotnet build -c Release | Out-Null
+if (-not (Test-Path $cliExe)) {
+    throw "CLI not found: $cliExe"
+}
+
+$proc = Start-Process -FilePath $cliExe -ArgumentList $cliArgs -WorkingDirectory $root -RedirectStandardOutput $outLog -RedirectStandardError $errLog -PassThru
+try {
+    if (-not (Wait-ForText -Path $outLog -Needle "HOTSWAP(ms):" -TimeoutMs 60000)) {
+        throw "Timed out waiting for initial HOTSWAP(ms) marker."
+    }
+
+    function Wait-ForFileLengthIncrease {
+        param(
+            [string]$Path,
+            [long]$PrevLength,
+            [int]$TimeoutMs
+        )
+
+        $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+        while ([DateTime]::UtcNow -lt $deadline) {
+            if (Test-Path $Path) {
+                try {
+                    $len = (Get-Item $Path).Length
+                    if ($len -gt $PrevLength) { return $len }
+                } catch {
+                    # ignore
+                }
+            }
+            Start-Sleep -Milliseconds 25
+        }
+        return -1
+    }
+
+    $prevLen = 0
+    if (Test-Path $outLog) { try { $prevLen = (Get-Item $outLog).Length } catch {} }
+
+    # Arm the watcher with a known edit so we don't get tripped up by any initial spurious change events.
+    $armed = $false
+    for ($w = 0; $w -lt 5; $w++) {
+        $prevLen = 0
+        if (Test-Path $outLog) { try { $prevLen = (Get-Item $outLog).Length } catch {} }
+
+        Touch-Sample -Path $sample -Tag ("warmup{0}" -f $w)
+        $sampleTouched = $true
+        Start-Sleep -Milliseconds $SleepAfterEditMs
+
+        $len = Wait-ForFileLengthIncrease -Path $outLog -PrevLength $prevLen -TimeoutMs $SwapTimeoutMs
+        if ($len -gt 0) {
+            $prevLen = $len
+            $armed = $true
+            break
+        }
+    }
+
+    if (-not $armed) {
+        $errText = ""
+        if (Test-Path $errLog) { try { $errText = Read-TextFileShared $errLog } catch {} }
+        throw "Timed out waiting for HOTSWAP(ms) after warmup edit(s). stderr=`n$errText"
+    }
+
+    for ($i = 0; $i -lt $Iterations; $i++) {
+        $prevLen = 0
+        if (Test-Path $outLog) { try { $prevLen = (Get-Item $outLog).Length } catch {} }
+
+        Touch-Sample -Path $sample -Tag $i
+        Start-Sleep -Milliseconds $SleepAfterEditMs
+
+        $len = Wait-ForFileLengthIncrease -Path $outLog -PrevLength $prevLen -TimeoutMs $SwapTimeoutMs
+        if ($len -lt 0) {
+            $errText = ""
+            if (Test-Path $errLog) { try { $errText = Read-TextFileShared $errLog } catch {} }
+            throw "Timed out waiting for HOTSWAP(ms) after edit $i. stderr=`n$errText"
+        }
+        $prevLen = $len
+    }
+
+    $lines = @()
+    if (Test-Path $outLog) {
+        $lines = (Read-TextFileShared $outLog) -split "`n"
+    }
+
+    $initialTotal = $null
+    $totals = @()
+    $latencies = @()
+    $loads = @()
+
+    foreach ($line in $lines) {
+        if ($line -notlike "*HOTSWAP(ms):*") { continue }
+
+        $mTotal = [regex]::Match($line, "total=(-?[0-9]+(?:\.[0-9]+)?)")
+        $mLatency = [regex]::Match($line, "latency=(-?[0-9]+(?:\.[0-9]+)?)")
+        $mLoad = [regex]::Match($line, "load=(-?[0-9]+(?:\.[0-9]+)?)")
+        if (-not ($mTotal.Success -and $mLatency.Success -and $mLoad.Success)) { continue }
+
+        if ($env:STASIS_BC_TIMING_DEBUG -eq "1") {
+            Write-Host ("DBG: totalRaw='{0}' latencyRaw='{1}' loadRaw='{2}'" -f $mTotal.Groups[1].Value, $mLatency.Groups[1].Value, $mLoad.Groups[1].Value)
+        }
+
+        $t = [double]$mTotal.Groups[1].Value
+        $lat = [double]$mLatency.Groups[1].Value
+        $load = [double]$mLoad.Groups[1].Value
+
+        if ($lat -lt 0 -or $load -lt 0) {
+            if ($initialTotal -eq $null) { $initialTotal = $t }
+            continue
+        }
+
+        $totals += $t
+        $latencies += $lat
+        $loads += $load
+    }
+
+    if ($initialTotal -ne $null) {
+        $ci = [System.Globalization.CultureInfo]::InvariantCulture
+        Write-Host ("Initial compile: {0}ms" -f ([double]$initialTotal).ToString("0.###", $ci))
+    }
+
+    $ci = [System.Globalization.CultureInfo]::InvariantCulture
+    $tStats = $totals | Measure-Object -Minimum -Maximum -Average
+    $latStats = $latencies | Measure-Object -Minimum -Maximum -Average
+    $loadStats = $loads | Measure-Object -Minimum -Maximum -Average
+
+    $tMin = ([math]::Round([double]$tStats.Minimum, 3)).ToString("0.###", $ci)
+    $tAvg = ([math]::Round([double]$tStats.Average, 3)).ToString("0.###", $ci)
+    $tMax = ([math]::Round([double]$tStats.Maximum, 3)).ToString("0.###", $ci)
+    Write-Host ("HOTSWAP total: min={0}ms avg={1}ms max={2}ms" -f $tMin, $tAvg, $tMax)
+
+    $latMin = ([math]::Round([double]$latStats.Minimum, 3)).ToString("0.###", $ci)
+    $latAvg = ([math]::Round([double]$latStats.Average, 3)).ToString("0.###", $ci)
+    $latMax = ([math]::Round([double]$latStats.Maximum, 3)).ToString("0.###", $ci)
+    Write-Host ("HOTSWAP latency: min={0}ms avg={1}ms max={2}ms" -f $latMin, $latAvg, $latMax)
+
+    $loadMin = ([math]::Round([double]$loadStats.Minimum, 3)).ToString("0.###", $ci)
+    $loadAvg = ([math]::Round([double]$loadStats.Average, 3)).ToString("0.###", $ci)
+    $loadMax = ([math]::Round([double]$loadStats.Maximum, 3)).ToString("0.###", $ci)
+    Write-Host ("HOTSWAP load: min={0}ms avg={1}ms max={2}ms" -f $loadMin, $loadAvg, $loadMax)
+    Write-Host ("Log: {0}" -f $outLog)
+}
+finally {
+    try { if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force } } catch {}
+
+    if ($sampleTouched) {
+        Set-Content -Path $sample -Value $originalSample -Encoding ascii
+    }
+}


### PR DESCRIPTION
Adds a dev-focused bytecode VM backend with a minimal compiler emitter and in-process tick watch path for fast hot swaps (no DLL LoadLibrary).\n\n- --backend bytecode support in CLI (headless tick VM, watch+hotswap)\n- VM + module model + hot swap global migration\n- Minimal bytecode compiler subset (globals/locals/if/for/basic exprs)\n- Timing harness: scripts/hotswap_timing_bytecode_counter.ps1\n- Docs + example program\n\nBenchmark (Windows, 2026-02-04): initial compile ~25ms; swap total avg ~0.35ms; swap load avg ~0.004ms; latency dominated by debounce (~75-90ms).\n\nLimitations: no structs/arrays/member access/externs/calls yet; intended for measuring swap overhead.