### PR TITLE
S15/S16: phase-gated extern effects and host-set budget enforcement

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -102,6 +102,7 @@ struct EngineBundleManifestCollectionMaxLengthRow {
 
 #[derive(Debug, Clone, Deserialize)]
 struct EngineBundleManifest {
+    #[allow(dead_code)]
     #[serde(default)]
     optimization_profile: Option<String>,
     functions: Vec<EngineBundleManifestFunctionRow>,

--- a/apps/stasis/src/events.rs
+++ b/apps/stasis/src/events.rs
@@ -29,6 +29,14 @@ pub enum RunnerEvent {
         error: Option<String>,
         commit_duration_ms: Option<u64>,
     },
+    HostSetBudgetReport {
+        request_id: u64,
+        phase: String,
+        effect_calls: u32,
+        effect_bytes: u32,
+        dropped_effects: u32,
+        violations: Vec<String>,
+    },
     Summary {
         ticks_executed: u32,
         compile_successes: u32,

--- a/apps/stasis/src/host_set_registry.rs
+++ b/apps/stasis/src/host_set_registry.rs
@@ -34,6 +34,59 @@ impl HostSetProfile {
 pub struct HostSetContract {
     pub host_set_id: String,
     pub host_set_hash: [u8; 32],
+    pub extern_phase_classes: BTreeMap<String, HostExternPhaseClass>,
+    pub budget_policy: HostSetBudgetPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostExternPhaseClass {
+    TickSafe,
+    CommitOnly,
+    EffectQueued,
+}
+
+impl HostExternPhaseClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HostExternPhaseClass::TickSafe => "tick_safe",
+            HostExternPhaseClass::CommitOnly => "commit_only",
+            HostExternPhaseClass::EffectQueued => "effect_queued",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "tick_safe" => Some(HostExternPhaseClass::TickSafe),
+            "commit_only" => Some(HostExternPhaseClass::CommitOnly),
+            "effect_queued" => Some(HostExternPhaseClass::EffectQueued),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostSetBudgetPolicy {
+    pub max_effect_calls_per_tick: u32,
+    pub max_effect_bytes_per_tick: u32,
+}
+
+impl HostSetBudgetPolicy {
+    fn default_for_profile(profile: HostSetProfile) -> Self {
+        match profile {
+            HostSetProfile::Dev => Self {
+                max_effect_calls_per_tick: 10_000,
+                max_effect_bytes_per_tick: 4 * 1024 * 1024,
+            },
+            HostSetProfile::Test => Self {
+                max_effect_calls_per_tick: 2_000,
+                max_effect_bytes_per_tick: 1024 * 1024,
+            },
+            HostSetProfile::Prod => Self {
+                max_effect_calls_per_tick: 1_000,
+                max_effect_bytes_per_tick: 512 * 1024,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -46,13 +99,226 @@ struct HostSetRegistryProfileEntry {
     id: String,
     #[serde(default)]
     hash: Option<String>,
+    #[serde(default)]
+    phase_classes: BTreeMap<String, String>,
+    #[serde(default)]
+    budgets: Option<HostSetRegistryBudgetEntry>,
 }
 
-pub fn contract_hash_from_id(host_set_id: &str) -> [u8; 32] {
-    // Deterministic placeholder hash until the contract includes export/phase metadata.
-    let input = format!("stasis.host_set_contract.v1:{host_set_id}");
+#[derive(Debug, Clone, Deserialize)]
+struct HostSetRegistryBudgetEntry {
+    #[serde(default)]
+    max_effect_calls_per_tick: Option<u32>,
+    #[serde(default)]
+    max_effect_bytes_per_tick: Option<u32>,
+}
+
+fn contract_hash_from_contract(
+    host_set_id: &str,
+    extern_phase_classes: &BTreeMap<String, HostExternPhaseClass>,
+    budget_policy: HostSetBudgetPolicy,
+) -> [u8; 32] {
+    let mut input = format!("stasis.host_set_contract.v2:{host_set_id}|");
+    for (symbol, phase_class) in extern_phase_classes {
+        input.push_str(symbol);
+        input.push('=');
+        input.push_str(phase_class.as_str());
+        input.push(';');
+    }
+    input.push_str(&format!(
+        "max_effect_calls_per_tick={};max_effect_bytes_per_tick={};",
+        budget_policy.max_effect_calls_per_tick, budget_policy.max_effect_bytes_per_tick
+    ));
     let digest: [u8; 32] = Sha256::digest(input.as_bytes()).into();
     digest
+}
+
+fn default_extern_phase_classes() -> BTreeMap<String, HostExternPhaseClass> {
+    let mut map = BTreeMap::new();
+    map.insert("print_i32".to_string(), HostExternPhaseClass::EffectQueued);
+    map.insert(
+        "stasis_jit_print_i32".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "print_string".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "stasis_jit_print_string".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "audio_push_f32_interleaved".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "stasis_audio_push_f32_interleaved".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "gfx_dump_bmp".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "stasis_gfx_dump_bmp".to_string(),
+        HostExternPhaseClass::EffectQueued,
+    );
+    map.insert(
+        "gfx_load_sprite".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_gfx_load_sprite".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("load_font".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_load_font".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("measure_text".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_measure_text".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("gfx_cache_text".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_gfx_cache_text".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "gfx_poll_reload".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_gfx_poll_reload".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "gfx_measure_text_cached".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_gfx_measure_text_cached".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("sleep_ms".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_jit_sleep_ms".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "audio_is_available".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_audio_is_available".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("audio_init".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_jit_audio_init".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert("audio_shutdown".to_string(), HostExternPhaseClass::TickSafe);
+    map.insert(
+        "stasis_jit_audio_shutdown".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "audio_get_sample_rate".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_audio_get_sample_rate".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "audio_get_channels".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_audio_get_channels".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "audio_get_queued_frames".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_audio_get_queued_frames".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "audio_get_underruns".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map.insert(
+        "stasis_jit_audio_get_underruns".to_string(),
+        HostExternPhaseClass::TickSafe,
+    );
+    map
+}
+
+fn parse_phase_class_overrides(
+    profile: HostSetProfile,
+    path: &Path,
+    overrides: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, HostExternPhaseClass>, String> {
+    let mut classes = default_extern_phase_classes();
+    for (raw_symbol, raw_phase_class) in overrides {
+        let symbol = raw_symbol.trim().to_string();
+        if symbol.is_empty() {
+            return Err(format!(
+                "host-set registry {} profile '{}' has empty phase class symbol",
+                path.display(),
+                profile.as_str()
+            ));
+        }
+        let Some(phase_class) = HostExternPhaseClass::parse(raw_phase_class) else {
+            return Err(format!(
+                "host-set registry {} profile '{}' has invalid phase class '{}' for symbol '{}' (expected tick_safe|commit_only|effect_queued)",
+                path.display(),
+                profile.as_str(),
+                raw_phase_class,
+                symbol
+            ));
+        };
+        classes.insert(symbol, phase_class);
+    }
+    Ok(classes)
+}
+
+fn resolve_budget_policy(
+    profile: HostSetProfile,
+    path: &Path,
+    override_entry: Option<&HostSetRegistryBudgetEntry>,
+) -> Result<HostSetBudgetPolicy, String> {
+    let mut budget = HostSetBudgetPolicy::default_for_profile(profile);
+    if let Some(entry) = override_entry {
+        if let Some(value) = entry.max_effect_calls_per_tick {
+            if value == 0 {
+                return Err(format!(
+                    "host-set registry {} profile '{}' max_effect_calls_per_tick must be > 0",
+                    path.display(),
+                    profile.as_str()
+                ));
+            }
+            budget.max_effect_calls_per_tick = value;
+        }
+        if let Some(value) = entry.max_effect_bytes_per_tick {
+            if value == 0 {
+                return Err(format!(
+                    "host-set registry {} profile '{}' max_effect_bytes_per_tick must be > 0",
+                    path.display(),
+                    profile.as_str()
+                ));
+            }
+            budget.max_effect_bytes_per_tick = value;
+        }
+    }
+    Ok(budget)
 }
 
 pub fn resolve_profile_contract(
@@ -90,6 +356,10 @@ pub fn resolve_profile_contract(
             ));
         }
 
+        let extern_phase_classes =
+            parse_phase_class_overrides(profile, path, &entry.phase_classes)?;
+        let budget_policy = resolve_budget_policy(profile, path, entry.budgets.as_ref())?;
+
         let host_set_hash = if let Some(hash) = entry.hash.as_deref() {
             parse_sha256_hex(hash).map_err(|message| {
                 format!(
@@ -99,19 +369,29 @@ pub fn resolve_profile_contract(
                 )
             })?
         } else {
-            contract_hash_from_id(&host_set_id)
+            contract_hash_from_contract(&host_set_id, &extern_phase_classes, budget_policy)
         };
 
         return Ok(HostSetContract {
             host_set_id,
             host_set_hash,
+            extern_phase_classes,
+            budget_policy,
         });
     }
 
     let host_set_id = format!("stasis-{}", profile.as_str());
+    let extern_phase_classes = default_extern_phase_classes();
+    let budget_policy = HostSetBudgetPolicy::default_for_profile(profile);
     Ok(HostSetContract {
         host_set_id: host_set_id.clone(),
-        host_set_hash: contract_hash_from_id(&host_set_id),
+        host_set_hash: contract_hash_from_contract(
+            &host_set_id,
+            &extern_phase_classes,
+            budget_policy,
+        ),
+        extern_phase_classes,
+        budget_policy,
     })
 }
 
@@ -140,6 +420,12 @@ mod tests {
         assert_eq!(a, b);
         assert_eq!(a.host_set_id, "stasis-dev");
         assert_ne!(a.host_set_hash, [0u8; 32]);
+        assert_eq!(
+            a.extern_phase_classes.get("print_i32"),
+            Some(&HostExternPhaseClass::EffectQueued)
+        );
+        assert!(a.budget_policy.max_effect_calls_per_tick > 0);
+        assert!(a.budget_policy.max_effect_bytes_per_tick > 0);
     }
 
     #[test]
@@ -149,7 +435,12 @@ mod tests {
             &tmp,
             r#"{
   "profiles": {
-    "dev": { "id": "editor-host", "hash": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" }
+    "dev": {
+      "id": "editor-host",
+      "hash": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "phase_classes": { "print_i32": "commit_only" },
+      "budgets": { "max_effect_calls_per_tick": 77, "max_effect_bytes_per_tick": 8888 }
+    }
   }
 }"#,
         )
@@ -159,6 +450,12 @@ mod tests {
         assert_eq!(contract.host_set_id, "editor-host");
         assert_eq!(contract.host_set_hash[0], 0);
         assert_eq!(contract.host_set_hash[31], 31);
+        assert_eq!(
+            contract.extern_phase_classes.get("print_i32"),
+            Some(&HostExternPhaseClass::CommitOnly)
+        );
+        assert_eq!(contract.budget_policy.max_effect_calls_per_tick, 77);
+        assert_eq!(contract.budget_policy.max_effect_bytes_per_tick, 8888);
     }
 
     #[test]
@@ -176,5 +473,25 @@ mod tests {
 
         let error = resolve_profile_contract(HostSetProfile::Dev, Some(&tmp)).unwrap_err();
         assert!(error.contains("missing profile entry"));
+    }
+
+    #[test]
+    fn registry_file_invalid_phase_class_is_error() {
+        let tmp = std::env::temp_dir().join("stasis_host_set_registry_invalid_phase.json");
+        fs::write(
+            &tmp,
+            r#"{
+  "profiles": {
+    "dev": {
+      "id": "editor-host",
+      "phase_classes": { "print_i32": "unknown_phase" }
+    }
+  }
+}"#,
+        )
+        .expect("write tmp");
+
+        let error = resolve_profile_contract(HostSetProfile::Dev, Some(&tmp)).unwrap_err();
+        assert!(error.contains("invalid phase class"));
     }
 }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -34,7 +34,7 @@ use stasis_runner::swap::contracts::{
     TextSource,
 };
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::thread;
@@ -124,6 +124,14 @@ pub struct RunnerSummary {
 const STASIS_HOST_SET_PROFILE_ENV: &str = "STASIS_HOST_SET_PROFILE";
 const STASIS_HOST_SET_REGISTRY_FILE_ENV: &str = "STASIS_HOST_SET_REGISTRY_FILE";
 
+struct HostRuntimeGuard;
+
+impl Drop for HostRuntimeGuard {
+    fn drop(&mut self) {
+        stasis_dynload::disable_host_runtime();
+    }
+}
+
 fn infer_host_set_profile_from_target_mode(
     target_mode: TargetMode,
 ) -> host_set_registry::HostSetProfile {
@@ -159,6 +167,38 @@ fn resolve_host_set_contract(
         });
 
     host_set_registry::resolve_profile_contract(profile, registry_file.as_deref())
+}
+
+fn to_dynload_phase_class(
+    phase_class: host_set_registry::HostExternPhaseClass,
+) -> stasis_dynload::HostExternPhaseClass {
+    match phase_class {
+        host_set_registry::HostExternPhaseClass::TickSafe => {
+            stasis_dynload::HostExternPhaseClass::TickSafe
+        }
+        host_set_registry::HostExternPhaseClass::CommitOnly => {
+            stasis_dynload::HostExternPhaseClass::CommitOnly
+        }
+        host_set_registry::HostExternPhaseClass::EffectQueued => {
+            stasis_dynload::HostExternPhaseClass::EffectQueued
+        }
+    }
+}
+
+fn configure_dynload_host_runtime(contract: &host_set_registry::HostSetContract) {
+    let mut extern_phase_classes: HashMap<String, stasis_dynload::HostExternPhaseClass> =
+        HashMap::new();
+    for (symbol, phase_class) in &contract.extern_phase_classes {
+        extern_phase_classes.insert(symbol.clone(), to_dynload_phase_class(*phase_class));
+    }
+    stasis_dynload::configure_host_runtime(stasis_dynload::HostSetRuntimeConfig {
+        enabled: true,
+        extern_phase_classes,
+        budget: stasis_dynload::HostSetRuntimeBudget {
+            max_effect_calls_per_tick: contract.budget_policy.max_effect_calls_per_tick,
+            max_effect_bytes_per_tick: contract.budget_policy.max_effect_bytes_per_tick,
+        },
+    });
 }
 
 pub fn run_with_default_backend(config: RunnerConfig) -> RunnerSummary {
@@ -241,6 +281,12 @@ pub fn run_play_in_process(
     }
 
     let watch_dir = resolve_play_watch_dir(watch_file, watch_dir);
+
+    let host_set_contract =
+        host_set_registry::resolve_profile_contract(host_set_registry::HostSetProfile::Dev, None)
+            .map_err(|error| format!("failed to resolve default dev host-set contract: {error}"))?;
+    configure_dynload_host_runtime(&host_set_contract);
+    let _host_runtime_guard = HostRuntimeGuard;
 
     // Make relative asset paths (e.g. "assets/ball.svg") resolve against the game directory.
     // Use the watch dir so dev workflows stay consistent across `stasis.exe` launch locations.
@@ -427,8 +473,16 @@ pub fn run_play_in_process(
                                 let t_hook = Instant::now();
                                 // Run the hook against the newly compiled code. If it fails, abort the swap attempt
                                 // and keep running last-known-good code/data.
-                                if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize)
-                                {
+                                stasis_dynload::begin_host_commit_phase();
+                                let hook_result = stasis_dynload::invoke_noarg_void(hook as usize);
+                                let hook_report = stasis_dynload::end_host_phase();
+                                if !hook_report.violations.is_empty() {
+                                    hook_ms = t_hook.elapsed().as_millis();
+                                    hook_failed = Some(format!(
+                                        "host-set policy violation(s): {}",
+                                        hook_report.violations.join(" | ")
+                                    ));
+                                } else if let Err(error) = hook_result {
                                     hook_ms = t_hook.elapsed().as_millis();
                                     hook_failed = Some(error);
                                 } else {
@@ -487,7 +541,16 @@ pub fn run_play_in_process(
             &host_req_window_h_px,
         )?;
 
-        let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
+        stasis_dynload::begin_host_tick_phase();
+        let tick_result = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize);
+        let tick_report = stasis_dynload::end_host_phase();
+        if !tick_report.violations.is_empty() {
+            return Err(format!(
+                "tick host-set policy violation(s): {}",
+                tick_report.violations.join(" | ")
+            ));
+        }
+        let tick_rc = tick_result?;
         if tick_rc != 0 {
             break;
         }
@@ -752,6 +815,8 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
             };
         }
     };
+    configure_dynload_host_runtime(&host_set_contract);
+    let _host_runtime_guard = HostRuntimeGuard;
 
     let mut pipeline = DevHotSwapPipeline::with_target_mode(backend, config.target_mode);
     pipeline.set_host_set_contract(
@@ -1190,7 +1255,28 @@ fn apply_commit_request(
                     swap_failure_reasons.push(hook_error.clone());
                     return SwapCommitResult::failed(request.request_id, hook_error);
                 }
-                if let Err(error) = stasis_dynload::invoke_noarg_void(code_ptr as usize) {
+                stasis_dynload::begin_host_commit_phase();
+                let hook_result = stasis_dynload::invoke_noarg_void(code_ptr as usize);
+                let hook_report = stasis_dynload::end_host_phase();
+                push_host_set_budget_event(events, request.request_id, &hook_report);
+                if !hook_report.violations.is_empty() {
+                    *hook_failures += 1;
+                    let hook_error = format!(
+                        "{hook_symbol} failed: host-set policy violation(s): {}",
+                        hook_report.violations.join(" | ")
+                    );
+                    hook_failure_reasons.push(hook_error.clone());
+                    events.push(RunnerEvent::HookResult {
+                        request_id: request.request_id.0,
+                        symbol: hook_symbol.to_string(),
+                        status: "failed".to_string(),
+                        error: Some(hook_error.clone()),
+                    });
+                    *swap_commit_failures += 1;
+                    swap_failure_reasons.push(hook_error.clone());
+                    return SwapCommitResult::failed(request.request_id, hook_error);
+                }
+                if let Err(error) = hook_result {
                     *hook_failures += 1;
                     let hook_error = format!("{hook_symbol} failed: {error}");
                     hook_failure_reasons.push(hook_error.clone());
@@ -1358,7 +1444,28 @@ fn apply_commit_request(
                 }
             };
 
-            if let Err(error) = stasis_dynload::invoke_noarg_void(address) {
+            stasis_dynload::begin_host_commit_phase();
+            let hook_result = stasis_dynload::invoke_noarg_void(address);
+            let hook_report = stasis_dynload::end_host_phase();
+            push_host_set_budget_event(events, request.request_id, &hook_report);
+            if !hook_report.violations.is_empty() {
+                *hook_failures += 1;
+                let hook_error = format!(
+                    "{hook_symbol} failed: host-set policy violation(s): {}",
+                    hook_report.violations.join(" | ")
+                );
+                hook_failure_reasons.push(hook_error.clone());
+                events.push(RunnerEvent::HookResult {
+                    request_id: request.request_id.0,
+                    symbol: hook_symbol.to_string(),
+                    status: "failed".to_string(),
+                    error: Some(hook_error.clone()),
+                });
+                *swap_commit_failures += 1;
+                swap_failure_reasons.push(hook_error.clone());
+                return SwapCommitResult::failed(request.request_id, hook_error);
+            }
+            if let Err(error) = hook_result {
                 *hook_failures += 1;
                 let hook_error = format!("{hook_symbol} failed: {error}");
                 hook_failure_reasons.push(hook_error.clone());
@@ -1429,6 +1536,29 @@ fn apply_commit_request(
         outcome.swapped_fn_ids,
         outcome.new_generation,
     )
+}
+
+fn push_host_set_budget_event(
+    events: &mut Vec<RunnerEvent>,
+    request_id: RequestId,
+    report: &stasis_dynload::HostSetRuntimeReport,
+) {
+    if report.effect_calls == 0
+        && report.effect_bytes == 0
+        && report.dropped_effects == 0
+        && report.violations.is_empty()
+    {
+        return;
+    }
+
+    events.push(RunnerEvent::HostSetBudgetReport {
+        request_id: request_id.0,
+        phase: report.phase.to_string(),
+        effect_calls: report.effect_calls,
+        effect_bytes: report.effect_bytes,
+        dropped_effects: report.dropped_effects,
+        violations: report.violations.clone(),
+    });
 }
 
 fn observe_pipeline_results(
@@ -1605,6 +1735,10 @@ mod tests {
     ) {
         request.host_set_id = Some(contract.host_set_id.clone());
         request.host_set_hash = Some(contract.host_set_hash);
+    }
+
+    extern "system" fn test_effectful_hook_print_i32() {
+        stasis_dynload::stasis_jit_print_i32(7);
     }
 
     #[test]
@@ -1967,6 +2101,86 @@ mod tests {
         );
         assert_eq!(pointer_table.generation().0, 0);
         assert!(pointer_table.code_ptr(FnId(9)).is_none());
+    }
+
+    #[test]
+    fn apply_commit_request_rejects_effect_queued_host_call_from_hook_phase() {
+        let request_id = RequestId(77);
+        let mut request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+            request_id,
+            LayoutHash([7; 32]),
+            FunctionPatchSet {
+                functions: vec![FunctionPatch { fn_id: FnId(9) }],
+            },
+            Some("on_code_swap".to_string()),
+        );
+        request.hook_fn_id = Some(FnId(7));
+
+        let mut pointer_table = FunctionPointerTable::new();
+        let config = RunnerConfig {
+            target_mode: TargetMode::JitDev,
+            runtime_launch: false,
+            ..RunnerConfig::default()
+        };
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
+        configure_dynload_host_runtime(&host_set_contract);
+        let _host_runtime_guard = HostRuntimeGuard;
+
+        let mut hook_runs = 0u32;
+        let mut hook_failures = 0u32;
+        let mut hook_failure_reasons = Vec::new();
+        let mut swap_commit_successes = 0u32;
+        let mut swap_commit_failures = 0u32;
+        let mut swap_failure_reasons = Vec::new();
+        let mut events = Vec::new();
+        let pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
+        let mut pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
+            BTreeMap::new();
+        pending_jit_code_ptr_overrides.insert(
+            request_id,
+            vec![JitCodePtrOverride {
+                fn_id: FnId(7),
+                code_ptr: test_effectful_hook_print_i32 as usize as u64,
+            }],
+        );
+
+        let result = apply_commit_request(
+            request,
+            &mut pointer_table,
+            &config,
+            &host_set_contract,
+            &mut hook_runs,
+            &mut hook_failures,
+            &mut hook_failure_reasons,
+            &mut swap_commit_successes,
+            &mut swap_commit_failures,
+            &mut swap_failure_reasons,
+            &mut events,
+            None,
+            None,
+            &pending_aot_metadata,
+            &pending_jit_code_ptr_overrides,
+        );
+
+        assert_eq!(result.status, SwapCommitStatus::Failed);
+        assert_eq!(hook_runs, 1);
+        assert_eq!(hook_failures, 1);
+        assert_eq!(swap_commit_successes, 0);
+        assert_eq!(swap_commit_failures, 1);
+        assert!(
+            result.error.as_ref().is_some_and(|error| {
+                error.contains("host-set policy violation") && error.contains("effect_queued")
+            }),
+            "expected host-set phase violation, got {:?}",
+            result.error
+        );
+        assert_eq!(pointer_table.generation().0, 0);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            RunnerEvent::HostSetBudgetReport { phase, violations, .. }
+                if phase == "commit" && !violations.is_empty()
+        )));
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -151,6 +151,267 @@ pub fn invoke_i32_i32_to_i32(address: usize, left: i32, right: i32) -> Result<i3
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostExternPhaseClass {
+    TickSafe,
+    CommitOnly,
+    EffectQueued,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostSetRuntimeBudget {
+    pub max_effect_calls_per_tick: u32,
+    pub max_effect_bytes_per_tick: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSetRuntimeConfig {
+    pub enabled: bool,
+    pub extern_phase_classes: HashMap<String, HostExternPhaseClass>,
+    pub budget: HostSetRuntimeBudget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSetRuntimeReport {
+    pub phase: &'static str,
+    pub effect_calls: u32,
+    pub effect_bytes: u32,
+    pub dropped_effects: u32,
+    pub violations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostRuntimePhase {
+    None,
+    Tick,
+    Commit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum QueuedHostEffect {
+    PrintI32(i32),
+    PrintString(String),
+}
+
+#[derive(Debug)]
+struct HostRuntimeState {
+    enabled: bool,
+    phase: HostRuntimePhase,
+    extern_phase_classes: HashMap<String, HostExternPhaseClass>,
+    max_effect_calls_per_tick: u32,
+    max_effect_bytes_per_tick: u32,
+    tick_effect_calls: u32,
+    tick_effect_bytes: u32,
+    dropped_effects: u32,
+    queued_effects: Vec<QueuedHostEffect>,
+    violations: Vec<String>,
+}
+
+impl Default for HostRuntimeState {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            phase: HostRuntimePhase::None,
+            extern_phase_classes: HashMap::new(),
+            max_effect_calls_per_tick: 0,
+            max_effect_bytes_per_tick: 0,
+            tick_effect_calls: 0,
+            tick_effect_bytes: 0,
+            dropped_effects: 0,
+            queued_effects: Vec::new(),
+            violations: Vec::new(),
+        }
+    }
+}
+
+fn host_runtime_state() -> &'static Mutex<HostRuntimeState> {
+    static STATE: OnceLock<Mutex<HostRuntimeState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HostRuntimeState::default()))
+}
+
+pub fn configure_host_runtime(config: HostSetRuntimeConfig) {
+    let state = host_runtime_state();
+    let mut guard = state.lock().expect("host runtime state mutex poisoned");
+    guard.enabled = config.enabled;
+    guard.phase = HostRuntimePhase::None;
+    guard.extern_phase_classes = config.extern_phase_classes;
+    guard.max_effect_calls_per_tick = config.budget.max_effect_calls_per_tick;
+    guard.max_effect_bytes_per_tick = config.budget.max_effect_bytes_per_tick;
+    guard.tick_effect_calls = 0;
+    guard.tick_effect_bytes = 0;
+    guard.dropped_effects = 0;
+    guard.queued_effects.clear();
+    guard.violations.clear();
+}
+
+pub fn disable_host_runtime() {
+    configure_host_runtime(HostSetRuntimeConfig {
+        enabled: false,
+        extern_phase_classes: HashMap::new(),
+        budget: HostSetRuntimeBudget {
+            max_effect_calls_per_tick: 0,
+            max_effect_bytes_per_tick: 0,
+        },
+    });
+}
+
+pub fn begin_host_tick_phase() {
+    let state = host_runtime_state();
+    let mut guard = state.lock().expect("host runtime state mutex poisoned");
+    guard.phase = HostRuntimePhase::Tick;
+    guard.tick_effect_calls = 0;
+    guard.tick_effect_bytes = 0;
+    guard.dropped_effects = 0;
+    guard.queued_effects.clear();
+    guard.violations.clear();
+}
+
+pub fn begin_host_commit_phase() {
+    let state = host_runtime_state();
+    let mut guard = state.lock().expect("host runtime state mutex poisoned");
+    guard.phase = HostRuntimePhase::Commit;
+    guard.violations.clear();
+}
+
+pub fn end_host_phase() -> HostSetRuntimeReport {
+    let state = host_runtime_state();
+    let (phase, effect_calls, effect_bytes, dropped_effects, queued, violations) = {
+        let mut guard = state.lock().expect("host runtime state mutex poisoned");
+        let phase = match guard.phase {
+            HostRuntimePhase::None => "none",
+            HostRuntimePhase::Tick => "tick",
+            HostRuntimePhase::Commit => "commit",
+        };
+        let effect_calls = guard.tick_effect_calls;
+        let effect_bytes = guard.tick_effect_bytes;
+        let dropped_effects = guard.dropped_effects;
+        let queued = std::mem::take(&mut guard.queued_effects);
+        let violations = std::mem::take(&mut guard.violations);
+        guard.phase = HostRuntimePhase::None;
+        (
+            phase,
+            effect_calls,
+            effect_bytes,
+            dropped_effects,
+            queued,
+            violations,
+        )
+    };
+
+    if phase == "tick" && violations.is_empty() {
+        for effect in queued {
+            match effect {
+                QueuedHostEffect::PrintI32(value) => {
+                    do_print_i32(value);
+                }
+                QueuedHostEffect::PrintString(text) => {
+                    do_print_string(&text);
+                }
+            }
+        }
+    }
+
+    HostSetRuntimeReport {
+        phase,
+        effect_calls,
+        effect_bytes,
+        dropped_effects,
+        violations,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostCallDecision {
+    ExecuteNow,
+    Queue,
+    Reject,
+}
+
+fn resolve_host_phase_class(
+    guard: &HostRuntimeState,
+    symbol: &str,
+) -> Result<HostExternPhaseClass, String> {
+    guard
+        .extern_phase_classes
+        .get(symbol)
+        .copied()
+        .ok_or_else(|| format!("host-set policy violation: extern '{symbol}' is not exported"))
+}
+
+fn evaluate_host_call(
+    symbol: &str,
+    estimated_effect_bytes: u32,
+    queue_supported: bool,
+) -> HostCallDecision {
+    let state = host_runtime_state();
+    let mut guard = state.lock().expect("host runtime state mutex poisoned");
+    if !guard.enabled || guard.phase == HostRuntimePhase::None {
+        return HostCallDecision::ExecuteNow;
+    }
+
+    let phase_class = match resolve_host_phase_class(&guard, symbol) {
+        Ok(phase_class) => phase_class,
+        Err(message) => {
+            guard.violations.push(message);
+            return HostCallDecision::Reject;
+        }
+    };
+
+    match guard.phase {
+        HostRuntimePhase::Tick => match phase_class {
+            HostExternPhaseClass::TickSafe => HostCallDecision::ExecuteNow,
+            HostExternPhaseClass::CommitOnly => {
+                guard.violations.push(format!(
+                    "host-set phase violation: extern '{symbol}' is commit_only and cannot run on tick path"
+                ));
+                HostCallDecision::Reject
+            }
+            HostExternPhaseClass::EffectQueued => {
+                if !queue_supported {
+                    guard.violations.push(format!(
+                        "host-set phase violation: extern '{symbol}' is effect_queued but queue support is unavailable"
+                    ));
+                    return HostCallDecision::Reject;
+                }
+                let next_calls = guard.tick_effect_calls.saturating_add(1);
+                let next_bytes = guard
+                    .tick_effect_bytes
+                    .saturating_add(estimated_effect_bytes);
+                if next_calls > guard.max_effect_calls_per_tick
+                    || next_bytes > guard.max_effect_bytes_per_tick
+                {
+                    let limit_calls = guard.max_effect_calls_per_tick;
+                    let limit_bytes = guard.max_effect_bytes_per_tick;
+                    guard.dropped_effects = guard.dropped_effects.saturating_add(1);
+                    guard.violations.push(format!(
+                        "host-set budget violation: extern '{symbol}' exceeded per-tick budget (calls={}, bytes={}, limit_calls={}, limit_bytes={})",
+                        next_calls,
+                        next_bytes,
+                        limit_calls,
+                        limit_bytes
+                    ));
+                    return HostCallDecision::Reject;
+                }
+                guard.tick_effect_calls = next_calls;
+                guard.tick_effect_bytes = next_bytes;
+                HostCallDecision::Queue
+            }
+        },
+        HostRuntimePhase::Commit => match phase_class {
+            HostExternPhaseClass::EffectQueued => {
+                guard.violations.push(format!(
+                    "host-set phase violation: extern '{symbol}' is effect_queued and cannot run on commit path"
+                ));
+                HostCallDecision::Reject
+            }
+            HostExternPhaseClass::TickSafe | HostExternPhaseClass::CommitOnly => {
+                HostCallDecision::ExecuteNow
+            }
+        },
+        HostRuntimePhase::None => HostCallDecision::ExecuteNow,
+    }
+}
+
 pub fn invoke_i32_i32_i32_i32_to_void(
     address: usize,
     arg0: i32,
@@ -173,8 +434,7 @@ pub fn invoke_i32_i32_i32_i32_to_void(
     }
     #[cfg(not(windows))]
     {
-        let callback: extern "C" fn(i32, i32, i32, i32) =
-            unsafe { std::mem::transmute(address) };
+        let callback: extern "C" fn(i32, i32, i32, i32) = unsafe { std::mem::transmute(address) };
         callback(arg0, arg1, arg2, arg3);
         Ok(())
     }
@@ -687,7 +947,9 @@ pub extern "C" fn stasis_jit_global_f32_array_ptr(
         let mut owned_guard = owned_f32_arrays()
             .lock()
             .expect("owned f32 array table mutex poisoned");
-        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0.0; requested_len]);
         if array.len() < requested_len {
             array.resize(requested_len, 0.0);
         }
@@ -747,7 +1009,9 @@ pub extern "C" fn stasis_jit_global_f64_array_ptr(
         let mut owned_guard = owned_f64_arrays()
             .lock()
             .expect("owned f64 array table mutex poisoned");
-        let array = owned_guard.entry(key).or_insert_with(|| vec![0.0; requested_len]);
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0.0; requested_len]);
         if array.len() < requested_len {
             array.resize(requested_len, 0.0);
         }
@@ -780,20 +1044,59 @@ pub extern "C" fn stasis_jit_global_f64_array_ptr(
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_print_i32(value: i32) {
-    print!("{value}");
-    let _ = std::io::stdout().flush();
+    match evaluate_host_call("print_i32", 12, true) {
+        HostCallDecision::ExecuteNow => do_print_i32(value),
+        HostCallDecision::Queue => {
+            let state = host_runtime_state();
+            let mut guard = state.lock().expect("host runtime state mutex poisoned");
+            guard.queued_effects.push(QueuedHostEffect::PrintI32(value));
+        }
+        HostCallDecision::Reject => {}
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_print_string(value_id: i32) {
+    let maybe_text = lookup_string_literal(value_id);
+    let estimated_bytes = maybe_text
+        .as_ref()
+        .map(|text| u32::try_from(text.len()).unwrap_or(u32::MAX))
+        .unwrap_or(0);
+    match evaluate_host_call("print_string", estimated_bytes, true) {
+        HostCallDecision::ExecuteNow => {
+            if let Some(text) = maybe_text.as_ref() {
+                do_print_string(text);
+            }
+        }
+        HostCallDecision::Queue => {
+            if let Some(text) = maybe_text {
+                let state = host_runtime_state();
+                let mut guard = state.lock().expect("host runtime state mutex poisoned");
+                guard
+                    .queued_effects
+                    .push(QueuedHostEffect::PrintString(text));
+            }
+        }
+        HostCallDecision::Reject => {}
+    }
+}
+
+fn do_print_i32(value: i32) {
+    print!("{value}");
+    let _ = std::io::stdout().flush();
+}
+
+fn do_print_string(text: &str) {
+    print!("{text}");
+    let _ = std::io::stdout().flush();
+}
+
+fn lookup_string_literal(value_id: i32) -> Option<String> {
     let table = jit_string_literal_table();
     let guard = table
         .lock()
         .expect("jit string literal table mutex poisoned");
-    if let Some(text) = guard.get(&value_id) {
-        print!("{text}");
-        let _ = std::io::stdout().flush();
-    }
+    guard.get(&value_id).cloned()
 }
 
 #[cfg(windows)]
@@ -816,6 +1119,9 @@ fn jit_string_literal_to_cstring(value_id: i32) -> Result<CString, String> {
 // translate that into a stable `const char*` when calling the C runtime.
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i32) -> i32 {
+    if evaluate_host_call("gfx_load_sprite", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     #[cfg(windows)]
     {
         let Ok(path) = jit_string_literal_to_cstring(path_id) else {
@@ -839,6 +1145,9 @@ pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i3
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_dump_bmp(path_id: i32) -> i32 {
+    if evaluate_host_call("gfx_dump_bmp", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     #[cfg(windows)]
     {
         let Ok(path) = jit_string_literal_to_cstring(path_id) else {
@@ -860,6 +1169,9 @@ pub extern "C" fn stasis_jit_gfx_dump_bmp(path_id: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_load_font(path_id: i32, size: i32) -> i32 {
+    if evaluate_host_call("load_font", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     #[cfg(windows)]
     {
         let Ok(path) = jit_string_literal_to_cstring(path_id) else {
@@ -882,6 +1194,9 @@ pub extern "C" fn stasis_jit_load_font(path_id: i32, size: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
+    if evaluate_host_call("measure_text", 0, false) != HostCallDecision::ExecuteNow {
+        return 0.0;
+    }
     #[cfg(windows)]
     {
         let Ok(text) = jit_string_literal_to_cstring(text_id) else {
@@ -904,6 +1219,9 @@ pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
+    if evaluate_host_call("gfx_cache_text", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     #[cfg(windows)]
     {
         let Ok(text) = jit_string_literal_to_cstring(text_id) else {
@@ -926,6 +1244,9 @@ pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_poll_reload(handle: i32) -> i32 {
+    if evaluate_host_call("stasis_jit_gfx_poll_reload", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     #[cfg(windows)]
     {
         let Ok(api) = stasis_graphics_assets_api() else {
@@ -944,6 +1265,11 @@ pub extern "C" fn stasis_jit_gfx_poll_reload(handle: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_measure_text_cached(run_handle: i32) -> f32 {
+    if evaluate_host_call("stasis_jit_gfx_measure_text_cached", 0, false)
+        != HostCallDecision::ExecuteNow
+    {
+        return 0.0;
+    }
     #[cfg(windows)]
     {
         let Ok(api) = stasis_graphics_assets_api() else {
@@ -964,6 +1290,9 @@ pub extern "C" fn stasis_jit_gfx_measure_text_cached(run_handle: i32) -> f32 {
 // block on sleeps during deterministic quality-gate runs.
 #[no_mangle]
 pub extern "C" fn stasis_jit_sleep_ms(ms: i32) {
+    if evaluate_host_call("stasis_jit_sleep_ms", 0, false) != HostCallDecision::ExecuteNow {
+        return;
+    }
     let _ = ms;
 }
 
@@ -1793,7 +2122,11 @@ pub extern "C" fn stasis_jit_sys_memmove_f32(
 // Brickout uses `audio_is_available()` as a gate; return false so the game runs without calling
 // pointer-typed audio externs (e.g. `audio_push_f32_interleaved`).
 #[no_mangle]
-pub extern "C" fn stasis_jit_audio_init(_sample_rate: i32, _channels: i32, _target_latency_frames: i32) -> i32 {
+pub extern "C" fn stasis_jit_audio_init(
+    _sample_rate: i32,
+    _channels: i32,
+    _target_latency_frames: i32,
+) -> i32 {
     0
 }
 
@@ -1802,6 +2135,9 @@ pub extern "C" fn stasis_jit_audio_shutdown() {}
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_audio_is_available() -> i32 {
+    if evaluate_host_call("audio_is_available", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     0
 }
 
@@ -1828,6 +2164,9 @@ pub extern "C" fn stasis_jit_audio_get_underruns() -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_audio_push_f32_interleaved(_samples: i32, _frame_count: i32) -> i32 {
+    if evaluate_host_call("audio_push_f32_interleaved", 0, false) != HostCallDecision::ExecuteNow {
+        return 0;
+    }
     0
 }
 
@@ -2353,5 +2692,100 @@ mod tests {
             .expect("resolve GetTickCount");
         let value = invoke_noarg_u64(address).expect("invoke GetTickCount");
         assert!(value <= u64::from(u32::MAX));
+    }
+
+    #[test]
+    fn host_runtime_rejects_effect_queued_calls_during_commit_phase() {
+        let mut extern_phase_classes = HashMap::new();
+        extern_phase_classes.insert("print_i32".to_string(), HostExternPhaseClass::EffectQueued);
+        configure_host_runtime(HostSetRuntimeConfig {
+            enabled: true,
+            extern_phase_classes,
+            budget: HostSetRuntimeBudget {
+                max_effect_calls_per_tick: 10,
+                max_effect_bytes_per_tick: 256,
+            },
+        });
+
+        begin_host_commit_phase();
+        stasis_jit_print_i32(7);
+        let report = end_host_phase();
+
+        assert_eq!(report.phase, "commit");
+        assert_eq!(report.effect_calls, 0);
+        assert_eq!(report.effect_bytes, 0);
+        assert_eq!(report.dropped_effects, 0);
+        assert!(
+            report
+                .violations
+                .iter()
+                .any(|message| message.contains("effect_queued")),
+            "expected effect_queued commit-phase violation, got {:?}",
+            report.violations
+        );
+
+        disable_host_runtime();
+    }
+
+    #[test]
+    fn host_runtime_enforces_effect_budget_during_tick_phase() {
+        let mut extern_phase_classes = HashMap::new();
+        extern_phase_classes.insert("print_i32".to_string(), HostExternPhaseClass::EffectQueued);
+        configure_host_runtime(HostSetRuntimeConfig {
+            enabled: true,
+            extern_phase_classes,
+            budget: HostSetRuntimeBudget {
+                max_effect_calls_per_tick: 1,
+                max_effect_bytes_per_tick: 16,
+            },
+        });
+
+        begin_host_tick_phase();
+        stasis_jit_print_i32(1);
+        stasis_jit_print_i32(2);
+        let report = end_host_phase();
+
+        assert_eq!(report.phase, "tick");
+        assert_eq!(report.effect_calls, 1);
+        assert_eq!(report.dropped_effects, 1);
+        assert!(
+            report
+                .violations
+                .iter()
+                .any(|message| message.contains("budget violation")),
+            "expected budget violation, got {:?}",
+            report.violations
+        );
+
+        disable_host_runtime();
+    }
+
+    #[test]
+    fn host_runtime_rejects_unmapped_extern_calls_when_enabled() {
+        configure_host_runtime(HostSetRuntimeConfig {
+            enabled: true,
+            extern_phase_classes: HashMap::new(),
+            budget: HostSetRuntimeBudget {
+                max_effect_calls_per_tick: 1,
+                max_effect_bytes_per_tick: 1,
+            },
+        });
+
+        begin_host_tick_phase();
+        let _ = stasis_jit_audio_is_available();
+        let report = end_host_phase();
+
+        assert_eq!(report.phase, "tick");
+        assert_eq!(report.effect_calls, 0);
+        assert!(
+            report
+                .violations
+                .iter()
+                .any(|message| message.contains("not exported")),
+            "expected missing-export violation, got {:?}",
+            report.violations
+        );
+
+        disable_host_runtime();
     }
 }

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -970,7 +970,13 @@ Archived priority override (2026-02-13, historical):
 - `on_code_swap` phase-policy rejection + rollback tests.
 - Done gate:
 - Nondeterministic host effects cannot bypass queued/snapshotted paths.
-- Status: `planned (post-S10b)`
+- Current progress:
+- `apps/stasis/src/host_set_registry.rs` now materializes host-set phase-class metadata (`tick_safe`, `commit_only`, `effect_queued`) and per-profile default budgets; registry JSON can override phase classes and budgets per profile.
+- `crates/stasis_dynload/src/lib.rs` now enforces active phase at runtime:
+- tick phase supports deterministic queueing for `effect_queued` print externs (`print_i32`, `print_string`)
+- commit phase rejects `effect_queued` extern calls with deterministic violation diagnostics
+- `apps/stasis/src/lib.rs` now brackets tick and hook execution with runtime phase boundaries (`begin_host_tick_phase`/`begin_host_commit_phase`) and treats phase violations as hard failures.
+- Status: `in_progress`
 
 ### S16 - Host-Set Budgets and Failure Containment
 - Language:
@@ -986,7 +992,13 @@ Archived priority override (2026-02-13, historical):
 - Budget-overrun rollback/preservation tests.
 - Done gate:
 - Host-set misuse cannot produce partial state mutation or silent nondeterminism.
-- Status: `planned (post-S10b)`
+- Current progress:
+- Runtime per-tick effect budgets (`max_effect_calls_per_tick`, `max_effect_bytes_per_tick`) are enforced in `stasis_dynload` for queued tick effects; overrun produces deterministic budget violations and dropped-effect accounting.
+- Commit-hook path now emits host-set budget/violation telemetry through runner events (`RunnerEvent::HostSetBudgetReport`) and fails swap before patch commit when policy is violated.
+- Added regression coverage:
+- `stasis_dynload` unit tests for commit-phase rejection, per-tick budget enforcement, and deny-by-default missing export behavior.
+- `apps/stasis` unit test for rejecting effect-queued extern usage from `on_code_swap` with rollback-preserving failure semantics.
+- Status: `in_progress`
 
 ## PR Sequence
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -609,6 +609,26 @@ Console output contract:
 Bootstrap compatibility note:
 - Current bootstrap runtime symbol is `print_int`; stdlib provides `print_i32` wrapper to preserve Stasis naming.
 
+### 12.1.1 Host-Set Phase Policy and Budgets
+
+Host-set contracts carry runtime policy metadata for extern symbols:
+- phase class per extern symbol:
+- `tick_safe`: callable during tick and commit phases
+- `commit_only`: callable during commit/swap-hook phase only
+- `effect_queued`: callable on tick path only via deterministic queueing; not callable on commit path
+- per-tick effect budgets:
+- `max_effect_calls_per_tick`
+- `max_effect_bytes_per_tick`
+
+Runtime enforcement rules:
+- Tick phase:
+- `effect_queued` calls are queued in deterministic call order and flushed only after tick completes without policy violations.
+- Budget overrun rejects the call, records deterministic diagnostics, and drops queued effects for that phase.
+- Commit (`on_code_swap`) phase:
+- `effect_queued` calls are rejected as phase violations.
+- Hook phase violations fail the swap before pointer-table commit (all-or-nothing preserved).
+- If host runtime policy is disabled, extern behavior falls back to legacy direct execution.
+
 ### 12.2 Future Direction: Optional Plugin Libraries
 
 This section is intentionally **out of scope** for the current release approach.

--- a/docs/spec_implementation_status.md
+++ b/docs/spec_implementation_status.md
@@ -33,7 +33,7 @@ Status legend:
 | 9. Modules and Imports | Implemented | `import` and project-local module resolution are implemented. |
 | 10. Testing Construct | Partial | `.test.stasis` discovery/execution exists in JIT dev/test workflows. AOT test execution parity is not a current priority. |
 | 11. Memory Model | Partial | Static globals and deterministic layout are central. Remaining gaps are mostly around richer compile-time enforcement and diagnostics, not basic execution. |
-| 12. Runtime Boundary and Extern | Partial | Host-set profile/registry plumbing exists. Required-host extraction/diagnostics are tracked separately (not complete). |
+| 12. Runtime Boundary and Extern | Partial | Host-set profile/registry plumbing exists. Runtime phase-policy and per-tick effect-budget enforcement are in progress (tick queue + commit-hook rejection path implemented for mapped externs). Required-host extraction/diagnostics are tracked separately (not complete). |
 | 12.2 Optional Plugin Libraries | Deferred (Out of Scope) | Plugin libraries are explicitly out of scope for the current release approach; do not plan features around them right now. |
 | 13. Tick Policy | Implemented | Tick-based semantics are supported and used by the runtime loop. |
 | 14. Incremental Compilation and Hot Swap | Partial | Development hot-swap is implemented (JIT). Production AOT is the release approach; it should run the same games as JIT, but "AOT parity" is still being hardened and is explicitly tracked as a release goal. |


### PR DESCRIPTION
## Summary
- extend host-set contracts with extern phase classes (	ick_safe, commit_only, effect_queued) and per-profile effect budgets (max_effect_calls_per_tick, max_effect_bytes_per_tick), including registry JSON overrides
- add runtime host policy enforcement in stasis_dynload:
  - explicit tick/commit phase boundaries
  - deterministic queueing for effect_queued print externs on tick path
  - commit-phase rejection for effect_queued extern calls
  - per-tick effect call/bytes budget enforcement with deterministic diagnostics
  - deny-by-default rejection for unmapped externs when policy is enabled
- wire enforcement in runner paths:
  - un_play_in_process now brackets tick and swap-hook execution with host phases
  - pply_commit_request now fails swap on hook host-policy violations before pointer-table commit
  - emit RunnerEvent::HostSetBudgetReport when host-set budget/policy telemetry is present
- update docs (docs/spec.md, docs/build_checklist.md, docs/spec_implementation_status.md) to reflect S15/S16 progress
- silence release dead-code warning for EngineBundleManifest::optimization_profile in non-test builds

## Validation
- cargo build -p stasis --release
- cargo test -p stasis_dynload --release
- cargo test -p stasis --release --lib host_set -- --nocapture
- cargo test -p stasis --release --lib apply_commit_request_rejects_effect_queued_host_call_from_hook_phase -- --nocapture
- cargo test -p stasis --release --lib apply_commit_request_rejects_jit_hook -- --nocapture
- cargo test -p stasis --release --lib runner_loop_compiles_and_commits_one_change -- --nocapture
- cargo test -p stasis --release --lib real_backend_smoke_compiles_and_commits_brickout_v1 -- --nocapture

## Notes
- this slice implements deterministic queueing for mapped print extern effects and hard-failure containment on policy/budget violations
- additional externs can be moved to queued/snapshotted policies by extending host-set phase mappings and queue adapters in follow-up slices