### PR TITLE
ci: replace deprecated macos-13 runner with macos-15

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -71,7 +71,7 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             archive: stasis-nightly-win-x64
             ext: zip
-          - os: macos-13
+          - os: macos-15
             rust_target: x86_64-apple-darwin
             archive: stasis-nightly-osx-x64
             ext: tar.gz


### PR DESCRIPTION
## Summary
- GitHub Actions removed `macos-13` runner support, causing the nightly release to fail on the `x86_64-apple-darwin` build target
- Replaced `macos-13` with `macos-15` in the nightly release workflow matrix
- `macos-15` runners are Apple Silicon (ARM64) but Rust cross-compiles to `x86_64-apple-darwin` via the explicit `rust_target` parameter already configured in the matrix

## Test plan
- [ ] PR CI passes (confirms workflow syntax is valid)
- [ ] Next nightly release succeeds with all 4 platform builds completing
- [ ] Verify the `stasis-nightly-osx-x64` artifact is produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)