### PR TITLE
fix: keep Android AI edits focused and observable

### DIFF
--- a/docs/android_workshop_codex_harness.md
+++ b/docs/android_workshop_codex_harness.md
@@ -101,6 +101,13 @@ set and its deterministic edit/compile/test loop. The phone-native Codex client
 should adapt those handlers at the tool-call boundary instead of duplicating
 their behavior.
 
+Every model response also carries required, user-visible `working_notes`,
+bounded to 2,000 characters. The note records concise `Intent`, `Observed`,
+`Next`, and `Blocker` facts rather than private chain-of-thought. The latest
+valid note is shown in the Workshop status, written to the private bounded trace,
+and supplied with retained tool observations on the next otherwise stateless
+call. Oversized, missing, empty, or non-string notes fail response validation.
+
 ## Limits
 
 - **Codex subscription:** do not estimate dollars. Display Codex account

--- a/docs/android_workshop_tasks.md
+++ b/docs/android_workshop_tasks.md
@@ -19,6 +19,7 @@ issue **#116** (`da0c5e05-fb79-46b8-a0ce-942934d3c8ff`). Use the released
 - #126 (`78624c35`) - Finish the Exploration Garden tutorial.
 - #130 (`edf60a67`) - Finish GitHub sync semantics and acceptance.
 - #134 (`af6a9a54`) - Reconcile the PRD checklist and current UI.
+- #135 (`d48673e6`) - Prevent read-only AI tool-loop exhaustion.
 
 ## Device acceptance
 

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiObservationMemoryTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiObservationMemoryTest.java
@@ -1,0 +1,39 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public final class WorkshopAiObservationMemoryTest {
+    @Test
+    public void retainsEarlierBatchesAndMovesUpdatedTargetsToNewest() {
+        WorkshopAiObservationMemory memory = new WorkshopAiObservationMemory();
+        memory.remember("read_symbol:render", "{\"name\":\"render\",\"source\":\"old\"}");
+        memory.remember("read_symbol:tick", "{\"name\":\"tick\"}");
+        memory.remember("read_symbol:render", "{\"name\":\"render\",\"source\":\"current\"}");
+
+        List<String> snapshot = memory.snapshotNewestFirst();
+        assertEquals(2, snapshot.size());
+        assertTrue(snapshot.get(0).contains("current"));
+        assertFalse(snapshot.toString().contains("old"));
+        assertTrue(snapshot.get(1).contains("tick"));
+    }
+
+    @Test
+    public void boundsRetainedTargetsAndSnapshotCharacters() {
+        WorkshopAiObservationMemory memory = new WorkshopAiObservationMemory();
+        for (int index = 0; index < 30; index += 1) {
+            memory.remember("target-" + index, "target-" + index + ":" + "x".repeat(10_000));
+        }
+
+        assertEquals(16, memory.size());
+        List<String> snapshot = memory.snapshotNewestFirst();
+        assertTrue(snapshot.size() <= 10);
+        assertTrue(snapshot.get(0).startsWith("target-29:"));
+        assertFalse(snapshot.toString().contains("target-0"));
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiToolLoopPolicyTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiToolLoopPolicyTest.java
@@ -1,0 +1,24 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopAiToolLoopPolicyTest {
+    @Test
+    public void boundedInspectionTransitionsToWriteInsteadOfExecutingMoreReads() {
+        WorkshopAiToolLoopPolicy policy = new WorkshopAiToolLoopPolicy(2);
+
+        assertTrue(policy.shouldExecute(false));
+        policy.recordBatch(false);
+        assertTrue(policy.shouldExecute(false));
+        policy.recordBatch(false);
+        assertTrue(policy.requiresWriteOrDone());
+        assertFalse(policy.shouldExecute(false));
+
+        assertTrue(policy.shouldExecute(true));
+        policy.recordBatch(true);
+        assertFalse(policy.requiresWriteOrDone());
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiWorkingNotesTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiWorkingNotesTest.java
@@ -1,0 +1,25 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopAiWorkingNotesTest {
+    @Test
+    public void requiresConciseNonemptyNotesWithinTwoThousandCharacters() {
+        assertFalse(WorkshopAiWorkingNotes.isValid(""));
+        assertFalse(WorkshopAiWorkingNotes.isValid("   \n"));
+        assertTrue(WorkshopAiWorkingNotes.isValid("Intent: inspect render. Next: update both heights."));
+        assertTrue(WorkshopAiWorkingNotes.isValid("x".repeat(WorkshopAiWorkingNotes.MAX_CHARS)));
+        assertFalse(WorkshopAiWorkingNotes.isValid("x".repeat(WorkshopAiWorkingNotes.MAX_CHARS + 1)));
+    }
+
+    @Test
+    public void displayCopyIsWhitespaceCollapsedAndBounded() {
+        assertEquals("Intent: inspect render Next: write", WorkshopAiWorkingNotes.compactForDisplay(
+                "  Intent: inspect render\nNext: write  "));
+        assertEquals(320, WorkshopAiWorkingNotes.compactForDisplay("x".repeat(500)).length());
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -3667,6 +3667,15 @@ public final class MainActivity extends Activity {
         });
     }
 
+    private void postAiWorkingNotes(final String notes) {
+        final String display = WorkshopAiWorkingNotes.compactForDisplay(notes);
+        runOnUiThread(new Runnable() {
+            @Override public void run() {
+                setStatusText("AI working notes: " + display);
+            }
+        });
+    }
+
     private void showCodexDeviceCodeDialog(String verificationUrl, String userCode) {
         showCodexDeviceCodeDialog(verificationUrl, userCode, true);
     }
@@ -4571,15 +4580,18 @@ public final class MainActivity extends Activity {
         JSONArray acceptedShapes = new JSONArray()
                 .put(new JSONObject()
                         .put("mode", "tool_calls")
+                        .put("working_notes", "Intent: inspect the target. Observed: current facts. Next: one concrete action. Blocker: none.")
                         .put("summary", "short optional status")
                         .put("tool_calls", new JSONArray().put(new JSONObject()
                                 .put("tool", "read_symbol")
                                 .put("args", new JSONObject().put("name", "tick")))))
                 .put(new JSONObject()
                         .put("mode", "done")
+                        .put("working_notes", "Intent: finish. Observed: requested behavior is verified. Next: none. Blocker: none.")
                         .put("summary", "what was verified"))
                 .put(new JSONObject()
                         .put("mode", "edits")
+                        .put("working_notes", "Intent: finish. Observed: writes compiled and tests passed. Next: apply final edits. Blocker: none.")
                         .put("summary", "short change summary")
                         .put("edits", new JSONArray().put(new JSONObject()
                                 .put("kind", "replace_function")
@@ -4588,7 +4600,7 @@ public final class MainActivity extends Activity {
                                 .put("file", "src/player.stasis")
                                 .put("new_source", "function jump(self: Player): void {\n}"))));
         return new JSONObject()
-                .put("required", "Return exactly one JSON object. The top-level object must match one of the accepted_response_shapes.")
+                .put("required", "Return exactly one JSON object. The top-level object must match one accepted_response_shape and include concise working_notes of at most 2000 characters.")
                 .put("accepted_response_shapes", acceptedShapes)
                 .put("tool_call_rules", new JSONArray()
                         .put("Use the exact top-level property tool_calls for tool use.")
@@ -4626,6 +4638,16 @@ public final class MainActivity extends Activity {
     private static JSONArray validateAiResponseShape(JSONObject response) throws Exception {
         JSONArray errors = new JSONArray();
         String mode = response.optString("mode", "");
+        Object rawWorkingNotes = response.opt("working_notes");
+        if (!(rawWorkingNotes instanceof String)
+                || !WorkshopAiWorkingNotes.isValid((String)rawWorkingNotes)) {
+            errors.put(new JSONObject()
+                    .put("kind", "validation_error")
+                    .put("error", "response requires nonempty string working_notes within 2000 characters")
+                    .put("maximum_characters", WorkshopAiWorkingNotes.MAX_CHARS)
+                    .put("accepted_shape", "Intent: ... Observed: ... Next: ... Blocker: ..."));
+            return errors;
+        }
         if (!"tool_calls".equals(mode) && !"done".equals(mode) && !"edits".equals(mode)) {
             errors.put(new JSONObject()
                     .put("kind", "validation_error")
@@ -4636,10 +4658,10 @@ public final class MainActivity extends Activity {
             return errors;
         }
         JSONArray unsupported = "tool_calls".equals(mode)
-                ? unsupportedJsonKeys(response, "mode", "summary", "tool_calls")
+                ? unsupportedJsonKeys(response, "mode", "working_notes", "summary", "tool_calls")
                 : ("done".equals(mode)
-                        ? unsupportedJsonKeys(response, "mode", "summary")
-                        : unsupportedJsonKeys(response, "mode", "summary", "edits"));
+                        ? unsupportedJsonKeys(response, "mode", "working_notes", "summary")
+                        : unsupportedJsonKeys(response, "mode", "working_notes", "summary", "edits"));
         if (unsupported.length() > 0) {
             errors.put(new JSONObject()
                     .put("kind", "validation_error")
@@ -4757,10 +4779,19 @@ public final class MainActivity extends Activity {
                 followup.put("original_request", new JSONObject(initialRequestJson));
                 followup.put("tool_observations", responseValidationErrors);
                 followup.put("response_contract", aiResponseContract());
-                followup.put("instruction", "Your previous JSON response shape was invalid. Return exactly one JSON object matching the stable request response_contract. For tool use, use mode=tool_calls and a top-level tool_calls array. Each call must be {\"tool\":\"name\",\"args\":{...}} with no aliases such as calls, name, function, arguments, type, or source.");
+                if (!session.workingNotes.isEmpty()) {
+                    followup.put("working_notes", session.workingNotes);
+                }
+                followup.put("instruction", "Your previous JSON response shape was invalid. Return exactly one JSON object matching the stable request response_contract, including nonempty working_notes within 2000 characters. For tool use, use mode=tool_calls and a top-level tool_calls array. Each call must be {\"tool\":\"name\",\"args\":{...}} with no aliases such as calls, name, function, arguments, type, or source.");
                 currentRequestJson = followup.toString();
                 continue;
             }
+            session.workingNotes = WorkshopAiWorkingNotes.normalize(
+                    response.getString("working_notes"));
+            postAiWorkingNotes(session.workingNotes);
+            appendAiTrace("working_notes", new JSONObject()
+                    .put("turn", session.currentStep)
+                    .put("notes", session.workingNotes));
             String mode = response.getString("mode");
             JSONArray toolCalls = response.optJSONArray("tool_calls");
             if (!"tool_calls".equals(mode) || toolCalls == null || toolCalls.length() == 0) {
@@ -4774,6 +4805,7 @@ public final class MainActivity extends Activity {
                 postAiProgress(session.currentStep, session.actionCount, "repeated tools");
                 JSONObject repeated = new JSONObject()
                         .put("mode", "done")
+                        .put("working_notes", session.workingNotes)
                         .put("summary", "Stopped after repeated identical tool calls")
                         .put("tool_calls", new JSONArray())
                         .put("edits", new JSONArray())
@@ -4828,7 +4860,8 @@ public final class MainActivity extends Activity {
             followup.put("latest_tool_observations", observations);
             followup.put("test_observation", testObservation);
             followup.put("tool_specs", aiToolSpecs());
-            String instruction = "Use the retained tool_observations as cumulative memory; do not read targets already present there. Inspect only the minimum missing context needed for the requested change. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so compile failures and test results return observations you can correct. Tool errors, validation_error observations, and test failures are not final; correct them. Return mode=edits only after the intended code has been written, compiled, and the latest runnable tests pass. If no further action is needed, return mode=done.";
+            followup.put("working_notes", session.workingNotes);
+            String instruction = "Use the retained tool_observations and working_notes as cumulative memory; update working_notes with concise Intent, Observed, Next, and Blocker facts on this response. Do not expose private chain-of-thought. Do not read targets already present in retained observations. Inspect only the minimum missing context needed for the requested change. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so compile failures and test results return observations you can correct. Tool errors, validation_error observations, and test failures are not final; correct them. Return mode=edits only after the intended code has been written, compiled, and the latest runnable tests pass. If no further action is needed, return mode=done.";
             if (session.toolLoopPolicy.requiresWriteOrDone()) {
                 instruction += " You have completed the maximum read-only inspection batches. Your next response must contain at least one write tool call or mode=done; do not request list/read/diagnostic tools.";
             }
@@ -4840,6 +4873,7 @@ public final class MainActivity extends Activity {
             String summary = "Applied " + session.successfulWriteCount + " tool write(s) before response limit";
             JSONObject synthetic = new JSONObject()
                     .put("mode", "done")
+                    .put("working_notes", session.workingNotes)
                     .put("summary", summary)
                     .put("tool_calls", new JSONArray())
                     .put("edits", new JSONArray())
@@ -6008,6 +6042,7 @@ public final class MainActivity extends Activity {
             }
         }
         String stableInstruction = "Return only one JSON object. You may inspect and edit any Stasis symbol in the workspace; selected_symbols are optional context only. You may use mode=tool_calls with tool_calls to inspect or write the Stasis workspace using only these tools: list_symbols, list_owner_symbols, read_symbol, read_imports, write_imports, write_symbol, delete_symbol, list_tests, read_test_file, write_test_file, delete_test_file, run_tests, get_diagnostics, set_input_state, run_frame, inspect_runtime_state, take_screenshot. take_screenshot returns a compact logical render snapshot with decoded commands, runtime state, and input. set_input_state controls simulated test input; run_frame advances one frame and returns runtime/render state. Before writing, inspect only the minimum target symbols or tests needed for the request; use either a compact list tool or a direct read when possible, not every inspection tool. Never reread a target already present in selected_symbols or retained tool_observations. Small constant, size, color, position, or tuning changes should normally move from one focused inspection batch to a write. Do not use read_file; the workshop edits symbols, imports, and tests rather than whole source files. For behavior-changing requests, add or update a tests/*.test.stasis test before returning done. A valid test uses test `name`(): bool and returns true or false; do not create .ai_test.json files or use assert_runtime helpers, which are not Stasis syntax. run_tests executes the native bridge tests on the Android device. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so failed writes and automatic compile/test_observation results return observations you can correct. The app compiles once after each tool-call batch that contains writes; read-only inspection batches do not rerun tests. Use write_test_file/run_tests or take_screenshot for validation instead of direct runtime pokes. Use on_code_swap() only for post-hot-swap migration, reinitialization, or compatibility work when a running game actually needs state adjusted after code changes; do not inspect it by default. Use tool_specs in the request for required_args, optional_args, and examples. Each tool call must use {\"tool\":\"name\",\"args\":{...}}; include only args relevant to that tool. Return mode=edits with replace_function/replace_struct edits only after write_symbol/delete_symbol/write_imports has successfully written, compiled, and the latest test_observation has passed runnable tests, including any new or updated behavior test for the request. If the requested work is already complete or no code changes are needed, return mode=done with a summary only. A replace_function edit for a missing function in an existing file is treated as an added helper. Do not use markdown.";
+        stableInstruction += " Every response must include working_notes as a concise user-visible state summary of at most 2000 characters using Intent, Observed, Next, and Blocker. Report decisions and evidence, not private chain-of-thought. Update working_notes from the retained prior note and current observations on every call.";
         stableInstruction += " write_symbol creates or replaces a symbol. Before writing, inspect the current target. Follow game_design_rules, prefer_lifecycle_local_state, avoid_global_tick_for_per_entity_progression, and architecture_recommendations. Follow architecture_recommendations. Use command/event-style functions for durable gameplay concepts. Tool errors, validation_error observations, and test_observation failures are not final; correct them before returning mode=done. A failed write batch rolls back the whole batch and returns diagnostics.";
         JSONArray input = new JSONArray()
                 .put(aiInputMessage("system", stableInstruction, false))
@@ -6185,6 +6220,10 @@ public final class MainActivity extends Activity {
                 .put("tool_calls")
                 .put("edits")
                 .put("done")));
+        responseProperties.put("working_notes", new JSONObject()
+                .put("type", "string")
+                .put("minLength", 1)
+                .put("maxLength", WorkshopAiWorkingNotes.MAX_CHARS));
         responseProperties.put("summary", new JSONObject().put("type", "string"));
         responseProperties.put("tool_calls", new JSONObject().put("type", "array").put("items", toolSchema));
         responseProperties.put("edits", new JSONObject().put("type", "array").put("items", editSchema));
@@ -6193,7 +6232,8 @@ public final class MainActivity extends Activity {
         schema.put("type", "object");
         schema.put("additionalProperties", false);
         schema.put("required", new JSONArray()
-                .put("mode"));
+                .put("mode")
+                .put("working_notes"));
         schema.put("properties", responseProperties);
 
         JSONObject format = new JSONObject();
@@ -9186,6 +9226,7 @@ public final class MainActivity extends Activity {
         int rolledBackWriteCount;
         String lastToolSummary = "none";
         String lastToolError = "";
+        String workingNotes = "";
         TreeSet<String> lastPassingTestKeys = new TreeSet<>();
         JSONObject latestTestObservation = new JSONObject();
         final WorkshopAiObservationMemory observationMemory = new WorkshopAiObservationMemory();

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -129,6 +129,8 @@ public final class MainActivity extends Activity {
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
     private static final int MAX_RENDER_COMMANDS = 8;
     private static final int MAX_AI_AGENT_TURNS = 15;
+    private static final int MAX_AI_TOOL_CALLS_PER_BATCH = 12;
+    private static final int MAX_AI_READ_ONLY_BATCHES = 2;
     private static final int MAX_AI_OUTPUT_TOKENS = 8192;
     private static final int MAX_AI_IMAGE_ATTACHMENTS = 4;
     private static final int MAX_AI_IMAGE_ATTACHMENT_BYTES = 12 * 1024 * 1024;
@@ -4536,7 +4538,7 @@ public final class MainActivity extends Activity {
                     .put("As features grow, split toward files named for durable gameplay concepts, such as actors, projectiles, abilities, resources, objectives, camera, score, encounters, and systems/<system>.stasis.")
                     .put("Preserve hot reload when possible by preferring function-body changes and tuning constants; call out struct/global layout changes as ResetRequired.")
                     .put("Use command/event-style functions for lifecycle boundaries, such as spawn_actor(), reset_encounter(), award_resource(kind, amount), start_phase(mode), and fire_projectile().")
-                    .put("Before writing, inspect the full feature path: state definition, creation/reset, tick update, render output, and test/input path.")
+                    .put("For multi-symbol behavior changes, inspect the relevant state, lifecycle, update, render, and test paths; for small constant or dimension edits, inspect only the target symbol and its test.")
                     .put("Keep mobile input abstracted through Stasis Input globals and helper functions so logic can move across platforms.")
                     .put("Add or use testable invariants by setting input/state, running ticks, and checking state or render output.")
                     .put("Avoid broad rewrites; make the smallest structural change that gives the feature a clear owner.")
@@ -4654,6 +4656,15 @@ public final class MainActivity extends Activity {
                         .put("kind", "validation_error")
                         .put("error", "mode=tool_calls requires top-level tool_calls array")
                         .put("response_contract", aiResponseContract()));
+                return errors;
+            }
+            if (toolCalls.length() > MAX_AI_TOOL_CALLS_PER_BATCH) {
+                errors.put(new JSONObject()
+                        .put("kind", "validation_error")
+                        .put("error", "tool-call batch exceeds the bounded per-turn limit")
+                        .put("received", toolCalls.length())
+                        .put("maximum", MAX_AI_TOOL_CALLS_PER_BATCH)
+                        .put("correction_instruction", "Request only the minimum tools needed for the next decision."));
                 return errors;
             }
             for (int index = 0; index < toolCalls.length(); index += 1) {
@@ -4785,18 +4796,43 @@ public final class MainActivity extends Activity {
             previousToolCallBatch = currentToolCallBatch;
             postAiProgress(session.currentStep, session.actionCount, "tools " + toolCalls.length());
             appendAiTrace("tool_calls", new JSONObject().put("turn", session.currentStep).put("tool_calls", toolCalls));
-            JSONArray observations = executeAiToolCalls(toolCalls, session);
+            boolean batchHasWrites = aiToolCallsContainWrites(toolCalls);
+            boolean blockedReadOnlyBatch = !session.toolLoopPolicy.shouldExecute(batchHasWrites);
+            JSONArray observations;
+            if (blockedReadOnlyBatch) {
+                observations = new JSONArray().put(new JSONObject()
+                        .put("kind", "progress_policy")
+                        .put("status", "read_only_batch_not_executed")
+                        .put("error", "Inspection is complete; the next response must write the intended change or return done.")
+                        .put("retained_observation_count", session.observationMemory.size()));
+            } else {
+                observations = executeAiToolCalls(toolCalls, session);
+                session.rememberToolObservations(observations);
+            }
+            session.toolLoopPolicy.recordBatch(batchHasWrites);
             throwIfAiCancelled();
             appendAiTrace("tool_observations", new JSONObject().put("turn", session.currentStep).put("observations", observations));
-            JSONObject testObservation = runAiTestsAfterBatch(session);
-            session.latestTestObservation = testObservation;
+            JSONObject testObservation;
+            if (batchHasWrites) {
+                testObservation = runAiTestsAfterBatch(session);
+                session.latestTestObservation = testObservation;
+            } else {
+                testObservation = new JSONObject()
+                        .put("kind", "test_run")
+                        .put("status", "not_run_for_read_only_batch");
+            }
             appendAiTrace("test_observation", new JSONObject().put("turn", session.currentStep).put("result", testObservation));
             JSONObject followup = new JSONObject();
             followup.put("original_request", new JSONObject(initialRequestJson));
-            followup.put("tool_observations", observations);
+            followup.put("tool_observations", session.retainedToolObservations());
+            followup.put("latest_tool_observations", observations);
             followup.put("test_observation", testObservation);
             followup.put("tool_specs", aiToolSpecs());
-            followup.put("instruction", "Use the tool observations to either request more tools or return final edits. Inspect current symbols/imports/tests before writing unless the exact current source is already available. Do not use read_file; use read_symbol/read_imports/read_test_file. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so compile failures and test_observation results return observations you can correct. Tool errors, validation_error observations, and test_observation failures are not final; use accepted_shape, required_args, response_contract, and the error observation to choose another tool call or corrected write. Return mode=edits only after the intended code has been written, compiled, and the latest test_observation has passed runnable tests. If no further action is needed, return mode=done.");
+            String instruction = "Use the retained tool_observations as cumulative memory; do not read targets already present there. Inspect only the minimum missing context needed for the requested change. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so compile failures and test results return observations you can correct. Tool errors, validation_error observations, and test failures are not final; correct them. Return mode=edits only after the intended code has been written, compiled, and the latest runnable tests pass. If no further action is needed, return mode=done.";
+            if (session.toolLoopPolicy.requiresWriteOrDone()) {
+                instruction += " You have completed the maximum read-only inspection batches. Your next response must contain at least one write tool call or mode=done; do not request list/read/diagnostic tools.";
+            }
+            followup.put("instruction", instruction);
             currentRequestJson = followup.toString();
         }
         postAiProgress(MAX_AI_AGENT_TURNS, session.actionCount, "limit hit");
@@ -4925,6 +4961,14 @@ public final class MainActivity extends Activity {
     }
     private static boolean isAiWriteTool(String tool) {
         return "write_symbol".equals(tool) || "delete_symbol".equals(tool) || "write_imports".equals(tool) || "write_test_file".equals(tool) || "delete_test_file".equals(tool);
+    }
+
+    private static boolean aiToolCallsContainWrites(JSONArray toolCalls) {
+        for (int index = 0; index < toolCalls.length(); index += 1) {
+            JSONObject call = toolCalls.optJSONObject(index);
+            if (call != null && isAiWriteTool(call.optString("tool", ""))) return true;
+        }
+        return false;
     }
 
     private void annotateAiBatchWriteResults(JSONArray observations, String batchStatus, JSONObject diagnostics, JSONObject restoredDiagnostics, AiAgentSession session) throws Exception {
@@ -5963,7 +6007,7 @@ public final class MainActivity extends Activity {
                 }
             }
         }
-        String stableInstruction = "Return only one JSON object. You may inspect and edit any Stasis symbol in the workspace; selected_symbols are optional context only. You may use mode=tool_calls with tool_calls to inspect or write the Stasis workspace using only these tools: list_symbols, list_owner_symbols, read_symbol, read_imports, write_imports, write_symbol, delete_symbol, list_tests, read_test_file, write_test_file, delete_test_file, run_tests, get_diagnostics, set_input_state, run_frame, inspect_runtime_state, take_screenshot. take_screenshot returns a compact logical render snapshot with decoded commands, runtime state, and input. set_input_state controls simulated test input; run_frame advances one frame and returns runtime/render state. Before writing, inspect the current target with list_symbols, list_owner_symbols, read_symbol, read_imports, list_tests, and read_test_file unless the exact current source was already provided in selected_symbols or tool observations. Do not use read_file; the workshop edits symbols, imports, and tests rather than whole source files. For behavior-changing requests, add or update a tests/*.test.stasis test before returning done. A valid test uses test `name`(): bool and returns true or false; do not create .ai_test.json files or use assert_runtime helpers, which are not Stasis syntax. run_tests executes the native bridge tests on the Android device. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so failed writes and automatic compile/test_observation results return observations you can correct. The app compiles once after each tool-call batch that contains writes and runs tests after each tool-call batch; use write_test_file/run_tests or take_screenshot for validation instead of direct runtime pokes. Use on_code_swap() for post-hot-swap migration, reinitialization, or compatibility work when a running game needs state adjusted after code changes. Use tool_specs in the request for required_args, optional_args, and examples. Each tool call must use {\"tool\":\"name\",\"args\":{...}}; include only args relevant to that tool. Return mode=edits with replace_function/replace_struct edits only after write_symbol/delete_symbol/write_imports has successfully written, compiled, and the latest test_observation has passed runnable tests, including any new or updated behavior test for the request. If the requested work is already complete or no code changes are needed, return mode=done with a summary only. A replace_function edit for a missing function in an existing file is treated as an added helper. Do not use markdown.";
+        String stableInstruction = "Return only one JSON object. You may inspect and edit any Stasis symbol in the workspace; selected_symbols are optional context only. You may use mode=tool_calls with tool_calls to inspect or write the Stasis workspace using only these tools: list_symbols, list_owner_symbols, read_symbol, read_imports, write_imports, write_symbol, delete_symbol, list_tests, read_test_file, write_test_file, delete_test_file, run_tests, get_diagnostics, set_input_state, run_frame, inspect_runtime_state, take_screenshot. take_screenshot returns a compact logical render snapshot with decoded commands, runtime state, and input. set_input_state controls simulated test input; run_frame advances one frame and returns runtime/render state. Before writing, inspect only the minimum target symbols or tests needed for the request; use either a compact list tool or a direct read when possible, not every inspection tool. Never reread a target already present in selected_symbols or retained tool_observations. Small constant, size, color, position, or tuning changes should normally move from one focused inspection batch to a write. Do not use read_file; the workshop edits symbols, imports, and tests rather than whole source files. For behavior-changing requests, add or update a tests/*.test.stasis test before returning done. A valid test uses test `name`(): bool and returns true or false; do not create .ai_test.json files or use assert_runtime helpers, which are not Stasis syntax. run_tests executes the native bridge tests on the Android device. Apply code changes with write_symbol, delete_symbol, write_imports, write_test_file, or delete_test_file before final edits so failed writes and automatic compile/test_observation results return observations you can correct. The app compiles once after each tool-call batch that contains writes; read-only inspection batches do not rerun tests. Use write_test_file/run_tests or take_screenshot for validation instead of direct runtime pokes. Use on_code_swap() only for post-hot-swap migration, reinitialization, or compatibility work when a running game actually needs state adjusted after code changes; do not inspect it by default. Use tool_specs in the request for required_args, optional_args, and examples. Each tool call must use {\"tool\":\"name\",\"args\":{...}}; include only args relevant to that tool. Return mode=edits with replace_function/replace_struct edits only after write_symbol/delete_symbol/write_imports has successfully written, compiled, and the latest test_observation has passed runnable tests, including any new or updated behavior test for the request. If the requested work is already complete or no code changes are needed, return mode=done with a summary only. A replace_function edit for a missing function in an existing file is treated as an added helper. Do not use markdown.";
         stableInstruction += " write_symbol creates or replaces a symbol. Before writing, inspect the current target. Follow game_design_rules, prefer_lifecycle_local_state, avoid_global_tick_for_per_entity_progression, and architecture_recommendations. Follow architecture_recommendations. Use command/event-style functions for durable gameplay concepts. Tool errors, validation_error observations, and test_observation failures are not final; correct them before returning mode=done. A failed write batch rolls back the whole batch and returns diagnostics.";
         JSONArray input = new JSONArray()
                 .put(aiInputMessage("system", stableInstruction, false))
@@ -9144,6 +9188,9 @@ public final class MainActivity extends Activity {
         String lastToolError = "";
         TreeSet<String> lastPassingTestKeys = new TreeSet<>();
         JSONObject latestTestObservation = new JSONObject();
+        final WorkshopAiObservationMemory observationMemory = new WorkshopAiObservationMemory();
+        final WorkshopAiToolLoopPolicy toolLoopPolicy =
+                new WorkshopAiToolLoopPolicy(MAX_AI_READ_ONLY_BATCHES);
         boolean deferBatchCompile;
         private ProjectSnapshot cachedProject;
 
@@ -9156,6 +9203,25 @@ public final class MainActivity extends Activity {
 
         boolean latestRunnableTestsPassed() {
             return latestTestObservation != null && latestTestObservation.optBoolean("all_runnable_tests_passed", false);
+        }
+
+        void rememberToolObservations(JSONArray observations) throws Exception {
+            for (int index = 0; index < observations.length(); index += 1) {
+                JSONObject observation = observations.optJSONObject(index);
+                if (observation == null) continue;
+                String tool = observation.optString("tool", "observation");
+                JSONObject args = observation.optJSONObject("args");
+                String key = tool + "|" + (args == null ? "{}" : args.toString());
+                observationMemory.remember(key, observation.toString());
+            }
+        }
+
+        JSONArray retainedToolObservations() throws Exception {
+            JSONArray retained = new JSONArray();
+            for (String observation : observationMemory.snapshotNewestFirst()) {
+                retained.put(new JSONObject(observation));
+            }
+            return retained;
         }
 
         void invalidateProject() {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiObservationMemory.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiObservationMemory.java
@@ -1,0 +1,41 @@
+package com.stasislang.workshop;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class WorkshopAiObservationMemory {
+    private static final int MAX_ENTRIES = 16;
+    private static final int MAX_SNAPSHOT_CHARS = 96 * 1024;
+
+    private final LinkedHashMap<String, String> observations = new LinkedHashMap<>();
+
+    void remember(String key, String observationJson) {
+        if (key == null || key.isEmpty() || observationJson == null || observationJson.isEmpty()) return;
+        observations.remove(key);
+        observations.put(key, observationJson);
+        while (observations.size() > MAX_ENTRIES) {
+            String oldest = observations.keySet().iterator().next();
+            observations.remove(oldest);
+        }
+    }
+
+    List<String> snapshotNewestFirst() {
+        ArrayList<Map.Entry<String, String>> entries = new ArrayList<>(observations.entrySet());
+        ArrayList<String> retained = new ArrayList<>();
+        int chars = 0;
+        for (int index = entries.size() - 1; index >= 0; index -= 1) {
+            String value = entries.get(index).getValue();
+            if (value.length() > MAX_SNAPSHOT_CHARS) continue;
+            if (chars + value.length() > MAX_SNAPSHOT_CHARS) break;
+            retained.add(value);
+            chars += value.length();
+        }
+        return retained;
+    }
+
+    int size() {
+        return observations.size();
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiToolLoopPolicy.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiToolLoopPolicy.java
@@ -1,0 +1,23 @@
+package com.stasislang.workshop;
+
+final class WorkshopAiToolLoopPolicy {
+    private final int maxReadOnlyBatches;
+    private int consecutiveReadOnlyBatches;
+
+    WorkshopAiToolLoopPolicy(int maxReadOnlyBatches) {
+        if (maxReadOnlyBatches < 1) throw new IllegalArgumentException("read-only limit must be positive");
+        this.maxReadOnlyBatches = maxReadOnlyBatches;
+    }
+
+    boolean shouldExecute(boolean hasWrites) {
+        return hasWrites || consecutiveReadOnlyBatches < maxReadOnlyBatches;
+    }
+
+    void recordBatch(boolean hasWrites) {
+        consecutiveReadOnlyBatches = hasWrites ? 0 : consecutiveReadOnlyBatches + 1;
+    }
+
+    boolean requiresWriteOrDone() {
+        return consecutiveReadOnlyBatches >= maxReadOnlyBatches;
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiWorkingNotes.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiWorkingNotes.java
@@ -1,0 +1,22 @@
+package com.stasislang.workshop;
+
+final class WorkshopAiWorkingNotes {
+    static final int MAX_CHARS = 2_000;
+    private static final int MAX_DISPLAY_CHARS = 320;
+
+    private WorkshopAiWorkingNotes() {}
+
+    static boolean isValid(String notes) {
+        return notes != null && !notes.trim().isEmpty() && notes.length() <= MAX_CHARS;
+    }
+
+    static String normalize(String notes) {
+        return notes == null ? "" : notes.trim();
+    }
+
+    static String compactForDisplay(String notes) {
+        String compact = normalize(notes).replaceAll("\\s+", " ");
+        if (compact.length() <= MAX_DISPLAY_CHARS) return compact;
+        return compact.substring(0, MAX_DISPLAY_CHARS - 3) + "...";
+    }
+}

--- a/tools/android_ai_agent_host.py
+++ b/tools/android_ai_agent_host.py
@@ -27,6 +27,7 @@ DEFAULT_MODEL = "gpt-5.6-sol"
 DEFAULT_REASONING_EFFORT = "medium"
 DEFAULT_TRACE_DIR = ROOT / "artifacts/android_ai_runs"
 MAX_TURNS = 15
+MAX_WORKING_NOTES_CHARS = 2_000
 PROMPT_CACHE_KEY = "stasis-android-ai-agent-v2"
 
 
@@ -492,11 +493,11 @@ def tool_specs() -> list[dict[str, Any]]:
 
 def response_contract() -> dict[str, Any]:
     return {
-        "required": "Return exactly one JSON object. The top-level object must match one of the accepted_response_shapes.",
+        "required": "Return exactly one JSON object. Include user-visible working_notes of at most 2000 characters.",
         "accepted_response_shapes": [
-            {"mode": "tool_calls", "summary": "short optional status", "tool_calls": [{"tool": "read_symbol", "args": {"name": "tick"}}]},
-            {"mode": "done", "summary": "what was verified"},
-            {"mode": "edits", "summary": "short change summary", "edits": [{"kind": "replace_function", "owner": "Player", "name": "jump", "file": "src/player.stasis", "new_source": "function jump(self: Player): void {\n}"}]},
+            {"mode": "tool_calls", "working_notes": "Intent: inspect. Observed: facts. Next: action. Blocker: none.", "summary": "short optional status", "tool_calls": [{"tool": "read_symbol", "args": {"name": "tick"}}]},
+            {"mode": "done", "working_notes": "Intent: finish. Observed: verified. Next: none. Blocker: none.", "summary": "what was verified"},
+            {"mode": "edits", "working_notes": "Intent: finish. Observed: writes and tests passed. Next: apply. Blocker: none.", "summary": "short change summary", "edits": [{"kind": "replace_function", "owner": "Player", "name": "jump", "file": "src/player.stasis", "new_source": "function jump(self: Player): void {\n}"}]},
         ],
         "tool_call_rules": [
             "Use the exact top-level property tool_calls for tool use.",
@@ -555,6 +556,13 @@ def build_agent_request(project: Path, prompt: str, turn_state: dict[str, Any]) 
     }
 
 
+def retain_working_notes(turn_state: dict[str, Any], working_notes: str) -> dict[str, Any]:
+    retained = dict(turn_state)
+    if working_notes:
+        retained["working_notes"] = working_notes
+    return retained
+
+
 def parse_json_object(text: str) -> dict[str, Any]:
     stripped = text.strip()
     try:
@@ -594,6 +602,7 @@ def response_json_schema() -> dict[str, Any]:
         "type": "object",
         "properties": {
             "mode": {"type": "string"},
+            "working_notes": {"type": "string", "minLength": 1, "maxLength": MAX_WORKING_NOTES_CHARS},
             "summary": {"type": "string"},
             "tool_calls": {
                 "type": "array",
@@ -623,7 +632,7 @@ def response_json_schema() -> dict[str, Any]:
                 },
             },
         },
-        "required": ["mode"],
+        "required": ["mode", "working_notes"],
         "additionalProperties": False,
     }
 
@@ -653,6 +662,7 @@ def summarize_response_for_trace(body: dict[str, Any], parsed: dict[str, Any]) -
         "usage": response_usage_from_body(body),
         "mode": parsed.get("mode"),
         "summary": parsed.get("summary", ""),
+        "working_notes": parsed.get("working_notes", ""),
         "tool_call_count": len(parsed.get("tool_calls") or []),
         "edit_count": len(parsed.get("edits") or []),
         "response_keys": sorted(parsed.keys()),
@@ -662,6 +672,7 @@ def summarize_response_for_trace(body: dict[str, Any], parsed: dict[str, Any]) -
 def build_openai_payload(model: str, request: dict[str, Any]) -> dict[str, Any]:
     stable_instruction = (
         "Return only one JSON object matching request.shared_context.protocol.response_contract exactly. "
+        "Every response must include working_notes of at most 2000 characters with concise Intent, Observed, Next, and Blocker facts. These are user-visible state notes, not private chain-of-thought. "
         "Use mode=tool_calls to inspect/write with the provided fine-grained symbol, import, and test tools. Do not use read_file; use list_symbols/list_owner_symbols/read_symbol/read_imports/list_tests/read_test_file instead. "
         "For tool calls, the top-level key is tool_calls and each call is exactly {\"tool\":\"name\",\"args\":{...}}. "
         "Do not use aliases such as calls, name, function, arguments, type, or source. "
@@ -782,10 +793,14 @@ def validate_response_shape(response: dict[str, Any]) -> tuple[list[dict[str, An
     errors: list[dict[str, Any]] = []
     contract = response_contract()
     mode = response.get("mode")
+    working_notes = response.get("working_notes")
+    if not isinstance(working_notes, str) or not working_notes.strip() or len(working_notes) > MAX_WORKING_NOTES_CHARS:
+        errors.append({"kind": "validation_error", "error": "response requires nonempty string working_notes within 2000 characters", "maximum_characters": MAX_WORKING_NOTES_CHARS, "accepted_shape": "Intent: ... Observed: ... Next: ... Blocker: ..."})
+        return [], errors
     if mode not in {"tool_calls", "done", "edits"}:
         errors.append({"kind": "validation_error", "error": "response requires top-level mode equal to tool_calls, done, or edits", "received_keys": sorted(response.keys()), "received_mode": mode, "response_contract": contract})
         return [], errors
-    allowed_top_level = {"tool_calls": {"mode", "summary", "tool_calls"}, "done": {"mode", "summary"}, "edits": {"mode", "summary", "edits"}}[mode]
+    allowed_top_level = {"tool_calls": {"mode", "working_notes", "summary", "tool_calls"}, "done": {"mode", "working_notes", "summary"}, "edits": {"mode", "working_notes", "summary", "edits"}}[mode]
     extra_top_level = sorted(set(response.keys()) - allowed_top_level)
     if extra_top_level:
         errors.append({"kind": "validation_error", "error": "response contains unsupported top-level properties for this mode", "mode": mode, "unsupported_properties": extra_top_level, "accepted_top_level_properties": sorted(allowed_top_level), "response_contract": contract})
@@ -986,6 +1001,7 @@ def main() -> int:
         reset_paddle_speed_feature(project)
     last_diagnostics: dict[str, Any] = {}
     total_actions = 0
+    working_notes = ""
     for turn in range(1, MAX_TURNS + 1):
         try:
             response = call_openai(api_key, args.model, request, trace_events, turn)
@@ -996,16 +1012,18 @@ def main() -> int:
             return 1
         mode = response.get("mode")
         tool_calls, response_validation_errors = validate_response_shape(response)
-        print(json.dumps({"turn": turn, "mode": mode, "response_keys": sorted(response.keys()), "summary": response.get("summary", ""), "tool_call_count": len(tool_calls), "validation_error_count": len(response_validation_errors), "edit_count": len(response.get("edits") or [])}, indent=2))
+        print(json.dumps({"turn": turn, "mode": mode, "working_notes": response.get("working_notes", ""), "response_keys": sorted(response.keys()), "summary": response.get("summary", ""), "tool_call_count": len(tool_calls), "validation_error_count": len(response_validation_errors), "edit_count": len(response.get("edits") or [])}, indent=2))
         if response_validation_errors:
             print(json.dumps({"response_validation_errors": response_validation_errors}, indent=2))
             trace_events.append({"kind": "response_validation_errors", "turn": turn, "errors": response_validation_errors})
             if turn >= MAX_TURNS:
                 write_trace_file(trace_file, trace_meta, trace_events, 1, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
                 return 1
-            request = build_agent_request(project, args.prompt, {"phase": "response_validation_error", "tool_observations": response_validation_errors, "instruction": "Your previous JSON response shape was invalid. Return exactly one JSON object matching shared_context.protocol.response_contract. For tool use, use mode=tool_calls and a top-level tool_calls array. Each call must be {\"tool\":\"name\",\"args\":{...}} with no aliases such as calls, name, function, arguments, type, or source."})
+            request = build_agent_request(project, args.prompt, retain_working_notes({"phase": "response_validation_error", "tool_observations": response_validation_errors, "instruction": "Your previous JSON response shape was invalid. Return exactly one JSON object matching shared_context.protocol.response_contract, including bounded working_notes. For tool use, use mode=tool_calls and a top-level tool_calls array. Each call must be {\"tool\":\"name\",\"args\":{...}} with no aliases such as calls, name, function, arguments, type, or source."}, working_notes))
             trace_events.append({"kind": "next_request", "turn": turn, "summary": summarize_request_for_trace(request)})
             continue
+        working_notes = response["working_notes"].strip()
+        trace_events.append({"kind": "working_notes", "turn": turn, "notes": working_notes})
         if mode == "edits" or (mode != "tool_calls" and response.get("edits")):
             observations = []
             for edit in response.get("edits") or []:
@@ -1020,7 +1038,7 @@ def main() -> int:
             if turn >= MAX_TURNS:
                 write_trace_file(trace_file, trace_meta, trace_events, 1, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
                 return 1
-            request = build_agent_request(project, args.prompt, {"phase": "direct_edit_test_failure", "tool_observations": observations, "test_observation": final, "instruction": "Direct edits were applied or rolled back, but the required local behavior test failed. Inspect shared_context.workflow_rules.behavior_test_expectations and current source, then fix it using tool calls. Use precise write_symbol calls; write_file is reserved for host recovery and is not part of the normal tool list."})
+            request = build_agent_request(project, args.prompt, retain_working_notes({"phase": "direct_edit_test_failure", "tool_observations": observations, "test_observation": final, "instruction": "Direct edits were applied or rolled back, but the required local behavior test failed. Update working_notes, inspect the exact failure, then fix it using precise tool calls."}, working_notes))
             continue
         if mode != "tool_calls" or not tool_calls:
             final = run_behavior_tests(project)
@@ -1032,13 +1050,13 @@ def main() -> int:
             if turn >= MAX_TURNS:
                 write_trace_file(trace_file, trace_meta, trace_events, 1, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
                 return 1
-            request = build_agent_request(project, args.prompt, {"phase": "done_or_empty_test_failure", "tool_observations": [], "test_observation": final, "instruction": "The model returned done or an unsupported shape, but the required local behavior test failed. Inspect shared_context.workflow_rules.behavior_test_expectations and current source, then fix it using tool calls. Fix duplicate or misplaced symbols with precise write_symbol calls; write_file is not part of the normal tool list."})
+            request = build_agent_request(project, args.prompt, retain_working_notes({"phase": "done_or_empty_test_failure", "tool_observations": [], "test_observation": final, "instruction": "The model returned done, but the required local behavior test failed. Update working_notes with the failure and fix it using precise tool calls."}, working_notes))
             continue
         observations, last_diagnostics = execute_tool_batch(project, tool_calls, last_diagnostics)
         total_actions += len(tool_calls)
         print(json.dumps({"tool_observations": summarize_observations(observations)}, indent=2))
         trace_events.append({"kind": "tool_observations", "turn": turn, "observations": observations, "summary": summarize_observations(observations)})
-        request = build_agent_request(project, args.prompt, {"phase": "tool_observations", "tool_observations": observations, "instruction": "Use observations to continue or return mode=done. If tests fail, inspect shared_context.workflow_rules.behavior_test_expectations and fix the exact required state/checks. Do not repeat identical tool calls."})
+        request = build_agent_request(project, args.prompt, retain_working_notes({"phase": "tool_observations", "tool_observations": observations, "instruction": "Use observations and retained working_notes to continue or return mode=done. Update Intent, Observed, Next, and Blocker on the next response. If tests fail, fix the exact required state/checks. Do not repeat identical tool calls."}, working_notes))
         trace_events.append({"kind": "next_request", "turn": turn, "summary": summarize_request_for_trace(request)})
     print(json.dumps({"error": "tool_call_limit", "actions": total_actions, "last_diagnostics": last_diagnostics}, indent=2))
     trace_events.append({"kind": "tool_call_limit", "actions": total_actions, "last_diagnostics": last_diagnostics})

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -29,6 +29,7 @@ REQUIRED_FILES = [
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiObservationMemory.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiToolLoopPolicy.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiWorkingNotes.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopConnectivity.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopBackgroundWorkPolicy.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopLongWorkCoordinator.java",
@@ -886,6 +887,11 @@ def main() -> int:
     assert "retainedToolObservations" in activity
     assert "read_only_batch_not_executed" in activity
     assert "Never reread a target already present" in activity
+    assert 'responseProperties.put("working_notes"' in activity
+    assert 'put("maxLength", WorkshopAiWorkingNotes.MAX_CHARS)' in activity
+    assert 'setStatusText("AI working notes: " + display)' in activity
+    assert 'appendAiTrace("working_notes"' in activity
+    assert "Report decisions and evidence, not private chain-of-thought" in activity
     assert "runtimeStateJson" in activity
     assert "frameValuesToJson" in activity
     assert "aiToolGetDiagnostics" in activity
@@ -943,6 +949,9 @@ def main() -> int:
     assert "AI_PREF_MODEL_DEFAULT_VERSION" in activity
     assert 'DEFAULT_MODEL = "gpt-5.6-sol"' in host_agent
     assert 'DEFAULT_REASONING_EFFORT = "medium"' in host_agent
+    assert "MAX_WORKING_NOTES_CHARS = 2_000" in host_agent
+    assert '"required": ["mode", "working_notes"]' in host_agent
+    assert '"kind": "working_notes"' in host_agent
     assert '"cache_write": 6.25' in host_agent
     assert "prompt_cache_key" in activity
     assert "prompt_cache_breakpoint" in activity

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -27,6 +27,8 @@ REQUIRED_FILES = [
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAssetIdentity.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopMoney.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiPricing.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiObservationMemory.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiToolLoopPolicy.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopConnectivity.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopBackgroundWorkPolicy.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopLongWorkCoordinator.java",
@@ -877,8 +879,13 @@ def main() -> int:
     assert "aiToolSetInputState" in activity
     assert "nativeRunTests" in activity
     assert "test `name`(): bool" in activity
-    assert "The app compiles once after each tool-call batch that contains writes and runs tests after each tool-call batch" in activity
-    assert "Use on_code_swap() for post-hot-swap migration" in activity
+    assert "read-only inspection batches do not rerun tests" in activity
+    assert "Use on_code_swap() only for post-hot-swap migration" in activity
+    assert "MAX_AI_TOOL_CALLS_PER_BATCH = 12" in activity
+    assert "MAX_AI_READ_ONLY_BATCHES = 2" in activity
+    assert "retainedToolObservations" in activity
+    assert "read_only_batch_not_executed" in activity
+    assert "Never reread a target already present" in activity
     assert "runtimeStateJson" in activity
     assert "frameValuesToJson" in activity
     assert "aiToolGetDiagnostics" in activity


### PR DESCRIPTION
## What changed

- Retain bounded cumulative tool observations across stateless AI turns.
- Stop rerunning tests for read-only batches and cap tool batches at 12 calls.
- Require a write or completion after two read-only inspection batches.
- Require a user-visible 2,000-character working_notes field on every response with concise Intent, Observed, Next, and Blocker facts.
- Carry the latest valid note into the next turn, show a compact copy in Workshop status, and retain the full note in the private bounded trace.
- Mirror the working-notes response contract in the host harness.
- Add deterministic host tests for memory bounds, read-to-write progression, and note limits/display.

## Root cause

Each model call received only the immediately previous observation batch while the prompt encouraged broad feature-path inspection. Non-identical read batches bypassed the exact-repeat guard, causing the model to reread source until the 15-turn limit with zero writes. The UI also exposed only code/tool outcomes, not the model's concise current intent and learned facts.

## Validation

- gradle :app:testWorkshopDebugUnitTest
- gradle :app:compileWorkshopReleaseJavaWithJavac
- gradle :app:assembleWorkshopDebug
- python tools/ci/check_android_shell.py
- python tools/android_ai_agent_host.py --preflight --prompt 'paddles should be double height'
- Installed the debug APK on the connected Samsung device without launching it.

Live reproduction of the original Pong prompt remains pending explicit user confirmation for active device testing.