### PR TITLE
feat: simplify stdlib naming and prefer receiver-form calls

### DIFF
--- a/docs/demo-day.md
+++ b/docs/demo-day.md
@@ -121,7 +121,7 @@ Run:
 ### Render submission benchmark (per-call vs batched vs command buffer)
 
 Features:
-- Compares many host calls (`draw_line`) vs one batched call (`draw_lines_f32`) vs one command-buffer submit (`gfx_submit_*`)
+- Compares many host calls (`draw_line`) vs one batched call (`draw_lines`) vs one command-buffer submit (`gfx_submit_*`)
 - Uses debug hash to validate all paths submit identical draw streams
 - See `docs/graphics-command-buffer-v1.md` for the command buffer layout
 

--- a/docs/graphics-command-buffer-v1.md
+++ b/docs/graphics-command-buffer-v1.md
@@ -106,7 +106,7 @@ The current prototype uses fixed maxima (see `runtime/stasis_graphics.c`):
 
 1. Calls `stasis_begin_frame()`
 2. If `(flags & 1) != 0`: calls `stasis_clear(r,g,b,a)`
-3. If `line_count > 0`: calls `stasis_draw_lines_f32(...)`
+3. If `line_count > 0`: calls `draw_lines(...)`
 4. If `sprite_count > 0`: loops and calls `stasis_gfx_draw_sprite(...)`
 5. If `cmd_u8 != NULL` and text present: loops and calls `stasis_draw_text(...)`
 6. If `(flags & 2) != 0`: calls `stasis_end_frame()` (present)
@@ -124,7 +124,7 @@ This "present bit" exists so benchmarks can exclude swap/vsync while still exerc
 
 - `samples/render_command_buffer_bench_submit.stasis` compares:
   - per-call `draw_line` (many host calls)
-  - batched `draw_lines_f32` (1 host call)
+  - batched `draw_lines` (1 host call)
   - `gfx_cmd_submit_*` (1 host call; can measure build vs prebuilt)
 - `samples/render_heavy_submit_bench.stasis` compares the same submission styles with both lines and sprites, so the signal is large enough to see on native.
 

--- a/docs/host-snapshot-command-buffer.md
+++ b/docs/host-snapshot-command-buffer.md
@@ -245,7 +245,7 @@ For Stasis v1, prefer (2). Reasons:
 - No variable-length parsing logic required in the host.
 - Fixed layouts remain easy to version.
 - Fast to validate (counts + bounds checks).
-- Matches existing "batched" APIs (`draw_lines_f32`, `gfx_draw_sprites_i32`).
+- Matches existing "batched" APIs (`draw_lines`, `gfx_draw_sprites`).
 
 #### Graphics command buffer v1 (SoA)
 
@@ -264,7 +264,7 @@ Example layout (one possible split):
   - reserved
 - `gfx_f32[]` payload for `lines`:
   - `line_count * 8` floats: `x1,y1,x2,y2,r,g,b,a`
-- `gfx_i32[]` payload for `sprites` (if keeping `gfx_draw_sprites_i32`-style packing)
+- `gfx_i32[]` payload for `sprites` (if keeping `gfx_draw_sprites`-style packing)
   - `sprite_count * SPRITE_STRIDE_I32`
 
 Alternatively, make sprites a `gfx_f32[]` stream (handle as i32 + six f32, or all f32 with handle converted) if you want a single float stream.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,7 +132,7 @@ ascii[N]   // ASCII-only string buffers with a single length header
 
 - `print_string(utf8[N])` prints a UTF-8 buffer; the compiler lowers string literals to static storage with UTF-8 headers and a null sentinel, and the runtime passes the payload pointer to the host I/O layer.
 - `string` and `string[N]` are `utf8` aliases, so any string passed to built-ins uses the UTF-8 header layout by default.
-- `ascii[N]` and `utf8[N]` are distinct; there is no implicit widening between them. Use explicit conversion helpers (for example, a stdlib `from_ascii` function) when crossing the boundary.
+- `ascii[N]` and `utf8[N]` are distinct; there is no implicit widening between them. Use explicit conversion helpers (for example, a stdlib `utf8_from_ascii` function) when crossing the boundary.
 - Helpers like `print(i32)`, `print_int(i32)`, and `print_char(i32)` cover common prompt cases, while `print_cell(i32)` renders Sudoku grid cells with coloring metadata.
 - Input helpers include `read_char()` and `read_int()`; higher-level readers such as `read_line()` and `parse_seed_input()` can be implemented in Stasis using these primitives, which is how `samples/sudoku.stasis` parses seeds and user moves.
 - `time()` returns the current wall-clock epoch truncated to `i32`, so samples can seed deterministic generators from the clock when the user does not supply a value.
@@ -511,6 +511,11 @@ Call forms:
 
 - Receiver form (recommended): `enemy.damage(5)`
 - Function form (supported): `damage(enemy, 5)`
+
+Style guidance:
+
+- Prefer receiver form for receiver-centric operations.
+- Write `receiver.doAction(action)` instead of `doAction(receiver, action)` unless function form is clearer for a specific context.
 
 Resolution rules:
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -110,7 +110,8 @@ ascii_recount(s: ascii[]): i32           // Recompute length from sentinel, fix 
 ascii_clear(s: ascii[])                  // Reset length to 0 and write sentinel
 ascii_copy(dst: ascii[], src: ascii[]): i32
 ascii_append(dst: ascii[], src: ascii[]): i32
-ascii_append_byte(dst: ascii[], b: u8): i32
+ascii_push(dst: ascii[], b: u8): i32
+ascii_push_i32(dst: ascii[], value: i32): void
 ascii_cmp(a: ascii[], b: ascii[]): i32
 ascii_eq(a: ascii[], b: ascii[]): bool
 ascii_find_byte(s: ascii[], b: u8): i32

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -17,6 +17,7 @@ import "src/stdlib/stdlib.stasis";
 5. **No app-specific functions**: Generic primitives only
 6. **Explicit about bytes vs codepoints**: Function names and docs clearly indicate which unit they operate on
 7. **No globals in stdlib**: standard library files may declare consts, structs, enums, and functions only
+8. **Prefer receiver-form calls**: write `receiver.doAction(action)` over `doAction(receiver, action)` for receiver-centric operations
 
 ---
 
@@ -101,7 +102,7 @@ ascii_from_hex(d: i32): u8       // 0->'0', 10->'a', else '?'
 ### ASCII String Buffers
 
 ```stasis
-ascii_len(s: ascii[]): i32               // Length from header
+length(s: ascii[]): i32                  // Length from header
 ascii_is_empty(s: ascii[]): bool         // True if length == 0
 ascii_get(s: ascii[], index: i32): u8    // Get byte at index
 ascii_set(s: ascii[], index: i32, b: u8) // Set byte, update header if needed
@@ -241,7 +242,7 @@ str_sanitize_utf8(s: utf8[]): i32               // Replace invalid sequences wit
 ### Conversion (Explicit Only)
 
 ```stasis
-from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32  // Copy ASCII bytes into UTF-8 buffer, return byte length
+utf8_from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32  // Copy ASCII bytes into UTF-8 buffer, return byte length
 ```
 
 ---

--- a/docs/stdlib-naming-pass.md
+++ b/docs/stdlib-naming-pass.md
@@ -1,0 +1,58 @@
+# Stdlib Naming Pass (Receiver-Scoped APIs)
+
+This pass makes stdlib call sites shorter and removes legacy alias names.
+
+## Why this is scoped
+
+Stasis now disallows arity-based overloading for the same function name. That means very generic names like `clear(...)` can collide across modules if they use different parameter counts.
+
+Because of that, this pass focuses on:
+
+- concise names that are still namespace-safe
+- first-parameter overloads where the receiver type differs
+- migration to a single canonical name per operation
+
+## New preferred names
+
+### `src/stdlib/stdlib.stasis`
+
+- `ascii_push(dst: ascii[], b: u8): i32`
+- `ascii_push_i32(dst: ascii[], value: i32): void`
+- `length_bytes(s: utf8[]): i32`
+- `length_chars(s: utf8[]): i32`
+- `utf8_from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32`
+
+### `src/stdlib/game_math.stasis`
+
+- `game_abs(x: i32): i32`
+- `game_abs(x: f32): f32`
+- `game_min(a: i32, b: i32): i32`
+- `game_min(a: f32, b: f32): f32`
+- `game_max(a: i32, b: i32): i32`
+- `game_max(a: f32, b: f32): f32`
+- `game_clamp(x: i32, lo: i32, hi: i32): i32`
+- `game_clamp(x: f32, lo: f32, hi: f32): f32`
+- `game_lerp(a: f32, b: f32, t: f32): f32`
+
+Legacy names (`*_i32`, `*_f32`) are removed.
+
+## Call style guidance
+
+Prefer receiver form for receiver-centric operations:
+
+- write `receiver.doAction(action)` over `doAction(receiver, action)`.
+
+```stasis
+name_buf.ascii_clear();
+name_buf.ascii_append("HP=");
+name_buf.ascii_push_i32(42);
+
+out_text.utf8_from_ascii(name_buf, out_text.length);
+```
+
+Function form is still supported and can be clearer for utility/math helpers:
+
+```stasis
+let clamped: f32 = game_clamp(v, 0.0, 1.0);
+let eased: f32 = game_lerp(0.0, 1.0, t);
+```

--- a/examples/templates/template_io.stasis
+++ b/examples/templates/template_io.stasis
@@ -5,11 +5,11 @@ import "../../src/stdlib/stdlib.stasis";
 function t_append_i32(dst: ascii[], value: i32): void {
     let v: i32 = value;
     if (v == 0) {
-        ascii_append_byte(dst, 48);
+        ascii_push(dst, 48);
         return;
     }
     if (v < 0) {
-        ascii_append_byte(dst, 45);
+        ascii_push(dst, 45);
         v = 0 - v;
     }
     let pow10: i32 = 1;
@@ -17,7 +17,7 @@ function t_append_i32(dst: ascii[], value: i32): void {
     }
     for (; pow10 > 0; pow10 = pow10 / 10) {
         let digit: i32 = (v / pow10) % 10;
-        ascii_append_byte(dst, i32_to_u8_trunc(48 + digit));
+        ascii_push(dst, i32_to_u8_trunc(48 + digit));
     }
 }
 
@@ -35,5 +35,5 @@ function t_path_set_csv(out_path: ascii[], base: ascii[]): void {
 }
 
 function t_write_ascii_file(path: ascii[], text: ascii[]): bool {
-    return sys_write_file(path, text, ascii_len(text)) == 1;
+    return sys_write_file(path, text, length(text)) == 1;
 }

--- a/samples/brickout_revenge/brickout_revenge.stasis
+++ b/samples/brickout_revenge/brickout_revenge.stasis
@@ -168,8 +168,8 @@ function tick(): i32 {
     clear(0.05, 0.05, 0.15, 1.0);
     
     //update_game(dt, delta_ms);
-    gfx_draw_sprites_i32(state.gfx.sprites_i32, state.gfx.sprite_count);
-    draw_lines_f32(state.gfx.lines_f32, state.gfx.line_count);
+    gfx_draw_sprites(state.gfx.sprites_i32, state.gfx.sprite_count);
+    draw_lines(state.gfx.lines_f32, state.gfx.line_count);
     draw_frame();
 
     end_frame();

--- a/samples/brickout_revenge/brickout_revenge_v1_core.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_core.stasis
@@ -111,12 +111,12 @@ function brickout_shop_anim_step(anim: f32, open: i32, dt: f32, speed: f32): f32
 function brickout_ascii_append_i32(dst: ascii[], value: i32): void {
     let v: i32 = value;
     if (v == 0) {
-        ascii_append_byte(dst, 48);
+        ascii_push(dst, 48);
         return;
     }
 
     if (v < 0) {
-        ascii_append_byte(dst, 45); // '-'
+        ascii_push(dst, 45); // '-'
         v = 0 - v;
     }
 
@@ -130,7 +130,7 @@ function brickout_ascii_append_i32(dst: ascii[], value: i32): void {
 
     let i: i32 = count - 1;
     for (; i >= 0; i = i - 1) {
-        ascii_append_byte(dst, brickout_digits_tmp[i]);
+        ascii_push(dst, brickout_digits_tmp[i]);
     }
 }
 
@@ -147,7 +147,7 @@ function brickout_ascii_write_scraps_power_line(
     brickout_ascii_append_i32(tmp_ascii, scraps);
     ascii_append(tmp_ascii, "   Power: ");
     brickout_ascii_append_i32(tmp_ascii, power_used);
-    ascii_append_byte(tmp_ascii, 47); // '/'
+    ascii_push(tmp_ascii, 47); // '/'
     brickout_ascii_append_i32(tmp_ascii, power_cap);
-    from_ascii(out, tmp_ascii, out_max);
+    utf8_from_ascii(out, tmp_ascii, out_max);
 }

--- a/samples/brickout_revenge/brickout_revenge_v1_levels.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_levels.stasis
@@ -4,15 +4,15 @@ function init_level_defs(): void {
     brickout_levels_magic = 1;
     ascii_clear(brickout_level_name_tmp);
     ascii_append(brickout_level_name_tmp, "Level 1 - Warmup");
-    from_ascii(brickout_level_name_0, brickout_level_name_tmp, 32);
+    utf8_from_ascii(brickout_level_name_0, brickout_level_name_tmp, 32);
 
     ascii_clear(brickout_level_name_tmp);
     ascii_append(brickout_level_name_tmp, "Level 2 - Mixed");
-    from_ascii(brickout_level_name_1, brickout_level_name_tmp, 32);
+    utf8_from_ascii(brickout_level_name_1, brickout_level_name_tmp, 32);
 
     ascii_clear(brickout_level_name_tmp);
     ascii_append(brickout_level_name_tmp, "Level 3 - Swarm");
-    from_ascii(brickout_level_name_2, brickout_level_name_tmp, 32);
+    utf8_from_ascii(brickout_level_name_2, brickout_level_name_tmp, 32);
 
     brickout_level_initial_scraps[0] = 60;
     brickout_level_initial_scraps[1] = 75;

--- a/samples/bucket_catcher.stasis
+++ b/samples/bucket_catcher.stasis
@@ -304,10 +304,10 @@ function draw_ui(): void {
     if (state.ui_font == 0) { return; }
     ascii_clear(state.ui_ascii);
     ascii_append(state.ui_ascii, "Catches: ");
-    ascii_append_i32(state.ui_ascii, state.catches);
+    ascii_push_i32(state.ui_ascii, state.catches);
     ascii_append(state.ui_ascii, "  Misses: ");
-    ascii_append_i32(state.ui_ascii, state.misses);
-    from_ascii(state.ui_text, state.ui_ascii, 64);
+    ascii_push_i32(state.ui_ascii, state.misses);
+    utf8_from_ascii(state.ui_text, state.ui_ascii, 64);
 
     draw_text(state.ui_font, state.ui_text, 12.0, 10.0, state.config.ui_red, state.config.ui_green, state.config.ui_blue, 1.0);
 }

--- a/samples/interactive_showcase.stasis
+++ b/samples/interactive_showcase.stasis
@@ -183,7 +183,7 @@ function fill_audio_chunk(sample_rate: i32): void {
             click_env = 0.0;
         }
 
-        let s: f32 = game_clamp_f32((music + click) * 0.5 + 0.5, 0.0, 1.0) * 2.0 - 1.0;
+        let s: f32 = game_clamp((music + click) * 0.5 + 0.5, 0.0, 1.0) * 2.0 - 1.0;
 
         let idx: i32 = i * 2;
         audio_buf[idx] = s;

--- a/samples/render_command_buffer_bench.stasis
+++ b/samples/render_command_buffer_bench.stasis
@@ -3,7 +3,7 @@ import "../src/stdlib/graphics.stasis";
 
 // Render command buffer microbench:
 // - Per-call: many draw_line() calls from Stasis.
-// - Batched: one draw_lines_f32() call that loops in the runtime.
+// - Batched: one draw_lines() call that loops in the runtime.
 //
 // Notes:
 // - This times submission only (no end_frame()), so it isolates host<->runtime call overhead.
@@ -59,7 +59,7 @@ function submit_lines_per_call(): void {
 }
 
 function submit_lines_batched(): void {
-    draw_lines_f32(state.lines, LINE_COUNT);
+    draw_lines(state.lines, LINE_COUNT);
 }
 
 function bench_per_call(iterations: i32): i32 {

--- a/samples/render_command_buffer_bench_submit.stasis
+++ b/samples/render_command_buffer_bench_submit.stasis
@@ -4,7 +4,7 @@ import "../src/gfx_cmd.stasis";
 
 // Render submission microbench:
 // - Per-call: many draw_line() calls from Stasis (many host boundary calls).
-// - Batched: one draw_lines_f32() call that loops in the runtime.
+// - Batched: one draw_lines() call that loops in the runtime.
 // - Submit: one gfx_cmd_submit_no_present() call (command buffer) that loops in the runtime.
 //
 // Notes:
@@ -61,18 +61,18 @@ function submit_lines_per_call(): void {
 }
 
 function submit_lines_batched(): void {
-    draw_lines_f32(state.lines, LINE_COUNT);
+    draw_lines(state.lines, LINE_COUNT);
 }
 
 function submit_lines_cmd(): void {
     gfx_cmd_begin();
-    gfx_cmd_lines_from_f32(state.lines, LINE_COUNT);
+    gfx_cmd_lines_from(state.lines, LINE_COUNT);
     gfx_cmd_submit_no_present();
 }
 
 function build_lines_cmd_once(): void {
     gfx_cmd_begin();
-    gfx_cmd_lines_from_f32(state.lines, LINE_COUNT);
+    gfx_cmd_lines_from(state.lines, LINE_COUNT);
 }
 
 function bench_per_call(iterations: i32): i32 {

--- a/samples/render_heavy_submit_bench.stasis
+++ b/samples/render_heavy_submit_bench.stasis
@@ -4,7 +4,7 @@ import "../src/gfx_cmd.stasis";
 
 // Heavy render submission benchmark:
 // - Per-call: draw_line() + gfx_draw_sprite() in loops (many host boundary calls).
-// - Batched: draw_lines_f32() + gfx_draw_sprites_i32() (2 host calls).
+// - Batched: draw_lines() + gfx_draw_sprites() (2 host calls).
 // - Cmd (build): build gfx_cmd streams per-iter + gfx_cmd_submit_no_present().
 // - Cmd (prebuilt): build gfx_cmd once + submit only.
 //
@@ -104,16 +104,16 @@ function submit_per_call(): void {
 
 function submit_batched(): void {
     clear(0.08, 0.09, 0.11, 1.0);
-    draw_lines_f32(state.lines, LINE_COUNT);
-    gfx_draw_sprites_i32(state.sprites, SPRITE_COUNT);
+    draw_lines(state.lines, LINE_COUNT);
+    gfx_draw_sprites(state.sprites, SPRITE_COUNT);
 }
 
 function submit_cmd_build(): void {
     gfx_cmd_begin();
     gfx_cmd_clear(0.08, 0.09, 0.11, 1.0);
 
-    gfx_cmd_lines_from_f32(state.lines, LINE_COUNT);
-    gfx_cmd_sprites_from_i32(state.sprites, SPRITE_COUNT);
+    gfx_cmd_lines_from(state.lines, LINE_COUNT);
+    gfx_cmd_sprites_from(state.sprites, SPRITE_COUNT);
 
     gfx_cmd_submit_no_present();
 }
@@ -122,8 +122,8 @@ function build_cmd_once(): void {
     gfx_cmd_begin();
     gfx_cmd_clear(0.08, 0.09, 0.11, 1.0);
 
-    gfx_cmd_lines_from_f32(state.lines, LINE_COUNT);
-    gfx_cmd_sprites_from_i32(state.sprites, SPRITE_COUNT);
+    gfx_cmd_lines_from(state.lines, LINE_COUNT);
+    gfx_cmd_sprites_from(state.sprites, SPRITE_COUNT);
 }
 
 function bench_per_call(iters: i32): i32 {

--- a/src/gfx_cmd.stasis
+++ b/src/gfx_cmd.stasis
@@ -212,7 +212,7 @@ function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b
         return;
     }
 
-    let byte_len: i32 = utf8_byte_len(text);
+    let byte_len: i32 = length_bytes(text);
     if (byte_len < 0) { byte_len = 0; }
     if (byte_len > 1024) { byte_len = 1024; } // hard cap per command to keep worst-case bounded
 

--- a/src/gfx_cmd.stasis
+++ b/src/gfx_cmd.stasis
@@ -145,7 +145,7 @@ function gfx_cmd_set_sprite_at(index: i32, handle: i32, x: i32, y: i32, w: i32, 
     gfx_cmd_i32[base + 6] = a;
 }
 
-function gfx_cmd_lines_from_f32(lines: f32[], count: i32): void {
+function gfx_cmd_lines_from(lines: f32[], count: i32): void {
     if (count <= 0) {
         return;
     }
@@ -167,7 +167,7 @@ function gfx_cmd_lines_from_f32(lines: f32[], count: i32): void {
     gfx_cmd_i32[GFX_I_LINE_COUNT] = start + n;
 }
 
-function gfx_cmd_sprites_from_i32(cmds: i32[], count: i32): void {
+function gfx_cmd_sprites_from(cmds: i32[], count: i32): void {
     if (count <= 0) {
         return;
     }

--- a/src/stdlib/game_math.stasis
+++ b/src/stdlib/game_math.stasis
@@ -1,6 +1,9 @@
 // Game math helpers (not loaded by default).
+//
+// Preferred names use first-parameter overloading (`game_abs`, `game_min`, ...).
+// Legacy `*_i32` / `*_f32` names are kept as compatibility wrappers.
 
-function game_abs_i32(x: i32): i32 {
+function game_abs(x: i32): i32 {
     if (x < 0) {
         // i32 abs is undefined for INT_MIN; clamp so callers stay deterministic.
         if (x == -2147483648) {
@@ -11,46 +14,46 @@ function game_abs_i32(x: i32): i32 {
     return x;
 }
 
-function game_abs_f32(x: f32): f32 {
+function game_abs(x: f32): f32 {
     if (x < 0.0) {
         return 0.0 - x;
     }
     return x;
 }
 
-function game_min_i32(a: i32, b: i32): i32 {
+function game_min(a: i32, b: i32): i32 {
     if (a < b) { return a; }
     return b;
 }
 
-function game_max_i32(a: i32, b: i32): i32 {
-    if (a > b) { return a; }
-    return b;
-}
-
-function game_min_f32(a: f32, b: f32): f32 {
+function game_min(a: f32, b: f32): f32 {
     if (a < b) { return a; }
     return b;
 }
 
-function game_max_f32(a: f32, b: f32): f32 {
+function game_max(a: i32, b: i32): i32 {
     if (a > b) { return a; }
     return b;
 }
 
-function game_clamp_i32(x: i32, lo: i32, hi: i32): i32 {
+function game_max(a: f32, b: f32): f32 {
+    if (a > b) { return a; }
+    return b;
+}
+
+function game_clamp(x: i32, lo: i32, hi: i32): i32 {
     if (x < lo) { return lo; }
     if (x > hi) { return hi; }
     return x;
 }
 
-function game_clamp_f32(x: f32, lo: f32, hi: f32): f32 {
+function game_clamp(x: f32, lo: f32, hi: f32): f32 {
     if (x < lo) { return lo; }
     if (x > hi) { return hi; }
     return x;
 }
 
-function game_lerp_f32(a: f32, b: f32, t: f32): f32 {
+function game_lerp(a: f32, b: f32, t: f32): f32 {
     return a + (b - a) * t;
 }
 

--- a/src/stdlib/gfx_cmd.stasis
+++ b/src/stdlib/gfx_cmd.stasis
@@ -122,7 +122,7 @@ function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b
         return;
     }
 
-    let byte_len: i32 = utf8_byte_len(text);
+    let byte_len: i32 = length_bytes(text);
     if (byte_len < 0) { byte_len = 0; }
     if (byte_len > 1024) { byte_len = 1024; } // hard cap per command to keep worst-case bounded
 

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -84,16 +84,16 @@ function draw_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a
     gfx_cmd_line(x1, y1, x2, y2, r, g, b, a);
 }
 
-function draw_lines_f32(lines: f32[], count: i32): void {
-    gfx_cmd_lines_from_f32(lines, count);
+function draw_lines(lines: f32[], count: i32): void {
+    gfx_cmd_lines_from(lines, count);
 }
 
 function gfx_draw_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
     gfx_cmd_sprite(handle, x, y, w, h, rot_deg, a);
 }
 
-function gfx_draw_sprites_i32(cmds: i32[], count: i32): void {
-    gfx_cmd_sprites_from_i32(cmds, count);
+function gfx_draw_sprites(cmds: i32[], count: i32): void {
+    gfx_cmd_sprites_from(cmds, count);
 }
 
 function draw_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {

--- a/src/stdlib/hud_draw.stasis
+++ b/src/stdlib/hud_draw.stasis
@@ -16,6 +16,6 @@ function hud_draw_text_from_ascii(
     b: f32,
     a: f32
 ): void {
-    hud_text_commit_utf8(out, tmp, out_max);
+    hud_text_commit(out, tmp, out_max);
     draw_text(font, out, x, y, r, g, b, a);
 }

--- a/src/stdlib/hud_table.stasis
+++ b/src/stdlib/hud_table.stasis
@@ -12,7 +12,7 @@ const HUD_RECT_W: i32 = 2;
 const HUD_RECT_H: i32 = 3;
 
 // Clamp utility (avoid extra imports).
-function hud_clamp_i32(v: i32, min: i32, max: i32): i32 {
+function hud_clamp(v: i32, min: i32, max: i32): i32 {
     if (v < min) { return min; }
     if (v > max) { return max; }
     return v;
@@ -80,7 +80,7 @@ function hud_table_place(out_table: f32[], parent: f32[], table_w: f32, table_h:
 }
 
 function hud_table_cell_x(table: f32[], col_w: f32[], col_count: i32, col_gap: f32, col: i32): f32 {
-    let c: i32 = hud_clamp_i32(col, 0, col_count - 1);
+    let c: i32 = hud_clamp(col, 0, col_count - 1);
     let x: f32 = table[HUD_RECT_X];
     let i: i32 = 0;
     for (i = 0; i < c; i = i + 1) {
@@ -90,7 +90,7 @@ function hud_table_cell_x(table: f32[], col_w: f32[], col_count: i32, col_gap: f
 }
 
 function hud_table_cell_w(col_w: f32[], col_count: i32, col: i32): f32 {
-    let c: i32 = hud_clamp_i32(col, 0, col_count - 1);
+    let c: i32 = hud_clamp(col, 0, col_count - 1);
     return col_w[c];
 }
 

--- a/src/stdlib/hud_text.stasis
+++ b/src/stdlib/hud_text.stasis
@@ -3,11 +3,11 @@
 
 import "stdlib.stasis";
 
-function hud_text_clear_ascii(tmp: ascii[]): void {
+function hud_text_clear(tmp: ascii[]): void {
     ascii_clear(tmp);
 }
 
-function hud_text_commit_utf8(out: utf8[], tmp: ascii[], out_max: i32): i32 {
+function hud_text_commit(out: utf8[], tmp: ascii[], out_max: i32): i32 {
     return utf8_from_ascii(out, tmp, out_max);
 }
 

--- a/src/stdlib/hud_text.stasis
+++ b/src/stdlib/hud_text.stasis
@@ -8,6 +8,6 @@ function hud_text_clear_ascii(tmp: ascii[]): void {
 }
 
 function hud_text_commit_utf8(out: utf8[], tmp: ascii[], out_max: i32): i32 {
-    return from_ascii(out, tmp, out_max);
+    return utf8_from_ascii(out, tmp, out_max);
 }
 

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -64,7 +64,7 @@ function ascii_from_hex(d: i32): u8 {
     return char_from_hex(d);
 }
 
-function ascii_len(s: ascii[]): i32 {
+function length(s: ascii[]): i32 {
     let b0: i32 = u8_to_i32(s[-4]);
     let b1: i32 = u8_to_i32(s[-3]);
     let b2: i32 = u8_to_i32(s[-2]);
@@ -88,7 +88,7 @@ function ascii_set_len(s: ascii[], len: i32) {
 }
 
 function ascii_is_empty(s: ascii[]): bool {
-    return ascii_len(s) == 0;
+    return length(s) == 0;
 }
 
 function ascii_get(s: ascii[], index: i32): u8 {
@@ -101,7 +101,7 @@ function ascii_set(s: ascii[], index: i32, b: u8) {
         ascii_set_len(s, index);
         return;
     }
-    if (index >= ascii_len(s)) {
+    if (index >= length(s)) {
         ascii_set_len(s, index + 1);
     }
 }
@@ -136,7 +136,7 @@ function ascii_copy(dst: ascii[], src: ascii[]): i32 {
 }
 
 function ascii_append(dst: ascii[], src: ascii[]): i32 {
-    let base: i32 = ascii_len(dst);
+    let base: i32 = length(dst);
     let i: i32 = 0;
     for (i = 0; 1; i = i + 1) {
         let b: u8 = src[i];
@@ -150,8 +150,8 @@ function ascii_append(dst: ascii[], src: ascii[]): i32 {
     return base;
 }
 
-function ascii_append_byte(dst: ascii[], b: u8): i32 {
-    let base: i32 = ascii_len(dst);
+function ascii_push(dst: ascii[], b: u8): i32 {
+    let base: i32 = length(dst);
     dst[base] = b;
     if (b == 0) {
         ascii_set_len(dst, base);
@@ -162,15 +162,15 @@ function ascii_append_byte(dst: ascii[], b: u8): i32 {
     return base + 1;
 }
 
-function ascii_append_i32(dst: ascii[], value: i32): void {
+function ascii_push_i32(dst: ascii[], value: i32): void {
     let v: i32 = value;
     if (v == 0) {
-        ascii_append_byte(dst, 48);
+        ascii_push(dst, 48);
         return;
     }
 
     if (v < 0) {
-        ascii_append_byte(dst, 45);
+        ascii_push(dst, 45);
         v = 0 - v;
     }
 
@@ -183,7 +183,7 @@ function ascii_append_i32(dst: ascii[], value: i32): void {
     // Emit digits.
     for (; pow10 > 0; ) {
         let digit: i32 = (v / pow10) % 10;
-        ascii_append_byte(dst, i32_to_u8_trunc(48 + digit));
+        ascii_push(dst, i32_to_u8_trunc(48 + digit));
         pow10 = pow10 / 10;
     }
 }
@@ -258,8 +258,8 @@ function ascii_starts_with(s: ascii[], prefix: ascii[]): bool {
 }
 
 function ascii_ends_with(s: ascii[], suffix: ascii[]): bool {
-    let len_s: i32 = ascii_len(s);
-    let len_suf: i32 = ascii_len(suffix);
+    let len_s: i32 = length(s);
+    let len_suf: i32 = length(suffix);
     if (len_suf > len_s) {
         return false;
     }
@@ -274,8 +274,8 @@ function ascii_ends_with(s: ascii[], suffix: ascii[]): bool {
 }
 
 function ascii_find(s: ascii[], needle: ascii[]): i32 {
-    let len_s: i32 = ascii_len(s);
-    let len_n: i32 = ascii_len(needle);
+    let len_s: i32 = length(s);
+    let len_n: i32 = length(needle);
     if (len_n == 0) {
         return 0;
     }
@@ -345,7 +345,7 @@ function mem_cmp(a: u8[], b: u8[], count: i32): i32 {
 // Note: `utf8_set_len_ascii` assumes the payload contains only ASCII bytes, so
 // `char_length == byte_length`.
 
-function utf8_byte_len(s: utf8[]): i32 {
+function length_bytes(s: utf8[]): i32 {
     let b0: i32 = u8_to_i32(s[-8]);
     let b1: i32 = u8_to_i32(s[-7]);
     let b2: i32 = u8_to_i32(s[-6]);
@@ -353,7 +353,7 @@ function utf8_byte_len(s: utf8[]): i32 {
     return b0 + b1 * 256 + b2 * 65536 + b3 * 16777216;
 }
 
-function utf8_char_len(s: utf8[]): i32 {
+function length_chars(s: utf8[]): i32 {
     let b0: i32 = u8_to_i32(s[-4]);
     let b1: i32 = u8_to_i32(s[-3]);
     let b2: i32 = u8_to_i32(s[-2]);
@@ -401,7 +401,7 @@ function utf8_clear_ascii(s: utf8[]): void {
     utf8_set_len_ascii(s, 0);
 }
 
-function from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
+function utf8_from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
     if (dst_max <= 0) {
         return 0;
     }

--- a/tests/hud_text_commit_utf8.stasis
+++ b/tests/hud_text_commit_utf8.stasis
@@ -7,11 +7,11 @@ global out: utf8[32];
 test `hud_text_commit_utf8 updates utf8 lengths`(): bool {
     hud_text_clear_ascii(tmp);
     ascii_append(tmp, "HP=");
-    ascii_append_i32(tmp, 42);
+    ascii_push_i32(tmp, 42);
     let n: i32 = hud_text_commit_utf8(out, tmp, 32);
     return n == 5
-        && utf8_byte_len(out) == 5
-        && utf8_char_len(out) == 5
+        && length_bytes(out) == 5
+        && length_chars(out) == 5
         && out[0] == 72
         && out[1] == 80
         && out[2] == 61

--- a/tests/hud_text_commit_utf8.stasis
+++ b/tests/hud_text_commit_utf8.stasis
@@ -4,11 +4,11 @@ import "../src/stdlib/hud_text.stasis";
 global tmp: ascii[32];
 global out: utf8[32];
 
-test `hud_text_commit_utf8 updates utf8 lengths`(): bool {
-    hud_text_clear_ascii(tmp);
+test `hud_text_commit updates utf8 lengths`(): bool {
+    hud_text_clear(tmp);
     ascii_append(tmp, "HP=");
     ascii_push_i32(tmp, 42);
-    let n: i32 = hud_text_commit_utf8(out, tmp, 32);
+    let n: i32 = hud_text_commit(out, tmp, 32);
     return n == 5
         && length_bytes(out) == 5
         && length_chars(out) == 5

--- a/tests/stdlib_ascii.stasis
+++ b/tests/stdlib_ascii.stasis
@@ -3,21 +3,21 @@ import "../src/stdlib/stdlib.stasis";
 global ascii_a: ascii[8];
 global ascii_b: ascii[8];
 
-test `ascii_len tracks header`() {
+test `len tracks header`() {
     ascii_clear(ascii_a);
-    ascii_append_byte(ascii_a, 65);
-    ascii_append_byte(ascii_a, 66);
-    return ascii_len(ascii_a) == 2
+    ascii_push(ascii_a, 65);
+    ascii_push(ascii_a, 66);
+    return length(ascii_a) == 2
         && ascii_get(ascii_a, 0) == 65
         && ascii_get(ascii_a, 1) == 66;
 }
 
 test `ascii_copy copies bytes`() {
     ascii_clear(ascii_a);
-    ascii_append_byte(ascii_a, 72);
-    ascii_append_byte(ascii_a, 105);
+    ascii_push(ascii_a, 72);
+    ascii_push(ascii_a, 105);
     ascii_copy(ascii_b, ascii_a);
-    return ascii_len(ascii_b) == 2
+    return length(ascii_b) == 2
         && ascii_get(ascii_b, 0) == 72
         && ascii_get(ascii_b, 1) == 105;
 }
@@ -25,8 +25,8 @@ test `ascii_copy copies bytes`() {
 test `ascii_cmp compares`() {
     ascii_clear(ascii_a);
     ascii_clear(ascii_b);
-    ascii_append_byte(ascii_a, 65);
-    ascii_append_byte(ascii_b, 66);
+    ascii_push(ascii_a, 65);
+    ascii_push(ascii_b, 66);
     return ascii_cmp(ascii_a, ascii_b) == -1
         && ascii_cmp(ascii_b, ascii_a) == 1
         && ascii_eq(ascii_a, ascii_a);
@@ -35,11 +35,11 @@ test `ascii_cmp compares`() {
 test `ascii_starts_with and ends_with`() {
     ascii_clear(ascii_a);
     ascii_clear(ascii_b);
-    ascii_append_byte(ascii_a, 65);
-    ascii_append_byte(ascii_a, 66);
-    ascii_append_byte(ascii_a, 67);
-    ascii_append_byte(ascii_b, 65);
-    ascii_append_byte(ascii_b, 66);
+    ascii_push(ascii_a, 65);
+    ascii_push(ascii_a, 66);
+    ascii_push(ascii_a, 67);
+    ascii_push(ascii_b, 65);
+    ascii_push(ascii_b, 66);
     return ascii_starts_with(ascii_a, ascii_b)
         && !ascii_ends_with(ascii_b, ascii_a);
 }
@@ -47,12 +47,12 @@ test `ascii_starts_with and ends_with`() {
 test `ascii_find and contains`() {
     ascii_clear(ascii_a);
     ascii_clear(ascii_b);
-    ascii_append_byte(ascii_a, 65);
-    ascii_append_byte(ascii_a, 66);
-    ascii_append_byte(ascii_a, 67);
-    ascii_append_byte(ascii_a, 68);
-    ascii_append_byte(ascii_b, 67);
-    ascii_append_byte(ascii_b, 68);
+    ascii_push(ascii_a, 65);
+    ascii_push(ascii_a, 66);
+    ascii_push(ascii_a, 67);
+    ascii_push(ascii_a, 68);
+    ascii_push(ascii_b, 67);
+    ascii_push(ascii_b, 68);
     return ascii_find(ascii_a, ascii_b) == 2
         && ascii_contains(ascii_a, ascii_b);
 }

--- a/tests/stdlib_ascii_append_i32.stasis
+++ b/tests/stdlib_ascii_append_i32.stasis
@@ -2,10 +2,10 @@ import "../src/stdlib/stdlib.stasis";
 
 global buf: ascii[64];
 
-test `ascii_append_i32 writes digits`(): bool {
+test `ascii_push_i32 writes digits`(): bool {
     ascii_clear(buf);
-    ascii_append_i32(buf, 12345);
-    return ascii_len(buf) == 5
+    ascii_push_i32(buf, 12345);
+    return length(buf) == 5
         && buf[0] == 49
         && buf[1] == 50
         && buf[2] == 51
@@ -13,10 +13,10 @@ test `ascii_append_i32 writes digits`(): bool {
         && buf[4] == 53;
 }
 
-test `ascii_append_i32 writes negative sign`(): bool {
+test `ascii_push_i32 writes negative sign`(): bool {
     ascii_clear(buf);
-    ascii_append_i32(buf, -7);
-    return ascii_len(buf) == 2
+    ascii_push_i32(buf, -7);
+    return length(buf) == 2
         && buf[0] == 45
         && buf[1] == 55;
 }

--- a/tests/stdlib_concise_names.stasis
+++ b/tests/stdlib_concise_names.stasis
@@ -1,0 +1,61 @@
+import "../src/stdlib/stdlib.stasis";
+import "../src/stdlib/game_math.stasis";
+
+global ascii_buf: ascii[32];
+global ascii_tmp: ascii[32];
+global utf8_buf: utf8[32];
+
+test `ascii concise names work with receiver form`() {
+    ascii_buf.ascii_clear();
+    ascii_buf.ascii_push(72); // H
+    ascii_buf.ascii_push(105); // i
+    ascii_buf.ascii_push_i32(7);
+
+    return length(ascii_buf) == 3
+        && ascii_buf.ascii_get(0) == 72
+        && ascii_buf.ascii_get(1) == 105
+        && ascii_buf.ascii_get(2) == 55;
+}
+
+test `utf8 concise names preserve header semantics`() {
+    ascii_tmp.ascii_clear();
+    ascii_tmp.ascii_append("HP=");
+    ascii_tmp.ascii_push_i32(42);
+
+    utf8_from_ascii(utf8_buf, ascii_tmp, utf8_buf.length);
+
+    return length_bytes(utf8_buf) == 5
+        && length_chars(utf8_buf) == 5
+        && utf8_from_ascii(utf8_buf, ascii_tmp, utf8_buf.length) == 5;
+}
+
+test `game math concise overloads remain deterministic`() {
+    return game_abs(-7) == 7
+        && game_abs(-1.5) == 1.5
+        && game_min(2, 9) == 2
+        && game_min(2.0, 1.5) == 1.5
+        && game_max(2, 9) == 9
+        && game_max(2.0, 1.5) == 2.0
+        && game_clamp(15, 0, 10) == 10
+        && game_clamp(-0.5, 0.0, 1.0) == 0.0
+        && game_lerp(0.0, 10.0, 0.5) == 5.0;
+}
+
+test `concise stdlib names work in function form`() {
+    ascii_tmp.ascii_clear();
+    ascii_push(ascii_tmp, 65);
+    ascii_push_i32(ascii_tmp, 9);
+    utf8_from_ascii(utf8_buf, ascii_tmp, utf8_buf.length);
+
+    return length(ascii_tmp) == 2
+        && ascii_get(ascii_tmp, 0) == 65
+        && ascii_get(ascii_tmp, 1) == 57
+        && length_bytes(utf8_buf) == 2
+        && length_chars(utf8_buf) == 2
+        && game_abs(-3) == 3
+        && game_abs(-2.5) == 2.5
+        && game_min(4, 6) == 4
+        && game_max(4.0, 6.0) == 6.0
+        && game_clamp(3.0, 0.0, 2.0) == 2.0
+        && game_lerp(0.0, 20.0, 0.5) == 10.0;
+}

--- a/tests/stdlib_from_ascii.stasis
+++ b/tests/stdlib_from_ascii.stasis
@@ -3,14 +3,14 @@ import "../src/stdlib/stdlib.stasis";
 global ascii_src: ascii[8];
 global utf8_dst: utf8[8];
 
-test `from_ascii copies ascii`(): bool {
+test `utf8_from_ascii copies ascii`(): bool {
     ascii_src[0] = 72;
     ascii_src[1] = 105;
     ascii_src[2] = 0;
 
-    from_ascii(utf8_dst, ascii_src, utf8_dst.length);
+    utf8_from_ascii(utf8_dst, ascii_src, utf8_dst.length);
 
-    return utf8_char_len(utf8_dst) == 2
+    return length_chars(utf8_dst) == 2
         && utf8_dst[0] == 72
         && utf8_dst[1] == 105;
 }

--- a/tests/stdlib_utf8_header.stasis
+++ b/tests/stdlib_utf8_header.stasis
@@ -6,7 +6,7 @@ test `utf8_set_len_ascii writes both lengths`(): bool {
     utf8_buf[0] = 65;
     utf8_buf[1] = 0;
     utf8_set_len_ascii(utf8_buf, 1);
-    return utf8_byte_len(utf8_buf) == 1 && utf8_char_len(utf8_buf) == 1;
+    return length_bytes(utf8_buf) == 1 && length_chars(utf8_buf) == 1;
 }
 
 test `utf8_clear_ascii clears header and payload`(): bool {
@@ -14,6 +14,6 @@ test `utf8_clear_ascii clears header and payload`(): bool {
     utf8_buf[1] = 0;
     utf8_set_len_ascii(utf8_buf, 1);
     utf8_clear_ascii(utf8_buf);
-    return utf8_buf[0] == 0 && utf8_byte_len(utf8_buf) == 0 && utf8_char_len(utf8_buf) == 0;
+    return utf8_buf[0] == 0 && length_bytes(utf8_buf) == 0 && length_chars(utf8_buf) == 0;
 }
 


### PR DESCRIPTION
## Summary\n- remove pre-1.0 stdlib alias names and keep one canonical callable name per operation\n- adopt explicit length naming for utf8 helpers: length_bytes / length_chars\n- adopt length(ascii[]) and concise push APIs (scii_push, scii_push_i32)\n- migrate stdlib, samples, examples, and tests to canonical names\n- document receiver-form preference (eceiver.doAction(action) over doAction(receiver, action))\n\n## Validation\n- ran scripts/pre-push-gate.ps1 (compiler tests + stasis test --all)\n