### PR TITLE
docs: sync README constraints with current Rewrite V1 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,13 @@ Watch mode:
 .\target\debug\stasis.exe test --dir tests/stasis --watch --watch-settle-ms 50
 ```
 
-## Known Issues (Rewrite V1 JIT Backend)
+## Current Constraints (Rewrite V1)
 
-The following limitations exist in the current JIT backend and are tracked for resolution:
+Current intentional language/runtime constraints:
 
-| Issue | Workaround |
-|-------|------------|
-| **Struct parameters**: passing a struct to a function parameter fails when accessing fields on the parameter | Access struct fields via global state with an index parameter instead of passing the struct directly |
-| **`i32_to_f32` builtin**: the integer-to-float conversion builtin is not resolved by the JIT. This also affects stdlib modules that use it (e.g. `game_draw.stasis`, `host_frame.stasis`) | Use `f32` constants directly instead of converting at runtime |
-| **`continue` statement**: not yet implemented in the JIT backend | Restructure loops to use `if`/`else` instead of `continue` |
-| **`for` loop without init clause**: loops like `for (; cond; step)` fail. This affects the stdlib `ascii_push_i32` function | Add a dummy init variable or write a custom implementation using three-part `for` loops |
+| Constraint | Notes |
+|------------|-------|
+| `for` header requires all 3 clauses (`init; condition; step`) | `for (; cond; step)` is intentionally rejected as a compile-time error in Rewrite V1. |
 
 ## Build From Source
 


### PR DESCRIPTION
﻿## Summary
- replace stale README JIT Known Issues table that listed already-resolved items
- switch section to Current Constraints and keep only intentional Rewrite V1 rule: for requires init, condition, and step

## Notes
- docs/spec.md on main already reflects continue as supported, so no spec edit was required on this branch.

## Validation
- verified no remaining README/spec text claiming continue is unimplemented or i32_to_f32 unresolved

## Task
- Maddox task #25
