### PR TITLE
feat: add local release extract and test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ cargo run -p stasis -- --ticks 300 --watch-dir samples/brickout_revenge --events
 cargo run -p stasis -- --scenario brickout-revenge-v1 --ticks 300
 ```
 
+Local-only Windows release source ZIP validation (auto-detects Cargo workspace or legacy build/test scripts):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-source-zip.ps1
+```
+
+Local-only Windows release CLI bundle validation (smoke checks `stasis run/build/test` directly from the downloaded release zip):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-cli.ps1
+```
+
 Structured event stream options:
 - `--events-jsonl` prints JSONL events to stdout (compile/swap/summary).
 - `--events-jsonl-file path\to\events.jsonl` writes JSONL events to a file.

--- a/tools/windows/verify-latest-release-cli.ps1
+++ b/tools/windows/verify-latest-release-cli.ps1
@@ -1,0 +1,168 @@
+param(
+    [string] $Owner = "benwmaddox",
+    [string] $Repo = "StasisLang",
+    [string] $OutputRoot = "",
+    [switch] $StableOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function New-TemporaryRoot {
+    $shortBase = Join-Path $env:SystemDrive "stasis_release_cli_verify"
+    New-Item -ItemType Directory -Path $shortBase -Force | Out-Null
+    $suffix = [System.Guid]::NewGuid().ToString("N").Substring(0, 8)
+    return Join-Path $shortBase ("cli-" + $suffix)
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [string] $Description,
+        [scriptblock] $Action,
+        [int] $ExpectedExitCode = 0
+    )
+
+    Write-Host $Description
+    & $Action
+    if ($LASTEXITCODE -ne $ExpectedExitCode) {
+        throw "$Description failed with exit code $LASTEXITCODE (expected $ExpectedExitCode)."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = New-TemporaryRoot
+}
+
+if (Test-Path $OutputRoot) {
+    throw "OutputRoot already exists: $OutputRoot"
+}
+
+$headers = @{
+    "Accept" = "application/vnd.github+json"
+    "User-Agent" = "$Owner-$Repo-release-cli-verify"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+}
+
+$releaseApiBase = "https://api.github.com/repos/$Owner/$Repo/releases"
+
+if ($StableOnly) {
+    $release = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/latest" -Method Get
+}
+else {
+    $releases = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}?per_page=20" -Method Get
+    $release = $releases |
+        Where-Object { -not $_.draft -and $_.published_at } |
+        Sort-Object { [DateTimeOffset]::Parse($_.published_at) } -Descending |
+        Select-Object -First 1
+
+    if (-not $release) {
+        throw "No published release found for $Owner/$Repo."
+    }
+}
+
+$tag = $release.tag_name
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    throw "Latest release payload did not include tag_name."
+}
+
+# Fetch by tag to ensure assets are fully populated for selection.
+$releaseWithAssets = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/tags/$tag" -Method Get
+
+$windowsZipAsset = $releaseWithAssets.assets |
+    Where-Object { $_.name -match "(?i)win.*\.zip$" } |
+    Select-Object -First 1
+
+if (-not $windowsZipAsset) {
+    throw "Latest release tag '$tag' has no Windows zip asset."
+}
+
+$publishedAt = $releaseWithAssets.published_at
+$assetName = $windowsZipAsset.name
+$assetUrl = $windowsZipAsset.browser_download_url
+
+if ([string]::IsNullOrWhiteSpace($assetUrl)) {
+    throw "Windows zip asset '$assetName' did not include browser_download_url."
+}
+
+Write-Host "Validating release CLI bundle:"
+Write-Host "  Repo: $Owner/$Repo"
+Write-Host "  Tag: $tag"
+Write-Host "  Published: $publishedAt"
+Write-Host "  Asset: $assetName"
+Write-Host "  Asset URL: $assetUrl"
+Write-Host "  Working Directory: $OutputRoot"
+
+$downloadDir = Join-Path $OutputRoot "download"
+$extractDir = Join-Path $OutputRoot "extract"
+$zipPath = Join-Path $downloadDir $assetName
+
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+Invoke-WebRequest -Headers $headers -Uri $assetUrl -OutFile $zipPath
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$cliExePath = Join-Path $extractDir "Stasis.Cli.exe"
+if (-not (Test-Path $cliExePath)) {
+    throw "Extracted bundle does not contain Stasis.Cli.exe at $cliExePath"
+}
+
+$stasisBatPath = Join-Path $extractDir "stasis.bat"
+$stasisBatContent = @"
+@echo off
+setlocal
+"%~dp0Stasis.Cli.exe" %*
+exit /b %ERRORLEVEL%
+"@
+Set-Content -Path $stasisBatPath -Value $stasisBatContent -Encoding ASCII
+
+$runFile = Join-Path $extractDir "smoke_run.stasis"
+$testFile = Join-Path $extractDir "smoke_test.stasis"
+$buildOut = Join-Path $extractDir "smoke_run.exe"
+$craneliftAotExe = Join-Path $extractDir "bin\stasis-cranelift-aot.exe"
+
+$runContent = @'
+function main(): i32 {
+    return 7;
+}
+'@
+Set-Content -Path $runFile -Value $runContent -Encoding ASCII
+
+$testContent = @'
+test `one equals one`(): bool {
+    return 1 == 1;
+}
+'@
+Set-Content -Path $testFile -Value $testContent -Encoding ASCII
+
+if (-not (Test-Path $craneliftAotExe)) {
+    throw "Extracted bundle does not contain Cranelift AOT helper at $craneliftAotExe"
+}
+
+$env:STASIS_CRANELIFT_AOT = $craneliftAotExe
+
+Push-Location $extractDir
+try {
+    Invoke-CheckedCommand -Description "Running stasis run smoke_run.stasis" -ExpectedExitCode 7 -Action {
+        & $stasisBatPath run $runFile --backend cranelift --no-cranelift-runner
+    }
+    Invoke-CheckedCommand -Description "Running stasis build smoke_run.stasis" -Action {
+        & $stasisBatPath build $runFile --backend cranelift --out $buildOut
+    }
+    if (-not (Test-Path $buildOut)) {
+        throw "stasis build did not produce expected output: $buildOut"
+    }
+    Invoke-CheckedCommand -Description "Running stasis test smoke_test.stasis" -Action {
+        & $stasisBatPath test $testFile --backend cranelift --no-cranelift-runner
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Release CLI bundle validation succeeded for tag $tag."
+Write-Host "Bundle location: $extractDir"
+Write-Host "Launcher path: $stasisBatPath"

--- a/tools/windows/verify-latest-release-source-zip.ps1
+++ b/tools/windows/verify-latest-release-source-zip.ps1
@@ -1,0 +1,150 @@
+param(
+    [string] $Owner = "benwmaddox",
+    [string] $Repo = "StasisLang",
+    [string] $OutputRoot = "",
+    [switch] $StableOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function New-TemporaryRoot {
+    $shortBase = Join-Path $env:SystemDrive "stasis_release_verify"
+    New-Item -ItemType Directory -Path $shortBase -Force | Out-Null
+    $suffix = [System.Guid]::NewGuid().ToString("N").Substring(0, 8)
+    return Join-Path $shortBase ("srv-" + $suffix)
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [string] $Description,
+        [scriptblock] $Action
+    )
+
+    Write-Host $Description
+    & $Action
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = New-TemporaryRoot
+}
+
+if (Test-Path $OutputRoot) {
+    throw "OutputRoot already exists: $OutputRoot"
+}
+
+$headers = @{
+    "Accept" = "application/vnd.github+json"
+    "User-Agent" = "$Owner-$Repo-release-verify"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    $headers["Authorization"] = "Bearer $($env:GITHUB_TOKEN)"
+}
+
+$releaseApiBase = "https://api.github.com/repos/$Owner/$Repo/releases"
+
+if ($StableOnly) {
+    $release = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}/latest" -Method Get
+}
+else {
+    $releases = Invoke-RestMethod -Headers $headers -Uri "${releaseApiBase}?per_page=20" -Method Get
+    $release = $releases |
+        Where-Object { -not $_.draft -and $_.published_at } |
+        Sort-Object { [DateTimeOffset]::Parse($_.published_at) } -Descending |
+        Select-Object -First 1
+
+    if (-not $release) {
+        throw "No published release found for $Owner/$Repo."
+    }
+}
+
+$tag = $release.tag_name
+$zipUrl = $release.zipball_url
+$publishedAt = $release.published_at
+
+if ([string]::IsNullOrWhiteSpace($tag)) {
+    throw "Latest release payload did not include tag_name."
+}
+
+if ([string]::IsNullOrWhiteSpace($zipUrl)) {
+    throw "Latest release payload did not include zipball_url."
+}
+
+Write-Host "Validating release source zip:"
+Write-Host "  Repo: $Owner/$Repo"
+Write-Host "  Tag: $tag"
+Write-Host "  Published: $publishedAt"
+Write-Host "  Source Zip URL: $zipUrl"
+Write-Host "  Working Directory: $OutputRoot"
+
+$downloadDir = Join-Path $OutputRoot "download"
+$extractDir = Join-Path $OutputRoot "extract"
+$zipPath = Join-Path $downloadDir "$tag-source.zip"
+
+New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $zipPath
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$sourceRoot = Get-ChildItem -Path $extractDir -Directory | Select-Object -First 1
+if (-not $sourceRoot) {
+    throw "Source archive extracted without a root directory."
+}
+
+$cargoToml = Join-Path $sourceRoot.FullName "Cargo.toml"
+$legacyBuildBat = Join-Path $sourceRoot.FullName "build.bat"
+$legacyTestBat = Join-Path $sourceRoot.FullName "test.bat"
+$legacySolution = Join-Path $sourceRoot.FullName "Stasis.sln"
+$validationMode = ""
+
+Push-Location $sourceRoot.FullName
+try {
+    if (Test-Path $cargoToml) {
+        $validationMode = "cargo"
+        Invoke-CheckedCommand -Description "Running cargo test --workspace --all-targets" -Action {
+            cargo test --workspace --all-targets
+        }
+        Invoke-CheckedCommand -Description "Running cargo build --workspace --all-targets" -Action {
+            cargo build --workspace --all-targets
+        }
+    }
+    elseif ((Test-Path $legacyBuildBat) -and (Test-Path $legacyTestBat)) {
+        $validationMode = "legacy-source"
+        $env:STASIS_CLEAN_RUNTIME_BUILD = "1"
+
+        Invoke-CheckedCommand -Description "Running runtime\\build.bat" -Action {
+            cmd /c runtime\build.bat
+        }
+        Invoke-CheckedCommand -Description "Running cargo build -p stasis-cranelift-aot --release --manifest-path tools\\cranelift-aot\\Cargo.toml" -Action {
+            cargo build -p stasis-cranelift-aot --release --manifest-path tools\cranelift-aot\Cargo.toml
+        }
+        Invoke-CheckedCommand -Description "Running dotnet build Stasis.sln -c Release -m:1" -Action {
+            dotnet build Stasis.sln -c Release -m:1
+        }
+        Invoke-CheckedCommand -Description "Running dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1" -Action {
+            dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1
+        }
+    }
+    elseif (Test-Path $legacySolution) {
+        $validationMode = "legacy-dotnet-fallback"
+        Invoke-CheckedCommand -Description "Running dotnet build Stasis.sln -c Release" -Action {
+            dotnet build Stasis.sln -c Release
+        }
+        Invoke-CheckedCommand -Description "Running dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1" -Action {
+            dotnet test Stasis.sln -c Release -- RunConfiguration.MaxCpuCount=1
+        }
+    }
+    else {
+        throw "Unable to determine build/test entrypoints in extracted source root: $($sourceRoot.FullName)"
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Release source zip validation succeeded for tag $tag (mode: $validationMode)."


### PR DESCRIPTION
## Summary
- add local-only Windows source-zip validation script for latest release
- add local-only Windows release-bundle CLI smoke script (`stasis run/build/test`)
- document both local commands in README

## Why
- keeps this flow out of CI (manual/local only)
- supports migration away from relying on `build.bat/test.bat` for release bundle verification

## Validation
- `powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-source-zip.ps1`
- `powershell -ExecutionPolicy Bypass -File tools/windows/verify-latest-release-cli.ps1`