### PR TITLE
S13/S14: host-set registry/profile selection + contract validation

### DIFF
--- a/apps/stasis/examples/engine_overhead_bench.rs
+++ b/apps/stasis/examples/engine_overhead_bench.rs
@@ -194,6 +194,8 @@ fn run_sample(mode: BenchMode, ticks: u32, tick_sleep_us: u64) -> Result<SampleM
         swap_failure_reason: None,
         runtime_launch: false,
         aot_probe_loadability: false,
+        host_set_profile: None,
+        host_set_registry_file: None,
     };
 
     let start = Instant::now();

--- a/apps/stasis/src/host_set_registry.rs
+++ b/apps/stasis/src/host_set_registry.rs
@@ -1,0 +1,180 @@
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostSetProfile {
+    Dev,
+    Test,
+    Prod,
+}
+
+impl HostSetProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HostSetProfile::Dev => "dev",
+            HostSetProfile::Test => "test",
+            HostSetProfile::Prod => "prod",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "dev" => Some(HostSetProfile::Dev),
+            "test" => Some(HostSetProfile::Test),
+            "prod" => Some(HostSetProfile::Prod),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSetContract {
+    pub host_set_id: String,
+    pub host_set_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct HostSetRegistryFile {
+    profiles: BTreeMap<String, HostSetRegistryProfileEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct HostSetRegistryProfileEntry {
+    id: String,
+    #[serde(default)]
+    hash: Option<String>,
+}
+
+pub fn contract_hash_from_id(host_set_id: &str) -> [u8; 32] {
+    // Deterministic placeholder hash until the contract includes export/phase metadata.
+    let input = format!("stasis.host_set_contract.v1:{host_set_id}");
+    let digest: [u8; 32] = Sha256::digest(input.as_bytes()).into();
+    digest
+}
+
+pub fn resolve_profile_contract(
+    profile: HostSetProfile,
+    registry_file: Option<&Path>,
+) -> Result<HostSetContract, String> {
+    if let Some(path) = registry_file {
+        let text = fs::read_to_string(path).map_err(|error| {
+            format!(
+                "failed reading host-set registry file {}: {error}",
+                path.display()
+            )
+        })?;
+        let registry: HostSetRegistryFile = serde_json::from_str(&text).map_err(|error| {
+            format!(
+                "invalid host-set registry JSON ({}): {error}",
+                path.display()
+            )
+        })?;
+        let key = profile.as_str().to_string();
+        let entry = registry.profiles.get(&key).ok_or_else(|| {
+            format!(
+                "host-set registry {} missing profile entry for '{}'",
+                path.display(),
+                profile.as_str()
+            )
+        })?;
+
+        let host_set_id = entry.id.trim().to_string();
+        if host_set_id.is_empty() {
+            return Err(format!(
+                "host-set registry {} profile '{}' has empty id",
+                path.display(),
+                profile.as_str()
+            ));
+        }
+
+        let host_set_hash = if let Some(hash) = entry.hash.as_deref() {
+            parse_sha256_hex(hash).map_err(|message| {
+                format!(
+                    "host-set registry {} profile '{}' invalid hash: {message}",
+                    path.display(),
+                    profile.as_str()
+                )
+            })?
+        } else {
+            contract_hash_from_id(&host_set_id)
+        };
+
+        return Ok(HostSetContract {
+            host_set_id,
+            host_set_hash,
+        });
+    }
+
+    let host_set_id = format!("stasis-{}", profile.as_str());
+    Ok(HostSetContract {
+        host_set_id: host_set_id.clone(),
+        host_set_hash: contract_hash_from_id(&host_set_id),
+    })
+}
+
+fn parse_sha256_hex(value: &str) -> Result<[u8; 32], String> {
+    let trimmed = value.trim().trim_start_matches("0x");
+    if trimmed.len() != 64 {
+        return Err(format!("expected 64 hex chars, got {}", trimmed.len()));
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in trimmed.as_bytes().chunks(2).enumerate() {
+        let s = std::str::from_utf8(chunk).map_err(|_| "hash is not valid utf-8".to_string())?;
+        out[i] = u8::from_str_radix(s, 16).map_err(|_| format!("invalid hex byte '{s}'"))?;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn default_contract_hash_is_deterministic() {
+        let a = resolve_profile_contract(HostSetProfile::Dev, None).expect("resolve");
+        let b = resolve_profile_contract(HostSetProfile::Dev, None).expect("resolve");
+        assert_eq!(a, b);
+        assert_eq!(a.host_set_id, "stasis-dev");
+        assert_ne!(a.host_set_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn registry_file_can_override_profile_id_and_hash() {
+        let tmp = std::env::temp_dir().join("stasis_host_set_registry_test.json");
+        fs::write(
+            &tmp,
+            r#"{
+  "profiles": {
+    "dev": { "id": "editor-host", "hash": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" }
+  }
+}"#,
+        )
+        .expect("write tmp");
+
+        let contract = resolve_profile_contract(HostSetProfile::Dev, Some(&tmp)).expect("resolve");
+        assert_eq!(contract.host_set_id, "editor-host");
+        assert_eq!(contract.host_set_hash[0], 0);
+        assert_eq!(contract.host_set_hash[31], 31);
+    }
+
+    #[test]
+    fn registry_file_missing_profile_is_error() {
+        let tmp: PathBuf = std::env::temp_dir().join("stasis_host_set_registry_missing.json");
+        fs::write(
+            &tmp,
+            r#"{
+  "profiles": {
+    "prod": { "id": "stasis-prod" }
+  }
+}"#,
+        )
+        .expect("write tmp");
+
+        let error = resolve_profile_contract(HostSetProfile::Dev, Some(&tmp)).unwrap_err();
+        assert!(error.contains("missing profile entry"));
+    }
+}

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod compiler_backend;
 mod events;
+mod host_set_registry;
 mod runtime_exec;
 mod self_host_runtime_bridge;
 mod stasis_test_runner;
@@ -64,6 +65,8 @@ pub struct RunnerConfig {
     pub swap_failure_reason: Option<String>,
     pub runtime_launch: bool,
     pub aot_probe_loadability: bool,
+    pub host_set_profile: Option<String>,
+    pub host_set_registry_file: Option<PathBuf>,
 }
 
 impl Default for RunnerConfig {
@@ -81,6 +84,8 @@ impl Default for RunnerConfig {
             swap_failure_reason: None,
             runtime_launch: true,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         }
     }
 }
@@ -116,6 +121,46 @@ pub struct RunnerSummary {
     pub retired_aot_linked_images: u32,
 }
 
+const STASIS_HOST_SET_PROFILE_ENV: &str = "STASIS_HOST_SET_PROFILE";
+const STASIS_HOST_SET_REGISTRY_FILE_ENV: &str = "STASIS_HOST_SET_REGISTRY_FILE";
+
+fn infer_host_set_profile_from_target_mode(
+    target_mode: TargetMode,
+) -> host_set_registry::HostSetProfile {
+    match target_mode {
+        TargetMode::JitDev => host_set_registry::HostSetProfile::Dev,
+        TargetMode::AotProd => host_set_registry::HostSetProfile::Prod,
+    }
+}
+
+fn resolve_host_set_contract(
+    config: &RunnerConfig,
+) -> Result<host_set_registry::HostSetContract, String> {
+    let profile = if let Some(profile) = config.host_set_profile.as_deref() {
+        host_set_registry::HostSetProfile::parse(profile).ok_or_else(|| {
+            format!("invalid --host-set-profile '{profile}' (expected dev|test|prod)")
+        })?
+    } else if let Ok(profile) = std::env::var(STASIS_HOST_SET_PROFILE_ENV) {
+        host_set_registry::HostSetProfile::parse(&profile).ok_or_else(|| {
+            format!("invalid {STASIS_HOST_SET_PROFILE_ENV}='{profile}' (expected dev|test|prod)")
+        })?
+    } else {
+        infer_host_set_profile_from_target_mode(config.target_mode)
+    };
+
+    let registry_file = config
+        .host_set_registry_file
+        .as_deref()
+        .map(|path| path.to_path_buf())
+        .or_else(|| {
+            std::env::var_os(STASIS_HOST_SET_REGISTRY_FILE_ENV)
+                .filter(|path| !path.is_empty())
+                .map(PathBuf::from)
+        });
+
+    host_set_registry::resolve_profile_contract(profile, registry_file.as_deref())
+}
+
 pub fn run_with_default_backend(config: RunnerConfig) -> RunnerSummary {
     let backend = move |request: CompileRequest| -> CompileResult {
         if config.fail_compile {
@@ -138,11 +183,18 @@ pub fn run_with_default_backend(config: RunnerConfig) -> RunnerSummary {
             } else {
                 None
             };
-            CompileResult::success_with_hook_symbol(
+            CompileResult::success_with_host_set_metadata(
                 request.request_id,
                 LayoutHash([1; 32]),
                 patch_set,
+                request.host_set_id.clone(),
+                request.host_set_hash,
                 hook_symbol,
+                None,
+                None,
+                None,
+                None,
+                None,
             )
         }
     };
@@ -666,7 +718,46 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         .and_then(|source| collect_watch_dependency_paths(source).ok());
     let window = config.window;
 
+    let host_set_contract = match resolve_host_set_contract(&config) {
+        Ok(contract) => contract,
+        Err(message) => {
+            return RunnerSummary {
+                ticks_executed: 0,
+                compile_successes: 0,
+                compile_failures: 1,
+                compile_diagnostics: vec![message],
+                hook_runs: 0,
+                hook_failures: 0,
+                hook_failure_reasons: Vec::new(),
+                swap_commit_successes: 0,
+                swap_commit_failures: 0,
+                swap_failure_reasons: Vec::new(),
+                swap_indicator_armed_count: 0,
+                swap_flash_peak_ticks: 0,
+                swap_flash_ticks_remaining: 0,
+                last_compile_duration_ms: None,
+                last_commit_duration_ms: None,
+                window,
+                last_swap_status: None,
+                has_in_flight_work: false,
+                events: Vec::new(),
+                runtime_launches: 0,
+                runtime_launch_failures: 0,
+                runtime_launch_failure_reasons: Vec::new(),
+                aot_linked_image_activations: 0,
+                active_aot_linked_image_path: None,
+                active_aot_linked_image_size_bytes: None,
+                active_aot_linked_image_generation: None,
+                retired_aot_linked_images: 0,
+            };
+        }
+    };
+
     let mut pipeline = DevHotSwapPipeline::with_target_mode(backend, config.target_mode);
+    pipeline.set_host_set_contract(
+        Some(host_set_contract.host_set_id.clone()),
+        Some(host_set_contract.host_set_hash),
+    );
     let mut pointer_table = FunctionPointerTable::new();
     let mut hook_runs: u32 = 0;
     let mut hook_failures: u32 = 0;
@@ -754,6 +845,7 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
                 request,
                 &mut pointer_table,
                 &config,
+                &host_set_contract,
                 &mut hook_runs,
                 &mut hook_failures,
                 &mut hook_failure_reasons,
@@ -843,6 +935,7 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
                 request,
                 &mut pointer_table,
                 &config,
+                &host_set_contract,
                 &mut hook_runs,
                 &mut hook_failures,
                 &mut hook_failure_reasons,
@@ -1013,6 +1106,7 @@ fn apply_commit_request(
     request: stasis_runner::swap::contracts::SwapCommitRequest,
     pointer_table: &mut FunctionPointerTable,
     config: &RunnerConfig,
+    expected_host_set: &host_set_registry::HostSetContract,
     hook_runs: &mut u32,
     hook_failures: &mut u32,
     hook_failure_reasons: &mut Vec<String>,
@@ -1025,6 +1119,18 @@ fn apply_commit_request(
     pending_aot_metadata: &BTreeMap<RequestId, PendingAotCompileMetadata>,
     pending_jit_code_ptr_overrides: &BTreeMap<RequestId, Vec<JitCodePtrOverride>>,
 ) -> SwapCommitResult {
+    if request.host_set_id.as_deref() != Some(expected_host_set.host_set_id.as_str())
+        || request.host_set_hash != Some(expected_host_set.host_set_hash)
+    {
+        let message = format!(
+            "host-set contract mismatch: expected id='{}' hash={:02x?}",
+            expected_host_set.host_set_id, expected_host_set.host_set_hash
+        );
+        *swap_commit_failures += 1;
+        swap_failure_reasons.push(message.clone());
+        return SwapCommitResult::failed(request.request_id, message);
+    }
+
     if config.target_mode == TargetMode::JitDev && !config.disable_on_code_swap_hook {
         if let Some(hook_symbol) = request.hook_symbol.as_deref() {
             *hook_runs += 1;
@@ -1489,6 +1595,146 @@ mod tests {
         }
     }
 
+    fn expected_host_set(config: &RunnerConfig) -> host_set_registry::HostSetContract {
+        resolve_host_set_contract(config).expect("host-set contract should resolve in tests")
+    }
+
+    fn attach_host_set(
+        request: &mut stasis_runner::swap::contracts::SwapCommitRequest,
+        contract: &host_set_registry::HostSetContract,
+    ) {
+        request.host_set_id = Some(contract.host_set_id.clone());
+        request.host_set_hash = Some(contract.host_set_hash);
+    }
+
+    #[test]
+    fn resolve_host_set_contract_prefers_explicit_config_profile_over_env() {
+        let config = RunnerConfig {
+            target_mode: TargetMode::AotProd,
+            host_set_profile: Some("dev".to_string()),
+            host_set_registry_file: None,
+            ..RunnerConfig::default()
+        };
+        with_env_var_set(STASIS_HOST_SET_PROFILE_ENV, "prod", || {
+            let contract =
+                resolve_host_set_contract(&config).expect("host-set contract should resolve");
+            assert_eq!(contract.host_set_id, "stasis-dev");
+        });
+    }
+
+    #[test]
+    fn resolve_host_set_contract_prefers_env_profile_over_target_mode_inference() {
+        let config = RunnerConfig {
+            target_mode: TargetMode::AotProd,
+            host_set_profile: None,
+            host_set_registry_file: None,
+            ..RunnerConfig::default()
+        };
+        with_env_var_set(STASIS_HOST_SET_PROFILE_ENV, "dev", || {
+            let contract =
+                resolve_host_set_contract(&config).expect("host-set contract should resolve");
+            assert_eq!(contract.host_set_id, "stasis-dev");
+        });
+    }
+
+    #[test]
+    fn resolve_host_set_contract_uses_registry_file_from_env_when_set() {
+        let config = RunnerConfig {
+            target_mode: TargetMode::JitDev,
+            host_set_profile: Some("dev".to_string()),
+            host_set_registry_file: None,
+            ..RunnerConfig::default()
+        };
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let tmp: PathBuf = std::env::temp_dir().join(format!(
+            "stasis_host_set_registry_env_resolution_{}.json",
+            stamp
+        ));
+        fs::write(
+            &tmp,
+            "{\"profiles\":{\"dev\":{\"id\":\"editor-host\",\"hash\":\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"}}}",
+        )
+        .expect("write registry");
+
+        let tmp_str = tmp.to_string_lossy().to_string();
+        with_env_var_set(STASIS_HOST_SET_REGISTRY_FILE_ENV, &tmp_str, || {
+            let contract =
+                resolve_host_set_contract(&config).expect("host-set contract should resolve");
+            assert_eq!(contract.host_set_id, "editor-host");
+            assert_eq!(contract.host_set_hash[0], 0);
+            assert_eq!(contract.host_set_hash[31], 31);
+        });
+
+        fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn apply_commit_request_rejects_missing_host_set_contract_metadata() {
+        let request_id = RequestId(44);
+        let request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+            request_id,
+            LayoutHash([7; 32]),
+            FunctionPatchSet {
+                functions: vec![FunctionPatch { fn_id: FnId(9) }],
+            },
+            None,
+        );
+
+        let mut pointer_table = FunctionPointerTable::new();
+        let config = RunnerConfig::default();
+        let host_set_contract = expected_host_set(&config);
+        let mut hook_runs = 0u32;
+        let mut hook_failures = 0u32;
+        let mut hook_failure_reasons = Vec::new();
+        let mut swap_commit_successes = 0u32;
+        let mut swap_commit_failures = 0u32;
+        let mut swap_failure_reasons = Vec::new();
+        let mut events = Vec::new();
+        let pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
+        let pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
+            BTreeMap::new();
+
+        let result = apply_commit_request(
+            request,
+            &mut pointer_table,
+            &config,
+            &host_set_contract,
+            &mut hook_runs,
+            &mut hook_failures,
+            &mut hook_failure_reasons,
+            &mut swap_commit_successes,
+            &mut swap_commit_failures,
+            &mut swap_failure_reasons,
+            &mut events,
+            None,
+            None,
+            &pending_aot_metadata,
+            &pending_jit_code_ptr_overrides,
+        );
+
+        assert_eq!(result.status, SwapCommitStatus::Failed);
+        assert_eq!(hook_runs, 0);
+        assert_eq!(hook_failures, 0);
+        assert_eq!(swap_commit_successes, 0);
+        assert_eq!(swap_commit_failures, 1);
+        assert!(
+            result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("host-set contract mismatch")),
+            "expected host-set contract mismatch error, got {:?}",
+            result.error
+        );
+        assert_eq!(swap_failure_reasons.len(), 1);
+        assert!(swap_failure_reasons[0].contains("host-set contract mismatch"));
+        assert_eq!(pointer_table.generation().0, 0);
+        assert!(pointer_table.code_ptr(FnId(9)).is_none());
+        assert!(events.is_empty());
+    }
+
     #[test]
     fn resolve_play_watch_dir_defaults_to_dot_for_basename_entry() {
         let resolved = resolve_play_watch_dir(Path::new("flappy.stasis"), None);
@@ -1519,7 +1765,7 @@ mod tests {
     #[test]
     fn apply_commit_request_uses_jit_code_ptr_overrides_when_present() {
         let request_id = RequestId(44);
-        let request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+        let mut request = stasis_runner::swap::contracts::SwapCommitRequest::new(
             request_id,
             LayoutHash([7; 32]),
             FunctionPatchSet {
@@ -1530,6 +1776,8 @@ mod tests {
 
         let mut pointer_table = FunctionPointerTable::new();
         let config = RunnerConfig::default();
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
         let mut hook_failure_reasons = Vec::new();
@@ -1552,6 +1800,7 @@ mod tests {
             request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1591,6 +1840,8 @@ mod tests {
             runtime_launch: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
         let mut hook_failure_reasons = Vec::new();
@@ -1613,6 +1864,7 @@ mod tests {
             request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1661,6 +1913,8 @@ mod tests {
             runtime_launch: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
         let mut hook_failure_reasons = Vec::new();
@@ -1684,6 +1938,7 @@ mod tests {
             request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1721,6 +1976,7 @@ mod tests {
             runtime_launch: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
         let pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
         let pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
             BTreeMap::new();
@@ -1734,7 +1990,7 @@ mod tests {
         let mut events = Vec::new();
 
         let first_request_id = RequestId(44);
-        let first_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+        let mut first_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
             first_request_id,
             LayoutHash([7; 32]),
             FunctionPatchSet {
@@ -1742,10 +1998,12 @@ mod tests {
             },
             None,
         );
+        attach_host_set(&mut first_request, &host_set_contract);
         let first = apply_commit_request(
             first_request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1772,6 +2030,7 @@ mod tests {
             },
             Some("on_code_swap".to_string()),
         );
+        attach_host_set(&mut second_request, &host_set_contract);
         second_request.hook_fn_id = Some(FnId(7));
         let mut second_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> = BTreeMap::new();
         // Note: override list doesn't include hook fn id 7, so commit must abort before swap.
@@ -1787,6 +2046,7 @@ mod tests {
             second_request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1823,6 +2083,8 @@ mod tests {
             runtime_launch: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
         let mut hook_failure_reasons = Vec::new();
@@ -1838,6 +2100,7 @@ mod tests {
             request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -1879,6 +2142,8 @@ mod tests {
                 runtime_launch: false,
                 ..RunnerConfig::default()
             };
+            let host_set_contract = expected_host_set(&config);
+            attach_host_set(&mut request, &host_set_contract);
             let mut hook_runs = 0u32;
             let mut hook_failures = 0u32;
             let mut hook_failure_reasons = Vec::new();
@@ -1895,6 +2160,7 @@ mod tests {
                 request,
                 &mut pointer_table,
                 &config,
+                &host_set_contract,
                 &mut hook_runs,
                 &mut hook_failures,
                 &mut hook_failure_reasons,
@@ -2052,6 +2318,8 @@ mod tests {
             aot_probe_loadability: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut commit_request, &host_set_contract);
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
         let mut hook_failure_reasons = Vec::new();
@@ -2065,6 +2333,7 @@ mod tests {
                 commit_request,
                 &mut pointer_table,
                 &config,
+                &host_set_contract,
                 &mut hook_runs,
                 &mut hook_failures,
                 &mut hook_failure_reasons,
@@ -2094,6 +2363,7 @@ mod tests {
             runtime_launch: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
         let pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
         let pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
             BTreeMap::new();
@@ -2107,7 +2377,7 @@ mod tests {
         let mut events = Vec::new();
 
         let first_request_id = RequestId(44);
-        let first_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+        let mut first_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
             first_request_id,
             LayoutHash([7; 32]),
             FunctionPatchSet {
@@ -2115,10 +2385,12 @@ mod tests {
             },
             None,
         );
+        attach_host_set(&mut first_request, &host_set_contract);
         let first = apply_commit_request(
             first_request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -2138,7 +2410,7 @@ mod tests {
 
         let reason = "state invariant mismatch".to_string();
         let second_request_id = RequestId(45);
-        let second_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+        let mut second_request = stasis_runner::swap::contracts::SwapCommitRequest::new(
             second_request_id,
             LayoutHash([7; 32]),
             FunctionPatchSet {
@@ -2146,10 +2418,12 @@ mod tests {
             },
             Some("on_code_swap".to_string()),
         );
+        attach_host_set(&mut second_request, &host_set_contract);
         let second = apply_commit_request(
             second_request,
             &mut pointer_table,
             &config,
+            &host_set_contract,
             &mut hook_runs,
             &mut hook_failures,
             &mut hook_failure_reasons,
@@ -2187,6 +2461,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2276,6 +2552,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2339,6 +2617,8 @@ mod tests {
             swap_failure_reason: Some("simulated swap rejection: layout mismatch".to_string()),
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2386,6 +2666,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2451,6 +2733,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2509,6 +2793,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2564,6 +2850,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2589,7 +2877,19 @@ mod tests {
             let patch_set = FunctionPatchSet {
                 functions: vec![FunctionPatch { fn_id: FnId(1) }],
             };
-            CompileResult::success(request.request_id, LayoutHash([2; 32]), patch_set)
+            CompileResult::success_with_host_set_metadata(
+                request.request_id,
+                LayoutHash([2; 32]),
+                patch_set,
+                request.host_set_id.clone(),
+                request.host_set_hash,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
         };
 
         let config = RunnerConfig {
@@ -2605,6 +2905,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_backend(config, backend);
@@ -2632,6 +2934,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: true,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_default_backend(config);
@@ -2658,6 +2962,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: true,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let resolved = resolve_initial_source_file(&config).expect("resolved source file");
@@ -2696,6 +3002,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: true,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let resolved = resolve_initial_source_file(&config).expect("resolved source file");
@@ -2803,8 +3111,8 @@ mod tests {
                 FunctionPatchSet {
                     functions: vec![FunctionPatch { fn_id: FnId(1) }],
                 },
-                None,
-                None,
+                request.host_set_id.clone(),
+                request.host_set_hash,
                 None,
                 None,
                 Some(linked_image_for_backend.clone()),
@@ -2827,6 +3135,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: true,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_backend(config, backend);
@@ -2859,8 +3169,8 @@ mod tests {
                 FunctionPatchSet {
                     functions: vec![FunctionPatch { fn_id: FnId(1) }],
                 },
-                None,
-                None,
+                request.host_set_id.clone(),
+                request.host_set_hash,
                 None,
                 None,
                 Some(linked_image_for_backend.clone()),
@@ -2883,6 +3193,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_backend(config, backend);
@@ -2922,6 +3234,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_real_backend(config);
@@ -2956,6 +3270,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_real_backend(config);
@@ -2990,6 +3306,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_real_backend(config);
@@ -3029,6 +3347,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_real_backend(config);
@@ -3083,6 +3403,11 @@ mod tests {
             aot_probe_loadability: false,
             ..RunnerConfig::default()
         };
+        let host_set_contract = expected_host_set(&config);
+        pipeline.set_host_set_contract(
+            Some(host_set_contract.host_set_id.clone()),
+            Some(host_set_contract.host_set_hash),
+        );
 
         let mut hook_runs = 0u32;
         let mut hook_failures = 0u32;
@@ -3113,6 +3438,7 @@ mod tests {
                     request,
                     &mut pointer_table,
                     &config,
+                    &host_set_contract,
                     &mut hook_runs,
                     &mut hook_failures,
                     &mut hook_failure_reasons,
@@ -3168,6 +3494,7 @@ mod tests {
                     request,
                     &mut pointer_table,
                     &config,
+                    &host_set_contract,
                     &mut hook_runs,
                     &mut hook_failures,
                     &mut hook_failure_reasons,
@@ -3250,6 +3577,8 @@ mod tests {
             swap_failure_reason: None,
             runtime_launch: false,
             aot_probe_loadability: false,
+            host_set_profile: None,
+            host_set_registry_file: None,
         };
 
         let summary = run_with_real_backend(config);

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -230,6 +230,16 @@ fn parse_args() -> CliOptions {
                     }
                 }
             }
+            "--host-set-profile" => {
+                if let Some(value) = args.next() {
+                    config.host_set_profile = Some(value);
+                }
+            }
+            "--host-set-registry-file" => {
+                if let Some(value) = args.next() {
+                    config.host_set_registry_file = Some(PathBuf::from(value));
+                }
+            }
             "--aot-prod" => {
                 config.target_mode = TargetMode::AotProd;
             }

--- a/crates/stasis_runner/src/swap/contracts.rs
+++ b/crates/stasis_runner/src/swap/contracts.rs
@@ -252,6 +252,10 @@ pub struct SwapCommitRequest {
     pub fn_patch_set: FunctionPatchSet,
     pub hook_symbol: Option<String>,
     #[serde(default)]
+    pub host_set_id: Option<String>,
+    #[serde(default)]
+    pub host_set_hash: Option<[u8; 32]>,
+    #[serde(default)]
     pub hook_fn_id: Option<FnId>,
 }
 
@@ -268,6 +272,8 @@ impl SwapCommitRequest {
             layout_hash,
             fn_patch_set,
             hook_symbol,
+            host_set_id: None,
+            host_set_hash: None,
             hook_fn_id: None,
         }
     }

--- a/crates/stasis_runner/src/swap/pipeline.rs
+++ b/crates/stasis_runner/src/swap/pipeline.rs
@@ -41,6 +41,8 @@ pub struct DevHotSwapPipeline {
     commit_result_rx: Receiver<SwapCommitResult>,
     pending_files: BTreeSet<PathBuf>,
     target_mode: TargetMode,
+    host_set_id: Option<String>,
+    host_set_hash: Option<[u8; 32]>,
     in_flight_compile: Option<RequestId>,
     in_flight_compile_started_at: Option<Instant>,
     in_flight_commit: Option<RequestId>,
@@ -90,6 +92,8 @@ impl DevHotSwapPipeline {
             commit_result_rx,
             pending_files: BTreeSet::new(),
             target_mode,
+            host_set_id: None,
+            host_set_hash: None,
             in_flight_compile: None,
             in_flight_compile_started_at: None,
             in_flight_commit: None,
@@ -105,6 +109,15 @@ impl DevHotSwapPipeline {
 
     pub fn watcher_sender(&self) -> Sender<FileChangeEvent> {
         self.file_change_tx.clone()
+    }
+
+    pub fn set_host_set_contract(
+        &mut self,
+        host_set_id: Option<String>,
+        host_set_hash: Option<[u8; 32]>,
+    ) {
+        self.host_set_id = host_set_id;
+        self.host_set_hash = host_set_hash;
     }
 
     pub fn submit_file_change(&self, event: FileChangeEvent) {
@@ -191,7 +204,9 @@ impl DevHotSwapPipeline {
         let changed_files: Vec<PathBuf> = self.pending_files.iter().cloned().collect();
         self.pending_files.clear();
 
-        let request = CompileRequest::new(request_id, changed_files, self.target_mode);
+        let mut request = CompileRequest::new(request_id, changed_files, self.target_mode);
+        request.host_set_id = self.host_set_id.clone();
+        request.host_set_hash = self.host_set_hash;
         let _ = self
             .compiler_tx
             .send(CompilerThreadMessage::Compile(request));
@@ -233,6 +248,8 @@ impl DevHotSwapPipeline {
                                 result.layout_hash,
                                 result.fn_patch_set,
                                 result.hook_symbol.clone(),
+                                result.host_set_id.clone(),
+                                result.host_set_hash,
                                 result.hook_fn_id,
                             );
                         }
@@ -249,6 +266,8 @@ impl DevHotSwapPipeline {
         layout_hash: Option<LayoutHash>,
         fn_patch_set: Option<FunctionPatchSet>,
         hook_symbol: Option<String>,
+        host_set_id: Option<String>,
+        host_set_hash: Option<[u8; 32]>,
         hook_fn_id: Option<FnId>,
     ) {
         let Some(layout_hash) = layout_hash else {
@@ -267,6 +286,8 @@ impl DevHotSwapPipeline {
             layout_hash,
             fn_patch_set,
             hook_symbol,
+            host_set_id,
+            host_set_hash,
             hook_fn_id,
         };
         let _ = self.commit_request_tx.send(request);
@@ -476,6 +497,43 @@ mod tests {
         let captured_requests = requests.lock().expect("poisoned");
         let request = captured_requests.first().expect("request should exist");
         assert_eq!(request.target_mode, TargetMode::AotProd);
+    }
+
+    #[test]
+    fn host_set_contract_flows_from_pipeline_to_compile_and_commit_requests() {
+        let host_set_id = "editor-host".to_string();
+        let host_set_hash = [7u8; 32];
+        let mut pipeline = DevHotSwapPipeline::new(move |request: CompileRequest| {
+            assert_eq!(request.host_set_id.as_deref(), Some("editor-host"));
+            assert_eq!(request.host_set_hash, Some(host_set_hash));
+            CompileResult::success_with_host_set_metadata(
+                request.request_id,
+                LayoutHash([6; 32]),
+                sample_patch_set(),
+                request.host_set_id.clone(),
+                request.host_set_hash,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        });
+        pipeline.set_host_set_contract(Some(host_set_id), Some(host_set_hash));
+
+        pipeline.submit_file_change(sample_change("samples/host_set.stasis", 1));
+        eventually(|| {
+            pipeline.pump_coordinator();
+            pipeline.pending_commit_requests() == 1
+        });
+
+        let processed = pipeline.process_commits_at_safe_point(|request| {
+            assert_eq!(request.host_set_id.as_deref(), Some("editor-host"));
+            assert_eq!(request.host_set_hash, Some(host_set_hash));
+            SwapCommitResult::success(request.request_id, vec![FnId(7)], CodeGeneration(1))
+        });
+        assert_eq!(processed, 1);
     }
 
     #[test]

--- a/docs/rewrite_v1_checklist.md
+++ b/docs/rewrite_v1_checklist.md
@@ -52,8 +52,8 @@ It is not part of the steady-state incremental JIT update loop.
 - Partially complete/in progress: `S8b`, `S10`.
 - New self-host track started: `S10b` (minimal `.stasis` AOT CLI core orchestration).
 - Decision update (2026-02-23): host-set sandbox architecture is now locked (`deny-by-default` host access via explicit extern symbols in selected host set).
-- Host-set contract selection is planned to be profile-only (`--host-set-profile` + optional registry mapping). Implementation is pending; do not reintroduce legacy direct contract flags (`--host-set-id`, `--host-set-hash`).
-- Compile contracts include optional host-set metadata (`host_set_id`, `host_set_hash`), but the current pipeline leaves it unset (selection + validation is tracked in `S13`/`S14`).
+- Host-set contract selection is profile-only (`--host-set-profile` + optional `--host-set-registry-file` mapping; env fallback: `STASIS_HOST_SET_PROFILE` / `STASIS_HOST_SET_REGISTRY_FILE`). Do not introduce legacy direct contract flags (`--host-set-id`, `--host-set-hash`).
+- Compile and commit contracts include host-set metadata (`host_set_id`, `host_set_hash`), and the runtime validates it at commit time (missing/mismatch fails before hook/pointer swap).
 - Planned host-set hardening slices (`S13`-`S16`) are scheduled after current self-host priority work unless they directly unblock `S10b`.
 - Strategy pivot (2026-02-23): active compiler-slice direction is now symbol-level reachability pruning (function + struct metadata) with simple one-pass lowering to Cranelift; additional parser-shape fallback expansion is deprecated and should be removed when touched.
 - Cleanup pivot progress (2026-02-23): detector-heavy simple-shape metadata extraction functions were removed from `compiler/simple_pass_compiler.stasis`; single-pass parser/fingerprint/layout coverage is now the active path.
@@ -908,12 +908,11 @@ It is not part of the steady-state incremental JIT update loop.
 - Done gate:
 - No swap can commit without host-set contract validation.
 - Current progress:
-- Compile contracts include optional host-set metadata fields (`host_set_id`, `host_set_hash`) on `CompileRequest`/`CompileResult`, but the pipeline does not set them yet.
-- `SwapCommitRequest` does not currently carry host-set metadata and the runtime does not yet validate host-set contracts during commit.
+- Compile contracts include optional host-set metadata fields (`host_set_id`, `host_set_hash`) on `CompileRequest`/`CompileResult`, and commit contracts include host-set metadata on `SwapCommitRequest`.
+- `apps/stasis` resolves a host-set contract by profile and sets it on the swap pipeline; commit-time validation rejects missing/mismatched host-set metadata before hook/pointer swap.
 - Outstanding questions / TODO:
 - Define `.stasis` required-host declaration syntax and deterministic diagnostics (source of truth: explicit directive vs inference from `@extern`/`@link` usage).
-- Define where host-set metadata is stored/validated across compile + commit (which fields must be transported on `SwapCommitRequest` vs stored as pending state).
-- Status: `in_progress (transport fields exist; extraction/selection/validation still pending)`
+- Status: `in_progress (contract transport + commit validation implemented; required-host extraction pending)`
 
 ### S14 - Host-Set Registry and Profile Selection
 - Language:
@@ -931,12 +930,12 @@ It is not part of the steady-state incremental JIT update loop.
 - Done gate:
 - Host access is deny-by-default across runtime dispatch paths and requires selected host set.
 - Current progress:
-- None yet: no runtime host-set registry module and no CLI/env surface for selecting a host-set profile.
+- `apps/stasis/src/host_set_registry.rs` implements deterministic profile-to-contract resolution with optional JSON registry file mapping.
+- CLI/env surface exists: `--host-set-profile`, `--host-set-registry-file`, `STASIS_HOST_SET_PROFILE`, `STASIS_HOST_SET_REGISTRY_FILE` (precedence: CLI > env > inferred target mode).
 - Outstanding questions / TODO:
-- Define registry file format and precedence rules (CLI flag vs env var vs inferred target mode).
-- Define default profile inference mapping (expected: `JitDev -> dev`, `AotProd -> prod`) and whether `test` is a first-class mode.
+- Profile inference mapping is implemented (`JitDev -> dev`, `AotProd -> prod`); decide whether `test` is a first-class mode and where it applies.
 - Decide which runtime dispatch paths must become deny-by-default as part of S14 vs later S15/S16 enforcement.
-- Status: `planned (post-S10b)`
+- Status: `in_progress (registry + profile selection implemented; deny-by-default dispatch pending)`
 
 ### S15 - Phase-Gated Effects and Tick Determinism
 - Language:


### PR DESCRIPTION
Closes Maddox task #33 (host-set registry/profile selection + contract plumbing + commit-time validation).\n\nChanges:\n- Add host-set registry/profile resolution (default contracts + optional JSON registry file).\n- Add CLI surface: --host-set-profile and --host-set-registry-file (env fallbacks: STASIS_HOST_SET_PROFILE / STASIS_HOST_SET_REGISTRY_FILE).\n- Plumb host_set_id/host_set_hash through CompileRequest/CompileResult and SwapCommitRequest; pipeline can be configured with a host-set contract.\n- Enforce commit-time validation in apps/stasis (missing/mismatch fails before hook/pointer swap).\n- Add unit tests for profile precedence, env registry mapping, and host-set contract propagation through pipeline.\n- Update rewrite_v1_checklist S13/S14 notes to reflect current implementation state.