### PR TITLE
Add Night Shift workflow support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ _ReSharper.Caches/
 # Local-only artifacts (screenshots, recordings, etc.)
 artifacts/
 scratch/
+logs/nightshift/
 
 # Build artifacts
 *.dll

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@
 - `cargo run -p stasis --release -- --ticks 300 --watch-dir samples/brickout_revenge`
 - Use `rg` for search (`rg pattern path`, `rg --files`).
 - Keep commands deterministic and scriptable.
+- Night Shift validation entrypoint:
+- `tools/validate_repo.sh`
 
 ## Coding Style & Naming Conventions
 - Keep files ASCII unless a file already uses non-ASCII and there is a clear reason.
@@ -36,7 +38,7 @@
 
 ## Testing Guidelines
 - Ship work in feature slices from `docs/build_checklist.md` and include tests in the same PR.
-- Only implement changes that map to active items in `docs/build_checklist.md`; if a proposed change is outside the checklist, pause and ask before changing requirements or code.
+- Only implement changes that map to active items in `docs/build_checklist.md`, or to inbox-synced PR review feedback in `docs/bugs.md`; if a proposed change is outside those sources, pause and ask before changing requirements or code.
 - Prefer deterministic, isolated tests with explicit expected output/state.
 - If test can reasonably be written in stasis for stasis code, do so. It can be in a .test.stasis file next to the .stasis file.
 - Cover parser/semantics/lowering/JIT boundaries and hot-swap safety behavior.
@@ -102,6 +104,15 @@
 - Compiler feature-slice completion gate: each slice must include at least one representative sample program that goes end-to-end through the compiler pipeline to Cranelift IR, is built into an executable, is run, and has its behavior verified by test assertions.
 - If a slice cannot yet pass that end-to-end executable verification path, the slice is not complete.
 - After each code change, run a quick simplicity review on the touched code and simplify again if a more direct version is possible.
+
+## Night Shift Workflow
+- Loop contract: `docs/night_shift_loop.md`
+- Reviewer personas: `docs/review_personas.md`
+- Bug queue: `docs/bugs.md`
+- Validation entrypoint: `tools/validate_repo.sh`
+- If an inbox process syncs PR review feedback into `docs/bugs.md`, treat that as the highest-priority bug work.
+- If the inbox sync changes tracked docs, commit that sync before launching the Night Shift runner so the run starts from a clean tree.
+- If the task came from PR review feedback, reply on GitHub when appropriate after fixing or clarifying the issue.
 
 ## Self-Reflection Loop (Required)
 - At the end of each compiler slice, record one `Good`, one `Bad`, and one `Adjustment` entry in the work summary, then update this file if a process rule should change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+@AGENTS.md
+@docs/night_shift_loop.md
+@docs/review_personas.md
+
+## Claude-specific notes
+
+- Import extra docs only when needed.
+- Keep output concise and audit-friendly.
+- Prefer separate commits for workflow fixes and behavior fixes.

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,21 @@
+# Bugs
+
+Allowed states: `READY`, `IN PROGRESS`, `DONE`, `NEEDS INPUT FROM USER`
+
+If you use a cross-repo inbox, it may maintain a generated `NED-INBOX` block under `## READY`. Treat those entries like normal bugs. Those synced items should include direct GitHub links for the source PR and individual review threads so the agent can reply when appropriate.
+
+## READY
+
+- None.
+
+## IN PROGRESS
+
+- None.
+
+## DONE
+
+- None.
+
+## NEEDS INPUT FROM USER
+
+- None.

--- a/docs/night_shift_loop.md
+++ b/docs/night_shift_loop.md
@@ -1,0 +1,60 @@
+# Night Shift Loop
+
+## Prime directive
+
+Run autonomously without requiring plan review. Own validation and leave the repository in a reviewable state.
+
+## Preparation
+
+1. Inspect `git status --short`.
+2. If the tree is dirty because an inbox process just synced review feedback into tracked docs, commit that sync first.
+3. Otherwise, if the tree is dirty, either create a protective WIP commit or stop and explain why the state is unsafe to modify.
+4. Run the quality gates in `tools/validate_repo.sh`.
+5. If validation fails, fix it first or move the task to `NEEDS INPUT FROM USER` with evidence.
+
+## Choose work
+
+1. Read `docs/bugs.md`; choose the highest-severity item in `READY`, including any PR review feedback synced there by an inbox process.
+2. If no bug is ready, choose the highest-priority active item from `docs/build_checklist.md`.
+3. If no implementation task is available, improve docs, validation, or task hygiene.
+
+## Understand the task
+
+- Read the chosen checklist or bug entry.
+- If the bug came from synced PR review feedback, use the included GitHub links and thread context to understand exactly what needs a reply.
+- Load only the docs needed for that task.
+- Read the relevant Rust and `.stasis` code before proposing changes.
+
+## Tests-first workflow
+
+1. Write a brief testing plan in working notes or commit history, not for human review.
+2. Add or expand automated checks to capture the desired behavior.
+3. Run the checks and confirm they fail for the expected reason before implementation.
+
+## Reviewer gate before implementation
+
+- Run the personas in `docs/review_personas.md`.
+- If any persona is `BLOCKED`, update docs, tests, or plan before changing code.
+
+## Implement
+
+- Make the smallest change that satisfies the failing checks.
+- Run the full quality gates after each meaningful change.
+
+## Reviewer gate after implementation
+
+- Re-run the personas against the diff.
+- Iterate until all personas are `GREEN` or the task is explicitly blocked by missing user input.
+
+## Wrap-up
+
+1. Update any docs that would prevent repeating the same mistake.
+2. If the task came from PR review feedback, reply on GitHub when appropriate with the fix, clarification, or follow-up question.
+3. Commit with a message that explains what changed, why, how it was verified, and any residual risks.
+4. Append a concise entry to `docs/night_shift_report.md`.
+
+## Stop conditions
+
+- No `READY` bugs remain and no runnable checklist/spec work remains.
+- The task requires a product, design, or business decision from the user.
+- Validation cannot be restored safely within the current run.

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -1,0 +1,8 @@
+# Night Shift Report
+
+## 2026-03-16
+
+- Prepared StasisLang for Night Shift style repo-local runs.
+- Added process docs, validation script, and launcher script aligned with the existing Cargo and CI workflow.
+- Verification: `tools/validate_repo.sh`
+- Needs input from user: decide whether inbox-synced review feedback should map to `docs/bugs.md` only or also back-reference explicit checklist sections when both apply.

--- a/docs/review_personas.md
+++ b/docs/review_personas.md
@@ -1,0 +1,31 @@
+# Review Personas
+
+Each reviewer must return:
+
+- `GREEN` or `BLOCKED`
+- Up to 5 short bullets
+- If `BLOCKED`, the smallest change needed to become `GREEN`
+
+## Language Designer
+
+Focus: language consistency, syntax semantics, and fit with `docs/spec.md`.
+
+## Compiler Architect
+
+Focus: slice alignment with `docs/build_checklist.md`, compiler ownership boundaries, and maintainability.
+
+## Runtime Engineer
+
+Focus: host/runtime boundaries, hot-swap safety, deterministic execution, and platform integration risk.
+
+## Code Expert
+
+Focus: Rust and `.stasis` readability, test quality, and idiomatic implementation.
+
+## Performance Expert
+
+Focus: compile-time budget, runtime hot paths, and cache/invalidation cost.
+
+## Human Advocate
+
+Focus: reviewability, changelog/report quality, GitHub follow-up, and identifying decisions that still need human judgment.

--- a/tools/nightshift.sh
+++ b/tools/nightshift.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-codex}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$ROOT/logs/nightshift"
+TS="$(date +"%Y-%m-%d_%H%M%S")"
+LOG_FILE="$LOG_DIR/run_$TS.log"
+BRANCH="nightshift/$TS"
+EXECUTOR_FILE="$ROOT/.nightshift-executor"
+
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+if [[ -f "$HOME/.cargo/env" ]]; then
+  source "$HOME/.cargo/env"
+fi
+
+if [[ -f "$EXECUTOR_FILE" ]]; then
+  MODE="$(tr -d '[:space:]' < "$EXECUTOR_FILE")"
+fi
+
+echo "== Night Shift starting at $TS =="
+echo "Repo: $ROOT"
+cd "$ROOT"
+
+if git diff --name-only --cached | grep -E '(^|/)(\.env|.*secret|.*credential)' >/dev/null 2>&1; then
+  echo "ERROR: staged changes may include secrets. Aborting."
+  exit 2
+fi
+
+echo "== Git status =="
+git status --short || true
+
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  git switch "$BRANCH"
+else
+  git switch -c "$BRANCH"
+fi
+
+echo "== Baseline validation =="
+"$ROOT/tools/validate_repo.sh"
+
+echo "== Launch agent =="
+case "$MODE" in
+  claude)
+    claude -p "@docs/night_shift_loop.md Follow the Night Shift loop now." --output-format text --dangerously-skip-permissions
+    ;;
+  codex)
+    codex exec --dangerously-bypass-approvals-and-sandbox "Read docs/night_shift_loop.md and execute the Night Shift loop."
+    ;;
+  *)
+    echo "ERROR: unknown mode: $MODE"
+    exit 3
+    ;;
+esac
+
+echo "== Night Shift finished =="
+git --no-pager log --oneline -20 || true

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ -f "$HOME/.cargo/env" ]]; then
+  source "$HOME/.cargo/env"
+fi
+
+python3 tools/ci/check_stasis_src_layout.py
+cargo test --workspace --all-targets -- --test-threads=1


### PR DESCRIPTION
## Summary
- add repo-local Night Shift loop, personas, bug queue, and report docs aligned with the existing checklist-driven workflow
- add a deterministic validation script and unattended launcher under tools/
- add a Claude shim and ignore Night Shift logs

## Verification
- ./tools/validate_repo.sh