### PR TITLE
feat: add Android AOT target prerequisites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,8 +686,10 @@ dependencies = [
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
+ "object",
  "stasis_dynload",
  "stasis_jit",
+ "target-lexicon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
-cranelift-codegen = "0.117"
+cranelift-codegen = { version = "0.117", features = ["arm64"] }
 cranelift-frontend = "0.117"
 cranelift-jit = "0.117"
 cranelift-module = "0.117"

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -1046,6 +1046,7 @@ impl IncrementalCompilerBackend {
         let mut process = AotProcess::with_optimization_profile(
             Self::aot_optimization_profile_from_compile_config(&self.aot_compile_config),
         );
+        process.set_target(self.aot_compile_config.target.clone());
         for (path, source) in &self.source_by_path {
             process.upsert_file(path.clone(), source.clone());
         }
@@ -1083,6 +1084,8 @@ impl IncrementalCompilerBackend {
             .values()
             .map(|(symbol, _)| symbol.clone())
             .collect();
+        let mut link_config = self.aot_link_config.clone();
+        link_config.target = self.aot_compile_config.target.clone();
 
         let (linked_image_path, linked_image_size_bytes, linked_image_sha256) =
             if self.enable_aot_link_step && !artifact_paths.is_empty() {
@@ -1101,7 +1104,7 @@ impl IncrementalCompilerBackend {
                     &object_paths,
                     &linked_output,
                     &export_symbols,
-                    &self.aot_link_config,
+                    &link_config,
                 )?;
                 let size = std::fs::metadata(&linked_output)
                     .map_err(|error| {
@@ -2138,8 +2141,8 @@ fn packaged_runtime_library_extension() -> &'static str {
     }
 }
 
-fn runtime_bridge_object_extension() -> &'static str {
-    if cfg!(windows) {
+fn runtime_bridge_object_extension(target: &stasis_jit::AotTarget) -> &'static str {
+    if matches!(target, stasis_jit::AotTarget::Native) && cfg!(windows) {
         "obj"
     } else {
         "o"
@@ -2796,6 +2799,7 @@ fn escape_c_string_literal(text: &str) -> String {
 }
 
 fn build_engine_bundle_runtime_bridge_source(
+    target: &stasis_jit::AotTarget,
     runtime_fields: &[PackagedRuntimeField],
     function_symbols: &[String],
     function_aliases: &[PackagedFunctionAlias],
@@ -2921,6 +2925,35 @@ STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
             ));
         }
     }
+    // Keep the Android ABI surface fixed while the host shell/input event mapping lands separately.
+    if matches!(target, stasis_jit::AotTarget::AndroidArm64 { .. }) {
+        source.push_str(
+            "STASIS_EXPORT void stasis_init(int width, int height) {\n\
+    host_i32[1] = width;\n\
+    host_i32[2] = height;\n\
+    host_i32[5] = width;\n\
+    host_i32[6] = height;\n\
+    host_i32[12] = width;\n\
+    host_i32[13] = height;\n\
+    host_req_window_w_px = width;\n\
+    host_req_window_h_px = height;\n\
+    main();\n\
+}\n\
+STASIS_EXPORT void stasis_tick(float dt) {\n\
+    (void)dt;\n\
+    host_i32[10] = host_i32[10] + 1;\n\
+    tick();\n\
+}\n\
+STASIS_EXPORT void stasis_render(void) {\n\
+    render();\n\
+}\n\
+STASIS_EXPORT void stasis_on_input(int type, int a, int b) {\n\
+    (void)type;\n\
+    (void)a;\n\
+    (void)b;\n\
+}\n",
+        );
+    }
     source.push_str("STASIS_EXPORT void stasis_aot_bind_runtime_globals(void) {\n");
     for line in register_lines {
         source.push_str("    ");
@@ -2943,9 +2976,10 @@ fn emit_engine_bundle_runtime_bridge_object(
         .join("engine_bundle_runtime_bridge.c");
     let object_path = backend.aot_artifact_root.join(format!(
         "engine_bundle_runtime_bridge.{}",
-        runtime_bridge_object_extension()
+        runtime_bridge_object_extension(&backend.aot_compile_config.target)
     ));
     let source = build_engine_bundle_runtime_bridge_source(
+        &backend.aot_compile_config.target,
         runtime_fields,
         function_symbols,
         function_aliases,
@@ -2970,7 +3004,8 @@ fn emit_engine_bundle_runtime_bridge_object(
         .and_then(|value| value.to_str())
         .unwrap_or_default()
         .to_ascii_lowercase();
-    let is_msvc_style = cfg!(windows)
+    let is_msvc_style = matches!(backend.aot_compile_config.target, stasis_jit::AotTarget::Native)
+        && cfg!(windows)
         && (compiler_name == "clang-cl"
             || compiler_name == "clang-cl.exe"
             || compiler_name == "cl"
@@ -2992,8 +3027,16 @@ fn emit_engine_bundle_runtime_bridge_object(
             .arg("c")
             .arg("-o")
             .arg(&object_path);
-        if !cfg!(windows) {
+        if !cfg!(windows)
+            || matches!(
+                backend.aot_compile_config.target,
+                stasis_jit::AotTarget::AndroidArm64 { .. }
+            )
+        {
             command.arg("-fPIC");
+        }
+        if let Some(target) = backend.aot_compile_config.target.clang_target() {
+            command.arg(format!("--target={target}"));
         }
         command.arg(&source_path);
     }
@@ -3135,6 +3178,7 @@ fn package_engine_bundle_release(
     }
 
     let mut link_config = backend.aot_link_config.clone();
+    link_config.target = backend.aot_compile_config.target.clone();
     let dynload_lib = ensure_stasis_dynload_staticlib()?;
     if !link_config
         .runtime_lib_paths
@@ -3293,7 +3337,9 @@ fn aot_call_conv() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(windows)]
     use object::Object;
+    #[cfg(windows)]
     use stasis_compiler::IncrementalCompilerHost;
     #[cfg(windows)]
     use stasis_dynload::{invoke_noarg_u64, Library as DynamicLibrary};
@@ -3314,6 +3360,41 @@ mod tests {
     #[test]
     fn identifier_hash_matches_incremental_function() {
         assert_eq!(hash_identifier("on_code_swap"), -663_287_521);
+    }
+
+    #[test]
+    fn engine_bundle_runtime_bridge_source_includes_android_entry_exports() {
+        let source = build_engine_bundle_runtime_bridge_source(
+            &stasis_jit::AotTarget::android_arm64_default(),
+            &[],
+            &["aot_fn_1".to_string(), "aot_fn_2".to_string(), "aot_fn_3".to_string()],
+            &[
+                PackagedFunctionAlias {
+                    alias: "main",
+                    target_symbol: "aot_fn_1".to_string(),
+                    returns_i32: true,
+                },
+                PackagedFunctionAlias {
+                    alias: "tick",
+                    target_symbol: "aot_fn_2".to_string(),
+                    returns_i32: true,
+                },
+                PackagedFunctionAlias {
+                    alias: "render",
+                    target_symbol: "aot_fn_3".to_string(),
+                    returns_i32: true,
+                },
+            ],
+            &[],
+        )
+        .expect("build android bridge source");
+
+        assert!(source.contains("STASIS_EXPORT void stasis_init(int width, int height)"));
+        assert!(source.contains("host_i32[1] = width;"));
+        assert!(source.contains("STASIS_EXPORT void stasis_tick(float dt)"));
+        assert!(source.contains("host_i32[10] = host_i32[10] + 1;"));
+        assert!(source.contains("STASIS_EXPORT void stasis_render(void)"));
+        assert!(source.contains("STASIS_EXPORT void stasis_on_input(int type, int a, int b)"));
     }
 
     #[test]
@@ -4909,6 +4990,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![stasis_dynload_lib],
+            target: stasis_jit::AotTarget::default(),
         };
 
         stasis_jit::link_objects_to_dynamic_library(
@@ -5344,6 +5426,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![stasis_dynload_lib],
+            target: stasis_jit::AotTarget::default(),
         };
 
         stasis_jit::link_objects_to_dynamic_library(
@@ -5695,6 +5778,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![stasis_dynload_lib],
+            target: stasis_jit::AotTarget::default(),
         };
 
         stasis_jit::link_objects_to_dynamic_library(
@@ -6076,6 +6160,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![stasis_dynload_lib],
+            target: stasis_jit::AotTarget::default(),
         };
         stasis_jit::link_objects_to_dynamic_library(
             &object_paths,
@@ -6331,6 +6416,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![stasis_dynload_lib],
+            target: stasis_jit::AotTarget::default(),
         };
         stasis_jit::link_objects_to_dynamic_library(
             &object_paths,
@@ -6979,6 +7065,7 @@ mod tests {
             AotLinkConfig {
                 linker_path: Some(linker_path),
                 runtime_lib_paths: vec![],
+                target: stasis_jit::AotTarget::default(),
             },
             temp_root.join("aot_artifacts"),
             true,
@@ -7058,6 +7145,7 @@ mod tests {
             AotLinkConfig {
                 linker_path: Some(linker_path),
                 runtime_lib_paths: vec![],
+                target: stasis_jit::AotTarget::default(),
             },
             temp_root.join("aot_artifacts"),
             true,
@@ -7185,6 +7273,7 @@ echo "signed" > "$1.signed"
             AotLinkConfig {
                 linker_path: Some(linker_path),
                 runtime_lib_paths: vec![],
+                target: stasis_jit::AotTarget::default(),
             },
             artifact_root,
             false,

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2981,6 +2981,7 @@ mod tests {
         let link_config = stasis_jit::AotLinkConfig {
             linker_path: Some(linker_path),
             runtime_lib_paths: vec![],
+            target: stasis_jit::AotTarget::default(),
         };
         let artifact_root = temp_root.join("aot_artifacts");
         let mut backend = IncrementalCompilerBackend::with_aot_compile_and_link_config(

--- a/crates/stasis_compiler/Cargo.toml
+++ b/crates/stasis_compiler/Cargo.toml
@@ -16,3 +16,7 @@ cranelift-native.workspace = true
 cranelift-object.workspace = true
 stasis_jit = { path = "../stasis_jit" }
 stasis_dynload = { path = "../stasis_dynload" }
+target-lexicon = "0.13"
+
+[dev-dependencies]
+object = "0.36"

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -10,8 +10,10 @@ use cranelift_object::{ObjectBuilder, ObjectModule};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
+use target_lexicon::Triple;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AotArtifact {
@@ -26,6 +28,7 @@ pub struct AotArtifact {
 pub struct AotProcess {
     compiler: Compiler,
     optimization_profile: AotOptimizationProfile,
+    target: stasis_jit::AotTarget,
     next_object_index: u32,
     artifacts: Vec<AotArtifact>,
     object_bytes: Vec<Vec<u8>>,
@@ -52,6 +55,7 @@ impl AotProcess {
         Self {
             compiler: Compiler::new(),
             optimization_profile,
+            target: stasis_jit::AotTarget::default(),
             next_object_index: 0,
             artifacts: Vec::new(),
             object_bytes: Vec::new(),
@@ -64,6 +68,10 @@ impl AotProcess {
 
     pub fn upsert_file(&mut self, path: impl Into<String>, content: impl Into<String>) {
         self.compiler.upsert_file(path, content);
+    }
+
+    pub fn set_target(&mut self, target: stasis_jit::AotTarget) {
+        self.target = target;
     }
 
     pub fn set_required_emit_roots(&mut self, roots: &[String]) {
@@ -140,6 +148,7 @@ impl AotProcess {
             object_bytes,
             optimization_profile,
             string_literals,
+            target,
         ) = (
             &mut self.compiler,
             &mut self.next_object_index,
@@ -147,6 +156,7 @@ impl AotProcess {
             &mut self.object_bytes,
             self.optimization_profile,
             &mut self.string_literals,
+            self.target.clone(),
         );
         let emit = compiler.emit_pass_for_ids_with(
             &emit_function_ids,
@@ -167,6 +177,7 @@ impl AotProcess {
                     &analysis.global_path_types,
                     &analysis.constant_values,
                     string_literals,
+                    &target,
                     &analysis.collection_infos,
                     &analysis.named_struct_field_types,
                 )?;
@@ -528,6 +539,7 @@ fn compile_function_to_object_bytes(
     global_path_types: &GlobalPathTypeMap,
     constant_values: &ConstantValueMap,
     string_literals: &mut BTreeMap<i32, String>,
+    target: &stasis_jit::AotTarget,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
 ) -> Result<Vec<u8>, String> {
@@ -536,8 +548,19 @@ fn compile_function_to_object_bytes(
         .set("opt_level", optimization_profile.as_cranelift_opt_level())
         .map_err(|error| format!("failed to configure Cranelift opt level: {error}"))?;
     let flags = settings::Flags::new(flag_builder);
-    let isa_builder = cranelift_native::builder()
-        .map_err(|error| format!("failed to construct native ISA builder: {error}"))?;
+    let isa_builder = match target.object_triple() {
+        Some(triple_text) => {
+            let triple = Triple::from_str(triple_text).map_err(|error| {
+                format!("failed to parse AOT target triple {triple_text}: {error}")
+            })?;
+            let triple_display = triple.to_string();
+            cranelift_codegen::isa::lookup(triple).map_err(|error| {
+                format!("failed to construct ISA builder for {triple_display}: {error}")
+            })?
+        }
+        None => cranelift_native::builder()
+            .map_err(|error| format!("failed to construct native ISA builder: {error}"))?,
+    };
     let isa = isa_builder
         .finish(flags)
         .map_err(|error| format!("failed to finalize native ISA: {error}"))?;
@@ -884,6 +907,7 @@ mod tests {
     use super::*;
     use crate::backend::jit::JitProcess;
     use crate::backend::EngineEntrypoints;
+    use object::{Architecture, BinaryFormat, File, Object};
     #[cfg(windows)]
     use std::process::Command;
     use std::sync::Arc;
@@ -1370,6 +1394,22 @@ mod tests {
     }
 
     #[test]
+    fn aot_process_emits_android_arm64_elf_objects_when_target_is_configured() {
+        let mut process = AotProcess::new();
+        process.set_target(stasis_jit::AotTarget::android_arm64_default());
+        process.upsert_file("sample.stasis", "function main(): i32 { return 7; }\n");
+        process.compile().expect("android aot compile");
+
+        let bytes = process
+            .object_bytes
+            .first()
+            .expect("expected first object bytes");
+        let object = File::parse(bytes.as_slice()).expect("parse emitted object");
+        assert_eq!(object.format(), BinaryFormat::Elf);
+        assert_eq!(object.architecture(), Architecture::Aarch64);
+    }
+
+    #[test]
     fn aot_engine_bundle_writes_manifest_and_required_entrypoints() {
         let mut process = AotProcess::new();
         process.upsert_file(
@@ -1847,6 +1887,7 @@ mod tests {
             return Some(stasis_jit::AotLinkConfig {
                 linker_path: Some(explicit),
                 runtime_lib_paths: vec![],
+                target: stasis_jit::AotTarget::default(),
             });
         }
         for candidate in ["lld-link.exe", "link.exe"] {
@@ -1855,6 +1896,7 @@ mod tests {
                 return Some(stasis_jit::AotLinkConfig {
                     linker_path: Some(PathBuf::from(candidate)),
                     runtime_lib_paths: vec![],
+                    target: stasis_jit::AotTarget::default(),
                 });
             }
         }

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -20,6 +20,7 @@ pub struct CommitOutcome {
 #[derive(Debug, Clone)]
 pub struct AotCompileConfig {
     pub opt_level: String,
+    pub target: AotTarget,
 }
 
 fn default_aot_opt_level() -> String {
@@ -41,7 +42,40 @@ impl Default for AotCompileConfig {
     fn default() -> Self {
         Self {
             opt_level: default_aot_opt_level(),
+            target: AotTarget::default(),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AotTarget {
+    Native,
+    AndroidArm64 { min_sdk: u32 },
+}
+
+impl AotTarget {
+    pub fn android_arm64_default() -> Self {
+        Self::AndroidArm64 { min_sdk: 26 }
+    }
+
+    pub fn object_triple(&self) -> Option<&'static str> {
+        match self {
+            Self::Native => None,
+            Self::AndroidArm64 { .. } => Some("aarch64-linux-android"),
+        }
+    }
+
+    pub fn clang_target(&self) -> Option<String> {
+        match self {
+            Self::Native => None,
+            Self::AndroidArm64 { min_sdk } => Some(format!("aarch64-linux-android{min_sdk}")),
+        }
+    }
+}
+
+impl Default for AotTarget {
+    fn default() -> Self {
+        Self::Native
     }
 }
 
@@ -49,6 +83,7 @@ impl Default for AotCompileConfig {
 pub struct AotLinkConfig {
     pub linker_path: Option<PathBuf>,
     pub runtime_lib_paths: Vec<PathBuf>,
+    pub target: AotTarget,
 }
 
 impl Default for AotLinkConfig {
@@ -60,6 +95,7 @@ impl Default for AotLinkConfig {
         Self {
             linker_path,
             runtime_lib_paths: Vec::new(),
+            target: AotTarget::default(),
         }
     }
 }
@@ -221,7 +257,7 @@ pub fn link_objects_to_dynamic_library(
 
     let linker = resolve_linker_path(config);
     let mut args: Vec<String> = Vec::new();
-    if cfg!(windows) {
+    if uses_msvc_linker_syntax(config) {
         args.push("/NOLOGO".to_string());
         args.push("/DLL".to_string());
         args.push(format!("/OUT:{}", output_library.display()));
@@ -260,6 +296,9 @@ pub fn link_objects_to_dynamic_library(
         args.push("-shared".to_string());
         args.push("-o".to_string());
         args.push(output_library.display().to_string());
+        if let Some(target) = config.target.clang_target() {
+            args.push(format!("--target={target}"));
+        }
     }
     for object_path in object_paths {
         args.push(object_path.display().to_string());
@@ -307,7 +346,7 @@ pub fn link_objects_to_executable(
 
     let linker = resolve_linker_path(config);
     let mut args: Vec<String> = Vec::new();
-    if cfg!(windows) {
+    if uses_msvc_linker_syntax(config) {
         args.push("/NOLOGO".to_string());
         args.push(format!("/OUT:{}", output_executable.display()));
         args.push(format!("/ENTRY:{entry_symbol}"));
@@ -325,6 +364,9 @@ pub fn link_objects_to_executable(
         args.push("-o".to_string());
         args.push(output_executable.display().to_string());
         args.push(format!("-Wl,-e,{entry_symbol}"));
+        if let Some(target) = config.target.clang_target() {
+            args.push(format!("--target={target}"));
+        }
     }
     for object_path in object_paths {
         args.push(object_path.display().to_string());
@@ -357,6 +399,10 @@ fn resolve_linker_path(config: &AotLinkConfig) -> PathBuf {
     } else {
         PathBuf::from("cc")
     }
+}
+
+fn uses_msvc_linker_syntax(config: &AotLinkConfig) -> bool {
+    matches!(config.target, AotTarget::Native) && cfg!(windows)
 }
 
 #[cfg(windows)]
@@ -725,6 +771,7 @@ echo "fake-shared" > "$OUT"
         let config = AotLinkConfig {
             linker_path: Some(fake_linker),
             runtime_lib_paths: vec![],
+            target: AotTarget::default(),
         };
         link_objects_to_dynamic_library(
             &[dummy_object],

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -1,5 +1,15 @@
 # Night Shift Report
 
+## 2026-03-21
+
+- Started the real Android AOT prerequisite slice for issue #254 instead of landing template-only scaffolding.
+- Enabled Cranelift arm64 support in the workspace, added an explicit `AotTarget` config path, and taught the AOT backend to emit `aarch64-linux-android` ELF objects when that target is selected.
+- Added Android bridge export coverage in `apps/stasis` so the runtime bridge now emits the fixed Android entry ABI symbols (`stasis_init`, `stasis_tick`, `stasis_render`, `stasis_on_input`) on the Android target path.
+- Verification: `cargo test -p stasis_compiler aot_process_emits_android_arm64_elf_objects_when_target_is_configured -- --nocapture`, `cargo test -p stasis engine_bundle_runtime_bridge_source_includes_android_entry_exports -- --nocapture`, `tools/validate_repo.sh`
+- Good: this slice stayed narrow but still proved the two core prerequisites in code and tests instead of only adding config plumbing.
+- Bad: the first Android target compile failed because the workspace had only host-arch Cranelift enabled, so the target-selection code alone was not enough.
+- Adjustment: whenever a new backend target is introduced, add one object-format test immediately so missing Cranelift feature flags surface before higher-level packaging work starts.
+
 ## 2026-03-19
 
 - Refreshed PR #252 again after `main` advanced, merging the current branch tip into `chore/night-shift-workflow` and resolving the only conflict in `docs/night_shift_report.md`.


### PR DESCRIPTION
## Summary
- add a typed Android ARM64 AOT target and route linker/bridge tool invocation through that target
- enable Cranelift arm64 support and prove the compiler emits `aarch64-linux-android` ELF objects
- add Android bridge exports for `stasis_init`, `stasis_tick`, `stasis_render`, and `stasis_on_input` on the Android target path

## Verification
- `cargo test -p stasis_compiler aot_process_emits_android_arm64_elf_objects_when_target_is_configured -- --nocapture`
- `cargo test -p stasis engine_bundle_runtime_bridge_source_includes_android_entry_exports -- --nocapture`
- `./tools/validate_repo.sh`

## Remaining Work
- This PR does not claim the full issue is done yet. It lands the compiler/runtime prerequisites only.
- Android project generation, real NDK link validation on Windows, Gradle `assembleDebug`, emulator install, and end-to-end input delivery still need follow-up slices for issue #254.

Refs #254