### PR TITLE
StasisLang: f64 end-to-end (JIT + AOT)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Use:
 - `cargo build`
 - `cargo test`
-- `cargo run -p stasis -- --ticks 300 --watch-dir samples/brickout_revenge`
+- `cargo run -p stasis --release -- --ticks 300 --watch-dir samples/brickout_revenge`
 - Use `rg` for search (`rg pattern path`, `rg --files`).
 - Keep commands deterministic and scriptable.
 - Legacy bootstrap tooling remains available for compiler smoke/reference:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Development runs in one process:
 Run Brickout Revenge v1 (Windows in-process dev runner):
 
 ```powershell
-.\target\debug\stasis.exe play samples\brickout_revenge\brickout_revenge_v1.stasis --watch-dir samples\brickout_revenge
+cargo run -p stasis --release -- play samples\brickout_revenge\brickout_revenge_v1.stasis --watch-dir samples\brickout_revenge
 ```
 
 Edit and save any `.stasis` file in the current import/dependency graph. You should see output like:
@@ -150,13 +150,13 @@ test `adds`(): bool {
 Run tests in a directory:
 
 ```powershell
-.\target\debug\stasis.exe test --dir tests/stasis
+cargo run -p stasis --release -- test --dir tests/stasis
 ```
 
 Watch mode:
 
 ```powershell
-.\target\debug\stasis.exe test --dir tests/stasis --watch --watch-settle-ms 50
+cargo run -p stasis --release -- test --dir tests/stasis --watch --watch-settle-ms 50
 ```
 
 ## Current Constraints

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3682,10 +3682,11 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
+        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        if !cfg!(debug_assertions) {
+            dynload_build_command.arg("--release");
+        }
         dynload_build_command
-            .arg("rustc")
-            .arg("-p")
-            .arg("stasis_dynload")
             .arg("--")
             .arg("--crate-type")
             .arg("staticlib")
@@ -3862,6 +3863,1286 @@ mod tests {
             let rc = stasis_dynload::invoke_noarg_i32(tick_ptr).expect("invoke tick");
             assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
         }
+
+        drop(library);
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_brickout_revenge_v1_jit_executes_1000_ticks() {
+        fn hash_global_path(path: &str) -> i32 {
+            // Must match `crates/stasis_compiler/src/backend/jit.rs` global path hashing.
+            let mut hash: u32 = 2166136261;
+            for byte in path.bytes() {
+                hash ^= u32::from(byte);
+                hash = hash.wrapping_mul(16777619);
+            }
+            hash as i32
+        }
+
+        // JIT execution consults process-global runtime tables; keep this deterministic.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+        let source = repo_root
+            .join("samples")
+            .join("brickout_revenge")
+            .join("brickout_revenge_v1.stasis");
+        assert!(
+            source.exists(),
+            "expected Brickout sample at {}",
+            source.display()
+        );
+
+        let mut backend = IncrementalCompilerBackend::new();
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_301),
+            vec![source],
+            TargetMode::JitDev,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected Brickout JIT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let package = backend
+            .last_jit_engine_package()
+            .expect("jit engine package should be present after successful compile");
+        let main_ptr = package
+            .symbol_code_ptrs
+            .get("main")
+            .copied()
+            .expect("expected main pointer in JIT engine package");
+        let tick_ptr = package.tick_code_ptr;
+        assert_ne!(main_ptr, 0);
+        assert_ne!(tick_ptr, 0);
+
+        let host_i32 = hash_global_path("host_i32");
+        let field = 0;
+        let store = |index: i32, value: i32| {
+            stasis_dynload::stasis_jit_global_i32_array_store(host_i32, field, index, value);
+        };
+
+        // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
+        // Indices from src/host_frame.stasis.
+        let t0_ms: i32 = 12345;
+        store(0, t0_ms); // HOST_I_TIME_MS
+        store(1, 360); // HOST_I_WINDOW_W_PX
+        store(2, 720); // HOST_I_WINDOW_H_PX
+        store(3, 0); // HOST_I_VIEWPORT_X_PX
+        store(4, 0); // HOST_I_VIEWPORT_Y_PX
+        store(5, 360); // HOST_I_VIEWPORT_W_PX
+        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store(7, 0); // HOST_I_POINTER_COUNT
+        store(8, 0); // HOST_I_DROPPED_POINTERS
+        store(9, 0); // HOST_I_QUIT_REQUESTED
+        store(10, 0); // HOST_I_TICK_INDEX
+        store(11, 1); // HOST_I_RESIZED
+        store(12, 360); // HOST_I_SCREEN_W_PX
+        store(13, 720); // HOST_I_SCREEN_H_PX
+        store(19, t0_ms * 1000); // HOST_I_TIME_US (coarse is fine)
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr as usize).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected Brickout main() to succeed");
+
+        // Clear resize flag for subsequent ticks.
+        store(11, 0);
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for tick_index in 0..ticks {
+            let time_ms = t0_ms + (tick_index + 1) * 16;
+            store(0, time_ms);
+            store(10, tick_index);
+            store(19, time_ms * 1000);
+
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=jit brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_brickout_revenge_v1_aot_speed_and_size_executes_1000_ticks() {
+        fn find_lld_link() -> Option<PathBuf> {
+            let candidates = [
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+            ];
+            for candidate in candidates {
+                let path = PathBuf::from(candidate);
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+            if std::process::Command::new("lld-link.exe")
+                .arg("/NOLOGO")
+                .output()
+                .is_ok()
+            {
+                return Some(PathBuf::from("lld-link.exe"));
+            }
+            None
+        }
+
+        fn hash_global_path(path: &str) -> i32 {
+            // Must match `crates/stasis_compiler/src/backend/jit.rs` global path hashing.
+            let mut hash: u32 = 2166136261;
+            for byte in path.bytes() {
+                hash ^= u32::from(byte);
+                hash = hash.wrapping_mul(16777619);
+            }
+            hash as i32
+        }
+
+        fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("..")
+                        .join("..")
+                        .join("target")
+                });
+            let mut candidates: Vec<PathBuf> = Vec::new();
+
+            for profile in ["debug", "release"] {
+                let base = target_dir.join(profile);
+                let direct = base.join("stasis_dynload.lib");
+                if direct.exists() {
+                    candidates.push(direct);
+                }
+
+                let deps = base.join("deps");
+                let Ok(entries) = fs::read_dir(&deps) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                        continue;
+                    };
+                    if !name.starts_with("stasis_dynload-") || !name.ends_with(".lib") {
+                        continue;
+                    }
+                    candidates.push(path);
+                }
+            }
+
+            candidates.into_iter().max_by_key(|path| {
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+                    .unwrap_or_default()
+            })
+        }
+
+        fn dir_size_bytes(path: &Path) -> u64 {
+            let mut total = 0u64;
+            let Ok(entries) = fs::read_dir(path) else {
+                return 0;
+            };
+            for entry in entries.flatten() {
+                let child = entry.path();
+                if let Ok(meta) = fs::metadata(&child) {
+                    if meta.is_dir() {
+                        total = total.saturating_add(dir_size_bytes(&child));
+                    } else {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+            total
+        }
+
+        // Compile/link steps can consult/modify process-wide env; serialize with other tests.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+
+        // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
+        let mut dynload_build_command = Command::new("cargo");
+        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        if !cfg!(debug_assertions) {
+            dynload_build_command.arg("--release");
+        }
+        dynload_build_command
+            .arg("--")
+            .arg("--crate-type")
+            .arg("staticlib")
+            .current_dir(&repo_root);
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            dynload_build_command.env("CARGO_TARGET_DIR", target_dir);
+        }
+        let dynload_build = dynload_build_command
+            .output()
+            .expect("spawn cargo rustc -p stasis_dynload --crate-type staticlib");
+        assert!(
+            dynload_build.status.success(),
+            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&dynload_build.stdout),
+            String::from_utf8_lossy(&dynload_build.stderr)
+        );
+
+        let linker_path = find_lld_link().expect("lld-link.exe required for AOT bench");
+        let stasis_dynload_lib =
+            resolve_stasis_dynload_lib().expect("stasis_dynload staticlib required for AOT bench");
+
+        let source = repo_root
+            .join("samples")
+            .join("brickout_revenge")
+            .join("brickout_revenge_v1.stasis");
+        assert!(
+            source.exists(),
+            "expected Brickout sample at {}",
+            source.display()
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_brickout_bench_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let artifact_root = temp_root.join("aot_artifacts");
+
+        let compile_config = AotCompileConfig {
+            opt_level: "speed_and_size".to_string(),
+            ..AotCompileConfig::default()
+        };
+        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_302),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected Brickout AOT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle should be present after successful compile");
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read engine bundle manifest");
+        assert_eq!(
+            manifest.optimization_profile.as_deref(),
+            Some("speed_and_size"),
+            "engine bundle manifest should report speed_and_size optimization"
+        );
+
+        let main_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "main")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include main");
+        let tick_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "tick")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include tick");
+
+        let object_paths: Vec<PathBuf> = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect();
+        assert!(
+            !object_paths.is_empty(),
+            "expected engine bundle to include object files"
+        );
+
+        let linked_output = temp_root.join("brickout_aot_bundle.dll");
+        let export_symbols = vec![
+            main_symbol.clone(),
+            tick_symbol.clone(),
+            // Seed host frame values in the same runtime instance as the linked AOT code.
+            "stasis_jit_global_i32_array_store".to_string(),
+        ];
+        let link_config = stasis_jit::AotLinkConfig {
+            linker_path: Some(linker_path),
+            runtime_lib_paths: vec![stasis_dynload_lib],
+        };
+
+        stasis_jit::link_objects_to_dynamic_library(
+            &object_paths,
+            &linked_output,
+            &export_symbols,
+            &link_config,
+        )
+        .expect("link engine bundle into dll");
+
+        let linked_bytes = fs::metadata(&linked_output)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let objects_bytes = object_paths
+            .iter()
+            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .sum::<u64>();
+        let manifest_bytes = fs::metadata(&bundle.manifest_path)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let artifacts_bytes = dir_size_bytes(&bundle.output_dir);
+        println!(
+            "bench=aot opt_level=speed_and_size linked_dll_bytes={} objects_bytes={} manifest_bytes={} bundle_dir_bytes={}",
+            linked_bytes, objects_bytes, manifest_bytes, artifacts_bytes
+        );
+
+        let library = stasis_dynload::Library::load(&linked_output).expect("load linked image");
+        let main_ptr = library
+            .symbol_address(&main_symbol)
+            .expect("resolve main export");
+        let tick_ptr = library
+            .symbol_address(&tick_symbol)
+            .expect("resolve tick export");
+        let store_ptr = library
+            .symbol_address("stasis_jit_global_i32_array_store")
+            .expect("resolve host_i32 store");
+
+        let host_i32 = hash_global_path("host_i32");
+        let field = 0;
+        let store = |index: i32, value: i32| {
+            stasis_dynload::invoke_i32_i32_i32_i32_to_void(store_ptr, host_i32, field, index, value)
+                .expect("invoke host_i32 store");
+        };
+
+        // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
+        // Indices from src/host_frame.stasis.
+        let t0_ms: i32 = 12345;
+        store(0, t0_ms); // HOST_I_TIME_MS
+        store(1, 360); // HOST_I_WINDOW_W_PX
+        store(2, 720); // HOST_I_WINDOW_H_PX
+        store(3, 0); // HOST_I_VIEWPORT_X_PX
+        store(4, 0); // HOST_I_VIEWPORT_Y_PX
+        store(5, 360); // HOST_I_VIEWPORT_W_PX
+        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store(7, 0); // HOST_I_POINTER_COUNT
+        store(8, 0); // HOST_I_DROPPED_POINTERS
+        store(9, 0); // HOST_I_QUIT_REQUESTED
+        store(10, 0); // HOST_I_TICK_INDEX
+        store(11, 1); // HOST_I_RESIZED
+        store(12, 360); // HOST_I_SCREEN_W_PX
+        store(13, 720); // HOST_I_SCREEN_H_PX
+        store(19, t0_ms * 1000); // HOST_I_TIME_US (coarse is fine)
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected Brickout main() to succeed");
+
+        // Clear resize flag for subsequent ticks.
+        store(11, 0);
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for tick_index in 0..ticks {
+            let time_ms = t0_ms + (tick_index + 1) * 16;
+            store(0, time_ms);
+            store(10, tick_index);
+            store(19, time_ms * 1000);
+
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=aot brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
+
+        drop(library);
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_brickout_revenge_v1_aot_speed_executes_1000_ticks() {
+        fn find_lld_link() -> Option<PathBuf> {
+            let candidates = [
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+            ];
+            for candidate in candidates {
+                let path = PathBuf::from(candidate);
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+            if std::process::Command::new("lld-link.exe")
+                .arg("/NOLOGO")
+                .output()
+                .is_ok()
+            {
+                return Some(PathBuf::from("lld-link.exe"));
+            }
+            None
+        }
+
+        fn hash_global_path(path: &str) -> i32 {
+            // Must match `crates/stasis_compiler/src/backend/jit.rs` global path hashing.
+            let mut hash: u32 = 2166136261;
+            for byte in path.bytes() {
+                hash ^= u32::from(byte);
+                hash = hash.wrapping_mul(16777619);
+            }
+            hash as i32
+        }
+
+        fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("..")
+                        .join("..")
+                        .join("target")
+                });
+            let mut candidates: Vec<PathBuf> = Vec::new();
+
+            for profile in ["debug", "release"] {
+                let base = target_dir.join(profile);
+                let direct = base.join("stasis_dynload.lib");
+                if direct.exists() {
+                    candidates.push(direct);
+                }
+
+                let deps = base.join("deps");
+                let Ok(entries) = fs::read_dir(&deps) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                        continue;
+                    };
+                    if !name.starts_with("stasis_dynload-") || !name.ends_with(".lib") {
+                        continue;
+                    }
+                    candidates.push(path);
+                }
+            }
+
+            candidates.into_iter().max_by_key(|path| {
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+                    .unwrap_or_default()
+            })
+        }
+
+        fn dir_size_bytes(path: &Path) -> u64 {
+            let mut total = 0u64;
+            let Ok(entries) = fs::read_dir(path) else {
+                return 0;
+            };
+            for entry in entries.flatten() {
+                let child = entry.path();
+                if let Ok(meta) = fs::metadata(&child) {
+                    if meta.is_dir() {
+                        total = total.saturating_add(dir_size_bytes(&child));
+                    } else {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+            total
+        }
+
+        // Compile/link steps can consult/modify process-wide env; serialize with other tests.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+
+        // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
+        let mut dynload_build_command = Command::new("cargo");
+        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        if !cfg!(debug_assertions) {
+            dynload_build_command.arg("--release");
+        }
+        dynload_build_command
+            .arg("--")
+            .arg("--crate-type")
+            .arg("staticlib")
+            .current_dir(&repo_root);
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            dynload_build_command.env("CARGO_TARGET_DIR", target_dir);
+        }
+        let dynload_build = dynload_build_command
+            .output()
+            .expect("spawn cargo rustc -p stasis_dynload --crate-type staticlib");
+        assert!(
+            dynload_build.status.success(),
+            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&dynload_build.stdout),
+            String::from_utf8_lossy(&dynload_build.stderr)
+        );
+
+        let linker_path = find_lld_link().expect("lld-link.exe required for AOT bench");
+        let stasis_dynload_lib =
+            resolve_stasis_dynload_lib().expect("stasis_dynload staticlib required for AOT bench");
+
+        let source = repo_root
+            .join("samples")
+            .join("brickout_revenge")
+            .join("brickout_revenge_v1.stasis");
+        assert!(
+            source.exists(),
+            "expected Brickout sample at {}",
+            source.display()
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_brickout_bench_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let artifact_root = temp_root.join("aot_artifacts");
+
+        let compile_config = AotCompileConfig {
+            opt_level: "speed".to_string(),
+            ..AotCompileConfig::default()
+        };
+        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_303),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected Brickout AOT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle should be present after successful compile");
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read engine bundle manifest");
+        assert_eq!(
+            manifest.optimization_profile.as_deref(),
+            Some("speed"),
+            "engine bundle manifest should report speed optimization"
+        );
+
+        let main_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "main")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include main");
+        let tick_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "tick")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include tick");
+
+        let object_paths: Vec<PathBuf> = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect();
+        assert!(
+            !object_paths.is_empty(),
+            "expected engine bundle to include object files"
+        );
+
+        let linked_output = temp_root.join("brickout_aot_bundle.dll");
+        let export_symbols = vec![
+            main_symbol.clone(),
+            tick_symbol.clone(),
+            // Seed host frame values in the same runtime instance as the linked AOT code.
+            "stasis_jit_global_i32_array_store".to_string(),
+        ];
+        let link_config = stasis_jit::AotLinkConfig {
+            linker_path: Some(linker_path),
+            runtime_lib_paths: vec![stasis_dynload_lib],
+        };
+
+        stasis_jit::link_objects_to_dynamic_library(
+            &object_paths,
+            &linked_output,
+            &export_symbols,
+            &link_config,
+        )
+        .expect("link engine bundle into dll");
+
+        let linked_bytes = fs::metadata(&linked_output)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let objects_bytes = object_paths
+            .iter()
+            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .sum::<u64>();
+        let manifest_bytes = fs::metadata(&bundle.manifest_path)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let artifacts_bytes = dir_size_bytes(&bundle.output_dir);
+        println!(
+            "bench=aot opt_level=speed linked_dll_bytes={} objects_bytes={} manifest_bytes={} bundle_dir_bytes={}",
+            linked_bytes, objects_bytes, manifest_bytes, artifacts_bytes
+        );
+
+        let library = stasis_dynload::Library::load(&linked_output).expect("load linked image");
+        let main_ptr = library
+            .symbol_address(&main_symbol)
+            .expect("resolve main export");
+        let tick_ptr = library
+            .symbol_address(&tick_symbol)
+            .expect("resolve tick export");
+        let store_ptr = library
+            .symbol_address("stasis_jit_global_i32_array_store")
+            .expect("resolve host_i32 store");
+
+        let host_i32 = hash_global_path("host_i32");
+        let field = 0;
+        let store = |index: i32, value: i32| {
+            stasis_dynload::invoke_i32_i32_i32_i32_to_void(store_ptr, host_i32, field, index, value)
+                .expect("invoke host_i32 store");
+        };
+
+        // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
+        // Indices from src/host_frame.stasis.
+        let t0_ms: i32 = 12345;
+        store(0, t0_ms); // HOST_I_TIME_MS
+        store(1, 360); // HOST_I_WINDOW_W_PX
+        store(2, 720); // HOST_I_WINDOW_H_PX
+        store(3, 0); // HOST_I_VIEWPORT_X_PX
+        store(4, 0); // HOST_I_VIEWPORT_Y_PX
+        store(5, 360); // HOST_I_VIEWPORT_W_PX
+        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store(7, 0); // HOST_I_POINTER_COUNT
+        store(8, 0); // HOST_I_DROPPED_POINTERS
+        store(9, 0); // HOST_I_QUIT_REQUESTED
+        store(10, 0); // HOST_I_TICK_INDEX
+        store(11, 1); // HOST_I_RESIZED
+        store(12, 360); // HOST_I_SCREEN_W_PX
+        store(13, 720); // HOST_I_SCREEN_H_PX
+        store(19, t0_ms * 1000); // HOST_I_TIME_US (coarse is fine)
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected Brickout main() to succeed");
+
+        // Clear resize flag for subsequent ticks.
+        store(11, 0);
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for tick_index in 0..ticks {
+            let time_ms = t0_ms + (tick_index + 1) * 16;
+            store(0, time_ms);
+            store(10, tick_index);
+            store(19, time_ms * 1000);
+
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=aot brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
+
+        drop(library);
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_perf_balls_bricks_v1_jit_executes_1000_ticks() {
+        // JIT execution consults process-global runtime tables; keep this deterministic.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+        let source = repo_root.join("samples").join("perf_balls_bricks.stasis");
+        assert!(
+            source.exists(),
+            "expected perf sample at {}",
+            source.display()
+        );
+
+        let mut backend = IncrementalCompilerBackend::new();
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_401),
+            vec![source],
+            TargetMode::JitDev,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected perf JIT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let package = backend
+            .last_jit_engine_package()
+            .expect("jit engine package should be present after successful compile");
+        let main_ptr = package
+            .symbol_code_ptrs
+            .get("main")
+            .copied()
+            .expect("expected main pointer in JIT engine package");
+        let tick_ptr = package.tick_code_ptr;
+        assert_ne!(main_ptr, 0);
+        assert_ne!(tick_ptr, 0);
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr as usize).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected perf main() to succeed");
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for _ in 0..ticks {
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=jit perf_balls_bricks_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_perf_balls_bricks_v1_aot_speed_executes_1000_ticks() {
+        fn find_lld_link() -> Option<PathBuf> {
+            let candidates = [
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+            ];
+            for candidate in candidates {
+                let path = PathBuf::from(candidate);
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+            if std::process::Command::new("lld-link.exe")
+                .arg("/NOLOGO")
+                .output()
+                .is_ok()
+            {
+                return Some(PathBuf::from("lld-link.exe"));
+            }
+            None
+        }
+
+        fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("..")
+                        .join("..")
+                        .join("target")
+                });
+            let mut candidates: Vec<PathBuf> = Vec::new();
+
+            for profile in ["debug", "release"] {
+                let base = target_dir.join(profile);
+                let direct = base.join("stasis_dynload.lib");
+                if direct.exists() {
+                    candidates.push(direct);
+                }
+
+                let deps = base.join("deps");
+                let Ok(entries) = fs::read_dir(&deps) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                        continue;
+                    };
+                    if !name.starts_with("stasis_dynload-") || !name.ends_with(".lib") {
+                        continue;
+                    }
+                    candidates.push(path);
+                }
+            }
+
+            candidates.into_iter().max_by_key(|path| {
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+                    .unwrap_or_default()
+            })
+        }
+
+        fn dir_size_bytes(path: &Path) -> u64 {
+            let mut total = 0u64;
+            let Ok(entries) = fs::read_dir(path) else {
+                return 0;
+            };
+            for entry in entries.flatten() {
+                let child = entry.path();
+                if let Ok(meta) = fs::metadata(&child) {
+                    if meta.is_dir() {
+                        total = total.saturating_add(dir_size_bytes(&child));
+                    } else {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+            total
+        }
+
+        // Compile/link steps can consult/modify process-wide env; serialize with other tests.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+
+        // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
+        let mut dynload_build_command = Command::new("cargo");
+        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        if !cfg!(debug_assertions) {
+            dynload_build_command.arg("--release");
+        }
+        dynload_build_command
+            .arg("--")
+            .arg("--crate-type")
+            .arg("staticlib")
+            .current_dir(&repo_root);
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            dynload_build_command.env("CARGO_TARGET_DIR", target_dir);
+        }
+        let dynload_build = dynload_build_command
+            .output()
+            .expect("spawn cargo rustc -p stasis_dynload --crate-type staticlib");
+        assert!(
+            dynload_build.status.success(),
+            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&dynload_build.stdout),
+            String::from_utf8_lossy(&dynload_build.stderr)
+        );
+
+        let linker_path = find_lld_link().expect("lld-link.exe required for AOT bench");
+        let stasis_dynload_lib =
+            resolve_stasis_dynload_lib().expect("stasis_dynload staticlib required for AOT bench");
+
+        let source = repo_root.join("samples").join("perf_balls_bricks.stasis");
+        assert!(
+            source.exists(),
+            "expected perf sample at {}",
+            source.display()
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_perf_balls_bricks_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let artifact_root = temp_root.join("aot_artifacts");
+
+        let compile_config = AotCompileConfig {
+            opt_level: "speed".to_string(),
+            ..AotCompileConfig::default()
+        };
+        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_402),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected perf AOT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle should be present after successful compile");
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read engine bundle manifest");
+        assert_eq!(
+            manifest.optimization_profile.as_deref(),
+            Some("speed"),
+            "engine bundle manifest should report speed optimization"
+        );
+
+        let main_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "main")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include main");
+        let tick_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "tick")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include tick");
+
+        let object_paths: Vec<PathBuf> = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect();
+        assert!(
+            !object_paths.is_empty(),
+            "expected engine bundle to include object files"
+        );
+
+        let linked_output = temp_root.join("perf_balls_bricks_aot_bundle.dll");
+        let export_symbols = vec![main_symbol.clone(), tick_symbol.clone()];
+        let link_config = stasis_jit::AotLinkConfig {
+            linker_path: Some(linker_path),
+            runtime_lib_paths: vec![stasis_dynload_lib],
+        };
+        stasis_jit::link_objects_to_dynamic_library(
+            &object_paths,
+            &linked_output,
+            &export_symbols,
+            &link_config,
+        )
+        .expect("link engine bundle into dll");
+
+        let linked_bytes = fs::metadata(&linked_output)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let objects_bytes = object_paths
+            .iter()
+            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .sum::<u64>();
+        let manifest_bytes = fs::metadata(&bundle.manifest_path)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let artifacts_bytes = dir_size_bytes(&bundle.output_dir);
+        println!(
+            "bench=aot opt_level=speed sample=perf_balls_bricks_v1 linked_dll_bytes={} objects_bytes={} manifest_bytes={} bundle_dir_bytes={}",
+            linked_bytes, objects_bytes, manifest_bytes, artifacts_bytes
+        );
+
+        let library = stasis_dynload::Library::load(&linked_output).expect("load linked image");
+        let main_ptr = library
+            .symbol_address(&main_symbol)
+            .expect("resolve main export");
+        let tick_ptr = library
+            .symbol_address(&tick_symbol)
+            .expect("resolve tick export");
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected perf main() to succeed");
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for _ in 0..ticks {
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=aot perf_balls_bricks_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
+
+        drop(library);
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore]
+    fn bench_perf_balls_bricks_v1_aot_speed_and_size_executes_1000_ticks() {
+        fn find_lld_link() -> Option<PathBuf> {
+            let candidates = [
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+                r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\lld-link.exe",
+            ];
+            for candidate in candidates {
+                let path = PathBuf::from(candidate);
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+            if std::process::Command::new("lld-link.exe")
+                .arg("/NOLOGO")
+                .output()
+                .is_ok()
+            {
+                return Some(PathBuf::from("lld-link.exe"));
+            }
+            None
+        }
+
+        fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| {
+                    Path::new(env!("CARGO_MANIFEST_DIR"))
+                        .join("..")
+                        .join("..")
+                        .join("target")
+                });
+            let mut candidates: Vec<PathBuf> = Vec::new();
+
+            for profile in ["debug", "release"] {
+                let base = target_dir.join(profile);
+                let direct = base.join("stasis_dynload.lib");
+                if direct.exists() {
+                    candidates.push(direct);
+                }
+
+                let deps = base.join("deps");
+                let Ok(entries) = fs::read_dir(&deps) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                        continue;
+                    };
+                    if !name.starts_with("stasis_dynload-") || !name.ends_with(".lib") {
+                        continue;
+                    }
+                    candidates.push(path);
+                }
+            }
+
+            candidates.into_iter().max_by_key(|path| {
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+                    .unwrap_or_default()
+            })
+        }
+
+        fn dir_size_bytes(path: &Path) -> u64 {
+            let mut total = 0u64;
+            let Ok(entries) = fs::read_dir(path) else {
+                return 0;
+            };
+            for entry in entries.flatten() {
+                let child = entry.path();
+                if let Ok(meta) = fs::metadata(&child) {
+                    if meta.is_dir() {
+                        total = total.saturating_add(dir_size_bytes(&child));
+                    } else {
+                        total = total.saturating_add(meta.len());
+                    }
+                }
+            }
+            total
+        }
+
+        // Compile/link steps can consult/modify process-wide env; serialize with other tests.
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+
+        // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
+        let mut dynload_build_command = Command::new("cargo");
+        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        if !cfg!(debug_assertions) {
+            dynload_build_command.arg("--release");
+        }
+        dynload_build_command
+            .arg("--")
+            .arg("--crate-type")
+            .arg("staticlib")
+            .current_dir(&repo_root);
+        if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+            dynload_build_command.env("CARGO_TARGET_DIR", target_dir);
+        }
+        let dynload_build = dynload_build_command
+            .output()
+            .expect("spawn cargo rustc -p stasis_dynload --crate-type staticlib");
+        assert!(
+            dynload_build.status.success(),
+            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&dynload_build.stdout),
+            String::from_utf8_lossy(&dynload_build.stderr)
+        );
+
+        let linker_path = find_lld_link().expect("lld-link.exe required for AOT bench");
+        let stasis_dynload_lib =
+            resolve_stasis_dynload_lib().expect("stasis_dynload staticlib required for AOT bench");
+
+        let source = repo_root.join("samples").join("perf_balls_bricks.stasis");
+        assert!(
+            source.exists(),
+            "expected perf sample at {}",
+            source.display()
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_perf_balls_bricks_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let artifact_root = temp_root.join("aot_artifacts");
+
+        let compile_config = AotCompileConfig {
+            opt_level: "speed_and_size".to_string(),
+            ..AotCompileConfig::default()
+        };
+        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_403),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "expected perf AOT compile success, got diagnostics: {:?}",
+            result.diagnostics
+        );
+
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle should be present after successful compile");
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read engine bundle manifest");
+        assert_eq!(
+            manifest.optimization_profile.as_deref(),
+            Some("speed_and_size"),
+            "engine bundle manifest should report speed_and_size optimization"
+        );
+
+        let main_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "main")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include main");
+        let tick_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "tick")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include tick");
+
+        let object_paths: Vec<PathBuf> = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect();
+        assert!(
+            !object_paths.is_empty(),
+            "expected engine bundle to include object files"
+        );
+
+        let linked_output = temp_root.join("perf_balls_bricks_aot_bundle.dll");
+        let export_symbols = vec![main_symbol.clone(), tick_symbol.clone()];
+        let link_config = stasis_jit::AotLinkConfig {
+            linker_path: Some(linker_path),
+            runtime_lib_paths: vec![stasis_dynload_lib],
+        };
+        stasis_jit::link_objects_to_dynamic_library(
+            &object_paths,
+            &linked_output,
+            &export_symbols,
+            &link_config,
+        )
+        .expect("link engine bundle into dll");
+
+        let linked_bytes = fs::metadata(&linked_output)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let objects_bytes = object_paths
+            .iter()
+            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .sum::<u64>();
+        let manifest_bytes = fs::metadata(&bundle.manifest_path)
+            .map(|meta| meta.len())
+            .unwrap_or_default();
+        let artifacts_bytes = dir_size_bytes(&bundle.output_dir);
+        println!(
+            "bench=aot opt_level=speed_and_size sample=perf_balls_bricks_v1 linked_dll_bytes={} objects_bytes={} manifest_bytes={} bundle_dir_bytes={}",
+            linked_bytes, objects_bytes, manifest_bytes, artifacts_bytes
+        );
+
+        let library = stasis_dynload::Library::load(&linked_output).expect("load linked image");
+        let main_ptr = library
+            .symbol_address(&main_symbol)
+            .expect("resolve main export");
+        let tick_ptr = library
+            .symbol_address(&tick_symbol)
+            .expect("resolve tick export");
+
+        let main_rc = stasis_dynload::invoke_noarg_i32(main_ptr).expect("invoke main");
+        assert_eq!(main_rc, 0, "expected perf main() to succeed");
+
+        let ticks: i32 = 1000;
+        let start = std::time::Instant::now();
+        for _ in 0..ticks {
+            let rc = stasis_dynload::invoke_noarg_i32(tick_ptr).expect("invoke tick");
+            assert_eq!(rc, 0, "expected tick() to return 0 (keep running)");
+        }
+        let elapsed = start.elapsed();
+        let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
+        let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
+        println!(
+            "bench=aot perf_balls_bricks_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            ticks,
+            elapsed.as_millis(),
+            ms_per_tick,
+            us_per_tick
+        );
 
         drop(library);
         fs::remove_dir_all(&temp_root).ok();

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -12,6 +12,8 @@ use cranelift_object::{ObjectBuilder, ObjectModule};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AotArtifact {
@@ -660,6 +662,9 @@ fn compile_function_to_object_bytes(
         builder.finalize();
     }
 
+    #[cfg(test)]
+    maybe_invoke_clif_dump_hook(meta, &context.func);
+
     module
         .define_function(function_id, &mut context)
         .map_err(|error| format!("failed to define AOT function {symbol}: {error}"))?;
@@ -668,6 +673,32 @@ fn compile_function_to_object_bytes(
     product
         .emit()
         .map_err(|error| format!("failed to emit AOT object bytes: {error}"))
+}
+
+#[cfg(test)]
+type ClifDumpHook =
+    Box<dyn Fn(&FunctionMeta, &cranelift_codegen::ir::Function) + Send + Sync + 'static>;
+
+#[cfg(test)]
+static CLIF_DUMP_HOOK: OnceLock<Mutex<Option<ClifDumpHook>>> = OnceLock::new();
+
+#[cfg(test)]
+fn clif_dump_hook() -> &'static Mutex<Option<ClifDumpHook>> {
+    CLIF_DUMP_HOOK.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(test)]
+fn set_clif_dump_hook(hook: Option<ClifDumpHook>) {
+    *clif_dump_hook().lock().expect("lock clif dump hook") = hook;
+}
+
+#[cfg(test)]
+fn maybe_invoke_clif_dump_hook(meta: &FunctionMeta, func: &cranelift_codegen::ir::Function) {
+    let guard = clif_dump_hook().lock().expect("lock clif dump hook");
+    let Some(hook) = guard.as_ref() else {
+        return;
+    };
+    hook(meta, func);
 }
 
 fn record_string_literal(out: &mut BTreeMap<i32, String>, value: &str) -> Result<(), String> {
@@ -948,6 +979,7 @@ mod tests {
     use super::*;
     use crate::backend::EngineEntrypoints;
     use std::process::Command;
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -1375,6 +1407,70 @@ mod tests {
         assert_eq!(second_status.code(), Some(9));
 
         let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    #[ignore]
+    fn dump_perf_balls_bricks_tick_clif_summary() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+        let source_path = repo_root.join("samples").join("perf_balls_bricks.stasis");
+        assert!(
+            source_path.exists(),
+            "expected perf sample at {}",
+            source_path.display()
+        );
+
+        let source_text = fs::read_to_string(&source_path).expect("read perf sample");
+        let mut process = AotProcess::new();
+        process.upsert_file(source_path.display().to_string(), source_text);
+
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let captured_hook = Arc::clone(&captured);
+        set_clif_dump_hook(Some(Box::new(move |meta, func| {
+            if meta.name == "tick" {
+                *captured_hook.lock().expect("lock clif capture") =
+                    Some(format!("{}", func.display()));
+            }
+        })));
+
+        let report = process.compile().expect("compile perf sample");
+        assert!(report.emit.emitted_functions > 0, "expected functions emitted");
+
+        set_clif_dump_hook(None);
+        let clif = captured
+            .lock()
+            .expect("lock clif capture")
+            .take()
+            .expect("expected tick clif capture");
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_millis();
+        let out_path = std::env::temp_dir()
+            .join(format!("stasis_perf_balls_bricks_tick_{stamp}.clif"));
+        fs::write(&out_path, &clif).expect("write clif dump");
+
+        let call_lines = clif.lines().filter(|line| line.contains("call ")).count();
+        let call_value_lines = clif.lines().filter(|line| line.contains("= call ")).count();
+        let call_void_lines = clif
+            .lines()
+            .filter(|line| line.trim_start().starts_with("call "))
+            .count();
+        let load_lines = clif.lines().filter(|line| line.contains("load")).count();
+        let store_lines = clif.lines().filter(|line| line.contains("store")).count();
+
+        println!(
+            "clif_dump=perf_balls_bricks tick_clif_path={} bytes={} lines={} call_lines={} call_value_lines={} call_void_lines={} load_lines={} store_lines={}",
+            out_path.display(),
+            clif.len(),
+            clif.lines().count(),
+            call_lines,
+            call_value_lines,
+            call_void_lines,
+            load_lines,
+            store_lines
+        );
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -81,14 +81,14 @@ impl AotProcess {
         let resolved_extern_signatures: Vec<ResolvedExternCallSignature> = extern_signatures
             .iter()
             .filter_map(|sig| {
-                sig.symbol_candidates.first().map(|symbol| {
-                    ResolvedExternCallSignature {
+                sig.symbol_candidates
+                    .first()
+                    .map(|symbol| ResolvedExternCallSignature {
                         name: sig.name.clone(),
                         symbol: symbol.clone(),
                         params: sig.params.clone(),
                         return_type: sig.return_type,
-                    }
-                })
+                    })
             })
             .collect();
         let call_signatures = collect_supported_call_signatures(
@@ -134,13 +134,7 @@ impl AotProcess {
             .map(|function| function.id)
             .collect();
 
-        let (
-            compiler,
-            next_object_index,
-            artifacts,
-            object_bytes,
-            optimization_profile,
-        ) = (
+        let (compiler, next_object_index, artifacts, object_bytes, optimization_profile) = (
             &mut self.compiler,
             &mut self.next_object_index,
             &mut self.artifacts,
@@ -244,7 +238,10 @@ impl AotProcess {
                 .iter()
                 .find(|function| function.id == artifact.function_id)
                 .ok_or_else(|| {
-                    format!("compiled function metadata missing for id {}", artifact.function_id)
+                    format!(
+                        "compiled function metadata missing for id {}",
+                        artifact.function_id
+                    )
                 })?;
             let object_bytes = self
                 .object_bytes
@@ -749,6 +746,19 @@ mod tests {
     }
 
     #[test]
+    fn aot_process_supports_f64_global_field_set_and_read() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Layout { width: f64; }\nglobal state: Layout;\nfunction main(): i32 { state.width = 3.5; let w: f64 = state.width; if (w > 3.0) { return 1; } return 0; }\n",
+        );
+        let report = process.compile().expect("aot compile");
+        assert_eq!(report.index.parsed_functions, 1);
+        assert_eq!(report.emit.emitted_functions, 1);
+        assert!(process.artifacts()[0].object_bytes_len > 0);
+    }
+
+    #[test]
     fn aot_process_supports_void_return_functions() {
         let mut process = AotProcess::new();
         process.upsert_file(
@@ -885,7 +895,11 @@ mod tests {
             "function helper(): i32 { return 9; }\nfunction main(): i32 { return helper() + 1; }\n",
         );
         process.compile().expect("compile");
-        assert_eq!(process.artifacts().len(), 2, "expected both functions emitted");
+        assert_eq!(
+            process.artifacts().len(),
+            2,
+            "expected both functions emitted"
+        );
 
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -931,7 +945,11 @@ mod tests {
             "function helper(): void { return; }\nfunction main(): i32 { helper(); return 7; }\n",
         );
         process.compile().expect("compile");
-        assert_eq!(process.artifacts().len(), 2, "expected both functions emitted");
+        assert_eq!(
+            process.artifacts().len(),
+            2,
+            "expected both functions emitted"
+        );
 
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -11,7 +11,7 @@ use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::ir::{
     condcodes::{FloatCC, IntCC},
     immediates::{Ieee32, Ieee64},
-    types, AbiParam, Block, FuncRef, InstBuilder, Value,
+    types, AbiParam, Block, FuncRef, InstBuilder, MemFlags, Value,
 };
 use cranelift_frontend::{FunctionBuilder, Variable};
 use cranelift_module::{FuncId, Linkage, Module};
@@ -92,6 +92,8 @@ pub(crate) struct ForeachBinding {
     pub(crate) index_var: Variable,
     pub(crate) element_type: Option<TypeId>,
     pub(crate) field_types: BTreeMap<String, TypeId>,
+    pub(crate) f32_array_base_ptrs: BTreeMap<String, Value>,
+    pub(crate) f64_array_base_ptrs: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1120,8 +1122,10 @@ pub(crate) struct RuntimeCallImportIds {
     pub(crate) global_i32_array_store: FuncId,
     pub(crate) global_f32_array_load: FuncId,
     pub(crate) global_f32_array_store: FuncId,
+    pub(crate) global_f32_array_ptr: FuncId,
     pub(crate) global_f64_array_load: FuncId,
     pub(crate) global_f64_array_store: FuncId,
+    pub(crate) global_f64_array_ptr: FuncId,
     pub(crate) collection_i32_load: FuncId,
     pub(crate) collection_i32_store: FuncId,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncId>,
@@ -1170,8 +1174,10 @@ pub(crate) struct RuntimeCallRefs {
     pub(crate) global_i32_array_store: FuncRef,
     pub(crate) global_f32_array_load: FuncRef,
     pub(crate) global_f32_array_store: FuncRef,
+    pub(crate) global_f32_array_ptr: FuncRef,
     pub(crate) global_f64_array_load: FuncRef,
     pub(crate) global_f64_array_store: FuncRef,
+    pub(crate) global_f64_array_ptr: FuncRef,
     pub(crate) collection_i32_load: FuncRef,
     pub(crate) collection_i32_store: FuncRef,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncRef>,
@@ -1492,6 +1498,20 @@ pub(crate) fn declare_f32_array_store_import(
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
+pub(crate) fn declare_f32_array_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::I64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
 pub(crate) fn declare_f64_array_load_import(
     module: &mut impl Module,
     symbol: &str,
@@ -1515,6 +1535,20 @@ pub(crate) fn declare_f64_array_store_import(
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::F64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f64_array_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::I64));
     module
         .declare_function(symbol, Linkage::Import, &signature)
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
@@ -4887,6 +4921,52 @@ pub(crate) fn emit_simple_statements(
                     TYPE_ID_I32,
                     type_table,
                 )?;
+
+                // Cache collection field pointers once per foreach loop, so hot inner loops can
+                // use direct loads/stores instead of calling runtime helpers on every iteration.
+                let collection_hash_value =
+                    emit_foreach_collection_handle_value(builder, collection_handle);
+                let len_value = builder
+                    .ins()
+                    .iconst(types::I32, i64::from(collection_info.len));
+                let mut f32_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
+                let mut f64_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
+                if collection_info.element_type == Some(TYPE_ID_F32) {
+                    let field_hash_value = builder.ins().iconst(types::I32, 0);
+                    let call = builder.ins().call(
+                        runtime_call_refs.global_f32_array_ptr,
+                        &[collection_hash_value, field_hash_value, len_value],
+                    );
+                    f32_array_base_ptrs.insert(String::new(), builder.inst_results(call)[0]);
+                }
+                if collection_info.element_type == Some(TYPE_ID_F64) {
+                    let field_hash_value = builder.ins().iconst(types::I32, 0);
+                    let call = builder.ins().call(
+                        runtime_call_refs.global_f64_array_ptr,
+                        &[collection_hash_value, field_hash_value, len_value],
+                    );
+                    f64_array_base_ptrs.insert(String::new(), builder.inst_results(call)[0]);
+                }
+                for (suffix, type_id) in &collection_info.field_types {
+                    let field_hash = hash_foreach_field_suffix(suffix);
+                    let field_hash_value =
+                        builder.ins().iconst(types::I32, i64::from(field_hash));
+                    if *type_id == TYPE_ID_F32 {
+                        let call = builder.ins().call(
+                            runtime_call_refs.global_f32_array_ptr,
+                            &[collection_hash_value, field_hash_value, len_value],
+                        );
+                        f32_array_base_ptrs.insert(suffix.clone(), builder.inst_results(call)[0]);
+                    }
+                    if *type_id == TYPE_ID_F64 {
+                        let call = builder.ins().call(
+                            runtime_call_refs.global_f64_array_ptr,
+                            &[collection_hash_value, field_hash_value, len_value],
+                        );
+                        f64_array_base_ptrs.insert(suffix.clone(), builder.inst_results(call)[0]);
+                    }
+                }
+
                 let mut loop_values = values_by_name.clone();
                 if let Some(index_name) = index_name {
                     loop_values.insert(
@@ -4905,6 +4985,8 @@ pub(crate) fn emit_simple_statements(
                         index_var,
                         element_type: collection_info.element_type,
                         field_types: collection_info.field_types.clone(),
+                        f32_array_base_ptrs,
+                        f64_array_base_ptrs,
                     },
                 );
 
@@ -6619,11 +6701,11 @@ pub(crate) fn emit_foreach_binding_load(
     suffix: &str,
 ) -> Result<ValueBinding, String> {
     let resolved = resolve_foreach_binding_value_type(binding, suffix)?;
-    let field_hash = hash_foreach_field_suffix(suffix);
-    let collection_hash = emit_foreach_collection_handle_value(builder, binding.collection_handle);
-    let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
     let index_value = builder.use_var(binding.index_var);
     if is_i32_abi_compatible_type(resolved, type_table) {
+        let field_hash = hash_foreach_field_suffix(suffix);
+        let collection_hash = emit_foreach_collection_handle_value(builder, binding.collection_handle);
+        let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
         let call = builder.ins().call(
             runtime_call_refs.global_i32_array_load,
             &[collection_hash, field_hash_value, index_value],
@@ -6634,6 +6716,20 @@ pub(crate) fn emit_foreach_binding_load(
         });
     }
     if resolved == TYPE_ID_F32 {
+        if let Some(base_ptr) = binding.f32_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            let value = builder.ins().load(types::F32, MemFlags::new(), addr, 0);
+            return Ok(ValueBinding {
+                value,
+                type_id: TYPE_ID_F32,
+            });
+        }
+
+        let field_hash = hash_foreach_field_suffix(suffix);
+        let collection_hash = emit_foreach_collection_handle_value(builder, binding.collection_handle);
+        let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
         let call = builder.ins().call(
             runtime_call_refs.global_f32_array_load,
             &[collection_hash, field_hash_value, index_value],
@@ -6644,6 +6740,20 @@ pub(crate) fn emit_foreach_binding_load(
         });
     }
     if resolved == TYPE_ID_F64 {
+        if let Some(base_ptr) = binding.f64_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            let value = builder.ins().load(types::F64, MemFlags::new(), addr, 0);
+            return Ok(ValueBinding {
+                value,
+                type_id: TYPE_ID_F64,
+            });
+        }
+
+        let field_hash = hash_foreach_field_suffix(suffix);
+        let collection_hash = emit_foreach_collection_handle_value(builder, binding.collection_handle);
+        let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
         let call = builder.ins().call(
             runtime_call_refs.global_f64_array_load,
             &[collection_hash, field_hash_value, index_value],
@@ -6812,10 +6922,17 @@ pub(crate) fn emit_foreach_binding_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f32_array_store,
-            &[collection_hash, field_hash_value, index_value, value],
-        );
+        if let Some(base_ptr) = binding.f32_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f32_array_store,
+                &[collection_hash, field_hash_value, index_value, value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -6872,10 +6989,17 @@ pub(crate) fn emit_foreach_binding_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f64_array_store,
-            &[collection_hash, field_hash_value, index_value, value],
-        );
+        if let Some(base_ptr) = binding.f64_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f64_array_store,
+                &[collection_hash, field_hash_value, index_value, value],
+            );
+        }
         return Ok(());
     }
     Err(format!(
@@ -8190,6 +8314,7 @@ pub(crate) fn build_runtime_call_import_ids(
             module,
             "stasis_jit_global_f32_array_store",
         )?,
+        global_f32_array_ptr: declare_f32_array_ptr_import(module, "stasis_jit_global_f32_array_ptr")?,
         global_f64_array_load: declare_f64_array_load_import(
             module,
             "stasis_jit_global_f64_array_load",
@@ -8198,6 +8323,7 @@ pub(crate) fn build_runtime_call_import_ids(
             module,
             "stasis_jit_global_f64_array_store",
         )?,
+        global_f64_array_ptr: declare_f64_array_ptr_import(module, "stasis_jit_global_f64_array_ptr")?,
         collection_i32_load: declare_i32_call_import(module, "stasis_jit_collection_i32_load", 2)?,
         collection_i32_store: declare_void_call_import(
             module,
@@ -8256,8 +8382,10 @@ pub(crate) fn build_runtime_call_refs(
         global_i32_array_store: module.declare_func_in_func(imports.global_i32_array_store, func),
         global_f32_array_load: module.declare_func_in_func(imports.global_f32_array_load, func),
         global_f32_array_store: module.declare_func_in_func(imports.global_f32_array_store, func),
+        global_f32_array_ptr: module.declare_func_in_func(imports.global_f32_array_ptr, func),
         global_f64_array_load: module.declare_func_in_func(imports.global_f64_array_load, func),
         global_f64_array_store: module.declare_func_in_func(imports.global_f64_array_store, func),
+        global_f64_array_ptr: module.declare_func_in_func(imports.global_f64_array_ptr, func),
         collection_i32_load: module.declare_func_in_func(imports.collection_i32_load, func),
         collection_i32_store: module.declare_func_in_func(imports.collection_i32_store, func),
         extern_calls: imports

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -4,12 +4,13 @@ use crate::frontend::parser::{
     ParsedField,
 };
 use crate::frontend::types::{
-    TypeCategory, TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_I32, TYPE_ID_VOID,
+    TypeCategory, TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
+    TYPE_ID_VOID,
 };
 use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::ir::{
     condcodes::{FloatCC, IntCC},
-    immediates::Ieee32,
+    immediates::{Ieee32, Ieee64},
     types, AbiParam, Block, FuncRef, InstBuilder, Value,
 };
 use cranelift_frontend::{FunctionBuilder, Variable};
@@ -73,6 +74,7 @@ pub(crate) struct CompileAnalysisCache {
 pub(crate) enum ConstantValue {
     I32 { value: i32, type_id: TypeId },
     F32(f32),
+    F64(f64),
     Bool(bool),
     String { value: String, type_id: TypeId },
 }
@@ -152,11 +154,17 @@ pub(crate) fn collect_supported_call_signatures(
     map
 }
 
-pub(crate) fn is_supported_call_lane_type(type_id: TypeId, type_table: &TypeTable, allow_void: bool) -> bool {
+pub(crate) fn is_supported_call_lane_type(
+    type_id: TypeId,
+    type_table: &TypeTable,
+    allow_void: bool,
+) -> bool {
     if allow_void && type_id == TYPE_ID_VOID {
         return true;
     }
-    type_id == TYPE_ID_F32 || is_i32_abi_compatible_type(type_id, type_table)
+    type_id == TYPE_ID_F32
+        || type_id == TYPE_ID_F64
+        || is_i32_abi_compatible_type(type_id, type_table)
 }
 
 pub(crate) fn collect_supported_extern_call_signatures(
@@ -200,7 +208,10 @@ pub(crate) fn build_extern_call_signature(
     })
 }
 
-pub(crate) fn build_extern_symbol_candidates(symbol_name: &str, explicit_symbol: bool) -> Vec<String> {
+pub(crate) fn build_extern_symbol_candidates(
+    symbol_name: &str,
+    explicit_symbol: bool,
+) -> Vec<String> {
     let mut out = Vec::new();
     if symbol_name.is_empty() {
         return out;
@@ -552,10 +563,16 @@ pub(crate) fn resolve_global_path_type_id(
 }
 
 pub(crate) fn is_primitive_scalar_type_id(type_id: TypeId) -> bool {
-    matches!(type_id, TYPE_ID_I32 | TYPE_ID_F32 | TYPE_ID_BOOL)
+    matches!(
+        type_id,
+        TYPE_ID_I32 | TYPE_ID_F32 | TYPE_ID_F64 | TYPE_ID_BOOL
+    )
 }
 
-pub(crate) fn resolve_primitive_scalar_type_id(type_name: &str, type_table: &TypeTable) -> Option<TypeId> {
+pub(crate) fn resolve_primitive_scalar_type_id(
+    type_name: &str,
+    type_table: &TypeTable,
+) -> Option<TypeId> {
     let type_id = type_table.resolve(type_name.trim())?;
     if is_primitive_scalar_type_id(type_id) {
         Some(type_id)
@@ -659,6 +676,12 @@ pub(crate) fn parse_top_level_constant_literal(
             .map_err(|error| format!("invalid f32 initializer for constant '{}': {error}", name))?;
         return Ok(Some(ConstantValue::F32(value)));
     }
+    if type_id == TYPE_ID_F64 {
+        let value = initializer
+            .parse::<f64>()
+            .map_err(|error| format!("invalid f64 initializer for constant '{}': {error}", name))?;
+        return Ok(Some(ConstantValue::F64(value)));
+    }
     if type_id == TYPE_ID_BOOL {
         return match initializer {
             "true" => Ok(Some(ConstantValue::Bool(true))),
@@ -684,7 +707,10 @@ pub(crate) fn parse_top_level_constant_literal(
     Ok(None)
 }
 
-pub(crate) fn parse_constant_string_initializer(name: &str, initializer: &str) -> Result<String, String> {
+pub(crate) fn parse_constant_string_initializer(
+    name: &str,
+    initializer: &str,
+) -> Result<String, String> {
     let tokens = tokenize_simple_expression(initializer).map_err(|error| {
         format!(
             "invalid string initializer for constant '{}': {error}",
@@ -1088,10 +1114,14 @@ pub(crate) struct RuntimeCallImportIds {
     pub(crate) global_i32_store: FuncId,
     pub(crate) global_f32_load: FuncId,
     pub(crate) global_f32_store: FuncId,
+    pub(crate) global_f64_load: FuncId,
+    pub(crate) global_f64_store: FuncId,
     pub(crate) global_i32_array_load: FuncId,
     pub(crate) global_i32_array_store: FuncId,
     pub(crate) global_f32_array_load: FuncId,
     pub(crate) global_f32_array_store: FuncId,
+    pub(crate) global_f64_array_load: FuncId,
+    pub(crate) global_f64_array_store: FuncId,
     pub(crate) collection_i32_load: FuncId,
     pub(crate) collection_i32_store: FuncId,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncId>,
@@ -1134,10 +1164,14 @@ pub(crate) struct RuntimeCallRefs {
     pub(crate) global_i32_store: FuncRef,
     pub(crate) global_f32_load: FuncRef,
     pub(crate) global_f32_store: FuncRef,
+    pub(crate) global_f64_load: FuncRef,
+    pub(crate) global_f64_store: FuncRef,
     pub(crate) global_i32_array_load: FuncRef,
     pub(crate) global_i32_array_store: FuncRef,
     pub(crate) global_f32_array_load: FuncRef,
     pub(crate) global_f32_array_store: FuncRef,
+    pub(crate) global_f64_array_load: FuncRef,
+    pub(crate) global_f64_array_store: FuncRef,
     pub(crate) collection_i32_load: FuncRef,
     pub(crate) collection_i32_store: FuncRef,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncRef>,
@@ -1181,10 +1215,12 @@ fn emit_aot_direct_call_for_signature(
         let symbol = aot_symbol_name(function_id);
         let mut import_signature = mode.module.make_signature();
         for param_type in &signature.params {
-            import_signature.params.push(AbiParam::new(clif_type_for_type_id(
-                *param_type,
-                type_table,
-            )?));
+            import_signature
+                .params
+                .push(AbiParam::new(clif_type_for_type_id(
+                    *param_type,
+                    type_table,
+                )?));
         }
         if signature.return_type != TYPE_ID_VOID {
             import_signature
@@ -1209,9 +1245,11 @@ fn emit_aot_direct_call_for_signature(
     if signature.return_type == TYPE_ID_VOID {
         Ok(None)
     } else {
-        let value = builder.inst_results(call).first().copied().ok_or_else(|| {
-            "direct call expected value result but produced none".to_string()
-        })?;
+        let value = builder
+            .inst_results(call)
+            .first()
+            .copied()
+            .ok_or_else(|| "direct call expected value result but produced none".to_string())?;
         Ok(Some(value))
     }
 }
@@ -1277,7 +1315,10 @@ pub(crate) fn declare_i32_f32_call_import(
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_lookup_code_ptr_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_lookup_code_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.returns.push(AbiParam::new(types::I64));
@@ -1286,7 +1327,10 @@ pub(crate) fn declare_lookup_code_ptr_import(module: &mut impl Module, symbol: &
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_direct_f32_unary_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_direct_f32_unary_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::F32));
     signature.returns.push(AbiParam::new(types::F32));
@@ -1344,7 +1388,10 @@ pub(crate) fn declare_void_call_import(
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_f32_global_load_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_f32_global_load_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.returns.push(AbiParam::new(types::F32));
@@ -1353,7 +1400,10 @@ pub(crate) fn declare_f32_global_load_import(module: &mut impl Module, symbol: &
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_f32_global_store_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_f32_global_store_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::F32));
@@ -1362,7 +1412,34 @@ pub(crate) fn declare_f32_global_store_import(module: &mut impl Module, symbol: 
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_i32_array_load_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_f64_global_load_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::F64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f64_global_store_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::F64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_i32_array_load_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
@@ -1373,7 +1450,10 @@ pub(crate) fn declare_i32_array_load_import(module: &mut impl Module, symbol: &s
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_i32_array_store_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_i32_array_store_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
@@ -1384,7 +1464,10 @@ pub(crate) fn declare_i32_array_store_import(module: &mut impl Module, symbol: &
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_f32_array_load_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_f32_array_load_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
@@ -1395,12 +1478,43 @@ pub(crate) fn declare_f32_array_load_import(module: &mut impl Module, symbol: &s
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
 }
 
-pub(crate) fn declare_f32_array_store_import(module: &mut impl Module, symbol: &str) -> Result<FuncId, String> {
+pub(crate) fn declare_f32_array_store_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::F32));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f64_array_load_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::F64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f64_array_store_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::I32));
+    signature.params.push(AbiParam::new(types::F64));
     module
         .declare_function(symbol, Linkage::Import, &signature)
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
@@ -1477,6 +1591,7 @@ pub(crate) fn clif_type_for_type_id(
     match type_id {
         TYPE_ID_I32 => Ok(types::I32),
         TYPE_ID_F32 => Ok(types::F32),
+        TYPE_ID_F64 => Ok(types::F64),
         TYPE_ID_BOOL => Ok(types::I32),
         TYPE_ID_VOID => Err("void is not a value type".to_string()),
         other => {
@@ -1570,6 +1685,7 @@ pub(crate) enum AssignTarget {
 pub(crate) enum ConversionKind {
     FromI32,
     FromF32,
+    FromF64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1866,7 +1982,10 @@ pub(crate) fn parse_assignment_statement(statement_text: &str) -> Result<SimpleS
     })
 }
 
-pub(crate) fn parse_assignment_target(source: &str, cursor: usize) -> Result<(AssignTarget, usize), String> {
+pub(crate) fn parse_assignment_target(
+    source: &str,
+    cursor: usize,
+) -> Result<(AssignTarget, usize), String> {
     let (first, mut next) = parse_identifier(source, cursor)?;
     let mut collection_path = first.to_string();
     let mut index_expr: Option<SimpleExpr> = None;
@@ -1946,13 +2065,16 @@ pub(crate) fn parse_from_conversion_statement(statement_text: &str) -> Result<Si
     let trimmed = statement_text.trim();
     let marker_i32 = ".from_i32(";
     let marker_f32 = ".from_f32(";
+    let marker_f64 = ".from_f64(";
     let (marker_pos, marker, kind) = if let Some(pos) = trimmed.find(marker_i32) {
         (pos, marker_i32, ConversionKind::FromI32)
     } else if let Some(pos) = trimmed.find(marker_f32) {
         (pos, marker_f32, ConversionKind::FromF32)
+    } else if let Some(pos) = trimmed.find(marker_f64) {
+        (pos, marker_f64, ConversionKind::FromF64)
     } else {
         return Err(format!(
-            "unsupported conversion statement '{}': expected from_i32 or from_f32",
+            "unsupported conversion statement '{}': expected from_i32, from_f32, or from_f64",
             statement_text
         ));
     };
@@ -2088,7 +2210,10 @@ pub(crate) fn parse_for_control_segment(
     if starts_with_keyword(trimmed, 0, "let") {
         return parse_let_statement(trimmed, type_table);
     }
-    if trimmed.contains(".from_i32(") || trimmed.contains(".from_f32(") {
+    if trimmed.contains(".from_i32(")
+        || trimmed.contains(".from_f32(")
+        || trimmed.contains(".from_f64(")
+    {
         return parse_from_conversion_statement(trimmed);
     }
     if looks_like_assignment(trimmed, 0) {
@@ -2391,7 +2516,9 @@ pub(crate) fn split_top_level_condition<'a>(condition_text: &'a str, op: &[u8; 2
     parts
 }
 
-pub(crate) fn find_condition_operator(condition_text: &str) -> Option<(ComparisonOp, usize, usize)> {
+pub(crate) fn find_condition_operator(
+    condition_text: &str,
+) -> Option<(ComparisonOp, usize, usize)> {
     let bytes = condition_text.as_bytes();
     let mut depth = 0i32;
     let mut index = 0usize;
@@ -2573,7 +2700,9 @@ pub(crate) fn looks_like_from_conversion_statement(source: &str, cursor: usize) 
         return false;
     }
     let method_tail = &tail[dot_pos..];
-    method_tail.starts_with(".from_i32(") || method_tail.starts_with(".from_f32(")
+    method_tail.starts_with(".from_i32(")
+        || method_tail.starts_with(".from_f32(")
+        || method_tail.starts_with(".from_f64(")
 }
 
 pub(crate) fn looks_like_call_statement(source: &str, cursor: usize) -> bool {
@@ -2728,7 +2857,12 @@ pub(crate) fn find_statement_terminator(source: &str, start: usize) -> Result<us
     ))
 }
 
-pub(crate) fn find_matching_delimiter(source: &str, open_index: usize, open: u8, close: u8) -> Option<usize> {
+pub(crate) fn find_matching_delimiter(
+    source: &str,
+    open_index: usize,
+    open: u8,
+    close: u8,
+) -> Option<usize> {
     let bytes = source.as_bytes();
     if bytes.get(open_index).copied() != Some(open) {
         return None;
@@ -2795,7 +2929,12 @@ pub(crate) fn find_matching_delimiter(source: &str, open_index: usize, open: u8,
     None
 }
 
-pub(crate) fn expect_byte(source: &str, cursor: usize, expected: u8, context: &str) -> Result<usize, String> {
+pub(crate) fn expect_byte(
+    source: &str,
+    cursor: usize,
+    expected: u8,
+    context: &str,
+) -> Result<usize, String> {
     if cursor >= source.len() || source.as_bytes()[cursor] != expected {
         return Err(format!(
             "expected {} near '{}'",
@@ -2825,7 +2964,10 @@ pub(crate) fn parse_identifier(source: &str, cursor: usize) -> Result<(&str, usi
     Ok((&source[cursor..end], end))
 }
 
-pub(crate) fn parse_identifier_path(source: &str, cursor: usize) -> Result<(String, usize), String> {
+pub(crate) fn parse_identifier_path(
+    source: &str,
+    cursor: usize,
+) -> Result<(String, usize), String> {
     let (first, mut next) = parse_identifier(source, cursor)?;
     let mut path = first.to_string();
     loop {
@@ -2892,6 +3034,7 @@ pub(crate) fn emit_host_print_call_statement(
     let argument = emit_simple_expression(
         builder,
         &args[0],
+        None,
         values_by_name,
         runtime_call_refs,
         internal_calls,
@@ -3074,6 +3217,7 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
     let target_index_binding = emit_simple_expression(
         builder,
         target_index,
+        None,
         values_by_name,
         runtime_call_refs,
         internal_calls,
@@ -3088,6 +3232,7 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
     let source_index_binding = emit_simple_expression(
         builder,
         source_index,
+        None,
         values_by_name,
         runtime_call_refs,
         internal_calls,
@@ -3387,6 +3532,7 @@ pub(crate) fn try_emit_struct_copy_from_indexed_to_global(
     let source_index_binding = emit_simple_expression(
         builder,
         source_index,
+        None,
         values_by_name,
         runtime_call_refs,
         internal_calls,
@@ -3501,6 +3647,7 @@ pub(crate) fn try_emit_struct_copy_from_global_to_indexed(
     let target_index_binding = emit_simple_expression(
         builder,
         target_index,
+        None,
         values_by_name,
         runtime_call_refs,
         internal_calls,
@@ -3570,6 +3717,7 @@ pub(crate) fn emit_simple_statements(
                 let binding = emit_simple_expression(
                     builder,
                     expression,
+                    *type_id,
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -3683,9 +3831,44 @@ pub(crate) fn emit_simple_statements(
                 )? {
                     continue;
                 }
+                let expected_rhs_type = match target {
+                    AssignTarget::Local(name) => values_by_name
+                        .get(name)
+                        .map(|binding| binding.type_id)
+                        .or_else(|| global_path_types.get(name).copied()),
+                    AssignTarget::GlobalPath(path) => {
+                        global_path_types.get(path).copied().or_else(|| {
+                            let (base, suffix) = path.rsplit_once('.')?;
+                            let local = values_by_name.get(base)?;
+                            let field_types = named_struct_field_types.get(&local.type_id)?;
+                            field_types.get(suffix).copied()
+                        })
+                    }
+                    AssignTarget::IndexedPath {
+                        collection_path,
+                        suffix,
+                        ..
+                    } => {
+                        if let Some(local_collection) = values_by_name.get(collection_path).copied()
+                        {
+                            Some(resolve_local_collection_value_type(
+                                local_collection.type_id,
+                                suffix,
+                                type_table,
+                                named_struct_field_types,
+                            )?)
+                        } else if let Some(collection_info) = collection_infos.get(collection_path)
+                        {
+                            Some(resolve_collection_value_type(collection_info, suffix)?)
+                        } else {
+                            None
+                        }
+                    }
+                };
                 let rhs = emit_simple_expression(
                     builder,
                     expression,
+                    expected_rhs_type,
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -3743,6 +3926,32 @@ pub(crate) fn emit_simple_statements(
                                     }
                                 }
                             } else if local.type_id == TYPE_ID_F32 {
+                                match op {
+                                    AssignOp::Set => rhs.value,
+                                    AssignOp::Add => {
+                                        let lhs = builder.use_var(local.var);
+                                        builder.ins().fadd(lhs, rhs.value)
+                                    }
+                                    AssignOp::Sub => {
+                                        let lhs = builder.use_var(local.var);
+                                        builder.ins().fsub(lhs, rhs.value)
+                                    }
+                                    AssignOp::Mul => {
+                                        let lhs = builder.use_var(local.var);
+                                        builder.ins().fmul(lhs, rhs.value)
+                                    }
+                                    AssignOp::Div => {
+                                        let lhs = builder.use_var(local.var);
+                                        builder.ins().fdiv(lhs, rhs.value)
+                                    }
+                                    AssignOp::Mod => {
+                                        return Err(format!(
+                                            "'%=' requires i32 target in current jit path for '{}'",
+                                            name
+                                        ));
+                                    }
+                                }
+                            } else if local.type_id == TYPE_ID_F64 {
                                 match op {
                                     AssignOp::Set => rhs.value,
                                     AssignOp::Add => {
@@ -4043,6 +4252,55 @@ pub(crate) fn emit_simple_statements(
                                         );
                                         continue;
                                     }
+                                    if field_type == TYPE_ID_F64 {
+                                        let value = match op {
+                                            AssignOp::Set => rhs.value,
+                                            AssignOp::Add => {
+                                                let call = builder.ins().call(
+                                                    runtime_call_refs.global_f64_load,
+                                                    &[path_hash],
+                                                );
+                                                let lhs = builder.inst_results(call)[0];
+                                                builder.ins().fadd(lhs, rhs.value)
+                                            }
+                                            AssignOp::Sub => {
+                                                let call = builder.ins().call(
+                                                    runtime_call_refs.global_f64_load,
+                                                    &[path_hash],
+                                                );
+                                                let lhs = builder.inst_results(call)[0];
+                                                builder.ins().fsub(lhs, rhs.value)
+                                            }
+                                            AssignOp::Mul => {
+                                                let call = builder.ins().call(
+                                                    runtime_call_refs.global_f64_load,
+                                                    &[path_hash],
+                                                );
+                                                let lhs = builder.inst_results(call)[0];
+                                                builder.ins().fmul(lhs, rhs.value)
+                                            }
+                                            AssignOp::Div => {
+                                                let call = builder.ins().call(
+                                                    runtime_call_refs.global_f64_load,
+                                                    &[path_hash],
+                                                );
+                                                let lhs = builder.inst_results(call)[0];
+                                                builder.ins().fdiv(lhs, rhs.value)
+                                            }
+                                            AssignOp::Mod => {
+                                                return Err(format!(
+                                                    "'%=' is unsupported for f64 local struct field '{}.{}'",
+                                                    base,
+                                                    suffix
+                                                ));
+                                            }
+                                        };
+                                        builder.ins().call(
+                                            runtime_call_refs.global_f64_store,
+                                            &[path_hash, value],
+                                        );
+                                        continue;
+                                    }
                                     return Err(format!(
                                         "unsupported local struct field type {} for '{}.{}'",
                                         field_type, base, suffix
@@ -4076,6 +4334,7 @@ pub(crate) fn emit_simple_statements(
                             let index_binding = emit_simple_expression(
                                 builder,
                                 index,
+                                Some(TYPE_ID_I32),
                                 values_by_name,
                                 runtime_call_refs,
                                 internal_calls,
@@ -4110,6 +4369,7 @@ pub(crate) fn emit_simple_statements(
                         let index_binding = emit_simple_expression(
                             builder,
                             index,
+                            Some(TYPE_ID_I32),
                             values_by_name,
                             runtime_call_refs,
                             internal_calls,
@@ -4140,9 +4400,15 @@ pub(crate) fn emit_simple_statements(
                 kind,
                 source,
             } => {
+                let expected_source_type = match kind {
+                    ConversionKind::FromI32 => Some(TYPE_ID_I32),
+                    ConversionKind::FromF32 => Some(TYPE_ID_F32),
+                    ConversionKind::FromF64 => Some(TYPE_ID_F64),
+                };
                 let source_binding = emit_simple_expression(
                     builder,
                     source,
+                    expected_source_type,
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -4218,6 +4484,7 @@ pub(crate) fn emit_simple_statements(
                         let index_binding = emit_simple_expression(
                             builder,
                             index,
+                            Some(TYPE_ID_I32),
                             values_by_name,
                             runtime_call_refs,
                             internal_calls,
@@ -4269,6 +4536,7 @@ pub(crate) fn emit_simple_statements(
                         let binding = emit_simple_expression(
                             builder,
                             arg,
+                            None,
                             values_by_name,
                             runtime_call_refs,
                             internal_calls,
@@ -4321,6 +4589,7 @@ pub(crate) fn emit_simple_statements(
                 let _ = emit_simple_expression(
                     builder,
                     expression,
+                    None,
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -4344,6 +4613,7 @@ pub(crate) fn emit_simple_statements(
                 let binding = emit_simple_expression(
                     builder,
                     expression,
+                    Some(expected_return_type),
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -4712,25 +4982,64 @@ pub(crate) fn emit_conversion_assignment_value(
             if source.type_id != TYPE_ID_I32 {
                 return Err("from_i32 source expression must be i32".to_string());
             }
-            if target_type != TYPE_ID_F32 {
-                return Err(format!("from_i32 target '{}' must be f32", target_name));
+            if target_type == TYPE_ID_F32 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fcvt_from_sint(types::F32, source.value),
+                    type_id: TYPE_ID_F32,
+                });
             }
-            Ok(ValueBinding {
-                value: builder.ins().fcvt_from_sint(types::F32, source.value),
-                type_id: TYPE_ID_F32,
-            })
+            if target_type == TYPE_ID_F64 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fcvt_from_sint(types::F64, source.value),
+                    type_id: TYPE_ID_F64,
+                });
+            }
+            Err(format!(
+                "from_i32 target '{}' must be f32 or f64",
+                target_name
+            ))
         }
         ConversionKind::FromF32 => {
             if source.type_id != TYPE_ID_F32 {
                 return Err("from_f32 source expression must be f32".to_string());
             }
-            if target_type != TYPE_ID_I32 {
-                return Err(format!("from_f32 target '{}' must be i32", target_name));
+            if target_type == TYPE_ID_I32 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fcvt_to_sint(types::I32, source.value),
+                    type_id: TYPE_ID_I32,
+                });
             }
-            Ok(ValueBinding {
-                value: builder.ins().fcvt_to_sint(types::I32, source.value),
-                type_id: TYPE_ID_I32,
-            })
+            if target_type == TYPE_ID_F64 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fpromote(types::F64, source.value),
+                    type_id: TYPE_ID_F64,
+                });
+            }
+            Err(format!(
+                "from_f32 target '{}' must be i32 or f64",
+                target_name
+            ))
+        }
+        ConversionKind::FromF64 => {
+            if source.type_id != TYPE_ID_F64 {
+                return Err("from_f64 source expression must be f64".to_string());
+            }
+            if target_type == TYPE_ID_I32 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fcvt_to_sint(types::I32, source.value),
+                    type_id: TYPE_ID_I32,
+                });
+            }
+            if target_type == TYPE_ID_F32 {
+                return Ok(ValueBinding {
+                    value: builder.ins().fdemote(types::F32, source.value),
+                    type_id: TYPE_ID_F32,
+                });
+            }
+            Err(format!(
+                "from_f64 target '{}' must be i32 or f32",
+                target_name
+            ))
         }
     }
 }
@@ -4789,7 +5098,7 @@ pub(crate) fn emit_for_control_statement(
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum SimpleExpr {
     Int(i64),
-    Float(f32),
+    Float(f64),
     Bool(bool),
     StringLiteral(String),
     Condition(Box<SimpleCondition>),
@@ -4903,7 +5212,7 @@ pub(crate) fn looks_like_condition_expression(expression: &str) -> bool {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ExprToken {
     Int(i64),
-    Float(f32),
+    Float(f64),
     StringLiteral(String),
     Identifier(String),
     Op(char),
@@ -5027,7 +5336,7 @@ pub(crate) fn tokenize_simple_expression(expression: &str) -> Result<Vec<ExprTok
                 }
                 let text = &expression[start..index];
                 let value = text
-                    .parse::<f32>()
+                    .parse::<f64>()
                     .map_err(|error| format!("invalid float literal '{text}': {error}"))?;
                 tokens.push(ExprToken::Float(value));
             } else {
@@ -5327,6 +5636,7 @@ pub(crate) fn resolve_call_signature<'a>(
 pub(crate) fn emit_simple_expression(
     builder: &mut FunctionBuilder<'_>,
     expression: &SimpleExpr,
+    expected_type: Option<TypeId>,
     values_by_name: &BTreeMap<String, LocalBinding>,
     runtime_call_refs: &RuntimeCallRefs,
     internal_calls: &mut InternalCallMode<'_>,
@@ -5348,10 +5658,19 @@ pub(crate) fn emit_simple_expression(
                 type_id: TYPE_ID_I32,
             })
         }
-        SimpleExpr::Float(value) => Ok(ValueBinding {
-            value: builder.ins().f32const(Ieee32::with_float(*value)),
-            type_id: TYPE_ID_F32,
-        }),
+        SimpleExpr::Float(value) => {
+            if expected_type == Some(TYPE_ID_F64) {
+                Ok(ValueBinding {
+                    value: builder.ins().f64const(Ieee64::with_float(*value)),
+                    type_id: TYPE_ID_F64,
+                })
+            } else {
+                Ok(ValueBinding {
+                    value: builder.ins().f32const(Ieee32::with_float(*value as f32)),
+                    type_id: TYPE_ID_F32,
+                })
+            }
+        }
         SimpleExpr::Bool(value) => Ok(ValueBinding {
             value: builder
                 .ins()
@@ -5442,6 +5761,15 @@ pub(crate) fn emit_simple_expression(
                                 type_id: TYPE_ID_F32,
                             });
                         }
+                        if field_type == TYPE_ID_F64 {
+                            let call = builder
+                                .ins()
+                                .call(runtime_call_refs.global_f64_load, &[path_hash]);
+                            return Ok(ValueBinding {
+                                value: builder.inst_results(call)[0],
+                                type_id: TYPE_ID_F64,
+                            });
+                        }
                         return Err(format!(
                             "unsupported local struct field type {} for '{}.{}'",
                             field_type, base, suffix
@@ -5484,6 +5812,7 @@ pub(crate) fn emit_simple_expression(
                 let index_binding = emit_simple_expression(
                     builder,
                     index,
+                    Some(TYPE_ID_I32),
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -5515,6 +5844,7 @@ pub(crate) fn emit_simple_expression(
             let index_binding = emit_simple_expression(
                 builder,
                 index,
+                Some(TYPE_ID_I32),
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -5543,6 +5873,7 @@ pub(crate) fn emit_simple_expression(
                 let binding = emit_simple_expression(
                     builder,
                     arg,
+                    None,
                     values_by_name,
                     runtime_call_refs,
                     internal_calls,
@@ -5996,6 +6327,19 @@ pub(crate) fn emit_simple_expression(
                         }
                     }
                 }
+            } else if signature.return_type == TYPE_ID_F64 {
+                let value = emit_indirect_call_for_signature(
+                    builder,
+                    runtime_call_refs,
+                    signature,
+                    &arg_values,
+                    type_table,
+                )?
+                .ok_or_else(|| format!("call target '{}' did not produce value", target))?;
+                return Ok(ValueBinding {
+                    value,
+                    type_id: TYPE_ID_F64,
+                });
             } else {
                 return Err(format!(
                     "unsupported return type {} for call target '{}'",
@@ -6013,9 +6357,15 @@ pub(crate) fn emit_simple_expression(
             })
         }
         SimpleExpr::Binary { lhs, op, rhs } => {
+            let child_expected = match expected_type {
+                Some(TYPE_ID_F32) => Some(TYPE_ID_F32),
+                Some(TYPE_ID_F64) => Some(TYPE_ID_F64),
+                _ => None,
+            };
             let lhs_value = emit_simple_expression(
                 builder,
                 lhs,
+                child_expected,
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -6030,6 +6380,7 @@ pub(crate) fn emit_simple_expression(
             let rhs_value = emit_simple_expression(
                 builder,
                 rhs,
+                child_expected,
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -6059,6 +6410,32 @@ pub(crate) fn emit_simple_expression(
                 return Ok(ValueBinding {
                     value,
                     type_id: TYPE_ID_I32,
+                });
+            }
+
+            if lhs_value.type_id == TYPE_ID_F64 || rhs_value.type_id == TYPE_ID_F64 {
+                let (lhs_f64, rhs_f64) =
+                    coerce_numeric_operands_to_f64(builder, lhs_value, rhs_value, *op, type_table)?;
+                let value = match op {
+                    '+' => builder.ins().fadd(lhs_f64, rhs_f64),
+                    '-' => builder.ins().fsub(lhs_f64, rhs_f64),
+                    '*' => builder.ins().fmul(lhs_f64, rhs_f64),
+                    '/' => builder.ins().fdiv(lhs_f64, rhs_f64),
+                    '%' => {
+                        return Err(
+                            "unsupported '%' operator for f64 expression in current jit path"
+                                .to_string(),
+                        )
+                    }
+                    other => {
+                        return Err(format!(
+                            "unsupported binary operator '{other}' in expression"
+                        ))
+                    }
+                };
+                return Ok(ValueBinding {
+                    value,
+                    type_id: TYPE_ID_F64,
                 });
             }
 
@@ -6119,6 +6496,40 @@ pub(crate) fn coerce_numeric_operands_to_f32(
     Ok((lhs_value, rhs_value))
 }
 
+pub(crate) fn coerce_numeric_operands_to_f64(
+    builder: &mut FunctionBuilder<'_>,
+    lhs: ValueBinding,
+    rhs: ValueBinding,
+    op: char,
+    type_table: &TypeTable,
+) -> Result<(Value, Value), String> {
+    let lhs_value = if lhs.type_id == TYPE_ID_F64 {
+        lhs.value
+    } else if lhs.type_id == TYPE_ID_F32 {
+        builder.ins().fpromote(types::F64, lhs.value)
+    } else if is_i32_numeric_type(lhs.type_id, type_table) {
+        builder.ins().fcvt_from_sint(types::F64, lhs.value)
+    } else {
+        return Err(format!(
+            "unsupported lhs type {} for '{}' expression",
+            lhs.type_id, op
+        ));
+    };
+    let rhs_value = if rhs.type_id == TYPE_ID_F64 {
+        rhs.value
+    } else if rhs.type_id == TYPE_ID_F32 {
+        builder.ins().fpromote(types::F64, rhs.value)
+    } else if is_i32_numeric_type(rhs.type_id, type_table) {
+        builder.ins().fcvt_from_sint(types::F64, rhs.value)
+    } else {
+        return Err(format!(
+            "unsupported rhs type {} for '{}' expression",
+            rhs.type_id, op
+        ));
+    };
+    Ok((lhs_value, rhs_value))
+}
+
 pub(crate) fn emit_constant_value(
     builder: &mut FunctionBuilder<'_>,
     constant: &ConstantValue,
@@ -6131,6 +6542,10 @@ pub(crate) fn emit_constant_value(
         ConstantValue::F32(value) => Ok(ValueBinding {
             value: builder.ins().f32const(Ieee32::with_float(*value)),
             type_id: TYPE_ID_F32,
+        }),
+        ConstantValue::F64(value) => Ok(ValueBinding {
+            value: builder.ins().f64const(Ieee64::with_float(*value)),
+            type_id: TYPE_ID_F64,
         }),
         ConstantValue::Bool(value) => Ok(ValueBinding {
             value: builder
@@ -6226,6 +6641,16 @@ pub(crate) fn emit_foreach_binding_load(
         return Ok(ValueBinding {
             value: builder.inst_results(call)[0],
             type_id: TYPE_ID_F32,
+        });
+    }
+    if resolved == TYPE_ID_F64 {
+        let call = builder.ins().call(
+            runtime_call_refs.global_f64_array_load,
+            &[collection_hash, field_hash_value, index_value],
+        );
+        return Ok(ValueBinding {
+            value: builder.inst_results(call)[0],
+            type_id: TYPE_ID_F64,
         });
     }
     Err(format!(
@@ -6389,6 +6814,66 @@ pub(crate) fn emit_foreach_binding_assignment(
         };
         builder.ins().call(
             runtime_call_refs.global_f32_array_store,
+            &[collection_hash, field_hash_value, index_value, value],
+        );
+        return Ok(());
+    }
+    if path_type == TYPE_ID_F64 {
+        let value = match op {
+            AssignOp::Set => rhs.value,
+            AssignOp::Add => {
+                let lhs = emit_foreach_binding_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    binding,
+                    suffix,
+                )?
+                .value;
+                builder.ins().fadd(lhs, rhs.value)
+            }
+            AssignOp::Sub => {
+                let lhs = emit_foreach_binding_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    binding,
+                    suffix,
+                )?
+                .value;
+                builder.ins().fsub(lhs, rhs.value)
+            }
+            AssignOp::Mul => {
+                let lhs = emit_foreach_binding_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    binding,
+                    suffix,
+                )?
+                .value;
+                builder.ins().fmul(lhs, rhs.value)
+            }
+            AssignOp::Div => {
+                let lhs = emit_foreach_binding_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    binding,
+                    suffix,
+                )?
+                .value;
+                builder.ins().fdiv(lhs, rhs.value)
+            }
+            AssignOp::Mod => {
+                return Err(format!(
+                    "'%=' is unsupported for f64 foreach binding '{}'",
+                    suffix
+                ))
+            }
+        };
+        builder.ins().call(
+            runtime_call_refs.global_f64_array_store,
             &[collection_hash, field_hash_value, index_value, value],
         );
         return Ok(());
@@ -6560,6 +7045,16 @@ pub(crate) fn emit_local_indexed_collection_load(
         return Ok(ValueBinding {
             value: builder.inst_results(call)[0],
             type_id: TYPE_ID_F32,
+        });
+    }
+    if resolved == TYPE_ID_F64 {
+        let call = builder.ins().call(
+            runtime_call_refs.global_f64_array_load,
+            &[collection_handle, field_hash, index_binding.value],
+        );
+        return Ok(ValueBinding {
+            value: builder.inst_results(call)[0],
+            type_id: TYPE_ID_F64,
         });
     }
     Err(format!(
@@ -6768,6 +7263,78 @@ pub(crate) fn emit_local_indexed_collection_assignment(
         );
         return Ok(());
     }
+    if path_type == TYPE_ID_F64 {
+        let value = match op {
+            AssignOp::Set => rhs.value,
+            AssignOp::Add => {
+                let lhs = emit_local_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    named_struct_field_types,
+                    collection_name,
+                    collection_binding,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fadd(lhs, rhs.value)
+            }
+            AssignOp::Sub => {
+                let lhs = emit_local_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    named_struct_field_types,
+                    collection_name,
+                    collection_binding,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fsub(lhs, rhs.value)
+            }
+            AssignOp::Mul => {
+                let lhs = emit_local_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    named_struct_field_types,
+                    collection_name,
+                    collection_binding,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fmul(lhs, rhs.value)
+            }
+            AssignOp::Div => {
+                let lhs = emit_local_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    named_struct_field_types,
+                    collection_name,
+                    collection_binding,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fdiv(lhs, rhs.value)
+            }
+            AssignOp::Mod => {
+                return Err(format!(
+                    "'%=' is unsupported for f64 local indexed assignment '{}[...].{}'",
+                    collection_name, suffix
+                ));
+            }
+        };
+        builder.ins().call(
+            runtime_call_refs.global_f64_array_store,
+            &[collection_handle, field_hash, index_binding.value, value],
+        );
+        return Ok(());
+    }
     Err(format!(
         "unsupported local indexed collection assignment type {} for '{}[...].{}'",
         path_type, collection_name, suffix
@@ -6809,6 +7376,16 @@ pub(crate) fn emit_indexed_collection_load(
         return Ok(ValueBinding {
             value: builder.inst_results(call)[0],
             type_id: TYPE_ID_F32,
+        });
+    }
+    if resolved == TYPE_ID_F64 {
+        let call = builder.ins().call(
+            runtime_call_refs.global_f64_array_load,
+            &[collection_hash, field_hash, index_binding.value],
+        );
+        return Ok(ValueBinding {
+            value: builder.inst_results(call)[0],
+            type_id: TYPE_ID_F64,
         });
     }
     Err(format!(
@@ -6999,6 +7576,74 @@ pub(crate) fn emit_indexed_collection_assignment(
         );
         return Ok(());
     }
+    if path_type == TYPE_ID_F64 {
+        let value = match op {
+            AssignOp::Set => rhs.value,
+            AssignOp::Add => {
+                let lhs = emit_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    collection_path,
+                    collection_info,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fadd(lhs, rhs.value)
+            }
+            AssignOp::Sub => {
+                let lhs = emit_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    collection_path,
+                    collection_info,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fsub(lhs, rhs.value)
+            }
+            AssignOp::Mul => {
+                let lhs = emit_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    collection_path,
+                    collection_info,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fmul(lhs, rhs.value)
+            }
+            AssignOp::Div => {
+                let lhs = emit_indexed_collection_load(
+                    builder,
+                    runtime_call_refs,
+                    type_table,
+                    collection_path,
+                    collection_info,
+                    suffix,
+                    index_binding,
+                )?
+                .value;
+                builder.ins().fdiv(lhs, rhs.value)
+            }
+            AssignOp::Mod => {
+                return Err(format!(
+                    "'%=' is unsupported for f64 indexed assignment '{}[...].{}'",
+                    collection_path, suffix
+                ))
+            }
+        };
+        builder.ins().call(
+            runtime_call_refs.global_f64_array_store,
+            &[collection_hash, field_hash, index_binding.value, value],
+        );
+        return Ok(());
+    }
     Err(format!(
         "unsupported indexed collection assignment type {} for '{}[...].{}'",
         path_type, collection_path, suffix
@@ -7037,6 +7682,15 @@ pub(crate) fn emit_global_load(
         return Ok(ValueBinding {
             value: builder.inst_results(call)[0],
             type_id: TYPE_ID_F32,
+        });
+    }
+    if path_type == TYPE_ID_F64 {
+        let call = builder
+            .ins()
+            .call(runtime_call_refs.global_f64_load, &[path_hash]);
+        return Ok(ValueBinding {
+            value: builder.inst_results(call)[0],
+            type_id: TYPE_ID_F64,
         });
     }
     Err(format!(
@@ -7165,6 +7819,48 @@ pub(crate) fn emit_global_assignment(
             .call(runtime_call_refs.global_f32_store, &[path_hash, value]);
         return Ok(());
     }
+    if path_type == TYPE_ID_F64 {
+        let value = match op {
+            AssignOp::Set => rhs.value,
+            AssignOp::Add => {
+                let lhs =
+                    emit_global_load(builder, runtime_call_refs, type_table, path, path_type)?
+                        .value;
+                builder.ins().fadd(lhs, rhs.value)
+            }
+            AssignOp::Sub => {
+                let lhs =
+                    emit_global_load(builder, runtime_call_refs, type_table, path, path_type)?
+                        .value;
+                builder.ins().fsub(lhs, rhs.value)
+            }
+            AssignOp::Mul => {
+                let lhs =
+                    emit_global_load(builder, runtime_call_refs, type_table, path, path_type)?
+                        .value;
+                builder.ins().fmul(lhs, rhs.value)
+            }
+            AssignOp::Div => {
+                let lhs =
+                    emit_global_load(builder, runtime_call_refs, type_table, path, path_type)?
+                        .value;
+                builder.ins().fdiv(lhs, rhs.value)
+            }
+            AssignOp::Mod => {
+                return Err(format!(
+                    "'%=' is unsupported for f64 global path '{}'",
+                    path
+                ))
+            }
+        };
+        let path_hash = builder
+            .ins()
+            .iconst(types::I32, i64::from(hash_global_path(path)));
+        builder
+            .ins()
+            .call(runtime_call_refs.global_f64_store, &[path_hash, value]);
+        return Ok(());
+    }
     Err(format!(
         "unsupported global path type {} for '{}'",
         path_type, path
@@ -7203,6 +7899,7 @@ pub(crate) fn emit_simple_condition(
             let lhs = emit_simple_expression(
                 builder,
                 lhs,
+                None,
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -7217,6 +7914,7 @@ pub(crate) fn emit_simple_condition(
             let rhs = emit_simple_expression(
                 builder,
                 rhs,
+                None,
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -7242,8 +7940,6 @@ pub(crate) fn emit_simple_condition(
                 return Ok(builder.ins().icmp(intcc, lhs.value, rhs.value));
             }
 
-            let (lhs_f32, rhs_f32) =
-                coerce_numeric_operands_to_f32(builder, lhs, rhs, '?', type_table)?;
             let floatcc = match op {
                 ComparisonOp::Eq => FloatCC::Equal,
                 ComparisonOp::Ne => FloatCC::NotEqual,
@@ -7252,12 +7948,22 @@ pub(crate) fn emit_simple_condition(
                 ComparisonOp::Gt => FloatCC::GreaterThan,
                 ComparisonOp::Ge => FloatCC::GreaterThanOrEqual,
             };
+
+            if lhs.type_id == TYPE_ID_F64 || rhs.type_id == TYPE_ID_F64 {
+                let (lhs_f64, rhs_f64) =
+                    coerce_numeric_operands_to_f64(builder, lhs, rhs, '?', type_table)?;
+                return Ok(builder.ins().fcmp(floatcc, lhs_f64, rhs_f64));
+            }
+
+            let (lhs_f32, rhs_f32) =
+                coerce_numeric_operands_to_f32(builder, lhs, rhs, '?', type_table)?;
             Ok(builder.ins().fcmp(floatcc, lhs_f32, rhs_f32))
         }
         SimpleCondition::Expr(expression) => {
             let binding = emit_simple_expression(
                 builder,
                 expression,
+                Some(TYPE_ID_BOOL),
                 values_by_name,
                 runtime_call_refs,
                 internal_calls,
@@ -7466,12 +8172,38 @@ pub(crate) fn build_runtime_call_import_ids(
         global_i32_store: declare_void_call_import(module, "stasis_jit_global_i32_store", 2)?,
         global_f32_load: declare_f32_global_load_import(module, "stasis_jit_global_f32_load")?,
         global_f32_store: declare_f32_global_store_import(module, "stasis_jit_global_f32_store")?,
-        global_i32_array_load: declare_i32_array_load_import(module, "stasis_jit_global_i32_array_load")?,
-        global_i32_array_store: declare_i32_array_store_import(module, "stasis_jit_global_i32_array_store")?,
-        global_f32_array_load: declare_f32_array_load_import(module, "stasis_jit_global_f32_array_load")?,
-        global_f32_array_store: declare_f32_array_store_import(module, "stasis_jit_global_f32_array_store")?,
+        global_f64_load: declare_f64_global_load_import(module, "stasis_jit_global_f64_load")?,
+        global_f64_store: declare_f64_global_store_import(module, "stasis_jit_global_f64_store")?,
+        global_i32_array_load: declare_i32_array_load_import(
+            module,
+            "stasis_jit_global_i32_array_load",
+        )?,
+        global_i32_array_store: declare_i32_array_store_import(
+            module,
+            "stasis_jit_global_i32_array_store",
+        )?,
+        global_f32_array_load: declare_f32_array_load_import(
+            module,
+            "stasis_jit_global_f32_array_load",
+        )?,
+        global_f32_array_store: declare_f32_array_store_import(
+            module,
+            "stasis_jit_global_f32_array_store",
+        )?,
+        global_f64_array_load: declare_f64_array_load_import(
+            module,
+            "stasis_jit_global_f64_array_load",
+        )?,
+        global_f64_array_store: declare_f64_array_store_import(
+            module,
+            "stasis_jit_global_f64_array_store",
+        )?,
         collection_i32_load: declare_i32_call_import(module, "stasis_jit_collection_i32_load", 2)?,
-        collection_i32_store: declare_void_call_import(module, "stasis_jit_collection_i32_store", 3)?,
+        collection_i32_store: declare_void_call_import(
+            module,
+            "stasis_jit_collection_i32_store",
+            3,
+        )?,
         extern_calls: declare_extern_call_imports(module, call_signatures, type_table)?,
     })
 }
@@ -7518,10 +8250,14 @@ pub(crate) fn build_runtime_call_refs(
         global_i32_store: module.declare_func_in_func(imports.global_i32_store, func),
         global_f32_load: module.declare_func_in_func(imports.global_f32_load, func),
         global_f32_store: module.declare_func_in_func(imports.global_f32_store, func),
+        global_f64_load: module.declare_func_in_func(imports.global_f64_load, func),
+        global_f64_store: module.declare_func_in_func(imports.global_f64_store, func),
         global_i32_array_load: module.declare_func_in_func(imports.global_i32_array_load, func),
         global_i32_array_store: module.declare_func_in_func(imports.global_i32_array_store, func),
         global_f32_array_load: module.declare_func_in_func(imports.global_f32_array_load, func),
         global_f32_array_store: module.declare_func_in_func(imports.global_f32_array_store, func),
+        global_f64_array_load: module.declare_func_in_func(imports.global_f64_array_load, func),
+        global_f64_array_store: module.declare_func_in_func(imports.global_f64_array_store, func),
         collection_i32_load: module.declare_func_in_func(imports.collection_i32_load, func),
         collection_i32_store: module.declare_func_in_func(imports.collection_i32_store, func),
         extern_calls: imports

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -63,6 +63,7 @@ impl JitProcess {
             stasis_dynload::clear_jit_f32_array_global_table();
             stasis_dynload::clear_jit_f64_array_global_table();
             stasis_dynload::clear_jit_string_literal_table();
+            stasis_dynload::clear_registered_global_memory();
         }
 
         Self {
@@ -976,12 +977,20 @@ fn compile_function_to_jit_module(
         stasis_dynload::stasis_jit_global_f32_array_store as *const u8,
     );
     jit_builder.symbol(
+        "stasis_jit_global_f32_array_ptr",
+        stasis_dynload::stasis_jit_global_f32_array_ptr as *const u8,
+    );
+    jit_builder.symbol(
         "stasis_jit_global_f64_array_load",
         stasis_dynload::stasis_jit_global_f64_array_load as *const u8,
     );
     jit_builder.symbol(
         "stasis_jit_global_f64_array_store",
         stasis_dynload::stasis_jit_global_f64_array_store as *const u8,
+    );
+    jit_builder.symbol(
+        "stasis_jit_global_f64_array_ptr",
+        stasis_dynload::stasis_jit_global_f64_array_ptr as *const u8,
     );
     for (extern_symbol, address) in extern_symbol_addresses {
         if *address == 0 {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -58,8 +58,10 @@ impl JitProcess {
             // deterministic by clearing under the test guard.
             stasis_dynload::clear_jit_i32_global_table();
             stasis_dynload::clear_jit_f32_global_table();
+            stasis_dynload::clear_jit_f64_global_table();
             stasis_dynload::clear_jit_i32_array_global_table();
             stasis_dynload::clear_jit_f32_array_global_table();
+            stasis_dynload::clear_jit_f64_array_global_table();
             stasis_dynload::clear_jit_string_literal_table();
         }
 
@@ -704,6 +706,8 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "stasis_jit_global_i32_store" => stasis_dynload::stasis_jit_global_i32_store as usize,
         "stasis_jit_global_f32_load" => stasis_dynload::stasis_jit_global_f32_load as usize,
         "stasis_jit_global_f32_store" => stasis_dynload::stasis_jit_global_f32_store as usize,
+        "stasis_jit_global_f64_load" => stasis_dynload::stasis_jit_global_f64_load as usize,
+        "stasis_jit_global_f64_store" => stasis_dynload::stasis_jit_global_f64_store as usize,
         "stasis_jit_collection_i32_load" => stasis_dynload::stasis_jit_collection_i32_load as usize,
         "stasis_jit_collection_i32_store" => {
             stasis_dynload::stasis_jit_collection_i32_store as usize
@@ -940,6 +944,14 @@ fn compile_function_to_jit_module(
         stasis_dynload::stasis_jit_global_f32_store as *const u8,
     );
     jit_builder.symbol(
+        "stasis_jit_global_f64_load",
+        stasis_dynload::stasis_jit_global_f64_load as *const u8,
+    );
+    jit_builder.symbol(
+        "stasis_jit_global_f64_store",
+        stasis_dynload::stasis_jit_global_f64_store as *const u8,
+    );
+    jit_builder.symbol(
         "stasis_jit_collection_i32_load",
         stasis_dynload::stasis_jit_collection_i32_load as *const u8,
     );
@@ -962,6 +974,14 @@ fn compile_function_to_jit_module(
     jit_builder.symbol(
         "stasis_jit_global_f32_array_store",
         stasis_dynload::stasis_jit_global_f32_array_store as *const u8,
+    );
+    jit_builder.symbol(
+        "stasis_jit_global_f64_array_load",
+        stasis_dynload::stasis_jit_global_f64_array_load as *const u8,
+    );
+    jit_builder.symbol(
+        "stasis_jit_global_f64_array_store",
+        stasis_dynload::stasis_jit_global_f64_array_store as *const u8,
     );
     for (extern_symbol, address) in extern_symbol_addresses {
         if *address == 0 {
@@ -998,148 +1018,14 @@ fn compile_function_to_jit_module(
     let function_id = module
         .declare_function(symbol, Linkage::Export, &context.func.signature)
         .map_err(|error| format!("failed to declare JIT function {symbol}: {error}"))?;
-    let runtime_call_imports = RuntimeCallImportIds {
-        call_i32_0: declare_i32_call_import(&mut module, "stasis_jit_call_i32_0", 1)?,
-        call_i32_1: declare_i32_call_import(&mut module, "stasis_jit_call_i32_1", 2)?,
-        call_i32_2: declare_i32_call_import(&mut module, "stasis_jit_call_i32_2", 3)?,
-        call_i32_3: declare_i32_call_import(&mut module, "stasis_jit_call_i32_3", 4)?,
-        call_i32_4: declare_i32_call_import(&mut module, "stasis_jit_call_i32_4", 5)?,
-        call_i32_5: declare_i32_call_import(&mut module, "stasis_jit_call_i32_5", 6)?,
-        call_i32_6: declare_i32_call_import(&mut module, "stasis_jit_call_i32_6", 7)?,
-        call_i32_7: declare_i32_call_import(&mut module, "stasis_jit_call_i32_7", 8)?,
-        call_i32_8: declare_i32_call_import(&mut module, "stasis_jit_call_i32_8", 9)?,
-        call_i32_f32_1: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_1", 1)?,
-        call_i32_f32_2: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_2", 2)?,
-        call_i32_f32_3: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_3", 3)?,
-        call_i32_f32_4: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_4", 4)?,
-        call_i32_f32_5: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_5", 5)?,
-        call_i32_f32_6: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_6", 6)?,
-        call_i32_f32_7: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_7", 7)?,
-        call_i32_f32_8: declare_i32_f32_call_import(&mut module, "stasis_jit_call_i32_f32_8", 8)?,
-        call_f32_0: declare_f32_call_import(&mut module, "stasis_jit_call_f32_0", 1)?,
-        call_f32_1: declare_f32_call_import(&mut module, "stasis_jit_call_f32_1", 2)?,
-        call_f32_2: declare_f32_call_import(&mut module, "stasis_jit_call_f32_2", 3)?,
-        call_f32_3: declare_f32_call_import(&mut module, "stasis_jit_call_f32_3", 4)?,
-        call_f32_4: declare_f32_call_import(&mut module, "stasis_jit_call_f32_4", 5)?,
-        call_f32_5: declare_f32_call_import(&mut module, "stasis_jit_call_f32_5", 6)?,
-        call_f32_6: declare_f32_call_import(&mut module, "stasis_jit_call_f32_6", 7)?,
-        call_f32_7: declare_f32_call_import(&mut module, "stasis_jit_call_f32_7", 8)?,
-        call_f32_8: declare_f32_call_import(&mut module, "stasis_jit_call_f32_8", 9)?,
-        call_f32_i32_1: declare_f32_i32_call_import(&mut module, "stasis_jit_call_f32_i32_1", 2)?,
-        print_i32: declare_void_call_import(&mut module, "stasis_jit_print_i32", 1)?,
-        print_string: declare_void_call_import(&mut module, "stasis_jit_print_string", 1)?,
-        lookup_code_ptr: declare_lookup_code_ptr_import(&mut module, "stasis_jit_lookup_code_ptr")?,
-        sin_fast: declare_direct_f32_unary_import(&mut module, "stasis_jit_sin_fast")?,
-        cos_fast: declare_direct_f32_unary_import(&mut module, "stasis_jit_cos_fast")?,
-        global_i32_load: declare_i32_call_import(&mut module, "stasis_jit_global_i32_load", 1)?,
-        global_i32_store: declare_void_call_import(&mut module, "stasis_jit_global_i32_store", 2)?,
-        global_f32_load: declare_f32_global_load_import(&mut module, "stasis_jit_global_f32_load")?,
-        global_f32_store: declare_f32_global_store_import(
-            &mut module,
-            "stasis_jit_global_f32_store",
-        )?,
-        global_i32_array_load: declare_i32_array_load_import(
-            &mut module,
-            "stasis_jit_global_i32_array_load",
-        )?,
-        global_i32_array_store: declare_i32_array_store_import(
-            &mut module,
-            "stasis_jit_global_i32_array_store",
-        )?,
-        global_f32_array_load: declare_f32_array_load_import(
-            &mut module,
-            "stasis_jit_global_f32_array_load",
-        )?,
-        global_f32_array_store: declare_f32_array_store_import(
-            &mut module,
-            "stasis_jit_global_f32_array_store",
-        )?,
-        collection_i32_load: declare_i32_call_import(
-            &mut module,
-            "stasis_jit_collection_i32_load",
-            2,
-        )?,
-        collection_i32_store: declare_void_call_import(
-            &mut module,
-            "stasis_jit_collection_i32_store",
-            3,
-        )?,
-        extern_calls: declare_extern_call_imports(&mut module, call_signatures, type_table)?,
-    };
+    let runtime_call_imports =
+        build_runtime_call_import_ids(&mut module, call_signatures, type_table)?;
 
     let mut function_builder_context = FunctionBuilderContext::new();
     {
         let mut builder = FunctionBuilder::new(&mut context.func, &mut function_builder_context);
-        let runtime_call_refs = RuntimeCallRefs {
-            call_i32_0: module.declare_func_in_func(runtime_call_imports.call_i32_0, builder.func),
-            call_i32_1: module.declare_func_in_func(runtime_call_imports.call_i32_1, builder.func),
-            call_i32_2: module.declare_func_in_func(runtime_call_imports.call_i32_2, builder.func),
-            call_i32_3: module.declare_func_in_func(runtime_call_imports.call_i32_3, builder.func),
-            call_i32_4: module.declare_func_in_func(runtime_call_imports.call_i32_4, builder.func),
-            call_i32_5: module.declare_func_in_func(runtime_call_imports.call_i32_5, builder.func),
-            call_i32_6: module.declare_func_in_func(runtime_call_imports.call_i32_6, builder.func),
-            call_i32_7: module.declare_func_in_func(runtime_call_imports.call_i32_7, builder.func),
-            call_i32_8: module.declare_func_in_func(runtime_call_imports.call_i32_8, builder.func),
-            call_i32_f32_1: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_1, builder.func),
-            call_i32_f32_2: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_2, builder.func),
-            call_i32_f32_3: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_3, builder.func),
-            call_i32_f32_4: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_4, builder.func),
-            call_i32_f32_5: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_5, builder.func),
-            call_i32_f32_6: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_6, builder.func),
-            call_i32_f32_7: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_7, builder.func),
-            call_i32_f32_8: module
-                .declare_func_in_func(runtime_call_imports.call_i32_f32_8, builder.func),
-            call_f32_0: module.declare_func_in_func(runtime_call_imports.call_f32_0, builder.func),
-            call_f32_1: module.declare_func_in_func(runtime_call_imports.call_f32_1, builder.func),
-            call_f32_2: module.declare_func_in_func(runtime_call_imports.call_f32_2, builder.func),
-            call_f32_3: module.declare_func_in_func(runtime_call_imports.call_f32_3, builder.func),
-            call_f32_4: module.declare_func_in_func(runtime_call_imports.call_f32_4, builder.func),
-            call_f32_5: module.declare_func_in_func(runtime_call_imports.call_f32_5, builder.func),
-            call_f32_6: module.declare_func_in_func(runtime_call_imports.call_f32_6, builder.func),
-            call_f32_7: module.declare_func_in_func(runtime_call_imports.call_f32_7, builder.func),
-            call_f32_8: module.declare_func_in_func(runtime_call_imports.call_f32_8, builder.func),
-            call_f32_i32_1: module
-                .declare_func_in_func(runtime_call_imports.call_f32_i32_1, builder.func),
-            print_i32: module.declare_func_in_func(runtime_call_imports.print_i32, builder.func),
-            print_string: module
-                .declare_func_in_func(runtime_call_imports.print_string, builder.func),
-            lookup_code_ptr: module
-                .declare_func_in_func(runtime_call_imports.lookup_code_ptr, builder.func),
-            sin_fast: module.declare_func_in_func(runtime_call_imports.sin_fast, builder.func),
-            cos_fast: module.declare_func_in_func(runtime_call_imports.cos_fast, builder.func),
-            global_i32_load: module
-                .declare_func_in_func(runtime_call_imports.global_i32_load, builder.func),
-            global_i32_store: module
-                .declare_func_in_func(runtime_call_imports.global_i32_store, builder.func),
-            global_f32_load: module
-                .declare_func_in_func(runtime_call_imports.global_f32_load, builder.func),
-            global_f32_store: module
-                .declare_func_in_func(runtime_call_imports.global_f32_store, builder.func),
-            global_i32_array_load: module
-                .declare_func_in_func(runtime_call_imports.global_i32_array_load, builder.func),
-            global_i32_array_store: module
-                .declare_func_in_func(runtime_call_imports.global_i32_array_store, builder.func),
-            global_f32_array_load: module
-                .declare_func_in_func(runtime_call_imports.global_f32_array_load, builder.func),
-            global_f32_array_store: module
-                .declare_func_in_func(runtime_call_imports.global_f32_array_store, builder.func),
-            collection_i32_load: module
-                .declare_func_in_func(runtime_call_imports.collection_i32_load, builder.func),
-            collection_i32_store: module
-                .declare_func_in_func(runtime_call_imports.collection_i32_store, builder.func),
-            extern_calls: runtime_call_imports
-                .extern_calls
-                .iter()
-                .map(|(key, id)| (key.clone(), module.declare_func_in_func(*id, builder.func)))
-                .collect(),
-        };
+        let runtime_call_refs =
+            build_runtime_call_refs(&mut module, &runtime_call_imports, builder.func);
         let entry = builder.create_block();
         for param_type in &meta.params {
             builder.append_block_param(entry, clif_type_for_type_id(*param_type, type_table)?);
@@ -1621,6 +1507,51 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_supports_typed_f64_global_path_set_and_read() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Layout { width: f64; }\nglobal state: Layout;\nfunction main(): i32 { state.width = 3.5; let w: f64 = state.width; if (w > 3.0) { return 1; } return 0; }\n",
+        );
+        process.compile().expect("compile");
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_supports_f64_array_set_and_read() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "global values: f64[4];\nfunction main(): i32 { values[0] = 3.5; let w: f64 = values[0]; if (w > 3.0) { return 1; } return 0; }\n",
+        );
+        process.compile().expect("compile");
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_executes_f64_return_call_and_conversions() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function helper(value: f64): f64 { return value + 1.0; }\nfunction main(): i32 {\n    let src: i32 = 8;\n    let x: f64 = 0.0;\n    x.from_i32(src);\n    let v: f64 = helper(x);\n    let out: i32 = 0;\n    out.from_f64(v);\n    return out;\n}\n",
+        );
+        process.compile().expect("compile");
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 9);
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/frontend/types.rs
+++ b/crates/stasis_compiler/src/frontend/types.rs
@@ -5,6 +5,7 @@ pub const TYPE_ID_VOID: TypeId = 0;
 pub const TYPE_ID_I32: TypeId = 1;
 pub const TYPE_ID_F32: TypeId = 2;
 pub const TYPE_ID_BOOL: TypeId = 3;
+pub const TYPE_ID_F64: TypeId = 4;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum BuiltinType {
@@ -12,6 +13,7 @@ enum BuiltinType {
     I32,
     F32,
     Bool,
+    F64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -70,6 +72,8 @@ impl TypeTable {
         table.intern_builtin("i32", BuiltinType::I32, 4);
         table.intern_builtin("f32", BuiltinType::F32, 4);
         table.intern_builtin("bool", BuiltinType::Bool, 1);
+        // Keep existing builtin ids stable; append new builtins at the end.
+        table.intern_builtin("f64", BuiltinType::F64, 8);
         table
     }
 
@@ -314,6 +318,9 @@ impl TypeTable {
         }
         if type_name == "bool" {
             return Some(TYPE_ID_BOOL);
+        }
+        if type_name == "f64" {
+            return Some(TYPE_ID_F64);
         }
         if type_name == "string" {
             return self.by_key.get(&TypeKey::Utf8View).copied();

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -551,6 +551,56 @@ fn registered_u8_arrays() -> &'static Mutex<HashMap<ArrayKey, (usize, usize)>> {
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn owned_f32_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f32>>> {
+    static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<f32>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f64>>> {
+    static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<f64>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn clear_registered_global_memory() {
+    registered_i32_ptrs()
+        .lock()
+        .expect("registered i32 ptr table mutex poisoned")
+        .clear();
+    registered_f32_ptrs()
+        .lock()
+        .expect("registered f32 ptr table mutex poisoned")
+        .clear();
+    registered_f64_ptrs()
+        .lock()
+        .expect("registered f64 ptr table mutex poisoned")
+        .clear();
+    registered_i32_arrays()
+        .lock()
+        .expect("registered i32 array table mutex poisoned")
+        .clear();
+    registered_f32_arrays()
+        .lock()
+        .expect("registered f32 array table mutex poisoned")
+        .clear();
+    registered_f64_arrays()
+        .lock()
+        .expect("registered f64 array table mutex poisoned")
+        .clear();
+    registered_u8_arrays()
+        .lock()
+        .expect("registered u8 array table mutex poisoned")
+        .clear();
+
+    owned_f32_arrays()
+        .lock()
+        .expect("owned f32 array table mutex poisoned")
+        .clear();
+    owned_f64_arrays()
+        .lock()
+        .expect("owned f64 array table mutex poisoned")
+        .clear();
+}
+
 pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
     let table = registered_i32_ptrs();
     let mut guard = table
@@ -605,6 +655,127 @@ pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut
         .lock()
         .expect("registered u8 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f32_array_ptr(
+    collection_hash: i32,
+    field_hash: i32,
+    len: i32,
+) -> *mut f32 {
+    if len <= 0 {
+        return std::ptr::null_mut();
+    }
+
+    // Fast path: already registered (host-owned or previously allocated).
+    {
+        let table = registered_f32_arrays();
+        let guard = table
+            .lock()
+            .expect("registered f32 array table mutex poisoned");
+        if let Some((ptr, _)) = guard.get(&(collection_hash, field_hash)).copied() {
+            return ptr as *mut f32;
+        }
+    }
+
+    let requested_len = len as usize;
+    let key = (collection_hash, field_hash);
+
+    // Allocate (or reuse) an owned backing array, then register it so subsequent helper calls
+    // can skip the fallback hash map path.
+    let ptr = {
+        let mut owned_guard = owned_f32_arrays()
+            .lock()
+            .expect("owned f32 array table mutex poisoned");
+        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        if array.len() < requested_len {
+            array.resize(requested_len, 0.0);
+        }
+
+        // Migrate any previously-stored values from the fallback hash map.
+        {
+            let table = jit_f32_array_global_table();
+            let mut guard = table.lock().expect("jit global table mutex poisoned");
+            for idx in 0..requested_len {
+                let idx_i32 = idx as i32;
+                if let Some(value) = guard.remove(&(collection_hash, field_hash, idx_i32)) {
+                    array[idx] = value;
+                }
+            }
+        }
+
+        array.as_mut_ptr()
+    };
+
+    {
+        let table = registered_f32_arrays();
+        let mut guard = table
+            .lock()
+            .expect("registered f32 array table mutex poisoned");
+        // Register with the requested len so helper loads/stores use the same bounds as foreach.
+        guard.insert(key, (ptr as usize, requested_len));
+    }
+
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_array_ptr(
+    collection_hash: i32,
+    field_hash: i32,
+    len: i32,
+) -> *mut f64 {
+    if len <= 0 {
+        return std::ptr::null_mut();
+    }
+
+    // Fast path: already registered (host-owned or previously allocated).
+    {
+        let table = registered_f64_arrays();
+        let guard = table
+            .lock()
+            .expect("registered f64 array table mutex poisoned");
+        if let Some((ptr, _)) = guard.get(&(collection_hash, field_hash)).copied() {
+            return ptr as *mut f64;
+        }
+    }
+
+    let requested_len = len as usize;
+    let key = (collection_hash, field_hash);
+
+    let ptr = {
+        let mut owned_guard = owned_f64_arrays()
+            .lock()
+            .expect("owned f64 array table mutex poisoned");
+        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        if array.len() < requested_len {
+            array.resize(requested_len, 0.0);
+        }
+
+        // Migrate any previously-stored values from the fallback hash map.
+        {
+            let table = jit_f64_array_global_table();
+            let mut guard = table.lock().expect("jit global table mutex poisoned");
+            for idx in 0..requested_len {
+                let idx_i32 = idx as i32;
+                if let Some(value) = guard.remove(&(collection_hash, field_hash, idx_i32)) {
+                    array[idx] = value;
+                }
+            }
+        }
+
+        array.as_mut_ptr()
+    };
+
+    {
+        let table = registered_f64_arrays();
+        let mut guard = table
+            .lock()
+            .expect("registered f64 array table mutex poisoned");
+        guard.insert(key, (ptr as usize, requested_len));
+    }
+
+    ptr
 }
 
 #[no_mangle]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -485,12 +485,22 @@ fn registered_f32_ptrs() -> &'static Mutex<HashMap<i32, usize>> {
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn registered_f64_ptrs() -> &'static Mutex<HashMap<i32, usize>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, usize>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 fn registered_i32_arrays() -> &'static Mutex<HashMap<ArrayKey, (usize, usize)>> {
     static TABLE: OnceLock<Mutex<HashMap<ArrayKey, (usize, usize)>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn registered_f32_arrays() -> &'static Mutex<HashMap<ArrayKey, (usize, usize)>> {
+    static TABLE: OnceLock<Mutex<HashMap<ArrayKey, (usize, usize)>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn registered_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, (usize, usize)>> {
     static TABLE: OnceLock<Mutex<HashMap<ArrayKey, (usize, usize)>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -516,6 +526,14 @@ pub fn register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
     guard.insert(path_hash, ptr as usize);
 }
 
+pub fn register_global_f64_ptr(path_hash: i32, ptr: *mut f64) {
+    let table = registered_f64_ptrs();
+    let mut guard = table
+        .lock()
+        .expect("registered f64 ptr table mutex poisoned");
+    guard.insert(path_hash, ptr as usize);
+}
+
 pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mut i32, len: usize) {
     let table = registered_i32_arrays();
     let mut guard = table
@@ -529,6 +547,14 @@ pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mu
     let mut guard = table
         .lock()
         .expect("registered f32 array table mutex poisoned");
+    guard.insert((collection_hash, field_hash), (ptr as usize, len));
+}
+
+pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mut f64, len: usize) {
+    let table = registered_f64_arrays();
+    let mut guard = table
+        .lock()
+        .expect("registered f64 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
 }
 
@@ -1089,6 +1115,41 @@ pub extern "C" fn stasis_jit_global_f32_store(path_hash: i32, value: f32) {
 }
 
 #[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_load(path_hash: i32) -> f64 {
+    {
+        let table = registered_f64_ptrs();
+        let guard = table
+            .lock()
+            .expect("registered f64 ptr table mutex poisoned");
+        if let Some(ptr) = guard.get(&path_hash).copied() {
+            // Safety: caller owns lifetime; this is a process-global registration.
+            return unsafe { *(ptr as *mut f64) };
+        }
+    }
+    let table = jit_f64_global_table();
+    let guard = table.lock().expect("jit global table mutex poisoned");
+    guard.get(&path_hash).copied().unwrap_or_default()
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_store(path_hash: i32, value: f64) {
+    {
+        let table = registered_f64_ptrs();
+        let guard = table
+            .lock()
+            .expect("registered f64 ptr table mutex poisoned");
+        if let Some(ptr) = guard.get(&path_hash).copied() {
+            // Safety: caller owns lifetime; this is a process-global registration.
+            unsafe { *(ptr as *mut f64) = value };
+            return;
+        }
+    }
+    let table = jit_f64_global_table();
+    let mut guard = table.lock().expect("jit global table mutex poisoned");
+    guard.insert(path_hash, value);
+}
+
+#[no_mangle]
 pub extern "C" fn stasis_jit_global_i32_array_load(
     collection_hash: i32,
     field_hash: i32,
@@ -1238,6 +1299,68 @@ pub extern "C" fn stasis_jit_global_f32_array_store(
     guard.insert((collection_hash, field_hash, index), value);
 }
 
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_array_load(
+    collection_hash: i32,
+    field_hash: i32,
+    index: i32,
+) -> f64 {
+    if index < 0 {
+        return 0.0;
+    }
+
+    let idx = index as usize;
+    {
+        let table = registered_f64_arrays();
+        let guard = table
+            .lock()
+            .expect("registered f64 array table mutex poisoned");
+        if let Some((ptr, len)) = guard.get(&(collection_hash, field_hash)).copied() {
+            if idx < len {
+                // Safety: caller owns lifetime; this is a process-global registration.
+                return unsafe { *((ptr as *mut f64).add(idx)) };
+            }
+            return 0.0;
+        }
+    }
+    let table = jit_f64_array_global_table();
+    let guard = table.lock().expect("jit global table mutex poisoned");
+    guard
+        .get(&(collection_hash, field_hash, index))
+        .copied()
+        .unwrap_or_default()
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_array_store(
+    collection_hash: i32,
+    field_hash: i32,
+    index: i32,
+    value: f64,
+) {
+    if index < 0 {
+        return;
+    }
+
+    let idx = index as usize;
+    {
+        let table = registered_f64_arrays();
+        let guard = table
+            .lock()
+            .expect("registered f64 array table mutex poisoned");
+        if let Some((ptr, len)) = guard.get(&(collection_hash, field_hash)).copied() {
+            if idx < len {
+                // Safety: caller owns lifetime; this is a process-global registration.
+                unsafe { *((ptr as *mut f64).add(idx)) = value };
+            }
+            return;
+        }
+    }
+    let table = jit_f64_array_global_table();
+    let mut guard = table.lock().expect("jit global table mutex poisoned");
+    guard.insert((collection_hash, field_hash, index), value);
+}
+
 pub fn clear_jit_i32_global_table() {
     let table = jit_i32_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
@@ -1250,6 +1373,12 @@ pub fn clear_jit_f32_global_table() {
     guard.clear();
 }
 
+pub fn clear_jit_f64_global_table() {
+    let table = jit_f64_global_table();
+    let mut guard = table.lock().expect("jit global table mutex poisoned");
+    guard.clear();
+}
+
 pub fn clear_jit_i32_array_global_table() {
     let table = jit_i32_array_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
@@ -1258,6 +1387,12 @@ pub fn clear_jit_i32_array_global_table() {
 
 pub fn clear_jit_f32_array_global_table() {
     let table = jit_f32_array_global_table();
+    let mut guard = table.lock().expect("jit global table mutex poisoned");
+    guard.clear();
+}
+
+pub fn clear_jit_f64_array_global_table() {
+    let table = jit_f64_array_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
 }
@@ -1808,8 +1943,10 @@ type JitDispatchMap = std::collections::HashMap<(u32, u8), usize>;
 type JitCodePtrMap = std::collections::HashMap<u32, usize>;
 type JitI32GlobalMap = std::collections::HashMap<i32, i32>;
 type JitF32GlobalMap = std::collections::HashMap<i32, f32>;
+type JitF64GlobalMap = std::collections::HashMap<i32, f64>;
 type JitI32ArrayGlobalMap = std::collections::HashMap<(i32, i32, i32), i32>;
 type JitF32ArrayGlobalMap = std::collections::HashMap<(i32, i32, i32), f32>;
+type JitF64ArrayGlobalMap = std::collections::HashMap<(i32, i32, i32), f64>;
 type JitStringLiteralMap = std::collections::HashMap<i32, String>;
 
 fn jit_i32_dispatch_table() -> &'static Mutex<JitDispatchMap> {
@@ -1837,6 +1974,11 @@ fn jit_f32_global_table() -> &'static Mutex<JitF32GlobalMap> {
     TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
 }
 
+fn jit_f64_global_table() -> &'static Mutex<JitF64GlobalMap> {
+    static TABLE: OnceLock<Mutex<JitF64GlobalMap>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
 fn jit_i32_array_global_table() -> &'static Mutex<JitI32ArrayGlobalMap> {
     static TABLE: OnceLock<Mutex<JitI32ArrayGlobalMap>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
@@ -1844,6 +1986,11 @@ fn jit_i32_array_global_table() -> &'static Mutex<JitI32ArrayGlobalMap> {
 
 fn jit_f32_array_global_table() -> &'static Mutex<JitF32ArrayGlobalMap> {
     static TABLE: OnceLock<Mutex<JitF32ArrayGlobalMap>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn jit_f64_array_global_table() -> &'static Mutex<JitF64ArrayGlobalMap> {
+    static TABLE: OnceLock<Mutex<JitF64ArrayGlobalMap>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
 }
 

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -637,7 +637,7 @@ Archived priority override (2026-02-13, historical):
 - Strengthen Windows executable/runtime parity smokes (JIT + AOT) on Brickout-oriented scenarios.
 - Lane B progress note:
 - Runtime commit path now supports JIT `FnId -> code_ptr` override application sourced from compile results when available (dev path can consume real JIT pointers instead of synthetic placeholder pointer generation).
-- Added engine-overhead benchmark harness for package/load/swap/render-loop timing slices: `cargo run -p stasis --example engine_overhead_bench -- --mode both --samples 3 --ticks 240`.
+- Added engine-overhead benchmark harness for package/load/swap/render-loop timing slices: `cargo run -p stasis --release --example engine_overhead_bench -- --mode both --samples 3 --ticks 240`.
 - Initial smoke snapshot recorded (single-sample run) in `docs/rust_native_compiler_prd.md` for both JIT and AOT runtime-overhead timing breakdown.
 - Runtime real-backend JIT smoke fixtures are now rust-native-compatible (`literal`, `binary literal`, `on_code_swap + literal`) so no-fallback dev mode stays deterministic while richer syntax slices are implemented.
 - Compile-speed lock-in checklist (PRD v2, current top compiler priority):
@@ -659,7 +659,7 @@ Archived priority override (2026-02-13, historical):
 - Tests: benchmark smoke runs in CI-optional mode and validates output format/consistency.
 - Done gate: baseline numbers are recorded in docs and used as acceptance checks for subsequent slices.
 - Current progress:
-- Added deterministic benchmark executable: `cargo run -p stasis_compiler --example compile_bench`.
+- Added deterministic benchmark executable: `cargo run -p stasis_compiler --release --example compile_bench`.
 - Benchmark executable now supports explicit mode selection: `--mode analysis` (in-process analysis only) and `--mode jit` (Cranelift machine-code generation via rust-native `JitProcess`).
 - Added benchmark smoke/unit checks: `cargo test -p stasis_compiler --example compile_bench`.
 - Baseline snapshot (2026-02-24, local machine, seed=1337, chunk_size=500, 1 sample each):
@@ -823,7 +823,7 @@ Archived priority override (2026-02-13, historical):
 - Tests: gated benchmark and invalidation suites.
 - Current progress:
 - Added `Perf CI` workflow (`.github/workflows/perf-ci.yml`) running `rust_native_jit_bench` for 1k functions with conservative stop conditions (cold p95 <= 1800ms, incremental p95 <= 35ms) to catch major compile-time regressions while PRD v2 targets are still being chased.
-- Engine-overhead benchmark task (separate from compiler-only timing gates): added Perf CI gate (`engine-overhead-bench`, windows) running `cargo run -p stasis --example engine_overhead_bench -- --mode both --samples 3 --ticks 240` and hard-failing if `total_ms_p95` exceeds a conservative stop condition (300ms).
+- Engine-overhead benchmark task (separate from compiler-only timing gates): added Perf CI gate (`engine-overhead-bench`, windows) running `cargo run -p stasis --release --example engine_overhead_bench -- --mode both --samples 3 --ticks 240` and hard-failing if `total_ms_p95` exceeds a conservative stop condition (300ms).
 - Engine hot-update benchmark task (separate from compiler-only timing gates): added end-to-end watch/update benchmark (`apps/stasis/examples/engine_hot_update_bench.rs`) measuring `watch change -> jit.compile -> build_engine_package -> swap pointers -> first tick+render with new code`, plus Perf CI gate (`engine-hot-update-bench`, windows) hard-failing if `warm_update_total_ms_p95` exceeds a conservative stop condition (100ms).
 - Outstanding: confirm CI environment baseline and set exact p50/p95 thresholds for PRD v2 hard-fail gating (stop conditions above are tripwires, not targets).
 - Done gate: project can reject regressions automatically against PRD v2 targets.

--- a/docs/rust_native_compiler_prd.md
+++ b/docs/rust_native_compiler_prd.md
@@ -68,7 +68,7 @@ This branch tracks an experimental Rust-native compiler direction focused on com
 
 ## Benchmark Snapshot (2026-02-24)
 - Command:
-- `cargo run -p stasis_compiler --example rust_native_jit_bench -- --functions 1000,5000 --cold-samples 3 --incremental-samples 5`
+- `cargo run -p stasis_compiler --release --example rust_native_jit_bench -- --functions 1000,5000 --cold-samples 3 --incremental-samples 5`
 - Results:
 - `1,000` functions: cold `p50=349.027ms`, cold `p95=354.803ms`; one-function JIT update `p50=2.982ms`, `p95=3.145ms`.
 - `5,000` functions: cold `p50=1738.212ms`, cold `p95=1755.483ms`; one-function JIT update `p50=13.262ms`, `p95=13.672ms`.
@@ -82,7 +82,7 @@ This branch tracks an experimental Rust-native compiler direction focused on com
 
 ## Engine Overhead Snapshot (2026-02-24)
 - Command:
-- `cargo run -p stasis --example engine_overhead_bench -- --mode both --samples 1 --ticks 240`
+- `cargo run -p stasis --release --example engine_overhead_bench -- --mode both --samples 1 --ticks 240`
 - Results (single-sample smoke baseline):
 - `jit`: total `124.577ms`, compile `2.000ms`, commit `0.000ms`, runtime-overhead `122.577ms`.
 - `aot`: total `124.029ms`, compile `2.000ms`, commit `0.000ms`, runtime-overhead `122.029ms`, load-artifact `0.049ms`.
@@ -92,4 +92,4 @@ This branch tracks an experimental Rust-native compiler direction focused on com
 - Improve compile-time performance against target gates (`<250ms @1k cold`, `<5ms typical single-function update`).
 - Add a deferred end-to-end engine overhead benchmark/test that includes package/build artifact handoff, load, swap commit, and render-loop progression timing.
 - Added engine-overhead benchmark harness command:
-- `cargo run -p stasis --example engine_overhead_bench -- --mode both --samples 3 --ticks 240`
+- `cargo run -p stasis --release --example engine_overhead_bench -- --mode both --samples 3 --ticks 240`

--- a/docs/spec_implementation_status.md
+++ b/docs/spec_implementation_status.md
@@ -1,6 +1,6 @@
 # Spec Implementation Status (Rust Compiler)
 
-Last updated: 2026-03-02
+Last updated: 2026-03-03
 
 This document tracks how much of `docs/spec.md` is implemented in the Rust compiler/runtime pipeline.
 It is intended to be concrete and release-oriented (JIT + AOT), and it explicitly excludes the experimental self-host `.stasis` compiler track under `compiler/`.
@@ -18,13 +18,13 @@ Status legend:
 | --- | --- | --- |
 | 1. Overview | Partial | Direction matches current approach (Rust compiler, JIT dev + AOT prod). Specific implementation details vary and are tracked per-section. |
 | 2. Core Principles | Partial | Static global memory + deterministic tick model are core. "No hidden allocation/copies" is a goal; some lowering paths still enforce this by restrictions rather than rich analysis. |
-| 3. Lexical Structure | Partial | Identifiers/keywords/integer literals are stable. Float literals are supported for the current float type (`f32`). Backtick literals exist for tests. |
-| 4. Types (overall) | Partial | `i32`, `f32`, `bool`, `void` are implemented as true builtins. Other "primitive" names currently behave as named scalar types with `i32` ABI compatibility rather than true narrow storage types. |
-| 4.1 Primitive Types | Partial | Implemented: `i32`, `f32`, `bool`, `void`. Missing: `f64` (planned soon). Paused: true `u16`/`u32` narrow-int semantics. `u8` is used as a named scalar type for byte buffers (ABI-compatible with `i32`). |
+| 3. Lexical Structure | Partial | Identifiers/keywords/integer literals are stable. Float literals are supported (defaulting to `f32`, producing `f64` when context expects it). Backtick literals exist for tests. |
+| 4. Types (overall) | Partial | `i32`, `f32`, `f64`, `bool`, `void` are implemented as true builtins. Other "primitive" names currently behave as named scalar types with `i32` ABI compatibility rather than true narrow storage types. |
+| 4.1 Primitive Types | Partial | Implemented: `i32`, `f32`, `f64`, `bool`, `void`. Paused: true `u16`/`u32` narrow-int semantics. `u8` is used as a named scalar type for byte buffers (ABI-compatible with `i32`). |
 | 4.2 Composite Types | Implemented | Fixed arrays `Type[N]`, views `Type[]`, structs, enums, and string buffer forms (`ascii[N]`, `ascii[]`, `utf8[N]`, `utf8[]`) are implemented enough to run samples (including Brickout Revenge). |
-| 4.3 Numeric Conversion Semantics | Partial | `from_*`/`to_*` conversions exist for the current numeric set. `f64` conversions are missing until `f64` exists. |
+| 4.3 Numeric Conversion Semantics | Partial | `from_*`/`to_*` conversions exist for `i32`/`f32`/`f64` in the shapes required by samples/tests. |
 | 4.4 Local Type Inference | Implemented | Local inference for `let name = <expr>` is supported; typed `let name: Type = ...` is supported. |
-| 5. Operators and Expressions | Partial | Implemented for `i32`/`f32`/`bool` forms required by current samples/tests. Missing: `f64` operator coverage until `f64` exists. |
+| 5. Operators and Expressions | Partial | Implemented for `i32`/`f32`/`f64`/`bool` forms required by current samples/tests. |
 | 6. Declarations and Statements | Partial | `let`, `global`, assignment, `if/else`, `for`, `foreach`, `return`, `continue` are supported in the Rust pipeline. Some shapes are still covered by "stub fallback" in AOT mode until parity hardening lands. |
 | 6.5.1 `for` loop (required init/condition/step) | Implemented | Omitting any of the three `for` header segments is rejected (init is required, condition is required, step is required). |
 | 6.5.5 `continue` | Implemented | Supported and enforced as loop-only. |
@@ -48,4 +48,3 @@ Status legend:
 - **AOT parity requirement**: AOT must run the same sample games as JIT (notably `samples/brickout_revenge/brickout_revenge_v1.stasis`).
 - **Quality gate**: AOT should reject shipping builds that still rely on "stub fallback" lowering in emitted artifacts.
 - **Not in scope**: optional plugin libraries and anything that requires a self-host `.stasis` compiler in the release pipeline.
-

--- a/samples/perf_balls_bricks.stasis
+++ b/samples/perf_balls_bricks.stasis
@@ -1,0 +1,184 @@
+// Perf sample: many bouncing balls colliding with many static bricks.
+//
+// Intent:
+// - Stress collision loops in a steady-state simulation (no objects break, no objects leave bounds).
+// - Keep it self-contained (no stdlib imports) so compilation is fast and deterministic.
+//
+// Contract:
+// - Defines engine entrypoints: main(), tick(), render().
+
+const WORLD_W: f32 = 360.0;
+const WORLD_H: f32 = 720.0;
+
+const BRICK_ROWS: i32 = 9;
+const BRICK_COLS: i32 = 10;
+const BRICK_COUNT: i32 = 90; // BRICK_ROWS * BRICK_COLS
+
+const BALL_COLS: i32 = 40;
+const BALL_ROWS: i32 = 25;
+const BALL_COUNT: i32 = 1000; // BALL_COLS * BALL_ROWS
+
+const BRICK_W: f32 = 28.0;
+const BRICK_H: f32 = 10.0;
+const BRICK_GAP: f32 = 4.0;
+const BRICK_X0: f32 = 16.0;
+const BRICK_Y0: f32 = 80.0;
+
+const BALL_R: f32 = 3.0;
+const BALL_SPEED_X: f32 = 220.0;
+const BALL_SPEED_Y: f32 = 180.0;
+const FIXED_DT: f32 = 0.016;
+
+// Keep this large enough that an external harness can run 1000 ticks without early exit.
+const AUTO_EXIT_TICKS: i32 = 10000;
+
+struct Ball {
+    x: f32;
+    y: f32;
+    vx: f32;
+    vy: f32;
+}
+
+struct Brick {
+    x: f32;
+    y: f32;
+}
+
+struct State {
+    initialized: i32;
+    running: i32;
+    tick_index: i32;
+    balls: Ball[1000];
+    bricks: Brick[90];
+}
+
+global state: State;
+
+function init_world(): void {
+    // Bricks: fixed grid near the top of the world.
+    let row: i32 = 0;
+    let col: i32 = 0;
+    for (row = 0; row < BRICK_ROWS; row = row + 1) {
+        for (col = 0; col < BRICK_COLS; col = col + 1) {
+            let idx: i32 = row * BRICK_COLS + col;
+
+            let row_f: f32;
+            row_f.from_i32(row);
+            let col_f: f32;
+            col_f.from_i32(col);
+
+            state.bricks[idx].x = BRICK_X0 + col_f * (BRICK_W + BRICK_GAP);
+            state.bricks[idx].y = BRICK_Y0 + row_f * (BRICK_H + BRICK_GAP);
+        }
+    }
+
+    // Balls: deterministic grid in the lower half of the world (no RNG required).
+    let i: i32 = 0;
+    for (i = 0; i < BALL_COUNT; i = i + 1) {
+        let gx: i32 = i % BALL_COLS;
+        let gy: i32 = i / BALL_COLS;
+        let gx_f: f32;
+        gx_f.from_i32(gx);
+        let gy_f: f32;
+        gy_f.from_i32(gy);
+
+        state.balls[i].x = 10.0 + gx_f * 8.0;
+        state.balls[i].y = 360.0 + gy_f * 8.0;
+
+        let vx: f32 = BALL_SPEED_X;
+        let vy: f32 = BALL_SPEED_Y;
+        if ((i % 2) == 1) { vx = 0.0 - vx; }
+        if (((i / 2) % 2) == 1) { vy = 0.0 - vy; }
+        state.balls[i].vx = vx;
+        state.balls[i].vy = vy;
+    }
+}
+
+function main(): i32 {
+    if (state.initialized == 0) {
+        init_world();
+        state.initialized = 1;
+    }
+    state.running = 1;
+    state.tick_index = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    if (state.running != 1) {
+        return 1;
+    }
+
+    let r: f32 = BALL_R;
+    let min_x: f32 = r;
+    let max_x: f32 = WORLD_W - r;
+    let min_y: f32 = r;
+    let max_y: f32 = WORLD_H - r;
+
+    foreach (let ball in state.balls) {
+        // Cache ball fields into locals so the inner brick loop doesn't repeatedly
+        // load/store struct fields.
+        let x: f32 = ball.x;
+        let y: f32 = ball.y;
+        let vx: f32 = ball.vx;
+        let vy: f32 = ball.vy;
+
+        // Integrate.
+        x = x + vx * FIXED_DT;
+        y = y + vy * FIXED_DT;
+
+        // World bounds.
+        if (x < min_x) { x = min_x; vx = 0.0 - vx; }
+        if (x > max_x) { x = max_x; vx = 0.0 - vx; }
+
+        if (y < min_y) { y = min_y; vy = 0.0 - vy; }
+        if (y > max_y) { y = max_y; vy = 0.0 - vy; }
+
+        // Ball AABB (updated if a collision response changes x/y).
+        let x0: f32 = x - r;
+        let x1: f32 = x + r;
+        let y0: f32 = y - r;
+        let y1: f32 = y + r;
+
+        // Brick collisions: basic AABB overlap check (treat ball as its AABB).
+        foreach (let brick in state.bricks) {
+            let left: f32 = brick.x;
+            let top: f32 = brick.y;
+            let right: f32 = left + BRICK_W;
+            let bottom: f32 = top + BRICK_H;
+
+            if (x1 > left && x0 < right && y1 > top && y0 < bottom) {
+                // Minimal collision response: reflect along the axis with the larger velocity component.
+                let vx2: f32 = vx * vx;
+                let vy2: f32 = vy * vy;
+                if (vx2 > vy2) {
+                    if (vx > 0.0) { x = left - r; } else { x = right + r; }
+                    vx = 0.0 - vx;
+                    x0 = x - r;
+                    x1 = x + r;
+                } else {
+                    if (vy > 0.0) { y = top - r; } else { y = bottom + r; }
+                    vy = 0.0 - vy;
+                    y0 = y - r;
+                    y1 = y + r;
+                }
+            }
+        }
+
+        ball.x = x;
+        ball.y = y;
+        ball.vx = vx;
+        ball.vy = vy;
+    }
+
+    state.tick_index = state.tick_index + 1;
+    if (AUTO_EXIT_TICKS > 0 && state.tick_index >= AUTO_EXIT_TICKS) {
+        state.running = 0;
+        return 1;
+    }
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}


### PR DESCRIPTION
﻿Implements MaddoxTasks #45: add **f64** end-to-end across the Rust compiler/runtime pipeline (JIT + AOT).

What changed:
- Frontend: `f64` added as a builtin type.
- Backend emit: f64 literals, arithmetic/comparisons with f64 coercion, and `from_f64(...)` conversion support.
- JIT runtime: f64 globals + f64 global arrays load/store exports in `stasis_dynload`; JIT symbol wiring for those runtime calls.
- JIT backend: runtime call import/ref construction now uses the shared builders (avoids future drift when adding runtime calls).
- Tests: JIT + AOT coverage for f64 global fields/arrays, and f64-returning helper call + conversions.
- Docs: spec implementation status updated.

Verification:
- `cargo test -p stasis_compiler`
- `cargo build -p stasis`
- Sample smoke: `target/debug/stasis.exe play samples\\brickout_revenge\\brickout_revenge_v1.stasis --watch-dir samples\\brickout_revenge --ticks 1`