### PR TITLE
feat: add semantic symbol editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,3 +138,7 @@
 - Good: adding host-required roots as explicit hashes injected into `.stasis` kept ownership clear and avoided parser/keyword surface expansion.
 - Bad: host compiler API had no compile-options channel, so root wiring currently rides through harness generation rather than a structured config object.
 - Adjustment: introduce a small explicit compile-config object in Rust host next, so required roots and future compile flags are passed through one typed path.
+- Current reflection (2026-07-16, semantic-edit protocol slice):
+- Good: one Rust parser-owned edit plan gave CLI and Android identical identity, import, validation, hash, and rollback behavior without duplicating scanners.
+- Bad: the first pass missed same-line declaration boundaries, import-only lifecycle roots, and the mismatch between Android display owners and Rust semantic owners.
+- Adjustment: semantic-edit slices must test non-textual reachability roots, multiple declarations on one line, cross-surface identity translation, and every failure point after source mutation but before receipt publication.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
+dependencies = [
+ "nix",
+ "rand",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +121,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -434,6 +450,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +616,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +691,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -814,6 +898,7 @@ dependencies = [
 name = "stasis_compiler"
 version = "0.1.0"
 dependencies = [
+ "atomic-write-file",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -823,6 +908,7 @@ dependencies = [
  "object",
  "serde",
  "serde_json",
+ "sha2",
  "stasis_dynload",
  "stasis_jit",
  "target-lexicon",
@@ -926,6 +1012,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
@@ -1110,6 +1205,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = "0.10"
 thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+atomic-write-file = "0.3"
 
 cranelift-codegen = { version = "0.117", features = ["arm64"] }
 cranelift-frontend = "0.117"

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -139,8 +139,15 @@ enum SymbolCommand {
     Add {
         #[command(flatten)]
         target: RequiredSymbolTargetArgs,
-        #[arg(long, value_name = "PATH")]
-        source_file: PathBuf,
+        #[arg(
+            long,
+            value_name = "SOURCE",
+            conflicts_with = "source_file",
+            required_unless_present = "source_file"
+        )]
+        source: Option<String>,
+        #[arg(long, value_name = "PATH", conflicts_with = "source")]
+        source_file: Option<PathBuf>,
         #[command(flatten)]
         options: SymbolEditOptions,
     },
@@ -148,8 +155,15 @@ enum SymbolCommand {
     Update {
         #[command(flatten)]
         target: SymbolSelectorArgs,
-        #[arg(long, value_name = "PATH")]
-        source_file: PathBuf,
+        #[arg(
+            long,
+            value_name = "SOURCE",
+            conflicts_with = "source_file",
+            required_unless_present = "source_file"
+        )]
+        source: Option<String>,
+        #[arg(long, value_name = "PATH", conflicts_with = "source")]
+        source_file: Option<PathBuf>,
         #[arg(long)]
         expected_source_hash: Option<String>,
         #[command(flatten)]
@@ -971,9 +985,9 @@ fn symbol_workspace(
             let mut items = workshop_source_items(&editable_files)?;
             items.retain(|item| {
                 kind.is_none_or(|kind| item.kind == kind.into())
-                    && file
-                        .as_deref()
-                        .is_none_or(|file| item.file.replace('\\', "/") == file.replace('\\', "/"))
+                    && file.as_deref().is_none_or(|file| {
+                        normalize_symbol_file(&item.file) == normalize_symbol_file(file)
+                    })
                     && owner
                         .as_deref()
                         .is_none_or(|owner| item.owner.as_deref() == Some(owner))
@@ -1033,10 +1047,11 @@ fn symbol_workspace(
         }
         SymbolCommand::Add {
             target,
+            source,
             source_file,
             options,
         } => {
-            let source = read_workspace_input(workspace, "symbol source", &source_file)?;
+            let source = read_symbol_source(workspace, source, source_file)?;
             let batch = WorkshopSemanticEditBatch {
                 schema_version: 1,
                 edits: vec![WorkshopSemanticEdit {
@@ -1050,11 +1065,12 @@ fn symbol_workspace(
         }
         SymbolCommand::Update {
             target,
+            source,
             source_file,
             expected_source_hash,
             options,
         } => {
-            let source = read_workspace_input(workspace, "symbol source", &source_file)?;
+            let source = read_symbol_source(workspace, source, source_file)?;
             let batch = WorkshopSemanticEditBatch {
                 schema_version: 1,
                 edits: vec![WorkshopSemanticEdit {
@@ -1093,6 +1109,23 @@ fn symbol_workspace(
             dry_run,
             no_tests,
         } => revert_symbol_plan(workspace, &receipt, dry_run, no_tests),
+    }
+}
+
+fn normalize_symbol_file(path: &str) -> String {
+    path.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+fn read_symbol_source(
+    workspace: &Workspace,
+    source: Option<String>,
+    source_file: Option<PathBuf>,
+) -> Result<String, String> {
+    match (source, source_file) {
+        (Some(source), None) => Ok(source),
+        (None, Some(path)) => read_workspace_input(workspace, "symbol source", &path),
+        (Some(_), Some(_)) => Err("use only one of --source or --source-file".to_string()),
+        (None, None) => Err("symbol add/update requires --source or --source-file".to_string()),
     }
 }
 
@@ -1269,6 +1302,12 @@ fn revert_symbol_plan(
     let source = read_workspace_input(workspace, "semantic edit receipt", receipt)?;
     let plan = serde_json::from_str::<WorkshopSemanticEditPlan>(&source)
         .map_err(|error| format!("invalid semantic edit receipt: {error}"))?;
+    if plan.schema_version != 1 {
+        return Err(format!(
+            "unsupported semantic edit receipt schema version {}",
+            plan.schema_version
+        ));
+    }
     let current =
         load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
     let mut restored = current.clone();

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use stasis::{
@@ -6,6 +6,13 @@ use stasis::{
     run_self_host_aot_cli_with_options, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
+use stasis_compiler::frontend::workshop::{
+    find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
+    workshop_reachable_files, workshop_source_hash, workshop_source_items,
+    write_workshop_semantic_plan, write_workshop_semantic_receipt, WorkshopSemanticEdit,
+    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
+    WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
+};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -16,7 +23,7 @@ const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
 const COMMANDS: &[&str] = &[
     "new", "init", "fmt", "check", "test", "run", "build", "package", "inspect", "replay",
-    "verify", "version", "env", "help",
+    "verify", "version", "env", "symbol", "help",
 ];
 
 #[derive(Debug, Parser)]
@@ -106,6 +113,130 @@ enum ToolchainCommand {
     Version,
     /// Print toolchain, workspace, cache, and offline capability information.
     Env,
+    /// Find and transactionally edit compiler-owned semantic symbols.
+    Symbol {
+        #[command(subcommand)]
+        command: SymbolCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum SymbolCommand {
+    /// List symbols in deterministic source order.
+    List {
+        #[arg(long, value_enum)]
+        kind: Option<SymbolKindArg>,
+        #[arg(long)]
+        file: Option<String>,
+        #[arg(long)]
+        owner: Option<String>,
+    },
+    /// Find symbol metadata without returning its source.
+    Find(SymbolSelectorArgs),
+    /// Read one unambiguous symbol and its source.
+    Read(SymbolSelectorArgs),
+    /// Add one declaration to an existing imported file.
+    Add {
+        #[command(flatten)]
+        target: RequiredSymbolTargetArgs,
+        #[arg(long, value_name = "PATH")]
+        source_file: PathBuf,
+        #[command(flatten)]
+        options: SymbolEditOptions,
+    },
+    /// Replace one existing declaration.
+    Update {
+        #[command(flatten)]
+        target: SymbolSelectorArgs,
+        #[arg(long, value_name = "PATH")]
+        source_file: PathBuf,
+        #[arg(long)]
+        expected_source_hash: Option<String>,
+        #[command(flatten)]
+        options: SymbolEditOptions,
+    },
+    /// Delete one existing declaration.
+    Delete {
+        #[command(flatten)]
+        target: SymbolSelectorArgs,
+        #[arg(long)]
+        expected_source_hash: Option<String>,
+        #[command(flatten)]
+        options: SymbolEditOptions,
+    },
+    /// Preview or apply a shared semantic-edit request JSON file.
+    Apply {
+        #[arg(long, value_name = "PATH")]
+        request: PathBuf,
+        #[command(flatten)]
+        options: SymbolEditOptions,
+    },
+    /// Revert a previously applied semantic-edit receipt.
+    Revert {
+        #[arg(long, value_name = "PATH")]
+        receipt: PathBuf,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        no_tests: bool,
+    },
+}
+
+#[derive(Debug, Clone, Args)]
+struct SymbolSelectorArgs {
+    name: String,
+    #[arg(long, value_enum)]
+    kind: Option<SymbolKindArg>,
+    #[arg(long)]
+    file: Option<String>,
+    #[arg(long)]
+    owner: Option<String>,
+    #[arg(long)]
+    signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+struct RequiredSymbolTargetArgs {
+    name: String,
+    #[arg(long, value_enum)]
+    kind: SymbolKindArg,
+    #[arg(long)]
+    file: String,
+    #[arg(long)]
+    owner: Option<String>,
+    #[arg(long)]
+    signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+struct SymbolEditOptions {
+    /// Validate and report the edit without writing files.
+    #[arg(long)]
+    dry_run: bool,
+    /// Skip project tests after compiler validation.
+    #[arg(long)]
+    no_tests: bool,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SymbolKindArg {
+    Imports,
+    Globals,
+    Struct,
+    Function,
+    Test,
+}
+
+impl From<SymbolKindArg> for WorkshopSourceItemKind {
+    fn from(value: SymbolKindArg) -> Self {
+        match value {
+            SymbolKindArg::Imports => Self::Imports,
+            SymbolKindArg::Globals => Self::Globals,
+            SymbolKindArg::Struct => Self::Struct,
+            SymbolKindArg::Function => Self::Function,
+            SymbolKindArg::Test => Self::Test,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -298,6 +429,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Verify => "verify",
         ToolchainCommand::Version => "version",
         ToolchainCommand::Env => "env",
+        ToolchainCommand::Symbol { .. } => "symbol",
     }
 }
 
@@ -359,6 +491,7 @@ fn execute(
                     package_workspace(&workspace, target, out.as_deref())
                 }
                 ToolchainCommand::Inspect => inspect_workspace(&workspace),
+                ToolchainCommand::Symbol { command } => symbol_workspace(&workspace, command),
                 _ => Err("unsupported command routing".to_string()),
             }
         }
@@ -796,6 +929,404 @@ fn package_mobile_workspace(
         format!("packaged {} at {}", target.as_str(), package_root.display()),
         json!({"target": target.as_str(), "output": display_path(package_root)}),
     ))
+}
+
+impl SymbolSelectorArgs {
+    fn selector(&self) -> WorkshopSymbolSelector {
+        WorkshopSymbolSelector {
+            name: self.name.clone(),
+            kind: self.kind.map(Into::into),
+            file: self.file.clone(),
+            owner: self.owner.clone(),
+            signature: self.signature.clone(),
+        }
+    }
+}
+
+impl RequiredSymbolTargetArgs {
+    fn selector(&self) -> WorkshopSymbolSelector {
+        WorkshopSymbolSelector {
+            name: self.name.clone(),
+            kind: Some(self.kind.into()),
+            file: Some(self.file.clone()),
+            owner: self.owner.clone(),
+            signature: self.signature.clone(),
+        }
+    }
+}
+
+fn symbol_workspace(
+    workspace: &Workspace,
+    command: SymbolCommand,
+) -> Result<CommandResult, String> {
+    let files =
+        load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
+    let editable_files = files
+        .iter()
+        .filter(|file| is_editable_workshop_path(&file.path))
+        .cloned()
+        .collect::<Vec<_>>();
+    match command {
+        SymbolCommand::List { kind, file, owner } => {
+            let mut items = workshop_source_items(&editable_files)?;
+            items.retain(|item| {
+                kind.is_none_or(|kind| item.kind == kind.into())
+                    && file
+                        .as_deref()
+                        .is_none_or(|file| item.file.replace('\\', "/") == file.replace('\\', "/"))
+                    && owner
+                        .as_deref()
+                        .is_none_or(|owner| item.owner.as_deref() == Some(owner))
+            });
+            let human = items
+                .iter()
+                .map(|item| {
+                    format!(
+                        "{:?}\t{}\t{}\t{}",
+                        item.kind,
+                        item.file,
+                        item.owner.as_deref().unwrap_or(""),
+                        item.name
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Ok(CommandResult::success(
+                human,
+                json!({"schema_version": 1, "items": items}),
+            ))
+        }
+        SymbolCommand::Find(args) => {
+            let items = find_workshop_symbols(&editable_files, &args.selector())?;
+            let metadata = items
+                .iter()
+                .map(|item| {
+                    json!({
+                        "kind": item.kind,
+                        "name": item.name,
+                        "owner": item.owner,
+                        "file": item.file,
+                        "signature": item.signature,
+                        "source_hash": item.source_hash,
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(CommandResult::success(
+                format!("found {} item(s)", metadata.len()),
+                json!({"schema_version": 1, "matches": metadata}),
+            ))
+        }
+        SymbolCommand::Read(args) => {
+            let selector = args.selector();
+            let mut items = find_workshop_symbols(&editable_files, &selector)?;
+            if items.len() != 1 {
+                return Err(format!(
+                    "symbol read requires exactly one match; found {}",
+                    items.len()
+                ));
+            }
+            let item = items.remove(0);
+            Ok(CommandResult::success(
+                item.source.clone(),
+                json!({"schema_version": 1, "item": item}),
+            ))
+        }
+        SymbolCommand::Add {
+            target,
+            source_file,
+            options,
+        } => {
+            let source = read_workspace_input(workspace, "symbol source", &source_file)?;
+            let batch = WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![WorkshopSemanticEdit {
+                    operation: WorkshopSemanticEditOperation::Add,
+                    target: target.selector(),
+                    new_source: Some(source),
+                    expected_source_hash: None,
+                }],
+            };
+            apply_symbol_batch(workspace, &files, batch, options)
+        }
+        SymbolCommand::Update {
+            target,
+            source_file,
+            expected_source_hash,
+            options,
+        } => {
+            let source = read_workspace_input(workspace, "symbol source", &source_file)?;
+            let batch = WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![WorkshopSemanticEdit {
+                    operation: WorkshopSemanticEditOperation::Update,
+                    target: target.selector(),
+                    new_source: Some(source),
+                    expected_source_hash,
+                }],
+            };
+            apply_symbol_batch(workspace, &files, batch, options)
+        }
+        SymbolCommand::Delete {
+            target,
+            expected_source_hash,
+            options,
+        } => {
+            let batch = WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![WorkshopSemanticEdit {
+                    operation: WorkshopSemanticEditOperation::Delete,
+                    target: target.selector(),
+                    new_source: None,
+                    expected_source_hash,
+                }],
+            };
+            apply_symbol_batch(workspace, &files, batch, options)
+        }
+        SymbolCommand::Apply { request, options } => {
+            let source = read_workspace_input(workspace, "semantic edit request", &request)?;
+            let batch = serde_json::from_str::<WorkshopSemanticEditBatch>(&source)
+                .map_err(|error| format!("invalid semantic edit request: {error}"))?;
+            apply_symbol_batch(workspace, &files, batch, options)
+        }
+        SymbolCommand::Revert {
+            receipt,
+            dry_run,
+            no_tests,
+        } => revert_symbol_plan(workspace, &receipt, dry_run, no_tests),
+    }
+}
+
+fn apply_symbol_batch(
+    workspace: &Workspace,
+    files: &[WorkshopSourceFile],
+    mut batch: WorkshopSemanticEditBatch,
+    options: SymbolEditOptions,
+) -> Result<CommandResult, String> {
+    normalize_cli_semantic_batch(files, &mut batch)?;
+    let (after, plan) = plan_workshop_semantic_edits(files, &batch)?;
+    validate_semantic_files(workspace, &after)?;
+    if options.dry_run {
+        return Ok(CommandResult::success(
+            format!(
+                "preview: {} file(s) would change; {:?}",
+                plan.changed_files.len(),
+                plan.reload.expected_reload
+            ),
+            json!({
+                "status": "preview",
+                "validated": true,
+                "tests": "not_run_for_preview",
+                "plan": plan,
+            }),
+        ));
+    }
+
+    write_workshop_semantic_plan(&workspace.root, &plan, false)?;
+    let validation = if options.no_tests {
+        Ok(json!({"compiler": "passed", "tests": "skipped"}))
+    } else {
+        test_workspace(workspace, None).map(
+            |result| json!({"compiler": "passed", "tests": "passed", "test_result": result.data}),
+        )
+    };
+    let validation = match validation {
+        Ok(validation) => validation,
+        Err(error) => {
+            write_workshop_semantic_plan(&workspace.root, &plan, true).map_err(|rollback| {
+                format!(
+                    "semantic edit validation failed: {error}; rollback also failed: {rollback}"
+                )
+            })?;
+            let restored = load_workshop_edit_workspace(
+                &workspace.root,
+                Path::new(&workspace.manifest.entry),
+            )?;
+            validate_semantic_files(workspace, &restored)?;
+            return Err(format!(
+                "semantic edit validation failed and all source changes were rolled back: {error}"
+            ));
+        }
+    };
+    let receipt = match write_symbol_receipt(workspace, &plan) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            write_workshop_semantic_plan(&workspace.root, &plan, true).map_err(|rollback| {
+                format!("semantic receipt failed: {error}; rollback also failed: {rollback}")
+            })?;
+            let restored = load_workshop_edit_workspace(
+                &workspace.root,
+                Path::new(&workspace.manifest.entry),
+            )?;
+            validate_semantic_files(workspace, &restored)?;
+            return Err(format!(
+                "semantic receipt failed and all source changes were rolled back: {error}"
+            ));
+        }
+    };
+    Ok(CommandResult::success(
+        format!(
+            "applied {} semantic edit(s); receipt {}",
+            plan.edits.len(),
+            receipt.display()
+        ),
+        json!({
+            "status": "applied",
+            "plan": plan,
+            "validation": validation,
+            "receipt": relative_display(&workspace.root, &receipt),
+        }),
+    ))
+}
+
+fn normalize_cli_semantic_batch(
+    files: &[WorkshopSourceFile],
+    batch: &mut WorkshopSemanticEditBatch,
+) -> Result<(), String> {
+    let editable = files
+        .iter()
+        .filter(|file| is_editable_workshop_path(&file.path))
+        .cloned()
+        .collect::<Vec<_>>();
+    for edit in &mut batch.edits {
+        if let Some(file) = edit.target.file.as_deref() {
+            if !is_editable_workshop_path(file) {
+                return Err(format!(
+                    "semantic edits are limited to project src/ and tests/ files: {file}"
+                ));
+            }
+            continue;
+        }
+        if edit.operation == WorkshopSemanticEditOperation::Add {
+            return Err("semantic add requires target.file".to_string());
+        }
+        let matches = find_workshop_symbols(&editable, &edit.target)?;
+        if matches.len() != 1 {
+            return Err(format!(
+                "semantic edit requires one editable target; found {}",
+                matches.len()
+            ));
+        }
+        edit.target.file = Some(matches[0].file.clone());
+    }
+    Ok(())
+}
+
+fn validate_semantic_files(
+    workspace: &Workspace,
+    files: &[WorkshopSourceFile],
+) -> Result<(), String> {
+    let files = workshop_reachable_files(files, Path::new(&workspace.manifest.entry))?;
+    let mut jit = JitProcess::new();
+    jit.set_local_runtime_helper_trampolines(true);
+    jit.set_required_emit_roots(&[
+        "main".to_string(),
+        "tick".to_string(),
+        "render".to_string(),
+        "on_code_swap".to_string(),
+    ]);
+    for file in &files {
+        let path = workspace.root.join(&file.path);
+        let compiler_path = path
+            .canonicalize()
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+        jit.upsert_file(compiler_path, file.source.clone());
+    }
+    jit.compile().map_err(|error| {
+        jit.last_source_diagnostic()
+            .map(|diagnostic| {
+                format!(
+                    "{}:{}-{}: {}",
+                    diagnostic.path, diagnostic.start, diagnostic.end, diagnostic.message
+                )
+            })
+            .unwrap_or_else(|| format!("{error:?}"))
+    })?;
+    Ok(())
+}
+
+fn write_symbol_receipt(
+    workspace: &Workspace,
+    plan: &WorkshopSemanticEditPlan,
+) -> Result<PathBuf, String> {
+    let relative_directory = Path::new(&workspace.manifest.output).join("semantic-edits");
+    let receipt = workspace
+        .root
+        .join(&relative_directory)
+        .join("receipt.json");
+    validate_workspace_destination(workspace, "semantic edit receipt", &receipt)?;
+    write_workshop_semantic_receipt(&workspace.root, &relative_directory, plan)
+        .map(|relative| workspace.root.join(relative))
+}
+
+fn revert_symbol_plan(
+    workspace: &Workspace,
+    receipt: &Path,
+    dry_run: bool,
+    no_tests: bool,
+) -> Result<CommandResult, String> {
+    let source = read_workspace_input(workspace, "semantic edit receipt", receipt)?;
+    let plan = serde_json::from_str::<WorkshopSemanticEditPlan>(&source)
+        .map_err(|error| format!("invalid semantic edit receipt: {error}"))?;
+    let current =
+        load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
+    let mut restored = current.clone();
+    for change in &plan.changed_files {
+        let file = restored
+            .iter_mut()
+            .find(|file| file.path == change.file)
+            .ok_or_else(|| format!("receipt file is no longer imported: {}", change.file))?;
+        if workshop_source_hash(&file.source) != change.after_hash {
+            return Err(format!(
+                "refusing revert because {} changed after the recorded edit",
+                change.file
+            ));
+        }
+        file.source = change.before_source.clone();
+    }
+    validate_semantic_files(workspace, &restored)?;
+    if dry_run {
+        return Ok(CommandResult::success(
+            format!(
+                "preview: {} file(s) would be restored",
+                plan.changed_files.len()
+            ),
+            json!({"status": "revert_preview", "validated": true, "plan": plan}),
+        ));
+    }
+    write_workshop_semantic_plan(&workspace.root, &plan, true)?;
+    if !no_tests {
+        if let Err(error) = test_workspace(workspace, None) {
+            write_workshop_semantic_plan(&workspace.root, &plan, false).map_err(|rollback| {
+                format!("revert tests failed: {error}; reapply also failed: {rollback}")
+            })?;
+            return Err(format!(
+                "revert tests failed and the edited sources were reapplied: {error}"
+            ));
+        }
+    }
+    Ok(CommandResult::success(
+        format!("reverted {} file(s)", plan.changed_files.len()),
+        json!({
+            "status": "reverted",
+            "changed_files": plan.changed_files.iter().map(|change| &change.file).collect::<Vec<_>>(),
+            "compiler": "passed",
+            "tests": if no_tests { "skipped" } else { "passed" },
+        }),
+    ))
+}
+
+fn read_workspace_input(workspace: &Workspace, field: &str, path: &Path) -> Result<String, String> {
+    validate_optional_workspace_path(workspace, field, Some(path))?;
+    let absolute = workspace.root.join(path);
+    fs::read_to_string(&absolute)
+        .map_err(|error| format!("failed to read {}: {error}", absolute.display()))
+}
+
+fn is_editable_workshop_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.starts_with("src/") || normalized.starts_with("tests/")
 }
 
 fn inspect_workspace(workspace: &Workspace) -> Result<CommandResult, String> {

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -116,3 +116,296 @@ fn usage_compile_test_and_guest_exit_codes_are_stable() {
 
     fs::remove_dir_all(&parent).ok();
 }
+
+#[test]
+fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
+    let parent = temp_dir("semantic_symbols");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    let created = stasis(&["new", "demo", "--dir", "demo"], &parent);
+    assert_eq!(created.status.code(), Some(0));
+
+    fs::write(
+        project.join("src/main.stasis"),
+        "import \"old.stasis\";\n\nconst LIMIT: i32 = 2;\n\nstruct Config { width: i32; }\n\nfunction main(): i32 { return tick(); }\n\n// Tick behavior.\nfunction tick(): i32 { return old_value(); }\n",
+    )
+    .expect("write main");
+    fs::write(
+        project.join("src/old.stasis"),
+        "function old_value(): i32 { return 1; }\n",
+    )
+    .expect("write old module");
+    fs::write(
+        project.join("src/new.stasis"),
+        "function new_value(): i32 { return 9; }\n",
+    )
+    .expect("write new module");
+    fs::create_dir_all(project.join("edits")).expect("create edits");
+    fs::write(
+        project.join("edits/tick.stasis"),
+        "// Tick behavior.\nfunction tick(): i32 {\n    import \"new.stasis\";\n    return new_value();\n}\n",
+    )
+    .expect("write edit");
+    fs::write(
+        project.join("edits/globals.stasis"),
+        "const LIMIT: i32 = 4;\n",
+    )
+    .expect("write globals edit");
+    fs::write(
+        project.join("edits/config.stasis"),
+        "struct Config { width: i32; height: i32; }\n",
+    )
+    .expect("write struct edit");
+
+    let listed = stasis(&["--json", "symbol", "list"], &project);
+    assert_eq!(listed.status.code(), Some(0));
+    let listed_json = json_stdout(&listed);
+    assert!(listed_json["result"]["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .any(|item| item["kind"] == "imports" && item["file"] == "src/main.stasis"));
+
+    let preview = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "tick",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/tick.stasis",
+            "--dry-run",
+        ],
+        &project,
+    );
+    assert_eq!(preview.status.code(), Some(0));
+    assert_eq!(json_stdout(&preview)["result"]["status"], "preview");
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("preview source")
+        .contains("old_value"));
+
+    let applied = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "tick",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/tick.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(
+        applied.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&applied.stderr)
+    );
+    let applied_json = json_stdout(&applied);
+    assert_eq!(applied_json["result"]["status"], "applied");
+    let receipt = applied_json["result"]["receipt"]
+        .as_str()
+        .expect("receipt")
+        .to_string();
+    let updated = fs::read_to_string(project.join("src/main.stasis")).expect("updated source");
+    assert!(updated.starts_with("import \"new.stasis\";\n"));
+    assert!(!updated.contains("old.stasis"));
+    assert!(!updated.contains("    import"));
+
+    let run = stasis(&["--json", "run", "--headless"], &project);
+    assert_eq!(run.status.code(), Some(9));
+    assert_eq!(json_stdout(&run)["result"]["exit_code"], 9);
+
+    let reverted = stasis(
+        &["--json", "symbol", "revert", "--receipt", &receipt],
+        &project,
+    );
+    assert_eq!(
+        reverted.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&reverted.stderr)
+    );
+    assert_eq!(json_stdout(&reverted)["result"]["status"], "reverted");
+    let restored = fs::read_to_string(project.join("src/main.stasis")).expect("restored source");
+    assert!(restored.contains("old.stasis"));
+    assert!(restored.contains("old_value"));
+
+    fs::create_dir_all(project.join("build")).expect("create build");
+    fs::remove_dir_all(project.join("build/semantic-edits")).expect("remove receipt directory");
+    fs::write(
+        project.join("build/semantic-edits"),
+        "blocks receipt directory",
+    )
+    .expect("block receipt directory");
+    let receipt_failure = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "tick",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/tick.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(receipt_failure.status.code(), Some(1));
+    assert!(json_stderr(&receipt_failure)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("rolled back"));
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("source after receipt failure"),
+        restored
+    );
+    fs::remove_file(project.join("build/semantic-edits")).expect("remove receipt blocker");
+
+    let globals = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "globals",
+            "--kind",
+            "globals",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/globals.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(globals.status.code(), Some(0));
+    let globals_receipt = json_stdout(&globals)["result"]["receipt"]
+        .as_str()
+        .expect("globals receipt")
+        .to_string();
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("constant source")
+        .contains("LIMIT: i32 = 4"));
+
+    let structure = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "Config",
+            "--kind",
+            "struct",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/config.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(structure.status.code(), Some(0));
+    let structure_receipt = json_stdout(&structure)["result"]["receipt"]
+        .as_str()
+        .expect("struct receipt")
+        .to_string();
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("struct source")
+        .contains("height: i32"));
+
+    assert_eq!(
+        stasis(
+            &[
+                "--json",
+                "symbol",
+                "revert",
+                "--receipt",
+                &structure_receipt
+            ],
+            &project,
+        )
+        .status
+        .code(),
+        Some(0)
+    );
+    assert_eq!(
+        stasis(
+            &["--json", "symbol", "revert", "--receipt", &globals_receipt],
+            &project,
+        )
+        .status
+        .code(),
+        Some(0)
+    );
+
+    fs::write(
+        project.join("edits/bad_tick.stasis"),
+        "function tick(): i32 { return missing_symbol(); }\n",
+    )
+    .expect("write invalid edit");
+    let invalid = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "tick",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source-file",
+            "edits/bad_tick.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(invalid.status.code(), Some(1));
+    assert!(json_stderr(&invalid)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("missing_symbol"));
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("source after invalid edit"),
+        restored
+    );
+
+    fs::write(
+        project.join("edits/failing_test.stasis"),
+        "test `new project is ready`(): bool {\n    return false;\n}\n",
+    )
+    .expect("write failing test edit");
+    let original_test =
+        fs::read_to_string(project.join("tests/main.test.stasis")).expect("read original test");
+    let failing_test = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "new project is ready",
+            "--kind",
+            "test",
+            "--file",
+            "tests/main.test.stasis",
+            "--source-file",
+            "edits/failing_test.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(failing_test.status.code(), Some(1));
+    assert!(json_stderr(&failing_test)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("rolled back"));
+    assert_eq!(
+        fs::read_to_string(project.join("tests/main.test.stasis")).expect("test after rollback"),
+        original_test
+    );
+
+    fs::remove_dir_all(&parent).ok();
+}

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -409,3 +409,489 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
 
     fs::remove_dir_all(&parent).ok();
 }
+
+#[test]
+fn semantic_symbol_cli_supports_inline_crud_and_stale_guards() {
+    let parent = temp_dir("semantic_inline");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    let created = stasis(&["new", "demo", "--dir", "demo"], &parent);
+    assert_eq!(created.status.code(), Some(0));
+
+    let added = stasis(
+        &[
+            "--json",
+            "symbol",
+            "add",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "// Inline helper.\nfunction helper(): i32 { return 4; }",
+        ],
+        &project,
+    );
+    assert_eq!(
+        added.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&added.stderr)
+    );
+
+    let found = stasis(
+        &["--json", "symbol", "find", "helper", "--kind", "function"],
+        &project,
+    );
+    assert_eq!(found.status.code(), Some(0));
+    assert_eq!(
+        json_stdout(&found)["result"]["matches"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let normalized_list = stasis(
+        &[
+            "--json",
+            "symbol",
+            "list",
+            "--kind",
+            "function",
+            "--file",
+            ".\\src\\main.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(normalized_list.status.code(), Some(0));
+    assert!(json_stdout(&normalized_list)["result"]["items"]
+        .as_array()
+        .expect("normalized items")
+        .iter()
+        .any(|item| item["name"] == "helper"));
+
+    let read = stasis(
+        &[
+            "--json",
+            "symbol",
+            "read",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(read.status.code(), Some(0));
+    let read_json = json_stdout(&read);
+    assert!(read_json["result"]["item"]["source"]
+        .as_str()
+        .unwrap()
+        .starts_with("// Inline helper."));
+    let original_hash = read_json["result"]["item"]["source_hash"]
+        .as_str()
+        .expect("source hash")
+        .to_string();
+
+    let preview = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "function helper(): i32 {\n    return 5;\n}",
+            "--expected-source-hash",
+            &original_hash,
+            "--dry-run",
+        ],
+        &project,
+    );
+    assert_eq!(preview.status.code(), Some(0));
+    assert_eq!(json_stdout(&preview)["result"]["status"], "preview");
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("preview source")
+        .contains("return 4;"));
+
+    fs::create_dir_all(project.join("edits")).expect("create edits");
+    fs::write(
+        project.join("edits/helper.stasis"),
+        "function helper(): i32 { return 6; }\n",
+    )
+    .expect("write helper source");
+    let conflicting_inputs = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "function helper(): i32 { return 5; }",
+            "--source-file",
+            "edits/helper.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(conflicting_inputs.status.code(), Some(2));
+    assert_eq!(json_stderr(&conflicting_inputs)["code"], "usage_error");
+
+    let stale = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "function helper(): i32 { return 5; }",
+            "--expected-source-hash",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        ],
+        &project,
+    );
+    assert_eq!(stale.status.code(), Some(1));
+    assert!(json_stderr(&stale)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("stale semantic edit target"));
+
+    let updated = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "function helper(): i32 { return 5; }",
+            "--expected-source-hash",
+            &original_hash,
+        ],
+        &project,
+    );
+    assert_eq!(updated.status.code(), Some(0));
+
+    let updated_read = stasis(
+        &["--json", "symbol", "read", "helper", "--kind", "function"],
+        &project,
+    );
+    let updated_json = json_stdout(&updated_read);
+    let updated_hash = updated_json["result"]["item"]["source_hash"]
+        .as_str()
+        .expect("updated hash")
+        .to_string();
+    assert!(updated_json["result"]["item"]["source"]
+        .as_str()
+        .unwrap()
+        .contains("return 5;"));
+
+    let deleted = stasis(
+        &[
+            "--json",
+            "symbol",
+            "delete",
+            "helper",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--expected-source-hash",
+            &updated_hash,
+        ],
+        &project,
+    );
+    assert_eq!(deleted.status.code(), Some(0));
+    let delete_receipt = json_stdout(&deleted)["result"]["receipt"]
+        .as_str()
+        .expect("delete receipt")
+        .to_string();
+    assert!(!fs::read_to_string(project.join("src/main.stasis"))
+        .expect("deleted source")
+        .contains("function helper"));
+
+    let mut future_receipt: Value = serde_json::from_str(
+        &fs::read_to_string(project.join(&delete_receipt)).expect("read delete receipt"),
+    )
+    .expect("parse delete receipt");
+    future_receipt["schema_version"] = Value::from(2);
+    let future_receipt_path = project.join("future-receipt.json");
+    fs::write(
+        &future_receipt_path,
+        serde_json::to_string(&future_receipt).expect("serialize future receipt"),
+    )
+    .expect("write future receipt");
+    let unsupported = stasis(
+        &[
+            "--json",
+            "symbol",
+            "revert",
+            "--receipt",
+            "future-receipt.json",
+        ],
+        &project,
+    );
+    assert_eq!(unsupported.status.code(), Some(1));
+    assert!(json_stderr(&unsupported)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("unsupported semantic edit receipt schema version 2"));
+    assert!(!fs::read_to_string(project.join("src/main.stasis"))
+        .expect("source after unsupported receipt")
+        .contains("function helper"));
+
+    let reverted = stasis(
+        &["--json", "symbol", "revert", "--receipt", &delete_receipt],
+        &project,
+    );
+    assert_eq!(reverted.status.code(), Some(0));
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("reverted source")
+        .contains("return 5;"));
+    fs::remove_dir_all(parent).ok();
+}
+
+#[test]
+fn semantic_symbol_cli_batch_apply_is_atomic_and_revertible() {
+    let parent = temp_dir("semantic_batch");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    let original_main = "import \"helper.stasis\";\nfunction main(): i32 { return helper(); }\n";
+    let original_helper = "function helper(): i32 { return 1; }\n";
+    fs::write(project.join("src/main.stasis"), original_main).expect("write main");
+    fs::write(project.join("src/helper.stasis"), original_helper).expect("write helper");
+    fs::create_dir_all(project.join("edits")).expect("create edits");
+    let request = serde_json::json!({
+        "schema_version": 1,
+        "edits": [
+            {
+                "operation": "update",
+                "target": {
+                    "kind": "function",
+                    "file": "src/main.stasis",
+                    "name": "main"
+                },
+                "new_source": "// Batch main.\nfunction main(): i32 { return helper(); }"
+            },
+            {
+                "operation": "update",
+                "target": {
+                    "kind": "function",
+                    "file": "src/helper.stasis",
+                    "name": "helper"
+                },
+                "new_source": "function helper(): i32 { return 2; }"
+            }
+        ]
+    });
+    fs::write(
+        project.join("edits/batch.json"),
+        serde_json::to_vec_pretty(&request).expect("serialize request"),
+    )
+    .expect("write request");
+
+    let preview = stasis(
+        &[
+            "--json",
+            "symbol",
+            "apply",
+            "--request",
+            "edits/batch.json",
+            "--dry-run",
+            "--no-tests",
+        ],
+        &project,
+    );
+    assert_eq!(preview.status.code(), Some(0));
+    let preview_json = json_stdout(&preview);
+    assert_eq!(preview_json["result"]["status"], "preview");
+    assert_eq!(
+        preview_json["result"]["plan"]["changed_files"]
+            .as_array()
+            .expect("changed files")
+            .len(),
+        2
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("preview main"),
+        original_main
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/helper.stasis")).expect("preview helper"),
+        original_helper
+    );
+
+    let applied = stasis(
+        &[
+            "--json",
+            "symbol",
+            "apply",
+            "--request",
+            "edits/batch.json",
+            "--no-tests",
+        ],
+        &project,
+    );
+    assert_eq!(applied.status.code(), Some(0));
+    let receipt = json_stdout(&applied)["result"]["receipt"]
+        .as_str()
+        .expect("receipt")
+        .to_string();
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("applied main")
+        .starts_with("import \"helper.stasis\";\n// Batch main."));
+    assert!(fs::read_to_string(project.join("src/helper.stasis"))
+        .expect("applied helper")
+        .contains("return 2;"));
+
+    let reverted = stasis(
+        &[
+            "--json",
+            "symbol",
+            "revert",
+            "--receipt",
+            &receipt,
+            "--no-tests",
+        ],
+        &project,
+    );
+    assert_eq!(reverted.status.code(), Some(0));
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("reverted main"),
+        original_main
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/helper.stasis")).expect("reverted helper"),
+        original_helper
+    );
+
+    let invalid_request = serde_json::json!({
+        "schema_version": 1,
+        "edits": [
+            {
+                "operation": "update",
+                "target": {"kind": "function", "file": "src/main.stasis", "name": "main"},
+                "new_source": "function main(): i32 { return 9; }"
+            },
+            {
+                "operation": "update",
+                "target": {"kind": "function", "file": "src/helper.stasis", "name": "missing"},
+                "new_source": "function missing(): i32 { return 9; }"
+            }
+        ]
+    });
+    fs::write(
+        project.join("edits/invalid-batch.json"),
+        serde_json::to_vec_pretty(&invalid_request).expect("serialize invalid request"),
+    )
+    .expect("write invalid request");
+    let invalid = stasis(
+        &[
+            "--json",
+            "symbol",
+            "apply",
+            "--request",
+            "edits/invalid-batch.json",
+            "--no-tests",
+        ],
+        &project,
+    );
+    assert_eq!(invalid.status.code(), Some(1));
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("atomic main"),
+        original_main
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/helper.stasis")).expect("atomic helper"),
+        original_helper
+    );
+    fs::remove_dir_all(parent).ok();
+}
+
+#[test]
+fn semantic_symbol_cli_reapplies_edit_when_revert_tests_fail() {
+    let parent = temp_dir("semantic_revert_failure");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    let rejected_source = "function main(): i32 { return 1; }\n";
+    let accepted_source = "function main(): i32 { return 0; }\n";
+    fs::write(project.join("src/main.stasis"), rejected_source).expect("write rejected source");
+    fs::write(
+        project.join("tests/main.test.stasis"),
+        "import \"../src/main.stasis\";\ntest `main remains zero`(): bool { return main() == 0; }\n",
+    )
+    .expect("write behavioral test");
+
+    let applied = stasis(
+        &[
+            "--json",
+            "symbol",
+            "update",
+            "main",
+            "--kind",
+            "function",
+            "--file",
+            "src/main.stasis",
+            "--source",
+            "function main(): i32 { return 0; }",
+        ],
+        &project,
+    );
+    assert_eq!(
+        applied.status.code(),
+        Some(0),
+        "{}",
+        String::from_utf8_lossy(&applied.stderr)
+    );
+    let receipt = json_stdout(&applied)["result"]["receipt"]
+        .as_str()
+        .expect("receipt")
+        .to_string();
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("accepted source"),
+        accepted_source
+    );
+
+    let reverted = stasis(
+        &["--json", "symbol", "revert", "--receipt", &receipt],
+        &project,
+    );
+    assert_eq!(reverted.status.code(), Some(1));
+    assert!(json_stderr(&reverted)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("edited sources were reapplied"));
+    assert_eq!(
+        fs::read_to_string(project.join("src/main.stasis")).expect("reapplied source"),
+        accepted_source
+    );
+    fs::remove_dir_all(parent).ok();
+}

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -320,17 +320,24 @@ pub fn execute_android_workshop_semantic_edit(
             ));
         }
     };
-    let receipt = write_android_semantic_receipt(project_root, &plan).map_err(|error| {
-        let rollback = write_workshop_semantic_plan(project_root, &plan, true);
-        match rollback {
-            Ok(()) => format!("failed writing semantic edit receipt; edit rolled back: {error}"),
-            Err(rollback) => {
+    let receipt = match write_android_semantic_receipt(project_root, &plan) {
+        Ok(receipt) => receipt,
+        Err(error) => {
+            write_workshop_semantic_plan(project_root, &plan, true).map_err(|rollback| {
                 format!(
                     "failed writing semantic edit receipt: {error}; rollback failed: {rollback}"
                 )
-            }
+            })?;
+            compile_android_workshop_project(project_root, entry_file).map_err(|restore| {
+                format!(
+                    "failed writing semantic edit receipt: {error}; restored compile failed: {restore}"
+                )
+            })?;
+            return Err(format!(
+                "failed writing semantic edit receipt; sources and runtime rolled back: {error}"
+            ));
         }
-    })?;
+    };
     Ok(serde_json::json!({
         "schema_version": 1,
         "status": "applied",
@@ -1381,6 +1388,16 @@ mod tests {
         });
     }
 
+    fn ffi_json(ptr: *mut c_char) -> serde_json::Value {
+        assert!(!ptr.is_null());
+        let source = unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .expect("FFI JSON UTF-8")
+            .to_string();
+        stasis_android_bridge_free_string(ptr);
+        serde_json::from_str(&source).expect("valid FFI JSON")
+    }
+
     fn default_tick_input() -> AndroidBridgeTickInput {
         AndroidBridgeTickInput {
             touch_x: 80,
@@ -2090,6 +2107,85 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
     }
 
     #[test]
+    fn c_semantic_bridge_returns_versioned_json_for_success_and_errors() {
+        let root = temp_project("semantic_ffi");
+        let original = "function main(): i32 { return 1; }\n";
+        fs::write(root.join("src/main.stasis"), original).expect("write source");
+        let root_c = CString::new(root.to_string_lossy().as_bytes()).expect("root cstr");
+        let entry_c = CString::new("src/main.stasis").expect("entry cstr");
+
+        let null_paths = ffi_json(stasis_android_bridge_source_items(
+            std::ptr::null(),
+            entry_c.as_ptr(),
+        ));
+        assert_eq!(null_paths["schema_version"], 1);
+        assert_eq!(null_paths["status"], "error");
+        assert!(null_paths["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("null project root"));
+
+        let items = ffi_json(stasis_android_bridge_source_items(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+        ));
+        assert_eq!(items["schema_version"], 1);
+        assert!(items["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .any(|item| item["name"] == "main"));
+
+        let invalid_request = CString::new("not json").expect("invalid request cstr");
+        let invalid = ffi_json(stasis_android_bridge_semantic_edit(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            invalid_request.as_ptr(),
+            1,
+            1,
+            0,
+        ));
+        assert_eq!(invalid["schema_version"], 1);
+        assert_eq!(invalid["status"], "error");
+        assert!(invalid["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("invalid semantic edit request"));
+
+        let request = CString::new(
+            serde_json::json!({
+                "schema_version": 1,
+                "edits": [{
+                    "operation": "update",
+                    "target": {
+                        "kind": "function",
+                        "file": "src/main.stasis",
+                        "name": "main"
+                    },
+                    "new_source": "function main(): i32 { return 2; }"
+                }]
+            })
+            .to_string(),
+        )
+        .expect("request cstr");
+        let preview = ffi_json(stasis_android_bridge_semantic_edit(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            request.as_ptr(),
+            1,
+            1,
+            0,
+        ));
+        assert_eq!(preview["schema_version"], 1);
+        assert_eq!(preview["status"], "preview");
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("preview source"),
+            original
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
     fn android_and_cli_share_rust_semantic_edit_contract() {
         let _guard = bridge_runtime_test_guard();
         clear_runtime_session_for_test();
@@ -2223,5 +2319,119 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
         assert!(source.contains("self: Player): i32 { return 7;"));
         assert!(source.contains("self: Enemy): i32 { return 2;"));
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn android_receipt_failure_restores_sources_and_live_runtime() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("semantic_receipt_rollback");
+        let entry = Path::new("src/main.stasis");
+        let original = "global State { value: i32; }\nfunction main(): void { State.value = 0; }\nfunction tick(): void { State.value += 1; }\n";
+        fs::write(root.join(entry), original).expect("write source");
+        compile_android_workshop_project(&root, entry).expect("initial compile");
+        fs::create_dir_all(root.join("build")).expect("create build");
+        fs::write(root.join("build/semantic-edits"), "block receipt directory")
+            .expect("block receipt directory");
+        let items = android_workshop_source_items(&root, entry).expect("source items");
+        let tick = items["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .find(|item| item["kind"] == "function" && item["name"] == "tick")
+            .expect("tick item");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "tick".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: Some(tick["signature"].as_str().expect("signature").to_string()),
+                },
+                new_source: Some("function tick(): void { State.value += 10; }".to_string()),
+                expected_source_hash: Some(
+                    tick["source_hash"]
+                        .as_str()
+                        .expect("source hash")
+                        .to_string(),
+                ),
+            }],
+        };
+        let error =
+            execute_android_workshop_semantic_edit(&root, entry, &batch, false, true, false)
+                .expect_err("receipt should fail");
+        assert!(error.contains("receipt"));
+        assert_eq!(
+            fs::read_to_string(root.join(entry)).expect("restored source"),
+            original
+        );
+        run_android_workshop_tick(&root, entry, default_tick_input()).expect("restored tick");
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "State.value").expect("restored value"),
+            1
+        );
+        clear_runtime_session_for_test();
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn android_test_failure_restores_sources_and_live_runtime() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("semantic_test_rollback");
+        let entry = Path::new("src/main.stasis");
+        let original = "global State { value: i32; }\nfunction main(): void { State.value = 0; }\nfunction tick(): void { State.value += 1; }\n";
+        fs::write(root.join(entry), original).expect("write source");
+        fs::create_dir_all(root.join("tests")).expect("create tests");
+        fs::write(
+            root.join("tests/failing.test.stasis"),
+            "test `reject edit`(): bool { return false; }\n",
+        )
+        .expect("write failing test");
+        compile_android_workshop_project(&root, entry).expect("initial compile");
+        let items = android_workshop_source_items(&root, entry).expect("source items");
+        let tick = items["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .find(|item| item["kind"] == "function" && item["name"] == "tick")
+            .expect("tick item");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "tick".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: Some(tick["signature"].as_str().expect("signature").to_string()),
+                },
+                new_source: Some("function tick(): void { State.value += 10; }".to_string()),
+                expected_source_hash: Some(
+                    tick["source_hash"]
+                        .as_str()
+                        .expect("source hash")
+                        .to_string(),
+                ),
+            }],
+        };
+        let error = execute_android_workshop_semantic_edit(&root, entry, &batch, false, true, true)
+            .expect_err("tests should reject edit");
+        assert!(error.contains("validation failed"));
+        assert_eq!(
+            fs::read_to_string(root.join(entry)).expect("restored source"),
+            original
+        );
+        run_android_workshop_tick(&root, entry, default_tick_input()).expect("restored tick");
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "State.value").expect("restored value"),
+            1
+        );
+        clear_runtime_session_for_test();
+        fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -10,8 +10,16 @@ use stasis_assets::{AssetFormat, AssetHandle, AssetLimits, ResolvedAssetManifest
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::frontend::parser::rewrite_top_level_test_declarations;
 use stasis_compiler::frontend::workshop::{
-    build_workshop_compile_plan, load_workshop_project, render_workshop_artifacts,
-    WorkshopCompilePlan, WorkshopReload, WorkshopSourceFile,
+    build_workshop_compile_plan, load_workshop_edit_workspace, load_workshop_project,
+    plan_workshop_semantic_edits, render_workshop_artifacts, workshop_reachable_files,
+    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
+    WorkshopCompilePlan, WorkshopReload, WorkshopSemanticEditBatch, WorkshopSemanticEditPlan,
+    WorkshopSourceFile,
+};
+#[cfg(test)]
+use stasis_compiler::frontend::workshop::{
+    WorkshopSemanticEdit, WorkshopSemanticEditOperation, WorkshopSourceItemKind,
+    WorkshopSymbolSelector,
 };
 use stasis_compiler::IncrementalCompilerHost;
 
@@ -224,6 +232,120 @@ pub fn run_android_workshop_stasis_tests(
     Ok(
         serde_json::json!({"kind": "stasis_test_run", "passed": passed, "failed": failed, "all_passed": failed == 0 && passed > 0, "results": results}),
     )
+}
+
+pub fn android_workshop_source_items(
+    project_root: impl AsRef<Path>,
+    entry_file: impl AsRef<Path>,
+) -> Result<serde_json::Value, String> {
+    let files = load_workshop_edit_workspace(project_root.as_ref(), entry_file.as_ref())?;
+    let editable = files
+        .into_iter()
+        .filter(|file| {
+            let path = file.path.replace('\\', "/");
+            path.starts_with("src/") || path.starts_with("tests/")
+        })
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "items": workshop_source_items(&editable)?,
+    }))
+}
+
+pub fn execute_android_workshop_semantic_edit(
+    project_root: impl AsRef<Path>,
+    entry_file: impl AsRef<Path>,
+    batch: &WorkshopSemanticEditBatch,
+    dry_run: bool,
+    validate: bool,
+    run_tests: bool,
+) -> Result<serde_json::Value, String> {
+    let project_root = project_root.as_ref();
+    let entry_file = entry_file.as_ref();
+    let files = load_workshop_edit_workspace(project_root, entry_file)?;
+    let (after, plan) = plan_workshop_semantic_edits(&files, batch)?;
+    let reachable = workshop_reachable_files(&after, entry_file)?;
+    let source_fingerprint = fingerprint_workshop_sources(&reachable);
+    build_runtime_session(project_root, &reachable, source_fingerprint)?;
+    if dry_run {
+        return Ok(serde_json::json!({
+            "schema_version": 1,
+            "status": "preview",
+            "validated": true,
+            "plan": plan,
+        }));
+    }
+
+    write_workshop_semantic_plan(project_root, &plan, false)?;
+    if !validate {
+        return Ok(serde_json::json!({
+            "schema_version": 1,
+            "status": "applied",
+            "validation": "pending_batch_compile",
+            "plan": plan,
+        }));
+    }
+
+    let validation = (|| {
+        let compile = compile_android_workshop_project(project_root, entry_file)?;
+        if run_tests {
+            let tests = run_android_workshop_stasis_tests(project_root)?;
+            if tests["all_passed"] != true {
+                return Err(format!("Stasis tests failed: {tests}"));
+            }
+            Ok(serde_json::json!({
+                "compiler": "passed",
+                "reload": compile.reload,
+                "tests": tests,
+            }))
+        } else {
+            Ok(serde_json::json!({
+                "compiler": "passed",
+                "reload": compile.reload,
+                "tests": "skipped",
+            }))
+        }
+    })();
+    let validation = match validation {
+        Ok(value) => value,
+        Err(error) => {
+            write_workshop_semantic_plan(project_root, &plan, true).map_err(|rollback| {
+                format!("semantic edit failed: {error}; rollback failed: {rollback}")
+            })?;
+            compile_android_workshop_project(project_root, entry_file).map_err(|restore| {
+                format!("semantic edit failed: {error}; restored compile failed: {restore}")
+            })?;
+            return Err(format!(
+                "semantic edit validation failed and sources were rolled back: {error}"
+            ));
+        }
+    };
+    let receipt = write_android_semantic_receipt(project_root, &plan).map_err(|error| {
+        let rollback = write_workshop_semantic_plan(project_root, &plan, true);
+        match rollback {
+            Ok(()) => format!("failed writing semantic edit receipt; edit rolled back: {error}"),
+            Err(rollback) => {
+                format!(
+                    "failed writing semantic edit receipt: {error}; rollback failed: {rollback}"
+                )
+            }
+        }
+    })?;
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "status": "applied",
+        "validation": validation,
+        "receipt": receipt,
+        "plan": plan,
+    }))
+}
+
+fn write_android_semantic_receipt(
+    project_root: &Path,
+    plan: &WorkshopSemanticEditPlan,
+) -> Result<String, String> {
+    write_workshop_semantic_receipt(project_root, Path::new("build/semantic-edits"), plan)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
 }
 
 fn collect_stasis_test_files(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
@@ -548,10 +670,12 @@ fn configure_runtime_jit(jit: &mut JitProcess, project_root: &Path, files: &[Wor
     ]);
     for file in files {
         let disk_path = project_root.join(&file.path);
-        jit.upsert_file(
-            disk_path.to_string_lossy().replace('\\', "/"),
-            file.source.clone(),
-        );
+        let compiler_path = disk_path
+            .canonicalize()
+            .unwrap_or(disk_path)
+            .to_string_lossy()
+            .to_string();
+        jit.upsert_file(compiler_path, file.source.clone());
     }
 }
 
@@ -811,6 +935,90 @@ pub extern "C" fn stasis_android_bridge_run_tests(project_root: *const c_char) -
     CString::new(message).unwrap().into_raw()
 }
 
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_source_items(
+    project_root: *const c_char,
+    entry_file: *const c_char,
+) -> *mut c_char {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        let (project_root, entry_file) = semantic_bridge_paths(project_root, entry_file)?;
+        android_workshop_source_items(&project_root, &entry_file)
+    }));
+    semantic_bridge_json_result(result, "source item indexing")
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_semantic_edit(
+    project_root: *const c_char,
+    entry_file: *const c_char,
+    request_json: *const c_char,
+    dry_run: i32,
+    validate: i32,
+    run_tests: i32,
+) -> *mut c_char {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        let (project_root, entry_file) = semantic_bridge_paths(project_root, entry_file)?;
+        if request_json.is_null() {
+            return Err("null semantic edit request".to_string());
+        }
+        let request_json = CStr::from_ptr(request_json)
+            .to_str()
+            .map_err(|error| format!("semantic edit request was not UTF-8: {error}"))?;
+        let batch = serde_json::from_str::<WorkshopSemanticEditBatch>(request_json)
+            .map_err(|error| format!("invalid semantic edit request: {error}"))?;
+        execute_android_workshop_semantic_edit(
+            &project_root,
+            &entry_file,
+            &batch,
+            dry_run != 0,
+            validate != 0,
+            run_tests != 0,
+        )
+    }));
+    semantic_bridge_json_result(result, "semantic edit")
+}
+
+unsafe fn semantic_bridge_paths(
+    project_root: *const c_char,
+    entry_file: *const c_char,
+) -> Result<(String, String), String> {
+    if project_root.is_null() || entry_file.is_null() {
+        return Err("null project root or entry file".to_string());
+    }
+    let project_root = CStr::from_ptr(project_root)
+        .to_str()
+        .map_err(|error| format!("project root was not UTF-8: {error}"))?;
+    let entry_file = CStr::from_ptr(entry_file)
+        .to_str()
+        .map_err(|error| format!("entry file was not UTF-8: {error}"))?;
+    Ok((project_root.to_string(), entry_file.to_string()))
+}
+
+fn semantic_bridge_json_result(
+    result: Result<Result<serde_json::Value, String>, Box<dyn std::any::Any + Send>>,
+    operation: &str,
+) -> *mut c_char {
+    let value = match result {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "error": error,
+        }),
+        Err(_) => serde_json::json!({
+            "schema_version": 1,
+            "status": "error",
+            "error": format!("panic during Android {operation}"),
+        }),
+    };
+    let message = serde_json::to_string(&value).unwrap_or_else(|_| {
+        "{\"status\":\"error\",\"error\":\"serialization failed\"}".to_string()
+    });
+    CString::new(message)
+        .unwrap_or_else(|_| CString::new("{\"status\":\"error\"}").unwrap())
+        .into_raw()
+}
+
 unsafe fn compile_project_from_c(
     project_root: *const c_char,
     entry_file: *const c_char,
@@ -832,11 +1040,15 @@ fn format_compiler_source_diagnostic(
     diagnostic: &stasis_compiler::SourceDiagnostic,
 ) -> String {
     let path = Path::new(&diagnostic.path);
+    let canonical_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
     let source = fs::read_to_string(path).unwrap_or_default();
     let (line, column) = source_line_column(&source, diagnostic.start);
     let (end_line, end_column) = source_line_column(&source, diagnostic.end);
     let file = path
         .strip_prefix(project_root)
+        .or_else(|_| path.strip_prefix(&canonical_root))
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/");
@@ -1874,6 +2086,142 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
         stasis_android_bridge_free_string(ptr);
         assert!(message.contains("CompilePlanned"));
         assert!(message.contains("functions="));
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn android_and_cli_share_rust_semantic_edit_contract() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("semantic_edit");
+        fs::write(
+            root.join("src/main.stasis"),
+            "import \"old.stasis\";\nfunction main(): i32 { return tick(); }\nfunction tick(): i32 { return old_value(); }\n",
+        )
+        .expect("write main");
+        fs::write(
+            root.join("src/old.stasis"),
+            "function old_value(): i32 { return 1; }\n",
+        )
+        .expect("write old");
+        fs::write(
+            root.join("src/new.stasis"),
+            "function new_value(): i32 { return 9; }\n",
+        )
+        .expect("write new");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "tick".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: None,
+                },
+                new_source: Some(
+                    "function tick(): i32 { import \"new.stasis\"; return new_value(); }"
+                        .to_string(),
+                ),
+                expected_source_hash: None,
+            }],
+        };
+        let preview = execute_android_workshop_semantic_edit(
+            &root,
+            Path::new("src/main.stasis"),
+            &batch,
+            true,
+            true,
+            false,
+        )
+        .expect("preview");
+        assert_eq!(preview["status"], "preview");
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("preview source")
+            .contains("old_value"));
+
+        let applied = execute_android_workshop_semantic_edit(
+            &root,
+            Path::new("src/main.stasis"),
+            &batch,
+            false,
+            true,
+            false,
+        )
+        .expect("apply");
+        assert_eq!(applied["status"], "applied");
+        let source = fs::read_to_string(root.join("src/main.stasis")).expect("applied source");
+        assert!(source.starts_with("import \"new.stasis\";\n"));
+        assert!(!source.contains("old.stasis"));
+        assert!(source.contains("return new_value();"));
+        assert!(root
+            .join(applied["receipt"].as_str().expect("receipt"))
+            .is_file());
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn android_semantic_items_use_rust_owner_and_signature_identity() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("semantic_identity");
+        fs::write(
+            root.join("src/main.stasis"),
+            "struct Player { value: i32; }\nstruct Enemy { value: i32; }\nfunction main(): i32 { return 0; }\nfunction tick(): void {}\nfunction adjust(self: Player): i32 { return 1; }\nfunction adjust(self: Enemy): i32 { return 2; }\n",
+        )
+        .expect("write overloads");
+        let response = android_workshop_source_items(&root, Path::new("src/main.stasis"))
+            .expect("source items");
+        let items = response["items"].as_array().expect("items array");
+        let tick = items
+            .iter()
+            .find(|item| item["kind"] == "function" && item["name"] == "tick")
+            .expect("tick item");
+        assert!(tick.get("owner").is_none());
+        let player_adjust = items
+            .iter()
+            .find(|item| {
+                item["kind"] == "function" && item["name"] == "adjust" && item["owner"] == "Player"
+            })
+            .expect("Player adjust item");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "adjust".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: Some("Player".to_string()),
+                    signature: Some(
+                        player_adjust["signature"]
+                            .as_str()
+                            .expect("signature")
+                            .to_string(),
+                    ),
+                },
+                new_source: Some("function adjust(self: Player): i32 { return 7; }".to_string()),
+                expected_source_hash: Some(
+                    player_adjust["source_hash"]
+                        .as_str()
+                        .expect("source hash")
+                        .to_string(),
+                ),
+            }],
+        };
+        execute_android_workshop_semantic_edit(
+            &root,
+            Path::new("src/main.stasis"),
+            &batch,
+            false,
+            true,
+            false,
+        )
+        .expect("update one overload");
+        let source = fs::read_to_string(root.join("src/main.stasis")).expect("updated source");
+        assert!(source.contains("self: Player): i32 { return 7;"));
+        assert!(source.contains("self: Enemy): i32 { return 2;"));
         fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/stasis_compiler/Cargo.toml
+++ b/crates/stasis_compiler/Cargo.toml
@@ -18,6 +18,9 @@ target-lexicon.workspace = true
 stasis_jit = { path = "../stasis_jit" }
 stasis_dynload = { path = "../stasis_dynload" }
 serde.workspace = true
+serde_json.workspace = true
+atomic-write-file.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 object = "0.36"

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -639,10 +639,19 @@ fn parse_simple_top_level_symbols(source: &str) -> Result<Vec<ParsedSimpleSymbol
                 let (name, signature, end_index) = match kind {
                     WorkshopSymbolKind::Global => {
                         let name_token = expect_token(&tokens, cursor + 1, TokenKind::Identifier)?;
-                        let open = find_next_token(&tokens, cursor + 2, TokenKind::LBrace)?;
-                        let close = find_matching_rbrace(&tokens, open + 1, 1)?;
                         let name = token_text(source, name_token).to_string();
-                        (name.clone(), format!("global {name}"), close)
+                        if tokens
+                            .get(cursor + 2)
+                            .is_some_and(|token| token.kind == TokenKind::LBrace)
+                        {
+                            let open = cursor + 2;
+                            let close = find_matching_rbrace(&tokens, open + 1, 1)?;
+                            (name.clone(), format!("global {name}"), close)
+                        } else {
+                            let end = find_next_token(&tokens, cursor + 2, TokenKind::Semicolon)?;
+                            let signature = source[token.start..tokens[end].end].trim().to_string();
+                            (name, signature, end)
+                        }
                     }
                     WorkshopSymbolKind::Constant => {
                         let name_token = expect_token(&tokens, cursor + 1, TokenKind::Identifier)?;
@@ -3588,7 +3597,7 @@ mod workshop_compile_plan_tests {
 
     #[test]
     fn source_items_use_rust_parser_owned_sections_and_comment_boundaries() {
-        let source = "import \"math.stasis\";\n\nconst SPEED: i32 = 2;\nglobal State { score: i32; }\n\n// Player state.\n// Kept with the struct.\nstruct Player { x: i32; }\n\n// Unrelated note.\n\n// Advances the player.\nfunction update(self: Player): void {\n    self.x += SPEED;\n}\n\nfunction main(): i32 { return State.score; }\n";
+        let source = "import \"math.stasis\";\n\nconst SPEED: i32 = 2;\nglobal score: i32;\nglobal State { score: i32; }\n\n// Player state.\n// Kept with the struct.\nstruct Player { x: i32; }\n\n// Unrelated note.\n\n// Advances the player.\nfunction update(self: Player): void {\n    self.x += SPEED;\n}\n\nfunction main(): i32 { return State.score; }\n";
         let files = vec![WorkshopSourceFile {
             path: "src/main.stasis".to_string(),
             source: source.to_string(),
@@ -3605,7 +3614,9 @@ mod workshop_compile_plan_tests {
             .find(|item| item.kind == WorkshopSourceItemKind::Globals)
             .expect("globals item");
         assert!(globals.source.contains("const SPEED"));
+        assert!(globals.source.contains("global score: i32;"));
         assert!(globals.source.contains("global State"));
+        assert!(!globals.source.contains("function update"));
         let player = items
             .iter()
             .find(|item| item.kind == WorkshopSourceItemKind::Struct && item.name == "Player")

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -1641,10 +1641,158 @@ fn prune_unused_workshop_imports(
 }
 
 fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
-    Ok(lex(source)?
-        .into_iter()
-        .filter(|token| matches!(token.kind, TokenKind::Identifier | TokenKind::FunctionKw))
-        .map(|token| token_text(source, token).to_string())
+    let tokens = lex(source)?;
+    let mut declarations = BTreeSet::new();
+    let mut scope_stack = Vec::new();
+    let mut scope_at = vec![None; tokens.len()];
+    let mut scope_ends = BTreeMap::new();
+    for (index, token) in tokens.iter().enumerate() {
+        if token.kind == TokenKind::LBrace {
+            scope_stack.push(index);
+        }
+        scope_at[index] = scope_stack.last().copied();
+        if token.kind == TokenKind::RBrace {
+            if let Some(start) = scope_stack.pop() {
+                scope_ends.insert(start, index);
+            }
+        }
+    }
+    let mut local_bindings = Vec::new();
+    for (function_index, token) in tokens.iter().enumerate() {
+        if token.kind != TokenKind::FunctionKw {
+            continue;
+        }
+        let Some(open_paren) = tokens[function_index + 1..]
+            .iter()
+            .position(|token| token.kind == TokenKind::LParen)
+            .map(|offset| function_index + 1 + offset)
+        else {
+            continue;
+        };
+        let mut paren_depth = 0usize;
+        let mut close_paren = None;
+        for (index, token) in tokens.iter().enumerate().skip(open_paren) {
+            match token.kind {
+                TokenKind::LParen => paren_depth += 1,
+                TokenKind::RParen => {
+                    paren_depth = paren_depth.saturating_sub(1);
+                    if paren_depth == 0 {
+                        close_paren = Some(index);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(close_paren) = close_paren else {
+            continue;
+        };
+        let Some(body_start) = tokens[close_paren + 1..]
+            .iter()
+            .take_while(|token| token.kind != TokenKind::Semicolon)
+            .position(|token| token.kind == TokenKind::LBrace)
+            .map(|offset| close_paren + 1 + offset)
+        else {
+            continue;
+        };
+        let Some(body_end) = scope_ends.get(&body_start).copied() else {
+            continue;
+        };
+        for index in open_paren + 1..close_paren {
+            if tokens[index].kind == TokenKind::Identifier
+                && tokens
+                    .get(index + 1)
+                    .is_some_and(|next| next.kind == TokenKind::Colon)
+            {
+                local_bindings.push((
+                    token_text(source, tokens[index]).to_string(),
+                    body_start,
+                    body_end,
+                ));
+            }
+        }
+    }
+    let mut brace_depth = 0usize;
+    let mut pending_enum = false;
+    let mut enum_depth = None;
+    for (index, token) in tokens.iter().copied().enumerate() {
+        if token.kind == TokenKind::Identifier && token_text(source, token) == "enum" {
+            pending_enum = true;
+        } else if token.kind == TokenKind::LBrace {
+            brace_depth += 1;
+            if pending_enum {
+                enum_depth = Some(brace_depth);
+                pending_enum = false;
+            }
+        } else if token.kind == TokenKind::RBrace {
+            if enum_depth == Some(brace_depth) {
+                enum_depth = None;
+            }
+            brace_depth = brace_depth.saturating_sub(1);
+        }
+        if token.kind != TokenKind::Identifier {
+            continue;
+        }
+        let previous = index.checked_sub(1).and_then(|index| tokens.get(index));
+        let next = tokens.get(index + 1);
+        let follows_declaration_keyword = previous.is_some_and(|previous| {
+            previous.kind == TokenKind::FunctionKw
+                || (previous.kind == TokenKind::Identifier
+                    && matches!(
+                        token_text(source, *previous),
+                        "struct" | "global" | "const" | "let" | "enum"
+                    ))
+        });
+        let is_enum_variant = enum_depth == Some(brace_depth)
+            && previous.is_some_and(|previous| {
+                matches!(previous.kind, TokenKind::LBrace | TokenKind::Comma)
+            });
+        if follows_declaration_keyword
+            || next.is_some_and(|next| next.kind == TokenKind::Colon)
+            || is_enum_variant
+        {
+            declarations.insert(index);
+        }
+        if previous.is_some_and(|previous| {
+            previous.kind == TokenKind::Identifier && token_text(source, *previous) == "let"
+        }) {
+            if let Some(scope_start) = scope_at[index] {
+                if let Some(scope_end) = scope_ends.get(&scope_start) {
+                    local_bindings.push((
+                        token_text(source, token).to_string(),
+                        index,
+                        *scope_end,
+                    ));
+                }
+            }
+        }
+    }
+    Ok(tokens
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, token)| token.kind == TokenKind::Identifier)
+        .filter_map(|(index, token)| {
+            if declarations.contains(&index) {
+                return None;
+            }
+            let name = token_text(source, token);
+            if local_bindings.iter().any(|(binding, start, end)| {
+                binding == name && index >= *start && index <= *end
+            }) {
+                return None;
+            }
+            let previous_is_dot = index.checked_sub(1).is_some_and(|index| {
+                tokens[index].kind == TokenKind::Other && token_text(source, tokens[index]) == "."
+            });
+            let next_is_call = tokens
+                .get(index + 1)
+                .is_some_and(|next| next.kind == TokenKind::LParen);
+            if previous_is_dot && !next_is_call {
+                return None;
+            }
+            Some(name.to_string())
+        })
         .collect())
 }
 
@@ -1853,6 +2001,15 @@ pub fn write_workshop_semantic_plan(
     plan: &WorkshopSemanticEditPlan,
     restore: bool,
 ) -> Result<(), String> {
+    write_workshop_semantic_plan_with(project_root, plan, restore, atomic_write)
+}
+
+fn write_workshop_semantic_plan_with(
+    project_root: &Path,
+    plan: &WorkshopSemanticEditPlan,
+    restore: bool,
+    mut write: impl FnMut(&Path, &str) -> Result<(), String>,
+) -> Result<(), String> {
     for change in &plan.changed_files {
         let relative = Path::new(&change.file);
         if !safe_relative_path(relative) {
@@ -1885,7 +2042,8 @@ pub fn write_workshop_semantic_plan(
         } else {
             &change.after_source
         };
-        if let Err(error) = atomic_write(&path, source) {
+        if let Err(error) = write(&path, source) {
+            let mut rollback_errors = Vec::new();
             for completed in written.into_iter().rev() {
                 let prior = plan
                     .changed_files
@@ -1897,9 +2055,16 @@ pub fn write_workshop_semantic_plan(
                 } else {
                     &prior.before_source
                 };
-                let _ = atomic_write(&project_root.join(&completed), rollback_source);
+                if let Err(rollback) = write(&project_root.join(&completed), rollback_source) {
+                    rollback_errors.push(format!("{completed}: {rollback}"));
+                }
             }
-            return Err(format!("failed writing {}: {error}", path.display()));
+            let rollback = if rollback_errors.is_empty() {
+                String::new()
+            } else {
+                format!("; rollback incomplete: {}", rollback_errors.join("; "))
+            };
+            return Err(format!("failed writing {}: {error}{rollback}", path.display()));
         }
         written.push(change.file.clone());
     }
@@ -3490,6 +3655,33 @@ mod workshop_compile_plan_tests {
         path
     }
 
+    fn semantic_selector(
+        name: &str,
+        kind: WorkshopSourceItemKind,
+        file: &str,
+    ) -> WorkshopSymbolSelector {
+        WorkshopSymbolSelector {
+            name: name.to_string(),
+            kind: Some(kind),
+            file: Some(file.to_string()),
+            owner: None,
+            signature: None,
+        }
+    }
+
+    fn semantic_edit(
+        operation: WorkshopSemanticEditOperation,
+        target: WorkshopSymbolSelector,
+        new_source: Option<&str>,
+    ) -> WorkshopSemanticEdit {
+        WorkshopSemanticEdit {
+            operation,
+            target,
+            new_source: new_source.map(str::to_string),
+            expected_source_hash: None,
+        }
+    }
+
     #[test]
     fn workshop_compile_plan_uses_incremental_compiler_metrics() {
         let root = temp_project("initial");
@@ -3744,6 +3936,47 @@ mod workshop_compile_plan_tests {
     }
 
     #[test]
+    fn semantic_import_pruning_distinguishes_fields_from_receiver_calls() {
+        let files = vec![
+            WorkshopSourceFile {
+                path: "src/main.stasis".to_string(),
+                source: "import \"unused.stasis\";\nimport \"mixed.stasis\";\nimport \"combat.stasis\";\nenum Phase { Ready = 1 }\nstruct Player { value: i32; }\nglobal State { player: Player; }\nfunction main(): i32 { let value: i32 = 1; State.player.damage(1); return value; }\nfunction parameter(amount: i32): i32 { return amount; }\nfunction shadow(): i32 { let helper: i32 = 3; return helper; }\nfunction imported_call(): i32 { return helper(); }\n"
+                    .to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/unused.stasis".to_string(),
+                source: "function value(): i32 { return 9; }\nfunction amount(): i32 { return 7; }\nfunction Ready(): i32 { return 10; }\n"
+                    .to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/mixed.stasis".to_string(),
+                source: "function helper(): i32 { return 8; }\n".to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/combat.stasis".to_string(),
+                source: "function damage(self: Player, amount: i32): void {}\n".to_string(),
+            },
+        ];
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![semantic_edit(
+                WorkshopSemanticEditOperation::Update,
+                semantic_selector("main", WorkshopSourceItemKind::Function, "src/main.stasis"),
+                Some("function main(): i32 { let value: i32 = 2; State.player.damage(2); return value; }"),
+            )],
+        };
+        let (after, _) = plan_workshop_semantic_edits(&files, &batch).expect("update main");
+        let source = &after
+            .iter()
+            .find(|file| file.path == "src/main.stasis")
+            .expect("main")
+            .source;
+        assert!(!source.contains("unused.stasis"));
+        assert!(source.contains("mixed.stasis"));
+        assert!(source.contains("combat.stasis"));
+    }
+
+    #[test]
     fn semantic_global_delete_removes_only_the_parser_selected_declaration() {
         let files = vec![WorkshopSourceFile {
             path: "src/main.stasis".to_string(),
@@ -3817,5 +4050,341 @@ mod workshop_compile_plan_tests {
             .expect_err("stale apply")
             .contains("expected current hash"));
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn semantic_item_hash_ignores_formatting_outside_the_item() {
+        let first = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "function main(): i32 { return tick(); }\n\n// Stable tick.\nfunction tick(): i32 { return 1; }\n"
+                .to_string(),
+        }];
+        let second = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "function main(): i32 {\n    return tick();\n}\n\n\n// Stable tick.\nfunction tick(): i32 { return 1; }\n\n"
+                .to_string(),
+        }];
+        let tick = |files: &[WorkshopSourceFile]| {
+            workshop_source_items(files)
+                .expect("items")
+                .into_iter()
+                .find(|item| item.kind == WorkshopSourceItemKind::Function && item.name == "tick")
+                .expect("tick")
+        };
+        let first_tick = tick(&first);
+        let second_tick = tick(&second);
+        assert_eq!(first_tick.source, second_tick.source);
+        assert_eq!(first_tick.source_hash, second_tick.source_hash);
+        assert_ne!(
+            workshop_source_hash(&first[0].source),
+            workshop_source_hash(&second[0].source)
+        );
+    }
+
+    #[test]
+    fn semantic_batch_reindexes_shifted_items_between_edits() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "function first(): i32 { return 1; }\nfunction second(): i32 { return 2; }\n"
+                .to_string(),
+        }];
+        let items = workshop_source_items(&files).expect("items");
+        let item_hash = |name: &str| {
+            items
+                .iter()
+                .find(|item| item.kind == WorkshopSourceItemKind::Function && item.name == name)
+                .expect("function item")
+                .source_hash
+                .clone()
+        };
+        let mut first = semantic_edit(
+            WorkshopSemanticEditOperation::Update,
+            semantic_selector("first", WorkshopSourceItemKind::Function, "src/main.stasis"),
+            Some("function first(): i32 {\n    return 11;\n}"),
+        );
+        first.expected_source_hash = Some(item_hash("first"));
+        let mut second = semantic_edit(
+            WorkshopSemanticEditOperation::Update,
+            semantic_selector(
+                "second",
+                WorkshopSourceItemKind::Function,
+                "src/main.stasis",
+            ),
+            Some("function second(): i32 { return 22; }"),
+        );
+        second.expected_source_hash = Some(item_hash("second"));
+        let (after, plan) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![first, second],
+            },
+        )
+        .expect("plan shifted edits");
+        assert!(after[0].source.contains("return 11;"));
+        assert!(after[0].source.contains("return 22;"));
+        assert_eq!(plan.changed_files.len(), 1);
+        assert_eq!(plan.edits.len(), 2);
+    }
+
+    #[test]
+    fn semantic_multi_file_preflight_prevents_partial_writes() {
+        let root = temp_project("semantic_preflight");
+        let first_path = write_project_file(
+            &root,
+            "src/first.stasis",
+            "function first(): i32 { return 1; }\n",
+        );
+        let second_path = write_project_file(
+            &root,
+            "src/second.stasis",
+            "function second(): i32 { return 2; }\n",
+        );
+        let files = vec![
+            WorkshopSourceFile {
+                path: "src/first.stasis".to_string(),
+                source: fs::read_to_string(&first_path).expect("first source"),
+            },
+            WorkshopSourceFile {
+                path: "src/second.stasis".to_string(),
+                source: fs::read_to_string(&second_path).expect("second source"),
+            },
+        ];
+        let (_, plan) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![
+                    semantic_edit(
+                        WorkshopSemanticEditOperation::Update,
+                        semantic_selector(
+                            "first",
+                            WorkshopSourceItemKind::Function,
+                            "src/first.stasis",
+                        ),
+                        Some("function first(): i32 { return 11; }"),
+                    ),
+                    semantic_edit(
+                        WorkshopSemanticEditOperation::Update,
+                        semantic_selector(
+                            "second",
+                            WorkshopSourceItemKind::Function,
+                            "src/second.stasis",
+                        ),
+                        Some("function second(): i32 { return 22; }"),
+                    ),
+                ],
+            },
+        )
+        .expect("multi-file plan");
+        fs::write(&second_path, "function second(): i32 { return 3; }\n")
+            .expect("make second stale");
+        assert!(write_workshop_semantic_plan(&root, &plan, false)
+            .expect_err("stale plan")
+            .contains("expected current hash"));
+        assert_eq!(
+            fs::read_to_string(&first_path).expect("unchanged first"),
+            "function first(): i32 { return 1; }\n"
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn semantic_multi_file_write_reports_incomplete_rollback() {
+        let root = temp_project("semantic_rollback_failure");
+        write_project_file(
+            &root,
+            "src/first.stasis",
+            "function first(): i32 { return 1; }\n",
+        );
+        write_project_file(
+            &root,
+            "src/second.stasis",
+            "function second(): i32 { return 2; }\n",
+        );
+        let files = vec![
+            WorkshopSourceFile {
+                path: "src/first.stasis".to_string(),
+                source: "function first(): i32 { return 1; }\n".to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/second.stasis".to_string(),
+                source: "function second(): i32 { return 2; }\n".to_string(),
+            },
+        ];
+        let (_, plan) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![
+                    semantic_edit(
+                        WorkshopSemanticEditOperation::Update,
+                        semantic_selector(
+                            "first",
+                            WorkshopSourceItemKind::Function,
+                            "src/first.stasis",
+                        ),
+                        Some("function first(): i32 { return 11; }"),
+                    ),
+                    semantic_edit(
+                        WorkshopSemanticEditOperation::Update,
+                        semantic_selector(
+                            "second",
+                            WorkshopSourceItemKind::Function,
+                            "src/second.stasis",
+                        ),
+                        Some("function second(): i32 { return 22; }"),
+                    ),
+                ],
+            },
+        )
+        .expect("plan");
+        let mut writes = 0;
+        let error = write_workshop_semantic_plan_with(&root, &plan, false, |_, _| {
+            writes += 1;
+            match writes {
+                1 => Ok(()),
+                2 => Err("injected write failure".to_string()),
+                _ => Err("injected rollback failure".to_string()),
+            }
+        })
+        .expect_err("write and rollback fail");
+        assert!(error.contains("injected write failure"));
+        assert!(error.contains("rollback incomplete"));
+        assert!(error.contains("src/first.stasis: injected rollback failure"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn semantic_receipts_are_deterministic_and_reject_unsafe_directories() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "function main(): i32 { return 1; }\n".to_string(),
+        }];
+        let (_, plan) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![semantic_edit(
+                    WorkshopSemanticEditOperation::Update,
+                    semantic_selector("main", WorkshopSourceItemKind::Function, "src/main.stasis"),
+                    Some("function main(): i32 { return 2; }"),
+                )],
+            },
+        )
+        .expect("plan");
+        let root = temp_project("semantic_deterministic_receipt");
+        let first =
+            write_workshop_semantic_receipt(&root, Path::new("build/semantic-edits"), &plan)
+                .expect("first receipt");
+        let first_source = fs::read_to_string(root.join(&first)).expect("first receipt source");
+        let second =
+            write_workshop_semantic_receipt(&root, Path::new("build/semantic-edits"), &plan)
+                .expect("second receipt");
+        assert_eq!(first, second);
+        assert_eq!(
+            first_source,
+            fs::read_to_string(root.join(&second)).expect("second receipt source")
+        );
+        assert_eq!(workshop_source_hash("source").len(), 64);
+        assert!(
+            write_workshop_semantic_receipt(&root, Path::new("../outside"), &plan)
+                .expect_err("unsafe receipt directory")
+                .contains("unsafe semantic receipt directory")
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn semantic_delete_preserves_crlf_neighbor_boundaries() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "// Remove me.\r\nfunction removed(): i32 { return 1; }\r\n// Keep me.\r\nfunction kept(): i32 { return 2; }\r\n"
+                .to_string(),
+        }];
+        let removed = workshop_source_items(&files)
+            .expect("items")
+            .into_iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Function && item.name == "removed")
+            .expect("removed item");
+        assert!(removed.source.ends_with("}\r\n"));
+        let (after, _) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits: vec![semantic_edit(
+                    WorkshopSemanticEditOperation::Delete,
+                    semantic_selector(
+                        "removed",
+                        WorkshopSourceItemKind::Function,
+                        "src/main.stasis",
+                    ),
+                    None,
+                )],
+            },
+        )
+        .expect("delete CRLF item");
+        assert_eq!(
+            after[0].source,
+            "// Keep me.\r\nfunction kept(): i32 { return 2; }\r\n"
+        );
+    }
+
+    #[test]
+    fn semantic_batch_adds_each_item_kind_without_span_overlap() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "function main(): i32 { return helper(); }\n".to_string(),
+        }];
+        let edits = vec![
+            semantic_edit(
+                WorkshopSemanticEditOperation::Add,
+                semantic_selector(
+                    "imports",
+                    WorkshopSourceItemKind::Imports,
+                    "src/main.stasis",
+                ),
+                Some("import \"external.stasis\";"),
+            ),
+            semantic_edit(
+                WorkshopSemanticEditOperation::Add,
+                semantic_selector(
+                    "globals",
+                    WorkshopSourceItemKind::Globals,
+                    "src/main.stasis",
+                ),
+                Some("const LIMIT: i32 = 3;"),
+            ),
+            semantic_edit(
+                WorkshopSemanticEditOperation::Add,
+                semantic_selector("Config", WorkshopSourceItemKind::Struct, "src/main.stasis"),
+                Some("// Configuration.\nstruct Config { value: i32; }"),
+            ),
+            semantic_edit(
+                WorkshopSemanticEditOperation::Add,
+                semantic_selector(
+                    "helper",
+                    WorkshopSourceItemKind::Function,
+                    "src/main.stasis",
+                ),
+                Some("// Helper.\nfunction helper(): i32 { return LIMIT; }"),
+            ),
+        ];
+        let (after, plan) = plan_workshop_semantic_edits(
+            &files,
+            &WorkshopSemanticEditBatch {
+                schema_version: 1,
+                edits,
+            },
+        )
+        .expect("add mixed items");
+        let source = &after[0].source;
+        assert!(source.starts_with("import \"external.stasis\";\nconst LIMIT: i32 = 3;\n"));
+        assert_eq!(source.matches("struct Config").count(), 1);
+        assert_eq!(source.matches("function helper").count(), 1);
+        assert_eq!(plan.edits.len(), 4);
+        let items = workshop_source_items(&after).expect("re-index added items");
+        assert!(items.iter().any(|item| item.name == "Config"));
+        assert!(items.iter().any(|item| item.name == "helper"));
     }
 }

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
+use sha2::{Digest, Sha256};
+
 use crate::frontend::lexer::{lex, Token, TokenKind};
 use crate::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
 use crate::IncrementalCompileOutput;
@@ -14,29 +16,38 @@ use crate::IncrementalCompileOutput;
 pub enum WorkshopSymbolKind {
     Struct,
     Function,
+    Global,
+    Constant,
+    Test,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
 pub enum WorkshopSymbolGroupKind {
     Main,
     Struct,
+    Global,
+    Constant,
     System,
     Root,
+    Test,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopSourceFile {
     pub path: String,
     pub source: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopSourceSpan {
     pub start: u32,
     pub end: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopSymbol {
     pub kind: WorkshopSymbolKind,
     pub name: String,
@@ -47,14 +58,14 @@ pub struct WorkshopSymbol {
     pub source: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopSymbolGroup {
     pub kind: WorkshopSymbolGroupKind,
     pub name: String,
     pub symbols: Vec<WorkshopSymbol>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopSymbolTree {
     pub groups: Vec<WorkshopSymbolGroup>,
 }
@@ -389,8 +400,11 @@ pub fn build_workshop_symbol_tree(
     for group_kind in [
         WorkshopSymbolGroupKind::Main,
         WorkshopSymbolGroupKind::Struct,
+        WorkshopSymbolGroupKind::Global,
+        WorkshopSymbolGroupKind::Constant,
         WorkshopSymbolGroupKind::System,
         WorkshopSymbolGroupKind::Root,
+        WorkshopSymbolGroupKind::Test,
     ] {
         let keys = by_group
             .keys()
@@ -466,6 +480,207 @@ fn index_file_symbols(
         });
     }
 
+    for parsed in parse_simple_top_level_symbols(&file.source)? {
+        let (group_kind, group_name, owner) = match parsed.kind {
+            WorkshopSymbolKind::Global => (
+                WorkshopSymbolGroupKind::Global,
+                "Globals".to_string(),
+                Some("Globals".to_string()),
+            ),
+            WorkshopSymbolKind::Constant => (
+                WorkshopSymbolGroupKind::Constant,
+                "Constants".to_string(),
+                Some("Constants".to_string()),
+            ),
+            WorkshopSymbolKind::Test => (
+                WorkshopSymbolGroupKind::Test,
+                "Tests".to_string(),
+                Some("Tests".to_string()),
+            ),
+            WorkshopSymbolKind::Struct | WorkshopSymbolKind::Function => continue,
+        };
+        out.push(PendingSymbol {
+            group_kind,
+            group_name,
+            symbol: WorkshopSymbol {
+                kind: parsed.kind,
+                name: parsed.name,
+                owner,
+                file: file.path.clone(),
+                signature: parsed.signature,
+                source_span: span_from_range(parsed.range.clone())?,
+                source: source_for_range(&file.source, parsed.range)?,
+            },
+        });
+    }
+
+    Ok(out)
+}
+
+pub fn load_workshop_edit_workspace(
+    project_root: &Path,
+    entry_file: &Path,
+) -> Result<Vec<WorkshopSourceFile>, String> {
+    let mut files = load_workshop_project(project_root, entry_file)?;
+    let mut known = files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<BTreeSet<_>>();
+    for directory in ["src", "tests"] {
+        collect_workshop_source_files(
+            project_root,
+            &project_root.join(directory),
+            &mut known,
+            &mut files,
+        )?;
+    }
+    files.sort_by_key(|file| file.path.clone());
+    Ok(files)
+}
+
+pub fn workshop_reachable_files(
+    files: &[WorkshopSourceFile],
+    entry_file: &Path,
+) -> Result<Vec<WorkshopSourceFile>, String> {
+    let by_path = files
+        .iter()
+        .map(|file| (normalize_project_path_text(&file.path), file))
+        .collect::<BTreeMap<_, _>>();
+    let entry = normalize_project_path_text(&entry_file.to_string_lossy());
+    let mut pending = vec![entry];
+    let mut visited = BTreeSet::new();
+    let mut out = Vec::new();
+    while let Some(path) = pending.pop() {
+        if !visited.insert(path.clone()) {
+            continue;
+        }
+        let file = by_path
+            .get(&path)
+            .ok_or_else(|| format!("import graph file is not loaded: {path}"))?;
+        for import in parse_workshop_import_paths(&file.source)?.into_iter().rev() {
+            pending.push(resolve_project_import_path(&file.path, &import));
+        }
+        out.push((*file).clone());
+    }
+    out.sort_by_key(|file| file.path.clone());
+    Ok(out)
+}
+
+fn collect_workshop_source_files(
+    project_root: &Path,
+    directory: &Path,
+    known: &mut BTreeSet<String>,
+    out: &mut Vec<WorkshopSourceFile>,
+) -> Result<(), String> {
+    if !directory.exists() {
+        return Ok(());
+    }
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| format!("failed reading {}: {error}", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed enumerating {}: {error}", directory.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed inspecting {}: {error}", path.display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_workshop_source_files(project_root, &path, known, out)?;
+            continue;
+        }
+        if path.extension().and_then(|value| value.to_str()) != Some("stasis") {
+            continue;
+        }
+        let relative = normalize_workshop_project_path(project_root, &path);
+        if known.insert(relative.clone()) {
+            out.push(WorkshopSourceFile {
+                path: relative,
+                source: fs::read_to_string(&path)
+                    .map_err(|error| format!("failed reading {}: {error}", path.display()))?,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedSimpleSymbol {
+    kind: WorkshopSymbolKind,
+    name: String,
+    signature: String,
+    range: Range<usize>,
+}
+
+fn parse_simple_top_level_symbols(source: &str) -> Result<Vec<ParsedSimpleSymbol>, String> {
+    let tokens = lex(source)?;
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+    let mut depth = 0usize;
+    while cursor < tokens.len() {
+        let token = tokens[cursor];
+        match token.kind {
+            TokenKind::LBrace => depth += 1,
+            TokenKind::RBrace => depth = depth.saturating_sub(1),
+            TokenKind::Identifier if depth == 0 => {
+                let keyword = token_text(source, token);
+                let kind = match keyword {
+                    "global" => WorkshopSymbolKind::Global,
+                    "const" => WorkshopSymbolKind::Constant,
+                    "test" => WorkshopSymbolKind::Test,
+                    _ => {
+                        cursor += 1;
+                        continue;
+                    }
+                };
+                let (name, signature, end_index) = match kind {
+                    WorkshopSymbolKind::Global => {
+                        let name_token = expect_token(&tokens, cursor + 1, TokenKind::Identifier)?;
+                        let open = find_next_token(&tokens, cursor + 2, TokenKind::LBrace)?;
+                        let close = find_matching_rbrace(&tokens, open + 1, 1)?;
+                        let name = token_text(source, name_token).to_string();
+                        (name.clone(), format!("global {name}"), close)
+                    }
+                    WorkshopSymbolKind::Constant => {
+                        let name_token = expect_token(&tokens, cursor + 1, TokenKind::Identifier)?;
+                        let end = find_next_token(&tokens, cursor + 2, TokenKind::Semicolon)?;
+                        let name = token_text(source, name_token).to_string();
+                        let signature = source[token.start..tokens[end].end].trim().to_string();
+                        (name, signature, end)
+                    }
+                    WorkshopSymbolKind::Test => {
+                        let open = find_next_token(&tokens, cursor + 1, TokenKind::LBrace)?;
+                        let close = find_matching_rbrace(&tokens, open + 1, 1)?;
+                        let header = &source[token.end..tokens[open].start];
+                        let first_tick = header.find('`').ok_or_else(|| {
+                            "test declaration must contain a backtick-quoted name".to_string()
+                        })?;
+                        let rest = &header[first_tick + 1..];
+                        let second_tick = rest.find('`').ok_or_else(|| {
+                            "test declaration must contain a closing backtick".to_string()
+                        })?;
+                        let name = rest[..second_tick].to_string();
+                        let signature = format!("test `{name}`");
+                        (name, signature, close)
+                    }
+                    WorkshopSymbolKind::Struct | WorkshopSymbolKind::Function => unreachable!(),
+                };
+                out.push(ParsedSimpleSymbol {
+                    kind,
+                    name,
+                    signature,
+                    range: token.start..tokens[end_index].end,
+                });
+                cursor = end_index + 1;
+                continue;
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
     Ok(out)
 }
 
@@ -661,6 +876,15 @@ fn expect_token(tokens: &[Token], cursor: usize, kind: TokenKind) -> Result<Toke
     Ok(token)
 }
 
+fn find_next_token(tokens: &[Token], start: usize, kind: TokenKind) -> Result<usize, String> {
+    tokens
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(index, token)| (token.kind == kind).then_some(index))
+        .ok_or_else(|| format!("expected token {kind:?}"))
+}
+
 fn find_matching_rbrace(tokens: &[Token], start: usize, mut depth: usize) -> Result<usize, String> {
     let mut cursor = start;
     while cursor < tokens.len() {
@@ -685,6 +909,995 @@ fn token_text<'a>(source: &'a str, token: Token) -> &'a str {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSymbolSelector {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<WorkshopSourceItemKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkshopSourceItemKind {
+    Imports,
+    Globals,
+    Struct,
+    Function,
+    Test,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSourceItem {
+    pub kind: WorkshopSourceItemKind,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    pub file: String,
+    pub signature: String,
+    pub source_spans: Vec<WorkshopSourceSpan>,
+    pub source: String,
+    pub source_hash: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkshopSemanticEditOperation {
+    Add,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSemanticEdit {
+    pub operation: WorkshopSemanticEditOperation,
+    pub target: WorkshopSymbolSelector,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_source_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSemanticEditBatch {
+    #[serde(default = "semantic_edit_schema_version")]
+    pub schema_version: u32,
+    pub edits: Vec<WorkshopSemanticEdit>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSemanticFileChange {
+    pub file: String,
+    pub before_source: String,
+    pub after_source: String,
+    pub before_hash: String,
+    pub after_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopSemanticEditPlan {
+    pub schema_version: u32,
+    pub edits: Vec<WorkshopSemanticEdit>,
+    pub changed_files: Vec<WorkshopSemanticFileChange>,
+    pub reload: WorkshopReloadClassification,
+}
+
+const fn semantic_edit_schema_version() -> u32 {
+    1
+}
+
+pub fn workshop_symbols(files: &[WorkshopSourceFile]) -> Result<Vec<WorkshopSymbol>, String> {
+    let mut symbols = build_workshop_symbol_tree(files)?
+        .groups
+        .into_iter()
+        .flat_map(|group| group.symbols)
+        .collect::<Vec<_>>();
+    symbols.sort_by_key(|symbol| {
+        (
+            symbol.file.clone(),
+            symbol.source_span.start,
+            symbol.name.clone(),
+        )
+    });
+    Ok(symbols)
+}
+
+pub fn workshop_source_items(
+    files: &[WorkshopSourceFile],
+) -> Result<Vec<WorkshopSourceItem>, String> {
+    let symbols = workshop_symbols(files)?;
+    let mut items = Vec::new();
+    for file in files {
+        let imports = parse_import_spans(&file.source)?;
+        items.push(source_item_from_ranges(
+            file,
+            WorkshopSourceItemKind::Imports,
+            "imports",
+            None,
+            "imports",
+            imports,
+            false,
+        )?);
+
+        let globals = parse_simple_top_level_symbols(&file.source)?
+            .into_iter()
+            .filter(|parsed| {
+                matches!(
+                    parsed.kind,
+                    WorkshopSymbolKind::Global | WorkshopSymbolKind::Constant
+                )
+            })
+            .map(|parsed| parsed.range)
+            .collect::<Vec<_>>();
+        items.push(source_item_from_ranges(
+            file,
+            WorkshopSourceItemKind::Globals,
+            "globals",
+            Some("Globals".to_string()),
+            "globals",
+            globals,
+            true,
+        )?);
+
+        for symbol in symbols.iter().filter(|symbol| symbol.file == file.path) {
+            let kind = match symbol.kind {
+                WorkshopSymbolKind::Struct => WorkshopSourceItemKind::Struct,
+                WorkshopSymbolKind::Function => WorkshopSourceItemKind::Function,
+                WorkshopSymbolKind::Test => WorkshopSourceItemKind::Test,
+                WorkshopSymbolKind::Global | WorkshopSymbolKind::Constant => continue,
+            };
+            items.push(source_item_from_ranges(
+                file,
+                kind,
+                &symbol.name,
+                symbol.owner.clone(),
+                &symbol.signature,
+                vec![symbol.source_span.start as usize..symbol.source_span.end as usize],
+                matches!(
+                    kind,
+                    WorkshopSourceItemKind::Struct | WorkshopSourceItemKind::Function
+                ),
+            )?);
+        }
+    }
+    items.sort_by_key(|item| {
+        let order = match item.kind {
+            WorkshopSourceItemKind::Imports => 0,
+            WorkshopSourceItemKind::Globals => 1,
+            WorkshopSourceItemKind::Struct => 2,
+            WorkshopSourceItemKind::Function => 3,
+            WorkshopSourceItemKind::Test => 4,
+        };
+        let start = item
+            .source_spans
+            .first()
+            .map(|span| span.start)
+            .unwrap_or(0);
+        (item.file.clone(), order, start, item.name.clone())
+    });
+    Ok(items)
+}
+
+fn source_item_from_ranges(
+    file: &WorkshopSourceFile,
+    kind: WorkshopSourceItemKind,
+    name: &str,
+    owner: Option<String>,
+    signature: &str,
+    ranges: Vec<Range<usize>>,
+    include_comments: bool,
+) -> Result<WorkshopSourceItem, String> {
+    let mut ranges = ranges
+        .into_iter()
+        .map(|range| {
+            if include_comments {
+                expand_declaration_item_range(&file.source, range)
+            } else {
+                expand_range_through_newline(&file.source, range)
+            }
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|range| range.start);
+    let source = ranges
+        .iter()
+        .map(|range| source_for_range(&file.source, range.clone()))
+        .collect::<Result<Vec<_>, _>>()?
+        .join("");
+    let source_spans = ranges
+        .into_iter()
+        .map(span_from_range)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(WorkshopSourceItem {
+        kind,
+        name: name.to_string(),
+        owner,
+        file: file.path.clone(),
+        signature: signature.to_string(),
+        source_hash: workshop_source_hash(&source),
+        source,
+        source_spans,
+    })
+}
+
+fn expand_range_through_newline(source: &str, range: Range<usize>) -> Range<usize> {
+    let mut end = range.end.min(source.len());
+    while end < source.len() && matches!(source.as_bytes()[end], b' ' | b'\t' | b'\r') {
+        end += 1;
+    }
+    if end < source.len() && source.as_bytes()[end] == b'\n' {
+        end += 1;
+    }
+    range.start..end
+}
+
+fn expand_declaration_item_range(source: &str, range: Range<usize>) -> Range<usize> {
+    let declaration_line_start = source[..range.start.min(source.len())]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let prefix = &source[declaration_line_start..range.start.min(source.len())];
+    let mut start = if prefix.trim().is_empty() {
+        declaration_line_start
+    } else {
+        range.start
+    };
+    if start != declaration_line_start {
+        return start..expand_range_through_newline(source, range).end;
+    }
+    while start > 0 {
+        let previous_end = start - 1;
+        let previous_start = source[..previous_end]
+            .rfind('\n')
+            .map(|index| index + 1)
+            .unwrap_or(0);
+        let line = source[previous_start..previous_end].trim();
+        if line.starts_with("//") {
+            start = previous_start;
+            continue;
+        }
+        break;
+    }
+    start..expand_range_through_newline(source, range).end
+}
+
+fn parse_import_spans(source: &str) -> Result<Vec<Range<usize>>, String> {
+    parse_import_spans_with_depth(source, true)
+}
+
+fn parse_any_import_spans(source: &str) -> Result<Vec<Range<usize>>, String> {
+    parse_import_spans_with_depth(source, false)
+}
+
+fn parse_import_spans_with_depth(
+    source: &str,
+    top_level_only: bool,
+) -> Result<Vec<Range<usize>>, String> {
+    let tokens = lex(source)?;
+    let mut spans = Vec::new();
+    let mut cursor = 0usize;
+    let mut depth = 0usize;
+    while cursor < tokens.len() {
+        match tokens[cursor].kind {
+            TokenKind::LBrace => depth += 1,
+            TokenKind::RBrace => depth = depth.saturating_sub(1),
+            TokenKind::Identifier
+                if (!top_level_only || depth == 0)
+                    && token_text(source, tokens[cursor]) == "import" =>
+            {
+                let literal = expect_token(&tokens, cursor + 1, TokenKind::StringLiteral)?;
+                let semicolon = expect_token(&tokens, cursor + 2, TokenKind::Semicolon)?;
+                if literal.end > semicolon.start {
+                    return Err("invalid import declaration".to_string());
+                }
+                spans.push(tokens[cursor].start..semicolon.end);
+                cursor += 3;
+                continue;
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    Ok(spans)
+}
+
+pub fn find_workshop_symbols(
+    files: &[WorkshopSourceFile],
+    selector: &WorkshopSymbolSelector,
+) -> Result<Vec<WorkshopSourceItem>, String> {
+    let normalized_file = selector.file.as_deref().map(normalize_project_path_text);
+    Ok(workshop_source_items(files)?
+        .into_iter()
+        .filter(|item| {
+            item.name == selector.name
+                && selector.kind.is_none_or(|kind| item.kind == kind)
+                && normalized_file
+                    .as_deref()
+                    .is_none_or(|file| normalize_project_path_text(&item.file) == file)
+                && selector
+                    .owner
+                    .as_deref()
+                    .is_none_or(|owner| item.owner.as_deref() == Some(owner))
+                && selector
+                    .signature
+                    .as_deref()
+                    .is_none_or(|signature| item.signature == signature)
+        })
+        .collect())
+}
+
+pub fn plan_workshop_semantic_edits(
+    files: &[WorkshopSourceFile],
+    batch: &WorkshopSemanticEditBatch,
+) -> Result<(Vec<WorkshopSourceFile>, WorkshopSemanticEditPlan), String> {
+    if batch.schema_version != semantic_edit_schema_version() {
+        return Err(format!(
+            "unsupported semantic edit schema_version {}; expected {}",
+            batch.schema_version,
+            semantic_edit_schema_version()
+        ));
+    }
+    if batch.edits.is_empty() {
+        return Err("semantic edit batch must contain at least one edit".to_string());
+    }
+    let before = files.to_vec();
+    let mut after = before.clone();
+    for edit in &batch.edits {
+        apply_one_semantic_edit(&mut after, edit)?;
+    }
+    let touched_files = before
+        .iter()
+        .filter_map(|before_file| {
+            after
+                .iter()
+                .find(|after_file| after_file.path == before_file.path)
+                .filter(|after_file| after_file.source != before_file.source)
+                .map(|_| before_file.path.clone())
+        })
+        .collect::<BTreeSet<_>>();
+    prune_unused_workshop_imports(&mut after, &touched_files)?;
+    let mut changed_files = Vec::new();
+    for before_file in &before {
+        let after_file = after
+            .iter()
+            .find(|file| file.path == before_file.path)
+            .ok_or_else(|| format!("edited project lost file {}", before_file.path))?;
+        if after_file.source != before_file.source {
+            changed_files.push(WorkshopSemanticFileChange {
+                file: before_file.path.clone(),
+                before_source: before_file.source.clone(),
+                after_source: after_file.source.clone(),
+                before_hash: workshop_source_hash(&before_file.source),
+                after_hash: workshop_source_hash(&after_file.source),
+            });
+        }
+    }
+    if changed_files.is_empty() {
+        return Err("semantic edit batch made no changes".to_string());
+    }
+    let reload = classify_workshop_reload(&before, &after)?;
+    Ok((
+        after,
+        WorkshopSemanticEditPlan {
+            schema_version: semantic_edit_schema_version(),
+            edits: batch.edits.clone(),
+            changed_files,
+            reload,
+        },
+    ))
+}
+
+fn apply_one_semantic_edit(
+    files: &mut [WorkshopSourceFile],
+    edit: &WorkshopSemanticEdit,
+) -> Result<(), String> {
+    if edit.operation == WorkshopSemanticEditOperation::Delete
+        && edit.target.kind == Some(WorkshopSourceItemKind::Globals)
+        && edit.target.name != "globals"
+    {
+        return delete_global_member(files, edit);
+    }
+    match edit.operation {
+        WorkshopSemanticEditOperation::Add => apply_add_semantic_edit(files, edit),
+        WorkshopSemanticEditOperation::Update | WorkshopSemanticEditOperation::Delete => {
+            let matches = find_workshop_symbols(files, &edit.target)?;
+            let item = unique_semantic_target(&edit.target, matches)?;
+            if let Some(expected) = edit.expected_source_hash.as_deref() {
+                let actual = item.source_hash.clone();
+                if actual != expected {
+                    return Err(format!(
+                        "stale semantic edit target {}; expected source hash {} but found {}",
+                        item.name, expected, actual
+                    ));
+                }
+            }
+            let (replacement, embedded_imports) = match edit.operation {
+                WorkshopSemanticEditOperation::Update => {
+                    let source = required_edit_source(edit)?;
+                    let (source, imports) = extract_embedded_imports(source)?;
+                    validate_source_item_replacement(item.kind, &item.name, &source)?;
+                    (source.trim().to_string(), imports)
+                }
+                WorkshopSemanticEditOperation::Delete => (String::new(), Vec::new()),
+                WorkshopSemanticEditOperation::Add => unreachable!(),
+            };
+            replace_source_item(files, &item, &replacement)?;
+            merge_workshop_imports(files, &item.file, &embedded_imports)?;
+            build_workshop_symbol_tree(files)?;
+            Ok(())
+        }
+    }
+}
+
+fn delete_global_member(
+    files: &mut [WorkshopSourceFile],
+    edit: &WorkshopSemanticEdit,
+) -> Result<(), String> {
+    let requested_file = edit
+        .target
+        .file
+        .as_deref()
+        .ok_or_else(|| "semantic global delete requires target.file".to_string())?;
+    let normalized_file = normalize_project_path_text(requested_file);
+    let globals = workshop_source_items(files)?
+        .into_iter()
+        .find(|item| {
+            item.kind == WorkshopSourceItemKind::Globals
+                && normalize_project_path_text(&item.file) == normalized_file
+        })
+        .ok_or_else(|| format!("globals item not found for {requested_file}"))?;
+    if let Some(expected) = edit.expected_source_hash.as_deref() {
+        if globals.source_hash != expected {
+            return Err(format!(
+                "stale semantic globals target {}; expected source hash {} but found {}",
+                edit.target.name, expected, globals.source_hash
+            ));
+        }
+    }
+    let matches = workshop_symbols(files)?
+        .into_iter()
+        .filter(|symbol| {
+            matches!(
+                symbol.kind,
+                WorkshopSymbolKind::Global | WorkshopSymbolKind::Constant
+            ) && symbol.name == edit.target.name
+                && normalize_project_path_text(&symbol.file) == normalized_file
+        })
+        .collect::<Vec<_>>();
+    let symbol = match matches.as_slice() {
+        [symbol] => symbol,
+        [] => {
+            return Err(format!(
+                "semantic global not found: {} in {}",
+                edit.target.name, requested_file
+            ))
+        }
+        _ => {
+            return Err(format!(
+                "semantic global is ambiguous: {} in {}",
+                edit.target.name, requested_file
+            ))
+        }
+    };
+    let file = files
+        .iter_mut()
+        .find(|file| normalize_project_path_text(&file.path) == normalized_file)
+        .expect("global symbol file remains loaded");
+    let range = expand_range_through_newline(
+        &file.source,
+        symbol.source_span.start as usize..symbol.source_span.end as usize,
+    );
+    file.source.replace_range(range, "");
+    build_workshop_symbol_tree(files)?;
+    Ok(())
+}
+
+fn apply_add_semantic_edit(
+    files: &mut [WorkshopSourceFile],
+    edit: &WorkshopSemanticEdit,
+) -> Result<(), String> {
+    let kind = edit
+        .target
+        .kind
+        .ok_or_else(|| "semantic add requires target.kind".to_string())?;
+    if !matches!(
+        kind,
+        WorkshopSourceItemKind::Imports | WorkshopSourceItemKind::Globals
+    ) && !find_workshop_symbols(files, &edit.target)?.is_empty()
+    {
+        return Err(format!(
+            "semantic add target already exists: {}",
+            describe_selector(&edit.target)
+        ));
+    }
+    let requested_file = edit
+        .target
+        .file
+        .as_deref()
+        .ok_or_else(|| "semantic add requires target.file".to_string())?;
+    let normalized_file = normalize_project_path_text(requested_file);
+    let (source, embedded_imports) = extract_embedded_imports(required_edit_source(edit)?)?;
+    validate_source_item_replacement(kind, &edit.target.name, &source)?;
+    let file_index = files
+        .iter()
+        .position(|file| normalize_project_path_text(&file.path) == normalized_file)
+        .ok_or_else(|| {
+            format!(
+                "semantic add file is not in the loaded import graph: {}",
+                requested_file
+            )
+        })?;
+    if matches!(
+        kind,
+        WorkshopSourceItemKind::Imports | WorkshopSourceItemKind::Globals
+    ) {
+        let item = workshop_source_items(files)?
+            .into_iter()
+            .find(|item| item.file == files[file_index].path && item.kind == kind)
+            .ok_or_else(|| format!("missing {:?} item for {}", kind, requested_file))?;
+        let merged = if kind == WorkshopSourceItemKind::Imports {
+            let mut imports = parse_workshop_import_paths(&files[file_index].source)?;
+            imports.extend(parse_workshop_import_paths(&source)?);
+            render_imports(imports)
+        } else if item.source.trim().is_empty() {
+            source.trim().to_string()
+        } else {
+            format!("{}\n{}", item.source.trim(), source.trim())
+        };
+        replace_source_item(files, &item, &merged)?;
+    } else {
+        let file = &mut files[file_index];
+        if !file.source.ends_with('\n') {
+            file.source.push('\n');
+        }
+        if !file.source.ends_with("\n\n") {
+            file.source.push('\n');
+        }
+        file.source.push_str(source.trim());
+        file.source.push('\n');
+    }
+    merge_workshop_imports(files, requested_file, &embedded_imports)?;
+    let matches = find_workshop_symbols(files, &edit.target)?;
+    unique_semantic_target(&edit.target, matches)?;
+    Ok(())
+}
+
+fn unique_semantic_target(
+    selector: &WorkshopSymbolSelector,
+    matches: Vec<WorkshopSourceItem>,
+) -> Result<WorkshopSourceItem, String> {
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().expect("one semantic match")),
+        0 => Err(format!(
+            "semantic symbol not found: {}",
+            describe_selector(selector)
+        )),
+        count => Err(format!(
+            "semantic symbol is ambiguous ({} matches): {}; add --kind, --file, --owner, or --signature",
+            count,
+            describe_selector(selector)
+        )),
+    }
+}
+
+fn required_edit_source(edit: &WorkshopSemanticEdit) -> Result<&str, String> {
+    edit.new_source
+        .as_deref()
+        .filter(|source| !source.trim().is_empty())
+        .ok_or_else(|| format!("semantic {:?} requires new_source", edit.operation))
+}
+
+fn extract_embedded_imports(source: &str) -> Result<(String, Vec<String>), String> {
+    let imports = parse_workshop_import_paths(source)?;
+    let ranges = parse_any_import_spans(source)?
+        .into_iter()
+        .map(|range| expand_import_line_range(source, range))
+        .collect::<Vec<_>>();
+    let cleaned = remove_source_ranges(source, &ranges)?;
+    Ok((cleaned.trim().to_string(), imports))
+}
+
+fn expand_import_line_range(source: &str, range: Range<usize>) -> Range<usize> {
+    let line_start = source[..range.start.min(source.len())]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let line_end = source[range.end.min(source.len())..]
+        .find('\n')
+        .map(|offset| range.end + offset + 1)
+        .unwrap_or(source.len());
+    let before = &source[line_start..range.start];
+    let after = &source[range.end..line_end];
+    if before.trim().is_empty() && after.trim().is_empty() {
+        line_start..line_end
+    } else {
+        range
+    }
+}
+
+fn remove_source_ranges(source: &str, ranges: &[Range<usize>]) -> Result<String, String> {
+    let mut out = source.to_string();
+    let mut ranges = ranges.to_vec();
+    ranges.sort_by_key(|range| range.start);
+    for range in ranges.into_iter().rev() {
+        if range.end > out.len()
+            || range.start > range.end
+            || !out.is_char_boundary(range.start)
+            || !out.is_char_boundary(range.end)
+        {
+            return Err("source range is invalid".to_string());
+        }
+        out.replace_range(range, "");
+    }
+    Ok(out)
+}
+
+fn render_imports(mut imports: Vec<String>) -> String {
+    imports.sort();
+    imports.dedup();
+    imports
+        .into_iter()
+        .map(|path| format!("import \"{}\";", escape_import_path(&path)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn escape_import_path(path: &str) -> String {
+    path.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn merge_workshop_imports(
+    files: &mut [WorkshopSourceFile],
+    file_path: &str,
+    added: &[String],
+) -> Result<(), String> {
+    if added.is_empty() {
+        return Ok(());
+    }
+    let normalized = normalize_project_path_text(file_path);
+    let file = files
+        .iter()
+        .find(|file| normalize_project_path_text(&file.path) == normalized)
+        .ok_or_else(|| format!("semantic import target file not loaded: {file_path}"))?;
+    let mut imports = parse_workshop_import_paths(&file.source)?;
+    imports.extend(added.iter().cloned());
+    let item = workshop_source_items(files)?
+        .into_iter()
+        .find(|item| {
+            item.kind == WorkshopSourceItemKind::Imports
+                && normalize_project_path_text(&item.file) == normalized
+        })
+        .ok_or_else(|| format!("imports item not found for {file_path}"))?;
+    replace_source_item(files, &item, &render_imports(imports))
+}
+
+fn prune_unused_workshop_imports(
+    files: &mut [WorkshopSourceFile],
+    touched_files: &BTreeSet<String>,
+) -> Result<(), String> {
+    let by_path = files
+        .iter()
+        .enumerate()
+        .map(|(index, file)| (normalize_project_path_text(&file.path), index))
+        .collect::<BTreeMap<_, _>>();
+    let mut replacements = Vec::new();
+    for file in files.iter() {
+        if !touched_files.contains(&file.path) {
+            continue;
+        }
+        let imports = parse_workshop_import_paths(&file.source)?;
+        if imports.is_empty() {
+            continue;
+        }
+        let import_ranges = parse_import_spans(&file.source)?;
+        let body = remove_source_ranges(&file.source, &import_ranges)?;
+        let identifiers = source_identifiers(&body)?;
+        let mut kept = Vec::new();
+        for import in imports {
+            let imported_path = resolve_project_import_path(&file.path, &import);
+            let Some(_) = by_path.get(&imported_path) else {
+                kept.push(import);
+                continue;
+            };
+            let mut visiting = BTreeSet::new();
+            let exports = exported_identifiers(&imported_path, files, &by_path, &mut visiting)?;
+            if exports.is_empty()
+                || exports.iter().any(|name| identifiers.contains(name))
+                || exports.iter().any(|name| {
+                    matches!(name.as_str(), "main" | "tick" | "render" | "on_code_swap")
+                })
+            {
+                kept.push(import);
+            }
+        }
+        let rendered = render_imports(kept);
+        let existing = render_imports(parse_workshop_import_paths(&file.source)?);
+        if rendered != existing {
+            replacements.push((file.path.clone(), rendered));
+        }
+    }
+    for (file_path, rendered) in replacements {
+        let item = workshop_source_items(files)?
+            .into_iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Imports && item.file == file_path)
+            .ok_or_else(|| format!("imports item not found for {file_path}"))?;
+        replace_source_item(files, &item, &rendered)?;
+    }
+    Ok(())
+}
+
+fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
+    Ok(lex(source)?
+        .into_iter()
+        .filter(|token| matches!(token.kind, TokenKind::Identifier | TokenKind::FunctionKw))
+        .map(|token| token_text(source, token).to_string())
+        .collect())
+}
+
+fn exported_identifiers(
+    path: &str,
+    files: &[WorkshopSourceFile],
+    by_path: &BTreeMap<String, usize>,
+    visiting: &mut BTreeSet<String>,
+) -> Result<BTreeSet<String>, String> {
+    if !visiting.insert(path.to_string()) {
+        return Ok(BTreeSet::new());
+    }
+    let Some(index) = by_path.get(path).copied() else {
+        return Ok(BTreeSet::new());
+    };
+    let file = &files[index];
+    let mut exports = workshop_symbols(std::slice::from_ref(file))?
+        .into_iter()
+        .filter(|symbol| symbol.kind != WorkshopSymbolKind::Test)
+        .map(|symbol| symbol.name)
+        .collect::<BTreeSet<_>>();
+    for import in parse_workshop_import_paths(&file.source)? {
+        let imported_path = resolve_project_import_path(&file.path, &import);
+        exports.extend(exported_identifiers(
+            &imported_path,
+            files,
+            by_path,
+            visiting,
+        )?);
+    }
+    visiting.remove(path);
+    Ok(exports)
+}
+
+fn resolve_project_import_path(file: &str, import: &str) -> String {
+    let base = Path::new(file).parent().unwrap_or_else(|| Path::new(""));
+    normalize_filesystem_path(&base.join(import))
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn validate_source_item_replacement(
+    kind: WorkshopSourceItemKind,
+    name: &str,
+    source: &str,
+) -> Result<(), String> {
+    reject_rust_style_replacement("semantic", source)?;
+    if kind == WorkshopSourceItemKind::Imports {
+        let spans = parse_import_spans(source)?;
+        let remainder = remove_source_ranges(source, &spans)?;
+        if !remainder.trim().is_empty() {
+            return Err("imports item may contain only import declarations".to_string());
+        }
+        return Ok(());
+    }
+    let file = WorkshopSourceFile {
+        path: "src/semantic_validation.stasis".to_string(),
+        source: source.trim().to_string(),
+    };
+    let items = workshop_source_items(&[file])?;
+    if kind == WorkshopSourceItemKind::Globals {
+        let globals = items
+            .iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Globals)
+            .expect("globals item always exists");
+        if globals.source.trim() != source.trim() {
+            return Err("globals item may contain only const and global declarations".to_string());
+        }
+        return Ok(());
+    }
+    let declarations = items
+        .into_iter()
+        .filter(|item| {
+            !matches!(
+                item.kind,
+                WorkshopSourceItemKind::Imports | WorkshopSourceItemKind::Globals
+            ) && !item.source.trim().is_empty()
+        })
+        .collect::<Vec<_>>();
+    if declarations.len() != 1 || declarations[0].kind != kind || declarations[0].name != name {
+        return Err(format!(
+            "semantic edit source must define exactly one {:?} named `{}`",
+            kind, name
+        ));
+    }
+    Ok(())
+}
+
+fn replace_source_item(
+    files: &mut [WorkshopSourceFile],
+    item: &WorkshopSourceItem,
+    replacement: &str,
+) -> Result<(), String> {
+    let file = files
+        .iter_mut()
+        .find(|file| file.path == item.file)
+        .ok_or_else(|| format!("semantic edit file not loaded: {}", item.file))?;
+    let mut ranges = item
+        .source_spans
+        .iter()
+        .map(|span| span.start as usize..span.end as usize)
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|range| range.start);
+    let insertion = ranges.first().map(|range| range.start).unwrap_or_else(|| {
+        if item.kind == WorkshopSourceItemKind::Imports {
+            0
+        } else {
+            parse_import_spans(&file.source)
+                .ok()
+                .and_then(|spans| {
+                    spans
+                        .last()
+                        .map(|span| expand_range_through_newline(&file.source, span.clone()).end)
+                })
+                .unwrap_or(0)
+        }
+    });
+    for range in ranges.into_iter().rev() {
+        if range.end > file.source.len()
+            || range.start > range.end
+            || !file.source.is_char_boundary(range.start)
+            || !file.source.is_char_boundary(range.end)
+        {
+            return Err("semantic edit target span is invalid".to_string());
+        }
+        file.source.replace_range(range, "");
+    }
+    if !replacement.trim().is_empty() {
+        let mut rendered = replacement.trim().to_string();
+        rendered.push('\n');
+        file.source
+            .insert_str(insertion.min(file.source.len()), &rendered);
+    }
+    Ok(())
+}
+
+fn describe_selector(selector: &WorkshopSymbolSelector) -> String {
+    format!(
+        "kind={:?} file={:?} owner={:?} name={} signature={:?}",
+        selector.kind, selector.file, selector.owner, selector.name, selector.signature
+    )
+}
+
+fn normalize_project_path_text(path: &str) -> String {
+    path.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+pub fn workshop_source_hash(source: &str) -> String {
+    format!("{:x}", Sha256::digest(source.as_bytes()))
+}
+
+fn safe_relative_path(path: &Path) -> bool {
+    !path.as_os_str().is_empty()
+        && !path.is_absolute()
+        && !path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+}
+
+fn atomic_write(path: &Path, source: &str) -> Result<(), String> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed creating {}: {error}", parent.display()))?;
+    let mut file = atomic_write_file::AtomicWriteFile::open(path)
+        .map_err(|error| format!("failed staging {}: {error}", path.display()))?;
+    file.write_all(source.as_bytes())
+        .and_then(|()| file.sync_all())
+        .map_err(|error| format!("failed staging {}: {error}", path.display()))?;
+    file.commit()
+        .map_err(|error| format!("failed committing {}: {error}", path.display()))
+}
+
+pub fn write_workshop_semantic_receipt(
+    project_root: &Path,
+    relative_directory: &Path,
+    plan: &WorkshopSemanticEditPlan,
+) -> Result<PathBuf, String> {
+    if !safe_relative_path(relative_directory) {
+        return Err(format!(
+            "unsafe semantic receipt directory: {}",
+            relative_directory.display()
+        ));
+    }
+    let serialized = serde_json::to_string(plan)
+        .map_err(|error| format!("failed serializing semantic edit receipt: {error}"))?;
+    let relative = relative_directory.join(format!("{}.json", workshop_source_hash(&serialized)));
+    let path = project_root.join(&relative);
+    let mut pretty = serde_json::to_string_pretty(plan)
+        .map_err(|error| format!("failed serializing semantic edit receipt: {error}"))?;
+    pretty.push('\n');
+    atomic_write(&path, &pretty)?;
+    Ok(relative)
+}
+
+pub fn write_workshop_semantic_plan(
+    project_root: &Path,
+    plan: &WorkshopSemanticEditPlan,
+    restore: bool,
+) -> Result<(), String> {
+    for change in &plan.changed_files {
+        let relative = Path::new(&change.file);
+        if !safe_relative_path(relative) {
+            return Err(format!("unsafe semantic edit path: {}", change.file));
+        }
+        let path = project_root.join(relative);
+        let current = fs::read_to_string(&path)
+            .map_err(|error| format!("failed reading {}: {error}", path.display()))?;
+        let expected_hash = if restore {
+            &change.after_hash
+        } else {
+            &change.before_hash
+        };
+        let current_hash = workshop_source_hash(&current);
+        if current_hash != *expected_hash {
+            return Err(format!(
+                "refusing semantic {} for {}: expected current hash {} but found {}",
+                if restore { "revert" } else { "apply" },
+                change.file,
+                expected_hash,
+                current_hash
+            ));
+        }
+    }
+    let mut written = Vec::new();
+    for change in &plan.changed_files {
+        let path = project_root.join(&change.file);
+        let source = if restore {
+            &change.before_source
+        } else {
+            &change.after_source
+        };
+        if let Err(error) = atomic_write(&path, source) {
+            for completed in written.into_iter().rev() {
+                let prior = plan
+                    .changed_files
+                    .iter()
+                    .find(|candidate| candidate.file == completed)
+                    .expect("written semantic file remains in plan");
+                let rollback_source = if restore {
+                    &prior.after_source
+                } else {
+                    &prior.before_source
+                };
+                let _ = atomic_write(&project_root.join(&completed), rollback_source);
+            }
+            return Err(format!("failed writing {}: {error}", path.display()));
+        }
+        written.push(change.file.clone());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AiCodeRequest {
     pub user_prompt: String,
     pub selected_symbols: Vec<AiSelectedSymbol>,
@@ -706,6 +1919,9 @@ pub struct AiSelectedSymbol {
 pub enum AiSelectedSymbolKind {
     Struct,
     Function,
+    Global,
+    Constant,
+    Test,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -767,6 +1983,9 @@ pub fn selected_symbol_from_workshop_symbol(symbol: &WorkshopSymbol) -> AiSelect
         kind: match symbol.kind {
             WorkshopSymbolKind::Struct => AiSelectedSymbolKind::Struct,
             WorkshopSymbolKind::Function => AiSelectedSymbolKind::Function,
+            WorkshopSymbolKind::Global => AiSelectedSymbolKind::Global,
+            WorkshopSymbolKind::Constant => AiSelectedSymbolKind::Constant,
+            WorkshopSymbolKind::Test => AiSelectedSymbolKind::Test,
         },
         name: symbol.name.clone(),
         owner: symbol.owner.clone(),
@@ -2365,5 +3584,227 @@ mod workshop_compile_plan_tests {
                 state.contains("reload=ResetRequired") && state.contains("tick_count=0")
             }));
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn source_items_use_rust_parser_owned_sections_and_comment_boundaries() {
+        let source = "import \"math.stasis\";\n\nconst SPEED: i32 = 2;\nglobal State { score: i32; }\n\n// Player state.\n// Kept with the struct.\nstruct Player { x: i32; }\n\n// Unrelated note.\n\n// Advances the player.\nfunction update(self: Player): void {\n    self.x += SPEED;\n}\n\nfunction main(): i32 { return State.score; }\n";
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: source.to_string(),
+        }];
+        let items = workshop_source_items(&files).expect("source items");
+        let imports = items
+            .iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Imports)
+            .expect("imports item");
+        assert_eq!(imports.name, "imports");
+        assert_eq!(imports.source, "import \"math.stasis\";\n");
+        let globals = items
+            .iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Globals)
+            .expect("globals item");
+        assert!(globals.source.contains("const SPEED"));
+        assert!(globals.source.contains("global State"));
+        let player = items
+            .iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Struct && item.name == "Player")
+            .expect("Player item");
+        assert!(player.source.starts_with("// Player state."));
+        assert!(player.source.ends_with("}\n"));
+        let update = items
+            .iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Function && item.name == "update")
+            .expect("update item");
+        assert!(update.source.starts_with("// Advances the player."));
+        assert!(!update.source.contains("Unrelated note"));
+        assert!(update.source.ends_with("}\n"));
+    }
+
+    #[test]
+    fn semantic_update_hoists_embedded_import_and_prunes_unused_import() {
+        let files = vec![
+            WorkshopSourceFile {
+                path: "src/main.stasis".to_string(),
+                source: "import \"old.stasis\";\n\nfunction main(): i32 { return tick(); }\n\n// old comment\nfunction tick(): i32 { return helper_old(); }\n"
+                    .to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/old.stasis".to_string(),
+                source: "function helper_old(): i32 { return 1; }\n".to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/new.stasis".to_string(),
+                source: "function helper_new(): i32 { return 9; }\n".to_string(),
+            },
+        ];
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "tick".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: None,
+                },
+                new_source: Some(
+                    "function tick(): i32 {\n    import \"new.stasis\";\n    return helper_new();\n}"
+                        .to_string(),
+                ),
+                expected_source_hash: None,
+            }],
+        };
+        let (after, plan) = plan_workshop_semantic_edits(&files, &batch).expect("plan edit");
+        let main = after
+            .iter()
+            .find(|file| file.path == "src/main.stasis")
+            .expect("main file");
+        assert!(main.source.starts_with("import \"new.stasis\";\n"));
+        assert!(!main.source.contains("old.stasis"));
+        assert!(!main.source.contains("    import"));
+        assert!(main.source.contains("return helper_new();"));
+        assert_eq!(plan.changed_files.len(), 1);
+        assert_eq!(plan.changed_files[0].file, "src/main.stasis");
+    }
+
+    #[test]
+    fn semantic_items_do_not_cross_same_line_declarations() {
+        let source = "function first(): i32 { return 1; } function second(): i32 { return 2; }\n";
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: source.to_string(),
+        }];
+        let second = workshop_source_items(&files)
+            .expect("items")
+            .into_iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Function && item.name == "second")
+            .expect("second item");
+        assert_eq!(second.source, "function second(): i32 { return 2; }\n");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Delete,
+                target: WorkshopSymbolSelector {
+                    name: "second".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: None,
+                },
+                new_source: None,
+                expected_source_hash: Some(second.source_hash),
+            }],
+        };
+        let (after, _) = plan_workshop_semantic_edits(&files, &batch).expect("delete second");
+        assert_eq!(after[0].source, "function first(): i32 { return 1; } ");
+    }
+
+    #[test]
+    fn semantic_edit_preserves_imported_lifecycle_roots() {
+        let files = vec![
+            WorkshopSourceFile {
+                path: "src/main.stasis".to_string(),
+                source: "import \"game.stasis\";\nfunction main(): i32 { return 1; }\n".to_string(),
+            },
+            WorkshopSourceFile {
+                path: "src/game.stasis".to_string(),
+                source: "function tick(): void {}\n".to_string(),
+            },
+        ];
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "main".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: None,
+                },
+                new_source: Some("function main(): i32 { return 2; }".to_string()),
+                expected_source_hash: None,
+            }],
+        };
+        let (after, _) = plan_workshop_semantic_edits(&files, &batch).expect("update main");
+        assert!(after[0].source.contains("import \"game.stasis\";"));
+    }
+
+    #[test]
+    fn semantic_global_delete_removes_only_the_parser_selected_declaration() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "const FIRST: i32 = 1;\nconst SECOND: i32 = 1;\nfunction main(): i32 { return SECOND; }\n"
+                .to_string(),
+        }];
+        let globals = workshop_source_items(&files)
+            .expect("items")
+            .into_iter()
+            .find(|item| item.kind == WorkshopSourceItemKind::Globals)
+            .expect("globals");
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Delete,
+                target: WorkshopSymbolSelector {
+                    name: "FIRST".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Globals),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: Some("Globals".to_string()),
+                    signature: None,
+                },
+                new_source: None,
+                expected_source_hash: Some(globals.source_hash),
+            }],
+        };
+        let (after, _) = plan_workshop_semantic_edits(&files, &batch).expect("delete FIRST");
+        assert!(!after[0].source.contains("FIRST"));
+        assert!(after[0].source.contains("const SECOND: i32 = 1;"));
+    }
+
+    #[test]
+    fn semantic_plan_apply_and_revert_are_hash_guarded() {
+        let root = temp_project("semantic_receipt");
+        let path = write_project_file(
+            &root,
+            "src/main.stasis",
+            "function main(): i32 { return 1; }\n",
+        );
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: fs::read_to_string(&path).expect("read source"),
+        }];
+        let batch = WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation: WorkshopSemanticEditOperation::Update,
+                target: WorkshopSymbolSelector {
+                    name: "main".to_string(),
+                    kind: Some(WorkshopSourceItemKind::Function),
+                    file: Some("src/main.stasis".to_string()),
+                    owner: None,
+                    signature: None,
+                },
+                new_source: Some("function main(): i32 { return 7; }".to_string()),
+                expected_source_hash: None,
+            }],
+        };
+        let (_, plan) = plan_workshop_semantic_edits(&files, &batch).expect("plan");
+        write_workshop_semantic_plan(&root, &plan, false).expect("apply");
+        assert!(fs::read_to_string(&path)
+            .expect("read applied")
+            .contains("return 7"));
+        write_workshop_semantic_plan(&root, &plan, true).expect("revert");
+        assert!(fs::read_to_string(&path)
+            .expect("read reverted")
+            .contains("return 1"));
+        let stale = fs::write(&path, "function main(): i32 { return 3; }\n");
+        stale.expect("write stale source");
+        assert!(write_workshop_semantic_plan(&root, &plan, false)
+            .expect_err("stale apply")
+            .contains("expected current hash"));
+        fs::remove_dir_all(root).ok();
     }
 }

--- a/docs/semantic_edit_protocol.md
+++ b/docs/semantic_edit_protocol.md
@@ -1,0 +1,99 @@
+# Semantic Edit Protocol
+
+Stasis symbol editing is owned by the Rust compiler frontend. The desktop CLI and Android
+Workshop use the same versioned JSON request, parser-derived source items, source hashes,
+validation, and rollback plan. Neither surface scans source text to choose edit spans.
+
+## Source items
+
+Each editable `src/**/*.stasis` or `tests/**/*.stasis` file exposes these deterministic items:
+
+1. `imports`: one item containing the file's imports, including an empty item when none exist.
+2. `globals`: one item containing every top-level `const` and `global` declaration.
+3. `struct`: one item per struct.
+4. `function`: one item per function.
+5. `test`: one item per test declaration.
+
+A struct or function item starts at its immediately preceding `//` comment block and ends after
+the newline following its closing brace. Blank lines before that comment block remain outside the
+item. This makes comments move, update, and delete with the declaration they describe while
+unrelated formatting remains untouched.
+
+The stable selector fields are `kind`, project-relative `file`, `name`, optional `owner`, and
+optional normalized `signature`. Every item also returns a deterministic `source_hash`. Apply and
+delete requests may include the full SHA-256 `expected_source_hash`; a mismatch rejects a stale
+edit. Android may delete one named constant/global through the shared protocol; Rust resolves its
+exact parser span inside the aggregate globals item rather than performing a text replacement.
+
+## Import ownership
+
+Imports are always owned by the file's `imports` item. An import included in a globals, struct,
+function, or test replacement is removed from that replacement and merged into the imports item.
+Imports are sorted and deduplicated.
+
+After an edit, the compiler collects identifier references from each touched file and compares
+them with parser-derived exports from each imported file, including transitive exports. An import
+is removed when none of its exported identifiers remain referenced. Imports whose target is not
+available in the loaded workspace are retained because the compiler cannot prove them unused.
+Imports that supply `main`, `tick`, `render`, or `on_code_swap` are also retained because those
+host roots can be reachable without a textual call in the importing file.
+
+## JSON request
+
+```json
+{
+  "schema_version": 1,
+  "edits": [
+    {
+      "operation": "update",
+      "target": {
+        "kind": "function",
+        "file": "src/main.stasis",
+        "name": "tick",
+        "signature": "tick(): i32"
+      },
+      "expected_source_hash": "cd966a7b3b8d7e7bb02f7049e46b90493a6621f83de2a94f311618aa4bc24529",
+      "new_source": "function tick(): i32 { return 2; }"
+    }
+  ]
+}
+```
+
+`operation` is `add`, `update`, or `delete`. A batch is planned entirely in memory, parsed again,
+and compiler-validated before any write. Apply writes all changed files, runs tests unless skipped,
+and restores every changed file if validation fails. Successful applies write a receipt under
+`build/semantic-edits/`; source files and receipts use flushed atomic replacement so interrupted
+writes retain either the old or complete new contents. Revert verifies the post-edit hashes before
+restoring the recorded source.
+
+## CLI
+
+```text
+stasis symbol list [--kind KIND] [--file FILE] [--owner OWNER]
+stasis symbol find NAME [--kind KIND] [--file FILE] [--owner OWNER] [--signature SIGNATURE]
+stasis symbol read NAME [selection options]
+stasis symbol add NAME --kind KIND --file FILE --source-file PATH [--dry-run] [--no-tests]
+stasis symbol update NAME [selection options] --source-file PATH [--expected-source-hash HASH] [--dry-run] [--no-tests]
+stasis symbol delete NAME [selection options] [--expected-source-hash HASH] [--dry-run] [--no-tests]
+stasis symbol apply --request PATH [--dry-run] [--no-tests]
+stasis symbol revert --receipt PATH [--dry-run] [--no-tests]
+```
+
+`KIND` is `imports`, `globals`, `struct`, `function`, or `test`. `--json` returns the same typed
+items, selectors, edit plan, hashes, reload classification, and receipt contract used by Android.
+
+Symbol commands deliberately have no legacy-project fallback. They require the versioned
+`stasis.json` workspace contract; run `stasis init` in an older source tree before editing it.
+Existing legacy compiler/runner entrypoints remain separate and are never selected implicitly by
+`stasis symbol`.
+
+## Android capability audit
+
+Android already provided symbol list/read/write/delete, compile-on-batch, test execution, and
+rollback behavior. Its earlier private Java scanner and direct span mutation were not reused.
+AI `write_symbol` and `delete_symbol` now resolve the corresponding Rust source item and submit
+the shared semantic request through `stasis_android_bridge_semantic_edit`. The bridge exposes the
+same source-item JSON through `stasis_android_bridge_source_items`, compiles once at the requested
+transaction boundary, and restores the Rust-generated plan on failure. Android's manual editor
+continues to provide draft/recovery UI, but compiler-owned parsing remains the authority for
+scripted symbol transactions.

--- a/docs/semantic_edit_protocol.md
+++ b/docs/semantic_edit_protocol.md
@@ -72,8 +72,8 @@ restoring the recorded source.
 stasis symbol list [--kind KIND] [--file FILE] [--owner OWNER]
 stasis symbol find NAME [--kind KIND] [--file FILE] [--owner OWNER] [--signature SIGNATURE]
 stasis symbol read NAME [selection options]
-stasis symbol add NAME --kind KIND --file FILE --source-file PATH [--dry-run] [--no-tests]
-stasis symbol update NAME [selection options] --source-file PATH [--expected-source-hash HASH] [--dry-run] [--no-tests]
+stasis symbol add NAME --kind KIND --file FILE (--source SOURCE | --source-file PATH) [--dry-run] [--no-tests]
+stasis symbol update NAME [selection options] (--source SOURCE | --source-file PATH) [--expected-source-hash HASH] [--dry-run] [--no-tests]
 stasis symbol delete NAME [selection options] [--expected-source-hash HASH] [--dry-run] [--no-tests]
 stasis symbol apply --request PATH [--dry-run] [--no-tests]
 stasis symbol revert --receipt PATH [--dry-run] [--no-tests]
@@ -81,6 +81,8 @@ stasis symbol revert --receipt PATH [--dry-run] [--no-tests]
 
 `KIND` is `imports`, `globals`, `struct`, `function`, or `test`. `--json` returns the same typed
 items, selectors, edit plan, hashes, reload classification, and receipt contract used by Android.
+`--source` accepts the complete replacement definition inline and is the preferred scripted path;
+`--source-file` remains available for large definitions. Exactly one is required for add/update.
 
 Symbol commands deliberately have no legacy-project fallback. They require the versioned
 `stasis.json` workspace contract; run `stasis init` in an older source tree before editing it.

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -14,6 +14,8 @@ Current scope:
 - Keeps timing/budget diagnostics visible over the game; Exploration additionally shows keepsake progress and its current tap/find/complete lesson without covering the voice shortcut.
 - Seeds bundled `.stasis` files into app-private storage when missing and preserves edits across app launches.
 - Lets a selected symbol display and edit its source from the app-private `.stasis` file.
+- Routes AI symbol writes/deletes through the shared Rust semantic-edit protocol used by the
+  desktop `stasis symbol` CLI; see `docs/semantic_edit_protocol.md`.
 - Saves selected symbol edits back to the app-private `.stasis` file, reparses the project so later edits use fresh symbol spans, and reports `FastReload` versus `ResetRequired` expectations.
 - Provides a dev-first AI edit panel whose primary provider is phone-native Codex with ChatGPT device-code sign-in. The existing OpenAI Responses API harness remains an explicit API-key fallback with `gpt-5.6-sol` and medium reasoning.
 - Codex sign-in copies the one-time device code before opening the official verification page, survives repeated browser/app switching with one resumable poll, keeps a selectable copy and explicit completion status in-app, retries transient polling network failures, and clears the matching clipboard value after success.

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -30,6 +30,8 @@ typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root,
 typedef char *(*stasis_android_bridge_set_i32_global_fn)(const char *project_root, const char *entry_file, const char *path, int value);
 typedef char *(*stasis_android_bridge_get_i32_global_fn)(const char *project_root, const char *entry_file, const char *path);
 typedef char *(*stasis_android_bridge_resolve_sprite_asset_fn)(const char *project_root, int handle);
+typedef char *(*stasis_android_bridge_source_items_fn)(const char *project_root, const char *entry_file);
+typedef char *(*stasis_android_bridge_semantic_edit_fn)(const char *project_root, const char *entry_file, const char *request_json, int dry_run, int validate, int run_tests);
 typedef void (*stasis_android_bridge_free_string_fn)(char *value);
 typedef char *(*stasis_codex_android_string_fn)(const char *codex_home);
 typedef uint64_t (*stasis_codex_android_begin_response_fn)(void);
@@ -66,6 +68,8 @@ typedef struct RustBridgeApi {
     stasis_android_bridge_set_i32_global_fn set_i32_global;
     stasis_android_bridge_get_i32_global_fn get_i32_global;
     stasis_android_bridge_resolve_sprite_asset_fn resolve_sprite_asset;
+    stasis_android_bridge_source_items_fn source_items;
+    stasis_android_bridge_semantic_edit_fn semantic_edit;
     stasis_android_bridge_free_string_fn free_string;
     int attempted;
 } RustBridgeApi;
@@ -943,6 +947,10 @@ static RustBridgeApi *load_rust_bridge_api(void) {
             (stasis_android_bridge_get_i32_global_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_get_i32_global");
     rust_bridge_api.resolve_sprite_asset =
             (stasis_android_bridge_resolve_sprite_asset_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_sprite_asset");
+    rust_bridge_api.source_items =
+            (stasis_android_bridge_source_items_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_source_items");
+    rust_bridge_api.semantic_edit =
+            (stasis_android_bridge_semantic_edit_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_semantic_edit");
     rust_bridge_api.free_string =
             (stasis_android_bridge_free_string_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_free_string");
     if (rust_bridge_api.compile_project == NULL ||
@@ -1360,6 +1368,57 @@ Java_com_stasislang_workshop_MainActivity_nativeCompileProject(JNIEnv *env, jcla
     __android_log_print(ANDROID_LOG_INFO, STASIS_ANDROID_LOG_TAG, "%s", message);
     return (*env)->NewStringUTF(env, message);
 #endif
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeSourceItems(
+        JNIEnv *env, jclass activity_class, jstring project_root) {
+    (void)activity_class;
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->source_items == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"Rust source item bridge unavailable\"}");
+    }
+    const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
+    if (root == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"unable to read project root\"}");
+    }
+    char *result = bridge->source_items(root, "src/main.stasis");
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
+    if (result == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"source item bridge returned null\"}");
+    }
+    jstring response = (*env)->NewStringUTF(env, result);
+    bridge->free_string(result);
+    return response;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeSemanticEdit(
+        JNIEnv *env, jclass activity_class, jstring project_root, jstring request_json,
+        jboolean dry_run, jboolean validate, jboolean run_tests) {
+    (void)activity_class;
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->semantic_edit == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"Rust semantic edit bridge unavailable\"}");
+    }
+    const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
+    const char *request = (*env)->GetStringUTFChars(env, request_json, NULL);
+    if (root == NULL || request == NULL) {
+        if (root != NULL) (*env)->ReleaseStringUTFChars(env, project_root, root);
+        if (request != NULL) (*env)->ReleaseStringUTFChars(env, request_json, request);
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"unable to read semantic edit input\"}");
+    }
+    char *result = bridge->semantic_edit(
+            root, "src/main.stasis", request,
+            dry_run ? 1 : 0, validate ? 1 : 0, run_tests ? 1 : 0);
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
+    (*env)->ReleaseStringUTFChars(env, request_json, request);
+    if (result == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"error\",\"error\":\"semantic edit bridge returned null\"}");
+    }
+    jstring response = (*env)->NewStringUTF(env, result);
+    bridge->free_string(result);
+    return response;
 }
 JNIEXPORT jint JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h, jintArray frame_values) {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -318,6 +318,9 @@ public final class MainActivity extends Activity {
 
     private static native String nativeStatus();
     private static native String nativeCompileProject(String projectRoot);
+    private static native String nativeSourceItems(String projectRoot);
+    private static native String nativeSemanticEdit(String projectRoot, String requestJson,
+                                                    boolean dryRun, boolean validate, boolean runTests);
     private static native String nativeRunTick(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight);
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight, int[] frameValues);
     private static native String nativeSetRuntimeI32(String projectRoot, String path, int value);
@@ -5457,6 +5460,8 @@ public final class MainActivity extends Activity {
         }
 
         Map<String, String> batchOriginalSources = batchHasWrites ? snapshotProjectSources(session.project()) : null;
+        boolean batchWriteFailed = false;
+        String batchWriteError = "";
         throwIfAiCancelled();
         session.deferBatchCompile = batchHasWrites;
         try {
@@ -5480,6 +5485,10 @@ public final class MainActivity extends Activity {
                     observation.put("error", session.lastToolError);
                     observation.put("validation", validationError);
                     observations.put(observation);
+                    if (batchHasWrites && isAiWriteTool(tool)) {
+                        batchWriteFailed = true;
+                        batchWriteError = session.lastToolError;
+                    }
                     continue;
                 }
                 if (batchHasWrites && "run_tests".equals(tool)) {
@@ -5497,6 +5506,10 @@ public final class MainActivity extends Activity {
                 } catch (Exception error) {
                     session.lastToolError = error.getMessage();
                     observation.put("error", error.getMessage());
+                    if (batchHasWrites && isAiWriteTool(tool)) {
+                        batchWriteFailed = true;
+                        batchWriteError = error.getMessage();
+                    }
                 }
                 observations.put(observation);
             }
@@ -5505,6 +5518,23 @@ public final class MainActivity extends Activity {
         }
 
         if (!batchHasWrites) {
+            return observations;
+        }
+
+        if (batchWriteFailed) {
+            restoreProjectSources(batchOriginalSources);
+            session.invalidateProject();
+            String restoredCompile = nativeCompileProject(projectRootPath());
+            lastCompileResult = restoredCompile;
+            compileReady = isRunnableCompile(restoredCompile);
+            compileAttempted = true;
+            JSONObject diagnostics = new JSONObject()
+                    .put("status", "batch_edit_failed")
+                    .put("error", batchWriteError);
+            JSONObject restoredDiagnostics = compileResultToJson(restoredCompile);
+            annotateAiBatchWriteResults(observations, "rolled_back", diagnostics, restoredDiagnostics, session);
+            session.failedWriteBatchCount += 1;
+            annotatePendingRunTestsBlocked(observations, pendingRunTestObservationIndexes, diagnostics);
             return observations;
         }
 
@@ -5794,7 +5824,8 @@ public final class MainActivity extends Activity {
                 continue;
             }
             String status = result.optString("status", "");
-            if (!"written".equals(status) && !"created".equals(status)) {
+            if (!"written".equals(status) && !"created".equals(status)
+                    && !"deleted".equals(status)) {
                 continue;
             }
             result.put("diagnostics", diagnostics);
@@ -6374,66 +6405,35 @@ public final class MainActivity extends Activity {
     }
     private JSONObject aiToolDeleteSymbol(AiAgentSession session, JSONObject call) throws Exception {
         ProjectSnapshot project = session.project();
-        Map<String, String> originalSources = snapshotProjectSources(project);
         String kind = call.optString("kind", "");
         SymbolEntry target = kind.isEmpty()
                 ? findAnySymbolForAiLookup(project, call, selectedSymbol)
                 : findSymbolForAiEdit(project, aiLookupExpectedKind(kind), call, selectedSymbol);
-        try {
-            String before = target.sourceFile.source.substring(0, target.start).replaceFirst("\\s+$", "");
-            String after = target.sourceFile.source.substring(target.end).replaceFirst("^\\s+", "");
-            String updatedSource = before.isEmpty() ? after : after.isEmpty() ? before + "\n" : before + "\n\n" + after;
-            target.sourceFile.source = updatedSource;
-            writeTextFile(target.sourceFile.diskFile, updatedSource);
-            session.invalidateProject();
-
-            if (session.deferBatchCompile) {
-                return new JSONObject()
-                        .put("file", target.file)
-                        .put("kind", target.kind)
-                        .put("name", target.name)
-                        .put("owner", target.owner)
-                        .put("status", "deleted")
-                        .put("diagnostics", new JSONObject().put("status", "pending_batch_compile"));
-            }
-
-            String compileResult = nativeCompileProject(projectRootPath());
-            lastCompileResult = compileResult;
-            compileReady = isRunnableCompile(compileResult);
-            compileAttempted = true;
-            JSONObject diagnostics = compileResultToJson(compileResult);
-            if (!compileReady) {
-                restoreProjectSources(originalSources);
-                session.invalidateProject();
-                String restoredCompile = nativeCompileProject(projectRootPath());
-                lastCompileResult = restoredCompile;
-                compileReady = isRunnableCompile(restoredCompile);
-                compileAttempted = true;
-                return new JSONObject()
-                        .put("file", target.file)
-                        .put("kind", target.kind)
-                        .put("name", target.name)
-                        .put("owner", target.owner)
-                        .put("status", "rolled_back")
-                        .put("diagnostics", diagnostics)
-                        .put("restored_diagnostics", compileResultToJson(restoredCompile));
-            }
-            return new JSONObject()
-                    .put("file", target.file)
-                    .put("kind", target.kind)
-                    .put("name", target.name)
-                    .put("owner", target.owner)
-                    .put("status", "deleted")
-                    .put("diagnostics", diagnostics);
-        } catch (Exception error) {
-            restoreProjectSources(originalSources);
-            session.invalidateProject();
-            throw error;
+        String semanticKind = semanticItemKind(target.kind);
+        String semanticName = target.name;
+        String newSource = null;
+        String operation = "delete";
+        JSONObject rustItem;
+        if ("globals".equals(semanticKind)) {
+            rustItem = rustSourceItem(target.file, "globals", "globals", "");
+        } else {
+            rustItem = rustSourceItem(target.file, semanticKind, semanticName, target.signature);
         }
+        JSONObject result = runRustSemanticEdit(operation, semanticKind, semanticName,
+                target.file, rustItem.optString("owner"), rustItem.optString("signature"),
+                rustItem.optString("source_hash"),
+                newSource, !session.deferBatchCompile);
+        session.invalidateProject();
+        return new JSONObject()
+                .put("file", target.file)
+                .put("kind", target.kind)
+                .put("name", target.name)
+                .put("owner", target.owner)
+                .put("status", "deleted")
+                .put("diagnostics", result);
     }
     private JSONObject aiToolWriteSymbol(AiAgentSession session, JSONObject call) throws Exception {
         ProjectSnapshot project = session.project();
-        Map<String, String> originalSources = snapshotProjectSources(project);
         String kind = call.optString("kind", "replace_function");
         String expectedKind = "replace_struct".equals(kind) || "struct".equals(kind) ? "struct" : "function";
         String editKind = "struct".equals(expectedKind) ? "replace_struct" : "replace_function";
@@ -6441,57 +6441,80 @@ public final class MainActivity extends Activity {
         if (newSource.isEmpty()) {
             throw new IOException("No value for new_source");
         }
-        boolean existed = findSymbolForAiEditOrNull(project, expectedKind, call, selectedSymbol) != null;
-        try {
-            SymbolEntry target = resolveAiEditTarget(project, editKind, expectedKind, call, selectedSymbol, newSource);
-            validateAiReplacementSource(editKind, target.name, newSource);
-            persistSelectedEdit(target, newSource);
-            session.invalidateProject();
+        SymbolEntry existing = findSymbolForAiEditOrNull(project, expectedKind, call, selectedSymbol);
+        String name = call.optString("name", existing == null ? "" : existing.name).trim();
+        String file = call.optString("file", existing == null ? "" : existing.file).trim();
+        if (name.isEmpty() || file.isEmpty()) throw new IOException("write_symbol requires file and name");
+        validateAiReplacementSource(editKind, name, newSource);
+        JSONObject rustItem = existing == null ? null : rustSourceItem(file, expectedKind, name,
+                existing == null ? "" : existing.signature);
+        JSONObject result = runRustSemanticEdit(existing == null ? "add" : "update",
+                expectedKind, name, file, rustItem == null ? "" : rustItem.optString("owner"),
+                rustItem == null ? "" : rustItem.optString("signature"),
+                rustItem == null ? "" : rustItem.optString("source_hash"),
+                newSource, !session.deferBatchCompile);
+        session.invalidateProject();
+        return new JSONObject()
+                .put("file", file)
+                .put("kind", expectedKind)
+                .put("name", name)
+                .put("owner", existing == null ? call.optString("owner", "") : existing.owner)
+                .put("status", existing == null ? "created" : "written")
+                .put("diagnostics", result);
+    }
 
-            if (session.deferBatchCompile) {
-                return new JSONObject()
-                        .put("file", target.file)
-                        .put("kind", target.kind)
-                        .put("name", target.name)
-                        .put("owner", target.owner)
-                        .put("status", existed ? "written" : "created")
-                        .put("diagnostics", new JSONObject().put("status", "pending_batch_compile"));
-            }
+    private static String semanticItemKind(String androidKind) {
+        if ("global".equals(androidKind)) return "globals";
+        if ("struct".equals(androidKind)) return "struct";
+        if ("test".equals(androidKind)) return "test";
+        return "function";
+    }
 
-            String compileResult = nativeCompileProject(projectRootPath());
-            lastCompileResult = compileResult;
-            compileReady = isRunnableCompile(compileResult);
-            compileAttempted = true;
-            JSONObject diagnostics = compileResultToJson(compileResult);
-            if (!compileReady) {
-                restoreProjectSources(originalSources);
-                session.invalidateProject();
-                String restoredCompile = nativeCompileProject(projectRootPath());
-                lastCompileResult = restoredCompile;
-                compileReady = isRunnableCompile(restoredCompile);
-                compileAttempted = true;
-                return new JSONObject()
-                        .put("file", target.file)
-                        .put("kind", target.kind)
-                        .put("name", target.name)
-                        .put("owner", target.owner)
-                        .put("status", "rolled_back")
-                        .put("diagnostics", diagnostics)
-                        .put("restored_diagnostics", compileResultToJson(restoredCompile));
-            }
-
-            return new JSONObject()
-                    .put("file", target.file)
-                    .put("kind", target.kind)
-                    .put("name", target.name)
-                    .put("owner", target.owner)
-                    .put("status", existed ? "written" : "created")
-                    .put("diagnostics", diagnostics);
-        } catch (Exception error) {
-            restoreProjectSources(originalSources);
-            session.invalidateProject();
-            throw error;
+    private JSONObject rustSourceItem(String file, String kind, String name,
+                                      String signature) throws Exception {
+        JSONObject response = new JSONObject(nativeSourceItems(projectRootPath()));
+        if ("error".equals(response.optString("status"))) {
+            throw new IOException(response.optString("error", "Rust source item indexing failed"));
         }
+        JSONArray items = response.getJSONArray("items");
+        JSONObject match = null;
+        for (int index = 0; index < items.length(); index += 1) {
+            JSONObject item = items.getJSONObject(index);
+            if (file.equals(item.optString("file")) && kind.equals(item.optString("kind"))
+                    && name.equals(item.optString("name"))
+                    && (signature == null || signature.isEmpty()
+                    || signature.equals(item.optString("signature")))) {
+                if (match != null) throw new IOException(
+                        "Rust source item is ambiguous: " + kind + " " + file + " " + name);
+                match = item;
+            }
+        }
+        if (match != null) return match;
+        throw new IOException("Rust source item not found: " + kind + " " + file + " " + name);
+    }
+
+    private JSONObject runRustSemanticEdit(String operation, String kind, String name, String file,
+                                             String owner, String signature, String expectedSourceHash,
+                                             String newSource, boolean validate) throws Exception {
+        JSONObject target = new JSONObject().put("kind", kind).put("name", name).put("file", file);
+        if (owner != null && !owner.isEmpty()) target.put("owner", owner);
+        if (signature != null && !signature.isEmpty()) target.put("signature", signature);
+        JSONObject edit = new JSONObject().put("operation", operation).put("target", target);
+        if (newSource != null) edit.put("new_source", newSource);
+        if (expectedSourceHash != null && !expectedSourceHash.isEmpty()) {
+            edit.put("expected_source_hash", expectedSourceHash);
+        }
+        JSONObject request = new JSONObject().put("schema_version", 1)
+                .put("edits", new JSONArray().put(edit));
+        JSONObject result = new JSONObject(nativeSemanticEdit(
+                projectRootPath(), request.toString(), false, validate, false));
+        if ("error".equals(result.optString("status"))) {
+            throw new IOException(result.optString("error", "Rust semantic edit failed"));
+        }
+        lastCompileResult = validate ? "CompilePlanned: semantic_edit=RustValidated" : lastCompileResult;
+        compileReady = validate || compileReady;
+        compileAttempted = validate || compileAttempted;
+        return result;
     }
 
     private JSONObject writeSymbolTransaction(AiAgentSession session, SymbolEntry target, String newSource) throws Exception {


### PR DESCRIPTION
## Summary
- add Rust parser-owned imports/globals/struct/function/test source items and a versioned semantic edit plan
- expose list/find/read/add/update/delete/apply/revert through the desktop CLI with SHA-256 stale guards, atomic writes, validation, receipts, and rollback
- route Android Workshop AI symbol edits through the same Rust contract, including exact global deletion and transactional batch failure recovery
- hoist embedded imports, prune proven-unused imports while retaining lifecycle roots, and document legacy workspace behavior

## Tests
- cargo test -p stasis_compiler -- --test-threads=1
- cargo test -p stasis_android_bridge -- --nocapture
- cargo test -p stasis --test toolchain_cli semantic_symbol_cli_previews_applies_runs_and_reverts -- --nocapture
- cargo check -p stasis_compiler -p stasis_android_bridge -p stasis
- gradle :app:testWorkshopDebugUnitTest :app:assembleWorkshopDebug --no-daemon
- Android Rust bridge arm64 rebuild
- AOT semantic smoke executable (expected exit 1)

## Validation note
The bash wrapper cannot launch on this Windows host. Its direct layout check passed; the full workspace command reaches two pre-existing Windows path-separator assertions in apps/stasis/src/main.rs (expected nested/helper.stasis, actual nested\\helper.stasis). Task-scoped and compiler-wide suites pass.

Maddox task #152.