### PR TITLE
AOT: default speed_and_size optimization

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -949,7 +949,7 @@ impl IncrementalCompilerBackend {
             "none" => AotOptimizationProfile::None,
             "speed_and_size" => AotOptimizationProfile::SpeedAndSize,
             "speed" => AotOptimizationProfile::Speed,
-            _ => AotOptimizationProfile::Speed,
+            _ => AotOptimizationProfile::SpeedAndSize,
         }
     }
 
@@ -3733,8 +3733,8 @@ mod tests {
         };
         assert_eq!(
             compile_config.opt_level.as_str(),
-            "speed",
-            "AOT compile config default opt_level should be speed for release-like engine bundles"
+            "speed_and_size",
+            "AOT compile config default opt_level should be speed_and_size for release-like engine bundles"
         );
         let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
@@ -3756,8 +3756,8 @@ mod tests {
             .expect("read engine bundle manifest");
         assert_eq!(
             manifest.optimization_profile.as_deref(),
-            Some("speed"),
-            "engine bundle manifest should report speed optimization by default"
+            Some("speed_and_size"),
+            "engine bundle manifest should report speed_and_size optimization by default"
         );
 
         let main_symbol = manifest

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -25,13 +25,28 @@ pub struct AotCompileConfig {
     pub opt_level: String,
 }
 
+fn default_aot_opt_level() -> String {
+    if let Ok(value) = std::env::var("STASIS_AOT_OPT_LEVEL") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            let normalized = trimmed.to_ascii_lowercase();
+            match normalized.as_str() {
+                "none" | "speed" | "speed_and_size" => return normalized,
+                "speed-and-size" => return "speed_and_size".to_string(),
+                _ => {}
+            }
+        }
+    }
+    "speed_and_size".to_string()
+}
+
 impl Default for AotCompileConfig {
     fn default() -> Self {
         Self {
             helper_path: None,
             target: default_target_triple(),
             module_name: "stasis_module".to_string(),
-            opt_level: "speed".to_string(),
+            opt_level: default_aot_opt_level(),
         }
     }
 }
@@ -442,6 +457,24 @@ fn resolve_aot_helper_path(config: &AotCompileConfig) -> Result<PathBuf, String>
             .join(default_aot_exe_name()),
     );
 
+    // Alternate dev-friendly default: allow building the helper into the workspace target dir.
+    // This avoids relying on `tools/cranelift-aot/target`, which can be blocked by path-based
+    // execution policies in some Windows environments.
+    candidates.push(
+        repo_root
+            .join("target")
+            .join("cranelift-aot")
+            .join("release")
+            .join(default_aot_exe_name()),
+    );
+    candidates.push(
+        repo_root
+            .join("target")
+            .join("cranelift-aot")
+            .join("debug")
+            .join(default_aot_exe_name()),
+    );
+
     // Allow running with the helper on PATH / in the current directory.
     candidates.push(PathBuf::from(default_aot_exe_name()));
 
@@ -835,12 +868,8 @@ echo "fake-shared" > "$OUT"
     #[test]
     fn aot_helper_compiles_minimal_clif_to_object() {
         let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
-        let helper = repo_root
-            .join("tools")
-            .join("cranelift-aot")
-            .join("target")
-            .join("debug")
-            .join("stasis-cranelift-aot.exe");
+        let helper_target_dir = repo_root.join("target").join("cranelift-aot");
+        let helper = helper_target_dir.join("debug").join(default_aot_exe_name());
 
         if !helper.exists() {
             let build_output = Command::new("cargo")
@@ -852,6 +881,8 @@ echo "fake-shared" > "$OUT"
                         .join("cranelift-aot")
                         .join("Cargo.toml"),
                 )
+                .arg("--target-dir")
+                .arg(&helper_target_dir)
                 .current_dir(&repo_root)
                 .output()
                 .expect("failed to build AOT helper");

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -46,6 +46,10 @@ Current canonical workspace commands:
 - `cargo build`
 - `cargo test`
 
+Release AOT optimization:
+- Default AOT opt level is `speed_and_size` (release-friendly).
+- Override with `STASIS_AOT_OPT_LEVEL`: `none` | `speed` | `speed_and_size`.
+
 Bootstrap compiler tooling is seed-only for initial bring-up.
 It is not part of the steady-state incremental JIT update loop.
 


### PR DESCRIPTION
﻿Changes
- Default AOT opt level is now `speed_and_size` (override via `STASIS_AOT_OPT_LEVEL`: `none|speed|speed_and_size`).
- Unknown/invalid opt level now falls back to `speed_and_size` when mapping to `AotOptimizationProfile`.
- AOT helper path resolution also checks `target/cranelift-aot/{debug,release}`; Windows test builds helper with `--target-dir target/cranelift-aot` to avoid path-based execution policies.

Tests
- `cargo test --workspace --all-targets -- --test-threads=1`
- `cargo run -p stasis -- play samples/brickout_revenge/brickout_revenge_v1.stasis --watch-dir samples/brickout_revenge --ticks 1`