### PR TITLE
fix: sync Pong sprite manifest hash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 *.sh text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+*.svg text eol=lf
+mobile/android/app/src/main/assets/**/assets/manifest.json text eol=lf

--- a/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
+++ b/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
@@ -5,7 +5,7 @@
     {
       "id": "ball",
       "path": "assets/ball.svg",
-      "content_sha256": "70609d72c6242dba12810fb0a8f8a4a61fbe9b22dae4785c72d08055fcbfadfa",
+      "content_sha256": "075baafd6990059e87d662eadac088b339ba713f39ccea9303d59fe6529f880b",
       "format": {
         "kind": "sprite",
         "encoding": "svg",

--- a/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
+++ b/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
@@ -5,7 +5,7 @@
     {
       "id": "ball",
       "path": "assets/ball.svg",
-      "content_sha256": "075baafd6990059e87d662eadac088b339ba713f39ccea9303d59fe6529f880b",
+      "content_sha256": "70609d72c6242dba12810fb0a8f8a4a61fbe9b22dae4785c72d08055fcbfadfa",
       "format": {
         "kind": "sprite",
         "encoding": "svg",


### PR DESCRIPTION
## Summary
- force SVG assets and Android asset manifests to check out with LF line endings
- restore the bundled Pong `ball.svg` manifest hash to the LF blob hash used by CI and APK packaging
- keep the published/shared sprite resolver deterministic on both Windows and Linux

## Tests
- `cargo test -p stasis --bin stasis tests::android_aot_bundle_writes_pong_symbols_header -- --nocapture`
- `cargo test -p stasis_android_bridge sprite -- --nocapture`
- `python tools\ci\check_android_shell.py`
- source hash sanity: `assets/manifest.json` hash matches `assets/ball.svg`
- `powershell -ExecutionPolicy Bypass -File .\mobile\android\build_published.ps1 -ValidateAot`
- `python tools\ci\check_android_published_apk.py mobile\android\app\build\outputs\apk\published\release\app-published-release-unsigned.apk`
- APK zip sanity: packaged manifest hash matches packaged `ball.svg`

## CI
- PR CI run 29249832270 is green: `test` and `bootstrap-smoke-windows` passed.