### PR TITLE
aot-cli: package stable release bundles

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -118,6 +118,44 @@ struct EngineBundleManifest {
     collection_max_lengths: Option<Vec<EngineBundleManifestCollectionMaxLengthRow>>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct StructMetaFieldExportRow {
+    name: String,
+    size: usize,
+    #[serde(rename = "type")]
+    field_type: String,
+    #[serde(rename = "arrayCount")]
+    array_count: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct StructMetaExportFile {
+    fields: Vec<StructMetaFieldExportRow>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PackagedAotSupportFiles {
+    data_bind_json_rel: Option<String>,
+    data_bind_meta_rel: Option<String>,
+    export_symbols: Vec<String>,
+    runtime_fields: Vec<PackagedRuntimeField>,
+}
+
+#[derive(Debug, Clone)]
+struct PackagedFunctionAlias {
+    alias: &'static str,
+    target_symbol: String,
+    returns_i32: bool,
+}
+
+#[derive(Debug, Clone)]
+struct PackagedRuntimeField {
+    name: String,
+    size: usize,
+    field_type: String,
+    array_count: usize,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct SourceCacheDelta {
     touched_paths: Vec<String>,
@@ -2238,6 +2276,64 @@ fn aot_symbol_name(metric: &stasis_compiler::FunctionMetric) -> String {
     )
 }
 
+fn parse_aot_symbol_unsigned_id_hash(symbol: &str) -> Option<u32> {
+    let mut parts = symbol.split('_');
+    let tag = parts.next()?;
+    if tag != "fn" {
+        return None;
+    }
+    let id_hash = parts.next()?.parse::<u32>().ok()?;
+    let _sig_hash = parts.next()?;
+    let _ordinal = parts.next()?;
+    Some(id_hash)
+}
+
+fn parse_aot_fn_symbol_id(symbol: &str) -> Option<i32> {
+    symbol.strip_prefix("aot_fn_")?.parse::<i32>().ok()
+}
+
+fn resolve_self_host_aot_entry_symbol(
+    backend: &IncrementalCompilerBackend,
+    result: &CompileResult,
+    entry_name: &str,
+) -> Result<String, String> {
+    let symbols = result.aot_function_symbols.as_ref();
+    let entry_id_hash = hash_identifier(entry_name);
+    if let Some(symbols) = symbols {
+        if let Some(fn_id) = backend.existing_fn_id_for_identifier_hash(entry_id_hash) {
+            if let Some(symbol) = symbols
+                .iter()
+                .find(|entry| entry.fn_id == fn_id)
+                .map(|entry| entry.symbol.clone())
+            {
+                return Ok(symbol);
+            }
+        }
+    }
+
+    if let Some(bundle) = backend.last_aot_engine_bundle.as_ref() {
+        let manifest = backend.read_engine_bundle_manifest(&bundle.manifest_path)?;
+        if let Some(row) = manifest.functions.iter().find(|row| row.name == entry_name) {
+            return Ok(row.symbol.clone());
+        }
+    }
+
+    let target_unsigned_id_hash = entry_id_hash.unsigned_abs();
+    let mut matches = symbols.into_iter().flatten().filter(|entry| {
+        parse_aot_symbol_unsigned_id_hash(&entry.symbol) == Some(target_unsigned_id_hash)
+    });
+    let Some(first) = matches.next() else {
+        return Err(format!("missing AOT symbol mapping for {entry_name}"));
+    };
+    if let Some(second) = matches.next() {
+        return Err(format!(
+            "multiple AOT symbol mappings matched {entry_name} by id hash: {} and {}",
+            first.symbol, second.symbol
+        ));
+    }
+    Ok(first.symbol.clone())
+}
+
 fn compute_file_sha256_hex(path: &Path) -> Result<String, String> {
     let file = std::fs::File::open(path)
         .map_err(|error| format!("failed to open {}: {error}", path.display()))?;
@@ -2254,6 +2350,1100 @@ fn compute_file_sha256_hex(path: &Path) -> Result<String, String> {
         hasher.update(&buffer[..read]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn self_host_repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn resolve_self_host_aot_entry_file(project_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let Some(entry_file) = std::env::var_os("STASIS_AOT_ENTRY_FILE") else {
+        return Ok(None);
+    };
+    if entry_file.is_empty() {
+        return Ok(None);
+    }
+    let entry_path = PathBuf::from(entry_file);
+    let full_path = if entry_path.is_absolute() {
+        entry_path
+    } else {
+        project_dir.join(entry_path)
+    };
+    let canonical = full_path.canonicalize().map_err(|error| {
+        format!(
+            "failed to canonicalize AOT entry file {}: {error}",
+            full_path.display()
+        )
+    })?;
+    Ok(Some(canonical))
+}
+
+fn resolve_latest_existing_path(candidates: Vec<PathBuf>) -> Option<PathBuf> {
+    candidates
+        .into_iter()
+        .filter(|path| path.exists())
+        .max_by_key(|path| {
+            std::fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+        })
+}
+
+fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+    let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| self_host_repo_root().join("target"));
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    for profile in ["debug", "release"] {
+        let base = target_dir.join(profile);
+        let direct = base.join("stasis_dynload.lib");
+        if direct.exists() {
+            candidates.push(direct);
+        }
+
+        let deps = base.join("deps");
+        let Ok(entries) = std::fs::read_dir(&deps) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if name.starts_with("stasis_dynload-") && name.ends_with(".lib") {
+                candidates.push(path);
+            }
+        }
+    }
+
+    resolve_latest_existing_path(candidates)
+}
+
+fn ensure_stasis_dynload_staticlib() -> Result<PathBuf, String> {
+    let repo_root = self_host_repo_root();
+    let mut command = std::process::Command::new("cargo");
+    command.arg("rustc").arg("-p").arg("stasis_dynload");
+    if !cfg!(debug_assertions) {
+        command.arg("--release");
+    }
+    command
+        .arg("--")
+        .arg("--crate-type")
+        .arg("staticlib")
+        .current_dir(&repo_root);
+    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+        command.env("CARGO_TARGET_DIR", target_dir);
+    }
+
+    let output = command.output().map_err(|error| {
+        format!("failed to spawn cargo rustc -p stasis_dynload --crate-type staticlib: {error}")
+    })?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    resolve_stasis_dynload_lib()
+        .ok_or_else(|| "stasis_dynload staticlib build reported success but no .lib was found".to_string())
+}
+
+fn resolve_runtime_runner_path(repo_root: &Path) -> Option<PathBuf> {
+    resolve_latest_existing_path(vec![
+        repo_root.join("stasis_runner.exe"),
+        repo_root.join("build").join("stasis_runner.exe"),
+        repo_root
+            .join("runtime")
+            .join("build")
+            .join("bin")
+            .join("Release")
+            .join("stasis_runner.exe"),
+    ])
+}
+
+fn resolve_runtime_graphics_path(repo_root: &Path) -> Option<PathBuf> {
+    resolve_latest_existing_path(vec![
+        repo_root.join("stasis_graphics.dll"),
+        repo_root.join("build").join("stasis_graphics.dll"),
+        repo_root
+            .join("runtime")
+            .join("build")
+            .join("bin")
+            .join("Release")
+            .join("stasis_graphics.dll"),
+    ])
+}
+
+fn resolve_msvc_link_exe() -> Option<PathBuf> {
+    let roots = [
+        PathBuf::from(r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"),
+        PathBuf::from(r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"),
+    ];
+    let mut candidates = Vec::new();
+    for root in roots {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path().join("bin").join("HostX64").join("x64").join("link.exe");
+            if path.exists() {
+                candidates.push(path);
+            }
+        }
+    }
+    resolve_latest_existing_path(candidates)
+}
+
+fn resolve_rust_lld_exe() -> Option<PathBuf> {
+    let toolchain = std::env::var_os("RUSTUP_TOOLCHAIN")
+        .unwrap_or_else(|| "stable-x86_64-pc-windows-msvc".into());
+    let candidate = PathBuf::from(std::env::var_os("USERPROFILE")?)
+        .join(".rustup")
+        .join("toolchains")
+        .join(toolchain)
+        .join("lib")
+        .join("rustlib")
+        .join("x86_64-pc-windows-msvc")
+        .join("bin")
+        .join("rust-lld.exe");
+    candidate.exists().then_some(candidate)
+}
+
+fn ensure_rust_lld_link_wrapper(artifact_root: &Path) -> Option<PathBuf> {
+    let rust_lld = resolve_rust_lld_exe()?;
+    let wrapper_path = artifact_root.join("rust-lld-link.cmd");
+    let script = format!("@echo off\r\n\"{}\" -flavor link %*\r\n", rust_lld.display());
+    std::fs::write(&wrapper_path, script).ok()?;
+    Some(wrapper_path)
+}
+
+fn ensure_runtime_release_artifacts() -> Result<(PathBuf, PathBuf), String> {
+    let repo_root = self_host_repo_root();
+    let runner = resolve_runtime_runner_path(&repo_root);
+    let graphics = resolve_runtime_graphics_path(&repo_root);
+    if let (Some(runner), Some(graphics)) = (runner, graphics) {
+        return Ok((runner, graphics));
+    }
+
+    let output = std::process::Command::new("cmd")
+        .arg("/c")
+        .arg("runtime\\build.bat")
+        .current_dir(&repo_root)
+        .output()
+        .map_err(|error| format!("failed to spawn runtime\\build.bat: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "runtime\\build.bat failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let runner = resolve_runtime_runner_path(&repo_root)
+        .ok_or_else(|| "runtime build succeeded but stasis_runner.exe was not found".to_string())?;
+    let graphics = resolve_runtime_graphics_path(&repo_root)
+        .ok_or_else(|| "runtime build succeeded but stasis_graphics.dll was not found".to_string())?;
+    Ok((runner, graphics))
+}
+
+fn copy_file_creating_parent(src: &Path, dst: &Path) -> Result<(), String> {
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create parent directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    std::fs::copy(src, dst).map_err(|error| {
+        format!(
+            "failed to copy {} to {}: {error}",
+            src.display(),
+            dst.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dst).map_err(|error| {
+        format!(
+            "failed to create directory {}: {error}",
+            dst.display()
+        )
+    })?;
+    let entries = std::fs::read_dir(src)
+        .map_err(|error| format!("failed to read directory {}: {error}", src.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read directory entry in {}: {error}",
+                src.display()
+            )
+        })?;
+        let path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|error| {
+            format!("failed to read file type for {}: {error}", path.display())
+        })?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&path, &dst_path)?;
+        } else if file_type.is_file() {
+            copy_file_creating_parent(&path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, String> {
+    fn walk(dir: &Path, out: &mut BTreeMap<String, PackagedRuntimeField>) -> Result<(), String> {
+        let entries = std::fs::read_dir(dir)
+            .map_err(|error| format!("failed to read directory {}: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "failed to read directory entry in {}: {error}",
+                    dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let file_type = entry.file_type().map_err(|error| {
+                format!("failed to read file type for {}: {error}", path.display())
+            })?;
+            if file_type.is_dir() {
+                walk(&path, out)?;
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".struct-meta.json") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)
+                .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+            let meta: StructMetaExportFile = serde_json::from_str(&text).map_err(|error| {
+                format!("failed to parse {}: {error}", path.display())
+            })?;
+            for field in meta.fields {
+                out.entry(field.name.clone()).or_insert(PackagedRuntimeField {
+                    name: field.name,
+                    size: field.size,
+                    field_type: field.field_type,
+                    array_count: field.array_count,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    let mut fields = BTreeMap::new();
+    if root.exists() {
+        walk(root, &mut fields)?;
+    }
+    Ok(fields.into_values().collect())
+}
+
+fn is_bundleable_asset_extension(path: &Path) -> bool {
+    let Some(ext) = path.extension().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "json" | "svg" | "png" | "jpg" | "jpeg" | "gif" | "bmp" | "webp"
+    )
+}
+
+fn copy_json_referenced_absolute_assets(
+    value: &mut serde_json::Value,
+    staged_entry_dir: &Path,
+    package_rel_root: &str,
+    copied_assets: &mut BTreeMap<PathBuf, String>,
+) -> Result<bool, String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut changed = false;
+            for child in map.values_mut() {
+                changed |= copy_json_referenced_absolute_assets(
+                    child,
+                    staged_entry_dir,
+                    package_rel_root,
+                    copied_assets,
+                )?;
+            }
+            Ok(changed)
+        }
+        serde_json::Value::Array(items) => {
+            let mut changed = false;
+            for child in items {
+                changed |= copy_json_referenced_absolute_assets(
+                    child,
+                    staged_entry_dir,
+                    package_rel_root,
+                    copied_assets,
+                )?;
+            }
+            Ok(changed)
+        }
+        serde_json::Value::String(text) => {
+            let source = PathBuf::from(text.as_str());
+            if !source.is_absolute() || !source.exists() || !is_bundleable_asset_extension(&source) {
+                return Ok(false);
+            }
+
+            if let Some(existing) = copied_assets.get(&source) {
+                *text = existing.clone();
+                return Ok(true);
+            }
+
+            let asset_dir = staged_entry_dir.join("assets");
+            std::fs::create_dir_all(&asset_dir).map_err(|error| {
+                format!(
+                    "failed to create asset directory {}: {error}",
+                    asset_dir.display()
+                )
+            })?;
+
+            let file_name = source
+                .file_name()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| format!("invalid asset file name {}", source.display()))?;
+            let mut destination = asset_dir.join(file_name);
+            if destination.exists() {
+                let stem = source
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("asset");
+                let ext = source.extension().and_then(|value| value.to_str()).unwrap_or("");
+                let mut counter: usize = 1;
+                while destination.exists() {
+                    let candidate = if ext.is_empty() {
+                        format!("{stem}_{counter}")
+                    } else {
+                        format!("{stem}_{counter}.{ext}")
+                    };
+                    destination = asset_dir.join(candidate);
+                    counter += 1;
+                }
+            }
+
+            copy_file_creating_parent(&source, &destination)?;
+            let rel_name = destination
+                .file_name()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| format!("invalid packaged asset path {}", destination.display()))?;
+            let rel_path = format!("{package_rel_root}/assets/{rel_name}");
+            copied_assets.insert(source, rel_path.clone());
+            *text = rel_path;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn rewrite_packaged_json_asset_paths(
+    staged_entry_dir: &Path,
+    package_rel_root: &str,
+) -> Result<(), String> {
+    fn walk(
+        dir: &Path,
+        staged_entry_dir: &Path,
+        package_rel_root: &str,
+        copied_assets: &mut BTreeMap<PathBuf, String>,
+    ) -> Result<(), String> {
+        let entries = std::fs::read_dir(dir)
+            .map_err(|error| format!("failed to read directory {}: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "failed to read directory entry in {}: {error}",
+                    dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let file_type = entry.file_type().map_err(|error| {
+                format!("failed to read file type for {}: {error}", path.display())
+            })?;
+            if file_type.is_dir() {
+                walk(&path, staged_entry_dir, package_rel_root, copied_assets)?;
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".json") || name.ends_with(".struct-meta.json") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)
+                .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+            let mut value: serde_json::Value = match serde_json::from_str(&text) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            if copy_json_referenced_absolute_assets(
+                &mut value,
+                staged_entry_dir,
+                package_rel_root,
+                copied_assets,
+            )? {
+                let next = serde_json::to_string_pretty(&value)
+                    .map_err(|error| format!("failed to serialize {}: {error}", path.display()))?;
+                std::fs::write(&path, next)
+                    .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+            }
+        }
+        Ok(())
+    }
+
+    let mut copied_assets = BTreeMap::new();
+    if staged_entry_dir.exists() {
+        walk(
+            staged_entry_dir,
+            staged_entry_dir,
+            package_rel_root,
+            &mut copied_assets,
+        )?;
+    }
+    Ok(())
+}
+
+fn stage_entry_support_files(
+    project_dir: &Path,
+    entry_file: Option<&Path>,
+    output_root: &Path,
+) -> Result<PackagedAotSupportFiles, String> {
+    let Some(entry_file) = entry_file else {
+        return Ok(PackagedAotSupportFiles::default());
+    };
+    let entry_root = entry_file.parent().unwrap_or(project_dir);
+    let package_dir_name = entry_file
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| format!("invalid entry file name {}", entry_file.display()))?
+        .to_string();
+    let source_bundle_dir = entry_root.join(&package_dir_name);
+    if !source_bundle_dir.exists() {
+        return Ok(PackagedAotSupportFiles::default());
+    }
+
+    let staged_bundle_dir = output_root.join(&package_dir_name);
+    if staged_bundle_dir.exists() {
+        std::fs::remove_dir_all(&staged_bundle_dir).map_err(|error| {
+            format!(
+                "failed to clear existing staged asset directory {}: {error}",
+                staged_bundle_dir.display()
+            )
+        })?;
+    }
+    copy_dir_recursive(&source_bundle_dir, &staged_bundle_dir)?;
+    rewrite_packaged_json_asset_paths(&staged_bundle_dir, &package_dir_name)?;
+
+    let runtime_fields = collect_struct_meta_fields(&staged_bundle_dir)?;
+    let mut support = PackagedAotSupportFiles {
+        export_symbols: runtime_fields.iter().map(|field| field.name.clone()).collect(),
+        runtime_fields,
+        ..PackagedAotSupportFiles::default()
+    };
+
+    let data_json = staged_bundle_dir.join("data").join("config.json");
+    let data_meta = staged_bundle_dir.join("data").join("config.struct-meta.json");
+    if data_json.exists() && data_meta.exists() {
+        support.data_bind_json_rel = Some(format!("{package_dir_name}/data/config.json"));
+        support.data_bind_meta_rel = Some(format!("{package_dir_name}/data/config.struct-meta.json"));
+    }
+
+    Ok(support)
+}
+
+fn append_runtime_bridge_field_source(
+    source: &mut String,
+    register_lines: &mut Vec<String>,
+    field: &PackagedRuntimeField,
+) -> Result<(), String> {
+    let runtime_path = field.name.replace("__", ".");
+    let field_hash = crate::hash_global_path(&runtime_path);
+    match field.field_type.as_str() {
+        "bool" | "u8" | "u16" | "u32" | "i32" => {
+            if field.array_count > 1 {
+                source.push_str(&format!(
+                    "__declspec(dllexport) int32_t {}[{}] = {{0}};\n",
+                    field.name, field.array_count
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_i32_array({field_hash}, 0, {name}, {len});",
+                    name = field.name,
+                    len = field.array_count
+                ));
+            } else {
+                source.push_str(&format!(
+                    "__declspec(dllexport) int32_t {} = 0;\n",
+                    field.name
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_i32_ptr({field_hash}, &{name});",
+                    name = field.name
+                ));
+            }
+        }
+        "f32" => {
+            if field.array_count > 1 {
+                source.push_str(&format!(
+                    "__declspec(dllexport) float {}[{}] = {{0}};\n",
+                    field.name, field.array_count
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_f32_array({field_hash}, 0, {name}, {len});",
+                    name = field.name,
+                    len = field.array_count
+                ));
+            } else {
+                source.push_str(&format!(
+                    "__declspec(dllexport) float {} = 0.0f;\n",
+                    field.name
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_f32_ptr({field_hash}, &{name});",
+                    name = field.name
+                ));
+            }
+        }
+        "f64" => {
+            if field.array_count > 1 {
+                source.push_str(&format!(
+                    "__declspec(dllexport) double {}[{}] = {{0}};\n",
+                    field.name, field.array_count
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_f64_array({field_hash}, 0, {name}, {len});",
+                    name = field.name,
+                    len = field.array_count
+                ));
+            } else {
+                source.push_str(&format!(
+                    "__declspec(dllexport) double {} = 0.0;\n",
+                    field.name
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_f64_ptr({field_hash}, &{name});",
+                    name = field.name
+                ));
+            }
+        }
+        "string" => {
+            let len = field.size.max(1);
+            let header_bytes = field.size.saturating_sub(field.array_count);
+            let payload_len = field.array_count.max(1);
+            source.push_str(&format!(
+                "__declspec(dllexport) uint8_t {}[{}] = {{0}};\n",
+                field.name, len
+            ));
+            if header_bytes >= 8 {
+                let max_length_hash =
+                    crate::hash_global_path(&format!("{}.max_length", runtime_path));
+                register_lines.push(format!(
+                    "*((int32_t*)({name} + 4)) = {payload_len};",
+                    name = field.name
+                ));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_i32_ptr({max_length_hash}, (int32_t*)({name} + 4));",
+                    name = field.name
+                ));
+            }
+            if header_bytes >= 8 {
+                let length_hash = crate::hash_global_path(&format!("{}.length", runtime_path));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_i32_ptr({length_hash}, (int32_t*){name});",
+                    name = field.name
+                ));
+            }
+            if header_bytes >= 12 {
+                let char_length_hash =
+                    crate::hash_global_path(&format!("{}.char_length", runtime_path));
+                register_lines.push(format!(
+                    "stasis_jit_register_global_i32_ptr({char_length_hash}, (int32_t*)({name} + 8));",
+                    name = field.name
+                ));
+            }
+            register_lines.push(format!(
+                "stasis_jit_register_global_u8_array({field_hash}, 0, {name} + {header_bytes}, {payload_len});",
+                name = field.name,
+                header_bytes = header_bytes,
+                payload_len = payload_len
+            ));
+        }
+        other => {
+            return Err(format!(
+                "unsupported packaged runtime field type {other} for {}",
+                field.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn escape_c_string_literal(text: &str) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_ascii_graphic() || c == ' ' => out.push(c),
+            c => out.push_str(&format!("\\x{:02X}", c as u32)),
+        }
+    }
+    out
+}
+
+fn build_engine_bundle_runtime_bridge_source(
+    runtime_fields: &[PackagedRuntimeField],
+    function_symbols: &[String],
+    function_aliases: &[PackagedFunctionAlias],
+    string_literals: &[EngineBundleManifestStringLiteralRow],
+) -> Result<String, String> {
+    let host_i32_hash = crate::hash_global_path("host_i32");
+    let host_f32_hash = crate::hash_global_path("host_f32");
+    let gfx_cmd_i32_hash = crate::hash_global_path("gfx_cmd_i32");
+    let gfx_cmd_f32_hash = crate::hash_global_path("gfx_cmd_f32");
+    let gfx_cmd_u8_hash = crate::hash_global_path("gfx_cmd_u8");
+    let host_req_seq_hash = crate::hash_global_path("host_req_seq");
+    let host_req_flags_hash = crate::hash_global_path("host_req_flags");
+    let host_req_window_w_px_hash = crate::hash_global_path("host_req_window_w_px");
+    let host_req_window_h_px_hash = crate::hash_global_path("host_req_window_h_px");
+
+    let mut source = String::new();
+    source.push_str("#include <stdint.h>\n");
+    source.push_str(
+        "void stasis_jit_register_global_i32_ptr(int32_t path_hash, int32_t* ptr);\n\
+void stasis_jit_register_global_f32_ptr(int32_t path_hash, float* ptr);\n\
+void stasis_jit_register_global_f64_ptr(int32_t path_hash, double* ptr);\n\
+void stasis_jit_register_global_i32_array(int32_t collection_hash, int32_t field_hash, int32_t* ptr, int32_t len);\n\
+void stasis_jit_register_global_f32_array(int32_t collection_hash, int32_t field_hash, float* ptr, int32_t len);\n\
+void stasis_jit_register_global_f64_array(int32_t collection_hash, int32_t field_hash, double* ptr, int32_t len);\n\
+void stasis_jit_register_global_u8_array(int32_t collection_hash, int32_t field_hash, uint8_t* ptr, int32_t len);\n\
+void stasis_jit_register_code_ptr(int32_t fn_id_raw, int64_t code_ptr);\n\
+void stasis_jit_clear_string_literal_table(void);\n\
+void stasis_jit_upsert_string_literal(int32_t id, const char* value);\n",
+    );
+
+    for symbol in function_symbols {
+        source.push_str(&format!("void {}(void);\n", symbol));
+    }
+    for literal in string_literals {
+        source.push_str(&format!(
+            "static const char stasis_literal_{}[] = \"{}\";\n",
+            literal.id.unsigned_abs(),
+            escape_c_string_literal(&literal.value)
+        ));
+    }
+
+    source.push_str(
+        "__declspec(dllexport) int32_t host_i32[768] = {0};\n\
+__declspec(dllexport) float host_f32[64] = {0};\n\
+__declspec(dllexport) int32_t gfx_cmd_i32[34848] = {0};\n\
+__declspec(dllexport) float gfx_cmd_f32[92292] = {0};\n\
+__declspec(dllexport) uint8_t gfx_cmd_u8[65536] = {0};\n\
+__declspec(dllexport) int32_t host_req_seq = 0;\n\
+__declspec(dllexport) int32_t host_req_flags = 0;\n\
+__declspec(dllexport) int32_t host_req_window_w_px = 0;\n\
+__declspec(dllexport) int32_t host_req_window_h_px = 0;\n",
+    );
+
+    let mut register_lines = vec![
+        format!(
+            "stasis_jit_register_global_i32_array({host_i32_hash}, 0, host_i32, 768);"
+        ),
+        format!(
+            "stasis_jit_register_global_f32_array({host_f32_hash}, 0, host_f32, 64);"
+        ),
+        format!(
+            "stasis_jit_register_global_i32_array({gfx_cmd_i32_hash}, 0, gfx_cmd_i32, 34848);"
+        ),
+        format!(
+            "stasis_jit_register_global_f32_array({gfx_cmd_f32_hash}, 0, gfx_cmd_f32, 92292);"
+        ),
+        format!(
+            "stasis_jit_register_global_u8_array({gfx_cmd_u8_hash}, 0, gfx_cmd_u8, 65536);"
+        ),
+        format!(
+            "stasis_jit_register_global_i32_ptr({host_req_seq_hash}, &host_req_seq);"
+        ),
+        format!(
+            "stasis_jit_register_global_i32_ptr({host_req_flags_hash}, &host_req_flags);"
+        ),
+        format!(
+            "stasis_jit_register_global_i32_ptr({host_req_window_w_px_hash}, &host_req_window_w_px);"
+        ),
+        format!(
+            "stasis_jit_register_global_i32_ptr({host_req_window_h_px_hash}, &host_req_window_h_px);"
+        ),
+    ];
+
+    for field in runtime_fields {
+        append_runtime_bridge_field_source(&mut source, &mut register_lines, field)?;
+    }
+    for symbol in function_symbols {
+        let Some(fn_id) = parse_aot_fn_symbol_id(symbol) else {
+            continue;
+        };
+        register_lines.push(format!(
+            "stasis_jit_register_code_ptr({fn_id}, (int64_t)(uintptr_t)&{symbol});"
+        ));
+    }
+    register_lines.push("stasis_jit_clear_string_literal_table();".to_string());
+    for literal in string_literals {
+        register_lines.push(format!(
+            "stasis_jit_upsert_string_literal({id}, stasis_literal_{name});",
+            id = literal.id,
+            name = literal.id.unsigned_abs()
+        ));
+    }
+
+    for alias in function_aliases {
+        if alias.returns_i32 {
+            source.push_str(&format!(
+                "__declspec(dllexport) int32_t {alias}(void) {{ return ((int32_t (*)(void)){target})(); }}\n",
+                alias = alias.alias,
+                target = alias.target_symbol
+            ));
+        } else {
+            source.push_str(&format!(
+                "__declspec(dllexport) void {alias}(void) {{ ((void (*)(void)){target})(); }}\n",
+                alias = alias.alias,
+                target = alias.target_symbol
+            ));
+        }
+    }
+    source.push_str("__declspec(dllexport) void stasis_aot_bind_runtime_globals(void) {\n");
+    for line in register_lines {
+        source.push_str("    ");
+        source.push_str(&line);
+        source.push('\n');
+    }
+    source.push_str("}\n");
+    Ok(source)
+}
+
+fn emit_engine_bundle_runtime_bridge_object(
+    backend: &IncrementalCompilerBackend,
+    runtime_fields: &[PackagedRuntimeField],
+    function_symbols: &[String],
+    function_aliases: &[PackagedFunctionAlias],
+    string_literals: &[EngineBundleManifestStringLiteralRow],
+) -> Result<PathBuf, String> {
+    let source_path = backend
+        .aot_artifact_root
+        .join("engine_bundle_runtime_bridge.c");
+    let object_path = backend
+        .aot_artifact_root
+        .join("engine_bundle_runtime_bridge.obj");
+    let source = build_engine_bundle_runtime_bridge_source(
+        runtime_fields,
+        function_symbols,
+        function_aliases,
+        string_literals,
+    )?;
+    std::fs::write(&source_path, source).map_err(|error| {
+        format!(
+            "failed to write engine bundle runtime bridge source {}: {error}",
+            source_path.display()
+        )
+    })?;
+
+    let output = std::process::Command::new("clang-cl.exe")
+        .arg("/nologo")
+        .arg("/c")
+        .arg("/O2")
+        .arg("/TC")
+        .arg(format!("/Fo{}", object_path.display()))
+        .arg(&source_path)
+        .output()
+        .map_err(|error| format!("failed to spawn clang-cl.exe for runtime bridge object: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "failed to build engine bundle runtime bridge object\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(object_path)
+}
+
+fn resolve_engine_bundle_symbol(
+    manifest: &EngineBundleManifest,
+    name: &str,
+) -> Result<String, String> {
+    manifest
+        .functions
+        .iter()
+        .find(|row| row.name == name)
+        .map(|row| row.symbol.clone())
+        .ok_or_else(|| format!("engine bundle manifest is missing required symbol {name}"))
+}
+
+fn packaged_launch_sidecar_path(output_exe: &Path) -> Result<PathBuf, String> {
+    let file_name = output_exe
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| format!("invalid output file name {}", output_exe.display()))?;
+    Ok(output_exe.with_file_name(format!("{file_name}.launch")))
+}
+
+fn package_engine_bundle_release(
+    backend: &mut IncrementalCompilerBackend,
+    bundle: &AotEngineBundle,
+    output_exe: &Path,
+    project_dir: &Path,
+) -> Result<SelfHostedAotCliSummary, String> {
+    let manifest = backend.read_engine_bundle_manifest(&bundle.manifest_path)?;
+    let entry_symbol = resolve_engine_bundle_symbol(&manifest, "main")?;
+    let tick_symbol = manifest
+        .functions
+        .iter()
+        .find(|row| row.name == "tick")
+        .map(|row| row.symbol.clone());
+    let render_symbol = manifest
+        .functions
+        .iter()
+        .find(|row| row.name == "render")
+        .map(|row| row.symbol.clone());
+    let on_code_swap_symbol = manifest
+        .functions
+        .iter()
+        .find(|row| row.name == "on_code_swap")
+        .map(|row| row.symbol.clone());
+
+    let output_root = output_exe.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(output_root).map_err(|error| {
+        format!(
+            "failed to create AOT output directory {}: {error}",
+            output_root.display()
+        )
+    })?;
+
+    let entry_file = resolve_self_host_aot_entry_file(project_dir)?;
+    let support = stage_entry_support_files(project_dir, entry_file.as_deref(), output_root)?;
+    let mut function_aliases = vec![PackagedFunctionAlias {
+        alias: "main",
+        target_symbol: entry_symbol.clone(),
+        returns_i32: true,
+    }];
+    if let Some(symbol) = tick_symbol.as_ref() {
+        function_aliases.push(PackagedFunctionAlias {
+            alias: "tick",
+            target_symbol: symbol.clone(),
+            returns_i32: true,
+        });
+    }
+    if let Some(symbol) = render_symbol.as_ref() {
+        function_aliases.push(PackagedFunctionAlias {
+            alias: "render",
+            target_symbol: symbol.clone(),
+            returns_i32: true,
+        });
+    }
+    if let Some(symbol) = on_code_swap_symbol.as_ref() {
+        function_aliases.push(PackagedFunctionAlias {
+            alias: "on_code_swap",
+            target_symbol: symbol.clone(),
+            returns_i32: false,
+        });
+    }
+
+    let mut export_symbols: BTreeSet<String> = BTreeSet::new();
+    export_symbols.insert(entry_symbol.clone());
+    export_symbols.insert("main".to_string());
+    export_symbols.insert("stasis_aot_bind_runtime_globals".to_string());
+    if let Some(symbol) = tick_symbol.as_ref() {
+        export_symbols.insert(symbol.clone());
+        export_symbols.insert("tick".to_string());
+    }
+    if let Some(symbol) = render_symbol.as_ref() {
+        export_symbols.insert(symbol.clone());
+        export_symbols.insert("render".to_string());
+    }
+    if let Some(on_code_swap) = on_code_swap_symbol.as_ref() {
+        export_symbols.insert(on_code_swap.clone());
+        export_symbols.insert("on_code_swap".to_string());
+    }
+    for symbol in [
+        "host_i32",
+        "host_f32",
+        "gfx_cmd_i32",
+        "gfx_cmd_f32",
+        "gfx_cmd_u8",
+        "host_req_seq",
+        "host_req_flags",
+        "host_req_window_w_px",
+        "host_req_window_h_px",
+    ] {
+        export_symbols.insert(format!("{symbol},DATA"));
+    }
+    for symbol in &support.export_symbols {
+        export_symbols.insert(format!("{symbol},DATA"));
+    }
+
+    let mut link_config = backend.aot_link_config.clone();
+    let dynload_lib = ensure_stasis_dynload_staticlib()?;
+    if !link_config.runtime_lib_paths.iter().any(|path| path == &dynload_lib) {
+        link_config.runtime_lib_paths.push(dynload_lib);
+    }
+    if cfg!(windows) {
+        if let Some(wrapper) = ensure_rust_lld_link_wrapper(&backend.aot_artifact_root) {
+            link_config.linker_path = Some(wrapper);
+        }
+    }
+
+    let linked_library_path = output_exe.with_extension("dll");
+    let function_symbols: Vec<String> = manifest
+        .functions
+        .iter()
+        .map(|row| row.symbol.clone())
+        .collect();
+    let string_literals = manifest.string_literals.clone().unwrap_or_default();
+    let bridge_object = emit_engine_bundle_runtime_bridge_object(
+        backend,
+        &support.runtime_fields,
+        &function_symbols,
+        &function_aliases,
+        &string_literals,
+    )?;
+    let mut object_paths: Vec<PathBuf> = bundle.object_paths_by_function.values().cloned().collect();
+    object_paths.push(bridge_object);
+    let export_symbols: Vec<String> = export_symbols.into_iter().collect();
+    let initial_link = link_objects_to_dynamic_library(
+        &object_paths,
+        &linked_library_path,
+        &export_symbols,
+        &link_config,
+    );
+    if let Err(initial_error) = initial_link {
+        if cfg!(windows) {
+            if let Some(link_exe) = resolve_msvc_link_exe() {
+                let mut fallback_config = link_config.clone();
+                fallback_config.linker_path = Some(link_exe);
+                link_objects_to_dynamic_library(
+                    &object_paths,
+                    &linked_library_path,
+                    &export_symbols,
+                    &fallback_config,
+                )
+                .map_err(|fallback_error| {
+                    format!(
+                        "dynamic library link failed with configured linker and MSVC fallback\nconfigured_link_error:\n{initial_error}\nmsvc_link_error:\n{fallback_error}"
+                    )
+                })?;
+            } else {
+                return Err(initial_error);
+            }
+        } else {
+            return Err(initial_error);
+        }
+    }
+
+    let (runner_src, graphics_src) = ensure_runtime_release_artifacts()?;
+    copy_file_creating_parent(&runner_src, output_exe)?;
+    copy_file_creating_parent(&graphics_src, &output_root.join("stasis_graphics.dll"))?;
+
+    let launch_path = packaged_launch_sidecar_path(output_exe)?;
+    let linked_library_name = linked_library_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| format!("invalid linked library path {}", linked_library_path.display()))?;
+    let mut launch_lines = vec![
+        format!("dll={linked_library_name}"),
+        "entry=main".to_string(),
+        "fps=60".to_string(),
+    ];
+    if tick_symbol.is_some() {
+        launch_lines.push("tick=tick".to_string());
+    }
+    if render_symbol.is_some() {
+        launch_lines.push("render=render".to_string());
+    }
+    if let (Some(data_json), Some(data_meta)) = (
+        support.data_bind_json_rel.as_ref(),
+        support.data_bind_meta_rel.as_ref(),
+    ) {
+        launch_lines.push(format!("data_bind_json={data_json}"));
+        launch_lines.push(format!("data_bind_meta={data_meta}"));
+    }
+    std::fs::write(&launch_path, launch_lines.join("\n")).map_err(|error| {
+        format!(
+            "failed to write launch manifest {}: {error}",
+            launch_path.display()
+        )
+    })?;
+
+    let import_lib_path = linked_library_path.with_extension("lib");
+    if import_lib_path.exists() {
+        std::fs::remove_file(&import_lib_path).map_err(|error| {
+            format!(
+                "failed to remove import library {}: {error}",
+                import_lib_path.display()
+            )
+        })?;
+    }
+    let export_map_path = linked_library_path.with_extension("exp");
+    if export_map_path.exists() {
+        std::fs::remove_file(&export_map_path).map_err(|error| {
+            format!(
+                "failed to remove export map {}: {error}",
+                export_map_path.display()
+            )
+        })?;
+    }
+    let runner_copy_path = output_root.join("stasis_runner.exe");
+    if runner_copy_path.exists() && runner_copy_path != output_exe {
+        std::fs::remove_file(&runner_copy_path).map_err(|error| {
+            format!(
+                "failed to remove stale runner copy {}: {error}",
+                runner_copy_path.display()
+            )
+        })?;
+    }
+    let default_summary_path = resolve_aot_cli_summary_sidecar_path(output_exe, None);
+    if default_summary_path.exists() {
+        std::fs::remove_file(&default_summary_path).map_err(|error| {
+            format!(
+                "failed to remove stale summary sidecar {}: {error}",
+                default_summary_path.display()
+            )
+        })?;
+    }
+    let legacy_cache_root = output_root.join(".stasis_cache");
+    if legacy_cache_root.exists() {
+        std::fs::remove_dir_all(&legacy_cache_root).map_err(|error| {
+            format!(
+                "failed to remove stale release cache {}: {error}",
+                legacy_cache_root.display()
+            )
+        })?;
+    }
+
+    maybe_sign_output_executable(output_exe)?;
+
+    let object_file_names = object_paths
+        .iter()
+        .map(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_default()
+        })
+        .collect();
+    Ok(SelfHostedAotCliSummary {
+        source_file_count: object_paths.len(),
+        linked_image_path: output_exe.to_path_buf(),
+        entry_symbol: "main".to_string(),
+        ir_bundle_path: PathBuf::new(),
+        object_bundle_path: bundle.manifest_path.clone(),
+        object_file_names,
+    })
 }
 
 fn aot_call_conv() -> &'static str {
@@ -8479,20 +9669,8 @@ echo "signed" > "$1.signed"
         by_hash
     }
 
-    fn parse_aot_symbol_unsigned_id_hash(symbol: &str) -> Option<u32> {
-        let mut parts = symbol.split('_');
-        let tag = parts.next()?;
-        if tag != "fn" {
-            return None;
-        }
-        let id_hash = parts.next()?.parse::<u32>().ok()?;
-        let _sig_hash = parts.next()?;
-        let _ordinal = parts.next()?;
-        Some(id_hash)
-    }
-
-    #[test]
-    fn self_host_aot_cli_links_runnable_executable_with_main_entry_symbol() {
+#[test]
+fn self_host_aot_cli_links_runnable_executable_with_main_entry_symbol() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
@@ -11362,62 +12540,76 @@ fn host_emit_ir_from_compiler_state_with_backend(
         }
         return Err(format_compile_diagnostics(&result.diagnostics));
     }
-    let main_fn_id = backend
-        .existing_fn_id_for_identifier_hash(hash_identifier("main"))
-        .ok_or_else(|| "missing resolved fn_id for main".to_string())?;
-    let entry_symbol = result
-        .aot_function_symbols
-        .as_ref()
-        .and_then(|symbols| {
-            symbols
-                .iter()
-                .find(|entry| entry.fn_id == main_fn_id)
-                .map(|entry| entry.symbol.clone())
-        })
-        .ok_or_else(|| "missing AOT symbol mapping for main".to_string())?;
+    let entry_symbol = resolve_self_host_aot_entry_symbol(backend, &result, "main")?;
 
     let manifest_path = backend.aot_artifact_root.join("last_patch_manifest.json");
-    let manifest_text = std::fs::read_to_string(&manifest_path).map_err(|error| {
-        format!(
-            "failed to read AOT patch manifest {}: {error}",
-            manifest_path.display()
-        )
-    })?;
-    let manifest: AotPatchManifest = serde_json::from_str(&manifest_text).map_err(|error| {
-        format!(
-            "failed to parse AOT patch manifest {}: {error}",
-            manifest_path.display()
-        )
-    })?;
-    if env_snapshot.strict_self_host
-        && !env_snapshot.allow_stub_fallback
-        && !manifest.fallback_stub_symbols.is_empty()
-    {
-        let preview = manifest
-            .fallback_stub_symbols
-            .iter()
-            .take(6)
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ");
+    let object_paths: Vec<String> = if manifest_path.exists() {
+        let manifest_text = std::fs::read_to_string(&manifest_path).map_err(|error| {
+            format!(
+                "failed to read AOT patch manifest {}: {error}",
+                manifest_path.display()
+            )
+        })?;
+        let manifest: AotPatchManifest = serde_json::from_str(&manifest_text).map_err(|error| {
+            format!(
+                "failed to parse AOT patch manifest {}: {error}",
+                manifest_path.display()
+            )
+        })?;
+        if env_snapshot.strict_self_host
+            && !env_snapshot.allow_stub_fallback
+            && !manifest.fallback_stub_symbols.is_empty()
+        {
+            let preview = manifest
+                .fallback_stub_symbols
+                .iter()
+                .take(6)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "self-host aot-cli strict mode rejected stub fallback lowering for i32 functions: {preview}; set STASIS_AOT_ALLOW_STUB_FALLBACK=1 to bypass temporarily"
+            ));
+        }
+        if env_snapshot.quality_gate
+            && manifest
+                .fallback_stub_symbols
+                .iter()
+                .any(|symbol| symbol == &entry_symbol)
+        {
+            return Err(format!(
+                "quality gate rejected output: entry symbol {entry_symbol} still uses fallback stub lowering; add lowering coverage for selected entry path before producing game executable"
+            ));
+        }
+        manifest.artifact_paths
+    } else if let Some(bundle) = backend.last_aot_engine_bundle.as_ref() {
+        if env_snapshot.strict_self_host && !env_snapshot.allow_stub_fallback {
+            return Err(
+                "self-host aot-cli strict mode is not yet supported for engine-bundle AOT outputs"
+                    .to_string(),
+            );
+        }
+        if env_snapshot.quality_gate {
+            return Err(
+                "self-host aot-cli quality gate is not yet supported for engine-bundle AOT outputs"
+                    .to_string(),
+            );
+        }
+        bundle
+            .object_paths_by_function
+            .values()
+            .map(|path| path.display().to_string())
+            .collect()
+    } else {
         return Err(format!(
-            "self-host aot-cli strict mode rejected stub fallback lowering for i32 functions: {preview}; set STASIS_AOT_ALLOW_STUB_FALLBACK=1 to bypass temporarily"
+            "failed to find AOT artifact manifest at {} and no engine bundle was available",
+            manifest_path.display()
         ));
-    }
-    if env_snapshot.quality_gate
-        && manifest
-            .fallback_stub_symbols
-            .iter()
-            .any(|symbol| symbol == &entry_symbol)
-    {
-        return Err(format!(
-            "quality gate rejected output: entry symbol {entry_symbol} still uses fallback stub lowering; add lowering coverage for selected entry path before producing game executable"
-        ));
-    }
+    };
     let ir_bundle = SelfHostIrBundle {
         source_file_count: changed_files.len(),
         entry_symbol,
-        object_paths: manifest.artifact_paths,
+        object_paths,
     };
     let ir_bundle_path = backend.aot_artifact_root.join("self_host_ir_bundle.json");
     let ir_json = serde_json::to_string_pretty(&ir_bundle)
@@ -11476,7 +12668,12 @@ fn host_link_executable_from_object_bundle_with_backend(
     backend: &mut IncrementalCompilerBackend,
     object_bundle_path: &Path,
     output_exe: &Path,
+    project_dir: &Path,
 ) -> Result<SelfHostedAotCliSummary, String> {
+    if let Some(bundle) = backend.last_aot_engine_bundle.as_ref().cloned() {
+        return package_engine_bundle_release(backend, &bundle, output_exe, project_dir);
+    }
+
     let object_text = std::fs::read_to_string(object_bundle_path).map_err(|error| {
         format!(
             "failed to read object bundle {}: {error}",
@@ -12384,11 +13581,17 @@ fn run_self_host_aot_cli_with_backend(
         backend,
         &object_bundle_path,
         output_exe,
+        project_dir,
     )?;
     summary.source_file_count = changed_files.len();
     summary.ir_bundle_path = ir_bundle_path;
     summary.object_bundle_path = object_bundle_path;
-    write_default_aot_cli_summary_sidecar(&summary, env_snapshot.summary_file_path.as_deref())?;
+    let is_packaged_output = packaged_launch_sidecar_path(&summary.linked_image_path)
+        .ok()
+        .is_some_and(|path| path.exists());
+    if env_snapshot.summary_file_path.is_some() || !is_packaged_output {
+        write_default_aot_cli_summary_sidecar(&summary, env_snapshot.summary_file_path.as_deref())?;
+    }
     Ok(summary)
 }
 
@@ -12396,11 +13599,17 @@ pub fn run_self_host_aot_cli(
     project_dir: &Path,
     output_exe: &Path,
 ) -> Result<SelfHostedAotCliSummary, String> {
-    let artifact_root = output_exe
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
+    let output_key = output_exe
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("aot_output");
+    let artifact_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
         .join(".stasis_cache")
-        .join("aot_cli");
+        .join("aot_cli")
+        .join(output_key);
     let mut backend = IncrementalCompilerBackend::new_self_host_aot_cli(artifact_root);
     run_self_host_aot_cli_with_backend(&mut backend, project_dir, output_exe)
 }

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2394,12 +2394,19 @@ fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
         .map(PathBuf::from)
         .unwrap_or_else(|| self_host_repo_root().join("target"));
     let mut candidates: Vec<PathBuf> = Vec::new();
+    let static_lib_names: &[&str] = if cfg!(windows) {
+        &["stasis_dynload.lib"]
+    } else {
+        &["libstasis_dynload.a", "stasis_dynload.a"]
+    };
 
     for profile in ["debug", "release"] {
         let base = target_dir.join(profile);
-        let direct = base.join("stasis_dynload.lib");
-        if direct.exists() {
-            candidates.push(direct);
+        for name in static_lib_names {
+            let direct = base.join(name);
+            if direct.exists() {
+                candidates.push(direct);
+            }
         }
 
         let deps = base.join("deps");
@@ -2411,13 +2418,56 @@ fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
             let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
                 continue;
             };
-            if name.starts_with("stasis_dynload-") && name.ends_with(".lib") {
+            if cfg!(windows) {
+                if name.starts_with("stasis_dynload-") && name.ends_with(".lib") {
+                    candidates.push(path);
+                }
+            } else if (name.starts_with("libstasis_dynload-")
+                || name.starts_with("stasis_dynload-"))
+                && name.ends_with(".a")
+            {
                 candidates.push(path);
             }
         }
     }
 
     resolve_latest_existing_path(candidates)
+}
+
+fn runtime_runner_file_name() -> &'static str {
+    if cfg!(windows) {
+        "stasis_runner.exe"
+    } else {
+        "stasis_runner"
+    }
+}
+
+fn runtime_graphics_file_names() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["stasis_graphics.dll"]
+    } else if cfg!(target_os = "macos") {
+        &["libstasis_graphics.dylib", "stasis_graphics.dylib"]
+    } else {
+        &["libstasis_graphics.so", "stasis_graphics.so"]
+    }
+}
+
+fn packaged_runtime_library_extension() -> &'static str {
+    if cfg!(windows) {
+        "dll"
+    } else if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    }
+}
+
+fn runtime_bridge_object_extension() -> &'static str {
+    if cfg!(windows) {
+        "obj"
+    } else {
+        "o"
+    }
 }
 
 fn ensure_stasis_dynload_staticlib() -> Result<PathBuf, String> {
@@ -2447,39 +2497,60 @@ fn ensure_stasis_dynload_staticlib() -> Result<PathBuf, String> {
         ));
     }
 
-    resolve_stasis_dynload_lib()
-        .ok_or_else(|| "stasis_dynload staticlib build reported success but no .lib was found".to_string())
+    resolve_stasis_dynload_lib().ok_or_else(|| {
+        "stasis_dynload staticlib build reported success but no static library was found"
+            .to_string()
+    })
 }
 
 fn resolve_runtime_runner_path(repo_root: &Path) -> Option<PathBuf> {
+    let runner_name = runtime_runner_file_name();
     resolve_latest_existing_path(vec![
-        repo_root.join("stasis_runner.exe"),
-        repo_root.join("build").join("stasis_runner.exe"),
+        repo_root.join(runner_name),
+        repo_root.join("build").join(runner_name),
         repo_root
             .join("runtime")
             .join("build")
             .join("bin")
             .join("Release")
-            .join("stasis_runner.exe"),
+            .join(runner_name),
+        repo_root
+            .join("runtime")
+            .join("build")
+            .join("bin")
+            .join(runner_name),
     ])
 }
 
 fn resolve_runtime_graphics_path(repo_root: &Path) -> Option<PathBuf> {
-    resolve_latest_existing_path(vec![
-        repo_root.join("stasis_graphics.dll"),
-        repo_root.join("build").join("stasis_graphics.dll"),
-        repo_root
-            .join("runtime")
-            .join("build")
-            .join("bin")
-            .join("Release")
-            .join("stasis_graphics.dll"),
-    ])
+    let mut candidates = Vec::new();
+    for name in runtime_graphics_file_names() {
+        candidates.push(repo_root.join(name));
+        candidates.push(repo_root.join("build").join(name));
+        candidates.push(
+            repo_root
+                .join("runtime")
+                .join("build")
+                .join("bin")
+                .join("Release")
+                .join(name),
+        );
+        candidates.push(
+            repo_root
+                .join("runtime")
+                .join("build")
+                .join("bin")
+                .join(name),
+        );
+    }
+    resolve_latest_existing_path(candidates)
 }
 
 fn resolve_msvc_link_exe() -> Option<PathBuf> {
     let roots = [
-        PathBuf::from(r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"),
+        PathBuf::from(
+            r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC",
+        ),
         PathBuf::from(r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"),
     ];
     let mut candidates = Vec::new();
@@ -2488,7 +2559,12 @@ fn resolve_msvc_link_exe() -> Option<PathBuf> {
             continue;
         };
         for entry in entries.flatten() {
-            let path = entry.path().join("bin").join("HostX64").join("x64").join("link.exe");
+            let path = entry
+                .path()
+                .join("bin")
+                .join("HostX64")
+                .join("x64")
+                .join("link.exe");
             if path.exists() {
                 candidates.push(path);
             }
@@ -2515,7 +2591,10 @@ fn resolve_rust_lld_exe() -> Option<PathBuf> {
 fn ensure_rust_lld_link_wrapper(artifact_root: &Path) -> Option<PathBuf> {
     let rust_lld = resolve_rust_lld_exe()?;
     let wrapper_path = artifact_root.join("rust-lld-link.cmd");
-    let script = format!("@echo off\r\n\"{}\" -flavor link %*\r\n", rust_lld.display());
+    let script = format!(
+        "@echo off\r\n\"{}\" -flavor link %*\r\n",
+        rust_lld.display()
+    );
     std::fs::write(&wrapper_path, script).ok()?;
     Some(wrapper_path)
 }
@@ -2528,24 +2607,67 @@ fn ensure_runtime_release_artifacts() -> Result<(PathBuf, PathBuf), String> {
         return Ok((runner, graphics));
     }
 
-    let output = std::process::Command::new("cmd")
-        .arg("/c")
-        .arg("runtime\\build.bat")
-        .current_dir(&repo_root)
-        .output()
-        .map_err(|error| format!("failed to spawn runtime\\build.bat: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "runtime\\build.bat failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        ));
+    if cfg!(windows) {
+        let output = std::process::Command::new("cmd")
+            .arg("/c")
+            .arg("runtime\\build.bat")
+            .current_dir(&repo_root)
+            .output()
+            .map_err(|error| format!("failed to spawn runtime\\build.bat: {error}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "runtime\\build.bat failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+    } else {
+        let configure = std::process::Command::new("cmake")
+            .arg("-S")
+            .arg("runtime")
+            .arg("-B")
+            .arg("runtime/build")
+            .arg("-DCMAKE_BUILD_TYPE=Release")
+            .current_dir(&repo_root)
+            .output()
+            .map_err(|error| format!("failed to spawn cmake configure for runtime: {error}"))?;
+        if !configure.status.success() {
+            return Err(format!(
+                "cmake runtime configure failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&configure.stdout),
+                String::from_utf8_lossy(&configure.stderr)
+            ));
+        }
+
+        let build = std::process::Command::new("cmake")
+            .arg("--build")
+            .arg("runtime/build")
+            .arg("--config")
+            .arg("Release")
+            .current_dir(&repo_root)
+            .output()
+            .map_err(|error| format!("failed to spawn cmake build for runtime: {error}"))?;
+        if !build.status.success() {
+            return Err(format!(
+                "cmake runtime build failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&build.stdout),
+                String::from_utf8_lossy(&build.stderr)
+            ));
+        }
     }
 
-    let runner = resolve_runtime_runner_path(&repo_root)
-        .ok_or_else(|| "runtime build succeeded but stasis_runner.exe was not found".to_string())?;
-    let graphics = resolve_runtime_graphics_path(&repo_root)
-        .ok_or_else(|| "runtime build succeeded but stasis_graphics.dll was not found".to_string())?;
+    let runner = resolve_runtime_runner_path(&repo_root).ok_or_else(|| {
+        format!(
+            "runtime build succeeded but {} was not found",
+            runtime_runner_file_name()
+        )
+    })?;
+    let graphics = resolve_runtime_graphics_path(&repo_root).ok_or_else(|| {
+        format!(
+            "runtime build succeeded but none of {:?} were found",
+            runtime_graphics_file_names()
+        )
+    })?;
     Ok((runner, graphics))
 }
 
@@ -2569,12 +2691,8 @@ fn copy_file_creating_parent(src: &Path, dst: &Path) -> Result<(), String> {
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(dst).map_err(|error| {
-        format!(
-            "failed to create directory {}: {error}",
-            dst.display()
-        )
-    })?;
+    std::fs::create_dir_all(dst)
+        .map_err(|error| format!("failed to create directory {}: {error}", dst.display()))?;
     let entries = std::fs::read_dir(src)
         .map_err(|error| format!("failed to read directory {}: {error}", src.display()))?;
     for entry in entries {
@@ -2586,9 +2704,9 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
         })?;
         let path = entry.path();
         let dst_path = dst.join(entry.file_name());
-        let file_type = entry.file_type().map_err(|error| {
-            format!("failed to read file type for {}: {error}", path.display())
-        })?;
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to read file type for {}: {error}", path.display()))?;
         if file_type.is_dir() {
             copy_dir_recursive(&path, &dst_path)?;
         } else if file_type.is_file() {
@@ -2625,16 +2743,16 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
             }
             let text = std::fs::read_to_string(&path)
                 .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
-            let meta: StructMetaExportFile = serde_json::from_str(&text).map_err(|error| {
-                format!("failed to parse {}: {error}", path.display())
-            })?;
+            let meta: StructMetaExportFile = serde_json::from_str(&text)
+                .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
             for field in meta.fields {
-                out.entry(field.name.clone()).or_insert(PackagedRuntimeField {
-                    name: field.name,
-                    size: field.size,
-                    field_type: field.field_type,
-                    array_count: field.array_count,
-                });
+                out.entry(field.name.clone())
+                    .or_insert(PackagedRuntimeField {
+                        name: field.name,
+                        size: field.size,
+                        field_type: field.field_type,
+                        array_count: field.array_count,
+                    });
             }
         }
         Ok(())
@@ -2690,7 +2808,8 @@ fn copy_json_referenced_absolute_assets(
         }
         serde_json::Value::String(text) => {
             let source = PathBuf::from(text.as_str());
-            if !source.is_absolute() || !source.exists() || !is_bundleable_asset_extension(&source) {
+            if !source.is_absolute() || !source.exists() || !is_bundleable_asset_extension(&source)
+            {
                 return Ok(false);
             }
 
@@ -2717,7 +2836,10 @@ fn copy_json_referenced_absolute_assets(
                     .file_stem()
                     .and_then(|value| value.to_str())
                     .unwrap_or("asset");
-                let ext = source.extension().and_then(|value| value.to_str()).unwrap_or("");
+                let ext = source
+                    .extension()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("");
                 let mut counter: usize = 1;
                 while destination.exists() {
                     let candidate = if ext.is_empty() {
@@ -2843,16 +2965,22 @@ fn stage_entry_support_files(
 
     let runtime_fields = collect_struct_meta_fields(&staged_bundle_dir)?;
     let mut support = PackagedAotSupportFiles {
-        export_symbols: runtime_fields.iter().map(|field| field.name.clone()).collect(),
+        export_symbols: runtime_fields
+            .iter()
+            .map(|field| field.name.clone())
+            .collect(),
         runtime_fields,
         ..PackagedAotSupportFiles::default()
     };
 
     let data_json = staged_bundle_dir.join("data").join("config.json");
-    let data_meta = staged_bundle_dir.join("data").join("config.struct-meta.json");
+    let data_meta = staged_bundle_dir
+        .join("data")
+        .join("config.struct-meta.json");
     if data_json.exists() && data_meta.exists() {
         support.data_bind_json_rel = Some(format!("{package_dir_name}/data/config.json"));
-        support.data_bind_meta_rel = Some(format!("{package_dir_name}/data/config.struct-meta.json"));
+        support.data_bind_meta_rel =
+            Some(format!("{package_dir_name}/data/config.struct-meta.json"));
     }
 
     Ok(support)
@@ -2869,7 +2997,7 @@ fn append_runtime_bridge_field_source(
         "bool" | "u8" | "u16" | "u32" | "i32" => {
             if field.array_count > 1 {
                 source.push_str(&format!(
-                    "__declspec(dllexport) int32_t {}[{}] = {{0}};\n",
+                    "STASIS_EXPORT int32_t {}[{}] = {{0}};\n",
                     field.name, field.array_count
                 ));
                 register_lines.push(format!(
@@ -2878,10 +3006,7 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!(
-                    "__declspec(dllexport) int32_t {} = 0;\n",
-                    field.name
-                ));
+                source.push_str(&format!("STASIS_EXPORT int32_t {} = 0;\n", field.name));
                 register_lines.push(format!(
                     "stasis_jit_register_global_i32_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2891,7 +3016,7 @@ fn append_runtime_bridge_field_source(
         "f32" => {
             if field.array_count > 1 {
                 source.push_str(&format!(
-                    "__declspec(dllexport) float {}[{}] = {{0}};\n",
+                    "STASIS_EXPORT float {}[{}] = {{0}};\n",
                     field.name, field.array_count
                 ));
                 register_lines.push(format!(
@@ -2900,10 +3025,7 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!(
-                    "__declspec(dllexport) float {} = 0.0f;\n",
-                    field.name
-                ));
+                source.push_str(&format!("STASIS_EXPORT float {} = 0.0f;\n", field.name));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f32_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2913,7 +3035,7 @@ fn append_runtime_bridge_field_source(
         "f64" => {
             if field.array_count > 1 {
                 source.push_str(&format!(
-                    "__declspec(dllexport) double {}[{}] = {{0}};\n",
+                    "STASIS_EXPORT double {}[{}] = {{0}};\n",
                     field.name, field.array_count
                 ));
                 register_lines.push(format!(
@@ -2922,10 +3044,7 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!(
-                    "__declspec(dllexport) double {} = 0.0;\n",
-                    field.name
-                ));
+                source.push_str(&format!("STASIS_EXPORT double {} = 0.0;\n", field.name));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f64_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2937,7 +3056,7 @@ fn append_runtime_bridge_field_source(
             let header_bytes = field.size.saturating_sub(field.array_count);
             let payload_len = field.array_count.max(1);
             source.push_str(&format!(
-                "__declspec(dllexport) uint8_t {}[{}] = {{0}};\n",
+                "STASIS_EXPORT uint8_t {}[{}] = {{0}};\n",
                 field.name, len
             ));
             if header_bytes >= 8 {
@@ -3019,6 +3138,13 @@ fn build_engine_bundle_runtime_bridge_source(
     let mut source = String::new();
     source.push_str("#include <stdint.h>\n");
     source.push_str(
+        "#if defined(_WIN32)\n\
+#define STASIS_EXPORT __declspec(dllexport)\n\
+#else\n\
+#define STASIS_EXPORT __attribute__((visibility(\"default\")))\n\
+#endif\n",
+    );
+    source.push_str(
         "void stasis_jit_register_global_i32_ptr(int32_t path_hash, int32_t* ptr);\n\
 void stasis_jit_register_global_f32_ptr(int32_t path_hash, float* ptr);\n\
 void stasis_jit_register_global_f64_ptr(int32_t path_hash, double* ptr);\n\
@@ -3043,15 +3169,15 @@ void stasis_jit_upsert_string_literal(int32_t id, const char* value);\n",
     }
 
     source.push_str(
-        "__declspec(dllexport) int32_t host_i32[768] = {0};\n\
-__declspec(dllexport) float host_f32[64] = {0};\n\
-__declspec(dllexport) int32_t gfx_cmd_i32[34848] = {0};\n\
-__declspec(dllexport) float gfx_cmd_f32[92292] = {0};\n\
-__declspec(dllexport) uint8_t gfx_cmd_u8[65536] = {0};\n\
-__declspec(dllexport) int32_t host_req_seq = 0;\n\
-__declspec(dllexport) int32_t host_req_flags = 0;\n\
-__declspec(dllexport) int32_t host_req_window_w_px = 0;\n\
-__declspec(dllexport) int32_t host_req_window_h_px = 0;\n",
+        "STASIS_EXPORT int32_t host_i32[768] = {0};\n\
+STASIS_EXPORT float host_f32[64] = {0};\n\
+STASIS_EXPORT int32_t gfx_cmd_i32[34848] = {0};\n\
+STASIS_EXPORT float gfx_cmd_f32[92292] = {0};\n\
+STASIS_EXPORT uint8_t gfx_cmd_u8[65536] = {0};\n\
+STASIS_EXPORT int32_t host_req_seq = 0;\n\
+STASIS_EXPORT int32_t host_req_flags = 0;\n\
+STASIS_EXPORT int32_t host_req_window_w_px = 0;\n\
+STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
     );
 
     let mut register_lines = vec![
@@ -3107,19 +3233,19 @@ __declspec(dllexport) int32_t host_req_window_h_px = 0;\n",
     for alias in function_aliases {
         if alias.returns_i32 {
             source.push_str(&format!(
-                "__declspec(dllexport) int32_t {alias}(void) {{ return ((int32_t (*)(void)){target})(); }}\n",
+                "STASIS_EXPORT int32_t {alias}(void) {{ return ((int32_t (*)(void)){target})(); }}\n",
                 alias = alias.alias,
                 target = alias.target_symbol
             ));
         } else {
             source.push_str(&format!(
-                "__declspec(dllexport) void {alias}(void) {{ ((void (*)(void)){target})(); }}\n",
+                "STASIS_EXPORT void {alias}(void) {{ ((void (*)(void)){target})(); }}\n",
                 alias = alias.alias,
                 target = alias.target_symbol
             ));
         }
     }
-    source.push_str("__declspec(dllexport) void stasis_aot_bind_runtime_globals(void) {\n");
+    source.push_str("STASIS_EXPORT void stasis_aot_bind_runtime_globals(void) {\n");
     for line in register_lines {
         source.push_str("    ");
         source.push_str(&line);
@@ -3139,9 +3265,10 @@ fn emit_engine_bundle_runtime_bridge_object(
     let source_path = backend
         .aot_artifact_root
         .join("engine_bundle_runtime_bridge.c");
-    let object_path = backend
-        .aot_artifact_root
-        .join("engine_bundle_runtime_bridge.obj");
+    let object_path = backend.aot_artifact_root.join(format!(
+        "engine_bundle_runtime_bridge.{}",
+        runtime_bridge_object_extension()
+    ));
     let source = build_engine_bundle_runtime_bridge_source(
         runtime_fields,
         function_symbols,
@@ -3155,20 +3282,62 @@ fn emit_engine_bundle_runtime_bridge_object(
         )
     })?;
 
-    let output = std::process::Command::new("clang-cl.exe")
-        .arg("/nologo")
-        .arg("/c")
-        .arg("/O2")
-        .arg("/TC")
-        .arg(format!("/Fo{}", object_path.display()))
-        .arg(&source_path)
-        .output()
-        .map_err(|error| format!("failed to spawn clang-cl.exe for runtime bridge object: {error}"))?;
+    let compiler = std::env::var_os("CC").unwrap_or_else(|| {
+        if cfg!(windows) {
+            "clang-cl.exe".into()
+        } else {
+            "cc".into()
+        }
+    });
+    let compiler_name = Path::new(&compiler)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let is_msvc_style = cfg!(windows)
+        && (compiler_name == "clang-cl"
+            || compiler_name == "clang-cl.exe"
+            || compiler_name == "cl"
+            || compiler_name == "cl.exe");
+    let mut command = std::process::Command::new(&compiler);
+    if is_msvc_style {
+        command
+            .arg("/nologo")
+            .arg("/c")
+            .arg("/O2")
+            .arg("/TC")
+            .arg(format!("/Fo{}", object_path.display()))
+            .arg(&source_path);
+    } else {
+        command
+            .arg("-c")
+            .arg("-O2")
+            .arg("-x")
+            .arg("c")
+            .arg("-o")
+            .arg(&object_path);
+        if !cfg!(windows) {
+            command.arg("-fPIC");
+        }
+        command.arg(&source_path);
+    }
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to spawn C compiler {:?} for runtime bridge object: {error}",
+            compiler
+        )
+    })?;
     if !output.status.success() {
         return Err(format!(
             "failed to build engine bundle runtime bridge object\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    if !object_path.exists() {
+        return Err(format!(
+            "runtime bridge compile succeeded but did not produce {}",
+            object_path.display()
         ));
     }
     Ok(object_path)
@@ -3290,7 +3459,11 @@ fn package_engine_bundle_release(
 
     let mut link_config = backend.aot_link_config.clone();
     let dynload_lib = ensure_stasis_dynload_staticlib()?;
-    if !link_config.runtime_lib_paths.iter().any(|path| path == &dynload_lib) {
+    if !link_config
+        .runtime_lib_paths
+        .iter()
+        .any(|path| path == &dynload_lib)
+    {
         link_config.runtime_lib_paths.push(dynload_lib);
     }
     if cfg!(windows) {
@@ -3299,7 +3472,7 @@ fn package_engine_bundle_release(
         }
     }
 
-    let linked_library_path = output_exe.with_extension("dll");
+    let linked_library_path = output_exe.with_extension(packaged_runtime_library_extension());
     let function_symbols: Vec<String> = manifest
         .functions
         .iter()
@@ -3313,7 +3486,8 @@ fn package_engine_bundle_release(
         &function_aliases,
         &string_literals,
     )?;
-    let mut object_paths: Vec<PathBuf> = bundle.object_paths_by_function.values().cloned().collect();
+    let mut object_paths: Vec<PathBuf> =
+        bundle.object_paths_by_function.values().cloned().collect();
     object_paths.push(bridge_object);
     let export_symbols: Vec<String> = export_symbols.into_iter().collect();
     let initial_link = link_objects_to_dynamic_library(
@@ -3348,13 +3522,23 @@ fn package_engine_bundle_release(
 
     let (runner_src, graphics_src) = ensure_runtime_release_artifacts()?;
     copy_file_creating_parent(&runner_src, output_exe)?;
-    copy_file_creating_parent(&graphics_src, &output_root.join("stasis_graphics.dll"))?;
+    let graphics_dst = output_root.join(
+        graphics_src
+            .file_name()
+            .ok_or_else(|| format!("invalid graphics runtime path {}", graphics_src.display()))?,
+    );
+    copy_file_creating_parent(&graphics_src, &graphics_dst)?;
 
     let launch_path = packaged_launch_sidecar_path(output_exe)?;
     let linked_library_name = linked_library_path
         .file_name()
         .and_then(|value| value.to_str())
-        .ok_or_else(|| format!("invalid linked library path {}", linked_library_path.display()))?;
+        .ok_or_else(|| {
+            format!(
+                "invalid linked library path {}",
+                linked_library_path.display()
+            )
+        })?;
     let mut launch_lines = vec![
         format!("dll={linked_library_name}"),
         "entry=main".to_string(),
@@ -3398,35 +3582,9 @@ fn package_engine_bundle_release(
             )
         })?;
     }
-    let runner_copy_path = output_root.join("stasis_runner.exe");
-    if runner_copy_path.exists() && runner_copy_path != output_exe {
-        std::fs::remove_file(&runner_copy_path).map_err(|error| {
-            format!(
-                "failed to remove stale runner copy {}: {error}",
-                runner_copy_path.display()
-            )
-        })?;
-    }
-    let default_summary_path = resolve_aot_cli_summary_sidecar_path(output_exe, None);
-    if default_summary_path.exists() {
-        std::fs::remove_file(&default_summary_path).map_err(|error| {
-            format!(
-                "failed to remove stale summary sidecar {}: {error}",
-                default_summary_path.display()
-            )
-        })?;
-    }
-    let legacy_cache_root = output_root.join(".stasis_cache");
-    if legacy_cache_root.exists() {
-        std::fs::remove_dir_all(&legacy_cache_root).map_err(|error| {
-            format!(
-                "failed to remove stale release cache {}: {error}",
-                legacy_cache_root.display()
-            )
-        })?;
-    }
-
-    maybe_sign_output_executable(output_exe)?;
+    maybe_sign_output_artifact(output_exe)?;
+    maybe_sign_output_artifact(&linked_library_path)?;
+    maybe_sign_output_artifact(&graphics_dst)?;
 
     let object_file_names = object_paths
         .iter()
@@ -5283,14 +5441,11 @@ mod tests {
         store(11, 0);
 
         // Force in-level gameplay (not title screen): enter level 1, place a brick, then start battle.
-        stasis_dynload::invoke_i32_to_void(start_level_ptr as usize, 0).expect("invoke start_level");
-        let place_rc = stasis_dynload::invoke_i32_i32_i32_to_i32(
-            place_brick_at_grid_ptr as usize,
-            0,
-            0,
-            0,
-        )
-        .expect("invoke place_brick_at_grid");
+        stasis_dynload::invoke_i32_to_void(start_level_ptr as usize, 0)
+            .expect("invoke start_level");
+        let place_rc =
+            stasis_dynload::invoke_i32_i32_i32_to_i32(place_brick_at_grid_ptr as usize, 0, 0, 0)
+                .expect("invoke place_brick_at_grid");
         assert_ne!(place_rc, 0, "expected place_brick_at_grid to succeed");
         stasis_dynload::invoke_noarg_void(try_start_battle_ptr as usize)
             .expect("invoke brickout_try_start_battle");
@@ -9669,8 +9824,8 @@ echo "signed" > "$1.signed"
         by_hash
     }
 
-#[test]
-fn self_host_aot_cli_links_runnable_executable_with_main_entry_symbol() {
+    #[test]
+    fn self_host_aot_cli_links_runnable_executable_with_main_entry_symbol() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
@@ -13614,29 +13769,33 @@ pub fn run_self_host_aot_cli(
     run_self_host_aot_cli_with_backend(&mut backend, project_dir, output_exe)
 }
 
-fn maybe_sign_output_executable(output_exe: &Path) -> Result<(), String> {
+fn maybe_sign_output_artifact(artifact_path: &Path) -> Result<(), String> {
     let Some(sign_tool) = std::env::var_os("STASIS_AOT_SIGN_TOOL") else {
         return Ok(());
     };
     let status = std::process::Command::new(&sign_tool)
-        .arg(output_exe)
+        .arg(artifact_path)
         .status()
         .map_err(|error| {
             format!(
                 "failed to launch signer tool {:?} for {}: {error}",
                 sign_tool,
-                output_exe.display()
+                artifact_path.display()
             )
         })?;
     if !status.success() {
         return Err(format!(
             "signer tool {:?} failed for {} with status {:?}",
             sign_tool,
-            output_exe.display(),
+            artifact_path.display(),
             status.code()
         ));
     }
     Ok(())
+}
+
+fn maybe_sign_output_executable(output_exe: &Path) -> Result<(), String> {
+    maybe_sign_output_artifact(output_exe)
 }
 
 fn metric_uses_stub_fallback(metric: &stasis_compiler::FunctionMetric) -> bool {

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1,13 +1,14 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
 use std::collections::HashMap;
+use std::ffi::c_char;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 #[cfg(windows)]
-use std::ffi::{c_char, c_void, CString, OsStr};
+use std::ffi::{c_void, CString, OsStr};
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 
@@ -564,6 +565,19 @@ pub fn replace_jit_code_ptr_table(entries: &[(u32, usize)]) {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_code_ptr(fn_id_raw: i32, code_ptr: i64) {
+    if fn_id_raw < 0 || code_ptr == 0 {
+        return;
+    }
+    let _dispatch_lock = jit_dispatch_lock()
+        .lock()
+        .expect("jit dispatch lock mutex poisoned");
+    let table = jit_code_ptr_table();
+    let mut guard = table.lock().expect("jit code ptr table mutex poisoned");
+    guard.insert(fn_id_raw as u32, code_ptr as usize);
+}
+
 pub fn clear_jit_string_literal_table() {
     let table = jit_string_literal_table();
     let mut guard = table
@@ -578,6 +592,25 @@ pub fn upsert_jit_string_literal(id: i32, value: &str) {
         .lock()
         .expect("jit string literal table mutex poisoned");
     guard.insert(id, value.to_string());
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_clear_string_literal_table() {
+    clear_jit_string_literal_table();
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_upsert_string_literal(id: i32, value: *const c_char) {
+    if value.is_null() {
+        return;
+    }
+    #[cfg(windows)]
+    let text = unsafe { std::ffi::CStr::from_ptr(value) };
+    #[cfg(not(windows))]
+    let text = unsafe { std::ffi::CStr::from_ptr(value) };
+    if let Ok(text) = text.to_str() {
+        upsert_jit_string_literal(id, text);
+    }
 }
 
 pub fn jit_string_literal_value(id: i32) -> Option<String> {
@@ -742,6 +775,73 @@ pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut
         .lock()
         .expect("registered u8 array table mutex poisoned");
     guard.insert((collection_hash, field_hash), (ptr as usize, len));
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
+    register_global_i32_ptr(path_hash, ptr);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
+    register_global_f32_ptr(path_hash, ptr);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_f64_ptr(path_hash: i32, ptr: *mut f64) {
+    register_global_f64_ptr(path_hash, ptr);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_i32_array(
+    collection_hash: i32,
+    field_hash: i32,
+    ptr: *mut i32,
+    len: i32,
+) {
+    if len <= 0 {
+        return;
+    }
+    register_global_i32_array(collection_hash, field_hash, ptr, len as usize);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_f32_array(
+    collection_hash: i32,
+    field_hash: i32,
+    ptr: *mut f32,
+    len: i32,
+) {
+    if len <= 0 {
+        return;
+    }
+    register_global_f32_array(collection_hash, field_hash, ptr, len as usize);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_f64_array(
+    collection_hash: i32,
+    field_hash: i32,
+    ptr: *mut f64,
+    len: i32,
+) {
+    if len <= 0 {
+        return;
+    }
+    register_global_f64_array(collection_hash, field_hash, ptr, len as usize);
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_register_global_u8_array(
+    collection_hash: i32,
+    field_hash: i32,
+    ptr: *mut u8,
+    len: i32,
+) {
+    if len <= 0 {
+        return;
+    }
+    register_global_u8_array(collection_hash, field_hash, ptr, len as usize);
 }
 
 #[no_mangle]

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -227,55 +227,60 @@ pub fn link_objects_to_dynamic_library(
     }
 
     let linker = resolve_linker_path(config);
-    let mut command = Command::new(&linker);
+    let mut args: Vec<String> = Vec::new();
     if cfg!(windows) {
-        command.arg("/NOLOGO");
-        command.arg("/DLL");
-        command.arg(format!("/OUT:{}", output_library.display()));
+        args.push("/NOLOGO".to_string());
+        args.push("/DLL".to_string());
+        args.push(format!("/OUT:{}", output_library.display()));
         for symbol in export_symbols {
-            command.arg(format!("/EXPORT:{symbol}"));
+            args.push(format!("/EXPORT:{symbol}"));
         }
         let windows_lib_paths = resolve_windows_link_lib_paths();
         for lib_path in &windows_lib_paths {
-            command.arg(format!("/LIBPATH:{}", lib_path.display()));
+            args.push(format!("/LIBPATH:{}", lib_path.display()));
         }
         if let Some(kernel32) = resolve_kernel32_lib_path(&windows_lib_paths) {
-            command.arg(kernel32);
+            args.push(kernel32.display().to_string());
         } else {
-            command.arg("kernel32.lib");
+            args.push("kernel32.lib".to_string());
         }
         // When linking against Rust `staticlib` runtime shims (e.g. `stasis_dynload.lib`),
         // lld-link does not automatically pull in the CRT/system libraries that those objects
         // depend on. Add the common MSVC + Windows SDK libraries so AOT bundles link cleanly.
-        command.arg("ucrt.lib");
-        command.arg("vcruntime.lib");
-        command.arg("msvcrt.lib");
-        command.arg("legacy_stdio_definitions.lib");
-        command.arg("advapi32.lib");
-        command.arg("bcrypt.lib");
-        command.arg("dbghelp.lib");
-        command.arg("ntdll.lib");
-        command.arg("ole32.lib");
-        command.arg("oleaut32.lib");
-        command.arg("psapi.lib");
-        command.arg("secur32.lib");
-        command.arg("shell32.lib");
-        command.arg("user32.lib");
-        command.arg("userenv.lib");
-        command.arg("ws2_32.lib");
+        args.push("ucrt.lib".to_string());
+        args.push("vcruntime.lib".to_string());
+        args.push("msvcrt.lib".to_string());
+        args.push("legacy_stdio_definitions.lib".to_string());
+        args.push("advapi32.lib".to_string());
+        args.push("bcrypt.lib".to_string());
+        args.push("dbghelp.lib".to_string());
+        args.push("ntdll.lib".to_string());
+        args.push("ole32.lib".to_string());
+        args.push("oleaut32.lib".to_string());
+        args.push("psapi.lib".to_string());
+        args.push("secur32.lib".to_string());
+        args.push("shell32.lib".to_string());
+        args.push("user32.lib".to_string());
+        args.push("userenv.lib".to_string());
+        args.push("ws2_32.lib".to_string());
     } else {
-        command.arg("-shared");
-        command.arg("-o");
-        command.arg(output_library);
+        args.push("-shared".to_string());
+        args.push("-o".to_string());
+        args.push(output_library.display().to_string());
     }
     for object_path in object_paths {
-        command.arg(object_path);
+        args.push(object_path.display().to_string());
     }
     for runtime_lib in &config.runtime_lib_paths {
-        command.arg(runtime_lib);
+        args.push(runtime_lib.display().to_string());
     }
 
-    run_link_command(&mut command, "dynamic library link", &linker)?;
+    run_link_command_with_args(
+        &linker,
+        &args,
+        "dynamic library link",
+        &output_library.with_extension("link.rsp"),
+    )?;
     if !output_library.exists() {
         return Err(format!(
             "link step reported success but did not produce {}",
@@ -308,34 +313,39 @@ pub fn link_objects_to_executable(
     }
 
     let linker = resolve_linker_path(config);
-    let mut command = Command::new(&linker);
+    let mut args: Vec<String> = Vec::new();
     if cfg!(windows) {
-        command.arg("/NOLOGO");
-        command.arg(format!("/OUT:{}", output_executable.display()));
-        command.arg(format!("/ENTRY:{entry_symbol}"));
-        command.arg("/SUBSYSTEM:CONSOLE");
+        args.push("/NOLOGO".to_string());
+        args.push(format!("/OUT:{}", output_executable.display()));
+        args.push(format!("/ENTRY:{entry_symbol}"));
+        args.push("/SUBSYSTEM:CONSOLE".to_string());
         let windows_lib_paths = resolve_windows_link_lib_paths();
         for lib_path in &windows_lib_paths {
-            command.arg(format!("/LIBPATH:{}", lib_path.display()));
+            args.push(format!("/LIBPATH:{}", lib_path.display()));
         }
         if let Some(kernel32) = resolve_kernel32_lib_path(&windows_lib_paths) {
-            command.arg(kernel32);
+            args.push(kernel32.display().to_string());
         } else {
-            command.arg("kernel32.lib");
+            args.push("kernel32.lib".to_string());
         }
     } else {
-        command.arg("-o");
-        command.arg(output_executable);
-        command.arg(format!("-Wl,-e,{entry_symbol}"));
+        args.push("-o".to_string());
+        args.push(output_executable.display().to_string());
+        args.push(format!("-Wl,-e,{entry_symbol}"));
     }
     for object_path in object_paths {
-        command.arg(object_path);
+        args.push(object_path.display().to_string());
     }
     for runtime_lib in &config.runtime_lib_paths {
-        command.arg(runtime_lib);
+        args.push(runtime_lib.display().to_string());
     }
 
-    run_link_command(&mut command, "executable link", &linker)?;
+    run_link_command_with_args(
+        &linker,
+        &args,
+        "executable link",
+        &output_executable.with_extension("link.rsp"),
+    )?;
     if !output_executable.exists() {
         return Err(format!(
             "link step reported success but did not produce {}",
@@ -621,6 +631,43 @@ fn run_link_command(command: &mut Command, mode: &str, linker: &Path) -> Result<
         ));
     }
     Ok(())
+}
+
+fn run_link_command_with_args(
+    linker: &Path,
+    args: &[String],
+    mode: &str,
+    response_file_path: &Path,
+) -> Result<(), String> {
+    let mut command = Command::new(linker);
+    if cfg!(windows) {
+        let response_body = args
+            .iter()
+            .map(|arg| escape_linker_response_arg(arg))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(response_file_path, response_body).map_err(|error| {
+            format!(
+                "failed to write linker response file {}: {error}",
+                response_file_path.display()
+            )
+        })?;
+        command.arg(format!("@{}", response_file_path.display()));
+        let result = run_link_command(&mut command, mode, linker);
+        let _ = fs::remove_file(response_file_path);
+        return result;
+    }
+
+    command.args(args);
+    run_link_command(&mut command, mode, linker)
+}
+
+fn escape_linker_response_arg(arg: &str) -> String {
+    if arg.contains([' ', '\t', '"']) {
+        format!("\"{}\"", arg.replace('"', "\\\""))
+    } else {
+        arg.to_string()
+    }
 }
 
 fn default_target_triple() -> String {

--- a/runtime/stasis_data.c
+++ b/runtime/stasis_data.c
@@ -385,7 +385,7 @@ static void apply_string_value_to_dest(const FieldMeta* field, void* dest, cJSON
     if (field->array_count > field->size) return;
 
     int header_bytes = field->size - field->array_count;
-    if (header_bytes != 4 && header_bytes != 8) {
+    if (header_bytes != 8 && header_bytes != 12) {
         return;
     }
 
@@ -397,7 +397,7 @@ static void apply_string_value_to_dest(const FieldMeta* field, void* dest, cJSON
     int max_copy = payload_cap - 1;
     if (max_copy < 0) max_copy = 0;
 
-    if (header_bytes == 4) {
+    if (header_bytes == 8) {
         int copy_len = 0;
         copy_ascii_bounded(value->valuestring, payload, max_copy, &copy_len);
         if (copy_len >= 0 && copy_len < payload_cap) {
@@ -407,10 +407,11 @@ static void apply_string_value_to_dest(const FieldMeta* field, void* dest, cJSON
             copy_len = payload_cap - 1;
         }
         *((int32_t*)base) = (int32_t)copy_len;
+        *((int32_t*)(base + 4)) = (int32_t)payload_cap;
         return;
     }
 
-    /* UTF-8: [byte_len:i32][char_len:i32][u8[N]] */
+    /* UTF-8: [byte_len:i32][max_length:i32][char_len:i32][u8[N]] */
     int copy_bytes = 0;
     int copy_chars = 0;
     copy_utf8_bounded(value->valuestring, payload, max_copy, &copy_bytes, &copy_chars);
@@ -432,7 +433,8 @@ static void apply_string_value_to_dest(const FieldMeta* field, void* dest, cJSON
     }
 
     *((int32_t*)base) = (int32_t)copy_bytes;
-    *((int32_t*)(base + 4)) = (int32_t)copy_chars;
+    *((int32_t*)(base + 4)) = (int32_t)payload_cap;
+    *((int32_t*)(base + 8)) = (int32_t)copy_chars;
 }
 
 static void apply_scalar_value_to_dest(const FieldMeta* field, void* dest, cJSON* value) {

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -267,6 +267,434 @@ static void set_runtime_dir(const char *dll_path)
 #endif
 }
 
+static char *stasis_trim_ascii(char *text)
+{
+    while (*text == ' ' || *text == '\t' || *text == '\r' || *text == '\n')
+    {
+        text++;
+    }
+    char *end = text + strlen(text);
+    while (end > text && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r' || end[-1] == '\n'))
+    {
+        end--;
+    }
+    *end = '\0';
+    return text;
+}
+
+static int stasis_try_get_self_path(const char *argv0, char *out, size_t out_cap)
+{
+    if (!out || out_cap == 0)
+    {
+        return 0;
+    }
+#ifdef _WIN32
+    DWORD written = GetModuleFileNameA(NULL, out, (DWORD)out_cap);
+    if (written == 0 || written >= out_cap)
+    {
+        if (!argv0 || !argv0[0])
+        {
+            return 0;
+        }
+        strncpy(out, argv0, out_cap - 1);
+        out[out_cap - 1] = '\0';
+        return 1;
+    }
+    if (strncmp(out, "\\\\?\\", 4) == 0)
+    {
+        memmove(out, out + 4, strlen(out + 4) + 1);
+    }
+    return 1;
+#else
+    if (!argv0 || !argv0[0])
+    {
+        return 0;
+    }
+    strncpy(out, argv0, out_cap - 1);
+    out[out_cap - 1] = '\0';
+    return 1;
+#endif
+}
+
+static int stasis_extract_dir(const char *path, char *out, size_t out_cap)
+{
+    if (!path || !out || out_cap == 0)
+    {
+        return 0;
+    }
+    size_t len = strlen(path);
+    if (len >= out_cap)
+    {
+        return 0;
+    }
+    strncpy(out, path, out_cap - 1);
+    out[out_cap - 1] = '\0';
+
+    char *slash = strrchr(out, '\\');
+    char *fslash = strrchr(out, '/');
+    char *sep = slash > fslash ? slash : fslash;
+    if (!sep)
+    {
+        return 0;
+    }
+    *sep = '\0';
+    return 1;
+}
+
+static int stasis_set_current_dir(const char *path)
+{
+    if (!path || !path[0])
+    {
+        return 0;
+    }
+#ifdef _WIN32
+    return SetCurrentDirectoryA(path) != 0;
+#else
+    return chdir(path) == 0;
+#endif
+}
+
+static void stasis_set_asset_root_env(const char *path)
+{
+    if (!path || !path[0])
+    {
+        return;
+    }
+#ifdef _WIN32
+    SetEnvironmentVariableA("STASIS_ASSET_ROOT", path);
+#else
+    setenv("STASIS_ASSET_ROOT", path, 1);
+#endif
+}
+
+static int stasis_path_is_absolute(const char *path)
+{
+    if (!path || !path[0])
+    {
+        return 0;
+    }
+#ifdef _WIN32
+    if ((path[0] && path[1] == ':') ||
+        (path[0] == '\\' && path[1] == '\\') ||
+        (path[0] == '/' && path[1] == '/'))
+    {
+        return 1;
+    }
+    return 0;
+#else
+    return path[0] == '/';
+#endif
+}
+
+static int stasis_join_path(
+    const char *dir,
+    const char *path,
+    char *out,
+    size_t out_cap)
+{
+    if (!dir || !dir[0] || !path || !path[0] || !out || out_cap == 0)
+    {
+        return 0;
+    }
+    if (stasis_path_is_absolute(path))
+    {
+        strncpy(out, path, out_cap - 1);
+        out[out_cap - 1] = '\0';
+        return 1;
+    }
+    if (snprintf(out, out_cap, "%s/%s", dir, path) >= (int)out_cap)
+    {
+        return 0;
+    }
+    return 1;
+}
+
+static FILE *stasis_try_open_launch_file(
+    const char *argv0,
+    const char *self_path,
+    const char *exe_dir,
+    char *launch_path,
+    size_t launch_path_cap)
+{
+    FILE *file = NULL;
+
+    if (self_path && self_path[0])
+    {
+        if (snprintf(launch_path, launch_path_cap, "%s.launch", self_path) < (int)launch_path_cap)
+        {
+            file = fopen(launch_path, "rb");
+            if (file)
+            {
+                return file;
+            }
+        }
+    }
+
+    if (argv0 && argv0[0])
+    {
+        if (snprintf(launch_path, launch_path_cap, "%s.launch", argv0) < (int)launch_path_cap)
+        {
+            file = fopen(launch_path, "rb");
+            if (file)
+            {
+                return file;
+            }
+        }
+    }
+
+    if (exe_dir && exe_dir[0] && self_path && self_path[0])
+    {
+        const char *slash = strrchr(self_path, '\\');
+        const char *fslash = strrchr(self_path, '/');
+        const char *sep = slash > fslash ? slash : fslash;
+        const char *base = sep ? sep + 1 : self_path;
+        if (snprintf(launch_path, launch_path_cap, "%s/%s.launch", exe_dir, base) < (int)launch_path_cap)
+        {
+            file = fopen(launch_path, "rb");
+            if (file)
+            {
+                return file;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+static int stasis_try_load_launch_config(
+    const char *argv0,
+    char *dll_out,
+    size_t dll_out_cap,
+    char *entry_out,
+    size_t entry_out_cap,
+    char *tick_out,
+    size_t tick_out_cap,
+    char *render_out,
+    size_t render_out_cap,
+    char *data_json_out,
+    size_t data_json_out_cap,
+    char *data_meta_out,
+    size_t data_meta_out_cap,
+    int *fps_out)
+{
+    char self_path[2048];
+    char launch_path[2080];
+    char exe_dir[2048];
+    char resolved_path[2048];
+    char line[2048];
+    int runner_diag = stasis_env_flag("STASIS_RUNNER_DIAG", 0);
+
+    if (!stasis_try_get_self_path(argv0, self_path, sizeof(self_path)))
+    {
+        if (runner_diag)
+        {
+            fprintf(stderr, "RUNNER_DIAG: failed to resolve self path for launch config\n");
+            fflush(stderr);
+        }
+        return 0;
+    }
+    if (!stasis_extract_dir(self_path, exe_dir, sizeof(exe_dir)))
+    {
+        if (runner_diag)
+        {
+            fprintf(stderr, "RUNNER_DIAG: failed to extract exe dir from %s\n", self_path);
+            fflush(stderr);
+        }
+        return 0;
+    }
+    FILE *file = stasis_try_open_launch_file(argv0, self_path, exe_dir, launch_path, sizeof(launch_path));
+    if (!file)
+    {
+        if (runner_diag)
+        {
+            fprintf(stderr,
+                    "RUNNER_DIAG: launch config not found self=%s argv0=%s attempted=%s\n",
+                    self_path,
+                    argv0 ? argv0 : "(null)",
+                    launch_path[0] ? launch_path : "(none)");
+            fflush(stderr);
+        }
+        return 0;
+    }
+    if (runner_diag)
+    {
+        fprintf(stderr, "RUNNER_DIAG: launch config=%s\n", launch_path);
+        fflush(stderr);
+    }
+
+    if (dll_out && dll_out_cap > 0)
+    {
+        dll_out[0] = '\0';
+    }
+    if (entry_out && entry_out_cap > 0)
+    {
+        entry_out[0] = '\0';
+    }
+    if (tick_out && tick_out_cap > 0)
+    {
+        tick_out[0] = '\0';
+    }
+    if (render_out && render_out_cap > 0)
+    {
+        render_out[0] = '\0';
+    }
+    if (data_json_out && data_json_out_cap > 0)
+    {
+        data_json_out[0] = '\0';
+    }
+    if (data_meta_out && data_meta_out_cap > 0)
+    {
+        data_meta_out[0] = '\0';
+    }
+    if (fps_out)
+    {
+        *fps_out = 60;
+    }
+
+    while (fgets(line, sizeof(line), file))
+    {
+        char *trimmed = stasis_trim_ascii(line);
+        if (!trimmed[0] || trimmed[0] == '#')
+        {
+            continue;
+        }
+        char *eq = strchr(trimmed, '=');
+        if (!eq)
+        {
+            continue;
+        }
+        *eq = '\0';
+        char *key = stasis_trim_ascii(trimmed);
+        char *value = stasis_trim_ascii(eq + 1);
+
+        if (strcmp(key, "dll") == 0 && dll_out && dll_out_cap > 0)
+        {
+            strncpy(dll_out, value, dll_out_cap - 1);
+            dll_out[dll_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "entry") == 0 && entry_out && entry_out_cap > 0)
+        {
+            strncpy(entry_out, value, entry_out_cap - 1);
+            entry_out[entry_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "tick") == 0 && tick_out && tick_out_cap > 0)
+        {
+            strncpy(tick_out, value, tick_out_cap - 1);
+            tick_out[tick_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "render") == 0 && render_out && render_out_cap > 0)
+        {
+            strncpy(render_out, value, render_out_cap - 1);
+            render_out[render_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "data_bind_json") == 0 && data_json_out && data_json_out_cap > 0)
+        {
+            strncpy(data_json_out, value, data_json_out_cap - 1);
+            data_json_out[data_json_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "data_bind_meta") == 0 && data_meta_out && data_meta_out_cap > 0)
+        {
+            strncpy(data_meta_out, value, data_meta_out_cap - 1);
+            data_meta_out[data_meta_out_cap - 1] = '\0';
+            continue;
+        }
+        if (strcmp(key, "fps") == 0 && fps_out)
+        {
+            int value_i32 = atoi(value);
+            if (value_i32 >= 1 && value_i32 <= 240)
+            {
+                *fps_out = value_i32;
+            }
+            continue;
+        }
+    }
+    fclose(file);
+
+    if (!dll_out || !dll_out[0])
+    {
+        return 0;
+    }
+    if (!entry_out || !entry_out[0])
+    {
+        strncpy(entry_out, "main", entry_out_cap - 1);
+        entry_out[entry_out_cap - 1] = '\0';
+    }
+
+    if (dll_out && dll_out[0] && stasis_join_path(exe_dir, dll_out, resolved_path, sizeof(resolved_path)))
+    {
+        strncpy(dll_out, resolved_path, dll_out_cap - 1);
+        dll_out[dll_out_cap - 1] = '\0';
+    }
+    if (data_json_out && data_json_out[0] &&
+        stasis_join_path(exe_dir, data_json_out, resolved_path, sizeof(resolved_path)))
+    {
+        strncpy(data_json_out, resolved_path, data_json_out_cap - 1);
+        data_json_out[data_json_out_cap - 1] = '\0';
+    }
+    if (data_meta_out && data_meta_out[0] &&
+        stasis_join_path(exe_dir, data_meta_out, resolved_path, sizeof(resolved_path)))
+    {
+        strncpy(data_meta_out, resolved_path, data_meta_out_cap - 1);
+        data_meta_out[data_meta_out_cap - 1] = '\0';
+    }
+
+    /* Make relative asset/data paths stable for packaged game builds. */
+    stasis_set_asset_root_env(exe_dir);
+    stasis_set_current_dir(exe_dir);
+    return 1;
+}
+
+static void stasis_build_related_symbol_names(
+    const char *entry_name,
+    char *tick_name,
+    size_t tick_name_cap,
+    char *render_name,
+    size_t render_name_cap)
+{
+    if (tick_name && tick_name_cap > 0)
+    {
+        tick_name[0] = '\0';
+    }
+    if (render_name && render_name_cap > 0)
+    {
+        render_name[0] = '\0';
+    }
+    if (!entry_name || !entry_name[0])
+    {
+        return;
+    }
+
+    const char *sep = strstr(entry_name, "__");
+    if (sep)
+    {
+        size_t prefix_len = (size_t)(sep - entry_name) + 2;
+        if (tick_name && prefix_len + 4 < tick_name_cap)
+        {
+            memcpy(tick_name, entry_name, prefix_len);
+            memcpy(tick_name + prefix_len, "tick", 5);
+        }
+        if (render_name && prefix_len + 6 < render_name_cap)
+        {
+            memcpy(render_name, entry_name, prefix_len);
+            memcpy(render_name + prefix_len, "render", 7);
+        }
+        return;
+    }
+
+    if (tick_name && tick_name_cap >= 5)
+    {
+        memcpy(tick_name, "tick", 5);
+    }
+    if (render_name && render_name_cap >= 7)
+    {
+        memcpy(render_name, "render", 7);
+    }
+}
 #ifdef _WIN32
 static int file_exists(const char *path);
 
@@ -1616,23 +2044,37 @@ int main(int argc, char **argv)
     }
 
     /* Optional tick loop: if `<module>__tick` is exported, call init once then tick at target FPS. */
-    char tick_name[512];
-    tick_name[0] = '\0';
-    const char *sep = strstr(entry_name, "__");
-    if (sep)
+    char tick_name[512] = {0};
+    char render_name[512] = {0};
+    if (tick_name_override && tick_name_override[0])
     {
-        size_t prefix_len = (size_t)(sep - entry_name) + 2;
-        if (prefix_len + 4 < sizeof(tick_name))
-        {
-            memcpy(tick_name, entry_name, prefix_len);
-            memcpy(tick_name + prefix_len, "tick", 5);
-        }
+        strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);
+        tick_name[sizeof(tick_name) - 1] = '\0';
+    }
+    if (render_name_override && render_name_override[0])
+    {
+        strncpy(render_name, render_name_override, sizeof(render_name) - 1);
+        render_name[sizeof(render_name) - 1] = '\0';
+    }
+    if (tick_name[0] == '\0' && render_name[0] == '\0')
+    {
+        stasis_build_related_symbol_names(
+            entry_name,
+            tick_name,
+            sizeof(tick_name),
+            render_name,
+            sizeof(render_name));
     }
 
     FARPROC tick_sym = NULL;
     if (tick_name[0] != '\0')
     {
         tick_sym = GetProcAddress(lib, tick_name);
+    }
+    FARPROC render_sym = NULL;
+    if (render_name[0] != '\0')
+    {
+        render_sym = GetProcAddress(lib, render_name);
     }
 
     /* Host window request globals are used by bulk mode (defined in src/runtime/host_window_request.stasis). */
@@ -1662,9 +2104,10 @@ int main(int argc, char **argv)
     stasis_entry_fn entry = (stasis_entry_fn)symbol;
     int result = entry();
 
-    if (result == 0 && tick_sym)
+    if (result == 0 && (tick_sym || render_sym))
     {
         stasis_tick_fn tick = (stasis_tick_fn)tick_sym;
+        stasis_tick_fn render = (stasis_tick_fn)render_sym;
         LARGE_INTEGER freq;
         QueryPerformanceFrequency(&freq);
         long long target_us = 1000000LL / (long long)fps;
@@ -2184,22 +2627,36 @@ int main(int argc, char **argv)
         fflush(stderr);
     }
 
-    char tick_name[512];
-    tick_name[0] = '\0';
-    void *tick_sym = NULL;
-    size_t entry_len = strlen(entry_name);
-    if (entry_len >= 4 && strcmp(entry_name + entry_len - 4, "main") == 0)
+    char tick_name[512] = {0};
+    char render_name[512] = {0};
+    if (tick_name_override && tick_name_override[0])
     {
-        size_t prefix_len = entry_len - 4;
-        if (prefix_len + 4 < sizeof(tick_name))
-        {
-            memcpy(tick_name, entry_name, prefix_len);
-            memcpy(tick_name + prefix_len, "tick", 5);
-        }
+        strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);
+        tick_name[sizeof(tick_name) - 1] = '\0';
     }
+    if (render_name_override && render_name_override[0])
+    {
+        strncpy(render_name, render_name_override, sizeof(render_name) - 1);
+        render_name[sizeof(render_name) - 1] = '\0';
+    }
+    if (tick_name[0] == '\0' && render_name[0] == '\0')
+    {
+        stasis_build_related_symbol_names(
+            entry_name,
+            tick_name,
+            sizeof(tick_name),
+            render_name,
+            sizeof(render_name));
+    }
+    void *tick_sym = NULL;
     if (tick_name[0] != '\0')
     {
         tick_sym = dlsym(lib, tick_name);
+    }
+    void *render_sym = NULL;
+    if (render_name[0] != '\0')
+    {
+        render_sym = dlsym(lib, render_name);
     }
     if (runner_diag)
     {
@@ -2244,9 +2701,10 @@ int main(int argc, char **argv)
         fflush(stderr);
     }
 
-    if (result == 0 && tick_sym)
+    if (result == 0 && (tick_sym || render_sym))
     {
         stasis_tick_fn tick = (stasis_tick_fn)tick_sym;
+        stasis_tick_fn render = (stasis_tick_fn)render_sym;
         long long target_us = 1000000LL / (long long)fps;
         struct timespec ts_last;
         clock_gettime(CLOCK_MONOTONIC, &ts_last);

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -40,6 +40,7 @@
 
 typedef int (*stasis_entry_fn)(void);
 typedef int (*stasis_tick_fn)(void);
+typedef void (*stasis_aot_bind_runtime_globals_fn)(void);
 typedef void (*stasis_sys_set_args_fn)(int argc, const char *const *argv);
 typedef void (*stasis_host_get_frame_fn)(int32_t *out_i32, float *out_f32);
 typedef void (*stasis_gfx_submit_u8_fn)(const int32_t *cmd_i32, const float *cmd_f32, const uint8_t *cmd_u8);
@@ -292,17 +293,7 @@ static int stasis_try_get_self_path(const char *argv0, char *out, size_t out_cap
     DWORD written = GetModuleFileNameA(NULL, out, (DWORD)out_cap);
     if (written == 0 || written >= out_cap)
     {
-        if (!argv0 || !argv0[0])
-        {
-            return 0;
-        }
-        strncpy(out, argv0, out_cap - 1);
-        out[out_cap - 1] = '\0';
-        return 1;
-    }
-    if (strncmp(out, "\\\\?\\", 4) == 0)
-    {
-        memmove(out, out + 4, strlen(out + 4) + 1);
+        return 0;
     }
     return 1;
 #else
@@ -354,113 +345,6 @@ static int stasis_set_current_dir(const char *path)
 #endif
 }
 
-static void stasis_set_asset_root_env(const char *path)
-{
-    if (!path || !path[0])
-    {
-        return;
-    }
-#ifdef _WIN32
-    SetEnvironmentVariableA("STASIS_ASSET_ROOT", path);
-#else
-    setenv("STASIS_ASSET_ROOT", path, 1);
-#endif
-}
-
-static int stasis_path_is_absolute(const char *path)
-{
-    if (!path || !path[0])
-    {
-        return 0;
-    }
-#ifdef _WIN32
-    if ((path[0] && path[1] == ':') ||
-        (path[0] == '\\' && path[1] == '\\') ||
-        (path[0] == '/' && path[1] == '/'))
-    {
-        return 1;
-    }
-    return 0;
-#else
-    return path[0] == '/';
-#endif
-}
-
-static int stasis_join_path(
-    const char *dir,
-    const char *path,
-    char *out,
-    size_t out_cap)
-{
-    if (!dir || !dir[0] || !path || !path[0] || !out || out_cap == 0)
-    {
-        return 0;
-    }
-    if (stasis_path_is_absolute(path))
-    {
-        strncpy(out, path, out_cap - 1);
-        out[out_cap - 1] = '\0';
-        return 1;
-    }
-    if (snprintf(out, out_cap, "%s/%s", dir, path) >= (int)out_cap)
-    {
-        return 0;
-    }
-    return 1;
-}
-
-static FILE *stasis_try_open_launch_file(
-    const char *argv0,
-    const char *self_path,
-    const char *exe_dir,
-    char *launch_path,
-    size_t launch_path_cap)
-{
-    FILE *file = NULL;
-
-    if (self_path && self_path[0])
-    {
-        if (snprintf(launch_path, launch_path_cap, "%s.launch", self_path) < (int)launch_path_cap)
-        {
-            file = fopen(launch_path, "rb");
-            if (file)
-            {
-                return file;
-            }
-        }
-    }
-
-    if (argv0 && argv0[0])
-    {
-        if (snprintf(launch_path, launch_path_cap, "%s.launch", argv0) < (int)launch_path_cap)
-        {
-            file = fopen(launch_path, "rb");
-            if (file)
-            {
-                return file;
-            }
-        }
-    }
-
-    if (exe_dir && exe_dir[0] && self_path && self_path[0])
-    {
-        const char *slash = strrchr(self_path, '\\');
-        const char *fslash = strrchr(self_path, '/');
-        const char *sep = slash > fslash ? slash : fslash;
-        const char *base = sep ? sep + 1 : self_path;
-        if (snprintf(launch_path, launch_path_cap, "%s/%s.launch", exe_dir, base) < (int)launch_path_cap)
-        {
-            file = fopen(launch_path, "rb");
-            if (file)
-            {
-                return file;
-            }
-        }
-    }
-
-    return NULL;
-}
-
 static int stasis_try_load_launch_config(
     const char *argv0,
     char *dll_out,
@@ -480,46 +364,25 @@ static int stasis_try_load_launch_config(
     char self_path[2048];
     char launch_path[2080];
     char exe_dir[2048];
-    char resolved_path[2048];
     char line[2048];
-    int runner_diag = stasis_env_flag("STASIS_RUNNER_DIAG", 0);
 
     if (!stasis_try_get_self_path(argv0, self_path, sizeof(self_path)))
     {
-        if (runner_diag)
-        {
-            fprintf(stderr, "RUNNER_DIAG: failed to resolve self path for launch config\n");
-            fflush(stderr);
-        }
         return 0;
     }
     if (!stasis_extract_dir(self_path, exe_dir, sizeof(exe_dir)))
     {
-        if (runner_diag)
-        {
-            fprintf(stderr, "RUNNER_DIAG: failed to extract exe dir from %s\n", self_path);
-            fflush(stderr);
-        }
         return 0;
     }
-    FILE *file = stasis_try_open_launch_file(argv0, self_path, exe_dir, launch_path, sizeof(launch_path));
+    if (snprintf(launch_path, sizeof(launch_path), "%s.launch", self_path) >= (int)sizeof(launch_path))
+    {
+        return 0;
+    }
+
+    FILE *file = fopen(launch_path, "rb");
     if (!file)
     {
-        if (runner_diag)
-        {
-            fprintf(stderr,
-                    "RUNNER_DIAG: launch config not found self=%s argv0=%s attempted=%s\n",
-                    self_path,
-                    argv0 ? argv0 : "(null)",
-                    launch_path[0] ? launch_path : "(none)");
-            fflush(stderr);
-        }
         return 0;
-    }
-    if (runner_diag)
-    {
-        fprintf(stderr, "RUNNER_DIAG: launch config=%s\n", launch_path);
-        fflush(stderr);
     }
 
     if (dll_out && dll_out_cap > 0)
@@ -625,26 +488,7 @@ static int stasis_try_load_launch_config(
         entry_out[entry_out_cap - 1] = '\0';
     }
 
-    if (dll_out && dll_out[0] && stasis_join_path(exe_dir, dll_out, resolved_path, sizeof(resolved_path)))
-    {
-        strncpy(dll_out, resolved_path, dll_out_cap - 1);
-        dll_out[dll_out_cap - 1] = '\0';
-    }
-    if (data_json_out && data_json_out[0] &&
-        stasis_join_path(exe_dir, data_json_out, resolved_path, sizeof(resolved_path)))
-    {
-        strncpy(data_json_out, resolved_path, data_json_out_cap - 1);
-        data_json_out[data_json_out_cap - 1] = '\0';
-    }
-    if (data_meta_out && data_meta_out[0] &&
-        stasis_join_path(exe_dir, data_meta_out, resolved_path, sizeof(resolved_path)))
-    {
-        strncpy(data_meta_out, resolved_path, data_meta_out_cap - 1);
-        data_meta_out[data_meta_out_cap - 1] = '\0';
-    }
-
     /* Make relative asset/data paths stable for packaged game builds. */
-    stasis_set_asset_root_env(exe_dir);
     stasis_set_current_dir(exe_dir);
     return 1;
 }
@@ -695,6 +539,7 @@ static void stasis_build_related_symbol_names(
         memcpy(render_name, "render", 7);
     }
 }
+
 #ifdef _WIN32
 static int file_exists(const char *path);
 
@@ -1701,7 +1546,21 @@ int main(int argc, char **argv)
     const char *swap_file_path = NULL;
     const char *data_bind_json = NULL;
     const char *data_bind_meta = NULL;
+    const char *tick_name_override = NULL;
+    const char *render_name_override = NULL;
+    char launch_dll_buf[2048];
+    char launch_entry_buf[512];
+    char launch_tick_buf[512];
+    char launch_render_buf[512];
+    char launch_data_json_buf[2048];
+    char launch_data_meta_buf[2048];
     int fps = 60;
+    launch_dll_buf[0] = '\0';
+    launch_entry_buf[0] = '\0';
+    launch_tick_buf[0] = '\0';
+    launch_render_buf[0] = '\0';
+    launch_data_json_buf[0] = '\0';
+    launch_data_meta_buf[0] = '\0';
 
     if (argc >= 2 && strcmp(argv[1], "--server") == 0)
     {
@@ -1838,12 +1697,46 @@ int main(int argc, char **argv)
 
     if (argc < 2)
     {
-        print_usage();
-        return 1;
+        if (!stasis_try_load_launch_config(
+                argv[0],
+                launch_dll_buf,
+                sizeof(launch_dll_buf),
+                launch_entry_buf,
+                sizeof(launch_entry_buf),
+                launch_tick_buf,
+                sizeof(launch_tick_buf),
+                launch_render_buf,
+                sizeof(launch_render_buf),
+                launch_data_json_buf,
+                sizeof(launch_data_json_buf),
+                launch_data_meta_buf,
+                sizeof(launch_data_meta_buf),
+                &fps))
+        {
+            print_usage();
+            return 1;
+        }
+        dll_path = launch_dll_buf;
+        entry_name = launch_entry_buf[0] ? launch_entry_buf : "main";
+        if (launch_data_json_buf[0] && launch_data_meta_buf[0])
+        {
+            data_bind_json = launch_data_json_buf;
+            data_bind_meta = launch_data_meta_buf;
+        }
+        if (launch_tick_buf[0])
+        {
+            tick_name_override = launch_tick_buf;
+        }
+        if (launch_render_buf[0])
+        {
+            render_name_override = launch_render_buf;
+        }
     }
-
-    dll_path = argv[1];
-    entry_name = argc >= 3 ? argv[2] : "run_tests";
+    else
+    {
+        dll_path = argv[1];
+        entry_name = argc >= 3 ? argv[2] : "run_tests";
+    }
 
     for (int i = 2; i < argc; i++)
     {
@@ -1903,6 +1796,7 @@ int main(int argc, char **argv)
 
 #ifdef _WIN32
     stasis_enable_dll_search(argv[0], dll_path);
+    int runner_diag = stasis_env_flag("STASIS_RUNNER_DIAG", 0);
     HMODULE lib = stasis_load_program_library(dll_path);
     if (!lib)
     {
@@ -1918,6 +1812,14 @@ int main(int argc, char **argv)
                        NULL);
         fprintf(stderr, "error: failed to load %s (err=%lu %s)\n", dll_path, err, msg);
         return 1;
+    }
+
+    {
+        FARPROC bind_globals_sym = GetProcAddress(lib, "stasis_aot_bind_runtime_globals");
+        if (bind_globals_sym)
+        {
+            ((stasis_aot_bind_runtime_globals_fn)bind_globals_sym)();
+        }
     }
 
     /* Set DLL handle for data binding system */
@@ -1939,6 +1841,15 @@ int main(int argc, char **argv)
         fprintf(stderr, "error: entrypoint %s not found in %s\n", entry_name, dll_path);
         FreeLibrary(lib);
         return 1;
+    }
+    if (runner_diag)
+    {
+        fprintf(stderr, "RUNNER_DIAG: dll=%s entry=%s tick=%s render=%s\n",
+                dll_path ? dll_path : "(null)",
+                entry_name ? entry_name : "(null)",
+                tick_name_override ? tick_name_override : "(auto)",
+                render_name_override ? render_name_override : "(auto)");
+        fflush(stderr);
     }
 
     /* Default window policy: create a small window if graphics runtime is present.
@@ -2044,8 +1955,8 @@ int main(int argc, char **argv)
     }
 
     /* Optional tick loop: if `<module>__tick` is exported, call init once then tick at target FPS. */
-    char tick_name[512] = {0};
-    char render_name[512] = {0};
+    char tick_name[512];
+    char render_name[512];
     if (tick_name_override && tick_name_override[0])
     {
         strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);
@@ -2102,7 +2013,17 @@ int main(int argc, char **argv)
 
     stasis_try_set_sys_args(lib, argc, argv);
     stasis_entry_fn entry = (stasis_entry_fn)symbol;
+    if (runner_diag)
+    {
+        fprintf(stderr, "RUNNER_DIAG: calling entry\n");
+        fflush(stderr);
+    }
     int result = entry();
+    if (runner_diag)
+    {
+        fprintf(stderr, "RUNNER_DIAG: entry returned=%d\n", result);
+        fflush(stderr);
+    }
 
     if (result == 0 && (tick_sym || render_sym))
     {
@@ -2318,13 +2239,22 @@ int main(int argc, char **argv)
                                 continue;
                             }
 
+                            FARPROC new_tick_sym = NULL;
+                            FARPROC new_render_sym = NULL;
                             QueryPerformanceCounter(&sw_t0);
-                            FARPROC new_tick_sym = GetProcAddress(new_lib, tick_name);
+                            if (tick_name[0] != '\0')
+                            {
+                                new_tick_sym = GetProcAddress(new_lib, tick_name);
+                            }
+                            if (render_name[0] != '\0')
+                            {
+                                new_render_sym = GetProcAddress(new_lib, render_name);
+                            }
                             QueryPerformanceCounter(&sw_t1);
                             tick_us = (sw_t1.QuadPart - sw_t0.QuadPart) * 1000000LL / sw_freq.QuadPart;
-                            if (!new_tick_sym)
+                            if (!new_tick_sym && !new_render_sym)
                             {
-                                fprintf(stderr, "HOTSWAP warning: tick entrypoint %s not found in %s\n", tick_name, new_path);
+                                fprintf(stderr, "HOTSWAP warning: tick/render entrypoints not found in %s\n", new_path);
                                 fflush(stderr);
                                 FreeLibrary(new_lib);
                                 free(buffer);
@@ -2377,7 +2307,15 @@ int main(int argc, char **argv)
 
                             FreeLibrary(lib);
                             lib = new_lib;
+                            {
+                                FARPROC bind_globals_sym = GetProcAddress(lib, "stasis_aot_bind_runtime_globals");
+                                if (bind_globals_sym)
+                                {
+                                    ((stasis_aot_bind_runtime_globals_fn)bind_globals_sym)();
+                                }
+                            }
                             tick = (stasis_tick_fn)new_tick_sym;
+                            render = (stasis_tick_fn)new_render_sym;
                             stasis_try_set_sys_args(lib, argc, argv);
                             stasis_rebind_bulk_pointers(
                                 lib,
@@ -2425,7 +2363,7 @@ int main(int argc, char **argv)
             /* Poll data bindings for changes (fast path: just checks mtimes) */
             stasis_data_poll_all();
 
-            if (bulk_active && host_bulk_step && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
+            if (bulk_active && host_bulk_step && !render && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
             {
                 int step_result = host_bulk_step(
                     host_i32,
@@ -2446,6 +2384,12 @@ int main(int argc, char **argv)
             }
             else if (bulk_active)
             {
+                if (!host_get_frame)
+                {
+                    fprintf(stderr, "error: manual tick/render path requires stasis_host_get_frame\n");
+                    result = 1;
+                    break;
+                }
                 host_get_frame(host_i32, host_f32);
 
                 /* Exit if host requested quit (avoid requiring guest queries). */
@@ -2474,11 +2418,25 @@ int main(int argc, char **argv)
                     }
                 }
 
-                int tick_result = tick();
-                if (tick_result != 0)
+                int step_result = 0;
+                if (tick)
                 {
-                    result = tick_result == 1 ? 0 : tick_result;
-                    break;
+                    step_result = tick();
+                    if (step_result != 0)
+                    {
+                        result = step_result == 1 ? 0 : step_result;
+                        break;
+                    }
+                }
+
+                if (render)
+                {
+                    step_result = render();
+                    if (step_result != 0)
+                    {
+                        result = step_result == 1 ? 0 : step_result;
+                        break;
+                    }
                 }
 
                 if (log_cmd_remaining > 0 && gfx_cmd_i32)
@@ -2608,6 +2566,13 @@ int main(int argc, char **argv)
         fprintf(stderr, "error: failed to load %s: %s\n", dll_path, dlerror());
         return 1;
     }
+    {
+        void *bind_globals_sym = dlsym(lib, "stasis_aot_bind_runtime_globals");
+        if (bind_globals_sym)
+        {
+            ((stasis_aot_bind_runtime_globals_fn)bind_globals_sym)();
+        }
+    }
     if (runner_diag)
     {
         fprintf(stderr, "RUNNER_DIAG: dlopen ok\n");
@@ -2627,8 +2592,8 @@ int main(int argc, char **argv)
         fflush(stderr);
     }
 
-    char tick_name[512] = {0};
-    char render_name[512] = {0};
+    char tick_name[512];
+    char render_name[512];
     if (tick_name_override && tick_name_override[0])
     {
         strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);
@@ -2660,7 +2625,11 @@ int main(int argc, char **argv)
     }
     if (runner_diag)
     {
-        fprintf(stderr, "RUNNER_DIAG: tick_name=%s tick_sym=%s\n", tick_name[0] ? tick_name : "(none)", tick_sym ? "yes" : "no");
+        fprintf(stderr, "RUNNER_DIAG: tick_name=%s tick_sym=%s render_name=%s render_sym=%s\n",
+                tick_name[0] ? tick_name : "(none)",
+                tick_sym ? "yes" : "no",
+                render_name[0] ? render_name : "(none)",
+                render_sym ? "yes" : "no");
         fflush(stderr);
     }
 
@@ -2913,13 +2882,22 @@ int main(int argc, char **argv)
                         continue;
                     }
 
+                    void *new_tick_sym = NULL;
+                    void *new_render_sym = NULL;
                     clock_gettime(CLOCK_MONOTONIC, &t0);
-                    void *new_tick_sym = dlsym(new_lib, tick_name);
+                    if (tick_name[0] != '\0')
+                    {
+                        new_tick_sym = dlsym(new_lib, tick_name);
+                    }
+                    if (render_name[0] != '\0')
+                    {
+                        new_render_sym = dlsym(new_lib, render_name);
+                    }
                     clock_gettime(CLOCK_MONOTONIC, &t1);
                     tick_us = (t1.tv_sec - t0.tv_sec) * 1000000LL + (t1.tv_nsec - t0.tv_nsec) / 1000LL;
-                    if (!new_tick_sym)
+                    if (!new_tick_sym && !new_render_sym)
                     {
-                        fprintf(stderr, "HOTSWAP warning: tick entrypoint %s not found in %s\n", tick_name, new_path);
+                        fprintf(stderr, "HOTSWAP warning: tick/render entrypoints not found in %s\n", new_path);
                         fflush(stderr);
                         dlclose(new_lib);
                         free(buffer);
@@ -2972,7 +2950,15 @@ int main(int argc, char **argv)
 
                     dlclose(lib);
                     lib = new_lib;
+                    {
+                        void *bind_globals_sym = dlsym(lib, "stasis_aot_bind_runtime_globals");
+                        if (bind_globals_sym)
+                        {
+                            ((stasis_aot_bind_runtime_globals_fn)bind_globals_sym)();
+                        }
+                    }
                     tick = (stasis_tick_fn)new_tick_sym;
+                    render = (stasis_tick_fn)new_render_sym;
                     stasis_try_set_sys_args(lib, argc, argv);
                     stasis_data_set_dll(new_lib);
                     bulk_active = stasis_rebind_bulk_pointers_linux(
@@ -3031,7 +3017,7 @@ int main(int argc, char **argv)
 
             stasis_data_poll_all();
 
-            if (bulk_active && host_bulk_step && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
+            if (bulk_active && host_bulk_step && !render && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
             {
                 int step_result = host_bulk_step(
                     host_i32,
@@ -3056,6 +3042,12 @@ int main(int argc, char **argv)
                 {
                     host_get_frame(host_i32, host_f32);
                 }
+                else
+                {
+                    fprintf(stderr, "error: manual tick/render path requires stasis_host_get_frame\n");
+                    result = 1;
+                    break;
+                }
                 if (host_i32 && host_i32[9] != 0)
                 {
                     result = 0;
@@ -3076,7 +3068,11 @@ int main(int argc, char **argv)
                     fflush(stderr);
                 }
 
-                int tick_result = tick();
+                int tick_result = 0;
+                if (tick)
+                {
+                    tick_result = tick();
+                }
                 if (runner_diag && tick_diag_count < 10)
                 {
                     fprintf(stderr, "RUNNER_DIAG: tick end %d result=%d\n", tick_diag_count, tick_result);
@@ -3087,6 +3083,15 @@ int main(int argc, char **argv)
                 {
                     result = tick_result == 1 ? 0 : tick_result;
                     break;
+                }
+                if (render)
+                {
+                    int render_result = render();
+                    if (render_result != 0)
+                    {
+                        result = render_result == 1 ? 0 : render_result;
+                        break;
+                    }
                 }
                 if (gfx_submit_u8 && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
                 {

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -1957,6 +1957,8 @@ int main(int argc, char **argv)
     /* Optional tick loop: if `<module>__tick` is exported, call init once then tick at target FPS. */
     char tick_name[512];
     char render_name[512];
+    tick_name[0] = '\0';
+    render_name[0] = '\0';
     if (tick_name_override && tick_name_override[0])
     {
         strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);
@@ -2594,6 +2596,8 @@ int main(int argc, char **argv)
 
     char tick_name[512];
     char render_name[512];
+    tick_name[0] = '\0';
+    render_name[0] = '\0';
     if (tick_name_override && tick_name_override[0])
     {
         strncpy(tick_name, tick_name_override, sizeof(tick_name) - 1);


### PR DESCRIPTION
## Summary
- restore the packaged AOT release path for engine-bundle outputs
- export stable packaged DLL aliases for \\main\\, \\	ick\\, and \\ender\\ and use them in the launch sidecar
- keep release outputs slim by avoiding default summary/cache artifacts in \\out\\ and pruning import-lib/runner leftovers

## Verification
- \\cmd /c runtime\\build.bat\\
- \\cargo run -p stasis --release -- aot-cli --project-dir . --entry-file samples\\bucket_catcher.stasis --out out\\bucket_catcher_aot.exe\\
- launch smoke: packaged \\ucket_catcher_aot.exe\\ stayed alive for 5 seconds