### PR TITLE
runner: state-map aware layout migration for hot swap

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3,7 +3,7 @@ use sha2::{Digest, Sha256};
 use stasis_compiler::backend::aot::{AotEngineBundle, AotProcess};
 use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess};
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
-use stasis_compiler::frontend::parser::parse_top_level_functions;
+use stasis_compiler::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
 #[cfg(test)]
 use stasis_compiler::{SimpleI32Condition, SimpleI32ReturnExpr};
 use stasis_jit::{
@@ -12,7 +12,8 @@ use stasis_jit::{
 };
 use stasis_runner::swap::contracts::{
     AotFunctionSymbol, CompileRequest, CompileResult, Diagnostic, DiagnosticSeverity, FnId,
-    FunctionPatch, FunctionPatchSet, JitCodePtrOverride, LayoutHash, RequestId, TargetMode,
+    FunctionPatch, FunctionPatchSet, JitCodePtrOverride, LayoutHash, RequestId, StateMapEntry,
+    TargetMode,
 };
 use stasis_runner::swap::pipeline::CompilerBackend;
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,6 +81,12 @@ struct SelfHostObjectBundle {
 struct EngineFunctionEntry {
     path: String,
     name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructFieldType {
+    field_name: String,
+    type_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -608,6 +615,22 @@ impl IncrementalCompilerBackend {
             aot_function_symbols,
         );
         result.jit_code_ptr_overrides = jit_code_ptr_overrides;
+        let state_map = match self.state_map_from_source_cache() {
+            Ok(map) => map,
+            Err(message) => {
+                return CompileResult::failed(
+                    request.request_id,
+                    vec![Diagnostic {
+                        severity: DiagnosticSeverity::Error,
+                        message,
+                        path: request.changed_files.first().cloned(),
+                        line: None,
+                        column: None,
+                    }],
+                );
+            }
+        };
+        result.state_map = Some(state_map);
         result
     }
 
@@ -679,6 +702,7 @@ impl IncrementalCompilerBackend {
             None,
         );
         result.jit_code_ptr_overrides = Some(jit_code_ptr_overrides);
+        result.state_map = Some(self.state_map_from_source_cache()?);
         Ok(result)
     }
 
@@ -763,6 +787,8 @@ impl IncrementalCompilerBackend {
             aot_linked_image_sha256,
             Some(aot_function_symbols),
         );
+        let mut result = result;
+        result.state_map = Some(self.state_map_from_source_cache()?);
         Ok(result)
     }
 
@@ -868,6 +894,101 @@ impl IncrementalCompilerBackend {
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(&digest);
         LayoutHash(bytes)
+    }
+
+    fn state_map_from_source_cache(&self) -> Result<Vec<StateMapEntry>, String> {
+        let mut struct_fields_by_name: BTreeMap<String, Vec<StructFieldType>> = BTreeMap::new();
+        for (path, source) in &self.source_by_path {
+            let parsed = parse_top_level_type_layout(source).map_err(|error| {
+                format!(
+                    "failed parsing top-level type layout in {} for state map extraction: {error}",
+                    path
+                )
+            })?;
+            for struct_def in parsed.structs {
+                let mut fields = Vec::new();
+                for field in struct_def.fields {
+                    fields.push(StructFieldType {
+                        field_name: field.name,
+                        type_name: field.type_name,
+                    });
+                }
+                struct_fields_by_name.insert(struct_def.name, fields);
+            }
+        }
+
+        let mut leaf_by_path: BTreeMap<String, StateMapEntry> = BTreeMap::new();
+        for (path, source) in &self.source_by_path {
+            let parsed = parse_top_level_type_layout(source).map_err(|error| {
+                format!(
+                    "failed parsing top-level type layout in {} for state map extraction: {error}",
+                    path
+                )
+            })?;
+            for global in parsed.globals {
+                Self::collect_state_map_leaf_entries(
+                    &global.name,
+                    &global.type_name,
+                    &struct_fields_by_name,
+                    &mut Vec::new(),
+                    &mut leaf_by_path,
+                )?;
+            }
+            for block in parsed.global_blocks {
+                for field in block.fields {
+                    let field_path = format!("{}.{}", block.name, field.name);
+                    Self::collect_state_map_leaf_entries(
+                        &field_path,
+                        &field.type_name,
+                        &struct_fields_by_name,
+                        &mut Vec::new(),
+                        &mut leaf_by_path,
+                    )?;
+                }
+            }
+        }
+
+        Ok(leaf_by_path.into_values().collect())
+    }
+
+    fn collect_state_map_leaf_entries(
+        path: &str,
+        type_name: &str,
+        struct_fields_by_name: &BTreeMap<String, Vec<StructFieldType>>,
+        struct_stack: &mut Vec<String>,
+        leaf_by_path: &mut BTreeMap<String, StateMapEntry>,
+    ) -> Result<(), String> {
+        if let Some(fields) = struct_fields_by_name.get(type_name) {
+            if struct_stack.iter().any(|name| name == type_name) {
+                return Err(format!(
+                    "state-map extraction rejected recursive struct '{}' in path '{}'",
+                    type_name, path
+                ));
+            }
+            struct_stack.push(type_name.to_string());
+            for field in fields {
+                let child_path = format!("{}.{}", path, field.field_name);
+                Self::collect_state_map_leaf_entries(
+                    &child_path,
+                    &field.type_name,
+                    struct_fields_by_name,
+                    struct_stack,
+                    leaf_by_path,
+                )?;
+            }
+            struct_stack.pop();
+            return Ok(());
+        }
+
+        leaf_by_path.insert(
+            path.to_string(),
+            StateMapEntry {
+                path: path.to_string(),
+                path_hash: crate::hash_global_path(path),
+                type_name: type_name.to_string(),
+            },
+        );
+        Ok(())
     }
 
     fn compile_jit_engine_package_from_cache(
@@ -3665,7 +3786,12 @@ mod tests {
             let build_output = Command::new("cargo")
                 .arg("build")
                 .arg("--manifest-path")
-                .arg(repo_root.join("tools").join("cranelift-aot").join("Cargo.toml"))
+                .arg(
+                    repo_root
+                        .join("tools")
+                        .join("cranelift-aot")
+                        .join("Cargo.toml"),
+                )
                 .current_dir(&repo_root)
                 .output()
                 .expect("spawn cargo build for cranelift-aot helper");
@@ -3684,7 +3810,10 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
-        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        dynload_build_command
+            .arg("rustc")
+            .arg("-p")
+            .arg("stasis_dynload");
         if !cfg!(debug_assertions) {
             dynload_build_command.arg("--release");
         }
@@ -3707,8 +3836,8 @@ mod tests {
         );
 
         let linker_path = find_lld_link().expect("lld-link.exe required for AOT quality gate");
-        let stasis_dynload_lib =
-            resolve_stasis_dynload_lib().expect("stasis_dynload staticlib required for AOT quality gate");
+        let stasis_dynload_lib = resolve_stasis_dynload_lib()
+            .expect("stasis_dynload staticlib required for AOT quality gate");
 
         let source = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("..")
@@ -3739,7 +3868,8 @@ mod tests {
             "speed_and_size",
             "AOT compile config default opt_level should be speed_and_size for release-like engine bundles"
         );
-        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
             RequestId(9_202),
             vec![source],
@@ -3776,11 +3906,8 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
 
-        let object_paths: Vec<PathBuf> = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect();
+        let object_paths: Vec<PathBuf> =
+            bundle.object_paths_by_function.values().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -3822,11 +3949,7 @@ mod tests {
         let field = 0;
         let store = |index: i32, value: i32| {
             stasis_dynload::invoke_i32_i32_i32_i32_to_void(
-                store_ptr,
-                host_i32,
-                field,
-                index,
-                value,
+                store_ptr, host_i32, field, index, value,
             )
             .expect("invoke host_i32 store");
         };
@@ -4110,7 +4233,10 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
-        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        dynload_build_command
+            .arg("rustc")
+            .arg("-p")
+            .arg("stasis_dynload");
         if !cfg!(debug_assertions) {
             dynload_build_command.arg("--release");
         }
@@ -4158,7 +4284,8 @@ mod tests {
             opt_level: "speed_and_size".to_string(),
             ..AotCompileConfig::default()
         };
-        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
             RequestId(9_302),
             vec![source],
@@ -4214,11 +4341,8 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include brickout_try_start_battle");
 
-        let object_paths: Vec<PathBuf> = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect();
+        let object_paths: Vec<PathBuf> =
+            bundle.object_paths_by_function.values().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -4252,7 +4376,11 @@ mod tests {
             .unwrap_or_default();
         let objects_bytes = object_paths
             .iter()
-            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .map(|path| {
+                fs::metadata(path)
+                    .map(|meta| meta.len())
+                    .unwrap_or_default()
+            })
             .sum::<u64>();
         let manifest_bytes = fs::metadata(&bundle.manifest_path)
             .map(|meta| meta.len())
@@ -4286,8 +4414,10 @@ mod tests {
         let host_i32 = hash_global_path("host_i32");
         let field = 0;
         let store = |index: i32, value: i32| {
-            stasis_dynload::invoke_i32_i32_i32_i32_to_void(store_ptr, host_i32, field, index, value)
-                .expect("invoke host_i32 store");
+            stasis_dynload::invoke_i32_i32_i32_i32_to_void(
+                store_ptr, host_i32, field, index, value,
+            )
+            .expect("invoke host_i32 store");
         };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
@@ -4454,7 +4584,10 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
-        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        dynload_build_command
+            .arg("rustc")
+            .arg("-p")
+            .arg("stasis_dynload");
         if !cfg!(debug_assertions) {
             dynload_build_command.arg("--release");
         }
@@ -4502,7 +4635,8 @@ mod tests {
             opt_level: "speed".to_string(),
             ..AotCompileConfig::default()
         };
-        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
             RequestId(9_303),
             vec![source],
@@ -4558,11 +4692,8 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include brickout_try_start_battle");
 
-        let object_paths: Vec<PathBuf> = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect();
+        let object_paths: Vec<PathBuf> =
+            bundle.object_paths_by_function.values().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -4596,7 +4727,11 @@ mod tests {
             .unwrap_or_default();
         let objects_bytes = object_paths
             .iter()
-            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .map(|path| {
+                fs::metadata(path)
+                    .map(|meta| meta.len())
+                    .unwrap_or_default()
+            })
             .sum::<u64>();
         let manifest_bytes = fs::metadata(&bundle.manifest_path)
             .map(|meta| meta.len())
@@ -4630,8 +4765,10 @@ mod tests {
         let host_i32 = hash_global_path("host_i32");
         let field = 0;
         let store = |index: i32, value: i32| {
-            stasis_dynload::invoke_i32_i32_i32_i32_to_void(store_ptr, host_i32, field, index, value)
-                .expect("invoke host_i32 store");
+            stasis_dynload::invoke_i32_i32_i32_i32_to_void(
+                store_ptr, host_i32, field, index, value,
+            )
+            .expect("invoke host_i32 store");
         };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
@@ -4857,7 +4994,10 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
-        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        dynload_build_command
+            .arg("rustc")
+            .arg("-p")
+            .arg("stasis_dynload");
         if !cfg!(debug_assertions) {
             dynload_build_command.arg("--release");
         }
@@ -4902,7 +5042,8 @@ mod tests {
             opt_level: "speed".to_string(),
             ..AotCompileConfig::default()
         };
-        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
             RequestId(9_402),
             vec![source],
@@ -4940,11 +5081,8 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
 
-        let object_paths: Vec<PathBuf> = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect();
+        let object_paths: Vec<PathBuf> =
+            bundle.object_paths_by_function.values().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -4969,7 +5107,11 @@ mod tests {
             .unwrap_or_default();
         let objects_bytes = object_paths
             .iter()
-            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .map(|path| {
+                fs::metadata(path)
+                    .map(|meta| meta.len())
+                    .unwrap_or_default()
+            })
             .sum::<u64>();
         let manifest_bytes = fs::metadata(&bundle.manifest_path)
             .map(|meta| meta.len())
@@ -5107,7 +5249,10 @@ mod tests {
 
         // Ensure the `stasis_dynload` staticlib exists and is up-to-date before linking.
         let mut dynload_build_command = Command::new("cargo");
-        dynload_build_command.arg("rustc").arg("-p").arg("stasis_dynload");
+        dynload_build_command
+            .arg("rustc")
+            .arg("-p")
+            .arg("stasis_dynload");
         if !cfg!(debug_assertions) {
             dynload_build_command.arg("--release");
         }
@@ -5152,7 +5297,8 @@ mod tests {
             opt_level: "speed_and_size".to_string(),
             ..AotCompileConfig::default()
         };
-        let mut backend = IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(compile_config, artifact_root);
         let result = backend.compile(CompileRequest::new(
             RequestId(9_403),
             vec![source],
@@ -5190,11 +5336,8 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
 
-        let object_paths: Vec<PathBuf> = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect();
+        let object_paths: Vec<PathBuf> =
+            bundle.object_paths_by_function.values().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -5219,7 +5362,11 @@ mod tests {
             .unwrap_or_default();
         let objects_bytes = object_paths
             .iter()
-            .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or_default())
+            .map(|path| {
+                fs::metadata(path)
+                    .map(|meta| meta.len())
+                    .unwrap_or_default()
+            })
             .sum::<u64>();
         let manifest_bytes = fs::metadata(&bundle.manifest_path)
             .map(|meta| meta.len())
@@ -5373,6 +5520,70 @@ mod tests {
         assert!(backend.last_jit_engine_package().is_none());
         assert!(backend.last_aot_engine_bundle().is_none());
         fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[test]
+    fn jit_dev_non_engine_result_includes_flattened_state_map_entries() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_jit_state_map_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let source = temp_root.join("game_logic.stasis");
+        fs::write(
+            &source,
+            "struct Enemy { hp: i32; speed: f32; }\nglobal Game { score: i32; first_enemy: Enemy; }\nfunction main(): i32 { return Game.score; }\n",
+        )
+        .expect("write source");
+
+        let mut backend = IncrementalCompilerBackend::new();
+        let result = backend.compile(CompileRequest::new(
+            RequestId(9_103),
+            vec![source],
+            TargetMode::JitDev,
+        ));
+        assert_eq!(result.status, CompileStatus::Success);
+        let state_map = result
+            .state_map
+            .as_ref()
+            .expect("state map should be populated on successful compile");
+        assert!(
+            state_map
+                .iter()
+                .any(|entry| entry.path == "Game.score" && entry.type_name == "i32"),
+            "expected scalar global block entry in state map"
+        );
+        assert!(
+            state_map
+                .iter()
+                .any(|entry| entry.path == "Game.first_enemy.hp" && entry.type_name == "i32"),
+            "expected flattened struct field entry in state map"
+        );
+        assert!(
+            state_map
+                .iter()
+                .any(|entry| entry.path == "Game.first_enemy.speed" && entry.type_name == "f32"),
+            "expected flattened struct field entry in state map"
+        );
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[test]
+    fn state_map_extraction_rejects_recursive_structs() {
+        let mut backend = IncrementalCompilerBackend::new();
+        backend.source_by_path.insert(
+            "recursive.stasis".to_string(),
+            "struct Node { next: Node; }\nglobal root: Node;\nfunction main(): i32 { return 0; }\n"
+                .to_string(),
+        );
+        let result = backend.state_map_from_source_cache();
+        assert!(
+            result.is_err(),
+            "recursive struct layout should be rejected"
+        );
+        let message = result.expect_err("state map extraction should fail");
+        assert!(message.contains("recursive struct"));
     }
 
     #[test]

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -31,8 +31,8 @@ use stasis_jit::FunctionPointerTable;
 use stasis_runner::swap::contracts::{
     AotFunctionSymbol, CompileRequest, CompileResult, CompileStatus, Diagnostic,
     DiagnosticSeverity, FileChangeEvent, FileChangeKind, FnId, FunctionPatch, FunctionPatchSet,
-    JitCodePtrOverride, LayoutHash, RequestId, SwapCommitResult, SwapCommitStatus, TargetMode,
-    TextSource,
+    JitCodePtrOverride, LayoutHash, RequestId, StateMapEntry, SwapCommitResult, SwapCommitStatus,
+    TargetMode, TextSource,
 };
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
 use std::collections::{BTreeMap, BTreeSet};
@@ -785,6 +785,7 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
     let mut pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
         BTreeMap::new();
     let mut active_layout_hash: Option<LayoutHash> = None;
+    let mut active_state_map: Option<Vec<StateMapEntry>> = None;
     let mut aot_linked_image_activations: u32 = 0;
     let mut active_aot_linked_image_path: Option<PathBuf> = None;
     let mut active_aot_linked_image_size_bytes: Option<u64> = None;
@@ -843,16 +844,36 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
         pipeline.process_commits_at_safe_point(|request| {
-            if let Some(result) = enforce_layout_change_policy(
-                request.request_id,
-                active_layout_hash,
-                request.layout_hash,
-                &mut swap_commit_failures,
-                &mut swap_failure_reasons,
-            ) {
-                return result;
-            }
             let request_layout_hash = request.layout_hash;
+            let request_state_map = request.state_map.clone();
+            if let Err(message) = validate_layout_transition(
+                active_layout_hash,
+                request_layout_hash,
+                active_state_map.as_deref(),
+                request_state_map.as_deref(),
+            ) {
+                record_swap_failure(
+                    &message,
+                    &mut swap_commit_failures,
+                    &mut swap_failure_reasons,
+                );
+                return SwapCommitResult::failed(request.request_id, message);
+            }
+            let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
+            if layout_changed {
+                if let (Some(from), Some(to)) =
+                    (active_state_map.as_deref(), request_state_map.as_deref())
+                {
+                    if let Err(message) = migrate_state_map_fields(from, to) {
+                        record_swap_failure(
+                            &message,
+                            &mut swap_commit_failures,
+                            &mut swap_failure_reasons,
+                        );
+                        return SwapCommitResult::failed(request.request_id, message);
+                    }
+                }
+            }
             let result = apply_commit_request(
                 request,
                 &mut pointer_table,
@@ -872,6 +893,9 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
             );
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
+                if let Some(state_map) = request_state_map {
+                    active_state_map = Some(state_map);
+                }
             }
             result
         });
@@ -947,16 +971,36 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
         pipeline.process_commits_at_safe_point(|request| {
-            if let Some(result) = enforce_layout_change_policy(
-                request.request_id,
-                active_layout_hash,
-                request.layout_hash,
-                &mut swap_commit_failures,
-                &mut swap_failure_reasons,
-            ) {
-                return result;
-            }
             let request_layout_hash = request.layout_hash;
+            let request_state_map = request.state_map.clone();
+            if let Err(message) = validate_layout_transition(
+                active_layout_hash,
+                request_layout_hash,
+                active_state_map.as_deref(),
+                request_state_map.as_deref(),
+            ) {
+                record_swap_failure(
+                    &message,
+                    &mut swap_commit_failures,
+                    &mut swap_failure_reasons,
+                );
+                return SwapCommitResult::failed(request.request_id, message);
+            }
+            let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
+            if layout_changed {
+                if let (Some(from), Some(to)) =
+                    (active_state_map.as_deref(), request_state_map.as_deref())
+                {
+                    if let Err(message) = migrate_state_map_fields(from, to) {
+                        record_swap_failure(
+                            &message,
+                            &mut swap_commit_failures,
+                            &mut swap_failure_reasons,
+                        );
+                        return SwapCommitResult::failed(request.request_id, message);
+                    }
+                }
+            }
             let result = apply_commit_request(
                 request,
                 &mut pointer_table,
@@ -976,6 +1020,9 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
             );
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
+                if let Some(state_map) = request_state_map {
+                    active_state_map = Some(state_map);
+                }
             }
             result
         });
@@ -1141,28 +1188,129 @@ fn format_layout_hash_hex(layout_hash: LayoutHash) -> String {
     out
 }
 
-fn enforce_layout_change_policy(
-    request_id: RequestId,
-    active_layout_hash: Option<LayoutHash>,
-    request_layout_hash: LayoutHash,
+fn record_swap_failure(
+    message: &str,
     swap_commit_failures: &mut u32,
     swap_failure_reasons: &mut Vec<String>,
-) -> Option<SwapCommitResult> {
+) {
+    *swap_commit_failures += 1;
+    swap_failure_reasons.push(message.to_string());
+}
+
+fn normalize_state_map(
+    entries: &[StateMapEntry],
+    label: &str,
+) -> Result<BTreeMap<String, StateMapEntry>, String> {
+    let mut by_path: BTreeMap<String, StateMapEntry> = BTreeMap::new();
+    for entry in entries {
+        if entry.path.trim().is_empty() {
+            return Err(format!(
+                "{label} state-map contains empty path entry (restart required)"
+            ));
+        }
+        if let Some(previous) = by_path.insert(entry.path.clone(), entry.clone()) {
+            if previous.type_name != entry.type_name || previous.path_hash != entry.path_hash {
+                return Err(format!(
+                    "{label} state-map contains conflicting duplicate path '{}' (restart required)",
+                    entry.path
+                ));
+            }
+        }
+    }
+    Ok(by_path)
+}
+
+fn validate_layout_transition(
+    active_layout_hash: Option<LayoutHash>,
+    request_layout_hash: LayoutHash,
+    active_state_map: Option<&[StateMapEntry]>,
+    request_state_map: Option<&[StateMapEntry]>,
+) -> Result<(), String> {
     let Some(active_layout_hash) = active_layout_hash else {
-        return None;
+        return Ok(());
     };
     if active_layout_hash == request_layout_hash {
-        return None;
+        return Ok(());
+    }
+    let Some(active_state_map) = active_state_map else {
+        return Err(format!(
+            "layout hash changed from {} to {}, but active state-map metadata is missing (restart required)",
+            format_layout_hash_hex(active_layout_hash),
+            format_layout_hash_hex(request_layout_hash)
+        ));
+    };
+    let Some(request_state_map) = request_state_map else {
+        return Err(format!(
+            "layout hash changed from {} to {}, but incoming state-map metadata is missing (restart required)",
+            format_layout_hash_hex(active_layout_hash),
+            format_layout_hash_hex(request_layout_hash)
+        ));
+    };
+
+    let active_by_path = normalize_state_map(active_state_map, "active")?;
+    let request_by_path = normalize_state_map(request_state_map, "incoming")?;
+    for (path, request_entry) in &request_by_path {
+        if let Some(active_entry) = active_by_path.get(path) {
+            if active_entry.type_name != request_entry.type_name {
+                return Err(format!(
+                    "layout hash changed from {} to {} and state-map path '{}' changed type '{}' -> '{}' (restart required)",
+                    format_layout_hash_hex(active_layout_hash),
+                    format_layout_hash_hex(request_layout_hash),
+                    path,
+                    active_entry.type_name,
+                    request_entry.type_name
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn type_name_is_f32(type_name: &str) -> bool {
+    type_name.trim() == "f32"
+}
+
+fn type_name_is_f64(type_name: &str) -> bool {
+    type_name.trim() == "f64"
+}
+
+fn type_name_is_collection_like(type_name: &str) -> bool {
+    let normalized = type_name.trim();
+    normalized.contains('[') || normalized == "ascii" || normalized == "utf8"
+}
+
+fn migrate_state_map_fields(
+    active_state_map: &[StateMapEntry],
+    request_state_map: &[StateMapEntry],
+) -> Result<(), String> {
+    let active_by_path = normalize_state_map(active_state_map, "active")?;
+    let request_by_path = normalize_state_map(request_state_map, "incoming")?;
+
+    for (path, request_entry) in &request_by_path {
+        let Some(active_entry) = active_by_path.get(path) else {
+            continue;
+        };
+        if active_entry.type_name != request_entry.type_name {
+            continue;
+        }
+        if type_name_is_collection_like(&request_entry.type_name) {
+            continue;
+        }
+        if type_name_is_f32(&request_entry.type_name) {
+            let value = stasis_dynload::stasis_jit_global_f32_load(active_entry.path_hash);
+            stasis_dynload::stasis_jit_global_f32_store(request_entry.path_hash, value);
+            continue;
+        }
+        if type_name_is_f64(&request_entry.type_name) {
+            let value = stasis_dynload::stasis_jit_global_f64_load(active_entry.path_hash);
+            stasis_dynload::stasis_jit_global_f64_store(request_entry.path_hash, value);
+            continue;
+        }
+        let value = stasis_dynload::stasis_jit_global_i32_load(active_entry.path_hash);
+        stasis_dynload::stasis_jit_global_i32_store(request_entry.path_hash, value);
     }
 
-    let message = format!(
-        "layout hash changed from {} to {}; hot reload state migration is not implemented yet, restart required",
-        format_layout_hash_hex(active_layout_hash),
-        format_layout_hash_hex(request_layout_hash)
-    );
-    *swap_commit_failures += 1;
-    swap_failure_reasons.push(message.clone());
-    Some(SwapCommitResult::failed(request_id, message))
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1672,49 +1820,87 @@ mod tests {
     }
 
     #[test]
-    fn layout_change_policy_accepts_initial_and_matching_layout_hashes() {
-        let mut swap_commit_failures = 0u32;
-        let mut swap_failure_reasons = Vec::new();
-        assert!(enforce_layout_change_policy(
-            RequestId(1),
-            None,
-            LayoutHash([1; 32]),
-            &mut swap_commit_failures,
-            &mut swap_failure_reasons,
-        )
-        .is_none());
-        assert!(enforce_layout_change_policy(
-            RequestId(2),
+    fn validate_layout_transition_rejects_type_change_for_existing_path() {
+        let active_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: 11,
+            type_name: "i32".to_string(),
+        }];
+        let incoming_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: 11,
+            type_name: "f32".to_string(),
+        }];
+        let result = validate_layout_transition(
             Some(LayoutHash([1; 32])),
-            LayoutHash([1; 32]),
-            &mut swap_commit_failures,
-            &mut swap_failure_reasons,
-        )
-        .is_none());
-        assert_eq!(swap_commit_failures, 0);
-        assert!(swap_failure_reasons.is_empty());
+            LayoutHash([2; 32]),
+            Some(active_map.as_slice()),
+            Some(incoming_map.as_slice()),
+        );
+        assert!(result.is_err());
+        let message = result.expect_err("transition should fail");
+        assert!(message.contains("changed type"));
+        assert!(message.contains("restart required"));
     }
 
     #[test]
-    fn layout_change_policy_rejects_layout_hash_change_with_restart_required() {
-        let mut swap_commit_failures = 0u32;
-        let mut swap_failure_reasons = Vec::new();
-        let result = enforce_layout_change_policy(
-            RequestId(3),
-            Some(LayoutHash([1; 32])),
-            LayoutHash([2; 32]),
-            &mut swap_commit_failures,
-            &mut swap_failure_reasons,
-        )
-        .expect("layout change should be rejected");
+    fn validate_layout_transition_allows_added_and_removed_paths_when_types_match() {
+        let active_map = vec![
+            StateMapEntry {
+                path: "State.score".to_string(),
+                path_hash: 11,
+                type_name: "i32".to_string(),
+            },
+            StateMapEntry {
+                path: "State.removed".to_string(),
+                path_hash: 12,
+                type_name: "i32".to_string(),
+            },
+        ];
+        let incoming_map = vec![
+            StateMapEntry {
+                path: "State.score".to_string(),
+                path_hash: 21,
+                type_name: "i32".to_string(),
+            },
+            StateMapEntry {
+                path: "State.added".to_string(),
+                path_hash: 22,
+                type_name: "i32".to_string(),
+            },
+        ];
+        let result = validate_layout_transition(
+            Some(LayoutHash([3; 32])),
+            LayoutHash([4; 32]),
+            Some(active_map.as_slice()),
+            Some(incoming_map.as_slice()),
+        );
+        assert!(result.is_ok(), "expected migration-compatible transition");
+    }
 
-        assert_eq!(result.status, SwapCommitStatus::Failed);
-        assert_eq!(swap_commit_failures, 1);
-        assert_eq!(swap_failure_reasons.len(), 1);
-        let error = result.error.expect("error should be present");
-        assert!(error.contains("layout hash changed from"));
-        assert!(error.contains("hot reload state migration is not implemented yet"));
-        assert!(error.contains("restart required"));
+    #[test]
+    fn migrate_state_map_fields_copies_i32_for_matching_paths() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_jit_i32_global_table();
+        stasis_dynload::stasis_jit_global_i32_store(11, 777);
+        stasis_dynload::stasis_jit_global_i32_store(22, 0);
+
+        let active_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: 11,
+            type_name: "i32".to_string(),
+        }];
+        let incoming_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: 22,
+            type_name: "i32".to_string(),
+        }];
+
+        migrate_state_map_fields(&active_map, &incoming_map).expect("migration should succeed");
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(22), 777);
+        stasis_dynload::clear_jit_i32_global_table();
     }
 
     #[test]

--- a/crates/stasis_runner/src/swap/contracts.rs
+++ b/crates/stasis_runner/src/swap/contracts.rs
@@ -128,6 +128,13 @@ pub struct JitCodePtrOverride {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateMapEntry {
+    pub path: String,
+    pub path_hash: i32,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompileStatus {
     Success,
     Failed,
@@ -158,6 +165,8 @@ pub struct CompileResult {
     pub aot_function_symbols: Option<Vec<AotFunctionSymbol>>,
     #[serde(default)]
     pub jit_code_ptr_overrides: Option<Vec<JitCodePtrOverride>>,
+    #[serde(default)]
+    pub state_map: Option<Vec<StateMapEntry>>,
 }
 
 impl CompileResult {
@@ -220,6 +229,7 @@ impl CompileResult {
             aot_linked_image_sha256,
             aot_function_symbols,
             jit_code_ptr_overrides: None,
+            state_map: None,
         }
     }
 
@@ -240,6 +250,7 @@ impl CompileResult {
             aot_linked_image_sha256: None,
             aot_function_symbols: None,
             jit_code_ptr_overrides: None,
+            state_map: None,
         }
     }
 }
@@ -257,6 +268,8 @@ pub struct SwapCommitRequest {
     pub host_set_hash: Option<[u8; 32]>,
     #[serde(default)]
     pub hook_fn_id: Option<FnId>,
+    #[serde(default)]
+    pub state_map: Option<Vec<StateMapEntry>>,
 }
 
 impl SwapCommitRequest {
@@ -275,6 +288,7 @@ impl SwapCommitRequest {
             host_set_id: None,
             host_set_hash: None,
             hook_fn_id: None,
+            state_map: None,
         }
     }
 }

--- a/crates/stasis_runner/src/swap/pipeline.rs
+++ b/crates/stasis_runner/src/swap/pipeline.rs
@@ -251,6 +251,7 @@ impl DevHotSwapPipeline {
                                 result.host_set_id.clone(),
                                 result.host_set_hash,
                                 result.hook_fn_id,
+                                result.state_map.clone(),
                             );
                         }
                     }
@@ -269,6 +270,7 @@ impl DevHotSwapPipeline {
         host_set_id: Option<String>,
         host_set_hash: Option<[u8; 32]>,
         hook_fn_id: Option<FnId>,
+        state_map: Option<Vec<crate::swap::contracts::StateMapEntry>>,
     ) {
         let Some(layout_hash) = layout_hash else {
             return;
@@ -289,6 +291,7 @@ impl DevHotSwapPipeline {
             host_set_id,
             host_set_hash,
             hook_fn_id,
+            state_map,
         };
         let _ = self.commit_request_tx.send(request);
         self.in_flight_commit = Some(request_id);

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -685,7 +685,7 @@ Rules:
 - Retire previous code generation.
 
 Swap is rejected if:
-- Global layout changes.
+- Global layout changes and state-map migration is missing or incompatible.
 - Signature compatibility changes.
 - `on_code_swap()` fails.
 
@@ -694,6 +694,11 @@ Current policy (pre-1.0):
 - Automatic blob state migration (`state-map` old->new layout copy) is planned but not yet implemented.
 
 On rejection, old code and old data remain active.
+
+Current migration policy (pre-1.0):
+- Layout hash changes can commit only when both active and incoming builds provide deterministic state-map metadata.
+- Migration compatibility is path-based: overlapping paths must keep compatible type shape; added/removed paths are allowed.
+- Incompatible or missing state-map metadata fails commit deterministically with actionable `restart required` diagnostics.
 
 ### 14.4 Development File-Change Boundary Contracts
 
@@ -708,8 +713,8 @@ Role ownership:
 Required high-level message contracts:
 - `FileChangeEvent(path, revision, text_source, change_kind)`
 - `CompileRequest(request_id, changed_files[], target_mode)`
-- `CompileResult(request_id, status, diagnostics[], layout_hash, fn_patch_set, hook_symbol?)`
-- `SwapCommitRequest(request_id, layout_hash, fn_patch_set, hook_symbol)`
+- `CompileResult(request_id, status, diagnostics[], layout_hash, fn_patch_set, hook_symbol?, state_map?)`
+- `SwapCommitRequest(request_id, layout_hash, fn_patch_set, hook_symbol, state_map?)`
 - `SwapCommitResult(request_id, status, swapped_fn_ids[], new_generation, error)`
 
 Rules:


### PR DESCRIPTION
## Summary
- add state_map metadata to compile/commit swap contracts and pipeline propagation
- extract deterministic flattened state-map entries from compiler source cache (including struct-field flattening)
- reject recursive struct layouts during state-map extraction with deterministic diagnostics
- add layout-transition validation in runner: allow layout-hash changes only when state-map metadata exists and overlapping paths keep compatible type shape
- apply best-effort migration for scalar paths (i32 lane, 32, 64) across layout-change commits
- keep deterministic estart required failures for missing/incompatible state-map metadata

## Validation
- cargo test -p stasis_runner --release
- cargo test -p stasis --release --lib validate_layout_transition_ -- --nocapture
- cargo test -p stasis --release --lib migrate_state_map_fields_ -- --nocapture
- cargo test -p stasis --release --lib jit_dev_non_engine_result_includes_flattened_state_map_entries -- --nocapture
- cargo test -p stasis --release --lib state_map_extraction_rejects_recursive_structs -- --nocapture
- cargo test -p stasis --release --lib runner_loop_compiles_and_commits_one_change -- --nocapture
- cargo test -p stasis --release --lib real_backend_smoke_compiles_and_commits_literal_main -- --nocapture
- cargo test -p stasis --release --lib bench_perf_balls_bricks_v1_jit_executes_1000_ticks -- --ignored --nocapture
- cargo test -p stasis --release --lib bench_brickout_revenge_v1_jit_executes_1000_ticks -- --ignored --nocapture

## Notes
- State-map compatibility is currently path-based (overlapping path names must keep type shape). Added/removed paths are allowed.
- Migration writes scalar values into incoming state-map path hashes; collection/string-like entries are treated as non-scalar and skipped for direct scalar copy in this slice.
