### PR TITLE
test/docs: close CS2 mixed-file coverage and mark checklist done

### DIFF
--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -362,6 +362,40 @@ mod tests {
     }
 
     #[test]
+    fn mixed_file_body_edit_only_emits_changed_file_function() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "core.stasis",
+            "function helper(): i32 { return 1; }\nfunction main(): i32 { return helper(); }\n",
+        );
+        compiler.upsert_file("extra.stasis", "function utility(): i32 { return 3; }\n");
+        compiler
+            .compile_with(|_, _| Ok(()))
+            .expect("initial compile");
+
+        compiler.upsert_file(
+            "extra.stasis",
+            "function utility(): i32 { return 4; }\n",
+        );
+        let index = compiler.index_pass().expect("index pass");
+        assert_eq!(index.signature_changed_functions, 0);
+        assert_eq!(index.dirty_functions, 1);
+        assert!(!function_by_name(&compiler, "helper").dirty);
+        assert!(!function_by_name(&compiler, "main").dirty);
+        assert!(function_by_name(&compiler, "utility").dirty);
+
+        let mut emitted_names = Vec::new();
+        let emit = compiler
+            .emit_pass_with(&mut |meta, _| {
+                emitted_names.push(meta.name.clone());
+                Ok(())
+            })
+            .expect("emit pass");
+        assert_eq!(emit.emitted_functions, 1);
+        assert_eq!(emitted_names, vec!["utility".to_string()]);
+    }
+
+    #[test]
     fn signature_change_propagates_dirty_to_dependents() {
         let mut compiler = Compiler::new();
         compiler.upsert_file(

--- a/docs/rewrite_v1_checklist.md
+++ b/docs/rewrite_v1_checklist.md
@@ -734,7 +734,10 @@ It is not part of the steady-state incremental JIT update loop.
 - Deliverable: unchanged files/functions skip body parse and skip CLIF emission.
 - Tests: signature-only change, body-only change, unchanged-file no-op, and mixed-file edit cases.
 - Done gate: dirty-function set is deterministic and minimal for covered scenarios.
-- Status: `pending`
+- Current progress:
+- Rust-native compiler flow runs explicit index then emit stages (`Compiler::index_pass`, `Compiler::emit_pass_with`) and emit work is restricted to dirty function ids only.
+- Regression coverage now includes signature-only changes, body-only changes, unchanged-source no-op, and mixed-file body edit gating in `crates/stasis_compiler::compiler::tests::*`.
+- Status: `done`
 - Slice CS3: Implement O(1) function symbol lookup via open-addressed hash table in `.stasis`.
 - Language: `.stasis`.
 - Scope: replace linear function-name scans for call resolution and file-function lookup with open-addressed table operations.
@@ -965,4 +968,3 @@ Each PR must include:
 ## Backlog
 
 - Evaluate hard security sandbox options (separate process / OS sandbox / WASM runtime) for adversarial plugin or untrusted code scenarios.
-


### PR DESCRIPTION
﻿## Summary
- add explicit mixed-file incremental compile regression test for CS2 acceptance
- verify dirty/emit gating only touches changed-file function for body-only edit across files
- update rewrite_v1_checklist CS2 section with progress evidence and mark status done

## Validation
- cargo test -p stasis_compiler compiler::tests:: -- --nocapture

## Task
- Maddox task #26
