### PR TITLE
Fix self-hosted AOT CLI artifact paths

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -7819,9 +7819,7 @@ pub fn run_self_host_aot_cli_with_options(
         .and_then(|value| value.to_str())
         .filter(|value| !value.is_empty())
         .unwrap_or("aot_output");
-    let artifact_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..")
+    let artifact_root = project_dir
         .join(".stasis_cache")
         .join("aot_cli")
         .join(output_key);

--- a/runtime/build.bat
+++ b/runtime/build.bat
@@ -2,7 +2,9 @@
 setlocal EnableDelayedExpansion
 
 pushd "%~dp0"
-call "%~dp0..\env.bat"
+if exist "%~dp0..\env.bat" (
+    call "%~dp0..\env.bat"
+)
 
 echo Building Stasis Graphics Runtime Library (static+shared)...
 


### PR DESCRIPTION
## Summary
- use the project directory for self-hosted ot-cli cache/artifact output instead of a build-machine path baked in via CARGO_MANIFEST_DIR
- make untime/build.bat tolerate a missing repo-root env.bat

## Why
Building a standalone game from the published Windows CLI failed in two places:
1. ot-cli tried to write under the GitHub Actions build path embedded in the release binary
2. the runtime build script unconditionally called ..\\env.bat, which is not present in a normal clone/release checkout

Using the Hearthstead sample project, the patched CLI now successfully:
- runs stasis.exe test --dir tests
- runs stasis.exe aot-cli --project-dir <project> --entry-file <entry> --out build\\hearthstead.exe

This keeps generated artifacts local to the project and removes the hard dependency on an optional environment shim.