### PR TITLE
feat: ship integrated Stasis CLI

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Build stasis (release)
         run: cargo build -p stasis --release
 
+      - name: Build native AOT bridge (unix)
+        if: runner.os != 'Windows'
+        run: cargo rustc -p stasis_dynload --release -- --crate-type staticlib
+
+      - name: Build native AOT bridge (windows)
+        if: runner.os == 'Windows'
+        run: cargo build -p stasis_dynload --release
+
       - name: Build stasis_graphics runtime (windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -58,10 +66,10 @@ jobs:
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
-            -DSTASIS_BUILD_RUNNER=OFF `
+            -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -71,6 +79,7 @@ jobs:
           out="dist/stasis-release-${{ runner.os }}"
           mkdir -p "${out}/bin"
           cp "target/release/stasis" "${out}/bin/"
+          cp "target/release/libstasis_dynload.a" "${out}/bin/"
           cp README.md "${out}/"
           cp LICENSE "${out}/"
           cp -R src "${out}/"
@@ -84,10 +93,25 @@ jobs:
           $out = "dist/stasis-release-${{ runner.os }}"
           New-Item -ItemType Directory -Force -Path "$out/bin" | Out-Null
           Copy-Item "target/release/stasis.exe" "$out/" -Force
+          Copy-Item "target/release/stasis_dynload.dll" "$out/" -Force
+          Copy-Item "target/release/stasis_dynload.dll.lib" "$out/" -Force
+          $rustLld = Join-Path (rustc --print sysroot) "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          Copy-Item $rustLld "$out/lld-link.exe" -Force
+          $clangCl = (Get-Command clang-cl.exe -ErrorAction Stop).Source
+          Copy-Item $clangCl "$out/clang-cl.exe" -Force
+          $rustCopyright = Join-Path (rustc --print sysroot) "share/doc/rust/COPYRIGHT.html"
+          Copy-Item $rustCopyright "$out/RUST-LLVM-COPYRIGHT.html" -Force
+          $vsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio/Installer/vswhere.exe"
+          $vsRoot = & $vsWhere -latest -property installationPath
+          $vsNotice = Get-ChildItem (Join-Path $vsRoot "Licenses") -Recurse -Filter "ThirdPartyNotices.txt" | Select-Object -First 1
+          if (-not $vsNotice) { throw "Visual Studio LLVM third-party notices not found" }
+          Copy-Item $vsNotice.FullName "$out/LLVM-THIRD-PARTY-NOTICES.txt" -Force
           # Keep the runtime DLL beside stasis.exe so `stasis.exe play ...` works from the archive root.
           Copy-Item "runtime/build_ci/bin/Release/*.dll" "$out/" -Force
+          Copy-Item "runtime/build_ci/bin/Release/stasis_runner.exe" "$out/" -Force
           Copy-Item README.md "$out/" -Force
           Copy-Item LICENSE "$out/" -Force
+          Copy-Item THIRD_PARTY_NOTICES.md "$out/" -Force
           Copy-Item src "$out/" -Recurse -Force
           Copy-Item samples "$out/" -Recurse -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/stasis-release-${{ runner.os }}.zip" -Force
@@ -98,9 +122,36 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           Remove-Item Env:STASIS_RUNTIME_DLL_PATH -ErrorAction SilentlyContinue
+          Remove-Item Env:LIB -ErrorAction SilentlyContinue
+          Remove-Item Env:CC -ErrorAction SilentlyContinue
           Push-Location "dist/stasis-release-${{ runner.os }}"
           .\stasis.exe probe-graphics-runtime
+          .\stasis.exe new ci_smoke --dir cli-smoke
+          .\stasis.exe --workspace cli-smoke check
+          .\stasis.exe --workspace cli-smoke test
+          .\stasis.exe --workspace cli-smoke build --mode release
+          .\cli-smoke\build\ci_smoke.exe
+          Set-Content -Path "cli-smoke/src/main.stasis" -Encoding ASCII -Value @(
+            "function main(): i32 { return 0; }",
+            "function tick(): i32 { return 0; }",
+            "function render(): i32 { return 0; }"
+          )
+          .\stasis.exe --workspace cli-smoke package --target desktop
+          if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.exe")) { throw "game package runner missing" }
+          if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.dll")) { throw "game package library missing" }
           Pop-Location
+
+      - name: Smoke test bundled CLI (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "dist/stasis-release-${{ runner.os }}"
+          ./bin/stasis new ci_smoke --dir cli-smoke
+          ./bin/stasis --workspace cli-smoke check
+          ./bin/stasis --workspace cli-smoke test
+          ./bin/stasis --workspace cli-smoke build --mode release
+          ./cli-smoke/build/ci_smoke
 
       - name: Upload artifact (unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Build stasis (release)
         run: cargo build -p stasis --release --target ${{ matrix.rust_target }}
 
+      - name: Build native AOT bridge (unix)
+        if: runner.os != 'Windows'
+        run: cargo rustc -p stasis_dynload --release --target ${{ matrix.rust_target }} -- --crate-type staticlib
+
+      - name: Build native AOT bridge (windows)
+        if: runner.os == 'Windows'
+        run: cargo build -p stasis_dynload --release --target ${{ matrix.rust_target }}
+
       - name: Build stasis_graphics runtime (windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -121,10 +129,10 @@ jobs:
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
-            -DSTASIS_BUILD_RUNNER=OFF `
+            -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -134,6 +142,7 @@ jobs:
           out="dist/${{ matrix.archive }}"
           mkdir -p "${out}/bin"
           cp "target/${{ matrix.rust_target }}/release/stasis" "${out}/bin/"
+          cp "target/${{ matrix.rust_target }}/release/libstasis_dynload.a" "${out}/bin/"
           cp README.md "${out}/"
           cp LICENSE "${out}/"
           # Ship the stdlib + samples so relative imports keep working in the bundle.
@@ -148,10 +157,25 @@ jobs:
           $out = "dist/${{ matrix.archive }}"
           New-Item -ItemType Directory -Force -Path "$out/bin" | Out-Null
           Copy-Item "target/${{ matrix.rust_target }}/release/stasis.exe" "$out/" -Force
+          Copy-Item "target/${{ matrix.rust_target }}/release/stasis_dynload.dll" "$out/" -Force
+          Copy-Item "target/${{ matrix.rust_target }}/release/stasis_dynload.dll.lib" "$out/" -Force
+          $rustLld = Join-Path (rustc --print sysroot) "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          Copy-Item $rustLld "$out/lld-link.exe" -Force
+          $clangCl = (Get-Command clang-cl.exe -ErrorAction Stop).Source
+          Copy-Item $clangCl "$out/clang-cl.exe" -Force
+          $rustCopyright = Join-Path (rustc --print sysroot) "share/doc/rust/COPYRIGHT.html"
+          Copy-Item $rustCopyright "$out/RUST-LLVM-COPYRIGHT.html" -Force
+          $vsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio/Installer/vswhere.exe"
+          $vsRoot = & $vsWhere -latest -property installationPath
+          $vsNotice = Get-ChildItem (Join-Path $vsRoot "Licenses") -Recurse -Filter "ThirdPartyNotices.txt" | Select-Object -First 1
+          if (-not $vsNotice) { throw "Visual Studio LLVM third-party notices not found" }
+          Copy-Item $vsNotice.FullName "$out/LLVM-THIRD-PARTY-NOTICES.txt" -Force
           # Keep the runtime DLL beside stasis.exe so `stasis.exe play ...` works from the archive root.
           Copy-Item "runtime/build_ci/bin/Release/*.dll" "$out/" -Force
+          Copy-Item "runtime/build_ci/bin/Release/stasis_runner.exe" "$out/" -Force
           Copy-Item README.md "$out/" -Force
           Copy-Item LICENSE "$out/" -Force
+          Copy-Item THIRD_PARTY_NOTICES.md "$out/" -Force
           # Ship the stdlib + samples so relative imports keep working in the bundle.
           Copy-Item src "$out/" -Recurse -Force
           Copy-Item samples "$out/" -Recurse -Force
@@ -163,9 +187,36 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           Remove-Item Env:STASIS_RUNTIME_DLL_PATH -ErrorAction SilentlyContinue
+          Remove-Item Env:LIB -ErrorAction SilentlyContinue
+          Remove-Item Env:CC -ErrorAction SilentlyContinue
           Push-Location "dist/${{ matrix.archive }}"
           .\stasis.exe probe-graphics-runtime
+          .\stasis.exe new ci_smoke --dir cli-smoke
+          .\stasis.exe --workspace cli-smoke check
+          .\stasis.exe --workspace cli-smoke test
+          .\stasis.exe --workspace cli-smoke build --mode release
+          .\cli-smoke\build\ci_smoke.exe
+          Set-Content -Path "cli-smoke/src/main.stasis" -Encoding ASCII -Value @(
+            "function main(): i32 { return 0; }",
+            "function tick(): i32 { return 0; }",
+            "function render(): i32 { return 0; }"
+          )
+          .\stasis.exe --workspace cli-smoke package --target desktop
+          if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.exe")) { throw "game package runner missing" }
+          if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.dll")) { throw "game package library missing" }
           Pop-Location
+
+      - name: Smoke test bundled CLI (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "dist/${{ matrix.archive }}"
+          ./bin/stasis new ci_smoke --dir cli-smoke
+          ./bin/stasis --workspace cli-smoke check
+          ./bin/stasis --workspace cli-smoke test
+          ./bin/stasis --workspace cli-smoke build --mode release
+          ./cli-smoke/build/ci_smoke
 
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +111,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -364,6 +460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +494,12 @@ checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -511,6 +619,12 @@ dependencies = [
  "memchr",
  "ruzstd",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -665,6 +779,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "stasis"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "notify",
  "object",
  "serde",
@@ -740,6 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +898,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ Direct influences:
 
 Most users will:
 
-1. Write a `.stasis` game with `main()`, `tick()`, `render()`.
-2. Run it in dev with `play` (watch + hot swap).
-3. Write `.stasis` tests and run them with `test`.
-4. Later: build production artifacts with AOT (WIP).
+1. Install one release archive and put its `stasis` executable on `PATH`.
+2. Run `stasis new my_game`, then work from the project root or any subdirectory.
+3. Use `stasis fmt`, `stasis check`, `stasis test`, and `stasis run` during development.
+4. Use `stasis build --mode release` or `stasis package --target desktop` to ship.
+
+The integrated CLI, `stasis.json` workspace contract, JSON output, offline behavior, and
+installation layout are documented in `docs/toolchain_cli.md`.
 
 Mobile AOT artifacts for Android arm64 and iOS arm64 are documented in
 `docs/mobile_aot_artifacts.md`.
@@ -48,6 +51,8 @@ Windows release zip layout:
 
 - `stasis.exe` at the archive root
 - `stasis_graphics.dll` at the archive root
+- `lld-link.exe`, `clang-cl.exe`, `stasis_dynload.dll`, and `stasis_dynload.dll.lib` for offline AOT builds
+- `stasis_runner.exe` and `stasis_graphics.dll` for packaged desktop games
 - `src/` and `samples/` at the archive root
 
 That keeps the common Windows command simple:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,11 @@
+# Third-party notices
+
+Windows Stasis toolchain archives include `clang-cl.exe` from the LLVM Project so the generated
+game runtime bridge can be compiled without a separate toolchain installation. LLVM is licensed
+under the Apache License v2.0 with LLVM Exceptions. Windows archives include the applicable
+license, exception, copyright, and third-party notice text in `RUST-LLVM-COPYRIGHT.html` and
+`LLVM-THIRD-PARTY-NOTICES.txt`; the upstream license is also published at
+<https://llvm.org/LICENSE.txt>.
+
+The archive also includes `lld-link.exe` from the Rust toolchain distribution. LLVM and Rust
+license notices remain applicable to those binaries.

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -9,6 +9,7 @@ stasis_runner = { path = "../../crates/stasis_runner" }
 stasis_jit = { path = "../../crates/stasis_jit" }
 stasis_compiler = { path = "../../crates/stasis_compiler" }
 notify.workspace = true
+clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -207,6 +207,10 @@ impl IncrementalCompilerBackend {
     pub fn new_self_host_aot_cli(aot_artifact_root: PathBuf) -> Self {
         let mut backend = Self::new();
         backend.aot_artifact_root = aot_artifact_root;
+        if cfg!(windows) && backend.aot_link_config.linker_path.is_none() {
+            backend.aot_link_config.linker_path = resolve_installed_lld_link()
+                .or_else(|| ensure_rust_lld_link_wrapper(&backend.aot_artifact_root));
+        }
         backend.enable_aot_link_step = false;
         backend
     }
@@ -2069,19 +2073,31 @@ fn resolve_latest_existing_path(candidates: Vec<PathBuf>) -> Option<PathBuf> {
 }
 
 fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
+    let installed_name = if cfg!(windows) {
+        "stasis_dynload.dll.lib"
+    } else {
+        "libstasis_dynload.a"
+    };
+    if let Some(installed) = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|parent| parent.join(installed_name)))
+        .filter(|path| path.is_file())
+    {
+        return Some(installed);
+    }
     let target_dir = std::env::var_os("CARGO_TARGET_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| self_host_repo_root().join("target"));
     let mut candidates: Vec<PathBuf> = Vec::new();
-    let static_lib_names: &[&str] = if cfg!(windows) {
-        &["stasis_dynload.lib"]
+    let link_lib_names: &[&str] = if cfg!(windows) {
+        &["stasis_dynload.dll.lib"]
     } else {
         &["libstasis_dynload.a", "stasis_dynload.a"]
     };
 
     for profile in ["debug", "release"] {
         let base = target_dir.join(profile);
-        for name in static_lib_names {
+        for name in link_lib_names {
             let direct = base.join(name);
             if direct.exists() {
                 candidates.push(direct);
@@ -2098,7 +2114,7 @@ fn resolve_stasis_dynload_lib() -> Option<PathBuf> {
                 continue;
             };
             if cfg!(windows) {
-                if name.starts_with("stasis_dynload-") && name.ends_with(".lib") {
+                if name.starts_with("stasis_dynload-") && name.ends_with(".dll.lib") {
                     candidates.push(path);
                 }
             } else if (name.starts_with("libstasis_dynload-")
@@ -2149,7 +2165,7 @@ fn runtime_bridge_object_extension(target: &stasis_jit::AotTarget) -> &'static s
     }
 }
 
-fn should_link_stasis_dynload_staticlib(target: &stasis_jit::AotTarget) -> bool {
+fn should_link_stasis_dynload(target: &stasis_jit::AotTarget) -> bool {
     matches!(target, stasis_jit::AotTarget::Native)
 }
 
@@ -2157,48 +2173,115 @@ fn default_runtime_bridge_compiler(target: &stasis_jit::AotTarget) -> PathBuf {
     if matches!(target, stasis_jit::AotTarget::AndroidArm64 { .. }) {
         PathBuf::from("clang")
     } else if cfg!(windows) {
-        PathBuf::from("clang-cl.exe")
+        std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|parent| parent.join("clang-cl.exe")))
+            .filter(|path| path.is_file())
+            .or_else(resolve_host_clang_cl)
+            .unwrap_or_else(|| PathBuf::from("clang-cl.exe"))
     } else {
         PathBuf::from("cc")
     }
 }
 
-fn ensure_stasis_dynload_staticlib() -> Result<PathBuf, String> {
+#[cfg(windows)]
+fn resolve_host_clang_cl() -> Option<PathBuf> {
+    ["BuildTools", "Enterprise", "Community", "Professional"]
+        .into_iter()
+        .map(|edition| {
+            PathBuf::from(r"C:\Program Files (x86)\Microsoft Visual Studio\2022")
+                .join(edition)
+                .join("VC/Tools/Llvm/x64/bin/clang-cl.exe")
+        })
+        .find(|path| path.is_file())
+}
+
+#[cfg(not(windows))]
+fn resolve_host_clang_cl() -> Option<PathBuf> {
+    None
+}
+
+fn ensure_stasis_dynload_link_library() -> Result<PathBuf, String> {
+    if let Some(existing) = resolve_stasis_dynload_lib() {
+        return Ok(existing);
+    }
     let repo_root = self_host_repo_root();
     let mut command = std::process::Command::new("cargo");
-    command.arg("rustc").arg("-p").arg("stasis_dynload");
+    if cfg!(windows) {
+        command.arg("build").arg("-p").arg("stasis_dynload");
+    } else {
+        command.arg("rustc").arg("-p").arg("stasis_dynload");
+    }
     if !cfg!(debug_assertions) {
         command.arg("--release");
     }
-    command
-        .arg("--")
-        .arg("--crate-type")
-        .arg("staticlib")
-        .current_dir(&repo_root);
+    if !cfg!(windows) {
+        command.arg("--").arg("--crate-type").arg("staticlib");
+    }
+    command.current_dir(&repo_root);
     if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
         command.env("CARGO_TARGET_DIR", target_dir);
     }
 
     let output = command.output().map_err(|error| {
-        format!("failed to spawn cargo rustc -p stasis_dynload --crate-type staticlib: {error}")
+        format!("failed to spawn Cargo for the stasis_dynload link library: {error}")
     })?;
     if !output.status.success() {
         return Err(format!(
-            "failed to build stasis_dynload staticlib\nstdout:\n{}\nstderr:\n{}",
+            "failed to build stasis_dynload link library\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         ));
     }
 
     resolve_stasis_dynload_lib().ok_or_else(|| {
-        "stasis_dynload staticlib build reported success but no static library was found"
-            .to_string()
+        "stasis_dynload build reported success but no link library was found".to_string()
     })
+}
+
+#[cfg(windows)]
+fn stage_stasis_dynload_runtime(link_library: &Path, output: &Path) -> Result<(), String> {
+    let file_name = link_library
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "invalid stasis_dynload link library {}",
+                link_library.display()
+            )
+        })?;
+    let dll_name = file_name
+        .strip_suffix(".lib")
+        .ok_or_else(|| format!("expected a .lib import library, got {file_name}"))?;
+    let dll = link_library.with_file_name(dll_name);
+    if !dll.is_file() {
+        return Err(format!(
+            "stasis_dynload runtime DLL is missing: {}",
+            dll.display()
+        ));
+    }
+    let destination = output
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(dll_name);
+    copy_file_creating_parent(&dll, &destination)
+}
+
+#[cfg(not(windows))]
+fn stage_stasis_dynload_runtime(_link_library: &Path, _output: &Path) -> Result<(), String> {
+    Ok(())
 }
 
 fn resolve_runtime_runner_path(repo_root: &Path) -> Option<PathBuf> {
     let runner_name = runtime_runner_file_name();
-    resolve_latest_existing_path(vec![
+    let mut candidates = Vec::new();
+    if let Some(installed) = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|parent| parent.join(runner_name)))
+    {
+        candidates.push(installed);
+    }
+    candidates.extend([
         repo_root.join(runner_name),
         repo_root.join("build").join(runner_name),
         repo_root
@@ -2212,12 +2295,19 @@ fn resolve_runtime_runner_path(repo_root: &Path) -> Option<PathBuf> {
             .join("build")
             .join("bin")
             .join(runner_name),
-    ])
+    ]);
+    resolve_latest_existing_path(candidates)
 }
 
 fn resolve_runtime_graphics_path(repo_root: &Path) -> Option<PathBuf> {
     let mut candidates = Vec::new();
     for name in runtime_graphics_file_names() {
+        if let Some(installed) = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|parent| parent.join(name)))
+        {
+            candidates.push(installed);
+        }
         candidates.push(repo_root.join(name));
         candidates.push(repo_root.join("build").join(name));
         candidates.push(
@@ -2281,8 +2371,14 @@ fn resolve_rust_lld_exe() -> Option<PathBuf> {
     candidate.exists().then_some(candidate)
 }
 
+fn resolve_installed_lld_link() -> Option<PathBuf> {
+    let path = std::env::current_exe().ok()?.parent()?.join("lld-link.exe");
+    path.is_file().then_some(path)
+}
+
 fn ensure_rust_lld_link_wrapper(artifact_root: &Path) -> Option<PathBuf> {
     let rust_lld = resolve_rust_lld_exe()?;
+    std::fs::create_dir_all(artifact_root).ok()?;
     let wrapper_path = artifact_root.join("rust-lld-link.cmd");
     let script = format!(
         "@echo off\r\n\"{}\" -flavor link %*\r\n",
@@ -2830,7 +2926,16 @@ fn build_engine_bundle_runtime_bridge_source(
     let host_req_window_h_px_hash = crate::hash_global_path("host_req_window_h_px");
 
     let mut source = String::new();
-    source.push_str("#include <stdint.h>\n");
+    source.push_str(
+        "#if defined(_WIN32)\n\
+typedef signed int int32_t;\n\
+typedef signed long long int64_t;\n\
+typedef unsigned char uint8_t;\n\
+typedef unsigned long long uintptr_t;\n\
+#else\n\
+#include <stdint.h>\n\
+#endif\n",
+    );
     source.push_str(
         "#if defined(_WIN32)\n\
 #define STASIS_EXPORT __declspec(dllexport)\n\
@@ -3029,6 +3134,9 @@ fn emit_engine_bundle_runtime_bridge_object(
             .arg("/c")
             .arg("/O2")
             .arg("/TC")
+            .arg("/Zl")
+            .arg("/GS-")
+            .arg("/X")
             .arg(format!("/Fo{}", object_path.display()))
             .arg(&source_path);
     } else {
@@ -3191,15 +3299,17 @@ fn package_engine_bundle_release(
 
     let mut link_config = backend.aot_link_config.clone();
     link_config.target = backend.aot_compile_config.target.clone();
-    if should_link_stasis_dynload_staticlib(&link_config.target) {
-        let dynload_lib = ensure_stasis_dynload_staticlib()?;
+    let mut dynload_link_library = None;
+    if should_link_stasis_dynload(&link_config.target) {
+        let dynload_lib = ensure_stasis_dynload_link_library()?;
         if !link_config
             .runtime_lib_paths
             .iter()
             .any(|path| path == &dynload_lib)
         {
-            link_config.runtime_lib_paths.push(dynload_lib);
+            link_config.runtime_lib_paths.push(dynload_lib.clone());
         }
+        dynload_link_library = Some(dynload_lib);
     }
     if cfg!(windows) {
         if let Some(wrapper) = ensure_rust_lld_link_wrapper(&backend.aot_artifact_root) {
@@ -3253,6 +3363,9 @@ fn package_engine_bundle_release(
         } else {
             return Err(initial_error);
         }
+    }
+    if let Some(link_library) = dynload_link_library.as_deref() {
+        stage_stasis_dynload_runtime(link_library, &linked_library_path)?;
     }
 
     let (runner_src, graphics_src) = ensure_runtime_release_artifacts()?;
@@ -3352,7 +3465,7 @@ fn aot_call_conv() -> &'static str {
 mod tests {
     use super::*;
     #[cfg(windows)]
-    use object::Object;
+    use object::{Object, ObjectSection};
     #[cfg(windows)]
     use stasis_compiler::IncrementalCompilerHost;
     #[cfg(windows)]
@@ -3415,9 +3528,57 @@ mod tests {
         assert!(source.contains("STASIS_EXPORT void stasis_on_input(int type, int a, int b)"));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_runtime_bridge_object_has_no_default_library_directives() {
+        let source = build_engine_bundle_runtime_bridge_source(
+            &stasis_jit::AotTarget::Native,
+            &[],
+            &["aot_fn_1".to_string()],
+            &[PackagedFunctionAlias {
+                alias: "main",
+                target_symbol: "aot_fn_1".to_string(),
+                returns_i32: true,
+            }],
+            &[],
+        )
+        .expect("build bridge source");
+        assert!(source.contains("typedef signed int int32_t;"));
+        assert!(!source.starts_with("#include <stdint.h>"));
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_bridge_directives_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let source_path = temp_root.join("bridge.c");
+        let object_path = temp_root.join("bridge.obj");
+        fs::write(&source_path, source).expect("write bridge source");
+        let compiler = default_runtime_bridge_compiler(&stasis_jit::AotTarget::Native);
+        let output = Command::new(compiler)
+            .args(["/nologo", "/c", "/O2", "/TC", "/Zl", "/GS-", "/X"])
+            .arg(format!("/Fo{}", object_path.display()))
+            .arg(&source_path)
+            .output()
+            .expect("compile bridge object");
+        assert!(
+            output.status.success(),
+            "bridge compile failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let bytes = fs::read(&object_path).expect("read bridge object");
+        let object = object::File::parse(&*bytes).expect("parse bridge object");
+        if let Some(section) = object.section_by_name(".drectve") {
+            let directives = String::from_utf8_lossy(section.data().expect("read directives"));
+            assert!(!directives.to_ascii_uppercase().contains("DEFAULTLIB"));
+        }
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
     #[test]
     fn android_engine_bundle_skips_host_dynload_staticlib() {
-        assert!(!should_link_stasis_dynload_staticlib(
+        assert!(!should_link_stasis_dynload(
             &stasis_jit::AotTarget::android_arm64_default()
         ));
     }
@@ -7771,12 +7932,17 @@ fn run_self_host_aot_cli_with_backend_and_options(
             .values()
             .map(|(_, path)| path.clone())
             .collect();
-        link_objects_to_executable(
-            &object_paths,
-            output_exe,
-            &entry_symbol,
-            &backend.aot_link_config,
-        )?;
+        let mut link_config = backend.aot_link_config.clone();
+        let mut dynload_link_library = None;
+        if should_link_stasis_dynload(&link_config.target) {
+            let link_library = ensure_stasis_dynload_link_library()?;
+            link_config.runtime_lib_paths.push(link_library.clone());
+            dynload_link_library = Some(link_library);
+        }
+        link_objects_to_executable(&object_paths, output_exe, &entry_symbol, &link_config)?;
+        if let Some(link_library) = dynload_link_library.as_deref() {
+            stage_stasis_dynload_runtime(link_library, output_exe)?;
+        }
         maybe_sign_output_executable(output_exe)?;
         let object_bundle_path =
             write_object_bundle_manifest(&compile.output_dir, &entry_symbol, &object_paths)?;

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
+mod toolchain_cli;
+
 use std::collections::BTreeSet;
 use std::env;
 use std::fs::{self, File};
@@ -2641,6 +2643,10 @@ mod tests {
 
 fn main() {
     maybe_cleanup_stale_stasis_cache();
+
+    if let Some(exit) = toolchain_cli::try_run() {
+        std::process::exit(exit);
+    }
 
     if let Some(exit) = try_run_probe_graphics_runtime_subcommand() {
         std::process::exit(exit);

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,0 +1,1225 @@
+use clap::{Parser, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use stasis::{
+    run_jit_tests_in_directory_with_session, run_play_in_process,
+    run_self_host_aot_cli_with_options, StasisTestRunSession,
+};
+use stasis_compiler::backend::jit::JitProcess;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+const MANIFEST_NAME: &str = "stasis.json";
+const MANIFEST_VERSION: u32 = 1;
+const COMMANDS: &[&str] = &[
+    "new", "init", "fmt", "check", "test", "run", "build", "package", "inspect", "replay",
+    "verify", "version", "env", "help",
+];
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "stasis",
+    version,
+    about = "The batteries-included Stasis toolchain",
+    long_about = "Create, format, check, test, run, build, inspect, and package Stasis projects without invoking Cargo."
+)]
+struct ToolchainCli {
+    #[arg(
+        long,
+        global = true,
+        help = "Emit one deterministic JSON result object"
+    )]
+    json: bool,
+
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help = "Use this project or project directory"
+    )]
+    workspace: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: ToolchainCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ToolchainCommand {
+    /// Create a project in a new directory.
+    New {
+        name: String,
+        #[arg(long, value_name = "PATH")]
+        dir: Option<PathBuf>,
+    },
+    /// Initialize a project in an existing directory.
+    Init {
+        #[arg(default_value = ".")]
+        dir: PathBuf,
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Format project source files deterministically.
+    Fmt {
+        #[arg(long)]
+        check: bool,
+    },
+    /// Parse, analyze, and JIT-compile the project without running it.
+    Check,
+    /// Run project tests in one isolated JIT session.
+    Test {
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+    },
+    /// JIT-compile and run main() in the headless toolchain runtime.
+    Run {
+        /// Recompile and rerun when project .stasis files change.
+        #[arg(long)]
+        watch: bool,
+        /// Explicitly select the headless runtime (currently the default).
+        #[arg(long)]
+        headless: bool,
+    },
+    /// Build the project for development or as a release executable.
+    Build {
+        #[arg(long, value_enum, default_value_t = BuildMode::Release)]
+        mode: BuildMode,
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+    },
+    /// Assemble a distributable desktop or mobile directory.
+    Package {
+        #[arg(long, value_enum, default_value_t = PackageTarget::Desktop)]
+        target: PackageTarget,
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+    },
+    /// Report deterministic workspace and output layout information.
+    Inspect,
+    /// Replay support is reserved until the replay runtime lands.
+    Replay,
+    /// Replay verification is reserved until the replay runtime lands.
+    Verify,
+    /// Print the installed toolchain version.
+    Version,
+    /// Print toolchain, workspace, cache, and offline capability information.
+    Env,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum BuildMode {
+    Dev,
+    Release,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PackageTarget {
+    Desktop,
+    AndroidArm64,
+    IosArm64,
+}
+
+impl PackageTarget {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Desktop => "desktop",
+            Self::AndroidArm64 => "android-arm64",
+            Self::IosArm64 => "ios-arm64",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ProjectManifest {
+    manifest_version: u32,
+    name: String,
+    entry: String,
+    tests: String,
+    output: String,
+}
+
+impl ProjectManifest {
+    fn new(name: String) -> Self {
+        Self {
+            manifest_version: MANIFEST_VERSION,
+            name,
+            entry: "src/main.stasis".to_string(),
+            tests: "tests".to_string(),
+            output: "build".to_string(),
+        }
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.manifest_version != MANIFEST_VERSION {
+            return Err(format!(
+                "unsupported manifest_version {}; expected {}",
+                self.manifest_version, MANIFEST_VERSION
+            ));
+        }
+        validate_project_name(&self.name)?;
+        for (field, value) in [
+            ("entry", self.entry.as_str()),
+            ("tests", self.tests.as_str()),
+            ("output", self.output.as_str()),
+        ] {
+            validate_relative_path(field, Path::new(value))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Workspace {
+    root: PathBuf,
+    manifest: ProjectManifest,
+}
+
+#[derive(Debug)]
+struct CommandResult {
+    code: i32,
+    human: String,
+    data: Value,
+}
+
+impl CommandResult {
+    fn success(human: impl Into<String>, data: Value) -> Self {
+        Self {
+            code: 0,
+            human: human.into(),
+            data,
+        }
+    }
+}
+
+pub(super) fn try_run() -> Option<i32> {
+    let args: Vec<OsString> = env::args_os().collect();
+    if !is_toolchain_invocation(&args) {
+        return None;
+    }
+    let wants_json = args.iter().any(|arg| arg == "--json");
+    let wants_version = args.iter().any(|arg| arg == "--version" || arg == "-V");
+    let parsed = match ToolchainCli::try_parse_from(args) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            let exit_code = error.exit_code();
+            if wants_json {
+                if exit_code == 0 {
+                    if wants_version {
+                        println!(
+                            "{}",
+                            json!({
+                                "ok": true,
+                                "command": "version",
+                                "result": {"version": env!("CARGO_PKG_VERSION")},
+                            })
+                        );
+                    } else {
+                        println!("{}", json!({"ok": true, "commands": COMMANDS}));
+                    }
+                } else {
+                    eprintln!(
+                        "{}",
+                        json!({
+                            "ok": false,
+                            "code": "usage_error",
+                            "message": error.to_string(),
+                        })
+                    );
+                }
+            } else {
+                let _ = error.print();
+            }
+            return Some(exit_code);
+        }
+    };
+    let command_name = command_name(&parsed.command);
+    match execute(parsed.command, parsed.workspace, parsed.json) {
+        Ok(result) => {
+            if parsed.json {
+                println!(
+                    "{}",
+                    json!({
+                        "ok": true,
+                        "command": command_name,
+                        "result": result.data,
+                    })
+                );
+            } else if !result.human.is_empty() {
+                println!("{}", result.human);
+            }
+            Some(result.code)
+        }
+        Err(message) => {
+            if parsed.json {
+                eprintln!(
+                    "{}",
+                    json!({
+                        "ok": false,
+                        "command": command_name,
+                        "code": "command_failed",
+                        "message": message,
+                    })
+                );
+            } else {
+                eprintln!("stasis {command_name}: {message}");
+            }
+            Some(1)
+        }
+    }
+}
+
+fn is_toolchain_invocation(args: &[OsString]) -> bool {
+    let Some(first) = args.get(1).and_then(|arg| arg.to_str()) else {
+        return true;
+    };
+    first == "--help"
+        || first == "-h"
+        || first == "--version"
+        || first == "-V"
+        || first == "--json"
+        || first == "--workspace"
+        || COMMANDS.contains(&first)
+}
+
+fn command_name(command: &ToolchainCommand) -> &'static str {
+    match command {
+        ToolchainCommand::New { .. } => "new",
+        ToolchainCommand::Init { .. } => "init",
+        ToolchainCommand::Fmt { .. } => "fmt",
+        ToolchainCommand::Check => "check",
+        ToolchainCommand::Test { .. } => "test",
+        ToolchainCommand::Run { .. } => "run",
+        ToolchainCommand::Build { .. } => "build",
+        ToolchainCommand::Package { .. } => "package",
+        ToolchainCommand::Inspect => "inspect",
+        ToolchainCommand::Replay => "replay",
+        ToolchainCommand::Verify => "verify",
+        ToolchainCommand::Version => "version",
+        ToolchainCommand::Env => "env",
+    }
+}
+
+fn execute(
+    command: ToolchainCommand,
+    workspace_arg: Option<PathBuf>,
+    json_output: bool,
+) -> Result<CommandResult, String> {
+    match command {
+        ToolchainCommand::New { name, dir } => create_project(dir.unwrap_or_else(|| PathBuf::from(&name)), name),
+        ToolchainCommand::Init { dir, name } => {
+            let root = absolute_path(&dir)?;
+            let inferred = root
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("stasis_game")
+                .to_string();
+            create_project(root, name.unwrap_or(inferred))
+        }
+        ToolchainCommand::Version => Ok(version_result()),
+        ToolchainCommand::Env => env_result(workspace_arg.as_deref()),
+        ToolchainCommand::Replay => Err(
+            "replay is unavailable in toolchain 0.1; no replay runtime contract is implemented"
+                .to_string(),
+        ),
+        ToolchainCommand::Verify => Err(
+            "verify is unavailable in toolchain 0.1; no replay verification contract is implemented"
+                .to_string(),
+        ),
+        other => {
+            let workspace = load_workspace(workspace_arg.as_deref())?;
+            match other {
+                ToolchainCommand::Fmt { check } => format_workspace(&workspace, check),
+                ToolchainCommand::Check => check_workspace(&workspace),
+                ToolchainCommand::Test { path } => {
+                    validate_optional_workspace_path(&workspace, "test path", path.as_deref())?;
+                    test_workspace(&workspace, path.as_deref())
+                }
+                ToolchainCommand::Run {
+                    watch,
+                    headless,
+                } => {
+                    if watch && json_output {
+                        Err("--json cannot be combined with --watch; watch mode is an unbounded event stream".to_string())
+                    } else if watch && headless {
+                        Err("--headless cannot be combined with --watch; watch mode uses the graphical hot-swap runner".to_string())
+                    } else if watch {
+                        run_workspace_watch(&workspace)
+                    } else {
+                        run_workspace(&workspace, headless)
+                    }
+                }
+                ToolchainCommand::Build { mode, out } => {
+                    validate_optional_workspace_path(&workspace, "build output", out.as_deref())?;
+                    build_workspace(&workspace, mode, out.as_deref())
+                }
+                ToolchainCommand::Package { target, out } => {
+                    validate_optional_workspace_path(&workspace, "package output", out.as_deref())?;
+                    package_workspace(&workspace, target, out.as_deref())
+                }
+                ToolchainCommand::Inspect => inspect_workspace(&workspace),
+                _ => Err("unsupported command routing".to_string()),
+            }
+        }
+    }
+}
+
+fn create_project(path: PathBuf, name: String) -> Result<CommandResult, String> {
+    validate_project_name(&name)?;
+    let root = absolute_path(&path)?;
+    let bundled_stdlib = bundled_stdlib_dir()?;
+    let manifest_path = root.join(MANIFEST_NAME);
+    let reserved_paths = [
+        manifest_path.clone(),
+        root.join("src/main.stasis"),
+        root.join("tests/main.test.stasis"),
+        root.join("stdlib"),
+    ];
+    for reserved in &reserved_paths {
+        if reserved.exists() {
+            return Err(format!("refusing to overwrite {}", reserved.display()));
+        }
+    }
+    fs::create_dir_all(root.join("src"))
+        .map_err(|error| format!("failed to create {}: {error}", root.display()))?;
+    fs::create_dir_all(root.join("tests"))
+        .map_err(|error| format!("failed to create tests directory: {error}"))?;
+    let manifest = ProjectManifest::new(name.clone());
+    write_manifest(&manifest_path, &manifest)?;
+    copy_dir_if_exists(&bundled_stdlib, &root.join("stdlib"))?;
+    write_new_file(
+        &root.join("src/main.stasis"),
+        "import \"../stdlib/stdlib.stasis\";\n\nfunction main(): i32 {\n    return 0;\n}\n",
+    )?;
+    write_new_file(
+        &root.join("tests/main.test.stasis"),
+        "test `new project is ready`(): bool {\n    return 1 == 1;\n}\n",
+    )?;
+    Ok(CommandResult::success(
+        format!("created {} at {}", name, root.display()),
+        json!({"name": name, "root": display_path(&root), "manifest": MANIFEST_NAME}),
+    ))
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), String> {
+    if path.exists() {
+        return Err(format!("refusing to overwrite {}", path.display()));
+    }
+    fs::write(path, contents)
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+fn write_manifest(path: &Path, manifest: &ProjectManifest) -> Result<(), String> {
+    let mut contents = serde_json::to_string_pretty(manifest)
+        .map_err(|error| format!("failed to serialize manifest: {error}"))?;
+    contents.push('\n');
+    fs::write(path, contents)
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+fn load_workspace(explicit: Option<&Path>) -> Result<Workspace, String> {
+    if let Some(path) = explicit {
+        let absolute = absolute_path(path)?;
+        if !absolute.exists() {
+            return Err(format!(
+                "workspace path does not exist: {}",
+                absolute.display()
+            ));
+        }
+    }
+    let start = explicit.map(absolute_path).transpose()?.unwrap_or(
+        env::current_dir().map_err(|error| format!("failed to read current directory: {error}"))?,
+    );
+    let start_dir = if start.is_file() {
+        start.parent().unwrap_or(&start).to_path_buf()
+    } else {
+        start
+    };
+    let root = find_workspace_root(&start_dir).ok_or_else(|| {
+        format!(
+            "no {MANIFEST_NAME} found from {}; run 'stasis init' first",
+            start_dir.display()
+        )
+    })?;
+    let bytes = fs::read(root.join(MANIFEST_NAME))
+        .map_err(|error| format!("failed to read {MANIFEST_NAME}: {error}"))?;
+    let manifest: ProjectManifest = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("invalid {MANIFEST_NAME}: {error}"))?;
+    manifest.validate()?;
+    Ok(Workspace { root, manifest })
+}
+
+fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(MANIFEST_NAME).is_file() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+fn format_workspace(workspace: &Workspace, check: bool) -> Result<CommandResult, String> {
+    let mut files = Vec::new();
+    let source_root = workspace.root.join("src");
+    let test_root = workspace.root.join(&workspace.manifest.tests);
+    validate_workspace_destination(workspace, "source directory", &source_root)?;
+    validate_workspace_destination(workspace, "test directory", &test_root)?;
+    collect_stasis_files(&source_root, &mut files)?;
+    collect_stasis_files(&test_root, &mut files)?;
+    files.sort();
+    files.dedup();
+    let mut changed = Vec::new();
+    for file in files {
+        let original = fs::read_to_string(&file)
+            .map_err(|error| format!("failed to read {}: {error}", file.display()))?;
+        let formatted = format_source(&original);
+        if original != formatted {
+            changed.push(relative_display(&workspace.root, &file));
+            if !check {
+                fs::write(&file, formatted)
+                    .map_err(|error| format!("failed to write {}: {error}", file.display()))?;
+            }
+        }
+    }
+    if check && !changed.is_empty() {
+        return Err(format!("formatting required: {}", changed.join(", ")));
+    }
+    Ok(CommandResult::success(
+        if changed.is_empty() {
+            "all Stasis files are formatted".to_string()
+        } else {
+            format!("formatted {} file(s)", changed.len())
+        },
+        json!({"changed": changed, "check": check}),
+    ))
+}
+
+fn format_source(source: &str) -> String {
+    let normalized = source.replace("\r\n", "\n").replace('\r', "\n");
+    let mut lines: Vec<&str> = normalized.lines().collect();
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+    let mut output = lines
+        .iter()
+        .map(|line| line.trim_end_matches([' ', '\t']))
+        .collect::<Vec<_>>()
+        .join("\n");
+    output.push('\n');
+    output
+}
+
+fn check_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
+    let jit = compile_workspace_jit(workspace)?;
+    Ok(CommandResult::success(
+        format!("checked {}", workspace.manifest.name),
+        json!({
+            "name": workspace.manifest.name,
+            "entry": workspace.manifest.entry,
+            "functions_emitted": jit.artifacts().len(),
+        }),
+    ))
+}
+
+fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    validate_workspace_destination(workspace, "entry", &entry)?;
+    let source = fs::read_to_string(&entry)
+        .map_err(|error| format!("failed to read entry {}: {error}", entry.display()))?;
+    let mut jit = JitProcess::new();
+    jit.set_required_emit_roots(&["main".to_string()]);
+    jit.upsert_file(display_path(&entry), source.clone());
+    jit.compile().map_err(|error| {
+        if let Some(diagnostic) = jit.last_source_diagnostic() {
+            let (line, column) = line_column(&source, diagnostic.start);
+            format!(
+                "{}:{}:{}: {}",
+                diagnostic.path, line, column, diagnostic.message
+            )
+        } else {
+            format!("{error:?}")
+        }
+    })?;
+    Ok(jit)
+}
+
+fn test_workspace(workspace: &Workspace, path: Option<&Path>) -> Result<CommandResult, String> {
+    let directory = path
+        .map(|value| workspace.root.join(value))
+        .unwrap_or_else(|| workspace.root.join(&workspace.manifest.tests));
+    validate_workspace_destination(workspace, "test directory", &directory)?;
+    let mut session = StasisTestRunSession::new();
+    let summary = run_jit_tests_in_directory_with_session(&directory, &mut session)?;
+    let data = json!({
+        "files_discovered": summary.files_discovered,
+        "files_with_tests": summary.files_with_tests,
+        "tests_discovered": summary.tests_discovered,
+        "tests_run": summary.tests_run,
+        "tests_passed": summary.tests_passed,
+        "tests_failed": summary.tests_failed,
+        "failures": summary.failures,
+    });
+    if summary.tests_failed > 0 {
+        return Err(format!(
+            "{} test(s) failed: {}",
+            summary.tests_failed,
+            summary.failures.join(" | ")
+        ));
+    }
+    Ok(CommandResult::success(
+        format!(
+            "{} test(s) passed in {} file(s)",
+            summary.tests_passed, summary.files_with_tests
+        ),
+        data,
+    ))
+}
+
+fn run_workspace(workspace: &Workspace, _headless: bool) -> Result<CommandResult, String> {
+    let jit = compile_workspace_jit(workspace)?;
+    let guest_exit = match jit.execute_i32_noarg_by_name("main") {
+        Ok(value) => value,
+        Err(error) if error.contains("not i32-returning") => {
+            jit.execute_void_noarg_by_name("main")?;
+            0
+        }
+        Err(error) => return Err(error),
+    };
+    Ok(CommandResult {
+        code: guest_exit,
+        human: format!("program exited with code {guest_exit}"),
+        data: json!({"exit_code": guest_exit, "backend": "jit", "headless": true}),
+    })
+}
+
+fn run_workspace_watch(workspace: &Workspace) -> Result<CommandResult, String> {
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    run_play_in_process(&entry, Some(&workspace.root), None, None, 16_000, None)?;
+    Ok(CommandResult::success(
+        "graphical watch session ended",
+        json!({"backend": "jit", "headless": false, "watch": true}),
+    ))
+}
+
+fn build_workspace(
+    workspace: &Workspace,
+    mode: BuildMode,
+    output: Option<&Path>,
+) -> Result<CommandResult, String> {
+    match mode {
+        BuildMode::Dev => {
+            let jit = compile_workspace_jit(workspace)?;
+            let receipt = output
+                .map(|path| workspace.root.join(path))
+                .unwrap_or_else(|| {
+                    workspace
+                        .root
+                        .join(&workspace.manifest.output)
+                        .join("dev-build.json")
+                });
+            validate_workspace_destination(workspace, "build output", &receipt)?;
+            if let Some(parent) = receipt.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+            }
+            let data = json!({
+                "backend": "jit",
+                "entry": workspace.manifest.entry,
+                "functions_emitted": jit.artifacts().len(),
+            });
+            let mut contents = serde_json::to_string_pretty(&data)
+                .map_err(|error| format!("failed to serialize dev build receipt: {error}"))?;
+            contents.push('\n');
+            fs::write(&receipt, contents)
+                .map_err(|error| format!("failed to write {}: {error}", receipt.display()))?;
+            Ok(CommandResult::success(
+                format!("built JIT development image: {}", receipt.display()),
+                json!({"backend": "jit", "receipt": display_path(&receipt)}),
+            ))
+        }
+        BuildMode::Release => {
+            let output = output
+                .map(|path| workspace.root.join(path))
+                .unwrap_or_else(|| default_release_output(workspace));
+            validate_workspace_destination(workspace, "build output", &output)?;
+            if let Some(parent) = output.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+            }
+            let summary = run_self_host_aot_cli_with_options(
+                &workspace.root,
+                &output,
+                None,
+                Some(Path::new(&workspace.manifest.entry)),
+            )?;
+            Ok(CommandResult::success(
+                format!("built release executable: {}", output.display()),
+                json!({
+                    "backend": "aot",
+                    "output": display_path(&output),
+                    "source_files": summary.source_file_count,
+                    "entry_symbol": summary.entry_symbol,
+                }),
+            ))
+        }
+    }
+}
+
+fn package_workspace(
+    workspace: &Workspace,
+    target: PackageTarget,
+    output: Option<&Path>,
+) -> Result<CommandResult, String> {
+    let package_root = output
+        .map(|path| workspace.root.join(path))
+        .unwrap_or_else(|| {
+            workspace.root.join("dist").join(format!(
+                "{}-{}",
+                workspace.manifest.name,
+                target.as_str()
+            ))
+        });
+    validate_workspace_destination(workspace, "package output", &package_root)?;
+    if package_root.exists() {
+        return Err(format!(
+            "package output already exists: {}",
+            package_root.display()
+        ));
+    }
+    if !matches!(target, PackageTarget::Desktop) {
+        return package_mobile_workspace(workspace, target, &package_root);
+    }
+    let staging_name = format!(
+        ".{}.staging",
+        package_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("stasis-package")
+    );
+    let staging_root = package_root.with_file_name(staging_name);
+    if staging_root.exists() {
+        return Err(format!(
+            "package staging output already exists: {}",
+            staging_root.display()
+        ));
+    }
+    fs::create_dir_all(&staging_root)
+        .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
+    let assembled = (|| -> Result<(), String> {
+        let executable = staging_root.join(executable_name(&workspace.manifest.name));
+        build_workspace(workspace, BuildMode::Release, Some(&executable))?;
+        let summary = executable.with_file_name(format!(
+            "{}.summary.json",
+            executable.file_name().unwrap_or_default().to_string_lossy()
+        ));
+        if summary.exists() {
+            fs::remove_file(&summary).map_err(|error| {
+                format!(
+                    "failed to remove package build receipt {}: {error}",
+                    summary.display()
+                )
+            })?;
+        }
+        copy_file(
+            &workspace.root.join(MANIFEST_NAME),
+            &staging_root.join(MANIFEST_NAME),
+        )?;
+        let assets = workspace.root.join("assets");
+        validate_workspace_destination(workspace, "assets directory", &assets)?;
+        copy_dir_if_exists(&assets, &staging_root.join("assets"))?;
+        if let Some(runtime) = installed_runtime_library() {
+            copy_file(
+                &runtime,
+                &staging_root.join(runtime.file_name().unwrap_or_default()),
+            )?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = assembled {
+        let _ = fs::remove_dir_all(&staging_root);
+        return Err(error);
+    }
+    fs::rename(&staging_root, &package_root).map_err(|error| {
+        let _ = fs::remove_dir_all(&staging_root);
+        format!(
+            "failed to publish package {}: {error}",
+            package_root.display()
+        )
+    })?;
+    Ok(CommandResult::success(
+        format!("packaged {} at {}", target.as_str(), package_root.display()),
+        json!({"target": target.as_str(), "output": display_path(&package_root)}),
+    ))
+}
+
+fn package_mobile_workspace(
+    workspace: &Workspace,
+    target: PackageTarget,
+    package_root: &Path,
+) -> Result<CommandResult, String> {
+    fs::create_dir_all(package_root)
+        .map_err(|error| format!("failed to create {}: {error}", package_root.display()))?;
+    let child_result = (|| -> Result<(), String> {
+        let executable = env::current_exe()
+            .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
+        let child = Command::new(executable)
+            .arg("mobile-aot-bundle")
+            .arg("--target")
+            .arg(target.as_str())
+            .arg("--project-dir")
+            .arg(&workspace.root)
+            .arg("--entry-file")
+            .arg(&workspace.manifest.entry)
+            .arg("--out-dir")
+            .arg(package_root)
+            .output()
+            .map_err(|error| format!("failed to launch mobile AOT packaging: {error}"))?;
+        if !child.status.success() {
+            return Err(format!(
+                "mobile AOT packaging failed with exit code {}: stdout={} stderr={}",
+                child.status.code().unwrap_or(1),
+                String::from_utf8_lossy(&child.stdout).trim(),
+                String::from_utf8_lossy(&child.stderr).trim()
+            ));
+        }
+        Ok(())
+    })();
+    if let Err(error) = child_result {
+        let _ = fs::remove_dir_all(package_root);
+        return Err(error);
+    }
+    Ok(CommandResult::success(
+        format!("packaged {} at {}", target.as_str(), package_root.display()),
+        json!({"target": target.as_str(), "output": display_path(package_root)}),
+    ))
+}
+
+fn inspect_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    let tests = workspace.root.join(&workspace.manifest.tests);
+    let output = workspace.root.join(&workspace.manifest.output);
+    Ok(CommandResult::success(
+        format!(
+            "workspace={} entry={} tests={} output={}",
+            workspace.root.display(),
+            entry.display(),
+            tests.display(),
+            output.display()
+        ),
+        json!({
+            "name": workspace.manifest.name,
+            "root": display_path(&workspace.root),
+            "entry": display_path(&entry),
+            "tests": display_path(&tests),
+            "output": display_path(&output),
+            "manifest_version": workspace.manifest.manifest_version,
+        }),
+    ))
+}
+
+fn env_result(explicit: Option<&Path>) -> Result<CommandResult, String> {
+    let executable = env::current_exe()
+        .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
+    let workspace = if explicit.is_some() {
+        Some(load_workspace(explicit)?)
+    } else {
+        load_workspace(None).ok()
+    };
+    let cache = workspace
+        .as_ref()
+        .map(|value| value.root.join(".stasis_cache"));
+    let data = json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "executable": display_path(&executable),
+        "toolchain_root": display_path(executable.parent().unwrap_or(Path::new("."))),
+        "workspace": workspace.as_ref().map(|value| display_path(&value.root)),
+        "cache": cache.as_ref().map(|value| display_path(value)),
+        "offline_core_workflows": true,
+        "manifest": MANIFEST_NAME,
+    });
+    Ok(CommandResult::success(
+        format!(
+            "stasis={} executable={} workspace={}",
+            env!("CARGO_PKG_VERSION"),
+            executable.display(),
+            workspace
+                .as_ref()
+                .map(|value| value.root.display().to_string())
+                .unwrap_or_else(|| "none".to_string())
+        ),
+        data,
+    ))
+}
+
+fn version_result() -> CommandResult {
+    CommandResult::success(
+        format!("stasis {}", env!("CARGO_PKG_VERSION")),
+        json!({"version": env!("CARGO_PKG_VERSION")}),
+    )
+}
+
+fn default_release_output(workspace: &Workspace) -> PathBuf {
+    workspace
+        .root
+        .join(&workspace.manifest.output)
+        .join(executable_name(&workspace.manifest.name))
+}
+
+fn executable_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn installed_runtime_library() -> Option<PathBuf> {
+    let executable = env::current_exe().ok()?;
+    let directory = executable.parent()?;
+    let name = if cfg!(windows) {
+        "stasis_graphics.dll"
+    } else if cfg!(target_os = "macos") {
+        "libstasis_graphics.dylib"
+    } else {
+        "libstasis_graphics.so"
+    };
+    let path = directory.join(name);
+    path.is_file().then_some(path)
+}
+
+fn bundled_stdlib_dir() -> Result<PathBuf, String> {
+    let executable = env::current_exe()
+        .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
+    let executable_dir = executable.parent().unwrap_or(Path::new("."));
+    let source_tree = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src/stdlib");
+    for candidate in [
+        executable_dir.join("src/stdlib"),
+        executable_dir.join("../src/stdlib"),
+        source_tree,
+    ] {
+        if candidate.join("stdlib.stasis").is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(
+        "installed toolchain is missing src/stdlib; reinstall the complete release archive"
+            .to_string(),
+    )
+}
+
+fn collect_stasis_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut entries: Vec<_> = fs::read_dir(root)
+        .map_err(|error| format!("failed to read {}: {error}", root.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to enumerate {}: {error}", root.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect {}: {error}", entry.path().display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_stasis_files(&entry.path(), files)?;
+        } else if entry.path().extension().and_then(|value| value.to_str()) == Some("stasis") {
+            files.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_if_exists(source: &Path, destination: &Path) -> Result<(), String> {
+    if !source.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(destination)
+        .map_err(|error| format!("failed to create {}: {error}", destination.display()))?;
+    let mut entries: Vec<_> = fs::read_dir(source)
+        .map_err(|error| format!("failed to read {}: {error}", source.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to enumerate {}: {error}", source.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let kind = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect {}: {error}", entry.path().display()))?;
+        let target = destination.join(entry.file_name());
+        if kind.is_symlink() {
+            continue;
+        }
+        if kind.is_dir() {
+            copy_dir_if_exists(&entry.path(), &target)?;
+        } else {
+            copy_file(&entry.path(), &target)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_file(source: &Path, destination: &Path) -> Result<(), String> {
+    fs::copy(source, destination).map(|_| ()).map_err(|error| {
+        format!(
+            "failed to copy {} to {}: {error}",
+            source.display(),
+            destination.display()
+        )
+    })
+}
+
+fn validate_project_name(name: &str) -> Result<(), String> {
+    let valid = !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-');
+    if valid {
+        Ok(())
+    } else {
+        Err("project name must be 1-64 ASCII letters, digits, '-' or '_'".to_string())
+    }
+}
+
+fn validate_relative_path(field: &str, path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err(format!("{field} must be a non-empty project-relative path"));
+    }
+    Ok(())
+}
+
+fn validate_optional_workspace_path(
+    workspace: &Workspace,
+    field: &str,
+    path: Option<&Path>,
+) -> Result<(), String> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    validate_relative_path(field, path)?;
+    validate_workspace_destination(workspace, field, &workspace.root.join(path))
+}
+
+fn validate_workspace_destination(
+    workspace: &Workspace,
+    field: &str,
+    candidate: &Path,
+) -> Result<(), String> {
+    let root = workspace
+        .root
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve workspace root: {error}"))?;
+    let mut ancestor = candidate;
+    while !ancestor.exists() {
+        ancestor = ancestor
+            .parent()
+            .ok_or_else(|| format!("failed to resolve {field}"))?;
+    }
+    let resolved = ancestor
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve {field}: {error}"))?;
+    if !resolved.starts_with(&root) {
+        return Err(format!("{field} resolves outside the workspace"));
+    }
+    Ok(())
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        env::current_dir()
+            .map(|current| current.join(path))
+            .map_err(|error| format!("failed to read current directory: {error}"))
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn relative_display(root: &Path, path: &Path) -> String {
+    display_path(path.strip_prefix(root).unwrap_or(path))
+}
+
+fn line_column(source: &str, offset: usize) -> (usize, usize) {
+    let mut bounded = offset.min(source.len());
+    while !source.is_char_boundary(bounded) {
+        bounded -= 1;
+    }
+    let prefix = &source[..bounded];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix
+        .rsplit_once('\n')
+        .map(|(_, tail)| tail.chars().count() + 1)
+        .unwrap_or_else(|| prefix.chars().count() + 1);
+    (line, column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
+
+    fn temp_dir(name: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "stasis_toolchain_cli_{name}_{}_{}",
+            std::process::id(),
+            NEXT_TEMP.fetch_add(1, Ordering::SeqCst)
+        ))
+    }
+
+    fn remove_temp(path: &Path) {
+        let _ = fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn workspace_discovery_works_from_nested_directories() {
+        let root = temp_dir("discovery");
+        create_project(root.clone(), "demo".to_string()).expect("create project");
+        let nested = root.join("src/nested");
+        fs::create_dir_all(&nested).expect("create nested");
+        assert_eq!(find_workspace_root(&nested), Some(root.clone()));
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn source_formatter_is_deterministic() {
+        let source = "function main(): i32 {  \r\n    return 0;\t\r\n}\r\n\r\n";
+        let expected = "function main(): i32 {\n    return 0;\n}\n";
+        assert_eq!(format_source(source), expected);
+        assert_eq!(format_source(expected), expected);
+    }
+
+    #[test]
+    fn generated_project_checks_tests_and_runs_through_jit() {
+        let root = temp_dir("smoke");
+        create_project(root.clone(), "smoke".to_string()).expect("create project");
+        let workspace = load_workspace(Some(&root)).expect("load workspace");
+        check_workspace(&workspace).expect("check project");
+        test_workspace(&workspace, None).expect("test project");
+        let run = run_workspace(&workspace, true).expect("run project");
+        assert_eq!(run.code, 0);
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn run_accepts_headless_and_watch_modes() {
+        let parsed = ToolchainCli::try_parse_from([
+            "stasis",
+            "--workspace",
+            "demo",
+            "run",
+            "--headless",
+            "--watch",
+        ])
+        .expect("parse run flags");
+        assert!(matches!(
+            parsed.command,
+            ToolchainCommand::Run {
+                watch: true,
+                headless: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn manifest_rejects_paths_that_escape_the_project() {
+        let manifest = ProjectManifest {
+            output: "../outside".to_string(),
+            ..ProjectManifest::new("demo".to_string())
+        };
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn init_preflights_reserved_paths_without_partial_writes() {
+        let root = temp_dir("preflight");
+        fs::create_dir_all(root.join("src")).expect("create source directory");
+        fs::write(root.join("src/main.stasis"), "user source\n").expect("write user source");
+
+        let error = create_project(root.clone(), "demo".to_string()).expect_err("reject conflict");
+        assert!(error.contains("refusing to overwrite"));
+        assert!(!root.join(MANIFEST_NAME).exists());
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("read user source"),
+            "user source\n"
+        );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn cli_output_paths_cannot_escape_the_workspace() {
+        let root = temp_dir("output_path");
+        create_project(root.clone(), "demo".to_string()).expect("create project");
+        let workspace = load_workspace(Some(&root)).expect("load workspace");
+        assert!(validate_optional_workspace_path(
+            &workspace,
+            "build output",
+            Some(Path::new("../outside"))
+        )
+        .is_err());
+        assert!(validate_optional_workspace_path(
+            &workspace,
+            "build output",
+            Some(Path::new("build/game"))
+        )
+        .is_ok());
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn failed_package_does_not_publish_or_leave_staging_output() {
+        let root = temp_dir("package_failure");
+        create_project(root.clone(), "demo".to_string()).expect("create project");
+        fs::write(root.join("src/main.stasis"), "function main(: i32 {\n")
+            .expect("write invalid source");
+        let workspace = load_workspace(Some(&root)).expect("load workspace");
+
+        assert!(package_workspace(
+            &workspace,
+            PackageTarget::Desktop,
+            Some(Path::new("dist/out"))
+        )
+        .is_err());
+        assert!(!root.join("dist/out").exists());
+        assert!(!root.join("dist/.out.staging").exists());
+        remove_temp(&root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn default_manifest_output_rejects_symlink_escape() {
+        use std::os::windows::fs::symlink_dir;
+
+        let root = temp_dir("symlink_output");
+        let outside = temp_dir("symlink_outside");
+        create_project(root.clone(), "demo".to_string()).expect("create project");
+        fs::create_dir_all(&outside).expect("create outside directory");
+        if symlink_dir(&outside, root.join("build")).is_err() {
+            remove_temp(&root);
+            remove_temp(&outside);
+            return;
+        }
+        let workspace = load_workspace(Some(&root)).expect("load workspace");
+        assert!(build_workspace(&workspace, BuildMode::Dev, None)
+            .expect_err("reject escaped default output")
+            .contains("outside the workspace"));
+        remove_temp(&root);
+        remove_temp(&outside);
+    }
+}

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1,0 +1,118 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
+
+fn temp_dir(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "stasis_cli_integration_{name}_{}_{}",
+        std::process::id(),
+        NEXT_TEMP.fetch_add(1, Ordering::SeqCst)
+    ))
+}
+
+fn stasis(args: &[&str], cwd: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_stasis"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run stasis CLI")
+}
+
+fn json_stdout(output: &Output) -> Value {
+    assert!(
+        output.stderr.is_empty(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("single JSON stdout object")
+}
+
+fn json_stderr(output: &Output) -> Value {
+    assert!(
+        output.stdout.is_empty(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    serde_json::from_slice(&output.stderr).expect("single JSON stderr object")
+}
+
+#[test]
+fn project_commands_emit_stable_json_from_nested_directories() {
+    let parent = temp_dir("success");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+
+    let created = stasis(&["--json", "new", "demo", "--dir", "demo"], &parent);
+    assert_eq!(created.status.code(), Some(0));
+    let created_json = json_stdout(&created);
+    assert_eq!(created_json["ok"], true);
+    assert_eq!(created_json["command"], "new");
+
+    let version = stasis(&["--json", "--version"], &parent);
+    assert_eq!(version.status.code(), Some(0));
+    assert_eq!(json_stdout(&version)["command"], "version");
+
+    let checked = stasis(&["--json", "check"], &project.join("src"));
+    assert_eq!(checked.status.code(), Some(0));
+    let checked_json = json_stdout(&checked);
+    assert_eq!(checked_json["command"], "check");
+    assert_eq!(checked_json["result"]["name"], "demo");
+
+    let missing = stasis(&["--json", "--workspace", "missing", "check"], &project);
+    assert_eq!(missing.status.code(), Some(1));
+    assert!(json_stderr(&missing)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("does not exist"));
+
+    fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+fn usage_compile_test_and_guest_exit_codes_are_stable() {
+    let parent = temp_dir("failures");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    let created = stasis(&["new", "demo", "--dir", "demo"], &parent);
+    assert_eq!(created.status.code(), Some(0));
+
+    let usage = stasis(&["--json", "build", "--unknown"], &project);
+    assert_eq!(usage.status.code(), Some(2));
+    assert_eq!(json_stderr(&usage)["code"], "usage_error");
+
+    fs::write(project.join("src/main.stasis"), "function main(: i32 {\n")
+        .expect("write invalid source");
+    let compile = stasis(&["--json", "check"], &project);
+    assert_eq!(compile.status.code(), Some(1));
+    assert_eq!(json_stderr(&compile)["code"], "command_failed");
+
+    fs::write(
+        project.join("tests/main.test.stasis"),
+        "test `fails`(): bool {\n    return false;\n}\n",
+    )
+    .expect("write failing test");
+    let tests = stasis(&["--json", "test"], &project);
+    assert_eq!(tests.status.code(), Some(1));
+    let test_json = json_stderr(&tests);
+    assert_eq!(test_json["code"], "command_failed");
+    assert!(test_json["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("fails"));
+
+    fs::write(
+        project.join("src/main.stasis"),
+        "function main(): i32 {\n    return 7;\n}\n",
+    )
+    .expect("write runnable source");
+    let run = stasis(&["--json", "run", "--headless"], &project);
+    assert_eq!(run.status.code(), Some(7));
+    let run_json = json_stdout(&run);
+    assert_eq!(run_json["result"]["exit_code"], 7);
+
+    fs::remove_dir_all(&parent).ok();
+}

--- a/crates/stasis_dynload/Cargo.toml
+++ b/crates/stasis_dynload/Cargo.toml
@@ -6,4 +6,5 @@ license.workspace = true
 
 [lib]
 path = "src/lib.rs"
+crate-type = ["rlib", "cdylib"]
 

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -271,6 +271,7 @@ pub fn link_objects_to_dynamic_library(
     if uses_msvc_linker_syntax(config) {
         args.push("/NOLOGO".to_string());
         args.push("/DLL".to_string());
+        args.push("/NOENTRY".to_string());
         args.push(format!("/OUT:{}", output_library.display()));
         for symbol in export_symbols {
             args.push(format!("/EXPORT:{symbol}"));
@@ -279,30 +280,6 @@ pub fn link_objects_to_dynamic_library(
         for lib_path in &windows_lib_paths {
             args.push(format!("/LIBPATH:{}", lib_path.display()));
         }
-        if let Some(kernel32) = resolve_kernel32_lib_path(&windows_lib_paths) {
-            args.push(kernel32.display().to_string());
-        } else {
-            args.push("kernel32.lib".to_string());
-        }
-        // When linking against Rust `staticlib` runtime shims (e.g. `stasis_dynload.lib`),
-        // lld-link does not automatically pull in the CRT/system libraries that those objects
-        // depend on. Add the common MSVC + Windows SDK libraries so AOT bundles link cleanly.
-        args.push("ucrt.lib".to_string());
-        args.push("vcruntime.lib".to_string());
-        args.push("msvcrt.lib".to_string());
-        args.push("legacy_stdio_definitions.lib".to_string());
-        args.push("advapi32.lib".to_string());
-        args.push("bcrypt.lib".to_string());
-        args.push("dbghelp.lib".to_string());
-        args.push("ntdll.lib".to_string());
-        args.push("ole32.lib".to_string());
-        args.push("oleaut32.lib".to_string());
-        args.push("psapi.lib".to_string());
-        args.push("secur32.lib".to_string());
-        args.push("shell32.lib".to_string());
-        args.push("user32.lib".to_string());
-        args.push("userenv.lib".to_string());
-        args.push("ws2_32.lib".to_string());
     } else {
         args.push("-shared".to_string());
         args.push("-o".to_string());
@@ -366,11 +343,6 @@ pub fn link_objects_to_executable(
         for lib_path in &windows_lib_paths {
             args.push(format!("/LIBPATH:{}", lib_path.display()));
         }
-        if let Some(kernel32) = resolve_kernel32_lib_path(&windows_lib_paths) {
-            args.push(kernel32.display().to_string());
-        } else {
-            args.push("kernel32.lib".to_string());
-        }
     } else {
         args.push("-o".to_string());
         args.push(output_executable.display().to_string());
@@ -420,104 +392,12 @@ fn uses_msvc_linker_syntax(config: &AotLinkConfig) -> bool {
 
 #[cfg(windows)]
 fn resolve_windows_link_lib_paths() -> Vec<PathBuf> {
-    let mut out: Vec<PathBuf> = Vec::new();
-
-    if let Ok(lib_env) = std::env::var("LIB") {
-        for raw in lib_env.split(';') {
-            let trimmed = raw.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let path = PathBuf::from(trimmed);
-            if path.exists() && !out.contains(&path) {
-                out.push(path);
-            }
-        }
-    }
-
-    if let Ok(vc_tools) = std::env::var("VCToolsInstallDir") {
-        let vc_lib = PathBuf::from(vc_tools).join("lib").join("x64");
-        if vc_lib.exists() && !out.contains(&vc_lib) {
-            out.push(vc_lib);
-        }
-    }
-
-    let msvc_roots = [
-        r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC",
-        r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC",
-        r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC",
-        r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC",
-    ];
-    for root in msvc_roots {
-        if let Some(version_dir) = latest_child_dir(Path::new(root)) {
-            let vc_lib = version_dir.join("lib").join("x64");
-            if vc_lib.exists() && !out.contains(&vc_lib) {
-                out.push(vc_lib);
-            }
-        }
-    }
-
-    let windows_kits_roots = [
-        r"C:\Program Files (x86)\Windows Kits\10\Lib",
-        r"C:\Program Files\Windows Kits\10\Lib",
-    ];
-    for root in windows_kits_roots {
-        if let Some(version_dir) = latest_child_dir(Path::new(root)) {
-            let um = version_dir.join("um").join("x64");
-            if um.exists() && !out.contains(&um) {
-                out.push(um);
-            }
-            let ucrt = version_dir.join("ucrt").join("x64");
-            if ucrt.exists() && !out.contains(&ucrt) {
-                out.push(ucrt);
-            }
-        }
-    }
-
-    out
+    Vec::new()
 }
 
 #[cfg(not(windows))]
 fn resolve_windows_link_lib_paths() -> Vec<PathBuf> {
     Vec::new()
-}
-
-#[cfg(windows)]
-fn resolve_kernel32_lib_path(lib_paths: &[PathBuf]) -> Option<PathBuf> {
-    for lib_path in lib_paths {
-        let candidate = lib_path.join("kernel32.lib");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
-#[cfg(not(windows))]
-fn resolve_kernel32_lib_path(_lib_paths: &[PathBuf]) -> Option<PathBuf> {
-    None
-}
-
-#[cfg(windows)]
-fn latest_child_dir(root: &Path) -> Option<PathBuf> {
-    let entries = fs::read_dir(root).ok()?;
-    let mut dirs: Vec<PathBuf> = entries
-        .filter_map(Result::ok)
-        .filter(|entry| entry.path().is_dir())
-        .map(|entry| entry.path())
-        .collect();
-    dirs.sort_by(|a, b| {
-        let an = a
-            .file_name()
-            .map(|value| value.to_string_lossy())
-            .unwrap_or_default();
-        let bn = b
-            .file_name()
-            .map(|value| value.to_string_lossy())
-            .unwrap_or_default();
-        bn.cmp(&an)
-    });
-    dirs.into_iter().next()
 }
 
 fn run_link_command(command: &mut Command, mode: &str, linker: &Path) -> Result<(), String> {

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -1,0 +1,108 @@
+# Stasis integrated CLI
+
+The `stasis` executable is the supported entry point for ordinary project work. A release
+archive contains the compiler, JIT/AOT runtime bridge, standard library, templates, target
+metadata, and the runtime bridge needed by the archive's native target. Project commands do not
+invoke Cargo and do not download dependencies.
+
+## Install
+
+Extract a release archive and add its executable directory to `PATH`:
+
+- Windows: the archive root contains `stasis.exe`, `stasis_runner.exe`, `stasis_graphics.dll`,
+  `lld-link.exe`, `clang-cl.exe`, and the project-built `stasis_dynload.dll` /
+  `stasis_dynload.dll.lib` runtime bridge pair. The bundled LLVM tools compile/link generated game
+  bridges; no Windows SDK or MSVC import libraries are redistributed.
+- Linux/macOS: use `bin/stasis`; the matching static runtime bridge is beside it. Native AOT
+  linking currently uses the platform `cc` driver supplied by the supported host image.
+
+Run `stasis version` and `stasis env` to verify the selected installation. Upgrades are explicit:
+extract a newer versioned archive and update `PATH`. Keeping two extracted versions is supported;
+the first executable on `PATH` wins.
+
+## Create and use a project
+
+```text
+stasis new brick_game
+cd brick_game
+stasis fmt
+stasis check
+stasis test
+stasis run --headless
+stasis run --watch
+stasis build --mode dev
+stasis build --mode release
+stasis package --target desktop
+```
+
+`stasis init --name brick_game .` initializes an existing directory. The built-in template copies
+the version-matched standard library into `stdlib/`, so imports remain offline and project-local.
+Commands discover
+`stasis.json` by walking from the selected path toward the filesystem root, so they work from the
+project root and nested directories. `--workspace PATH` selects a project explicitly.
+
+## Workspace contract
+
+`stasis.json` is versioned and deterministic:
+
+```json
+{
+  "manifest_version": 1,
+  "name": "brick_game",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}
+```
+
+Manifest paths must be project-relative and cannot contain `..`. Generated projects include a
+runnable `main()` and a real `.test.stasis` test.
+
+## Commands and outputs
+
+- `new` / `init`: create the manifest and built-in starter template without network access.
+- `fmt [--check]`: normalize line endings, trailing whitespace, blank EOF lines, and the final
+  newline. The operation is idempotent and never follows symlinks.
+- `check`: run the shared frontend and Cranelift JIT compilation path without executing `main`.
+- `test [PATH]`: run Stasis tests in one isolated JIT session.
+- `run [--headless]`: JIT-compile and execute no-argument `main(): i32` or `main(): void`; an
+  `i32` result is the process exit code. Headless execution is the default.
+- `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
+  Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
+- `build --mode dev`: compile through JIT and write `build/dev-build.json` as a deterministic
+  receipt.
+- `build --mode release`: use the shared Cranelift AOT pipeline and write the native executable to
+  `build/`.
+- `package --target desktop`: create a standalone directory with the AOT executable, manifest,
+  assets, and graphics runtime when present.
+- `package --target android-arm64|ios-arm64`: delegate to the shared mobile AOT bundle pipeline.
+- `inspect`, `version`, and `env`: report workspace, installation, cache, and output locations.
+
+`replay` and `verify` intentionally return deterministic unsupported diagnostics until the replay
+runtime contract lands; they do not fake successful behavior.
+
+Add `--json` to receive one stable JSON result object. Usage errors exit 2, command/compile/test
+failures exit 1, and successful commands exit 0 except `run`, which preserves the guest's `i32`
+exit code. Guest program output may precede the final JSON object for `run`.
+
+## Cache and offline behavior
+
+Compiler artifacts live under `<project>/.stasis_cache`; declared build outputs live under the
+manifest's `output` directory, and packages default to `dist/`. These paths can be removed safely
+while no Stasis command is running. Core create/format/check/test/run/native-build workflows are
+offline after installation. Mobile builds still require the documented platform SDK/NDK and
+signing tools for their target.
+
+## CI
+
+A minimal CI job can install one release archive and run:
+
+```text
+stasis fmt --check
+stasis check --json
+stasis test --json
+stasis build --mode release --json
+```
+
+Release workflows smoke-test a freshly assembled archive rather than borrowing compiler assets
+from the repository checkout.

--- a/tools/windows/verify-latest-release-cli.ps1
+++ b/tools/windows/verify-latest-release-cli.ps1
@@ -115,31 +115,33 @@ if (-not (Test-Path $graphicsDllPath)) {
     throw "Extracted bundle does not contain stasis_graphics.dll at $graphicsDllPath"
 }
 
-$runFile = Join-Path $extractDir "smoke_run.stasis"
-$testFile = Join-Path $extractDir "smoke_test.stasis"
-$buildOut = Join-Path $extractDir "smoke_run.exe"
+$projectRoot = Join-Path $extractDir "smoke_project"
+$runFile = Join-Path $projectRoot "src/main.stasis"
+$buildOut = Join-Path $projectRoot "build/smoke_project.exe"
 
 $runContent = @'
 function main(): i32 {
     return 7;
 }
 '@
-Set-Content -Path $runFile -Value $runContent -Encoding ASCII
-
-$testContent = @'
-test `one equals one`(): bool {
-    return 1 == 1;
-}
-'@
-Set-Content -Path $testFile -Value $testContent -Encoding ASCII
 
 Push-Location $extractDir
 try {
-    Invoke-CheckedCommand -Description "Running stasis run smoke_run.stasis" -ExpectedExitCode 7 -Action {
-        & $stasisExePath run $runFile --backend cranelift --no-cranelift-runner
+    Invoke-CheckedCommand -Description "Creating a project with stasis new" -Action {
+        & $stasisExePath new smoke_project --dir $projectRoot
     }
-    Invoke-CheckedCommand -Description "Running stasis build smoke_run.stasis" -Action {
-        & $stasisExePath build $runFile --backend cranelift --out $buildOut
+    Set-Content -Path $runFile -Value $runContent -Encoding ASCII
+    Invoke-CheckedCommand -Description "Checking from a project subdirectory" -Action {
+        & $stasisExePath --workspace (Join-Path $projectRoot "src") check --json
+    }
+    Invoke-CheckedCommand -Description "Running project tests" -Action {
+        & $stasisExePath --workspace $projectRoot test --json
+    }
+    Invoke-CheckedCommand -Description "Running project main through JIT" -ExpectedExitCode 7 -Action {
+        & $stasisExePath --workspace $projectRoot run
+    }
+    Invoke-CheckedCommand -Description "Building an offline AOT executable" -Action {
+        & $stasisExePath --workspace $projectRoot build --mode release
     }
     if (-not (Test-Path $buildOut)) {
         throw "stasis build did not produce expected output: $buildOut"
@@ -147,9 +149,6 @@ try {
     Invoke-CheckedCommand -Description "Running stasis.exe probe-graphics-runtime" -Action {
         Remove-Item Env:STASIS_RUNTIME_DLL_PATH -ErrorAction SilentlyContinue
         & $stasisExePath probe-graphics-runtime
-    }
-    Invoke-CheckedCommand -Description "Running stasis test smoke_test.stasis" -Action {
-        & $stasisExePath test $testFile --backend cranelift --no-cranelift-runner
     }
 }
 finally {


### PR DESCRIPTION
## Summary
- add one manifest-based \stasis\ CLI for new/init/fmt/check/test/run/build/package/inspect/replay/verify/version/env
- route watch through the existing graphical hot-swap runner and share the real JIT/AOT pipelines
- ship a clean Windows AOT/game toolchain using project-owned runtime bridge artifacts plus LLVM tools, runner, graphics runtime, and license notices
- add deterministic JSON/exit-code integration coverage, failure-safe packaging, workspace discovery/path safety, and release-archive smoke coverage

## Verification
- \cargo test -p stasis toolchain_cli::tests -- --test-threads=1\: 9 passed
- \cargo test -p stasis --test toolchain_cli -- --test-threads=1\: 2 passed
- \cargo test -p stasis windows_runtime_bridge_object_has_no_default_library_directives -- --test-threads=1\: 1 passed
- \cargo test -p stasis self_host_aot_cli_links_runnable_executable_with_main_entry_symbol -- --test-threads=1\: 1 passed
- \cargo test -p stasis aot_brickout_revenge_v1_engine_bundle_executes_two_ticks -- --test-threads=1\: 1 passed
- \cargo test -p stasis_jit -- --test-threads=1\: 14 passed
- clean assembled Windows install with LIB/VCToolsInstallDir/CC removed: new/check/test/AOT executable run/desktop package/package executable run passed; tick+render game package passed
- repository gate: 139 library tests passed; 35/37 binary tests passed. The two failures are pre-existing Windows path-separator assertions in legacy lookup tests.

## Cruft
- removed Windows SDK/MSVC import-library discovery and distribution
- no fake replay behavior; unsupported commands fail deterministically

Maddox Tasks: #160