### PR TITLE
feat: JIT swaps queued/applied

### DIFF
--- a/Stasis.Cli.Tests/CliSnapshotTests.cs
+++ b/Stasis.Cli.Tests/CliSnapshotTests.cs
@@ -93,6 +93,35 @@ public class CliSnapshotTests
         return (process.ExitCode, stdout.ToString().TrimEnd(), stderr.ToString().TrimEnd());
     }
 
+    private static (int exitCode, string stdout, string stderr) RunProcess(ProcessStartInfo psi)
+    {
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return (process.ExitCode, stdout.ToString().TrimEnd(), stderr.ToString().TrimEnd());
+    }
+
     private static (int exitCode, string stdout, string stderr) RunCliWithEnv(IDictionary<string, string?> environment, params string[] args)
     {
         var root = GetRepoRoot();
@@ -216,13 +245,10 @@ public class CliSnapshotTests
                 WorkingDirectory = root
             };
 
-            using var process = Process.Start(psi)!;
-            process.WaitForExit();
-            if (process.ExitCode != 0)
+            var (exitCode, stdout, stderr) = RunProcess(psi);
+            if (exitCode != 0)
             {
-                var stdout = process.StandardOutput.ReadToEnd();
-                var stderr = process.StandardError.ReadToEnd();
-                throw new InvalidOperationException($"Failed to build CLI ({process.ExitCode}).\nstdout:\n{stdout}\nstderr:\n{stderr}");
+                throw new InvalidOperationException($"Failed to build CLI ({exitCode}).\nstdout:\n{stdout}\nstderr:\n{stderr}");
             }
 
             BuiltCliConfiguration = configuration;

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3613,6 +3613,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
     StreamReader? runnerOut = null;
 
     var pendingSwaps = new Dictionary<ulong, (DateTime ChangeUtc, DateTime SendUtc, long LowerMs)>();
+    var sentButNotQueued = new Queue<(DateTime ChangeUtc, DateTime SendUtc, long LowerMs)>();
     var pendingLock = new object();
 
     static void StartLogPump(StreamReader reader, string path, CancellationToken token, Action<string>? onLine = null)
@@ -3679,6 +3680,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         lock (pendingLock)
         {
             pendingSwaps.Clear();
+            sentButNotQueued.Clear();
         }
 
         try
@@ -3787,6 +3789,28 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                                     $"latency={runnerMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} " +
                                     $"lower={pending.Value.LowerMs} compile={compileMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} " +
                                     $"apply={applyMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} id={appliedId}");
+                            }
+                        }
+                    }
+                    else if (line.StartsWith("QUEUED ", StringComparison.Ordinal))
+                    {
+                        var idMatch = Regex.Match(line, @"\bid=(\d+)\b");
+                        if (idMatch.Success && ulong.TryParse(idMatch.Groups[1].Value, out var queuedId))
+                        {
+                            lock (pendingLock)
+                            {
+                                var supersedesMatch = Regex.Match(line, @"\bsupersedes=(\d+)\b");
+                                if (supersedesMatch.Success &&
+                                    ulong.TryParse(supersedesMatch.Groups[1].Value, out var supersedesId) &&
+                                    supersedesId != 0)
+                                {
+                                    _ = pendingSwaps.Remove(supersedesId);
+                                }
+
+                                if (sentButNotQueued.Count > 0)
+                                {
+                                    pendingSwaps[queuedId] = sentButNotQueued.Dequeue();
+                                }
                             }
                         }
                     }
@@ -4101,43 +4125,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         WriteUtf8(runnerIn, $"SWAP {clifBytes}\n");
         WriteUtf8(runnerIn, clif);
         runnerIn.Flush();
-
-        var queuedLine = ReadRunnerLineWithTimeout(timeoutMs: 5000).GetAwaiter().GetResult();
-        if (queuedLine is null || !queuedLine.StartsWith("QUEUED ", StringComparison.Ordinal))
+        lock (pendingLock)
         {
-            Console.Error.WriteLine($"warning: jit swap queue failed: {queuedLine ?? "<timeout>"}; waiting for changes to retry.");
-            try
-            {
-                runner?.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // ignore
-            }
-            runner = null;
-            runnerIn = null;
-            runnerStdin = null;
-            runnerOut = null;
-            runnerOutLines = null;
-            continue;
-        }
-
-        var idMatch = Regex.Match(queuedLine, @"\bid=(\d+)\b");
-        if (idMatch.Success && ulong.TryParse(idMatch.Groups[1].Value, out var queuedId))
-        {
-            lock (pendingLock)
-            {
-                var supersedesMatch = Regex.Match(queuedLine, @"\bsupersedes=(\d+)\b");
-                if (supersedesMatch.Success && ulong.TryParse(supersedesMatch.Groups[1].Value, out var supersedesId) && supersedesId != 0)
-                {
-                    _ = pendingSwaps.Remove(supersedesId);
-                }
-                pendingSwaps[queuedId] = (ChangeUtc: changeUtc, SendUtc: sendUtc, LowerMs: lowerMs);
-            }
-        }
-        else
-        {
-            Console.Error.WriteLine($"warning: jit swap queue response missing id: {queuedLine}");
+            sentButNotQueued.Enqueue((ChangeUtc: changeUtc, SendUtc: sendUtc, LowerMs: lowerMs));
         }
 
         lastGoodClif = clif;

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3669,6 +3669,27 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         }
     }
 
+    async Task<string?> ReadRunnerLineUntil(int timeoutMs, Func<string, bool> predicate)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            var remaining = (int)Math.Max(1, timeoutMs - sw.ElapsedMilliseconds);
+            var line = await ReadRunnerLineWithTimeout(remaining);
+            if (line is null)
+            {
+                return null;
+            }
+
+            if (predicate(line))
+            {
+                return line;
+            }
+        }
+
+        return null;
+    }
+
     async Task<bool> EnsureRunnerStarted(string initialClif)
     {
         if (runner is not null && !runner.HasExited)
@@ -3828,9 +3849,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
             }
         }, cts.Token);
 
-        // Wait for READY via stdout pump
-        var ready = await ReadRunnerLineWithTimeout(10000);
-        if (!string.Equals(ready?.Trim(), "READY", StringComparison.Ordinal))
+        // Wait for READY via stdout pump (ignore guest stdout noise).
+        var ready = await ReadRunnerLineUntil(10000, l => string.Equals(l.Trim(), "READY", StringComparison.Ordinal));
+        if (ready is null)
         {
             Console.Error.WriteLine("error: jit runner did not print READY.");
             return false;
@@ -3859,7 +3880,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         // Larger programs (e.g. Brickout) can take a while to JIT on the first load.
         // Larger programs (e.g. Brickout) can take a while to JIT on the first load,
         // especially on cold caches / under AV scanning. Keep this high to avoid false timeouts.
-        var initResp = await ReadRunnerLineWithTimeout(600000);
+        var initResp = await ReadRunnerLineUntil(
+            600000,
+            l => l.StartsWith("OK init", StringComparison.Ordinal) || l.StartsWith("ERR", StringComparison.Ordinal));
         if (initResp is null)
         {
             Console.Error.WriteLine("error: jit runner init timed out.");
@@ -3884,7 +3907,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                 WriteUtf8(runnerIn, metaPath);
                 runnerIn.Flush();
 
-                var bindResp = await ReadRunnerLineWithTimeout(30000);
+                var bindResp = await ReadRunnerLineUntil(
+                    30000,
+                    l => l.StartsWith("OK", StringComparison.Ordinal) || l.StartsWith("ERR", StringComparison.Ordinal));
                 if (bindResp is null || !bindResp.StartsWith("OK", StringComparison.Ordinal))
                 {
                     Console.Error.WriteLine($"warning: jit runner data bind failed: {bindResp ?? "<timeout>"}");

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3606,6 +3606,14 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
 
     Process? runner = null;
     DataBindingPlan? dataBindingPlan = null;
+    Channel<string>? runnerOutLines = null;
+    Task? runnerOutPump = null;
+    Stream? runnerIn = null;
+    StreamWriter? runnerStdin = null;
+    StreamReader? runnerOut = null;
+
+    var pendingSwaps = new Dictionary<ulong, (DateTime ChangeUtc, DateTime SendUtc, long LowerMs)>();
+    var pendingLock = new object();
 
     static void StartLogPump(StreamReader reader, string path, CancellationToken token, Action<string>? onLine = null)
     {
@@ -3635,57 +3643,29 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         }, token);
     }
 
-    static async Task<string?> ReadLineWithTimeout(StreamReader reader, int timeoutMs, CancellationToken token)
-    {
-        var readTask = Task.Run(() => reader.ReadLine(), token);
-        var done = await Task.WhenAny(readTask, Task.Delay(timeoutMs, token));
-        if (done == readTask)
-        {
-            return await readTask;
-        }
-        return null;
-    }
-
     static void WriteUtf8(Stream stream, string s)
     {
         var bytes = Encoding.UTF8.GetBytes(s);
         stream.Write(bytes, 0, bytes.Length);
     }
 
-    async Task<(bool ok, int latencyMs, string? response)> SendSwapAndWaitForAck(string clif, int timeoutMs)
+    async Task<string?> ReadRunnerLineWithTimeout(int timeoutMs)
     {
-        if (runner is null || runner.HasExited)
+        if (runnerOutLines is null)
         {
-            return (false, -1, "runner not running");
+            return null;
         }
 
-        var sw = Stopwatch.StartNew();
-        var clifBytes = Encoding.UTF8.GetByteCount(clif);
-        WriteUtf8(runner.StandardInput.BaseStream, $"SWAP {clifBytes}\n");
-        WriteUtf8(runner.StandardInput.BaseStream, clif);
-        runner.StandardInput.BaseStream.Flush();
-
-        var resp = await ReadLineWithTimeout(runner.StandardOutput, timeoutMs, cts.Token);
-        sw.Stop();
-
-        if (resp is not null)
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        timeoutCts.CancelAfter(timeoutMs);
+        try
         {
-            try
-            {
-                await File.AppendAllTextAsync(runnerOutLog, resp + Environment.NewLine, Encoding.UTF8, cts.Token);
-            }
-            catch
-            {
-                // ignore
-            }
+            return await runnerOutLines.Reader.ReadAsync(timeoutCts.Token);
         }
-
-        if (resp is null)
+        catch
         {
-            return (false, -1, null);
+            return null;
         }
-
-        return (resp.StartsWith("OK", StringComparison.Ordinal), (int)sw.ElapsedMilliseconds, resp);
     }
 
     async Task<bool> EnsureRunnerStarted(string initialClif)
@@ -3693,6 +3673,12 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         if (runner is not null && !runner.HasExited)
         {
             return true;
+        }
+
+        // Reset pending swap tracking across restarts.
+        lock (pendingLock)
+        {
+            pendingSwaps.Clear();
         }
 
         try
@@ -3737,14 +3723,94 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
             runnerErrLog,
             cts.Token);
 
-        // Wait for READY
-        var ready = await ReadLineWithTimeout(runner.StandardOutput, 10000, cts.Token);
+        // Keep the StreamWriter alive for the lifetime of the runner process.
+        // Some platforms/drivers can close stdin early if the StandardInput writer is dropped.
+        runnerStdin = runner.StandardInput;
+        runnerStdin.AutoFlush = true;
+        runnerIn = runnerStdin.BaseStream;
+        runnerOut = runner.StandardOutput;
+        runnerOutLines = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { SingleWriter = true, SingleReader = false });
+
+        runnerOutPump = Task.Run(async () =>
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(runnerOutLog)!);
+                using var fs = new FileStream(runnerOutLog, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+                using var writer = new StreamWriter(fs, Encoding.UTF8) { AutoFlush = true };
+                while (!cts.IsCancellationRequested && runnerOut is not null)
+                {
+                    var line = await runnerOut.ReadLineAsync();
+                    if (line is null)
+                    {
+                        break;
+                    }
+
+                    writer.WriteLine(line);
+
+                    if (line.StartsWith("APPLIED ", StringComparison.Ordinal))
+                    {
+                        // Example: APPLIED id=1 save_us=... compile_us=... restore_us=... missing_save=... missing_restore=...
+                        var idMatch = Regex.Match(line, @"\bid=(\d+)\b");
+                        if (idMatch.Success && ulong.TryParse(idMatch.Groups[1].Value, out var appliedId))
+                        {
+                            (DateTime ChangeUtc, DateTime SendUtc, long LowerMs)? pending = null;
+                            lock (pendingLock)
+                            {
+                                if (pendingSwaps.TryGetValue(appliedId, out var p))
+                                {
+                                    pending = p;
+                                    pendingSwaps.Remove(appliedId);
+                                }
+                            }
+
+                            if (pending is not null)
+                            {
+                                static double ParseUs(string input, string name)
+                                {
+                                    var m = Regex.Match(input, $@"\b{name}=(\d+)\b");
+                                    if (!m.Success) return 0;
+                                    if (!double.TryParse(m.Groups[1].Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var v)) return 0;
+                                    return v / 1000.0;
+                                }
+
+                                var nowUtc = DateTime.UtcNow;
+                                var endToEndMs = Math.Max(0, (nowUtc - pending.Value.ChangeUtc).TotalMilliseconds);
+                                var runnerMs = Math.Max(0, (nowUtc - pending.Value.SendUtc).TotalMilliseconds);
+                                var compileMs = ParseUs(line, "compile_us");
+                                var saveMs = ParseUs(line, "save_us");
+                                var restoreMs = ParseUs(line, "restore_us");
+                                var applyMs = saveMs + restoreMs;
+
+                                Console.WriteLine(
+                                    $"HOTSWAP(ms): total={endToEndMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                    $"latency={runnerMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                    $"lower={pending.Value.LowerMs} compile={compileMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} " +
+                                    $"apply={applyMs.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} id={appliedId}");
+                            }
+                        }
+                    }
+
+                    await runnerOutLines.Writer.WriteAsync(line, cts.Token);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+            finally
+            {
+                try { runnerOutLines.Writer.TryComplete(); } catch { }
+            }
+        }, cts.Token);
+
+        // Wait for READY via stdout pump
+        var ready = await ReadRunnerLineWithTimeout(10000);
         if (!string.Equals(ready?.Trim(), "READY", StringComparison.Ordinal))
         {
             Console.Error.WriteLine("error: jit runner did not print READY.");
             return false;
         }
-        await File.AppendAllTextAsync(runnerOutLog, ready + Environment.NewLine, Encoding.UTF8, cts.Token);
 
         var entry = $"{moduleName}__main";
         var tick = $"{moduleName}__tick";
@@ -3753,24 +3819,29 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         var tickBytes = Encoding.UTF8.GetByteCount(tick);
         var clifBytes = Encoding.UTF8.GetByteCount(initialClif);
 
-        WriteUtf8(runner.StandardInput.BaseStream, $"INIT {moduleBytes} {entryBytes} {tickBytes} {clifBytes}\n");
-        WriteUtf8(runner.StandardInput.BaseStream, moduleName);
-        WriteUtf8(runner.StandardInput.BaseStream, entry);
-        WriteUtf8(runner.StandardInput.BaseStream, tick);
-        WriteUtf8(runner.StandardInput.BaseStream, initialClif);
-        runner.StandardInput.BaseStream.Flush();
+        if (runnerIn is null)
+        {
+            Console.Error.WriteLine("error: jit runner stdin not initialized.");
+            return false;
+        }
+
+        WriteUtf8(runnerIn, $"INIT {moduleBytes} {entryBytes} {tickBytes} {clifBytes}\n");
+        WriteUtf8(runnerIn, moduleName);
+        WriteUtf8(runnerIn, entry);
+        WriteUtf8(runnerIn, tick);
+        WriteUtf8(runnerIn, initialClif);
+        runnerIn.Flush();
 
         // Larger programs (e.g. Brickout) can take a while to JIT on the first load.
         // Larger programs (e.g. Brickout) can take a while to JIT on the first load,
         // especially on cold caches / under AV scanning. Keep this high to avoid false timeouts.
-        var initResp = await ReadLineWithTimeout(runner.StandardOutput, 600000, cts.Token);
+        var initResp = await ReadRunnerLineWithTimeout(600000);
         if (initResp is null)
         {
             Console.Error.WriteLine("error: jit runner init timed out.");
             return false;
         }
-        await File.AppendAllTextAsync(runnerOutLog, initResp + Environment.NewLine, Encoding.UTF8, cts.Token);
-        if (!initResp.StartsWith("OK", StringComparison.Ordinal))
+        if (!initResp.StartsWith("OK init", StringComparison.Ordinal))
         {
             Console.Error.WriteLine($"error: jit runner init failed: {initResp}");
             return false;
@@ -3784,16 +3855,12 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                 var metaPath = dataBindingPlan.StructMetaPath;
                 var jsonBytes = Encoding.UTF8.GetByteCount(jsonPath);
                 var metaBytes = Encoding.UTF8.GetByteCount(metaPath);
-                WriteUtf8(runner.StandardInput.BaseStream, $"BIND {jsonBytes} {metaBytes}\n");
-                WriteUtf8(runner.StandardInput.BaseStream, jsonPath);
-                WriteUtf8(runner.StandardInput.BaseStream, metaPath);
-                runner.StandardInput.BaseStream.Flush();
+                WriteUtf8(runnerIn, $"BIND {jsonBytes} {metaBytes}\n");
+                WriteUtf8(runnerIn, jsonPath);
+                WriteUtf8(runnerIn, metaPath);
+                runnerIn.Flush();
 
-                var bindResp = await ReadLineWithTimeout(runner.StandardOutput, 30000, cts.Token);
-                if (bindResp is not null)
-                {
-                    await File.AppendAllTextAsync(runnerOutLog, bindResp + Environment.NewLine, Encoding.UTF8, cts.Token);
-                }
+                var bindResp = await ReadRunnerLineWithTimeout(30000);
                 if (bindResp is null || !bindResp.StartsWith("OK", StringComparison.Ordinal))
                 {
                     Console.Error.WriteLine($"warning: jit runner data bind failed: {bindResp ?? "<timeout>"}");
@@ -3845,9 +3912,12 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         if (sema.Diagnostics.Count > 0)
         {
             PrintDiagnostics(sema.Diagnostics, source, sourcePath);
-            clif = string.Empty;
-            lowerMs = 0;
-            return HasErrors(sema.Diagnostics) ? 1 : 0;
+            if (HasErrors(sema.Diagnostics))
+            {
+                clif = string.Empty;
+                lowerMs = 0;
+                return 1;
+            }
         }
 
         if (!ContainsTopLevelFunction(parse.CompilationUnit, "tick"))
@@ -3887,9 +3957,12 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         if (result.Diagnostics.Count > 0)
         {
             PrintDiagnostics(result.Diagnostics, source, sourcePath);
-            Console.WriteLine(result.Ir);
-            clif = string.Empty;
-            return 1;
+            if (HasErrors(result.Diagnostics))
+            {
+                Console.WriteLine(result.Ir);
+                clif = string.Empty;
+                return 1;
+            }
         }
 
         clif = result.Ir;
@@ -3981,6 +4054,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         // Debounce quick successive writes
         Thread.Sleep(50);
 
+        var changeUtc = DateTime.UtcNow;
         var swTotal = Stopwatch.StartNew();
         var rc = BuildClif(out var clif, out var lowerMs);
         if (rc != 0)
@@ -4003,11 +4077,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
             continue;
         }
 
-        var (swapOk, swapLatencyMs, resp) = SendSwapAndWaitForAck(clif, timeoutMs: 120000).GetAwaiter().GetResult();
-        Console.WriteLine($"HOTSWAP(ms): total={swTotal.ElapsedMilliseconds} latency={swapLatencyMs}");
-        if (!swapOk)
+        if (runnerIn is null)
         {
-            Console.Error.WriteLine($"warning: jit swap failed: {resp ?? "<timeout>"}; waiting for changes to retry.");
+            Console.Error.WriteLine("warning: jit runner stdin not available; restarting.");
             try
             {
                 runner?.Kill(entireProcessTree: true);
@@ -4017,7 +4089,55 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                 // ignore
             }
             runner = null;
+            runnerIn = null;
+            runnerStdin = null;
+            runnerOut = null;
+            runnerOutLines = null;
             continue;
+        }
+
+        var sendUtc = DateTime.UtcNow;
+        var clifBytes = Encoding.UTF8.GetByteCount(clif);
+        WriteUtf8(runnerIn, $"SWAP {clifBytes}\n");
+        WriteUtf8(runnerIn, clif);
+        runnerIn.Flush();
+
+        var queuedLine = ReadRunnerLineWithTimeout(timeoutMs: 5000).GetAwaiter().GetResult();
+        if (queuedLine is null || !queuedLine.StartsWith("QUEUED ", StringComparison.Ordinal))
+        {
+            Console.Error.WriteLine($"warning: jit swap queue failed: {queuedLine ?? "<timeout>"}; waiting for changes to retry.");
+            try
+            {
+                runner?.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // ignore
+            }
+            runner = null;
+            runnerIn = null;
+            runnerStdin = null;
+            runnerOut = null;
+            runnerOutLines = null;
+            continue;
+        }
+
+        var idMatch = Regex.Match(queuedLine, @"\bid=(\d+)\b");
+        if (idMatch.Success && ulong.TryParse(idMatch.Groups[1].Value, out var queuedId))
+        {
+            lock (pendingLock)
+            {
+                var supersedesMatch = Regex.Match(queuedLine, @"\bsupersedes=(\d+)\b");
+                if (supersedesMatch.Success && ulong.TryParse(supersedesMatch.Groups[1].Value, out var supersedesId) && supersedesId != 0)
+                {
+                    _ = pendingSwaps.Remove(supersedesId);
+                }
+                pendingSwaps[queuedId] = (ChangeUtc: changeUtc, SendUtc: sendUtc, LowerMs: lowerMs);
+            }
+        }
+        else
+        {
+            Console.Error.WriteLine($"warning: jit swap queue response missing id: {queuedLine}");
         }
 
         lastGoodClif = clif;
@@ -4029,8 +4149,11 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
     {
         if (runner is not null && !runner.HasExited)
         {
-            WriteUtf8(runner.StandardInput.BaseStream, "QUIT\n");
-            runner.StandardInput.BaseStream.Flush();
+            if (runnerIn is not null)
+            {
+                WriteUtf8(runnerIn, "QUIT\n");
+                runnerIn.Flush();
+            }
             runner.WaitForExit(1000);
         }
     }
@@ -4872,7 +4995,14 @@ static PrepareResult PrepareForLower(string path, bool includeTests, string modu
 
 static string LoadSourceWithImports(string path, out List<Diagnostic> importDiagnostics, out string sourceForDiagnostics)
 {
-    var original = File.ReadAllText(path);
+    static string ReadAllTextShared(string p)
+    {
+        using var fs = new FileStream(p, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var sr = new StreamReader(fs, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return sr.ReadToEnd();
+    }
+
+    var original = ReadAllTextShared(path);
     var diagnostics = new List<Diagnostic>();
     var result = SourceImporter.ExpandImports(path, original, diagnostics);
     importDiagnostics = diagnostics;

--- a/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
+++ b/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
@@ -550,6 +550,151 @@ public sealed class HotSwapIntegrationTests
     }
 
     [HotSwapFact]
+    public async Task WatchTickJitSwap_LoadsSvgSprite()
+    {
+        var repoRoot = FindRepoRoot();
+        var samplePath = Path.Combine(repoRoot, "samples", "gfx_cmd_smoke.stasis");
+        Assert.True(File.Exists(samplePath), $"missing sample: {samplePath}");
+
+        var cliDll = FindCliDll(repoRoot);
+        var jitRunnerExe = FindCraneliftJitRunnerExe(repoRoot);
+
+        Assert.NotNull(cliDll);
+        Assert.NotNull(jitRunnerExe);
+
+        var moduleName = "gfx";
+        var swapDir = Path.Combine(repoRoot, "build", "hotstate");
+        Directory.CreateDirectory(swapDir);
+
+        var runnerOutLog = Path.Combine(swapDir, $"gfx_cmd_smoke.{moduleName}.runner.out.log");
+        var runnerErrLog = Path.Combine(swapDir, $"gfx_cmd_smoke.{moduleName}.runner.err.log");
+        var startTime = DateTime.UtcNow;
+
+        Process? proc = null;
+        try
+        {
+            TryDelete(runnerOutLog);
+            TryDelete(runnerErrLog);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = QuoteArgs(cliDll, "run", samplePath, "--watch", "--backend", "cranelift", "--module", moduleName, "--fps", "60"),
+                UseShellExecute = false,
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            psi.EnvironmentVariables["STASIS_ASSET_ROOT"] = repoRoot;
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER"] = "1";
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER_EXE"] = jitRunnerExe;
+
+            // Make the runner emit a positive "gfx_load_sprite: ... handle=.." line on success.
+            psi.EnvironmentVariables["STASIS_GFX_LOG_SPRITES"] = "1";
+
+            // CI / headless stability knobs (these are no-ops on platforms where they don't apply).
+            psi.EnvironmentVariables["STASIS_SKIP_RENDER_TEST"] = "1";
+            psi.EnvironmentVariables["STASIS_USE_SDL"] = "1";
+            if (OperatingSystem.IsLinux())
+            {
+                psi.EnvironmentVariables["SDL_VIDEODRIVER"] = "dummy";
+            }
+
+            proc = Process.Start(psi);
+            Assert.NotNull(proc);
+
+            using var outLines = new AsyncLineCollector(proc!.StandardOutput);
+            using var errLines = new AsyncLineCollector(proc.StandardError);
+
+            await WaitForAnyLineAsync(
+                proc,
+                () => outLines.AnyContains("HOTSWAP(ms):") || errLines.AnyContains("error:"),
+                timeout: TimeSpan.FromMinutes(5));
+
+            // Wait for the sprite load log (stasis_graphics prints via SDL_Log -> stderr).
+            await WaitForAnyLineAsync(
+                proc,
+                () =>
+                {
+                    if (!File.Exists(runnerErrLog))
+                    {
+                        return false;
+                    }
+                    if (!TryReadTextShared(runnerErrLog, out var errText))
+                    {
+                        return false;
+                    }
+
+                    // Success path (requires STASIS_GFX_LOG_SPRITES=1).
+                    if (errText.Contains("gfx_load_sprite:", StringComparison.OrdinalIgnoreCase) &&
+                        errText.Contains("handle=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+
+                    // Failure signals: stop waiting so we can assert with the log content.
+                    if (errText.Contains("gfx_load_sprite: failed", StringComparison.OrdinalIgnoreCase) ||
+                        errText.Contains("gfx_load_sprite: could not resolve", StringComparison.OrdinalIgnoreCase) ||
+                        errText.Contains("failed to parse", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                },
+                timeout: TimeSpan.FromSeconds(60));
+
+            Assert.True(File.Exists(runnerErrLog), $"missing runner err log: {runnerErrLog}");
+            Assert.True(TryReadTextShared(runnerErrLog, out var finalErr), "failed to read runner err log");
+            Assert.DoesNotContain("gfx_load_sprite: failed", finalErr, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("gfx_load_sprite: could not resolve", finalErr, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("failed to parse", finalErr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("gfx_load_sprite:", finalErr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("handle=", finalErr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try
+            {
+                if (proc is not null && !proc.HasExited)
+                {
+                    proc.Kill(entireProcessTree: true);
+                    proc.WaitForExit(10_000);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+
+            // Best-effort: cleanup fresh jit runner processes.
+            try
+            {
+                foreach (var p in Process.GetProcessesByName("stasis-cranelift-jit-runner"))
+                {
+                    try
+                    {
+                        if (p.StartTime.ToUniversalTime() >= startTime.AddSeconds(-5))
+                        {
+                            p.Kill(entireProcessTree: true);
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    [HotSwapFact]
     public async Task WatchTickHotSwap_ReportsSemanticErrors_AndKeepsRunning()
     {
         var repoRoot = FindRepoRoot();

--- a/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
+++ b/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
@@ -13,20 +13,15 @@ public sealed class HotSwapIntegrationTests
         Assert.True(File.Exists(samplePath), $"missing sample: {samplePath}");
 
         var cliDll = FindCliDll(repoRoot);
-        var runnerExe = FindRunnerExe(repoRoot);
-        var aotExe = FindCraneliftAotExe(repoRoot);
-        var clangExeDir = FindClangBinDir(repoRoot);
+        var jitRunnerExe = FindCraneliftJitRunnerExe(repoRoot);
 
         Assert.NotNull(cliDll);
-        Assert.NotNull(runnerExe);
-        Assert.NotNull(aotExe);
-        Assert.NotNull(clangExeDir);
+        Assert.NotNull(jitRunnerExe);
 
         var moduleName = "hot";
         var swapDir = Path.Combine(repoRoot, "build", "hotstate");
         Directory.CreateDirectory(swapDir);
 
-        var swapFile = Path.Combine(swapDir, $"hotstate_tick_watch.{moduleName}.swap");
         var runnerOutLog = Path.Combine(swapDir, $"hotstate_tick_watch.{moduleName}.runner.out.log");
         var runnerErrLog = Path.Combine(swapDir, $"hotstate_tick_watch.{moduleName}.runner.err.log");
 
@@ -36,7 +31,6 @@ public sealed class HotSwapIntegrationTests
         Process? proc = null;
         try
         {
-            TryDelete(swapFile);
             TryDelete(runnerOutLog);
             TryDelete(runnerErrLog);
 
@@ -52,14 +46,8 @@ public sealed class HotSwapIntegrationTests
             };
 
             psi.EnvironmentVariables["STASIS_ASSET_ROOT"] = repoRoot;
-            psi.EnvironmentVariables["STASIS_CRANELIFT_AOT"] = aotExe;
-            psi.EnvironmentVariables["STASIS_CRANELIFT_RUNNER_EXE"] = runnerExe;
-            psi.EnvironmentVariables["PATH"] = clangExeDir + Path.PathSeparator + (Environment.GetEnvironmentVariable("PATH") ?? string.Empty);
-            var clangExe = Path.Combine(clangExeDir, OperatingSystem.IsWindows() ? "clang.exe" : "clang");
-            if (File.Exists(clangExe))
-            {
-                psi.EnvironmentVariables["STASIS_CLANG"] = clangExe;
-            }
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER"] = "1";
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER_EXE"] = jitRunnerExe;
 
             proc = Process.Start(psi);
             Assert.NotNull(proc);
@@ -89,75 +77,46 @@ public sealed class HotSwapIntegrationTests
                     $"watch failed to produce initial HOTSWAP(ms) marker.\n\nwatch stdout tail:\n{outLines.GetTail()}\n\nwatch stderr tail:\n{errLines.GetTail()}");
             }
 
-            // Inject a bad swap (missing DLL path). Older behavior could exit the runner; the watch loop should continue.
-            var badSwapPath = OperatingSystem.IsWindows()
-                ? @"Z:\this\does\not\exist.swap.dll"
-                : "/this/does/not/exist.swap.so";
-            File.WriteAllText(swapFile, badSwapPath + "\n", System.Text.Encoding.ASCII);
+            // Kill the JIT runner process; the watch loop should notice and restart it.
+            await WaitForAnyLineAsync(
+                proc,
+                () => Process.GetProcessesByName("stasis-cranelift-jit-runner")
+                    .Any(p => p.StartTime.ToUniversalTime() >= startTime.AddSeconds(-5)),
+                timeout: TimeSpan.FromSeconds(30));
 
-            try
+            foreach (var p in Process.GetProcessesByName("stasis-cranelift-jit-runner"))
             {
-                await WaitForAnyLineAsync(
-                    proc,
-                    () =>
+                try
+                {
+                    if (p.StartTime.ToUniversalTime() >= startTime.AddSeconds(-5))
                     {
-                        if (!File.Exists(swapFile))
-                        {
-                            return true; // runner consumed it
-                        }
-                        if (!File.Exists(runnerErrLog) && !File.Exists(runnerOutLog))
-                        {
-                            return false;
-                        }
-                        var ok = false;
-                        if (File.Exists(runnerErrLog) && TryReadTextShared(runnerErrLog, out var errText))
-                        {
-                            ok |= errText.Contains("HOTSWAP warning:", StringComparison.Ordinal);
-                        }
-                        if (File.Exists(runnerOutLog) && TryReadTextShared(runnerOutLog, out var outText))
-                        {
-                            ok |= outText.Contains("HOTSWAP warning:", StringComparison.Ordinal);
-                        }
-                        return ok;
-                    },
-                    timeout: TimeSpan.FromSeconds(30));
+                        p.Kill(entireProcessTree: true);
+                    }
+                }
+                catch
+                {
+                    // ignore
+                }
             }
-            catch (XunitException)
-            {
-                var runnerErr = File.Exists(runnerErrLog) && TryReadTextShared(runnerErrLog, out var errText) ? errText : "<missing>";
-                var runnerOut = File.Exists(runnerOutLog) && TryReadTextShared(runnerOutLog, out var outText) ? outText : "<missing>";
-                throw new XunitException(
-                    $"timeout waiting for runner to consume bad swap or report warning.\n\nrunner.err.log:\n{runnerErr}\n\nrunner.out.log:\n{runnerOut}\n");
-            }
+
+            await WaitForAnyLineAsync(
+                proc,
+                () => errLines.AnyContains("warning: jit runner exited"),
+                timeout: TimeSpan.FromSeconds(60));
 
             if (proc.HasExited)
             {
-                throw new XunitException($"watch process exited unexpectedly after bad swap (code={proc.ExitCode}).");
+                throw new XunitException($"watch process exited unexpectedly after killing jit runner (code={proc.ExitCode}).");
             }
 
             // Trigger a real rebuild + swap.
             await File.AppendAllTextAsync(samplePath, "\n// test edit " + DateTime.UtcNow.Ticks + "\n", System.Text.Encoding.ASCII);
 
+            var initialSwapCount = outLines.CountContains("HOTSWAP(ms):");
             await WaitForAnyLineAsync(
                 proc,
-                () =>
-                {
-                    if (!File.Exists(runnerErrLog) && !File.Exists(runnerOutLog))
-                    {
-                        return false;
-                    }
-                    var ok = false;
-                    if (File.Exists(runnerErrLog) && TryReadTextShared(runnerErrLog, out var errText))
-                    {
-                        ok |= errText.Contains("HOTSWAP ok:", StringComparison.Ordinal);
-                    }
-                    if (File.Exists(runnerOutLog) && TryReadTextShared(runnerOutLog, out var outText))
-                    {
-                        ok |= outText.Contains("HOTSWAP ok:", StringComparison.Ordinal);
-                    }
-                    return ok;
-                },
-                timeout: TimeSpan.FromSeconds(60));
+                () => outLines.CountContains("HOTSWAP(ms):") > initialSwapCount,
+                timeout: TimeSpan.FromMinutes(5));
         }
         finally
         {
@@ -186,7 +145,7 @@ public sealed class HotSwapIntegrationTests
             // If anything else is still running, try to clean up only fresh processes (avoid killing a developer's unrelated session).
             try
             {
-                foreach (var p in Process.GetProcessesByName("stasis_runner"))
+                foreach (var p in Process.GetProcessesByName("stasis-cranelift-jit-runner"))
                 {
                     try
                     {
@@ -598,14 +557,10 @@ public sealed class HotSwapIntegrationTests
         Assert.True(File.Exists(samplePath), $"missing sample: {samplePath}");
 
         var cliDll = FindCliDll(repoRoot);
-        var runnerExe = FindRunnerExe(repoRoot);
-        var aotExe = FindCraneliftAotExe(repoRoot);
-        var clangExeDir = FindClangBinDir(repoRoot);
+        var jitRunnerExe = FindCraneliftJitRunnerExe(repoRoot);
 
         Assert.NotNull(cliDll);
-        Assert.NotNull(runnerExe);
-        Assert.NotNull(aotExe);
-        Assert.NotNull(clangExeDir);
+        Assert.NotNull(jitRunnerExe);
 
         var original = await File.ReadAllTextAsync(samplePath);
 
@@ -624,9 +579,8 @@ public sealed class HotSwapIntegrationTests
             };
 
             psi.EnvironmentVariables["STASIS_ASSET_ROOT"] = repoRoot;
-            psi.EnvironmentVariables["STASIS_CRANELIFT_AOT"] = aotExe;
-            psi.EnvironmentVariables["STASIS_CRANELIFT_RUNNER_EXE"] = runnerExe;
-            psi.EnvironmentVariables["PATH"] = clangExeDir + Path.PathSeparator + (Environment.GetEnvironmentVariable("PATH") ?? string.Empty);
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER"] = "1";
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER_EXE"] = jitRunnerExe;
 
             proc = Process.Start(psi);
             Assert.NotNull(proc);

--- a/Stasis.Compiler.Tests/SemanticTests.cs
+++ b/Stasis.Compiler.Tests/SemanticTests.cs
@@ -149,6 +149,30 @@ public class SemanticTests
     }
 
     [Fact]
+    public void Does_not_warn_on_struct_fields_used_via_array_access()
+    {
+        var source = """
+            struct S { used: i32; }
+            struct Outer { xs: S[2]; }
+            global state: Outer;
+            function f(): void {
+                state.xs[0].used = 1;
+                let y: i32 = state.xs[1].used;
+            }
+            """;
+
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
+        Assert.DoesNotContain(sema.Diagnostics, d =>
+            d.Severity == DiagnosticSeverity.Warning &&
+            d.Message.Contains("S.used", StringComparison.Ordinal) &&
+            d.Message.Contains("never assigned or referenced", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Flags_calling_non_function_symbol()
     {
         var source = """

--- a/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
+++ b/Stasis.Compiler/Semantic/SemanticAnalyzer.cs
@@ -1760,18 +1760,14 @@ public sealed class SemanticAnalyzer
             current = m.Receiver;
         }
 
-        if (current is not IdentifierExpressionSyntax rootId)
+        // Support member access rooted at any expression (e.g., `xs[0].field`, `state.arr[i].x`).
+        // The previous Identifier-only restriction caused false unused-field warnings because
+        // field uses behind array indexing were not recorded.
+        var currentType = ResolveExpressionType(current, scope);
+        if (currentType is null)
         {
             return null;
         }
-
-        if (!scope.TryGetValue(rootId.Identifier.Text, out var rootSym) &&
-            !_symbols.TryGetValue(rootId.Identifier.Text, out rootSym))
-        {
-            return null;
-        }
-
-        var currentType = rootSym.Type;
         chain.Reverse();
 
         foreach (var (memberName, memberSpan) in chain)

--- a/dev_brickout_revenge_v1.bat
+++ b/dev_brickout_revenge_v1.bat
@@ -10,7 +10,7 @@ rem Prefer toolchains configured by env.bat (LLVM, CMake, Rust, vcpkg).
 call "%SCRIPT_DIR%env.bat" >nul 2>nul
 
 rem Dev defaults: prefer no-disk Cranelift JIT hot-swap for faster iteration.
-set "STASIS_CRANELIFT_JIT_RUNNER=0"
+set "STASIS_CRANELIFT_JIT_RUNNER=1"
 rem If the JIT runner becomes unresponsive, exit so the watch loop can restart it.
 if not defined STASIS_JIT_WATCHDOG_MS set "STASIS_JIT_WATCHDOG_MS=15000"
 if not defined STASIS_CRANELIFT_JIT_RUNNER_EXE (

--- a/samples/hotstate_tick_watch.stasis
+++ b/samples/hotstate_tick_watch.stasis
@@ -6,6 +6,7 @@ global state: WatchState;
 
 function main(): i32 {
     print_string("init tick watch\n");
+    state.ticks = 0;
     return 0;
 }
 

--- a/tools/cranelift-jit-runner/src/main.rs
+++ b/tools/cranelift-jit-runner/src/main.rs
@@ -36,6 +36,7 @@
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::io::{self, BufRead, BufReader, Read, Write};
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -106,9 +107,7 @@ fn env_u64(name: &str, default: u64) -> u64
 pub extern "win64" fn stasis_printf3(fmt: i64, a0: i64, _a1: i64) -> i32
 {
     unsafe {
-        let fmt = fmt as *const i8;
-        let a0 = a0 as *const i8;
-        libc::printf(fmt, a0)
+        stasis_printf3_impl(fmt as *const i8, a0, _a1)
     }
 }
 
@@ -117,10 +116,121 @@ pub extern "win64" fn stasis_printf3(fmt: i64, a0: i64, _a1: i64) -> i32
 pub extern "C" fn stasis_printf3(fmt: i64, a0: i64, _a1: i64) -> i32
 {
     unsafe {
-        let fmt = fmt as *const libc::c_char;
-        let a0 = a0 as *const libc::c_char;
-        libc::printf(fmt, a0)
+        stasis_printf3_impl(fmt as *const libc::c_char, a0, _a1)
     }
+}
+
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn stasis_printf3_impl(fmt: *const libc::c_char, arg1: i64, arg2: i64) -> i32
+{
+    if fmt.is_null()
+    {
+        return 0;
+    }
+
+    // Mirror runtime/stasis_sys.c behavior: support up to two format specifiers and pass
+    // correctly-typed args to the C variadic printf implementation.
+    //
+    // This avoids ABI issues (Cranelift calls fixed-arity imports) and prevents UB where
+    // integer args were previously treated as pointers.
+    let mut spec_count = 0usize;
+    let mut specs: [u8; 2] = [0, 0];
+    let mut lens: [u8; 2] = [0, 0]; // 0=default, 1=l, 2=ll
+
+    let mut p = fmt as *const u8;
+    while *p != 0 && spec_count < 2
+    {
+        if *p != b'%'
+        {
+            p = p.add(1);
+            continue;
+        }
+
+        p = p.add(1);
+        if *p == 0
+        {
+            break;
+        }
+        if *p == b'%'
+        {
+            p = p.add(1);
+            continue;
+        }
+
+        let mut len = 0u8;
+        if *p == b'l'
+        {
+            len = 1;
+            if *p.add(1) == b'l'
+            {
+                len = 2;
+                p = p.add(1);
+            }
+            p = p.add(1);
+        }
+
+        let s = *p;
+        if matches!(s, b'd' | b'i' | b'u' | b'x' | b'X' | b'c' | b's')
+        {
+            lens[spec_count] = len;
+            specs[spec_count] = s;
+            spec_count += 1;
+        }
+
+        p = p.add(1);
+    }
+
+    if spec_count == 0
+    {
+        return libc::printf(b"%s\0".as_ptr() as *const libc::c_char, fmt) as i32;
+    }
+
+    if spec_count == 1
+    {
+        match specs[0]
+        {
+            b's' => return libc::printf(fmt, arg1 as *const libc::c_char) as i32,
+            b'c' => return libc::printf(fmt, arg1 as libc::c_int) as i32,
+            b'u' | b'x' | b'X' =>
+            {
+                return match lens[0]
+                {
+                    2 => libc::printf(fmt, arg1 as libc::c_ulonglong) as i32,
+                    1 => libc::printf(fmt, arg1 as libc::c_ulong) as i32,
+                    _ => libc::printf(fmt, arg1 as libc::c_uint) as i32,
+                };
+            }
+            b'd' | b'i' | _ =>
+            {
+                return match lens[0]
+                {
+                    2 => libc::printf(fmt, arg1 as libc::c_longlong) as i32,
+                    1 => libc::printf(fmt, arg1 as libc::c_long) as i32,
+                    _ => libc::printf(fmt, arg1 as libc::c_int) as i32,
+                };
+            }
+        }
+    }
+
+    // spec_count == 2
+    if specs[0] == b's' && specs[1] == b's'
+    {
+        return libc::printf(fmt, arg1 as *const libc::c_char, arg2 as *const libc::c_char) as i32;
+    }
+    if specs[0] == b's' && (specs[1] == b'd' || specs[1] == b'i')
+    {
+        return libc::printf(fmt, arg1 as *const libc::c_char, arg2 as libc::c_int) as i32;
+    }
+    if (specs[0] == b'd' || specs[0] == b'i') && (specs[1] == b'd' || specs[1] == b'i')
+    {
+        return libc::printf(fmt, arg1 as libc::c_int, arg2 as libc::c_int) as i32;
+    }
+    if specs[0] == b'c' && specs[1] == b'c'
+    {
+        return libc::printf(fmt, arg1 as libc::c_int, arg2 as libc::c_int) as i32;
+    }
+
+    libc::printf(fmt, arg1 as libc::c_longlong, arg2 as libc::c_longlong) as i32
 }
 
 #[unsafe(no_mangle)]
@@ -642,11 +752,29 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
     let last_progress_ms = Arc::new(AtomicU64::new(now_ms()));
     let tick_counter = Arc::new(AtomicU64::new(0));
     let swap_counter = Arc::new(AtomicU64::new(0));
+    let stage = Arc::new(AtomicU32::new(0));
+
+    fn stage_name(stage: u32) -> &'static str
+    {
+        match stage
+        {
+            0 => "idle",
+            1 => "rx",
+            2 => "databind",
+            3 => "host_get_frame",
+            4 => "apply_window_requests",
+            5 => "tick",
+            6 => "gfx_submit",
+            7 => "bulk_step",
+            _ => "unknown",
+        }
+    }
 
     if watchdog_ms > 0
     {
         let last_progress_ms = Arc::clone(&last_progress_ms);
         let tick_counter = Arc::clone(&tick_counter);
+        let stage = Arc::clone(&stage);
         thread::spawn(move || loop {
             thread::sleep(Duration::from_millis(250));
             let last_ms = last_progress_ms.load(Ordering::Relaxed);
@@ -654,9 +782,11 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
             if now.saturating_sub(last_ms) > watchdog_ms
             {
                 eprintln!(
-                    "error: jit runner watchdog fired (no tick progress for {}ms; ticks={}); exiting so watch can restart.",
+                    "error: jit runner watchdog fired (no tick progress for {}ms; ticks={}; stage={}({})); exiting so watch can restart.",
                     now.saturating_sub(last_ms),
-                    tick_counter.load(Ordering::Relaxed)
+                    tick_counter.load(Ordering::Relaxed),
+                    stage.load(Ordering::Relaxed),
+                    stage_name(stage.load(Ordering::Relaxed))
                 );
                 std::process::exit(124);
             }
@@ -669,12 +799,15 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
     {
         let tick_counter = Arc::clone(&tick_counter);
         let swap_counter = Arc::clone(&swap_counter);
+        let stage = Arc::clone(&stage);
         thread::spawn(move || loop {
             thread::sleep(Duration::from_millis(heartbeat_ms.max(50)));
             eprintln!(
-                "HEARTBEAT ticks={} swaps={}",
+                "HEARTBEAT ticks={} swaps={} stage={}({})",
                 tick_counter.load(Ordering::Relaxed),
-                swap_counter.load(Ordering::Relaxed)
+                swap_counter.load(Ordering::Relaxed),
+                stage.load(Ordering::Relaxed),
+                stage_name(stage.load(Ordering::Relaxed))
             );
         });
     }
@@ -902,6 +1035,7 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
 
         if let Some(b) = data_binding.as_mut()
         {
+            stage.store(2, Ordering::Relaxed);
             if b.apply_if_changed(instance).unwrap_or(false)
             {
                 eprintln!("DATABIND: reloaded {}", b.json_path);
@@ -923,6 +1057,8 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                     )
                 {
                     unsafe {
+                        stage.store(7, Ordering::Relaxed);
+                        last_progress_ms.store(now_ms(), Ordering::Relaxed);
                         let rc = host_bulk_step(
                             host_i32,
                             host_f32,
@@ -952,6 +1088,8 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                     (instance.graphics.as_ref().and_then(|x| x.host_get_frame), instance.host_i32, instance.host_f32)
                 {
                     unsafe {
+                        stage.store(3, Ordering::Relaxed);
+                        last_progress_ms.store(now_ms(), Ordering::Relaxed);
                         host_get_frame(host_i32, host_f32);
                         if *host_i32.add(9) != 0
                         {
@@ -960,8 +1098,11 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                     }
                 }
 
+                stage.store(4, Ordering::Relaxed);
                 apply_window_requests(instance, &mut last_req_seq);
 
+                stage.store(5, Ordering::Relaxed);
+                last_progress_ms.store(now_ms(), Ordering::Relaxed);
                 let rc = (instance.tick_fn)();
                 if rc != 0
                 {
@@ -973,6 +1114,8 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                     (instance.graphics.as_ref().and_then(|x| x.gfx_submit_u8), instance.gfx_cmd_i32, instance.gfx_cmd_f32, instance.gfx_cmd_u8)
                 {
                     unsafe {
+                        stage.store(6, Ordering::Relaxed);
+                        last_progress_ms.store(now_ms(), Ordering::Relaxed);
                         gfx_submit_u8(cmd_i32, cmd_f32, cmd_u8);
                     }
                 }
@@ -980,6 +1123,8 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
         }
         else
         {
+            stage.store(5, Ordering::Relaxed);
+            last_progress_ms.store(now_ms(), Ordering::Relaxed);
             let rc = (instance.tick_fn)();
             if rc != 0
             {

--- a/tools/cranelift-jit-runner/src/main.rs
+++ b/tools/cranelift-jit-runner/src/main.rs
@@ -714,6 +714,12 @@ fn run_server(fps: u32) -> Result<()>
                     continue;
                 }
 
+                // Match stasis_runner behavior: apply any window requests made during main()
+                // before entering the tick loop. Some games set initial portrait sizing via
+                // host window request globals and expect it to be applied immediately.
+                let mut last_req_seq = 0i32;
+                apply_window_requests(&mut new_instance, &mut last_req_seq);
+
                 writeln!(stdout, "OK init")?;
                 stdout.flush()?;
 

--- a/tools/cranelift-jit-runner/src/main.rs
+++ b/tools/cranelift-jit-runner/src/main.rs
@@ -604,7 +604,7 @@ fn run_server(fps: u32) -> Result<()>
                     continue;
                 }
 
-                writeln!(stdout, "OK")?;
+                writeln!(stdout, "OK init")?;
                 stdout.flush()?;
 
                 let tick_loop_result = run_tick_loop(fps, &mut new_instance, &rx, &mut stdout);
@@ -622,7 +622,7 @@ fn run_server(fps: u32) -> Result<()>
             }
             Request::Quit =>
             {
-                writeln!(stdout, "OK")?;
+                writeln!(stdout, "OK quit")?;
                 stdout.flush()?;
                 break;
             }
@@ -683,9 +683,18 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
     // The tick loop only does a fast apply step + pointer swap when compilation finishes.
     let (swap_job_tx, swap_job_rx) = mpsc::channel::<SwapJob>();
     let (swap_result_tx, swap_result_rx) = mpsc::channel::<SwapResult>();
+    let latest_requested_id = Arc::new(AtomicU64::new(0));
+    let latest_requested_id_worker = Arc::clone(&latest_requested_id);
     thread::spawn(move || {
         while let Ok(job) = swap_job_rx.recv()
         {
+            // Best-effort coalescing: if a newer swap request arrived before we started compiling this job,
+            // skip the work entirely. This keeps iteration responsive when edits arrive faster than compile time.
+            if job.id != latest_requested_id_worker.load(Ordering::Relaxed)
+            {
+                continue;
+            }
+
             let t0 = Instant::now();
             let outcome = match JitInstance::compile(&job.module_name, &job.entry_name, &job.tick_name, &job.clif)
             {
@@ -802,8 +811,8 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
 
                     writeln!(
                         stdout,
-                        "OK id={} save_us={} compile_us={} restore_us={}",
-                        result.id, save_us, compile_us, restore_us
+                        "APPLIED id={} save_us={} compile_us={} restore_us={} missing_save={} missing_restore={}",
+                        result.id, save_us, compile_us, restore_us, missing_save, missing_restore
                     )?;
                     stdout.flush()?;
                 }
@@ -852,18 +861,12 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                 }
                 Request::Swap { clif } =>
                 {
-                    if pending_swap_id.is_some()
-                    {
-                        writeln!(stdout, "ERR swap already pending")?;
-                        stdout.flush()?;
-                        continue;
-                    }
-
                     let id = next_swap_id;
                     next_swap_id = next_swap_id.saturating_add(1);
-                    pending_swap_id = Some(id);
+                    let supersedes = pending_swap_id.replace(id).unwrap_or(0);
+                    latest_requested_id.store(id, Ordering::Relaxed);
 
-                    eprintln!("HOTSWAP queued: id={} bytes={}", id, clif.len());
+                    eprintln!("HOTSWAP queued: id={} bytes={} supersedes={}", id, clif.len(), supersedes);
                     let job = SwapJob {
                         id,
                         module_name: instance.module_name.clone(),
@@ -876,7 +879,12 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                         pending_swap_id = None;
                         writeln!(stdout, "ERR swap worker unavailable")?;
                         stdout.flush()?;
+                        continue;
                     }
+
+                    // Acknowledge receipt immediately; compilation happens asynchronously.
+                    writeln!(stdout, "QUEUED id={} supersedes={}", id, supersedes)?;
+                    stdout.flush()?;
                 }
                 Request::Quit =>
                 {
@@ -1065,6 +1073,7 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
             let bytes = reader.read_line(&mut line).unwrap_or(0);
             if bytes == 0
             {
+                eprintln!("stasis-cranelift-jit-runner: stdin EOF (request reader exiting)");
                 let _ = tx2.send(Request::Quit);
                 break;
             }
@@ -1086,6 +1095,7 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
                 let parts: Vec<_> = trimmed.split_whitespace().collect();
                 if parts.len() != 5
                 {
+                    eprintln!("stasis-cranelift-jit-runner: bad INIT header (expected 5 parts): '{trimmed}'");
                     let _ = tx2.send(Request::Quit);
                     break;
                 }
@@ -1095,6 +1105,9 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
                 let clif_len = parts[4].parse::<usize>().unwrap_or(0);
                 if module_len == 0 || entry_len == 0 || tick_len == 0 || clif_len == 0
                 {
+                    eprintln!(
+                        "stasis-cranelift-jit-runner: bad INIT lengths module={module_len} entry={entry_len} tick={tick_len} clif={clif_len} (line='{trimmed}')"
+                    );
                     let _ = tx2.send(Request::Quit);
                     break;
                 }
@@ -1111,12 +1124,14 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
                 let parts: Vec<_> = trimmed.split_whitespace().collect();
                 if parts.len() != 2
                 {
+                    eprintln!("stasis-cranelift-jit-runner: bad SWAP header (expected 2 parts): '{trimmed}'");
                     let _ = tx2.send(Request::Quit);
                     break;
                 }
                 let clif_len = parts[1].parse::<usize>().unwrap_or(0);
                 if clif_len == 0
                 {
+                    eprintln!("stasis-cranelift-jit-runner: bad SWAP length clif={clif_len} (line='{trimmed}')");
                     let _ = tx2.send(Request::Quit);
                     break;
                 }
@@ -1130,6 +1145,7 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
                 let parts: Vec<_> = trimmed.split_whitespace().collect();
                 if parts.len() != 3
                 {
+                    eprintln!("stasis-cranelift-jit-runner: bad BIND header (expected 3 parts): '{trimmed}'");
                     let _ = tx2.send(Request::Quit);
                     break;
                 }
@@ -1137,6 +1153,9 @@ fn spawn_request_reader(tx: mpsc::Sender<Request>) -> Result<()>
                 let meta_len = parts[2].parse::<usize>().unwrap_or(0);
                 if json_len == 0 || meta_len == 0
                 {
+                    eprintln!(
+                        "stasis-cranelift-jit-runner: bad BIND lengths json={json_len} meta={meta_len} (line='{trimmed}')"
+                    );
                     let _ = tx2.send(Request::Quit);
                     break;
                 }


### PR DESCRIPTION
Makes Cranelift JIT hot swap robust for long compiles: SWAP is always accepted (QUEUED id=..), stale swaps are coalesced (latest wins), and completion is reported asynchronously (APPLIED id=..). CLI watch prints a single HOTSWAP(ms) line on apply and no longer blocks on compile timeouts. Also fixes CLI watch to continue lowering on warnings and avoids file locking in import expansion.

Tests: dotnet test -c Release --no-build