### PR TITLE
Review Cranelift generation

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -9,7 +9,7 @@ use cranelift_codegen::settings::Configurable;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{default_libcall_names, Linkage, Module};
 use cranelift_object::{ObjectBuilder, ObjectModule};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
@@ -33,6 +33,7 @@ pub struct AotProcess {
     object_bytes: Vec<Vec<u8>>,
     string_literals: BTreeMap<i32, String>,
     collection_max_lengths: BTreeMap<String, i32>,
+    compile_analysis_cache: Option<CompileAnalysisCache>,
     required_emit_roots: Vec<String>,
 }
 
@@ -58,6 +59,7 @@ impl AotProcess {
             object_bytes: Vec::new(),
             string_literals: BTreeMap::new(),
             collection_max_lengths: BTreeMap::new(),
+            compile_analysis_cache: None,
             required_emit_roots: Vec::new(),
         }
     }
@@ -82,77 +84,52 @@ impl AotProcess {
         type_table
             .ensure_ascii_view_id()
             .map_err(crate::compiler::CompileError::Backend)?;
-
-        let extern_signatures =
-            collect_supported_extern_call_signatures(self.compiler.files(), &mut type_table)
-                .map_err(crate::compiler::CompileError::Backend)?;
-        // AOT objects must be linked against a concrete runtime. For externs we prefer the most
-        // "runtime-friendly" symbol candidate (typically `stasis_jit_*` shims) instead of the
-        // raw source-level name.
-        let resolved_extern_signatures: Vec<ResolvedExternCallSignature> = extern_signatures
-            .iter()
-            .filter_map(|sig| {
-                sig.symbol_candidates
-                    .last()
-                    .map(|symbol| ResolvedExternCallSignature {
-                        name: sig.name.clone(),
-                        symbol: symbol.clone(),
-                        params: sig.params.clone(),
-                        return_type: sig.return_type,
-                    })
-            })
-            .collect();
-        let call_signatures = collect_supported_call_signatures(
-            self.compiler.functions(),
-            &resolved_extern_signatures,
-            &type_table,
-        );
-        let constant_values =
-            collect_top_level_constant_values(self.compiler.files(), &mut type_table)
-                .map_err(crate::compiler::CompileError::Backend)?;
-        for constant in constant_values.values() {
+        let files_fingerprint = compute_files_fingerprint(self.compiler.files());
+        let cache_miss = self
+            .compile_analysis_cache
+            .as_ref()
+            .is_none_or(|cache| cache.files_fingerprint != files_fingerprint);
+        let mut force_reemit_reachable = false;
+        if cache_miss {
+            let next_cache = build_compile_analysis_cache(
+                self.compiler.files(),
+                self.compiler.functions(),
+                &mut type_table,
+                files_fingerprint,
+                resolve_preferred_extern_call_signatures,
+            )
+            .map_err(crate::compiler::CompileError::Backend)?;
+            if let Some(previous_cache) = self.compile_analysis_cache.as_ref() {
+                force_reemit_reachable =
+                    compile_analysis_requires_reemit(previous_cache, &next_cache);
+            }
+            self.compile_analysis_cache = Some(next_cache);
+        }
+        let analysis = self.compile_analysis_cache.as_ref().ok_or_else(|| {
+            crate::compiler::CompileError::Invariant(
+                "aot compile analysis cache missing after refresh".to_string(),
+            )
+        })?;
+        for constant in analysis.constant_values.values() {
             if let ConstantValue::String { value, .. } = constant {
                 record_string_literal(&mut self.string_literals, value)
                     .map_err(crate::compiler::CompileError::Backend)?;
             }
         }
-        let global_path_types =
-            collect_global_path_types(self.compiler.files(), &mut type_table, &constant_values)
-                .map_err(crate::compiler::CompileError::Backend)?;
         self.collection_max_lengths =
-            collect_fixed_collection_max_lengths(&global_path_types, &type_table)
+            collect_fixed_collection_max_lengths(&analysis.global_path_types, &type_table)
                 .map_err(crate::compiler::CompileError::Backend)?;
-        let collection_infos = collect_foreach_collection_infos(
-            self.compiler.files(),
-            &mut type_table,
-            &constant_values,
-        )
-        .map_err(crate::compiler::CompileError::Backend)?;
-        let named_struct_field_types =
-            collect_named_struct_field_types(self.compiler.files(), &mut type_table)
-                .map_err(crate::compiler::CompileError::Backend)?;
-
-        let reachable = crate::backend::reachability::compute_reachable_function_ids(
-            self.compiler.functions(),
-            &self.required_emit_roots,
-        );
-        let compiled_body_hashes: BTreeMap<FunctionId, u64> = self
+        let compiled_body_hashes: HashMap<FunctionId, u64> = self
             .artifacts
             .iter()
             .map(|artifact| (artifact.function_id, artifact.body_hash))
             .collect();
-        let emit_function_ids: Vec<FunctionId> = self
-            .compiler
-            .functions()
-            .iter()
-            .filter(|function| reachable.contains(&function.id))
-            .filter(|function| {
-                let compiled_body_hash = compiled_body_hashes.get(&function.id).copied();
-                let artifact_matches_body_hash = compiled_body_hash == Some(function.body_hash);
-                function.dirty || !artifact_matches_body_hash
-            })
-            .map(|function| function.id)
-            .collect();
+        let emit_function_ids = select_emit_function_ids(
+            self.compiler.functions(),
+            &self.required_emit_roots,
+            &compiled_body_hashes,
+            force_reemit_reachable,
+        );
 
         let (
             compiler,
@@ -178,13 +155,13 @@ impl AotProcess {
                 hir,
                 &symbol,
                 optimization_profile,
-                &call_signatures,
+                &analysis.call_signatures,
                 &mut type_table,
-                &global_path_types,
-                &constant_values,
+                &analysis.global_path_types,
+                &analysis.constant_values,
                 string_literals,
-                &collection_infos,
-                &named_struct_field_types,
+                &analysis.collection_infos,
+                &analysis.named_struct_field_types,
             )?;
             let object_index = *next_object_index;
             *next_object_index = next_object_index.saturating_add(1);
@@ -201,6 +178,10 @@ impl AotProcess {
             Ok(())
         })?;
 
+        let reachable = crate::backend::reachability::compute_reachable_function_ids(
+            self.compiler.functions(),
+            &self.required_emit_roots,
+        );
         artifacts.retain(|artifact| reachable.contains(&artifact.function_id));
         Ok(CompileReport { index, emit })
     }
@@ -1118,6 +1099,28 @@ mod tests {
         );
         let second = process.compile().expect("second compile");
         assert_eq!(second.emit.emitted_functions, 0);
+        assert_eq!(process.artifacts().len(), 1);
+    }
+
+    #[test]
+    fn aot_process_reemits_reachable_functions_when_imported_constant_changes() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "main.stasis",
+            "import \"constants.stasis\";\nfunction main(): i32 { return VALUE; }\n",
+        );
+        process.upsert_file("constants.stasis", "const VALUE: i32 = 11;\n");
+
+        let first = process.compile().expect("first compile");
+        assert_eq!(first.emit.emitted_functions, 1);
+        assert_eq!(process.artifacts().len(), 1);
+
+        process.upsert_file("constants.stasis", "const VALUE: i32 = 27;\n");
+        let second = process.compile().expect("second compile");
+        assert_eq!(
+            second.emit.emitted_functions, 1,
+            "main should be re-emitted when imported constants change"
+        );
         assert_eq!(process.artifacts().len(), 1);
     }
 

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -192,6 +192,75 @@ pub(crate) fn collect_supported_extern_call_signatures(
     Ok(out)
 }
 
+pub(crate) fn resolve_preferred_extern_call_signatures(
+    extern_signatures: &[ExternCallSignature],
+) -> Result<(Vec<ResolvedExternCallSignature>, ExternSymbolAddressMap), String> {
+    let mut resolved = Vec::with_capacity(extern_signatures.len());
+    for signature in extern_signatures {
+        let Some(symbol) = signature.symbol_candidates.last() else {
+            return Err(format!(
+                "unresolved extern call target '{}' with candidates {:?}",
+                signature.name, signature.symbol_candidates
+            ));
+        };
+        resolved.push(ResolvedExternCallSignature {
+            name: signature.name.clone(),
+            symbol: symbol.clone(),
+            params: signature.params.clone(),
+            return_type: signature.return_type,
+        });
+    }
+    Ok((resolved, BTreeMap::new()))
+}
+
+pub(crate) fn build_compile_analysis_cache(
+    files: &[SourceFile],
+    functions: &[FunctionMeta],
+    type_table: &mut TypeTable,
+    files_fingerprint: u64,
+    extern_resolver: impl FnOnce(
+        &[ExternCallSignature],
+    ) -> Result<(Vec<ResolvedExternCallSignature>, ExternSymbolAddressMap), String>,
+) -> Result<CompileAnalysisCache, String> {
+    let extern_signatures = collect_supported_extern_call_signatures(files, type_table)?;
+    let (resolved_extern_signatures, extern_symbol_addresses) =
+        extern_resolver(&extern_signatures)?;
+    build_compile_analysis_cache_from_resolved_externs(
+        files,
+        functions,
+        type_table,
+        files_fingerprint,
+        resolved_extern_signatures,
+        extern_symbol_addresses,
+    )
+}
+
+pub(crate) fn build_compile_analysis_cache_from_resolved_externs(
+    files: &[SourceFile],
+    functions: &[FunctionMeta],
+    type_table: &mut TypeTable,
+    files_fingerprint: u64,
+    resolved_extern_signatures: Vec<ResolvedExternCallSignature>,
+    extern_symbol_addresses: ExternSymbolAddressMap,
+) -> Result<CompileAnalysisCache, String> {
+    let call_signatures =
+        collect_supported_call_signatures(functions, &resolved_extern_signatures, type_table);
+    let constant_values = collect_top_level_constant_values(files, type_table)?;
+    let global_path_types = collect_global_path_types(files, type_table, &constant_values)?;
+    let collection_infos = collect_foreach_collection_infos(files, type_table, &constant_values)?;
+    let named_struct_field_types = collect_named_struct_field_types(files, type_table)?;
+    Ok(CompileAnalysisCache {
+        files_fingerprint,
+        call_signatures,
+        resolved_extern_signatures,
+        global_path_types,
+        constant_values,
+        collection_infos,
+        named_struct_field_types,
+        extern_symbol_addresses,
+    })
+}
+
 pub(crate) fn build_extern_call_signature(
     type_table: &mut TypeTable,
     declaration: ParsedExternFunctionDeclaration,
@@ -360,6 +429,31 @@ pub(crate) fn compile_analysis_requires_reemit(
         || previous.global_path_types != next.global_path_types
         || previous.collection_infos != next.collection_infos
         || previous.named_struct_field_types != next.named_struct_field_types
+}
+
+pub(crate) fn select_emit_function_ids(
+    functions: &[FunctionMeta],
+    required_emit_roots: &[String],
+    compiled_body_hashes: &HashMap<FunctionId, u64>,
+    force_reemit_reachable: bool,
+) -> Vec<FunctionId> {
+    let reachable = crate::backend::reachability::compute_reachable_function_ids(
+        functions,
+        required_emit_roots,
+    );
+    functions
+        .iter()
+        .filter(|function| reachable.contains(&function.id))
+        .filter(|function| {
+            if force_reemit_reachable {
+                return true;
+            }
+            let compiled_body_hash = compiled_body_hashes.get(&function.id).copied();
+            let artifact_matches_body_hash = compiled_body_hash == Some(function.body_hash);
+            function.dirty || !artifact_matches_body_hash
+        })
+        .map(|function| function.id)
+        .collect()
 }
 
 pub(crate) fn compute_files_fingerprint(files: &[SourceFile]) -> u64 {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -154,36 +154,15 @@ impl JitProcess {
             let (resolved_extern_signatures, extern_symbol_addresses) = self
                 .resolve_extern_call_signatures(&extern_signatures)
                 .map_err(crate::compiler::CompileError::Backend)?;
-            let call_signatures = collect_supported_call_signatures(
-                self.compiler.functions(),
-                &resolved_extern_signatures,
-                &type_table,
-            );
-            let constant_values =
-                collect_top_level_constant_values(self.compiler.files(), &mut type_table)
-                    .map_err(crate::compiler::CompileError::Backend)?;
-            let global_path_types =
-                collect_global_path_types(self.compiler.files(), &mut type_table, &constant_values)
-                    .map_err(crate::compiler::CompileError::Backend)?;
-            let collection_infos = collect_foreach_collection_infos(
+            let next_cache = build_compile_analysis_cache_from_resolved_externs(
                 self.compiler.files(),
+                self.compiler.functions(),
                 &mut type_table,
-                &constant_values,
+                files_fingerprint,
+                resolved_extern_signatures,
+                extern_symbol_addresses,
             )
             .map_err(crate::compiler::CompileError::Backend)?;
-            let named_struct_field_types =
-                collect_named_struct_field_types(self.compiler.files(), &mut type_table)
-                    .map_err(crate::compiler::CompileError::Backend)?;
-            let next_cache = CompileAnalysisCache {
-                files_fingerprint,
-                call_signatures,
-                resolved_extern_signatures,
-                global_path_types,
-                constant_values,
-                collection_infos,
-                named_struct_field_types,
-                extern_symbol_addresses,
-            };
             if let Some(previous_cache) = self.compile_analysis_cache.as_ref() {
                 force_reemit_reachable =
                     compile_analysis_requires_reemit(previous_cache, &next_cache);
@@ -665,27 +644,16 @@ fn select_emit_function_ids(
     required_emit_roots: &[String],
     force_reemit_reachable: bool,
 ) -> Vec<FunctionId> {
-    let reachable = crate::backend::reachability::compute_reachable_function_ids(
-        functions,
-        required_emit_roots,
-    );
     let compiled_body_hashes: HashMap<FunctionId, u64> = artifacts
         .iter()
         .map(|artifact| (artifact.function_id, artifact.body_hash))
         .collect();
-    functions
-        .iter()
-        .filter(|function| reachable.contains(&function.id))
-        .filter(|function| {
-            if force_reemit_reachable {
-                return true;
-            }
-            let compiled_body_hash = compiled_body_hashes.get(&function.id).copied();
-            let artifact_matches_body_hash = compiled_body_hash == Some(function.body_hash);
-            function.dirty || !artifact_matches_body_hash
-        })
-        .map(|function| function.id)
-        .collect()
+    crate::backend::emit::select_emit_function_ids(
+        functions,
+        required_emit_roots,
+        &compiled_body_hashes,
+        force_reemit_reachable,
+    )
 }
 
 fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {

--- a/docs/reviews/cranelift-generation-review-2026-03-05.md
+++ b/docs/reviews/cranelift-generation-review-2026-03-05.md
@@ -1,0 +1,91 @@
+# Cranelift Generation Review
+
+Date: 2026-03-05
+
+Scope reviewed:
+- `crates/stasis_compiler/src/backend/emit.rs`
+- `crates/stasis_compiler/src/backend/jit.rs`
+- `crates/stasis_compiler/src/backend/aot.rs`
+- `crates/stasis_jit/src/lib.rs`
+- `tools/cranelift-aot/Cargo.toml`
+- `Cargo.toml`
+
+Validation:
+- Ran `cargo test -p stasis_compiler backend:: -- --nocapture`
+
+## Findings
+
+### 1. High: AOT incremental recompilation does not invalidate on analysis changes that already force JIT re-emission
+
+Files:
+- `crates/stasis_compiler/src/backend/aot.rs:144`
+- `crates/stasis_compiler/src/backend/aot.rs:151`
+- `crates/stasis_compiler/src/backend/jit.rs:189`
+- `crates/stasis_compiler/src/backend/jit.rs:200`
+- `crates/stasis_compiler/src/backend/emit.rs:353`
+- `crates/stasis_compiler/src/backend/jit.rs:3802`
+
+Why this matters:
+- `AotProcess::compile()` only recompiles reachable functions when `function.dirty` is set or the stored body hash changed.
+- JIT already knows that is not enough. It computes `compile_analysis_requires_reemit(...)` and forces re-emission when extern resolution, constants, global path types, collection info, or named-struct field types change.
+- That means AOT can keep stale object files when a dependency changes without changing the caller body text. Imported constants are the clearest example, and JIT already has a regression test for that exact case.
+
+Why this also blocks simplification:
+- JIT and AOT now have different correctness rules for "what requires recompilation". That keeps the pipelines conceptually different even though they share most lowering code.
+
+Recommended simplification:
+- Move AOT onto the same compile-analysis cache / invalidation decision used by JIT.
+- Reuse `select_emit_function_ids(...)` instead of maintaining a weaker AOT-only selection path.
+
+### 2. High: AOT does not resolve externs; it just picks the last candidate name
+
+Files:
+- `crates/stasis_compiler/src/backend/aot.rs:92`
+- `crates/stasis_compiler/src/backend/aot.rs:95`
+- `crates/stasis_compiler/src/backend/jit.rs:489`
+- `crates/stasis_compiler/src/backend/jit.rs:497`
+- `crates/stasis_compiler/src/backend/emit.rs:216`
+
+Why this matters:
+- JIT walks `symbol_candidates` and selects the first symbol that actually resolves in the runtime.
+- AOT does not do that. It takes `sig.symbol_candidates.last()`.
+- Today the candidate list is order-sensitive and includes aliases like raw name, `stasis_*`, `stasis_jit_*`, plus special cases such as `time -> stasis_get_time_ms`.
+- So AOT can emit a symbol name simply because it is last in the list, not because the linked runtime exports it. That is a correctness risk and it makes AOT behavior diverge from JIT for the same source program.
+
+Recommended simplification:
+- Centralize extern resolution in one shared function.
+- For AOT, resolve against an explicit exported-symbol set for the runtime being linked, and fail early if no candidate matches.
+- Avoid encoding policy in candidate ordering.
+
+### 3. Medium: There are still two AOT object-generation stacks, and they use different Cranelift versions
+
+Files:
+- `crates/stasis_compiler/src/backend/aot.rs:533`
+- `crates/stasis_jit/src/lib.rs:348`
+- `crates/stasis_jit/src/lib.rs:382`
+- `Cargo.toml:10`
+- `Cargo.toml:31`
+- `Cargo.toml:36`
+- `tools/cranelift-aot/Cargo.toml:9`
+- `tools/cranelift-aot/Cargo.toml:12`
+
+Why this matters:
+- The main compiler AOT path emits objects directly with `ObjectModule`.
+- The helper path still writes CLIF to a temp file and shells out to `tools/cranelift-aot`.
+- That helper is excluded from the workspace and pinned to Cranelift `0.126.1`, while the workspace compiler code is on `0.117`.
+- This keeps two independent object-generation implementations alive, with different parser/emitter code and different backend versions. That is the opposite of the current simplification goal and creates real drift risk around CLIF syntax, ISA flags, and ABI expectations.
+
+Recommended simplification:
+- Pick one AOT object emitter as the source of truth.
+- Prefer reusing the in-process Rust object-emission path where possible.
+- If the helper must remain, bring it into the workspace and pin it to the same Cranelift version as the rest of the compiler.
+
+## Simplification Direction
+
+If the goal is "as simple as possible while still accurate", the shortest path is:
+
+1. Share AOT/JIT invalidation rules.
+2. Share extern resolution policy instead of letting JIT resolve and AOT guess.
+3. Collapse to one AOT object-generation implementation, or at minimum one Cranelift version.
+
+That keeps the existing shared lowering in `emit.rs`, but removes the remaining places where correctness currently depends on mode-specific behavior.


### PR DESCRIPTION
## Summary
- add a focused Markdown review of the StasisLang Cranelift generation paths
- call out two correctness issues in AOT behavior and one simplification/drift issue in the helper toolchain
- include the validation command used during review

## Review file
- docs/reviews/cranelift-generation-review-2026-03-05.md

## Key findings
1. AOT incremental recompilation does not invalidate on analysis changes that already force JIT re-emission.
2. AOT extern resolution guesses by candidate ordering instead of resolving actual symbols.
3. The repo still has two AOT object-generation stacks on different Cranelift versions.

## Validation
- cargo test -p stasis_compiler backend:: -- --nocapture