### PR TITLE
docs: normalize README quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Stasis is built around a few pragmatic ideas that work well for games and simula
 Direct influences:
 
 - **Age of Empires II**: deterministic, tick-style simulation mindset (good for replay/debug/lockstep-style thinking).
-- **Handmade Hero**: “simple and debuggable” game code, data-oriented structures, and skepticism of hidden complexity.
+- **Handmade Hero**: "simple and debuggable" game code, data-oriented structures, and skepticism of hidden complexity.
 
 ## Start Here
 


### PR DESCRIPTION
Follow-up docs hygiene: replace smart quotes with ASCII in README to avoid mojibake/encoding issues in some terminals.\n\nRelated: Maddox #25 (docs drift/formatting cleanup).