### PR TITLE
feat: extract shared mobile runtime core

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2085,8 +2085,22 @@ mod tests {
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    const STASIS_GRAPHICS_SOURCE: &str =
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../runtime/stasis_graphics.c"));
+    const STASIS_GRAPHICS_SOURCE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_graphics.c"
+    ));
+    const STASIS_MOBILE_RUNTIME_SOURCE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_mobile_runtime.c"
+    ));
+    const STASIS_MOBILE_RUNTIME_HEADER: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_mobile_runtime.h"
+    ));
+    const STASIS_RUNTIME_CMAKE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/CMakeLists.txt"
+    ));
 
     fn jit_global_table_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
@@ -2120,6 +2134,61 @@ mod tests {
                     "clamp_i32(SPRITE_TABLE_INITIAL_CAPACITY, 1, limit)"
                 ),
             "runtime sprite allocation should clamp the initial growth step to STASIS_GFX_MAX_SPRITES"
+        );
+    }
+
+    #[test]
+    fn mobile_runtime_uses_fixed_entries_and_sdl_only_static_target() {
+        for required in [
+            "typedef void (*StasisMobileEntry)(void)",
+            "StasisMobileEntry bind_runtime_entry",
+            "StasisMobileEntry main_entry",
+            "StasisMobileEntry tick_entry",
+            "StasisMobileEntry render_entry",
+            "STASIS_MOBILE_RUNTIME_ABI_VERSION 1",
+        ] {
+            assert!(
+                STASIS_MOBILE_RUNTIME_HEADER.contains(required),
+                "mobile runtime ABI should contain {required}"
+            );
+        }
+        for required in [
+            "runtime_state.entries.bind_runtime_entry()",
+            "runtime_state.entries.main_entry()",
+            "runtime_state.entries.tick_entry()",
+            "runtime_state.entries.render_entry()",
+            "stasis_should_quit()",
+            "stasis_mobile_poll_events()",
+            "stasis_mobile_set_paused(runtime_state.paused)",
+            "void stasis_mobile_runtime_shutdown(void)",
+        ] {
+            assert!(
+                STASIS_MOBILE_RUNTIME_SOURCE.contains(required),
+                "mobile lifecycle should contain {required}"
+            );
+        }
+        assert!(
+            STASIS_RUNTIME_CMAKE
+                .contains("configure_stasis_target(stasis_mobile_runtime ON TRUE OFF)"),
+            "mobile target should be static, SDL-only, and exclude the SDL desktop main shim"
+        );
+        assert!(
+            !STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_dynload")
+                && !STASIS_MOBILE_RUNTIME_SOURCE.contains("on_code_swap")
+                && !STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_runner"),
+            "mobile runtime must not acquire desktop loader or hot-swap dependencies"
+        );
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains("SDL_DestroyRenderer(g_renderer);")
+                && STASIS_GRAPHICS_SOURCE.contains("g_renderer = NULL;")
+                && STASIS_GRAPHICS_SOURCE.contains("g_window = NULL;"),
+            "mobile lifecycle cleanup should support safe shutdown and initialization retry"
+        );
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains("STASIS_EXPORT int stasis_mobile_poll_events(void)")
+                && STASIS_GRAPHICS_SOURCE
+                    .contains("SDL_PauseAudioDevice(g_audio_device, paused ? 1 : 0)"),
+            "mobile pause should continue polling events and pause the audio device"
         );
     }
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1319,6 +1319,10 @@ fn try_run_mobile_aot_bundle_subcommand() -> Option<i32> {
                 "mobile_aot_symbols_header={}",
                 summary.symbols_header.display()
             );
+            println!(
+                "mobile_aot_bindings_source={}",
+                summary.bindings_source.display()
+            );
             if let Some(cmake_file) = summary.cmake_file.as_ref() {
                 println!("mobile_aot_cmake_file={}", cmake_file.display());
             }
@@ -1378,6 +1382,7 @@ struct AndroidAotBundleSummary {
     bundle_dir: PathBuf,
     object_count: usize,
     symbols_header: PathBuf,
+    bindings_source: PathBuf,
     cmake_file: PathBuf,
     asset_dir: PathBuf,
 }
@@ -1387,6 +1392,7 @@ struct MobileAotBundleSummary {
     bundle_dir: PathBuf,
     object_count: usize,
     symbols_header: PathBuf,
+    bindings_source: PathBuf,
     cmake_file: Option<PathBuf>,
     asset_dir: PathBuf,
     package_manifest: PathBuf,
@@ -1418,6 +1424,7 @@ fn write_android_aot_engine_bundle(
         bundle_dir: summary.bundle_dir,
         object_count: summary.object_count,
         symbols_header: summary.symbols_header,
+        bindings_source: summary.bindings_source,
         cmake_file,
         asset_dir: summary.asset_dir,
     })
@@ -1448,6 +1455,8 @@ fn write_mobile_aot_engine_bundle(
         .map_err(|error| format!("failed to parse mobile AOT manifest: {error}"))?;
     let symbols_header = output_dir.join("published_aot_symbols.h");
     write_mobile_aot_symbols_header(&manifest_json, &symbols_header)?;
+    let bindings_source = output_dir.join("published_aot_bindings.c");
+    write_mobile_aot_bindings_source(&manifest_json, &bindings_source)?;
     let cmake_file = if target == MobileAotTarget::AndroidArm64 {
         let path = output_dir.join("published_aot_objects.cmake");
         write_android_aot_cmake_file(&bundle.object_paths_by_function, &path)?;
@@ -1462,6 +1471,7 @@ fn write_mobile_aot_engine_bundle(
         &asset_dir,
         &bundle.object_paths_by_function,
         &symbols_header,
+        &bindings_source,
         cmake_file.as_deref(),
         output_dir,
     )?;
@@ -1470,6 +1480,7 @@ fn write_mobile_aot_engine_bundle(
         bundle_dir: bundle.output_dir,
         object_count: bundle.object_paths_by_function.len(),
         symbols_header,
+        bindings_source,
         cmake_file,
         asset_dir,
         package_manifest,
@@ -1673,6 +1684,7 @@ fn write_mobile_aot_symbols_header(
     let on_code_swap = mobile_aot_symbol_for(manifest, "on_code_swap").ok();
     let mut out = String::new();
     out.push_str("#pragma once\n\n");
+    out.push_str("extern void stasis_aot_bind_runtime_globals(void);\n");
     for symbol in [&main, &tick, &render] {
         out.push_str(&format!("extern void {symbol}(void);\n"));
     }
@@ -1680,6 +1692,7 @@ fn write_mobile_aot_symbols_header(
         out.push_str(&format!("extern void {symbol}(void);\n"));
     }
     out.push_str("\n");
+    out.push_str("#define STASIS_AOT_BIND_RUNTIME_GLOBALS stasis_aot_bind_runtime_globals\n");
     out.push_str(&format!("#define STASIS_AOT_MAIN {main}\n"));
     out.push_str(&format!("#define STASIS_AOT_TICK {tick}\n"));
     out.push_str(&format!("#define STASIS_AOT_RENDER {render}\n"));
@@ -1697,6 +1710,76 @@ fn write_mobile_aot_symbols_header(
     fs::write(output_path, out).map_err(|error| {
         format!(
             "failed to write mobile AOT symbol header {}: {error}",
+            output_path.display()
+        )
+    })
+}
+
+fn write_mobile_aot_bindings_source(
+    manifest: &serde_json::Value,
+    output_path: &Path,
+) -> Result<(), String> {
+    let functions = manifest
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
+    let literals = manifest
+        .get("string_literals")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
+    let mut out = String::from("#include <stdint.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n");
+    for function in functions {
+        let symbol = function
+            .get("symbol")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
+        out.push_str(&format!("extern void {symbol}(void);\n"));
+    }
+    for literal in literals {
+        let id = literal
+            .get("id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
+        let value = literal
+            .get("value")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT string literal missing value".to_string())?;
+        out.push_str(&format!(
+            "static const char stasis_mobile_literal_{}[] = {};\n",
+            id.unsigned_abs(),
+            serde_json::to_string(value)
+                .map_err(|error| format!("failed to encode mobile string literal: {error}"))?
+        ));
+    }
+    out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
+    for function in functions {
+        let symbol = function
+            .get("symbol")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
+        let fn_id = symbol
+            .strip_prefix("aot_fn_")
+            .and_then(|value| value.parse::<i32>().ok())
+            .ok_or_else(|| format!("mobile AOT function has invalid symbol '{symbol}'"))?;
+        out.push_str(&format!(
+            "    stasis_jit_register_code_ptr({fn_id}, (int64_t)(uintptr_t)&{symbol});\n"
+        ));
+    }
+    out.push_str("    stasis_jit_clear_string_literal_table();\n");
+    for literal in literals {
+        let id = literal
+            .get("id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
+        out.push_str(&format!(
+            "    stasis_jit_upsert_string_literal({id}, stasis_mobile_literal_{});\n",
+            id.unsigned_abs()
+        ));
+    }
+    out.push_str("}\n");
+    fs::write(output_path, out).map_err(|error| {
+        format!(
+            "failed to write mobile AOT bindings source {}: {error}",
             output_path.display()
         )
     })
@@ -1724,6 +1807,7 @@ fn write_mobile_aot_package_manifest(
     asset_dir: &Path,
     object_paths_by_function: &std::collections::BTreeMap<String, PathBuf>,
     symbols_header: &Path,
+    bindings_source: &Path,
     cmake_file: Option<&Path>,
     output_dir: &Path,
 ) -> Result<PathBuf, String> {
@@ -1741,6 +1825,7 @@ fn write_mobile_aot_package_manifest(
         "target": target.as_str(),
         "engine_manifest": engine_manifest_path.to_string_lossy().replace('\\', "/"),
         "symbols_header": symbols_header.to_string_lossy().replace('\\', "/"),
+        "bindings_source": bindings_source.to_string_lossy().replace('\\', "/"),
         "asset_root": asset_dir.to_string_lossy().replace('\\', "/"),
         "asset_manifest": asset_dir.join("stasis_game").join(DEFAULT_ASSET_MANIFEST_PATH).to_string_lossy().replace('\\', "/"),
         "objects": objects,
@@ -2219,6 +2304,8 @@ mod tests {
 
     #[test]
     fn android_aot_bundle_writes_pong_symbols_header() {
+        use object::{Object, ObjectSymbol};
+
         let stamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("clock")
@@ -2236,11 +2323,87 @@ mod tests {
 
         assert!(summary.object_count >= 3, "expected lifecycle objects");
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
+        assert!(
+            header
+                .lines()
+                .filter(|line| line.starts_with("extern void aot_fn_") && line.ends_with("(void);"))
+                .count()
+                >= 3,
+            "mobile AOT lifecycle symbols must match StasisMobileEntry void(void) callbacks"
+        );
+        let mobile_runtime_header =
+            fs::read_to_string(repo_root.join("runtime/stasis_mobile_runtime.h"))
+                .expect("read mobile runtime header");
+        assert!(mobile_runtime_header.contains("typedef void (*StasisMobileEntry)(void)"));
+        let bindings =
+            fs::read_to_string(&summary.bindings_source).expect("read mobile AOT bindings source");
+        assert!(bindings.contains("void stasis_aot_bind_runtime_globals(void)"));
+        assert!(bindings.contains("stasis_jit_register_code_ptr(0"));
         assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
+        assert!(header.contains("#define STASIS_AOT_BIND_RUNTIME_GLOBALS"));
         assert!(header.contains("#define STASIS_AOT_TICK aot_fn_"));
         assert!(header.contains("#define STASIS_AOT_RENDER aot_fn_"));
         let cmake = fs::read_to_string(&summary.cmake_file).expect("read cmake file");
         assert!(cmake.contains("set(STASIS_PUBLISHED_AOT_OBJECTS"));
+        assert!(!cmake.contains("published_aot_bindings.c"));
+
+        let mut defined = BTreeSet::new();
+        let mut undefined = BTreeSet::new();
+        for entry in fs::read_dir(&summary.bundle_dir).expect("read bundle directory") {
+            let path = entry.expect("bundle entry").path();
+            if path.extension().and_then(|value| value.to_str()) != Some("o") {
+                continue;
+            }
+            let bytes = fs::read(&path).expect("read AOT object");
+            let object = object::File::parse(bytes.as_slice()).expect("parse AOT object");
+            for symbol in object.symbols() {
+                let Ok(name) = symbol.name() else { continue };
+                if symbol.is_undefined() {
+                    undefined.insert(name.to_string());
+                } else {
+                    defined.insert(name.to_string());
+                }
+            }
+        }
+        let mobile_aot_runtime =
+            fs::read_to_string(repo_root.join("runtime/stasis_mobile_aot_runtime.c"))
+                .expect("read shared mobile AOT runtime");
+        let mobile_aot_header =
+            fs::read_to_string(repo_root.join("runtime/stasis_mobile_aot_runtime.h"))
+                .expect("read shared mobile AOT runtime header");
+        let graphics_runtime = fs::read_to_string(repo_root.join("runtime/stasis_graphics.c"))
+            .expect("read graphics runtime");
+        let missing: Vec<_> = undefined
+            .difference(&defined)
+            .filter(|symbol| {
+                !mobile_aot_runtime.contains(&format!("{symbol}("))
+                    && !mobile_aot_header.contains(&format!("{symbol}("))
+                    && !graphics_runtime.contains(&format!("{symbol}("))
+            })
+            .cloned()
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "shared mobile core must provide AOT imports: {missing:?}"
+        );
+        let runtime_exports = fs::read_to_string(
+            repo_root.join("crates/stasis_compiler/src/backend/runtime_exports.rs"),
+        )
+        .expect("read compiler AOT runtime exports");
+        let unsupported_exports: Vec<_> = runtime_exports
+            .lines()
+            .map(str::trim)
+            .filter_map(|line| line.strip_prefix('"')?.strip_suffix("\","))
+            .filter(|symbol| {
+                !mobile_aot_runtime.contains(&format!("{symbol}("))
+                    && !mobile_aot_header.contains(&format!("{symbol}("))
+                    && !graphics_runtime.contains(&format!("{symbol}("))
+            })
+            .collect();
+        assert!(
+            unsupported_exports.is_empty(),
+            "shared mobile core must cover every compiler AOT import: {unsupported_exports:?}"
+        );
         assert!(summary
             .asset_dir
             .join("stasis_game/assets/manifest.json")

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1745,10 +1745,9 @@ fn write_mobile_aot_bindings_source(
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| "mobile AOT string literal missing value".to_string())?;
         out.push_str(&format!(
-            "static const char stasis_mobile_literal_{}[] = {};\n",
+            "static const char stasis_mobile_literal_{}[] = \"{}\";\n",
             id.unsigned_abs(),
-            serde_json::to_string(value)
-                .map_err(|error| format!("failed to encode mobile string literal: {error}"))?
+            escape_mobile_c_string_literal(value)
         ));
     }
     out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
@@ -1783,6 +1782,22 @@ fn write_mobile_aot_bindings_source(
             output_path.display()
         )
     })
+}
+
+fn escape_mobile_c_string_literal(value: &str) -> String {
+    let mut escaped = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'\\' => escaped.push_str("\\\\"),
+            b'"' => escaped.push_str("\\\""),
+            b'\n' => escaped.push_str("\\n"),
+            b'\r' => escaped.push_str("\\r"),
+            b'\t' => escaped.push_str("\\t"),
+            b' '..=b'~' => escaped.push(char::from(byte)),
+            _ => escaped.push_str(&format!("\\{byte:03o}")),
+        }
+    }
+    escaped
 }
 
 fn mobile_aot_symbol_for(
@@ -1923,6 +1938,14 @@ fn try_run_aot_cli_subcommand() -> Option<i32> {
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn mobile_c_string_literal_escaping_is_byte_exact() {
+        assert_eq!(
+            escape_mobile_c_string_literal("a\0b\n\"\\\u{e9}"),
+            "a\\000b\\n\\\"\\\\\\303\\251"
+        );
+    }
 
     fn temp_lookup_root(name: &str) -> PathBuf {
         let stamp = SystemTime::now()

--- a/docs/mobile_aot_artifacts.md
+++ b/docs/mobile_aot_artifacts.md
@@ -22,6 +22,8 @@ Each bundle contains:
   string literal metadata, collection max lengths, and optimization profile.
 - `published_aot_symbols.h`: C macros for `main`, `tick`, `render`, and optional
   `on_code_swap` symbols.
+- `published_aot_bindings.c`: platform-neutral registration for linked function
+  pointers and string literals consumed by the shared mobile runtime core.
 - `mobile_aot_bundle_manifest.json`: package-level target, object, symbol-header,
   engine-manifest, asset-root, and asset-manifest paths for platform shells.
 - `apk_assets/stasis_game/...` for Android assets or `ios_assets/stasis_game/...`

--- a/docs/mobile_runtime_core.md
+++ b/docs/mobile_runtime_core.md
@@ -1,0 +1,62 @@
+# Shared Mobile Runtime Core
+
+Android and iOS release apps link the same `stasis_mobile_runtime` static C
+library. The target compiles the existing Stasis graphics, input, audio, and
+asset host APIs with `STASIS_GRAPHICS_SDL_ONLY`; it never links the desktop SDL
+entry shim, DLL runner, dynamic loader, JIT, watcher, or hot-swap code.
+
+## Shell integration
+
+A thin platform shell supplies the compiler-generated `main`, `tick`, and
+`render` symbols through `StasisMobileGameEntries`, then calls:
+
+```c
+#include "stasis_mobile_runtime.h"
+#include "published_aot_symbols.h"
+
+StasisMobileGameEntries game = {
+    STASIS_AOT_BIND_RUNTIME_GLOBALS,
+    STASIS_AOT_MAIN,
+    STASIS_AOT_TICK,
+    STASIS_AOT_RENDER
+};
+StasisMobileRuntimeConfig config = {1280, 720, "My Stasis Game"};
+
+int status = stasis_mobile_runtime_initialize(&config, &game);
+while (status == STASIS_MOBILE_RUNTIME_OK) {
+    status = stasis_mobile_runtime_step();
+}
+stasis_mobile_runtime_shutdown();
+```
+
+The generated AOT symbol header declares each entry as `void(void)` and is the
+source of the actual symbol names. The generated `published_aot_bindings.c`
+registers linked function pointers and string literals with the shared AOT
+state/dispatch layer; shells compile it as an ordinary source file and do not
+discover symbols dynamically.
+
+Platform pause and resume callbacks call `stasis_mobile_runtime_set_paused`.
+The platform adapter also maps the packaged `stasis_game` asset root to a path
+or SDL-backed resource view that the unchanged Stasis asset APIs can consume.
+
+## CMake
+
+Mobile toolchains enable the target by default. A shell embedding the runtime
+from a parent CMake project can also request it explicitly:
+
+```cmake
+set(STASIS_BUILD_MOBILE_RUNTIME ON CACHE BOOL "" FORCE)
+set(STASIS_GRAPHICS_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+set(STASIS_GRAPHICS_BUILD_STATIC OFF CACHE BOOL "" FORCE)
+set(STASIS_BUILD_RUNNER OFF CACHE BOOL "" FORCE)
+set(STASIS_BUILD_SYS OFF CACHE BOOL "" FORCE)
+add_subdirectory(path/to/stasis/runtime stasis-runtime)
+target_link_libraries(my_mobile_shell PRIVATE stasis_mobile_runtime)
+```
+
+The parent project may provide `SDL2::SDL2` and `SDL2_image::SDL2_image`
+targets directly. Otherwise the runtime resolves their CMake packages.
+
+Android's generated `published_aot_objects.cmake` includes the bindings source.
+An iOS target adds the package manifest's `bindings_source` alongside its AOT
+objects before linking `stasis_mobile_runtime`.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,17 +1,41 @@
 cmake_minimum_required(VERSION 3.16)
 project(stasis_graphics C)
 
-option(STASIS_GRAPHICS_BUILD_SHARED "Build the graphics runtime as a DLL" ON)
-option(STASIS_GRAPHICS_BUILD_STATIC "Build the graphics runtime as a static library" ON)
-option(STASIS_BUILD_RUNNER "Build the stasis DLL runner executable" ON)
-option(STASIS_BUILD_SYS "Build the sys runtime (file/argv/exec)" ON)
+set(STASIS_MOBILE_PLATFORM OFF)
+if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(STASIS_MOBILE_PLATFORM ON)
+endif()
+
+set(STASIS_DESKTOP_TARGET_DEFAULT ON)
+if(STASIS_MOBILE_PLATFORM)
+    set(STASIS_DESKTOP_TARGET_DEFAULT OFF)
+endif()
+
+option(
+    STASIS_GRAPHICS_BUILD_SHARED
+    "Build the graphics runtime as a DLL"
+    ${STASIS_DESKTOP_TARGET_DEFAULT}
+)
+option(
+    STASIS_GRAPHICS_BUILD_STATIC
+    "Build the desktop graphics static library"
+    ${STASIS_DESKTOP_TARGET_DEFAULT}
+)
+option(STASIS_BUILD_RUNNER "Build the stasis DLL runner executable" ${STASIS_DESKTOP_TARGET_DEFAULT})
+option(STASIS_BUILD_SYS "Build the sys runtime (file/argv/exec)" ${STASIS_DESKTOP_TARGET_DEFAULT})
+option(
+    STASIS_BUILD_MOBILE_RUNTIME
+    "Build the shared SDL-only mobile runtime core"
+    ${STASIS_MOBILE_PLATFORM}
+)
+option(STASIS_MOBILE_RUNTIME_BUILD_TESTS "Build mobile runtime lifecycle tests" OFF)
 
 # Android and other restricted platforms do not support the OpenGL 2.1 + GLEW path.
-set(STASIS_GRAPHICS_SDL_ONLY_DEFAULT OFF)
-if(ANDROID)
-    set(STASIS_GRAPHICS_SDL_ONLY_DEFAULT ON)
-endif()
-option(STASIS_GRAPHICS_SDL_ONLY "Build SDL_Renderer-only runtime (no OpenGL/GLEW backend)" ${STASIS_GRAPHICS_SDL_ONLY_DEFAULT})
+option(
+    STASIS_GRAPHICS_SDL_ONLY
+    "Build SDL_Renderer-only runtime (no OpenGL/GLEW backend)"
+    ${STASIS_MOBILE_PLATFORM}
+)
 
 # Prefer static CRT when possible (for single-exe bundling)
 if (MSVC)
@@ -19,27 +43,34 @@ if (MSVC)
 endif()
 
 # Find graphics deps only when building graphics targets.
-if(STASIS_GRAPHICS_BUILD_SHARED OR STASIS_GRAPHICS_BUILD_STATIC)
+if(STASIS_GRAPHICS_BUILD_SHARED OR STASIS_GRAPHICS_BUILD_STATIC OR STASIS_BUILD_MOBILE_RUNTIME)
     # Find SDL2 (via vcpkg or system)
-    find_package(SDL2 CONFIG REQUIRED)
-    find_package(SDL2_image CONFIG REQUIRED)
+    if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
+        find_package(SDL2 CONFIG REQUIRED)
+    endif()
+    if(NOT TARGET SDL2_image::SDL2_image AND NOT TARGET SDL2_image::SDL2_image-static)
+        find_package(SDL2_image CONFIG REQUIRED)
+    endif()
 
-    if(NOT STASIS_GRAPHICS_SDL_ONLY)
+    if((STASIS_GRAPHICS_BUILD_SHARED OR STASIS_GRAPHICS_BUILD_STATIC) AND
+       NOT STASIS_GRAPHICS_SDL_ONLY)
         # Find OpenGL and GLEW (desktop backend)
         find_package(OpenGL REQUIRED)
         find_package(GLEW REQUIRED)
     endif()
 endif()
 
-function(configure_stasis_target target is_static)
+function(configure_stasis_target target is_static sdl_only link_sdl_main)
     target_sources(${target} PRIVATE stasis_graphics.c)
+    if(link_sdl_main)
+        target_link_libraries(${target} PRIVATE $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>)
+    endif()
     target_link_libraries(${target} PRIVATE
-        $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
         $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
         $<IF:$<TARGET_EXISTS:SDL2_image::SDL2_image>,SDL2_image::SDL2_image,SDL2_image::SDL2_image-static>
     )
 
-    if(NOT STASIS_GRAPHICS_SDL_ONLY)
+    if(NOT sdl_only)
         target_link_libraries(${target} PRIVATE
             OpenGL::GL
             GLEW::GLEW
@@ -62,7 +93,7 @@ function(configure_stasis_target target is_static)
     endif()
 
     if(${is_static})
-        if(NOT STASIS_GRAPHICS_SDL_ONLY)
+        if(NOT sdl_only)
             target_compile_definitions(${target} PRIVATE STASIS_GRAPHICS_STATIC GLEW_STATIC)
         else()
             target_compile_definitions(${target} PRIVATE STASIS_GRAPHICS_STATIC)
@@ -72,7 +103,7 @@ endfunction()
 
 if(STASIS_GRAPHICS_BUILD_SHARED)
     add_library(stasis_graphics SHARED)
-    configure_stasis_target(stasis_graphics OFF)
+    configure_stasis_target(stasis_graphics OFF ${STASIS_GRAPHICS_SDL_ONLY} ON)
 
     # On Windows, use .def file for explicit exports
     if(WIN32)
@@ -92,7 +123,7 @@ endif()
 
 if(STASIS_GRAPHICS_BUILD_STATIC)
     add_library(stasis_graphics_static STATIC)
-    configure_stasis_target(stasis_graphics_static ON)
+    configure_stasis_target(stasis_graphics_static ON ${STASIS_GRAPHICS_SDL_ONLY} ON)
     set_target_properties(stasis_graphics_static PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Release"
         ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/Release"
@@ -101,6 +132,48 @@ if(STASIS_GRAPHICS_BUILD_STATIC)
     install(TARGETS stasis_graphics_static
         ARCHIVE DESTINATION lib
     )
+endif()
+
+if(STASIS_BUILD_MOBILE_RUNTIME)
+    add_library(
+        stasis_mobile_runtime STATIC
+        stasis_mobile_runtime.c
+        stasis_mobile_aot_runtime.c
+    )
+    configure_stasis_target(stasis_mobile_runtime ON TRUE OFF)
+    target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+    set_target_properties(stasis_mobile_runtime PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/mobile"
+    )
+    install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
+    install(
+        FILES stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
+        DESTINATION include
+    )
+endif()
+
+if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
+    enable_testing()
+    add_executable(
+        stasis_mobile_runtime_test
+        tests/stasis_mobile_runtime_test.c
+        stasis_mobile_runtime.c
+        stasis_mobile_aot_runtime.c
+    )
+    target_include_directories(stasis_mobile_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_mobile_runtime_lifecycle COMMAND stasis_mobile_runtime_test)
+    add_executable(
+        stasis_mobile_aot_runtime_test
+        tests/stasis_mobile_aot_runtime_test.c
+        stasis_mobile_aot_runtime.c
+    )
+    target_include_directories(stasis_mobile_aot_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    if(NOT WIN32)
+        target_link_libraries(stasis_mobile_runtime_test PRIVATE m)
+        target_link_libraries(stasis_mobile_aot_runtime_test PRIVATE m)
+    endif()
+    add_test(NAME stasis_mobile_aot_runtime_contract COMMAND stasis_mobile_aot_runtime_test)
 endif()
 
 if(STASIS_BUILD_SYS)

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -43,6 +43,12 @@ Android builds currently use the SDL_Renderer backend only (no OpenGL 2.1/GLEW p
 Build helper:
 - `runtime/build_android.ps1` (requires `ANDROID_NDK_HOME` and vcpkg via `VCPKG_ROOT` or `C:\vcpkg`)
 
+## Shared mobile core
+
+Android and iOS release shells link the `stasis_mobile_runtime` static target.
+It forces the SDL-only backend and excludes the desktop runner and SDL main
+shim. See `docs/mobile_runtime_core.md` for the lifecycle ABI and CMake setup.
+
 Brickout Revenge debug APK workflow:
 - See `docs/brickout-android-debug-plan.md` and use `android/build_brickout_android_debug.ps1` + `android/install_brickout_android_debug.ps1`.
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -3252,6 +3252,8 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
         if (!g_renderer) {
             SDL_Log("SDL_CreateRenderer failed: %s", SDL_GetError());
             SDL_DestroyWindow(g_window);
+            g_window = NULL;
+            g_use_sdl_renderer = false;
             SDL_Quit();
             return 0;
         }
@@ -4494,6 +4496,19 @@ STASIS_EXPORT int stasis_should_quit(void) {
     return g_should_quit ? 1 : 0;
 }
 
+/* Mobile lifecycle polling remains responsive while no frame is presented. */
+STASIS_EXPORT int stasis_mobile_poll_events(void) {
+    stasis_pump_events();
+    g_events_pumped_this_frame = 0;
+    return g_should_quit ? 1 : 0;
+}
+
+STASIS_EXPORT void stasis_mobile_set_paused(int paused) {
+    if (g_audio_device != 0) {
+        SDL_PauseAudioDevice(g_audio_device, paused ? 1 : 0);
+    }
+}
+
 /*
  * Get current window width in pixels
  */
@@ -4602,6 +4617,11 @@ STASIS_EXPORT void stasis_shutdown(void) {
             g_fonts[i].active = false;
         }
     }
+    if (g_renderer) {
+        SDL_DestroyRenderer(g_renderer);
+        g_renderer = NULL;
+    }
+    g_use_sdl_renderer = false;
     if (g_gl_context) {
         SDL_GL_DeleteContext(g_gl_context);
         g_gl_context = NULL;

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -1,0 +1,523 @@
+#include "stasis_mobile_aot_runtime.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STASIS_MOBILE_MAX_SCALARS 2048
+#define STASIS_MOBILE_MAX_ARRAYS 512
+#define STASIS_MOBILE_MAX_FUNCTIONS 1024
+#define STASIS_MOBILE_MAX_STRINGS 512
+#define STASIS_MOBILE_MAX_ARRAY_LENGTH 1048576
+
+int stasis_audio_init(int sample_rate, int channels, int target_latency_frames);
+void stasis_audio_shutdown(void);
+int stasis_audio_is_available(void);
+int stasis_audio_get_sample_rate(void);
+int stasis_audio_get_channels(void);
+int stasis_audio_get_queued_frames(void);
+int stasis_audio_get_underruns(void);
+int stasis_audio_push_f32_interleaved(const float *samples, int frames);
+int stasis_gfx_load_sprite(const char *path, int max_w, int max_h);
+void stasis_gfx_release_sprite(int handle);
+int stasis_gfx_dump_bmp(const char *path);
+int stasis_gfx_cache_text(int font, const char *text);
+int stasis_gfx_poll_reload(int handle);
+float stasis_gfx_measure_text_cached(int handle);
+int stasis_load_font(const char *path, int size);
+float stasis_measure_text(int font, const char *text);
+void stasis_sleep_ms(int ms);
+
+typedef union StasisScalarValue {
+    int32_t i32_value;
+    float f32_value;
+    double f64_value;
+    void *ptr;
+} StasisScalarValue;
+
+typedef struct StasisScalar {
+    int32_t hash;
+    int kind;
+    int external;
+    StasisScalarValue value;
+} StasisScalar;
+
+typedef struct StasisArray {
+    int32_t collection_hash;
+    int32_t field_hash;
+    int kind;
+    int external;
+    size_t length;
+    void *data;
+} StasisArray;
+
+typedef struct StasisCodePtr {
+    int32_t fn_id;
+    int64_t code_ptr;
+} StasisCodePtr;
+
+typedef struct StasisStringLiteral {
+    int32_t id;
+    const char *value;
+} StasisStringLiteral;
+
+enum {
+    STASIS_VALUE_I32 = 1,
+    STASIS_VALUE_F32 = 2,
+    STASIS_VALUE_F64 = 3,
+    STASIS_VALUE_U8 = 4
+};
+
+static StasisScalar scalars[STASIS_MOBILE_MAX_SCALARS];
+static size_t scalar_count;
+static StasisArray arrays[STASIS_MOBILE_MAX_ARRAYS];
+static size_t array_count;
+static StasisCodePtr code_ptrs[STASIS_MOBILE_MAX_FUNCTIONS];
+static size_t code_ptr_count;
+static StasisStringLiteral strings[STASIS_MOBILE_MAX_STRINGS];
+static size_t string_count;
+
+static size_t value_size(int kind) {
+    if (kind == STASIS_VALUE_I32) return sizeof(int32_t);
+    if (kind == STASIS_VALUE_F32) return sizeof(float);
+    if (kind == STASIS_VALUE_F64) return sizeof(double);
+    if (kind == STASIS_VALUE_U8) return sizeof(uint8_t);
+    return 0;
+}
+
+static StasisScalar *find_scalar(int32_t hash, int kind, int create) {
+    size_t index;
+    for (index = 0; index < scalar_count; index += 1) {
+        if (scalars[index].hash == hash && scalars[index].kind == kind) {
+            return &scalars[index];
+        }
+    }
+    if (!create || scalar_count >= STASIS_MOBILE_MAX_SCALARS) return NULL;
+    scalars[scalar_count].hash = hash;
+    scalars[scalar_count].kind = kind;
+    return &scalars[scalar_count++];
+}
+
+static StasisArray *find_array(
+    int32_t collection_hash, int32_t field_hash, int kind, int create
+) {
+    size_t index;
+    for (index = 0; index < array_count; index += 1) {
+        StasisArray *entry = &arrays[index];
+        if (entry->collection_hash == collection_hash &&
+            entry->field_hash == field_hash && entry->kind == kind) {
+            return entry;
+        }
+    }
+    if (!create || array_count >= STASIS_MOBILE_MAX_ARRAYS) return NULL;
+    arrays[array_count].collection_hash = collection_hash;
+    arrays[array_count].field_hash = field_hash;
+    arrays[array_count].kind = kind;
+    return &arrays[array_count++];
+}
+
+static void *ensure_array(StasisArray *entry, size_t length) {
+    size_t bytes;
+    void *next;
+    if (entry == NULL || length == 0 || length > STASIS_MOBILE_MAX_ARRAY_LENGTH) return NULL;
+    if (entry->external) return length <= entry->length ? entry->data : NULL;
+    if (length <= entry->length) return entry->data;
+    bytes = length * value_size(entry->kind);
+    next = realloc(entry->data, bytes);
+    if (next == NULL) return NULL;
+    memset((unsigned char *)next + entry->length * value_size(entry->kind),
+        0, (length - entry->length) * value_size(entry->kind));
+    entry->data = next;
+    entry->length = length;
+    return next;
+}
+
+static void register_scalar_ptr(int32_t hash, int kind, void *ptr) {
+    StasisScalar *entry = find_scalar(hash, kind, 1);
+    if (entry == NULL) return;
+    entry->external = 1;
+    entry->value.ptr = ptr;
+}
+
+static void register_array(
+    int32_t collection_hash, int32_t field_hash, int kind, void *ptr, int32_t len
+) {
+    StasisArray *entry;
+    if (ptr == NULL || len <= 0) return;
+    entry = find_array(collection_hash, field_hash, kind, 1);
+    if (entry == NULL) return;
+    if (!entry->external) free(entry->data);
+    entry->external = 1;
+    entry->data = ptr;
+    entry->length = (size_t)len;
+}
+
+void stasis_mobile_aot_reset(void) {
+    size_t index;
+    for (index = 0; index < array_count; index += 1) {
+        if (!arrays[index].external) free(arrays[index].data);
+    }
+    memset(scalars, 0, sizeof(scalars));
+    memset(arrays, 0, sizeof(arrays));
+    memset(code_ptrs, 0, sizeof(code_ptrs));
+    memset(strings, 0, sizeof(strings));
+    scalar_count = 0;
+    array_count = 0;
+    code_ptr_count = 0;
+    string_count = 0;
+}
+
+void stasis_jit_register_global_i32_ptr(int32_t hash, int32_t *ptr) {
+    register_scalar_ptr(hash, STASIS_VALUE_I32, ptr);
+}
+void stasis_jit_register_global_f32_ptr(int32_t hash, float *ptr) {
+    register_scalar_ptr(hash, STASIS_VALUE_F32, ptr);
+}
+void stasis_jit_register_global_f64_ptr(int32_t hash, double *ptr) {
+    register_scalar_ptr(hash, STASIS_VALUE_F64, ptr);
+}
+void stasis_jit_register_global_i32_array(int32_t c, int32_t f, int32_t *p, int32_t n) {
+    register_array(c, f, STASIS_VALUE_I32, p, n);
+}
+void stasis_jit_register_global_f32_array(int32_t c, int32_t f, float *p, int32_t n) {
+    register_array(c, f, STASIS_VALUE_F32, p, n);
+}
+void stasis_jit_register_global_f64_array(int32_t c, int32_t f, double *p, int32_t n) {
+    register_array(c, f, STASIS_VALUE_F64, p, n);
+}
+void stasis_jit_register_global_u8_array(int32_t c, int32_t f, uint8_t *p, int32_t n) {
+    register_array(c, f, STASIS_VALUE_U8, p, n);
+}
+
+void stasis_jit_register_code_ptr(int32_t fn_id, int64_t code_ptr) {
+    size_t index;
+    for (index = 0; index < code_ptr_count; index += 1) {
+        if (code_ptrs[index].fn_id == fn_id) {
+            code_ptrs[index].code_ptr = code_ptr;
+            return;
+        }
+    }
+    if (code_ptr_count >= STASIS_MOBILE_MAX_FUNCTIONS) return;
+    code_ptrs[code_ptr_count++] = (StasisCodePtr){fn_id, code_ptr};
+}
+
+int64_t stasis_jit_lookup_code_ptr(int32_t fn_id) {
+    size_t index;
+    for (index = 0; index < code_ptr_count; index += 1) {
+        if (code_ptrs[index].fn_id == fn_id) return code_ptrs[index].code_ptr;
+    }
+    return 0;
+}
+
+#define DECLARE_I32_CALL_TYPE(name, ...) typedef int32_t (*name)(__VA_ARGS__)
+#define DECLARE_F32_CALL_TYPE(name, ...) typedef float (*name)(__VA_ARGS__)
+DECLARE_I32_CALL_TYPE(I32Call0, void);
+DECLARE_I32_CALL_TYPE(I32Call1, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call2, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call3, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call4, int32_t, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call5, int32_t, int32_t, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call6, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call7, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32Call8, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+DECLARE_I32_CALL_TYPE(I32F32Call1, float);
+DECLARE_I32_CALL_TYPE(I32F32Call2, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call3, float, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call4, float, float, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call5, float, float, float, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call6, float, float, float, float, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call7, float, float, float, float, float, float, float);
+DECLARE_I32_CALL_TYPE(I32F32Call8, float, float, float, float, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call0, void);
+DECLARE_F32_CALL_TYPE(F32Call1, float);
+DECLARE_F32_CALL_TYPE(F32Call2, float, float);
+DECLARE_F32_CALL_TYPE(F32Call3, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call4, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call5, float, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call6, float, float, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call7, float, float, float, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32Call8, float, float, float, float, float, float, float, float);
+DECLARE_F32_CALL_TYPE(F32I32Call1, int32_t);
+
+#define STASIS_CALL_PTR(fn, type) ((type)(uintptr_t)stasis_jit_lookup_code_ptr(fn))
+#define CALL_OR_ZERO(fn, type, call) do { type target = STASIS_CALL_PTR(fn, type); return target ? (call) : 0; } while (0)
+
+int32_t stasis_jit_call_i32_0(int32_t fn) { CALL_OR_ZERO(fn, I32Call0, target()); }
+int32_t stasis_jit_call_i32_1(int32_t fn, int32_t a0) { CALL_OR_ZERO(fn, I32Call1, target(a0)); }
+int32_t stasis_jit_call_i32_2(int32_t fn, int32_t a0, int32_t a1) { CALL_OR_ZERO(fn, I32Call2, target(a0,a1)); }
+int32_t stasis_jit_call_i32_3(int32_t fn, int32_t a0, int32_t a1, int32_t a2) { CALL_OR_ZERO(fn, I32Call3, target(a0,a1,a2)); }
+int32_t stasis_jit_call_i32_4(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3) { CALL_OR_ZERO(fn, I32Call4, target(a0,a1,a2,a3)); }
+int32_t stasis_jit_call_i32_5(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4) { CALL_OR_ZERO(fn, I32Call5, target(a0,a1,a2,a3,a4)); }
+int32_t stasis_jit_call_i32_6(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5) { CALL_OR_ZERO(fn, I32Call6, target(a0,a1,a2,a3,a4,a5)); }
+int32_t stasis_jit_call_i32_7(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5, int32_t a6) { CALL_OR_ZERO(fn, I32Call7, target(a0,a1,a2,a3,a4,a5,a6)); }
+int32_t stasis_jit_call_i32_8(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5, int32_t a6, int32_t a7) { CALL_OR_ZERO(fn, I32Call8, target(a0,a1,a2,a3,a4,a5,a6,a7)); }
+
+int32_t stasis_jit_call_i32_f32_1(int32_t fn, float a0) { CALL_OR_ZERO(fn, I32F32Call1, target(a0)); }
+int32_t stasis_jit_call_i32_f32_2(int32_t fn, float a0, float a1) { CALL_OR_ZERO(fn, I32F32Call2, target(a0,a1)); }
+int32_t stasis_jit_call_i32_f32_3(int32_t fn, float a0, float a1, float a2) { CALL_OR_ZERO(fn, I32F32Call3, target(a0,a1,a2)); }
+int32_t stasis_jit_call_i32_f32_4(int32_t fn, float a0, float a1, float a2, float a3) { CALL_OR_ZERO(fn, I32F32Call4, target(a0,a1,a2,a3)); }
+int32_t stasis_jit_call_i32_f32_5(int32_t fn, float a0, float a1, float a2, float a3, float a4) { CALL_OR_ZERO(fn, I32F32Call5, target(a0,a1,a2,a3,a4)); }
+int32_t stasis_jit_call_i32_f32_6(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5) { CALL_OR_ZERO(fn, I32F32Call6, target(a0,a1,a2,a3,a4,a5)); }
+int32_t stasis_jit_call_i32_f32_7(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6) { CALL_OR_ZERO(fn, I32F32Call7, target(a0,a1,a2,a3,a4,a5,a6)); }
+int32_t stasis_jit_call_i32_f32_8(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7) { CALL_OR_ZERO(fn, I32F32Call8, target(a0,a1,a2,a3,a4,a5,a6,a7)); }
+
+float stasis_jit_call_f32_0(int32_t fn) { CALL_OR_ZERO(fn, F32Call0, target()); }
+float stasis_jit_call_f32_1(int32_t fn, float a0) { CALL_OR_ZERO(fn, F32Call1, target(a0)); }
+float stasis_jit_call_f32_2(int32_t fn, float a0, float a1) { CALL_OR_ZERO(fn, F32Call2, target(a0,a1)); }
+float stasis_jit_call_f32_3(int32_t fn, float a0, float a1, float a2) { CALL_OR_ZERO(fn, F32Call3, target(a0,a1,a2)); }
+float stasis_jit_call_f32_4(int32_t fn, float a0, float a1, float a2, float a3) { CALL_OR_ZERO(fn, F32Call4, target(a0,a1,a2,a3)); }
+float stasis_jit_call_f32_5(int32_t fn, float a0, float a1, float a2, float a3, float a4) { CALL_OR_ZERO(fn, F32Call5, target(a0,a1,a2,a3,a4)); }
+float stasis_jit_call_f32_6(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5) { CALL_OR_ZERO(fn, F32Call6, target(a0,a1,a2,a3,a4,a5)); }
+float stasis_jit_call_f32_7(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6) { CALL_OR_ZERO(fn, F32Call7, target(a0,a1,a2,a3,a4,a5,a6)); }
+float stasis_jit_call_f32_8(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7) { CALL_OR_ZERO(fn, F32Call8, target(a0,a1,a2,a3,a4,a5,a6,a7)); }
+float stasis_jit_call_f32_i32_1(int32_t fn, int32_t a0) { CALL_OR_ZERO(fn, F32I32Call1, target(a0)); }
+
+void stasis_jit_clear_string_literal_table(void) {
+    memset(strings, 0, sizeof(strings));
+    string_count = 0;
+}
+
+void stasis_jit_upsert_string_literal(int32_t id, const char *value) {
+    size_t index;
+    for (index = 0; index < string_count; index += 1) {
+        if (strings[index].id == id) {
+            strings[index].value = value;
+            return;
+        }
+    }
+    if (string_count >= STASIS_MOBILE_MAX_STRINGS) return;
+    strings[string_count++] = (StasisStringLiteral){id, value};
+}
+
+static const char *find_string(int32_t id) {
+    size_t index;
+    for (index = 0; index < string_count; index += 1) {
+        if (strings[index].id == id) return strings[index].value;
+    }
+    return NULL;
+}
+
+static int32_t collection_meta_hash(int32_t hash, int32_t kind);
+
+static char *resolve_text(int32_t id) {
+    StasisArray *entry = find_array(id, 0, STASIS_VALUE_U8, 0);
+    int32_t length;
+    char *text;
+    size_t index;
+    const char *literal;
+
+    if (entry == NULL) entry = find_array(id, 0, STASIS_VALUE_I32, 0);
+    if (entry != NULL) {
+        length = stasis_jit_global_i32_load(collection_meta_hash(id, 1));
+        if (length < 0 || (size_t)length > entry->length) return NULL;
+        text = (char *)malloc((size_t)length + 1);
+        if (text == NULL) return NULL;
+        for (index = 0; index < (size_t)length; index += 1) {
+            int32_t value = stasis_jit_global_i32_array_load(id, 0, (int32_t)index);
+            if (value <= 0 || value > 255) {
+                free(text);
+                return NULL;
+            }
+            text[index] = (char)value;
+        }
+        text[length] = '\0';
+        return text;
+    }
+
+    literal = find_string(id);
+    if (literal == NULL) return NULL;
+    text = (char *)malloc(strlen(literal) + 1);
+    if (text != NULL) strcpy(text, literal);
+    return text;
+}
+
+int stasis_jit_audio_init(int32_t rate, int32_t channels, int32_t latency) {
+    return stasis_audio_init(rate, channels, latency);
+}
+void stasis_jit_audio_shutdown(void) { stasis_audio_shutdown(); }
+int stasis_jit_audio_is_available(void) { return stasis_audio_is_available(); }
+int stasis_jit_audio_get_sample_rate(void) { return stasis_audio_get_sample_rate(); }
+int stasis_jit_audio_get_channels(void) { return stasis_audio_get_channels(); }
+int stasis_jit_audio_get_queued_frames(void) { return stasis_audio_get_queued_frames(); }
+int stasis_jit_audio_get_underruns(void) { return stasis_audio_get_underruns(); }
+int stasis_jit_audio_push_f32_interleaved(int32_t samples, int32_t frames) {
+    int32_t channels = stasis_audio_get_channels();
+    float *values;
+    if (frames <= 0 || channels <= 0) return 0;
+    values = stasis_jit_global_f32_array_ptr(samples, 0, frames * channels);
+    return values == NULL ? 0 : stasis_audio_push_f32_interleaved(values, frames);
+}
+
+int stasis_jit_gfx_load_sprite(int32_t path, int32_t max_w, int32_t max_h) {
+    char *value = resolve_text(path);
+    int result = value == NULL ? 0 : stasis_gfx_load_sprite(value, max_w, max_h);
+    free(value);
+    return result;
+}
+void stasis_jit_gfx_release_sprite(int32_t handle) { stasis_gfx_release_sprite(handle); }
+int stasis_jit_gfx_dump_bmp(int32_t path) {
+    char *value = resolve_text(path);
+    int result = value == NULL ? 0 : stasis_gfx_dump_bmp(value);
+    free(value);
+    return result;
+}
+int stasis_jit_gfx_cache_text(int32_t font, int32_t text) {
+    char *value = resolve_text(text);
+    int result = value == NULL ? 0 : stasis_gfx_cache_text(font, value);
+    free(value);
+    return result;
+}
+int stasis_jit_gfx_poll_reload(int32_t handle) { return stasis_gfx_poll_reload(handle); }
+float stasis_jit_gfx_measure_text_cached(int32_t handle) {
+    return stasis_gfx_measure_text_cached(handle);
+}
+int stasis_jit_load_font(int32_t path, int32_t size) {
+    char *value = resolve_text(path);
+    int result = value == NULL ? 0 : stasis_load_font(value, size);
+    free(value);
+    return result;
+}
+float stasis_jit_measure_text(int32_t font, int32_t text) {
+    char *value = resolve_text(text);
+    float result = value == NULL ? 0.0f : stasis_measure_text(font, value);
+    free(value);
+    return result;
+}
+void stasis_jit_sleep_ms(int32_t ms) { stasis_sleep_ms(ms); }
+
+#define DEFINE_SCALAR_ACCESSORS(name, type, kind, member) \
+type stasis_jit_global_##name##_load(int32_t hash) { \
+    StasisScalar *entry = find_scalar(hash, kind, 0); \
+    if (entry == NULL) return (type)0; \
+    return entry->external ? *(type *)entry->value.ptr : entry->value.member; \
+} \
+void stasis_jit_global_##name##_store(int32_t hash, type value) { \
+    StasisScalar *entry = find_scalar(hash, kind, 1); \
+    if (entry == NULL) return; \
+    if (entry->external) *(type *)entry->value.ptr = value; \
+    else entry->value.member = value; \
+}
+
+DEFINE_SCALAR_ACCESSORS(i32, int32_t, STASIS_VALUE_I32, i32_value)
+DEFINE_SCALAR_ACCESSORS(f32, float, STASIS_VALUE_F32, f32_value)
+DEFINE_SCALAR_ACCESSORS(f64, double, STASIS_VALUE_F64, f64_value)
+
+#define DEFINE_ARRAY_ACCESSORS(name, type, kind) \
+type stasis_jit_global_##name##_array_load(int32_t c, int32_t f, int32_t i) { \
+    StasisArray *entry; \
+    if (i < 0) return (type)0; \
+    entry = find_array(c, f, kind, 0); \
+    return entry != NULL && (size_t)i < entry->length ? ((type *)entry->data)[i] : (type)0; \
+} \
+void stasis_jit_global_##name##_array_store(int32_t c, int32_t f, int32_t i, type value) { \
+    StasisArray *entry; \
+    if (i < 0) return; \
+    entry = find_array(c, f, kind, 1); \
+    if (ensure_array(entry, (size_t)i + 1) != NULL) ((type *)entry->data)[i] = value; \
+} \
+type *stasis_jit_global_##name##_array_ptr(int32_t c, int32_t f, int32_t len) { \
+    StasisArray *entry; \
+    if (len <= 0) return NULL; \
+    entry = find_array(c, f, kind, 1); \
+    return (type *)ensure_array(entry, (size_t)len); \
+}
+
+DEFINE_ARRAY_ACCESSORS(f32, float, STASIS_VALUE_F32)
+DEFINE_ARRAY_ACCESSORS(f64, double, STASIS_VALUE_F64)
+
+int32_t stasis_jit_global_i32_array_load(int32_t c, int32_t f, int32_t i) {
+    StasisArray *entry;
+    if (i < 0) return 0;
+    entry = find_array(c, f, STASIS_VALUE_I32, 0);
+    if (entry != NULL && (size_t)i < entry->length) return ((int32_t *)entry->data)[i];
+    entry = find_array(c, f, STASIS_VALUE_U8, 0);
+    if (entry != NULL && (size_t)i < entry->length) return ((uint8_t *)entry->data)[i];
+    return 0;
+}
+
+void stasis_jit_global_i32_array_store(
+    int32_t c, int32_t f, int32_t i, int32_t value
+) {
+    StasisArray *entry;
+    if (i < 0) return;
+    entry = find_array(c, f, STASIS_VALUE_I32, 0);
+    if (entry != NULL) {
+        if (ensure_array(entry, (size_t)i + 1) != NULL) ((int32_t *)entry->data)[i] = value;
+        return;
+    }
+    entry = find_array(c, f, STASIS_VALUE_U8, 0);
+    if (entry != NULL) {
+        if ((size_t)i < entry->length) ((uint8_t *)entry->data)[i] = (uint8_t)value;
+        return;
+    }
+    entry = find_array(c, f, STASIS_VALUE_I32, 1);
+    if (ensure_array(entry, (size_t)i + 1) != NULL) ((int32_t *)entry->data)[i] = value;
+}
+
+int32_t *stasis_jit_global_i32_array_ptr(int32_t c, int32_t f, int32_t len) {
+    StasisArray *entry;
+    if (len <= 0) return NULL;
+    entry = find_array(c, f, STASIS_VALUE_I32, 1);
+    return (int32_t *)ensure_array(entry, (size_t)len);
+}
+
+static int32_t collection_meta_hash(int32_t hash, int32_t kind) {
+    const char *suffix = kind == 1 ? ".length" : kind == 2 ? ".max_length" :
+        kind == 3 ? ".char_length" : NULL;
+    uint32_t value = (uint32_t)hash;
+    if (suffix == NULL) return 0;
+    while (*suffix != '\0') {
+        value ^= (uint8_t)*suffix++;
+        value *= 16777619U;
+    }
+    return (int32_t)value;
+}
+
+int32_t stasis_jit_collection_i32_load(int32_t hash, int32_t kind) {
+    int32_t derived = collection_meta_hash(hash, kind);
+    return derived == 0 ? 0 : stasis_jit_global_i32_load(derived);
+}
+void stasis_jit_collection_i32_store(int32_t hash, int32_t kind, int32_t value) {
+    int32_t derived = collection_meta_hash(hash, kind);
+    if (derived != 0) stasis_jit_global_i32_store(derived, value);
+}
+
+void stasis_jit_print_i32(int32_t value) { printf("%d", value); }
+void stasis_jit_print_string(int32_t id) {
+    char *value = resolve_text(id);
+    if (value != NULL) fputs(value, stdout);
+    free(value);
+}
+float stasis_jit_sin_fast(float value) { return sinf(value); }
+float stasis_jit_cos_fast(float value) { return cosf(value); }
+
+static void copy_i32_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
+    int32_t *values;
+    int32_t index;
+    if (count <= 0 || di < 0 || si < 0) return;
+    values = (int32_t *)malloc((size_t)count * sizeof(int32_t));
+    if (values == NULL) return;
+    for (index = 0; index < count; index += 1) values[index] = stasis_jit_global_i32_array_load(src, 0, si + index);
+    for (index = 0; index < count; index += 1) stasis_jit_global_i32_array_store(dst, 0, di + index, values[index]);
+    free(values);
+}
+
+static void copy_f32_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
+    float *values;
+    int32_t index;
+    if (count <= 0 || di < 0 || si < 0) return;
+    values = (float *)malloc((size_t)count * sizeof(float));
+    if (values == NULL) return;
+    for (index = 0; index < count; index += 1) values[index] = stasis_jit_global_f32_array_load(src, 0, si + index);
+    for (index = 0; index < count; index += 1) stasis_jit_global_f32_array_store(dst, 0, di + index, values[index]);
+    free(values);
+}
+
+void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memcpy_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memcpy_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }
+void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memmove_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memmove_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -1,0 +1,98 @@
+#ifndef STASIS_MOBILE_AOT_RUNTIME_H
+#define STASIS_MOBILE_AOT_RUNTIME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void stasis_jit_register_global_i32_ptr(int32_t path_hash, int32_t *ptr);
+void stasis_jit_register_global_f32_ptr(int32_t path_hash, float *ptr);
+void stasis_jit_register_global_f64_ptr(int32_t path_hash, double *ptr);
+void stasis_jit_register_global_i32_array(
+    int32_t collection_hash, int32_t field_hash, int32_t *ptr, int32_t len);
+void stasis_jit_register_global_f32_array(
+    int32_t collection_hash, int32_t field_hash, float *ptr, int32_t len);
+void stasis_jit_register_global_f64_array(
+    int32_t collection_hash, int32_t field_hash, double *ptr, int32_t len);
+void stasis_jit_register_global_u8_array(
+    int32_t collection_hash, int32_t field_hash, uint8_t *ptr, int32_t len);
+void stasis_jit_register_code_ptr(int32_t fn_id, int64_t code_ptr);
+void stasis_jit_clear_string_literal_table(void);
+void stasis_jit_upsert_string_literal(int32_t id, const char *value);
+int64_t stasis_jit_lookup_code_ptr(int32_t fn_id);
+int32_t stasis_jit_global_i32_load(int32_t hash);
+void stasis_jit_global_i32_store(int32_t hash, int32_t value);
+float stasis_jit_global_f32_load(int32_t hash);
+void stasis_jit_global_f32_store(int32_t hash, float value);
+double stasis_jit_global_f64_load(int32_t hash);
+void stasis_jit_global_f64_store(int32_t hash, double value);
+int32_t stasis_jit_global_i32_array_load(int32_t c, int32_t f, int32_t i);
+void stasis_jit_global_i32_array_store(int32_t c, int32_t f, int32_t i, int32_t value);
+int32_t *stasis_jit_global_i32_array_ptr(int32_t c, int32_t f, int32_t len);
+float stasis_jit_global_f32_array_load(int32_t c, int32_t f, int32_t i);
+void stasis_jit_global_f32_array_store(int32_t c, int32_t f, int32_t i, float value);
+float *stasis_jit_global_f32_array_ptr(int32_t c, int32_t f, int32_t len);
+double stasis_jit_global_f64_array_load(int32_t c, int32_t f, int32_t i);
+void stasis_jit_global_f64_array_store(int32_t c, int32_t f, int32_t i, double value);
+double *stasis_jit_global_f64_array_ptr(int32_t c, int32_t f, int32_t len);
+int32_t stasis_jit_collection_i32_load(int32_t hash, int32_t kind);
+void stasis_jit_collection_i32_store(int32_t hash, int32_t kind, int32_t value);
+int32_t stasis_jit_call_i32_0(int32_t fn);
+int32_t stasis_jit_call_i32_1(int32_t fn, int32_t a0);
+int32_t stasis_jit_call_i32_2(int32_t fn, int32_t a0, int32_t a1);
+int32_t stasis_jit_call_i32_3(int32_t fn, int32_t a0, int32_t a1, int32_t a2);
+int32_t stasis_jit_call_i32_4(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3);
+int32_t stasis_jit_call_i32_5(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4);
+int32_t stasis_jit_call_i32_6(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5);
+int32_t stasis_jit_call_i32_7(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5, int32_t a6);
+int32_t stasis_jit_call_i32_8(int32_t fn, int32_t a0, int32_t a1, int32_t a2, int32_t a3, int32_t a4, int32_t a5, int32_t a6, int32_t a7);
+int32_t stasis_jit_call_i32_f32_1(int32_t fn, float a0);
+int32_t stasis_jit_call_i32_f32_2(int32_t fn, float a0, float a1);
+int32_t stasis_jit_call_i32_f32_3(int32_t fn, float a0, float a1, float a2);
+int32_t stasis_jit_call_i32_f32_4(int32_t fn, float a0, float a1, float a2, float a3);
+int32_t stasis_jit_call_i32_f32_5(int32_t fn, float a0, float a1, float a2, float a3, float a4);
+int32_t stasis_jit_call_i32_f32_6(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5);
+int32_t stasis_jit_call_i32_f32_7(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6);
+int32_t stasis_jit_call_i32_f32_8(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7);
+float stasis_jit_call_f32_0(int32_t fn);
+float stasis_jit_call_f32_1(int32_t fn, float a0);
+float stasis_jit_call_f32_2(int32_t fn, float a0, float a1);
+float stasis_jit_call_f32_3(int32_t fn, float a0, float a1, float a2);
+float stasis_jit_call_f32_4(int32_t fn, float a0, float a1, float a2, float a3);
+float stasis_jit_call_f32_5(int32_t fn, float a0, float a1, float a2, float a3, float a4);
+float stasis_jit_call_f32_6(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5);
+float stasis_jit_call_f32_7(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6);
+float stasis_jit_call_f32_8(int32_t fn, float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7);
+float stasis_jit_call_f32_i32_1(int32_t fn, int32_t a0);
+void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_sys_memcpy_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_sys_memcpy_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_sys_memmove_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_sys_memmove_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+int stasis_jit_audio_init(int32_t rate, int32_t channels, int32_t latency);
+void stasis_jit_audio_shutdown(void);
+int stasis_jit_audio_is_available(void);
+int stasis_jit_audio_get_sample_rate(void);
+int stasis_jit_audio_get_channels(void);
+int stasis_jit_audio_get_queued_frames(void);
+int stasis_jit_audio_get_underruns(void);
+int stasis_jit_audio_push_f32_interleaved(int32_t samples, int32_t frames);
+int stasis_jit_gfx_load_sprite(int32_t path, int32_t max_w, int32_t max_h);
+void stasis_jit_gfx_release_sprite(int32_t handle);
+int stasis_jit_gfx_dump_bmp(int32_t path);
+int stasis_jit_gfx_cache_text(int32_t font, int32_t text);
+int stasis_jit_gfx_poll_reload(int32_t handle);
+float stasis_jit_gfx_measure_text_cached(int32_t handle);
+int stasis_jit_load_font(int32_t path, int32_t size);
+float stasis_jit_measure_text(int32_t font, int32_t text);
+void stasis_jit_sleep_ms(int32_t ms);
+void stasis_mobile_aot_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -104,7 +104,19 @@ int32_t stasis_mobile_runtime_initialize(
     runtime_state.paused = 0;
     runtime_state.entries.bind_runtime_entry();
     bind_host_globals();
+    stasis_host_bulk_apply_requests(
+        &host_req_seq,
+        &host_req_flags,
+        &host_req_window_w_px,
+        &host_req_window_h_px
+    );
     runtime_state.entries.main_entry();
+    stasis_host_bulk_apply_requests(
+        &host_req_seq,
+        &host_req_flags,
+        &host_req_window_w_px,
+        &host_req_window_h_px
+    );
     return STASIS_MOBILE_RUNTIME_OK;
 }
 

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -1,0 +1,157 @@
+#include "stasis_mobile_runtime.h"
+#include "stasis_mobile_aot_runtime.h"
+
+#include <stddef.h>
+#include <string.h>
+
+/* Implemented by the SDL-only stasis_graphics.c linked into the mobile core. */
+int stasis_init_window(int width, int height, const char *title);
+int stasis_should_quit(void);
+int stasis_mobile_poll_events(void);
+void stasis_mobile_set_paused(int paused);
+void stasis_begin_frame(void);
+void stasis_end_frame(void);
+void stasis_host_get_frame(int32_t *out_i32, float *out_f32);
+void stasis_host_bulk_apply_requests(
+    const int32_t *seq,
+    const int32_t *flags,
+    const int32_t *width,
+    const int32_t *height
+);
+void stasis_gfx_submit_u8(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8
+);
+void stasis_shutdown(void);
+
+static int32_t host_i32[768];
+static float host_f32[64];
+static int32_t gfx_cmd_i32[34848];
+static float gfx_cmd_f32[92292];
+static uint8_t gfx_cmd_u8[65536];
+static int32_t host_req_seq;
+static int32_t host_req_flags;
+static int32_t host_req_window_w_px;
+static int32_t host_req_window_h_px;
+
+typedef struct StasisMobileRuntimeState {
+    StasisMobileGameEntries entries;
+    int initialized;
+    int paused;
+} StasisMobileRuntimeState;
+
+static StasisMobileRuntimeState runtime_state;
+
+static int32_t hash_global_path(const char *path) {
+    uint32_t hash = 2166136261U;
+    while (*path != '\0') {
+        hash ^= (uint8_t)*path++;
+        hash *= 16777619U;
+    }
+    return (int32_t)hash;
+}
+
+static void bind_host_globals(void) {
+    memset(host_i32, 0, sizeof(host_i32));
+    memset(host_f32, 0, sizeof(host_f32));
+    memset(gfx_cmd_i32, 0, sizeof(gfx_cmd_i32));
+    memset(gfx_cmd_f32, 0, sizeof(gfx_cmd_f32));
+    memset(gfx_cmd_u8, 0, sizeof(gfx_cmd_u8));
+    host_req_seq = 0;
+    host_req_flags = 0;
+    host_req_window_w_px = 0;
+    host_req_window_h_px = 0;
+    stasis_jit_register_global_i32_array(hash_global_path("host_i32"), 0, host_i32, 768);
+    stasis_jit_register_global_f32_array(hash_global_path("host_f32"), 0, host_f32, 64);
+    stasis_jit_register_global_i32_array(hash_global_path("gfx_cmd_i32"), 0, gfx_cmd_i32, 34848);
+    stasis_jit_register_global_f32_array(hash_global_path("gfx_cmd_f32"), 0, gfx_cmd_f32, 92292);
+    stasis_jit_register_global_u8_array(hash_global_path("gfx_cmd_u8"), 0, gfx_cmd_u8, 65536);
+    stasis_jit_register_global_i32_ptr(hash_global_path("host_req_seq"), &host_req_seq);
+    stasis_jit_register_global_i32_ptr(hash_global_path("host_req_flags"), &host_req_flags);
+    stasis_jit_register_global_i32_ptr(
+        hash_global_path("host_req_window_w_px"), &host_req_window_w_px);
+    stasis_jit_register_global_i32_ptr(
+        hash_global_path("host_req_window_h_px"), &host_req_window_h_px);
+}
+
+static int entries_are_valid(const StasisMobileGameEntries *entries) {
+    return entries != NULL &&
+        entries->bind_runtime_entry != NULL &&
+        entries->main_entry != NULL &&
+        entries->tick_entry != NULL &&
+        entries->render_entry != NULL;
+}
+
+int32_t stasis_mobile_runtime_initialize(
+    const StasisMobileRuntimeConfig *config,
+    const StasisMobileGameEntries *entries
+) {
+    if (runtime_state.initialized) {
+        return STASIS_MOBILE_RUNTIME_ALREADY_INITIALIZED;
+    }
+    if (config == NULL || config->width <= 0 || config->height <= 0 ||
+        !entries_are_valid(entries)) {
+        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
+    }
+    stasis_mobile_aot_reset();
+    if (!stasis_init_window(config->width, config->height, config->title)) {
+        return STASIS_MOBILE_RUNTIME_GRAPHICS_UNAVAILABLE;
+    }
+
+    runtime_state.entries = *entries;
+    runtime_state.initialized = 1;
+    runtime_state.paused = 0;
+    runtime_state.entries.bind_runtime_entry();
+    bind_host_globals();
+    runtime_state.entries.main_entry();
+    return STASIS_MOBILE_RUNTIME_OK;
+}
+
+int32_t stasis_mobile_runtime_step(void) {
+    if (!runtime_state.initialized) {
+        return STASIS_MOBILE_RUNTIME_NOT_INITIALIZED;
+    }
+    if (runtime_state.paused) {
+        return stasis_mobile_poll_events()
+            ? STASIS_MOBILE_RUNTIME_STOP_REQUESTED
+            : STASIS_MOBILE_RUNTIME_OK;
+    }
+    if (stasis_should_quit()) {
+        return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
+    }
+
+    stasis_host_get_frame(host_i32, host_f32);
+    stasis_host_bulk_apply_requests(
+        &host_req_seq,
+        &host_req_flags,
+        &host_req_window_w_px,
+        &host_req_window_h_px
+    );
+    runtime_state.entries.tick_entry();
+    stasis_begin_frame();
+    runtime_state.entries.render_entry();
+    stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
+    stasis_end_frame();
+    return STASIS_MOBILE_RUNTIME_OK;
+}
+
+void stasis_mobile_runtime_set_paused(int32_t paused) {
+    if (runtime_state.initialized) {
+        runtime_state.paused = paused != 0;
+        stasis_mobile_set_paused(runtime_state.paused);
+    }
+}
+
+int32_t stasis_mobile_runtime_is_initialized(void) {
+    return runtime_state.initialized;
+}
+
+void stasis_mobile_runtime_shutdown(void) {
+    if (!runtime_state.initialized) {
+        return;
+    }
+    stasis_shutdown();
+    stasis_mobile_aot_reset();
+    runtime_state = (StasisMobileRuntimeState){0};
+}

--- a/runtime/stasis_mobile_runtime.h
+++ b/runtime/stasis_mobile_runtime.h
@@ -1,0 +1,56 @@
+#ifndef STASIS_MOBILE_RUNTIME_H
+#define STASIS_MOBILE_RUNTIME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STASIS_MOBILE_RUNTIME_ABI_VERSION 1
+
+enum StasisMobileRuntimeResult {
+    STASIS_MOBILE_RUNTIME_OK = 0,
+    STASIS_MOBILE_RUNTIME_STOP_REQUESTED = 1,
+    STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT = -1,
+    STASIS_MOBILE_RUNTIME_NOT_INITIALIZED = -2,
+    STASIS_MOBILE_RUNTIME_ALREADY_INITIALIZED = -3,
+    STASIS_MOBILE_RUNTIME_GRAPHICS_UNAVAILABLE = -4
+};
+
+typedef void (*StasisMobileEntry)(void);
+
+typedef struct StasisMobileGameEntries {
+    StasisMobileEntry bind_runtime_entry;
+    StasisMobileEntry main_entry;
+    StasisMobileEntry tick_entry;
+    StasisMobileEntry render_entry;
+} StasisMobileGameEntries;
+
+typedef struct StasisMobileRuntimeConfig {
+    int32_t width;
+    int32_t height;
+    const char *title;
+} StasisMobileRuntimeConfig;
+
+/* Initializes the SDL-only host APIs and calls the game main entry exactly once. */
+int32_t stasis_mobile_runtime_initialize(
+    const StasisMobileRuntimeConfig *config,
+    const StasisMobileGameEntries *entries
+);
+
+/* Pumps input, advances one deterministic tick, and renders one frame. */
+int32_t stasis_mobile_runtime_step(void);
+
+/* Paused runtimes remain initialized but do not tick or render. */
+void stasis_mobile_runtime_set_paused(int32_t paused);
+int32_t stasis_mobile_runtime_is_initialized(void);
+
+/* Releases graphics and audio state. Safe to call more than once. */
+void stasis_mobile_runtime_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -1,0 +1,96 @@
+#include "stasis_mobile_aot_runtime.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+static int32_t add_two(int32_t left, int32_t right) {
+    return left + right;
+}
+
+static char last_sprite_path[64];
+
+int stasis_audio_init(int rate, int channels, int latency) {
+    return rate > 0 && channels == 2 && latency > 0;
+}
+void stasis_audio_shutdown(void) {}
+int stasis_audio_is_available(void) { return 1; }
+int stasis_audio_get_sample_rate(void) { return 48000; }
+int stasis_audio_get_channels(void) { return 2; }
+int stasis_audio_get_queued_frames(void) { return 0; }
+int stasis_audio_get_underruns(void) { return 0; }
+int stasis_audio_push_f32_interleaved(const float *samples, int frames) {
+    return samples == NULL ? 0 : frames;
+}
+int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) {
+    if (path != NULL) {
+        strncpy(last_sprite_path, path, sizeof(last_sprite_path) - 1);
+        last_sprite_path[sizeof(last_sprite_path) - 1] = '\0';
+    }
+    return path != NULL && max_w > 0 && max_h > 0 ? 1 : 0;
+}
+void stasis_gfx_release_sprite(int handle) { (void)handle; }
+int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
+int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
+int stasis_gfx_poll_reload(int handle) { return handle; }
+float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
+int stasis_load_font(const char *path, int size) { return path != NULL ? size : 0; }
+float stasis_measure_text(int font, const char *text) {
+    return text != NULL ? (float)font : 0.0f;
+}
+void stasis_sleep_ms(int ms) { (void)ms; }
+
+int main(void) {
+    int32_t external = 4;
+    int32_t external_array[3] = {7, 8, 9};
+    uint8_t external_u8[4] = {1, 2, 3, 4};
+    uint8_t dynamic_path[] = "sprite.bmp";
+    int32_t *owned;
+
+    stasis_mobile_aot_reset();
+    stasis_jit_global_i32_store(10, 42);
+    CHECK(stasis_jit_global_i32_load(10) == 42);
+
+    stasis_jit_register_global_i32_ptr(11, &external);
+    stasis_jit_global_i32_store(11, 6);
+    CHECK(external == 6);
+
+    stasis_jit_register_global_i32_array(20, 0, external_array, 3);
+    CHECK(stasis_jit_global_i32_array_load(20, 0, 1) == 8);
+    stasis_jit_global_i32_array_store(20, 0, 2, 12);
+    CHECK(external_array[2] == 12);
+
+    stasis_jit_register_global_u8_array(22, 0, external_u8, 4);
+    stasis_jit_global_i32_array_store(22, 0, 1, 258);
+    CHECK(external_u8[1] == 2);
+    CHECK(stasis_jit_global_i32_array_load(22, 0, 1) == 2);
+    stasis_jit_sys_memcpy_u8(22, 2, 22, 0, 2);
+    CHECK(external_u8[2] == 1 && external_u8[3] == 2);
+
+    stasis_jit_register_global_u8_array(23, 0, dynamic_path, sizeof(dynamic_path) - 1);
+    stasis_jit_collection_i32_store(23, 1, sizeof(dynamic_path) - 1);
+    CHECK(stasis_jit_gfx_load_sprite(23, 32, 32) == 1);
+    CHECK(strcmp(last_sprite_path, "sprite.bmp") == 0);
+
+    owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
+    CHECK(owned != NULL);
+    stasis_jit_global_i32_array_store(21, 0, 3, 99);
+    CHECK(owned[3] == 99);
+
+    stasis_jit_register_code_ptr(30, (int64_t)(uintptr_t)&add_two);
+    CHECK(stasis_jit_call_i32_2(30, 5, 7) == 12);
+    CHECK(stasis_jit_call_i32_0(999) == 0);
+
+    stasis_mobile_aot_reset();
+    CHECK(stasis_jit_global_i32_load(10) == 0);
+    puts("stasis_mobile_aot_runtime_test: ok");
+    return 0;
+}

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -1,0 +1,268 @@
+#include "stasis_mobile_runtime.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Keep lifecycle checks active in Release builds where NDEBUG removes assert. */
+#undef assert
+#define assert(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+static int init_window_result = 1;
+static int should_quit_result;
+static int init_window_calls;
+static int should_quit_calls;
+static int mobile_poll_events_calls;
+static int mobile_set_paused_calls;
+static int mobile_paused;
+static int bind_runtime_calls;
+static int main_calls;
+static int tick_calls;
+static int render_calls;
+static int begin_frame_calls;
+static int end_frame_calls;
+static int host_frame_calls;
+static int host_request_calls;
+static int gfx_submit_calls;
+static int shutdown_calls;
+
+int stasis_init_window(int width, int height, const char *title) {
+    assert(width == 1280);
+    assert(height == 720);
+    assert(title != NULL);
+    init_window_calls += 1;
+    return init_window_result;
+}
+
+int stasis_should_quit(void) {
+    should_quit_calls += 1;
+    return should_quit_result;
+}
+
+int stasis_mobile_poll_events(void) {
+    mobile_poll_events_calls += 1;
+    return should_quit_result;
+}
+
+void stasis_mobile_set_paused(int paused) {
+    mobile_set_paused_calls += 1;
+    mobile_paused = paused;
+}
+
+void stasis_begin_frame(void) {
+    begin_frame_calls += 1;
+}
+
+void stasis_end_frame(void) {
+    end_frame_calls += 1;
+}
+
+void stasis_host_get_frame(int32_t *out_i32, float *out_f32) {
+    assert(out_i32 != NULL);
+    assert(out_f32 != NULL);
+    host_frame_calls += 1;
+}
+
+void stasis_host_bulk_apply_requests(
+    const int32_t *seq,
+    const int32_t *flags,
+    const int32_t *width,
+    const int32_t *height
+) {
+    assert(seq != NULL && flags != NULL && width != NULL && height != NULL);
+    host_request_calls += 1;
+}
+
+void stasis_gfx_submit_u8(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8
+) {
+    assert(cmd_i32 != NULL && cmd_f32 != NULL && cmd_u8 != NULL);
+    gfx_submit_calls += 1;
+}
+
+void stasis_shutdown(void) {
+    shutdown_calls += 1;
+}
+
+int stasis_audio_init(int rate, int channels, int latency) { return rate + channels + latency; }
+void stasis_audio_shutdown(void) {}
+int stasis_audio_is_available(void) { return 1; }
+int stasis_audio_get_sample_rate(void) { return 48000; }
+int stasis_audio_get_channels(void) { return 2; }
+int stasis_audio_get_queued_frames(void) { return 0; }
+int stasis_audio_get_underruns(void) { return 0; }
+int stasis_audio_push_f32_interleaved(const float *samples, int frames) { return samples ? frames : 0; }
+int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) { return path && max_w && max_h; }
+void stasis_gfx_release_sprite(int handle) { (void)handle; }
+int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
+int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
+int stasis_gfx_poll_reload(int handle) { return handle; }
+float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
+int stasis_load_font(const char *path, int size) { return path ? size : 0; }
+float stasis_measure_text(int font, const char *text) { return text ? (float)font : 0.0f; }
+void stasis_sleep_ms(int ms) { (void)ms; }
+
+static void game_main(void) {
+    main_calls += 1;
+}
+
+static void bind_runtime(void) {
+    bind_runtime_calls += 1;
+}
+
+static void game_tick(void) {
+    tick_calls += 1;
+}
+
+static void game_render(void) {
+    render_calls += 1;
+}
+
+static StasisMobileRuntimeConfig config(void) {
+    StasisMobileRuntimeConfig value = {1280, 720, "Mobile test"};
+    return value;
+}
+
+static StasisMobileGameEntries entries(void) {
+    StasisMobileGameEntries value = {bind_runtime, game_main, game_tick, game_render};
+    return value;
+}
+
+static int32_t hash_path(const char *path) {
+    uint32_t hash = 2166136261U;
+    while (*path != '\0') {
+        hash ^= (uint8_t)*path++;
+        hash *= 16777619U;
+    }
+    return (int32_t)hash;
+}
+
+static void reset_fakes(void) {
+    init_window_result = 1;
+    should_quit_result = 0;
+    init_window_calls = 0;
+    should_quit_calls = 0;
+    mobile_poll_events_calls = 0;
+    mobile_set_paused_calls = 0;
+    mobile_paused = 0;
+    bind_runtime_calls = 0;
+    main_calls = 0;
+    tick_calls = 0;
+    render_calls = 0;
+    begin_frame_calls = 0;
+    end_frame_calls = 0;
+    host_frame_calls = 0;
+    host_request_calls = 0;
+    gfx_submit_calls = 0;
+    shutdown_calls = 0;
+}
+
+static void test_rejects_invalid_configuration(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+    StasisMobileGameEntries missing_render = valid_entries;
+    missing_render.render_entry = NULL;
+
+    assert(stasis_mobile_runtime_initialize(NULL, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT);
+    assert(stasis_mobile_runtime_initialize(&valid_config, &missing_render) ==
+        STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT);
+    assert(init_window_calls == 0);
+}
+
+static void test_runs_mobile_lifecycle(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_mobile_runtime_is_initialized() == 1);
+    assert(init_window_calls == 1);
+    assert(bind_runtime_calls == 1);
+    assert(main_calls == 1);
+
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(should_quit_calls == 1);
+    assert(tick_calls == 1);
+    assert(render_calls == 1);
+    assert(host_frame_calls == 1);
+    assert(host_request_calls == 1);
+    assert(gfx_submit_calls == 1);
+    assert(begin_frame_calls == 1);
+    assert(end_frame_calls == 1);
+
+    stasis_mobile_runtime_set_paused(1);
+    assert(mobile_set_paused_calls == 1);
+    assert(mobile_paused == 1);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(should_quit_calls == 1);
+    assert(mobile_poll_events_calls == 1);
+    assert(tick_calls == 1);
+    assert(render_calls == 1);
+
+    stasis_mobile_runtime_set_paused(0);
+    assert(mobile_set_paused_calls == 2);
+    assert(mobile_paused == 0);
+    should_quit_result = 1;
+    assert(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    assert(should_quit_calls == 2);
+    assert(tick_calls == 1);
+
+    stasis_mobile_runtime_shutdown();
+    stasis_mobile_runtime_shutdown();
+    assert(shutdown_calls == 1);
+    assert(stasis_mobile_runtime_is_initialized() == 0);
+    assert(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_NOT_INITIALIZED);
+}
+
+static void test_rejects_duplicate_initialization(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_ALREADY_INITIALIZED);
+    assert(init_window_calls == 1);
+    assert(main_calls == 1);
+    stasis_jit_global_i32_array_store(hash_path("host_i32"), 0, 0, 77);
+    stasis_mobile_runtime_shutdown();
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_jit_global_i32_array_load(hash_path("host_i32"), 0, 0) == 0);
+    assert(main_calls == 2);
+    stasis_mobile_runtime_shutdown();
+}
+
+static void test_reports_graphics_initialization_failure(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+
+    init_window_result = 0;
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_GRAPHICS_UNAVAILABLE);
+    assert(main_calls == 0);
+    assert(shutdown_calls == 0);
+
+    init_window_result = 1;
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_OK);
+    assert(main_calls == 1);
+    stasis_mobile_runtime_shutdown();
+}
+
+int main(void) {
+    reset_fakes();
+    test_rejects_invalid_configuration();
+    test_runs_mobile_lifecycle();
+    reset_fakes();
+    test_rejects_duplicate_initialization();
+    reset_fakes();
+    test_reports_graphics_initialization_failure();
+    puts("stasis_mobile_runtime_test: ok");
+    return 0;
+}

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* Keep lifecycle checks active in Release builds where NDEBUG removes assert. */
 #undef assert
@@ -28,6 +29,7 @@ static int begin_frame_calls;
 static int end_frame_calls;
 static int host_frame_calls;
 static int host_request_calls;
+static int32_t host_request_sequences[8];
 static int gfx_submit_calls;
 static int shutdown_calls;
 
@@ -75,6 +77,7 @@ void stasis_host_bulk_apply_requests(
     const int32_t *height
 ) {
     assert(seq != NULL && flags != NULL && width != NULL && height != NULL);
+    if (host_request_calls < 8) host_request_sequences[host_request_calls] = *seq;
     host_request_calls += 1;
 }
 
@@ -109,8 +112,14 @@ int stasis_load_font(const char *path, int size) { return path ? size : 0; }
 float stasis_measure_text(int font, const char *text) { return text ? (float)font : 0.0f; }
 void stasis_sleep_ms(int ms) { (void)ms; }
 
+static int32_t hash_path(const char *path);
+
 static void game_main(void) {
     main_calls += 1;
+    stasis_jit_global_i32_store(hash_path("host_req_seq"), 1);
+    stasis_jit_global_i32_store(hash_path("host_req_flags"), 1);
+    stasis_jit_global_i32_store(hash_path("host_req_window_w_px"), 960);
+    stasis_jit_global_i32_store(hash_path("host_req_window_h_px"), 540);
 }
 
 static void bind_runtime(void) {
@@ -160,6 +169,7 @@ static void reset_fakes(void) {
     end_frame_calls = 0;
     host_frame_calls = 0;
     host_request_calls = 0;
+    memset(host_request_sequences, 0, sizeof(host_request_sequences));
     gfx_submit_calls = 0;
     shutdown_calls = 0;
 }
@@ -186,13 +196,16 @@ static void test_runs_mobile_lifecycle(void) {
     assert(init_window_calls == 1);
     assert(bind_runtime_calls == 1);
     assert(main_calls == 1);
+    assert(host_request_calls == 2);
+    assert(host_request_sequences[0] == 0);
+    assert(host_request_sequences[1] == 1);
 
     assert(stasis_mobile_runtime_step() == 0);
     assert(should_quit_calls == 1);
     assert(tick_calls == 1);
     assert(render_calls == 1);
     assert(host_frame_calls == 1);
-    assert(host_request_calls == 1);
+    assert(host_request_calls == 3);
     assert(gfx_submit_calls == 1);
     assert(begin_frame_calls == 1);
     assert(end_frame_calls == 1);


### PR DESCRIPTION
## Summary
- add a fixed-entry SDL-only mobile lifecycle core for Android and iOS shells
- provide the AOT host ABI, generated function/string bindings, and dynamic string-buffer adapters
- add deterministic native lifecycle/AOT tests and compiler export/import contract coverage

## Validation
- cargo test -p stasis --lib -- --test-threads=1 (139 passed, 6 ignored)
- cargo test -p stasis android_aot_bundle_writes_pong_symbols_header -- --test-threads=1 (passed)
- CMake/Ninja mobile runtime tests via ctest (2 passed)
- python tools/ci/check_stasis_src_layout.py (passed)
- cargo test --workspace --all-targets -- --test-threads=1 (task-relevant suites pass; 2 pre-existing Windows path-separator lookup assertions fail in apps/stasis/src/main.rs)

Maddox task #112.