### PR TITLE
Share Cranelift analysis and extern resolution policy

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1103,6 +1103,63 @@ mod tests {
     }
 
     #[test]
+    fn aot_process_prefers_known_runtime_extern_symbol_over_source_alias() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "extern function print_i32(value: i32): void;\nfunction main(): i32 { print_i32(7); return 0; }\n",
+        );
+
+        process.compile().expect("compile");
+        let analysis = process
+            .compile_analysis_cache
+            .as_ref()
+            .expect("compile analysis cache");
+        assert_eq!(analysis.resolved_extern_signatures.len(), 1);
+        assert_eq!(
+            analysis.resolved_extern_signatures[0].symbol,
+            "stasis_jit_print_i32"
+        );
+    }
+
+    #[test]
+    fn aot_process_accepts_explicit_single_symbol_extern() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function @extern(\"custom_symbol\") custom(value: i32): i32;\nfunction main(): i32 { return custom(7); }\n",
+        );
+
+        process.compile().expect("compile");
+        let analysis = process
+            .compile_analysis_cache
+            .as_ref()
+            .expect("compile analysis cache");
+        assert_eq!(analysis.resolved_extern_signatures.len(), 1);
+        assert_eq!(analysis.resolved_extern_signatures[0].symbol, "custom_symbol");
+    }
+
+    #[test]
+    fn aot_process_rejects_nonexplicit_unknown_extern_without_known_runtime_symbol() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "extern function totally_unknown(value: i32): i32;\nfunction main(): i32 { return totally_unknown(7); }\n",
+        );
+
+        let error = process.compile().expect_err("compile should fail");
+        match error {
+            crate::compiler::CompileError::Backend(message) => {
+                assert!(
+                    message.contains("unresolved extern call target 'totally_unknown'"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected backend error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn aot_process_reemits_reachable_functions_when_imported_constant_changes() {
         let mut process = AotProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1140,6 +1140,30 @@ mod tests {
     }
 
     #[test]
+    fn aot_process_accepts_known_runtime_shim_families() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "extern function sleep_ms(ms: i32): void;\nextern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;\nfunction main(): i32 { sleep_ms(1); if (audio_init(48000, 2, 512)) { return 1; } return 0; }\n",
+        );
+
+        process.compile().expect("compile");
+        let analysis = process
+            .compile_analysis_cache
+            .as_ref()
+            .expect("compile analysis cache");
+        assert_eq!(analysis.resolved_extern_signatures.len(), 2);
+        assert_eq!(
+            analysis.resolved_extern_signatures[0].symbol,
+            "stasis_jit_sleep_ms"
+        );
+        assert_eq!(
+            analysis.resolved_extern_signatures[1].symbol,
+            "stasis_jit_audio_init"
+        );
+    }
+
+    #[test]
     fn aot_process_rejects_nonexplicit_unknown_extern_without_known_runtime_symbol() {
         let mut process = AotProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -192,25 +192,81 @@ pub(crate) fn collect_supported_extern_call_signatures(
     Ok(out)
 }
 
-pub(crate) fn resolve_preferred_extern_call_signatures(
+pub(crate) fn resolve_extern_call_signatures_with(
     extern_signatures: &[ExternCallSignature],
+    mut resolve_candidate: impl FnMut(&ExternCallSignature, &str) -> Option<usize>,
 ) -> Result<(Vec<ResolvedExternCallSignature>, ExternSymbolAddressMap), String> {
     let mut resolved = Vec::with_capacity(extern_signatures.len());
+    let mut symbol_addresses: ExternSymbolAddressMap = BTreeMap::new();
     for signature in extern_signatures {
-        let Some(symbol) = signature.symbol_candidates.last() else {
+        let mut selected: Option<(String, usize)> = None;
+        for candidate in &signature.symbol_candidates {
+            if let Some(address) = resolve_candidate(signature, candidate) {
+                selected = Some((candidate.clone(), address));
+                break;
+            }
+        }
+        let Some((symbol, address)) = selected else {
             return Err(format!(
                 "unresolved extern call target '{}' with candidates {:?}",
                 signature.name, signature.symbol_candidates
             ));
         };
+        symbol_addresses.insert(symbol.clone(), address);
         resolved.push(ResolvedExternCallSignature {
             name: signature.name.clone(),
-            symbol: symbol.clone(),
+            symbol,
             params: signature.params.clone(),
             return_type: signature.return_type,
         });
     }
-    Ok((resolved, BTreeMap::new()))
+    Ok((resolved, symbol_addresses))
+}
+
+pub(crate) fn is_known_aot_runtime_extern_symbol(symbol: &str) -> bool {
+    matches!(
+        symbol,
+        "stasis_jit_print_i32"
+            | "stasis_jit_print_string"
+            | "stasis_jit_gfx_load_sprite"
+            | "stasis_jit_gfx_dump_bmp"
+            | "stasis_jit_load_font"
+            | "stasis_jit_measure_text"
+            | "stasis_jit_gfx_cache_text"
+            | "stasis_jit_audio_is_available"
+            | "stasis_jit_audio_push_f32_interleaved"
+            | "stasis_jit_sin_fast"
+            | "stasis_jit_cos_fast"
+            | "stasis_jit_global_i32_load"
+            | "stasis_jit_global_i32_store"
+            | "stasis_jit_global_f32_load"
+            | "stasis_jit_global_f32_store"
+            | "stasis_jit_global_f64_load"
+            | "stasis_jit_global_f64_store"
+            | "stasis_jit_collection_i32_load"
+            | "stasis_jit_collection_i32_store"
+            | "stasis_jit_sys_memcpy_u8"
+            | "stasis_jit_sys_memcpy_i32"
+            | "stasis_jit_sys_memcpy_f32"
+            | "stasis_jit_sys_memmove_u8"
+            | "stasis_jit_sys_memmove_i32"
+            | "stasis_jit_sys_memmove_f32"
+            | "stasis_get_time_ms"
+            | "stasis_get_time_us"
+    )
+}
+
+pub(crate) fn resolve_preferred_extern_call_signatures(
+    extern_signatures: &[ExternCallSignature],
+) -> Result<(Vec<ResolvedExternCallSignature>, ExternSymbolAddressMap), String> {
+    resolve_extern_call_signatures_with(extern_signatures, |signature, candidate| {
+        if is_known_aot_runtime_extern_symbol(candidate) || signature.symbol_candidates.len() == 1
+        {
+            Some(0)
+        } else {
+            None
+        }
+    })
 }
 
 pub(crate) fn build_compile_analysis_cache(

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -224,36 +224,34 @@ pub(crate) fn resolve_extern_call_signatures_with(
 }
 
 pub(crate) fn is_known_aot_runtime_extern_symbol(symbol: &str) -> bool {
-    matches!(
-        symbol,
-        "stasis_jit_print_i32"
-            | "stasis_jit_print_string"
-            | "stasis_jit_gfx_load_sprite"
-            | "stasis_jit_gfx_dump_bmp"
-            | "stasis_jit_load_font"
-            | "stasis_jit_measure_text"
-            | "stasis_jit_gfx_cache_text"
-            | "stasis_jit_audio_is_available"
-            | "stasis_jit_audio_push_f32_interleaved"
-            | "stasis_jit_sin_fast"
-            | "stasis_jit_cos_fast"
-            | "stasis_jit_global_i32_load"
-            | "stasis_jit_global_i32_store"
-            | "stasis_jit_global_f32_load"
-            | "stasis_jit_global_f32_store"
-            | "stasis_jit_global_f64_load"
-            | "stasis_jit_global_f64_store"
-            | "stasis_jit_collection_i32_load"
-            | "stasis_jit_collection_i32_store"
-            | "stasis_jit_sys_memcpy_u8"
-            | "stasis_jit_sys_memcpy_i32"
-            | "stasis_jit_sys_memcpy_f32"
-            | "stasis_jit_sys_memmove_u8"
-            | "stasis_jit_sys_memmove_i32"
-            | "stasis_jit_sys_memmove_f32"
-            | "stasis_get_time_ms"
-            | "stasis_get_time_us"
-    )
+    symbol == "stasis_get_time_ms"
+        || symbol == "stasis_get_time_us"
+        || matches!(
+            symbol,
+            "stasis_jit_print_i32"
+                | "stasis_jit_print_string"
+                | "stasis_jit_load_font"
+                | "stasis_jit_measure_text"
+                | "stasis_jit_sleep_ms"
+                | "stasis_jit_sin_fast"
+                | "stasis_jit_cos_fast"
+                | "stasis_jit_global_i32_load"
+                | "stasis_jit_global_i32_store"
+                | "stasis_jit_global_f32_load"
+                | "stasis_jit_global_f32_store"
+                | "stasis_jit_global_f64_load"
+                | "stasis_jit_global_f64_store"
+                | "stasis_jit_collection_i32_load"
+                | "stasis_jit_collection_i32_store"
+                | "stasis_jit_sys_memcpy_u8"
+                | "stasis_jit_sys_memcpy_i32"
+                | "stasis_jit_sys_memcpy_f32"
+                | "stasis_jit_sys_memmove_u8"
+                | "stasis_jit_sys_memmove_i32"
+                | "stasis_jit_sys_memmove_f32"
+        )
+        || symbol.starts_with("stasis_jit_gfx_")
+        || symbol.starts_with("stasis_jit_audio_")
 }
 
 pub(crate) fn resolve_preferred_extern_call_signatures(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -469,31 +469,9 @@ impl JitProcess {
         &mut self,
         extern_signatures: &[ExternCallSignature],
     ) -> Result<(Vec<ResolvedExternCallSignature>, ExternSymbolAddressMap), String> {
-        let mut resolved = Vec::with_capacity(extern_signatures.len());
-        let mut symbol_addresses: ExternSymbolAddressMap = BTreeMap::new();
-        for signature in extern_signatures {
-            let mut selected: Option<(String, usize)> = None;
-            for candidate in &signature.symbol_candidates {
-                if let Some(address) = self.resolve_host_symbol_address(candidate) {
-                    selected = Some((candidate.clone(), address));
-                    break;
-                }
-            }
-            let Some((symbol, address)) = selected else {
-                return Err(format!(
-                    "unresolved extern call target '{}' with candidates {:?}",
-                    signature.name, signature.symbol_candidates
-                ));
-            };
-            symbol_addresses.insert(symbol.clone(), address);
-            resolved.push(ResolvedExternCallSignature {
-                name: signature.name.clone(),
-                params: signature.params.clone(),
-                return_type: signature.return_type,
-                symbol,
-            });
-        }
-        Ok((resolved, symbol_addresses))
+        resolve_extern_call_signatures_with(extern_signatures, |_signature, candidate| {
+            self.resolve_host_symbol_address(candidate)
+        })
     }
 
     fn resolve_host_symbol_address(&mut self, symbol: &str) -> Option<usize> {


### PR DESCRIPTION
## Summary\n- share compile-analysis invalidation rules between JIT and AOT\n- centralize extern candidate resolution in shared backend code\n- make AOT resolve to known runtime-exported symbols or explicit single-symbol externs instead of guessing by candidate order\n- add AOT regression coverage for extern symbol selection behavior\n\n## What changed\n- extracted shared extern candidate selection helper in emit.rs\n- switched JIT extern resolution to use the shared helper\n- switched AOT to use the same shared helper with an AOT-specific symbol policy\n- added tests for: runtime alias selection, explicit extern preservation, and rejection of ambiguous unknown externs\n\n## Validation\n- cargo test -p stasis_compiler backend:: -- --nocapture\n- rebuilt release app and launched Brickout interactively on this branch