### PR TITLE
fix: support GPT-5+ pricing and device-wide budget

### DIFF
--- a/docs/android_workshop_codex_harness.md
+++ b/docs/android_workshop_codex_harness.md
@@ -1,0 +1,93 @@
+# Android Workshop Codex Harness
+
+## Outcome
+
+The Workshop should support two AI providers without changing its role as the
+authoritative UI and runtime harness:
+
+1. **Direct API mode** sends Responses API requests from the Android device. It
+   enforces one device-wide monthly USD limit. There is no separate per-action
+   or per-run limit.
+2. **Codex subscription mode** pairs the Android Workshop with a trusted desktop
+   companion running `codex app-server`. Codex signs in with ChatGPT on the
+   desktop, while the Workshop supplies the Stasis-specific tools and displays
+   progress, approvals, and results.
+
+This follows the supported Codex authentication split: ChatGPT sign-in uses
+subscription entitlements, while API-key sign-in uses usage-based Platform
+billing. See [Codex authentication](https://learn.chatgpt.com/docs/auth).
+
+## Recommended boundary
+
+```text
+Android Workshop
+  voice, prompt, source/runtime state, screenshots, approvals
+        |
+        | outbound authenticated TLS pairing
+        v
+Desktop companion
+  secure session relay + Workshop MCP proxy
+        |
+        | local stdio JSON-RPC
+        v
+codex app-server
+  ChatGPT login, threads, turns, events, rate limits
+```
+
+`codex app-server` is the supported integration surface for embedding Codex in
+another product. It provides account login, thread/turn lifecycle, streaming
+events, approvals, and rate-limit reads. Its WebSocket transport is currently
+experimental, so the companion should use the stable stdio transport and own
+the authenticated network connection to the phone. See the
+[Codex app-server documentation](https://learn.chatgpt.com/docs/app-server).
+
+The app-server must not be exposed directly to the public network. The phone
+initiates pairing to a companion with TLS, a high-entropy one-time pairing
+secret, explicit user approval, and a pinned device identity. This is consistent
+with the security guidance for [Codex remote connections](https://learn.chatgpt.com/docs/remote-connections).
+
+## Workshop as the harness
+
+The phone remains authoritative for the running Stasis project. The companion
+exposes a local MCP server to Codex and relays its tool calls to the paired
+Workshop. The first tool set should cover the existing Workshop operations:
+
+- list and read symbols
+- update source or a symbol
+- compile and run tests
+- capture the rendered game
+- inspect runtime diagnostics
+- request an explicit approval for consequential changes
+
+The app-server owns generic agent behavior: conversation history, turn state,
+streaming progress, tool-call routing, cancellation, and approvals. This avoids
+reimplementing the Codex agent loop on Android while preserving the Workshop's
+specialized Stasis context.
+
+## Authentication and limits
+
+For an individual ChatGPT account, authentication occurs interactively on the
+trusted desktop using browser or device-code login. ChatGPT credentials and
+tokens are never copied to or extracted by the Android application. Codex access
+tokens are an additional automation option for supported Business and Enterprise
+workspaces; see [Codex access tokens](https://learn.chatgpt.com/docs/enterprise/access-tokens).
+
+Budget presentation depends on provider:
+
+- **Direct API:** show estimated API cost and enforce the device-wide monthly
+  USD limit after every response or image generation.
+- **Codex subscription:** do not estimate dollars. Read and display the Codex
+  account limits from `account/rateLimits/read` and subscribe to
+  `account/rateLimits/updated`.
+
+## Implementation slices
+
+1. Remove the direct API per-run limit and retain the device monthly cap.
+2. Build a desktop companion prototype with local app-server process management
+   and authenticated phone pairing.
+3. Implement app-server initialization, account status, thread resume/start,
+   turn streaming, cancellation, and approvals.
+4. Relay the Workshop tool surface through an MCP proxy and test a complete
+   edit-compile-run-screenshot loop.
+5. Add an API/Codex provider selector, subscription rate-limit display, session
+   recovery, and an explicit API fallback.

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -92,6 +92,10 @@ android {
     }
 }
 
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+}
+
 tasks.register('prepareWorkshopAssets', Sync) {
     from(file('src/main/assets')) {
         exclude 'workshop_sample/build/**'

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiBudgetPolicyTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiBudgetPolicyTest.java
@@ -1,0 +1,23 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopAiBudgetPolicyTest {
+    @Test
+    public void usesOnlyTheDeviceMonthlyLimit() {
+        assertTrue(WorkshopAiBudgetPolicy.canStart(5.00, 0.09));
+        assertEquals(4.91, WorkshopAiBudgetPolicy.remainingUsd(5.00, 0.09), 0.0000001);
+        assertFalse(WorkshopAiBudgetPolicy.canStart(5.00, 5.00));
+        assertFalse(WorkshopAiBudgetPolicy.canStart(0.00, 0.00));
+    }
+
+    @Test
+    public void neverReturnsNegativeRemainingBudget() {
+        assertEquals(0.0, WorkshopAiBudgetPolicy.remainingUsd(5.00, 5.25), 0.0);
+        assertEquals(5.0, WorkshopAiBudgetPolicy.remainingUsd(5.00, -1.00), 0.0);
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiPricingTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiPricingTest.java
@@ -9,16 +9,39 @@ import org.junit.Test;
 
 public final class WorkshopAiPricingTest {
     @Test
-    public void recognizesEverySupportedGpt56ModelAndAlias() {
+    public void recognizesSupportedGpt5AndLaterModelsAndSnapshots() {
+        String[] models = {
+                "gpt-5", "gpt-5-2025-08-07", "gpt-5-mini", "gpt-5-mini-2025-08-07",
+                "gpt-5-nano", "gpt-5-nano-2025-08-07", "gpt-5-pro", "gpt-5-pro-2025-10-06",
+                "gpt-5.1", "gpt-5.1-2025-11-13", "gpt-5.2", "gpt-5.2-2025-12-11",
+                "gpt-5.2-pro", "gpt-5.2-pro-2025-12-11", "gpt-5.3-codex",
+                "gpt-5.4", "gpt-5.4-2026-03-05", "gpt-5.4-mini", "gpt-5.4-mini-2026-03-17",
+                "gpt-5.4-nano", "gpt-5.4-nano-2026-03-17", "gpt-5.4-pro", "gpt-5.4-pro-2026-03-05",
+                "gpt-5.5", "gpt-5.5-2026-04-23", "gpt-5.5-pro", "gpt-5.5-pro-2026-04-23",
+                "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"
+        };
+        for (String model : models) assertTrue(model, WorkshopAiPricing.isKnown(model));
         assertTrue(WorkshopAiPricing.isKnown("gpt-5.6"));
-        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-sol"));
-        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-terra"));
-        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-luna"));
+        assertFalse(WorkshopAiPricing.isKnown("gpt-5.2-chat-latest"));
+        assertFalse(WorkshopAiPricing.isKnown("gpt-5.2-codex"));
+        assertFalse(WorkshopAiPricing.isKnown("gpt-5.3-codex-spark"));
         assertFalse(WorkshopAiPricing.isKnown("gpt-5.6-unknown"));
     }
 
     @Test
     public void exposesPublishedStandardAndCacheWriteRates() {
+        assertRates("gpt-5", 1.25, 0.125, 1.25, 10.00);
+        assertRates("gpt-5-mini", 0.25, 0.025, 0.25, 2.00);
+        assertRates("gpt-5-nano", 0.05, 0.005, 0.05, 0.40);
+        assertRates("gpt-5-pro", 15.00, 15.00, 15.00, 120.00);
+        assertRates("gpt-5.2", 1.75, 0.175, 1.75, 14.00);
+        assertRates("gpt-5.2-pro", 21.00, 21.00, 21.00, 168.00);
+        assertRates("gpt-5.4", 2.50, 0.25, 2.50, 15.00);
+        assertRates("gpt-5.4-mini", 0.75, 0.075, 0.75, 4.50);
+        assertRates("gpt-5.4-nano", 0.20, 0.02, 0.20, 1.25);
+        assertRates("gpt-5.4-pro", 30.00, 30.00, 30.00, 180.00);
+        assertRates("gpt-5.5", 5.00, 0.50, 5.00, 30.00);
+        assertRates("gpt-5.5-pro", 30.00, 30.00, 30.00, 180.00);
         assertRates("gpt-5.6-sol", 5.00, 0.50, 6.25, 30.00);
         assertRates("gpt-5.6-terra", 2.50, 0.25, 3.125, 15.00);
         assertRates("gpt-5.6-luna", 1.00, 0.10, 1.25, 6.00);
@@ -32,6 +55,18 @@ public final class WorkshopAiPricingTest {
         assertEquals(24.0, rates.estimate(300_000, 0, 0, 1_000_000), 0.0000001);
         assertEquals(1.875, rates.conservativeInputCostUsd(300_000), 0.0000001);
         assertEquals(22.5, rates.effectiveOutputUsdPerMillion(300_000), 0.0000001);
+        WorkshopAiPricing.Rates legacy = WorkshopAiPricing.forModel("gpt-5.2");
+        assertNotNull(legacy);
+        assertEquals(legacy.outputUsdPerMillion, legacy.effectiveOutputUsdPerMillion(300_000), 0.0);
+    }
+
+    @Test
+    public void exposesModelSpecificRequestCompatibility() {
+        assertFalse(WorkshopAiPricing.forModel("gpt-5.5").explicitCacheBreakpoints);
+        assertTrue(WorkshopAiPricing.forModel("gpt-5.6-sol").explicitCacheBreakpoints);
+        assertEquals("high", WorkshopAiPricing.forModel("gpt-5-pro").reasoningEffort);
+        assertFalse(WorkshopAiPricing.forModel("gpt-5.2-pro").structuredOutputs);
+        assertFalse(WorkshopAiPricing.forModel("gpt-5.4-pro").structuredOutputs);
     }
 
     private static void assertRates(String model, double input, double cached, double cacheWrite,

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiPricingTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiPricingTest.java
@@ -1,0 +1,46 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopAiPricingTest {
+    @Test
+    public void recognizesEverySupportedGpt56ModelAndAlias() {
+        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6"));
+        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-sol"));
+        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-terra"));
+        assertTrue(WorkshopAiPricing.isKnown("gpt-5.6-luna"));
+        assertFalse(WorkshopAiPricing.isKnown("gpt-5.6-unknown"));
+    }
+
+    @Test
+    public void exposesPublishedStandardAndCacheWriteRates() {
+        assertRates("gpt-5.6-sol", 5.00, 0.50, 6.25, 30.00);
+        assertRates("gpt-5.6-terra", 2.50, 0.25, 3.125, 15.00);
+        assertRates("gpt-5.6-luna", 1.00, 0.10, 1.25, 6.00);
+    }
+
+    @Test
+    public void estimatesUsageWithCacheAndLongContextMultipliers() {
+        WorkshopAiPricing.Rates rates = WorkshopAiPricing.forModel("gpt-5.6-terra");
+        assertNotNull(rates);
+        assertEquals(0.0191875, rates.estimate(2_000, 500, 500, 1_000), 0.0000001);
+        assertEquals(24.0, rates.estimate(300_000, 0, 0, 1_000_000), 0.0000001);
+        assertEquals(1.875, rates.conservativeInputCostUsd(300_000), 0.0000001);
+        assertEquals(22.5, rates.effectiveOutputUsdPerMillion(300_000), 0.0000001);
+    }
+
+    private static void assertRates(String model, double input, double cached, double cacheWrite,
+            double output) {
+        WorkshopAiPricing.Rates rates = WorkshopAiPricing.forModel(model);
+        assertNotNull(rates);
+        assertEquals(input, rates.inputUsdPerMillion, 0.0);
+        assertEquals(cached, rates.cachedInputUsdPerMillion, 0.0);
+        assertEquals(cacheWrite, rates.cacheWriteUsdPerMillion, 0.0);
+        assertEquals(output, rates.outputUsdPerMillion, 0.0);
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -104,7 +104,6 @@ public final class MainActivity extends Activity {
     private static final String GITHUB_PREF_REVIEW_FINGERPRINT = "github_review_fingerprint";
     private static final String AI_TRACE_LOG = "ai_trace.jsonl";
     private static final String DEFAULT_AI_MODEL = "gpt-5.6-sol";
-    private static final String DEFAULT_AI_REASONING_EFFORT = "medium";
     private static final int DEFAULT_AI_MODEL_VERSION = 2;
     private static final String AI_PROMPT_CACHE_KEY = "stasis-android-workshop-v2";
     private static final long AI_TRACE_RETENTION_MS = 24L * 60L * 60L * 1000L;
@@ -5085,7 +5084,8 @@ public final class MainActivity extends Activity {
         return "function";
     }
 
-    private JSONArray buildAiOpenAiInput(String requestJson, boolean includeImages) throws Exception {
+    private JSONArray buildAiOpenAiInput(String requestJson, boolean includeImages,
+            boolean explicitCacheBreakpoints) throws Exception {
         JSONObject request = new JSONObject(requestJson);
         JSONObject stableRequest = request.optJSONObject("original_request");
         JSONObject volatileRequest = new JSONObject();
@@ -5105,7 +5105,7 @@ public final class MainActivity extends Activity {
         stableInstruction += " write_symbol creates or replaces a symbol. Before writing, inspect the current target. Follow game_design_rules, prefer_lifecycle_local_state, avoid_global_tick_for_per_entity_progression, and architecture_recommendations. Follow architecture_recommendations. Use command/event-style functions for durable gameplay concepts. Tool errors, validation_error observations, and test_observation failures are not final; correct them before returning mode=done. A failed write batch rolls back the whole batch and returns diagnostics.";
         JSONArray input = new JSONArray()
                 .put(aiInputMessage("system", stableInstruction, false))
-                .put(aiInputMessage("user", "Stable request context: " + stableRequest.toString(), true));
+                .put(aiInputMessage("user", "Stable request context: " + stableRequest.toString(), explicitCacheBreakpoints));
         if (includeImages && !activeAiImageAttachments.isEmpty()) {
             input.put(aiImageInputMessage(activeAiImageAttachments));
         }
@@ -5144,7 +5144,8 @@ public final class MainActivity extends Activity {
             boolean reserveImageGeneration) throws Exception {
         WorkshopAiPricing.Rates pricing = WorkshopAiPricing.forModel(model);
         if (pricing == null) throw new IOException("AI pricing is unavailable for " + model);
-        byte[] inputBytes = buildAiOpenAiInput(requestJson, false).toString().getBytes(StandardCharsets.UTF_8);
+        byte[] inputBytes = buildAiOpenAiInput(requestJson, false, pricing.explicitCacheBreakpoints)
+                .toString().getBytes(StandardCharsets.UTF_8);
         long imageTokens = 0L;
         for (AiImageAttachment attachment : activeAiImageAttachments) imageTokens += attachment.estimatedPatchTokens();
         long conservativeInputTokens = inputBytes.length + imageTokens;
@@ -5161,14 +5162,18 @@ public final class MainActivity extends Activity {
 
     private AiApiResponse callOpenAiResponsesApi(String apiKey, String model, String requestJson,
             int maxOutputTokens, boolean allowImageGeneration) throws Exception {
+        WorkshopAiPricing.Rates pricing = WorkshopAiPricing.forModel(model);
+        if (pricing == null) throw new IOException("AI pricing is unavailable for " + model);
         JSONObject payload = new JSONObject();
         payload.put("model", model);
-        payload.put("reasoning", new JSONObject().put("effort", DEFAULT_AI_REASONING_EFFORT));
+        payload.put("reasoning", new JSONObject().put("effort", pricing.reasoningEffort));
         payload.put("max_output_tokens", maxOutputTokens);
         payload.put("prompt_cache_key", AI_PROMPT_CACHE_KEY);
-        payload.put("prompt_cache_options", new JSONObject().put("mode", "explicit").put("ttl", "30m"));
-        payload.put("text", buildAiResponseTextFormat());
-        payload.put("input", buildAiOpenAiInput(requestJson, true));
+        if (pricing.explicitCacheBreakpoints) {
+            payload.put("prompt_cache_options", new JSONObject().put("mode", "explicit").put("ttl", "30m"));
+        }
+        if (pricing.structuredOutputs) payload.put("text", buildAiResponseTextFormat());
+        payload.put("input", buildAiOpenAiInput(requestJson, true, pricing.explicitCacheBreakpoints));
         if (allowImageGeneration) {
             payload.put("tools", new JSONArray().put(new JSONObject()
                     .put("type", "image_generation")

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -90,7 +90,6 @@ public final class MainActivity extends Activity {
     private static final String AI_PREF_LAST_USAGE = "last_ai_usage";
     private static final String AI_PREF_COMMAND_HISTORY_PREFIX = "command_history_";
     private static final String AI_PREF_OUTCOME_HISTORY_PREFIX = "outcome_history_";
-    private static final String AI_PREF_MAX_RUN_USD = "max_run_usd";
     private static final String AI_PREF_MONTHLY_LIMIT_USD = "monthly_limit_usd";
     private static final String AI_PREF_MONTH_KEY = "monthly_spend_month";
     private static final String AI_PREF_MONTH_SPEND_USD = "monthly_spend_usd";
@@ -153,7 +152,6 @@ public final class MainActivity extends Activity {
     private EditText aiPromptEditor;
     private EditText aiApiKeyEditor;
     private EditText aiModelEditor;
-    private EditText aiMaxRunUsdEditor;
     private EditText aiMonthlyLimitUsdEditor;
     private TextView aiBudgetStatus;
     private TextView aiAttachmentStatus;
@@ -1603,14 +1601,8 @@ public final class MainActivity extends Activity {
         reasoningSummary.setTextSize(12.0f);
         aiSettingsBody.addView(reasoningSummary, fullWidth());
 
-        aiMaxRunUsdEditor = new EditText(this);
-        aiMaxRunUsdEditor.setHint("Maximum USD per AI run");
-        aiMaxRunUsdEditor.setSingleLine(true);
-        aiMaxRunUsdEditor.setText(aiPrefs.getString(AI_PREF_MAX_RUN_USD, "0.25"));
-        aiSettingsBody.addView(aiMaxRunUsdEditor, fullWidth());
-
         aiMonthlyLimitUsdEditor = new EditText(this);
-        aiMonthlyLimitUsdEditor.setHint("Monthly AI limit USD");
+        aiMonthlyLimitUsdEditor.setHint("Device monthly AI limit USD");
         aiMonthlyLimitUsdEditor.setSingleLine(true);
         aiMonthlyLimitUsdEditor.setText(aiPrefs.getString(AI_PREF_MONTHLY_LIMIT_USD, "5.00"));
         aiSettingsBody.addView(aiMonthlyLimitUsdEditor, fullWidth());
@@ -3146,19 +3138,17 @@ public final class MainActivity extends Activity {
     private void saveAiSettingsFromEditors() {
         String apiKey = aiApiKeyEditor == null ? "" : aiApiKeyEditor.getText().toString().trim();
         String model = aiModelEditor == null ? "" : aiModelEditor.getText().toString().trim();
-        String maxRunText = aiMaxRunUsdEditor == null ? "0.25" : aiMaxRunUsdEditor.getText().toString().trim();
         String monthlyLimitText = aiMonthlyLimitUsdEditor == null ? "5.00" : aiMonthlyLimitUsdEditor.getText().toString().trim();
         if (apiKey.isEmpty()) {
             setStatusText("AI settings need an API key before a run can start");
             return;
         }
-        if (parseNonNegativeUsd(maxRunText) < 0.0 || parseNonNegativeUsd(monthlyLimitText) < 0.0) {
-            setStatusText("AI budget limits must be non-negative USD values");
+        if (parseNonNegativeUsd(monthlyLimitText) < 0.0) {
+            setStatusText("The device monthly AI limit must be a non-negative USD value");
             return;
         }
         if (!saveAiSettings(apiKey, model.isEmpty() ? DEFAULT_AI_MODEL : model)) return;
         getSharedPreferences(AI_PREFS, MODE_PRIVATE).edit()
-                .putString(AI_PREF_MAX_RUN_USD, maxRunText)
                 .putString(AI_PREF_MONTHLY_LIMIT_USD, monthlyLimitText)
                 .apply();
         refreshAiBudgetStatus();
@@ -3420,7 +3410,6 @@ public final class MainActivity extends Activity {
         if (model.isEmpty()) {
             model = DEFAULT_AI_MODEL;
         }
-        double maxRunUsd = configuredAiLimit(AI_PREF_MAX_RUN_USD, "0.25");
         double monthlyLimitUsd = configuredAiLimit(AI_PREF_MONTHLY_LIMIT_USD, "5.00");
         final boolean requestImageGeneration = queuedEntry == null
                 ? allowAiImageGeneration != null && allowAiImageGeneration.isChecked()
@@ -3431,10 +3420,10 @@ public final class MainActivity extends Activity {
             failQueuedAiPreflight(queuedEntry, "Model pricing was unavailable at execution time");
             return;
         }
-        if (maxRunUsd <= 0.0 || monthlyLimitUsd <= 0.0 || monthlyAiSpendUsd() >= monthlyLimitUsd) {
-            setStatusText("AI run blocked by configured spending limit; open AI Settings");
+        if (!WorkshopAiBudgetPolicy.canStart(monthlyLimitUsd, monthlyAiSpendUsd())) {
+            setStatusText("AI run blocked by the device monthly spending limit; open AI Settings");
             updateAiProgress(0, 0, "budget blocked");
-            failQueuedAiPreflight(queuedEntry, "Configured spending limit blocked execution");
+            failQueuedAiPreflight(queuedEntry, "Device monthly AI limit blocked execution");
             return;
         }
         recordCommandHistory(prompt);
@@ -3493,11 +3482,11 @@ public final class MainActivity extends Activity {
             failQueuedAiPreflight(queuedEntry, "Attachment snapshot failed validation: " + error.getMessage());
             return;
         }
-        if (requestImageGeneration && (maxRunUsd < GPT_IMAGE_2_LOW_1024_USD
-                || monthlyLimitUsd - monthlyAiSpendUsd() < GPT_IMAGE_2_LOW_1024_USD)) {
-            setStatusText("AI image generation blocked: spending limits do not cover the reserved image output");
+        if (requestImageGeneration && WorkshopAiBudgetPolicy.remainingUsd(
+                monthlyLimitUsd, monthlyAiSpendUsd()) < GPT_IMAGE_2_LOW_1024_USD) {
+            setStatusText("AI image generation blocked: the device monthly limit does not cover the reserved image output");
             updateAiProgress(0, 0, "image budget blocked");
-            failQueuedAiPreflight(queuedEntry, "Image generation reserve exceeded the spending limit");
+            failQueuedAiPreflight(queuedEntry, "Image generation reserve exceeded the device monthly AI limit");
             return;
         }
         final String requestJson = buildAiCodeRequestJson(prompt, symbol, selectedSource, aiProject,
@@ -3844,10 +3833,9 @@ public final class MainActivity extends Activity {
         String previousToolCallBatch = "";
         for (int turn = 0; turn < MAX_AI_AGENT_TURNS; turn += 1) {
             throwIfAiCancelled();
-            double maxRunUsd = configuredAiLimit(AI_PREF_MAX_RUN_USD, "0.25");
             double monthlyLimitUsd = configuredAiLimit(AI_PREF_MONTHLY_LIMIT_USD, "5.00");
-            if (usage.estimatedCostUsd >= maxRunUsd || monthlyAiSpendUsd() >= monthlyLimitUsd) {
-                throw new IOException("AI spending limit reached before agent turn " + (turn + 1));
+            if (!WorkshopAiBudgetPolicy.canStart(monthlyLimitUsd, monthlyAiSpendUsd())) {
+                throw new IOException("Device monthly AI spending limit reached before agent turn " + (turn + 1));
             }
             session.currentStep = turn + 1;
             postAiProgress(session.currentStep, session.actionCount, "calling AI");
@@ -3855,7 +3843,7 @@ public final class MainActivity extends Activity {
                     .put("turn", session.currentStep)
                     .put("model", model)
                     .put("summary", summarizeAiRequestForTrace(currentRequestJson)));
-            double remainingUsd = Math.min(maxRunUsd - usage.estimatedCostUsd, monthlyLimitUsd - monthlyAiSpendUsd());
+            double remainingUsd = WorkshopAiBudgetPolicy.remainingUsd(monthlyLimitUsd, monthlyAiSpendUsd());
             boolean allowImageOnThisTurn = allowImageGeneration && turn == 0;
             int maxOutputTokens = maxOutputTokensForBudget(model, currentRequestJson, remainingUsd, allowImageOnThisTurn);
             AiApiResponse apiResponse = callOpenAiResponsesApi(
@@ -5155,7 +5143,7 @@ public final class MainActivity extends Activity {
         int outputTokens = (int)Math.floor(outputBudget * 1000000.0
                 / pricing.effectiveOutputUsdPerMillion(conservativeInputTokens));
         if (outputTokens < 64) {
-            throw new IOException("AI spending limit leaves insufficient budget for another response");
+            throw new IOException("Device monthly AI limit leaves insufficient budget for another response");
         }
         return Math.min(MAX_AI_OUTPUT_TOKENS, outputTokens);
     }

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -133,10 +133,6 @@ public final class MainActivity extends Activity {
     private static final int IMPORT_IMAGE_REQUEST = 73;
     private static final int IMPORT_AUDIO_REQUEST = 74;
     private static final int EXPORT_SUPPORT_BUNDLE_REQUEST = 75;
-    private static final double GPT_5_6_SOL_INPUT_USD_PER_MILLION = 5.00;
-    private static final double GPT_5_6_SOL_CACHED_INPUT_USD_PER_MILLION = 0.50;
-    private static final double GPT_5_6_SOL_CACHE_WRITE_USD_PER_MILLION = 6.25;
-    private static final double GPT_5_6_SOL_OUTPUT_USD_PER_MILLION = 30.00;
     private static final double GPT_IMAGE_2_LOW_1024_USD = 0.006;
     private static final int RENDER_FRAME_HEADER_SIZE = 6;
     private static final int RENDER_COMMAND_STRIDE = 7;
@@ -3862,7 +3858,7 @@ public final class MainActivity extends Activity {
                     .put("summary", summarizeAiRequestForTrace(currentRequestJson)));
             double remainingUsd = Math.min(maxRunUsd - usage.estimatedCostUsd, monthlyLimitUsd - monthlyAiSpendUsd());
             boolean allowImageOnThisTurn = allowImageGeneration && turn == 0;
-            int maxOutputTokens = maxOutputTokensForBudget(currentRequestJson, remainingUsd, allowImageOnThisTurn);
+            int maxOutputTokens = maxOutputTokensForBudget(model, currentRequestJson, remainingUsd, allowImageOnThisTurn);
             AiApiResponse apiResponse = callOpenAiResponsesApi(
                     apiKey, model, currentRequestJson, maxOutputTokens, allowImageOnThisTurn);
             usage.add(model, apiResponse.usage);
@@ -5144,16 +5140,19 @@ public final class MainActivity extends Activity {
         return new JSONObject().put("role", "user").put("content", content);
     }
 
-    private int maxOutputTokensForBudget(String requestJson, double remainingUsd,
+    private int maxOutputTokensForBudget(String model, String requestJson, double remainingUsd,
             boolean reserveImageGeneration) throws Exception {
+        WorkshopAiPricing.Rates pricing = WorkshopAiPricing.forModel(model);
+        if (pricing == null) throw new IOException("AI pricing is unavailable for " + model);
         byte[] inputBytes = buildAiOpenAiInput(requestJson, false).toString().getBytes(StandardCharsets.UTF_8);
-        double inputRate = Math.max(GPT_5_6_SOL_INPUT_USD_PER_MILLION, GPT_5_6_SOL_CACHE_WRITE_USD_PER_MILLION);
         long imageTokens = 0L;
         for (AiImageAttachment attachment : activeAiImageAttachments) imageTokens += attachment.estimatedPatchTokens();
-        double conservativeInputCost = (inputBytes.length + imageTokens) * inputRate / 1000000.0;
+        long conservativeInputTokens = inputBytes.length + imageTokens;
+        double conservativeInputCost = pricing.conservativeInputCostUsd(conservativeInputTokens);
         double outputBudget = remainingUsd - conservativeInputCost
                 - (reserveImageGeneration ? GPT_IMAGE_2_LOW_1024_USD : 0.0);
-        int outputTokens = (int)Math.floor(outputBudget * 1000000.0 / GPT_5_6_SOL_OUTPUT_USD_PER_MILLION);
+        int outputTokens = (int)Math.floor(outputBudget * 1000000.0
+                / pricing.effectiveOutputUsdPerMillion(conservativeInputTokens));
         if (outputTokens < 64) {
             throw new IOException("AI spending limit leaves insufficient budget for another response");
         }
@@ -5491,23 +5490,29 @@ public final class MainActivity extends Activity {
     }
 
     private static boolean hasKnownAiPricing(String model) {
-        return DEFAULT_AI_MODEL.equals(model);
+        return WorkshopAiPricing.isKnown(model);
     }
 
     private static double estimateAiCostUsd(String model, long inputTokens, long cachedInputTokens, long cacheWriteInputTokens, long outputTokens) {
-        if (!hasKnownAiPricing(model)) {
-            return 0.0;
-        }
-        double inputCost = Math.max(0L, inputTokens - cachedInputTokens - cacheWriteInputTokens) * GPT_5_6_SOL_INPUT_USD_PER_MILLION;
-        double cachedInputCost = cachedInputTokens * GPT_5_6_SOL_CACHED_INPUT_USD_PER_MILLION;
-        double cacheWriteCost = cacheWriteInputTokens * GPT_5_6_SOL_CACHE_WRITE_USD_PER_MILLION;
-        double outputCost = outputTokens * GPT_5_6_SOL_OUTPUT_USD_PER_MILLION;
-        return (inputCost + cachedInputCost + cacheWriteCost + outputCost) / 1000000.0;
+        WorkshopAiPricing.Rates pricing = WorkshopAiPricing.forModel(model);
+        return pricing == null ? 0.0
+                : pricing.estimate(inputTokens, cachedInputTokens, cacheWriteInputTokens, outputTokens);
     }
 
     private static String formatAiCostUsd(double costUsd) {
         return WorkshopMoney.formatUsd(costUsd);
     }
+
+    private String selectedAiModelForPricing() {
+        String model = aiModelEditor == null ? "" : aiModelEditor.getText().toString().trim();
+        return model.isEmpty() ? DEFAULT_AI_MODEL : model;
+    }
+
+    private double selectedAiInputCostUsd(long tokens) {
+        WorkshopAiPricing.Rates pricing = WorkshopAiPricing.forModel(selectedAiModelForPricing());
+        return pricing == null ? 0.0 : pricing.estimate(tokens, 0L, 0L, 0L);
+    }
+
     private void applyAiCodeResponse(AiAgentResult aiResult, SymbolEntry fallbackSymbol) {
         Map<String, String> originalSources = null;
         try {
@@ -6718,8 +6723,8 @@ public final class MainActivity extends Activity {
             long patches = estimatedImagePatchTokens(selected);
             aiAttachmentStatus.setText("AI images: " + selected.size() + " selected, about " + patches
                     + " original-detail image tokens / "
-                    + formatAiCostUsd(patches * GPT_5_6_SOL_INPUT_USD_PER_MILLION / 1000000.0)
-                    + " Sol input (review before Queue AI Change)");
+                    + formatAiCostUsd(selectedAiInputCostUsd(patches))
+                    + " " + selectedAiModelForPricing() + " input (review before Queue AI Change)");
         } catch (Exception error) {
             aiAttachmentStatus.setText("AI images: selection needs review - " + error.getMessage());
         }
@@ -6853,8 +6858,8 @@ public final class MainActivity extends Activity {
         screenshotAttachmentStatus.setText("AI preview: " + selections + " - "
                 + pendingPreviewScreenshot.getWidth() + "x" + pendingPreviewScreenshot.getHeight()
                 + (attachPreviewPixels ? ", about " + patches + " image tokens / "
-                        + formatAiCostUsd(patches * GPT_5_6_SOL_INPUT_USD_PER_MILLION / 1000000.0)
-                        + " Sol input" : "") + " (tap to review)");
+                        + formatAiCostUsd(selectedAiInputCostUsd(patches))
+                        + " " + selectedAiModelForPricing() + " input" : "") + " (tap to review)");
     }
 
     private void reviewPreviewCaptureForAi() {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiBudgetPolicy.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiBudgetPolicy.java
@@ -1,0 +1,13 @@
+package com.stasislang.workshop;
+
+final class WorkshopAiBudgetPolicy {
+    private WorkshopAiBudgetPolicy() {}
+
+    static boolean canStart(double monthlyLimitUsd, double monthlySpendUsd) {
+        return monthlyLimitUsd > 0.0 && remainingUsd(monthlyLimitUsd, monthlySpendUsd) > 0.0;
+    }
+
+    static double remainingUsd(double monthlyLimitUsd, double monthlySpendUsd) {
+        return Math.max(0.0, monthlyLimitUsd - Math.max(0.0, monthlySpendUsd));
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java
@@ -1,0 +1,61 @@
+package com.stasislang.workshop;
+
+final class WorkshopAiPricing {
+    static final long LONG_CONTEXT_INPUT_TOKENS = 272_000L;
+
+    static final class Rates {
+        final double inputUsdPerMillion;
+        final double cachedInputUsdPerMillion;
+        final double cacheWriteUsdPerMillion;
+        final double outputUsdPerMillion;
+
+        Rates(double input, double cachedInput, double cacheWrite, double output) {
+            inputUsdPerMillion = input;
+            cachedInputUsdPerMillion = cachedInput;
+            cacheWriteUsdPerMillion = cacheWrite;
+            outputUsdPerMillion = output;
+        }
+
+        double estimate(long inputTokens, long cachedInputTokens, long cacheWriteInputTokens,
+                long outputTokens) {
+            long uncached = Math.max(0L, inputTokens - cachedInputTokens - cacheWriteInputTokens);
+            double inputMultiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 2.0 : 1.0;
+            double outputMultiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 1.5 : 1.0;
+            double inputCost = uncached * inputUsdPerMillion * inputMultiplier;
+            double cachedCost = cachedInputTokens * cachedInputUsdPerMillion * inputMultiplier;
+            double cacheWriteCost = cacheWriteInputTokens * cacheWriteUsdPerMillion * inputMultiplier;
+            double outputCost = outputTokens * outputUsdPerMillion * outputMultiplier;
+            return (inputCost + cachedCost + cacheWriteCost + outputCost) / 1_000_000.0;
+        }
+
+        double conservativeInputUsdPerMillion() {
+            return Math.max(inputUsdPerMillion, cacheWriteUsdPerMillion);
+        }
+
+        double conservativeInputCostUsd(long inputTokens) {
+            double multiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 2.0 : 1.0;
+            return inputTokens * conservativeInputUsdPerMillion() * multiplier / 1_000_000.0;
+        }
+
+        double effectiveOutputUsdPerMillion(long inputTokens) {
+            return outputUsdPerMillion * (inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 1.5 : 1.0);
+        }
+    }
+
+    private static final Rates SOL = new Rates(5.00, 0.50, 6.25, 30.00);
+    private static final Rates TERRA = new Rates(2.50, 0.25, 3.125, 15.00);
+    private static final Rates LUNA = new Rates(1.00, 0.10, 1.25, 6.00);
+
+    private WorkshopAiPricing() {}
+
+    static Rates forModel(String model) {
+        if ("gpt-5.6".equals(model) || "gpt-5.6-sol".equals(model)) return SOL;
+        if ("gpt-5.6-terra".equals(model)) return TERRA;
+        if ("gpt-5.6-luna".equals(model)) return LUNA;
+        return null;
+    }
+
+    static boolean isKnown(String model) {
+        return forModel(model) != null;
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java
@@ -8,19 +8,28 @@ final class WorkshopAiPricing {
         final double cachedInputUsdPerMillion;
         final double cacheWriteUsdPerMillion;
         final double outputUsdPerMillion;
+        final boolean longContextPricing;
+        final boolean explicitCacheBreakpoints;
+        final boolean structuredOutputs;
+        final String reasoningEffort;
 
-        Rates(double input, double cachedInput, double cacheWrite, double output) {
+        Rates(double input, double cachedInput, double cacheWrite, double output,
+                boolean longContext, boolean explicitCache, boolean structured, String effort) {
             inputUsdPerMillion = input;
             cachedInputUsdPerMillion = cachedInput;
             cacheWriteUsdPerMillion = cacheWrite;
             outputUsdPerMillion = output;
+            longContextPricing = longContext;
+            explicitCacheBreakpoints = explicitCache;
+            structuredOutputs = structured;
+            reasoningEffort = effort;
         }
 
         double estimate(long inputTokens, long cachedInputTokens, long cacheWriteInputTokens,
                 long outputTokens) {
             long uncached = Math.max(0L, inputTokens - cachedInputTokens - cacheWriteInputTokens);
-            double inputMultiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 2.0 : 1.0;
-            double outputMultiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 1.5 : 1.0;
+            double inputMultiplier = usesLongContextPricing(inputTokens) ? 2.0 : 1.0;
+            double outputMultiplier = usesLongContextPricing(inputTokens) ? 1.5 : 1.0;
             double inputCost = uncached * inputUsdPerMillion * inputMultiplier;
             double cachedCost = cachedInputTokens * cachedInputUsdPerMillion * inputMultiplier;
             double cacheWriteCost = cacheWriteInputTokens * cacheWriteUsdPerMillion * inputMultiplier;
@@ -33,22 +42,52 @@ final class WorkshopAiPricing {
         }
 
         double conservativeInputCostUsd(long inputTokens) {
-            double multiplier = inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 2.0 : 1.0;
+            double multiplier = usesLongContextPricing(inputTokens) ? 2.0 : 1.0;
             return inputTokens * conservativeInputUsdPerMillion() * multiplier / 1_000_000.0;
         }
 
         double effectiveOutputUsdPerMillion(long inputTokens) {
-            return outputUsdPerMillion * (inputTokens > LONG_CONTEXT_INPUT_TOKENS ? 1.5 : 1.0);
+            return outputUsdPerMillion * (usesLongContextPricing(inputTokens) ? 1.5 : 1.0);
+        }
+
+        private boolean usesLongContextPricing(long inputTokens) {
+            return longContextPricing && inputTokens > LONG_CONTEXT_INPUT_TOKENS;
         }
     }
 
-    private static final Rates SOL = new Rates(5.00, 0.50, 6.25, 30.00);
-    private static final Rates TERRA = new Rates(2.50, 0.25, 3.125, 15.00);
-    private static final Rates LUNA = new Rates(1.00, 0.10, 1.25, 6.00);
+    private static final Rates GPT_5 = standard(1.25, 0.125, 10.00);
+    private static final Rates GPT_5_MINI = standard(0.25, 0.025, 2.00);
+    private static final Rates GPT_5_NANO = standard(0.05, 0.005, 0.40);
+    private static final Rates GPT_5_PRO = pro(15.00, 120.00, false, true, "high");
+    private static final Rates GPT_5_2 = standard(1.75, 0.175, 14.00);
+    private static final Rates GPT_5_2_PRO = pro(21.00, 168.00, false, false, "medium");
+    private static final Rates GPT_5_4 = longContext(2.50, 0.25, 15.00);
+    private static final Rates GPT_5_4_MINI = standard(0.75, 0.075, 4.50);
+    private static final Rates GPT_5_4_NANO = standard(0.20, 0.02, 1.25);
+    private static final Rates GPT_5_4_PRO = pro(30.00, 180.00, true, false, "medium");
+    private static final Rates GPT_5_5 = longContext(5.00, 0.50, 30.00);
+    private static final Rates GPT_5_5_PRO = pro(30.00, 180.00, false, true, "medium");
+    private static final Rates SOL = gpt56(5.00, 0.50, 6.25, 30.00);
+    private static final Rates TERRA = gpt56(2.50, 0.25, 3.125, 15.00);
+    private static final Rates LUNA = gpt56(1.00, 0.10, 1.25, 6.00);
 
     private WorkshopAiPricing() {}
 
     static Rates forModel(String model) {
+        if ("gpt-5".equals(model) || "gpt-5-2025-08-07".equals(model)
+                || "gpt-5.1".equals(model) || "gpt-5.1-2025-11-13".equals(model)) return GPT_5;
+        if ("gpt-5-mini".equals(model) || "gpt-5-mini-2025-08-07".equals(model)) return GPT_5_MINI;
+        if ("gpt-5-nano".equals(model) || "gpt-5-nano-2025-08-07".equals(model)) return GPT_5_NANO;
+        if ("gpt-5-pro".equals(model) || "gpt-5-pro-2025-10-06".equals(model)) return GPT_5_PRO;
+        if ("gpt-5.2".equals(model) || "gpt-5.2-2025-12-11".equals(model)
+                || "gpt-5.3-codex".equals(model)) return GPT_5_2;
+        if ("gpt-5.2-pro".equals(model) || "gpt-5.2-pro-2025-12-11".equals(model)) return GPT_5_2_PRO;
+        if ("gpt-5.4".equals(model) || "gpt-5.4-2026-03-05".equals(model)) return GPT_5_4;
+        if ("gpt-5.4-mini".equals(model) || "gpt-5.4-mini-2026-03-17".equals(model)) return GPT_5_4_MINI;
+        if ("gpt-5.4-nano".equals(model) || "gpt-5.4-nano-2026-03-17".equals(model)) return GPT_5_4_NANO;
+        if ("gpt-5.4-pro".equals(model) || "gpt-5.4-pro-2026-03-05".equals(model)) return GPT_5_4_PRO;
+        if ("gpt-5.5".equals(model) || "gpt-5.5-2026-04-23".equals(model)) return GPT_5_5;
+        if ("gpt-5.5-pro".equals(model) || "gpt-5.5-pro-2026-04-23".equals(model)) return GPT_5_5_PRO;
         if ("gpt-5.6".equals(model) || "gpt-5.6-sol".equals(model)) return SOL;
         if ("gpt-5.6-terra".equals(model)) return TERRA;
         if ("gpt-5.6-luna".equals(model)) return LUNA;
@@ -57,5 +96,22 @@ final class WorkshopAiPricing {
 
     static boolean isKnown(String model) {
         return forModel(model) != null;
+    }
+
+    private static Rates standard(double input, double cached, double output) {
+        return new Rates(input, cached, input, output, false, false, true, "medium");
+    }
+
+    private static Rates longContext(double input, double cached, double output) {
+        return new Rates(input, cached, input, output, true, false, true, "medium");
+    }
+
+    private static Rates pro(double input, double output, boolean longContext,
+            boolean structured, String effort) {
+        return new Rates(input, input, input, output, longContext, false, structured, effort);
+    }
+
+    private static Rates gpt56(double input, double cached, double cacheWrite, double output) {
+        return new Rates(input, cached, cacheWrite, output, true, true, true, "medium");
     }
 }


### PR DESCRIPTION
## Summary

- centralize published pricing and request compatibility for supported GPT-5 through GPT-5.6 models and official snapshots
- replace the per-run/action USD ceiling with one device-wide monthly API limit, checked after every response and image generation
- keep deprecated aliases and unpriced previews blocked rather than guessing rates
- document a secure Workshop-as-harness design for subscription-backed Codex through a paired desktop companion and `codex app-server`

## Budget behavior

Direct API mode now has one limit: the configured device monthly USD allowance. The former `$0.25` per-run setting and UI are removed. Usage is still recorded after each API response or image, so a multi-turn request can continue until the overall device balance is exhausted.

For the planned subscription mode, the Workshop will not estimate dollars. A trusted desktop signed into ChatGPT will run Codex app-server, and the UI will display Codex account rate-limit data instead.

## Harness research

- Android remains authoritative for Stasis source, runtime state, screenshots, and approvals
- a paired desktop companion uses authenticated TLS to the phone and local stdio to Codex app-server
- Workshop operations are relayed as MCP tools, allowing Codex to perform the edit/compile/run/screenshot loop
- ChatGPT credentials remain on the trusted desktop; app-server is never exposed directly to the public network
- design: `docs/android_workshop_codex_harness.md`

## Validation

- `gradle :app:testWorkshopDebugUnitTest :app:compileWorkshopReleaseJavaWithJavac :app:assembleWorkshopDebug`
- 6 tests passed: 4 pricing/compatibility and 2 monthly-budget policy tests
- Workshop debug APK installed and launched on Samsung SM-G991U1; no launch/runtime error in logcat

## Official references

- https://learn.chatgpt.com/docs/auth
- https://learn.chatgpt.com/docs/app-server
- https://learn.chatgpt.com/docs/remote-connections
- https://learn.chatgpt.com/docs/enterprise/access-tokens
- https://developers.openai.com/api/docs/models