### PR TITLE
test/docs: finalize CS4 invalidation coverage and status

### DIFF
--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -481,6 +481,29 @@ mod tests {
     }
 
     #[test]
+    fn body_change_keeps_fan_out_dependents_clean() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "sample.stasis",
+            "function helper(): i32 { return 1; }\nfunction left(): i32 { return helper(); }\nfunction right(): i32 { return helper(); }\n",
+        );
+        compiler
+            .compile_with(|_, _| Ok(()))
+            .expect("initial compile");
+
+        compiler.upsert_file(
+            "sample.stasis",
+            "function helper(): i32 { return 2; }\nfunction left(): i32 { return helper(); }\nfunction right(): i32 { return helper(); }\n",
+        );
+        let index = compiler.index_pass().expect("index pass");
+        assert_eq!(index.signature_changed_functions, 0);
+        assert_eq!(index.dirty_functions, 1);
+        assert!(function_by_name(&compiler, "helper").dirty);
+        assert!(!function_by_name(&compiler, "left").dirty);
+        assert!(!function_by_name(&compiler, "right").dirty);
+    }
+
+    #[test]
     fn signature_change_propagates_dirty_through_multi_level_chain() {
         let mut compiler = Compiler::new();
         compiler.upsert_file(

--- a/docs/rewrite_v1_checklist.md
+++ b/docs/rewrite_v1_checklist.md
@@ -748,7 +748,11 @@ It is not part of the steady-state incremental JIT update loop.
 - Deliverable: deterministic ripple invalidation without full-project rebuild for local edits.
 - Tests: single-edge, fan-out, multi-level chain, and no-op signature-equal edits.
 - Done gate: invalidation matches expected closure and touches only impacted functions.
-- Status: `pending`
+- Current progress:
+- Rust-native compiler index stage builds forward/dependent adjacency from dependency hashes each pass and stores edges in compact per-function vectors (`dependencies`, `dependents`).
+- Signature-change ripple propagation is enforced via queue walk (`propagate_dirty_from_signature_changes`) with regression coverage for single-edge, fan-out, and multi-level chain closures.
+- No-op signature-equivalent edits remain clean (`signature_equivalent_formatting_edit_does_not_dirty_or_emit`), and body-only fan-out edits keep dependents clean to preserve minimal invalidation (`body_change_keeps_fan_out_dependents_clean`).
+- Status: `done`
 - Slice CS5: Remove legacy `simple_*` detector metadata channels from compiler state and host contracts.
 - Language: `.stasis + Rust`.
 - Scope: delete obsolete detector/fallback metrics and rely on real parse/resolve/emit behavior for supported slices.
@@ -965,4 +969,3 @@ Each PR must include:
 ## Backlog
 
 - Evaluate hard security sandbox options (separate process / OS sandbox / WASM runtime) for adversarial plugin or untrusted code scenarios.
-


### PR DESCRIPTION
﻿## Summary
- add CS4 regression coverage for body-only fan-out edits to confirm minimal invalidation (dependents remain clean)
- keep single-edge/fan-out/chain/no-op invalidation coverage grouped under compiler::tests
- update rewrite_v1_checklist CS4 section to done with explicit implementation/test evidence

## Validation
- cargo test -p stasis_compiler compiler::tests:: -- --nocapture

## Task
- Maddox task #28
