### PR TITLE
feat: add interactive live desktop workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "rand",
 ]
 
@@ -121,6 +121,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -167,6 +173,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -398,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,13 +638,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -770,6 +803,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "clipboard-win",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ruzstd"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +918,7 @@ dependencies = [
  "clap",
  "notify",
  "object",
+ "rustyline",
  "serde",
  "serde_json",
  "sha2",
@@ -931,6 +984,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "serde",
+ "serde_json",
  "stasis_assets",
 ]
 
@@ -984,6 +1038,18 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -13,6 +13,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
+rustyline = { version = "14.0", default-features = false }
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }
 

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4,6 +4,7 @@
 mod compiler_backend;
 mod events;
 mod host_set_registry;
+mod live_workspace;
 mod runtime_exec;
 mod stasis_test_runner;
 mod watch;
@@ -12,6 +13,7 @@ mod window_config;
 pub use compiler_backend::run_self_host_aot_cli;
 pub use compiler_backend::run_self_host_aot_cli_with_options;
 pub use events::RunnerEvent;
+pub use live_workspace::LiveRunConfig;
 pub use stasis_test_runner::{
     run_jit_tests_in_directory, run_jit_tests_in_directory_with_session, StasisTestRunSession,
     StasisTestRunSummary,
@@ -19,6 +21,7 @@ pub use stasis_test_runner::{
 pub use window_config::WindowConfig;
 
 use compiler_backend::IncrementalCompilerBackend;
+use live_workspace::LiveWorkspace;
 use runtime_exec::RuntimeLauncher;
 use serde::Deserialize;
 use serde_json::Value;
@@ -523,6 +526,46 @@ pub fn run_play_in_process(
     tick_sleep_micros: u64,
     max_ticks: Option<u64>,
 ) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
+        tick_sleep_micros,
+        max_ticks,
+        None,
+    )
+}
+
+pub fn run_live_in_process(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    server: stasis_runner::live::LiveSessionServer,
+    config: LiveRunConfig,
+) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        None,
+        None,
+        tick_sleep_micros,
+        max_ticks,
+        Some((server, config)),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_play_in_process_inner(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    live: Option<(stasis_runner::live::LiveSessionServer, LiveRunConfig)>,
+) -> Result<(), String> {
     if !cfg!(windows) {
         return Err("in-process play runner currently supports Windows only".to_string());
     }
@@ -666,14 +709,35 @@ pub fn run_play_in_process(
 
     let mut tick_code_ptr = package.tick_code_ptr;
     let mut render_code_ptr = package.render_code_ptr;
+    let mut live = live
+        .map(|(server, config)| LiveWorkspace::new(server, config, &jit))
+        .transpose()?;
 
     let mut ticks_executed: u64 = 0;
     loop {
+        if let Some(live) = live.as_mut() {
+            live.process_boundary(
+                ticks_executed,
+                &mut jit,
+                &mut tick_code_ptr,
+                &mut render_code_ptr,
+            );
+            if live.should_quit() {
+                break;
+            }
+        }
         // Drain file events and recompile at tick boundaries (all-or-nothing).
         let mut needs_recompile = false;
         let mut ignored_changes: u32 = 0;
         let mut triggered_paths: Vec<String> = Vec::new();
         for event in watcher.drain_stasis_changes() {
+            if live
+                .as_mut()
+                .is_some_and(|workspace| workspace.consumes_self_write(&event.path))
+            {
+                ignored_changes = ignored_changes.saturating_add(1);
+                continue;
+            }
             let submit = should_submit_watch_event(
                 &event,
                 Some(&root_path),
@@ -750,6 +814,9 @@ pub fn run_play_in_process(
                                 // Commit the swap (all-or-nothing).
                                 tick_code_ptr = candidate_tick_code_ptr;
                                 render_code_ptr = candidate_render_code_ptr;
+                                if let Some(live) = live.as_mut() {
+                                    live.refresh_after_external_edit(&jit);
+                                }
                                 println!(
                                     "[swap] swapped ok total={total_ms}ms (compile={compile_ms}ms package={package_ms}ms hook={hook_ms}ms deps={deps_ms}ms)"
                                 );
@@ -785,9 +852,12 @@ pub fn run_play_in_process(
             &host_req_window_h_px,
         )?;
 
-        let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
-        if tick_rc != 0 {
-            break;
+        let run_tick = live.as_ref().is_none_or(LiveWorkspace::should_run_tick);
+        if run_tick {
+            let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
+            if tick_rc != 0 {
+                break;
+            }
         }
         let render_rc = stasis_dynload::invoke_noarg_i32(render_code_ptr as usize)?;
         if render_rc != 0 {
@@ -802,7 +872,15 @@ pub fn run_play_in_process(
             }
         }
 
-        ticks_executed = ticks_executed.saturating_add(1);
+        if let Some(live) = live.as_mut() {
+            if run_tick {
+                ticks_executed = ticks_executed.saturating_add(1);
+                live.after_tick();
+            }
+            live.publish_watches(ticks_executed, &jit);
+        } else {
+            ticks_executed = ticks_executed.saturating_add(1);
+        }
         if let Some(limit) = max_ticks {
             if ticks_executed >= limit {
                 break;

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1,0 +1,2515 @@
+use serde_json::{json, Value};
+use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess, JitScalarValue};
+use stasis_compiler::backend::EngineEntrypoints;
+use stasis_compiler::compiler::CompileError;
+use stasis_compiler::frontend::workshop::{
+    find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
+    workshop_source_hash, workshop_source_items, write_workshop_semantic_plan,
+    write_workshop_semantic_receipt, ExpectedReload, WorkshopSemanticEdit,
+    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
+    WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
+};
+use stasis_runner::live::{
+    CompletionIndex, CompletionItem, LiveCommand, LiveEditOperation, LiveRequest, LiveResponse,
+    LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
+};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc, Arc};
+
+const REQUESTS_PER_TICK: usize = 8;
+const MAX_PENDING_LIVE_REQUESTS: usize = 64;
+const MAX_LIVE_EDIT_SOURCE_BYTES: usize = 256 * 1024;
+const MAX_LIVE_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
+const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
+const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
+
+#[derive(Debug, Clone)]
+pub struct LiveRunConfig {
+    pub project_root: PathBuf,
+    pub entry: PathBuf,
+    pub output: PathBuf,
+}
+
+impl LiveRunConfig {
+    pub fn new(project_root: PathBuf, entry: PathBuf, output: PathBuf) -> Self {
+        Self {
+            project_root,
+            entry,
+            output,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HistoryEntry {
+    plan: WorkshopSemanticEditPlan,
+    receipt: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+enum PreparedAction {
+    Preview,
+    ApplyNew,
+    ApplyPending,
+    Undo { index: usize },
+    Redo { index: usize },
+}
+
+struct PreparedEdit {
+    request_id: u64,
+    plan: WorkshopSemanticEditPlan,
+    restore: bool,
+    action: PreparedAction,
+    tests_ran: bool,
+    candidate: JitProcess,
+    package: JitEnginePackage,
+    source_items: Vec<WorkshopSourceItem>,
+    input_hashes: BTreeMap<String, String>,
+}
+
+struct EditPreparation {
+    request_id: u64,
+    canceled: Arc<AtomicBool>,
+    receiver: mpsc::Receiver<Result<PreparedEdit, String>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+#[derive(Debug, Clone)]
+enum EditPreparationInput {
+    Edit {
+        operation: LiveEditOperation,
+        target: LiveSymbolTarget,
+        source: Option<String>,
+        expected_source_hash: Option<String>,
+        preview: bool,
+        run_tests: bool,
+    },
+    Plan {
+        plan: WorkshopSemanticEditPlan,
+        restore: bool,
+        run_tests: bool,
+        action: PreparedAction,
+    },
+    Persist {
+        target: LiveSymbolTarget,
+        source: String,
+        preview: bool,
+        run_tests: bool,
+    },
+}
+
+pub(crate) struct LiveWorkspace {
+    server: LiveSessionServer,
+    config: LiveRunConfig,
+    paused: bool,
+    step_remaining: u32,
+    quit: bool,
+    history: Vec<HistoryEntry>,
+    history_cursor: usize,
+    completion: CompletionIndex,
+    source_items: Vec<WorkshopSourceItem>,
+    scratch: ScratchWorkspace,
+    watches: BTreeMap<String, Option<JitScalarValue>>,
+    pending_plan: Option<WorkshopSemanticEditPlan>,
+    pending_requests: VecDeque<LiveRequest>,
+    pending_responses: VecDeque<LiveResponse>,
+    self_write_hashes: BTreeMap<PathBuf, String>,
+    edit_preparation: Option<EditPreparation>,
+    dropped_watch_events: u64,
+}
+
+impl Drop for LiveWorkspace {
+    fn drop(&mut self) {
+        if let Some(mut preparation) = self.edit_preparation.take() {
+            preparation.canceled.store(true, Ordering::Release);
+            if let Some(worker) = preparation.worker.take() {
+                let _ = worker.join();
+            }
+        }
+    }
+}
+
+impl LiveWorkspace {
+    pub(crate) fn new(
+        server: LiveSessionServer,
+        config: LiveRunConfig,
+        jit: &JitProcess,
+    ) -> Result<Self, String> {
+        let mut workspace = Self {
+            server,
+            config,
+            paused: false,
+            step_remaining: 0,
+            quit: false,
+            history: Vec::new(),
+            history_cursor: 0,
+            completion: CompletionIndex::default(),
+            source_items: Vec::new(),
+            scratch: ScratchWorkspace::default(),
+            watches: BTreeMap::new(),
+            pending_plan: None,
+            pending_requests: VecDeque::new(),
+            pending_responses: VecDeque::new(),
+            self_write_hashes: BTreeMap::new(),
+            edit_preparation: None,
+            dropped_watch_events: 0,
+        };
+        workspace.refresh_completion(jit)?;
+        Ok(workspace)
+    }
+
+    pub(crate) fn process_boundary(
+        &mut self,
+        tick: u64,
+        jit: &mut JitProcess,
+        tick_code_ptr: &mut u64,
+        render_code_ptr: &mut u64,
+    ) {
+        while let Some(response) = self.pending_responses.pop_front() {
+            match self.server.respond(response) {
+                Ok(()) => {}
+                Err(LiveResponseSendError::Full(response)) => {
+                    self.pending_responses.push_front(response);
+                    return;
+                }
+                Err(LiveResponseSendError::Disconnected) => {
+                    self.quit = true;
+                    return;
+                }
+            }
+        }
+        let incoming = self.server.drain(usize::MAX);
+        let cancellation_targets = incoming
+            .iter()
+            .filter_map(|request| match request.command {
+                LiveCommand::Cancel { request_id } => Some(request_id),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        let mut background_canceled_targets = BTreeSet::new();
+        for canceled in &cancellation_targets {
+            if let Some(preparation) = self
+                .edit_preparation
+                .as_ref()
+                .filter(|preparation| preparation.request_id == *canceled)
+            {
+                preparation.canceled.store(true, Ordering::Release);
+                background_canceled_targets.insert(*canceled);
+            }
+        }
+        let quit_queued = incoming
+            .iter()
+            .any(|request| matches!(request.command, LiveCommand::Quit));
+        if quit_queued {
+            if let Some(preparation) = self.edit_preparation.as_ref() {
+                preparation.canceled.store(true, Ordering::Release);
+            }
+        }
+        let mut controls = Vec::new();
+        for request in incoming {
+            if matches!(
+                request.command,
+                LiveCommand::Cancel { .. } | LiveCommand::Quit
+            ) {
+                controls.push(request);
+            } else if self.pending_requests.len() < MAX_PENDING_LIVE_REQUESTS {
+                self.pending_requests.push_back(request);
+            } else {
+                self.enqueue_response(LiveResponse::failure(
+                    request.request_id,
+                    tick,
+                    format!(
+                        "live request backlog exceeds {MAX_PENDING_LIVE_REQUESTS}; retry after backpressure clears"
+                    ),
+                ));
+            }
+        }
+        for canceled in &cancellation_targets {
+            if let Some(index) = self
+                .pending_requests
+                .iter()
+                .position(|request| request.request_id == *canceled)
+            {
+                let request = self
+                    .pending_requests
+                    .remove(index)
+                    .expect("pending cancellation index exists");
+                self.enqueue_response(LiveResponse::failure(
+                    request.request_id,
+                    tick,
+                    "live request canceled before boundary execution",
+                ));
+            }
+        }
+        if let Some(response) =
+            self.finish_edit_preparation(tick, jit, tick_code_ptr, render_code_ptr)
+        {
+            self.enqueue_response(response);
+        }
+        for request in controls {
+            let response = match request.command {
+                LiveCommand::Cancel {
+                    request_id: canceled,
+                } => LiveResponse::success(
+                    request.request_id,
+                    tick,
+                    "cancellation_requested",
+                    json!({"request_id": canceled, "background": background_canceled_targets.contains(&canceled)}),
+                ),
+                LiveCommand::Quit => {
+                    self.quit = true;
+                    LiveResponse::success(
+                        request.request_id,
+                        tick,
+                        "quitting",
+                        json!({"tick": tick}),
+                    )
+                }
+                _ => unreachable!("only controls are separated"),
+            };
+            self.enqueue_response(response);
+        }
+        if self.quit {
+            return;
+        }
+        for _ in 0..REQUESTS_PER_TICK {
+            let Some(request) = self.pending_requests.pop_front() else {
+                break;
+            };
+            let request_id = request.request_id;
+            let response = match request.validate() {
+                Ok(()) => self.handle_request(request, tick, jit),
+                Err(error) => LiveResponse::failure(request_id, tick, error),
+            };
+            self.enqueue_response(response);
+            if self.quit {
+                break;
+            }
+        }
+    }
+
+    fn enqueue_response(&mut self, response: LiveResponse) {
+        match self.server.respond(response) {
+            Ok(()) => {}
+            Err(LiveResponseSendError::Full(response)) => {
+                self.pending_responses.push_back(response);
+            }
+            Err(LiveResponseSendError::Disconnected) => self.quit = true,
+        }
+    }
+
+    pub(crate) fn should_run_tick(&self) -> bool {
+        !self.paused || self.step_remaining > 0
+    }
+
+    pub(crate) fn after_tick(&mut self) {
+        if self.paused && self.step_remaining > 0 {
+            self.step_remaining -= 1;
+        }
+    }
+
+    pub(crate) fn should_quit(&self) -> bool {
+        self.quit
+    }
+
+    pub(crate) fn refresh_after_external_edit(&mut self, jit: &JitProcess) {
+        let _ = self.refresh_completion(jit);
+    }
+
+    pub(crate) fn consumes_self_write(&mut self, path: &Path) -> bool {
+        let Some(expected_hash) = self.self_write_hashes.get(path) else {
+            return false;
+        };
+        let matches = std::fs::read_to_string(path)
+            .is_ok_and(|source| workshop_source_hash(&source) == *expected_hash);
+        if !matches {
+            self.self_write_hashes.remove(path);
+        }
+        matches
+    }
+
+    pub(crate) fn publish_watches(&mut self, tick: u64, jit: &JitProcess) {
+        if self.dropped_watch_events > 0 {
+            let dropped = self.dropped_watch_events;
+            match self.server.respond(LiveResponse::success(
+                0,
+                tick,
+                "watch_backpressure",
+                json!({"dropped_events": dropped}),
+            )) {
+                Ok(()) => self.dropped_watch_events = 0,
+                Err(LiveResponseSendError::Full(_)) => return,
+                Err(LiveResponseSendError::Disconnected) => {
+                    self.quit = true;
+                    return;
+                }
+            }
+        }
+        let paths = self.watches.keys().cloned().collect::<Vec<_>>();
+        for path in paths {
+            let Ok(value) = jit.read_global_scalar(&path) else {
+                continue;
+            };
+            let prior = self.watches.get(&path).copied().flatten();
+            if prior == Some(value) {
+                continue;
+            }
+            self.watches.insert(path.clone(), Some(value));
+            match self.server.respond(LiveResponse::success(
+                0,
+                tick,
+                "watch",
+                json!({"path": path, "value": value}),
+            )) {
+                Ok(()) => {}
+                Err(LiveResponseSendError::Full(_)) => {
+                    self.dropped_watch_events = self.dropped_watch_events.saturating_add(1);
+                }
+                Err(LiveResponseSendError::Disconnected) => {
+                    self.quit = true;
+                    return;
+                }
+            }
+        }
+    }
+
+    fn handle_request(
+        &mut self,
+        request: LiveRequest,
+        tick: u64,
+        jit: &mut JitProcess,
+    ) -> LiveResponse {
+        let request_id = request.request_id;
+        let result: Result<(&'static str, Value), String> = (|| match request.command {
+            LiveCommand::Help => Ok(("help", help_data())),
+            LiveCommand::Status => Ok((
+                "status",
+                json!({
+                    "paused": self.paused,
+                    "step_remaining": self.step_remaining,
+                    "tick": tick,
+                    "history_length": self.history.len(),
+                    "history_cursor": self.history_cursor,
+                    "watches": self.watches.keys().collect::<Vec<_>>(),
+                    "scratch_cells": self.scratch.list(),
+                    "dropped_watch_events": self.dropped_watch_events,
+                    "preparing_request_id": self.edit_preparation.as_ref().map(|job| job.request_id),
+                }),
+            )),
+            LiveCommand::Pause => {
+                self.paused = true;
+                self.step_remaining = 0;
+                Ok(("paused", json!({"paused": true, "tick": tick})))
+            }
+            LiveCommand::Resume => {
+                self.paused = false;
+                self.step_remaining = 0;
+                Ok(("resumed", json!({"paused": false, "tick": tick})))
+            }
+            LiveCommand::Step { ticks } if ticks == 0 => {
+                Err("step ticks must be greater than zero".to_string())
+            }
+            LiveCommand::Step { ticks } => {
+                self.paused = true;
+                self.step_remaining = ticks;
+                Ok((
+                    "step_scheduled",
+                    json!({"ticks": ticks, "after_tick": tick}),
+                ))
+            }
+            LiveCommand::Cancel { .. } => unreachable!("cancellation handled before dispatch"),
+            LiveCommand::Quit => {
+                if let Some(preparation) = self.edit_preparation.as_ref() {
+                    preparation.canceled.store(true, Ordering::Release);
+                }
+                self.quit = true;
+                Ok(("quitting", json!({"tick": tick})))
+            }
+            LiveCommand::Symbols { query, page, limit } => {
+                self.symbols(query.as_deref(), page, limit)
+            }
+            LiveCommand::Read {
+                name,
+                kind,
+                file,
+                owner,
+                signature,
+            } => self.read_symbol(LiveSymbolTarget {
+                name,
+                kind,
+                file,
+                owner,
+                signature,
+            }),
+            LiveCommand::Complete {
+                buffer,
+                cursor,
+                limit,
+            } => Ok((
+                "completion",
+                json!({"items": self.completion.complete(&buffer, cursor, limit)}),
+            )),
+            LiveCommand::Edit {
+                operation,
+                target,
+                source,
+                expected_source_hash,
+                preview,
+                run_tests,
+            } => self.start_edit_preparation(
+                request_id,
+                EditPreparationInput::Edit {
+                    operation,
+                    target,
+                    source,
+                    expected_source_hash,
+                    preview,
+                    run_tests,
+                },
+            ),
+            LiveCommand::Preview => self
+                .pending_plan
+                .as_ref()
+                .map(|plan| ("edit_preview", json!({"validated": true, "plan": plan})))
+                .ok_or_else(|| "no validated live semantic preview is pending".to_string()),
+            LiveCommand::Apply { run_tests } => {
+                let plan = self
+                    .pending_plan
+                    .clone()
+                    .ok_or_else(|| "no validated live semantic preview is pending".to_string())?;
+                self.start_edit_preparation(
+                    request_id,
+                    EditPreparationInput::Plan {
+                        plan,
+                        restore: false,
+                        run_tests,
+                        action: PreparedAction::ApplyPending,
+                    },
+                )
+            }
+            LiveCommand::Changes => Ok((
+                "changes",
+                json!({
+                    "cursor": self.history_cursor,
+                    "entries": self.history.iter().enumerate().map(|(index, entry)| json!({
+                        "index": index,
+                        "applied": index < self.history_cursor,
+                        "receipt": entry.receipt,
+                        "changed_files": entry.plan.changed_files.iter().map(|change| &change.file).collect::<Vec<_>>(),
+                        "changed_symbols": entry.plan.reload.changed_symbols,
+                    })).collect::<Vec<_>>()
+                }),
+            )),
+            LiveCommand::Undo { run_tests } => {
+                let index = self
+                    .history_cursor
+                    .checked_sub(1)
+                    .ok_or_else(|| "no live semantic edit to undo".to_string())?;
+                self.start_edit_preparation(
+                    request_id,
+                    EditPreparationInput::Plan {
+                        plan: self.history[index].plan.clone(),
+                        restore: true,
+                        run_tests,
+                        action: PreparedAction::Undo { index },
+                    },
+                )
+            }
+            LiveCommand::Redo { run_tests } => {
+                if self.history_cursor >= self.history.len() {
+                    Err("no live semantic edit to redo".to_string())
+                } else {
+                    let index = self.history_cursor;
+                    self.start_edit_preparation(
+                        request_id,
+                        EditPreparationInput::Plan {
+                            plan: self.history[index].plan.clone(),
+                            restore: false,
+                            run_tests,
+                            action: PreparedAction::Redo { index },
+                        },
+                    )
+                }
+            }
+            LiveCommand::Inspect { path } => inspect_scalar(jit, &path),
+            LiveCommand::Watch { path } => {
+                let value = jit.read_global_scalar(&path)?;
+                self.watches.insert(path.clone(), Some(value));
+                Ok((
+                    "watch_added",
+                    json!({"path": path, "value": value, "tick": tick}),
+                ))
+            }
+            LiveCommand::Unwatch { path } => {
+                if let Some(path) = path {
+                    self.watches.remove(&path);
+                } else {
+                    self.watches.clear();
+                }
+                Ok((
+                    "watch_removed",
+                    json!({"watches": self.watches.keys().collect::<Vec<_>>()}),
+                ))
+            }
+            LiveCommand::Set {
+                path,
+                expression,
+                preview,
+            } => set_scalar(jit, &path, &expression, preview),
+            LiveCommand::Print { expression } => print_scalar(jit, &expression),
+            LiveCommand::Do { code, preview } => apply_scalar_transaction(jit, &code, preview),
+            LiveCommand::CellPut { name, code } => {
+                self.scratch.put(&name, code)?;
+                self.rebuild_completion(jit);
+                Ok(("cell_saved", json!({"name": name, "persistent": false})))
+            }
+            LiveCommand::CellRun { name, preview } => {
+                let code = self
+                    .scratch
+                    .get(&name)
+                    .ok_or_else(|| format!("scratch cell '{name}' not found"))?
+                    .code
+                    .clone();
+                let (kind, data) = apply_scalar_transaction(jit, &code, preview)?;
+                self.scratch.record_result(&name, tick, data.to_string())?;
+                Ok((
+                    kind,
+                    json!({"name": name, "result": data, "persistent": false}),
+                ))
+            }
+            LiveCommand::CellList => Ok(("cells", json!({"cells": self.scratch.list()}))),
+            LiveCommand::CellClear { name } => {
+                self.scratch.clear(name.as_deref())?;
+                self.rebuild_completion(jit);
+                Ok(("cells_cleared", json!({"name": name})))
+            }
+            LiveCommand::CellPersist {
+                name,
+                target,
+                preview,
+                run_tests,
+            } => {
+                let source = self
+                    .scratch
+                    .get(&name)
+                    .ok_or_else(|| format!("scratch cell '{name}' not found"))?
+                    .code
+                    .clone();
+                self.start_edit_preparation(
+                    request_id,
+                    EditPreparationInput::Persist {
+                        target,
+                        source,
+                        preview,
+                        run_tests,
+                    },
+                )
+            }
+        })();
+        match result {
+            Ok((kind, data)) => LiveResponse::success(request_id, tick, kind, data),
+            Err(error) => LiveResponse::failure(request_id, tick, error),
+        }
+    }
+
+    fn load_files(&self) -> Result<Vec<WorkshopSourceFile>, String> {
+        load_workshop_edit_workspace(&self.config.project_root, &self.config.entry)
+    }
+
+    fn symbols(
+        &self,
+        query: Option<&str>,
+        page: u32,
+        limit: usize,
+    ) -> Result<(&'static str, Value), String> {
+        let query = query.unwrap_or("").to_ascii_lowercase();
+        let matching = self
+            .source_items
+            .iter()
+            .filter(|item| {
+                query.is_empty()
+                    || item.name.to_ascii_lowercase().contains(&query)
+                    || item.signature.to_ascii_lowercase().contains(&query)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let limit = limit.clamp(1, 200);
+        let offset = usize::try_from(page)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(limit);
+        let total = matching.len();
+        let items = matching
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .map(|item| {
+                json!({
+                    "kind": item.kind,
+                    "name": item.name,
+                    "owner": item.owner,
+                    "file": item.file,
+                    "signature": item.signature,
+                    "source_hash": item.source_hash,
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok((
+            "symbols",
+            json!({"schema_version": 1, "page": page, "limit": limit, "total": total, "items": items}),
+        ))
+    }
+
+    fn read_symbol(&self, target: LiveSymbolTarget) -> Result<(&'static str, Value), String> {
+        let selector = selector(&target)?;
+        let normalized_file = selector.file.as_deref().map(normalize_file);
+        let mut items = self
+            .source_items
+            .iter()
+            .filter(|item| {
+                item.name == selector.name
+                    && selector.kind.is_none_or(|kind| item.kind == kind)
+                    && normalized_file
+                        .as_deref()
+                        .is_none_or(|file| normalize_file(&item.file) == file)
+                    && selector
+                        .owner
+                        .as_deref()
+                        .is_none_or(|owner| item.owner.as_deref() == Some(owner))
+                    && selector
+                        .signature
+                        .as_deref()
+                        .is_none_or(|signature| item.signature == signature)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if items.len() != 1 {
+            return Err(format!(
+                "live symbol read requires exactly one code-aware match; found {}",
+                items.len()
+            ));
+        }
+        Ok((
+            "symbol",
+            serde_json::to_value(items.remove(0)).map_err(|error| error.to_string())?,
+        ))
+    }
+
+    fn start_edit_preparation(
+        &mut self,
+        request_id: u64,
+        input: EditPreparationInput,
+    ) -> Result<(&'static str, Value), String> {
+        if let Some(preparation) = self.edit_preparation.as_ref() {
+            return Err(format!(
+                "live edit request {} is still preparing; cancel or wait for it",
+                preparation.request_id
+            ));
+        }
+        validate_edit_input_size(&input)?;
+        let config = self.config.clone();
+        let canceled = Arc::new(AtomicBool::new(false));
+        let worker_canceled = Arc::clone(&canceled);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name(format!("stasis-live-edit-{request_id}"))
+            .spawn(move || {
+                let result = prepare_edit(request_id, &config, input, &worker_canceled);
+                let _ = sender.send(result);
+            })
+            .map_err(|error| format!("failed starting live edit preparation: {error}"))?;
+        self.edit_preparation = Some(EditPreparation {
+            request_id,
+            canceled,
+            receiver,
+            worker: Some(worker),
+        });
+        Ok((
+            "edit_preparing",
+            json!({"request_id": request_id, "background": true}),
+        ))
+    }
+
+    fn finish_edit_preparation(
+        &mut self,
+        tick: u64,
+        jit: &mut JitProcess,
+        tick_code_ptr: &mut u64,
+        render_code_ptr: &mut u64,
+    ) -> Option<LiveResponse> {
+        let preparation = self.edit_preparation.as_ref()?;
+        let result = match preparation.receiver.try_recv() {
+            Ok(result) => result,
+            Err(mpsc::TryRecvError::Empty) => return None,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                Err("live edit preparation worker disconnected".to_string())
+            }
+        };
+        let mut preparation = self.edit_preparation.take().expect("preparation exists");
+        if let Some(worker) = preparation.worker.take() {
+            let _ = worker.join();
+        }
+        if preparation.canceled.load(Ordering::Acquire) {
+            return Some(LiveResponse::failure(
+                preparation.request_id,
+                tick,
+                "live edit preparation canceled",
+            ));
+        }
+        let prepared = match result {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                return Some(LiveResponse::failure(preparation.request_id, tick, error));
+            }
+        };
+        if matches!(prepared.action, PreparedAction::Preview) {
+            self.pending_plan = Some(prepared.plan.clone());
+            return Some(LiveResponse::success(
+                prepared.request_id,
+                tick,
+                "edit_preview",
+                json!({"validated": true, "plan": prepared.plan}),
+            ));
+        }
+        let request_id = prepared.request_id;
+        match self.commit_prepared(prepared, jit, tick_code_ptr, render_code_ptr) {
+            Ok((kind, data)) => Some(LiveResponse::success(request_id, tick, kind, data)),
+            Err(error) => Some(LiveResponse::failure(request_id, tick, error)),
+        }
+    }
+
+    fn commit_prepared(
+        &mut self,
+        prepared: PreparedEdit,
+        jit: &mut JitProcess,
+        tick_code_ptr: &mut u64,
+        render_code_ptr: &mut u64,
+    ) -> Result<(&'static str, Value), String> {
+        verify_prepared_input_hashes(&self.config, &prepared.input_hashes)?;
+        let snapshot =
+            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_LIVE_STATE_SNAPSHOT_BYTES)?;
+        let receipt_directory = self.config.output.join("live-edits");
+        let serialized_plan = serde_json::to_string(&prepared.plan)
+            .map_err(|error| format!("failed serializing live receipt: {error}"))?;
+        let expected_receipt =
+            receipt_directory.join(format!("{}.json", workshop_source_hash(&serialized_plan)));
+        let receipt_existed = self.config.project_root.join(&expected_receipt).is_file();
+        self.remember_plan_hashes(&prepared.plan, prepared.restore);
+        if let Err(error) = write_workshop_semantic_plan(
+            &self.config.project_root,
+            &prepared.plan,
+            prepared.restore,
+        ) {
+            self.remember_plan_hashes(&prepared.plan, !prepared.restore);
+            return Err(error);
+        }
+        let receipt = match write_workshop_semantic_receipt(
+            &self.config.project_root,
+            &receipt_directory,
+            &prepared.plan,
+        ) {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                self.rollback_prepared(&prepared, jit, &snapshot)?;
+                return Err(format!(
+                    "live receipt failed; disk/runtime remained unchanged: {error}"
+                ));
+            }
+        };
+
+        if let Err(error) = prepared.candidate.activate_staged_runtime() {
+            self.rollback_prepared(&prepared, jit, &snapshot)?;
+            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+            return Err(format!(
+                "live runtime activation failed; disk/code/state remained unchanged: {error}"
+            ));
+        }
+        stasis_dynload::restore_jit_runtime_state(&snapshot);
+        if let Some(hook) = prepared.package.on_code_swap_code_ptr {
+            if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize) {
+                self.rollback_prepared(&prepared, jit, &snapshot)?;
+                cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+                return Err(format!(
+                    "on_code_swap failed; disk/code/state remained on the prior version: {error}"
+                ));
+            }
+        }
+        *tick_code_ptr = prepared.package.tick_code_ptr;
+        *render_code_ptr = prepared.package.render_code_ptr;
+        let plan = prepared.plan.clone();
+        let action = prepared.action.clone();
+        let source_items = prepared.source_items;
+        let tests = if prepared.tests_ran {
+            "passed"
+        } else {
+            "skipped"
+        };
+        *jit = prepared.candidate;
+        self.source_items = source_items;
+        self.remember_plan_hashes(&plan, prepared.restore);
+        let (kind, data) = match action {
+            PreparedAction::ApplyNew => {
+                self.history.truncate(self.history_cursor);
+                self.history.push(HistoryEntry {
+                    plan: plan.clone(),
+                    receipt: receipt.clone(),
+                });
+                self.history_cursor = self.history.len();
+                (
+                    "edit_applied",
+                    json!({"plan": plan, "receipt": receipt, "tests": tests}),
+                )
+            }
+            PreparedAction::ApplyPending => {
+                self.history.truncate(self.history_cursor);
+                self.history.push(HistoryEntry {
+                    plan: plan.clone(),
+                    receipt: receipt.clone(),
+                });
+                self.history_cursor = self.history.len();
+                self.pending_plan = None;
+                (
+                    "edit_applied",
+                    json!({"plan": plan, "receipt": receipt, "tests": tests}),
+                )
+            }
+            PreparedAction::Undo { index } => {
+                self.history_cursor = index;
+                (
+                    "edit_undone",
+                    json!({"index": index, "receipt": receipt, "tests": tests}),
+                )
+            }
+            PreparedAction::Redo { index } => {
+                self.history_cursor = index + 1;
+                (
+                    "edit_redone",
+                    json!({"index": index, "receipt": receipt, "tests": tests}),
+                )
+            }
+            PreparedAction::Preview => unreachable!("preview never commits"),
+        };
+        self.rebuild_completion(jit);
+        Ok((kind, data))
+    }
+
+    fn rollback_prepared(
+        &mut self,
+        prepared: &PreparedEdit,
+        active: &JitProcess,
+        snapshot: &stasis_dynload::JitRuntimeStateSnapshot,
+    ) -> Result<(), String> {
+        let result = rollback_prepared_disk(&self.config, prepared, active, snapshot);
+        self.remember_plan_hashes(&prepared.plan, !prepared.restore);
+        result
+    }
+
+    fn remember_plan_hashes(&mut self, plan: &WorkshopSemanticEditPlan, restore: bool) {
+        for change in &plan.changed_files {
+            let source = if restore {
+                &change.before_source
+            } else {
+                &change.after_source
+            };
+            self.self_write_hashes.insert(
+                self.config.project_root.join(&change.file),
+                workshop_source_hash(source),
+            );
+        }
+    }
+
+    fn refresh_completion(&mut self, jit: &JitProcess) -> Result<(), String> {
+        let files = self.load_files()?;
+        self.source_items = workshop_source_items(&files)?;
+        self.rebuild_completion(jit);
+        Ok(())
+    }
+
+    fn rebuild_completion(&mut self, jit: &JitProcess) {
+        let mut items = live_command_completions();
+        items.extend(self.source_items.iter().map(|item| CompletionItem {
+            text: item.name.clone(),
+            kind: format!("{:?}", item.kind).to_ascii_lowercase(),
+            detail: item.signature.clone(),
+        }));
+        items.extend(
+            jit.global_scalar_paths()
+                .into_iter()
+                .map(|(path, type_name)| CompletionItem {
+                    text: path,
+                    kind: "state_path".to_string(),
+                    detail: type_name.to_string(),
+                }),
+        );
+        items.extend(self.scratch.list().into_iter().map(|cell| CompletionItem {
+            text: cell.name,
+            kind: "scratch_cell".to_string(),
+            detail: "session-only scratch cell".to_string(),
+        }));
+        self.completion.replace(items);
+    }
+}
+
+fn validate_edit_input_size(input: &EditPreparationInput) -> Result<(), String> {
+    let source = match input {
+        EditPreparationInput::Edit { source, .. } => source.as_deref(),
+        EditPreparationInput::Persist { source, .. } => Some(source.as_str()),
+        EditPreparationInput::Plan { .. } => None,
+    };
+    if source.is_some_and(|source| source.len() > MAX_LIVE_EDIT_SOURCE_BYTES) {
+        return Err(format!(
+            "live edit source exceeds {MAX_LIVE_EDIT_SOURCE_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+fn prepare_edit(
+    request_id: u64,
+    config: &LiveRunConfig,
+    input: EditPreparationInput,
+    canceled: &AtomicBool,
+) -> Result<PreparedEdit, String> {
+    check_preparation_canceled(canceled)?;
+    let files = load_workshop_edit_workspace(&config.project_root, &config.entry)?;
+    let input_hashes = files
+        .iter()
+        .map(|file| (file.path.clone(), workshop_source_hash(&file.source)))
+        .collect::<BTreeMap<_, _>>();
+    let (candidate_files, plan, restore, run_tests, action) = match input {
+        EditPreparationInput::Edit {
+            operation,
+            target,
+            source,
+            expected_source_hash,
+            preview,
+            run_tests,
+        } => {
+            let (after, plan) =
+                plan_live_edit(&files, operation, target, source, expected_source_hash)?;
+            (
+                after,
+                plan,
+                false,
+                run_tests && !preview,
+                if preview {
+                    PreparedAction::Preview
+                } else {
+                    PreparedAction::ApplyNew
+                },
+            )
+        }
+        EditPreparationInput::Persist {
+            target,
+            source,
+            preview,
+            run_tests,
+        } => {
+            let operation = if find_workshop_symbols(&files, &selector(&target)?)?.is_empty() {
+                LiveEditOperation::Add
+            } else {
+                LiveEditOperation::Update
+            };
+            let (after, plan) = plan_live_edit(&files, operation, target, Some(source), None)?;
+            (
+                after,
+                plan,
+                false,
+                run_tests && !preview,
+                if preview {
+                    PreparedAction::Preview
+                } else {
+                    PreparedAction::ApplyNew
+                },
+            )
+        }
+        EditPreparationInput::Plan {
+            plan,
+            restore,
+            run_tests,
+            action,
+        } => {
+            let candidate_files = files_for_plan(&files, &plan, restore)?;
+            (candidate_files, plan, restore, run_tests, action)
+        }
+    };
+    if plan.reload.expected_reload == ExpectedReload::ResetRequired {
+        return Err(format!(
+            "live edit rejected until layout migration support lands in Maddox #153: {}",
+            plan.reload.reason
+        ));
+    }
+    check_preparation_canceled(canceled)?;
+    let (candidate, package) = compile_candidate(config, &candidate_files)?;
+    check_preparation_canceled(canceled)?;
+    if run_tests {
+        run_staged_tests(config, &candidate_files, request_id, canceled).map_err(|error| {
+            format!("live edit tests failed; disk/runtime remained unchanged: {error}")
+        })?;
+    }
+    check_preparation_canceled(canceled)?;
+    let source_items = workshop_source_items(&candidate_files)?;
+    Ok(PreparedEdit {
+        request_id,
+        plan,
+        restore,
+        action,
+        tests_ran: run_tests,
+        candidate,
+        package,
+        source_items,
+        input_hashes,
+    })
+}
+
+fn plan_live_edit(
+    files: &[WorkshopSourceFile],
+    operation: LiveEditOperation,
+    target: LiveSymbolTarget,
+    source: Option<String>,
+    expected_source_hash: Option<String>,
+) -> Result<(Vec<WorkshopSourceFile>, WorkshopSemanticEditPlan), String> {
+    let mut target = selector(&target)?;
+    let operation = match operation {
+        LiveEditOperation::Add => WorkshopSemanticEditOperation::Add,
+        LiveEditOperation::Update => WorkshopSemanticEditOperation::Update,
+        LiveEditOperation::Delete => WorkshopSemanticEditOperation::Delete,
+    };
+    if operation == WorkshopSemanticEditOperation::Add && target.file.is_none() {
+        return Err("code-aware live add requires a project src/ or tests/ file".to_string());
+    }
+    if operation != WorkshopSemanticEditOperation::Add && target.file.is_none() {
+        let matches = find_workshop_symbols(files, &target)?;
+        if matches.len() != 1 {
+            return Err(format!(
+                "code-aware live edit requires one target; found {}",
+                matches.len()
+            ));
+        }
+        target.file = Some(matches[0].file.clone());
+    }
+    plan_workshop_semantic_edits(
+        files,
+        &WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: vec![WorkshopSemanticEdit {
+                operation,
+                target,
+                new_source: source,
+                expected_source_hash,
+            }],
+        },
+    )
+}
+
+fn compile_candidate(
+    config: &LiveRunConfig,
+    files: &[WorkshopSourceFile],
+) -> Result<(JitProcess, JitEnginePackage), String> {
+    let mut candidate = JitProcess::new();
+    candidate.set_required_emit_roots(&[
+        "main".to_string(),
+        "tick".to_string(),
+        "render".to_string(),
+        "on_code_swap".to_string(),
+    ]);
+    for file in files {
+        let path = config.project_root.join(&file.path);
+        candidate.upsert_file(path.to_string_lossy().to_string(), file.source.clone());
+    }
+    candidate
+        .compile_staged()
+        .map_err(|error| candidate_diagnostic(&candidate, error))?;
+    let package = candidate
+        .build_engine_package(&EngineEntrypoints::runtime_default())
+        .map_err(|error| format!("live engine package failed: {error}"))?;
+    Ok((candidate, package))
+}
+
+fn run_staged_tests(
+    config: &LiveRunConfig,
+    files: &[WorkshopSourceFile],
+    request_id: u64,
+    canceled: &AtomicBool,
+) -> Result<(), String> {
+    let stamp = workshop_source_hash(
+        &files
+            .iter()
+            .map(|file| format!("{}:{}", file.path, workshop_source_hash(&file.source)))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    let root = std::env::temp_dir().join(format!(
+        "stasis-live-prepare-{}-{request_id}-{}",
+        std::process::id(),
+        &stamp[..stamp.len().min(16)]
+    ));
+    if root.exists() {
+        fs::remove_dir_all(&root)
+            .map_err(|error| format!("failed clearing live test overlay: {error}"))?;
+    }
+    fs::create_dir_all(&root)
+        .map_err(|error| format!("failed creating live test overlay: {error}"))?;
+    let result = (|| {
+        let manifest = config.project_root.join("stasis.json");
+        if manifest.is_file() {
+            fs::copy(&manifest, root.join("stasis.json"))
+                .map_err(|error| format!("failed staging stasis.json: {error}"))?;
+        }
+        for file in files {
+            check_preparation_canceled(canceled)?;
+            let destination = root.join(&file.path);
+            if !destination.starts_with(&root) {
+                return Err(format!("refusing live test overlay path {}", file.path));
+            }
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("failed creating live test directory: {error}"))?;
+            }
+            fs::write(&destination, &file.source)
+                .map_err(|error| format!("failed staging {}: {error}", file.path))?;
+        }
+        let executable = locate_stasis_executable()?.ok_or_else(|| {
+            "isolated staged tests require a stasis executable beside the running test binary"
+                .to_string()
+        })?;
+        run_staged_test_process(&executable, &root, canceled)
+    })();
+    let cleanup = fs::remove_dir_all(&root);
+    match (result, cleanup) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(format!("failed cleaning live test overlay: {error}")),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn locate_stasis_executable() -> Result<Option<PathBuf>, String> {
+    let current = std::env::current_exe()
+        .map_err(|error| format!("failed locating stasis test executable: {error}"))?;
+    if current.file_stem().and_then(|stem| stem.to_str()) == Some("stasis") {
+        return Ok(Some(current));
+    }
+    let Some(debug_directory) = current.parent().and_then(Path::parent) else {
+        return Ok(None);
+    };
+    let candidate = debug_directory.join(if cfg!(windows) {
+        "stasis.exe"
+    } else {
+        "stasis"
+    });
+    Ok(candidate.is_file().then_some(candidate))
+}
+
+fn run_staged_test_process(
+    executable: &Path,
+    root: &Path,
+    canceled: &AtomicBool,
+) -> Result<(), String> {
+    let mut child = Command::new(executable)
+        .args(["--json", "test"])
+        .current_dir(root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("failed starting staged live tests: {error}"))?;
+    let total_bytes = Arc::new(AtomicUsize::new(0));
+    let output_overflow = Arc::new(AtomicBool::new(false));
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "staged test stdout pipe is unavailable".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "staged test stderr pipe is unavailable".to_string())?;
+    let stdout_total = Arc::clone(&total_bytes);
+    let stdout_overflow = Arc::clone(&output_overflow);
+    let stdout_worker = std::thread::spawn(move || {
+        drain_bounded_test_output(stdout, &stdout_total, &stdout_overflow)
+    });
+    let stderr_total = Arc::clone(&total_bytes);
+    let stderr_overflow = Arc::clone(&output_overflow);
+    let stderr_worker = std::thread::spawn(move || {
+        drain_bounded_test_output(stderr, &stderr_total, &stderr_overflow)
+    });
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
+    let outcome = loop {
+        if canceled.load(Ordering::Acquire) {
+            let _ = child.kill();
+            let _ = child.wait();
+            break Err("live edit preparation canceled during tests".to_string());
+        }
+        if output_overflow.load(Ordering::Acquire) {
+            let _ = child.kill();
+            let _ = child.wait();
+            break Err(format!(
+                "staged live test output exceeded {MAX_STAGED_TEST_OUTPUT_BYTES} bytes"
+            ));
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break Err("staged live tests exceeded 300 seconds".to_string());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break Ok(status),
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break Err(format!("failed polling staged live tests: {error}"));
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+    let stdout = stdout_worker
+        .join()
+        .map_err(|_| "staged test stdout reader panicked".to_string())??;
+    let stderr = stderr_worker
+        .join()
+        .map_err(|_| "staged test stderr reader panicked".to_string())??;
+    if output_overflow.load(Ordering::Acquire) {
+        return Err(format!(
+            "staged live test output exceeded {MAX_STAGED_TEST_OUTPUT_BYTES} bytes"
+        ));
+    }
+    let status = outcome?;
+    if status.success() {
+        return Ok(());
+    }
+    let diagnostics = format!("{stdout}{stderr}");
+    Err(format!(
+        "staged live tests failed: {}",
+        diagnostics
+            .chars()
+            .take(MAX_STAGED_TEST_DIAGNOSTIC_BYTES)
+            .collect::<String>()
+    ))
+}
+
+fn drain_bounded_test_output(
+    mut reader: impl Read,
+    total_bytes: &AtomicUsize,
+    overflow: &AtomicBool,
+) -> Result<String, String> {
+    let mut captured = Vec::with_capacity(MAX_STAGED_TEST_DIAGNOSTIC_BYTES);
+    let mut buffer = [0u8; 8192];
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|error| format!("failed draining staged test output: {error}"))?;
+        if count == 0 {
+            break;
+        }
+        let previous = total_bytes.fetch_add(count, Ordering::AcqRel);
+        if previous.saturating_add(count) > MAX_STAGED_TEST_OUTPUT_BYTES {
+            overflow.store(true, Ordering::Release);
+        }
+        let remaining = MAX_STAGED_TEST_DIAGNOSTIC_BYTES.saturating_sub(captured.len());
+        captured.extend_from_slice(&buffer[..count.min(remaining)]);
+    }
+    Ok(String::from_utf8_lossy(&captured).into_owned())
+}
+
+fn check_preparation_canceled(canceled: &AtomicBool) -> Result<(), String> {
+    if canceled.load(Ordering::Acquire) {
+        Err("live edit preparation canceled".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn rollback_prepared_disk(
+    config: &LiveRunConfig,
+    prepared: &PreparedEdit,
+    active: &JitProcess,
+    snapshot: &stasis_dynload::JitRuntimeStateSnapshot,
+) -> Result<(), String> {
+    let rollback =
+        write_workshop_semantic_plan(&config.project_root, &prepared.plan, !prepared.restore);
+    let activation = active.activate_staged_runtime();
+    stasis_dynload::restore_jit_runtime_state(snapshot);
+    rollback.map_err(|error| format!("disk rollback failed: {error}"))?;
+    activation.map_err(|error| format!("runtime rollback failed: {error}"))
+}
+
+fn verify_prepared_input_hashes(
+    config: &LiveRunConfig,
+    expected: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let current = load_workshop_edit_workspace(&config.project_root, &config.entry)?
+        .into_iter()
+        .map(|file| (file.path, workshop_source_hash(&file.source)))
+        .collect::<BTreeMap<_, _>>();
+    if current == *expected {
+        return Ok(());
+    }
+    let changed = current
+        .keys()
+        .chain(expected.keys())
+        .find(|path| current.get(*path) != expected.get(*path))
+        .cloned()
+        .unwrap_or_else(|| "project sources".to_string());
+    Err(format!(
+        "refusing live commit because {changed} changed during background preparation"
+    ))
+}
+
+fn cleanup_new_receipt(
+    config: &LiveRunConfig,
+    receipt: &Path,
+    receipt_existed: bool,
+) -> Result<(), String> {
+    if receipt_existed {
+        return Ok(());
+    }
+    fs::remove_file(config.project_root.join(receipt))
+        .map_err(|error| format!("receipt cleanup failed: {error}"))
+}
+
+fn help_data() -> Value {
+    json!({
+        "commands": [
+            ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
+            ":symbols [query] [--page N --limit N]",
+            ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]", ":complete BUFFER",
+            ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
+            ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
+            ":inspect PATH", ":watch PATH", ":unwatch [PATH]", ":set PATH VALUE",
+            ":print VALUE_OR_PATH", ":do ... :end", ":cell put|run|list|clear"
+        ],
+        "multiline_terminator": ":end",
+        "multiline_cancel": ":abort or Ctrl-C",
+        "line_editor": "session history and compiler-backed Tab completion",
+        "durability": "semantic edits persist through code-aware receipts; scratch cells do not persist unless explicitly promoted",
+    })
+}
+
+fn live_command_completions() -> Vec<CompletionItem> {
+    [
+        ":help",
+        ":status",
+        ":pause",
+        ":resume",
+        ":step",
+        ":cancel",
+        ":quit",
+        ":symbols",
+        ":find",
+        ":read",
+        ":complete",
+        ":add",
+        ":update",
+        ":delete",
+        ":preview",
+        ":apply",
+        ":changes",
+        ":undo",
+        ":redo",
+        ":inspect",
+        ":watch",
+        ":unwatch",
+        ":set",
+        ":print",
+        ":do",
+        ":cell",
+    ]
+    .into_iter()
+    .map(|text| CompletionItem {
+        text: text.to_string(),
+        kind: "command".to_string(),
+        detail: "live command".to_string(),
+    })
+    .collect()
+}
+
+fn selector(target: &LiveSymbolTarget) -> Result<WorkshopSymbolSelector, String> {
+    Ok(WorkshopSymbolSelector {
+        name: target.name.clone(),
+        kind: target.kind.as_deref().map(parse_kind).transpose()?,
+        file: target.file.as_deref().map(normalize_file),
+        owner: target.owner.clone(),
+        signature: target.signature.clone(),
+    })
+}
+
+fn parse_kind(kind: &str) -> Result<WorkshopSourceItemKind, String> {
+    match kind.to_ascii_lowercase().as_str() {
+        "imports" | "import" => Ok(WorkshopSourceItemKind::Imports),
+        "globals" | "global" | "constant" => Ok(WorkshopSourceItemKind::Globals),
+        "struct" => Ok(WorkshopSourceItemKind::Struct),
+        "function" | "fn" => Ok(WorkshopSourceItemKind::Function),
+        "test" => Ok(WorkshopSourceItemKind::Test),
+        _ => Err(format!(
+            "unsupported symbol kind '{kind}'; use imports, globals, struct, function, or test"
+        )),
+    }
+}
+
+fn normalize_file(file: &str) -> String {
+    file.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+fn files_for_plan(
+    current: &[WorkshopSourceFile],
+    plan: &WorkshopSemanticEditPlan,
+    restore: bool,
+) -> Result<Vec<WorkshopSourceFile>, String> {
+    let mut files = current.to_vec();
+    for change in &plan.changed_files {
+        let file = files
+            .iter_mut()
+            .find(|file| file.path == change.file)
+            .ok_or_else(|| format!("semantic plan file is no longer imported: {}", change.file))?;
+        let expected = if restore {
+            &change.after_hash
+        } else {
+            &change.before_hash
+        };
+        if workshop_source_hash(&file.source) != *expected {
+            return Err(format!(
+                "refusing live {} because {} changed since the plan",
+                if restore { "undo" } else { "apply" },
+                change.file
+            ));
+        }
+        file.source = if restore {
+            change.before_source.clone()
+        } else {
+            change.after_source.clone()
+        };
+    }
+    Ok(files)
+}
+
+fn candidate_diagnostic(candidate: &JitProcess, error: CompileError) -> String {
+    candidate
+        .last_source_diagnostic()
+        .map(|diagnostic| {
+            format!(
+                "{}:{}-{}: {}",
+                diagnostic.path, diagnostic.start, diagnostic.end, diagnostic.message
+            )
+        })
+        .unwrap_or_else(|| format!("live compile failed: {error:?}"))
+}
+
+fn inspect_scalar(jit: &JitProcess, path: &str) -> Result<(&'static str, Value), String> {
+    let value = jit.read_global_scalar(path)?;
+    Ok((
+        "inspection",
+        json!({"path": path, "static_type": value.type_name(), "value": value}),
+    ))
+}
+
+fn print_scalar(jit: &JitProcess, expression: &str) -> Result<(&'static str, Value), String> {
+    if jit.has_global_path(expression) {
+        return inspect_scalar(jit, expression);
+    }
+    if let Ok(value) = expression.parse::<i32>() {
+        return Ok(("print", json!({"static_type": "i32", "value": value})));
+    }
+    if matches!(expression, "true" | "false") {
+        return Ok((
+            "print",
+            json!({"static_type": "bool", "value": expression == "true"}),
+        ));
+    }
+    Err("live print currently accepts a compiler-indexed scalar path, i32 literal, or bool literal; unsupported expressions fail instead of using a second evaluator".to_string())
+}
+
+fn set_scalar(
+    jit: &JitProcess,
+    path: &str,
+    expression: &str,
+    preview: bool,
+) -> Result<(&'static str, Value), String> {
+    let old = jit.read_global_scalar(path)?;
+    let new = parse_scalar_value(jit, expression, old)?;
+    if !preview {
+        jit.write_global_scalar(path, new)?;
+    }
+    Ok((
+        if preview {
+            "mutation_preview"
+        } else {
+            "mutation_committed"
+        },
+        json!({"path": path, "static_type": old.type_name(), "old": old, "new": new, "preview": preview}),
+    ))
+}
+
+fn parse_scalar_value(
+    jit: &JitProcess,
+    expression: &str,
+    expected: JitScalarValue,
+) -> Result<JitScalarValue, String> {
+    if jit.has_global_path(expression) {
+        let value = jit.read_global_scalar(expression)?;
+        if value.type_name() == expected.type_name() {
+            return Ok(value);
+        }
+        return Err(format!(
+            "state path '{expression}' has type {}, expected {}",
+            value.type_name(),
+            expected.type_name()
+        ));
+    }
+    match expected {
+        JitScalarValue::I32(_) => expression
+            .parse::<i32>()
+            .map(JitScalarValue::I32)
+            .map_err(|error| format!("invalid i32 expression '{expression}': {error}")),
+        JitScalarValue::F32(_) => expression
+            .parse::<f32>()
+            .map(JitScalarValue::F32)
+            .map_err(|error| format!("invalid f32 expression '{expression}': {error}")),
+        JitScalarValue::F64(_) => expression
+            .parse::<f64>()
+            .map(JitScalarValue::F64)
+            .map_err(|error| format!("invalid f64 expression '{expression}': {error}")),
+        JitScalarValue::Bool(_) => match expression {
+            "true" => Ok(JitScalarValue::Bool(true)),
+            "false" => Ok(JitScalarValue::Bool(false)),
+            _ => Err(format!("invalid bool expression '{expression}'")),
+        },
+    }
+}
+
+fn apply_scalar_transaction(
+    jit: &JitProcess,
+    code: &str,
+    preview: bool,
+) -> Result<(&'static str, Value), String> {
+    if code.len() > MAX_LIVE_EDIT_SOURCE_BYTES {
+        return Err(format!(
+            "typed live transaction exceeds {MAX_LIVE_EDIT_SOURCE_BYTES} bytes"
+        ));
+    }
+    let mut mutations = Vec::new();
+    for raw in code.split(';') {
+        let statement = raw.trim();
+        if statement.is_empty() {
+            continue;
+        }
+        let (path, expression) = statement.split_once('=').ok_or_else(|| {
+            format!("typed live transaction requires PATH = VALUE: '{statement}'")
+        })?;
+        let path = path.trim();
+        let expression = expression.trim();
+        if path.contains('(') || expression.contains('(') {
+            return Err("calls are not allowed in typed live transactions".to_string());
+        }
+        let old = jit.read_global_scalar(path)?;
+        let new = parse_scalar_value(jit, expression, old)?;
+        mutations.push((path.to_string(), old, new));
+        if mutations.len() > MAX_LIVE_TRANSACTION_ASSIGNMENTS {
+            return Err(format!(
+                "typed live transaction exceeds {MAX_LIVE_TRANSACTION_ASSIGNMENTS} assignments"
+            ));
+        }
+    }
+    if mutations.is_empty() {
+        return Err("typed live transaction contains no assignments".to_string());
+    }
+    if !preview {
+        for (path, _, value) in &mutations {
+            jit.write_global_scalar(path, *value)?;
+        }
+    }
+    Ok((
+        if preview {
+            "transaction_preview"
+        } else {
+            "transaction_committed"
+        },
+        json!({
+            "preview": preview,
+            "mutations": mutations.into_iter().map(|(path, old, new)| json!({
+                "path": path, "static_type": old.type_name(), "old": old, "new": new
+            })).collect::<Vec<_>>()
+        }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn project() -> (PathBuf, LiveRunConfig) {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_live_workspace_{stamp}"));
+        fs::create_dir_all(root.join("src")).expect("src");
+        fs::create_dir_all(root.join("tests")).expect("tests");
+        fs::write(
+            root.join("src/main.stasis"),
+            "global score: i32;\nfunction main(): i32 { score = 1; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("source");
+        fs::write(
+            root.join("tests/main.test.stasis"),
+            "test `live project remains valid`(): bool { return 1 == 1; }\n",
+        )
+        .expect("test");
+        let config = LiveRunConfig::new(
+            root.clone(),
+            PathBuf::from("src/main.stasis"),
+            PathBuf::from("build"),
+        );
+        (root, config)
+    }
+
+    fn compile(config: &LiveRunConfig) -> (JitProcess, JitEnginePackage) {
+        let files =
+            load_workshop_edit_workspace(&config.project_root, &config.entry).expect("files");
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&[
+            "main".into(),
+            "tick".into(),
+            "render".into(),
+            "on_code_swap".into(),
+        ]);
+        for file in files {
+            jit.upsert_file(
+                config.project_root.join(file.path).to_string_lossy(),
+                file.source,
+            );
+        }
+        jit.compile().expect("compile");
+        let package = jit
+            .build_engine_package(&EngineEntrypoints::runtime_default())
+            .expect("package");
+        (jit, package)
+    }
+
+    fn run_request(
+        client: &stasis_runner::live::LiveSessionClient,
+        workspace: &mut LiveWorkspace,
+        jit: &mut JitProcess,
+        tick_ptr: &mut u64,
+        render_ptr: &mut u64,
+        request: LiveRequest,
+    ) -> LiveResponse {
+        let request_id = request.request_id;
+        client.submit(request).expect("submit live request");
+        for tick in 1..=500 {
+            workspace.process_boundary(tick, jit, tick_ptr, render_ptr);
+            if let Ok(response) = client.receive_timeout(std::time::Duration::from_millis(10)) {
+                if response.request_id == request_id && response.kind != "edit_preparing" {
+                    return response;
+                }
+            }
+        }
+        panic!("live request {request_id} did not finish");
+    }
+
+    fn prepared_tick_edit(config: &LiveRunConfig, request_id: u64) -> PreparedEdit {
+        prepare_edit(
+            request_id,
+            config,
+            EditPreparationInput::Edit {
+                operation: LiveEditOperation::Update,
+                target: LiveSymbolTarget {
+                    name: "tick".into(),
+                    kind: Some("function".into()),
+                    file: Some("src/main.stasis".into()),
+                    owner: None,
+                    signature: None,
+                },
+                source: Some("function tick(): i32 { score += 4; return 0; }".into()),
+                expected_source_hash: None,
+                preview: false,
+                run_tests: false,
+            },
+            &AtomicBool::new(false),
+        )
+        .expect("prepare edit")
+    }
+
+    fn install_ready_preparation(workspace: &mut LiveWorkspace, prepared: PreparedEdit) {
+        let request_id = prepared.request_id;
+        let canceled = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = mpsc::sync_channel(1);
+        sender.send(Ok(prepared)).expect("queue prepared edit");
+        workspace.edit_preparation = Some(EditPreparation {
+            request_id,
+            canceled,
+            receiver,
+            worker: None,
+        });
+    }
+
+    #[test]
+    fn scalar_transactions_preview_and_commit_atomically() {
+        let (root, config) = project();
+        let (jit, _) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        apply_scalar_transaction(&jit, "score = 9;", true).expect("preview");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(1)));
+        apply_scalar_transaction(&jit, "score = 9;", false).expect("commit");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(9)));
+        assert!(apply_scalar_transaction(&jit, "score = nope;", false).is_err());
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(9)));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn staged_test_output_drain_caps_diagnostics_and_flags_overflow() {
+        let bytes = vec![b'x'; MAX_STAGED_TEST_OUTPUT_BYTES + 1];
+        let total = AtomicUsize::new(0);
+        let overflow = AtomicBool::new(false);
+        let captured = drain_bounded_test_output(std::io::Cursor::new(bytes), &total, &overflow)
+            .expect("drain output");
+        assert_eq!(captured.len(), MAX_STAGED_TEST_DIAGNOSTIC_BYTES);
+        assert_eq!(
+            total.load(Ordering::Acquire),
+            MAX_STAGED_TEST_OUTPUT_BYTES + 1
+        );
+        assert!(overflow.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn pause_step_and_watch_events_are_boundary_exact() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    40,
+                    LiveCommand::Watch {
+                        path: "score".into()
+                    }
+                ),
+            )
+            .ok
+        );
+        workspace.publish_watches(1, &jit);
+        assert!(client
+            .receive_timeout(std::time::Duration::from_millis(10))
+            .is_err());
+
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    41,
+                    LiveCommand::Set {
+                        path: "score".into(),
+                        expression: "9".into(),
+                        preview: false,
+                    },
+                ),
+            )
+            .ok
+        );
+        workspace.publish_watches(1, &jit);
+        let watch = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("watch event");
+        assert_eq!(watch.request_id, 0);
+        assert_eq!(watch.tick, 1);
+        assert_eq!(watch.data.expect("watch data")["value"]["value"], 9);
+        workspace.publish_watches(1, &jit);
+        assert!(client
+            .receive_timeout(std::time::Duration::from_millis(10))
+            .is_err());
+
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(42, LiveCommand::Pause),
+            )
+            .ok
+        );
+        assert!(!workspace.should_run_tick());
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(43, LiveCommand::Step { ticks: 2 }),
+            )
+            .ok
+        );
+        assert!(workspace.should_run_tick());
+        workspace.after_tick();
+        assert!(workspace.should_run_tick());
+        workspace.after_tick();
+        assert!(!workspace.should_run_tick());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn code_aware_edit_preview_apply_and_undo_preserve_runtime_and_disk() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let target = LiveSymbolTarget {
+            name: "tick".into(),
+            kind: Some("function".into()),
+            file: Some("src/main.stasis".into()),
+            owner: None,
+            signature: None,
+        };
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                1,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target,
+                    source: Some("function tick(): i32 { score += 4; return 0; }".into()),
+                    expected_source_hash: None,
+                    preview: true,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("score += 1"));
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(2, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("new tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(5)));
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("score += 4"));
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(3, LiveCommand::Undo { run_tests: false }),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("old tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(6)));
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("score += 1"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn layout_edit_is_rejected_before_disk_or_runtime_change() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                1,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Add,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global extra: i32;".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(!response.ok);
+        assert!(response.error.expect("error").contains("#153"));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn code_aware_add_delete_refreshes_completion_and_rejects_stale_hash() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let target = LiveSymbolTarget {
+            name: "helper".into(),
+            kind: Some("function".into()),
+            file: Some("src/main.stasis".into()),
+            owner: None,
+            signature: None,
+        };
+        let added = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                10,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Add,
+                    target: target.clone(),
+                    source: Some("function helper(): i32 { return 7; }".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(added.ok, "{:?}", added.error);
+        assert_eq!(
+            workspace.completion.complete(":read hel", 9, 10)[0].text,
+            "helper"
+        );
+        assert!(workspace.consumes_self_write(&root.join("src/main.stasis")));
+
+        let stale = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                11,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: target.clone(),
+                    source: Some("function helper(): i32 { return 8; }".into()),
+                    expected_source_hash: Some("stale".into()),
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(!stale.ok);
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("return 7"));
+
+        let files = load_workshop_edit_workspace(&root, &config.entry).expect("files");
+        let helper = find_workshop_symbols(&files, &selector(&target).expect("selector"))
+            .expect("symbols")
+            .remove(0);
+        let deleted = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                12,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Delete,
+                    target,
+                    source: None,
+                    expected_source_hash: Some(helper.source_hash),
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(deleted.ok, "{:?}", deleted.error);
+        assert!(workspace.completion.complete(":read hel", 9, 10).is_empty());
+        assert!(!fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("function helper"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn receipt_failure_rolls_back_disk_dispatch_and_state() {
+        let (root, mut config) = project();
+        config.output = PathBuf::from("receipt-blocker");
+        fs::write(root.join("receipt-blocker"), "not a directory").expect("block receipt");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                20,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): i32 { score += 4; return 0; }".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(!response.ok);
+        assert!(response.error.expect("error").contains("receipt"));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        assert!(workspace.consumes_self_write(&root.join("src/main.stasis")));
+        stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("old tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(2)));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn compiler_failure_leaves_disk_dispatch_and_state_unchanged() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                25,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): i32 { missing syntax }".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(!response.ok);
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("old tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(2)));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn cached_browse_disambiguates_same_name_overloads_and_completion_keeps_both() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/overloads.stasis"),
+            "function convert(value: i32): i32 { return value; }\nfunction convert(value: f32): f32 { return value; }\n",
+        )
+        .expect("overloads");
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let overloads = workspace
+            .source_items
+            .iter()
+            .filter(|item| item.name == "convert")
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(overloads.len(), 2);
+        assert_eq!(workspace.completion.complete(":read con", 9, 10).len(), 2);
+        for (request_id, overload) in (50..).zip(overloads) {
+            let response = run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    request_id,
+                    LiveCommand::Read {
+                        name: "convert".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/overloads.stasis".into()),
+                        owner: None,
+                        signature: Some(overload.signature.clone()),
+                    },
+                ),
+            );
+            assert!(response.ok, "{:?}", response.error);
+            assert_eq!(
+                response.data.expect("symbol")["signature"],
+                overload.signature
+            );
+        }
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn background_edit_preparation_keeps_status_responsive() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        client
+            .submit(LiveRequest::new(
+                30,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): i32 { score += 2; return 0; }".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: true,
+                },
+            ))
+            .expect("edit");
+        client
+            .submit(LiveRequest::new(31, LiveCommand::Status))
+            .expect("status");
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+        let preparing = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("preparing");
+        let status = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("status");
+        assert_eq!(preparing.kind, "edit_preparing");
+        assert_eq!(status.kind, "status");
+        assert_eq!(status.data.expect("data")["preparing_request_id"], 30);
+        client
+            .submit(LiveRequest::new(32, LiveCommand::Cancel { request_id: 30 }))
+            .expect("cancel");
+        workspace.process_boundary(2, &mut jit, &mut tick_ptr, &mut render_ptr);
+        let cancellation = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("cancellation acknowledgement");
+        assert_eq!(cancellation.request_id, 32);
+        assert!(cancellation.ok);
+        assert_eq!(cancellation.data.expect("cancel data")["background"], true);
+        let mut canceled = false;
+        for tick in 3..=500 {
+            workspace.process_boundary(tick, &mut jit, &mut tick_ptr, &mut render_ptr);
+            if let Ok(response) = client.receive_timeout(std::time::Duration::from_millis(10)) {
+                if response.request_id == 30 && response.kind != "edit_preparing" {
+                    canceled = !response.ok;
+                    break;
+                }
+            }
+        }
+        assert!(canceled);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn queued_cancel_wins_over_a_ready_background_commit() {
+        let (root, config) = project();
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let prepared = prepared_tick_edit(&config, 50);
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(32);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        install_ready_preparation(&mut workspace, prepared);
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        for request_id in 100..109 {
+            client
+                .submit(LiveRequest::new(request_id, LiveCommand::Status))
+                .expect("queued status");
+        }
+        client
+            .submit(LiveRequest::new(51, LiveCommand::Cancel { request_id: 50 }))
+            .expect("cancel");
+
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+
+        let canceled = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("canceled edit");
+        let acknowledgement = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("cancel acknowledgement");
+        assert_eq!(canceled.request_id, 50);
+        assert!(!canceled.ok);
+        assert_eq!(acknowledgement.request_id, 51);
+        assert_eq!(acknowledgement.data.expect("data")["background"], true);
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        for request_id in 100..108 {
+            let response = client
+                .receive_timeout(std::time::Duration::from_secs(1))
+                .expect("status response");
+            assert_eq!(response.request_id, request_id);
+        }
+        workspace.process_boundary(2, &mut jit, &mut tick_ptr, &mut render_ptr);
+        let final_status = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("final status");
+        assert_eq!(final_status.request_id, 108);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn sustained_request_refill_keeps_internal_backlog_bounded() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(MAX_PENDING_LIVE_REQUESTS);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let mut request_id = 1000u64;
+        let mut saw_backpressure = false;
+
+        for tick in 1..=10 {
+            for _ in 0..MAX_PENDING_LIVE_REQUESTS {
+                client
+                    .submit(LiveRequest::new(request_id, LiveCommand::Status))
+                    .expect("bounded request submit");
+                request_id += 1;
+            }
+            workspace.process_boundary(tick, &mut jit, &mut tick_ptr, &mut render_ptr);
+            assert!(workspace.pending_requests.len() <= MAX_PENDING_LIVE_REQUESTS);
+            while let Ok(response) = client.receive_timeout(std::time::Duration::from_millis(1)) {
+                saw_backpressure |= response
+                    .error
+                    .as_deref()
+                    .is_some_and(|error| error.contains("backpressure"));
+            }
+        }
+        assert!(saw_backpressure);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn unrelated_source_change_rejects_a_ready_background_commit() {
+        let (root, config) = project();
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let prepared = prepared_tick_edit(&config, 60);
+        fs::write(
+            root.join("tests/main.test.stasis"),
+            "test `changed during preparation`(): bool { return 2 == 2; }\n",
+        )
+        .expect("change unrelated test input");
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        install_ready_preparation(&mut workspace, prepared);
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+
+        let response = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("stale rejection");
+        assert_eq!(response.request_id, 60);
+        assert!(!response.ok);
+        assert!(response
+            .error
+            .expect("error")
+            .contains("changed during background preparation"));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn cancellation_in_same_boundary_prevents_command_execution() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        client
+            .submit(LiveRequest::new(1, LiveCommand::Pause))
+            .expect("pause");
+        client
+            .submit(LiveRequest::new(2, LiveCommand::Cancel { request_id: 1 }))
+            .expect("cancel");
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+        let canceled = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("canceled response");
+        let acknowledged = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("cancel acknowledgement");
+        assert_eq!(canceled.request_id, 1);
+        assert!(!canceled.ok);
+        assert_eq!(acknowledged.request_id, 2);
+        assert!(workspace.should_run_tick());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn quit_cancels_and_joins_background_preparation() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let canceled = Arc::new(AtomicBool::new(false));
+        let worker_canceled = Arc::clone(&canceled);
+        let stopped = Arc::new(AtomicBool::new(false));
+        let worker_stopped = Arc::clone(&stopped);
+        let (_sender, receiver) = mpsc::sync_channel(1);
+        let worker = std::thread::spawn(move || {
+            while !worker_canceled.load(Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            worker_stopped.store(true, Ordering::Release);
+        });
+        workspace.edit_preparation = Some(EditPreparation {
+            request_id: 70,
+            canceled,
+            receiver,
+            worker: Some(worker),
+        });
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        client
+            .submit(LiveRequest::new(71, LiveCommand::Quit))
+            .expect("quit");
+
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+        assert!(workspace.should_quit());
+        drop(workspace);
+        assert!(stopped.load(Ordering::Acquire));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn failing_live_edit_tests_restore_source_dispatch_and_state() {
+        let (root, config) = project();
+        fs::write(
+            root.join("tests/main.test.stasis"),
+            "import \"../src/main.stasis\";\ntest `tick increments once`(): bool { score = 0; let code: i32 = tick(); return code == 0 && score == 1; }\n",
+        )
+        .expect("behavioral test");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                1,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): i32 { score += 4; return 0; }".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: true,
+                },
+            ),
+        );
+        assert!(!response.ok);
+        assert!(response
+            .error
+            .expect("error")
+            .contains("disk/runtime remained unchanged"));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("old tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(2)));
+        assert!(!root.join("build/live-edits").exists());
+        fs::remove_dir_all(root).ok();
+    }
+}

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -4,10 +4,11 @@ use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
-    workshop_source_hash, workshop_source_items, write_workshop_semantic_plan,
-    write_workshop_semantic_receipt, ExpectedReload, WorkshopSemanticEdit,
-    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
-    WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
+    workshop_reachable_files, workshop_source_hash, workshop_source_items,
+    write_workshop_semantic_plan, write_workshop_semantic_receipt, ExpectedReload,
+    WorkshopSemanticEdit, WorkshopSemanticEditBatch, WorkshopSemanticEditOperation,
+    WorkshopSemanticEditPlan, WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind,
+    WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
     CompletionIndex, CompletionItem, LiveCommand, LiveEditOperation, LiveRequest, LiveResponse,
@@ -1111,6 +1112,7 @@ fn compile_candidate(
     config: &LiveRunConfig,
     files: &[WorkshopSourceFile],
 ) -> Result<(JitProcess, JitEnginePackage), String> {
+    let runtime_files = workshop_reachable_files(files, &config.entry)?;
     let mut candidate = JitProcess::new();
     candidate.set_required_emit_roots(&[
         "main".to_string(),
@@ -1118,9 +1120,9 @@ fn compile_candidate(
         "render".to_string(),
         "on_code_swap".to_string(),
     ]);
-    for file in files {
+    for file in runtime_files {
         let path = config.project_root.join(&file.path);
-        candidate.upsert_file(path.to_string_lossy().to_string(), file.source.clone());
+        candidate.upsert_file(path.to_string_lossy().to_string(), file.source);
     }
     candidate
         .compile_staged()
@@ -1776,6 +1778,29 @@ mod tests {
             MAX_STAGED_TEST_OUTPUT_BYTES + 1
         );
         assert!(overflow.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn live_runtime_candidate_excludes_test_only_symbols() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global score: i32;\nfunction helper(): i32 { return 7; }\nfunction main(): i32 { score = 0; return 0; }\nfunction tick(): i32 { score = helper(); return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("main source");
+        fs::write(
+            root.join("tests/main.test.stasis"),
+            "function helper(): i32 { return 99; }\ntest `helper stays isolated`(): bool { return helper() == 99; }\n",
+        )
+        .expect("test-only helper");
+
+        let files = load_workshop_edit_workspace(&root, &config.entry).expect("workspace files");
+        let (jit, package) = compile_candidate(&config, &files).expect("runtime candidate");
+        jit.activate_staged_runtime().expect("activate candidate");
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        stasis_dynload::invoke_noarg_i32(package.tick_code_ptr as usize).expect("tick");
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1074,20 +1074,379 @@ fn print_live_response(response: &LiveResponse, json_lines: bool) -> Result<(), 
                 .map_err(|error| format!("failed serializing live response: {error}"))?
         );
     } else if response.ok {
-        println!(
-            "[live tick {}] {} {}",
-            response.tick,
-            response.kind,
-            response.data.as_ref().unwrap_or(&Value::Null)
-        );
+        println!("{}", format_live_response(response));
     } else {
-        eprintln!(
-            "[live tick {}] error: {}",
+        eprintln!("{}", format_live_response(response));
+    }
+    Ok(())
+}
+
+fn format_live_response(response: &LiveResponse) -> String {
+    if !response.ok {
+        return format!(
+            "error @ tick {}: {}",
             response.tick,
             response.error.as_deref().unwrap_or("unknown live error")
         );
     }
-    Ok(())
+    let data = response.data.as_ref().unwrap_or(&Value::Null);
+    match response.kind.as_str() {
+        "help" => format_live_help(data),
+        "status" => format_live_status(data, response.tick),
+        "paused" => format!("paused @ tick {}", response.tick),
+        "resumed" => format!("running @ tick {}", response.tick),
+        "step_scheduled" => format!(
+            "step scheduled: {} tick(s) after tick {}",
+            data.get("ticks").and_then(Value::as_u64).unwrap_or(0),
+            data.get("after_tick")
+                .and_then(Value::as_u64)
+                .unwrap_or(response.tick)
+        ),
+        "quitting" => format!("session closed @ tick {}", response.tick),
+        "cancellation_requested" => format!(
+            "cancel requested for #{}{}",
+            data.get("request_id").and_then(Value::as_u64).unwrap_or(0),
+            if data
+                .get("background")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                " (background edit)"
+            } else {
+                ""
+            }
+        ),
+        "symbols" => format_live_symbols(data),
+        "symbol" => format_live_symbol(data),
+        "completion" => format_live_completion(data),
+        "inspection" => format!(
+            "{}: {} = {} @ tick {}",
+            string_field(data, "path", "value"),
+            string_field(data, "static_type", "unknown"),
+            scalar_text(data.get("value").unwrap_or(&Value::Null)),
+            response.tick
+        ),
+        "print" => format!(
+            "{} = {} @ tick {}",
+            string_field(data, "static_type", "value"),
+            scalar_text(data.get("value").unwrap_or(&Value::Null)),
+            response.tick
+        ),
+        "watch_added" => format!(
+            "watching {} = {} @ tick {}",
+            string_field(data, "path", "value"),
+            scalar_text(data.get("value").unwrap_or(&Value::Null)),
+            response.tick
+        ),
+        "watch" => format!(
+            "{} -> {} @ tick {}",
+            string_field(data, "path", "value"),
+            scalar_text(data.get("value").unwrap_or(&Value::Null)),
+            response.tick
+        ),
+        "watch_removed" => format_live_watch_removed(data),
+        "watch_backpressure" => format!(
+            "watch output dropped {} event(s)",
+            data.get("dropped_events")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        ),
+        "mutation_preview" => format_live_mutation(data, "preview", response.tick),
+        "mutation_committed" => format_live_mutation(data, "set", response.tick),
+        "transaction_preview" => format_live_transaction(data, "preview", response.tick),
+        "transaction_committed" => format_live_transaction(data, "committed", response.tick),
+        "cell_saved" => format!(
+            "saved scratch cell '{}'",
+            string_field(data, "name", "unnamed")
+        ),
+        "cells" => format_live_cells(data),
+        "cells_cleared" => match data.get("name").and_then(Value::as_str) {
+            Some(name) => format!("cleared scratch cell '{name}'"),
+            None => "cleared all scratch cells".to_string(),
+        },
+        "edit_preparing" => format!(
+            "preparing edit #{}...",
+            data.get("request_id").and_then(Value::as_u64).unwrap_or(0)
+        ),
+        "edit_preview" => format!(
+            "preview ready: {} @ tick {}",
+            format_live_plan(data),
+            response.tick
+        ),
+        "edit_applied" => format!(
+            "applied: {} (tests {}) @ tick {}",
+            format_live_plan(data),
+            string_field(data, "tests", "unknown"),
+            response.tick
+        ),
+        "edit_undone" => format!(
+            "undo complete (tests {}) @ tick {}",
+            string_field(data, "tests", "unknown"),
+            response.tick
+        ),
+        "edit_redone" => format!(
+            "redo complete (tests {}) @ tick {}",
+            string_field(data, "tests", "unknown"),
+            response.tick
+        ),
+        "changes" => format_live_changes(data),
+        kind => format!("{kind} @ tick {}", response.tick),
+    }
+}
+
+fn string_field<'a>(data: &'a Value, name: &str, fallback: &'a str) -> &'a str {
+    data.get(name).and_then(Value::as_str).unwrap_or(fallback)
+}
+
+fn scalar_text(value: &Value) -> String {
+    let value = value.get("value").unwrap_or(value);
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => value.clone(),
+        _ => "<structured value>".to_string(),
+    }
+}
+
+fn format_live_help(data: &Value) -> String {
+    let commands = data
+        .get("commands")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let mut lines = vec!["Commands:".to_string()];
+    for group in commands.chunks(3) {
+        lines.push(format!(
+            "  {}",
+            group
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join("  ")
+        ));
+    }
+    lines.push("Multiline: :end to submit; :abort or Ctrl-C to cancel.".to_string());
+    lines.join("\n")
+}
+
+fn format_live_status(data: &Value, tick: u64) -> String {
+    let state = if data.get("paused").and_then(Value::as_bool).unwrap_or(false) {
+        "paused"
+    } else {
+        "running"
+    };
+    let cursor = data
+        .get("history_cursor")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let history = data
+        .get("history_length")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let watches = string_array(data.get("watches"));
+    let cells = data
+        .get("scratch_cells")
+        .and_then(Value::as_array)
+        .map(|cells| {
+            cells
+                .iter()
+                .filter_map(|cell| cell.get("name").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let mut line = format!("{state} @ tick {tick} | edits {cursor}/{history}");
+    if !watches.is_empty() {
+        line.push_str(&format!(" | watches {watches}"));
+    }
+    if !cells.is_empty() {
+        line.push_str(&format!(" | cells {cells}"));
+    }
+    if let Some(request) = data.get("preparing_request_id").and_then(Value::as_u64) {
+        line.push_str(&format!(" | preparing #{request}"));
+    }
+    line
+}
+
+fn string_array(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default()
+}
+
+fn format_live_symbols(data: &Value) -> String {
+    let total = data.get("total").and_then(Value::as_u64).unwrap_or(0);
+    let page = data.get("page").and_then(Value::as_u64).unwrap_or(0);
+    let mut lines = vec![format!("{total} symbol(s), page {page}:")];
+    if let Some(items) = data.get("items").and_then(Value::as_array) {
+        for item in items {
+            lines.push(format!(
+                "  {}  [{}]",
+                string_field(item, "signature", string_field(item, "name", "unnamed")),
+                string_field(item, "file", "unknown file")
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+fn format_live_symbol(data: &Value) -> String {
+    let header = format!(
+        "{}  [{}]",
+        string_field(data, "signature", string_field(data, "name", "unnamed")),
+        string_field(data, "file", "unknown file")
+    );
+    match data.get("source").and_then(Value::as_str) {
+        Some(source) => format!("{header}\n{}", source.trim()),
+        None => header,
+    }
+}
+
+fn format_live_completion(data: &Value) -> String {
+    let mut lines = Vec::new();
+    if let Some(items) = data.get("items").and_then(Value::as_array) {
+        for item in items {
+            lines.push(format!(
+                "{}  {}  {}",
+                string_field(item, "text", ""),
+                string_field(item, "kind", ""),
+                string_field(item, "detail", "")
+            ));
+        }
+    }
+    if lines.is_empty() {
+        "no completions".to_string()
+    } else {
+        lines.join("\n")
+    }
+}
+
+fn format_live_watch_removed(data: &Value) -> String {
+    let watches = string_array(data.get("watches"));
+    if watches.is_empty() {
+        "no active watches".to_string()
+    } else {
+        format!("active watches: {watches}")
+    }
+}
+
+fn format_live_mutation(data: &Value, action: &str, tick: u64) -> String {
+    format!(
+        "{action} {}: {} -> {} ({}) @ tick {tick}",
+        string_field(data, "path", "value"),
+        scalar_text(data.get("old").unwrap_or(&Value::Null)),
+        scalar_text(data.get("new").unwrap_or(&Value::Null)),
+        string_field(data, "static_type", "unknown")
+    )
+}
+
+fn format_live_transaction(data: &Value, action: &str, tick: u64) -> String {
+    let transaction = data.get("result").unwrap_or(data);
+    let name = data.get("name").and_then(Value::as_str);
+    let mut lines = vec![match name {
+        Some(name) => format!("scratch '{name}' {action} @ tick {tick}:"),
+        None => format!("transaction {action} @ tick {tick}:"),
+    }];
+    if let Some(mutations) = transaction.get("mutations").and_then(Value::as_array) {
+        for mutation in mutations {
+            lines.push(format!(
+                "  {}: {} -> {} ({})",
+                string_field(mutation, "path", "value"),
+                scalar_text(mutation.get("old").unwrap_or(&Value::Null)),
+                scalar_text(mutation.get("new").unwrap_or(&Value::Null)),
+                string_field(mutation, "static_type", "unknown")
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+fn format_live_cells(data: &Value) -> String {
+    let Some(cells) = data.get("cells").and_then(Value::as_array) else {
+        return "no scratch cells".to_string();
+    };
+    if cells.is_empty() {
+        return "no scratch cells".to_string();
+    }
+    cells
+        .iter()
+        .map(|cell| {
+            let name = string_field(cell, "name", "unnamed");
+            match cell.get("last_tick").and_then(Value::as_u64) {
+                Some(tick) => format!("{name} (last run @ tick {tick})"),
+                None => name.to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_live_plan(data: &Value) -> String {
+    let plan = data.get("plan").unwrap_or(data);
+    let file_count = plan
+        .get("changed_files")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let symbols = plan
+        .pointer("/reload/changed_symbols")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("name").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    let reload = plan
+        .pointer("/reload/expected_reload")
+        .and_then(Value::as_str)
+        .unwrap_or("reload unknown");
+    if symbols.is_empty() {
+        format!("{file_count} file(s), {reload}")
+    } else {
+        format!("{symbols}; {file_count} file(s), {reload}")
+    }
+}
+
+fn format_live_changes(data: &Value) -> String {
+    let cursor = data.get("cursor").and_then(Value::as_u64).unwrap_or(0);
+    let Some(entries) = data.get("entries").and_then(Value::as_array) else {
+        return "no semantic edit history".to_string();
+    };
+    if entries.is_empty() {
+        return "no semantic edit history".to_string();
+    }
+    let mut lines = vec![format!(
+        "edit history ({cursor}/{} applied):",
+        entries.len()
+    )];
+    for entry in entries {
+        let index = entry.get("index").and_then(Value::as_u64).unwrap_or(0);
+        let marker = if entry
+            .get("applied")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "*"
+        } else {
+            " "
+        };
+        let files = entry
+            .get("changed_files")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        lines.push(format!(" {marker} #{index}: {files} file(s)"));
+    }
+    lines.join("\n")
 }
 
 fn build_workspace(
@@ -2257,6 +2616,109 @@ mod tests {
         assert_eq!(start, 6);
         assert_eq!(matches[0].replacement, "tick");
         assert!(matches[0].display.contains("tick(): i32"));
+    }
+
+    #[test]
+    fn human_live_output_formats_scalars_without_json_envelopes() {
+        let response = LiveResponse::success(
+            7,
+            42,
+            "inspection",
+            json!({
+                "path": "player.score",
+                "static_type": "i32",
+                "value": {"type": "i32", "value": 12}
+            }),
+        );
+        assert_eq!(
+            format_live_response(&response),
+            "player.score: i32 = 12 @ tick 42"
+        );
+    }
+
+    #[test]
+    fn human_live_output_summarizes_plans_without_source_or_receipt_json() {
+        let response = LiveResponse::success(
+            8,
+            43,
+            "edit_applied",
+            json!({
+                "plan": {
+                    "changed_files": [{
+                        "file": "src/main.stasis",
+                        "before_source": "old source",
+                        "after_source": "very long new source"
+                    }],
+                    "reload": {
+                        "changed_symbols": [{"name": "tick"}],
+                        "expected_reload": "FastReload"
+                    }
+                },
+                "receipt": "build/live-edits/receipt.json",
+                "tests": "passed"
+            }),
+        );
+        let output = format_live_response(&response);
+        assert_eq!(
+            output,
+            "applied: tick; 1 file(s), FastReload (tests passed) @ tick 43"
+        );
+        assert!(!output.contains("source"));
+        assert!(!output.contains("receipt"));
+        assert!(!output.contains('{'));
+    }
+
+    #[test]
+    fn human_live_output_formats_scratch_transactions_as_mutation_lines() {
+        let response = LiveResponse::success(
+            9,
+            44,
+            "transaction_preview",
+            json!({
+                "name": "lift_ball",
+                "persistent": false,
+                "result": {
+                    "preview": true,
+                    "mutations": [{
+                        "path": "ball_y",
+                        "static_type": "f32",
+                        "old": {"type": "f32", "value": 300.0},
+                        "new": {"type": "f32", "value": 180.0}
+                    }]
+                }
+            }),
+        );
+        assert_eq!(
+            format_live_response(&response),
+            "scratch 'lift_ball' preview @ tick 44:\n  ball_y: 300.0 -> 180.0 (f32)"
+        );
+    }
+
+    #[test]
+    fn human_live_output_never_uses_raw_json_as_an_unknown_fallback() {
+        let response = LiveResponse::success(
+            10,
+            45,
+            "future_response",
+            json!({"large": {"nested": [1, 2, 3]}}),
+        );
+        assert_eq!(format_live_response(&response), "future_response @ tick 45");
+
+        let failure = LiveResponse::failure(11, 46, "layout change rejected");
+        assert_eq!(
+            format_live_response(&failure),
+            "error @ tick 46: layout change rejected"
+        );
+    }
+
+    #[test]
+    fn human_live_output_reports_watch_backpressure_count() {
+        let response =
+            LiveResponse::success(12, 47, "watch_backpressure", json!({"dropped_events": 9}));
+        assert_eq!(
+            format_live_response(&response),
+            "watch output dropped 9 event(s)"
+        );
     }
     use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -954,6 +954,11 @@ fn run_live_terminal_inner(
                 }
             }
         }
+        if terminal.cancel_pending() {
+            return Err(
+                "live script ended with unfinished multiline input; add :end or :abort".to_string(),
+            );
+        }
     } else {
         println!("Stasis live workspace (:help, :quit, Tab completion, Ctrl-C cancels multiline)");
         let mut editor = Editor::<LiveLineHelper, DefaultHistory>::new()

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1089,25 +1089,21 @@ fn print_live_response(response: &LiveResponse, json_lines: bool) -> Result<(), 
 fn format_live_response(response: &LiveResponse) -> String {
     if !response.ok {
         return format!(
-            "error @ tick {}: {}",
-            response.tick,
+            "error: {}",
             response.error.as_deref().unwrap_or("unknown live error")
         );
     }
     let data = response.data.as_ref().unwrap_or(&Value::Null);
     match response.kind.as_str() {
         "help" => format_live_help(data),
-        "status" => format_live_status(data, response.tick),
-        "paused" => format!("paused @ tick {}", response.tick),
-        "resumed" => format!("running @ tick {}", response.tick),
+        "status" => format_live_status(data),
+        "paused" => "paused".to_string(),
+        "resumed" => "running".to_string(),
         "step_scheduled" => format!(
-            "step scheduled: {} tick(s) after tick {}",
-            data.get("ticks").and_then(Value::as_u64).unwrap_or(0),
-            data.get("after_tick")
-                .and_then(Value::as_u64)
-                .unwrap_or(response.tick)
+            "step scheduled: {} tick(s)",
+            data.get("ticks").and_then(Value::as_u64).unwrap_or(0)
         ),
-        "quitting" => format!("session closed @ tick {}", response.tick),
+        "quitting" => "session closed".to_string(),
         "cancellation_requested" => format!(
             "cancel requested for #{}{}",
             data.get("request_id").and_then(Value::as_u64).unwrap_or(0),
@@ -1125,29 +1121,25 @@ fn format_live_response(response: &LiveResponse) -> String {
         "symbol" => format_live_symbol(data),
         "completion" => format_live_completion(data),
         "inspection" => format!(
-            "{}: {} = {} @ tick {}",
+            "{}: {} = {}",
             string_field(data, "path", "value"),
             string_field(data, "static_type", "unknown"),
-            scalar_text(data.get("value").unwrap_or(&Value::Null)),
-            response.tick
+            scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
         "print" => format!(
-            "{} = {} @ tick {}",
+            "{} = {}",
             string_field(data, "static_type", "value"),
-            scalar_text(data.get("value").unwrap_or(&Value::Null)),
-            response.tick
+            scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
         "watch_added" => format!(
-            "watching {} = {} @ tick {}",
+            "watching {} = {}",
             string_field(data, "path", "value"),
-            scalar_text(data.get("value").unwrap_or(&Value::Null)),
-            response.tick
+            scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
         "watch" => format!(
-            "{} -> {} @ tick {}",
+            "{} -> {}",
             string_field(data, "path", "value"),
-            scalar_text(data.get("value").unwrap_or(&Value::Null)),
-            response.tick
+            scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
         "watch_removed" => format_live_watch_removed(data),
         "watch_backpressure" => format!(
@@ -1156,10 +1148,10 @@ fn format_live_response(response: &LiveResponse) -> String {
                 .and_then(Value::as_u64)
                 .unwrap_or(0)
         ),
-        "mutation_preview" => format_live_mutation(data, "preview", response.tick),
-        "mutation_committed" => format_live_mutation(data, "set", response.tick),
-        "transaction_preview" => format_live_transaction(data, "preview", response.tick),
-        "transaction_committed" => format_live_transaction(data, "committed", response.tick),
+        "mutation_preview" => format_live_mutation(data, "preview"),
+        "mutation_committed" => format_live_mutation(data, "set"),
+        "transaction_preview" => format_live_transaction(data, "preview"),
+        "transaction_committed" => format_live_transaction(data, "committed"),
         "cell_saved" => format!(
             "saved scratch cell '{}'",
             string_field(data, "name", "unnamed")
@@ -1173,29 +1165,22 @@ fn format_live_response(response: &LiveResponse) -> String {
             "preparing edit #{}...",
             data.get("request_id").and_then(Value::as_u64).unwrap_or(0)
         ),
-        "edit_preview" => format!(
-            "preview ready: {} @ tick {}",
-            format_live_plan(data),
-            response.tick
-        ),
+        "edit_preview" => format!("preview ready: {}", format_live_plan(data)),
         "edit_applied" => format!(
-            "applied: {} (tests {}) @ tick {}",
+            "applied: {} (tests {})",
             format_live_plan(data),
-            string_field(data, "tests", "unknown"),
-            response.tick
+            string_field(data, "tests", "unknown")
         ),
         "edit_undone" => format!(
-            "undo complete (tests {}) @ tick {}",
-            string_field(data, "tests", "unknown"),
-            response.tick
+            "undo complete (tests {})",
+            string_field(data, "tests", "unknown")
         ),
         "edit_redone" => format!(
-            "redo complete (tests {}) @ tick {}",
-            string_field(data, "tests", "unknown"),
-            response.tick
+            "redo complete (tests {})",
+            string_field(data, "tests", "unknown")
         ),
         "changes" => format_live_changes(data),
-        kind => format!("{kind} @ tick {}", response.tick),
+        kind => kind.to_string(),
     }
 }
 
@@ -1235,7 +1220,7 @@ fn format_live_help(data: &Value) -> String {
     lines.join("\n")
 }
 
-fn format_live_status(data: &Value, tick: u64) -> String {
+fn format_live_status(data: &Value) -> String {
     let state = if data.get("paused").and_then(Value::as_bool).unwrap_or(false) {
         "paused"
     } else {
@@ -1261,7 +1246,7 @@ fn format_live_status(data: &Value, tick: u64) -> String {
                 .join(", ")
         })
         .unwrap_or_default();
-    let mut line = format!("{state} @ tick {tick} | edits {cursor}/{history}");
+    let mut line = format!("{state} | edits {cursor}/{history}");
     if !watches.is_empty() {
         line.push_str(&format!(" | watches {watches}"));
     }
@@ -1343,9 +1328,9 @@ fn format_live_watch_removed(data: &Value) -> String {
     }
 }
 
-fn format_live_mutation(data: &Value, action: &str, tick: u64) -> String {
+fn format_live_mutation(data: &Value, action: &str) -> String {
     format!(
-        "{action} {}: {} -> {} ({}) @ tick {tick}",
+        "{action} {}: {} -> {} ({})",
         string_field(data, "path", "value"),
         scalar_text(data.get("old").unwrap_or(&Value::Null)),
         scalar_text(data.get("new").unwrap_or(&Value::Null)),
@@ -1353,12 +1338,12 @@ fn format_live_mutation(data: &Value, action: &str, tick: u64) -> String {
     )
 }
 
-fn format_live_transaction(data: &Value, action: &str, tick: u64) -> String {
+fn format_live_transaction(data: &Value, action: &str) -> String {
     let transaction = data.get("result").unwrap_or(data);
     let name = data.get("name").and_then(Value::as_str);
     let mut lines = vec![match name {
-        Some(name) => format!("scratch '{name}' {action} @ tick {tick}:"),
-        None => format!("transaction {action} @ tick {tick}:"),
+        Some(name) => format!("scratch '{name}' {action}:"),
+        None => format!("transaction {action}:"),
     }];
     if let Some(mutations) = transaction.get("mutations").and_then(Value::as_array) {
         for mutation in mutations {
@@ -1383,13 +1368,7 @@ fn format_live_cells(data: &Value) -> String {
     }
     cells
         .iter()
-        .map(|cell| {
-            let name = string_field(cell, "name", "unnamed");
-            match cell.get("last_tick").and_then(Value::as_u64) {
-                Some(tick) => format!("{name} (last run @ tick {tick})"),
-                None => name.to_string(),
-            }
-        })
+        .map(|cell| string_field(cell, "name", "unnamed").to_string())
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -2635,10 +2614,7 @@ mod tests {
                 "value": {"type": "i32", "value": 12}
             }),
         );
-        assert_eq!(
-            format_live_response(&response),
-            "player.score: i32 = 12 @ tick 42"
-        );
+        assert_eq!(format_live_response(&response), "player.score: i32 = 12");
     }
 
     #[test]
@@ -2666,7 +2642,7 @@ mod tests {
         let output = format_live_response(&response);
         assert_eq!(
             output,
-            "applied: tick; 1 file(s), FastReload (tests passed) @ tick 43"
+            "applied: tick; 1 file(s), FastReload (tests passed)"
         );
         assert!(!output.contains("source"));
         assert!(!output.contains("receipt"));
@@ -2695,7 +2671,7 @@ mod tests {
         );
         assert_eq!(
             format_live_response(&response),
-            "scratch 'lift_ball' preview @ tick 44:\n  ball_y: 300.0 -> 180.0 (f32)"
+            "scratch 'lift_ball' preview:\n  ball_y: 300.0 -> 180.0 (f32)"
         );
     }
 
@@ -2707,12 +2683,12 @@ mod tests {
             "future_response",
             json!({"large": {"nested": [1, 2, 3]}}),
         );
-        assert_eq!(format_live_response(&response), "future_response @ tick 45");
+        assert_eq!(format_live_response(&response), "future_response");
 
         let failure = LiveResponse::failure(11, 46, "layout change rejected");
         assert_eq!(
             format_live_response(&failure),
-            "error @ tick 46: layout change rejected"
+            "error: layout change rejected"
         );
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,9 +1,15 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use rustyline::completion::{Completer, Pair};
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::history::DefaultHistory;
+use rustyline::validate::Validator;
+use rustyline::{Context, Editor, Helper};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use stasis::{
-    run_jit_tests_in_directory_with_session, run_play_in_process,
-    run_self_host_aot_cli_with_options, StasisTestRunSession,
+    run_jit_tests_in_directory_with_session, run_live_in_process, run_play_in_process,
+    run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::frontend::workshop::{
@@ -13,11 +19,18 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
     WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
+use stasis_runner::live::{
+    live_session, CompletionItem, LiveCommand, LiveRequest, LiveResponse, TerminalBuffer,
+    TerminalInput,
+};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
+use std::io::{self, BufRead};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
@@ -102,6 +115,15 @@ enum ToolchainCommand {
         /// Explicitly select the headless runtime (currently the default).
         #[arg(long)]
         headless: bool,
+        /// Keep the graphical game running while accepting live workspace commands.
+        #[arg(long, conflicts_with_all = ["watch", "headless"])]
+        interactive: bool,
+        /// Read interactive commands from a deterministic script instead of stdin.
+        #[arg(long, value_name = "PATH", requires = "interactive")]
+        live_script: Option<PathBuf>,
+        /// Emit versioned live response envelopes as JSON lines.
+        #[arg(long, requires = "interactive")]
+        live_json: bool,
     },
     /// Build the project for development or as a release executable.
     Build {
@@ -524,8 +546,20 @@ fn execute(
                 ToolchainCommand::Run {
                     watch,
                     headless,
+                    interactive,
+                    live_script,
+                    live_json,
                 } => {
-                    if watch && json_output {
+                    if interactive && json_output {
+                        Err("--json cannot be combined with --interactive; use --live-json for the response stream".to_string())
+                    } else if interactive {
+                        validate_optional_workspace_path(
+                            &workspace,
+                            "live script",
+                            live_script.as_deref(),
+                        )?;
+                        run_workspace_live(&workspace, live_script.as_deref(), live_json)
+                    } else if watch && json_output {
                         Err("--json cannot be combined with --watch; watch mode is an unbounded event stream".to_string())
                     } else if watch && headless {
                         Err("--headless cannot be combined with --watch; watch mode uses the graphical hot-swap runner".to_string())
@@ -807,6 +841,253 @@ fn run_workspace_watch(workspace: &Workspace) -> Result<CommandResult, String> {
         "graphical watch session ended",
         json!({"backend": "jit", "headless": false, "watch": true}),
     ))
+}
+
+fn run_workspace_live(
+    workspace: &Workspace,
+    script: Option<&Path>,
+    json_lines: bool,
+) -> Result<CommandResult, String> {
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
+    let script = script.map(|path| workspace.root.join(path));
+    let terminal = thread::spawn(move || run_live_terminal(client, script.as_deref(), json_lines));
+    let config = LiveRunConfig::new(
+        workspace.root.clone(),
+        PathBuf::from(&workspace.manifest.entry),
+        PathBuf::from(&workspace.manifest.output),
+    );
+    let run_result =
+        run_live_in_process(&entry, Some(&workspace.root), 16_000, None, server, config);
+    if !terminal.is_finished() {
+        return match run_result {
+            Ok(()) => Err("live runner ended before the terminal session completed".to_string()),
+            Err(error) => Err(error),
+        };
+    }
+    let terminal_result = terminal
+        .join()
+        .map_err(|_| "live terminal thread panicked".to_string())?;
+    run_result?;
+    terminal_result?;
+    Ok(CommandResult::success(
+        "interactive live session ended",
+        json!({"backend": "jit", "headless": false, "interactive": true}),
+    ))
+}
+
+struct LiveLineHelper {
+    items: Vec<CompletionItem>,
+}
+
+impl Helper for LiveLineHelper {}
+impl Highlighter for LiveLineHelper {}
+impl Validator for LiveLineHelper {}
+impl Hinter for LiveLineHelper {
+    type Hint = String;
+}
+
+impl Completer for LiveLineHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        position: usize,
+        _context: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let mut position = position.min(line.len());
+        while !line.is_char_boundary(position) {
+            position -= 1;
+        }
+        let start = line[..position]
+            .rfind(|character: char| {
+                character.is_whitespace() || character == '(' || character == ','
+            })
+            .map_or(0, |index| index + 1);
+        let prefix = &line[start..position];
+        let candidates = self
+            .items
+            .iter()
+            .filter(|item| item.text.starts_with(prefix))
+            .map(|item| Pair {
+                display: format!("{}  {}", item.text, item.detail),
+                replacement: item.text.clone(),
+            })
+            .collect();
+        Ok((start, candidates))
+    }
+}
+
+fn run_live_terminal(
+    client: stasis_runner::live::LiveSessionClient,
+    script: Option<&Path>,
+    json_lines: bool,
+) -> Result<(), String> {
+    let result = run_live_terminal_inner(&client, script, json_lines);
+    if result.is_err() {
+        let _ = client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
+    }
+    result
+}
+
+fn run_live_terminal_inner(
+    client: &stasis_runner::live::LiveSessionClient,
+    script: Option<&Path>,
+    json_lines: bool,
+) -> Result<(), String> {
+    let mut terminal = TerminalBuffer::new();
+    let mut saw_quit = false;
+    let mut script_failure = None;
+    if let Some(script) = script {
+        let file = fs::File::open(script)
+            .map_err(|error| format!("failed to open live script {}: {error}", script.display()))?;
+        for line in io::BufReader::new(file).lines() {
+            let line = line.map_err(|error| format!("failed reading live script: {error}"))?;
+            if let TerminalInput::Request(request) = terminal.feed_line(&line)? {
+                saw_quit |= matches!(&request.command, LiveCommand::Quit);
+                let request_id = request.request_id;
+                if !submit_and_print_live_response(client, request, json_lines, true)?
+                    && script_failure.is_none()
+                {
+                    script_failure = Some(format!("live request {request_id} failed"));
+                }
+            }
+        }
+    } else {
+        println!("Stasis live workspace (:help, :quit, Tab completion, Ctrl-C cancels multiline)");
+        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::new()
+            .map_err(|error| format!("failed initializing live line editor: {error}"))?;
+        editor.set_helper(Some(LiveLineHelper { items: Vec::new() }));
+        let mut prompt = "stasis> ";
+        let mut completion_request_id = 1u64 << 63;
+        loop {
+            if let Ok(items) = fetch_live_completions(client, completion_request_id, json_lines) {
+                if let Some(helper) = editor.helper_mut() {
+                    helper.items = items;
+                }
+            }
+            completion_request_id = completion_request_id.saturating_add(1);
+            let line = match editor.readline(prompt) {
+                Ok(line) => line,
+                Err(rustyline::error::ReadlineError::Interrupted) => {
+                    if terminal.cancel_pending() {
+                        println!("multiline command canceled");
+                        prompt = "stasis> ";
+                    }
+                    continue;
+                }
+                Err(rustyline::error::ReadlineError::Eof) => break,
+                Err(error) => return Err(format!("failed reading live terminal: {error}")),
+            };
+            let _ = editor.add_history_entry(line.as_str());
+            match terminal.feed_line(&line)? {
+                TerminalInput::Continue { prompt: next } => {
+                    prompt = next;
+                    continue;
+                }
+                TerminalInput::Request(request) => {
+                    prompt = "stasis> ";
+                    saw_quit |= matches!(&request.command, LiveCommand::Quit);
+                    submit_and_print_live_response(client, request, json_lines, false)?;
+                    if saw_quit {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if !saw_quit {
+        submit_and_print_live_response(
+            client,
+            LiveRequest::new(u64::MAX, LiveCommand::Quit),
+            json_lines,
+            true,
+        )?;
+    }
+    match script_failure {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn fetch_live_completions(
+    client: &stasis_runner::live::LiveSessionClient,
+    request_id: u64,
+    json_lines: bool,
+) -> Result<Vec<CompletionItem>, String> {
+    client.submit(LiveRequest::new(
+        request_id,
+        LiveCommand::Complete {
+            buffer: String::new(),
+            cursor: 0,
+            limit: 256,
+        },
+    ))?;
+    loop {
+        let response = client.receive_timeout(Duration::from_secs(5))?;
+        if response.request_id != request_id {
+            print_live_response(&response, json_lines)?;
+            continue;
+        }
+        if !response.ok {
+            return Err(response
+                .error
+                .unwrap_or_else(|| "live completion failed".to_string()));
+        }
+        return serde_json::from_value(
+            response
+                .data
+                .and_then(|data| data.get("items").cloned())
+                .unwrap_or_else(|| json!([])),
+        )
+        .map_err(|error| format!("invalid live completion response: {error}"));
+    }
+}
+
+fn submit_and_print_live_response(
+    client: &stasis_runner::live::LiveSessionClient,
+    request: LiveRequest,
+    json_lines: bool,
+    wait_for_preparation: bool,
+) -> Result<bool, String> {
+    let request_id = request.request_id;
+    client.submit(request)?;
+    loop {
+        let response = client.receive_timeout(Duration::from_secs(300))?;
+        let request_succeeded = response.ok;
+        print_live_response(&response, json_lines)?;
+        if response.request_id == request_id {
+            if wait_for_preparation && response.kind == "edit_preparing" {
+                continue;
+            }
+            return Ok(request_succeeded);
+        }
+    }
+}
+
+fn print_live_response(response: &LiveResponse, json_lines: bool) -> Result<(), String> {
+    if json_lines {
+        println!(
+            "{}",
+            serde_json::to_string(response)
+                .map_err(|error| format!("failed serializing live response: {error}"))?
+        );
+    } else if response.ok {
+        println!(
+            "[live tick {}] {} {}",
+            response.tick,
+            response.kind,
+            response.data.as_ref().unwrap_or(&Value::Null)
+        );
+    } else {
+        eprintln!(
+            "[live tick {}] error: {}",
+            response.tick,
+            response.error.as_deref().unwrap_or("unknown live error")
+        );
+    }
+    Ok(())
 }
 
 fn build_workspace(
@@ -1958,6 +2239,25 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn live_line_helper_completes_current_token_with_compiler_detail() {
+        let helper = LiveLineHelper {
+            items: vec![CompletionItem {
+                text: "tick".into(),
+                kind: "function".into(),
+                detail: "tick(): i32".into(),
+            }],
+        };
+        let history = DefaultHistory::new();
+        let context = Context::new(&history);
+        let (start, matches) = helper
+            .complete(":read ti", 8, &context)
+            .expect("completion");
+        assert_eq!(start, 6);
+        assert_eq!(matches[0].replacement, "tick");
+        assert!(matches[0].display.contains("tick(): i32"));
+    }
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1055,6 +1055,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
         .map(|line| serde_json::from_str::<Value>(line).expect("live response JSON"))
         .collect::<Vec<_>>();
     assert!(responses.iter().all(|response| response["ok"] == true));
+    assert!(responses.iter().all(|response| response["tick"].is_u64()));
     let inspected = responses
         .iter()
         .filter(|response| response["kind"] == "inspection")
@@ -1119,10 +1120,11 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
         String::from_utf8_lossy(&human.stderr)
     );
     let human_stdout = String::from_utf8_lossy(&human.stdout);
-    assert!(human_stdout.contains("paused @ tick"));
+    assert!(human_stdout.contains("paused"));
     assert!(human_stdout.contains("score: i32 ="));
     assert!(human_stdout.contains("edits 0/0"));
-    assert!(human_stdout.contains("session closed @ tick"));
+    assert!(human_stdout.contains("session closed"));
+    assert!(!human_stdout.contains("@ tick"));
     assert!(!human_stdout.contains("[live tick"));
     assert!(!human_stdout.contains("{\"path\""));
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1004,6 +1004,101 @@ fn semantic_symbol_cli_reapplies_edit_when_revert_tests_fail() {
     fs::remove_dir_all(parent).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
+    let parent = temp_dir("interactive_live");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    fs::write(
+        project.join("src/main.stasis"),
+        "global score: i32;\nglobal swaps: i32;\nfunction main(): i32 { score = 1; swaps = 0; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { swaps += 1; return; }\n",
+    )
+    .expect("write live project");
+    fs::write(
+        project.join("tests/main.test.stasis"),
+        "test `live edit remains valid`(): bool { return 1 == 1; }\n",
+    )
+    .expect("write live test");
+    fs::write(
+        project.join("live.commands"),
+        ":pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
+    )
+    .expect("write live script");
+
+    let output = stasis(
+        &[
+            "run",
+            "--interactive",
+            "--live-script",
+            "live.commands",
+            "--live-json",
+        ],
+        &project,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let responses = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| line.starts_with('{'))
+        .map(|line| serde_json::from_str::<Value>(line).expect("live response JSON"))
+        .collect::<Vec<_>>();
+    assert!(responses.iter().all(|response| response["ok"] == true));
+    let inspected = responses
+        .iter()
+        .filter(|response| response["kind"] == "inspection")
+        .map(|response| {
+            response["data"]["value"]["value"]
+                .as_i64()
+                .expect("i32 value")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(inspected, vec![1, 14, 2, 15]);
+    assert!(fs::read_to_string(project.join("src/main.stasis"))
+        .expect("final source")
+        .contains("score += 1"));
+
+    fs::write(
+        project.join("failed-live.commands"),
+        ":pause\n:inspect missing_global\n:quit\n",
+    )
+    .expect("write failing live script");
+    let failed = stasis(
+        &[
+            "run",
+            "--interactive",
+            "--live-script",
+            "failed-live.commands",
+            "--live-json",
+        ],
+        &project,
+    );
+    assert_eq!(
+        failed.status.code(),
+        Some(1),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&failed.stdout),
+        String::from_utf8_lossy(&failed.stderr)
+    );
+    assert!(String::from_utf8_lossy(&failed.stdout)
+        .lines()
+        .filter(|line| line.starts_with('{'))
+        .map(|line| serde_json::from_str::<Value>(line).expect("failed live response JSON"))
+        .any(|response| response["ok"] == false));
+    fs::remove_dir_all(parent).ok();
+}
+
 fn walk_files(root: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     let mut pending = vec![root.to_path_buf()];

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1125,6 +1125,30 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     assert!(human_stdout.contains("session closed @ tick"));
     assert!(!human_stdout.contains("[live tick"));
     assert!(!human_stdout.contains("{\"path\""));
+
+    fs::write(
+        project.join("unfinished-live.commands"),
+        ":update function tick src/main.stasis\nfunction tick(): i32 { score += 9; return 0; }\n",
+    )
+    .expect("write unfinished live script");
+    let unfinished = stasis(
+        &[
+            "run",
+            "--interactive",
+            "--live-script",
+            "unfinished-live.commands",
+        ],
+        &project,
+    );
+    assert_eq!(
+        unfinished.status.code(),
+        Some(1),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&unfinished.stdout),
+        String::from_utf8_lossy(&unfinished.stderr)
+    );
+    assert!(String::from_utf8_lossy(&unfinished.stderr)
+        .contains("live script ended with unfinished multiline input"));
     fs::remove_dir_all(parent).ok();
 }
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1096,6 +1096,35 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
         .filter(|line| line.starts_with('{'))
         .map(|line| serde_json::from_str::<Value>(line).expect("failed live response JSON"))
         .any(|response| response["ok"] == false));
+
+    fs::write(
+        project.join("human-live.commands"),
+        ":pause\n:inspect score\n:status\n:quit\n",
+    )
+    .expect("write human live script");
+    let human = stasis(
+        &[
+            "run",
+            "--interactive",
+            "--live-script",
+            "human-live.commands",
+        ],
+        &project,
+    );
+    assert_eq!(
+        human.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&human.stdout),
+        String::from_utf8_lossy(&human.stderr)
+    );
+    let human_stdout = String::from_utf8_lossy(&human.stdout);
+    assert!(human_stdout.contains("paused @ tick"));
+    assert!(human_stdout.contains("score: i32 ="));
+    assert!(human_stdout.contains("edits 0/0"));
+    assert!(human_stdout.contains("session closed @ tick"));
+    assert!(!human_stdout.contains("[live tick"));
+    assert!(!human_stdout.contains("{\"path\""));
     fs::remove_dir_all(parent).ok();
 }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2,8 +2,10 @@ use crate::backend::emit::RuntimeHelperLinkage;
 use crate::backend::EngineEntrypoints;
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
 use crate::frontend::indexer::hash_text;
+use crate::frontend::lexer::{lex, TokenKind};
+use crate::frontend::parser::parse_string_literal_text;
 use crate::frontend::types::{
-    TypeCategory, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_I32, TYPE_ID_VOID,
+    TypeCategory, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32, TYPE_ID_VOID,
 };
 use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::settings::{self, Configurable};
@@ -14,6 +16,26 @@ use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum JitScalarValue {
+    I32(i32),
+    F32(f32),
+    F64(f64),
+    Bool(bool),
+}
+
+impl JitScalarValue {
+    pub fn type_name(self) -> &'static str {
+        match self {
+            Self::I32(_) => "i32",
+            Self::F32(_) => "f32",
+            Self::F64(_) => "f64",
+            Self::Bool(_) => "bool",
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JitArtifact {
@@ -35,6 +57,7 @@ pub struct JitProcess {
     source_disk_probe_cache: BTreeMap<String, SourceDiskProbe>,
     import_parse_cache: BTreeMap<String, ImportParseCacheEntry>,
     compile_analysis_cache: Option<CompileAnalysisCache>,
+    staged_string_literals: HashMap<i32, String>,
     required_emit_roots: Vec<String>,
     local_runtime_helper_trampolines: bool,
     #[cfg(test)]
@@ -79,6 +102,7 @@ impl JitProcess {
             source_disk_probe_cache: BTreeMap::new(),
             import_parse_cache: BTreeMap::new(),
             compile_analysis_cache: None,
+            staged_string_literals: HashMap::new(),
             required_emit_roots: Vec::new(),
             local_runtime_helper_trampolines: false,
             #[cfg(test)]
@@ -136,7 +160,30 @@ impl JitProcess {
     }
 
     pub fn compile(&mut self) -> CompileResult<CompileReport> {
-        stasis_dynload::clear_jit_string_literal_table();
+        let report = self.compile_staged()?;
+        self.activate_staged_runtime()
+            .map_err(crate::compiler::CompileError::Backend)?;
+        Ok(report)
+    }
+
+    pub fn compile_staged(&mut self) -> CompileResult<CompileReport> {
+        stasis_dynload::begin_jit_string_literal_staging()
+            .map_err(crate::compiler::CompileError::Backend)?;
+        let result = self.compile_internal();
+        let literals = stasis_dynload::finish_jit_string_literal_staging()
+            .map_err(crate::compiler::CompileError::Backend);
+        match result {
+            Err(error) => Err(error),
+            Ok(report) => {
+                literals?;
+                self.staged_string_literals = collect_current_string_literals(&self.compiler)
+                    .map_err(crate::compiler::CompileError::Backend)?;
+                Ok(report)
+            }
+        }
+    }
+
+    fn compile_internal(&mut self) -> CompileResult<CompileReport> {
         self.load_import_graph_sources()
             .map_err(crate::compiler::CompileError::Backend)?;
         let index = self.compiler.index_pass()?;
@@ -185,8 +232,6 @@ impl JitProcess {
                 "jit compile analysis cache missing after refresh".to_string(),
             )
         })?;
-        seed_fixed_collection_max_length_headers(&analysis.global_path_types, &analysis_type_table)
-            .map_err(crate::compiler::CompileError::Backend)?;
         let emit_function_ids = select_emit_function_ids(
             self.compiler.functions(),
             self.artifacts(),
@@ -244,7 +289,6 @@ impl JitProcess {
             .retain(|artifact| reachable.contains(&artifact.function_id));
         let report = CompileReport { index, emit };
         self.rebuild_artifact_index();
-        self.refresh_runtime_dispatch_table();
         Ok(report)
     }
 
@@ -257,7 +301,22 @@ impl JitProcess {
     }
 
     pub fn activate_runtime_dispatch_table(&self) {
+        stasis_dynload::replace_jit_string_literal_table(&self.staged_string_literals);
         self.refresh_runtime_dispatch_table();
+    }
+
+    pub fn activate_staged_runtime(&self) -> Result<(), String> {
+        let analysis = self
+            .compile_analysis_cache
+            .as_ref()
+            .ok_or_else(|| "cannot activate an uncompiled JIT process".to_string())?;
+        seed_fixed_collection_max_length_headers(
+            &analysis.global_path_types,
+            self.compiler.types(),
+        )?;
+        stasis_dynload::replace_jit_string_literal_table(&self.staged_string_literals);
+        self.refresh_runtime_dispatch_table();
+        Ok(())
     }
 
     pub fn artifact_slot_for_function_name(&self, name: &str) -> Option<u32> {
@@ -323,6 +382,93 @@ impl JitProcess {
         self.compile_analysis_cache
             .as_ref()
             .is_some_and(|analysis| analysis.global_path_types.contains_key(path))
+    }
+
+    pub fn global_scalar_paths(&self) -> Vec<(String, &'static str)> {
+        let Some(analysis) = self.compile_analysis_cache.as_ref() else {
+            return Vec::new();
+        };
+        analysis
+            .global_path_types
+            .iter()
+            .filter_map(|(path, type_id)| {
+                scalar_type_name(*type_id).map(|type_name| (path.clone(), type_name))
+            })
+            .collect()
+    }
+
+    pub fn read_global_scalar(&self, path: &str) -> Result<JitScalarValue, String> {
+        let type_id = self.global_path_type(path)?;
+        let path_hash = hash_global_path(path);
+        match type_id {
+            TYPE_ID_I32 => Ok(JitScalarValue::I32(
+                stasis_dynload::stasis_jit_global_i32_load(path_hash),
+            )),
+            TYPE_ID_F32 => Ok(JitScalarValue::F32(
+                stasis_dynload::stasis_jit_global_f32_load(path_hash),
+            )),
+            TYPE_ID_F64 => Ok(JitScalarValue::F64(
+                stasis_dynload::stasis_jit_global_f64_load(path_hash),
+            )),
+            TYPE_ID_BOOL => Ok(JitScalarValue::Bool(
+                stasis_dynload::stasis_jit_global_i32_load(path_hash) != 0,
+            )),
+            _ => Err(format!("global path '{path}' is not a supported scalar")),
+        }
+    }
+
+    pub fn write_global_scalar(&self, path: &str, value: JitScalarValue) -> Result<(), String> {
+        let type_id = self.global_path_type(path)?;
+        let path_hash = hash_global_path(path);
+        match (type_id, value) {
+            (TYPE_ID_I32, JitScalarValue::I32(value)) => {
+                stasis_dynload::stasis_jit_global_i32_store(path_hash, value)
+            }
+            (TYPE_ID_F32, JitScalarValue::F32(value)) => {
+                stasis_dynload::stasis_jit_global_f32_store(path_hash, value)
+            }
+            (TYPE_ID_F64, JitScalarValue::F64(value)) => {
+                stasis_dynload::stasis_jit_global_f64_store(path_hash, value)
+            }
+            (TYPE_ID_BOOL, JitScalarValue::Bool(value)) => {
+                stasis_dynload::stasis_jit_global_i32_store(path_hash, i32::from(value))
+            }
+            (_, value) => {
+                return Err(format!(
+                    "global path '{path}' does not accept {}",
+                    value.type_name()
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    pub fn snapshot_global_scalars(&self) -> Vec<(String, JitScalarValue)> {
+        self.global_scalar_paths()
+            .into_iter()
+            .filter_map(|(path, _)| {
+                self.read_global_scalar(&path)
+                    .ok()
+                    .map(|value| (path, value))
+            })
+            .collect()
+    }
+
+    pub fn restore_global_scalars(
+        &self,
+        snapshot: &[(String, JitScalarValue)],
+    ) -> Result<(), String> {
+        for (path, value) in snapshot {
+            self.write_global_scalar(path, *value)?;
+        }
+        Ok(())
+    }
+
+    fn global_path_type(&self, path: &str) -> Result<u16, String> {
+        self.compile_analysis_cache
+            .as_ref()
+            .and_then(|analysis| analysis.global_path_types.get(path).copied())
+            .ok_or_else(|| format!("global path '{path}' was not found in compiler metadata"))
     }
 
     pub fn write_i32_global_path(&self, path: &str, value: i32) {
@@ -637,6 +783,39 @@ impl JitProcess {
         );
         import_paths
     }
+}
+
+fn scalar_type_name(type_id: u16) -> Option<&'static str> {
+    match type_id {
+        TYPE_ID_I32 => Some("i32"),
+        TYPE_ID_F32 => Some("f32"),
+        TYPE_ID_F64 => Some("f64"),
+        TYPE_ID_BOOL => Some("bool"),
+        _ => None,
+    }
+}
+
+fn collect_current_string_literals(compiler: &Compiler) -> Result<HashMap<i32, String>, String> {
+    let mut literals = HashMap::new();
+    for file in compiler.files() {
+        for token in lex(&file.content)? {
+            if token.kind != TokenKind::StringLiteral {
+                continue;
+            }
+            let value = parse_string_literal_text(&file.content[token.start..token.end])?;
+            let id = crate::backend::emit::hash_string_literal(&value);
+            if let Some(previous) = literals.get(&id) {
+                if previous != &value {
+                    return Err(format!(
+                        "JIT string literal hash collision for id {id}: '{previous}' vs '{value}'"
+                    ));
+                }
+            } else {
+                literals.insert(id, value);
+            }
+        }
+    }
+    Ok(literals)
 }
 
 impl Default for JitProcess {
@@ -1399,6 +1578,46 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_process_exposes_typed_scalar_state_for_live_transactions() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "global score: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal ready: bool;\nfunction main(): i32 { score = 4; ratio = 1.5; precise = 2.25; ready = true; return 0; }\n",
+        );
+        process.compile().expect("compile");
+        process.execute_i32_noarg_by_name("main").expect("main");
+
+        let paths = process.global_scalar_paths();
+        assert!(paths.contains(&("score".to_string(), "i32")));
+        assert!(paths.contains(&("ratio".to_string(), "f32")));
+        assert!(paths.contains(&("precise".to_string(), "f64")));
+        assert!(paths.contains(&("ready".to_string(), "bool")));
+        assert_eq!(
+            process.read_global_scalar("score"),
+            Ok(JitScalarValue::I32(4))
+        );
+
+        let snapshot = process.snapshot_global_scalars();
+        process
+            .write_global_scalar("score", JitScalarValue::I32(99))
+            .expect("write score");
+        assert_eq!(
+            process.read_global_scalar("score"),
+            Ok(JitScalarValue::I32(99))
+        );
+        process.restore_global_scalars(&snapshot).expect("restore");
+        assert_eq!(
+            process.read_global_scalar("score"),
+            Ok(JitScalarValue::I32(4))
+        );
+        assert!(process
+            .write_global_scalar("score", JitScalarValue::Bool(true))
+            .expect_err("type mismatch")
+            .contains("does not accept bool"));
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_process_executes_call_expression_statement() {
         let mut process = JitProcess::new();
         process.upsert_file(
@@ -1455,6 +1674,41 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 1);
+    }
+
+    #[test]
+    fn jit_process_stages_string_literals_until_runtime_activation() {
+        let mut process = JitProcess::new();
+        let live_id = crate::backend::emit::hash_string_literal("live");
+        let candidate_id = crate::backend::emit::hash_string_literal("candidate");
+        stasis_dynload::upsert_jit_string_literal(live_id, "live");
+        process.upsert_file(
+            "sample.stasis",
+            "function main(): i32 { print_string(\"candidate\"); return 0; }\n",
+        );
+
+        process.compile_staged().expect("staged compile");
+        assert_eq!(
+            stasis_dynload::jit_string_literal_value(live_id).as_deref(),
+            Some("live")
+        );
+        assert_eq!(stasis_dynload::jit_string_literal_value(candidate_id), None);
+
+        process
+            .activate_staged_runtime()
+            .expect("runtime activation");
+        assert_eq!(stasis_dynload::jit_string_literal_value(live_id), None);
+        assert_eq!(
+            stasis_dynload::jit_string_literal_value(candidate_id).as_deref(),
+            Some("candidate")
+        );
+
+        process.upsert_file("sample.stasis", "function main(): i32 { return 1; }\n");
+        process.compile_staged().expect("replacement compile");
+        process
+            .activate_staged_runtime()
+            .expect("replacement activation");
+        assert_eq!(stasis_dynload::jit_string_literal_value(candidate_id), None);
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -815,7 +815,7 @@ fn parse_extern_symbol_annotation(
     Ok(Some(symbol))
 }
 
-fn parse_string_literal_text(literal_text: &str) -> Result<String, String> {
+pub(crate) fn parse_string_literal_text(literal_text: &str) -> Result<String, String> {
     let bytes = literal_text.as_bytes();
     if bytes.len() < 2 || bytes[0] != b'"' || *bytes.last().unwrap_or(&0) != b'"' {
         return Err(format!("invalid string literal token '{}'", literal_text));

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_char;
 use std::io::Write;
@@ -588,7 +589,60 @@ pub fn clear_jit_string_literal_table() {
     guard.clear();
 }
 
+pub fn begin_jit_string_literal_staging() -> Result<(), String> {
+    JIT_STRING_LITERAL_STAGE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_some() {
+            return Err("JIT string literal staging is already active on this thread".to_string());
+        }
+        *slot = Some(JitStringLiteralStage::default());
+        Ok(())
+    })
+}
+
+pub fn finish_jit_string_literal_staging() -> Result<HashMap<i32, String>, String> {
+    JIT_STRING_LITERAL_STAGE.with(|slot| {
+        let stage = slot
+            .borrow_mut()
+            .take()
+            .ok_or_else(|| "JIT string literal staging is not active".to_string())?;
+        if let Some(error) = stage.collision {
+            Err(error)
+        } else {
+            Ok(stage.literals)
+        }
+    })
+}
+
+pub fn replace_jit_string_literal_table(literals: &HashMap<i32, String>) {
+    let table = jit_string_literal_table();
+    let mut guard = table
+        .lock()
+        .expect("jit string literal table mutex poisoned");
+    guard.clear();
+    guard.extend(literals.iter().map(|(id, value)| (*id, value.clone())));
+}
+
 pub fn upsert_jit_string_literal(id: i32, value: &str) {
+    let staged = JIT_STRING_LITERAL_STAGE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let Some(stage) = slot.as_mut() else {
+            return false;
+        };
+        if let Some(previous) = stage.literals.get(&id) {
+            if previous != value && stage.collision.is_none() {
+                stage.collision = Some(format!(
+                    "JIT string literal hash collision for id {id}: '{previous}' vs '{value}'"
+                ));
+            }
+        } else {
+            stage.literals.insert(id, value.to_string());
+        }
+        true
+    });
+    if staged {
+        return;
+    }
     let table = jit_string_literal_table();
     let mut guard = table
         .lock()
@@ -723,7 +777,257 @@ pub fn clear_registered_global_memory() {
         .clear();
 }
 
+#[derive(Debug, Clone)]
+pub struct JitRuntimeStateSnapshot {
+    i32_globals: JitI32GlobalMap,
+    f32_globals: JitF32GlobalMap,
+    f64_globals: JitF64GlobalMap,
+    i32_array_globals: JitI32ArrayGlobalMap,
+    f32_array_globals: JitF32ArrayGlobalMap,
+    f64_array_globals: JitF64ArrayGlobalMap,
+    i32_ptrs: Vec<(usize, i32)>,
+    f32_ptrs: Vec<(usize, f32)>,
+    f64_ptrs: Vec<(usize, f64)>,
+    i32_arrays: Vec<(usize, Vec<i32>)>,
+    f32_arrays: Vec<(usize, Vec<f32>)>,
+    f64_arrays: Vec<(usize, Vec<f64>)>,
+    u8_arrays: Vec<(usize, Vec<u8>)>,
+}
+
+pub fn snapshot_jit_runtime_state() -> JitRuntimeStateSnapshot {
+    snapshot_jit_runtime_state_bounded(usize::MAX)
+        .expect("unbounded JIT runtime snapshot cannot exceed usize")
+}
+
+pub fn snapshot_jit_runtime_state_bounded(
+    max_bytes: usize,
+) -> Result<JitRuntimeStateSnapshot, String> {
+    let snapshot_bytes = runtime_snapshot_bytes()?;
+    if snapshot_bytes > max_bytes {
+        return Err(format!(
+            "live runtime snapshot requires {snapshot_bytes} bytes; limit is {max_bytes} bytes"
+        ));
+    }
+    Ok(JitRuntimeStateSnapshot {
+        i32_globals: jit_i32_global_table()
+            .lock()
+            .expect("jit i32 global table mutex poisoned")
+            .clone(),
+        f32_globals: jit_f32_global_table()
+            .lock()
+            .expect("jit f32 global table mutex poisoned")
+            .clone(),
+        f64_globals: jit_f64_global_table()
+            .lock()
+            .expect("jit f64 global table mutex poisoned")
+            .clone(),
+        i32_array_globals: jit_i32_array_global_table()
+            .lock()
+            .expect("jit i32 array global table mutex poisoned")
+            .clone(),
+        f32_array_globals: jit_f32_array_global_table()
+            .lock()
+            .expect("jit f32 array global table mutex poisoned")
+            .clone(),
+        f64_array_globals: jit_f64_array_global_table()
+            .lock()
+            .expect("jit f64 array global table mutex poisoned")
+            .clone(),
+        i32_ptrs: snapshot_registered_ptrs(registered_i32_ptrs()),
+        f32_ptrs: snapshot_registered_ptrs(registered_f32_ptrs()),
+        f64_ptrs: snapshot_registered_ptrs(registered_f64_ptrs()),
+        i32_arrays: snapshot_registered_arrays(registered_i32_arrays()),
+        f32_arrays: snapshot_registered_arrays(registered_f32_arrays()),
+        f64_arrays: snapshot_registered_arrays(registered_f64_arrays()),
+        u8_arrays: snapshot_registered_arrays(registered_u8_arrays()),
+    })
+}
+
+fn runtime_snapshot_bytes() -> Result<usize, String> {
+    let mut bytes = 0usize;
+    let mut add = |count: usize, item_bytes: usize| -> Result<(), String> {
+        bytes = bytes
+            .checked_add(
+                count
+                    .checked_mul(item_bytes)
+                    .ok_or_else(|| "live runtime snapshot size overflow".to_string())?,
+            )
+            .ok_or_else(|| "live runtime snapshot size overflow".to_string())?;
+        Ok(())
+    };
+    add(
+        jit_i32_global_table()
+            .lock()
+            .expect("jit i32 global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<(i32, i32)>(),
+    )?;
+    add(
+        jit_f32_global_table()
+            .lock()
+            .expect("jit f32 global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<(i32, f32)>(),
+    )?;
+    add(
+        jit_f64_global_table()
+            .lock()
+            .expect("jit f64 global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<(i32, f64)>(),
+    )?;
+    add(
+        jit_i32_array_global_table()
+            .lock()
+            .expect("jit i32 array global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<((i32, i32, i32), i32)>(),
+    )?;
+    add(
+        jit_f32_array_global_table()
+            .lock()
+            .expect("jit f32 array global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<((i32, i32, i32), f32)>(),
+    )?;
+    add(
+        jit_f64_array_global_table()
+            .lock()
+            .expect("jit f64 array global table mutex poisoned")
+            .len(),
+        std::mem::size_of::<((i32, i32, i32), f64)>(),
+    )?;
+    add_registered_ptr_bytes(&mut add, registered_i32_ptrs(), std::mem::size_of::<i32>())?;
+    add_registered_ptr_bytes(&mut add, registered_f32_ptrs(), std::mem::size_of::<f32>())?;
+    add_registered_ptr_bytes(&mut add, registered_f64_ptrs(), std::mem::size_of::<f64>())?;
+    add_registered_array_bytes(
+        &mut add,
+        registered_i32_arrays(),
+        std::mem::size_of::<i32>(),
+    )?;
+    add_registered_array_bytes(
+        &mut add,
+        registered_f32_arrays(),
+        std::mem::size_of::<f32>(),
+    )?;
+    add_registered_array_bytes(
+        &mut add,
+        registered_f64_arrays(),
+        std::mem::size_of::<f64>(),
+    )?;
+    add_registered_array_bytes(&mut add, registered_u8_arrays(), std::mem::size_of::<u8>())?;
+    Ok(bytes)
+}
+
+fn add_registered_ptr_bytes(
+    add: &mut impl FnMut(usize, usize) -> Result<(), String>,
+    table: &Mutex<HashMap<i32, usize>>,
+    item_bytes: usize,
+) -> Result<(), String> {
+    add(
+        table
+            .lock()
+            .expect("registered global pointer table mutex poisoned")
+            .len(),
+        item_bytes,
+    )
+}
+
+fn add_registered_array_bytes(
+    add: &mut impl FnMut(usize, usize) -> Result<(), String>,
+    table: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
+    item_bytes: usize,
+) -> Result<(), String> {
+    let elements = table
+        .lock()
+        .expect("registered global array table mutex poisoned")
+        .values()
+        .try_fold(0usize, |total, (_, len)| {
+            total
+                .checked_add(*len)
+                .ok_or_else(|| "live runtime snapshot size overflow".to_string())
+        })?;
+    add(elements, item_bytes)
+}
+
+pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
+    *jit_i32_global_table()
+        .lock()
+        .expect("jit i32 global table mutex poisoned") = snapshot.i32_globals.clone();
+    *jit_f32_global_table()
+        .lock()
+        .expect("jit f32 global table mutex poisoned") = snapshot.f32_globals.clone();
+    *jit_f64_global_table()
+        .lock()
+        .expect("jit f64 global table mutex poisoned") = snapshot.f64_globals.clone();
+    *jit_i32_array_global_table()
+        .lock()
+        .expect("jit i32 array global table mutex poisoned") = snapshot.i32_array_globals.clone();
+    *jit_f32_array_global_table()
+        .lock()
+        .expect("jit f32 array global table mutex poisoned") = snapshot.f32_array_globals.clone();
+    *jit_f64_array_global_table()
+        .lock()
+        .expect("jit f64 array global table mutex poisoned") = snapshot.f64_array_globals.clone();
+    restore_registered_ptrs(&snapshot.i32_ptrs);
+    restore_registered_ptrs(&snapshot.f32_ptrs);
+    restore_registered_ptrs(&snapshot.f64_ptrs);
+    restore_registered_arrays(&snapshot.i32_arrays);
+    restore_registered_arrays(&snapshot.f32_arrays);
+    restore_registered_arrays(&snapshot.f64_arrays);
+    restore_registered_arrays(&snapshot.u8_arrays);
+}
+
+fn snapshot_registered_ptrs<T: Copy>(table: &Mutex<HashMap<i32, usize>>) -> Vec<(usize, T)> {
+    table
+        .lock()
+        .expect("registered global pointer table mutex poisoned")
+        .values()
+        .copied()
+        .map(|address| {
+            // Registered pointers remain host-owned and stable for the in-process runtime.
+            let value = unsafe { *(address as *const T) };
+            (address, value)
+        })
+        .collect()
+}
+
+fn restore_registered_ptrs<T: Copy>(values: &[(usize, T)]) {
+    for (address, value) in values {
+        // Restoration runs at a main-thread tick boundary while the registered owner is alive.
+        unsafe { *(*address as *mut T) = *value };
+    }
+}
+
+fn snapshot_registered_arrays<T: Copy>(
+    table: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
+) -> Vec<(usize, Vec<T>)> {
+    table
+        .lock()
+        .expect("registered global array table mutex poisoned")
+        .values()
+        .copied()
+        .map(|(address, len)| {
+            // Registered array memory remains valid until the in-process runner unregisters it.
+            let values = unsafe { std::slice::from_raw_parts(address as *const T, len) }.to_vec();
+            (address, values)
+        })
+        .collect()
+}
+
+fn restore_registered_arrays<T: Copy>(arrays: &[(usize, Vec<T>)]) {
+    for (address, values) in arrays {
+        // Restoration is serialized with guest execution at the between-tick boundary.
+        unsafe {
+            std::slice::from_raw_parts_mut(*address as *mut T, values.len()).copy_from_slice(values)
+        };
+    }
+}
+
 pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_i32_ptrs();
     let mut guard = table
         .lock()
@@ -732,6 +1036,9 @@ pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
 }
 
 pub fn register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_f32_ptrs();
     let mut guard = table
         .lock()
@@ -740,6 +1047,9 @@ pub fn register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
 }
 
 pub fn register_global_f64_ptr(path_hash: i32, ptr: *mut f64) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_f64_ptrs();
     let mut guard = table
         .lock()
@@ -748,6 +1058,9 @@ pub fn register_global_f64_ptr(path_hash: i32, ptr: *mut f64) {
 }
 
 pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mut i32, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_i32_arrays();
     let mut guard = table
         .lock()
@@ -756,6 +1069,9 @@ pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mu
 }
 
 pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mut f32, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_f32_arrays();
     let mut guard = table
         .lock()
@@ -764,6 +1080,9 @@ pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mu
 }
 
 pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mut f64, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_f64_arrays();
     let mut guard = table
         .lock()
@@ -772,6 +1091,9 @@ pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mu
 }
 
 pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut u8, len: usize) {
+    if ptr.is_null() {
+        return;
+    }
     let table = registered_u8_arrays();
     let mut guard = table
         .lock()
@@ -2599,6 +2921,16 @@ type JitF32ArrayGlobalMap = std::collections::HashMap<(i32, i32, i32), f32>;
 type JitF64ArrayGlobalMap = std::collections::HashMap<(i32, i32, i32), f64>;
 type JitStringLiteralMap = std::collections::HashMap<i32, String>;
 
+#[derive(Default)]
+struct JitStringLiteralStage {
+    literals: JitStringLiteralMap,
+    collision: Option<String>,
+}
+
+thread_local! {
+    static JIT_STRING_LITERAL_STAGE: RefCell<Option<JitStringLiteralStage>> = const { RefCell::new(None) };
+}
+
 fn jit_i32_dispatch_table() -> &'static Mutex<JitDispatchMap> {
     static TABLE: OnceLock<Mutex<JitDispatchMap>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
@@ -2736,6 +3068,44 @@ mod tests {
     }
 
     #[test]
+    fn runtime_state_snapshot_restores_registered_and_fallback_memory() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_f32_global_table();
+        clear_jit_f64_global_table();
+        clear_jit_i32_array_global_table();
+        clear_jit_f32_array_global_table();
+        clear_jit_f64_array_global_table();
+
+        register_global_i32_ptr(1, std::ptr::null_mut());
+        register_global_u8_array(2, 0, std::ptr::null_mut(), 4);
+        let mut scalar = 7i32;
+        let mut bytes = vec![1u8, 2, 3, 4];
+        register_global_i32_ptr(10, &mut scalar);
+        register_global_u8_array(20, 0, bytes.as_mut_ptr(), bytes.len());
+        stasis_jit_global_i32_store(30, 9);
+        stasis_jit_global_f32_array_store(40, 2, 0, 1.5);
+        assert!(snapshot_jit_runtime_state_bounded(1)
+            .expect_err("snapshot should be bounded")
+            .contains("limit"));
+        let snapshot = snapshot_jit_runtime_state();
+
+        scalar = 70;
+        bytes.copy_from_slice(&[9, 9, 9, 9]);
+        stasis_jit_global_i32_store(30, 90);
+        stasis_jit_global_i32_store(31, 100);
+        stasis_jit_global_f32_array_store(40, 2, 0, 8.5);
+        restore_jit_runtime_state(&snapshot);
+
+        assert_eq!(scalar, 7);
+        assert_eq!(bytes, vec![1, 2, 3, 4]);
+        assert_eq!(stasis_jit_global_i32_load(30), 9);
+        assert_eq!(stasis_jit_global_i32_load(31), 0);
+        assert_eq!(stasis_jit_global_f32_array_load(40, 2, 0), 1.5);
+    }
+
+    #[test]
     fn jit_text_arg_bytes_reads_string_literals() {
         let _lock = test_lock();
         clear_registered_global_memory();
@@ -2746,6 +3116,31 @@ mod tests {
         upsert_jit_string_literal(1234, "hello");
 
         assert_eq!(jit_text_arg_bytes(1234), Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn staged_string_literals_do_not_mutate_live_table_before_publish() {
+        let _lock = test_lock();
+        clear_jit_string_literal_table();
+        upsert_jit_string_literal(1, "live");
+
+        begin_jit_string_literal_staging().expect("begin staging");
+        upsert_jit_string_literal(2, "candidate");
+        assert_eq!(jit_string_literal_value(1).as_deref(), Some("live"));
+        assert_eq!(jit_string_literal_value(2), None);
+        let staged = finish_jit_string_literal_staging().expect("finish staging");
+
+        replace_jit_string_literal_table(&staged);
+        assert_eq!(jit_string_literal_value(1), None);
+        assert_eq!(jit_string_literal_value(2).as_deref(), Some("candidate"));
+
+        begin_jit_string_literal_staging().expect("begin collision staging");
+        upsert_jit_string_literal(3, "first");
+        upsert_jit_string_literal(3, "second");
+        assert!(finish_jit_string_literal_staging()
+            .expect_err("hash collision")
+            .contains("collision"));
+        assert_eq!(jit_string_literal_value(3), None);
     }
 
     #[test]

--- a/crates/stasis_runner/Cargo.toml
+++ b/crates/stasis_runner/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 crossbeam-channel.workspace = true
 stasis_assets = { path = "../stasis_assets" }
 

--- a/crates/stasis_runner/src/lib.rs
+++ b/crates/stasis_runner/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
+pub mod live;
 pub mod swap;
 pub use stasis_assets as assets;

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -1,0 +1,1047 @@
+use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError, TrySendError};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+pub const LIVE_SCHEMA_VERSION: u16 = 1;
+pub const DEFAULT_LIVE_QUEUE_CAPACITY: usize = 64;
+pub const DEFAULT_LIVE_OUTPUT_BYTES: usize = 64 * 1024;
+pub const MAX_LIVE_REQUEST_BYTES: usize = 512 * 1024;
+pub const MAX_LIVE_MULTILINE_BYTES: usize = 256 * 1024;
+pub const MAX_SCRATCH_CELLS: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveRequest {
+    #[serde(default = "live_schema_version")]
+    pub schema_version: u16,
+    pub request_id: u64,
+    #[serde(flatten)]
+    pub command: LiveCommand,
+}
+
+impl LiveRequest {
+    pub fn new(request_id: u64, command: LiveCommand) -> Self {
+        Self {
+            schema_version: LIVE_SCHEMA_VERSION,
+            request_id,
+            command,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != LIVE_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported live-session schema version {}; expected {}",
+                self.schema_version, LIVE_SCHEMA_VERSION
+            ));
+        }
+        if self.request_id == 0 {
+            return Err("request_id must be greater than zero".to_string());
+        }
+        let bytes = serde_json::to_vec(self)
+            .map_err(|error| format!("failed serializing live request: {error}"))?
+            .len();
+        if bytes > MAX_LIVE_REQUEST_BYTES {
+            return Err(format!(
+                "live request requires {bytes} bytes; limit is {MAX_LIVE_REQUEST_BYTES} bytes"
+            ));
+        }
+        Ok(())
+    }
+}
+
+const fn live_schema_version() -> u16 {
+    LIVE_SCHEMA_VERSION
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LiveCommand {
+    Help,
+    Status,
+    Pause,
+    Resume,
+    Step {
+        #[serde(default = "one_tick")]
+        ticks: u32,
+    },
+    Cancel {
+        request_id: u64,
+    },
+    Quit,
+    Symbols {
+        #[serde(default)]
+        query: Option<String>,
+        #[serde(default)]
+        page: u32,
+        #[serde(default = "default_symbol_page_limit")]
+        limit: usize,
+    },
+    Read {
+        name: String,
+        #[serde(default)]
+        kind: Option<String>,
+        #[serde(default)]
+        file: Option<String>,
+        #[serde(default)]
+        owner: Option<String>,
+        #[serde(default)]
+        signature: Option<String>,
+    },
+    Complete {
+        buffer: String,
+        cursor: usize,
+        #[serde(default = "default_completion_limit")]
+        limit: usize,
+    },
+    Edit {
+        operation: LiveEditOperation,
+        target: LiveSymbolTarget,
+        #[serde(default)]
+        source: Option<String>,
+        #[serde(default)]
+        expected_source_hash: Option<String>,
+        #[serde(default)]
+        preview: bool,
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
+    Preview,
+    Apply {
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
+    Changes,
+    Undo {
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
+    Redo {
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
+    Inspect {
+        path: String,
+    },
+    Watch {
+        path: String,
+    },
+    Unwatch {
+        #[serde(default)]
+        path: Option<String>,
+    },
+    Set {
+        path: String,
+        expression: String,
+        #[serde(default)]
+        preview: bool,
+    },
+    Print {
+        expression: String,
+    },
+    Do {
+        code: String,
+        #[serde(default)]
+        preview: bool,
+    },
+    CellPut {
+        name: String,
+        code: String,
+    },
+    CellRun {
+        name: String,
+        #[serde(default)]
+        preview: bool,
+    },
+    CellList,
+    CellClear {
+        #[serde(default)]
+        name: Option<String>,
+    },
+    CellPersist {
+        name: String,
+        target: LiveSymbolTarget,
+        #[serde(default)]
+        preview: bool,
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
+}
+
+const fn one_tick() -> u32 {
+    1
+}
+
+const fn default_completion_limit() -> usize {
+    32
+}
+
+const fn default_symbol_page_limit() -> usize {
+    50
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LiveEditOperation {
+    Add,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveSymbolTarget {
+    pub name: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub file: Option<String>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default)]
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LiveResponse {
+    pub schema_version: u16,
+    pub request_id: u64,
+    pub tick: u64,
+    pub ok: bool,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+impl LiveResponse {
+    pub fn success(request_id: u64, tick: u64, kind: impl Into<String>, data: Value) -> Self {
+        Self {
+            schema_version: LIVE_SCHEMA_VERSION,
+            request_id,
+            tick,
+            ok: true,
+            kind: kind.into(),
+            data: Some(data),
+            error: None,
+            truncated: false,
+        }
+    }
+
+    pub fn failure(request_id: u64, tick: u64, error: impl Into<String>) -> Self {
+        Self {
+            schema_version: LIVE_SCHEMA_VERSION,
+            request_id,
+            tick,
+            ok: false,
+            kind: "error".to_string(),
+            data: None,
+            error: Some(error.into()),
+            truncated: false,
+        }
+    }
+
+    pub fn bounded(mut self, max_bytes: usize) -> Self {
+        let Ok(encoded) = serde_json::to_vec(&self) else {
+            return Self::failure(
+                self.request_id,
+                self.tick,
+                "failed to serialize live response",
+            );
+        };
+        if encoded.len() <= max_bytes {
+            return self;
+        }
+        self.data = Some(serde_json::json!({
+            "message": "live response exceeded the configured output limit",
+            "original_bytes": encoded.len(),
+            "limit_bytes": max_bytes,
+        }));
+        self.error = (!self.ok).then(|| "live response exceeded the output limit".to_string());
+        self.truncated = true;
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct LiveSessionClient {
+    requests: Sender<LiveRequest>,
+    responses: Receiver<LiveResponse>,
+}
+
+pub struct LiveSessionServer {
+    requests: Receiver<LiveRequest>,
+    responses: Sender<LiveResponse>,
+    output_limit: usize,
+}
+
+#[derive(Debug)]
+pub enum LiveResponseSendError {
+    Full(LiveResponse),
+    Disconnected,
+}
+
+pub fn live_session(capacity: usize) -> (LiveSessionClient, LiveSessionServer) {
+    let capacity = capacity.max(1);
+    let (request_tx, request_rx) = bounded(capacity);
+    let (response_tx, response_rx) = bounded(capacity);
+    (
+        LiveSessionClient {
+            requests: request_tx,
+            responses: response_rx,
+        },
+        LiveSessionServer {
+            requests: request_rx,
+            responses: response_tx,
+            output_limit: DEFAULT_LIVE_OUTPUT_BYTES,
+        },
+    )
+}
+
+impl LiveSessionClient {
+    pub fn submit(&self, request: LiveRequest) -> Result<(), String> {
+        request.validate()?;
+        self.requests
+            .try_send(request)
+            .map_err(|error| match error {
+                TrySendError::Full(_) => "live-session command queue is full".to_string(),
+                TrySendError::Disconnected(_) => "live session has ended".to_string(),
+            })
+    }
+
+    pub fn receive_timeout(&self, timeout: Duration) -> Result<LiveResponse, String> {
+        self.responses
+            .recv_timeout(timeout)
+            .map_err(|error| format!("live-session response unavailable: {error}"))
+    }
+}
+
+impl LiveSessionServer {
+    pub fn set_output_limit(&mut self, bytes: usize) {
+        self.output_limit = bytes.max(256);
+    }
+
+    pub fn drain(&self, limit: usize) -> Vec<LiveRequest> {
+        let mut requests = Vec::new();
+        while requests.len() < limit {
+            match self.requests.try_recv() {
+                Ok(request) => requests.push(request),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+        requests
+    }
+
+    pub fn respond(&self, response: LiveResponse) -> Result<(), LiveResponseSendError> {
+        self.responses
+            .try_send(response.bounded(self.output_limit))
+            .map_err(|error| match error {
+                TrySendError::Full(response) => LiveResponseSendError::Full(response),
+                TrySendError::Disconnected(_) => LiveResponseSendError::Disconnected,
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionItem {
+    pub text: String,
+    pub kind: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CompletionIndex {
+    items: BTreeMap<(String, String, String), CompletionItem>,
+}
+
+impl CompletionIndex {
+    pub fn replace<I>(&mut self, items: I)
+    where
+        I: IntoIterator<Item = CompletionItem>,
+    {
+        self.items.clear();
+        for item in items {
+            self.items.insert(
+                (item.text.clone(), item.kind.clone(), item.detail.clone()),
+                item,
+            );
+        }
+    }
+
+    pub fn complete(&self, buffer: &str, cursor: usize, limit: usize) -> Vec<CompletionItem> {
+        let mut cursor = cursor.min(buffer.len());
+        while !buffer.is_char_boundary(cursor) {
+            cursor -= 1;
+        }
+        let prefix = buffer[..cursor]
+            .rsplit(|character: char| {
+                character.is_whitespace() || character == '(' || character == ','
+            })
+            .next()
+            .unwrap_or("");
+        let mut matches = self
+            .items
+            .values()
+            .filter(|item| item.text.starts_with(prefix))
+            .cloned()
+            .collect::<Vec<_>>();
+        matches.sort_by_key(|item| {
+            (
+                item.text != prefix,
+                item.text.len().saturating_sub(prefix.len()),
+                item.text.clone(),
+                item.kind.clone(),
+            )
+        });
+        matches.truncate(limit.min(256));
+        matches
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScratchCell {
+    pub name: String,
+    pub code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_tick: Option<u64>,
+}
+
+#[derive(Debug, Default)]
+pub struct ScratchWorkspace {
+    cells: BTreeMap<String, ScratchCell>,
+}
+
+impl ScratchWorkspace {
+    pub fn put(&mut self, name: &str, code: String) -> Result<(), String> {
+        validate_cell_name(name)?;
+        if code.len() > MAX_LIVE_MULTILINE_BYTES {
+            return Err(format!(
+                "scratch cell exceeds {MAX_LIVE_MULTILINE_BYTES} bytes"
+            ));
+        }
+        if !self.cells.contains_key(name) && self.cells.len() >= MAX_SCRATCH_CELLS {
+            return Err(format!(
+                "scratch workspace is limited to {MAX_SCRATCH_CELLS} cells"
+            ));
+        }
+        self.cells.insert(
+            name.to_string(),
+            ScratchCell {
+                name: name.to_string(),
+                code,
+                last_result: None,
+                last_tick: None,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Option<&ScratchCell> {
+        self.cells.get(name)
+    }
+
+    pub fn record_result(&mut self, name: &str, tick: u64, result: String) -> Result<(), String> {
+        let cell = self
+            .cells
+            .get_mut(name)
+            .ok_or_else(|| format!("scratch cell '{name}' not found"))?;
+        cell.last_result = Some(result);
+        cell.last_tick = Some(tick);
+        Ok(())
+    }
+
+    pub fn list(&self) -> Vec<ScratchCell> {
+        self.cells.values().cloned().collect()
+    }
+
+    pub fn clear(&mut self, name: Option<&str>) -> Result<(), String> {
+        if let Some(name) = name {
+            if self.cells.remove(name).is_none() {
+                return Err(format!("scratch cell '{name}' not found"));
+            }
+        } else {
+            self.cells.clear();
+        }
+        Ok(())
+    }
+}
+
+fn validate_cell_name(name: &str) -> Result<(), String> {
+    let mut chars = name.chars();
+    if !chars
+        .next()
+        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+        || !chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    {
+        return Err(format!("invalid scratch cell name '{name}'"));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminalInput {
+    Request(LiveRequest),
+    Continue { prompt: &'static str },
+}
+
+#[derive(Debug, Default)]
+pub struct TerminalBuffer {
+    next_request_id: u64,
+    pending: Option<PendingMultiline>,
+}
+
+#[derive(Debug)]
+struct PendingMultiline {
+    request_id: u64,
+    command: PendingCommand,
+    lines: Vec<String>,
+    bytes: usize,
+}
+
+#[derive(Debug)]
+enum PendingCommand {
+    Edit {
+        operation: LiveEditOperation,
+        target: LiveSymbolTarget,
+        preview: bool,
+    },
+    Do {
+        preview: bool,
+    },
+    CellPut {
+        name: String,
+    },
+}
+
+impl TerminalBuffer {
+    pub fn new() -> Self {
+        Self {
+            next_request_id: 1,
+            pending: None,
+        }
+    }
+
+    pub fn feed_line(&mut self, line: &str) -> Result<TerminalInput, String> {
+        if let Some(pending) = self.pending.as_mut() {
+            if line.trim() == ":abort" {
+                self.pending = None;
+                return Ok(TerminalInput::Continue { prompt: "stasis> " });
+            }
+            if line.trim() != ":end" {
+                if pending.bytes.saturating_add(line.len()).saturating_add(1)
+                    > MAX_LIVE_MULTILINE_BYTES
+                {
+                    self.pending = None;
+                    return Err(format!(
+                        "multiline input exceeds {MAX_LIVE_MULTILINE_BYTES} bytes"
+                    ));
+                }
+                pending.lines.push(line.to_string());
+                pending.bytes = pending.bytes.saturating_add(line.len()).saturating_add(1);
+                return Ok(TerminalInput::Continue { prompt: "... " });
+            }
+            let pending = self.pending.take().expect("pending command");
+            let source = pending.lines.join("\n");
+            let command = match pending.command {
+                PendingCommand::Edit {
+                    operation,
+                    target,
+                    preview,
+                } => LiveCommand::Edit {
+                    operation,
+                    target,
+                    source: (operation != LiveEditOperation::Delete).then_some(source),
+                    expected_source_hash: None,
+                    preview,
+                    run_tests: true,
+                },
+                PendingCommand::Do { preview } => LiveCommand::Do {
+                    code: source,
+                    preview,
+                },
+                PendingCommand::CellPut { name } => LiveCommand::CellPut { name, code: source },
+            };
+            return Ok(TerminalInput::Request(LiveRequest::new(
+                pending.request_id,
+                command,
+            )));
+        }
+
+        if line.trim_start().starts_with('{') {
+            let request = serde_json::from_str::<LiveRequest>(line)
+                .map_err(|error| format!("invalid live request JSON: {error}"))?;
+            request.validate()?;
+            self.next_request_id = self
+                .next_request_id
+                .max(request.request_id.saturating_add(1));
+            return Ok(TerminalInput::Request(request));
+        }
+
+        let request_id = self.next_request_id;
+        self.next_request_id = self.next_request_id.saturating_add(1);
+        let command = parse_terminal_command(line)?;
+        if let ParsedTerminalCommand::Pending(command) = command {
+            self.pending = Some(PendingMultiline {
+                request_id,
+                command,
+                lines: Vec::new(),
+                bytes: 0,
+            });
+            return Ok(TerminalInput::Continue { prompt: "... " });
+        }
+        let ParsedTerminalCommand::Ready(command) = command else {
+            unreachable!()
+        };
+        Ok(TerminalInput::Request(LiveRequest::new(
+            request_id, command,
+        )))
+    }
+
+    pub fn cancel_pending(&mut self) -> bool {
+        self.pending.take().is_some()
+    }
+}
+
+enum ParsedTerminalCommand {
+    Ready(LiveCommand),
+    Pending(PendingCommand),
+}
+
+fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
+    let args = split_terminal_args(line)?;
+    let Some(command) = args.first().map(String::as_str) else {
+        return Err("empty live command".to_string());
+    };
+    let ready = |command| Ok(ParsedTerminalCommand::Ready(command));
+    match command {
+        ":help" => ready(LiveCommand::Help),
+        ":status" => ready(LiveCommand::Status),
+        ":pause" => ready(LiveCommand::Pause),
+        ":resume" => ready(LiveCommand::Resume),
+        ":quit" => ready(LiveCommand::Quit),
+        ":step" => ready(LiveCommand::Step {
+            ticks: args
+                .get(1)
+                .map(|value| parse_u32("ticks", value))
+                .transpose()?
+                .unwrap_or(1),
+        }),
+        ":cancel" => ready(LiveCommand::Cancel {
+            request_id: required_arg(&args, 1, "request id")?
+                .parse::<u64>()
+                .map_err(|error| format!("invalid request id: {error}"))?,
+        }),
+        ":symbols" | ":find" => ready(LiveCommand::Symbols {
+            query: args.get(1).filter(|arg| !arg.starts_with("--")).cloned(),
+            page: terminal_selector_value(&args, "--page")
+                .map(|value| parse_u32("page", &value))
+                .transpose()?
+                .unwrap_or(0),
+            limit: terminal_selector_value(&args, "--limit")
+                .map(|value| parse_u32("limit", &value))
+                .transpose()?
+                .map(|value| value as usize)
+                .unwrap_or_else(default_symbol_page_limit),
+        }),
+        ":read" => ready(LiveCommand::Read {
+            name: required_arg(&args, 1, "symbol name")?.to_string(),
+            kind: args.get(2).cloned(),
+            file: terminal_selector_value(&args, "--file")
+                .or_else(|| args.get(3).filter(|arg| !arg.starts_with("--")).cloned()),
+            owner: terminal_selector_value(&args, "--owner"),
+            signature: terminal_selector_value(&args, "--signature"),
+        }),
+        ":complete" => {
+            let buffer = args.get(1).cloned().unwrap_or_default();
+            ready(LiveCommand::Complete {
+                cursor: buffer.len(),
+                buffer,
+                limit: 32,
+            })
+        }
+        ":preview" => ready(LiveCommand::Preview),
+        ":apply" => ready(LiveCommand::Apply { run_tests: true }),
+        ":changes" => ready(LiveCommand::Changes),
+        ":undo" => ready(LiveCommand::Undo { run_tests: true }),
+        ":redo" => ready(LiveCommand::Redo { run_tests: true }),
+        ":inspect" => ready(LiveCommand::Inspect {
+            path: required_arg(&args, 1, "state path")?.to_string(),
+        }),
+        ":watch" => ready(LiveCommand::Watch {
+            path: required_arg(&args, 1, "state path")?.to_string(),
+        }),
+        ":unwatch" => ready(LiveCommand::Unwatch {
+            path: args.get(1).cloned(),
+        }),
+        ":set" => ready(LiveCommand::Set {
+            path: required_arg(&args, 1, "state path")?.to_string(),
+            expression: required_arg(&args, 2, "expression")?.to_string(),
+            preview: args.iter().any(|arg| arg == "--preview"),
+        }),
+        ":print" => ready(LiveCommand::Print {
+            expression: required_arg(&args, 1, "expression")?.to_string(),
+        }),
+        ":do" => Ok(ParsedTerminalCommand::Pending(PendingCommand::Do {
+            preview: args.iter().any(|arg| arg == "--preview"),
+        })),
+        ":cell" if args.get(1).map(String::as_str) == Some("put") => {
+            Ok(ParsedTerminalCommand::Pending(PendingCommand::CellPut {
+                name: required_arg(&args, 2, "cell name")?.to_string(),
+            }))
+        }
+        ":cell" if args.get(1).map(String::as_str) == Some("run") => ready(LiveCommand::CellRun {
+            name: required_arg(&args, 2, "cell name")?.to_string(),
+            preview: args.iter().any(|arg| arg == "--preview"),
+        }),
+        ":cell" if args.get(1).map(String::as_str) == Some("list") => ready(LiveCommand::CellList),
+        ":cell" if args.get(1).map(String::as_str) == Some("clear") => {
+            ready(LiveCommand::CellClear {
+                name: args.get(2).cloned(),
+            })
+        }
+        ":cell" if args.get(1).map(String::as_str) == Some("persist") => {
+            ready(LiveCommand::CellPersist {
+                name: required_arg(&args, 2, "cell name")?.to_string(),
+                target: LiveSymbolTarget {
+                    kind: Some(required_arg(&args, 3, "symbol kind")?.to_string()),
+                    name: required_arg(&args, 4, "symbol name")?.to_string(),
+                    file: terminal_selector_value(&args, "--file")
+                        .or_else(|| args.get(5).filter(|arg| !arg.starts_with("--")).cloned()),
+                    owner: terminal_selector_value(&args, "--owner"),
+                    signature: terminal_selector_value(&args, "--signature"),
+                },
+                preview: args.iter().any(|arg| arg == "--preview"),
+                run_tests: true,
+            })
+        }
+        ":add" | ":update" | ":delete" => {
+            let operation = match command {
+                ":add" => LiveEditOperation::Add,
+                ":update" => LiveEditOperation::Update,
+                _ => LiveEditOperation::Delete,
+            };
+            let target = LiveSymbolTarget {
+                kind: Some(required_arg(&args, 1, "symbol kind")?.to_string()),
+                name: required_arg(&args, 2, "symbol name")?.to_string(),
+                file: terminal_selector_value(&args, "--file")
+                    .or_else(|| args.get(3).filter(|arg| !arg.starts_with("--")).cloned()),
+                owner: terminal_selector_value(&args, "--owner"),
+                signature: terminal_selector_value(&args, "--signature"),
+            };
+            let preview = args.iter().any(|arg| arg == "--preview");
+            if operation == LiveEditOperation::Delete {
+                ready(LiveCommand::Edit {
+                    operation,
+                    target,
+                    source: None,
+                    expected_source_hash: None,
+                    preview,
+                    run_tests: true,
+                })
+            } else {
+                Ok(ParsedTerminalCommand::Pending(PendingCommand::Edit {
+                    operation,
+                    target,
+                    preview,
+                }))
+            }
+        }
+        _ => Err(format!("unknown live command '{command}'; use :help")),
+    }
+}
+
+fn terminal_selector_value(args: &[String], option: &str) -> Option<String> {
+    args.windows(2)
+        .find(|pair| pair[0] == option)
+        .map(|pair| pair[1].clone())
+}
+
+fn required_arg<'a>(args: &'a [String], index: usize, name: &str) -> Result<&'a str, String> {
+    args.get(index)
+        .map(String::as_str)
+        .ok_or_else(|| format!("missing {name}"))
+}
+
+fn parse_u32(name: &str, value: &str) -> Result<u32, String> {
+    value
+        .parse::<u32>()
+        .map_err(|error| format!("invalid {name} '{value}': {error}"))
+}
+
+fn split_terminal_args(line: &str) -> Result<Vec<String>, String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    for character in line.trim().chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+            continue;
+        }
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(expected) = quote {
+            if character == expected {
+                quote = None;
+            } else {
+                current.push(character);
+            }
+            continue;
+        }
+        if character == '\'' || character == '"' {
+            quote = Some(character);
+        } else if character.is_whitespace() {
+            if !current.is_empty() {
+                args.push(std::mem::take(&mut current));
+            }
+        } else {
+            current.push(character);
+        }
+    }
+    if quote.is_some() {
+        return Err("unterminated quoted argument".to_string());
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+    Ok(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_queue_reports_backpressure_without_blocking() {
+        let (client, server) = live_session(1);
+        client
+            .submit(LiveRequest::new(1, LiveCommand::Status))
+            .expect("first request");
+        assert_eq!(
+            client
+                .submit(LiveRequest::new(2, LiveCommand::Status))
+                .expect_err("queue should be full"),
+            "live-session command queue is full"
+        );
+        assert_eq!(server.drain(1)[0].request_id, 1);
+    }
+
+    #[test]
+    fn response_output_is_bounded_and_explicitly_truncated() {
+        let (client, mut server) = live_session(1);
+        server.set_output_limit(256);
+        server
+            .respond(LiveResponse::success(
+                7,
+                9,
+                "symbols",
+                serde_json::json!({"source": "x".repeat(4096)}),
+            ))
+            .expect("response");
+        let response = client
+            .receive_timeout(Duration::from_millis(10))
+            .expect("receive");
+        assert!(response.truncated);
+        assert_eq!(response.request_id, 7);
+        assert_eq!(response.tick, 9);
+
+        server
+            .respond(LiveResponse::failure(8, 10, "x".repeat(4096)))
+            .expect("failure response");
+        let failure = client
+            .receive_timeout(Duration::from_millis(10))
+            .expect("receive failure");
+        assert!(failure.truncated);
+        assert_eq!(
+            failure.error.as_deref(),
+            Some("live response exceeded the output limit")
+        );
+        assert!(serde_json::to_vec(&failure).expect("encode").len() <= 256);
+    }
+
+    #[test]
+    fn terminal_multiline_edit_preserves_inline_source() {
+        let mut terminal = TerminalBuffer::new();
+        assert!(matches!(
+            terminal
+                .feed_line(":update function tick src/main.stasis")
+                .expect("start"),
+            TerminalInput::Continue { .. }
+        ));
+        terminal
+            .feed_line("function tick(): i32 {")
+            .expect("body one");
+        terminal.feed_line("    return 2;").expect("body two");
+        terminal.feed_line("}").expect("body three");
+        let TerminalInput::Request(request) = terminal.feed_line(":end").expect("finish") else {
+            panic!("expected request")
+        };
+        let LiveCommand::Edit { source, target, .. } = request.command else {
+            panic!("expected edit")
+        };
+        assert_eq!(target.name, "tick");
+        assert_eq!(target.file.as_deref(), Some("src/main.stasis"));
+        assert!(source.expect("source").contains("return 2"));
+    }
+
+    #[test]
+    fn completion_uses_deterministic_prefix_ranking_and_deduplication() {
+        let mut index = CompletionIndex::default();
+        index.replace([
+            CompletionItem {
+                text: "tick".into(),
+                kind: "function".into(),
+                detail: "tick(): i32".into(),
+            },
+            CompletionItem {
+                text: "tick".into(),
+                kind: "function".into(),
+                detail: "tick(): i32".into(),
+            },
+            CompletionItem {
+                text: "tick".into(),
+                kind: "function".into(),
+                detail: "tick(value: i32): i32".into(),
+            },
+            CompletionItem {
+                text: "ticker".into(),
+                kind: "global".into(),
+                detail: "i32".into(),
+            },
+            CompletionItem {
+                text: "title".into(),
+                kind: "global".into(),
+                detail: "utf8[32]".into(),
+            },
+        ]);
+        let result = index.complete(":read tick", 10, 10);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].text, "tick");
+        assert_eq!(result[1].text, "tick");
+        assert_eq!(result[2].text, "ticker");
+        assert_eq!(index.complete("éti", 1, 10).len(), 4);
+    }
+
+    #[test]
+    fn scratch_cells_are_session_only_and_record_tick_stamped_results() {
+        let mut scratch = ScratchWorkspace::default();
+        scratch
+            .put("score", "score = score + 1;".into())
+            .expect("put");
+        scratch
+            .record_result("score", 12, "ok".into())
+            .expect("result");
+        let cell = scratch.get("score").expect("cell");
+        assert_eq!(cell.last_tick, Some(12));
+        assert_eq!(cell.last_result.as_deref(), Some("ok"));
+        scratch.clear(Some("score")).expect("clear");
+        assert!(scratch.list().is_empty());
+    }
+
+    #[test]
+    fn request_schema_and_ids_are_validated() {
+        let (client, _) = live_session(1);
+        let mut request = LiveRequest::new(0, LiveCommand::Status);
+        assert!(client
+            .submit(request.clone())
+            .expect_err("zero id")
+            .contains("request_id"));
+        request.request_id = 1;
+        request.schema_version = 99;
+        assert!(client
+            .submit(request)
+            .expect_err("schema")
+            .contains("schema version"));
+
+        let oversized = LiveRequest::new(
+            2,
+            LiveCommand::Do {
+                code: "x".repeat(MAX_LIVE_REQUEST_BYTES),
+                preview: false,
+            },
+        );
+        assert!(oversized.validate().expect_err("size").contains("limit"));
+    }
+
+    #[test]
+    fn terminal_json_preserves_protocol_request_id() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(request) = terminal
+            .feed_line(r#"{"schema_version":1,"request_id":42,"type":"status"}"#)
+            .expect("json request")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(request.request_id, 42);
+        assert_eq!(request.command, LiveCommand::Status);
+    }
+
+    #[test]
+    fn terminal_multiline_can_be_canceled_and_is_bounded() {
+        let mut terminal = TerminalBuffer::new();
+        terminal.feed_line(":do").expect("start");
+        assert!(terminal.cancel_pending());
+        assert!(!terminal.cancel_pending());
+        terminal.feed_line(":do").expect("restart");
+        assert!(terminal
+            .feed_line(&"x".repeat(MAX_LIVE_MULTILINE_BYTES + 1))
+            .expect_err("bounded")
+            .contains("exceeds"));
+        assert!(!terminal.cancel_pending());
+    }
+
+    #[test]
+    fn terminal_selectors_and_symbol_paging_are_explicit() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(request) = terminal
+            .feed_line(
+                r#":read update function --file src/game.stasis --owner Enemy --signature "update(i32): void""#,
+            )
+            .expect("selector")
+        else {
+            panic!("expected request")
+        };
+        let LiveCommand::Read {
+            file,
+            owner,
+            signature,
+            ..
+        } = request.command
+        else {
+            panic!("expected read")
+        };
+        assert_eq!(file.as_deref(), Some("src/game.stasis"));
+        assert_eq!(owner.as_deref(), Some("Enemy"));
+        assert_eq!(signature.as_deref(), Some("update(i32): void"));
+
+        let TerminalInput::Request(request) = terminal
+            .feed_line(":symbols update --page 2 --limit 10")
+            .expect("page")
+        else {
+            panic!("expected request")
+        };
+        assert!(matches!(
+            request.command,
+            LiveCommand::Symbols {
+                page: 2,
+                limit: 10,
+                ..
+            }
+        ));
+    }
+}

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -8,8 +8,8 @@ edit and receipt contracts, but intentionally keeps its own mobile interaction m
 
 The default terminal is a human workspace view, not a protocol dump. It prints concise scalar,
 symbol, edit, scratch, status, and diagnostic lines; large semantic plans are summarized by changed
-symbols/files and reload class. Add `--live-json` only for clients that need complete schema-v1
-response envelopes.
+symbols/files and reload class. Routine human responses omit protocol request and tick metadata. Add
+`--live-json` only for clients that need complete schema-v1 response envelopes.
 
 The project must provide the graphical lifecycle entry points `main`, `tick`, and `render`.
 `on_code_swap` is optional. This mode is local-only and does not open a network listener.

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -1,0 +1,126 @@
+# Interactive live workspace
+
+`stasis run --interactive` starts the manifest entry in the normal in-process graphical runner
+and opens a desktop-focused local terminal prompt. Rendering remains on the main thread. Terminal
+input enters the bounded `stasis_runner::live` protocol queue and every request is observed or
+committed at a normalized between-tick boundary. Android Workshop shares compiler-owned semantic
+edit and receipt contracts, but intentionally keeps its own mobile interaction model.
+
+The project must provide the graphical lifecycle entry points `main`, `tick`, and `render`.
+`on_code_swap` is optional. This mode is local-only and does not open a network listener.
+
+## Commands
+
+```text
+:help
+:status
+:pause
+:resume
+:step 1
+:cancel 42
+:symbols tick --page 0 --limit 50
+:read tick function --file src/main.stasis --owner Game --signature "tick(): i32"
+:complete ti
+:preview
+:apply
+:inspect score
+:watch score
+:set score 10
+:print score
+:changes
+:undo
+:redo
+:quit
+```
+
+Code-aware add and update commands use an inline multiline buffer ending with `:end`:
+
+```text
+:update function tick src/main.stasis
+function tick(): i32 {
+    score += 4;
+    return 0;
+}
+:end
+```
+
+The line editor provides session command history and compiler-backed Tab completion. Press
+Ctrl-C or enter `:abort` to discard a multiline buffer without submitting it. Symbol results are
+paged; selectors accept `--file`, `--owner`, and `--signature` for same-name overloads and receiver
+methods.
+
+Add, update, delete, read, list, and completion operate on the compiler-owned symbol and type
+indexes. Edits use the same semantic selectors, expected source hashes, import reconciliation,
+atomic source writes, test gate, and content-addressed receipts as `stasis symbol`. Successful
+edits are parsed, planned, compiled, and tested on a bounded background preparation worker. The
+graphics thread remains responsive and performs only the hash guard, atomic source/receipt write,
+bounded state snapshot, hook invocation, and pointer commit between ticks. `:undo` and `:redo` use
+the recorded semantic plan; they do not reverse arbitrary text ranges.
+
+Preparation records every `src/` and `tests/` input hash, stages JIT literals without publishing
+them, and runs tests in a cancellable helper process whose output cannot block the worker. A queued
+cancel or quit is observed before a ready candidate can commit, and session shutdown joins the
+worker.
+
+Add `--preview` to an inline `:add`, `:update`, or `:delete` to compile and retain a validated
+plan without writing. `:preview` displays that staged plan and `:apply` commits it only if its
+source hashes are still current.
+
+Layout-changing edits return a deterministic diagnostic until the first-class migration contract
+tracked by Maddox #153 is available. Compiler, test, stale-hash, receipt, or `on_code_swap`
+invocation failure restores the prior disk sources, dispatch table, and bounded typed runtime
+state. The current `on_code_swap(): void` ABI has no application-level rejection return value.
+
+## Scratch and state transactions
+
+`:inspect`, `:set`, and `:do` accept compiler-indexed scalar paths (`i32`, `f32`, `f64`, or
+`bool`). `:do` is a semicolon-separated assignment transaction:
+
+```text
+:do --preview
+score = 20;
+ready = true;
+:end
+```
+
+All paths and values are validated before any assignment is written. Preview performs no write.
+Calls, arbitrary addresses, and unsupported expressions fail clearly instead of using a second
+parser or lowering pipeline.
+
+Named cells retain code and results only for the current development session:
+
+```text
+:cell put reset_score
+score = 0;
+:end
+:cell run reset_score --preview
+:cell run reset_score
+:cell list
+:cell clear reset_score
+```
+
+`:cell persist NAME KIND SYMBOL [FILE]` explicitly promotes a cell through the normal semantic
+edit path. Scratch text never silently becomes project source.
+
+## Automation protocol
+
+Use `--live-json` to print schema-v1 response envelopes as JSON lines. A command file can mix the
+terminal spelling above with request JSON:
+
+```json
+{"schema_version":1,"request_id":42,"type":"inspect","path":"score"}
+```
+
+Every response includes `schema_version`, `request_id`, `tick`, `ok`, `kind`, and either `data` or
+`error`. An edit first returns `edit_preparing`; its final response reuses the same request ID after
+background validation and the between-tick commit. Watch events use request ID `0`, and dropped
+watch notifications are followed by a `watch_backpressure` count. Queue length, serialized request
+and response bytes, multiline/cell size, symbol/completion pages, transaction assignments, and
+runtime snapshot bytes are bounded; overload is reported as backpressure, rejection, or explicit
+truncation.
+
+Run a repeatable session without Cargo or repository-only tools:
+
+```text
+stasis run --interactive --live-script live.commands --live-json
+```

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -6,6 +6,11 @@ input enters the bounded `stasis_runner::live` protocol queue and every request 
 committed at a normalized between-tick boundary. Android Workshop shares compiler-owned semantic
 edit and receipt contracts, but intentionally keeps its own mobile interaction model.
 
+The default terminal is a human workspace view, not a protocol dump. It prints concise scalar,
+symbol, edit, scratch, status, and diagnostic lines; large semantic plans are summarized by changed
+symbols/files and reload class. Add `--live-json` only for clients that need complete schema-v1
+response envelopes.
+
 The project must provide the graphical lifecycle entry points `main`, `tick`, and `render`.
 `on_code_swap` is optional. This mode is local-only and does not open a network listener.
 
@@ -118,6 +123,9 @@ watch notifications are followed by a `watch_backpressure` count. Queue length, 
 and response bytes, multiline/cell size, symbol/completion pages, transaction assignments, and
 runtime snapshot bytes are bounded; overload is reported as backpressure, rejection, or explicit
 truncation.
+
+`--live-json` changes only presentation. The normal terminal and JSON-lines clients use the same
+request queue, compiler indexes, edit plans, tick boundaries, and response objects.
 
 Run a repeatable session without Cargo or repository-only tools:
 

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -75,8 +75,9 @@ runnable `main()` and a real `.test.stasis` test.
 - `run --interactive`: keep the graphical runner and tick loop alive while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
   typed between-tick inspection or mutation. The terminal includes history, compiler-backed Tab
-  completion, paging, and multiline cancellation. Use `--live-json` for response envelopes or
-  `--live-script PATH` for a deterministic command script. See
+  completion, paging, multiline cancellation, and concise command-specific output. Use
+  `--live-json` for complete schema-v1 response envelopes or `--live-script PATH` for a
+  deterministic command script. See
   [Interactive live workspace](live_cli_workspace.md).
 - `build --mode dev`: compile through JIT and write `build/dev-build.json` as a deterministic
   receipt.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -30,6 +30,7 @@ stasis check
 stasis test
 stasis run --headless
 stasis run --watch
+stasis run --interactive
 stasis build --mode dev
 stasis build --mode release
 stasis package --target desktop
@@ -71,6 +72,12 @@ runnable `main()` and a real `.test.stasis` test.
   `i32` result is the process exit code. Headless execution is the default.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
+- `run --interactive`: keep the graphical runner and tick loop alive while a desktop terminal uses
+  the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
+  typed between-tick inspection or mutation. The terminal includes history, compiler-backed Tab
+  completion, paging, and multiline cancellation. Use `--live-json` for response envelopes or
+  `--live-script PATH` for a deterministic command script. See
+  [Interactive live workspace](live_cli_workspace.md).
 - `build --mode dev`: compile through JIT and write `build/dev-build.json` as a deterministic
   receipt.
 - `build --mode release`: use the shared Cranelift AOT pipeline and write the native executable to


### PR DESCRIPTION
## Summary
- add a desktop-first `stasis run --interactive` workspace with Rustyline history/Tab completion and a bounded schema-v1 JSON protocol
- use compiler-owned semantic CRUD, selectors, stale guards, preview/apply/history/undo/redo, typed state inspection/transactions, watches, and exact pause/step control
- prepare edits on one cancellable background worker, test in an isolated bounded subprocess, then atomically commit source/receipt/JIT/state between ticks with rollback
- stage JIT literals until activation, bound requests/responses/output/state, and document the #153 layout-migration dependency and void hook limitation

## Tests
- `cargo test -p stasis --lib -- --test-threads=1` (156 passed, 6 ignored)
- `cargo test -p stasis --test toolchain_cli -- --test-threads=1` (8 passed, including real Windows graphical interactive E2E)
- `cargo test -p stasis_compiler backend::jit -- --test-threads=1` (153 passed)
- `cargo test -p stasis_compiler backend::aot -- --test-threads=1` (30 passed, 1 ignored)
- `cargo test -p stasis_runner -- --test-threads=1` (25 passed)
- `cargo test -p stasis_dynload -- --test-threads=1` (8 passed)
- touched-file `rustfmt --check`, `git diff --check`, and `python tools/ci/check_stasis_src_layout.py` passed
- repository validation Cargo command reaches two pre-existing Windows separator assertions in `apps/stasis/src/main.rs` (`nested\\helper.stasis` vs `nested/helper.stasis`); no task-specific failure

## Simplicity / cruft review
- removed the unsafe in-process staged-test fallback
- kept one compiler/JIT path; candidate-only behavior is staging and activation, not alternate lowering
- bounded internal backlog and child output rather than accumulating deferred work
- independent review completed with no remaining P1/P2 findings

## Compiler-slice reflection
- Good: compiler-owned semantic edits and staged activation kept desktop and Android contracts aligned without sharing UI/session code.
- Bad: initial candidate preparation leaked process-global literals and under-specified cancellation/backpressure edges.
- Adjustment: treat every background candidate resource (inputs, output, literals, workers, and rollback writes) as explicitly bounded and unpublished until the commit boundary.