### PR TITLE
feat: add lean mobile app packaging

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -84,6 +84,12 @@ jobs:
           cp LICENSE "${out}/"
           cp -R src "${out}/"
           cp -R samples "${out}/"
+          mkdir -p "${out}/mobile"
+          cp -R mobile/shells "${out}/mobile/"
+          mkdir -p "${out}/runtime"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          mkdir -p "${out}/docs"
+          cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/stasis-release-${{ runner.os }}.tar.gz" "stasis-release-${{ runner.os }}"
 
       - name: Assemble bundle (windows)
@@ -114,6 +120,12 @@ jobs:
           Copy-Item THIRD_PARTY_NOTICES.md "$out/" -Force
           Copy-Item src "$out/" -Recurse -Force
           Copy-Item samples "$out/" -Recurse -Force
+          New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
+          Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
+          New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
+          Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/stasis-release-${{ runner.os }}.zip" -Force
 
       - name: Smoke test bundled graphics runtime (windows)
@@ -136,9 +148,15 @@ jobs:
             "function tick(): i32 { return 0; }",
             "function render(): i32 { return 0; }"
           )
+          New-Item -ItemType Directory -Force -Path "cli-smoke/assets" | Out-Null
+          Set-Content -Path "cli-smoke/assets/manifest.json" -Encoding ASCII -Value '{"schema":"stasis-assets","version":1,"assets":[]}'
           .\stasis.exe --workspace cli-smoke package --target desktop
           if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.exe")) { throw "game package runner missing" }
           if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.dll")) { throw "game package library missing" }
+          .\stasis.exe --workspace cli-smoke package-mobile --target android-arm64 --out dist/android
+          .\stasis.exe --workspace cli-smoke package-mobile --target ios-arm64 --out dist/ios
+          if (-not (Test-Path "cli-smoke/dist/android/android/app/src/main/cpp/CMakeLists.txt")) { throw "Android mobile shell missing" }
+          if (-not (Test-Path "cli-smoke/dist/ios/ios/StasisMobile.xcodeproj/project.pbxproj")) { throw "iOS mobile shell missing" }
           Pop-Location
 
       - name: Smoke test bundled CLI (unix)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -148,6 +148,12 @@ jobs:
           # Ship the stdlib + samples so relative imports keep working in the bundle.
           cp -R src "${out}/"
           cp -R samples "${out}/"
+          mkdir -p "${out}/mobile"
+          cp -R mobile/shells "${out}/mobile/"
+          mkdir -p "${out}/runtime"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          mkdir -p "${out}/docs"
+          cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/${{ matrix.archive }}.${{ matrix.ext }}" "${{ matrix.archive }}"
 
       - name: Assemble bundle (windows)
@@ -179,6 +185,12 @@ jobs:
           # Ship the stdlib + samples so relative imports keep working in the bundle.
           Copy-Item src "$out/" -Recurse -Force
           Copy-Item samples "$out/" -Recurse -Force
+          New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
+          Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
+          New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
+          Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/${{ matrix.archive }}.${{ matrix.ext }}" -Force
 
       - name: Smoke test bundled graphics runtime (windows)
@@ -201,9 +213,15 @@ jobs:
             "function tick(): i32 { return 0; }",
             "function render(): i32 { return 0; }"
           )
+          New-Item -ItemType Directory -Force -Path "cli-smoke/assets" | Out-Null
+          Set-Content -Path "cli-smoke/assets/manifest.json" -Encoding ASCII -Value '{"schema":"stasis-assets","version":1,"assets":[]}'
           .\stasis.exe --workspace cli-smoke package --target desktop
           if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.exe")) { throw "game package runner missing" }
           if (-not (Test-Path "cli-smoke/dist/ci_smoke-desktop/ci_smoke.dll")) { throw "game package library missing" }
+          .\stasis.exe --workspace cli-smoke package-mobile --target android-arm64 --out dist/android
+          .\stasis.exe --workspace cli-smoke package-mobile --target ios-arm64 --out dist/ios
+          if (-not (Test-Path "cli-smoke/dist/android/android/app/src/main/cpp/CMakeLists.txt")) { throw "Android mobile shell missing" }
+          if (-not (Test-Path "cli-smoke/dist/ios/ios/StasisMobile.xcodeproj/project.pbxproj")) { throw "iOS mobile shell missing" }
           Pop-Location
 
       - name: Smoke test bundled CLI (unix)

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Most users will:
 1. Install one release archive and put its `stasis` executable on `PATH`.
 2. Run `stasis new my_game`, then work from the project root or any subdirectory.
 3. Use `stasis fmt`, `stasis check`, `stasis test`, and `stasis run` during development.
-4. Use `stasis build --mode release` or `stasis package --target desktop` to ship.
+4. Use `stasis build --mode release`, `stasis package --target desktop`, or
+   `stasis package-mobile --target android-arm64|ios-arm64` to ship.
 
 The integrated CLI, `stasis.json` workspace contract, JSON output, offline behavior, and
 installation layout are documented in `docs/toolchain_cli.md`.
 
-Mobile AOT artifacts for Android arm64 and iOS arm64 are documented in
-`docs/mobile_aot_artifacts.md`.
+Lean Android/iOS app packaging is documented in `docs/mobile_packaging.md`;
+the lower-level AOT artifact contract is in `docs/mobile_aot_artifacts.md`.
 
 Nightly releases are published from `main`:
 
@@ -53,7 +54,7 @@ Windows release zip layout:
 - `stasis_graphics.dll` at the archive root
 - `lld-link.exe`, `clang-cl.exe`, `stasis_dynload.dll`, and `stasis_dynload.dll.lib` for offline AOT builds
 - `stasis_runner.exe` and `stasis_graphics.dll` for packaged desktop games
-- `src/` and `samples/` at the archive root
+- `src/`, `samples/`, `mobile/shells/`, and `runtime/` at the archive root
 
 That keeps the common Windows command simple:
 
@@ -222,3 +223,4 @@ After the runtime exists under the repo (`runtime/build/...` or `runtime/build_c
 - `docs/live-compilation-prd.md`: hot swap + product/architecture requirements
 - `docs/build_checklist.md`: execution plan and slice ordering
 - `docs/mobile_packaging_abi.md`: v1 Android/iOS AOT packaging ABI
+- `docs/mobile_packaging.md`: one-command lean Android/iOS app packaging

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2140,11 +2140,13 @@ mod tests {
     #[test]
     fn mobile_runtime_uses_fixed_entries_and_sdl_only_static_target() {
         for required in [
-            "typedef void (*StasisMobileEntry)(void)",
-            "StasisMobileEntry bind_runtime_entry",
-            "StasisMobileEntry main_entry",
-            "StasisMobileEntry tick_entry",
-            "StasisMobileEntry render_entry",
+            "typedef void (*StasisMobileBindEntry)(void)",
+            "typedef int32_t (*StasisMobileI32Entry)(void)",
+            "StasisMobileBindEntry bind_runtime_entry",
+            "StasisMobileI32Entry main_entry",
+            "StasisMobileI32Entry tick_entry",
+            "StasisMobileI32Entry render_entry",
+            "stasis_mobile_runtime_last_entry_result(void)",
             "STASIS_MOBILE_RUNTIME_ABI_VERSION 1",
         ] {
             assert!(
@@ -2157,6 +2159,7 @@ mod tests {
             "runtime_state.entries.main_entry()",
             "runtime_state.entries.tick_entry()",
             "runtime_state.entries.render_entry()",
+            "runtime_state.last_entry_result != 0",
             "stasis_should_quit()",
             "stasis_mobile_poll_events()",
             "stasis_mobile_set_paused(runtime_state.paused)",

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1685,10 +1685,10 @@ fn write_mobile_aot_symbols_header(
     let render = mobile_aot_symbol_for(manifest, "render")?;
     let on_code_swap = mobile_aot_symbol_for(manifest, "on_code_swap").ok();
     let mut out = String::new();
-    out.push_str("#pragma once\n\n");
+    out.push_str("#pragma once\n\n#include <stdint.h>\n\n");
     out.push_str("extern void stasis_aot_bind_runtime_globals(void);\n");
     for symbol in [&main, &tick, &render] {
-        out.push_str(&format!("extern void {symbol}(void);\n"));
+        out.push_str(&format!("extern int32_t {symbol}(void);\n"));
     }
     if let Some(symbol) = on_code_swap.as_ref() {
         out.push_str(&format!("extern void {symbol}(void);\n"));
@@ -1731,11 +1731,20 @@ fn write_mobile_aot_bindings_source(
         .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
     let mut out = String::from("#include <stdint.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n");
     for function in functions {
+        let name = function
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT function missing name".to_string())?;
         let symbol = function
             .get("symbol")
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
-        out.push_str(&format!("extern void {symbol}(void);\n"));
+        let return_type = if matches!(name, "main" | "tick" | "render") {
+            "int32_t"
+        } else {
+            "void"
+        };
+        out.push_str(&format!("extern {return_type} {symbol}(void);\n"));
     }
     for literal in literals {
         let id = literal
@@ -1828,23 +1837,26 @@ fn write_mobile_aot_package_manifest(
     cmake_file: Option<&Path>,
     output_dir: &Path,
 ) -> Result<PathBuf, String> {
-    let objects: Vec<serde_json::Value> = object_paths_by_function
+    let objects = object_paths_by_function
         .iter()
         .map(|(name, path)| {
-            serde_json::json!({
+            Ok(serde_json::json!({
                 "function": name,
-                "path": path.to_string_lossy().replace('\\', "/")
-            })
+                "path": mobile_aot_relative_path(output_dir, path)?
+            }))
         })
-        .collect();
+        .collect::<Result<Vec<serde_json::Value>, String>>()?;
+    let asset_manifest = asset_dir
+        .join("stasis_game")
+        .join(DEFAULT_ASSET_MANIFEST_PATH);
     let mut manifest = serde_json::json!({
         "schema": "stasis.mobile_aot_bundle.v1",
         "target": target.as_str(),
-        "engine_manifest": engine_manifest_path.to_string_lossy().replace('\\', "/"),
-        "symbols_header": symbols_header.to_string_lossy().replace('\\', "/"),
-        "bindings_source": bindings_source.to_string_lossy().replace('\\', "/"),
-        "asset_root": asset_dir.to_string_lossy().replace('\\', "/"),
-        "asset_manifest": asset_dir.join("stasis_game").join(DEFAULT_ASSET_MANIFEST_PATH).to_string_lossy().replace('\\', "/"),
+        "engine_manifest": mobile_aot_relative_path(output_dir, engine_manifest_path)?,
+        "symbols_header": mobile_aot_relative_path(output_dir, symbols_header)?,
+        "bindings_source": mobile_aot_relative_path(output_dir, bindings_source)?,
+        "asset_root": mobile_aot_relative_path(output_dir, asset_dir)?,
+        "asset_manifest": mobile_aot_relative_path(output_dir, &asset_manifest)?,
         "objects": objects,
         "entrypoints": {
             "main": "main",
@@ -1855,7 +1867,7 @@ fn write_mobile_aot_package_manifest(
     });
     if let Some(cmake_file) = cmake_file {
         manifest["android_cmake_file"] =
-            serde_json::Value::String(cmake_file.to_string_lossy().replace('\\', "/"));
+            serde_json::Value::String(mobile_aot_relative_path(output_dir, cmake_file)?);
     }
     let path = output_dir.join("mobile_aot_bundle_manifest.json");
     let body = serde_json::to_string_pretty(&manifest)
@@ -1869,17 +1881,33 @@ fn write_mobile_aot_package_manifest(
     Ok(path)
 }
 
+fn mobile_aot_relative_path(output_dir: &Path, path: &Path) -> Result<String, String> {
+    path.strip_prefix(output_dir)
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .map_err(|_| {
+            format!(
+                "mobile AOT metadata path {} is outside output directory {}",
+                path.display(),
+                output_dir.display()
+            )
+        })
+}
+
 fn write_android_aot_cmake_file(
     object_paths_by_function: &std::collections::BTreeMap<String, PathBuf>,
     output_path: &Path,
 ) -> Result<(), String> {
+    let output_dir = output_path.parent().ok_or_else(|| {
+        format!(
+            "Android AOT CMake output has no parent: {}",
+            output_path.display()
+        )
+    })?;
     let mut out = String::new();
     out.push_str("set(STASIS_PUBLISHED_AOT_OBJECTS\n");
     for path in object_paths_by_function.values() {
-        out.push_str(&format!(
-            "  \"{}\"\n",
-            path.to_string_lossy().replace('\\', "/")
-        ));
+        let relative = mobile_aot_relative_path(output_dir, path)?;
+        out.push_str(&format!("  \"${{CMAKE_CURRENT_LIST_DIR}}/{relative}\"\n"));
     }
     out.push_str(")\n");
     fs::write(output_path, out).map_err(|error| {
@@ -2351,17 +2379,20 @@ mod tests {
         assert!(
             header
                 .lines()
-                .filter(|line| line.starts_with("extern void aot_fn_") && line.ends_with("(void);"))
+                .filter(
+                    |line| line.starts_with("extern int32_t aot_fn_") && line.ends_with("(void);")
+                )
                 .count()
                 >= 3,
-            "mobile AOT lifecycle symbols must match StasisMobileEntry void(void) callbacks"
+            "mobile AOT lifecycle symbols must match StasisMobileI32Entry callbacks"
         );
         let mobile_runtime_header =
             fs::read_to_string(repo_root.join("runtime/stasis_mobile_runtime.h"))
                 .expect("read mobile runtime header");
-        assert!(mobile_runtime_header.contains("typedef void (*StasisMobileEntry)(void)"));
+        assert!(mobile_runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         let bindings =
             fs::read_to_string(&summary.bindings_source).expect("read mobile AOT bindings source");
+        assert!(bindings.contains("extern int32_t aot_fn_"));
         assert!(bindings.contains("void stasis_aot_bind_runtime_globals(void)"));
         assert!(bindings.contains("stasis_jit_register_code_ptr(0"));
         assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
@@ -2370,7 +2401,42 @@ mod tests {
         assert!(header.contains("#define STASIS_AOT_RENDER aot_fn_"));
         let cmake = fs::read_to_string(&summary.cmake_file).expect("read cmake file");
         assert!(cmake.contains("set(STASIS_PUBLISHED_AOT_OBJECTS"));
+        assert!(cmake.contains("${CMAKE_CURRENT_LIST_DIR}/"));
+        assert!(!cmake.contains(&output_dir.to_string_lossy().replace('\\', "/")));
         assert!(!cmake.contains("published_aot_bindings.c"));
+        let package_manifest: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.join("mobile_aot_bundle_manifest.json"))
+                .expect("read package manifest"),
+        )
+        .expect("parse package manifest");
+        assert_eq!(
+            package_manifest["engine_manifest"],
+            "engine_bundle_manifest.json"
+        );
+        assert_eq!(
+            package_manifest["symbols_header"],
+            "published_aot_symbols.h"
+        );
+        assert_eq!(
+            package_manifest["bindings_source"],
+            "published_aot_bindings.c"
+        );
+        assert_eq!(package_manifest["asset_root"], "apk_assets");
+        assert_eq!(
+            package_manifest["asset_manifest"],
+            "apk_assets/stasis_game/assets/manifest.json"
+        );
+        assert_eq!(
+            package_manifest["android_cmake_file"],
+            "published_aot_objects.cmake"
+        );
+        assert!(package_manifest["objects"]
+            .as_array()
+            .expect("objects")
+            .iter()
+            .all(|entry| entry["path"]
+                .as_str()
+                .is_some_and(|path| !Path::new(path).is_absolute())));
 
         let mut defined = BTreeSet::new();
         let mut undefined = BTreeSet::new();
@@ -2544,13 +2610,28 @@ mod tests {
             .asset_dir
             .join("stasis_game/assets/manifest.json")
             .is_file());
-        let package_manifest =
-            fs::read_to_string(&summary.package_manifest).expect("read package manifest");
-        assert!(package_manifest.contains("\"target\": \"ios-arm64\""));
-        assert!(package_manifest.contains("\"schema\": \"stasis.mobile_aot_bundle.v1\""));
-        assert!(package_manifest.contains("\"asset_manifest\""));
-        assert!(package_manifest.contains("\"function\": \"main\""));
-        assert!(package_manifest.contains(".o\""));
+        let package_manifest: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(&summary.package_manifest).expect("read package manifest"),
+        )
+        .expect("parse package manifest");
+        assert_eq!(package_manifest["target"], "ios-arm64");
+        assert_eq!(package_manifest["schema"], "stasis.mobile_aot_bundle.v1");
+        assert_eq!(
+            package_manifest["engine_manifest"],
+            "engine_bundle_manifest.json"
+        );
+        assert_eq!(package_manifest["asset_root"], "ios_assets");
+        assert_eq!(
+            package_manifest["asset_manifest"],
+            "ios_assets/stasis_game/assets/manifest.json"
+        );
+        assert!(package_manifest["objects"]
+            .as_array()
+            .expect("objects")
+            .iter()
+            .all(|entry| entry["path"]
+                .as_str()
+                .is_some_and(|path| { path.ends_with(".o") && !Path::new(path).is_absolute() })));
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
         assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -22,8 +22,22 @@ use std::process::Command;
 const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
 const COMMANDS: &[&str] = &[
-    "new", "init", "fmt", "check", "test", "run", "build", "package", "inspect", "replay",
-    "verify", "version", "env", "symbol", "help",
+    "new",
+    "init",
+    "fmt",
+    "check",
+    "test",
+    "run",
+    "build",
+    "package",
+    "package-mobile",
+    "inspect",
+    "replay",
+    "verify",
+    "version",
+    "env",
+    "symbol",
+    "help",
 ];
 
 #[derive(Debug, Parser)]
@@ -100,6 +114,15 @@ enum ToolchainCommand {
     Package {
         #[arg(long, value_enum, default_value_t = PackageTarget::Desktop)]
         target: PackageTarget,
+        #[arg(long, value_name = "PATH")]
+        out: Option<PathBuf>,
+    },
+    /// Assemble a release-only Android or iOS app project around one AOT game.
+    PackageMobile {
+        #[arg(long, value_enum)]
+        target: MobilePackageTarget,
+        #[arg(long, value_name = "PATH")]
+        entry: Option<PathBuf>,
         #[arg(long, value_name = "PATH")]
         out: Option<PathBuf>,
     },
@@ -264,6 +287,21 @@ enum PackageTarget {
     Desktop,
     AndroidArm64,
     IosArm64,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum MobilePackageTarget {
+    AndroidArm64,
+    IosArm64,
+}
+
+impl MobilePackageTarget {
+    fn package_target(self) -> PackageTarget {
+        match self {
+            Self::AndroidArm64 => PackageTarget::AndroidArm64,
+            Self::IosArm64 => PackageTarget::IosArm64,
+        }
+    }
 }
 
 impl PackageTarget {
@@ -438,6 +476,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Run { .. } => "run",
         ToolchainCommand::Build { .. } => "build",
         ToolchainCommand::Package { .. } => "package",
+        ToolchainCommand::PackageMobile { .. } => "package-mobile",
         ToolchainCommand::Inspect => "inspect",
         ToolchainCommand::Replay => "replay",
         ToolchainCommand::Verify => "verify",
@@ -503,6 +542,24 @@ fn execute(
                 ToolchainCommand::Package { target, out } => {
                     validate_optional_workspace_path(&workspace, "package output", out.as_deref())?;
                     package_workspace(&workspace, target, out.as_deref())
+                }
+                ToolchainCommand::PackageMobile { target, entry, out } => {
+                    validate_optional_workspace_path(
+                        &workspace,
+                        "mobile entry",
+                        entry.as_deref(),
+                    )?;
+                    validate_optional_workspace_path(
+                        &workspace,
+                        "package output",
+                        out.as_deref(),
+                    )?;
+                    package_mobile_command(
+                        &workspace,
+                        target,
+                        entry.as_deref(),
+                        out.as_deref(),
+                    )
                 }
                 ToolchainCommand::Inspect => inspect_workspace(&workspace),
                 ToolchainCommand::Symbol { command } => symbol_workspace(&workspace, command),
@@ -838,7 +895,12 @@ fn package_workspace(
         ));
     }
     if !matches!(target, PackageTarget::Desktop) {
-        return package_mobile_workspace(workspace, target, &package_root);
+        return package_mobile_workspace(
+            workspace,
+            target,
+            Path::new(&workspace.manifest.entry),
+            &package_root,
+        );
     }
     let staging_name = format!(
         ".{}.staging",
@@ -903,14 +965,56 @@ fn package_workspace(
     ))
 }
 
+fn package_mobile_command(
+    workspace: &Workspace,
+    target: MobilePackageTarget,
+    entry: Option<&Path>,
+    output: Option<&Path>,
+) -> Result<CommandResult, String> {
+    let target = target.package_target();
+    let entry = entry.unwrap_or_else(|| Path::new(&workspace.manifest.entry));
+    let package_root = output
+        .map(|path| workspace.root.join(path))
+        .unwrap_or_else(|| {
+            workspace.root.join("dist").join(format!(
+                "{}-{}",
+                workspace.manifest.name,
+                target.as_str()
+            ))
+        });
+    validate_workspace_destination(workspace, "package output", &package_root)?;
+    package_mobile_workspace(workspace, target, entry, &package_root)
+}
+
 fn package_mobile_workspace(
     workspace: &Workspace,
     target: PackageTarget,
+    entry: &Path,
     package_root: &Path,
 ) -> Result<CommandResult, String> {
-    fs::create_dir_all(package_root)
-        .map_err(|error| format!("failed to create {}: {error}", package_root.display()))?;
+    if package_root.exists() {
+        return Err(format!(
+            "package output already exists: {}",
+            package_root.display()
+        ));
+    }
+    let staging_root = package_root.with_file_name(format!(
+        ".{}.staging",
+        package_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("stasis-mobile")
+    ));
+    if staging_root.exists() {
+        return Err(format!(
+            "package staging output already exists: {}",
+            staging_root.display()
+        ));
+    }
+    fs::create_dir_all(&staging_root)
+        .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
     let child_result = (|| -> Result<(), String> {
+        let aot_root = staging_root.join("aot");
         let executable = env::current_exe()
             .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
         let child = Command::new(executable)
@@ -920,9 +1024,9 @@ fn package_mobile_workspace(
             .arg("--project-dir")
             .arg(&workspace.root)
             .arg("--entry-file")
-            .arg(&workspace.manifest.entry)
+            .arg(entry)
             .arg("--out-dir")
-            .arg(package_root)
+            .arg(&aot_root)
             .output()
             .map_err(|error| format!("failed to launch mobile AOT packaging: {error}"))?;
         if !child.status.success() {
@@ -933,16 +1037,203 @@ fn package_mobile_workspace(
                 String::from_utf8_lossy(&child.stderr).trim()
             ));
         }
+        assemble_mobile_shell(workspace, target, &aot_root, &staging_root)?;
         Ok(())
     })();
     if let Err(error) = child_result {
-        let _ = fs::remove_dir_all(package_root);
+        let _ = fs::remove_dir_all(&staging_root);
         return Err(error);
     }
+    fs::rename(&staging_root, package_root).map_err(|error| {
+        let _ = fs::remove_dir_all(&staging_root);
+        format!(
+            "failed to publish mobile package {}: {error}",
+            package_root.display()
+        )
+    })?;
     Ok(CommandResult::success(
         format!("packaged {} at {}", target.as_str(), package_root.display()),
-        json!({"target": target.as_str(), "output": display_path(package_root)}),
+        json!({
+            "target": target.as_str(),
+            "output": display_path(package_root),
+            "entry": display_path(entry),
+            "project": match target {
+                PackageTarget::AndroidArm64 => "android",
+                PackageTarget::IosArm64 => "ios/StasisMobile.xcodeproj",
+                PackageTarget::Desktop => unreachable!(),
+            },
+        }),
     ))
+}
+
+fn assemble_mobile_shell(
+    workspace: &Workspace,
+    target: PackageTarget,
+    aot_root: &Path,
+    staging_root: &Path,
+) -> Result<(), String> {
+    let mobile_assets = bundled_mobile_assets_dir()?;
+    let runtime = bundled_mobile_runtime_dir()?;
+    let platform = match target {
+        PackageTarget::AndroidArm64 => "android",
+        PackageTarget::IosArm64 => "ios",
+        PackageTarget::Desktop => return Err("desktop is not a mobile package target".to_string()),
+    };
+    let common_destination = staging_root.join("common");
+    let platform_destination = staging_root.join(platform);
+    copy_required_dir(&mobile_assets.join("common"), &common_destination)?;
+    copy_required_dir(&mobile_assets.join(platform), &platform_destination)?;
+    copy_mobile_runtime(&runtime, &staging_root.join("runtime"))?;
+
+    let asset_source = match target {
+        PackageTarget::AndroidArm64 => aot_root.join("apk_assets/stasis_game"),
+        PackageTarget::IosArm64 => aot_root.join("ios_assets/stasis_game"),
+        PackageTarget::Desktop => unreachable!(),
+    };
+    let asset_destination = match target {
+        PackageTarget::AndroidArm64 => staging_root.join("android/app/src/main/assets/stasis_game"),
+        PackageTarget::IosArm64 => staging_root.join("ios/StasisMobile/stasis_game"),
+        PackageTarget::Desktop => unreachable!(),
+    };
+    let package_id = mobile_package_id(&workspace.manifest.name);
+    let jni_package = package_id.replace('.', "_");
+    let replacements = [
+        ("@STASIS_APP_NAME@", workspace.manifest.name.as_str()),
+        ("@STASIS_PACKAGE_ID@", package_id.as_str()),
+        ("@STASIS_JNI_PACKAGE@", jni_package.as_str()),
+    ];
+    replace_shell_tokens(&common_destination, &replacements)?;
+    replace_shell_tokens(&platform_destination, &replacements)?;
+    copy_required_dir(&asset_source, &asset_destination)?;
+    if !asset_destination.join("assets/manifest.json").is_file() {
+        return Err(format!(
+            "mobile AOT bundle is missing asset manifest: {}",
+            asset_destination.join("assets/manifest.json").display()
+        ));
+    }
+    if matches!(target, PackageTarget::IosArm64) {
+        write_ios_object_config(aot_root, &staging_root.join("ios/StasisMobile.xcconfig"))?;
+    }
+    fs::write(
+        staging_root.join("stasis_mobile_package.json"),
+        serde_json::to_string_pretty(&json!({
+            "schema": "stasis.mobile_package.v1",
+            "target": target.as_str(),
+            "name": workspace.manifest.name,
+            "aot_manifest": "aot/mobile_aot_bundle_manifest.json",
+            "assets": match target {
+                PackageTarget::AndroidArm64 => "android/app/src/main/assets/stasis_game",
+                PackageTarget::IosArm64 => "ios/StasisMobile/stasis_game",
+                PackageTarget::Desktop => unreachable!(),
+            },
+        }))
+        .map_err(|error| format!("failed to encode mobile package manifest: {error}"))?
+            + "\n",
+    )
+    .map_err(|error| format!("failed to write mobile package manifest: {error}"))?;
+    Ok(())
+}
+
+fn mobile_package_id(project_name: &str) -> String {
+    let mut component = "game".to_string();
+    for byte in project_name.bytes() {
+        if byte.is_ascii_alphanumeric() {
+            component.push((byte as char).to_ascii_lowercase());
+        } else {
+            component.push_str(&format!("x{byte:02x}"));
+        }
+    }
+    format!("com.stasislang.{component}")
+}
+
+fn copy_required_dir(source: &Path, destination: &Path) -> Result<(), String> {
+    if !source.is_dir() {
+        return Err(format!(
+            "required directory is missing: {}",
+            source.display()
+        ));
+    }
+    copy_dir_if_exists(source, destination)
+}
+
+fn copy_mobile_runtime(source: &Path, destination: &Path) -> Result<(), String> {
+    fs::create_dir_all(destination)
+        .map_err(|error| format!("failed to create {}: {error}", destination.display()))?;
+    for name in [
+        "CMakeLists.txt",
+        "nanosvg.h",
+        "nanosvgrast.h",
+        "stasis_graphics.c",
+        "stasis_mobile_aot_runtime.c",
+        "stasis_mobile_aot_runtime.h",
+        "stasis_mobile_runtime.c",
+        "stasis_mobile_runtime.h",
+        "stb_truetype.h",
+    ] {
+        copy_file(&source.join(name), &destination.join(name))?;
+    }
+    Ok(())
+}
+
+fn replace_shell_tokens(root: &Path, replacements: &[(&str, &str)]) -> Result<(), String> {
+    for entry in
+        fs::read_dir(root).map_err(|error| format!("failed to read {}: {error}", root.display()))?
+    {
+        let path = entry
+            .map_err(|error| format!("failed to read {} entry: {error}", root.display()))?
+            .path();
+        if path.is_dir() {
+            replace_shell_tokens(&path, replacements)?;
+            continue;
+        }
+        let Ok(mut source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let original = source.clone();
+        for (token, value) in replacements {
+            source = source.replace(token, value);
+        }
+        if source != original {
+            fs::write(&path, source)
+                .map_err(|error| format!("failed to update {}: {error}", path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_ios_object_config(aot_root: &Path, output: &Path) -> Result<(), String> {
+    let mut objects = Vec::new();
+    for entry in fs::read_dir(aot_root)
+        .map_err(|error| format!("failed to read {}: {error}", aot_root.display()))?
+    {
+        let path = entry
+            .map_err(|error| format!("failed to read {} entry: {error}", aot_root.display()))?
+            .path();
+        if path.extension().and_then(|value| value.to_str()) == Some("o") {
+            objects.push(path);
+        }
+    }
+    objects.sort();
+    if objects.is_empty() {
+        return Err("mobile AOT bundle did not emit any object files".to_string());
+    }
+    let object_flags = objects
+        .iter()
+        .map(|path| {
+            format!(
+                "$(PROJECT_DIR)/../aot/{}",
+                path.file_name().unwrap_or_default().to_string_lossy()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    fs::write(
+        output,
+        format!(
+            "GCC_PREPROCESSOR_DEFINITIONS = $(inherited) STASIS_GRAPHICS_SDL_ONLY=1\nFRAMEWORK_SEARCH_PATHS = $(inherited) $(STASIS_SDL_FRAMEWORKS)/SDL2.xcframework/ios-arm64 $(STASIS_SDL_FRAMEWORKS)/SDL2_image.xcframework/ios-arm64\nHEADER_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/../aot $(PROJECT_DIR)/../runtime $(STASIS_SDL_FRAMEWORKS)/SDL2.xcframework/ios-arm64/SDL2.framework/Headers $(STASIS_SDL_FRAMEWORKS)/SDL2_image.xcframework/ios-arm64/SDL2_image.framework/Headers\nLD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks\nOTHER_LDFLAGS = $(inherited) -framework SDL2 -framework SDL2_image {object_flags}\n"
+        ),
+    )
+    .map_err(|error| format!("failed to write {}: {error}", output.display()))
 }
 
 impl SymbolSelectorArgs {
@@ -1481,6 +1772,33 @@ fn bundled_stdlib_dir() -> Result<PathBuf, String> {
     )
 }
 
+fn bundled_mobile_assets_dir() -> Result<PathBuf, String> {
+    bundled_toolchain_directory("mobile/shells", "mobile shell templates")
+}
+
+fn bundled_mobile_runtime_dir() -> Result<PathBuf, String> {
+    bundled_toolchain_directory("runtime", "mobile runtime sources")
+}
+
+fn bundled_toolchain_directory(relative: &str, label: &str) -> Result<PathBuf, String> {
+    let executable = env::current_exe()
+        .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
+    let executable_dir = executable.parent().unwrap_or(Path::new("."));
+    let source_tree = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    for candidate in [
+        executable_dir.join(relative),
+        executable_dir.join("..").join(relative),
+        source_tree.join(relative),
+    ] {
+        if candidate.is_dir() {
+            return Ok(candidate);
+        }
+    }
+    Err(format!(
+        "installed toolchain is missing {relative} ({label}); reinstall the complete release archive"
+    ))
+}
+
 fn collect_stasis_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
     if !root.exists() {
         return Ok(());
@@ -1705,6 +2023,135 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn package_mobile_cli_accepts_entry_override() {
+        let parsed = ToolchainCli::try_parse_from([
+            "stasis",
+            "--workspace",
+            "demo",
+            "package-mobile",
+            "--target",
+            "ios-arm64",
+            "--entry",
+            "src/mobile.stasis",
+            "--out",
+            "dist/ios",
+        ])
+        .expect("parse package-mobile flags");
+        assert!(matches!(
+            parsed.command,
+            ToolchainCommand::PackageMobile {
+                target: MobilePackageTarget::IosArm64,
+                entry: Some(ref entry),
+                out: Some(ref out),
+            } if entry == Path::new("src/mobile.stasis") && out == Path::new("dist/ios")
+        ));
+    }
+
+    #[test]
+    fn mobile_package_ids_are_valid_for_java_and_apple() {
+        assert_eq!(
+            mobile_package_id("mobile_game"),
+            "com.stasislang.gamemobilex5fgame"
+        );
+        assert_eq!(
+            mobile_package_id("123-game"),
+            "com.stasislang.game123x2dgame"
+        );
+        for name in ["mobile_game", "123-game"] {
+            let package_id = mobile_package_id(name);
+            let component = package_id.rsplit('.').next().expect("package component");
+            assert!(component
+                .chars()
+                .next()
+                .is_some_and(|value| value.is_ascii_alphabetic()));
+            assert!(component.chars().all(|value| value.is_ascii_alphanumeric()));
+        }
+    }
+
+    #[test]
+    fn mobile_shells_are_platform_projects_over_one_shared_runtime() {
+        let root = temp_dir("mobile_shells");
+        let aot = root.join("aot");
+        fs::create_dir_all(aot.join("apk_assets/stasis_game/assets"))
+            .expect("create Android AOT assets");
+        fs::create_dir_all(aot.join("ios_assets/stasis_game/assets"))
+            .expect("create iOS AOT assets");
+        fs::write(aot.join("game.o"), b"object").expect("write object");
+        fs::write(
+            aot.join("apk_assets/stasis_game/assets/manifest.json"),
+            "{\"schema\":\"stasis-assets\",\"version\":1,\"assets\":[]}",
+        )
+        .expect("write Android asset manifest");
+        fs::write(
+            aot.join("apk_assets/stasis_game/assets/token.txt"),
+            "@STASIS_APP_NAME@ @STASIS_PACKAGE_ID@",
+        )
+        .expect("write Android token asset");
+        fs::write(
+            aot.join("ios_assets/stasis_game/assets/manifest.json"),
+            "{\"schema\":\"stasis-assets\",\"version\":1,\"assets\":[]}",
+        )
+        .expect("write iOS asset manifest");
+        let workspace = Workspace {
+            root: root.clone(),
+            manifest: ProjectManifest::new("mobile_smoke".to_string()),
+        };
+
+        let android = root.join("android-package");
+        fs::create_dir_all(&android).expect("create Android staging");
+        assemble_mobile_shell(&workspace, PackageTarget::AndroidArm64, &aot, &android)
+            .expect("assemble Android shell");
+        let android_cmake =
+            fs::read_to_string(android.join("android/app/src/main/cpp/CMakeLists.txt"))
+                .expect("read Android CMake");
+        assert!(android_cmake.contains("stasis_mobile_runtime"));
+        assert!(android_cmake.contains("STASIS_AOT_OBJECTS"));
+        assert!(!android_cmake.contains("stasis_dynload"));
+        assert!(android
+            .join("android/app/src/main/assets/stasis_game/assets/manifest.json")
+            .is_file());
+        assert_eq!(
+            fs::read_to_string(
+                android.join("android/app/src/main/assets/stasis_game/assets/token.txt")
+            )
+            .expect("read packaged token asset"),
+            "@STASIS_APP_NAME@ @STASIS_PACKAGE_ID@"
+        );
+        let java = fs::read_to_string(
+            android.join("android/app/src/main/java/com/stasislang/game/MainActivity.java"),
+        )
+        .expect("read Android activity");
+        assert!(java.contains(".stasis_game.staging"));
+        let jni =
+            fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
+                .expect("read Android asset bridge");
+        assert!(
+            jni.contains("Java_com_stasislang_gamemobilex5fsmoke_MainActivity_nativeSetAssetRoot")
+        );
+        assert!(!jni.contains("@STASIS_"));
+
+        let ios = root.join("ios-package");
+        fs::create_dir_all(&ios).expect("create iOS staging");
+        assemble_mobile_shell(&workspace, PackageTarget::IosArm64, &aot, &ios)
+            .expect("assemble iOS shell");
+        let project = fs::read_to_string(ios.join("ios/StasisMobile.xcodeproj/project.pbxproj"))
+            .expect("read Xcode project");
+        let config =
+            fs::read_to_string(ios.join("ios/StasisMobile.xcconfig")).expect("read Xcode config");
+        assert!(project.contains("stasis_mobile_runtime.c in Sources"));
+        assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
+        assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
+        assert!(config.contains("@executable_path/Frameworks"));
+        assert!(project.contains("Embed SDL frameworks"));
+        assert!(ios
+            .join("ios/StasisMobile/stasis_game/assets/manifest.json")
+            .is_file());
+        assert!(!project.contains("@STASIS_"));
+
+        remove_temp(&root);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -2110,6 +2110,12 @@ mod tests {
         assert!(android_cmake.contains("stasis_mobile_runtime"));
         assert!(android_cmake.contains("STASIS_AOT_OBJECTS"));
         assert!(!android_cmake.contains("stasis_dynload"));
+        let mobile_main = fs::read_to_string(android.join("common/stasis_mobile_main.c"))
+            .expect("read shared mobile main");
+        assert!(mobile_main.contains("stasis_mobile_runtime_last_entry_result"));
+        let runtime_header = fs::read_to_string(android.join("runtime/stasis_mobile_runtime.h"))
+            .expect("read shared mobile runtime header");
+        assert!(runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         assert!(android
             .join("android/app/src/main/assets/stasis_game/assets/manifest.json")
             .is_file());

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -411,6 +411,92 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
 }
 
 #[test]
+fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
+    let parent = temp_dir("mobile_package");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("mobile_game");
+    let created = stasis(&["new", "mobile_game", "--dir", "mobile_game"], &parent);
+    assert_eq!(created.status.code(), Some(0));
+    fs::write(
+        project.join("src/main.stasis"),
+        "function main(): i32 { return 0; }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
+    )
+    .expect("write mobile entry");
+    fs::create_dir_all(project.join("assets")).expect("create assets");
+    fs::write(
+        project.join("assets/manifest.json"),
+        "{\n  \"schema\": \"stasis-assets\",\n  \"version\": 1,\n  \"assets\": []\n}\n",
+    )
+    .expect("write asset manifest");
+
+    for (target, output) in [("android-arm64", "android"), ("ios-arm64", "ios")] {
+        let packaged = stasis(
+            &[
+                "package-mobile",
+                "--target",
+                target,
+                "--entry",
+                "src/main.stasis",
+                "--out",
+                output,
+            ],
+            &project,
+        );
+        assert_eq!(
+            packaged.status.code(),
+            Some(0),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&packaged.stdout),
+            String::from_utf8_lossy(&packaged.stderr)
+        );
+        assert!(project
+            .join(output)
+            .join("stasis_mobile_package.json")
+            .is_file());
+        assert!(project
+            .join(output)
+            .join("aot/mobile_aot_bundle_manifest.json")
+            .is_file());
+    }
+    assert!(project
+        .join("android/android/app/src/main/cpp/CMakeLists.txt")
+        .is_file());
+    assert!(project
+        .join("android/android/app/src/main/assets/stasis_game/assets/manifest.json")
+        .is_file());
+    assert!(project
+        .join("ios/ios/StasisMobile.xcodeproj/project.pbxproj")
+        .is_file());
+    assert!(project
+        .join("ios/ios/StasisMobile/stasis_game/assets/manifest.json")
+        .is_file());
+    assert!(!walk_files(&project.join("android"))
+        .iter()
+        .any(|path| path.extension().and_then(|value| value.to_str()) == Some("stasis")));
+    assert!(!walk_files(&project.join("ios"))
+        .iter()
+        .any(|path| path.extension().and_then(|value| value.to_str()) == Some("stasis")));
+
+    fs::write(project.join("src/main.stasis"), "function main(: i32 {\n")
+        .expect("write invalid mobile entry");
+    let failed = stasis(
+        &[
+            "package-mobile",
+            "--target",
+            "android-arm64",
+            "--out",
+            "broken",
+        ],
+        &project,
+    );
+    assert_eq!(failed.status.code(), Some(1));
+    assert!(!project.join("broken").exists());
+    assert!(!project.join(".broken.staging").exists());
+
+    fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
 fn semantic_symbol_cli_supports_inline_crud_and_stale_guards() {
     let parent = temp_dir("semantic_inline");
     fs::create_dir_all(&parent).expect("create temp parent");
@@ -894,4 +980,20 @@ fn semantic_symbol_cli_reapplies_edit_when_revert_tests_fail() {
         accepted_source
     );
     fs::remove_dir_all(parent).ok();
+}
+
+fn walk_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory).expect("read directory") {
+            let path = entry.expect("read entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+    files
 }

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -453,10 +453,32 @@ fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
             .join(output)
             .join("stasis_mobile_package.json")
             .is_file());
-        assert!(project
+        let aot_manifest_path = project
             .join(output)
-            .join("aot/mobile_aot_bundle_manifest.json")
-            .is_file());
+            .join("aot/mobile_aot_bundle_manifest.json");
+        assert!(aot_manifest_path.is_file());
+        let aot_manifest: Value = serde_json::from_str(
+            &fs::read_to_string(&aot_manifest_path).expect("read mobile AOT manifest"),
+        )
+        .expect("parse mobile AOT manifest");
+        for field in [
+            "engine_manifest",
+            "symbols_header",
+            "bindings_source",
+            "asset_root",
+            "asset_manifest",
+        ] {
+            let path = aot_manifest[field].as_str().expect("manifest path");
+            assert!(!Path::new(path).is_absolute(), "{field} must be relative");
+            assert!(!path.contains(".staging"), "{field} must survive publish");
+        }
+        assert!(aot_manifest["objects"]
+            .as_array()
+            .expect("manifest objects")
+            .iter()
+            .all(|entry| entry["path"].as_str().is_some_and(|path| {
+                !Path::new(path).is_absolute() && !path.contains(".staging")
+            })));
     }
     assert!(project
         .join("android/android/app/src/main/cpp/CMakeLists.txt")

--- a/docs/mobile_aot_artifacts.md
+++ b/docs/mobile_aot_artifacts.md
@@ -32,3 +32,6 @@ Each bundle contains:
 The older `android-aot-bundle` command remains as an Android compatibility
 wrapper and writes `published_aot_objects.cmake` for the Android shell. Android
 published builds pass the descriptor-owned `entrySource` as `--entry-file`.
+
+Ordinary users should use `stasis package-mobile`; the raw bundle subcommands
+are compiler/shell integration seams. See `docs/mobile_packaging.md`.

--- a/docs/mobile_aot_artifacts.md
+++ b/docs/mobile_aot_artifacts.md
@@ -29,6 +29,10 @@ Each bundle contains:
 - `apk_assets/stasis_game/...` for Android assets or `ios_assets/stasis_game/...`
   for iOS assets.
 
+All paths in `mobile_aot_bundle_manifest.json` are relative to its containing
+directory, so the bundle remains valid when atomic staging is renamed to the
+final package path.
+
 The older `android-aot-bundle` command remains as an Android compatibility
 wrapper and writes `published_aot_objects.cmake` for the Android shell. Android
 published builds pass the descriptor-owned `entrySource` as `--entry-file`.

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -1,0 +1,57 @@
+# Lean mobile packaging
+
+Stasis mobile releases are AOT-only, one game per app, and arm64-only. The one
+Stasis-specific command is:
+
+```text
+stasis --workspace path/to/game package-mobile --target android-arm64
+stasis --workspace path/to/game package-mobile --target ios-arm64
+```
+
+`stasis.json` supplies the entry source. Use `--entry path/to/main.stasis` to
+select another project-relative import root and `--out path` to select a new,
+nonexistent output directory. Packaging is atomic: compiler or file failures do
+not publish a partial app project.
+
+Each output contains the same pieces:
+
+- `aot/`: target-native game objects, generated entry bindings, ABI metadata
+- `runtime/`: the shared SDL-only mobile runtime sources
+- `common/`: the fixed `SDL_main` lifecycle adapter
+- `stasis_mobile_package.json`: the versioned package receipt
+- `android/` or `ios/`: a thin platform-native app project
+
+No package contains the Stasis compiler, JIT, watcher, dynamic game loader, or
+writable Stasis source.
+
+## Android arm64
+
+Install JDK 17, Android SDK 35, NDK, CMake 3.22.1, Ninja, and Gradle 8.9. Keep
+local SDL2 and SDL2_image source checkouts and set:
+
+```text
+STASIS_SDL2_SOURCE=/absolute/path/to/SDL
+STASIS_SDL2_IMAGE_SOURCE=/absolute/path/to/SDL_image
+```
+
+From the generated `android/` directory run `gradle :app:assembleDebug` or
+`gradle :app:installDebug`. Gradle/CMake builds only `arm64-v8a`, compiles the
+shared runtime, links the generated AOT objects, and packages
+`assets/stasis_game`. No vcpkg installation is used.
+
+## iOS arm64
+
+On macOS install Xcode and obtain device-capable `SDL2.xcframework` and
+`SDL2_image.xcframework` bundles in one directory. From generated `ios/` run:
+
+```text
+xcodebuild -project StasisMobile.xcodeproj -scheme StasisMobile \
+  -configuration Debug -sdk iphoneos -arch arm64 \
+  STASIS_SDL_FRAMEWORKS=/absolute/path/to/frameworks \
+  DEVELOPMENT_TEAM=YOUR_TEAM_ID build
+```
+
+The checked-in Xcode shell compiles the same runtime, links the iOS AOT objects,
+and copies `StasisMobile/stasis_game` into the app resources. Device arm64 is
+the v1 target; simulator and multi-architecture packaging are intentionally out
+of scope.

--- a/docs/mobile_packaging_abi.md
+++ b/docs/mobile_packaging_abi.md
@@ -73,11 +73,9 @@ Required outputs:
 - `stasis_mobile_abi.json`, a versioned metadata file described below
 - packaged assets under the platform bundle root described below
 
-The current Android AOT bundle helper already writes generated symbol and link
-metadata for Android packaging, but it does not yet satisfy this full contract:
-mobile v1 must also carry the `main` entrypoint and the versioned ABI metadata
-below. Follow-up mobile tasks should converge Android and iOS on this contract
-instead of adding platform-specific symbol discovery.
+The shared mobile AOT helper writes the fixed entry symbols, link inputs, and
+asset metadata consumed by both generated platform shells. Neither shell
+discovers symbols independently.
 
 ### Metadata Schema
 
@@ -177,5 +175,6 @@ Follow-up tasks should use this note as their contract boundary:
 - AOT emission work should produce the linkable outputs and metadata above.
 - Android shell work should consume those outputs for one `arm64-v8a` app.
 - iOS shell work should consume the same outputs for one `arm64` app.
-- The eventual `package-mobile` command should be a thin orchestration layer
-  around this contract.
+- `package-mobile` is the thin orchestration layer around this contract; it
+  copies the AOT bundle into a Gradle or Xcode shell without adding another
+  compiler or runtime path.

--- a/docs/mobile_runtime_core.md
+++ b/docs/mobile_runtime_core.md
@@ -29,8 +29,10 @@ while (status == STASIS_MOBILE_RUNTIME_OK) {
 stasis_mobile_runtime_shutdown();
 ```
 
-The generated AOT symbol header declares each entry as `void(void)` and is the
-source of the actual symbol names. The generated `published_aot_bindings.c`
+The generated AOT symbol header declares `main`, `tick`, and `render` as
+`int32_t(void)` and is the source of the actual symbol names. The runtime turns
+any non-zero entry result into a stop request and retains the exact result for
+the platform shell to log or return. The generated `published_aot_bindings.c`
 registers linked function pointers and string literals with the shared AOT
 state/dispatch layer; shells compile it as an ordinary source file and do not
 discover symbols dynamically.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -33,6 +33,8 @@ stasis run --watch
 stasis build --mode dev
 stasis build --mode release
 stasis package --target desktop
+stasis package-mobile --target android-arm64
+stasis package-mobile --target ios-arm64
 ```
 
 `stasis init --name brick_game .` initializes an existing directory. The built-in template copies
@@ -75,7 +77,9 @@ runnable `main()` and a real `.test.stasis` test.
   `build/`.
 - `package --target desktop`: create a standalone directory with the AOT executable, manifest,
   assets, and graphics runtime when present.
-- `package --target android-arm64|ios-arm64`: delegate to the shared mobile AOT bundle pipeline.
+- `package-mobile --target android-arm64|ios-arm64 [--entry PATH]`: atomically assemble the
+  shared AOT output, SDL-only runtime, bundled assets, and thin Gradle or Xcode app shell.
+- `package --target android-arm64|ios-arm64`: compatibility spelling that uses the manifest entry.
 - `inspect`, `version`, and `env`: report workspace, installation, cache, and output locations.
 
 `replay` and `verify` intentionally return deterministic unsupported diagnostics until the replay

--- a/mobile/shells/android/README.md
+++ b/mobile/shells/android/README.md
@@ -1,0 +1,15 @@
+# Android arm64 package
+
+Install JDK 17, Android SDK 35, NDK, CMake 3.22.1, Ninja, and Gradle 8.9.
+Set `ANDROID_HOME`, `STASIS_SDL2_SOURCE`, and `STASIS_SDL2_IMAGE_SOURCE` to
+local SDL2 and SDL2_image source checkouts, then run:
+
+```text
+gradle :app:assembleDebug
+gradle :app:installDebug
+```
+
+Only `arm64-v8a` is built. The app links the AOT objects under `../aot`, the
+shared SDL-only Stasis runtime under `../runtime`, and bundled assets under
+`app/src/main/assets/stasis_game`. No Stasis compiler, JIT, watcher, dynamic
+game loader, or writable source is included.

--- a/mobile/shells/android/app/build.gradle
+++ b/mobile/shells/android/app/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'com.android.application'
+}
+
+def sdl2Source = providers.gradleProperty('stasisSdl2Source')
+        .orElse(providers.environmentVariable('STASIS_SDL2_SOURCE'))
+def sdl2ImageSource = providers.gradleProperty('stasisSdl2ImageSource')
+        .orElse(providers.environmentVariable('STASIS_SDL2_IMAGE_SOURCE'))
+if (!sdl2Source.isPresent() || !sdl2ImageSource.isPresent()) {
+    throw new GradleException('Set STASIS_SDL2_SOURCE and STASIS_SDL2_IMAGE_SOURCE to SDL2 and SDL2_image source trees')
+}
+
+android {
+    namespace '@STASIS_PACKAGE_ID@'
+    compileSdk 35
+
+    defaultConfig {
+        applicationId '@STASIS_PACKAGE_ID@'
+        minSdk 26
+        targetSdk 35
+        versionCode 1
+        versionName '1.0'
+        ndk {
+            abiFilters 'arm64-v8a'
+        }
+        externalNativeBuild {
+            cmake {
+                arguments '-DSTASIS_SDL2_SOURCE=' + sdl2Source.get(),
+                        '-DSTASIS_SDL2_IMAGE_SOURCE=' + sdl2ImageSource.get()
+            }
+        }
+    }
+
+    sourceSets.main.java.srcDir(new File(sdl2Source.get(), 'android-project/app/src/main/java'))
+    externalNativeBuild {
+        cmake {
+            path 'src/main/cpp/CMakeLists.txt'
+            version '3.22.1'
+        }
+    }
+}

--- a/mobile/shells/android/app/src/main/AndroidManifest.xml
+++ b/mobile/shells/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
+    <application
+        android:allowBackup="false"
+        android:label="@STASIS_APP_NAME@"
+        android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
+            android:exported="true"
+            android:screenOrientation="sensorLandscape">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(stasis_mobile_android C)
+
+if(NOT STASIS_SDL2_SOURCE OR NOT STASIS_SDL2_IMAGE_SOURCE)
+    message(FATAL_ERROR "STASIS_SDL2_SOURCE and STASIS_SDL2_IMAGE_SOURCE are required")
+endif()
+
+set(STASIS_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../../..")
+set(STASIS_AOT_DIR "${STASIS_ROOT}/aot")
+set(STASIS_BUILD_MOBILE_RUNTIME ON CACHE BOOL "" FORCE)
+set(STASIS_GRAPHICS_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+set(STASIS_GRAPHICS_BUILD_STATIC OFF CACHE BOOL "" FORCE)
+set(STASIS_BUILD_RUNNER OFF CACHE BOOL "" FORCE)
+set(STASIS_BUILD_SYS OFF CACHE BOOL "" FORCE)
+
+add_subdirectory("${STASIS_SDL2_SOURCE}" "${CMAKE_BINARY_DIR}/sdl2")
+set(SDL2IMAGE_SAMPLES OFF CACHE BOOL "" FORCE)
+set(SDL2IMAGE_TESTS OFF CACHE BOOL "" FORCE)
+add_subdirectory("${STASIS_SDL2_IMAGE_SOURCE}" "${CMAKE_BINARY_DIR}/sdl2_image")
+add_subdirectory("${STASIS_ROOT}/runtime" "${CMAKE_BINARY_DIR}/stasis_runtime")
+
+file(GLOB STASIS_AOT_OBJECTS CONFIGURE_DEPENDS "${STASIS_AOT_DIR}/*.o")
+if(NOT STASIS_AOT_OBJECTS)
+    message(FATAL_ERROR "No Android AOT objects found in ${STASIS_AOT_DIR}")
+endif()
+
+add_library(main SHARED
+    "${STASIS_ROOT}/common/stasis_mobile_main.c"
+    "${CMAKE_CURRENT_LIST_DIR}/stasis_android_assets.c"
+    "${STASIS_AOT_DIR}/published_aot_bindings.c"
+    ${STASIS_AOT_OBJECTS}
+)
+target_include_directories(main PRIVATE "${STASIS_AOT_DIR}" "${STASIS_ROOT}/runtime")
+target_link_libraries(main PRIVATE stasis_mobile_runtime SDL2::SDL2 SDL2_image::SDL2_image log android)

--- a/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
+++ b/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
@@ -1,0 +1,17 @@
+#include <jni.h>
+#include <stdlib.h>
+
+JNIEXPORT void JNICALL
+Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetAssetRoot(
+    JNIEnv *env,
+    jclass activity,
+    jstring path
+) {
+    (void)activity;
+    const char *root = (*env)->GetStringUTFChars(env, path, NULL);
+    if (root == NULL) {
+        return;
+    }
+    setenv("STASIS_ASSET_ROOT", root, 1);
+    (*env)->ReleaseStringUTFChars(env, path, root);
+}

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -1,0 +1,80 @@
+package @STASIS_PACKAGE_ID@;
+
+import android.content.res.AssetManager;
+import android.os.Bundle;
+import org.libsdl.app.SDLActivity;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class MainActivity extends SDLActivity {
+    private static native void nativeSetAssetRoot(String path);
+
+    @Override
+    protected void onCreate(Bundle state) {
+        System.loadLibrary("SDL2");
+        System.loadLibrary("SDL2_image");
+        System.loadLibrary("main");
+        File root = new File(getFilesDir(), "stasis_game");
+        File staging = new File(getFilesDir(), ".stasis_game.staging");
+        try {
+            deleteTree(staging);
+            copyAssetTree(getAssets(), "stasis_game", staging);
+            deleteTree(root);
+            if (!staging.renameTo(root)) {
+                throw new IOException("Unable to publish " + root);
+            }
+        } catch (IOException error) {
+            throw new IllegalStateException("Unable to install bundled Stasis assets", error);
+        }
+        nativeSetAssetRoot(root.getAbsolutePath());
+        super.onCreate(state);
+    }
+
+    private static void copyAssetTree(AssetManager assets, String assetPath, File output)
+            throws IOException {
+        String[] children = assets.list(assetPath);
+        if (children != null && children.length > 0) {
+            if (!output.isDirectory() && !output.mkdirs()) {
+                throw new IOException("Unable to create " + output);
+            }
+            for (String child : children) {
+                copyAssetTree(assets, assetPath + "/" + child, new File(output, child));
+            }
+            return;
+        }
+        File parent = output.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("Unable to create " + parent);
+        }
+        try (InputStream input = assets.open(assetPath);
+                FileOutputStream stream = new FileOutputStream(output)) {
+            byte[] buffer = new byte[16384];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                stream.write(buffer, 0, count);
+            }
+        }
+    }
+
+    private static void deleteTree(File path) throws IOException {
+        if (!path.exists()) {
+            return;
+        }
+        File[] children = path.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteTree(child);
+            }
+        }
+        if (!path.delete()) {
+            throw new IOException("Unable to remove " + path);
+        }
+    }
+
+    @Override
+    protected String[] getLibraries() {
+        return new String[] {"SDL2", "SDL2_image", "main"};
+    }
+}

--- a/mobile/shells/android/build.gradle
+++ b/mobile/shells/android/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.application' version '8.7.3' apply false
+}

--- a/mobile/shells/android/gradle.properties
+++ b/mobile/shells/android/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true

--- a/mobile/shells/android/settings.gradle
+++ b/mobile/shells/android/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = '@STASIS_APP_NAME@'
+include ':app'

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -44,6 +44,11 @@ int SDL_main(int argc, char **argv) {
         status = stasis_mobile_runtime_step();
         SDL_Delay(1);
     }
+    int32_t game_result = stasis_mobile_runtime_last_entry_result();
     stasis_mobile_runtime_shutdown();
+    if (game_result != 0) {
+        SDL_Log("Stasis game entry requested stop with code %d", game_result);
+        return game_result;
+    }
     return status == STASIS_MOBILE_RUNTIME_STOP_REQUESTED ? 0 : status;
 }

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -1,0 +1,49 @@
+#define SDL_MAIN_HANDLED
+#include <SDL.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "published_aot_symbols.h"
+#include "stasis_mobile_runtime.h"
+
+static int configure_asset_root(void) {
+#if defined(__APPLE__) && !defined(__ANDROID__)
+    char *base = SDL_GetBasePath();
+    if (base == NULL) {
+        return -1;
+    }
+    char path[1024];
+    int written = snprintf(path, sizeof(path), "%sstasis_game", base);
+    SDL_free(base);
+    if (written < 0 || (size_t)written >= sizeof(path)) {
+        return -1;
+    }
+    return setenv("STASIS_ASSET_ROOT", path, 1);
+#else
+    return 0;
+#endif
+}
+
+int SDL_main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+    if (configure_asset_root() != 0) {
+        SDL_Log("Stasis could not configure the bundled asset root");
+        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
+    }
+    StasisMobileGameEntries game = {
+        STASIS_AOT_BIND_RUNTIME_GLOBALS,
+        STASIS_AOT_MAIN,
+        STASIS_AOT_TICK,
+        STASIS_AOT_RENDER,
+    };
+    StasisMobileRuntimeConfig config = {1280, 720, "@STASIS_APP_NAME@"};
+    int status = stasis_mobile_runtime_initialize(&config, &game);
+    while (status == STASIS_MOBILE_RUNTIME_OK) {
+        status = stasis_mobile_runtime_step();
+        SDL_Delay(1);
+    }
+    stasis_mobile_runtime_shutdown();
+    return status == STASIS_MOBILE_RUNTIME_STOP_REQUESTED ? 0 : status;
+}

--- a/mobile/shells/ios/README.md
+++ b/mobile/shells/ios/README.md
@@ -1,0 +1,17 @@
+# iOS arm64 package
+
+On macOS, install Xcode and place device-capable `SDL2.xcframework` and
+`SDL2_image.xcframework` in one directory. Build the checked-in thin Xcode
+project with your signing team:
+
+```text
+xcodebuild -project StasisMobile.xcodeproj -scheme StasisMobile \
+  -configuration Debug -sdk iphoneos -arch arm64 \
+  STASIS_SDL_FRAMEWORKS=/absolute/path/to/frameworks \
+  DEVELOPMENT_TEAM=YOUR_TEAM_ID build
+```
+
+The target links the AOT objects from `../aot`, compiles the shared SDL-only
+runtime from `../runtime`, and copies `StasisMobile/stasis_game` into the app
+resources. It contains no JIT, hot swap, dynamic game loader, or writable
+Stasis source.

--- a/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
+++ b/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
@@ -1,0 +1,120 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {};
+	objectVersion = 56;
+	objects = {
+
+		100000000000000000000001 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000001 /* main.m */; };
+		100000000000000000000002 /* stasis_mobile_main.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000002 /* stasis_mobile_main.c */; };
+		100000000000000000000003 /* stasis_mobile_runtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000003 /* stasis_mobile_runtime.c */; };
+		100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000004 /* stasis_mobile_aot_runtime.c */; };
+		100000000000000000000005 /* stasis_graphics.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000005 /* stasis_graphics.c */; };
+		100000000000000000000006 /* published_aot_bindings.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000006 /* published_aot_bindings.c */; };
+		100000000000000000000007 /* stasis_game in Resources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000007 /* stasis_game */; };
+
+		300000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				100000000000000000000001 /* main.m in Sources */,
+				100000000000000000000002 /* stasis_mobile_main.c in Sources */,
+				100000000000000000000003 /* stasis_mobile_runtime.c in Sources */,
+				100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */,
+				100000000000000000000005 /* stasis_graphics.c in Sources */,
+				100000000000000000000006 /* published_aot_bindings.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		300000000000000000000002 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		300000000000000000000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (100000000000000000000007 /* stasis_game in Resources */);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		300000000000000000000004 /* Embed SDL frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = ();
+			inputPaths = ();
+			outputPaths = ();
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\nfor name in SDL2 SDL2_image; do\n  source=\"${STASIS_SDL_FRAMEWORKS}/${name}.xcframework/ios-arm64/${name}.framework\"\n  test -d \"${source}\" || { echo \"missing ${source}\" >&2; exit 1; }\n  destination=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n  mkdir -p \"${destination}\"\n  ditto \"${source}\" \"${destination}/${name}.framework\"\n  if test -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\"; then\n    codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${destination}/${name}.framework\"\n  fi\ndone\n";
+		};
+
+		200000000000000000000001 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StasisMobile/main.m; sourceTree = "<group>"; };
+		200000000000000000000002 /* stasis_mobile_main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../common/stasis_mobile_main.c; sourceTree = "<group>"; };
+		200000000000000000000003 /* stasis_mobile_runtime.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_mobile_runtime.c; sourceTree = "<group>"; };
+		200000000000000000000004 /* stasis_mobile_aot_runtime.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_mobile_aot_runtime.c; sourceTree = "<group>"; };
+		200000000000000000000005 /* stasis_graphics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_graphics.c; sourceTree = "<group>"; };
+		200000000000000000000006 /* published_aot_bindings.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../aot/published_aot_bindings.c; sourceTree = "<group>"; };
+		200000000000000000000007 /* stasis_game */ = {isa = PBXFileReference; lastKnownFileType = folder; path = StasisMobile/stasis_game; sourceTree = "<group>"; };
+		200000000000000000000008 /* StasisMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StasisMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		200000000000000000000009 /* StasisMobile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StasisMobile.xcconfig; sourceTree = "<group>"; };
+
+		400000000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				200000000000000000000001 /* main.m */,
+				200000000000000000000002 /* stasis_mobile_main.c */,
+				200000000000000000000003 /* stasis_mobile_runtime.c */,
+				200000000000000000000004 /* stasis_mobile_aot_runtime.c */,
+				200000000000000000000005 /* stasis_graphics.c */,
+				200000000000000000000006 /* published_aot_bindings.c */,
+				200000000000000000000007 /* stasis_game */,
+				200000000000000000000009 /* StasisMobile.xcconfig */,
+				400000000000000000000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		400000000000000000000002 /* Products */ = {isa = PBXGroup; children = (200000000000000000000008 /* StasisMobile.app */); name = Products; sourceTree = "<group>"; };
+
+		500000000000000000000001 /* StasisMobile */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 600000000000000000000002 /* Build configuration list for PBXNativeTarget */;
+			buildPhases = (300000000000000000000001 /* Sources */, 300000000000000000000002 /* Frameworks */, 300000000000000000000004 /* Embed SDL frameworks */, 300000000000000000000003 /* Resources */);
+			buildRules = ();
+			dependencies = ();
+			name = StasisMobile;
+			productName = StasisMobile;
+			productReference = 200000000000000000000008 /* StasisMobile.app */;
+			productType = "com.apple.product-type.application";
+		};
+
+		700000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {BuildIndependentTargetsInParallel = 1; LastUpgradeCheck = 1600; TargetAttributes = {500000000000000000000001 = {CreatedOnToolsVersion = 16.0; }; }; };
+			buildConfigurationList = 600000000000000000000001 /* Build configuration list for PBXProject */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (en, Base);
+			mainGroup = 400000000000000000000001;
+			productRefGroup = 400000000000000000000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (500000000000000000000001 /* StasisMobile */);
+		};
+
+		800000000000000000000001 /* Debug */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; IPHONEOS_DEPLOYMENT_TARGET = 15.0; SDKROOT = iphoneos; SUPPORTED_PLATFORMS = iphoneos; }; name = Debug; };
+		800000000000000000000002 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {ARCHS = arm64; IPHONEOS_DEPLOYMENT_TARGET = 15.0; SDKROOT = iphoneos; SUPPORTED_PLATFORMS = iphoneos; }; name = Release; };
+		800000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 200000000000000000000009 /* StasisMobile.xcconfig */;
+			buildSettings = {CLANG_C_LANGUAGE_STANDARD = c11; INFOPLIST_FILE = StasisMobile/Info.plist; PRODUCT_BUNDLE_IDENTIFIER = @STASIS_PACKAGE_ID@; PRODUCT_NAME = "$(TARGET_NAME)"; TARGETED_DEVICE_FAMILY = "1,2"; };
+			name = Debug;
+		};
+		800000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 200000000000000000000009 /* StasisMobile.xcconfig */;
+			buildSettings = {CLANG_C_LANGUAGE_STANDARD = c11; INFOPLIST_FILE = StasisMobile/Info.plist; PRODUCT_BUNDLE_IDENTIFIER = @STASIS_PACKAGE_ID@; PRODUCT_NAME = "$(TARGET_NAME)"; TARGETED_DEVICE_FAMILY = "1,2"; };
+			name = Release;
+		};
+
+		600000000000000000000001 /* Build configuration list for PBXProject */ = {isa = XCConfigurationList; buildConfigurations = (800000000000000000000001 /* Debug */, 800000000000000000000002 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		600000000000000000000002 /* Build configuration list for PBXNativeTarget */ = {isa = XCConfigurationList; buildConfigurations = (800000000000000000000003 /* Debug */, 800000000000000000000004 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+	};
+	rootObject = 700000000000000000000001 /* Project object */;
+}

--- a/mobile/shells/ios/StasisMobile/Info.plist
+++ b/mobile/shells/ios/StasisMobile/Info.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key><string>@STASIS_APP_NAME@</string>
+    <key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>1.0</string>
+    <key>CFBundleVersion</key><string>1</string>
+    <key>LSRequiresIPhoneOS</key><true/>
+    <key>UILaunchScreen</key><dict/>
+    <key>UIRequiredDeviceCapabilities</key><array><string>arm64</string></array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array><string>UIInterfaceOrientationLandscapeLeft</string><string>UIInterfaceOrientationLandscapeRight</string></array>
+</dict>
+</plist>

--- a/mobile/shells/ios/StasisMobile/main.m
+++ b/mobile/shells/ios/StasisMobile/main.m
@@ -1,0 +1,9 @@
+#include <SDL_main.h>
+
+#ifdef main
+#undef main
+#endif
+
+int main(int argc, char **argv) {
+    return SDL_UIKitRunApp(argc, argv, SDL_main);
+}

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -39,6 +39,7 @@ typedef struct StasisMobileRuntimeState {
     StasisMobileGameEntries entries;
     int initialized;
     int paused;
+    int32_t last_entry_result;
 } StasisMobileRuntimeState;
 
 static StasisMobileRuntimeState runtime_state;
@@ -110,13 +111,16 @@ int32_t stasis_mobile_runtime_initialize(
         &host_req_window_w_px,
         &host_req_window_h_px
     );
-    runtime_state.entries.main_entry();
+    runtime_state.last_entry_result = runtime_state.entries.main_entry();
     stasis_host_bulk_apply_requests(
         &host_req_seq,
         &host_req_flags,
         &host_req_window_w_px,
         &host_req_window_h_px
     );
+    if (runtime_state.last_entry_result != 0) {
+        return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
+    }
     return STASIS_MOBILE_RUNTIME_OK;
 }
 
@@ -140,9 +144,16 @@ int32_t stasis_mobile_runtime_step(void) {
         &host_req_window_w_px,
         &host_req_window_h_px
     );
-    runtime_state.entries.tick_entry();
+    runtime_state.last_entry_result = runtime_state.entries.tick_entry();
+    if (runtime_state.last_entry_result != 0) {
+        return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
+    }
     stasis_begin_frame();
-    runtime_state.entries.render_entry();
+    runtime_state.last_entry_result = runtime_state.entries.render_entry();
+    if (runtime_state.last_entry_result != 0) {
+        stasis_end_frame();
+        return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
+    }
     stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
     stasis_end_frame();
     return STASIS_MOBILE_RUNTIME_OK;
@@ -157,6 +168,10 @@ void stasis_mobile_runtime_set_paused(int32_t paused) {
 
 int32_t stasis_mobile_runtime_is_initialized(void) {
     return runtime_state.initialized;
+}
+
+int32_t stasis_mobile_runtime_last_entry_result(void) {
+    return runtime_state.last_entry_result;
 }
 
 void stasis_mobile_runtime_shutdown(void) {

--- a/runtime/stasis_mobile_runtime.h
+++ b/runtime/stasis_mobile_runtime.h
@@ -18,13 +18,14 @@ enum StasisMobileRuntimeResult {
     STASIS_MOBILE_RUNTIME_GRAPHICS_UNAVAILABLE = -4
 };
 
-typedef void (*StasisMobileEntry)(void);
+typedef void (*StasisMobileBindEntry)(void);
+typedef int32_t (*StasisMobileI32Entry)(void);
 
 typedef struct StasisMobileGameEntries {
-    StasisMobileEntry bind_runtime_entry;
-    StasisMobileEntry main_entry;
-    StasisMobileEntry tick_entry;
-    StasisMobileEntry render_entry;
+    StasisMobileBindEntry bind_runtime_entry;
+    StasisMobileI32Entry main_entry;
+    StasisMobileI32Entry tick_entry;
+    StasisMobileI32Entry render_entry;
 } StasisMobileGameEntries;
 
 typedef struct StasisMobileRuntimeConfig {
@@ -45,6 +46,8 @@ int32_t stasis_mobile_runtime_step(void);
 /* Paused runtimes remain initialized but do not tick or render. */
 void stasis_mobile_runtime_set_paused(int32_t paused);
 int32_t stasis_mobile_runtime_is_initialized(void);
+/* Exact non-zero main/tick/render result; read before shutdown resets state. */
+int32_t stasis_mobile_runtime_last_entry_result(void);
 
 /* Releases graphics and audio state. Safe to call more than once. */
 void stasis_mobile_runtime_shutdown(void);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -25,6 +25,9 @@ static int bind_runtime_calls;
 static int main_calls;
 static int tick_calls;
 static int render_calls;
+static int32_t main_result;
+static int32_t tick_result;
+static int32_t render_result;
 static int begin_frame_calls;
 static int end_frame_calls;
 static int host_frame_calls;
@@ -114,24 +117,27 @@ void stasis_sleep_ms(int ms) { (void)ms; }
 
 static int32_t hash_path(const char *path);
 
-static void game_main(void) {
+static int32_t game_main(void) {
     main_calls += 1;
     stasis_jit_global_i32_store(hash_path("host_req_seq"), 1);
     stasis_jit_global_i32_store(hash_path("host_req_flags"), 1);
     stasis_jit_global_i32_store(hash_path("host_req_window_w_px"), 960);
     stasis_jit_global_i32_store(hash_path("host_req_window_h_px"), 540);
+    return main_result;
 }
 
 static void bind_runtime(void) {
     bind_runtime_calls += 1;
 }
 
-static void game_tick(void) {
+static int32_t game_tick(void) {
     tick_calls += 1;
+    return tick_result;
 }
 
-static void game_render(void) {
+static int32_t game_render(void) {
     render_calls += 1;
+    return render_result;
 }
 
 static StasisMobileRuntimeConfig config(void) {
@@ -165,6 +171,9 @@ static void reset_fakes(void) {
     main_calls = 0;
     tick_calls = 0;
     render_calls = 0;
+    main_result = 0;
+    tick_result = 0;
+    render_result = 0;
     begin_frame_calls = 0;
     end_frame_calls = 0;
     host_frame_calls = 0;
@@ -268,6 +277,38 @@ static void test_reports_graphics_initialization_failure(void) {
     stasis_mobile_runtime_shutdown();
 }
 
+static void test_stops_on_nonzero_game_entry_results(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+
+    main_result = 7;
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    assert(stasis_mobile_runtime_last_entry_result() == 7);
+    assert(tick_calls == 0 && render_calls == 0);
+    stasis_mobile_runtime_shutdown();
+
+    reset_fakes();
+    tick_result = 8;
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_OK);
+    assert(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    assert(stasis_mobile_runtime_last_entry_result() == 8);
+    assert(tick_calls == 1 && render_calls == 0);
+    assert(begin_frame_calls == 0 && end_frame_calls == 0 && gfx_submit_calls == 0);
+    stasis_mobile_runtime_shutdown();
+
+    reset_fakes();
+    render_result = 9;
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) ==
+        STASIS_MOBILE_RUNTIME_OK);
+    assert(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    assert(stasis_mobile_runtime_last_entry_result() == 9);
+    assert(tick_calls == 1 && render_calls == 1);
+    assert(begin_frame_calls == 1 && end_frame_calls == 1 && gfx_submit_calls == 0);
+    stasis_mobile_runtime_shutdown();
+}
+
 int main(void) {
     reset_fakes();
     test_rejects_invalid_configuration();
@@ -276,6 +317,8 @@ int main(void) {
     test_rejects_duplicate_initialization();
     reset_fakes();
     test_reports_graphics_initialization_failure();
+    reset_fakes();
+    test_stops_on_nonzero_game_entry_results();
     puts("stasis_mobile_runtime_test: ok");
     return 0;
 }


### PR DESCRIPTION
## Summary

- add `stasis package-mobile --target android-arm64|ios-arm64 [--entry PATH]`
- assemble target-native AOT objects, manifest assets, shared SDL-only runtime sources, and thin Gradle/Xcode shells atomically
- root packaged assets correctly on Android and iOS without shipping JIT, hot swap, dynamic game loading, or writable Stasis source
- include mobile templates/runtime sources/docs in release archives and smoke their generated structure

## Validation

- `cargo test -p stasis toolchain_cli::tests::mobile_ -- --test-threads=1` — 2 passed
- `cargo test -p stasis --test toolchain_cli package_mobile_builds_android_and_ios_projects_from_one_entry -- --test-threads=1` — passed; compiled and packaged both targets and verified failure cleanup
- `cargo test -p stasis mobile_aot_bundle -- --test-threads=1` — 3 passed
- `cargo test -p stasis android_aot_bundle -- --test-threads=1` — 2 passed
- `cargo test -p stasis_compiler backend::aot -- --test-threads=1` — 30 passed, 1 ignored
- `python tools/ci/check_stasis_src_layout.py` — passed
- `cargo test --workspace --all-targets -- --test-threads=1` — reached 138 passed, 6 ignored and stopped on the two existing Brickout JIT smoke failures
- `git diff --check` — passed

Native Gradle/Xcode builds are deferred to their platform hosts: this Windows machine has no configured SDL source paths or Xcode, and its CMake probe has no usable C compiler.

## Review

Independent review found and drove fixes for runtime asset roots, stale Android assets, user-asset token mutation, target-valid identifiers/JNI symbols, iOS SDL-only compilation, SDL entry declarations, framework embedding/runpaths, and filesystem error propagation. Final re-review was clean.
