### PR TITLE
compiler: direct scalar load/store for state access

### DIFF
--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1115,6 +1115,9 @@ pub(crate) struct RuntimeCallImportIds {
     pub(crate) lookup_code_ptr: FuncId,
     pub(crate) sin_fast: FuncId,
     pub(crate) cos_fast: FuncId,
+    pub(crate) global_i32_ptr: FuncId,
+    pub(crate) global_f32_ptr: FuncId,
+    pub(crate) global_f64_ptr: FuncId,
     pub(crate) global_i32_load: FuncId,
     pub(crate) global_i32_store: FuncId,
     pub(crate) global_f32_load: FuncId,
@@ -1168,6 +1171,9 @@ pub(crate) struct RuntimeCallRefs {
     pub(crate) lookup_code_ptr: FuncRef,
     pub(crate) sin_fast: FuncRef,
     pub(crate) cos_fast: FuncRef,
+    pub(crate) global_i32_ptr: FuncRef,
+    pub(crate) global_f32_ptr: FuncRef,
+    pub(crate) global_f64_ptr: FuncRef,
     pub(crate) global_i32_load: FuncRef,
     pub(crate) global_i32_store: FuncRef,
     pub(crate) global_f32_load: FuncRef,
@@ -1458,6 +1464,42 @@ pub(crate) fn declare_f64_global_store_import(
     let mut signature = module.make_signature();
     signature.params.push(AbiParam::new(types::I32));
     signature.params.push(AbiParam::new(types::F64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_i32_global_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::I64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f32_global_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::I64));
+    module
+        .declare_function(symbol, Linkage::Import, &signature)
+        .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
+}
+
+pub(crate) fn declare_f64_global_ptr_import(
+    module: &mut impl Module,
+    symbol: &str,
+) -> Result<FuncId, String> {
+    let mut signature = module.make_signature();
+    signature.params.push(AbiParam::new(types::I32));
+    signature.returns.push(AbiParam::new(types::I64));
     module
         .declare_function(symbol, Linkage::Import, &signature)
         .map_err(|error| format!("failed to declare JIT import {symbol}: {error}"))
@@ -7582,6 +7624,7 @@ pub(crate) fn emit_struct_view_field_load(
         ));
     }
     let index_value = builder.use_var(binding.index_var);
+    let len_value = builder.use_var(binding.len_var);
     let aos_condition = builder
         .ins()
         .icmp_imm(IntCC::SignedLessThan, index_value, 0);
@@ -7598,20 +7641,23 @@ pub(crate) fn emit_struct_view_field_load(
     builder.switch_to_block(aos_block);
     let path_hash = emit_local_struct_field_path_hash(base_hash, suffix, builder);
     let aos_value = if is_i32_abi_compatible_type(field_type, type_table) {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_load, &[path_hash]);
-        builder.inst_results(call)[0]
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().load(types::I32, MemFlags::new(), ptr, 0)
     } else if field_type == TYPE_ID_F32 {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f32_load, &[path_hash]);
-        builder.inst_results(call)[0]
+            .call(runtime_call_refs.global_f32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().load(types::F32, MemFlags::new(), ptr, 0)
     } else if field_type == TYPE_ID_F64 {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f64_load, &[path_hash]);
-        builder.inst_results(call)[0]
+            .call(runtime_call_refs.global_f64_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().load(types::F64, MemFlags::new(), ptr, 0)
     } else {
         return Err(format!(
             "unsupported struct view field type {} for suffix '{}'",
@@ -7625,23 +7671,35 @@ pub(crate) fn emit_struct_view_field_load(
     let field_hash = hash_foreach_field_suffix(suffix);
     let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
     let soa_value = if is_i32_abi_compatible_type(field_type, type_table) {
-        let call = builder.ins().call(
-            runtime_call_refs.global_i32_array_load,
-            &[base_hash, field_hash_value, index_value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
-        builder.inst_results(call)[0]
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().load(types::I32, MemFlags::new(), addr, 0)
     } else if field_type == TYPE_ID_F32 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f32_array_load,
-            &[base_hash, field_hash_value, index_value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f32_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
-        builder.inst_results(call)[0]
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().load(types::F32, MemFlags::new(), addr, 0)
     } else if field_type == TYPE_ID_F64 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f64_array_load,
-            &[base_hash, field_hash_value, index_value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f64_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
-        builder.inst_results(call)[0]
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().load(types::F64, MemFlags::new(), addr, 0)
     } else {
         return Err(format!(
             "unsupported struct view field type {} for suffix '{}'",
@@ -7689,6 +7747,7 @@ pub(crate) fn emit_struct_view_field_assignment(
     }
 
     let index_value = builder.use_var(binding.index_var);
+    let len_value = builder.use_var(binding.len_var);
     let aos_condition = builder
         .ins()
         .icmp_imm(IntCC::SignedLessThan, index_value, 0);
@@ -7705,10 +7764,11 @@ pub(crate) fn emit_struct_view_field_assignment(
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div | AssignOp::Mod => {
-                let call = builder
+                let ptr_call = builder
                     .ins()
-                    .call(runtime_call_refs.global_i32_load, &[path_hash]);
-                let lhs = builder.inst_results(call)[0];
+                    .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+                let ptr = builder.inst_results(ptr_call)[0];
+                let lhs = builder.ins().load(types::I32, MemFlags::new(), ptr, 0);
                 match op {
                     AssignOp::Add => builder.ins().iadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().isub(lhs, rhs.value),
@@ -7719,9 +7779,11 @@ pub(crate) fn emit_struct_view_field_assignment(
                 }
             }
         };
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
     } else if field_type == TYPE_ID_BOOL {
         if op != AssignOp::Set {
             return Err(format!(
@@ -7729,17 +7791,20 @@ pub(crate) fn emit_struct_view_field_assignment(
                 suffix
             ));
         }
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, rhs.value]);
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), rhs.value, ptr, 0);
     } else if field_type == TYPE_ID_F32 {
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div => {
-                let call = builder
+                let ptr_call = builder
                     .ins()
-                    .call(runtime_call_refs.global_f32_load, &[path_hash]);
-                let lhs = builder.inst_results(call)[0];
+                    .call(runtime_call_refs.global_f32_ptr, &[path_hash]);
+                let ptr = builder.inst_results(ptr_call)[0];
+                let lhs = builder.ins().load(types::F32, MemFlags::new(), ptr, 0);
                 match op {
                     AssignOp::Add => builder.ins().fadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().fsub(lhs, rhs.value),
@@ -7756,17 +7821,20 @@ pub(crate) fn emit_struct_view_field_assignment(
                 ));
             }
         };
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f32_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_f32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
     } else if field_type == TYPE_ID_F64 {
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div => {
-                let call = builder
+                let ptr_call = builder
                     .ins()
-                    .call(runtime_call_refs.global_f64_load, &[path_hash]);
-                let lhs = builder.inst_results(call)[0];
+                    .call(runtime_call_refs.global_f64_ptr, &[path_hash]);
+                let ptr = builder.inst_results(ptr_call)[0];
+                let lhs = builder.ins().load(types::F64, MemFlags::new(), ptr, 0);
                 match op {
                     AssignOp::Add => builder.ins().fadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().fsub(lhs, rhs.value),
@@ -7783,9 +7851,11 @@ pub(crate) fn emit_struct_view_field_assignment(
                 ));
             }
         };
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f64_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_f64_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
     } else {
         return Err(format!(
             "unsupported struct view field type {} for suffix '{}'",
@@ -7802,11 +7872,15 @@ pub(crate) fn emit_struct_view_field_assignment(
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div | AssignOp::Mod => {
-                let call = builder.ins().call(
-                    runtime_call_refs.global_i32_array_load,
-                    &[base_hash, field_hash_value, index_value],
+                let ptr_call = builder.ins().call(
+                    runtime_call_refs.global_i32_array_ptr,
+                    &[base_hash, field_hash_value, len_value],
                 );
-                let lhs = builder.inst_results(call)[0];
+                let base_ptr = builder.inst_results(ptr_call)[0];
+                let index_i64 = builder.ins().uextend(types::I64, index_value);
+                let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+                let addr = builder.ins().iadd(base_ptr, byte_offset);
+                let lhs = builder.ins().load(types::I32, MemFlags::new(), addr, 0);
                 match op {
                     AssignOp::Add => builder.ins().iadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().isub(lhs, rhs.value),
@@ -7817,10 +7891,15 @@ pub(crate) fn emit_struct_view_field_assignment(
                 }
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[base_hash, field_hash_value, index_value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
     } else if field_type == TYPE_ID_BOOL {
         if op != AssignOp::Set {
             return Err(format!(
@@ -7828,19 +7907,28 @@ pub(crate) fn emit_struct_view_field_assignment(
                 suffix
             ));
         }
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[base_hash, field_hash_value, index_value, rhs.value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), rhs.value, addr, 0);
     } else if field_type == TYPE_ID_F32 {
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div => {
-                let call = builder.ins().call(
-                    runtime_call_refs.global_f32_array_load,
-                    &[base_hash, field_hash_value, index_value],
+                let ptr_call = builder.ins().call(
+                    runtime_call_refs.global_f32_array_ptr,
+                    &[base_hash, field_hash_value, len_value],
                 );
-                let lhs = builder.inst_results(call)[0];
+                let base_ptr = builder.inst_results(ptr_call)[0];
+                let index_i64 = builder.ins().uextend(types::I64, index_value);
+                let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+                let addr = builder.ins().iadd(base_ptr, byte_offset);
+                let lhs = builder.ins().load(types::F32, MemFlags::new(), addr, 0);
                 match op {
                     AssignOp::Add => builder.ins().fadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().fsub(lhs, rhs.value),
@@ -7857,19 +7945,28 @@ pub(crate) fn emit_struct_view_field_assignment(
                 ));
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f32_array_store,
-            &[base_hash, field_hash_value, index_value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f32_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
     } else if field_type == TYPE_ID_F64 {
         let value = match op {
             AssignOp::Set => rhs.value,
             AssignOp::Add | AssignOp::Sub | AssignOp::Mul | AssignOp::Div => {
-                let call = builder.ins().call(
-                    runtime_call_refs.global_f64_array_load,
-                    &[base_hash, field_hash_value, index_value],
+                let ptr_call = builder.ins().call(
+                    runtime_call_refs.global_f64_array_ptr,
+                    &[base_hash, field_hash_value, len_value],
                 );
-                let lhs = builder.inst_results(call)[0];
+                let base_ptr = builder.inst_results(ptr_call)[0];
+                let index_i64 = builder.ins().uextend(types::I64, index_value);
+                let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+                let addr = builder.ins().iadd(base_ptr, byte_offset);
+                let lhs = builder.ins().load(types::F64, MemFlags::new(), addr, 0);
                 match op {
                     AssignOp::Add => builder.ins().fadd(lhs, rhs.value),
                     AssignOp::Sub => builder.ins().fsub(lhs, rhs.value),
@@ -7886,10 +7983,15 @@ pub(crate) fn emit_struct_view_field_assignment(
                 ));
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f64_array_store,
-            &[base_hash, field_hash_value, index_value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f64_array_ptr,
+            &[base_hash, field_hash_value, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
     } else {
         return Err(format!(
             "unsupported struct view field type {} for suffix '{}'",
@@ -8001,37 +8103,80 @@ pub(crate) fn emit_local_indexed_collection_load(
         named_struct_field_types,
     )?;
     let index_binding = normalize_index_binding(index_binding, type_table)?;
+    let collection_len = type_table.fixed_collection_len(collection_binding.type_id);
     let collection_handle = builder.use_var(collection_binding.var);
     let field_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_foreach_field_suffix(suffix)));
     if is_i32_abi_compatible_type(resolved, type_table) {
-        let call = builder.ins().call(
-            runtime_call_refs.global_i32_array_load,
-            &[collection_handle, field_hash, index_binding.value],
-        );
+        let value = if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_i32_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().load(types::I32, MemFlags::new(), addr, 0)
+        } else {
+            let call = builder.ins().call(
+                runtime_call_refs.global_i32_array_load,
+                &[collection_handle, field_hash, index_binding.value],
+            );
+            builder.inst_results(call)[0]
+        };
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: resolved,
         });
     }
     if resolved == TYPE_ID_F32 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f32_array_load,
-            &[collection_handle, field_hash, index_binding.value],
-        );
+        let value = if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_f32_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().load(types::F32, MemFlags::new(), addr, 0)
+        } else {
+            let call = builder.ins().call(
+                runtime_call_refs.global_f32_array_load,
+                &[collection_handle, field_hash, index_binding.value],
+            );
+            builder.inst_results(call)[0]
+        };
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: TYPE_ID_F32,
         });
     }
     if resolved == TYPE_ID_F64 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f64_array_load,
-            &[collection_handle, field_hash, index_binding.value],
-        );
+        let value = if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_f64_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().load(types::F64, MemFlags::new(), addr, 0)
+        } else {
+            let call = builder.ins().call(
+                runtime_call_refs.global_f64_array_load,
+                &[collection_handle, field_hash, index_binding.value],
+            );
+            builder.inst_results(call)[0]
+        };
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: TYPE_ID_F64,
         });
     }
@@ -8066,6 +8211,7 @@ pub(crate) fn emit_local_indexed_collection_assignment(
             collection_name, suffix, path_type, rhs.type_id
         ));
     }
+    let collection_len = type_table.fixed_collection_len(collection_binding.type_id);
     let collection_handle = builder.use_var(collection_binding.var);
     let field_hash = builder
         .ins()
@@ -8145,10 +8291,23 @@ pub(crate) fn emit_local_indexed_collection_assignment(
                 builder.ins().srem(lhs, rhs.value)
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[collection_handle, field_hash, index_binding.value, value],
-        );
+        if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_i32_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_i32_array_store,
+                &[collection_handle, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_BOOL {
@@ -8158,15 +8317,28 @@ pub(crate) fn emit_local_indexed_collection_assignment(
                 collection_name, suffix
             ));
         }
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[
-                collection_handle,
-                field_hash,
-                index_binding.value,
-                rhs.value,
-            ],
-        );
+        if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_i32_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), rhs.value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_i32_array_store,
+                &[
+                    collection_handle,
+                    field_hash,
+                    index_binding.value,
+                    rhs.value,
+                ],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_F32 {
@@ -8235,10 +8407,23 @@ pub(crate) fn emit_local_indexed_collection_assignment(
                 ));
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f32_array_store,
-            &[collection_handle, field_hash, index_binding.value, value],
-        );
+        if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_f32_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f32_array_store,
+                &[collection_handle, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -8307,10 +8492,23 @@ pub(crate) fn emit_local_indexed_collection_assignment(
                 ));
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f64_array_store,
-            &[collection_handle, field_hash, index_binding.value, value],
-        );
+        if let Some(collection_len) = collection_len {
+            let len_value = builder.ins().iconst(types::I32, i64::from(collection_len));
+            let ptr_call = builder.ins().call(
+                runtime_call_refs.global_f64_array_ptr,
+                &[collection_handle, field_hash, len_value],
+            );
+            let base_ptr = builder.inst_results(ptr_call)[0];
+            let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+            let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+            let addr = builder.ins().iadd(base_ptr, byte_offset);
+            builder.ins().store(MemFlags::new(), value, addr, 0);
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f64_array_store,
+                &[collection_handle, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     Err(format!(
@@ -8336,33 +8534,51 @@ pub(crate) fn emit_indexed_collection_load(
     let field_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_foreach_field_suffix(suffix)));
+    let len_value = builder
+        .ins()
+        .iconst(types::I32, i64::from(collection_info.len));
     if is_i32_abi_compatible_type(resolved, type_table) {
-        let call = builder.ins().call(
-            runtime_call_refs.global_i32_array_load,
-            &[collection_hash, field_hash, index_binding.value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        let value = builder.ins().load(types::I32, MemFlags::new(), addr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: resolved,
         });
     }
     if resolved == TYPE_ID_F32 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f32_array_load,
-            &[collection_hash, field_hash, index_binding.value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f32_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        let value = builder.ins().load(types::F32, MemFlags::new(), addr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: TYPE_ID_F32,
         });
     }
     if resolved == TYPE_ID_F64 {
-        let call = builder.ins().call(
-            runtime_call_refs.global_f64_array_load,
-            &[collection_hash, field_hash, index_binding.value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f64_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        let value = builder.ins().load(types::F64, MemFlags::new(), addr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value,
             type_id: TYPE_ID_F64,
         });
     }
@@ -8397,6 +8613,9 @@ pub(crate) fn emit_indexed_collection_assignment(
     let field_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_foreach_field_suffix(suffix)));
+    let len_value = builder
+        .ins()
+        .iconst(types::I32, i64::from(collection_info.len));
 
     if is_i32_scalar_lane_type(path_type, type_table) {
         let value = match op {
@@ -8467,10 +8686,15 @@ pub(crate) fn emit_indexed_collection_assignment(
                 builder.ins().srem(lhs, rhs.value)
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_BOOL {
@@ -8480,10 +8704,15 @@ pub(crate) fn emit_indexed_collection_assignment(
                 collection_path, suffix
             ));
         }
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[collection_hash, field_hash, index_binding.value, rhs.value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_i32_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), rhs.value, addr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_F32 {
@@ -8548,10 +8777,15 @@ pub(crate) fn emit_indexed_collection_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f32_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f32_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 2);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -8616,10 +8850,15 @@ pub(crate) fn emit_indexed_collection_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f64_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
+        let ptr_call = builder.ins().call(
+            runtime_call_refs.global_f64_array_ptr,
+            &[collection_hash, field_hash, len_value],
         );
+        let base_ptr = builder.inst_results(ptr_call)[0];
+        let index_i64 = builder.ins().uextend(types::I64, index_binding.value);
+        let byte_offset = builder.ins().ishl_imm(index_i64, 3);
+        let addr = builder.ins().iadd(base_ptr, byte_offset);
+        builder.ins().store(MemFlags::new(), value, addr, 0);
         return Ok(());
     }
     Err(format!(
@@ -8645,29 +8884,35 @@ pub(crate) fn emit_global_load(
         });
     }
     if is_i32_abi_compatible_type(path_type, type_table) {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_load, &[path_hash]);
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        let call = builder.ins().load(types::I32, MemFlags::new(), ptr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value: call,
             type_id: path_type,
         });
     }
     if path_type == TYPE_ID_F32 {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f32_load, &[path_hash]);
+            .call(runtime_call_refs.global_f32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        let call = builder.ins().load(types::F32, MemFlags::new(), ptr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value: call,
             type_id: TYPE_ID_F32,
         });
     }
     if path_type == TYPE_ID_F64 {
-        let call = builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f64_load, &[path_hash]);
+            .call(runtime_call_refs.global_f64_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        let call = builder.ins().load(types::F64, MemFlags::new(), ptr, 0);
         return Ok(ValueBinding {
-            value: builder.inst_results(call)[0],
+            value: call,
             type_id: TYPE_ID_F64,
         });
     }
@@ -8735,9 +8980,11 @@ pub(crate) fn emit_global_assignment(
         let path_hash = builder
             .ins()
             .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_BOOL {
@@ -8750,9 +8997,11 @@ pub(crate) fn emit_global_assignment(
         let path_hash = builder
             .ins()
             .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, rhs.value]);
+            .call(runtime_call_refs.global_i32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), rhs.value, ptr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_F32 {
@@ -8792,9 +9041,11 @@ pub(crate) fn emit_global_assignment(
         let path_hash = builder
             .ins()
             .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f32_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_f32_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -8834,9 +9085,11 @@ pub(crate) fn emit_global_assignment(
         let path_hash = builder
             .ins()
             .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
+        let ptr_call = builder
             .ins()
-            .call(runtime_call_refs.global_f64_store, &[path_hash, value]);
+            .call(runtime_call_refs.global_f64_ptr, &[path_hash]);
+        let ptr = builder.inst_results(ptr_call)[0];
+        builder.ins().store(MemFlags::new(), value, ptr, 0);
         return Ok(());
     }
     Err(format!(
@@ -9147,6 +9400,9 @@ pub(crate) fn build_runtime_call_import_ids(
         lookup_code_ptr: declare_lookup_code_ptr_import(module, "stasis_jit_lookup_code_ptr")?,
         sin_fast: declare_direct_f32_unary_import(module, "stasis_jit_sin_fast")?,
         cos_fast: declare_direct_f32_unary_import(module, "stasis_jit_cos_fast")?,
+        global_i32_ptr: declare_i32_global_ptr_import(module, "stasis_jit_global_i32_ptr")?,
+        global_f32_ptr: declare_f32_global_ptr_import(module, "stasis_jit_global_f32_ptr")?,
+        global_f64_ptr: declare_f64_global_ptr_import(module, "stasis_jit_global_f64_ptr")?,
         global_i32_load: declare_i32_call_import(module, "stasis_jit_global_i32_load", 1)?,
         global_i32_store: declare_void_call_import(module, "stasis_jit_global_i32_store", 2)?,
         global_f32_load: declare_f32_global_load_import(module, "stasis_jit_global_f32_load")?,
@@ -9242,6 +9498,9 @@ pub(crate) fn build_runtime_call_refs(
         lookup_code_ptr: module.declare_func_in_func(imports.lookup_code_ptr, func),
         sin_fast: module.declare_func_in_func(imports.sin_fast, func),
         cos_fast: module.declare_func_in_func(imports.cos_fast, func),
+        global_i32_ptr: module.declare_func_in_func(imports.global_i32_ptr, func),
+        global_f32_ptr: module.declare_func_in_func(imports.global_f32_ptr, func),
+        global_f64_ptr: module.declare_func_in_func(imports.global_f64_ptr, func),
         global_i32_load: module.declare_func_in_func(imports.global_i32_load, func),
         global_i32_store: module.declare_func_in_func(imports.global_i32_store, func),
         global_f32_load: module.declare_func_in_func(imports.global_f32_load, func),

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -711,10 +711,13 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         }
         "sin_fast" | "stasis_jit_sin_fast" => stasis_dynload::stasis_jit_sin_fast as usize,
         "cos_fast" | "stasis_jit_cos_fast" => stasis_dynload::stasis_jit_cos_fast as usize,
+        "stasis_jit_global_i32_ptr" => stasis_dynload::stasis_jit_global_i32_ptr as usize,
         "stasis_jit_global_i32_load" => stasis_dynload::stasis_jit_global_i32_load as usize,
         "stasis_jit_global_i32_store" => stasis_dynload::stasis_jit_global_i32_store as usize,
+        "stasis_jit_global_f32_ptr" => stasis_dynload::stasis_jit_global_f32_ptr as usize,
         "stasis_jit_global_f32_load" => stasis_dynload::stasis_jit_global_f32_load as usize,
         "stasis_jit_global_f32_store" => stasis_dynload::stasis_jit_global_f32_store as usize,
+        "stasis_jit_global_f64_ptr" => stasis_dynload::stasis_jit_global_f64_ptr as usize,
         "stasis_jit_global_f64_load" => stasis_dynload::stasis_jit_global_f64_load as usize,
         "stasis_jit_global_f64_store" => stasis_dynload::stasis_jit_global_f64_store as usize,
         "stasis_jit_collection_i32_load" => stasis_dynload::stasis_jit_collection_i32_load as usize,
@@ -937,6 +940,10 @@ fn compile_function_to_jit_module(
         stasis_dynload::stasis_jit_cos_fast as *const u8,
     );
     jit_builder.symbol(
+        "stasis_jit_global_i32_ptr",
+        stasis_dynload::stasis_jit_global_i32_ptr as *const u8,
+    );
+    jit_builder.symbol(
         "stasis_jit_global_i32_load",
         stasis_dynload::stasis_jit_global_i32_load as *const u8,
     );
@@ -945,12 +952,20 @@ fn compile_function_to_jit_module(
         stasis_dynload::stasis_jit_global_i32_store as *const u8,
     );
     jit_builder.symbol(
+        "stasis_jit_global_f32_ptr",
+        stasis_dynload::stasis_jit_global_f32_ptr as *const u8,
+    );
+    jit_builder.symbol(
         "stasis_jit_global_f32_load",
         stasis_dynload::stasis_jit_global_f32_load as *const u8,
     );
     jit_builder.symbol(
         "stasis_jit_global_f32_store",
         stasis_dynload::stasis_jit_global_f32_store as *const u8,
+    );
+    jit_builder.symbol(
+        "stasis_jit_global_f64_ptr",
+        stasis_dynload::stasis_jit_global_f64_ptr as *const u8,
     );
     jit_builder.symbol(
         "stasis_jit_global_f64_load",

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -174,7 +174,12 @@ pub fn invoke_i32_i32_to_i32(address: usize, left: i32, right: i32) -> Result<i3
     }
 }
 
-pub fn invoke_i32_i32_i32_to_i32(address: usize, arg0: i32, arg1: i32, arg2: i32) -> Result<i32, String> {
+pub fn invoke_i32_i32_i32_to_i32(
+    address: usize,
+    arg0: i32,
+    arg1: i32,
+    arg2: i32,
+) -> Result<i32, String> {
     if address == 0 {
         return Err("cannot invoke null function pointer".to_string());
     }
@@ -216,8 +221,7 @@ pub fn invoke_i32_i32_i32_i32_to_void(
     }
     #[cfg(not(windows))]
     {
-        let callback: extern "C" fn(i32, i32, i32, i32) =
-            unsafe { std::mem::transmute(address) };
+        let callback: extern "C" fn(i32, i32, i32, i32) = unsafe { std::mem::transmute(address) };
         callback(arg0, arg1, arg2, arg3);
         Ok(())
     }
@@ -635,6 +639,21 @@ fn owned_i32_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<i32>>> {
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn owned_i32_globals() -> &'static Mutex<HashMap<i32, Box<i32>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<i32>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_f32_globals() -> &'static Mutex<HashMap<i32, Box<f32>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<f32>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_f64_globals() -> &'static Mutex<HashMap<i32, Box<f64>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<f64>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 fn owned_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f64>>> {
     static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<f64>>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
@@ -681,6 +700,18 @@ pub fn clear_registered_global_memory() {
     owned_f64_arrays()
         .lock()
         .expect("owned f64 array table mutex poisoned")
+        .clear();
+    owned_i32_globals()
+        .lock()
+        .expect("owned i32 global table mutex poisoned")
+        .clear();
+    owned_f32_globals()
+        .lock()
+        .expect("owned f32 global table mutex poisoned")
+        .clear();
+    owned_f64_globals()
+        .lock()
+        .expect("owned f64 global table mutex poisoned")
         .clear();
 }
 
@@ -768,7 +799,9 @@ pub extern "C" fn stasis_jit_global_i32_array_ptr(
         let mut owned_guard = owned_i32_arrays()
             .lock()
             .expect("owned i32 array table mutex poisoned");
-        let array = owned_guard.entry(key).or_insert_with(|| vec![0; requested_len]);
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0; requested_len]);
         if array.len() < requested_len {
             array.resize(requested_len, 0);
         }
@@ -829,7 +862,9 @@ pub extern "C" fn stasis_jit_global_f32_array_ptr(
         let mut owned_guard = owned_f32_arrays()
             .lock()
             .expect("owned f32 array table mutex poisoned");
-        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0.0; requested_len]);
         if array.len() < requested_len {
             array.resize(requested_len, 0.0);
         }
@@ -889,7 +924,9 @@ pub extern "C" fn stasis_jit_global_f64_array_ptr(
         let mut owned_guard = owned_f64_arrays()
             .lock()
             .expect("owned f64 array table mutex poisoned");
-        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0.0; requested_len]);
         if array.len() < requested_len {
             array.resize(requested_len, 0.0);
         }
@@ -1434,38 +1471,104 @@ pub extern "C" fn stasis_jit_call_f32_i32_1(fn_id_raw: i32, arg0: i32) -> f32 {
 }
 
 #[no_mangle]
-pub extern "C" fn stasis_jit_global_i32_load(path_hash: i32) -> i32 {
+pub extern "C" fn stasis_jit_global_i32_ptr(path_hash: i32) -> *mut i32 {
     {
         let table = registered_i32_ptrs();
         let guard = table
             .lock()
             .expect("registered i32 ptr table mutex poisoned");
         if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            return unsafe { *(ptr as *mut i32) };
+            return ptr as *mut i32;
         }
     }
-    let table = jit_i32_global_table();
-    let guard = table.lock().expect("jit global table mutex poisoned");
-    guard.get(&path_hash).copied().unwrap_or_default()
+
+    let value = {
+        let table = jit_i32_global_table();
+        let mut guard = table.lock().expect("jit global table mutex poisoned");
+        guard.remove(&path_hash).unwrap_or_default()
+    };
+
+    let mut owned_guard = owned_i32_globals()
+        .lock()
+        .expect("owned i32 global table mutex poisoned");
+    let slot = owned_guard
+        .entry(path_hash)
+        .or_insert_with(|| Box::new(value));
+    (&mut **slot) as *mut i32
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f32_ptr(path_hash: i32) -> *mut f32 {
+    {
+        let table = registered_f32_ptrs();
+        let guard = table
+            .lock()
+            .expect("registered f32 ptr table mutex poisoned");
+        if let Some(ptr) = guard.get(&path_hash).copied() {
+            return ptr as *mut f32;
+        }
+    }
+
+    let value = {
+        let table = jit_f32_global_table();
+        let mut guard = table.lock().expect("jit global table mutex poisoned");
+        guard.remove(&path_hash).unwrap_or_default()
+    };
+
+    let mut owned_guard = owned_f32_globals()
+        .lock()
+        .expect("owned f32 global table mutex poisoned");
+    let slot = owned_guard
+        .entry(path_hash)
+        .or_insert_with(|| Box::new(value));
+    (&mut **slot) as *mut f32
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_f64_ptr(path_hash: i32) -> *mut f64 {
+    {
+        let table = registered_f64_ptrs();
+        let guard = table
+            .lock()
+            .expect("registered f64 ptr table mutex poisoned");
+        if let Some(ptr) = guard.get(&path_hash).copied() {
+            return ptr as *mut f64;
+        }
+    }
+
+    let value = {
+        let table = jit_f64_global_table();
+        let mut guard = table.lock().expect("jit global table mutex poisoned");
+        guard.remove(&path_hash).unwrap_or_default()
+    };
+
+    let mut owned_guard = owned_f64_globals()
+        .lock()
+        .expect("owned f64 global table mutex poisoned");
+    let slot = owned_guard
+        .entry(path_hash)
+        .or_insert_with(|| Box::new(value));
+    (&mut **slot) as *mut f64
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_global_i32_load(path_hash: i32) -> i32 {
+    let ptr = stasis_jit_global_i32_ptr(path_hash);
+    if ptr.is_null() {
+        return 0;
+    }
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr }
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_i32_store(path_hash: i32, value: i32) {
-    {
-        let table = registered_i32_ptrs();
-        let guard = table
-            .lock()
-            .expect("registered i32 ptr table mutex poisoned");
-        if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            unsafe { *(ptr as *mut i32) = value };
-            return;
-        }
+    let ptr = stasis_jit_global_i32_ptr(path_hash);
+    if ptr.is_null() {
+        return;
     }
-    let table = jit_i32_global_table();
-    let mut guard = table.lock().expect("jit global table mutex poisoned");
-    guard.insert(path_hash, value);
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr = value };
 }
 
 fn fnv1a_extend_u32(mut hash: u32, suffix: &[u8]) -> u32 {
@@ -1512,72 +1615,42 @@ pub extern "C" fn stasis_jit_collection_i32_store(
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_f32_load(path_hash: i32) -> f32 {
-    {
-        let table = registered_f32_ptrs();
-        let guard = table
-            .lock()
-            .expect("registered f32 ptr table mutex poisoned");
-        if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            return unsafe { *(ptr as *mut f32) };
-        }
+    let ptr = stasis_jit_global_f32_ptr(path_hash);
+    if ptr.is_null() {
+        return 0.0;
     }
-    let table = jit_f32_global_table();
-    let guard = table.lock().expect("jit global table mutex poisoned");
-    guard.get(&path_hash).copied().unwrap_or_default()
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr }
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_f32_store(path_hash: i32, value: f32) {
-    {
-        let table = registered_f32_ptrs();
-        let guard = table
-            .lock()
-            .expect("registered f32 ptr table mutex poisoned");
-        if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            unsafe { *(ptr as *mut f32) = value };
-            return;
-        }
+    let ptr = stasis_jit_global_f32_ptr(path_hash);
+    if ptr.is_null() {
+        return;
     }
-    let table = jit_f32_global_table();
-    let mut guard = table.lock().expect("jit global table mutex poisoned");
-    guard.insert(path_hash, value);
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr = value };
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_f64_load(path_hash: i32) -> f64 {
-    {
-        let table = registered_f64_ptrs();
-        let guard = table
-            .lock()
-            .expect("registered f64 ptr table mutex poisoned");
-        if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            return unsafe { *(ptr as *mut f64) };
-        }
+    let ptr = stasis_jit_global_f64_ptr(path_hash);
+    if ptr.is_null() {
+        return 0.0;
     }
-    let table = jit_f64_global_table();
-    let guard = table.lock().expect("jit global table mutex poisoned");
-    guard.get(&path_hash).copied().unwrap_or_default()
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr }
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_f64_store(path_hash: i32, value: f64) {
-    {
-        let table = registered_f64_ptrs();
-        let guard = table
-            .lock()
-            .expect("registered f64 ptr table mutex poisoned");
-        if let Some(ptr) = guard.get(&path_hash).copied() {
-            // Safety: caller owns lifetime; this is a process-global registration.
-            unsafe { *(ptr as *mut f64) = value };
-            return;
-        }
+    let ptr = stasis_jit_global_f64_ptr(path_hash);
+    if ptr.is_null() {
+        return;
     }
-    let table = jit_f64_global_table();
-    let mut guard = table.lock().expect("jit global table mutex poisoned");
-    guard.insert(path_hash, value);
+    // Safety: pointer comes from registered/owned global table.
+    unsafe { *ptr = value };
 }
 
 #[no_mangle]
@@ -1935,7 +2008,11 @@ pub extern "C" fn stasis_jit_sys_memmove_f32(
 // Brickout uses `audio_is_available()` as a gate; return false so the game runs without calling
 // pointer-typed audio externs (e.g. `audio_push_f32_interleaved`).
 #[no_mangle]
-pub extern "C" fn stasis_jit_audio_init(_sample_rate: i32, _channels: i32, _target_latency_frames: i32) -> i32 {
+pub extern "C" fn stasis_jit_audio_init(
+    _sample_rate: i32,
+    _channels: i32,
+    _target_latency_frames: i32,
+) -> i32 {
     0
 }
 
@@ -2534,6 +2611,27 @@ mod tests {
         );
 
         let ptr2 = stasis_jit_global_i32_array_ptr(collection_hash, field_hash, 4);
+        assert_eq!(ptr, ptr2);
+    }
+
+    #[test]
+    fn i32_global_ptr_migrates_fallback_value_and_supports_direct_access() {
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+
+        let path_hash = 0x1020_3040i32;
+        stasis_jit_global_i32_store(path_hash, 77);
+        let ptr = stasis_jit_global_i32_ptr(path_hash);
+        assert!(!ptr.is_null());
+        assert_eq!(stasis_jit_global_i32_load(path_hash), 77);
+
+        // Safety: pointer comes from dynload-owned registration table for this test process.
+        unsafe {
+            *ptr = 123;
+        }
+        assert_eq!(stasis_jit_global_i32_load(path_hash), 123);
+
+        let ptr2 = stasis_jit_global_i32_ptr(path_hash);
         assert_eq!(ptr, ptr2);
     }
 }


### PR DESCRIPTION
## Summary
- add scalar global pointer imports (stasis_jit_global_{i32,f32,f64}_ptr) to JIT symbol resolution
- switch scalar global/struct-view/local-indexed load/store emission to pointer-based direct CLIF load/store
- keep helper-call fallback for dynamic local collection views (non-fixed-length) to preserve correctness
- add owned scalar fallback slots in stasis_dynload so pointer APIs can materialize missing globals from legacy table values

## Validation
- cargo test -p stasis_dynload --release
- cargo test -p stasis_compiler --release
- cargo test -p stasis --release --lib bench_brickout_revenge_v1_ -- --ignored --nocapture
- cargo test -p stasis --release --lib bench_perf_balls_bricks_v1_ -- --ignored --nocapture

## Benchmark snapshot (1000 ticks)
- brickout_revenge_v1 (in-level): AOT speed+size 