### PR TITLE
Address issue #250: Completion task list

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -75,13 +75,15 @@ impl AotProcess {
         self.load_import_graph_sources()
             .map_err(crate::compiler::CompileError::Backend)?;
         let index = self.compiler.index_pass()?;
-        let mut type_table = self.compiler.types().clone();
-        type_table
+        self.compiler
+            .types_mut()
             .ensure_utf8_view_id()
             .map_err(crate::compiler::CompileError::Backend)?;
-        type_table
+        self.compiler
+            .types_mut()
             .ensure_ascii_view_id()
             .map_err(crate::compiler::CompileError::Backend)?;
+        let mut analysis_type_table = self.compiler.types().clone();
         let files_fingerprint = compute_files_fingerprint(self.compiler.files());
         let cache_miss = self
             .compile_analysis_cache
@@ -92,7 +94,7 @@ impl AotProcess {
             let next_cache = build_compile_analysis_cache(
                 self.compiler.files(),
                 self.compiler.functions(),
-                &mut type_table,
+                &mut analysis_type_table,
                 files_fingerprint,
                 resolve_preferred_extern_call_signatures,
             )
@@ -103,6 +105,7 @@ impl AotProcess {
             }
             self.compile_analysis_cache = Some(next_cache);
         }
+        *self.compiler.types_mut() = analysis_type_table.clone();
         let analysis = self.compile_analysis_cache.as_ref().ok_or_else(|| {
             crate::compiler::CompileError::Invariant(
                 "aot compile analysis cache missing after refresh".to_string(),
@@ -116,7 +119,7 @@ impl AotProcess {
             }
         }
         self.collection_max_lengths =
-            collect_fixed_collection_max_lengths(&analysis.global_path_types, &type_table)
+            collect_fixed_collection_max_lengths(&analysis.global_path_types, &analysis_type_table)
                 .map_err(crate::compiler::CompileError::Backend)?;
         let compiled_body_hashes: HashMap<FunctionId, u64> = self
             .artifacts
@@ -145,37 +148,43 @@ impl AotProcess {
             self.optimization_profile,
             &mut self.string_literals,
         );
-        let emit = compiler.emit_pass_for_ids_with(&emit_function_ids, &mut |meta, hir| {
-            // Stable per-function symbols are required so AOT objects can reference each other
-            // directly without forcing recompilation of callers on every body change.
-            let symbol = format!("aot_fn_{}", meta.id);
-            let bytes = compile_function_to_object_bytes(
-                meta,
-                hir,
-                &symbol,
-                optimization_profile,
-                &analysis.call_signatures,
-                &mut type_table,
-                &analysis.global_path_types,
-                &analysis.constant_values,
-                string_literals,
-                &analysis.collection_infos,
-                &analysis.named_struct_field_types,
-            )?;
-            let object_index = *next_object_index;
-            *next_object_index = next_object_index.saturating_add(1);
-            object_bytes.push(bytes);
-            let object_bytes_len = object_bytes.last().map_or(0usize, std::vec::Vec::len);
-            artifacts.retain(|artifact| artifact.function_id != meta.id);
-            artifacts.push(AotArtifact {
-                function_id: meta.id,
-                object_index,
-                body_hash: meta.body_hash,
-                symbol_name: symbol,
-                object_bytes_len,
-            });
-            Ok(())
-        })?;
+        let emit = compiler.emit_pass_for_ids_with(
+            &emit_function_ids,
+            &mut |meta, hir, lowered_types| {
+                // Stable per-function symbols are required so AOT objects can reference each other
+                // directly without forcing recompilation of callers on every body change.
+                let symbol = format!("aot_fn_{}", meta.id);
+                let mut type_table = lowered_types.clone();
+                type_table.ensure_utf8_view_id()?;
+                type_table.ensure_ascii_view_id()?;
+                let bytes = compile_function_to_object_bytes(
+                    meta,
+                    hir,
+                    &symbol,
+                    optimization_profile,
+                    &analysis.call_signatures,
+                    &mut type_table,
+                    &analysis.global_path_types,
+                    &analysis.constant_values,
+                    string_literals,
+                    &analysis.collection_infos,
+                    &analysis.named_struct_field_types,
+                )?;
+                let object_index = *next_object_index;
+                *next_object_index = next_object_index.saturating_add(1);
+                object_bytes.push(bytes);
+                let object_bytes_len = object_bytes.last().map_or(0usize, std::vec::Vec::len);
+                artifacts.retain(|artifact| artifact.function_id != meta.id);
+                artifacts.push(AotArtifact {
+                    function_id: meta.id,
+                    object_index,
+                    body_hash: meta.body_hash,
+                    symbol_name: symbol,
+                    object_bytes_len,
+                });
+                Ok(())
+            },
+        )?;
 
         let reachable = crate::backend::reachability::compute_reachable_function_ids(
             self.compiler.functions(),
@@ -1023,7 +1032,9 @@ mod tests {
 
         for expected_literal in case.expected_string_literals {
             assert!(
-                aot.string_literals().values().any(|value| value == expected_literal),
+                aot.string_literals()
+                    .values()
+                    .any(|value| value == expected_literal),
                 "missing string literal {:?} in fixture '{}'",
                 expected_literal,
                 case.label
@@ -1040,9 +1051,9 @@ mod tests {
         }
 
         for (function_name, markers) in case.expected_clif_markers {
-            let clif = captured_clif
-                .get(*function_name)
-                .unwrap_or_else(|| panic!("missing captured CLIF for function '{}'", function_name));
+            let clif = captured_clif.get(*function_name).unwrap_or_else(|| {
+                panic!("missing captured CLIF for function '{}'", function_name)
+            });
             for marker in *markers {
                 assert!(
                     clif.contains(marker),
@@ -1082,6 +1093,18 @@ mod tests {
         assert_eq!(report.emit.emitted_functions, 1);
         assert_eq!(process.artifacts().len(), 1);
         assert!(process.artifacts()[0].object_bytes_len > 0);
+    }
+
+    #[test]
+    fn aot_process_supports_local_annotation_only_type_during_emit() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function main(): i32 { let token: local_only = 7; return token; }\n",
+        );
+        let report = process.compile().expect("aot compile");
+        assert_eq!(report.emit.emitted_functions, 1);
+        assert_eq!(process.artifacts().len(), 1);
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1616,16 +1616,15 @@ where
                 imported_function_ids: HashMap::new(),
             }),
         };
-        let body = extract_function_body(hir)?;
         let mut terminated = false;
-        parse_simple_statements_from_block_with(body, type_table, |type_table, statement| {
+        for statement in &hir.statements {
             if terminated {
-                return Ok(());
+                break;
             }
-            before_statement(&statement)?;
+            before_statement(statement)?;
             terminated = emit_simple_statements(
                 &mut builder,
-                std::slice::from_ref(&statement),
+                std::slice::from_ref(statement),
                 &mut values_by_name,
                 &runtime_call_refs,
                 &mut internal_calls,
@@ -1640,8 +1639,7 @@ where
                 meta.return_type,
                 &mut next_variable,
             )?;
-            Ok(())
-        })?;
+        }
         if !terminated {
             if meta.return_type == TYPE_ID_VOID {
                 builder.ins().return_(&[]);
@@ -2198,13 +2196,6 @@ pub(crate) enum ComparisonOp {
     Le,
     Gt,
     Ge,
-}
-
-pub(crate) fn extract_function_body(hir: &FunctionHIR) -> Result<&str, String> {
-    let Some(block) = hir.blocks.first() else {
-        return Err("function body missing block text".to_string());
-    };
-    Ok(block.source.as_str())
 }
 
 pub(crate) fn parse_simple_statements_from_block_with<F>(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -132,13 +132,15 @@ impl JitProcess {
         self.load_import_graph_sources()
             .map_err(crate::compiler::CompileError::Backend)?;
         let index = self.compiler.index_pass()?;
-        let mut type_table = self.compiler.types().clone();
-        type_table
+        self.compiler
+            .types_mut()
             .ensure_utf8_view_id()
             .map_err(crate::compiler::CompileError::Backend)?;
-        type_table
+        self.compiler
+            .types_mut()
             .ensure_ascii_view_id()
             .map_err(crate::compiler::CompileError::Backend)?;
+        let mut analysis_type_table = self.compiler.types().clone();
         let files_fingerprint = compute_files_fingerprint(self.compiler.files());
         let cache_miss = self
             .compile_analysis_cache
@@ -146,16 +148,18 @@ impl JitProcess {
             .is_none_or(|cache| cache.files_fingerprint != files_fingerprint);
         let mut force_reemit_reachable = false;
         if cache_miss {
-            let extern_signatures =
-                collect_supported_extern_call_signatures(self.compiler.files(), &mut type_table)
-                    .map_err(crate::compiler::CompileError::Backend)?;
+            let extern_signatures = collect_supported_extern_call_signatures(
+                self.compiler.files(),
+                &mut analysis_type_table,
+            )
+            .map_err(crate::compiler::CompileError::Backend)?;
             let (resolved_extern_signatures, extern_symbol_addresses) = self
                 .resolve_extern_call_signatures(&extern_signatures)
                 .map_err(crate::compiler::CompileError::Backend)?;
             let next_cache = build_compile_analysis_cache_from_resolved_externs(
                 self.compiler.files(),
                 self.compiler.functions(),
-                &mut type_table,
+                &mut analysis_type_table,
                 files_fingerprint,
                 resolved_extern_signatures,
                 extern_symbol_addresses,
@@ -167,12 +171,13 @@ impl JitProcess {
             }
             self.compile_analysis_cache = Some(next_cache);
         }
+        *self.compiler.types_mut() = analysis_type_table.clone();
         let analysis = self.compile_analysis_cache.as_ref().ok_or_else(|| {
             crate::compiler::CompileError::Invariant(
                 "jit compile analysis cache missing after refresh".to_string(),
             )
         })?;
-        seed_fixed_collection_max_length_headers(&analysis.global_path_types, &type_table)
+        seed_fixed_collection_max_length_headers(&analysis.global_path_types, &analysis_type_table)
             .map_err(crate::compiler::CompileError::Backend)?;
         let emit_function_ids = select_emit_function_ids(
             self.compiler.functions(),
@@ -184,11 +189,14 @@ impl JitProcess {
         let mut next_symbol_seq = self.next_symbol_seq;
         let mut staged_artifacts = self.artifacts.clone();
         let mut staged_modules: Vec<JITModule> = Vec::new();
-        let emit = self
-            .compiler
-            .emit_pass_for_ids_with(&emit_function_ids, &mut |meta, hir| {
+        let emit = self.compiler.emit_pass_for_ids_with(
+            &emit_function_ids,
+            &mut |meta, hir, lowered_types| {
                 let symbol = format!("jit_fn_{}_{}", meta.id, next_symbol_seq);
                 next_symbol_seq = next_symbol_seq.saturating_add(1);
+                let mut type_table = lowered_types.clone();
+                type_table.ensure_utf8_view_id()?;
+                type_table.ensure_ascii_view_id()?;
                 let (module, code_ptr) = compile_function_to_jit_module(
                     meta,
                     hir,
@@ -212,7 +220,8 @@ impl JitProcess {
                     code_ptr,
                 });
                 Ok(())
-            })?;
+            },
+        )?;
         self.next_slot = next_slot;
         self.next_symbol_seq = next_symbol_seq;
         self.artifacts = staged_artifacts;
@@ -1032,6 +1041,18 @@ mod tests {
             .artifacts()
             .iter()
             .all(|artifact| artifact.code_ptr != 0));
+    }
+
+    #[test]
+    fn jit_process_supports_local_annotation_only_type_during_emit() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function main(): i32 { let token: local_only = 7; return token; }\n",
+        );
+        let report = process.compile().expect("jit compile");
+        assert_eq!(report.emit.emitted_functions, 1);
+        assert_eq!(process.artifacts().len(), 1);
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -60,6 +60,8 @@ mod tests {
     #[test]
     fn aot_runtime_export_contract_requires_exact_symbol_matches() {
         assert!(is_aot_runtime_export_symbol("stasis_jit_gfx_load_sprite"));
-        assert!(!is_aot_runtime_export_symbol("stasis_jit_gfx_totally_missing"));
+        assert!(!is_aot_runtime_export_symbol(
+            "stasis_jit_gfx_totally_missing"
+        ));
     }
 }

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::ops::Range;
 
+use crate::backend::emit::parse_simple_statements_from_block;
 use crate::frontend::indexer::{hash_text, index_file};
 use crate::frontend::types::{TypeId, TypeTable};
 use crate::ir::hir::{Block, FunctionHIR};
@@ -379,7 +380,7 @@ impl Compiler {
         }
     }
 
-    fn lower_function_to_hir(&self, function: &FunctionMeta) -> CompileResult<FunctionHIR> {
+    fn lower_function_to_hir(&mut self, function: &FunctionMeta) -> CompileResult<FunctionHIR> {
         let file = self.files.get(function.file_id as usize).ok_or_else(|| {
             CompileError::Invariant("function references missing file".to_string())
         })?;
@@ -390,8 +391,11 @@ impl Compiler {
                 CompileError::Invariant("function body range out of bounds".to_string())
             })?
             .to_string();
+        let statements =
+            parse_simple_statements_from_block(&body, &mut self.types).map_err(CompileError::Backend)?;
         Ok(FunctionHIR {
             blocks: vec![Block { source: body }],
+            statements,
         })
     }
 }
@@ -722,5 +726,26 @@ mod tests {
         assert!(function_by_name(&compiler, "leaf").dirty);
         assert!(function_by_name(&compiler, "mid").dirty);
         assert!(function_by_name(&compiler, "top").dirty);
+    }
+
+    #[test]
+    fn emitted_hir_contains_structured_statements() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "sample.stasis",
+            "function add_one(value: i32): i32 { let next = value + 1; return next; }\n",
+        );
+
+        let mut statement_counts = Vec::new();
+        compiler
+            .compile_with(|meta, hir| {
+                if meta.name == "add_one" {
+                    statement_counts.push(hir.statements.len());
+                }
+                Ok(())
+            })
+            .expect("compile should succeed");
+
+        assert_eq!(statement_counts, vec![2]);
     }
 }

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -210,7 +210,7 @@ impl Compiler {
 
     pub fn compile_with<F>(&mut self, mut emit_function: F) -> CompileResult<CompileReport>
     where
-        F: FnMut(&FunctionMeta, &FunctionHIR) -> Result<(), String>,
+        F: FnMut(&FunctionMeta, &FunctionHIR, &TypeTable) -> Result<(), String>,
     {
         let index = self.index_pass()?;
         let emit = self.emit_pass_with(&mut emit_function)?;
@@ -298,7 +298,7 @@ impl Compiler {
 
     pub fn emit_pass_with<F>(&mut self, emit_function: &mut F) -> CompileResult<EmitPassResult>
     where
-        F: FnMut(&FunctionMeta, &FunctionHIR) -> Result<(), String>,
+        F: FnMut(&FunctionMeta, &FunctionHIR, &TypeTable) -> Result<(), String>,
     {
         let dirty_ids: Vec<FunctionId> = self
             .functions
@@ -315,7 +315,7 @@ impl Compiler {
         emit_function: &mut F,
     ) -> CompileResult<EmitPassResult>
     where
-        F: FnMut(&FunctionMeta, &FunctionHIR) -> Result<(), String>,
+        F: FnMut(&FunctionMeta, &FunctionHIR, &TypeTable) -> Result<(), String>,
     {
         let mut emitted_functions = 0usize;
         let mut emitted_ids: Vec<FunctionId> = Vec::with_capacity(function_ids.len());
@@ -328,7 +328,7 @@ impl Compiler {
                 })?
                 .clone();
             let hir = self.lower_function_to_hir(&snapshot)?;
-            emit_function(&snapshot, &hir).map_err(CompileError::Backend)?;
+            emit_function(&snapshot, &hir, &self.types).map_err(CompileError::Backend)?;
             emitted_ids.push(*function_id);
             emitted_functions += 1;
         }
@@ -348,6 +348,10 @@ impl Compiler {
 
     pub fn types(&self) -> &TypeTable {
         &self.types
+    }
+
+    pub fn types_mut(&mut self) -> &mut TypeTable {
+        &mut self.types
     }
 
     fn capture_previous_hashes(&self) -> HashMap<(u32, u64), PreviousFunctionHashes> {
@@ -391,8 +395,8 @@ impl Compiler {
                 CompileError::Invariant("function body range out of bounds".to_string())
             })?
             .to_string();
-        let statements =
-            parse_simple_statements_from_block(&body, &mut self.types).map_err(CompileError::Backend)?;
+        let statements = parse_simple_statements_from_block(&body, &mut self.types)
+            .map_err(CompileError::Backend)?;
         Ok(FunctionHIR {
             blocks: vec![Block { source: body }],
             statements,
@@ -457,11 +461,13 @@ mod tests {
     fn unchanged_source_emits_nothing_after_initial_emit() {
         let mut compiler = Compiler::new();
         compiler.upsert_file("sample.stasis", "function main(): i32 { return 7; }\n");
-        let first = compiler.compile_with(|_, _| Ok(())).expect("first compile");
+        let first = compiler
+            .compile_with(|_, _, _| Ok(()))
+            .expect("first compile");
         assert_eq!(first.emit.emitted_functions, 1);
 
         let second = compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("second compile");
         assert_eq!(second.index.dirty_functions, 0);
         assert_eq!(second.emit.emitted_functions, 0);
@@ -475,7 +481,7 @@ mod tests {
             "function helper(): i32 { return 1; }\nfunction main(): i32 { return helper(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -488,7 +494,7 @@ mod tests {
         assert!(!function_by_name(&compiler, "main").dirty);
 
         let emit = compiler
-            .emit_pass_with(&mut |_, _| Ok(()))
+            .emit_pass_with(&mut |_, _, _| Ok(()))
             .expect("emit pass");
         assert_eq!(emit.emitted_functions, 1);
     }
@@ -502,7 +508,7 @@ mod tests {
         );
         compiler.upsert_file("extra.stasis", "function utility(): i32 { return 3; }\n");
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file("extra.stasis", "function utility(): i32 { return 4; }\n");
@@ -515,7 +521,7 @@ mod tests {
 
         let mut emitted_names = Vec::new();
         let emit = compiler
-            .emit_pass_with(&mut |meta, _| {
+            .emit_pass_with(&mut |meta, _, _| {
                 emitted_names.push(meta.name.clone());
                 Ok(())
             })
@@ -532,7 +538,7 @@ mod tests {
             "function helper(): i32 { return 1; }\nfunction main(): i32 { return helper(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -554,7 +560,7 @@ mod tests {
             "function helper(value: i32): i32 { return value; }\nfunction main(): i32 { return helper(7); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -568,7 +574,7 @@ mod tests {
         assert!(!function_by_name(&compiler, "main").dirty);
 
         let emit = compiler
-            .emit_pass_with(&mut |_, _| Ok(()))
+            .emit_pass_with(&mut |_, _, _| Ok(()))
             .expect("emit pass");
         assert_eq!(emit.emitted_functions, 0);
     }
@@ -581,7 +587,7 @@ mod tests {
             "function helper(): i32 { return 1; }\nfunction main(): i32 { return helper(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -592,7 +598,7 @@ mod tests {
 
         let mut emitted_names = Vec::new();
         let _ = compiler
-            .emit_pass_with(&mut |meta, _| {
+            .emit_pass_with(&mut |meta, _, _| {
                 emitted_names.push(meta.name.clone());
                 Ok(())
             })
@@ -609,7 +615,7 @@ mod tests {
         );
         let _ = compiler.index_pass().expect("index pass");
 
-        let error = compiler.emit_pass_with(&mut |meta, _| {
+        let error = compiler.emit_pass_with(&mut |meta, _, _| {
             if meta.name == "helper" {
                 return Err("forced emit failure".to_string());
             }
@@ -667,7 +673,7 @@ mod tests {
             "function helper(): i32 { return 1; }\nfunction left(): i32 { return helper(); }\nfunction right(): i32 { return helper(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -690,7 +696,7 @@ mod tests {
             "function helper(): i32 { return 1; }\nfunction left(): i32 { return helper(); }\nfunction right(): i32 { return helper(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -713,7 +719,7 @@ mod tests {
             "function leaf(): i32 { return 1; }\nfunction mid(): i32 { return leaf(); }\nfunction top(): i32 { return mid(); }\n",
         );
         compiler
-            .compile_with(|_, _| Ok(()))
+            .compile_with(|_, _, _| Ok(()))
             .expect("initial compile");
 
         compiler.upsert_file(
@@ -738,7 +744,7 @@ mod tests {
 
         let mut statement_counts = Vec::new();
         compiler
-            .compile_with(|meta, hir| {
+            .compile_with(|meta, hir, _| {
                 if meta.name == "add_one" {
                     statement_counts.push(hir.statements.len());
                 }

--- a/crates/stasis_compiler/src/ir/hir.rs
+++ b/crates/stasis_compiler/src/ir/hir.rs
@@ -1,6 +1,9 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+use crate::backend::emit::SimpleStmt;
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct FunctionHIR {
     pub blocks: Vec<Block>,
+    pub(crate) statements: Vec<SimpleStmt>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -6,42 +6,7 @@ If you use a cross-repo inbox, it may maintain a generated `NED-INBOX` block und
 
 ## READY
 
-<!-- NED-INBOX:START -->
-- [P1][PR #247] Address review feedback for `Preserve PR branches during Night Shift runs`
-  - Source: https://github.com/benwmaddox/StasisLang/pull/247
-  - Synced at: `2026-03-17T12:49:50.785669+00:00`
-  - Review decision: `UNKNOWN`
-  - When you fix or clarify this feedback, reply on the relevant GitHub review thread when appropriate.
-  - Review by chatgpt-codex-connector at 2026-03-17T12:40:34Z: ### 💡 Codex Review
-
-Here are some automated review suggestions for this pull request.
-
-**Reviewed commit:** `290660d65b`
-    
-
-<details> <summary>ℹ️ About Codex in GitHub</summary>
-<br/>
-
-Codex has been enabled to automatically review pull requests in this repo. Reviews are triggered when you
-- Open a pull request for review
-- Mark a draft as ready
-- Comment "@codex review".
-
-If Codex has suggestions, it will comment; otherwise it will react with 👍.
-
- 
-
-
-When you [sign up for Codex through ChatGPT](https://openai.com/codex), Codex can also answer questions or update the PR, like "@codex address that feedback".
-            
-</details>
-  - `tools/nightshift.sh:43` **<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Reject preserve mode on detached HEAD**
-
-When `NIGHTSHIFT_BRANCH_MODE=preserve`, the script accepts an empty branch name and continues (`${CURRENT_BRANCH:-DETACHED}`), which means runs started from a detached HEAD will still execute and create commits not attached to any branch. In that scenario the intended “preserve PR branch” behavior is lost and the resulting fixes are easy to strand or lose; this path should fail fast unless a real branch is checked out (or unless `EXPECTED_BRANCH` is provided and matches).
-
-Useful? React with 👍 / 👎.
-    - Reply on GitHub: https://github.com/benwmaddox/StasisLang/pull/247#discussion_r2946496401
-<!-- NED-INBOX:END -->
+- None.
 
 
 * Work through items in docs/reviews/rust-compilation-task-list-2026-03-10.md. All should be completed.
@@ -54,7 +19,12 @@ Useful? React with 👍 / 👎.
 
 ## DONE
 
-- None.
+- [P1][PR #247] Addressed review feedback for `Preserve PR branches during Night Shift runs`
+  - Source: https://github.com/benwmaddox/StasisLang/pull/247
+  - Completed: `2026-03-17`
+  - Fixed `tools/nightshift.sh` so `NIGHTSHIFT_BRANCH_MODE=preserve` rejects detached HEAD runs before validation/agent launch.
+  - Added `tools/ci/test_nightshift_preserve_mode.sh` and wired it into `tools/validate_repo.sh`.
+  - Reply on GitHub: https://github.com/benwmaddox/StasisLang/pull/247#discussion_r2946496401
 
 ## NEEDS INPUT FROM USER
 

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -1,5 +1,15 @@
 # Night Shift Report
 
+## 2026-03-17
+
+- Addressed PR #247 review feedback on preserve-mode branch safety in `tools/nightshift.sh`.
+- `NIGHTSHIFT_BRANCH_MODE=preserve` now fails fast when `HEAD` is detached instead of continuing with an unattached commit path.
+- Added `tools/ci/test_nightshift_preserve_mode.sh` and promoted it into the standard validation gate via `tools/validate_repo.sh`.
+- Verification: `tools/ci/test_nightshift_preserve_mode.sh`, `tools/validate_repo.sh`
+- Good: the launcher bug was easy to isolate once the shell regression ran inside a temporary git repo instead of the main workspace.
+- Bad: inherited `NIGHTSHIFT_EXPECT_BRANCH` environment in the local shell initially masked the detached-HEAD path and made the first failing test less precise.
+- Adjustment: clear inherited Night Shift environment variables in script-level regressions so each harness asserts one branch-management behavior at a time.
+
 ## 2026-03-16
 
 - Prepared StasisLang for Night Shift style repo-local runs.

--- a/docs/reviews/rust-compilation-task-list-2026-03-10.md
+++ b/docs/reviews/rust-compilation-task-list-2026-03-10.md
@@ -47,6 +47,12 @@ Benefit:
 
 Priority: High
 
+Status:
+- Completed
+- `Compiler::lower_function_to_hir` now parses function bodies once into structured statements during HIR construction
+- the shared backend consumes `hir.statements` directly instead of reparsing block source during emit
+- focused regression coverage now checks that emitted HIR carries the parsed statement list
+
 Task:
 - replace `FunctionHIR { blocks: Vec<Block { source: String }> }` with a typed statement/expression representation
 - parse once in the frontend, then lower that structured form in both JIT and AOT
@@ -205,3 +211,7 @@ The structured-HIR task is the largest internal compiler change. It is worth doi
 - `cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture`
 - `cargo test -p stasis_compiler aot_engine_bundle_manifest_includes_string_literals -- --nocapture`
 - `cargo test -p stasis_compiler aot_process_prefers_known_runtime_extern_symbol_over_source_alias -- --nocapture`
+- Task 2 is complete: `FunctionHIR` now carries parsed statements so the backend no longer reparses function-body source slices on each emit pass.
+- Task 2 verification:
+- `cargo test -p stasis_compiler emitted_hir_contains_structured_statements -- --nocapture`
+- `cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture`

--- a/tools/ci/test_nightshift_preserve_mode.sh
+++ b/tools/ci/test_nightshift_preserve_mode.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/repo/tools" "$TMP_DIR/bin"
+cp "$ROOT/tools/nightshift.sh" "$TMP_DIR/repo/tools/nightshift.sh"
+chmod +x "$TMP_DIR/repo/tools/nightshift.sh"
+
+cat > "$TMP_DIR/repo/tools/validate_repo.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_DIR/repo/tools/validate_repo.sh"
+
+cat > "$TMP_DIR/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/codex"
+
+cd "$TMP_DIR/repo"
+git init >/dev/null 2>&1
+git config user.name "Night Shift Test"
+git config user.email "nightshift-test@example.com"
+git checkout -b preserve-branch >/dev/null 2>&1
+printf 'base\n' > README.md
+git add README.md
+git commit -m "test: init" >/dev/null 2>&1
+git checkout --detach >/dev/null 2>&1
+
+set +e
+OUTPUT="$(
+  env -u NIGHTSHIFT_EXPECT_BRANCH -u EXPECTED_BRANCH \
+    PATH="$TMP_DIR/bin:$PATH" \
+    NIGHTSHIFT_BRANCH_MODE=preserve \
+    ./tools/nightshift.sh codex 2>&1
+)"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  printf 'expected preserve mode on detached HEAD to fail, but it succeeded\n' >&2
+  printf '%s\n' "$OUTPUT" >&2
+  exit 1
+fi
+
+if [[ "$OUTPUT" != *"current HEAD is detached"* ]]; then
+  printf 'expected detached HEAD preserve-mode error, got:\n%s\n' "$OUTPUT" >&2
+  exit 1
+fi

--- a/tools/nightshift.sh
+++ b/tools/nightshift.sh
@@ -36,11 +36,15 @@ git status --short || true
 
 if [[ "$BRANCH_MODE" == "preserve" ]]; then
   CURRENT_BRANCH="$(git branch --show-current)"
+  if [[ -z "$CURRENT_BRANCH" ]]; then
+    echo "ERROR: preserve branch mode requires a checked out branch; current HEAD is detached."
+    exit 4
+  fi
   if [[ -n "$EXPECTED_BRANCH" && "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]]; then
     echo "ERROR: expected to run on branch '$EXPECTED_BRANCH' but current branch is '$CURRENT_BRANCH'."
     exit 4
   fi
-  echo "== Branch mode: preserve current branch ${CURRENT_BRANCH:-DETACHED} =="
+  echo "== Branch mode: preserve current branch $CURRENT_BRANCH =="
 else
   if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
     git switch "$BRANCH"

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -9,4 +9,5 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 python3 tools/ci/check_stasis_src_layout.py
+tools/ci/test_nightshift_preserve_mode.sh
 cargo test --workspace --all-targets -- --test-threads=1


### PR DESCRIPTION
## Summary
- parse function bodies into structured statements during HIR lowering instead of storing only source slices
- make the shared backend consume structured HIR statements directly so emit no longer reparses body text
- update the Rust compilation task list to mark Task 2 complete with focused verification

## Verification
- cargo test -p stasis_compiler emitted_hir_contains_structured_statements -- --nocapture
- cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture

## Notes
- this completes the remaining item in `docs/reviews/rust-compilation-task-list-2026-03-10.md`
- the existing source block text is still retained in HIR for now, but the backend no longer depends on reparsing it during emit