### PR TITLE
AOT: seed collection max_length headers

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -95,10 +95,18 @@ struct EngineBundleManifestStringLiteralRow {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct EngineBundleManifestCollectionMaxLengthRow {
+    path: String,
+    max_length: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct EngineBundleManifest {
     functions: Vec<EngineBundleManifestFunctionRow>,
     #[serde(default)]
     string_literals: Option<Vec<EngineBundleManifestStringLiteralRow>>,
+    #[serde(default)]
+    collection_max_lengths: Option<Vec<EngineBundleManifestCollectionMaxLengthRow>>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -427,6 +435,18 @@ impl IncrementalCompilerBackend {
                     stasis_dynload::clear_jit_string_literal_table();
                     for literal in literals {
                         stasis_dynload::upsert_jit_string_literal(literal.id, &literal.value);
+                    }
+                }
+                if let Some(entries) = manifest.collection_max_lengths.as_ref() {
+                    // Fixed-size arrays/strings rely on .max_length headers stored in the global i32
+                    // table. The JIT path seeds these during compilation; AOT must seed them when
+                    // the bundle is loaded.
+                    for entry in entries {
+                        let max_length_path = format!("{}.max_length", entry.path);
+                        stasis_dynload::stasis_jit_global_i32_store(
+                            crate::hash_global_path(&max_length_path),
+                            entry.max_length,
+                        );
                     }
                 }
                 manifest_rows = manifest.functions;
@@ -5024,6 +5044,49 @@ mod tests {
             stasis_dynload::jit_string_literal_value(row.id),
             Some(literal_value.to_string()),
             "expected dynload string literal table to contain registered literal"
+        );
+
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[test]
+    fn aot_compile_seeds_collection_max_length_headers_from_bundle_manifest() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_collection_headers_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let source = temp_root.join("engine.stasis");
+
+        let global_name = format!("values_{stamp}");
+        let max_length_path = format!("{global_name}.max_length");
+        let max_length_hash = crate::hash_global_path(&max_length_path);
+        assert_eq!(
+            stasis_dynload::stasis_jit_global_i32_load(max_length_hash),
+            0,
+            "expected empty global table entry before seeding"
+        );
+
+        fs::write(
+            &source,
+            format!(
+                "global {global_name}: i32[12];\nfunction tick(): void {{ return; }}\nfunction render(): void {{ return; }}\nfunction on_code_swap(): void {{ return; }}\n"
+            ),
+        )
+        .expect("write source");
+
+        let mut backend = IncrementalCompilerBackend::new();
+        let result = backend.compile(CompileRequest::new(
+            RequestId(158),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(result.status, CompileStatus::Success);
+        assert_eq!(
+            stasis_dynload::stasis_jit_global_i32_load(max_length_hash),
+            12,
+            "expected max_length header to be seeded after AOT compile"
         );
 
         fs::remove_dir_all(&temp_root).ok();

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1,7 +1,7 @@
 use crate::backend::emit::*;
 use crate::backend::{AotOptimizationProfile, EngineEntrypoints};
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
-use crate::frontend::types::{TypeTable, TYPE_ID_I32, TYPE_ID_VOID};
+use crate::frontend::types::{TypeCategory, TypeTable, TYPE_ID_I32, TYPE_ID_VOID};
 use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::ir::{AbiParam, InstBuilder, Value};
 use cranelift_codegen::settings;
@@ -30,6 +30,7 @@ pub struct AotProcess {
     artifacts: Vec<AotArtifact>,
     object_bytes: Vec<Vec<u8>>,
     string_literals: BTreeMap<i32, String>,
+    collection_max_lengths: BTreeMap<String, i32>,
     required_emit_roots: Vec<String>,
 }
 
@@ -54,6 +55,7 @@ impl AotProcess {
             artifacts: Vec::new(),
             object_bytes: Vec::new(),
             string_literals: BTreeMap::new(),
+            collection_max_lengths: BTreeMap::new(),
             required_emit_roots: Vec::new(),
         }
     }
@@ -109,6 +111,9 @@ impl AotProcess {
         }
         let global_path_types =
             collect_global_path_types(self.compiler.files(), &mut type_table, &constant_values)
+                .map_err(crate::compiler::CompileError::Backend)?;
+        self.collection_max_lengths =
+            collect_fixed_collection_max_lengths(&global_path_types, &type_table)
                 .map_err(crate::compiler::CompileError::Backend)?;
         let collection_infos = collect_foreach_collection_infos(
             self.compiler.files(),
@@ -199,6 +204,10 @@ impl AotProcess {
 
     pub fn string_literals(&self) -> &BTreeMap<i32, String> {
         &self.string_literals
+    }
+
+    pub fn collection_max_lengths(&self) -> &BTreeMap<String, i32> {
+        &self.collection_max_lengths
     }
 
     pub fn optimization_profile(&self) -> AotOptimizationProfile {
@@ -368,6 +377,7 @@ impl AotProcess {
                 entrypoints,
                 &manifest_rows,
                 &self.string_literals,
+                &self.collection_max_lengths,
             );
         fs::write(&manifest_path, manifest).map_err(|error| {
             format!(
@@ -622,6 +632,40 @@ fn record_string_literal(out: &mut BTreeMap<i32, String>, value: &str) -> Result
     Ok(())
 }
 
+fn collect_fixed_collection_max_lengths(
+    global_path_types: &GlobalPathTypeMap,
+    type_table: &TypeTable,
+) -> Result<BTreeMap<String, i32>, String> {
+    let mut out: BTreeMap<String, i32> = BTreeMap::new();
+    for (path, type_id) in global_path_types {
+        let Some(type_info) = type_table.type_info(*type_id) else {
+            continue;
+        };
+        match type_info.category {
+            TypeCategory::AsciiFixed | TypeCategory::Utf8Fixed => {
+                let Some(payload_bytes) = type_info.layout.payload_size_bytes else {
+                    continue;
+                };
+                let max_length = i32::try_from(payload_bytes).map_err(|_| {
+                    format!(
+                        "collection max_length overflow for '{}' (payload bytes {})",
+                        path, payload_bytes
+                    )
+                })?;
+                out.insert(path.clone(), max_length);
+            }
+            TypeCategory::ArrayFixed => {
+                let Some(max_length) = type_table.fixed_collection_len(*type_id) else {
+                    continue;
+                };
+                out.insert(path.clone(), max_length);
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
 fn record_string_literals_in_assign_target(
     target: &AssignTarget,
     out: &mut BTreeMap<i32, String>,
@@ -781,6 +825,7 @@ fn build_engine_bundle_manifest(
     entrypoints: &EngineEntrypoints,
     rows: &[(String, String, String)],
     string_literals: &BTreeMap<i32, String>,
+    collection_max_lengths: &BTreeMap<String, i32>,
 ) -> String {
     let mut out = String::new();
     out.push_str("{\n");
@@ -826,6 +871,18 @@ fn build_engine_bundle_manifest(
             "    {{\"id\":{},\"value\":\"{}\"}}{}\n",
             id,
             json_escape(value),
+            comma
+        ));
+    }
+    out.push_str("  ],\n");
+    out.push_str("  \"collection_max_lengths\": [\n");
+    let collections_len = collection_max_lengths.len();
+    for (index, (path, max_length)) in collection_max_lengths.iter().enumerate() {
+        let comma = if index + 1 < collections_len { "," } else { "" };
+        out.push_str(&format!(
+            "    {{\"path\":\"{}\",\"max_length\":{}}}{}\n",
+            json_escape(path),
+            max_length,
             comma
         ));
     }
@@ -1009,6 +1066,37 @@ mod tests {
         assert!(
             manifest.contains("\"value\":\"hello\\n\""),
             "manifest should include escaped literal value"
+        );
+
+        let _ = fs::remove_dir_all(&bundle_dir);
+    }
+
+    #[test]
+    fn aot_engine_bundle_manifest_includes_collection_max_lengths() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "global values: i32[12];\nfunction tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n",
+        );
+        process.compile().expect("compile");
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let bundle_dir = std::env::temp_dir().join(format!("stasis_aot_bundle_collections_{stamp}"));
+        let bundle = process
+            .write_engine_bundle(&EngineEntrypoints::runtime_default(), &bundle_dir)
+            .expect("write bundle");
+
+        let manifest = fs::read_to_string(&bundle.manifest_path).expect("read manifest");
+        assert!(
+            manifest.contains("\"collection_max_lengths\""),
+            "manifest should include collection_max_lengths field"
+        );
+        assert!(
+            manifest.contains("\"path\":\"values\"") && manifest.contains("\"max_length\":12"),
+            "manifest should include seeded max_length row"
         );
 
         let _ = fs::remove_dir_all(&bundle_dir);


### PR DESCRIPTION
﻿Seeds fixed array/string .max_length headers for AOT by emitting max-length rows in the engine bundle manifest and applying them when the bundle is loaded.

Changes:
- stasis_compiler: compute fixed collection max lengths from global_path_types + type_table and serialize under "collection_max_lengths" in engine_bundle_manifest.json.
- apps/stasis: when reading the manifest, seed each {path}.max_length value into the dynload i32 global table.
- Add regression tests in stasis_compiler + stasis.

Depends on PR #206.
