### PR TITLE
docs: route contributors through a neutral workflow doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - `cargo run -p stasis --release -- --ticks 300 --watch-dir samples/brickout_revenge`
 - Use `rg` for search (`rg pattern path`, `rg --files`).
 - Keep commands deterministic and scriptable.
-- Night Shift validation entrypoint:
+- Validation entrypoint:
 - `tools/validate_repo.sh`
 
 ## Coding Style & Naming Conventions
@@ -105,13 +105,13 @@
 - If a slice cannot yet pass that end-to-end executable verification path, the slice is not complete.
 - After each code change, run a quick simplicity review on the touched code and simplify again if a more direct version is possible.
 
-## Night Shift Workflow
-- Loop contract: `docs/night_shift_loop.md`
+## Contributor Workflow
+- Workflow contract: `docs/contributor_workflow.md`
 - Reviewer personas: `docs/review_personas.md`
 - Bug queue: `docs/bugs.md`
 - Validation entrypoint: `tools/validate_repo.sh`
 - If an inbox process syncs PR review feedback into `docs/bugs.md`, treat that as the highest-priority bug work.
-- If the inbox sync changes tracked docs, commit that sync before launching the Night Shift runner so the run starts from a clean tree.
+- If the inbox sync changes tracked docs, commit that sync before continuing so the run starts from a clean tree.
 - If the task came from PR review feedback, reply on GitHub when appropriate after fixing or clarifying the issue.
 
 ## Self-Reflection Loop (Required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 @AGENTS.md
-@docs/night_shift_loop.md
+@docs/contributor_workflow.md
 @docs/review_personas.md
 
 ## Claude-specific notes

--- a/docs/contributor_workflow.md
+++ b/docs/contributor_workflow.md
@@ -1,0 +1,59 @@
+# Contributor Workflow
+
+## Goal
+
+Make the next useful change, verify it, and leave the repository in a reviewable state.
+
+## Preparation
+
+1. Inspect `git status --short`.
+2. If the tree is dirty because a cross-repo inbox synced tracked docs, either commit that sync first or stop if the state is unsafe to modify.
+3. Run the baseline validation command: `tools/validate_repo.sh`.
+4. If validation fails, fix it first or move the task to `NEEDS INPUT FROM USER` with evidence.
+
+## Choose work
+
+1. Read `docs/bugs.md`; choose the highest-severity item in `READY`.
+2. If no bug is ready, choose the highest-priority active item from `docs/build_checklist.md`.
+3. If no implementation task is available, improve docs, validation, or task hygiene.
+
+## Understand the task
+
+- Read the chosen checklist or bug entry.
+- If the task came from PR review feedback, use the included GitHub links and thread context to understand what needs a reply.
+- Load only the docs needed for that task.
+- Read the relevant Rust and `.stasis` code before proposing changes.
+
+## Tests-First Workflow
+
+1. Write a brief testing plan in working notes or commit history, not for human review.
+2. Add or expand automated checks to capture the desired behavior.
+3. Run the checks and confirm they fail for the expected reason before implementation.
+
+## Reviewer Gate Before Implementation
+
+- Run the personas in `docs/review_personas.md`.
+- If any persona is `BLOCKED`, update docs, tests, or plan before changing code.
+
+## Implement
+
+- Make the smallest change that satisfies the failing checks.
+- Run the full quality gates after each meaningful change.
+
+## Reviewer Gate After Implementation
+
+- Re-run the personas against the diff.
+- Iterate until all personas are `GREEN` or the task is explicitly blocked by missing user input.
+
+## Wrap-Up
+
+1. Update any docs that would prevent repeating the same mistake.
+2. If the task came from PR review feedback, reply on GitHub when appropriate with the fix, clarification, or follow-up question.
+3. Commit with a message that explains what changed, why, how it was verified, and any residual risks.
+4. Append a concise entry to `docs/night_shift_report.md`.
+
+## Stop Conditions
+
+- No `READY` bugs remain and no runnable checklist work remains.
+- The task requires a product, design, or business decision from the user.
+- Validation cannot be restored safely within the current run.


### PR DESCRIPTION
## Summary
- add a contributor-oriented workflow doc that describes how to pick work and validate changes
- point AGENTS.md and CLAUDE.md at the contributor workflow instead of the Night Shift-specific loop doc
- keep this PR scoped away from the files already under review in PR #247

## Verification
- documentation-only change

## Notes
- this PR intentionally does not touch tools/nightshift.sh or docs/night_shift_loop.md so it does not depend on PR #247