### PR TITLE
docs: spec implementation status table + clarify release scope

### DIFF
--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -51,20 +51,28 @@ It is not part of the steady-state incremental JIT update loop.
 
 ## Slice Plan
 
-### Current Snapshot (2026-02-23)
+### Current Snapshot (2026-03-02)
 - Completed slices (baseline): `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `S7`, `S8`, `S9`, `S11`.
 - Partially complete/in progress: `S8b`, `S10`.
-- New self-host track started: `S10b` (experimental `.stasis` AOT CLI core orchestration; not the stable compilation pipeline).
+- Release direction (locked):
+- Production/release backend is Cranelift AOT.
+- AOT must run the same sample games as JIT (notably Brickout Revenge).
+- Next language priority: add `f64` end-to-end (pause `u16`/`u32` narrow-int work for now).
+- Explicit non-goals for current release approach:
+- Optional plugin libraries.
+- Anything that depends on a self-host `.stasis` compiler for the release pipeline.
+- Self-host note:
+- `S10b` and other self-host `.stasis` compiler work under `compiler/` is experimental and must not block the Rust compiler release pipeline.
 - Decision update (2026-02-23): host-set sandbox architecture is now locked (`deny-by-default` host access via explicit extern symbols in selected host set).
 - Host-set contract selection is profile-only (`--host-set-profile` + optional `--host-set-registry-file` mapping; env fallback: `STASIS_HOST_SET_PROFILE` / `STASIS_HOST_SET_REGISTRY_FILE`). Do not introduce legacy direct contract flags (`--host-set-id`, `--host-set-hash`).
 - Compile and commit contracts include host-set metadata (`host_set_id`, `host_set_hash`), and the runtime validates it at commit time (missing/mismatch fails before hook/pointer swap).
-- Planned host-set hardening slices (`S13`-`S16`) are scheduled after current self-host priority work unless they directly unblock `S10b`.
+- Planned host-set hardening slices (`S13`-`S16`) are scheduled after current AOT parity + `f64` work unless they directly unblock the release pipeline.
 - Strategy pivot (2026-02-23): active compiler-slice direction is now symbol-level reachability pruning (function + struct metadata) with simple one-pass lowering to Cranelift; additional parser-shape fallback expansion is deprecated and should be removed when touched.
 - Cleanup pivot progress (2026-02-23): detector-heavy simple-shape metadata extraction functions were removed from `compiler/simple_pass_compiler.stasis`; single-pass parser/fingerprint/layout coverage is now the active path.
 - Reset update (2026-02-23): compiler implementation has been restarted as a straightforward single-pass pipeline in `compiler/simple_pass_compiler.stasis`; prior detector-metadata expansion work is superseded and should not be resumed.
-- Priority override (2026-02-13):
-- Single top priority is `S10b` (`SH1 -> SH2 -> SH3`) until `.stasis` self-host AOT CLI core is running end-to-end.
-- All other in-progress tracks (`S8b`, `S10`, and remaining `R*`/`H*` slices) are lower priority and should only be touched if they directly unblock `S10b`.
+Archived priority override (2026-02-13, historical):
+- At that time, `S10b` self-host AOT CLI core was treated as the top priority.
+- That is no longer the release priority; the stable release pipeline is Rust + AOT parity.
 - Main integration gap: real backend compile path is now default, but emitted function patches are metadata-only (`FnId` mapping from hashes) and are not yet executing newly generated machine code through the pointer table.
 - Shared global-layout arena lowering now emits one owning `global` declaration per compile unit and uses `global_import` for other lowered functions, enabling multi-object AOT linking without duplicate data symbol definitions.
 - Simple-pass compiler now builds a root-based function reachability set in `.stasis` (`main`, `tick`, `on_code_swap`) and emits reachable functions only through host analysis harness output (current call-edge discovery uses direct identifier-call tokens; files with no roots keep all functions reachable to avoid helper-file drops in current per-file host analysis flow).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4,6 +4,7 @@ This document is the language-level specification for Stasis.
 It is aligned with:
 - `docs/live-compilation-prd.md`
 - `docs/build_checklist.md`
+- `docs/spec_implementation_status.md` (spec section -> Rust implementation status table)
 
 The focus is deterministic simulation/game logic with static memory, in-process incremental compilation, and safe hot swap.
 
@@ -585,7 +586,16 @@ Bootstrap compatibility note:
 
 ### 12.2 Future Direction: Optional Plugin Libraries
 
-Long-term direction is opt-in runtime libraries/plugins rather than one monolithic host surface.
+This section is intentionally **out of scope** for the current release approach.
+
+Current release approach:
+- Development: in-process Cranelift JIT
+- Production/release: Cranelift AOT
+
+Optional plugin libraries may be revisited later, but they must not be a dependency for shipping AOT builds or for running the sample games.
+
+Historical note:
+Long-term direction could be opt-in runtime libraries/plugins rather than one monolithic host surface.
 
 Intent:
 - pull only required host libraries into a build/runtime

--- a/docs/spec_implementation_status.md
+++ b/docs/spec_implementation_status.md
@@ -1,0 +1,51 @@
+# Spec Implementation Status (Rust Compiler)
+
+Last updated: 2026-03-02
+
+This document tracks how much of `docs/spec.md` is implemented in the Rust compiler/runtime pipeline.
+It is intended to be concrete and release-oriented (JIT + AOT), and it explicitly excludes the experimental self-host `.stasis` compiler track under `compiler/`.
+
+Status legend:
+- **Implemented**: supported end-to-end in the Rust compiler/runtime.
+- **Partial**: implemented for some shapes/modes (often JIT-first) or with known gaps.
+- **Missing**: specified, but not implemented in the Rust compiler/runtime yet.
+- **Deferred (Out of Scope)**: intentionally not being built for the current release approach.
+- **Paused**: intentionally not being worked right now.
+
+## Spec Section -> Rust Implementation Status
+
+| Spec section | Status | Notes (JIT vs AOT, gaps, links) |
+| --- | --- | --- |
+| 1. Overview | Partial | Direction matches current approach (Rust compiler, JIT dev + AOT prod). Specific implementation details vary and are tracked per-section. |
+| 2. Core Principles | Partial | Static global memory + deterministic tick model are core. "No hidden allocation/copies" is a goal; some lowering paths still enforce this by restrictions rather than rich analysis. |
+| 3. Lexical Structure | Partial | Identifiers/keywords/integer literals are stable. Float literals are supported for the current float type (`f32`). Backtick literals exist for tests. |
+| 4. Types (overall) | Partial | `i32`, `f32`, `bool`, `void` are implemented as true builtins. Other "primitive" names currently behave as named scalar types with `i32` ABI compatibility rather than true narrow storage types. |
+| 4.1 Primitive Types | Partial | Implemented: `i32`, `f32`, `bool`, `void`. Missing: `f64` (planned soon). Paused: true `u16`/`u32` narrow-int semantics. `u8` is used as a named scalar type for byte buffers (ABI-compatible with `i32`). |
+| 4.2 Composite Types | Implemented | Fixed arrays `Type[N]`, views `Type[]`, structs, enums, and string buffer forms (`ascii[N]`, `ascii[]`, `utf8[N]`, `utf8[]`) are implemented enough to run samples (including Brickout Revenge). |
+| 4.3 Numeric Conversion Semantics | Partial | `from_*`/`to_*` conversions exist for the current numeric set. `f64` conversions are missing until `f64` exists. |
+| 4.4 Local Type Inference | Implemented | Local inference for `let name = <expr>` is supported; typed `let name: Type = ...` is supported. |
+| 5. Operators and Expressions | Partial | Implemented for `i32`/`f32`/`bool` forms required by current samples/tests. Missing: `f64` operator coverage until `f64` exists. |
+| 6. Declarations and Statements | Partial | `let`, `global`, assignment, `if/else`, `for`, `foreach`, `return`, `continue` are supported in the Rust pipeline. Some shapes are still covered by "stub fallback" in AOT mode until parity hardening lands. |
+| 6.5.1 `for` loop (required init/condition/step) | Implemented | Omitting any of the three `for` header segments is rejected (init is required, condition is required, step is required). |
+| 6.5.5 `continue` | Implemented | Supported and enforced as loop-only. |
+| 7. Functions and Calls | Partial | Function declarations and calls are stable; receiver-form call resolution is supported. Some AOT paths still rely on "stub fallback" for not-yet-supported lowering shapes. |
+| 8. Enums | Implemented | Enums are used by samples and supported by Rust lowering. |
+| 9. Modules and Imports | Implemented | `import` and project-local module resolution are implemented. |
+| 10. Testing Construct | Partial | `.test.stasis` discovery/execution exists in JIT dev/test workflows. AOT test execution parity is not a current priority. |
+| 11. Memory Model | Partial | Static globals and deterministic layout are central. Remaining gaps are mostly around richer compile-time enforcement and diagnostics, not basic execution. |
+| 12. Runtime Boundary and Extern | Partial | Host-set profile/registry plumbing exists. Required-host extraction/diagnostics are tracked separately (not complete). |
+| 12.2 Optional Plugin Libraries | Deferred (Out of Scope) | Plugin libraries are explicitly out of scope for the current release approach; do not plan features around them right now. |
+| 13. Tick Policy | Implemented | Tick-based semantics are supported and used by the runtime loop. |
+| 14. Incremental Compilation and Hot Swap | Partial | Development hot-swap is implemented (JIT). Production AOT is the release approach; it should run the same games as JIT, but "AOT parity" is still being hardened and is explicitly tracked as a release goal. |
+| 15. Swap Hook | Implemented | `on_code_swap()` exists and is invoked on successful commits. |
+| 16. Diagnostics | Partial | Diagnostics exist but need continued hardening for determinism and coverage. |
+| 17. Development Target | Partial | JIT dev is solid. AOT prod exists and is the release path, but still needs parity hardening and explicit speed/size optimization work for shippable builds. |
+| 18. Status Note | Implemented | Current direction is accurately represented. |
+
+## Release-Oriented Notes (JIT vs AOT)
+
+- **Release approach**: Cranelift AOT is the production/release backend; JIT is for development/watch/hot-swap.
+- **AOT parity requirement**: AOT must run the same sample games as JIT (notably `samples/brickout_revenge/brickout_revenge_v1.stasis`).
+- **Quality gate**: AOT should reject shipping builds that still rely on "stub fallback" lowering in emitted artifacts.
+- **Not in scope**: optional plugin libraries and anything that requires a self-host `.stasis` compiler in the release pipeline.
+


### PR DESCRIPTION
Adds a spec section -> Rust implementation status table and clarifies current release scope (AOT prod path, plugin libs out-of-scope, no self-host dependency).