### PR TITLE
cli: integrate core commands with slim default help

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ Use `.\stasis.bat` (Windows) / `./stasis.sh` (Unix) from the repo root.
 
 Common commands:
 
+- `.\stasis.bat run .\samples\basic.stasis` (default dev watch loop)
+- `.\stasis.bat run .\samples\basic.stasis --no-watch` (single run)
+- `.\stasis.bat build .\samples\basic.stasis --out .\artifacts\basic.exe` (optimized by default)
 - `.\stasis.bat run .\samples\asteroids.stasis --backend llvm --graphics`
 - `.\stasis.bat test --all --backend cranelift`
 - `.\stasis.bat run .\samples\basic.stasis --emit-ir > out.ll`
-- `.\stasis.bat run .\samples\basic.stasis --watch` (opt-in dev loop)
 - Capture screenshots of windowed demos (writes to `artifacts/screenshots/` and opens the folder): `powershell -ExecutionPolicy Bypass -File .\scripts\capture_sample_screenshots.ps1`
 
 Backends:

--- a/Stasis.Cli.Tests/CliSnapshotTests.cs
+++ b/Stasis.Cli.Tests/CliSnapshotTests.cs
@@ -290,6 +290,29 @@ public class CliSnapshotTests
     }
 
     [Fact]
+    public void Help_Basic_HidesAdvancedOptions()
+    {
+        var (exitCode, stdout, stderr) = RunCli("--help");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("stasisc run [<file>] [--watch|--no-watch]", stdout, StringComparison.Ordinal);
+        Assert.Contains("Use --help-advanced", stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("Advanced options:", stdout, StringComparison.Ordinal);
+        Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
+    }
+
+    [Fact]
+    public void Help_Advanced_ShowsAdvancedOptions()
+    {
+        var (exitCode, stdout, stderr) = RunCli("--help-advanced");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Advanced options:", stdout, StringComparison.Ordinal);
+        Assert.Contains("--backend <llvm|cranelift>", stdout, StringComparison.Ordinal);
+        Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
+    }
+
+    [Fact]
     public Task CraneliftRunner_UsesGraphicsImportLib()
     {
         if (!OperatingSystem.IsWindows())

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -34,6 +34,7 @@ var emitIrOnly = false;
 string? outputPath = null;
 var runAllInDirectory = false;
 var watch = false;
+var watchConfiguredByUser = false;
 string? optLevel = null;
 var enableLto = false;
 var enableGraphics = false;
@@ -62,9 +63,14 @@ while (cliArgs.Count > 0)
         case "dev":
             // Back-compat alias for the run dev workflow.
             mode = "run";
+            watch = true;
+            watchConfiguredByUser = true;
             break;
         case "build":
             mode = arg;
+            // Go-like default: build emits optimized artifacts.
+            optLevel ??= "3";
+            enableLto = true;
             break;
         case "release":
             mode = arg;
@@ -96,6 +102,11 @@ while (cliArgs.Count > 0)
             break;
         case "--watch":
             watch = true;
+            watchConfiguredByUser = true;
+            break;
+        case "--no-watch":
+            watch = false;
+            watchConfiguredByUser = true;
             break;
         case "--opt-level" when cliArgs.Count > 0:
             optLevel = cliArgs.Dequeue();
@@ -182,7 +193,12 @@ if (path is null)
         if (pickedWatch.HasValue)
         {
             watch = pickedWatch.Value;
+            watchConfiguredByUser = true;
         }
+    }
+    else if (mode == "format")
+    {
+        path = Directory.GetCurrentDirectory();
     }
     else
     {
@@ -195,6 +211,11 @@ if (optLevel is not null && !IsValidOptLevel(optLevel))
 {
     Console.Error.WriteLine($"error: invalid --opt-level '{optLevel}'. Use 0,1,2,3,s,z.");
     Environment.Exit(1);
+}
+
+if (mode == "run" && !watchConfiguredByUser)
+{
+    watch = true;
 }
 
 devMode = mode == "run";
@@ -305,11 +326,44 @@ static void AddHostAbiDataExports(LayoutPlan layout, List<string> exports)
 
 if (mode == "format")
 {
-    var input = File.ReadAllText(path);
-    var formatted = Stasis.Cli.StasisFormatter.Format(input);
-    if (!string.Equals(input, formatted, StringComparison.Ordinal))
+    if (Directory.Exists(path))
     {
-        File.WriteAllText(path, formatted);
+        var files = Directory.GetFiles(path, "*.stasis", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+        if (files.Length == 0)
+        {
+            Console.Error.WriteLine($"error: no .stasis files found under {path}");
+            Environment.Exit(1);
+        }
+
+        var changed = 0;
+        foreach (var file in files)
+        {
+            var input = File.ReadAllText(file);
+            var formatted = Stasis.Cli.StasisFormatter.Format(input);
+            if (!string.Equals(input, formatted, StringComparison.Ordinal))
+            {
+                File.WriteAllText(file, formatted);
+                changed++;
+            }
+        }
+
+        Console.WriteLine($"formatted {files.Length} file(s), changed {changed}.");
+    }
+    else
+    {
+        var input = File.ReadAllText(path);
+        var formatted = Stasis.Cli.StasisFormatter.Format(input);
+        if (!string.Equals(input, formatted, StringComparison.Ordinal))
+        {
+            File.WriteAllText(path, formatted);
+            Console.WriteLine($"formatted {path}.");
+        }
+        else
+        {
+            Console.WriteLine($"already formatted: {path}.");
+        }
     }
 
     return;
@@ -5688,15 +5742,19 @@ static void WriteIrOutput(string ir, string? outputPath)
 static void PrintUsage()
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  stasisc run [<file>] [--fps <1..240>] [--module <name>] [--emit-ir] [--out <path>]");
-    Console.WriteLine("  stasisc release <file> [--out <path>] [--module <name>]");
+    Console.WriteLine("  stasisc run [<file>] [--watch|--no-watch]");
+    Console.WriteLine("  stasisc build <file> [--out <path>]");
+    Console.WriteLine("  stasisc test [<file>|--all]");
+    Console.WriteLine("  stasisc format [<file-or-dir>]");
     Console.WriteLine();
-    Console.WriteLine("Other commands:");
-    Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift>]");
-    Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
-    Console.WriteLine("  stasisc format <file>");
+    Console.WriteLine("Integrated defaults:");
+    Console.WriteLine("  run   => dev watch loop by default (use --no-watch to run once)");
+    Console.WriteLine("  build => optimized output by default (-O3 + LTO)");
+    Console.WriteLine("  test  => with no path (or --all), run all tests under working dir");
+    Console.WriteLine("  format=> with no path, format all .stasis files under working dir");
     Console.WriteLine();
-    Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
+    Console.WriteLine("Compatibility: 'stasisc release <file>' remains available as a build alias.");
+    Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). Build/release require clang in PATH.");
     Console.WriteLine("Run: omit <file> to pick interactively (breadth-first listing) and optionally enable --watch.");
     Console.WriteLine("Run: use --watch for a dev loop (auto-rebuild + tick hot-swap + phase timings) with state preserved between swaps and no re-running main().");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
@@ -5708,6 +5766,129 @@ static void PrintUsage()
     Console.WriteLine("Cache: set STASIS_DISABLE_ARTIFACT_CACHE=1 to disable binary caching for Cranelift run/test.");
 }
 
+static int RunBridgeMode(Queue<string> args)
+{
+    var moduleName = "module";
+    string? optLevel = null;
+    var tickHostFps = 60;
+    while (args.Count > 0)
+    {
+        var arg = args.Dequeue();
+        switch (arg)
+        {
+            case "--module" when args.Count > 0:
+                moduleName = args.Dequeue();
+                break;
+            case "--opt-level" when args.Count > 0:
+                optLevel = args.Dequeue();
+                break;
+            case "--fps" when args.Count > 0:
+                if (!int.TryParse(args.Dequeue(), out tickHostFps) || tickHostFps < 1 || tickHostFps > 240)
+                {
+                    Console.Error.WriteLine("error: --fps expects an integer between 1 and 240.");
+                    return 1;
+                }
+                break;
+            default:
+                Console.Error.WriteLine($"error: unknown bridge argument '{arg}'");
+                return 1;
+        }
+    }
+
+    // Keep bridge protocol output in one stream.
+    Console.SetError(Console.Out);
+    Console.WriteLine("BRIDGE_READY 1");
+
+    for (;;)
+    {
+        var line = Console.ReadLine();
+        if (line == null)
+        {
+            return 0;
+        }
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            continue;
+        }
+
+        string op = string.Empty;
+        ulong requestId = 0;
+        string? requestPath = null;
+        try
+        {
+            using var json = JsonDocument.Parse(line);
+            var root = json.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                Console.WriteLine("BRIDGE_PROTOCOL_ERROR command_not_object");
+                continue;
+            }
+            if (root.TryGetProperty("op", out var opElement) && opElement.ValueKind == JsonValueKind.String)
+            {
+                op = opElement.GetString() ?? string.Empty;
+            }
+            if (root.TryGetProperty("request_id", out var requestIdElement))
+            {
+                if (requestIdElement.ValueKind == JsonValueKind.Number && requestIdElement.TryGetUInt64(out var parsedRequestId))
+                {
+                    requestId = parsedRequestId;
+                }
+                else
+                {
+                    Console.WriteLine("BRIDGE_PROTOCOL_ERROR invalid_request_id");
+                    continue;
+                }
+            }
+            if (root.TryGetProperty("path", out var pathElement) && pathElement.ValueKind == JsonValueKind.String)
+            {
+                requestPath = pathElement.GetString();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"BRIDGE_PROTOCOL_ERROR bad_json {ex.Message}");
+            continue;
+        }
+
+        if (string.Equals(op, "quit", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("BRIDGE_BYE");
+            return 0;
+        }
+
+        if (!string.Equals(op, "compile", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"BRIDGE_PROTOCOL_ERROR unknown_op {op}");
+            continue;
+        }
+
+        if (string.IsNullOrWhiteSpace(requestPath))
+        {
+            Console.WriteLine($"BRIDGE_PROTOCOL_ERROR missing_path {requestId}");
+            continue;
+        }
+
+        Console.WriteLine($"BRIDGE_BEGIN {requestId}");
+        var exit = ProcessFile(
+            requestPath,
+            mode: "run",
+            includeTests: false,
+            moduleName,
+            emitIrOnly: false,
+            outputPath: null,
+            optLevel,
+            enableLto: false,
+            enableGraphics: false,
+            graphicsLibPath: null,
+            backend: BackendType.Cranelift,
+            tickHostFps,
+            llvmTargetTriple: null,
+            useLowerLock: true,
+            useCraneliftRunner: true,
+            enableHotState: false);
+        Console.WriteLine($"BRIDGE_END {requestId} {exit}");
+    }
+}
 static bool TryPromptForRunPath(string root, out string? path, out bool? watch)
 {
     path = null;

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -19,9 +19,18 @@ using Stasis.Compiler.Syntax;
 using Stasis.Cli;
 
 var cliArgs = new Queue<string>(Environment.GetCommandLineArgs().Skip(1));
-if (cliArgs.Count == 0 || cliArgs.Contains("--help"))
+if (cliArgs.Count > 0 && string.Equals(cliArgs.Peek(), "bridge", StringComparison.OrdinalIgnoreCase))
 {
-    PrintUsage();
+    cliArgs.Dequeue();
+    var bridgeExit = RunBridgeMode(cliArgs);
+    Environment.Exit(bridgeExit);
+    return;
+}
+
+var showAdvancedHelp = cliArgs.Contains("--help-advanced");
+if (cliArgs.Count == 0 || cliArgs.Contains("--help") || showAdvancedHelp)
+{
+    PrintUsage(showAdvancedHelp);
     return;
 }
 
@@ -161,6 +170,9 @@ while (cliArgs.Count > 0)
             break;
         case "--help":
             PrintUsage();
+            return;
+        case "--help-advanced":
+            PrintUsage(advanced: true);
             return;
         default:
             if (path is null)
@@ -5739,7 +5751,7 @@ static void WriteIrOutput(string ir, string? outputPath)
     }
 }
 
-static void PrintUsage()
+static void PrintUsage(bool advanced = false)
 {
     Console.WriteLine("Usage:");
     Console.WriteLine("  stasisc run [<file>] [--watch|--no-watch]");
@@ -5754,16 +5766,23 @@ static void PrintUsage()
     Console.WriteLine("  format=> with no path, format all .stasis files under working dir");
     Console.WriteLine();
     Console.WriteLine("Compatibility: 'stasisc release <file>' remains available as a build alias.");
-    Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). Build/release require clang in PATH.");
-    Console.WriteLine("Run: omit <file> to pick interactively (breadth-first listing) and optionally enable --watch.");
-    Console.WriteLine("Run: use --watch for a dev loop (auto-rebuild + tick hot-swap + phase timings) with state preserved between swaps and no re-running main().");
-    Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
-    Console.WriteLine("Graphics: enabled automatically when graphics APIs are used; use --graphics to force it on. Use --graphics-lib to override library path.");
-    Console.WriteLine("Backend: use --backend to select code generation backend. Defaults to 'cranelift' for run/test/build (when available) and 'llvm' for release; Cranelift is experimental.");
-    Console.WriteLine("LLVM: pass --llvm-target <triple> to set the LLVM module target triple (useful for cross-compiling emitted IR).");
-    Console.WriteLine("Cranelift: run/test uses the native DLL runner when available (stasis_runner.exe). Set STASIS_CRANELIFT_RUNNER_EXE to override, or pass --no-cranelift-runner to force EXE mode.");
-    Console.WriteLine("Tick watch (experimental): set STASIS_CRANELIFT_INPROC_TICK=1 to run headless tick hot-swap in-process (no stasis-cranelift-jit-runner process).");
-    Console.WriteLine("Cache: set STASIS_DISABLE_ARTIFACT_CACHE=1 to disable binary caching for Cranelift run/test.");
+    Console.WriteLine("Defaults: execute via lli if available, else clang. Build/release require clang in PATH.");
+    Console.WriteLine("Use --help-advanced to see backend/graphics/target flags and experimental options.");
+    if (!advanced)
+    {
+        return;
+    }
+    Console.WriteLine();
+    Console.WriteLine("Advanced options:");
+    Console.WriteLine("  run/test/build: --backend <llvm|cranelift> --module <name> --emit-ir --out <path>");
+    Console.WriteLine("  run/test: --fps <1..240> --hot-state --cranelift-runner --no-cranelift-runner");
+    Console.WriteLine("  build/release: --opt-level <0|1|2|3|s|z> --lto|--no-lto");
+    Console.WriteLine("  graphics: --graphics --graphics-lib <path>");
+    Console.WriteLine("  llvm: --llvm-target <triple>");
+    Console.WriteLine("  test: --all --watch");
+    Console.WriteLine("Cranelift: run/test uses native runner when available; set STASIS_CRANELIFT_RUNNER_EXE to override.");
+    Console.WriteLine("Tick watch (experimental): STASIS_CRANELIFT_INPROC_TICK=1 for headless in-process tick hot-swap.");
+    Console.WriteLine("Cache: STASIS_DISABLE_ARTIFACT_CACHE=1 disables binary caching for Cranelift run/test.");
 }
 
 static int RunBridgeMode(Queue<string> args)

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -3111,7 +3111,7 @@ static int GetHotSwapDelayMs()
 
 static int GetTestExecutionTimeoutMs()
 {
-    const int defaultMs = 120000;
+    const int defaultMs = 30000;
     var env = Environment.GetEnvironmentVariable("STASIS_TEST_TIMEOUT_MS");
     if (string.IsNullOrWhiteSpace(env))
     {
@@ -5781,6 +5781,7 @@ static void PrintUsage(bool advanced = false)
     Console.WriteLine("  llvm: --llvm-target <triple>");
     Console.WriteLine("  test: --all --watch");
     Console.WriteLine("Cranelift: run/test uses native runner when available; set STASIS_CRANELIFT_RUNNER_EXE to override.");
+    Console.WriteLine("Tests: default execution timeout is 30000ms; set STASIS_TEST_TIMEOUT_MS to override.");
     Console.WriteLine("Tick watch (experimental): STASIS_CRANELIFT_INPROC_TICK=1 for headless in-process tick hot-swap.");
     Console.WriteLine("Cache: STASIS_DISABLE_ARTIFACT_CACHE=1 disables binary caching for Cranelift run/test.");
 }

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -5539,6 +5539,13 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     var childArgs = Environment.GetCommandLineArgs()
         .Skip(1)
         .Where(arg => !string.Equals(arg, "--watch", StringComparison.OrdinalIgnoreCase))
+        .ToList();
+    // Watch child must always execute a single run; otherwise default run behavior re-enters watch mode.
+    if (mode == "run" && !childArgs.Any(arg => string.Equals(arg, "--no-watch", StringComparison.OrdinalIgnoreCase)))
+    {
+        childArgs.Add("--no-watch");
+    }
+    var quotedChildArgs = childArgs
         .Select(QuoteArg)
         .ToArray();
 
@@ -5549,7 +5556,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
         return 1;
     }
     if (Path.GetFileNameWithoutExtension(exePath).Equals("dotnet", StringComparison.OrdinalIgnoreCase) &&
-        childArgs.Length > 0 && childArgs[0].Equals("run", StringComparison.OrdinalIgnoreCase))
+        childArgs.Count > 0 && childArgs[0].Equals("run", StringComparison.OrdinalIgnoreCase))
     {
         Console.Error.WriteLine("error: --watch requires running the built CLI (not `dotnet run`).");
         return 1;
@@ -5558,7 +5565,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     Process? child = null;
     if (mode == "run")
     {
-        child = StartWatchChild(exePath, childArgs);
+        child = StartWatchChild(exePath, quotedChildArgs);
     }
     else
     {
@@ -5617,7 +5624,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
                         child.Kill(entireProcessTree: true);
                         child.WaitForExit();
                     }
-                    child = StartWatchChild(exePath, childArgs);
+                    child = StartWatchChild(exePath, quotedChildArgs);
                 }
             }
             else
@@ -5628,7 +5635,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
 
         if (mode == "run" && enableHotState && pendingRestart && (child is null || child.HasExited))
         {
-            child = StartWatchChild(exePath, childArgs);
+            child = StartWatchChild(exePath, quotedChildArgs);
             pendingRestart = false;
             if (restartRequestedAt != DateTime.MinValue)
             {

--- a/run.bat
+++ b/run.bat
@@ -2,4 +2,4 @@
 setlocal
 
 set SCRIPT_DIR=%~dp0
-"%SCRIPT_DIR%stasis.bat" run --watch --backend cranelift --graphics %*
+"%SCRIPT_DIR%stasis.bat" run --backend cranelift --graphics %*

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"${SCRIPT_DIR}/stasis.sh" run --watch --backend cranelift --graphics "$@"
+"${SCRIPT_DIR}/stasis.sh" run --backend cranelift --graphics "$@"

--- a/stasis.bat
+++ b/stasis.bat
@@ -8,7 +8,7 @@ if "%DOTNET_GCHeapHardLimit%"=="" set "DOTNET_GCHeapHardLimit=2147483648"
 if "%1"=="test" (
     set "DOTNET_ARGS=--no-build --configuration %CONFIG%"
     if "%STASIS_WINDOW_START_MINIMIZED%"=="" set "STASIS_WINDOW_START_MINIMIZED=1"
-    if "%STASIS_TEST_TIMEOUT_MS%"=="" set "STASIS_TEST_TIMEOUT_MS=120000"
+    if "%STASIS_TEST_TIMEOUT_MS%"=="" set "STASIS_TEST_TIMEOUT_MS=30000"
 )
 dotnet run %DOTNET_ARGS% --project "%SCRIPT_DIR%Stasis.Cli\Stasis.Cli.csproj" -- %*
 set "CODE=%ERRORLEVEL%"


### PR DESCRIPTION
## Summary
- make `run`/`build`/`test`/`format` the primary visible CLI workflow with integrated defaults
- split help output into basic (`--help`) and advanced (`--help-advanced`) modes
- keep hidden `bridge` dispatch compatibility in place and restore usage to avoid dead-code warnings
- refresh README CLI examples to match new defaults (`run` watches by default, `build` optimized by default)
- add tests that lock basic help vs advanced help behavior
- tighten test execution defaults to 30s (`STASIS_TEST_TIMEOUT_MS`) and align wrappers
- simplify `run.bat`/`run.sh` to rely on default watch behavior (fewer explicit flags)
- fix watch child recursion by forcing watcher-spawned run children to include `--no-watch`

## Validation
- `dotnet build Stasis.Cli/Stasis.Cli.csproj -c Release`
- `dotnet run --project Stasis.Cli -c Release --no-build -- --help`
- `dotnet run --project Stasis.Cli -c Release --no-build -- --help-advanced`
- `dotnet test Stasis.Cli.Tests/Stasis.Cli.Tests.csproj -c Release --filter FullyQualifiedName~Help_`