### PR TITLE
play: default watch dir for basename entry

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -10,7 +10,6 @@ mod window_config;
 
 pub use compiler_backend::run_self_host_aot_cli;
 pub use events::RunnerEvent;
-pub use window_config::WindowConfig;
 pub use self_host_runtime_bridge::{
     publish_cli_args_to_env, publish_source_files_to_env, publish_staged_bridge_paths_to_env,
     restore_cli_args_env, restore_source_files_env, restore_staged_bridge_paths_env,
@@ -20,6 +19,7 @@ pub use stasis_test_runner::{
     run_jit_tests_in_directory, run_jit_tests_in_directory_with_session, StasisTestRunSession,
     StasisTestRunSummary,
 };
+pub use window_config::WindowConfig;
 
 use compiler_backend::IncrementalCompilerBackend;
 use runtime_exec::RuntimeLauncher;
@@ -36,8 +36,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::Instant;
 use std::time::Duration;
+use std::time::Instant;
 use watch::WatchService;
 
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
@@ -213,8 +213,7 @@ pub fn run_play_in_process(
         )
     })?;
 
-    let mut watch_dependency_paths =
-        collect_watch_dependency_paths(&root_path).ok();
+    let mut watch_dependency_paths = collect_watch_dependency_paths(&root_path).ok();
 
     // Allocate and register all global buffers used by HostFrame / gfx_cmd + window requests.
     let mut host_i32: Vec<i32> = vec![0; 768];
@@ -336,9 +335,7 @@ pub fn run_play_in_process(
             }
         }
         if ignored_changes > 0 && !needs_recompile {
-            println!(
-                "[watch] ignored {ignored_changes} change(s) (not in dependency graph)"
-            );
+            println!("[watch] ignored {ignored_changes} change(s) (not in dependency graph)");
         }
         if needs_recompile {
             let changed = triggered_paths
@@ -367,7 +364,8 @@ pub fn run_play_in_process(
                             // Candidate pointers: do not commit them until after the swap hook succeeds.
                             let candidate_tick_code_ptr = next_package.tick_code_ptr;
                             let candidate_render_code_ptr = next_package.render_code_ptr;
-                            let candidate_on_code_swap_code_ptr = next_package.on_code_swap_code_ptr;
+                            let candidate_on_code_swap_code_ptr =
+                                next_package.on_code_swap_code_ptr;
 
                             let mut hook_ms: u128 = 0;
                             let mut hook_failed: Option<String> = None;
@@ -375,7 +373,8 @@ pub fn run_play_in_process(
                                 let t_hook = Instant::now();
                                 // Run the hook against the newly compiled code. If it fails, abort the swap attempt
                                 // and keep running last-known-good code/data.
-                                if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize) {
+                                if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize)
+                                {
                                     hook_ms = t_hook.elapsed().as_millis();
                                     hook_failed = Some(error);
                                 } else {
@@ -411,7 +410,6 @@ pub fn run_play_in_process(
                             );
                         }
                     }
-
                 }
                 Err(error) => {
                     // Keep running the last known-good code/data if compilation fails.
@@ -494,7 +492,9 @@ fn collect_stasis_sources_recursive(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
-    let mut paths: Vec<PathBuf> = entries.filter_map(|entry| entry.ok().map(|e| e.path())).collect();
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .collect();
     paths.sort();
     for path in paths {
         if path.is_dir() {
@@ -617,11 +617,7 @@ fn infer_watch_directory_entry_source(watch_directory: &Path) -> Option<PathBuf>
         return None;
     }
 
-    for preferred in [
-        "main.stasis",
-        "game.stasis",
-        "app.stasis",
-    ] {
+    for preferred in ["main.stasis", "game.stasis", "app.stasis"] {
         let candidate = watch_directory.join(preferred);
         if candidate.is_file() {
             return Some(candidate);
@@ -1267,8 +1263,10 @@ mod tests {
 
     #[test]
     fn resolve_play_watch_dir_prefers_explicit_watch_dir() {
-        let resolved =
-            resolve_play_watch_dir(Path::new("samples/game.stasis"), Some(Path::new("override")));
+        let resolved = resolve_play_watch_dir(
+            Path::new("samples/game.stasis"),
+            Some(Path::new("override")),
+        );
         assert_eq!(resolved, PathBuf::from("override"));
     }
 
@@ -1831,8 +1829,11 @@ mod tests {
             .as_nanos();
         let temp_root = std::env::temp_dir().join(format!("stasis_watch_entry_infer_{}", stamp));
         fs::create_dir_all(&temp_root).expect("create temp dir");
-        fs::write(temp_root.join("helper.stasis"), "function util(): i32 { return 1; }\n")
-            .expect("write helper");
+        fs::write(
+            temp_root.join("helper.stasis"),
+            "function util(): i32 { return 1; }\n",
+        )
+        .expect("write helper");
         fs::write(
             temp_root.join("main.stasis"),
             "function tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
@@ -1907,7 +1908,8 @@ mod tests {
         fs::write(&dep, "function dep(): i32 { return 0; }\n").expect("write dep");
         fs::write(&other, "function other(): i32 { return 0; }\n").expect("write other");
 
-        let mut dependency_paths: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut dependency_paths: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
         dependency_paths.insert(normalize_watch_path_for_log(&root));
         dependency_paths.insert(normalize_watch_path_for_log(&dep));
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -4,14 +4,14 @@ use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, RecvTimeoutError};
-use std::time::{Duration, Instant};
 use std::time::SystemTime;
+use std::time::{Duration, Instant};
 
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use stasis::{
     publish_cli_args_to_env, restore_cli_args_env, run_jit_tests_in_directory_with_session,
     run_play_in_process, run_self_host_aot_cli, run_with_default_backend, run_with_real_backend,
-    StasisTestRunSession, RunnerConfig,
+    RunnerConfig, StasisTestRunSession,
 };
 use stasis_runner::swap::contracts::TargetMode;
 
@@ -106,7 +106,10 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         i += 1;
     }
     let Some(watch_file) = watch_file else {
-        return Err("missing entry file. Use `stasis.exe play <path.stasis>` (or --watch-file <path>)".to_string());
+        return Err(
+            "missing entry file. Use `stasis.exe play <path.stasis>` (or --watch-file <path>)"
+                .to_string(),
+        );
     };
     Ok(PlayCliArgs {
         watch_file,
@@ -366,9 +369,7 @@ fn cleanup_stale_stasis_cache(
         return Ok(CacheCleanupSummary::default());
     }
     let now = SystemTime::now();
-    let cutoff = now
-        .checked_sub(max_age)
-        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let cutoff = now.checked_sub(max_age).unwrap_or(SystemTime::UNIX_EPOCH);
     let mut summary = CacheCleanupSummary::default();
     cleanup_stale_stasis_cache_dir(cache_root, cutoff, true, &mut summary)?;
     Ok(summary)
@@ -396,8 +397,12 @@ fn cleanup_stale_stasis_cache_dir(
             continue;
         }
         if cache_entry_is_stale(&metadata, cutoff) {
-            fs::remove_file(&path)
-                .map_err(|error| format!("failed removing stale cache file '{}': {error}", path.display()))?;
+            fs::remove_file(&path).map_err(|error| {
+                format!(
+                    "failed removing stale cache file '{}': {error}",
+                    path.display()
+                )
+            })?;
             summary.removed_files = summary.removed_files.saturating_add(1);
         }
     }
@@ -409,8 +414,12 @@ fn cleanup_stale_stasis_cache_dir(
         .next()
         .is_none();
     if is_empty {
-        fs::remove_dir(dir)
-            .map_err(|error| format!("failed removing stale cache directory '{}': {error}", dir.display()))?;
+        fs::remove_dir(dir).map_err(|error| {
+            format!(
+                "failed removing stale cache directory '{}': {error}",
+                dir.display()
+            )
+        })?;
         summary.removed_dirs = summary.removed_dirs.saturating_add(1);
     }
     Ok(())
@@ -831,10 +840,7 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "stasis_cache_cleanup_zero_{}",
-            stamp
-        ));
+        let root = std::env::temp_dir().join(format!("stasis_cache_cleanup_zero_{}", stamp));
         let cache_root = root.join(".stasis_cache");
         let nested = cache_root.join("nested");
         std::fs::create_dir_all(&nested).expect("mkdir");
@@ -855,20 +861,15 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "stasis_cache_cleanup_keep_{}",
-            stamp
-        ));
+        let root = std::env::temp_dir().join(format!("stasis_cache_cleanup_keep_{}", stamp));
         let cache_root = root.join(".stasis_cache");
         std::fs::create_dir_all(&cache_root).expect("mkdir");
         let file = cache_root.join("fresh.bin");
         std::fs::write(&file, "x").expect("write");
 
-        let summary = cleanup_stale_stasis_cache(
-            &cache_root,
-            Duration::from_secs(365 * 24 * 60 * 60),
-        )
-        .expect("cleanup");
+        let summary =
+            cleanup_stale_stasis_cache(&cache_root, Duration::from_secs(365 * 24 * 60 * 60))
+                .expect("cleanup");
         assert_eq!(summary.removed_files, 0, "{summary:?}");
         assert!(file.exists());
 
@@ -916,10 +917,7 @@ mod tests {
             "entry.stasis".to_string(),
         ];
         let parsed = parse_aot_cli_contract_args(&args).expect("parse should succeed");
-        assert_eq!(
-            parsed.entry_file,
-            Some(PathBuf::from("entry.stasis"))
-        );
+        assert_eq!(parsed.entry_file, Some(PathBuf::from("entry.stasis")));
         assert!(!parsed.quality_gate);
     }
 

--- a/apps/stasis/src/runtime_exec.rs
+++ b/apps/stasis/src/runtime_exec.rs
@@ -101,7 +101,10 @@ impl RuntimeLauncher {
 
         let mut command = Command::new(stasis_exe);
         // Always launch the generic play runner (no sample-specific scenarios).
-        command.arg("play").arg("--watch-file").arg(&self.source_file);
+        command
+            .arg("play")
+            .arg("--watch-file")
+            .arg(&self.source_file);
         command
             .arg("--tick-sleep-us")
             .arg("16000")

--- a/apps/stasis/src/window_config.rs
+++ b/apps/stasis/src/window_config.rs
@@ -9,4 +9,3 @@ impl WindowConfig {
         self.height > self.width
     }
 }
-

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -501,10 +501,7 @@ mod tests {
             .compile_with(|_, _| Ok(()))
             .expect("initial compile");
 
-        compiler.upsert_file(
-            "extra.stasis",
-            "function utility(): i32 { return 4; }\n",
-        );
+        compiler.upsert_file("extra.stasis", "function utility(): i32 { return 4; }\n");
         let index = compiler.index_pass().expect("index pass");
         assert_eq!(index.signature_changed_functions, 0);
         assert_eq!(index.dirty_functions, 1);

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1,8 +1,8 @@
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use std::collections::HashMap;
 
 #[cfg(windows)]
 use std::ffi::{c_char, c_void, CString, OsStr};
@@ -169,7 +169,8 @@ impl StasisGraphicsApi {
         let lib = Library::load(path)?;
         let stasis_init_window = lib.symbol_address("stasis_init_window")?;
         let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
-        let stasis_host_bulk_apply_requests = lib.symbol_address("stasis_host_bulk_apply_requests")?;
+        let stasis_host_bulk_apply_requests =
+            lib.symbol_address("stasis_host_bulk_apply_requests")?;
         let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
         let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
         Ok(Self {
@@ -197,7 +198,10 @@ impl StasisGraphicsApi {
             let _ = width;
             let _ = height;
             let _ = title;
-            Err("stasis_graphics init_window is only supported on windows in stasis_dynload".to_string())
+            Err(
+                "stasis_graphics init_window is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
         }
     }
 
@@ -213,7 +217,10 @@ impl StasisGraphicsApi {
         {
             let _ = out_i32;
             let _ = out_f32;
-            Err("stasis_graphics host_get_frame is only supported on windows in stasis_dynload".to_string())
+            Err(
+                "stasis_graphics host_get_frame is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
         }
     }
 
@@ -246,7 +253,12 @@ impl StasisGraphicsApi {
         }
     }
 
-    pub fn gfx_submit_u8(&self, cmd_i32: &[i32], cmd_f32: &[f32], cmd_u8: &[u8]) -> Result<(), String> {
+    pub fn gfx_submit_u8(
+        &self,
+        cmd_i32: &[i32],
+        cmd_f32: &[f32],
+        cmd_u8: &[u8],
+    ) -> Result<(), String> {
         #[cfg(windows)]
         {
             let callback: extern "system" fn(*const i32, *const f32, *const u8) =
@@ -259,7 +271,10 @@ impl StasisGraphicsApi {
             let _ = cmd_i32;
             let _ = cmd_f32;
             let _ = cmd_u8;
-            Err("stasis_graphics gfx_submit_u8 is only supported on windows in stasis_dynload".to_string())
+            Err(
+                "stasis_graphics gfx_submit_u8 is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
         }
     }
 
@@ -274,7 +289,10 @@ impl StasisGraphicsApi {
         #[cfg(not(windows))]
         {
             let _ = ms;
-            Err("stasis_graphics sleep_ms is only supported on windows in stasis_dynload".to_string())
+            Err(
+                "stasis_graphics sleep_ms is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
         }
     }
 }
@@ -463,31 +481,41 @@ fn registered_u8_arrays() -> &'static Mutex<HashMap<ArrayKey, (usize, usize)>> {
 
 pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
     let table = registered_i32_ptrs();
-    let mut guard = table.lock().expect("registered i32 ptr table mutex poisoned");
+    let mut guard = table
+        .lock()
+        .expect("registered i32 ptr table mutex poisoned");
     guard.insert(path_hash, ptr as usize);
 }
 
 pub fn register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
     let table = registered_f32_ptrs();
-    let mut guard = table.lock().expect("registered f32 ptr table mutex poisoned");
+    let mut guard = table
+        .lock()
+        .expect("registered f32 ptr table mutex poisoned");
     guard.insert(path_hash, ptr as usize);
 }
 
 pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mut i32, len: usize) {
     let table = registered_i32_arrays();
-    let mut guard = table.lock().expect("registered i32 array table mutex poisoned");
+    let mut guard = table
+        .lock()
+        .expect("registered i32 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
 }
 
 pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mut f32, len: usize) {
     let table = registered_f32_arrays();
-    let mut guard = table.lock().expect("registered f32 array table mutex poisoned");
+    let mut guard = table
+        .lock()
+        .expect("registered f32 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
 }
 
 pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut u8, len: usize) {
     let table = registered_u8_arrays();
-    let mut guard = table.lock().expect("registered u8 array table mutex poisoned");
+    let mut guard = table
+        .lock()
+        .expect("registered u8 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
 }
 
@@ -888,7 +916,9 @@ pub extern "C" fn stasis_jit_call_f32_i32_1(fn_id_raw: i32, arg0: i32) -> f32 {
 pub extern "C" fn stasis_jit_global_i32_load(path_hash: i32) -> i32 {
     {
         let table = registered_i32_ptrs();
-        let guard = table.lock().expect("registered i32 ptr table mutex poisoned");
+        let guard = table
+            .lock()
+            .expect("registered i32 ptr table mutex poisoned");
         if let Some(ptr) = guard.get(&path_hash).copied() {
             // Safety: caller owns lifetime; this is a process-global registration.
             return unsafe { *(ptr as *mut i32) };
@@ -902,7 +932,9 @@ pub extern "C" fn stasis_jit_global_i32_load(path_hash: i32) -> i32 {
 pub extern "C" fn stasis_jit_global_i32_store(path_hash: i32, value: i32) {
     {
         let table = registered_i32_ptrs();
-        let guard = table.lock().expect("registered i32 ptr table mutex poisoned");
+        let guard = table
+            .lock()
+            .expect("registered i32 ptr table mutex poisoned");
         if let Some(ptr) = guard.get(&path_hash).copied() {
             // Safety: caller owns lifetime; this is a process-global registration.
             unsafe { *(ptr as *mut i32) = value };
@@ -944,7 +976,11 @@ pub extern "C" fn stasis_jit_collection_i32_load(collection_hash: i32, meta_kind
 }
 
 #[no_mangle]
-pub extern "C" fn stasis_jit_collection_i32_store(collection_hash: i32, meta_kind: i32, value: i32) {
+pub extern "C" fn stasis_jit_collection_i32_store(
+    collection_hash: i32,
+    meta_kind: i32,
+    value: i32,
+) {
     let Some(suffix) = stasis_meta_suffix_bytes(meta_kind) else {
         return;
     };
@@ -955,7 +991,9 @@ pub extern "C" fn stasis_jit_collection_i32_store(collection_hash: i32, meta_kin
 pub extern "C" fn stasis_jit_global_f32_load(path_hash: i32) -> f32 {
     {
         let table = registered_f32_ptrs();
-        let guard = table.lock().expect("registered f32 ptr table mutex poisoned");
+        let guard = table
+            .lock()
+            .expect("registered f32 ptr table mutex poisoned");
         if let Some(ptr) = guard.get(&path_hash).copied() {
             // Safety: caller owns lifetime; this is a process-global registration.
             return unsafe { *(ptr as *mut f32) };
@@ -969,7 +1007,9 @@ pub extern "C" fn stasis_jit_global_f32_load(path_hash: i32) -> f32 {
 pub extern "C" fn stasis_jit_global_f32_store(path_hash: i32, value: f32) {
     {
         let table = registered_f32_ptrs();
-        let guard = table.lock().expect("registered f32 ptr table mutex poisoned");
+        let guard = table
+            .lock()
+            .expect("registered f32 ptr table mutex poisoned");
         if let Some(ptr) = guard.get(&path_hash).copied() {
             // Safety: caller owns lifetime; this is a process-global registration.
             unsafe { *(ptr as *mut f32) = value };
@@ -1295,7 +1335,8 @@ fn dispatch_i32_call3(fn_id_raw: i32, arg0: i32, arg1: i32, arg2: i32) -> Result
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=3"));
     }
-    let callback: extern "system" fn(i32, i32, i32) -> i32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(i32, i32, i32) -> i32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2))
 }
 
@@ -1311,7 +1352,8 @@ fn dispatch_i32_call4(
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=4"));
     }
-    let callback: extern "system" fn(i32, i32, i32, i32) -> i32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(i32, i32, i32, i32) -> i32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2, arg3))
 }
 
@@ -1419,7 +1461,8 @@ fn dispatch_i32_f32_call3(fn_id_raw: i32, arg0: f32, arg1: f32, arg2: f32) -> Re
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=3"));
     }
-    let callback: extern "system" fn(f32, f32, f32) -> i32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(f32, f32, f32) -> i32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2))
 }
 
@@ -1435,7 +1478,8 @@ fn dispatch_i32_f32_call4(
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=4"));
     }
-    let callback: extern "system" fn(f32, f32, f32, f32) -> i32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(f32, f32, f32, f32) -> i32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2, arg3))
 }
 
@@ -1553,7 +1597,8 @@ fn dispatch_f32_call3(fn_id_raw: i32, arg0: f32, arg1: f32, arg2: f32) -> Result
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=3"));
     }
-    let callback: extern "system" fn(f32, f32, f32) -> f32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(f32, f32, f32) -> f32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2))
 }
 
@@ -1569,7 +1614,8 @@ fn dispatch_f32_call4(
     if address == 0 {
         return Err(format!("missing code pointer for fn_id={fn_id}, arity=4"));
     }
-    let callback: extern "system" fn(f32, f32, f32, f32) -> f32 = unsafe { std::mem::transmute(address) };
+    let callback: extern "system" fn(f32, f32, f32, f32) -> f32 =
+        unsafe { std::mem::transmute(address) };
     Ok(callback(arg0, arg1, arg2, arg3))
 }
 


### PR DESCRIPTION
Fixes ReleaseTest regression: `stasis.exe play flappy.stasis` (basename entry in current dir) previously resolved an empty watch-dir (Path::parent() = "") and failed with os error 123 when setting cwd.

Changes:
- Normalize play watch-dir resolution so empty paths are treated as `.`
- Add unit tests for the resolution helper
- CLI now passes only explicit --watch-dir; lib handles defaulting

Task: Maddox #37
