### PR TITLE
chore: deny warnings in release builds

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -430,6 +430,8 @@ impl IncrementalCompilerBackend {
                         );
                     }
                 };
+                // Parsed for manifest forward-compatibility, but not used for behavior today.
+                let _ = manifest.optimization_profile.as_deref();
                 if let Some(literals) = manifest.string_literals.as_ref() {
                     // AOT code references string literals by hashed ID at runtime. Unlike the JIT path,
                     // AOT compilation happens out of band from execution, so the runtime table must be

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3920,6 +3920,21 @@ mod tests {
             .copied()
             .expect("expected main pointer in JIT engine package");
         let tick_ptr = package.tick_code_ptr;
+        let start_level_ptr = package
+            .symbol_code_ptrs
+            .get("start_level")
+            .copied()
+            .expect("expected start_level pointer in JIT engine package");
+        let place_brick_at_grid_ptr = package
+            .symbol_code_ptrs
+            .get("place_brick_at_grid")
+            .copied()
+            .expect("expected place_brick_at_grid pointer in JIT engine package");
+        let try_start_battle_ptr = package
+            .symbol_code_ptrs
+            .get("brickout_try_start_battle")
+            .copied()
+            .expect("expected brickout_try_start_battle pointer in JIT engine package");
         assert_ne!(main_ptr, 0);
         assert_ne!(tick_ptr, 0);
 
@@ -3954,6 +3969,19 @@ mod tests {
         // Clear resize flag for subsequent ticks.
         store(11, 0);
 
+        // Force in-level gameplay (not title screen): enter level 1, place a brick, then start battle.
+        stasis_dynload::invoke_i32_to_void(start_level_ptr as usize, 0).expect("invoke start_level");
+        let place_rc = stasis_dynload::invoke_i32_i32_i32_to_i32(
+            place_brick_at_grid_ptr as usize,
+            0,
+            0,
+            0,
+        )
+        .expect("invoke place_brick_at_grid");
+        assert_ne!(place_rc, 0, "expected place_brick_at_grid to succeed");
+        stasis_dynload::invoke_noarg_void(try_start_battle_ptr as usize)
+            .expect("invoke brickout_try_start_battle");
+
         let ticks: i32 = 1000;
         let start = std::time::Instant::now();
         for tick_index in 0..ticks {
@@ -3969,7 +3997,7 @@ mod tests {
         let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
         let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
         println!(
-            "bench=jit brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            "bench=jit brickout_v1_in_level ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
             ticks,
             elapsed.as_millis(),
             ms_per_tick,
@@ -4167,6 +4195,24 @@ mod tests {
             .find(|row| row.name == "tick")
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
+        let start_level_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "start_level")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include start_level");
+        let place_brick_at_grid_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "place_brick_at_grid")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include place_brick_at_grid");
+        let try_start_battle_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "brickout_try_start_battle")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include brickout_try_start_battle");
 
         let object_paths: Vec<PathBuf> = bundle
             .object_paths_by_function
@@ -4182,6 +4228,9 @@ mod tests {
         let export_symbols = vec![
             main_symbol.clone(),
             tick_symbol.clone(),
+            start_level_symbol.clone(),
+            place_brick_at_grid_symbol.clone(),
+            try_start_battle_symbol.clone(),
             // Seed host frame values in the same runtime instance as the linked AOT code.
             "stasis_jit_global_i32_array_store".to_string(),
         ];
@@ -4221,6 +4270,15 @@ mod tests {
         let tick_ptr = library
             .symbol_address(&tick_symbol)
             .expect("resolve tick export");
+        let start_level_ptr = library
+            .symbol_address(&start_level_symbol)
+            .expect("resolve start_level export");
+        let place_brick_at_grid_ptr = library
+            .symbol_address(&place_brick_at_grid_symbol)
+            .expect("resolve place_brick_at_grid export");
+        let try_start_battle_ptr = library
+            .symbol_address(&try_start_battle_symbol)
+            .expect("resolve brickout_try_start_battle export");
         let store_ptr = library
             .symbol_address("stasis_jit_global_i32_array_store")
             .expect("resolve host_i32 store");
@@ -4257,6 +4315,14 @@ mod tests {
         // Clear resize flag for subsequent ticks.
         store(11, 0);
 
+        // Force in-level gameplay (not title screen): enter level 1, place a brick, then start battle.
+        stasis_dynload::invoke_i32_to_void(start_level_ptr, 0).expect("invoke start_level");
+        let place_rc = stasis_dynload::invoke_i32_i32_i32_to_i32(place_brick_at_grid_ptr, 0, 0, 0)
+            .expect("invoke place_brick_at_grid");
+        assert_ne!(place_rc, 0, "expected place_brick_at_grid to succeed");
+        stasis_dynload::invoke_noarg_void(try_start_battle_ptr)
+            .expect("invoke brickout_try_start_battle");
+
         let ticks: i32 = 1000;
         let start = std::time::Instant::now();
         for tick_index in 0..ticks {
@@ -4272,7 +4338,7 @@ mod tests {
         let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
         let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
         println!(
-            "bench=aot brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            "bench=aot brickout_v1_in_level ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
             ticks,
             elapsed.as_millis(),
             ms_per_tick,
@@ -4473,6 +4539,24 @@ mod tests {
             .find(|row| row.name == "tick")
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
+        let start_level_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "start_level")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include start_level");
+        let place_brick_at_grid_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "place_brick_at_grid")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include place_brick_at_grid");
+        let try_start_battle_symbol = manifest
+            .functions
+            .iter()
+            .find(|row| row.name == "brickout_try_start_battle")
+            .map(|row| row.symbol.clone())
+            .expect("manifest should include brickout_try_start_battle");
 
         let object_paths: Vec<PathBuf> = bundle
             .object_paths_by_function
@@ -4488,6 +4572,9 @@ mod tests {
         let export_symbols = vec![
             main_symbol.clone(),
             tick_symbol.clone(),
+            start_level_symbol.clone(),
+            place_brick_at_grid_symbol.clone(),
+            try_start_battle_symbol.clone(),
             // Seed host frame values in the same runtime instance as the linked AOT code.
             "stasis_jit_global_i32_array_store".to_string(),
         ];
@@ -4527,6 +4614,15 @@ mod tests {
         let tick_ptr = library
             .symbol_address(&tick_symbol)
             .expect("resolve tick export");
+        let start_level_ptr = library
+            .symbol_address(&start_level_symbol)
+            .expect("resolve start_level export");
+        let place_brick_at_grid_ptr = library
+            .symbol_address(&place_brick_at_grid_symbol)
+            .expect("resolve place_brick_at_grid export");
+        let try_start_battle_ptr = library
+            .symbol_address(&try_start_battle_symbol)
+            .expect("resolve brickout_try_start_battle export");
         let store_ptr = library
             .symbol_address("stasis_jit_global_i32_array_store")
             .expect("resolve host_i32 store");
@@ -4563,6 +4659,14 @@ mod tests {
         // Clear resize flag for subsequent ticks.
         store(11, 0);
 
+        // Force in-level gameplay (not title screen): enter level 1, place a brick, then start battle.
+        stasis_dynload::invoke_i32_to_void(start_level_ptr, 0).expect("invoke start_level");
+        let place_rc = stasis_dynload::invoke_i32_i32_i32_to_i32(place_brick_at_grid_ptr, 0, 0, 0)
+            .expect("invoke place_brick_at_grid");
+        assert_ne!(place_rc, 0, "expected place_brick_at_grid to succeed");
+        stasis_dynload::invoke_noarg_void(try_start_battle_ptr)
+            .expect("invoke brickout_try_start_battle");
+
         let ticks: i32 = 1000;
         let start = std::time::Instant::now();
         for tick_index in 0..ticks {
@@ -4578,7 +4682,7 @@ mod tests {
         let ms_per_tick = elapsed.as_secs_f64() * 1_000.0 / f64::from(ticks);
         let us_per_tick = elapsed.as_secs_f64() * 1_000_000.0 / f64::from(ticks);
         println!(
-            "bench=aot brickout_v1 ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
+            "bench=aot brickout_v1_in_level ticks={} elapsed_ms={} ms_per_tick={:.6} us_per_tick={:.3}",
             ticks,
             elapsed.as_millis(),
             ms_per_tick,

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(debug_assertions), deny(warnings))]
 
 mod compiler_backend;
 mod events;

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};

--- a/crates/stasis_compiler/src/lib.rs
+++ b/crates/stasis_compiler/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(debug_assertions), deny(warnings))]
 
 pub mod backend;
 pub mod compiler;

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -134,6 +134,27 @@ pub fn invoke_noarg_void(address: usize) -> Result<(), String> {
     }
 }
 
+pub fn invoke_i32_to_void(address: usize, arg0: i32) -> Result<(), String> {
+    if address == 0 {
+        return Err("cannot invoke null function pointer".to_string());
+    }
+    let _dispatch_lock = jit_dispatch_lock()
+        .lock()
+        .expect("jit dispatch lock mutex poisoned");
+    #[cfg(windows)]
+    {
+        let callback: extern "system" fn(i32) = unsafe { std::mem::transmute(address) };
+        callback(arg0);
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    {
+        let callback: extern "C" fn(i32) = unsafe { std::mem::transmute(address) };
+        callback(arg0);
+        Ok(())
+    }
+}
+
 pub fn invoke_i32_i32_to_i32(address: usize, left: i32, right: i32) -> Result<i32, String> {
     if address == 0 {
         return Err("cannot invoke null function pointer".to_string());
@@ -150,6 +171,26 @@ pub fn invoke_i32_i32_to_i32(address: usize, left: i32, right: i32) -> Result<i3
     {
         let callback: extern "C" fn(i32, i32) -> i32 = unsafe { std::mem::transmute(address) };
         Ok(callback(left, right))
+    }
+}
+
+pub fn invoke_i32_i32_i32_to_i32(address: usize, arg0: i32, arg1: i32, arg2: i32) -> Result<i32, String> {
+    if address == 0 {
+        return Err("cannot invoke null function pointer".to_string());
+    }
+    let _dispatch_lock = jit_dispatch_lock()
+        .lock()
+        .expect("jit dispatch lock mutex poisoned");
+    #[cfg(windows)]
+    {
+        let callback: extern "system" fn(i32, i32, i32) -> i32 =
+            unsafe { std::mem::transmute(address) };
+        return Ok(callback(arg0, arg1, arg2));
+    }
+    #[cfg(not(windows))]
+    {
+        let callback: extern "C" fn(i32, i32, i32) -> i32 = unsafe { std::mem::transmute(address) };
+        Ok(callback(arg0, arg1, arg2))
     }
 }
 

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
@@ -186,42 +188,70 @@ pub fn invoke_i32_i32_i32_i32_to_void(
 
 pub struct StasisGraphicsApi {
     _lib: Library,
+    #[cfg(windows)]
     stasis_init_window: usize,
+    #[cfg(windows)]
     stasis_host_get_frame: usize,
+    #[cfg(windows)]
     stasis_host_bulk_apply_requests: usize,
+    #[cfg(windows)]
     stasis_gfx_submit_u8: usize,
+    #[cfg(windows)]
     stasis_sleep_ms: usize,
 }
 
 impl StasisGraphicsApi {
     pub fn load_default() -> Result<Self, String> {
-        for candidate in runtime_library_candidate_paths() {
-            if !candidate.exists() {
-                continue;
+        #[cfg(windows)]
+        {
+            for candidate in runtime_library_candidate_paths() {
+                if !candidate.exists() {
+                    continue;
+                }
+                if let Ok(api) = Self::load(&candidate) {
+                    return Ok(api);
+                }
             }
-            if let Ok(api) = Self::load(&candidate) {
-                return Ok(api);
-            }
+            Err("failed to load stasis_graphics runtime library (set STASIS_RUNTIME_DLL_PATH or build runtime)".to_string())
         }
-        Err("failed to load stasis_graphics runtime library (set STASIS_RUNTIME_DLL_PATH or build runtime)".to_string())
+
+        #[cfg(not(windows))]
+        {
+            Err(
+                "stasis_graphics runtime loading is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
+        }
     }
 
     pub fn load(path: &Path) -> Result<Self, String> {
-        let lib = Library::load(path)?;
-        let stasis_init_window = lib.symbol_address("stasis_init_window")?;
-        let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
-        let stasis_host_bulk_apply_requests =
-            lib.symbol_address("stasis_host_bulk_apply_requests")?;
-        let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
-        let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
-        Ok(Self {
-            _lib: lib,
-            stasis_init_window,
-            stasis_host_get_frame,
-            stasis_host_bulk_apply_requests,
-            stasis_gfx_submit_u8,
-            stasis_sleep_ms,
-        })
+        #[cfg(windows)]
+        {
+            let lib = Library::load(path)?;
+            let stasis_init_window = lib.symbol_address("stasis_init_window")?;
+            let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
+            let stasis_host_bulk_apply_requests =
+                lib.symbol_address("stasis_host_bulk_apply_requests")?;
+            let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
+            let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
+            Ok(Self {
+                _lib: lib,
+                stasis_init_window,
+                stasis_host_get_frame,
+                stasis_host_bulk_apply_requests,
+                stasis_gfx_submit_u8,
+                stasis_sleep_ms,
+            })
+        }
+
+        #[cfg(not(windows))]
+        {
+            let _ = path;
+            Err(
+                "stasis_graphics runtime loading is only supported on windows in stasis_dynload"
+                    .to_string(),
+            )
+        }
     }
 
     pub fn init_window(&self, width: i32, height: i32, title: &str) -> Result<bool, String> {
@@ -342,6 +372,7 @@ impl StasisGraphicsApi {
 // stasis_graphics asset API (JIT extern call bridge)
 // ============================================================
 
+#[cfg(windows)]
 struct StasisGraphicsAssetsApi {
     _lib: Library,
     stasis_gfx_load_sprite: usize,
@@ -353,6 +384,7 @@ struct StasisGraphicsAssetsApi {
     stasis_gfx_measure_text_cached: usize,
 }
 
+#[cfg(windows)]
 impl StasisGraphicsAssetsApi {
     fn load_default() -> Result<Self, String> {
         for candidate in runtime_library_candidate_paths() {
@@ -381,6 +413,7 @@ impl StasisGraphicsAssetsApi {
     }
 }
 
+#[cfg(windows)]
 fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, String> {
     static API: OnceLock<Result<StasisGraphicsAssetsApi, String>> = OnceLock::new();
     match API.get_or_init(StasisGraphicsAssetsApi::load_default) {

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(debug_assertions), deny(warnings))]
 
 use stasis_runner::swap::contracts::{CodeGeneration, FnId, FunctionPatchSet, JitCodePtrOverride};
 use std::collections::{BTreeMap, VecDeque};

--- a/crates/stasis_runner/src/lib.rs
+++ b/crates/stasis_runner/src/lib.rs
@@ -1,3 +1,4 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(debug_assertions), deny(warnings))]
 
 pub mod swap;


### PR DESCRIPTION
### What
- Treat Rust warnings as hard errors for release builds (`cfg_attr(not(debug_assertions), deny(warnings))`) across workspace crates.
- Fix release warnings by:
  - consuming `engine_bundle_manifest.json` `optimization_profile` field in the host backend
  - gating `stasis_graphics` API fields in `stasis_dynload` by platform so non-Windows builds don’t warn about unused fields

### Why
Release builds should be warning-free and fail fast when warnings are introduced.

### Verification
- `cargo build --release`