### PR TITLE
feat: add shared mobile runtime core

### DIFF
--- a/docs/mobile_runtime_core.md
+++ b/docs/mobile_runtime_core.md
@@ -1,0 +1,31 @@
+# Shared Mobile Runtime Core
+
+Android and iOS release shells link `stasis_mobile_runtime` together with the
+compiler-produced AOT game objects. The core is a fixed-entry lifecycle layer;
+it never loads game code dynamically and does not include the desktop runner.
+
+Platform shells provide `main`, `tick`, and `render` entry pointers plus the
+existing HostFrame, window-request, and render-command buffers in a
+`StasisMobileRuntimeConfig`. The core then:
+
+1. starts the shared SDL-only graphics runtime
+2. calls game `main` once
+3. snapshots input and applies window requests
+4. calls `tick` and `render` in order
+5. submits the shared render-command buffers
+
+Pause and focus state are explicit and do not replace or reload game code.
+`on_code_swap` remains ABI-compatible metadata but is never called on mobile.
+
+Mobile CMake builds default to `STASIS_GRAPHICS_SDL_ONLY=ON`, build the static
+`stasis_mobile_runtime` target, and leave the desktop dynamic runner and sys
+runtime disabled. Both platform shells consume the same public header and
+static library; platform SDK code remains a thin adapter around this API.
+
+Host-side link and lifecycle coverage lives under `runtime/tests`:
+
+```powershell
+cmake -S runtime/tests -B target/mobile-runtime-tests
+cmake --build target/mobile-runtime-tests --config Release
+ctest --test-dir target/mobile-runtime-tests -C Release --output-on-failure
+```

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,14 +1,24 @@
 cmake_minimum_required(VERSION 3.16)
 project(stasis_graphics C)
 
-option(STASIS_GRAPHICS_BUILD_SHARED "Build the graphics runtime as a DLL" ON)
+set(STASIS_MOBILE_PLATFORM OFF)
+set(STASIS_DESKTOP_RUNTIME_DEFAULT ON)
+set(STASIS_GRAPHICS_SHARED_DEFAULT ON)
+if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(STASIS_MOBILE_PLATFORM ON)
+    set(STASIS_DESKTOP_RUNTIME_DEFAULT OFF)
+    set(STASIS_GRAPHICS_SHARED_DEFAULT OFF)
+endif()
+
+option(STASIS_GRAPHICS_BUILD_SHARED "Build the graphics runtime as a DLL" ${STASIS_GRAPHICS_SHARED_DEFAULT})
 option(STASIS_GRAPHICS_BUILD_STATIC "Build the graphics runtime as a static library" ON)
-option(STASIS_BUILD_RUNNER "Build the stasis DLL runner executable" ON)
-option(STASIS_BUILD_SYS "Build the sys runtime (file/argv/exec)" ON)
+option(STASIS_BUILD_RUNNER "Build the stasis DLL runner executable" ${STASIS_DESKTOP_RUNTIME_DEFAULT})
+option(STASIS_BUILD_SYS "Build the sys runtime (file/argv/exec)" ${STASIS_DESKTOP_RUNTIME_DEFAULT})
+option(STASIS_BUILD_MOBILE_RUNTIME "Build the fixed-AOT mobile runtime core" ${STASIS_MOBILE_PLATFORM})
 
 # Android and other restricted platforms do not support the OpenGL 2.1 + GLEW path.
 set(STASIS_GRAPHICS_SDL_ONLY_DEFAULT OFF)
-if(ANDROID)
+if(STASIS_MOBILE_PLATFORM)
     set(STASIS_GRAPHICS_SDL_ONLY_DEFAULT ON)
 endif()
 option(STASIS_GRAPHICS_SDL_ONLY "Build SDL_Renderer-only runtime (no OpenGL/GLEW backend)" ${STASIS_GRAPHICS_SDL_ONLY_DEFAULT})
@@ -101,6 +111,22 @@ if(STASIS_GRAPHICS_BUILD_STATIC)
     install(TARGETS stasis_graphics_static
         ARCHIVE DESTINATION lib
     )
+endif()
+
+if(STASIS_BUILD_MOBILE_RUNTIME)
+    if(NOT STASIS_GRAPHICS_BUILD_STATIC)
+        message(FATAL_ERROR "STASIS_BUILD_MOBILE_RUNTIME requires STASIS_GRAPHICS_BUILD_STATIC=ON")
+    endif()
+    if(NOT STASIS_GRAPHICS_SDL_ONLY)
+        message(FATAL_ERROR "The mobile runtime requires STASIS_GRAPHICS_SDL_ONLY=ON")
+    endif()
+
+    add_library(stasis_mobile_runtime STATIC stasis_mobile_runtime.c)
+    target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+    target_link_libraries(stasis_mobile_runtime PUBLIC stasis_graphics_static)
+    set_target_properties(stasis_mobile_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
+    install(FILES stasis_mobile_runtime.h DESTINATION include)
 endif()
 
 if(STASIS_BUILD_SYS)

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2,6 +2,11 @@
 
 Native SDL2+OpenGL graphics library for Stasis programs.
 
+Mobile release shells use the shared fixed-AOT lifecycle core documented in
+`../docs/mobile_runtime_core.md`. Android and iOS both link the
+`stasis_mobile_runtime` static target with `STASIS_GRAPHICS_SDL_ONLY=ON`; they
+do not link the desktop dynamic runner.
+
 ## Prerequisites
 
 - CMake 3.16+

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -1,0 +1,142 @@
+#include "stasis_mobile_runtime.h"
+
+#include <string.h>
+
+int stasis_init_window(int width, int height, const char *title);
+int stasis_should_quit(void);
+void stasis_shutdown(void);
+void stasis_host_bulk_init(const int32_t *host_req_seq);
+void stasis_host_bulk_apply_requests(
+    const int32_t *host_req_seq,
+    const int32_t *host_req_flags,
+    const int32_t *host_req_window_w_px,
+    const int32_t *host_req_window_h_px);
+void stasis_host_get_frame(int32_t *out_i32, float *out_f32);
+void stasis_gfx_submit_u8(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8);
+
+static int stasis_mobile_game_is_valid(const StasisMobileGame *game)
+{
+    return game &&
+        game->main_entry && game->tick_entry && game->render_entry &&
+        game->host_i32 && game->host_f32 &&
+        game->gfx_cmd_i32 && game->gfx_cmd_f32 && game->gfx_cmd_u8;
+}
+
+static int32_t stasis_mobile_stop(StasisMobileRuntime *runtime, int32_t result)
+{
+    runtime->last_result = result;
+    runtime->stopped = 1;
+    return result;
+}
+
+int32_t stasis_mobile_runtime_start(
+    StasisMobileRuntime *runtime,
+    const StasisMobileRuntimeConfig *config)
+{
+    if (!runtime || !config || config->struct_size < sizeof(*config) ||
+        !stasis_mobile_game_is_valid(&config->game))
+    {
+        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
+    }
+    if (config->abi_version != STASIS_MOBILE_RUNTIME_ABI_VERSION)
+    {
+        return STASIS_MOBILE_RUNTIME_ABI_MISMATCH;
+    }
+
+    memset(runtime, 0, sizeof(*runtime));
+    runtime->config = *config;
+    runtime->focused = 1;
+
+    const char *title = config->window_title ? config->window_title : "Stasis";
+    if (stasis_init_window(config->window_width, config->window_height, title) != 0)
+    {
+        return stasis_mobile_stop(runtime, STASIS_MOBILE_RUNTIME_WINDOW_FAILED);
+    }
+
+    stasis_host_bulk_init(config->game.host_req_seq);
+    runtime->started = 1;
+    const int32_t main_result = config->game.main_entry();
+    if (main_result != 0)
+    {
+        return stasis_mobile_stop(runtime, main_result);
+    }
+    stasis_host_bulk_apply_requests(
+        config->game.host_req_seq,
+        config->game.host_req_flags,
+        config->game.host_req_window_w_px,
+        config->game.host_req_window_h_px);
+    return STASIS_MOBILE_RUNTIME_OK;
+}
+
+int32_t stasis_mobile_runtime_step(StasisMobileRuntime *runtime)
+{
+    if (!runtime || !runtime->started)
+    {
+        return STASIS_MOBILE_RUNTIME_NOT_STARTED;
+    }
+    if (runtime->stopped)
+    {
+        return runtime->last_result;
+    }
+    if (runtime->paused || !runtime->focused)
+    {
+        return STASIS_MOBILE_RUNTIME_OK;
+    }
+
+    StasisMobileGame *game = &runtime->config.game;
+    stasis_host_get_frame(game->host_i32, game->host_f32);
+    if (stasis_should_quit() || game->host_i32[9] != 0)
+    {
+        return stasis_mobile_stop(runtime, STASIS_MOBILE_RUNTIME_STOP);
+    }
+    stasis_host_bulk_apply_requests(
+        game->host_req_seq,
+        game->host_req_flags,
+        game->host_req_window_w_px,
+        game->host_req_window_h_px);
+
+    const int32_t tick_result = game->tick_entry();
+    if (tick_result != 0)
+    {
+        return stasis_mobile_stop(runtime, tick_result);
+    }
+    const int32_t render_result = game->render_entry();
+    if (render_result != 0)
+    {
+        return stasis_mobile_stop(runtime, render_result);
+    }
+
+    stasis_gfx_submit_u8(game->gfx_cmd_i32, game->gfx_cmd_f32, game->gfx_cmd_u8);
+    runtime->frame_count += 1;
+    return STASIS_MOBILE_RUNTIME_OK;
+}
+
+void stasis_mobile_runtime_set_paused(StasisMobileRuntime *runtime, int paused)
+{
+    if (runtime)
+    {
+        runtime->paused = paused ? 1 : 0;
+    }
+}
+
+void stasis_mobile_runtime_set_focused(StasisMobileRuntime *runtime, int focused)
+{
+    if (runtime)
+    {
+        runtime->focused = focused ? 1 : 0;
+    }
+}
+
+void stasis_mobile_runtime_shutdown(StasisMobileRuntime *runtime)
+{
+    if (!runtime || !runtime->started)
+    {
+        return;
+    }
+    stasis_shutdown();
+    runtime->started = 0;
+    runtime->stopped = 1;
+}

--- a/runtime/stasis_mobile_runtime.h
+++ b/runtime/stasis_mobile_runtime.h
@@ -1,0 +1,72 @@
+#ifndef STASIS_MOBILE_RUNTIME_H
+#define STASIS_MOBILE_RUNTIME_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STASIS_MOBILE_RUNTIME_ABI_VERSION 1u
+
+typedef int32_t (*StasisMobileI32Entry)(void);
+typedef void (*StasisMobileVoidEntry)(void);
+
+typedef struct StasisMobileGame {
+    StasisMobileI32Entry main_entry;
+    StasisMobileI32Entry tick_entry;
+    StasisMobileI32Entry render_entry;
+    StasisMobileVoidEntry on_code_swap_entry;
+    int32_t *host_i32;
+    float *host_f32;
+    int32_t *gfx_cmd_i32;
+    float *gfx_cmd_f32;
+    uint8_t *gfx_cmd_u8;
+    int32_t *host_req_seq;
+    int32_t *host_req_flags;
+    int32_t *host_req_window_w_px;
+    int32_t *host_req_window_h_px;
+} StasisMobileGame;
+
+typedef struct StasisMobileRuntimeConfig {
+    uint32_t abi_version;
+    size_t struct_size;
+    int32_t window_width;
+    int32_t window_height;
+    const char *window_title;
+    StasisMobileGame game;
+} StasisMobileRuntimeConfig;
+
+typedef struct StasisMobileRuntime {
+    StasisMobileRuntimeConfig config;
+    uint64_t frame_count;
+    int32_t last_result;
+    uint8_t started;
+    uint8_t paused;
+    uint8_t focused;
+    uint8_t stopped;
+} StasisMobileRuntime;
+
+enum {
+    STASIS_MOBILE_RUNTIME_OK = 0,
+    STASIS_MOBILE_RUNTIME_STOP = 1,
+    STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT = -1,
+    STASIS_MOBILE_RUNTIME_ABI_MISMATCH = -2,
+    STASIS_MOBILE_RUNTIME_WINDOW_FAILED = -3,
+    STASIS_MOBILE_RUNTIME_NOT_STARTED = -4
+};
+
+int32_t stasis_mobile_runtime_start(
+    StasisMobileRuntime *runtime,
+    const StasisMobileRuntimeConfig *config);
+int32_t stasis_mobile_runtime_step(StasisMobileRuntime *runtime);
+void stasis_mobile_runtime_set_paused(StasisMobileRuntime *runtime, int paused);
+void stasis_mobile_runtime_set_focused(StasisMobileRuntime *runtime, int focused);
+void stasis_mobile_runtime_shutdown(StasisMobileRuntime *runtime);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(stasis_mobile_runtime_tests C)
+
+enable_testing()
+
+add_library(stasis_mobile_runtime_core STATIC ../stasis_mobile_runtime.c)
+target_include_directories(stasis_mobile_runtime_core PUBLIC ..)
+
+add_library(stasis_mobile_fake_sdl STATIC fake_sdl_runtime.c)
+
+add_executable(stasis_mobile_runtime_test stasis_mobile_runtime_test.c)
+target_link_libraries(stasis_mobile_runtime_test PRIVATE
+    stasis_mobile_runtime_core
+    stasis_mobile_fake_sdl)
+add_test(NAME stasis_mobile_runtime_lifecycle COMMAND stasis_mobile_runtime_test)
+
+foreach(platform android ios)
+    add_executable(stasis_${platform}_shell_link_test mobile_shell_link_test.c)
+    target_compile_definitions(stasis_${platform}_shell_link_test PRIVATE
+        STASIS_TEST_PLATFORM="${platform}")
+    target_link_libraries(stasis_${platform}_shell_link_test PRIVATE
+        stasis_mobile_runtime_core
+        stasis_mobile_fake_sdl)
+    add_test(NAME stasis_${platform}_shell_links_shared_core
+        COMMAND stasis_${platform}_shell_link_test)
+endforeach()

--- a/runtime/tests/fake_sdl_runtime.c
+++ b/runtime/tests/fake_sdl_runtime.c
@@ -1,0 +1,70 @@
+#include "fake_sdl_runtime.h"
+
+#include <stdint.h>
+#include <string.h>
+
+int fake_init_count;
+int fake_shutdown_count;
+int fake_host_frame_count;
+int fake_submit_count;
+int fake_quit_requested;
+
+void fake_sdl_runtime_reset(void)
+{
+    fake_init_count = 0;
+    fake_shutdown_count = 0;
+    fake_host_frame_count = 0;
+    fake_submit_count = 0;
+    fake_quit_requested = 0;
+}
+
+int stasis_init_window(int width, int height, const char *title)
+{
+    fake_init_count += 1;
+    return width > 0 && height > 0 && title ? 0 : -1;
+}
+
+int stasis_should_quit(void)
+{
+    return fake_quit_requested;
+}
+
+void stasis_shutdown(void)
+{
+    fake_shutdown_count += 1;
+}
+
+void stasis_host_bulk_init(const int32_t *host_req_seq)
+{
+    (void)host_req_seq;
+}
+
+void stasis_host_bulk_apply_requests(
+    const int32_t *host_req_seq,
+    const int32_t *host_req_flags,
+    const int32_t *host_req_window_w_px,
+    const int32_t *host_req_window_h_px)
+{
+    (void)host_req_seq;
+    (void)host_req_flags;
+    (void)host_req_window_w_px;
+    (void)host_req_window_h_px;
+}
+
+void stasis_host_get_frame(int32_t *out_i32, float *out_f32)
+{
+    fake_host_frame_count += 1;
+    memset(out_i32, 0, sizeof(int32_t) * 16);
+    memset(out_f32, 0, sizeof(float) * 16);
+}
+
+void stasis_gfx_submit_u8(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8)
+{
+    if (cmd_i32 && cmd_f32 && cmd_u8)
+    {
+        fake_submit_count += 1;
+    }
+}

--- a/runtime/tests/fake_sdl_runtime.h
+++ b/runtime/tests/fake_sdl_runtime.h
@@ -1,0 +1,12 @@
+#ifndef STASIS_MOBILE_FAKE_SDL_RUNTIME_H
+#define STASIS_MOBILE_FAKE_SDL_RUNTIME_H
+
+extern int fake_init_count;
+extern int fake_shutdown_count;
+extern int fake_host_frame_count;
+extern int fake_submit_count;
+extern int fake_quit_requested;
+
+void fake_sdl_runtime_reset(void);
+
+#endif

--- a/runtime/tests/mobile_shell_link_test.c
+++ b/runtime/tests/mobile_shell_link_test.c
@@ -1,0 +1,52 @@
+#include "stasis_mobile_runtime.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define CHECK(condition) do { if (!(condition)) return __LINE__; } while (0)
+
+#ifndef STASIS_TEST_PLATFORM
+#define STASIS_TEST_PLATFORM "unknown"
+#endif
+
+static int32_t entry(void)
+{
+    return 0;
+}
+
+int main(void)
+{
+    int32_t host_i32[16] = {0};
+    float host_f32[16] = {0};
+    int32_t gfx_i32[16] = {0};
+    float gfx_f32[16] = {0};
+    uint8_t gfx_u8[16] = {0};
+    int32_t request_values[4] = {0};
+    StasisMobileRuntimeConfig config;
+    StasisMobileRuntime runtime;
+
+    memset(&config, 0, sizeof(config));
+    config.abi_version = STASIS_MOBILE_RUNTIME_ABI_VERSION;
+    config.struct_size = sizeof(config);
+    config.window_width = 640;
+    config.window_height = 360;
+    config.window_title = STASIS_TEST_PLATFORM;
+    config.game.main_entry = entry;
+    config.game.tick_entry = entry;
+    config.game.render_entry = entry;
+    config.game.host_i32 = host_i32;
+    config.game.host_f32 = host_f32;
+    config.game.gfx_cmd_i32 = gfx_i32;
+    config.game.gfx_cmd_f32 = gfx_f32;
+    config.game.gfx_cmd_u8 = gfx_u8;
+    config.game.host_req_seq = &request_values[0];
+    config.game.host_req_flags = &request_values[1];
+    config.game.host_req_window_w_px = &request_values[2];
+    config.game.host_req_window_h_px = &request_values[3];
+
+    CHECK(stasis_mobile_runtime_start(&runtime, &config) == 0);
+    CHECK(stasis_mobile_runtime_step(&runtime) == 0);
+    CHECK(runtime.frame_count == 1);
+    stasis_mobile_runtime_shutdown(&runtime);
+    return 0;
+}

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -1,0 +1,115 @@
+#include "stasis_mobile_runtime.h"
+
+#include "fake_sdl_runtime.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define CHECK(condition) do { if (!(condition)) return __LINE__; } while (0)
+
+static int main_count;
+static int tick_count;
+static int render_count;
+static int tick_result;
+static int swap_count;
+
+static int32_t game_main(void)
+{
+    main_count += 1;
+    return 0;
+}
+
+static int32_t game_tick(void)
+{
+    tick_count += 1;
+    return tick_result;
+}
+
+static void game_on_code_swap(void)
+{
+    swap_count += 1;
+}
+
+static int32_t game_render(void)
+{
+    render_count += 1;
+    return 0;
+}
+
+static StasisMobileRuntimeConfig test_config(void)
+{
+    static int32_t host_i32[16];
+    static float host_f32[16];
+    static int32_t gfx_i32[16];
+    static float gfx_f32[16];
+    static uint8_t gfx_u8[16];
+    static int32_t request_values[4];
+    StasisMobileRuntimeConfig config;
+
+    memset(&config, 0, sizeof(config));
+    config.abi_version = STASIS_MOBILE_RUNTIME_ABI_VERSION;
+    config.struct_size = sizeof(config);
+    config.window_width = 800;
+    config.window_height = 600;
+    config.window_title = "test";
+    config.game.main_entry = game_main;
+    config.game.tick_entry = game_tick;
+    config.game.render_entry = game_render;
+    config.game.on_code_swap_entry = game_on_code_swap;
+    config.game.host_i32 = host_i32;
+    config.game.host_f32 = host_f32;
+    config.game.gfx_cmd_i32 = gfx_i32;
+    config.game.gfx_cmd_f32 = gfx_f32;
+    config.game.gfx_cmd_u8 = gfx_u8;
+    config.game.host_req_seq = &request_values[0];
+    config.game.host_req_flags = &request_values[1];
+    config.game.host_req_window_w_px = &request_values[2];
+    config.game.host_req_window_h_px = &request_values[3];
+    return config;
+}
+
+int main(void)
+{
+    StasisMobileRuntime runtime;
+    StasisMobileRuntimeConfig config = test_config();
+
+    fake_sdl_runtime_reset();
+    memset(&runtime, 0, sizeof(runtime));
+    CHECK(stasis_mobile_runtime_start(&runtime, &config) == 0);
+    CHECK(main_count == 1);
+    CHECK(fake_init_count == 1);
+
+    CHECK(stasis_mobile_runtime_step(&runtime) == 0);
+    CHECK(tick_count == 1);
+    CHECK(render_count == 1);
+    CHECK(fake_host_frame_count == 1);
+    CHECK(fake_submit_count == 1);
+    CHECK(runtime.frame_count == 1);
+    CHECK(swap_count == 0);
+
+    stasis_mobile_runtime_set_paused(&runtime, 1);
+    CHECK(stasis_mobile_runtime_step(&runtime) == 0);
+    stasis_mobile_runtime_set_paused(&runtime, 0);
+    stasis_mobile_runtime_set_focused(&runtime, 0);
+    CHECK(stasis_mobile_runtime_step(&runtime) == 0);
+    CHECK(tick_count == 1);
+
+    stasis_mobile_runtime_set_focused(&runtime, 1);
+    tick_result = 7;
+    CHECK(stasis_mobile_runtime_step(&runtime) == 7);
+    CHECK(render_count == 1);
+    CHECK(stasis_mobile_runtime_step(&runtime) == 7);
+
+    stasis_mobile_runtime_shutdown(&runtime);
+    stasis_mobile_runtime_shutdown(&runtime);
+    CHECK(fake_shutdown_count == 1);
+
+    config.abi_version += 1;
+    CHECK(stasis_mobile_runtime_start(&runtime, &config) ==
+        STASIS_MOBILE_RUNTIME_ABI_MISMATCH);
+    config.abi_version = STASIS_MOBILE_RUNTIME_ABI_VERSION;
+    config.game.render_entry = 0;
+    CHECK(stasis_mobile_runtime_start(&runtime, &config) ==
+        STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT);
+    return 0;
+}

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -9,4 +9,7 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 python3 tools/ci/check_stasis_src_layout.py
+cmake -S runtime/tests -B target/mobile-runtime-tests -DCMAKE_BUILD_TYPE=Release
+cmake --build target/mobile-runtime-tests --config Release
+ctest --test-dir target/mobile-runtime-tests -C Release --output-on-failure
 cargo test --workspace --all-targets -- --test-threads=1


### PR DESCRIPTION
## Summary
- add a platform-neutral fixed-AOT mobile lifecycle core for `main`, `tick`, and `render`
- link Android and iOS shells to the same SDL-only static runtime target without the desktop dynamic runner
- add always-on Release lifecycle and dual-shell link tests, documentation, and validation wiring

## Validation
- `cmake -S runtime/tests -B target/mobile-runtime-tests`
- `cmake --build target/mobile-runtime-tests --config Release`
- `ctest --test-dir target/mobile-runtime-tests -C Release --output-on-failure` (3/3 passed)
- configured and built real `stasis_mobile_runtime` + `stasis_graphics_static` with `STASIS_GRAPHICS_SDL_ONLY=ON` and local vcpkg
- `python tools/ci/check_stasis_src_layout.py`
- `git diff --check`

## Local environment note
`tools/validate_repo.sh` could not launch because Bash is unavailable. Direct workspace Cargo validation was attempted; parallel MSVC linking hit `LNK1318` PDB `LIMIT (12)`, and the serialized retry exhausted drive space while writing a Rust archive. The generated `target/debug` output was removed. GitHub CI is the clean full-suite gate.

Maddox task: #112