### PR TITLE
feat: add local windows release verification scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ cargo run -p stasis -- --ticks 300 --watch-dir samples/brickout_revenge --events
 cargo run -p stasis -- --scenario brickout-revenge-v1 --ticks 300
 ```
 
+Local-only Windows release source ZIP validation (auto-detects Cargo workspace or legacy build/test scripts):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-source-zip.ps1
+```
+
+Local-only Windows release CLI bundle validation (smoke checks `stasis run/build/test` directly from the downloaded release zip):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-cli.ps1
+```
+
 Structured event stream options:
 - `--events-jsonl` prints JSONL events to stdout (compile/swap/summary).
 - `--events-jsonl-file path\to\events.jsonl` writes JSONL events to a file.

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -5550,6 +5550,13 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     var childArgs = Environment.GetCommandLineArgs()
         .Skip(1)
         .Where(arg => !string.Equals(arg, "--watch", StringComparison.OrdinalIgnoreCase))
+        .ToList();
+    // Watch child must always execute a single run; otherwise default run behavior re-enters watch mode.
+    if (mode == "run" && !childArgs.Any(arg => string.Equals(arg, "--no-watch", StringComparison.OrdinalIgnoreCase)))
+    {
+        childArgs.Add("--no-watch");
+    }
+    var quotedChildArgs = childArgs
         .Select(QuoteArg)
         .ToArray();
 
@@ -5560,7 +5567,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
         return 1;
     }
     if (Path.GetFileNameWithoutExtension(exePath).Equals("dotnet", StringComparison.OrdinalIgnoreCase) &&
-        childArgs.Length > 0 && childArgs[0].Equals("run", StringComparison.OrdinalIgnoreCase))
+        childArgs.Count > 0 && childArgs[0].Equals("run", StringComparison.OrdinalIgnoreCase))
     {
         Console.Error.WriteLine("error: --watch requires running the built CLI (not `dotnet run`).");
         return 1;
@@ -5569,7 +5576,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
     Process? child = null;
     if (mode == "run")
     {
-        child = StartWatchChild(exePath, childArgs);
+        child = StartWatchChild(exePath, quotedChildArgs);
     }
     else
     {
@@ -5628,7 +5635,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
                         child.Kill(entireProcessTree: true);
                         child.WaitForExit();
                     }
-                    child = StartWatchChild(exePath, childArgs);
+                    child = StartWatchChild(exePath, quotedChildArgs);
                 }
             }
             else
@@ -5639,7 +5646,7 @@ static int WatchFile(string path, string mode, bool includeTests, string moduleN
 
         if (mode == "run" && enableHotState && pendingRestart && (child is null || child.HasExited))
         {
-            child = StartWatchChild(exePath, childArgs);
+            child = StartWatchChild(exePath, quotedChildArgs);
             pendingRestart = false;
             if (restartRequestedAt != DateTime.MinValue)
             {

--- a/Stasis.Cli/Program.cs
+++ b/Stasis.Cli/Program.cs
@@ -41,6 +41,7 @@ var emitIrOnly = false;
 string? outputPath = null;
 var runAllInDirectory = false;
 var watch = false;
+var watchConfiguredByUser = false;
 string? optLevel = null;
 var enableLto = false;
 var enableGraphics = false;
@@ -69,9 +70,14 @@ while (cliArgs.Count > 0)
         case "dev":
             // Back-compat alias for the run dev workflow.
             mode = "run";
+            watch = true;
+            watchConfiguredByUser = true;
             break;
         case "build":
             mode = arg;
+            // Go-like default: build emits optimized artifacts.
+            optLevel ??= "3";
+            enableLto = true;
             break;
         case "release":
             mode = arg;
@@ -103,6 +109,11 @@ while (cliArgs.Count > 0)
             break;
         case "--watch":
             watch = true;
+            watchConfiguredByUser = true;
+            break;
+        case "--no-watch":
+            watch = false;
+            watchConfiguredByUser = true;
             break;
         case "--opt-level" when cliArgs.Count > 0:
             optLevel = cliArgs.Dequeue();
@@ -189,7 +200,12 @@ if (path is null)
         if (pickedWatch.HasValue)
         {
             watch = pickedWatch.Value;
+            watchConfiguredByUser = true;
         }
+    }
+    else if (mode == "format")
+    {
+        path = Directory.GetCurrentDirectory();
     }
     else
     {
@@ -202,6 +218,11 @@ if (optLevel is not null && !IsValidOptLevel(optLevel))
 {
     Console.Error.WriteLine($"error: invalid --opt-level '{optLevel}'. Use 0,1,2,3,s,z.");
     Environment.Exit(1);
+}
+
+if (mode == "run" && !watchConfiguredByUser)
+{
+    watch = true;
 }
 
 devMode = mode == "run";
@@ -312,11 +333,44 @@ static void AddHostAbiDataExports(LayoutPlan layout, List<string> exports)
 
 if (mode == "format")
 {
-    var input = File.ReadAllText(path);
-    var formatted = Stasis.Cli.StasisFormatter.Format(input);
-    if (!string.Equals(input, formatted, StringComparison.Ordinal))
+    if (Directory.Exists(path))
     {
-        File.WriteAllText(path, formatted);
+        var files = Directory.GetFiles(path, "*.stasis", SearchOption.AllDirectories)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+        if (files.Length == 0)
+        {
+            Console.Error.WriteLine($"error: no .stasis files found under {path}");
+            Environment.Exit(1);
+        }
+
+        var changed = 0;
+        foreach (var file in files)
+        {
+            var input = File.ReadAllText(file);
+            var formatted = Stasis.Cli.StasisFormatter.Format(input);
+            if (!string.Equals(input, formatted, StringComparison.Ordinal))
+            {
+                File.WriteAllText(file, formatted);
+                changed++;
+            }
+        }
+
+        Console.WriteLine($"formatted {files.Length} file(s), changed {changed}.");
+    }
+    else
+    {
+        var input = File.ReadAllText(path);
+        var formatted = Stasis.Cli.StasisFormatter.Format(input);
+        if (!string.Equals(input, formatted, StringComparison.Ordinal))
+        {
+            File.WriteAllText(path, formatted);
+            Console.WriteLine($"formatted {path}.");
+        }
+        else
+        {
+            Console.WriteLine($"already formatted: {path}.");
+        }
     }
 
     return;
@@ -5711,15 +5765,19 @@ static void WriteIrOutput(string ir, string? outputPath)
 static void PrintUsage()
 {
     Console.WriteLine("Usage:");
-    Console.WriteLine("  stasisc run [<file>] [--fps <1..240>] [--module <name>] [--emit-ir] [--out <path>]");
-    Console.WriteLine("  stasisc release <file> [--out <path>] [--module <name>]");
+    Console.WriteLine("  stasisc run [<file>] [--watch|--no-watch]");
+    Console.WriteLine("  stasisc build <file> [--out <path>]");
+    Console.WriteLine("  stasisc test [<file>|--all]");
+    Console.WriteLine("  stasisc format [<file-or-dir>]");
     Console.WriteLine();
-    Console.WriteLine("Other commands:");
-    Console.WriteLine("  stasisc test [<file>|--all] [--watch] [--module <name>] [--emit-ir] [--backend <llvm|cranelift>]");
-    Console.WriteLine("  stasisc build <file> [--module <name>] [--with-tests] [--out <path>] [--opt-level <0|1|2|3|s|z>] [--lto|--no-lto] [--backend <llvm|cranelift>] [--graphics] [--graphics-lib <path>]");
-    Console.WriteLine("  stasisc format <file>");
+    Console.WriteLine("Integrated defaults:");
+    Console.WriteLine("  run   => dev watch loop by default (use --no-watch to run once)");
+    Console.WriteLine("  build => optimized output by default (-O3 + LTO)");
+    Console.WriteLine("  test  => with no path (or --all), run all tests under working dir");
+    Console.WriteLine("  format=> with no path, format all .stasis files under working dir");
     Console.WriteLine();
-    Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). With no path (or --all), 'test' runs every .stasis file under the working directory. Build/release require clang in PATH. 'release' defaults to -O3 with LTO.");
+    Console.WriteLine("Compatibility: 'stasisc release <file>' remains available as a build alias.");
+    Console.WriteLine("Defaults: execute via lli if available, else clang. Use --emit-ir to only write IR to stdout (or --out to write to a file). Build/release require clang in PATH.");
     Console.WriteLine("Run: omit <file> to pick interactively (breadth-first listing) and optionally enable --watch.");
     Console.WriteLine("Run: use --watch for a dev loop (auto-rebuild + tick hot-swap + phase timings) with state preserved between swaps and no re-running main().");
     Console.WriteLine("Hot state: use --hot-state (Cranelift run only) to restore and save the global 'state' across process runs (restart-based experiments).");
@@ -5849,7 +5907,7 @@ static int RunBridgeMode(Queue<string> args)
             tickHostFps,
             llvmTargetTriple: null,
             useLowerLock: true,
-            useCraneliftRunner: false,
+            useCraneliftRunner: true,
             enableHotState: false);
         Console.WriteLine($"BRIDGE_END {requestId} {exit}");
     }

--- a/tools/windows/verify-latest-release-cli.ps1
+++ b/tools/windows/verify-latest-release-cli.ps1
@@ -1,0 +1,168 @@
+param(
+    [string] $Owner = "benwmaddox",
+    [string] $Repo = "StasisLang",
+    [string] $OutputRoot = "",
+    [switch] $StableOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function New-TemporaryRoot {
+    $shortBase = Join-Path $env:SystemDrive "stasis_release_cli_verify"
+    New-Item -ItemType Directory -Path $shortBase -Force | Out-Null
+    $suffix = [System.Guid]::NewGuid().ToString("N").Substring(0, 8)
+    return Join-Path $shortBase ("cli-" + $suffix)
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [string] $Description,
+        [scriptblock] $Action,
+        [int] $ExpectedExitCode = 0
+    )
+
+    Write-Host $Description
+    & $Action
+    if ($LASTEXITCODE -ne $ExpectedExitCode) {
+        throw "$Description failed with exit code $LASTEXITCODE (expected $ExpectedExitCode)."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = New-TemporaryRoot
+}
+
+if (Test-Path $OutputRoot) {
+    throw "OutputRoot already exists: $OutputRoot"
+}
+
+$headers = @{
+    "Accept" = "application/vnd.github+json"
+    "User-Agent" = "$Owner-$Repo-release-cli-verify"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+}
+
+$releaseApiBase = "https://api.github.com/repos/$Owner/$Repo/releases"
+
+if ($StableOnly) {
+    $release = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/latest" -Method Get
+}
+else {
+    $releases = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}?per_page=20" -Method Get
+    $release = $releases |
+        Where-Object { -not $_.draft -and $_.published_at } |
+        Sort-Object { [DateTimeOffset]::Parse($_.published_at) } -Descending |
+        Select-Object -First 1
+
+    if (-not $release) {
+        throw "No published release found for $Owner/$Repo."
+    }
+}
+
+$tag = $release.tag_name
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    throw "Latest release payload did not include tag_name."
+}
+
+# Fetch by tag to ensure assets are fully populated for selection.
+$releaseWithAssets = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/tags/$tag" -Method Get
+
+$windowsZipAsset = $releaseWithAssets.assets |
+    Where-Object { $_.name -match "(?i)win.*\.zip$" } |
+    Select-Object -First 1
+
+if (-not $windowsZipAsset) {
+    throw "Latest release tag '$tag' has no Windows zip asset."
+}
+
+$publishedAt = $releaseWithAssets.published_at
+$assetName = $windowsZipAsset.name
+$assetUrl = $windowsZipAsset.browser_download_url
+
+if ([string]::IsNullOrWhiteSpace($assetUrl)) {
+    throw "Windows zip asset '$assetName' did not include browser_download_url."
+}
+
+Write-Host "Validating release CLI bundle:"
+Write-Host "  Repo: $Owner/$Repo"
+Write-Host "  Tag: $tag"
+Write-Host "  Published: $publishedAt"
+Write-Host "  Asset: $assetName"
+Write-Host "  Asset URL: $assetUrl"
+Write-Host "  Working Directory: $OutputRoot"
+
+$downloadDir = Join-Path $OutputRoot "download"
+$extractDir = Join-Path $OutputRoot "extract"
+$zipPath = Join-Path $downloadDir $assetName
+
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+Invoke-WebRequest -Headers $headers -Uri $assetUrl -OutFile $zipPath
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$cliExePath = Join-Path $extractDir "Stasis.Cli.exe"
+if (-not (Test-Path $cliExePath)) {
+    throw "Extracted bundle does not contain Stasis.Cli.exe at $cliExePath"
+}
+
+$stasisBatPath = Join-Path $extractDir "stasis.bat"
+$stasisBatContent = @"
+@echo off
+setlocal
+"%~dp0Stasis.Cli.exe" %*
+exit /b %ERRORLEVEL%
+"@
+Set-Content -Path $stasisBatPath -Value $stasisBatContent -Encoding ASCII
+
+$runFile = Join-Path $extractDir "smoke_run.stasis"
+$testFile = Join-Path $extractDir "smoke_test.stasis"
+$buildOut = Join-Path $extractDir "smoke_run.exe"
+$craneliftAotExe = Join-Path $extractDir "bin\stasis-cranelift-aot.exe"
+
+$runContent = @'
+function main(): i32 {
+    return 7;
+}
+'@
+Set-Content -Path $runFile -Value $runContent -Encoding ASCII
+
+$testContent = @'
+test `one equals one`(): bool {
+    return 1 == 1;
+}
+'@
+Set-Content -Path $testFile -Value $testContent -Encoding ASCII
+
+if (-not (Test-Path $craneliftAotExe)) {
+    throw "Extracted bundle does not contain Cranelift AOT helper at $craneliftAotExe"
+}
+
+$env:STASIS_CRANELIFT_AOT = $craneliftAotExe
+
+Push-Location $extractDir
+try {
+    Invoke-CheckedCommand -Description "Running stasis run smoke_run.stasis" -ExpectedExitCode 7 -Action {
+        & $stasisBatPath run $runFile --backend cranelift --no-cranelift-runner
+    }
+    Invoke-CheckedCommand -Description "Running stasis build smoke_run.stasis" -Action {
+        & $stasisBatPath build $runFile --backend cranelift --out $buildOut
+    }
+    if (-not (Test-Path $buildOut)) {
+        throw "stasis build did not produce expected output: $buildOut"
+    }
+    Invoke-CheckedCommand -Description "Running stasis test smoke_test.stasis" -Action {
+        & $stasisBatPath test $testFile --backend cranelift --no-cranelift-runner
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Release CLI bundle validation succeeded for tag $tag."
+Write-Host "Bundle location: $extractDir"
+Write-Host "Launcher path: $stasisBatPath"

--- a/tools/windows/verify-latest-release-source-zip.ps1
+++ b/tools/windows/verify-latest-release-source-zip.ps1
@@ -1,0 +1,150 @@
+param(
+    [string] $Owner = "benwmaddox",
+    [string] $Repo = "StasisLang",
+    [string] $OutputRoot = "",
+    [switch] $StableOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function New-TemporaryRoot {
+    $shortBase = Join-Path $env:SystemDrive "stasis_release_verify"
+    New-Item -ItemType Directory -Path $shortBase -Force | Out-Null
+    $suffix = [System.Guid]::NewGuid().ToString("N").Substring(0, 8)
+    return Join-Path $shortBase ("srv-" + $suffix)
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [string] $Description,
+        [scriptblock] $Action
+    )
+
+    Write-Host $Description
+    & $Action
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = New-TemporaryRoot
+}
+
+if (Test-Path $OutputRoot) {
+    throw "OutputRoot already exists: $OutputRoot"
+}
+
+$headers = @{
+    "Accept" = "application/vnd.github+json"
+    "User-Agent" = "$Owner-$Repo-release-verify"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+}
+
+$releaseApiBase = "https://api.github.com/repos/$Owner/$Repo/releases"
+
+if ($StableOnly) {
+    $release = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/latest" -Method Get
+}
+else {
+    $releases = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}?per_page=20" -Method Get
+    $release = $releases |
+        Where-Object { -not $_.draft -and $_.published_at } |
+        Sort-Object { [DateTimeOffset]::Parse($_.published_at) } -Descending |
+        Select-Object -First 1
+
+    if (-not $release) {
+        throw "No published release found for $Owner/$Repo."
+    }
+}
+
+$tag = $release.tag_name
+$zipUrl = $release.zipball_url
+$publishedAt = $release.published_at
+
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    throw "Latest release payload did not include tag_name."
+}
+
+if ([string]::IsNullOrWhiteSpace($zipUrl)) {
+    throw "Latest release payload did not include zipball_url."
+}
+
+Write-Host "Validating release source zip:"
+Write-Host "  Repo: $Owner/$Repo"
+Write-Host "  Tag: $tag"
+Write-Host "  Published: $publishedAt"
+Write-Host "  Source Zip URL: $zipUrl"
+Write-Host "  Working Directory: $OutputRoot"
+
+$downloadDir = Join-Path $OutputRoot "download"
+$extractDir = Join-Path $OutputRoot "extract"
+$zipPath = Join-Path $downloadDir "$tag-source.zip"
+
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $zipPath
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$sourceRoot = Get-ChildItem -Path $extractDir -Directory | Select-Object -First 1
+if (-not $sourceRoot) {
+    throw "Source archive extracted without a root directory."
+}
+
+$cargoToml = Join-Path $sourceRoot.FullName "Cargo.toml"
+$legacyBuildBat = Join-Path $sourceRoot.FullName "build.bat"
+$legacyTestBat = Join-Path $sourceRoot.FullName "test.bat"
+$legacySolution = Join-Path $sourceRoot.FullName "Stasis.sln"
+$validationMode = ""
+
+Push-Location $sourceRoot.FullName
+try {
+    if (Test-Path $cargoToml) {
+        $validationMode = "cargo"
+        Invoke-CheckedCommand -Description "Running cargo test --workspace --all-targets" -Action {
+            cargo test --workspace --all-targets
+        }
+        Invoke-CheckedCommand -Description "Running cargo build --workspace --all-targets" -Action {
+            cargo build --workspace --all-targets
+        }
+    }
+    elseif ((Test-Path $legacyBuildBat) -and (Test-Path $legacyTestBat)) {
+        $validationMode = "legacy-source"
+        $env:STASIS_CLEAN_RUNTIME_BUILD = "1"
+
+        Invoke-CheckedCommand -Description "Running runtime\\build.bat" -Action {
+            cmd /c runtime\build.bat
+        }
+        Invoke-CheckedCommand -Description "Running cargo build -p stasis-cranelift-aot --release --manifest-path tools\\cranelift-aot\\Cargo.toml" -Action {
+            cargo build -p stasis-cranelift-aot --release --manifest-path tools\cranelift-aot\Cargo.toml
+        }
+        Invoke-CheckedCommand -Description "Running dotnet build Stasis.sln -c Release -m:1" -Action {
+            dotnet build Stasis.sln -c Release -m:1
+        }
+        Invoke-CheckedCommand -Description "Running dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1" -Action {
+            dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1
+        }
+    }
+    elseif (Test-Path $legacySolution) {
+        $validationMode = "legacy-dotnet-fallback"
+        Invoke-CheckedCommand -Description "Running dotnet build Stasis.sln -c Release" -Action {
+            dotnet build Stasis.sln -c Release
+        }
+        Invoke-CheckedCommand -Description "Running dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1" -Action {
+            dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1
+        }
+    }
+    else {
+        throw "Unable to determine build/test entrypoints in extracted source root: $($sourceRoot.FullName)"
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Release source zip validation succeeded for tag $tag (mode: $validationMode)."


### PR DESCRIPTION
## Summary
- add `tools/windows/verify-latest-release-source-zip.ps1` for local-only latest release source zip validation
- add `tools/windows/verify-latest-release-cli.ps1` for local-only latest release bundle smoke using `stasis run/build/test`
- document both local commands in `README.md`

## Notes
- no CI workflow was added; this is local-run only to avoid blocking CI.
- release CLI smoke script writes a local `stasis.bat` shim inside the extracted bundle and validates run/build/test against tiny smoke fixtures.

## Validation
- `powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-source-zip.ps1`
- `powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-cli.ps1`