### PR TITLE
fix: page and recycle sprite atlases

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2085,6 +2085,9 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    const STASIS_GRAPHICS_SOURCE: &str =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../runtime/stasis_graphics.c"));
+
     fn jit_global_table_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
@@ -2107,6 +2110,32 @@ mod tests {
         } else {
             std::env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn sprite_runtime_clamps_initial_sprite_growth_to_configured_limit() {
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains(
+                "int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : 64;\n    if (new_capacity > g_sprite_limit) {\n        new_capacity = g_sprite_limit;\n    }"
+            ),
+            "runtime sprite allocation should clamp the initial growth step to STASIS_GFX_MAX_SPRITES"
+        );
+    }
+
+    #[test]
+    fn sprite_runtime_clears_reused_atlas_padding_before_mipmap_regeneration() {
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains(
+                "unsigned char* clear_pixels = (unsigned char*)calloc(pixel_count, 4);"
+            ),
+            "runtime sprite upload should zero the reused atlas allocation before writing sprite pixels"
+        );
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains(
+                "glBindTexture(GL_TEXTURE_2D, texture);\n    if (!sprite_atlas_clear_upload_rect(alloc_x, alloc_y, alloc_w, alloc_h)) {\n        glBindTexture(GL_TEXTURE_2D, 0);\n        return 0;\n    }\n    glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);\n    glGenerateMipmap(GL_TEXTURE_2D);"
+            ),
+            "runtime sprite upload should clear padded texels before updating the sprite interior and regenerating mipmaps"
+        );
     }
 
     fn decode_zero_terminated_utf8(bytes: &[u8]) -> String {

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -2,14 +2,14 @@
 
 ## 2026-03-27
 
-- Completed issue #263 by replacing the fixed OpenGL sprite atlas model with a paged atlas allocator that can grow across multiple textures and reuse freed regions on size-changing sprite reloads.
-- Removed the fixed `MAX_SPRITES` table in `runtime/stasis_graphics.c`; sprite handles now come from a heap-backed table so larger projects are no longer capped by one compile-time sprite slot array.
-- Added a direct allocator regression harness in `apps/stasis/src/lib.rs` that compiles and runs `runtime/stasis_sprite_atlas.c` during `cargo test`, covering both freed-region reuse and page growth once one page fills.
-- Documented the new atlas behavior in `runtime/README.md`, including the `2048x2048` default page size, runtime clamping to `GL_MAX_TEXTURE_SIZE`, and the `STASIS_GFX_ATLAS_PAGE_SIZE` override.
-- Verification: `cargo test -p stasis sprite_atlas_allocator_reuses_regions_and_grows_pages -- --nocapture`, `cargo test -p stasis --lib -- --test-threads=1`, `tools/validate_repo.sh`
-- Good: extracting the allocator into a small C module made the runtime change testable without needing a full renderer harness.
-- Bad: the first guillotine split heuristic fragmented the page badly enough that the new reuse test still forced an unnecessary second page.
-- Adjustment: when adding allocator-style runtime slices, run one direct fragmentation harness immediately so split and merge policy problems surface before the full repo validation pass.
+- Completed issue #263 by replacing the fixed OpenGL sprite atlas model with pageable atlas textures and reusable free-rect allocation in [runtime/stasis_graphics.c](/home/ben/StasisLang/runtime/stasis_graphics.c).
+- Removed the fixed compile-time sprite table ceiling by growing sprite handles at runtime and honoring `STASIS_GFX_MAX_SPRITES`, while atlas page sizing now respects runtime GL limits and the atlas env var overrides.
+- Added source-level regression checks in [apps/stasis/src/lib.rs](/home/ben/StasisLang/apps/stasis/src/lib.rs) for the two issue-critical guardrails: clamped sprite table growth and clearing reused atlas padding before mipmap regeneration.
+- Documented the run outcome here after rebasing onto the existing remote `ned/issue-263` branch instead of overwriting earlier issue work.
+- Verification: `tools/validate_repo.sh`
+- Good: fetching and rebasing onto the already-populated bot branch preserved the earlier issue implementation and avoided another non-fast-forward failure.
+- Bad: the first local pass started from `main` and only later discovered the remote issue branch already contained overlapping atlas work, which forced a rebase and report correction.
+- Adjustment: when rerunning work on a reused Ned branch, fetch the remote issue branch before coding so the starting point matches the real handoff state.
 
 ## 2026-03-21
 

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -99,3 +99,12 @@
 - Good: keeping the lookup output parser-backed made the new command small and let the whole-directory search ignore invalid fixture files cleanly.
 - Bad: the compiler parser exposed function ranges but not struct ranges, so exact struct-definition output needed a small parser extension before the CLI work could stay clean.
 - Adjustment: when a new tooling feature needs source excerpts, expose precise ranges from the shared parser first instead of duplicating extraction logic in the CLI.
+
+## 2026-03-27
+
+- Completed issue #263 by replacing the fixed GL sprite slot array with a dynamic table, adding paged sprite atlases with free-region reuse, and flushing sprite batches on atlas page changes instead of assuming one bound atlas texture.
+- Added runtime atlas diagnostics and config knobs in `runtime/stasis_graphics.c`, and documented the new `STASIS_GFX_ATLAS_SIZE` and `STASIS_GFX_MAX_SPRITES` behavior in `runtime/README.md`.
+- Verification: `tools/validate_repo.sh`; attempted direct runtime build verification, but this environment does not have `cmake`, `SDL.h`, or `GL/glew.h`, so the graphics runtime could not be compiled locally through its normal toolchain here.
+- Good: the issue comment already narrowed the architecture, so the implementation could stay on one reviewable path instead of mixing multiple atlas experiments.
+- Bad: repo validation still does not exercise `runtime/stasis_graphics.c`, which left the runtime-specific compile check dependent on local system tooling that is missing in this environment.
+- Adjustment: add a bounded CI-friendly graphics runtime compile check that does not depend on ad hoc local desktop SDK setup, so renderer slices get a real compiler pass alongside `tools/validate_repo.sh`.

--- a/docs/night_shift_report.md
+++ b/docs/night_shift_report.md
@@ -1,5 +1,16 @@
 # Night Shift Report
 
+## 2026-03-27
+
+- Completed issue #263 by replacing the fixed OpenGL sprite atlas model with a paged atlas allocator that can grow across multiple textures and reuse freed regions on size-changing sprite reloads.
+- Removed the fixed `MAX_SPRITES` table in `runtime/stasis_graphics.c`; sprite handles now come from a heap-backed table so larger projects are no longer capped by one compile-time sprite slot array.
+- Added a direct allocator regression harness in `apps/stasis/src/lib.rs` that compiles and runs `runtime/stasis_sprite_atlas.c` during `cargo test`, covering both freed-region reuse and page growth once one page fills.
+- Documented the new atlas behavior in `runtime/README.md`, including the `2048x2048` default page size, runtime clamping to `GL_MAX_TEXTURE_SIZE`, and the `STASIS_GFX_ATLAS_PAGE_SIZE` override.
+- Verification: `cargo test -p stasis sprite_atlas_allocator_reuses_regions_and_grows_pages -- --nocapture`, `cargo test -p stasis --lib -- --test-threads=1`, `tools/validate_repo.sh`
+- Good: extracting the allocator into a small C module made the runtime change testable without needing a full renderer harness.
+- Bad: the first guillotine split heuristic fragmented the page badly enough that the new reuse test still forced an unnecessary second page.
+- Adjustment: when adding allocator-style runtime slices, run one direct fragmentation harness immediately so split and merge policy problems surface before the full repo validation pass.
+
 ## 2026-03-21
 
 - Started the real Android AOT prerequisite slice for issue #254 instead of landing template-only scaffolding.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -71,7 +71,7 @@ The library exports these functions for Stasis programs:
 | `stasis_clear(r, g, b, a)` | Clear screen with color |
 | `stasis_draw_line(x1, y1, x2, y2, r, g, b, a)` | Queue a line for rendering |
 | `stasis_draw_lines_f32(lines, count)` | Batch: queue `count` lines from an `f32` array (8 floats per line) |
-| `stasis_gfx_load_sprite(path)` | Load and bake an SVG sprite into an atlas; returns handle |
+| `stasis_gfx_load_sprite(path)` | Load and bake an SVG sprite into the paged sprite atlas; returns handle |
 | `stasis_gfx_draw_sprite(handle, x, y, sx, sy, rot, r, g, b, a)` | Draw baked sprite (centered) with scale/rotation/tint |
 | `stasis_gfx_draw_sprites_i32(cmds, count)` | Batch: draw `count` sprites from an `i32` array (7 ints per sprite) |
 | `stasis_gfx_debug_bake_hash(path)` | Debug: bake SVG on CPU and return a pixel hash |
@@ -93,6 +93,11 @@ The library exports these functions for Stasis programs:
 | `stasis_audio_push_f32_interleaved(ptr, frames)` | Push `f32` interleaved frames (LRLR...); returns frames accepted |
 
 `play` and the native runner use HostFrame bulk snapshots for per-tick input/state now.
+
+Sprite atlas behavior:
+- The OpenGL path now grows across multiple atlas pages instead of one fixed texture.
+- Atlas page size defaults to `2048x2048`, clamps to `GL_MAX_TEXTURE_SIZE`, and can be overridden with `STASIS_GFX_ATLAS_SIZE`.
+- Sprite handle storage now grows dynamically; `STASIS_GFX_MAX_SPRITES` can set an optional runtime cap.
 Guest code should read keyboard/pointer/quit state through `src/runtime/host_frame.stasis`
 directly or via the HostFrame-backed stdlib wrappers in `src/stdlib/graphics.stasis` and
 `src/stdlib/game_input.stasis`.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -59,6 +59,16 @@ If you prefer to build manually or vcpkg is unavailable:
    cmake --build . --config Release
    ```
 
+## Sprite Atlas Runtime Settings
+
+The OpenGL sprite path now uses a multi-page atlas instead of one fixed texture.
+
+- `STASIS_GFX_ATLAS_W` and `STASIS_GFX_ATLAS_H` set the per-page atlas size.
+- The default page size is `2048x2048`, clamped to the runtime `GL_MAX_TEXTURE_SIZE`.
+- `STASIS_GFX_MAX_SPRITES` optionally caps sprite-handle growth; unset or `0` leaves the table heap-backed and effectively unbounded.
+- Size-stable reloads update in place. Size-changing reloads allocate a new region, switch the sprite handle, and free the old region.
+- Atlas allocation failures now log page count, page size, free-region summary, and current sprite-table usage.
+
 ## API
 
 The library exports these functions for Stasis programs:

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -71,7 +71,7 @@ The library exports these functions for Stasis programs:
 | `stasis_clear(r, g, b, a)` | Clear screen with color |
 | `stasis_draw_line(x1, y1, x2, y2, r, g, b, a)` | Queue a line for rendering |
 | `stasis_draw_lines_f32(lines, count)` | Batch: queue `count` lines from an `f32` array (8 floats per line) |
-| `stasis_gfx_load_sprite(path)` | Load and bake an SVG sprite into an atlas; returns handle |
+| `stasis_gfx_load_sprite(path, max_w, max_h)` | Load and bake an image into the sprite atlas system; returns handle |
 | `stasis_gfx_draw_sprite(handle, x, y, sx, sy, rot, r, g, b, a)` | Draw baked sprite (centered) with scale/rotation/tint |
 | `stasis_gfx_draw_sprites_i32(cmds, count)` | Batch: draw `count` sprites from an `i32` array (7 ints per sprite) |
 | `stasis_gfx_debug_bake_hash(path)` | Debug: bake SVG on CPU and return a pixel hash |
@@ -96,6 +96,22 @@ The library exports these functions for Stasis programs:
 Guest code should read keyboard/pointer/quit state through `src/runtime/host_frame.stasis`
 directly or via the HostFrame-backed stdlib wrappers in `src/stdlib/graphics.stasis` and
 `src/stdlib/game_input.stasis`.
+
+## Sprite Atlas Configuration
+
+The OpenGL sprite path now uses paged atlases with region reuse instead of one fixed compile-time atlas.
+The runtime creates new atlas pages on demand, reuses freed regions on reload/resize, and keeps sprite
+handles in a growable table.
+
+Environment variables:
+
+- `STASIS_GFX_ATLAS_SIZE=<n>` sets the default square atlas page size. Default: `2048`.
+- `STASIS_GFX_ATLAS_WIDTH=<n>` and `STASIS_GFX_ATLAS_HEIGHT=<n>` override page dimensions independently.
+- `STASIS_GFX_ATLAS_MAX_PAGES=<n>` caps how many atlas pages the runtime may create. Default: `32`.
+- `STASIS_GFX_MAX_SPRITES=<n>` caps how many sprite handles may be allocated. Default: `4096`.
+
+The runtime clamps atlas page width/height to the current GL `GL_MAX_TEXTURE_SIZE` limit when an OpenGL
+context is active and logs the effective atlas configuration at startup.
 
 ## SDL Scancodes
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -151,6 +151,7 @@ typedef struct SpriteEntry SpriteEntry;
 static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int h, int rot_degrees, int a, int do_hash);
 static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_count);
 static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int max_w, int max_h, int allow_reuse_slot);
+static SpriteEntry* sprite_get(int handle);
 
 /* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -160,7 +161,29 @@ static void reset_sprite_program(void);
 #endif
 
 /* Sprite atlas bookkeeping (paths + rasterized sprites). */
-#define MAX_SPRITES 256
+#define DEFAULT_MAX_SPRITES 4096
+#define DEFAULT_SPRITE_ATLAS_PAGE_SIZE 2048
+#define DEFAULT_SPRITE_ATLAS_MAX_PAGES 32
+#define MAX_SPRITE_ATLAS_PAGES 256
+
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} SpriteAtlasRect;
+
+typedef struct {
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    GLuint texture;
+#endif
+    int width;
+    int height;
+    SpriteAtlasRect* free_rects;
+    int free_rect_count;
+    int free_rect_capacity;
+    int used_pixels;
+} SpriteAtlasPage;
 
 typedef struct SpriteEntry {
     char* path;
@@ -168,6 +191,7 @@ typedef struct SpriteEntry {
     int h;              /* current rasterized height */
     int max_w;          /* requested max width (logical) */
     int max_h;          /* requested max height (logical) */
+    int atlas_page;
     int atlas_x;
     int atlas_y;
     float u0, v0, u1, v1;
@@ -178,8 +202,11 @@ typedef struct SpriteEntry {
     int reload_pending;  /* set when the asset watcher reloads this sprite */
 } SpriteEntry;
 
-static SpriteEntry g_sprites[MAX_SPRITES];
+static SpriteEntry* g_sprites = NULL;
+static int g_sprite_capacity = 0;
 static int g_sprite_count = 0;
+static int g_sprite_limit = DEFAULT_MAX_SPRITES;
+static int g_sprite_limits_ready = 0;
 
 /* Font rendering with stb_truetype. */
 #define MAX_FONTS 8
@@ -224,6 +251,18 @@ static float stasis_clampf(float v, float minv, float maxv) {
     if (v < minv) return minv;
     if (v > maxv) return maxv;
     return v;
+}
+
+static int sprite_slot_capacity(void) {
+    return g_sprite_capacity;
+}
+
+static void sprite_mark_all_for_reraster(void) {
+    for (int i = 0; i < sprite_slot_capacity(); i++) {
+        if (g_sprites[i].used && g_sprites[i].max_w > 0 && g_sprites[i].max_h > 0) {
+            g_sprites[i].needs_reraster = 1;
+        }
+    }
 }
 
 static void stasis_update_pointer_norm(int idx) {
@@ -367,11 +406,7 @@ static void stasis_pump_events(void) {
                         g_window_resized = true;
 
                         /* Mark all sized sprites for re-rasterization */
-                        for (int i = 0; i < MAX_SPRITES; i++) {
-                            if (g_sprites[i].used && g_sprites[i].max_w > 0 && g_sprites[i].max_h > 0) {
-                                g_sprites[i].needs_reraster = 1;
-                            }
-                        }
+                        sprite_mark_all_for_reraster();
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
                         if (!g_use_sdl_renderer) {
                             reset_line_program();
@@ -926,8 +961,6 @@ static char g_asset_base[512] = {0};
 static char g_asset_env[512] = {0};
 
 /* Sprite atlas + batching (baked from SVG sources) */
-#define SPRITE_ATLAS_W 1024
-#define SPRITE_ATLAS_H 1024
 #define SPRITE_ATLAS_PAD 2
 #define MAX_SPRITE_VERTS (6 * 4096)
 
@@ -946,10 +979,15 @@ static GLint g_sprite_uv_loc = -1;
 static GLint g_sprite_color_loc = -1;
 static GLint g_sprite_tex_loc = -1;
 
-static GLuint g_sprite_atlas_tex = 0;
-static int g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_cursor_y = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_row_h = 0;
+static SpriteAtlasPage* g_sprite_atlas_pages = NULL;
+static int g_sprite_atlas_page_count = 0;
+static int g_sprite_atlas_page_capacity = 0;
+static int g_sprite_atlas_page_width = DEFAULT_SPRITE_ATLAS_PAGE_SIZE;
+static int g_sprite_atlas_page_height = DEFAULT_SPRITE_ATLAS_PAGE_SIZE;
+static int g_sprite_atlas_max_pages = DEFAULT_SPRITE_ATLAS_MAX_PAGES;
+static int g_sprite_atlas_gl_limit = 0;
+static int g_sprite_atlas_config_ready = 0;
+static int g_sprite_batch_page_index = -1;
 #endif
 
 static SpriteVertex g_sprite_vertices[MAX_SPRITE_VERTS];
@@ -1379,42 +1417,441 @@ static char* stasis_strdup(const char* s) {
 #endif
 }
 
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-static int atlas_alloc(int w, int h, int* out_x, int* out_y) {
-    if (w <= 0 || h <= 0) return 0;
-    if (w + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_W) return 0;
-    if (h + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_H) return 0;
+static int parse_env_i32_clamped(const char* name, int default_value, int min_value, int max_value, int* out_present) {
+    const char* env = getenv(name);
+    if (out_present) *out_present = 0;
+    if (!env || !*env) return default_value;
 
-    if (g_sprite_atlas_cursor_x + w + SPRITE_ATLAS_PAD > SPRITE_ATLAS_W) {
-        g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-        g_sprite_atlas_cursor_y += g_sprite_atlas_row_h + SPRITE_ATLAS_PAD;
-        g_sprite_atlas_row_h = 0;
+    char* end = NULL;
+    long parsed = strtol(env, &end, 10);
+    if (!end || *end != 0) {
+        SDL_Log("%s: invalid integer '%s'; using %d", name, env, default_value);
+        return default_value;
     }
 
-    if (g_sprite_atlas_cursor_y + h + SPRITE_ATLAS_PAD > SPRITE_ATLAS_H) {
-        return 0;
+    if (parsed < (long)min_value) {
+        SDL_Log("%s: clamping %ld up to %d", name, parsed, min_value);
+        parsed = (long)min_value;
+    } else if (parsed > (long)max_value) {
+        SDL_Log("%s: clamping %ld down to %d", name, parsed, max_value);
+        parsed = (long)max_value;
     }
 
-    *out_x = g_sprite_atlas_cursor_x;
-    *out_y = g_sprite_atlas_cursor_y;
+    if (out_present) *out_present = 1;
+    return (int)parsed;
+}
 
-    g_sprite_atlas_cursor_x += w + SPRITE_ATLAS_PAD;
-    if (h > g_sprite_atlas_row_h) g_sprite_atlas_row_h = h;
+static void ensure_sprite_slot_limit(void) {
+    if (g_sprite_limits_ready) return;
+
+    g_sprite_limit = parse_env_i32_clamped("STASIS_GFX_MAX_SPRITES",
+                                           DEFAULT_MAX_SPRITES,
+                                           1,
+                                           1 << 20,
+                                           NULL);
+    g_sprite_limits_ready = 1;
+}
+
+static int sprite_ensure_capacity(int min_capacity) {
+    ensure_sprite_slot_limit();
+    if (min_capacity <= g_sprite_capacity) return 1;
+    if (min_capacity > g_sprite_limit) return 0;
+
+    int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : 64;
+    while (new_capacity < min_capacity) {
+        if (new_capacity >= g_sprite_limit) {
+            new_capacity = g_sprite_limit;
+            break;
+        }
+        new_capacity *= 2;
+        if (new_capacity > g_sprite_limit) {
+            new_capacity = g_sprite_limit;
+        }
+    }
+
+    if (new_capacity < min_capacity) return 0;
+
+    SpriteEntry* grown = (SpriteEntry*)realloc(g_sprites, sizeof(SpriteEntry) * (size_t)new_capacity);
+    if (!grown) return 0;
+
+    memset(grown + g_sprite_capacity, 0, sizeof(SpriteEntry) * (size_t)(new_capacity - g_sprite_capacity));
+    g_sprites = grown;
+    g_sprite_capacity = new_capacity;
     return 1;
 }
 
-static void ensure_sprite_atlas(void) {
-    if (g_sprite_atlas_tex != 0) return;
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+static int rect_contains(const SpriteAtlasRect* a, const SpriteAtlasRect* b) {
+    if (!a || !b) return 0;
+    return b->x >= a->x &&
+           b->y >= a->y &&
+           b->x + b->w <= a->x + a->w &&
+           b->y + b->h <= a->y + a->h;
+}
 
-    glGenTextures(1, &g_sprite_atlas_tex);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, SPRITE_ATLAS_W, SPRITE_ATLAS_H, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+static int sprite_atlas_page_reserve_free_rects(SpriteAtlasPage* page, int additional) {
+    if (!page || additional <= 0) return 1;
+    const int needed = page->free_rect_count + additional;
+    if (needed <= page->free_rect_capacity) return 1;
+
+    int new_capacity = page->free_rect_capacity > 0 ? page->free_rect_capacity : 8;
+    while (new_capacity < needed) {
+        new_capacity *= 2;
+    }
+
+    SpriteAtlasRect* grown = (SpriteAtlasRect*)realloc(page->free_rects, sizeof(SpriteAtlasRect) * (size_t)new_capacity);
+    if (!grown) return 0;
+    page->free_rects = grown;
+    page->free_rect_capacity = new_capacity;
+    return 1;
+}
+
+static void sprite_atlas_page_compact_free_rects(SpriteAtlasPage* page) {
+    if (!page) return;
+
+    for (;;) {
+        int merged = 0;
+
+        for (int i = 0; i < page->free_rect_count; i++) {
+            for (int j = i + 1; j < page->free_rect_count; j++) {
+                SpriteAtlasRect* a = &page->free_rects[i];
+                SpriteAtlasRect* b = &page->free_rects[j];
+
+                if (rect_contains(a, b)) {
+                    page->free_rects[j] = page->free_rects[page->free_rect_count - 1];
+                    page->free_rect_count--;
+                    merged = 1;
+                    break;
+                }
+                if (rect_contains(b, a)) {
+                    page->free_rects[i] = *b;
+                    page->free_rects[j] = page->free_rects[page->free_rect_count - 1];
+                    page->free_rect_count--;
+                    merged = 1;
+                    break;
+                }
+
+                if (a->x == b->x && a->w == b->w) {
+                    if (a->y + a->h == b->y) {
+                        a->h += b->h;
+                    } else if (b->y + b->h == a->y) {
+                        a->y = b->y;
+                        a->h += b->h;
+                    } else {
+                        continue;
+                    }
+                    page->free_rects[j] = page->free_rects[page->free_rect_count - 1];
+                    page->free_rect_count--;
+                    merged = 1;
+                    break;
+                }
+
+                if (a->y == b->y && a->h == b->h) {
+                    if (a->x + a->w == b->x) {
+                        a->w += b->w;
+                    } else if (b->x + b->w == a->x) {
+                        a->x = b->x;
+                        a->w += b->w;
+                    } else {
+                        continue;
+                    }
+                    page->free_rects[j] = page->free_rects[page->free_rect_count - 1];
+                    page->free_rect_count--;
+                    merged = 1;
+                    break;
+                }
+            }
+            if (merged) break;
+        }
+
+        if (!merged) break;
+    }
+}
+
+static int sprite_atlas_page_add_free_rect(SpriteAtlasPage* page, SpriteAtlasRect rect) {
+    if (!page || rect.w <= 0 || rect.h <= 0) return 1;
+    if (!sprite_atlas_page_reserve_free_rects(page, 1)) return 0;
+    page->free_rects[page->free_rect_count++] = rect;
+    sprite_atlas_page_compact_free_rects(page);
+    return 1;
+}
+
+static void sprite_log_atlas_usage_summary(const char* reason, const char* path, int w, int h) {
+    int total_free_pixels = 0;
+    int largest_free_w = 0;
+    int largest_free_h = 0;
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        SpriteAtlasPage* page = &g_sprite_atlas_pages[i];
+        for (int j = 0; j < page->free_rect_count; j++) {
+            const SpriteAtlasRect* rect = &page->free_rects[j];
+            total_free_pixels += rect->w * rect->h;
+            if (rect->w * rect->h > largest_free_w * largest_free_h) {
+                largest_free_w = rect->w;
+                largest_free_h = rect->h;
+            }
+        }
+    }
+
+    SDL_Log("gfx_load_sprite: %s for %s (%dx%d); page=%dx%d pages=%d/%d sprites=%d/%d free_px=%d largest_free=%dx%d",
+            reason,
+            path ? path : "<unknown>",
+            w,
+            h,
+            g_sprite_atlas_page_width,
+            g_sprite_atlas_page_height,
+            g_sprite_atlas_page_count,
+            g_sprite_atlas_max_pages,
+            g_sprite_count,
+            g_sprite_limit,
+            total_free_pixels,
+            largest_free_w,
+            largest_free_h);
+}
+
+static void ensure_sprite_atlas_config(void) {
+    if (g_sprite_atlas_config_ready) return;
+
+    ensure_sprite_slot_limit();
+
+    const int requested_size = parse_env_i32_clamped("STASIS_GFX_ATLAS_SIZE",
+                                                     DEFAULT_SPRITE_ATLAS_PAGE_SIZE,
+                                                     256,
+                                                     16384,
+                                                     NULL);
+    g_sprite_atlas_page_width = parse_env_i32_clamped("STASIS_GFX_ATLAS_WIDTH",
+                                                      requested_size,
+                                                      256,
+                                                      16384,
+                                                      NULL);
+    g_sprite_atlas_page_height = parse_env_i32_clamped("STASIS_GFX_ATLAS_HEIGHT",
+                                                       requested_size,
+                                                       256,
+                                                       16384,
+                                                       NULL);
+    g_sprite_atlas_max_pages = parse_env_i32_clamped("STASIS_GFX_ATLAS_MAX_PAGES",
+                                                     DEFAULT_SPRITE_ATLAS_MAX_PAGES,
+                                                     1,
+                                                     MAX_SPRITE_ATLAS_PAGES,
+                                                     NULL);
+
+    if (g_gl_context) {
+        GLint max_texture_size = 0;
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
+        if (max_texture_size > 0) {
+            g_sprite_atlas_gl_limit = (int)max_texture_size;
+            if (g_sprite_atlas_page_width > g_sprite_atlas_gl_limit) {
+                SDL_Log("STASIS_GFX_ATLAS_WIDTH: clamping atlas page width %d to GL_MAX_TEXTURE_SIZE=%d",
+                        g_sprite_atlas_page_width,
+                        g_sprite_atlas_gl_limit);
+                g_sprite_atlas_page_width = g_sprite_atlas_gl_limit;
+            }
+            if (g_sprite_atlas_page_height > g_sprite_atlas_gl_limit) {
+                SDL_Log("STASIS_GFX_ATLAS_HEIGHT: clamping atlas page height %d to GL_MAX_TEXTURE_SIZE=%d",
+                        g_sprite_atlas_page_height,
+                        g_sprite_atlas_gl_limit);
+                g_sprite_atlas_page_height = g_sprite_atlas_gl_limit;
+            }
+        }
+    }
+
+    g_sprite_atlas_config_ready = 1;
+    SDL_Log("gfx_sprite_atlas: page=%dx%d max_pages=%d max_sprites=%d%s",
+            g_sprite_atlas_page_width,
+            g_sprite_atlas_page_height,
+            g_sprite_atlas_max_pages,
+            g_sprite_limit,
+            g_sprite_atlas_gl_limit > 0 ? "" : " (GL limit unavailable)");
+}
+
+static int sprite_atlas_page_reserve(int min_capacity) {
+    if (min_capacity <= g_sprite_atlas_page_capacity) return 1;
+
+    int new_capacity = g_sprite_atlas_page_capacity > 0 ? g_sprite_atlas_page_capacity : 4;
+    while (new_capacity < min_capacity) {
+        new_capacity *= 2;
+    }
+
+    SpriteAtlasPage* grown = (SpriteAtlasPage*)realloc(g_sprite_atlas_pages, sizeof(SpriteAtlasPage) * (size_t)new_capacity);
+    if (!grown) return 0;
+    memset(grown + g_sprite_atlas_page_capacity, 0, sizeof(SpriteAtlasPage) * (size_t)(new_capacity - g_sprite_atlas_page_capacity));
+    g_sprite_atlas_pages = grown;
+    g_sprite_atlas_page_capacity = new_capacity;
+    return 1;
+}
+
+static int sprite_atlas_create_page(void) {
+    ensure_sprite_atlas_config();
+    if (g_sprite_atlas_page_count >= g_sprite_atlas_max_pages) return -1;
+    if (!sprite_atlas_page_reserve(g_sprite_atlas_page_count + 1)) return -1;
+
+    SpriteAtlasPage page;
+    memset(&page, 0, sizeof(page));
+    page.width = g_sprite_atlas_page_width;
+    page.height = g_sprite_atlas_page_height;
+
+    glGenTextures(1, &page.texture);
+    if (page.texture == 0) {
+        return -1;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, page.texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, page.width, page.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
+
+    if (!sprite_atlas_page_add_free_rect(&page, (SpriteAtlasRect){0, 0, page.width, page.height})) {
+        glDeleteTextures(1, &page.texture);
+        return -1;
+    }
+
+    g_sprite_atlas_pages[g_sprite_atlas_page_count] = page;
+    SDL_Log("gfx_sprite_atlas: created page %d/%d (%dx%d)",
+            g_sprite_atlas_page_count + 1,
+            g_sprite_atlas_max_pages,
+            page.width,
+            page.height);
+    return g_sprite_atlas_page_count++;
+}
+
+static int sprite_atlas_try_alloc_from_page(SpriteAtlasPage* page, int w, int h, int* out_x, int* out_y) {
+    if (!page || !out_x || !out_y || w <= 0 || h <= 0) return 0;
+
+    const int alloc_w = w + SPRITE_ATLAS_PAD * 2;
+    const int alloc_h = h + SPRITE_ATLAS_PAD * 2;
+    int best_index = -1;
+    int best_area = 0;
+
+    for (int i = 0; i < page->free_rect_count; i++) {
+        const SpriteAtlasRect* rect = &page->free_rects[i];
+        if (rect->w < alloc_w || rect->h < alloc_h) continue;
+        const int area = rect->w * rect->h;
+        if (best_index < 0 || area < best_area) {
+            best_index = i;
+            best_area = area;
+        }
+    }
+
+    if (best_index < 0) return 0;
+
+    const SpriteAtlasRect chosen = page->free_rects[best_index];
+    page->free_rects[best_index] = page->free_rects[page->free_rect_count - 1];
+    page->free_rect_count--;
+
+    const int remaining_w = chosen.w - alloc_w;
+    const int remaining_h = chosen.h - alloc_h;
+    SpriteAtlasRect split_rects[2];
+    int split_rect_count = 0;
+    if (remaining_w > remaining_h) {
+        if (remaining_w > 0) {
+            split_rects[split_rect_count++] = (SpriteAtlasRect){chosen.x + alloc_w, chosen.y, remaining_w, chosen.h};
+        }
+        if (remaining_h > 0) {
+            split_rects[split_rect_count++] = (SpriteAtlasRect){chosen.x, chosen.y + alloc_h, alloc_w, remaining_h};
+        }
+    } else {
+        if (remaining_h > 0) {
+            split_rects[split_rect_count++] = (SpriteAtlasRect){chosen.x, chosen.y + alloc_h, chosen.w, remaining_h};
+        }
+        if (remaining_w > 0) {
+            split_rects[split_rect_count++] = (SpriteAtlasRect){chosen.x + alloc_w, chosen.y, remaining_w, alloc_h};
+        }
+    }
+
+    if (!sprite_atlas_page_reserve_free_rects(page, split_rect_count)) {
+        page->free_rects[page->free_rect_count++] = chosen;
+        return 0;
+    }
+
+    for (int i = 0; i < split_rect_count; i++) {
+        page->free_rects[page->free_rect_count++] = split_rects[i];
+    }
+    sprite_atlas_page_compact_free_rects(page);
+
+    *out_x = chosen.x + SPRITE_ATLAS_PAD;
+    *out_y = chosen.y + SPRITE_ATLAS_PAD;
+    page->used_pixels += alloc_w * alloc_h;
+    return 1;
+}
+
+static int sprite_atlas_alloc_region(const char* path, int w, int h, int* out_page_index, int* out_x, int* out_y) {
+    ensure_sprite_atlas_config();
+    if (w <= 0 || h <= 0 || !out_page_index || !out_x || !out_y) return 0;
+
+    if (w + SPRITE_ATLAS_PAD * 2 > g_sprite_atlas_page_width ||
+        h + SPRITE_ATLAS_PAD * 2 > g_sprite_atlas_page_height) {
+        sprite_log_atlas_usage_summary("sprite exceeds atlas page size", path, w, h);
+        return 0;
+    }
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (sprite_atlas_try_alloc_from_page(&g_sprite_atlas_pages[i], w, h, out_x, out_y)) {
+            *out_page_index = i;
+            return 1;
+        }
+    }
+
+    const int new_page_index = sprite_atlas_create_page();
+    if (new_page_index < 0) {
+        if (g_sprite_atlas_page_count >= g_sprite_atlas_max_pages) {
+            sprite_log_atlas_usage_summary("atlas page limit reached", path, w, h);
+        } else {
+            sprite_log_atlas_usage_summary("failed to create atlas page", path, w, h);
+        }
+        return 0;
+    }
+
+    if (!sprite_atlas_try_alloc_from_page(&g_sprite_atlas_pages[new_page_index], w, h, out_x, out_y)) {
+        sprite_log_atlas_usage_summary("allocator could not place sprite on fresh page", path, w, h);
+        return 0;
+    }
+
+    *out_page_index = new_page_index;
+    return 1;
+}
+
+static void sprite_atlas_free_region(int page_index, int x, int y, int w, int h) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return;
+
+    const int alloc_x = x - SPRITE_ATLAS_PAD;
+    const int alloc_y = y - SPRITE_ATLAS_PAD;
+    const int alloc_w = w + SPRITE_ATLAS_PAD * 2;
+    const int alloc_h = h + SPRITE_ATLAS_PAD * 2;
+    if (alloc_w <= 0 || alloc_h <= 0) return;
+
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[page_index];
+    if (sprite_atlas_page_add_free_rect(page, (SpriteAtlasRect){alloc_x, alloc_y, alloc_w, alloc_h})) {
+        if (page->used_pixels >= alloc_w * alloc_h) {
+            page->used_pixels -= alloc_w * alloc_h;
+        } else {
+            page->used_pixels = 0;
+        }
+    }
+}
+
+static int sprite_atlas_upload_region(int page_index, int x, int y, int w, int h, const unsigned char* pixels) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count || !pixels) return 0;
+    GLuint texture = g_sprite_atlas_pages[page_index].texture;
+    if (texture == 0) return 0;
+
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return 1;
+}
+
+static int sprite_prepare_batch_page(int page_index) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return 0;
+    if (g_sprite_vert_count > 0 && g_sprite_batch_page_index != page_index) {
+        flush_sprites();
+    }
+    g_sprite_batch_page_index = page_index;
+    return 1;
 }
 
 static void ensure_sprite_program(void) {
@@ -2140,9 +2577,18 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
 static void flush_sprites(void) {
     if (g_sprite_vert_count == 0) return;
     ensure_sprite_program();
-    ensure_sprite_atlas();
-    if (g_sprite_program == 0 || g_sprite_atlas_tex == 0) {
+    if (g_sprite_program == 0 ||
+        g_sprite_batch_page_index < 0 ||
+        g_sprite_batch_page_index >= g_sprite_atlas_page_count) {
         g_sprite_vert_count = 0;
+        g_sprite_batch_page_index = -1;
+        return;
+    }
+
+    const GLuint batch_texture = g_sprite_atlas_pages[g_sprite_batch_page_index].texture;
+    if (batch_texture == 0) {
+        g_sprite_vert_count = 0;
+        g_sprite_batch_page_index = -1;
         return;
     }
 
@@ -2151,7 +2597,7 @@ static void flush_sprites(void) {
 
     glUseProgram(g_sprite_program);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
+    glBindTexture(GL_TEXTURE_2D, batch_texture);
     if (g_sprite_tex_loc >= 0) glUniform1i(g_sprite_tex_loc, 0);
 
     glBindVertexArray(g_sprite_vao);
@@ -2176,6 +2622,7 @@ static void flush_sprites(void) {
     glUseProgram(0);
 
     g_sprite_vert_count = 0;
+    g_sprite_batch_page_index = -1;
 }
 #endif
 
@@ -2217,10 +2664,9 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
         const int a = cmds[base + 6];
 
         if (w <= 0 || h <= 0) continue;
-        if (handle <= 0 || handle > MAX_SPRITES) continue;
 
-        SpriteEntry* e = &g_sprites[handle - 1];
-        if (!e->used) continue;
+        SpriteEntry* e = sprite_get(handle);
+        if (!e) continue;
 
         if (e->needs_reraster) {
             if (e->path) sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h, 1);
@@ -2233,6 +2679,9 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
 
         if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
             flush_sprites();
+        }
+        if (!sprite_prepare_batch_page(e->atlas_page)) {
+            continue;
         }
 
         const float af = (float)a / 255.0f;
@@ -2783,6 +3232,13 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
         g_use_sdl_renderer = false;
     }
 
+    ensure_sprite_slot_limit();
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    if (!g_use_sdl_renderer) {
+        ensure_sprite_atlas_config();
+    }
+#endif
+
     g_window_width = width;
     g_window_height = height;
     g_keyboard_state = SDL_GetKeyboardState(NULL);
@@ -3330,9 +3786,16 @@ STASIS_EXPORT void stasis_gfx_submit_u8(const int32_t* cmd_i32, const float* cmd
 
 static SpriteEntry* sprite_get(int handle) {
     int idx = handle - 1;
-    if (idx < 0 || idx >= MAX_SPRITES) return NULL;
+    if (idx < 0 || idx >= g_sprite_capacity) return NULL;
     if (!g_sprites[idx].used) return NULL;
     return &g_sprites[idx];
+}
+
+static int sprite_find_free_slot_index(void) {
+    for (int i = 0; i < sprite_slot_capacity(); i++) {
+        if (!g_sprites[i].used) return i;
+    }
+    return -1;
 }
 
 STASIS_EXPORT int stasis_gfx_poll_reload(int handle) {
@@ -3344,7 +3807,7 @@ STASIS_EXPORT int stasis_gfx_poll_reload(int handle) {
 }
 
 static int sprite_find_by_path(const char* path) {
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < sprite_slot_capacity(); i++) {
         if (g_sprites[i].used && g_sprites[i].path && strcmp(g_sprites[i].path, path) == 0) {
             return i + 1;
         }
@@ -3420,44 +3883,50 @@ static int sprite_build_into_entry(SpriteEntry* e, const char* path, int allow_r
     }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
+    int atlas_page = -1;
+    int ax = 0;
+    int ay = 0;
+    const int reusing_region = allow_reuse_slot &&
+                               e->w > 0 &&
+                               e->h > 0 &&
+                               e->atlas_page >= 0 &&
+                               w == e->w &&
+                               h == e->h;
+
+    if (reusing_region) {
+        atlas_page = e->atlas_page;
+        ax = e->atlas_x;
+        ay = e->atlas_y;
+    } else {
+        if (!sprite_atlas_alloc_region(path, w, h, &atlas_page, &ax, &ay)) {
+            free(pixels);
+            return 0;
+        }
+    }
+
+    if (!sprite_atlas_upload_region(atlas_page, ax, ay, w, h, pixels)) {
+        if (!reusing_region) {
+            sprite_atlas_free_region(atlas_page, ax, ay, w, h);
+        }
         free(pixels);
         return 0;
     }
 
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot) {
-        ax = e->atlas_x;
-        ay = e->atlas_y;
-        if (w != e->w || h != e->h) {
-            SDL_Log("gfx_reload: size change not supported (%s %dx%d -> %dx%d)", path, e->w, e->h, w, h);
-            free(pixels);
-            return 0;
-        }
-    } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-            free(pixels);
-            return 0;
-        }
+    if (!reusing_region && allow_reuse_slot && e->w > 0 && e->h > 0) {
+        sprite_atlas_free_region(e->atlas_page, e->atlas_x, e->atlas_y, e->w, e->h);
     }
-
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
 
     free(pixels);
 
     e->w = w;
     e->h = h;
+    e->atlas_page = atlas_page;
     e->atlas_x = ax;
     e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
+    e->u0 = (float)ax / (float)g_sprite_atlas_pages[atlas_page].width;
+    e->v0 = (float)ay / (float)g_sprite_atlas_pages[atlas_page].height;
+    e->u1 = (float)(ax + w) / (float)g_sprite_atlas_pages[atlas_page].width;
+    e->v1 = (float)(ay + h) / (float)g_sprite_atlas_pages[atlas_page].height;
     e->mtime = get_file_mtime(path);
     return 1;
 #else
@@ -3530,39 +3999,38 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
     }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
-        free(pixels);
-        return 0;
-    }
+    int atlas_page = -1;
+    int ax = 0;
+    int ay = 0;
+    const int reusing_region = allow_reuse_slot &&
+                               e->w > 0 &&
+                               e->h > 0 &&
+                               e->atlas_page >= 0 &&
+                               w == e->w &&
+                               h == e->h;
 
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot && e->w > 0 && e->h > 0) {
-        /* For re-rasterization, we may need to reallocate if size changed significantly */
-        if (w != e->w || h != e->h) {
-            /* Size changed - need new atlas slot. For now, just allocate new. */
-            /* TODO: could free old slot, but atlas doesn't support that yet */
-            if (!atlas_alloc(w, h, &ax, &ay)) {
-                SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-                free(pixels);
-                return 0;
-            }
-        } else {
-            ax = e->atlas_x;
-            ay = e->atlas_y;
-        }
+    if (reusing_region) {
+        atlas_page = e->atlas_page;
+        ax = e->atlas_x;
+        ay = e->atlas_y;
     } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
+        if (!sprite_atlas_alloc_region(path, w, h, &atlas_page, &ax, &ay)) {
             free(pixels);
             return 0;
         }
     }
 
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    if (!sprite_atlas_upload_region(atlas_page, ax, ay, w, h, pixels)) {
+        if (!reusing_region) {
+            sprite_atlas_free_region(atlas_page, ax, ay, w, h);
+        }
+        free(pixels);
+        return 0;
+    }
+
+    if (!reusing_region && allow_reuse_slot && e->w > 0 && e->h > 0) {
+        sprite_atlas_free_region(e->atlas_page, e->atlas_x, e->atlas_y, e->w, e->h);
+    }
 
     free(pixels);
 
@@ -3570,12 +4038,13 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
     e->h = h;
     e->max_w = max_w;
     e->max_h = max_h;
+    e->atlas_page = atlas_page;
     e->atlas_x = ax;
     e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
+    e->u0 = (float)ax / (float)g_sprite_atlas_pages[atlas_page].width;
+    e->v0 = (float)ay / (float)g_sprite_atlas_pages[atlas_page].height;
+    e->u1 = (float)(ax + w) / (float)g_sprite_atlas_pages[atlas_page].width;
+    e->v1 = (float)(ay + h) / (float)g_sprite_atlas_pages[atlas_page].height;
     e->mtime = get_file_mtime(path);
     e->needs_reraster = 0;
     return 1;
@@ -3593,7 +4062,7 @@ static void gfx_asset_watch_apply_pending_changes(void) {
         return;
     }
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < sprite_slot_capacity(); i++) {
         SpriteEntry* e = &g_sprites[i];
         if (!e->used || !e->path) continue;
 
@@ -3630,29 +4099,40 @@ STASIS_EXPORT int stasis_gfx_load_sprite(const char* path, int max_w, int max_h)
     /* Note: We don't check for existing sprites with same path because
      * the same SVG might be loaded at different sizes */
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
-        if (!g_sprites[i].used) {
-            SpriteEntry* e = &g_sprites[i];
-            memset(e, 0, sizeof(*e));
-            e->path = stasis_strdup(resolved);
-            if (!e->path) return 0;
-            e->used = 1;
-            if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
-                free(e->path);
-                memset(e, 0, sizeof(*e));
-                return 0;
-            }
-            g_sprite_count++;
-            if (gfx_should_log_sprite_loads()) {
-                SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d (%s)",
-                        resolved, max_w, max_h, i + 1, e->w, e->h,
-                        g_use_sdl_renderer ? "sdl" : "gl");
-            }
-            return i + 1;
+    int slot_index = sprite_find_free_slot_index();
+    if (slot_index < 0) {
+        const int requested_capacity = g_sprite_capacity > 0 ? g_sprite_capacity + 1 : 1;
+        if (!sprite_ensure_capacity(requested_capacity)) {
+            SDL_Log("gfx_load_sprite: sprite handle limit reached (%d)", g_sprite_limit);
+            return 0;
         }
+        slot_index = sprite_find_free_slot_index();
     }
 
-    SDL_Log("gfx_load_sprite: MAX_SPRITES reached");
+    if (slot_index >= 0) {
+        SpriteEntry* e = &g_sprites[slot_index];
+        memset(e, 0, sizeof(*e));
+        e->atlas_page = -1;
+        e->path = stasis_strdup(resolved);
+        if (!e->path) return 0;
+        e->used = 1;
+        if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
+            free(e->path);
+            memset(e, 0, sizeof(*e));
+            e->atlas_page = -1;
+            return 0;
+        }
+        g_sprite_count++;
+        if (gfx_should_log_sprite_loads()) {
+            SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d (%s page=%d)",
+                    resolved, max_w, max_h, slot_index + 1, e->w, e->h,
+                    g_use_sdl_renderer ? "sdl" : "gl",
+                    e->atlas_page);
+        }
+        return slot_index + 1;
+    }
+
+    SDL_Log("gfx_load_sprite: sprite handle allocation failed");
     return 0;
 }
 
@@ -3724,6 +4204,9 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
     if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
         flush_sprites();
+    }
+    if (!sprite_prepare_batch_page(e->atlas_page)) {
+        return;
     }
 #endif
 
@@ -4015,12 +4498,23 @@ STASIS_EXPORT void stasis_shutdown(void) {
         glDeleteVertexArrays(1, &g_sprite_vao);
         g_sprite_vao = 0;
     }
-    if (g_sprite_atlas_tex) {
-        glDeleteTextures(1, &g_sprite_atlas_tex);
-        g_sprite_atlas_tex = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (g_sprite_atlas_pages[i].texture) {
+            glDeleteTextures(1, &g_sprite_atlas_pages[i].texture);
+            g_sprite_atlas_pages[i].texture = 0;
+        }
+        free(g_sprite_atlas_pages[i].free_rects);
+        g_sprite_atlas_pages[i].free_rects = NULL;
+        g_sprite_atlas_pages[i].free_rect_count = 0;
+        g_sprite_atlas_pages[i].free_rect_capacity = 0;
     }
+    free(g_sprite_atlas_pages);
+    g_sprite_atlas_pages = NULL;
+    g_sprite_atlas_page_count = 0;
+    g_sprite_atlas_page_capacity = 0;
+    g_sprite_batch_page_index = -1;
 #endif
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < sprite_slot_capacity(); i++) {
         if (g_sprites[i].used) {
             if (g_sprites[i].sdl_tex) {
                 SDL_DestroyTexture(g_sprites[i].sdl_tex);
@@ -4028,8 +4522,21 @@ STASIS_EXPORT void stasis_shutdown(void) {
             }
             if (g_sprites[i].path) free(g_sprites[i].path);
             memset(&g_sprites[i], 0, sizeof(g_sprites[i]));
+            g_sprites[i].atlas_page = -1;
         }
     }
+    free(g_sprites);
+    g_sprites = NULL;
+    g_sprite_capacity = 0;
+    g_sprite_count = 0;
+    g_sprite_limits_ready = 0;
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    g_sprite_atlas_page_width = DEFAULT_SPRITE_ATLAS_PAGE_SIZE;
+    g_sprite_atlas_page_height = DEFAULT_SPRITE_ATLAS_PAGE_SIZE;
+    g_sprite_atlas_max_pages = DEFAULT_SPRITE_ATLAS_MAX_PAGES;
+    g_sprite_atlas_gl_limit = 0;
+    g_sprite_atlas_config_ready = 0;
+#endif
 
     for (int i = 0; i < MAX_FONTS; i++) {
         if (g_fonts[i].active) {

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -1408,15 +1408,22 @@ static char* stasis_strdup(const char* s) {
 #endif
 }
 
+static int clamp_i32(int value, int min_value, int max_value) {
+    if (value < min_value) return min_value;
+    if (value > max_value) return max_value;
+    return value;
+}
+
 static int parse_env_i32(const char* name, int fallback, int min_value, int max_value) {
+    int clamped_fallback = clamp_i32(fallback, min_value, max_value);
     const char* raw = getenv(name);
-    if (!raw || !raw[0]) return fallback;
+    if (!raw || !raw[0]) return clamped_fallback;
 
     char* end = NULL;
     long parsed = strtol(raw, &end, 10);
     if (end == raw || (end && *end != '\0')) {
-        SDL_Log("%s: invalid integer '%s'; using %d", name, raw, fallback);
-        return fallback;
+        SDL_Log("%s: invalid integer '%s'; using %d", name, raw, clamped_fallback);
+        return clamped_fallback;
     }
     if (parsed < (long)min_value) {
         SDL_Log("%s: clamping %ld to %d", name, parsed, min_value);
@@ -1444,7 +1451,7 @@ static int ensure_sprite_table_capacity(int min_capacity) {
         return 0;
     }
 
-    int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : SPRITE_TABLE_INITIAL_CAPACITY;
+    int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : clamp_i32(SPRITE_TABLE_INITIAL_CAPACITY, 1, limit);
     while (new_capacity < min_capacity) {
         if (new_capacity >= limit) {
             new_capacity = limit;

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <ctype.h>
@@ -160,7 +161,7 @@ static void reset_sprite_program(void);
 #endif
 
 /* Sprite atlas bookkeeping (paths + rasterized sprites). */
-#define MAX_SPRITES 256
+#define SPRITE_TABLE_INITIAL_CAPACITY 256
 
 typedef struct SpriteEntry {
     char* path;
@@ -168,8 +169,11 @@ typedef struct SpriteEntry {
     int h;              /* current rasterized height */
     int max_w;          /* requested max width (logical) */
     int max_h;          /* requested max height (logical) */
+    int atlas_page;
     int atlas_x;
     int atlas_y;
+    int atlas_alloc_w;
+    int atlas_alloc_h;
     float u0, v0, u1, v1;
     uint64_t mtime;
     SDL_Texture* sdl_tex;
@@ -178,8 +182,40 @@ typedef struct SpriteEntry {
     int reload_pending;  /* set when the asset watcher reloads this sprite */
 } SpriteEntry;
 
-static SpriteEntry g_sprites[MAX_SPRITES];
+static SpriteEntry* g_sprites = NULL;
+static int g_sprite_capacity = 0;
 static int g_sprite_count = 0;
+
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} SpriteAtlasFreeRect;
+
+typedef struct {
+    GLuint texture;
+    int width;
+    int height;
+    int cursor_x;
+    int cursor_y;
+    int row_h;
+    int live_area;
+    int committed_area;
+    SpriteAtlasFreeRect* free_rects;
+    int free_rect_count;
+    int free_rect_capacity;
+} SpriteAtlasPage;
+
+static SpriteAtlasPage* g_sprite_atlas_pages = NULL;
+static int g_sprite_atlas_page_count = 0;
+static int g_sprite_atlas_page_capacity = 0;
+static int g_sprite_atlas_page_size = 0;
+static int g_sprite_atlas_max_texture_size = 0;
+static int g_sprite_batch_page_index = -1;
+static int g_sprite_reload_reallocations = 0;
+#endif
 
 /* Font rendering with stb_truetype. */
 #define MAX_FONTS 8
@@ -367,7 +403,7 @@ static void stasis_pump_events(void) {
                         g_window_resized = true;
 
                         /* Mark all sized sprites for re-rasterization */
-                        for (int i = 0; i < MAX_SPRITES; i++) {
+                        for (int i = 0; i < g_sprite_capacity; i++) {
                             if (g_sprites[i].used && g_sprites[i].max_w > 0 && g_sprites[i].max_h > 0) {
                                 g_sprites[i].needs_reraster = 1;
                             }
@@ -926,8 +962,7 @@ static char g_asset_base[512] = {0};
 static char g_asset_env[512] = {0};
 
 /* Sprite atlas + batching (baked from SVG sources) */
-#define SPRITE_ATLAS_W 1024
-#define SPRITE_ATLAS_H 1024
+#define SPRITE_ATLAS_DEFAULT_PAGE_SIZE 2048
 #define SPRITE_ATLAS_PAD 2
 #define MAX_SPRITE_VERTS (6 * 4096)
 
@@ -945,11 +980,6 @@ static GLint g_sprite_pos_loc = -1;
 static GLint g_sprite_uv_loc = -1;
 static GLint g_sprite_color_loc = -1;
 static GLint g_sprite_tex_loc = -1;
-
-static GLuint g_sprite_atlas_tex = 0;
-static int g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_cursor_y = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_row_h = 0;
 #endif
 
 static SpriteVertex g_sprite_vertices[MAX_SPRITE_VERTS];
@@ -1379,43 +1409,490 @@ static char* stasis_strdup(const char* s) {
 #endif
 }
 
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-static int atlas_alloc(int w, int h, int* out_x, int* out_y) {
-    if (w <= 0 || h <= 0) return 0;
-    if (w + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_W) return 0;
-    if (h + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_H) return 0;
-
-    if (g_sprite_atlas_cursor_x + w + SPRITE_ATLAS_PAD > SPRITE_ATLAS_W) {
-        g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-        g_sprite_atlas_cursor_y += g_sprite_atlas_row_h + SPRITE_ATLAS_PAD;
-        g_sprite_atlas_row_h = 0;
+static int parse_positive_env_int(const char* name, int fallback) {
+    const char* value = getenv(name);
+    char* end = NULL;
+    long parsed = 0;
+    if (!value || !*value) return fallback;
+    parsed = strtol(value, &end, 10);
+    if (end == value || *end != 0 || parsed <= 0 || parsed > INT_MAX) {
+        SDL_Log("gfx_config: ignoring invalid %s=%s", name, value);
+        return fallback;
     }
+    return (int)parsed;
+}
 
-    if (g_sprite_atlas_cursor_y + h + SPRITE_ATLAS_PAD > SPRITE_ATLAS_H) {
+static int sprite_table_limit(void) {
+    static int cached_limit = INT_MIN;
+    if (cached_limit != INT_MIN) return cached_limit;
+    cached_limit = parse_positive_env_int("STASIS_GFX_MAX_SPRITES", 0);
+    return cached_limit;
+}
+
+static int ensure_sprite_table_capacity(int min_capacity) {
+    int new_capacity = g_sprite_capacity;
+    int limit = 0;
+    SpriteEntry* grown = NULL;
+
+    if (min_capacity <= g_sprite_capacity) return 1;
+
+    limit = sprite_table_limit();
+    if (limit > 0 && min_capacity > limit) {
         return 0;
     }
 
-    *out_x = g_sprite_atlas_cursor_x;
-    *out_y = g_sprite_atlas_cursor_y;
+    if (new_capacity <= 0) {
+        new_capacity = SPRITE_TABLE_INITIAL_CAPACITY;
+    }
+    while (new_capacity < min_capacity) {
+        if (new_capacity > INT_MAX / 2) {
+            new_capacity = min_capacity;
+            break;
+        }
+        new_capacity *= 2;
+    }
+    if (limit > 0 && new_capacity > limit) {
+        new_capacity = limit;
+    }
+    if (new_capacity < min_capacity) {
+        return 0;
+    }
 
-    g_sprite_atlas_cursor_x += w + SPRITE_ATLAS_PAD;
-    if (h > g_sprite_atlas_row_h) g_sprite_atlas_row_h = h;
+    grown = (SpriteEntry*)realloc(g_sprites, sizeof(SpriteEntry) * (size_t)new_capacity);
+    if (!grown) {
+        SDL_Log("gfx_load_sprite: failed to grow sprite table to %d slots", new_capacity);
+        return 0;
+    }
+
+    memset(grown + g_sprite_capacity, 0, sizeof(SpriteEntry) * (size_t)(new_capacity - g_sprite_capacity));
+    g_sprites = grown;
+    g_sprite_capacity = new_capacity;
     return 1;
 }
 
-static void ensure_sprite_atlas(void) {
-    if (g_sprite_atlas_tex != 0) return;
+static SpriteEntry* sprite_allocate_entry(int* out_handle) {
+    for (int i = 0; i < g_sprite_capacity; i++) {
+        if (!g_sprites[i].used) {
+            memset(&g_sprites[i], 0, sizeof(g_sprites[i]));
+            g_sprites[i].atlas_page = -1;
+            if (out_handle) *out_handle = i + 1;
+            return &g_sprites[i];
+        }
+    }
 
-    glGenTextures(1, &g_sprite_atlas_tex);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, SPRITE_ATLAS_W, SPRITE_ATLAS_H, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    {
+        const int old_capacity = g_sprite_capacity;
+        if (!ensure_sprite_table_capacity(g_sprite_capacity + 1)) {
+            return NULL;
+        }
+        memset(&g_sprites[old_capacity], 0, sizeof(g_sprites[old_capacity]));
+        g_sprites[old_capacity].atlas_page = -1;
+        if (out_handle) *out_handle = old_capacity + 1;
+        return &g_sprites[old_capacity];
+    }
+}
+
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+static int sprite_prepare_batch_page(int page_index) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return 0;
+    if (g_sprite_batch_page_index != -1 && g_sprite_batch_page_index != page_index) {
+        flush_sprites();
+    }
+    g_sprite_batch_page_index = page_index;
+    return 1;
+}
+
+static int sprite_atlas_footprint_w(int w) {
+    return w + SPRITE_ATLAS_PAD;
+}
+
+static int sprite_atlas_footprint_h(int h) {
+    return h + SPRITE_ATLAS_PAD;
+}
+
+static int sprite_atlas_total_free_area(void) {
+    int total = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        const SpriteAtlasPage* page = &g_sprite_atlas_pages[i];
+        for (int j = 0; j < page->free_rect_count; j++) {
+            total += page->free_rects[j].w * page->free_rects[j].h;
+        }
+    }
+    return total;
+}
+
+static int sprite_atlas_largest_free_area(void) {
+    int largest = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        const SpriteAtlasPage* page = &g_sprite_atlas_pages[i];
+        for (int j = 0; j < page->free_rect_count; j++) {
+            int area = page->free_rects[j].w * page->free_rects[j].h;
+            if (area > largest) largest = area;
+        }
+    }
+    return largest;
+}
+
+static int sprite_atlas_total_live_area(void) {
+    int total = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        total += g_sprite_atlas_pages[i].live_area;
+    }
+    return total;
+}
+
+static void sprite_atlas_usage_summary(char* out, size_t out_size) {
+    int page_area = 0;
+    int total_area = 0;
+    int total_live = 0;
+    int total_committed = 0;
+    int total_free = 0;
+    int largest_free = 0;
+
+    if (!out || out_size == 0) return;
+
+    if (g_sprite_atlas_page_size > 0) {
+        page_area = g_sprite_atlas_page_size * g_sprite_atlas_page_size;
+    }
+    total_area = page_area * g_sprite_atlas_page_count;
+    total_live = sprite_atlas_total_live_area();
+    total_free = sprite_atlas_total_free_area();
+    largest_free = sprite_atlas_largest_free_area();
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        total_committed += g_sprite_atlas_pages[i].committed_area;
+    }
+
+    snprintf(
+        out,
+        out_size,
+        "pages=%d page_size=%dx%d gl_max=%d slots=%d live_sprites=%d live_area=%d committed_area=%d reusable_area=%d total_area=%d largest_gap=%d reload_reallocations=%d",
+        g_sprite_atlas_page_count,
+        g_sprite_atlas_page_size,
+        g_sprite_atlas_page_size,
+        g_sprite_atlas_max_texture_size,
+        g_sprite_capacity,
+        g_sprite_count,
+        total_live,
+        total_committed,
+        total_free,
+        total_area,
+        largest_free,
+        g_sprite_reload_reallocations
+    );
+}
+
+static void log_sprite_atlas_failure(const char* reason, const char* path, int w, int h) {
+    char summary[256];
+    sprite_atlas_usage_summary(summary, sizeof(summary));
+    SDL_Log("gfx_load_sprite: %s for %s (%dx%d) [%s]", reason, path ? path : "(null)", w, h, summary);
+}
+
+static int ensure_sprite_atlas_config(void) {
+    int requested_page_size = 0;
+    GLint gl_limit = 0;
+
+    if (g_sprite_atlas_page_size > 0) return 1;
+    requested_page_size = parse_positive_env_int("STASIS_GFX_ATLAS_SIZE", SPRITE_ATLAS_DEFAULT_PAGE_SIZE);
+    if (g_gl_context && g_sprite_atlas_max_texture_size <= 0) {
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_limit);
+        if (gl_limit > 0) {
+            g_sprite_atlas_max_texture_size = (int)gl_limit;
+        }
+    }
+    if (g_sprite_atlas_max_texture_size > 0 && requested_page_size > g_sprite_atlas_max_texture_size) {
+        SDL_Log(
+            "gfx_atlas: clamping requested page size %d to GL_MAX_TEXTURE_SIZE %d",
+            requested_page_size,
+            g_sprite_atlas_max_texture_size
+        );
+        requested_page_size = g_sprite_atlas_max_texture_size;
+    }
+    if (requested_page_size <= SPRITE_ATLAS_PAD) {
+        SDL_Log("gfx_atlas: invalid effective page size %d", requested_page_size);
+        return 0;
+    }
+
+    g_sprite_atlas_page_size = requested_page_size;
+    return 1;
+}
+
+static int ensure_sprite_atlas_page_array(int min_capacity) {
+    int new_capacity = g_sprite_atlas_page_capacity;
+    SpriteAtlasPage* grown = NULL;
+
+    if (min_capacity <= g_sprite_atlas_page_capacity) return 1;
+    if (new_capacity <= 0) new_capacity = 4;
+    while (new_capacity < min_capacity) {
+        if (new_capacity > INT_MAX / 2) {
+            new_capacity = min_capacity;
+            break;
+        }
+        new_capacity *= 2;
+    }
+
+    grown = (SpriteAtlasPage*)realloc(g_sprite_atlas_pages, sizeof(SpriteAtlasPage) * (size_t)new_capacity);
+    if (!grown) {
+        SDL_Log("gfx_atlas: failed to grow page table to %d entries", new_capacity);
+        return 0;
+    }
+
+    memset(grown + g_sprite_atlas_page_capacity, 0, sizeof(SpriteAtlasPage) * (size_t)(new_capacity - g_sprite_atlas_page_capacity));
+    g_sprite_atlas_pages = grown;
+    g_sprite_atlas_page_capacity = new_capacity;
+    return 1;
+}
+
+static int sprite_atlas_page_ensure_free_capacity(SpriteAtlasPage* page, int min_capacity) {
+    SpriteAtlasFreeRect* grown = NULL;
+    int new_capacity = 0;
+
+    if (!page) return 0;
+    if (min_capacity <= page->free_rect_capacity) return 1;
+    new_capacity = page->free_rect_capacity > 0 ? page->free_rect_capacity : 8;
+    while (new_capacity < min_capacity) {
+        if (new_capacity > INT_MAX / 2) {
+            new_capacity = min_capacity;
+            break;
+        }
+        new_capacity *= 2;
+    }
+    grown = (SpriteAtlasFreeRect*)realloc(page->free_rects, sizeof(SpriteAtlasFreeRect) * (size_t)new_capacity);
+    if (!grown) {
+        SDL_Log("gfx_atlas: failed to grow free-rect list");
+        return 0;
+    }
+    page->free_rects = grown;
+    page->free_rect_capacity = new_capacity;
+    return 1;
+}
+
+static int sprite_atlas_page_add_free_rect(SpriteAtlasPage* page, int x, int y, int w, int h) {
+    if (!page || w <= 0 || h <= 0) return 1;
+    if (!sprite_atlas_page_ensure_free_capacity(page, page->free_rect_count + 1)) {
+        return 0;
+    }
+    page->free_rects[page->free_rect_count++] = (SpriteAtlasFreeRect){ x, y, w, h };
+    return 1;
+}
+
+static void sprite_atlas_page_remove_free_rect(SpriteAtlasPage* page, int index) {
+    if (!page || index < 0 || index >= page->free_rect_count) return;
+    if (index + 1 < page->free_rect_count) {
+        memmove(
+            &page->free_rects[index],
+            &page->free_rects[index + 1],
+            sizeof(SpriteAtlasFreeRect) * (size_t)(page->free_rect_count - index - 1)
+        );
+    }
+    page->free_rect_count--;
+}
+
+static void sprite_atlas_page_merge_free_rects(SpriteAtlasPage* page) {
+    int merged = 1;
+    if (!page) return;
+
+    while (merged) {
+        merged = 0;
+        for (int i = 0; i < page->free_rect_count && !merged; i++) {
+            SpriteAtlasFreeRect* a = &page->free_rects[i];
+            for (int j = i + 1; j < page->free_rect_count; j++) {
+                SpriteAtlasFreeRect* b = &page->free_rects[j];
+                if (a->x == b->x && a->w == b->w && a->y + a->h == b->y) {
+                    a->h += b->h;
+                    sprite_atlas_page_remove_free_rect(page, j);
+                    merged = 1;
+                    break;
+                }
+                if (a->x == b->x && a->w == b->w && b->y + b->h == a->y) {
+                    a->y = b->y;
+                    a->h += b->h;
+                    sprite_atlas_page_remove_free_rect(page, j);
+                    merged = 1;
+                    break;
+                }
+                if (a->y == b->y && a->h == b->h && a->x + a->w == b->x) {
+                    a->w += b->w;
+                    sprite_atlas_page_remove_free_rect(page, j);
+                    merged = 1;
+                    break;
+                }
+                if (a->y == b->y && a->h == b->h && b->x + b->w == a->x) {
+                    a->x = b->x;
+                    a->w += b->w;
+                    sprite_atlas_page_remove_free_rect(page, j);
+                    merged = 1;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+static int sprite_atlas_page_alloc_from_free_rect(SpriteAtlasPage* page, int alloc_w, int alloc_h, int* out_x, int* out_y) {
+    int best_index = -1;
+    int best_waste = INT_MAX;
+
+    if (!page) return 0;
+    for (int i = 0; i < page->free_rect_count; i++) {
+        const SpriteAtlasFreeRect* rect = &page->free_rects[i];
+        int waste = 0;
+        if (rect->w < alloc_w || rect->h < alloc_h) continue;
+        waste = rect->w * rect->h - alloc_w * alloc_h;
+        if (waste < best_waste) {
+            best_index = i;
+            best_waste = waste;
+            if (waste == 0) break;
+        }
+    }
+    if (best_index < 0) return 0;
+
+    SpriteAtlasFreeRect rect = page->free_rects[best_index];
+    if (!sprite_atlas_page_ensure_free_capacity(page, page->free_rect_count + 2)) {
+        return 0;
+    }
+    sprite_atlas_page_remove_free_rect(page, best_index);
+
+    *out_x = rect.x;
+    *out_y = rect.y;
+
+    if (!sprite_atlas_page_add_free_rect(page, rect.x + alloc_w, rect.y, rect.w - alloc_w, alloc_h)) {
+        return 0;
+    }
+    if (!sprite_atlas_page_add_free_rect(page, rect.x, rect.y + alloc_h, rect.w, rect.h - alloc_h)) {
+        return 0;
+    }
+    sprite_atlas_page_merge_free_rects(page);
+    return 1;
+}
+
+static int sprite_atlas_page_alloc_from_append(SpriteAtlasPage* page, int alloc_w, int alloc_h, int* out_x, int* out_y) {
+    if (!page) return 0;
+    if (alloc_w > page->width || alloc_h > page->height) return 0;
+
+    if (page->cursor_x + alloc_w > page->width) {
+        page->cursor_x = SPRITE_ATLAS_PAD;
+        page->cursor_y += page->row_h;
+        page->row_h = 0;
+    }
+    if (page->cursor_y + alloc_h > page->height) {
+        return 0;
+    }
+
+    *out_x = page->cursor_x;
+    *out_y = page->cursor_y;
+    page->cursor_x += alloc_w;
+    if (alloc_h > page->row_h) page->row_h = alloc_h;
+    page->committed_area += alloc_w * alloc_h;
+    return 1;
+}
+
+static int create_sprite_atlas_page(void) {
+    SpriteAtlasPage* page = NULL;
+    GLuint texture = 0;
+
+    if (!ensure_sprite_atlas_config()) return 0;
+    if (!ensure_sprite_atlas_page_array(g_sprite_atlas_page_count + 1)) return 0;
+
+    page = &g_sprite_atlas_pages[g_sprite_atlas_page_count];
+    memset(page, 0, sizeof(*page));
+    page->width = g_sprite_atlas_page_size;
+    page->height = g_sprite_atlas_page_size;
+    page->cursor_x = SPRITE_ATLAS_PAD;
+    page->cursor_y = SPRITE_ATLAS_PAD;
+
+    glGenTextures(1, &texture);
+    if (texture == 0) {
+        SDL_Log("gfx_atlas: glGenTextures failed for atlas page %d", g_sprite_atlas_page_count);
+        return 0;
+    }
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, page->width, page->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
+
+    page->texture = texture;
+    g_sprite_atlas_page_count++;
+    SDL_Log("gfx_atlas: created page=%d size=%dx%d", g_sprite_atlas_page_count - 1, page->width, page->height);
+    return 1;
 }
+
+static int sprite_atlas_upload_region(int page_index, int x, int y, int w, int h, const unsigned char* pixels) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return 0;
+    if (!pixels) return 0;
+
+    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_pages[page_index].texture);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return 1;
+}
+
+static void sprite_atlas_release_region(int page_index, int x, int y, int alloc_w, int alloc_h) {
+    SpriteAtlasPage* page = NULL;
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return;
+    if (alloc_w <= 0 || alloc_h <= 0) return;
+
+    page = &g_sprite_atlas_pages[page_index];
+    if (!sprite_atlas_page_add_free_rect(page, x, y, alloc_w, alloc_h)) {
+        return;
+    }
+    if (page->live_area >= alloc_w * alloc_h) {
+        page->live_area -= alloc_w * alloc_h;
+    } else {
+        page->live_area = 0;
+    }
+    sprite_atlas_page_merge_free_rects(page);
+}
+
+static int sprite_atlas_allocate_region(int w, int h, int* out_page, int* out_x, int* out_y, int* out_alloc_w, int* out_alloc_h) {
+    int alloc_w = 0;
+    int alloc_h = 0;
+
+    if (!ensure_sprite_atlas_config()) return 0;
+    if (w <= 0 || h <= 0) return 0;
+
+    alloc_w = sprite_atlas_footprint_w(w);
+    alloc_h = sprite_atlas_footprint_h(h);
+    if (alloc_w > g_sprite_atlas_page_size || alloc_h > g_sprite_atlas_page_size) {
+        return 0;
+    }
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (sprite_atlas_page_alloc_from_free_rect(&g_sprite_atlas_pages[i], alloc_w, alloc_h, out_x, out_y)) {
+            g_sprite_atlas_pages[i].live_area += alloc_w * alloc_h;
+            *out_page = i;
+            *out_alloc_w = alloc_w;
+            *out_alloc_h = alloc_h;
+            return 1;
+        }
+    }
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (sprite_atlas_page_alloc_from_append(&g_sprite_atlas_pages[i], alloc_w, alloc_h, out_x, out_y)) {
+            g_sprite_atlas_pages[i].live_area += alloc_w * alloc_h;
+            *out_page = i;
+            *out_alloc_w = alloc_w;
+            *out_alloc_h = alloc_h;
+            return 1;
+        }
+    }
+
+    if (!create_sprite_atlas_page()) return 0;
+    if (!sprite_atlas_page_alloc_from_append(&g_sprite_atlas_pages[g_sprite_atlas_page_count - 1], alloc_w, alloc_h, out_x, out_y)) {
+        return 0;
+    }
+
+    g_sprite_atlas_pages[g_sprite_atlas_page_count - 1].live_area += alloc_w * alloc_h;
+    *out_page = g_sprite_atlas_page_count - 1;
+    *out_alloc_w = alloc_w;
+    *out_alloc_h = alloc_h;
+    return 1;
+}
+#endif
 
 static void ensure_sprite_program(void) {
     if (g_sprite_program != 0) return;
@@ -2140,9 +2617,12 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
 static void flush_sprites(void) {
     if (g_sprite_vert_count == 0) return;
     ensure_sprite_program();
-    ensure_sprite_atlas();
-    if (g_sprite_program == 0 || g_sprite_atlas_tex == 0) {
+    if (g_sprite_program == 0 ||
+        g_sprite_batch_page_index < 0 ||
+        g_sprite_batch_page_index >= g_sprite_atlas_page_count ||
+        g_sprite_atlas_pages[g_sprite_batch_page_index].texture == 0) {
         g_sprite_vert_count = 0;
+        g_sprite_batch_page_index = -1;
         return;
     }
 
@@ -2151,7 +2631,7 @@ static void flush_sprites(void) {
 
     glUseProgram(g_sprite_program);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
+    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_pages[g_sprite_batch_page_index].texture);
     if (g_sprite_tex_loc >= 0) glUniform1i(g_sprite_tex_loc, 0);
 
     glBindVertexArray(g_sprite_vao);
@@ -2176,6 +2656,7 @@ static void flush_sprites(void) {
     glUseProgram(0);
 
     g_sprite_vert_count = 0;
+    g_sprite_batch_page_index = -1;
 }
 #endif
 
@@ -2217,7 +2698,7 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
         const int a = cmds[base + 6];
 
         if (w <= 0 || h <= 0) continue;
-        if (handle <= 0 || handle > MAX_SPRITES) continue;
+        if (handle <= 0 || handle > g_sprite_capacity) continue;
 
         SpriteEntry* e = &g_sprites[handle - 1];
         if (!e->used) continue;
@@ -2231,8 +2712,15 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
             continue;
         }
 
+        if (!sprite_prepare_batch_page(e->atlas_page)) {
+            continue;
+        }
+
         if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
             flush_sprites();
+        }
+        if (!sprite_prepare_batch_page(e->atlas_page)) {
+            continue;
         }
 
         const float af = (float)a / 255.0f;
@@ -2749,11 +3237,13 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
                 setup_ortho();
                 ensure_line_program();
                 init_postfx_shader();
+                ensure_sprite_atlas_config();
 
                 SDL_Log("Stasis graphics initialized: %dx%d", width, height);
                 SDL_Log("GL_VENDOR: %s", (const char*)glGetString(GL_VENDOR));
                 SDL_Log("GL_RENDERER: %s", (const char*)glGetString(GL_RENDERER));
                 SDL_Log("GL_VERSION: %s", (const char*)glGetString(GL_VERSION));
+                SDL_Log("gfx_atlas: configured page_size=%d gl_max_texture_size=%d", g_sprite_atlas_page_size, g_sprite_atlas_max_texture_size);
             }
         }
     }
@@ -3330,7 +3820,7 @@ STASIS_EXPORT void stasis_gfx_submit_u8(const int32_t* cmd_i32, const float* cmd
 
 static SpriteEntry* sprite_get(int handle) {
     int idx = handle - 1;
-    if (idx < 0 || idx >= MAX_SPRITES) return NULL;
+    if (idx < 0 || idx >= g_sprite_capacity) return NULL;
     if (!g_sprites[idx].used) return NULL;
     return &g_sprites[idx];
 }
@@ -3343,127 +3833,12 @@ STASIS_EXPORT int stasis_gfx_poll_reload(int handle) {
     return 1;
 }
 
-static int sprite_find_by_path(const char* path) {
-    for (int i = 0; i < MAX_SPRITES; i++) {
-        if (g_sprites[i].used && g_sprites[i].path && strcmp(g_sprites[i].path, path) == 0) {
-            return i + 1;
-        }
-    }
-    return 0;
-}
-
 static int gfx_should_log_sprite_loads(void) {
     static int cached = -1;
     if (cached != -1) return cached;
     const char* env = getenv("STASIS_GFX_LOG_SPRITES");
     cached = (env && env[0] == '1') ? 1 : 0;
     return cached;
-}
-
-static int sprite_build_into_entry(SpriteEntry* e, const char* path, int allow_reuse_slot) {
-    unsigned char* pixels = NULL;
-    int w = 0, h = 0;
-    if (!bake_svg_to_rgba(path, &pixels, &w, &h)) {
-        SDL_Log("gfx_load_sprite: failed to bake %s", path);
-        return 0;
-    }
-    e->max_w = w;
-    e->max_h = h;
-
-    if (g_use_sdl_renderer) {
-        if (!g_renderer) {
-            free(pixels);
-            return 0;
-        }
-
-        /* SDL expects straight alpha; convert from premultiplied. */
-        for (int i = 0; i < w * h; i++) {
-            unsigned char* p = pixels + i * 4;
-            unsigned char a = p[3];
-            if (a == 0) {
-                p[0] = 0; p[1] = 0; p[2] = 0;
-                continue;
-            }
-            int r = p[0];
-            int g = p[1];
-            int b = p[2];
-            p[0] = (unsigned char)((r * 255 + (a / 2)) / a);
-            p[1] = (unsigned char)((g * 255 + (a / 2)) / a);
-            p[2] = (unsigned char)((b * 255 + (a / 2)) / a);
-        }
-
-        if (e->sdl_tex) {
-            SDL_DestroyTexture(e->sdl_tex);
-            e->sdl_tex = NULL;
-        }
-
-        SDL_Texture* tex = SDL_CreateTexture(g_renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, w, h);
-        if (!tex) {
-            SDL_Log("gfx_load_sprite: SDL_CreateTexture failed: %s", SDL_GetError());
-            free(pixels);
-            return 0;
-        }
-        SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
-        if (SDL_UpdateTexture(tex, NULL, pixels, w * 4) != 0) {
-            SDL_Log("gfx_load_sprite: SDL_UpdateTexture failed: %s", SDL_GetError());
-            SDL_DestroyTexture(tex);
-            free(pixels);
-            return 0;
-        }
-
-        free(pixels);
-        e->w = w;
-        e->h = h;
-        e->sdl_tex = tex;
-        e->mtime = get_file_mtime(path);
-        return 1;
-    }
-
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
-        free(pixels);
-        return 0;
-    }
-
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot) {
-        ax = e->atlas_x;
-        ay = e->atlas_y;
-        if (w != e->w || h != e->h) {
-            SDL_Log("gfx_reload: size change not supported (%s %dx%d -> %dx%d)", path, e->w, e->h, w, h);
-            free(pixels);
-            return 0;
-        }
-    } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-            free(pixels);
-            return 0;
-        }
-    }
-
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    free(pixels);
-
-    e->w = w;
-    e->h = h;
-    e->atlas_x = ax;
-    e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
-    e->mtime = get_file_mtime(path);
-    return 1;
-#else
-    free(pixels);
-    return 0;
-#endif
 }
 
 /*
@@ -3523,6 +3898,11 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
         e->h = h;
         e->max_w = max_w;
         e->max_h = max_h;
+        e->atlas_page = -1;
+        e->atlas_x = 0;
+        e->atlas_y = 0;
+        e->atlas_alloc_w = 0;
+        e->atlas_alloc_h = 0;
         e->sdl_tex = tex;
         e->mtime = get_file_mtime(path);
         e->needs_reraster = 0;
@@ -3530,52 +3910,63 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
     }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
+    int old_page = e->atlas_page;
+    int old_x = e->atlas_x;
+    int old_y = e->atlas_y;
+    int old_alloc_w = e->atlas_alloc_w;
+    int old_alloc_h = e->atlas_alloc_h;
+    int page_index = -1;
+    int ax = 0;
+    int ay = 0;
+    int alloc_w = 0;
+    int alloc_h = 0;
+    int needs_new_region = 1;
+
+    if (allow_reuse_slot && e->w > 0 && e->h > 0 && w == e->w && h == e->h && e->atlas_page >= 0) {
+        page_index = e->atlas_page;
+        ax = e->atlas_x;
+        ay = e->atlas_y;
+        alloc_w = e->atlas_alloc_w;
+        alloc_h = e->atlas_alloc_h;
+        needs_new_region = 0;
+    } else if (!sprite_atlas_allocate_region(w, h, &page_index, &ax, &ay, &alloc_w, &alloc_h)) {
+        if (ensure_sprite_atlas_config() && (sprite_atlas_footprint_w(w) > g_sprite_atlas_page_size || sprite_atlas_footprint_h(h) > g_sprite_atlas_page_size)) {
+            log_sprite_atlas_failure("sprite exceeds atlas page size", path, w, h);
+        } else {
+            log_sprite_atlas_failure("atlas allocation failed", path, w, h);
+        }
         free(pixels);
         return 0;
     }
 
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot && e->w > 0 && e->h > 0) {
-        /* For re-rasterization, we may need to reallocate if size changed significantly */
-        if (w != e->w || h != e->h) {
-            /* Size changed - need new atlas slot. For now, just allocate new. */
-            /* TODO: could free old slot, but atlas doesn't support that yet */
-            if (!atlas_alloc(w, h, &ax, &ay)) {
-                SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-                free(pixels);
-                return 0;
-            }
-        } else {
-            ax = e->atlas_x;
-            ay = e->atlas_y;
+    if (!sprite_atlas_upload_region(page_index, ax, ay, w, h, pixels)) {
+        if (needs_new_region) {
+            sprite_atlas_release_region(page_index, ax, ay, alloc_w, alloc_h);
         }
-    } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-            free(pixels);
-            return 0;
-        }
+        free(pixels);
+        return 0;
     }
 
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
     free(pixels);
+
+    if (needs_new_region && allow_reuse_slot && e->w > 0 && e->h > 0) {
+        g_sprite_reload_reallocations++;
+        sprite_atlas_release_region(old_page, old_x, old_y, old_alloc_w, old_alloc_h);
+    }
 
     e->w = w;
     e->h = h;
     e->max_w = max_w;
     e->max_h = max_h;
+    e->atlas_page = page_index;
     e->atlas_x = ax;
     e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
+    e->atlas_alloc_w = alloc_w;
+    e->atlas_alloc_h = alloc_h;
+    e->u0 = (float)ax / (float)g_sprite_atlas_pages[page_index].width;
+    e->v0 = (float)ay / (float)g_sprite_atlas_pages[page_index].height;
+    e->u1 = (float)(ax + w) / (float)g_sprite_atlas_pages[page_index].width;
+    e->v1 = (float)(ay + h) / (float)g_sprite_atlas_pages[page_index].height;
     e->mtime = get_file_mtime(path);
     e->needs_reraster = 0;
     return 1;
@@ -3593,7 +3984,7 @@ static void gfx_asset_watch_apply_pending_changes(void) {
         return;
     }
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < g_sprite_capacity; i++) {
         SpriteEntry* e = &g_sprites[i];
         if (!e->used || !e->path) continue;
 
@@ -3630,30 +4021,42 @@ STASIS_EXPORT int stasis_gfx_load_sprite(const char* path, int max_w, int max_h)
     /* Note: We don't check for existing sprites with same path because
      * the same SVG might be loaded at different sizes */
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
-        if (!g_sprites[i].used) {
-            SpriteEntry* e = &g_sprites[i];
-            memset(e, 0, sizeof(*e));
-            e->path = stasis_strdup(resolved);
-            if (!e->path) return 0;
-            e->used = 1;
-            if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
-                free(e->path);
-                memset(e, 0, sizeof(*e));
-                return 0;
+    {
+        int handle = 0;
+        SpriteEntry* e = sprite_allocate_entry(&handle);
+        if (!e) {
+            if (sprite_table_limit() > 0) {
+                SDL_Log(
+                    "gfx_load_sprite: sprite table limit reached for %s [live_sprites=%d slot_capacity=%d configured_limit=%d]",
+                    resolved,
+                    g_sprite_count,
+                    g_sprite_capacity,
+                    sprite_table_limit()
+                );
+            } else {
+                SDL_Log("gfx_load_sprite: failed to grow sprite table for %s", resolved);
             }
-            g_sprite_count++;
-            if (gfx_should_log_sprite_loads()) {
-                SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d (%s)",
-                        resolved, max_w, max_h, i + 1, e->w, e->h,
-                        g_use_sdl_renderer ? "sdl" : "gl");
-            }
-            return i + 1;
+            return 0;
         }
-    }
 
-    SDL_Log("gfx_load_sprite: MAX_SPRITES reached");
-    return 0;
+        e->path = stasis_strdup(resolved);
+        if (!e->path) return 0;
+        e->used = 1;
+        if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
+            free(e->path);
+            memset(e, 0, sizeof(*e));
+            e->atlas_page = -1;
+            return 0;
+        }
+
+        g_sprite_count++;
+        if (gfx_should_log_sprite_loads()) {
+            SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d page=%d (%s)",
+                    resolved, max_w, max_h, handle, e->w, e->h, e->atlas_page,
+                    g_use_sdl_renderer ? "sdl" : "gl");
+        }
+        return handle;
+    }
 }
 
 /*
@@ -3722,8 +4125,14 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
     }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    if (!sprite_prepare_batch_page(e->atlas_page)) {
+        return;
+    }
     if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
         flush_sprites();
+    }
+    if (!sprite_prepare_batch_page(e->atlas_page)) {
+        return;
     }
 #endif
 
@@ -4015,12 +4424,28 @@ STASIS_EXPORT void stasis_shutdown(void) {
         glDeleteVertexArrays(1, &g_sprite_vao);
         g_sprite_vao = 0;
     }
-    if (g_sprite_atlas_tex) {
-        glDeleteTextures(1, &g_sprite_atlas_tex);
-        g_sprite_atlas_tex = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (g_sprite_atlas_pages[i].texture) {
+            glDeleteTextures(1, &g_sprite_atlas_pages[i].texture);
+            g_sprite_atlas_pages[i].texture = 0;
+        }
+        if (g_sprite_atlas_pages[i].free_rects) {
+            free(g_sprite_atlas_pages[i].free_rects);
+            g_sprite_atlas_pages[i].free_rects = NULL;
+        }
+        g_sprite_atlas_pages[i].free_rect_count = 0;
+        g_sprite_atlas_pages[i].free_rect_capacity = 0;
     }
+    free(g_sprite_atlas_pages);
+    g_sprite_atlas_pages = NULL;
+    g_sprite_atlas_page_count = 0;
+    g_sprite_atlas_page_capacity = 0;
+    g_sprite_batch_page_index = -1;
+    g_sprite_reload_reallocations = 0;
+    g_sprite_atlas_page_size = 0;
+    g_sprite_atlas_max_texture_size = 0;
 #endif
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < g_sprite_capacity; i++) {
         if (g_sprites[i].used) {
             if (g_sprites[i].sdl_tex) {
                 SDL_DestroyTexture(g_sprites[i].sdl_tex);
@@ -4028,8 +4453,13 @@ STASIS_EXPORT void stasis_shutdown(void) {
             }
             if (g_sprites[i].path) free(g_sprites[i].path);
             memset(&g_sprites[i], 0, sizeof(g_sprites[i]));
+            g_sprites[i].atlas_page = -1;
         }
     }
+    free(g_sprites);
+    g_sprites = NULL;
+    g_sprite_capacity = 0;
+    g_sprite_count = 0;
 
     for (int i = 0; i < MAX_FONTS; i++) {
         if (g_fonts[i].active) {

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -1458,6 +1458,9 @@ static int sprite_ensure_capacity(int min_capacity) {
     if (min_capacity > g_sprite_limit) return 0;
 
     int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : 64;
+    if (new_capacity > g_sprite_limit) {
+        new_capacity = g_sprite_limit;
+    }
     while (new_capacity < min_capacity) {
         if (new_capacity >= g_sprite_limit) {
             new_capacity = g_sprite_limit;
@@ -1833,12 +1836,44 @@ static void sprite_atlas_free_region(int page_index, int x, int y, int w, int h)
     }
 }
 
+static int sprite_atlas_clear_upload_rect(int x, int y, int w, int h) {
+    if (w <= 0 || h <= 0) return 0;
+
+    const size_t pixel_count = (size_t)w * (size_t)h;
+    if (pixel_count > SIZE_MAX / 4) return 0;
+
+    unsigned char* clear_pixels = (unsigned char*)calloc(pixel_count, 4);
+    if (!clear_pixels) return 0;
+
+    glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, clear_pixels);
+    free(clear_pixels);
+    return 1;
+}
+
 static int sprite_atlas_upload_region(int page_index, int x, int y, int w, int h, const unsigned char* pixels) {
     if (page_index < 0 || page_index >= g_sprite_atlas_page_count || !pixels) return 0;
-    GLuint texture = g_sprite_atlas_pages[page_index].texture;
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[page_index];
+    GLuint texture = page->texture;
     if (texture == 0) return 0;
 
+    const int alloc_x = x - SPRITE_ATLAS_PAD;
+    const int alloc_y = y - SPRITE_ATLAS_PAD;
+    const int alloc_w = w + SPRITE_ATLAS_PAD * 2;
+    const int alloc_h = h + SPRITE_ATLAS_PAD * 2;
+    if (alloc_x < 0 ||
+        alloc_y < 0 ||
+        alloc_w <= 0 ||
+        alloc_h <= 0 ||
+        alloc_x + alloc_w > page->width ||
+        alloc_y + alloc_h > page->height) {
+        return 0;
+    }
+
     glBindTexture(GL_TEXTURE_2D, texture);
+    if (!sprite_atlas_clear_upload_rect(alloc_x, alloc_y, alloc_w, alloc_h)) {
+        glBindTexture(GL_TEXTURE_2D, 0);
+        return 0;
+    }
     glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <stdint.h>
+#include <limits.h>
 #include <ctype.h>
 #include <time.h>
 #if defined(_WIN32)
@@ -148,6 +149,7 @@ STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, 
 
 /* Forward decls for internal helpers used before their definitions. */
 typedef struct SpriteEntry SpriteEntry;
+static SpriteEntry* sprite_get(int handle);
 static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int h, int rot_degrees, int a, int do_hash);
 static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_count);
 static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int max_w, int max_h, int allow_reuse_slot);
@@ -160,7 +162,7 @@ static void reset_sprite_program(void);
 #endif
 
 /* Sprite atlas bookkeeping (paths + rasterized sprites). */
-#define MAX_SPRITES 256
+#define SPRITE_TABLE_INITIAL_CAPACITY 256
 
 typedef struct SpriteEntry {
     char* path;
@@ -168,8 +170,13 @@ typedef struct SpriteEntry {
     int h;              /* current rasterized height */
     int max_w;          /* requested max width (logical) */
     int max_h;          /* requested max height (logical) */
+    int page_index;
     int atlas_x;
     int atlas_y;
+    int alloc_x;
+    int alloc_y;
+    int alloc_w;
+    int alloc_h;
     float u0, v0, u1, v1;
     uint64_t mtime;
     SDL_Texture* sdl_tex;
@@ -178,8 +185,10 @@ typedef struct SpriteEntry {
     int reload_pending;  /* set when the asset watcher reloads this sprite */
 } SpriteEntry;
 
-static SpriteEntry g_sprites[MAX_SPRITES];
+static SpriteEntry* g_sprites = NULL;
+static int g_sprite_capacity = 0;
 static int g_sprite_count = 0;
+static int g_sprite_table_limit = -1;
 
 /* Font rendering with stb_truetype. */
 #define MAX_FONTS 8
@@ -367,7 +376,7 @@ static void stasis_pump_events(void) {
                         g_window_resized = true;
 
                         /* Mark all sized sprites for re-rasterization */
-                        for (int i = 0; i < MAX_SPRITES; i++) {
+                        for (int i = 0; i < g_sprite_capacity; i++) {
                             if (g_sprites[i].used && g_sprites[i].max_w > 0 && g_sprites[i].max_h > 0) {
                                 g_sprites[i].needs_reraster = 1;
                             }
@@ -926,8 +935,8 @@ static char g_asset_base[512] = {0};
 static char g_asset_env[512] = {0};
 
 /* Sprite atlas + batching (baked from SVG sources) */
-#define SPRITE_ATLAS_W 1024
-#define SPRITE_ATLAS_H 1024
+#define SPRITE_ATLAS_DEFAULT_W 2048
+#define SPRITE_ATLAS_DEFAULT_H 2048
 #define SPRITE_ATLAS_PAD 2
 #define MAX_SPRITE_VERTS (6 * 4096)
 
@@ -938,6 +947,23 @@ typedef struct {
 } SpriteVertex;
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} AtlasFreeRect;
+
+typedef struct {
+    GLuint texture;
+    int w;
+    int h;
+    AtlasFreeRect* free_rects;
+    int free_rect_count;
+    int free_rect_capacity;
+    int used_pixels;
+} SpriteAtlasPage;
+
 static GLuint g_sprite_program = 0;
 static GLuint g_sprite_vbo = 0;
 static GLuint g_sprite_vao = 0;
@@ -946,10 +972,13 @@ static GLint g_sprite_uv_loc = -1;
 static GLint g_sprite_color_loc = -1;
 static GLint g_sprite_tex_loc = -1;
 
-static GLuint g_sprite_atlas_tex = 0;
-static int g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_cursor_y = SPRITE_ATLAS_PAD;
-static int g_sprite_atlas_row_h = 0;
+static SpriteAtlasPage* g_sprite_atlas_pages = NULL;
+static int g_sprite_atlas_page_count = 0;
+static int g_sprite_atlas_page_capacity = 0;
+static int g_sprite_atlas_page_w = 0;
+static int g_sprite_atlas_page_h = 0;
+static int g_sprite_atlas_gl_max_size = 0;
+static int g_sprite_batch_page = -1;
 #endif
 
 static SpriteVertex g_sprite_vertices[MAX_SPRITE_VERTS];
@@ -1379,42 +1408,421 @@ static char* stasis_strdup(const char* s) {
 #endif
 }
 
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-static int atlas_alloc(int w, int h, int* out_x, int* out_y) {
-    if (w <= 0 || h <= 0) return 0;
-    if (w + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_W) return 0;
-    if (h + SPRITE_ATLAS_PAD * 2 > SPRITE_ATLAS_H) return 0;
+static int parse_env_i32(const char* name, int fallback, int min_value, int max_value) {
+    const char* raw = getenv(name);
+    if (!raw || !raw[0]) return fallback;
 
-    if (g_sprite_atlas_cursor_x + w + SPRITE_ATLAS_PAD > SPRITE_ATLAS_W) {
-        g_sprite_atlas_cursor_x = SPRITE_ATLAS_PAD;
-        g_sprite_atlas_cursor_y += g_sprite_atlas_row_h + SPRITE_ATLAS_PAD;
-        g_sprite_atlas_row_h = 0;
+    char* end = NULL;
+    long parsed = strtol(raw, &end, 10);
+    if (end == raw || (end && *end != '\0')) {
+        SDL_Log("%s: invalid integer '%s'; using %d", name, raw, fallback);
+        return fallback;
+    }
+    if (parsed < (long)min_value) {
+        SDL_Log("%s: clamping %ld to %d", name, parsed, min_value);
+        return min_value;
+    }
+    if (parsed > (long)max_value) {
+        SDL_Log("%s: clamping %ld to %d", name, parsed, max_value);
+        return max_value;
+    }
+    return (int)parsed;
+}
+
+static int ensure_sprite_table_capacity(int min_capacity) {
+    if (min_capacity <= g_sprite_capacity) return 1;
+
+    if (g_sprite_table_limit < 0) {
+        g_sprite_table_limit = parse_env_i32("STASIS_GFX_MAX_SPRITES", 0, 0, INT_MAX / 2);
     }
 
-    if (g_sprite_atlas_cursor_y + h + SPRITE_ATLAS_PAD > SPRITE_ATLAS_H) {
+    int limit = g_sprite_table_limit;
+    if (limit <= 0) {
+        limit = INT_MAX / 2;
+    }
+    if (min_capacity > limit) {
         return 0;
     }
 
-    *out_x = g_sprite_atlas_cursor_x;
-    *out_y = g_sprite_atlas_cursor_y;
+    int new_capacity = g_sprite_capacity > 0 ? g_sprite_capacity : SPRITE_TABLE_INITIAL_CAPACITY;
+    while (new_capacity < min_capacity) {
+        if (new_capacity >= limit) {
+            new_capacity = limit;
+            break;
+        }
+        if (new_capacity > limit / 2) {
+            new_capacity = limit;
+        } else {
+            new_capacity *= 2;
+        }
+    }
+    if (new_capacity < min_capacity) {
+        return 0;
+    }
 
-    g_sprite_atlas_cursor_x += w + SPRITE_ATLAS_PAD;
-    if (h > g_sprite_atlas_row_h) g_sprite_atlas_row_h = h;
+    SpriteEntry* resized = (SpriteEntry*)realloc(g_sprites, sizeof(SpriteEntry) * (size_t)new_capacity);
+    if (!resized) {
+        return 0;
+    }
+    if (new_capacity > g_sprite_capacity) {
+        memset(resized + g_sprite_capacity, 0, sizeof(SpriteEntry) * (size_t)(new_capacity - g_sprite_capacity));
+    }
+    g_sprites = resized;
+    g_sprite_capacity = new_capacity;
     return 1;
 }
 
-static void ensure_sprite_atlas(void) {
-    if (g_sprite_atlas_tex != 0) return;
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+static int atlas_page_required_extent(int sprite_extent) {
+    if (sprite_extent <= 0) return 0;
+    if (sprite_extent > INT_MAX - SPRITE_ATLAS_PAD * 2) return 0;
+    return sprite_extent + SPRITE_ATLAS_PAD * 2;
+}
 
-    glGenTextures(1, &g_sprite_atlas_tex);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, SPRITE_ATLAS_W, SPRITE_ATLAS_H, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+static int atlas_page_free_area(const SpriteAtlasPage* page) {
+    int total = 0;
+    if (!page) return 0;
+    for (int i = 0; i < page->free_rect_count; i++) {
+        total += page->free_rects[i].w * page->free_rects[i].h;
+    }
+    return total;
+}
+
+static void atlas_page_remove_rect(SpriteAtlasPage* page, int index) {
+    if (!page || index < 0 || index >= page->free_rect_count) return;
+    page->free_rects[index] = page->free_rects[page->free_rect_count - 1];
+    page->free_rect_count--;
+}
+
+static int atlas_page_reserve_rects(SpriteAtlasPage* page, int additional) {
+    if (!page || additional <= 0) return 1;
+    if (page->free_rect_count + additional <= page->free_rect_capacity) return 1;
+
+    int new_capacity = page->free_rect_capacity > 0 ? page->free_rect_capacity : 8;
+    while (new_capacity < page->free_rect_count + additional) {
+        if (new_capacity > INT_MAX / 2) {
+            return 0;
+        }
+        new_capacity *= 2;
+    }
+
+    AtlasFreeRect* resized = (AtlasFreeRect*)realloc(page->free_rects, sizeof(AtlasFreeRect) * (size_t)new_capacity);
+    if (!resized) {
+        return 0;
+    }
+    page->free_rects = resized;
+    page->free_rect_capacity = new_capacity;
+    return 1;
+}
+
+static int atlas_page_push_rect(SpriteAtlasPage* page, AtlasFreeRect rect) {
+    if (!page || rect.w <= 0 || rect.h <= 0) return 1;
+    if (!atlas_page_reserve_rects(page, 1)) {
+        return 0;
+    }
+    page->free_rects[page->free_rect_count++] = rect;
+    return 1;
+}
+
+static int atlas_rect_contains(AtlasFreeRect a, AtlasFreeRect b) {
+    return b.x >= a.x && b.y >= a.y &&
+           b.x + b.w <= a.x + a.w &&
+           b.y + b.h <= a.y + a.h;
+}
+
+static int atlas_try_merge_rects(AtlasFreeRect* a, AtlasFreeRect* b) {
+    if (!a || !b) return 0;
+
+    if (a->x == b->x && a->w == b->w) {
+        if (a->y + a->h == b->y) {
+            a->h += b->h;
+            return 1;
+        }
+        if (b->y + b->h == a->y) {
+            a->y = b->y;
+            a->h += b->h;
+            return 1;
+        }
+    }
+
+    if (a->y == b->y && a->h == b->h) {
+        if (a->x + a->w == b->x) {
+            a->w += b->w;
+            return 1;
+        }
+        if (b->x + b->w == a->x) {
+            a->x = b->x;
+            a->w += b->w;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static void atlas_page_coalesce(SpriteAtlasPage* page) {
+    if (!page) return;
+
+    int changed = 1;
+    while (changed) {
+        changed = 0;
+        for (int i = 0; i < page->free_rect_count; i++) {
+            for (int j = i + 1; j < page->free_rect_count; j++) {
+                if (atlas_rect_contains(page->free_rects[i], page->free_rects[j])) {
+                    atlas_page_remove_rect(page, j);
+                    changed = 1;
+                    goto restart;
+                }
+                if (atlas_rect_contains(page->free_rects[j], page->free_rects[i])) {
+                    atlas_page_remove_rect(page, i);
+                    changed = 1;
+                    goto restart;
+                }
+                if (atlas_try_merge_rects(&page->free_rects[i], &page->free_rects[j])) {
+                    atlas_page_remove_rect(page, j);
+                    changed = 1;
+                    goto restart;
+                }
+            }
+        }
+restart:
+        ;
+    }
+}
+
+static void atlas_init_config(void) {
+    if (g_sprite_atlas_page_w > 0 && g_sprite_atlas_page_h > 0) return;
+
+    if (g_sprite_atlas_gl_max_size <= 0) {
+        GLint gl_limit = 0;
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_limit);
+        if (gl_limit <= 0) gl_limit = SPRITE_ATLAS_DEFAULT_W;
+        g_sprite_atlas_gl_max_size = (int)gl_limit;
+    }
+
+    g_sprite_atlas_page_w = parse_env_i32("STASIS_GFX_ATLAS_W",
+                                          SPRITE_ATLAS_DEFAULT_W,
+                                          64,
+                                          g_sprite_atlas_gl_max_size);
+    g_sprite_atlas_page_h = parse_env_i32("STASIS_GFX_ATLAS_H",
+                                          SPRITE_ATLAS_DEFAULT_H,
+                                          64,
+                                          g_sprite_atlas_gl_max_size);
+}
+
+static int atlas_page_upload_region(SpriteAtlasPage* page, int x, int y, int w, int h, const void* pixels) {
+    if (!page || page->texture == 0 || w <= 0 || h <= 0) return 0;
+    glBindTexture(GL_TEXTURE_2D, page->texture);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glGenerateMipmap(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return 1;
+}
+
+static void atlas_page_clear_region(SpriteAtlasPage* page, int x, int y, int w, int h) {
+    if (!page || page->texture == 0 || w <= 0 || h <= 0) return;
+    size_t pixel_count = (size_t)w * (size_t)h;
+    unsigned char* clear_pixels = (unsigned char*)calloc(pixel_count, 4);
+    if (!clear_pixels) return;
+    atlas_page_upload_region(page, x, y, w, h, clear_pixels);
+    free(clear_pixels);
+}
+
+static int atlas_add_page(void) {
+    atlas_init_config();
+
+    if (g_sprite_atlas_page_count == g_sprite_atlas_page_capacity) {
+        int new_capacity = g_sprite_atlas_page_capacity > 0 ? g_sprite_atlas_page_capacity * 2 : 4;
+        SpriteAtlasPage* resized =
+            (SpriteAtlasPage*)realloc(g_sprite_atlas_pages, sizeof(SpriteAtlasPage) * (size_t)new_capacity);
+        if (!resized) {
+            return -1;
+        }
+        memset(resized + g_sprite_atlas_page_capacity, 0,
+               sizeof(SpriteAtlasPage) * (size_t)(new_capacity - g_sprite_atlas_page_capacity));
+        g_sprite_atlas_pages = resized;
+        g_sprite_atlas_page_capacity = new_capacity;
+    }
+
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[g_sprite_atlas_page_count];
+    memset(page, 0, sizeof(*page));
+    page->w = g_sprite_atlas_page_w;
+    page->h = g_sprite_atlas_page_h;
+
+    glGenTextures(1, &page->texture);
+    if (page->texture == 0) {
+        return -1;
+    }
+
+    size_t pixel_count = (size_t)page->w * (size_t)page->h;
+    unsigned char* initial_pixels = (unsigned char*)calloc(pixel_count, 4);
+    if (!initial_pixels) {
+        glDeleteTextures(1, &page->texture);
+        page->texture = 0;
+        return -1;
+    }
+
+    glBindTexture(GL_TEXTURE_2D, page->texture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, page->w, page->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, initial_pixels);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
+    free(initial_pixels);
+
+    if (!atlas_page_push_rect(page, (AtlasFreeRect){ 0, 0, page->w, page->h })) {
+        glDeleteTextures(1, &page->texture);
+        page->texture = 0;
+        free(page->free_rects);
+        page->free_rects = NULL;
+        page->free_rect_capacity = 0;
+        return -1;
+    }
+
+    return g_sprite_atlas_page_count++;
+}
+
+static int atlas_page_alloc_rect(SpriteAtlasPage* page, int sprite_w, int sprite_h,
+                                 int* out_sprite_x, int* out_sprite_y,
+                                 int* out_alloc_x, int* out_alloc_y,
+                                 int* out_alloc_w, int* out_alloc_h) {
+    if (!page) return 0;
+
+    const int need_w = atlas_page_required_extent(sprite_w);
+    const int need_h = atlas_page_required_extent(sprite_h);
+    if (need_w <= 0 || need_h <= 0) return 0;
+    if (need_w > page->w || need_h > page->h) return 0;
+
+    int best_index = -1;
+    int best_area = INT_MAX;
+    for (int i = 0; i < page->free_rect_count; i++) {
+        AtlasFreeRect rect = page->free_rects[i];
+        if (rect.w < need_w || rect.h < need_h) continue;
+        int area = rect.w * rect.h;
+        if (best_index < 0 || area < best_area) {
+            best_index = i;
+            best_area = area;
+        }
+    }
+    if (best_index < 0) return 0;
+
+    AtlasFreeRect slot = page->free_rects[best_index];
+    if (!atlas_page_reserve_rects(page, 2)) {
+        return 0;
+    }
+    atlas_page_remove_rect(page, best_index);
+
+    if (!atlas_page_push_rect(page, (AtlasFreeRect){ slot.x + need_w, slot.y, slot.w - need_w, need_h }) ||
+        !atlas_page_push_rect(page, (AtlasFreeRect){ slot.x, slot.y + need_h, slot.w, slot.h - need_h })) {
+        return 0;
+    }
+
+    page->used_pixels += need_w * need_h;
+    *out_alloc_x = slot.x;
+    *out_alloc_y = slot.y;
+    *out_alloc_w = need_w;
+    *out_alloc_h = need_h;
+    *out_sprite_x = slot.x + SPRITE_ATLAS_PAD;
+    *out_sprite_y = slot.y + SPRITE_ATLAS_PAD;
+    return 1;
+}
+
+static void atlas_release_rect(int page_index, int alloc_x, int alloc_y, int alloc_w, int alloc_h) {
+    if (page_index < 0 || page_index >= g_sprite_atlas_page_count) return;
+    if (alloc_w <= 0 || alloc_h <= 0) return;
+
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[page_index];
+    atlas_page_clear_region(page, alloc_x, alloc_y, alloc_w, alloc_h);
+    if (atlas_page_push_rect(page, (AtlasFreeRect){ alloc_x, alloc_y, alloc_w, alloc_h })) {
+        page->used_pixels -= alloc_w * alloc_h;
+        if (page->used_pixels < 0) page->used_pixels = 0;
+        atlas_page_coalesce(page);
+    }
+}
+
+static void atlas_log_failure(const char* reason, const char* path, int sprite_w, int sprite_h) {
+    int best_w = 0;
+    int best_h = 0;
+    int best_area = 0;
+    int free_regions = 0;
+    int free_pixels = 0;
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        SpriteAtlasPage* page = &g_sprite_atlas_pages[i];
+        free_regions += page->free_rect_count;
+        free_pixels += atlas_page_free_area(page);
+        for (int j = 0; j < page->free_rect_count; j++) {
+            int area = page->free_rects[j].w * page->free_rects[j].h;
+            if (area > best_area) {
+                best_area = area;
+                best_w = page->free_rects[j].w;
+                best_h = page->free_rects[j].h;
+            }
+        }
+    }
+
+    SDL_Log(
+        "gfx_load_sprite: %s for %s raster=%dx%d pages=%d page=%dx%d gl_max=%d sprites=%d/%d free_pixels=%d free_regions=%d largest_free=%dx%d",
+        reason,
+        path ? path : "(null)",
+        sprite_w,
+        sprite_h,
+        g_sprite_atlas_page_count,
+        g_sprite_atlas_page_w,
+        g_sprite_atlas_page_h,
+        g_sprite_atlas_gl_max_size,
+        g_sprite_count,
+        g_sprite_capacity,
+        free_pixels,
+        free_regions,
+        best_w,
+        best_h);
+}
+
+static int atlas_alloc(int sprite_w, int sprite_h, const char* path,
+                       int* out_page_index, int* out_sprite_x, int* out_sprite_y,
+                       int* out_alloc_x, int* out_alloc_y, int* out_alloc_w, int* out_alloc_h) {
+    atlas_init_config();
+
+    const int need_w = atlas_page_required_extent(sprite_w);
+    const int need_h = atlas_page_required_extent(sprite_h);
+    if (need_w <= 0 || need_h <= 0) {
+        atlas_log_failure("invalid sprite extent", path, sprite_w, sprite_h);
+        return 0;
+    }
+    if (need_w > g_sprite_atlas_page_w || need_h > g_sprite_atlas_page_h) {
+        atlas_log_failure("sprite exceeds atlas page size", path, sprite_w, sprite_h);
+        return 0;
+    }
+
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (atlas_page_alloc_rect(&g_sprite_atlas_pages[i], sprite_w, sprite_h,
+                                  out_sprite_x, out_sprite_y,
+                                  out_alloc_x, out_alloc_y,
+                                  out_alloc_w, out_alloc_h)) {
+            *out_page_index = i;
+            return 1;
+        }
+    }
+
+    int page_index = atlas_add_page();
+    if (page_index < 0) {
+        atlas_log_failure("failed to create atlas page", path, sprite_w, sprite_h);
+        return 0;
+    }
+
+    if (!atlas_page_alloc_rect(&g_sprite_atlas_pages[page_index], sprite_w, sprite_h,
+                               out_sprite_x, out_sprite_y,
+                               out_alloc_x, out_alloc_y,
+                               out_alloc_w, out_alloc_h)) {
+        atlas_log_failure("new atlas page could not fit sprite", path, sprite_w, sprite_h);
+        return 0;
+    }
+
+    *out_page_index = page_index;
+    return 1;
 }
 
 static void ensure_sprite_program(void) {
@@ -2140,9 +2548,12 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
 static void flush_sprites(void) {
     if (g_sprite_vert_count == 0) return;
     ensure_sprite_program();
-    ensure_sprite_atlas();
-    if (g_sprite_program == 0 || g_sprite_atlas_tex == 0) {
+    if (g_sprite_program == 0 ||
+        g_sprite_batch_page < 0 ||
+        g_sprite_batch_page >= g_sprite_atlas_page_count ||
+        g_sprite_atlas_pages[g_sprite_batch_page].texture == 0) {
         g_sprite_vert_count = 0;
+        g_sprite_batch_page = -1;
         return;
     }
 
@@ -2151,7 +2562,7 @@ static void flush_sprites(void) {
 
     glUseProgram(g_sprite_program);
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
+    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_pages[g_sprite_batch_page].texture);
     if (g_sprite_tex_loc >= 0) glUniform1i(g_sprite_tex_loc, 0);
 
     glBindVertexArray(g_sprite_vao);
@@ -2176,6 +2587,7 @@ static void flush_sprites(void) {
     glUseProgram(0);
 
     g_sprite_vert_count = 0;
+    g_sprite_batch_page = -1;
 }
 #endif
 
@@ -2217,10 +2629,8 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
         const int a = cmds[base + 6];
 
         if (w <= 0 || h <= 0) continue;
-        if (handle <= 0 || handle > MAX_SPRITES) continue;
-
-        SpriteEntry* e = &g_sprites[handle - 1];
-        if (!e->used) continue;
+        SpriteEntry* e = sprite_get(handle);
+        if (!e) continue;
 
         if (e->needs_reraster) {
             if (e->path) sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h, 1);
@@ -2234,6 +2644,10 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
         if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
             flush_sprites();
         }
+        if (g_sprite_vert_count > 0 && g_sprite_batch_page != e->page_index) {
+            flush_sprites();
+        }
+        g_sprite_batch_page = e->page_index;
 
         const float af = (float)a / 255.0f;
         const float u0 = e->u0, v0 = e->v0, u1 = e->u1, v1 = e->v1;
@@ -3330,7 +3744,8 @@ STASIS_EXPORT void stasis_gfx_submit_u8(const int32_t* cmd_i32, const float* cmd
 
 static SpriteEntry* sprite_get(int handle) {
     int idx = handle - 1;
-    if (idx < 0 || idx >= MAX_SPRITES) return NULL;
+    if (idx < 0 || idx >= g_sprite_capacity) return NULL;
+    if (!g_sprites) return NULL;
     if (!g_sprites[idx].used) return NULL;
     return &g_sprites[idx];
 }
@@ -3343,15 +3758,6 @@ STASIS_EXPORT int stasis_gfx_poll_reload(int handle) {
     return 1;
 }
 
-static int sprite_find_by_path(const char* path) {
-    for (int i = 0; i < MAX_SPRITES; i++) {
-        if (g_sprites[i].used && g_sprites[i].path && strcmp(g_sprites[i].path, path) == 0) {
-            return i + 1;
-        }
-    }
-    return 0;
-}
-
 static int gfx_should_log_sprite_loads(void) {
     static int cached = -1;
     if (cached != -1) return cached;
@@ -3360,109 +3766,33 @@ static int gfx_should_log_sprite_loads(void) {
     return cached;
 }
 
-static int sprite_build_into_entry(SpriteEntry* e, const char* path, int allow_reuse_slot) {
-    unsigned char* pixels = NULL;
-    int w = 0, h = 0;
-    if (!bake_svg_to_rgba(path, &pixels, &w, &h)) {
-        SDL_Log("gfx_load_sprite: failed to bake %s", path);
-        return 0;
-    }
-    e->max_w = w;
-    e->max_h = h;
-
-    if (g_use_sdl_renderer) {
-        if (!g_renderer) {
-            free(pixels);
-            return 0;
-        }
-
-        /* SDL expects straight alpha; convert from premultiplied. */
-        for (int i = 0; i < w * h; i++) {
-            unsigned char* p = pixels + i * 4;
-            unsigned char a = p[3];
-            if (a == 0) {
-                p[0] = 0; p[1] = 0; p[2] = 0;
-                continue;
-            }
-            int r = p[0];
-            int g = p[1];
-            int b = p[2];
-            p[0] = (unsigned char)((r * 255 + (a / 2)) / a);
-            p[1] = (unsigned char)((g * 255 + (a / 2)) / a);
-            p[2] = (unsigned char)((b * 255 + (a / 2)) / a);
-        }
-
-        if (e->sdl_tex) {
-            SDL_DestroyTexture(e->sdl_tex);
-            e->sdl_tex = NULL;
-        }
-
-        SDL_Texture* tex = SDL_CreateTexture(g_renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STATIC, w, h);
-        if (!tex) {
-            SDL_Log("gfx_load_sprite: SDL_CreateTexture failed: %s", SDL_GetError());
-            free(pixels);
-            return 0;
-        }
-        SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
-        if (SDL_UpdateTexture(tex, NULL, pixels, w * 4) != 0) {
-            SDL_Log("gfx_load_sprite: SDL_UpdateTexture failed: %s", SDL_GetError());
-            SDL_DestroyTexture(tex);
-            free(pixels);
-            return 0;
-        }
-
-        free(pixels);
-        e->w = w;
-        e->h = h;
-        e->sdl_tex = tex;
-        e->mtime = get_file_mtime(path);
-        return 1;
-    }
-
+static void sprite_set_gl_region(SpriteEntry* e, int page_index, int sprite_x, int sprite_y,
+                                 int alloc_x, int alloc_y, int alloc_w, int alloc_h,
+                                 int sprite_w, int sprite_h) {
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
-        free(pixels);
-        return 0;
-    }
-
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot) {
-        ax = e->atlas_x;
-        ay = e->atlas_y;
-        if (w != e->w || h != e->h) {
-            SDL_Log("gfx_reload: size change not supported (%s %dx%d -> %dx%d)", path, e->w, e->h, w, h);
-            free(pixels);
-            return 0;
-        }
-    } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-            free(pixels);
-            return 0;
-        }
-    }
-
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    free(pixels);
-
-    e->w = w;
-    e->h = h;
-    e->atlas_x = ax;
-    e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
-    e->mtime = get_file_mtime(path);
-    return 1;
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[page_index];
+    e->page_index = page_index;
+    e->atlas_x = sprite_x;
+    e->atlas_y = sprite_y;
+    e->alloc_x = alloc_x;
+    e->alloc_y = alloc_y;
+    e->alloc_w = alloc_w;
+    e->alloc_h = alloc_h;
+    e->u0 = (float)sprite_x / (float)page->w;
+    e->v0 = (float)sprite_y / (float)page->h;
+    e->u1 = (float)(sprite_x + sprite_w) / (float)page->w;
+    e->v1 = (float)(sprite_y + sprite_h) / (float)page->h;
 #else
-    free(pixels);
-    return 0;
+    (void)e;
+    (void)page_index;
+    (void)sprite_x;
+    (void)sprite_y;
+    (void)alloc_x;
+    (void)alloc_y;
+    (void)alloc_w;
+    (void)alloc_h;
+    (void)sprite_w;
+    (void)sprite_h;
 #endif
 }
 
@@ -3523,6 +3853,13 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
         e->h = h;
         e->max_w = max_w;
         e->max_h = max_h;
+        e->page_index = -1;
+        e->atlas_x = 0;
+        e->atlas_y = 0;
+        e->alloc_x = 0;
+        e->alloc_y = 0;
+        e->alloc_w = 0;
+        e->alloc_h = 0;
         e->sdl_tex = tex;
         e->mtime = get_file_mtime(path);
         e->needs_reraster = 0;
@@ -3530,52 +3867,50 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
     }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    ensure_sprite_atlas();
-    if (g_sprite_atlas_tex == 0) {
-        free(pixels);
-        return 0;
+    if (g_sprite_vert_count > 0) {
+        flush_sprites();
     }
 
-    int ax = 0, ay = 0;
-    if (allow_reuse_slot && e->w > 0 && e->h > 0) {
-        /* For re-rasterization, we may need to reallocate if size changed significantly */
-        if (w != e->w || h != e->h) {
-            /* Size changed - need new atlas slot. For now, just allocate new. */
-            /* TODO: could free old slot, but atlas doesn't support that yet */
-            if (!atlas_alloc(w, h, &ax, &ay)) {
-                SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
-                free(pixels);
-                return 0;
-            }
-        } else {
-            ax = e->atlas_x;
-            ay = e->atlas_y;
-        }
-    } else {
-        if (!atlas_alloc(w, h, &ax, &ay)) {
-            SDL_Log("gfx_load_sprite: atlas full for %s (%dx%d)", path, w, h);
+    const int can_reuse_existing =
+        allow_reuse_slot && e->w > 0 && e->h > 0 && e->page_index >= 0 &&
+        w == e->w && h == e->h;
+
+    int page_index = e->page_index;
+    int sprite_x = e->atlas_x;
+    int sprite_y = e->atlas_y;
+    int alloc_x = e->alloc_x;
+    int alloc_y = e->alloc_y;
+    int alloc_w = e->alloc_w;
+    int alloc_h = e->alloc_h;
+
+    if (!can_reuse_existing) {
+        if (!atlas_alloc(w, h, path, &page_index, &sprite_x, &sprite_y, &alloc_x, &alloc_y, &alloc_w, &alloc_h)) {
             free(pixels);
             return 0;
         }
     }
 
-    glBindTexture(GL_TEXTURE_2D, g_sprite_atlas_tex);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, ax, ay, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    glGenerateMipmap(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, 0);
+    SpriteAtlasPage* page = &g_sprite_atlas_pages[page_index];
+    atlas_page_clear_region(page, alloc_x, alloc_y, alloc_w, alloc_h);
+    if (!atlas_page_upload_region(page, sprite_x, sprite_y, w, h, pixels)) {
+        if (!can_reuse_existing) {
+            atlas_release_rect(page_index, alloc_x, alloc_y, alloc_w, alloc_h);
+        }
+        free(pixels);
+        return 0;
+    }
 
     free(pixels);
+
+    if (!can_reuse_existing && e->page_index >= 0 && e->alloc_w > 0 && e->alloc_h > 0) {
+        atlas_release_rect(e->page_index, e->alloc_x, e->alloc_y, e->alloc_w, e->alloc_h);
+    }
 
     e->w = w;
     e->h = h;
     e->max_w = max_w;
     e->max_h = max_h;
-    e->atlas_x = ax;
-    e->atlas_y = ay;
-    e->u0 = (float)ax / (float)SPRITE_ATLAS_W;
-    e->v0 = (float)ay / (float)SPRITE_ATLAS_H;
-    e->u1 = (float)(ax + w) / (float)SPRITE_ATLAS_W;
-    e->v1 = (float)(ay + h) / (float)SPRITE_ATLAS_H;
+    sprite_set_gl_region(e, page_index, sprite_x, sprite_y, alloc_x, alloc_y, alloc_w, alloc_h, w, h);
     e->mtime = get_file_mtime(path);
     e->needs_reraster = 0;
     return 1;
@@ -3593,7 +3928,7 @@ static void gfx_asset_watch_apply_pending_changes(void) {
         return;
     }
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < g_sprite_capacity; i++) {
         SpriteEntry* e = &g_sprites[i];
         if (!e->used || !e->path) continue;
 
@@ -3629,31 +3964,59 @@ STASIS_EXPORT int stasis_gfx_load_sprite(const char* path, int max_w, int max_h)
 
     /* Note: We don't check for existing sprites with same path because
      * the same SVG might be loaded at different sizes */
+    if (!ensure_sprite_table_capacity(1)) {
+        SDL_Log("gfx_load_sprite: sprite table allocation failed for %s", resolved);
+        return 0;
+    }
 
-    for (int i = 0; i < MAX_SPRITES; i++) {
-        if (!g_sprites[i].used) {
-            SpriteEntry* e = &g_sprites[i];
-            memset(e, 0, sizeof(*e));
-            e->path = stasis_strdup(resolved);
-            if (!e->path) return 0;
-            e->used = 1;
-            if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
-                free(e->path);
-                memset(e, 0, sizeof(*e));
-                return 0;
+    int slot = -1;
+    while (slot < 0) {
+        for (int i = 0; i < g_sprite_capacity; i++) {
+            if (!g_sprites[i].used) {
+                slot = i;
+                break;
             }
-            g_sprite_count++;
-            if (gfx_should_log_sprite_loads()) {
-                SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d (%s)",
-                        resolved, max_w, max_h, i + 1, e->w, e->h,
-                        g_use_sdl_renderer ? "sdl" : "gl");
-            }
-            return i + 1;
+        }
+        if (slot >= 0) break;
+        if (!ensure_sprite_table_capacity(g_sprite_capacity + 1)) {
+            SDL_Log("gfx_load_sprite: sprite table full for %s sprites=%d capacity=%d limit=%d",
+                    resolved,
+                    g_sprite_count,
+                    g_sprite_capacity,
+                    g_sprite_table_limit);
+            return 0;
         }
     }
 
-    SDL_Log("gfx_load_sprite: MAX_SPRITES reached");
-    return 0;
+    SpriteEntry* e = &g_sprites[slot];
+    memset(e, 0, sizeof(*e));
+    e->page_index = -1;
+    e->path = stasis_strdup(resolved);
+    if (!e->path) return 0;
+    e->used = 1;
+    if (!sprite_build_into_entry_sized(e, resolved, max_w, max_h, 0)) {
+        free(e->path);
+        memset(e, 0, sizeof(*e));
+        e->page_index = -1;
+        return 0;
+    }
+
+    g_sprite_count++;
+    if (gfx_should_log_sprite_loads()) {
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+        const int page_count_for_log = g_use_sdl_renderer ? 0 : g_sprite_atlas_page_count;
+#else
+        const int page_count_for_log = 0;
+#endif
+        SDL_Log("gfx_load_sprite: %s (%dx%d) -> handle=%d raster=%dx%d backend=%s page=%d pages=%d sprites=%d/%d",
+                resolved, max_w, max_h, slot + 1, e->w, e->h,
+                g_use_sdl_renderer ? "sdl" : "gl",
+                e->page_index,
+                page_count_for_log,
+                g_sprite_count,
+                g_sprite_capacity);
+    }
+    return slot + 1;
 }
 
 /*
@@ -3725,6 +4088,10 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
     if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
         flush_sprites();
     }
+    if (g_sprite_vert_count > 0 && g_sprite_batch_page != e->page_index) {
+        flush_sprites();
+    }
+    g_sprite_batch_page = e->page_index;
 #endif
 
     float hw = (float)w * 0.5f;
@@ -4015,12 +4382,26 @@ STASIS_EXPORT void stasis_shutdown(void) {
         glDeleteVertexArrays(1, &g_sprite_vao);
         g_sprite_vao = 0;
     }
-    if (g_sprite_atlas_tex) {
-        glDeleteTextures(1, &g_sprite_atlas_tex);
-        g_sprite_atlas_tex = 0;
+    for (int i = 0; i < g_sprite_atlas_page_count; i++) {
+        if (g_sprite_atlas_pages[i].texture) {
+            glDeleteTextures(1, &g_sprite_atlas_pages[i].texture);
+            g_sprite_atlas_pages[i].texture = 0;
+        }
+        free(g_sprite_atlas_pages[i].free_rects);
+        g_sprite_atlas_pages[i].free_rects = NULL;
+        g_sprite_atlas_pages[i].free_rect_count = 0;
+        g_sprite_atlas_pages[i].free_rect_capacity = 0;
     }
+    free(g_sprite_atlas_pages);
+    g_sprite_atlas_pages = NULL;
+    g_sprite_atlas_page_count = 0;
+    g_sprite_atlas_page_capacity = 0;
+    g_sprite_atlas_page_w = 0;
+    g_sprite_atlas_page_h = 0;
+    g_sprite_atlas_gl_max_size = 0;
+    g_sprite_batch_page = -1;
 #endif
-    for (int i = 0; i < MAX_SPRITES; i++) {
+    for (int i = 0; i < g_sprite_capacity; i++) {
         if (g_sprites[i].used) {
             if (g_sprites[i].sdl_tex) {
                 SDL_DestroyTexture(g_sprites[i].sdl_tex);
@@ -4030,6 +4411,11 @@ STASIS_EXPORT void stasis_shutdown(void) {
             memset(&g_sprites[i], 0, sizeof(g_sprites[i]));
         }
     }
+    free(g_sprites);
+    g_sprites = NULL;
+    g_sprite_capacity = 0;
+    g_sprite_count = 0;
+    g_sprite_table_limit = -1;
 
     for (int i = 0; i < MAX_FONTS; i++) {
         if (g_fonts[i].active) {


### PR DESCRIPTION
## Summary
- replace the fixed sprite array with a growable sprite handle table
- replace the single fixed GL atlas with paged atlas textures plus reusable free-rect allocation
- add runtime atlas configuration and clearer atlas failure diagnostics, and document the new env vars

## Verification
- `./tools/validate_repo.sh`

## Environment Limits
- Native runtime build verification was blocked here because `cmake` is not installed.
- Direct `gcc -fsyntax-only runtime/stasis_graphics.c -Iruntime -DSTASIS_GRAPHICS_STATIC -DSTASIS_GRAPHICS_SDL_ONLY` also stops immediately because SDL development headers are not installed (`SDL.h` missing).

Closes #263
