### PR TITLE
feat: add live-compilation semantic gating and safe swap foundation

### DIFF
--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3835,6 +3835,17 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                             }
                         }
                     }
+                    else if (line.StartsWith("ERR ", StringComparison.Ordinal))
+                    {
+                        var idMatch = Regex.Match(line, @"\bid=(\d+)\b");
+                        if (idMatch.Success && ulong.TryParse(idMatch.Groups[1].Value, out var failedId))
+                        {
+                            lock (pendingLock)
+                            {
+                                _ = pendingSwaps.Remove(failedId);
+                            }
+                        }
+                    }
 
                     await runnerOutLines.Writer.WriteAsync(line, cts.Token);
                 }
@@ -3924,8 +3935,10 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         return true;
     }
 
-    int BuildClif(out string clif, out long lowerMs)
+    int BuildClif(string? previousSemanticFingerprint, out string clif, out long lowerMs, out string semanticFingerprint, out bool semanticChanged)
     {
+        semanticFingerprint = string.Empty;
+        semanticChanged = false;
         var sw = Stopwatch.StartNew();
         var source = LoadSourceWithImports(sourcePath, out var importDiagnostics, out var importSource);
         if (importDiagnostics.Count > 0)
@@ -3980,6 +3993,9 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
         MaybeLogGlobalMemoryUsageOnLayoutChange(sourcePath, moduleName, layout, enable: true);
 
+        semanticFingerprint = SemanticFingerprint.ComputeFileFingerprint(source, layout);
+        semanticChanged = !string.Equals(previousSemanticFingerprint, semanticFingerprint, StringComparison.Ordinal);
+
         if (!TryGetDataBindingPlan(sourcePath, layout, moduleName, new[] { $"{moduleName}__main", $"{moduleName}__tick" }, out var bindPlan))
         {
             clif = string.Empty;
@@ -3990,6 +4006,14 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         if (dataBindingPlan is not null)
         {
             Console.WriteLine($"Data binding: {dataBindingPlan.JsonPath}");
+        }
+
+        if (!semanticChanged && previousSemanticFingerprint is not null)
+        {
+            sw.Stop();
+            lowerMs = sw.ElapsedMilliseconds;
+            clif = string.Empty;
+            return 0;
         }
 
         var options = new CodeGenerationOptions(
@@ -4019,10 +4043,11 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
     }
 
     string? lastGoodClif = null;
+    string? lastAppliedSemanticFingerprint = null;
     var lastRunnerRestartAttemptUtc = DateTime.MinValue;
     var consecutiveRunnerExits = 0;
 
-    var initialRc = BuildClif(out var initialClif, out var initialLowerMs);
+    var initialRc = BuildClif(lastAppliedSemanticFingerprint, out var initialClif, out var initialLowerMs, out var initialSemanticFingerprint, out var initialSemanticChanged);
     if (initialRc != 0)
     {
         Console.Error.WriteLine("warning: initial build failed; waiting for changes.");
@@ -4034,6 +4059,10 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
             return 1;
         }
         lastGoodClif = initialClif;
+        if (initialSemanticChanged)
+        {
+            lastAppliedSemanticFingerprint = initialSemanticFingerprint;
+        }
         _ = initialLowerMs;
         Console.WriteLine($"HOTSWAP(ms): total={initialLowerMs} latency=-1");
     }
@@ -4105,12 +4134,22 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
 
         var changeUtc = DateTime.UtcNow;
         var swTotal = Stopwatch.StartNew();
-        var rc = BuildClif(out var clif, out var lowerMs);
+        var rc = BuildClif(lastAppliedSemanticFingerprint, out var clif, out var lowerMs, out var semanticFingerprint, out var semanticChanged);
         if (rc != 0)
         {
             if (runner is not null && !runner.HasExited)
             {
                 Console.Error.WriteLine("warning: rebuild failed; keeping previous code; waiting for changes.");
+            }
+            continue;
+        }
+
+        if (!semanticChanged)
+        {
+            Console.WriteLine("HOTSWAP(skip): semantic fingerprint unchanged; no swap queued.");
+            if ((runner is null || runner.HasExited) && lastGoodClif is not null)
+            {
+                _ = EnsureRunnerStarted(lastGoodClif).GetAwaiter().GetResult();
             }
             continue;
         }
@@ -4122,6 +4161,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
                 return 1;
             }
             lastGoodClif = clif;
+            lastAppliedSemanticFingerprint = semanticFingerprint;
             Console.WriteLine($"HOTSWAP(ms): total={lowerMs} latency=-1");
             continue;
         }
@@ -4156,6 +4196,7 @@ static int WatchCraneliftTickJitSwap(string sourcePath, string moduleName, int f
         }
 
         lastGoodClif = clif;
+        lastAppliedSemanticFingerprint = semanticFingerprint;
         swTotal.Stop();
         _ = lowerMs;
     }

--- a/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
+++ b/Stasis.Compiler.Tests/HotSwapIntegrationTests.cs
@@ -109,8 +109,9 @@ public sealed class HotSwapIntegrationTests
                 throw new XunitException($"watch process exited unexpectedly after killing jit runner (code={proc.ExitCode}).");
             }
 
-            // Trigger a real rebuild + swap.
-            await File.AppendAllTextAsync(samplePath, "\n// test edit " + DateTime.UtcNow.Ticks + "\n", System.Text.Encoding.ASCII);
+            // Trigger a real semantic rebuild + swap.
+            var semanticEdit = ApplyTickSemanticEdit(original, 7);
+            await File.WriteAllTextAsync(samplePath, semanticEdit, System.Text.Encoding.ASCII);
 
             var initialSwapCount = outLines.CountContains("HOTSWAP(ms):");
             await WaitForAnyLineAsync(
@@ -220,7 +221,8 @@ public sealed class HotSwapIntegrationTests
                 timeout: TimeSpan.FromMinutes(5));
             var initialSwapCount = outLines.CountContains("HOTSWAP(ms):");
 
-            await File.AppendAllTextAsync(samplePath, "\n// jit swap test edit " + DateTime.UtcNow.Ticks + "\n", System.Text.Encoding.ASCII);
+            var semanticEdit = ApplyTickSemanticEdit(original, 11);
+            await File.WriteAllTextAsync(samplePath, semanticEdit, System.Text.Encoding.ASCII);
 
             await WaitForAnyLineAsync(
                 proc,
@@ -342,7 +344,8 @@ public sealed class HotSwapIntegrationTests
             }
 
             // Fix the file; next rebuild should hot-swap again.
-            await File.WriteAllTextAsync(samplePath, original + "\n// jit swap recovery " + DateTime.UtcNow.Ticks + "\n", System.Text.Encoding.ASCII);
+            var semanticRecovery = ApplyTickSemanticEdit(original, 13);
+            await File.WriteAllTextAsync(samplePath, semanticRecovery, System.Text.Encoding.ASCII);
 
             await WaitForAnyLineAsync(
                 proc,
@@ -695,6 +698,208 @@ public sealed class HotSwapIntegrationTests
     }
 
     [HotSwapFact]
+    public async Task WatchTickJitSwap_UsesSwapHook_AndRejectsLayoutChanges()
+    {
+        var repoRoot = FindRepoRoot();
+        var cliDll = FindCliDll(repoRoot);
+        var jitRunnerExe = FindCraneliftJitRunnerExe(repoRoot);
+        Assert.NotNull(cliDll);
+        Assert.NotNull(jitRunnerExe);
+
+        var tempDir = Directory.CreateTempSubdirectory("stasis_jit_swap_hook");
+        var stasisPath = Path.Combine(tempDir.FullName, "jit_swap_hook_watch.stasis");
+
+        var initialSource = """
+            struct GameState {
+                value: i32;
+                swaps: i32;
+            }
+
+            global state: GameState;
+
+            function main(): i32 {
+                state.value = 1;
+                state.swaps = 0;
+                return 0;
+            }
+
+            function on_code_swap(): i32 {
+                state.swaps = state.swaps + 1;
+                print_string("SWAP_HOOK_OK\n");
+                return 0;
+            }
+
+            function tick(): i32 {
+                return 0;
+            }
+            """;
+
+        var layoutChangedSource = """
+            struct GameState {
+                value: i32;
+                swaps: i32;
+                extra: i32;
+            }
+
+            global state: GameState;
+
+            function main(): i32 {
+                state.value = 1;
+                state.swaps = 0;
+                state.extra = 0;
+                return 0;
+            }
+
+            function on_code_swap(): i32 {
+                state.swaps = state.swaps + 1;
+                print_string("SWAP_HOOK_OK\n");
+                return 0;
+            }
+
+            function tick(): i32 {
+                return 0;
+            }
+            """;
+
+        File.WriteAllText(stasisPath, initialSource, System.Text.Encoding.ASCII);
+
+        var moduleName = "hook";
+        var swapDir = Path.Combine(repoRoot, "build", "hotstate");
+        Directory.CreateDirectory(swapDir);
+        var baseName = Path.GetFileNameWithoutExtension(stasisPath);
+        var runnerOutLog = Path.Combine(swapDir, $"{baseName}.{moduleName}.runner.out.log");
+        var runnerErrLog = Path.Combine(swapDir, $"{baseName}.{moduleName}.runner.err.log");
+        var startTime = DateTime.UtcNow;
+
+        Process? proc = null;
+        try
+        {
+            TryDelete(runnerOutLog);
+            TryDelete(runnerErrLog);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = QuoteArgs(cliDll!, "run", stasisPath, "--watch", "--backend", "cranelift", "--module", moduleName, "--fps", "60"),
+                UseShellExecute = false,
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            psi.EnvironmentVariables["STASIS_ASSET_ROOT"] = repoRoot;
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER"] = "1";
+            psi.EnvironmentVariables["STASIS_CRANELIFT_JIT_RUNNER_EXE"] = jitRunnerExe!;
+
+            proc = Process.Start(psi);
+            Assert.NotNull(proc);
+
+            using var outLines = new AsyncLineCollector(proc!.StandardOutput);
+            using var errLines = new AsyncLineCollector(proc.StandardError);
+
+            await WaitForAnyLineAsync(
+                proc,
+                () => outLines.AnyContains("HOTSWAP(ms):") || errLines.AnyContains("error:"),
+                timeout: TimeSpan.FromMinutes(5));
+
+            var initialSwapCount = outLines.CountContains("HOTSWAP(ms):");
+            Assert.True(initialSwapCount > 0, "watch did not report initial HOTSWAP(ms).");
+
+            var semanticEdit = ApplyTickSemanticEdit(initialSource, 19);
+            await File.WriteAllTextAsync(stasisPath, semanticEdit, System.Text.Encoding.ASCII);
+
+            await WaitForAnyLineAsync(
+                proc,
+                () => outLines.CountContains("HOTSWAP(ms):") > initialSwapCount,
+                timeout: TimeSpan.FromMinutes(5));
+
+            await WaitForAnyLineAsync(
+                proc,
+                () =>
+                {
+                    if (!File.Exists(runnerErrLog))
+                    {
+                        return false;
+                    }
+
+                    return TryReadTextShared(runnerErrLog, out var errLog) &&
+                        errLog.Contains("HOTSWAP hook: on_code_swap rc=0", StringComparison.Ordinal);
+                },
+                timeout: TimeSpan.FromSeconds(60));
+
+            var swapCountAfterHook = outLines.CountContains("HOTSWAP(ms):");
+
+            await File.WriteAllTextAsync(stasisPath, layoutChangedSource, System.Text.Encoding.ASCII);
+
+            await WaitForAnyLineAsync(
+                proc,
+                () =>
+                {
+                    if (!File.Exists(runnerOutLog))
+                    {
+                        return false;
+                    }
+
+                    return TryReadTextShared(runnerOutLog, out var outLog) &&
+                        outLog.Contains("swap layout changed", StringComparison.OrdinalIgnoreCase);
+                },
+                timeout: TimeSpan.FromMinutes(2));
+
+            await Task.Delay(500);
+
+            Assert.Equal(swapCountAfterHook, outLines.CountContains("HOTSWAP(ms):"));
+            Assert.False(proc.HasExited, "watch process exited after layout rejection.");
+        }
+        finally
+        {
+            try
+            {
+                if (proc is not null && !proc.HasExited)
+                {
+                    proc.Kill(entireProcessTree: true);
+                    proc.WaitForExit(10_000);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+
+            try
+            {
+                tempDir.Delete(true);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            try
+            {
+                foreach (var p in Process.GetProcessesByName("stasis-cranelift-jit-runner"))
+                {
+                    try
+                    {
+                        if (p.StartTime.ToUniversalTime() >= startTime.AddSeconds(-5))
+                        {
+                            p.Kill(entireProcessTree: true);
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    [HotSwapFact]
     public async Task WatchTickHotSwap_ReportsSemanticErrors_AndKeepsRunning()
     {
         var repoRoot = FindRepoRoot();
@@ -782,8 +987,9 @@ public sealed class HotSwapIntegrationTests
                 throw new XunitException($"watch process exited unexpectedly after semantic error (code={proc.ExitCode}).");
             }
 
-            // Fix the file; watch should recover on the next build.
-            await File.WriteAllTextAsync(samplePath, original, System.Text.Encoding.ASCII);
+            // Fix the file with a semantic edit; watch should recover on the next build.
+            var semanticRecovery = ApplyTickSemanticEdit(original, 17);
+            await File.WriteAllTextAsync(samplePath, semanticRecovery, System.Text.Encoding.ASCII);
             await WaitForAnyLineAsync(
                 proc,
                 () => outLines.CountContains("HOTSWAP(ms):") > initialSwapCount,
@@ -1088,6 +1294,20 @@ public sealed class HotSwapIntegrationTests
 
     private static string QuoteArgs(params string[] args) =>
         string.Join(" ", args.Select(QuoteArg));
+
+    private static string AppendSemanticEditFunction(string source, string functionName)
+    {
+        var nl = source.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        return source + nl + $"function {functionName}(): i32 {{ return 0; }}" + nl;
+    }
+
+    private static string ApplyTickSemanticEdit(string source, int seed)
+    {
+        var nl = source.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+        var tick = "function tick(): i32 {" + nl + "    return 0;" + nl + "}";
+        var replacement = "function tick(): i32 {" + nl + $"    return {seed} - {seed};" + nl + "}";
+        return source.Replace(tick, replacement, StringComparison.Ordinal);
+    }
 
     private static string QuoteArg(string arg)
     {

--- a/Stasis.Compiler.Tests/SemanticFingerprintTests.cs
+++ b/Stasis.Compiler.Tests/SemanticFingerprintTests.cs
@@ -1,0 +1,114 @@
+using Stasis.Compiler.Layout;
+
+namespace Stasis.Compiler.Tests;
+
+public class SemanticFingerprintTests
+{
+    [Fact]
+    public void Ignores_whitespace_and_comments()
+    {
+        var sourceA = """
+            global counter: i32;
+
+            function main(): i32 {
+                return 0;
+            }
+
+            function tick(): i32 {
+                counter = counter + 1;
+                return counter;
+            }
+            """;
+
+        var sourceB = """
+            // formatting-only edit
+            global counter:i32; /* inline comment */
+
+            function main(): i32 { return 0; }
+
+            function tick(): i32 {
+                counter=counter+1; // same semantics
+                return counter;
+            }
+            """;
+
+        var hashA = Compute(sourceA);
+        var hashB = Compute(sourceB);
+
+        Assert.Equal(hashA, hashB);
+    }
+
+    [Fact]
+    public void Changes_when_behavior_changes()
+    {
+        var sourceA = """
+            function main(): i32 {
+                return 0;
+            }
+
+            function tick(): i32 {
+                return 1;
+            }
+            """;
+
+        var sourceB = """
+            function main(): i32 {
+                return 0;
+            }
+
+            function tick(): i32 {
+                return 2;
+            }
+            """;
+
+        var hashA = Compute(sourceA);
+        var hashB = Compute(sourceB);
+
+        Assert.NotEqual(hashA, hashB);
+    }
+
+    [Fact]
+    public void Changes_when_layout_changes()
+    {
+        var sourceA = """
+            global values: i32[2];
+
+            function main(): i32 {
+                return 0;
+            }
+
+            function tick(): i32 {
+                return values[0];
+            }
+            """;
+
+        var sourceB = """
+            global values: i32[3];
+
+            function main(): i32 {
+                return 0;
+            }
+
+            function tick(): i32 {
+                return values[0];
+            }
+            """;
+
+        var hashA = Compute(sourceA);
+        var hashB = Compute(sourceB);
+
+        Assert.NotEqual(hashA, hashB);
+    }
+
+    private static string Compute(string source)
+    {
+        var parse = Parser.Parse(source);
+        Assert.Empty(parse.Diagnostics);
+
+        var sema = new SemanticAnalyzer().Analyze(parse.CompilationUnit);
+        DiagnosticAsserts.AssertNoErrors(sema.Diagnostics);
+
+        var layout = new LayoutPlanner(parse.CompilationUnit, sema.Symbols).Plan();
+        return SemanticFingerprint.ComputeFileFingerprint(source, layout);
+    }
+}

--- a/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
+++ b/Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs
@@ -934,8 +934,11 @@ public sealed class CraneliftCodeGenerator : ICodeGenerator
             {
                 continue;
             }
-            if (!symbols.TryGetValue(func.Name.Text, out var symbol))
+            if (!symbols.TryGetValue(func.Name.Text, out var symbol) &&
+                !symbols.TryGetValue(CallableIdentity.GetCallableKey(func), out symbol))
+            {
                 continue;
+            }
 
             var returnTypeSymbol = func.ReturnType is null
                 ? new VoidTypeSymbol()

--- a/Stasis.Compiler/IR/Reachability.cs
+++ b/Stasis.Compiler/IR/Reachability.cs
@@ -57,6 +57,12 @@ public static class Reachability
                 queue.Enqueue(tickKey);
             }
 
+            // Hot-swap hook: keep optional on_code_swap reachable so JIT watch can invoke it.
+            if (TryGetReceiverlessCallable(functionsByName, "on_code_swap", out var swapHookKey))
+            {
+                queue.Enqueue(swapHookKey);
+            }
+
             foreach (var export in functionList.Where(fn => fn.IsExported))
             {
                 queue.Enqueue(CallableIdentity.GetCallableKey(export));

--- a/Stasis.Compiler/SemanticFingerprint.cs
+++ b/Stasis.Compiler/SemanticFingerprint.cs
@@ -1,0 +1,94 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Stasis.Compiler.Layout;
+
+namespace Stasis.Compiler;
+
+public static class SemanticFingerprint
+{
+    public static string ComputeFileFingerprint(string source, LayoutPlan layout)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(layout);
+
+        var lexerResult = Lexer.Lex(source);
+        var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        Span<byte> u64 = stackalloc byte[8];
+        Span<byte> u32 = stackalloc byte[4];
+
+        BinaryPrimitives.WriteUInt64LittleEndian(u64, ComputeLayoutHash(layout));
+        hasher.AppendData(u64);
+
+        foreach (var token in lexerResult.Tokens)
+        {
+            if (token.Kind == TokenKind.EndOfFile)
+            {
+                continue;
+            }
+
+            BinaryPrimitives.WriteInt32LittleEndian(u32, (int)token.Kind);
+            hasher.AppendData(u32);
+
+            if (token.Text.Length > 0)
+            {
+                hasher.AppendData(Encoding.UTF8.GetBytes(token.Text));
+            }
+
+            hasher.AppendData([0]);
+        }
+
+        var digest = hasher.GetHashAndReset();
+        return Convert.ToHexString(digest).ToLowerInvariant();
+    }
+
+    private static ulong ComputeLayoutHash(LayoutPlan layout)
+    {
+        // FNV-1a 64
+        ulong hash = 14695981039346656037UL;
+
+        static void AddBytes(ref ulong h, ReadOnlySpan<byte> bytes)
+        {
+            foreach (var b in bytes)
+            {
+                h ^= b;
+                h *= 1099511628211UL;
+            }
+        }
+
+        static void AddInt(ref ulong h, int value)
+        {
+            unchecked
+            {
+                var u = (uint)value;
+                for (var i = 0; i < 4; i++)
+                {
+                    h ^= (byte)(u & 0xFF);
+                    h *= 1099511628211UL;
+                    u >>= 8;
+                }
+            }
+        }
+
+        foreach (var global in layout.Globals)
+        {
+            AddBytes(ref hash, Encoding.UTF8.GetBytes(global.Name));
+            AddInt(ref hash, global.Offset);
+            AddInt(ref hash, global.Size);
+            AddInt(ref hash, global.Fields.Count);
+
+            foreach (var field in global.Fields)
+            {
+                AddBytes(ref hash, Encoding.UTF8.GetBytes(field.Name));
+                AddInt(ref hash, field.Offset);
+                AddInt(ref hash, field.Size);
+                AddInt(ref hash, (int)field.Type);
+                AddInt(ref hash, field.ArrayCount);
+            }
+        }
+
+        AddInt(ref hash, layout.TotalSize);
+        return hash;
+    }
+}

--- a/docs/live-compilation-status.md
+++ b/docs/live-compilation-status.md
@@ -1,0 +1,64 @@
+# Live Compilation Status (PRD Alignment)
+
+This document tracks implementation progress for the in-process live compilation/hot-swap PRD.
+
+## Implemented in this branch
+
+### File-level semantic fingerprint gate (JIT watch path)
+
+- Added `SemanticFingerprint.ComputeFileFingerprint(...)` in `Stasis.Compiler`.
+- Fingerprint combines:
+  - deterministic global layout hash
+  - normalized token stream hash (whitespace/comments ignored by lexer)
+- Integrated into `WatchCraneliftTickJitSwap` (`Stasis.Cli/Program.cs`):
+  - full parse + semantic + layout still run per edit
+  - if fingerprint is unchanged, no swap is queued (`HOTSWAP(skip)`)
+  - existing code remains active; no partial state change
+
+This is an incremental step toward PRD sections:
+- file-level correctness/invalidation
+- semantic hash gating
+- failure-safe swap behavior
+
+### Layout-safe swap rejection (JIT runner)
+
+- Added strict state-layout compatibility check before applying a compiled swap.
+- If persisted `state__*` globals differ by name or size, swap is rejected.
+- Rejected swaps keep old code and data active and emit an explicit `ERR id=... swap layout changed...`.
+
+This aligns with PRD layout stability and "abort cleanly, never partial" goals.
+
+### Optional `on_code_swap` hook (JIT runner)
+
+- Added optional hook discovery for `{module}__on_code_swap`.
+- Supported signatures:
+  - `function on_code_swap(): i32`
+  - `function on_code_swap()`
+- Hook runs on the currently active (old) code before state handoff to new code.
+- Non-zero return aborts swap; runner restores pre-hook state snapshot and keeps old code active.
+
+This provides explicit developer-controlled state adjustment while preserving safe failure semantics.
+
+## Already present before this branch
+
+- File watch + debounce + rebuild loop.
+- Tick-time swap workflow for Cranelift (runner protocol with `INIT` / `SWAP`).
+- Safe-point style behavior (swap between ticks in runner flow).
+- State-map and data-binding metadata emission.
+- Recovery behavior for failed builds and runner restarts.
+
+## Not implemented yet (planned)
+
+- Per-function semantic hashes (`fnSigHash` / `fnBodyHash`) and function-level codegen gating.
+- In-process JIT service replacing external runner process.
+- Explicit two-phase commit object model (`pending patch` + atomic commit step).
+- Generation-based code memory retirement inside host process.
+- VS Code buffer-native compilation input path (LSP push, no disk dependency).
+
+## Next concrete step
+
+Implement a `PendingSwapPlan` model in CLI/runtime boundary:
+- build patch in background
+- validate layout/signature compatibility
+- commit only at safe point
+- emit explicit commit telemetry (`compiled`, `queued`, `applied`, `rejected`).

--- a/tools/cranelift-jit-runner/src/main.rs
+++ b/tools/cranelift-jit-runner/src/main.rs
@@ -45,6 +45,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
+use cranelift_codegen::ir::types;
 use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
 use cranelift_module::{default_libcall_names, DataDescription, Linkage, Module};
@@ -664,6 +665,29 @@ struct SwapResult
     outcome: SwapOutcome,
 }
 
+#[derive(Clone, Copy)]
+enum SwapHookFn
+{
+    Void(extern "C" fn()),
+    I32(extern "C" fn() -> i32),
+}
+
+impl SwapHookFn
+{
+    fn call(self) -> i32
+    {
+        match self
+        {
+            SwapHookFn::Void(f) =>
+            {
+                f();
+                0
+            }
+            SwapHookFn::I32(f) => f(),
+        }
+    }
+}
+
 fn run_server(fps: u32) -> Result<()>
 {
     let mut stdout = io::stdout();
@@ -914,6 +938,47 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
             {
                 SwapOutcome::Ok { instance: mut new_instance, compile_us } =>
                 {
+                    let (layout_missing_save, layout_missing_restore) = state_layout_diff(instance, &new_instance);
+                    if layout_missing_save > 0 || layout_missing_restore > 0
+                    {
+                        eprintln!(
+                            "HOTSWAP reject: state layout changed (missing save={} restore={}); keeping old code.",
+                            layout_missing_save, layout_missing_restore
+                        );
+                        let _ = drop_tx.send(new_instance);
+                        writeln!(
+                            stdout,
+                            "ERR id={} swap layout changed: missing_save={} missing_restore={}",
+                            result.id, layout_missing_save, layout_missing_restore
+                        )?;
+                        stdout.flush()?;
+                        pending_swap_id = None;
+                        last_progress_ms.store(now_ms(), Ordering::Relaxed);
+                        continue;
+                    }
+
+                    if let Some(hook) = instance.on_code_swap_fn
+                    {
+                        let (rollback_missing_save, rollback_snapshot) = instance.save_state();
+                        let hook_rc = hook.call();
+                        if hook_rc != 0
+                        {
+                            let rollback_missing_restore = instance.restore_state(rollback_snapshot);
+                            eprintln!(
+                                "HOTSWAP reject: on_code_swap returned {}; swap aborted (rollback save-missing={} restore-missing={}).",
+                                hook_rc, rollback_missing_save, rollback_missing_restore
+                            );
+                            let _ = drop_tx.send(new_instance);
+                            writeln!(stdout, "ERR id={} swap hook failed: rc={}", result.id, hook_rc)?;
+                            stdout.flush()?;
+                            pending_swap_id = None;
+                            last_progress_ms.store(now_ms(), Ordering::Relaxed);
+                            continue;
+                        }
+
+                        eprintln!("HOTSWAP hook: on_code_swap rc=0");
+                    }
+
                     let t0 = Instant::now();
                     let (missing_save, save_bytes) = instance.save_state();
                     let save_us = t0.elapsed().as_micros() as u64;
@@ -921,6 +986,24 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                     let t2 = Instant::now();
                     let missing_restore = new_instance.restore_state(save_bytes);
                     let restore_us = t2.elapsed().as_micros() as u64;
+
+                    if missing_save > 0 || missing_restore > 0
+                    {
+                        eprintln!(
+                            "HOTSWAP reject: state transfer failed (missing save={} restore={}); keeping old code.",
+                            missing_save, missing_restore
+                        );
+                        let _ = drop_tx.send(new_instance);
+                        writeln!(
+                            stdout,
+                            "ERR id={} swap state transfer failed: missing_save={} missing_restore={}",
+                            result.id, missing_save, missing_restore
+                        )?;
+                        stdout.flush()?;
+                        pending_swap_id = None;
+                        last_progress_ms.store(now_ms(), Ordering::Relaxed);
+                        continue;
+                    }
 
                     if let Some(b) = data_binding.as_ref()
                     {
@@ -936,13 +1019,6 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                         "HOTSWAP ok: save={}us load={}us tick=0us restore={}us bytes={} symbols={}",
                         save_us, compile_us, restore_us, bytes, symbols
                     );
-                    if missing_save > 0 || missing_restore > 0
-                    {
-                        eprintln!(
-                            "HOTSWAP warning: state layout changed (missing save={} restore={}); consider restarting to resync state.",
-                            missing_save, missing_restore
-                        );
-                    }
 
                     let old = std::mem::replace(instance, new_instance);
                     let _ = drop_tx.send(old);
@@ -958,7 +1034,7 @@ fn run_tick_loop(fps: u32, instance: &mut JitInstance, rx: &mpsc::Receiver<Reque
                 SwapOutcome::Err { message } =>
                 {
                     eprintln!("HOTSWAP error: {}", message);
-                    writeln!(stdout, "ERR swap compile failed: {}", message.replace('\n', " "))?;
+                    writeln!(stdout, "ERR id={} swap compile failed: {}", result.id, message.replace('\n', " "))?;
                     stdout.flush()?;
                 }
             }
@@ -1338,6 +1414,7 @@ struct JitInstance
     _module: JITModule,
     entry_fn: extern "C" fn() -> i32,
     tick_fn: extern "C" fn() -> i32,
+    on_code_swap_fn: Option<SwapHookFn>,
     state_globals: Vec<(String, usize)>,
     data_ptrs: HashMap<String, *mut u8>,
 
@@ -1419,12 +1496,33 @@ impl JitInstance
             function_ids.insert(ext.name.clone(), id);
         }
 
+        let on_code_swap_name = format!("{module_name}__on_code_swap");
+        let mut on_code_swap_kind: Option<SwapHookFnKind> = None;
         for f in &parsed.functions
         {
             let id = module
                 .declare_function(&f.name, Linkage::Export, &f.signature)
                 .with_context(|| format!("declare_function failed for {}", f.name))?;
             function_ids.insert(f.name.clone(), id);
+
+            if f.name == on_code_swap_name
+            {
+                let kind = if f.signature.params.is_empty() && f.signature.returns.is_empty()
+                {
+                    SwapHookFnKind::Void
+                }
+                else if f.signature.params.is_empty()
+                    && f.signature.returns.len() == 1
+                    && f.signature.returns[0].value_type == types::I32
+                {
+                    SwapHookFnKind::I32
+                }
+                else
+                {
+                    bail!("on_code_swap must have signature `function on_code_swap(): i32` or `function on_code_swap()`");
+                };
+                on_code_swap_kind = Some(kind);
+            }
         }
 
         for f in parsed.functions
@@ -1473,6 +1571,22 @@ impl JitInstance
 
         let entry_ptr = module.get_finalized_function(entry_id);
         let tick_ptr = module.get_finalized_function(tick_id);
+        let on_code_swap_fn = if let Some(kind) = on_code_swap_kind
+        {
+            let hook_id = *function_ids
+                .get(&on_code_swap_name)
+                .with_context(|| format!("missing on_code_swap function {on_code_swap_name}"))?;
+            let hook_ptr = module.get_finalized_function(hook_id);
+            Some(match kind
+            {
+                SwapHookFnKind::Void => unsafe { SwapHookFn::Void(std::mem::transmute(hook_ptr)) },
+                SwapHookFnKind::I32 => unsafe { SwapHookFn::I32(std::mem::transmute(hook_ptr)) },
+            })
+        }
+        else
+        {
+            None
+        };
 
         Ok(JitInstance {
             module_name: module_name.to_string(),
@@ -1482,6 +1596,7 @@ impl JitInstance
             _module: module,
             entry_fn: unsafe { std::mem::transmute(entry_ptr) },
             tick_fn: unsafe { std::mem::transmute(tick_ptr) },
+            on_code_swap_fn,
             state_globals,
             data_ptrs,
             bulk_active,
@@ -1539,6 +1654,50 @@ impl JitInstance
         }
         missing
     }
+}
+
+#[derive(Clone, Copy)]
+enum SwapHookFnKind
+{
+    Void,
+    I32,
+}
+
+fn state_layout_diff(current: &JitInstance, next: &JitInstance) -> (u32, u32)
+{
+    let mut next_layout = HashMap::with_capacity(next.state_globals.len());
+    for (name, size) in &next.state_globals
+    {
+        next_layout.insert(name.as_str(), *size);
+    }
+
+    let mut current_layout = HashMap::with_capacity(current.state_globals.len());
+    for (name, size) in &current.state_globals
+    {
+        current_layout.insert(name.as_str(), *size);
+    }
+
+    let mut missing_save = 0u32;
+    for (name, size) in &current.state_globals
+    {
+        match next_layout.get(name.as_str())
+        {
+            Some(next_size) if *next_size == *size => {}
+            _ => missing_save = missing_save.saturating_add(1),
+        }
+    }
+
+    let mut missing_restore = 0u32;
+    for (name, size) in &next.state_globals
+    {
+        match current_layout.get(name.as_str())
+        {
+            Some(current_size) if *current_size == *size => {}
+            _ => missing_restore = missing_restore.saturating_add(1),
+        }
+    }
+
+    (missing_save, missing_restore)
 }
 
 fn build_flags(opt_level: &str, target: &Triple) -> Result<settings::Flags>


### PR DESCRIPTION
## Summary
This PR implements a focused foundation slice of the Live Compilation & Hot Swap PRD:

- file-level semantic fingerprinting to skip no-op swaps
- stricter swap safety in the JIT runner (layout mismatch rejection)
- optional `on_code_swap` hook executed on old code before state handoff
- test and doc updates for the new behavior

## Changes
- Added `SemanticFingerprint` in compiler core:
  - `Stasis.Compiler/SemanticFingerprint.cs`
- Integrated semantic fingerprint gating into watch/JIT swap path:
  - `Stasis.Cli/Program.cs`
  - emits `HOTSWAP(skip)` when semantic fingerprint is unchanged
- Added/updated tests:
  - `Stasis.Compiler.Tests/SemanticFingerprintTests.cs`
  - `Stasis.Compiler.Tests/HotSwapIntegrationTests.cs`
- Ensured optional hot-swap hook is reachable and emitted:
  - `Stasis.Compiler/IR/Reachability.cs`
  - `Stasis.Compiler/IR/Cranelift/CraneliftCodeGenerator.cs`
- Added safe JIT runner swap behavior:
  - `tools/cranelift-jit-runner/src/main.rs`
  - reject layout changes before applying
  - support `on_code_swap(): i32` and `on_code_swap()`
  - abort swap on hook failure and keep old code/data active

## Validation
- `dotnet build Stasis.sln`
- `cargo build --manifest-path tools/cranelift-jit-runner/Cargo.toml --release`
- `dotnet test Stasis.Compiler.Tests/Stasis.Compiler.Tests.csproj --no-build --filter "FullyQualifiedName~SemanticFingerprintTests|FullyQualifiedName~WatchTickHotSwap_SurvivesBadSwap_AndRecoversOnNextBuild|FullyQualifiedName~WatchTickJitSwap_SwapsOnEdit|FullyQualifiedName~WatchTickJitSwap_SurvivesBuildError_AndSwapsAfterFix|FullyQualifiedName~WatchTickHotSwap_ReportsSemanticErrors_AndKeepsRunning|FullyQualifiedName~WatchTickJitSwap_UsesSwapHook_AndRejectsLayoutChanges" --verbosity minimal`

## Notes
- This is an incremental PRD slice, not the full end-state architecture.
- Tracking doc added: `docs/live-compilation-status.md`.
