### PR TITLE
feat: add scope-aware live command palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio 1.2.2",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,10 +432,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "error-code"
@@ -578,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -590,7 +631,22 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -637,6 +693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +751,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -698,6 +775,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -733,6 +833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -803,6 +922,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustyline"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +947,7 @@ dependencies = [
  "log",
  "memchr",
  "nix 0.28.0",
+ "radix_trie",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -838,6 +971,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -894,6 +1033,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.2",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1086,7 @@ name = "stasis"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "crossterm",
  "notify",
  "object",
  "rustyline",
@@ -1101,6 +1272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1295,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -13,7 +13,8 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
-rustyline = { version = "14.0", default-features = false }
+rustyline = { version = "14.0", default-features = false, features = ["custom-bindings"] }
+crossterm = "0.28"
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -4,15 +4,15 @@ use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
-    workshop_reachable_files, workshop_source_hash, workshop_source_items,
-    write_workshop_semantic_plan, write_workshop_semantic_receipt, ExpectedReload,
-    WorkshopSemanticEdit, WorkshopSemanticEditBatch, WorkshopSemanticEditOperation,
-    WorkshopSemanticEditPlan, WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind,
-    WorkshopSymbolSelector,
+    workshop_completion_items, workshop_reachable_files, workshop_source_hash,
+    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
+    ExpectedReload, WorkshopCompletionItem, WorkshopSemanticEdit, WorkshopSemanticEditBatch,
+    WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
+    WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    CompletionIndex, CompletionItem, LiveCommand, LiveEditOperation, LiveRequest, LiveResponse,
-    LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
+    CompletionIndex, CompletionItem, CompletionScope, LiveCommand, LiveEditOperation, LiveRequest,
+    LiveResponse, LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
@@ -71,6 +71,7 @@ struct PreparedEdit {
     candidate: JitProcess,
     package: JitEnginePackage,
     source_items: Vec<WorkshopSourceItem>,
+    completion_items: Vec<WorkshopCompletionItem>,
     input_hashes: BTreeMap<String, String>,
 }
 
@@ -115,6 +116,7 @@ pub(crate) struct LiveWorkspace {
     history_cursor: usize,
     completion: CompletionIndex,
     source_items: Vec<WorkshopSourceItem>,
+    completion_items: Vec<WorkshopCompletionItem>,
     scratch: ScratchWorkspace,
     watches: BTreeMap<String, Option<JitScalarValue>>,
     pending_plan: Option<WorkshopSemanticEditPlan>,
@@ -152,6 +154,7 @@ impl LiveWorkspace {
             history_cursor: 0,
             completion: CompletionIndex::default(),
             source_items: Vec::new(),
+            completion_items: Vec::new(),
             scratch: ScratchWorkspace::default(),
             watches: BTreeMap::new(),
             pending_plan: None,
@@ -452,9 +455,27 @@ impl LiveWorkspace {
                 buffer,
                 cursor,
                 limit,
+                context,
             } => Ok((
                 "completion",
-                json!({"items": self.completion.complete(&buffer, cursor, limit)}),
+                json!(self
+                    .completion
+                    .query_with_context(&buffer, cursor, limit, &context)),
+            )),
+            LiveCommand::Palette {
+                query,
+                page,
+                limit,
+                context,
+            } => Ok((
+                "palette",
+                json!(paged_completion_query(
+                    &self.completion,
+                    &query,
+                    page,
+                    limit,
+                    &context,
+                )),
             )),
             LiveCommand::Edit {
                 operation,
@@ -845,6 +866,7 @@ impl LiveWorkspace {
         let plan = prepared.plan.clone();
         let action = prepared.action.clone();
         let source_items = prepared.source_items;
+        let completion_items = prepared.completion_items;
         let tests = if prepared.tests_ran {
             "passed"
         } else {
@@ -852,6 +874,7 @@ impl LiveWorkspace {
         };
         *jit = prepared.candidate;
         self.source_items = source_items;
+        self.completion_items = completion_items;
         self.remember_plan_hashes(&plan, prepared.restore);
         let (kind, data) = match action {
             PreparedAction::ApplyNew => {
@@ -927,16 +950,27 @@ impl LiveWorkspace {
     fn refresh_completion(&mut self, jit: &JitProcess) -> Result<(), String> {
         let files = self.load_files()?;
         self.source_items = workshop_source_items(&files)?;
+        self.completion_items = workshop_completion_items(&files)?;
         self.rebuild_completion(jit);
         Ok(())
     }
 
     fn rebuild_completion(&mut self, jit: &JitProcess) {
         let mut items = live_command_completions();
-        items.extend(self.source_items.iter().map(|item| CompletionItem {
-            text: item.name.clone(),
-            kind: format!("{:?}", item.kind).to_ascii_lowercase(),
-            detail: item.signature.clone(),
+        items.extend(self.completion_items.iter().map(|item| CompletionItem {
+            text: item.text.clone(),
+            kind: item.kind.clone(),
+            detail: item.detail.clone(),
+            type_name: item.type_name.clone(),
+            source: Some(item.file.clone()),
+            scope: item.scope.as_ref().map(|scope| CompletionScope {
+                owner: scope.owner.clone(),
+                file: scope.file.clone(),
+                owner_signature: scope.owner_signature.clone(),
+                owner_end: scope.owner_end,
+                visible_from: scope.visible_from,
+                visible_to: scope.visible_to,
+            }),
         }));
         items.extend(
             jit.global_scalar_paths()
@@ -945,15 +979,36 @@ impl LiveWorkspace {
                     text: path,
                     kind: "state_path".to_string(),
                     detail: type_name.to_string(),
+                    type_name: Some(type_name.to_string()),
+                    source: Some("runtime state".to_string()),
+                    scope: None,
                 }),
         );
         items.extend(self.scratch.list().into_iter().map(|cell| CompletionItem {
             text: cell.name,
             kind: "scratch_cell".to_string(),
             detail: "session-only scratch cell".to_string(),
+            type_name: None,
+            source: Some("scratch workspace".to_string()),
+            scope: None,
         }));
         self.completion.replace(items);
     }
+}
+
+fn paged_completion_query(
+    index: &CompletionIndex,
+    query: &str,
+    page: u32,
+    limit: usize,
+    context: &stasis_runner::live::CompletionContext,
+) -> stasis_runner::live::CompletionQuery {
+    let start = (page as usize).saturating_mul(limit);
+    let requested = start.saturating_add(limit).min(256);
+    let mut result = index.query_with_context(query, query.len(), requested, context);
+    result.page = page;
+    result.items = result.items.into_iter().skip(start).take(limit).collect();
+    result
 }
 
 fn validate_edit_input_size(input: &EditPreparationInput) -> Result<(), String> {
@@ -1055,6 +1110,7 @@ fn prepare_edit(
     }
     check_preparation_canceled(canceled)?;
     let source_items = workshop_source_items(&candidate_files)?;
+    let completion_items = workshop_completion_items(&candidate_files)?;
     Ok(PreparedEdit {
         request_id,
         plan,
@@ -1064,6 +1120,7 @@ fn prepare_edit(
         candidate,
         package,
         source_items,
+        completion_items,
         input_hashes,
     })
 }
@@ -1379,7 +1436,8 @@ fn help_data() -> Value {
         "commands": [
             ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
             ":symbols [query] [--page N --limit N]",
-            ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]", ":complete BUFFER",
+            ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
+            ":complete BUFFER", ":palette [QUERY]",
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
             ":inspect PATH", ":watch PATH", ":unwatch [PATH]", ":set PATH VALUE",
@@ -1387,7 +1445,7 @@ fn help_data() -> Value {
         ],
         "multiline_terminator": ":end",
         "multiline_cancel": ":abort or Ctrl-C",
-        "line_editor": "session history and compiler-backed Tab completion",
+        "line_editor": "session history; Ctrl-P opens the compiler-backed palette; Tab completes",
         "durability": "semantic edits persist through code-aware receipts; scratch cells do not persist unless explicitly promoted",
     })
 }
@@ -1405,6 +1463,7 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":find",
         ":read",
         ":complete",
+        ":palette",
         ":add",
         ":update",
         ":delete",
@@ -1426,6 +1485,9 @@ fn live_command_completions() -> Vec<CompletionItem> {
         text: text.to_string(),
         kind: "command".to_string(),
         detail: "live command".to_string(),
+        type_name: None,
+        source: Some("interactive workspace".to_string()),
+        scope: None,
     })
     .collect()
 }
@@ -2033,7 +2095,10 @@ mod tests {
                 LiveCommand::Edit {
                     operation: LiveEditOperation::Add,
                     target: target.clone(),
-                    source: Some("function helper(): i32 { return 7; }".into()),
+                    source: Some(
+                        "function helper(value: i32): i32 { let local: i32 = value; return local; }"
+                            .into(),
+                    ),
                     expected_source_hash: None,
                     preview: false,
                     run_tests: false,
@@ -2044,6 +2109,19 @@ mod tests {
         assert_eq!(
             workspace.completion.complete(":read hel", 9, 10)[0].text,
             "helper"
+        );
+        let helper_context = stasis_runner::live::CompletionContext {
+            owner: Some("helper".into()),
+            file: Some("src/main.stasis".into()),
+            ..stasis_runner::live::CompletionContext::default()
+        };
+        assert_eq!(
+            workspace
+                .completion
+                .query_with_context("lcl", 3, 10, &helper_context)
+                .items[0]
+                .text,
+            "local"
         );
         assert!(workspace.consumes_self_write(&root.join("src/main.stasis")));
 
@@ -2058,7 +2136,10 @@ mod tests {
                 LiveCommand::Edit {
                     operation: LiveEditOperation::Update,
                     target: target.clone(),
-                    source: Some("function helper(): i32 { return 8; }".into()),
+                    source: Some(
+                        "function helper(value: i32): i32 { let local: i32 = value; return 8; }"
+                            .into(),
+                    ),
                     expected_source_hash: Some("stale".into()),
                     preview: false,
                     run_tests: false,
@@ -2068,7 +2149,7 @@ mod tests {
         assert!(!stale.ok);
         assert!(fs::read_to_string(root.join("src/main.stasis"))
             .expect("source")
-            .contains("return 7"));
+            .contains("return local"));
 
         let files = load_workshop_edit_workspace(&root, &config.entry).expect("files");
         let helper = find_workshop_symbols(&files, &selector(&target).expect("selector"))
@@ -2093,10 +2174,92 @@ mod tests {
             ),
         );
         assert!(deleted.ok, "{:?}", deleted.error);
-        assert!(workspace.completion.complete(":read hel", 9, 10).is_empty());
+        assert!(workspace
+            .completion
+            .complete(":read hel", 9, 10)
+            .iter()
+            .all(|item| item.text != "helper"));
+        assert!(workspace
+            .completion
+            .query_with_context("lcl", 3, 10, &helper_context)
+            .items
+            .iter()
+            .all(|item| item.text != "local"));
         assert!(!fs::read_to_string(root.join("src/main.stasis"))
             .expect("source")
             .contains("function helper"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn large_palette_query_stays_bounded_and_completes_in_one_graphics_boundary() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut items = (0..10_000)
+            .map(|index| CompletionItem {
+                text: format!("generated_{index:05}"),
+                kind: "function".into(),
+                detail: format!("generated_{index:05}(): i32"),
+                type_name: Some("i32".into()),
+                source: Some("src/generated.stasis".into()),
+                scope: None,
+            })
+            .collect::<Vec<_>>();
+        items.push(CompletionItem {
+            text: "late_graphics_target".into(),
+            kind: "function".into(),
+            detail: "late_graphics_target(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/late.stasis".into()),
+            scope: None,
+        });
+        workspace.completion.replace(items);
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                13,
+                LiveCommand::Palette {
+                    query: "lgt".into(),
+                    page: 0,
+                    limit: 8,
+                    context: stasis_runner::live::CompletionContext::default(),
+                },
+            ),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        assert_eq!(response.tick, 1);
+        assert_eq!(
+            response.data.expect("palette")["items"][0]["text"],
+            "late_graphics_target"
+        );
+        let page = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                14,
+                LiveCommand::Palette {
+                    query: "generated".into(),
+                    page: 2,
+                    limit: 8,
+                    context: stasis_runner::live::CompletionContext::default(),
+                },
+            ),
+        );
+        assert_eq!(
+            page.data.expect("page")["items"][0]["text"],
+            "generated_00016"
+        );
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,10 +1,22 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{
+    self, Event as TerminalEvent, KeyCode, KeyEvent as TerminalKeyEvent, KeyEventKind, KeyModifiers,
+};
+use crossterm::execute;
+use crossterm::style::Print;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use rustyline::completion::{Completer, Pair};
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::history::DefaultHistory;
 use rustyline::validate::Validator;
-use rustyline::{Context, Editor, Helper};
+use rustyline::{
+    Cmd, CompletionType, ConditionalEventHandler, Config, Context, Editor, Event as LineEvent,
+    EventContext, EventHandler, Helper, KeyEvent as LineKeyEvent, RepeatCount,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use stasis::{
@@ -12,6 +24,7 @@ use stasis::{
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
+use stasis_compiler::frontend::parser::completion_expected_type;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
     workshop_reachable_files, workshop_source_hash, workshop_source_items,
@@ -20,15 +33,17 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    live_session, CompletionItem, LiveCommand, LiveRequest, LiveResponse, TerminalBuffer,
-    TerminalInput,
+    live_session, CompletionContext, CompletionItem, LiveCommand, LiveRequest, LiveResponse,
+    LiveSessionClient, TerminalBuffer, TerminalInput,
 };
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -877,7 +892,60 @@ fn run_workspace_live(
 }
 
 struct LiveLineHelper {
-    items: Vec<CompletionItem>,
+    client: LiveSessionClient,
+    next_request_id: AtomicU64,
+    context: Mutex<CompletionContext>,
+    deferred_responses: Mutex<Vec<LiveResponse>>,
+}
+
+impl LiveLineHelper {
+    fn new(client: LiveSessionClient) -> Self {
+        Self {
+            client,
+            next_request_id: AtomicU64::new(1u64 << 63),
+            context: Mutex::new(CompletionContext::default()),
+            deferred_responses: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn set_context(&self, context: CompletionContext) {
+        *self.context.lock().expect("completion context lock") = context;
+    }
+
+    fn take_deferred_responses(&self) -> Vec<LiveResponse> {
+        std::mem::take(
+            &mut *self
+                .deferred_responses
+                .lock()
+                .expect("deferred response lock"),
+        )
+    }
+
+    fn query(
+        &self,
+        line: &str,
+        position: usize,
+        limit: usize,
+    ) -> Result<stasis_runner::live::CompletionQuery, String> {
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let mut context = self
+            .context
+            .lock()
+            .expect("completion context lock")
+            .clone();
+        if context.expected_type.is_none() {
+            context.expected_type = completion_expected_type(line, position).unwrap_or_default();
+        }
+        fetch_live_completion_query(
+            &self.client,
+            request_id,
+            line,
+            position,
+            limit,
+            context,
+            &self.deferred_responses,
+        )
+    }
 }
 
 impl Helper for LiveLineHelper {}
@@ -896,27 +964,295 @@ impl Completer for LiveLineHelper {
         position: usize,
         _context: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        let mut position = position.min(line.len());
-        while !line.is_char_boundary(position) {
-            position -= 1;
-        }
-        let start = line[..position]
-            .rfind(|character: char| {
-                character.is_whitespace() || character == '(' || character == ','
-            })
-            .map_or(0, |index| index + 1);
-        let prefix = &line[start..position];
-        let candidates = self
+        let query = self
+            .query(line, position, 64)
+            .map_err(|error| rustyline::error::ReadlineError::Io(io::Error::other(error)))?;
+        let candidates = query
             .items
-            .iter()
-            .filter(|item| item.text.starts_with(prefix))
+            .into_iter()
             .map(|item| Pair {
-                display: format!("{}  {}", item.text, item.detail),
-                replacement: item.text.clone(),
+                display: format_completion_candidate(&item),
+                replacement: item.text,
             })
             .collect();
-        Ok((start, candidates))
+        Ok((query.replacement_start, candidates))
     }
+}
+
+fn format_completion_candidate(item: &CompletionItem) -> String {
+    let mut detail = item.detail.replace(['\r', '\n'], " ");
+    if detail.chars().count() > 48 {
+        detail = detail.chars().take(45).collect::<String>() + "...";
+    }
+    format!("{}  [{}]  {}", item.text, item.kind, detail)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PaletteOpen {
+    line: String,
+    cursor: usize,
+}
+
+struct PaletteTrigger {
+    pending: Arc<Mutex<Option<PaletteOpen>>>,
+}
+
+impl ConditionalEventHandler for PaletteTrigger {
+    fn handle(
+        &self,
+        _event: &LineEvent,
+        _repeat: RepeatCount,
+        _positive: bool,
+        context: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        *self.pending.lock().expect("palette trigger lock") = Some(PaletteOpen {
+            line: context.line().to_string(),
+            cursor: context.pos(),
+        });
+        Some(Cmd::AcceptLine)
+    }
+}
+
+const PALETTE_PAGE_SIZE: usize = 8;
+
+struct PaletteState {
+    query: String,
+    items: Vec<CompletionItem>,
+    selected: usize,
+    truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaletteAction {
+    Cancel,
+    Move(isize),
+    Select,
+    Backspace,
+    Type(char),
+    Ignore,
+}
+
+fn palette_action(key: TerminalKeyEvent) -> PaletteAction {
+    match key.code {
+        KeyCode::Esc => PaletteAction::Cancel,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            PaletteAction::Cancel
+        }
+        KeyCode::Up => PaletteAction::Move(-1),
+        KeyCode::Down => PaletteAction::Move(1),
+        KeyCode::PageUp => PaletteAction::Move(-(PALETTE_PAGE_SIZE as isize)),
+        KeyCode::PageDown => PaletteAction::Move(PALETTE_PAGE_SIZE as isize),
+        KeyCode::Enter | KeyCode::Tab => PaletteAction::Select,
+        KeyCode::Backspace => PaletteAction::Backspace,
+        KeyCode::Char(character)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            PaletteAction::Type(character)
+        }
+        _ => PaletteAction::Ignore,
+    }
+}
+
+impl PaletteState {
+    fn replace_results(&mut self, query: stasis_runner::live::CompletionQuery) {
+        self.items = query.items;
+        self.selected = 0;
+        self.truncated = query.truncated;
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.items.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        self.selected = self
+            .selected
+            .saturating_add_signed(delta)
+            .min(self.items.len() - 1);
+    }
+}
+
+struct PaletteTerminalGuard;
+
+impl PaletteTerminalGuard {
+    fn enter() -> Result<Self, String> {
+        enable_raw_mode().map_err(|error| format!("failed enabling palette input: {error}"))?;
+        if let Err(error) = execute!(io::stdout(), EnterAlternateScreen, Hide) {
+            let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            return Err(format!("failed opening palette screen: {error}"));
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for PaletteTerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+    }
+}
+
+fn run_live_palette(
+    helper: &LiveLineHelper,
+    open: PaletteOpen,
+) -> Result<(String, String), String> {
+    let initial = helper.query(&open.line, open.cursor, 64)?;
+    let replacement_start = initial.replacement_start;
+    let replacement_end = initial.replacement_end;
+    let mut state = PaletteState {
+        query: open.line[replacement_start..replacement_end].to_string(),
+        items: initial.items,
+        selected: 0,
+        truncated: initial.truncated,
+    };
+    let _guard = PaletteTerminalGuard::enter()?;
+    loop {
+        render_live_palette(&state)?;
+        let TerminalEvent::Key(key) =
+            event::read().map_err(|error| format!("failed reading palette input: {error}"))?
+        else {
+            continue;
+        };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        match palette_action(key) {
+            PaletteAction::Cancel => {
+                return Ok(split_palette_line(&open.line, open.cursor));
+            }
+            PaletteAction::Move(delta) => state.move_selection(delta),
+            PaletteAction::Select => {
+                if let Some(item) = state.items.get(state.selected) {
+                    return Ok(insert_palette_selection(
+                        &open.line,
+                        replacement_start,
+                        replacement_end,
+                        &item.text,
+                    ));
+                }
+            }
+            PaletteAction::Backspace => {
+                state.query.pop();
+                let query = query_live_palette(
+                    helper,
+                    &open.line,
+                    replacement_start,
+                    replacement_end,
+                    &state.query,
+                )?;
+                state.replace_results(query);
+            }
+            PaletteAction::Type(character) => {
+                state.query.push(character);
+                let query = query_live_palette(
+                    helper,
+                    &open.line,
+                    replacement_start,
+                    replacement_end,
+                    &state.query,
+                )?;
+                state.replace_results(query);
+            }
+            PaletteAction::Ignore => {}
+        }
+    }
+}
+
+fn query_live_palette(
+    helper: &LiveLineHelper,
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    query: &str,
+) -> Result<stasis_runner::live::CompletionQuery, String> {
+    let (line, cursor) = palette_query_input(line, replacement_start, replacement_end, query);
+    helper.query(&line, cursor, 64)
+}
+
+fn palette_query_input(
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    query: &str,
+) -> (String, usize) {
+    let mut line = line.to_string();
+    line.replace_range(replacement_start..replacement_end, query);
+    (line, replacement_start + query.len())
+}
+
+fn split_palette_line(line: &str, cursor: usize) -> (String, String) {
+    (line[..cursor].to_string(), line[cursor..].to_string())
+}
+
+fn insert_palette_selection(
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    selection: &str,
+) -> (String, String) {
+    let mut line = line.to_string();
+    line.replace_range(replacement_start..replacement_end, selection);
+    split_palette_line(&line, replacement_start + selection.len())
+}
+
+fn render_live_palette(state: &PaletteState) -> Result<(), String> {
+    let mut stdout = io::stdout();
+    let width = crossterm::terminal::size()
+        .map(|(width, _)| width as usize)
+        .unwrap_or(80)
+        .max(20);
+    execute!(
+        stdout,
+        MoveTo(0, 0),
+        Clear(ClearType::All),
+        Print(terminal_line("Stasis command palette", width)),
+        Print("\r\n"),
+        Print(terminal_line(&format!("> {}", state.query), width)),
+        Print("\r\n\r\n")
+    )
+    .map_err(|error| format!("failed drawing palette: {error}"))?;
+    let page_start = (state.selected / PALETTE_PAGE_SIZE) * PALETTE_PAGE_SIZE;
+    for index in page_start..page_start + PALETTE_PAGE_SIZE {
+        let line = state.items.get(index).map_or_else(String::new, |item| {
+            format!(
+                "{} {}  [{}]  {}",
+                if index == state.selected { ">" } else { " " },
+                item.text,
+                item.kind,
+                item.detail
+            )
+        });
+        execute!(stdout, Print(terminal_line(&line, width)), Print("\r\n"))
+            .map_err(|error| format!("failed drawing palette row: {error}"))?;
+    }
+    let more = if state.truncated {
+        " | more matches; keep typing"
+    } else {
+        ""
+    };
+    execute!(
+        stdout,
+        Print("\r\n"),
+        Print(terminal_line(
+            &format!(
+                "{} match(es){} | arrows/page select | Enter/Tab insert | Esc cancel",
+                state.items.len(),
+                more
+            ),
+            width
+        ))
+    )
+    .map_err(|error| format!("failed drawing palette footer: {error}"))?;
+    stdout
+        .flush()
+        .map_err(|error| format!("failed flushing palette: {error}"))
+}
+
+fn terminal_line(text: &str, width: usize) -> String {
+    text.chars().take(width.saturating_sub(1)).collect()
 }
 
 fn run_live_terminal(
@@ -960,20 +1296,31 @@ fn run_live_terminal_inner(
             );
         }
     } else {
-        println!("Stasis live workspace (:help, :quit, Tab completion, Ctrl-C cancels multiline)");
-        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::new()
+        println!(
+            "Stasis live workspace (:help, :quit, Ctrl-P palette, Tab completes, Ctrl-C cancels multiline)"
+        );
+        let config = live_editor_config();
+        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::with_config(config)
             .map_err(|error| format!("failed initializing live line editor: {error}"))?;
-        editor.set_helper(Some(LiveLineHelper { items: Vec::new() }));
+        let palette_pending = Arc::new(Mutex::new(None));
+        editor.bind_sequence(
+            live_palette_key(),
+            EventHandler::Conditional(Box::new(PaletteTrigger {
+                pending: Arc::clone(&palette_pending),
+            })),
+        );
+        editor.set_helper(Some(LiveLineHelper::new(client.clone())));
         let mut prompt = "stasis> ";
-        let mut completion_request_id = 1u64 << 63;
+        let mut initial = None::<(String, String)>;
         loop {
-            if let Ok(items) = fetch_live_completions(client, completion_request_id, json_lines) {
-                if let Some(helper) = editor.helper_mut() {
-                    helper.items = items;
-                }
+            if let Some(helper) = editor.helper() {
+                helper.set_context(terminal.completion_context());
             }
-            completion_request_id = completion_request_id.saturating_add(1);
-            let line = match editor.readline(prompt) {
+            let readline = match initial.take() {
+                Some((left, right)) => editor.readline_with_initial(prompt, (&left, &right)),
+                None => editor.readline(prompt),
+            };
+            let line = match readline {
                 Ok(line) => line,
                 Err(rustyline::error::ReadlineError::Interrupted) => {
                     if terminal.cancel_pending() {
@@ -985,6 +1332,17 @@ fn run_live_terminal_inner(
                 Err(rustyline::error::ReadlineError::Eof) => break,
                 Err(error) => return Err(format!("failed reading live terminal: {error}")),
             };
+            let palette_open = palette_pending.lock().expect("palette trigger lock").take();
+            if let Some(open) = palette_open {
+                let helper = editor.helper().expect("live line helper");
+                initial = Some(run_live_palette(helper, open)?);
+                continue;
+            }
+            if let Some(helper) = editor.helper() {
+                for response in helper.take_deferred_responses() {
+                    print_live_response(&response, json_lines)?;
+                }
+            }
             let _ = editor.add_history_entry(line.as_str());
             match terminal.feed_line(&line)? {
                 TerminalInput::Continue { prompt: next } => {
@@ -1016,23 +1374,42 @@ fn run_live_terminal_inner(
     }
 }
 
-fn fetch_live_completions(
-    client: &stasis_runner::live::LiveSessionClient,
+fn live_palette_key() -> LineKeyEvent {
+    LineKeyEvent::ctrl('P')
+}
+
+fn live_editor_config() -> Config {
+    Config::builder()
+        .completion_type(CompletionType::List)
+        .completion_prompt_limit(256)
+        .build()
+}
+
+fn fetch_live_completion_query(
+    client: &LiveSessionClient,
     request_id: u64,
-    json_lines: bool,
-) -> Result<Vec<CompletionItem>, String> {
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: CompletionContext,
+    deferred_responses: &Mutex<Vec<LiveResponse>>,
+) -> Result<stasis_runner::live::CompletionQuery, String> {
     client.submit(LiveRequest::new(
         request_id,
         LiveCommand::Complete {
-            buffer: String::new(),
-            cursor: 0,
-            limit: 256,
+            buffer: buffer.to_string(),
+            cursor,
+            limit,
+            context,
         },
     ))?;
     loop {
         let response = client.receive_timeout(Duration::from_secs(5))?;
         if response.request_id != request_id {
-            print_live_response(&response, json_lines)?;
+            deferred_responses
+                .lock()
+                .expect("deferred response lock")
+                .push(response);
             continue;
         }
         if !response.ok {
@@ -1040,13 +1417,11 @@ fn fetch_live_completions(
                 .error
                 .unwrap_or_else(|| "live completion failed".to_string()));
         }
-        return serde_json::from_value(
-            response
-                .data
-                .and_then(|data| data.get("items").cloned())
-                .unwrap_or_else(|| json!([])),
-        )
-        .map_err(|error| format!("invalid live completion response: {error}"));
+        if response.truncated {
+            return Err("live completion response exceeded the protocol output bound".to_string());
+        }
+        return serde_json::from_value(response.data.unwrap_or(Value::Null))
+            .map_err(|error| format!("invalid live completion response: {error}"));
     }
 }
 
@@ -1119,7 +1494,10 @@ fn format_live_response(response: &LiveResponse) -> String {
         ),
         "symbols" => format_live_symbols(data),
         "symbol" => format_live_symbol(data),
-        "completion" => format_live_completion(data),
+        "completion" | "palette" if response.truncated => {
+            "completion response exceeded the output bound; narrow the query".to_string()
+        }
+        "completion" | "palette" => format_live_completion(data),
         "inspection" => format!(
             "{}: {} = {}",
             string_field(data, "path", "value"),
@@ -1311,6 +1689,13 @@ fn format_live_completion(data: &Value) -> String {
                 string_field(item, "detail", "")
             ));
         }
+    }
+    if data
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        lines.push("... more matches; keep typing".to_string());
     }
     if lines.is_empty() {
         "no completions".to_string()
@@ -2584,22 +2969,110 @@ mod tests {
     use super::*;
 
     #[test]
-    fn live_line_helper_completes_current_token_with_compiler_detail() {
-        let helper = LiveLineHelper {
-            items: vec![CompletionItem {
-                text: "tick".into(),
-                kind: "function".into(),
-                detail: "tick(): i32".into(),
-            }],
+    fn live_palette_formats_compiler_detail_concisely() {
+        let display = format_completion_candidate(&CompletionItem {
+            text: "tick".into(),
+            kind: "function".into(),
+            detail: "tick(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: None,
+        });
+        assert_eq!(display, "tick  [function]  tick(): i32");
+    }
+
+    #[test]
+    fn live_palette_state_navigates_pages_and_preserves_cancel_buffer() {
+        let mut state = PaletteState {
+            query: "hero".into(),
+            items: (0..20)
+                .map(|index| CompletionItem {
+                    text: format!("hero.field_{index}"),
+                    kind: "field".into(),
+                    detail: "i32".into(),
+                    type_name: Some("i32".into()),
+                    source: Some("src/main.stasis".into()),
+                    scope: None,
+                })
+                .collect(),
+            selected: 0,
+            truncated: false,
         };
-        let history = DefaultHistory::new();
-        let context = Context::new(&history);
-        let (start, matches) = helper
-            .complete(":read ti", 8, &context)
-            .expect("completion");
-        assert_eq!(start, 6);
-        assert_eq!(matches[0].replacement, "tick");
-        assert!(matches[0].display.contains("tick(): i32"));
+        state.move_selection(PALETTE_PAGE_SIZE as isize);
+        assert_eq!(live_palette_key(), LineKeyEvent::ctrl('P'));
+        assert_eq!(live_editor_config().completion_type(), CompletionType::List);
+        assert_eq!(state.selected, PALETTE_PAGE_SIZE);
+        state.move_selection(-1);
+        assert_eq!(state.selected, PALETTE_PAGE_SIZE - 1);
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            PaletteAction::Move(PALETTE_PAGE_SIZE as isize)
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE
+            )),
+            PaletteAction::Type('x')
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(
+                KeyCode::Backspace,
+                KeyModifiers::NONE
+            )),
+            PaletteAction::Backspace
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            PaletteAction::Select
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            PaletteAction::Cancel
+        );
+        assert_eq!(
+            insert_palette_selection("call(hrohp)", 5, 10, "hero.hp"),
+            ("call(hero.hp".to_string(), ")".to_string())
+        );
+        assert_eq!(
+            split_palette_line("call(hero)", 9),
+            ("call(hero".to_string(), ")".to_string())
+        );
+        assert_eq!(
+            palette_query_input("let next: i32 = he", 16, 18, "hero.hp"),
+            ("let next: i32 = hero.hp".to_string(), 23)
+        );
+    }
+
+    #[test]
+    fn human_palette_output_reports_bounded_truncation() {
+        let response = LiveResponse::success(
+            9,
+            44,
+            "palette",
+            json!({
+                "replacement_start": 0,
+                "replacement_end": 2,
+                "page": 0,
+                "truncated": true,
+                "items": [{"text": "tick", "kind": "function", "detail": "tick(): i32"}]
+            }),
+        );
+        assert_eq!(
+            format_live_response(&response),
+            "tick  function  tick(): i32\n... more matches; keep typing"
+        );
+        let bounded = LiveResponse::success(
+            10,
+            45,
+            "palette",
+            json!({"items": [{"text": "x".repeat(1024), "kind": "function", "detail": "x"}]}),
+        )
+        .bounded(256);
+        assert_eq!(
+            format_live_response(&bounded),
+            "completion response exceeded the output bound; narrow the query"
+        );
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1344,7 +1344,14 @@ fn run_live_terminal_inner(
                 }
             }
             let _ = editor.add_history_entry(line.as_str());
-            match terminal.feed_line(&line)? {
+            let input = match terminal.feed_line(&line) {
+                Ok(input) => input,
+                Err(error) => {
+                    eprintln!("error: {error}");
+                    continue;
+                }
+            };
+            match input {
                 TerminalInput::Continue { prompt: next } => {
                     prompt = next;
                     continue;
@@ -3042,6 +3049,22 @@ mod tests {
             palette_query_input("let next: i32 = he", 16, 18, "hero.hp"),
             ("let next: i32 = hero.hp".to_string(), 23)
         );
+    }
+
+    #[test]
+    fn invalid_interactive_command_does_not_poison_terminal_buffer() {
+        let mut terminal = TerminalBuffer::new();
+        assert_eq!(
+            terminal.feed_line("view render"),
+            Err("unknown live command 'view'; use :help".to_string())
+        );
+        let TerminalInput::Request(request) = terminal
+            .feed_line(":status")
+            .expect("valid command after invalid input")
+        else {
+            panic!("expected status request")
+        };
+        assert_eq!(request.command, LiveCommand::Status);
     }
 
     #[test]

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1018,7 +1018,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     );
     fs::write(
         project.join("src/main.stasis"),
-        "global score: i32;\nglobal swaps: i32;\nfunction main(): i32 { score = 1; swaps = 0; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { swaps += 1; return; }\n",
+        "struct Player { hp: i32; }\nglobal score: i32;\nglobal swaps: i32;\nfunction main(): i32 { score = 1; swaps = 0; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { swaps += 1; return; }\nfunction damage(player: Player, amount: i32): i32 { let hero: Player; return amount; }\n",
     )
     .expect("write live project");
     fs::write(
@@ -1028,7 +1028,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write live test");
     fs::write(
         project.join("live.commands"),
-        ":pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
+        ":palette hrohp --owner damage --file src/main.stasis\n:palette :pa\n:pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
     )
     .expect("write live script");
 
@@ -1056,6 +1056,13 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
         .collect::<Vec<_>>();
     assert!(responses.iter().all(|response| response["ok"] == true));
     assert!(responses.iter().all(|response| response["tick"].is_u64()));
+    let palettes = responses
+        .iter()
+        .filter(|response| response["kind"] == "palette")
+        .collect::<Vec<_>>();
+    assert_eq!(palettes[0]["data"]["items"][0]["text"], "hero.hp");
+    assert_eq!(palettes[0]["data"]["items"][0]["kind"], "field");
+    assert_eq!(palettes[1]["data"]["items"][0]["text"], ":pause");
     let inspected = responses
         .iter()
         .filter(|response| response["kind"] == "inspection")
@@ -1100,7 +1107,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
 
     fs::write(
         project.join("human-live.commands"),
-        ":pause\n:inspect score\n:status\n:quit\n",
+        ":palette hrohp --owner damage --file src/main.stasis\n:pause\n:inspect score\n:status\n:quit\n",
     )
     .expect("write human live script");
     let human = stasis(
@@ -1121,6 +1128,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     );
     let human_stdout = String::from_utf8_lossy(&human.stdout);
     assert!(human_stdout.contains("paused"));
+    assert!(human_stdout.contains("hero.hp  field"));
     assert!(human_stdout.contains("score: i32 ="));
     assert!(human_stdout.contains("edits 0/0"));
     assert!(human_stdout.contains("session closed"));

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -9,6 +9,14 @@ pub struct ParsedParam {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedLocalBinding {
+    pub function_name: String,
+    pub name: String,
+    pub type_name: String,
+    pub visibility_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedFunctionSignature {
     pub name: String,
     pub params: Vec<ParsedParam>,
@@ -82,6 +90,101 @@ pub struct ParsedTypeLayout {
     pub globals: Vec<ParsedGlobalDefinition>,
     pub global_blocks: Vec<ParsedGlobalBlockDefinition>,
     pub constants: Vec<ParsedConstDefinition>,
+}
+
+pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding>, String> {
+    let tokens = lex(source)?;
+    let mut bindings = Vec::new();
+    for function in parse_top_level_functions(source)? {
+        let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
+        let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
+        while let Some(token) = tokens.get(cursor).copied() {
+            if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
+                break;
+            }
+            if token.kind != TokenKind::Identifier || token_text(source, token) != "let" {
+                cursor += 1;
+                continue;
+            }
+            let Some(name) = tokens.get(cursor + 1).copied() else {
+                break;
+            };
+            let Some(colon) = tokens.get(cursor + 2).copied() else {
+                break;
+            };
+            if name.kind != TokenKind::Identifier || colon.kind != TokenKind::Colon {
+                cursor += 1;
+                continue;
+            }
+            let (type_name, next) = parse_type_name(source, &tokens, cursor + 3)?;
+            let scope_end = scope_ranges
+                .iter()
+                .filter(|range| range.start <= token.start && token.end <= range.end)
+                .min_by_key(|range| range.end.saturating_sub(range.start))
+                .map(|range| range.end)
+                .unwrap_or(function.body_range.end);
+            bindings.push(ParsedLocalBinding {
+                function_name: function.name.clone(),
+                name: token_text(source, name).to_string(),
+                type_name,
+                visibility_range: name.end..scope_end,
+            });
+            cursor = next;
+        }
+    }
+    bindings.sort_by_key(|binding| {
+        (
+            binding.function_name.clone(),
+            binding.name.clone(),
+            binding.type_name.clone(),
+            binding.visibility_range.start,
+            binding.visibility_range.end,
+        )
+    });
+    bindings.dedup();
+    Ok(bindings)
+}
+
+pub fn completion_expected_type(source: &str, cursor: usize) -> Result<Option<String>, String> {
+    let cursor = cursor.min(source.len());
+    let tokens = lex(source)?;
+    let Some(colon_index) = tokens
+        .iter()
+        .enumerate()
+        .take_while(|(_, token)| token.start < cursor)
+        .filter(|(_, token)| token.kind == TokenKind::Colon)
+        .map(|(index, _)| index)
+        .last()
+    else {
+        return Ok(None);
+    };
+    let (type_name, next) = parse_type_name(source, &tokens, colon_index + 1)?;
+    let has_assignment = tokens[colon_index + 1..]
+        .iter()
+        .take_while(|token| token.start < cursor)
+        .skip(next.saturating_sub(colon_index + 1))
+        .any(|token| token.kind == TokenKind::Other && token_text(source, *token) == "=");
+    Ok(has_assignment.then_some(type_name))
+}
+
+fn lexical_scope_ranges(tokens: &[Token], body_range: Range<usize>) -> Vec<Range<usize>> {
+    let mut starts = Vec::new();
+    let mut ranges = Vec::new();
+    for token in tokens
+        .iter()
+        .filter(|token| body_range.start <= token.start && token.end <= body_range.end)
+    {
+        match token.kind {
+            TokenKind::LBrace => starts.push(token.start),
+            TokenKind::RBrace => {
+                if let Some(start) = starts.pop() {
+                    ranges.push(start..token.end);
+                }
+            }
+            _ => {}
+        }
+    }
+    ranges
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1127,6 +1230,56 @@ mod tests {
         assert_eq!(parsed[0].return_type_name, "i32");
         assert_eq!(parsed[0].params.len(), 0);
         assert_eq!(&source[parsed[0].body_range.clone()], "{ return 0; }");
+    }
+
+    #[test]
+    fn parses_typed_locals_without_treating_foreach_bindings_as_typed() {
+        let source = r#"
+function move_player(player: Player, delta: f32): f32 {
+    let speed: f32 = delta;
+    foreach (let enemy in state.enemies) {
+        let damage: i32 = 1;
+    }
+    return speed;
+}
+function reset(): void {
+    let player: Player;
+}
+"#;
+        let bindings = parse_typed_local_bindings(source).expect("typed locals");
+        assert_eq!(
+            bindings
+                .iter()
+                .map(|binding| (
+                    binding.function_name.as_str(),
+                    binding.name.as_str(),
+                    binding.type_name.as_str(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("move_player", "damage", "i32"),
+                ("move_player", "speed", "f32"),
+                ("reset", "player", "Player"),
+            ]
+        );
+        let damage = bindings
+            .iter()
+            .find(|binding| binding.name == "damage")
+            .expect("nested binding");
+        assert!(damage.visibility_range.end < source.find("return speed").expect("return"));
+    }
+
+    #[test]
+    fn completion_expected_type_uses_typed_binding_before_cursor() {
+        let source = "let next_score: i32 = sco";
+        assert_eq!(
+            completion_expected_type(source, source.len()).expect("expected type"),
+            Some("i32".to_string())
+        );
+        assert_eq!(
+            completion_expected_type(":palette sco", 12).expect("command"),
+            None
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -97,6 +97,7 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
     let mut bindings = Vec::new();
     for function in parse_top_level_functions(source)? {
         let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
+        let loop_ranges = for_scope_ranges(source, &tokens, function.body_range.clone());
         let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
         while let Some(token) = tokens.get(cursor).copied() {
             if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
@@ -119,6 +120,7 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
             let (type_name, next) = parse_type_name(source, &tokens, cursor + 3)?;
             let scope_end = scope_ranges
                 .iter()
+                .chain(loop_ranges.iter())
                 .filter(|range| range.start <= token.start && token.end <= range.end)
                 .min_by_key(|range| range.end.saturating_sub(range.start))
                 .map(|range| range.end)
@@ -185,6 +187,69 @@ fn lexical_scope_ranges(tokens: &[Token], body_range: Range<usize>) -> Vec<Range
         }
     }
     ranges
+}
+
+fn for_scope_ranges(source: &str, tokens: &[Token], body_range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut cursor = tokens.partition_point(|token| token.start < body_range.start);
+    while let Some(token) = tokens.get(cursor).copied() {
+        if token.start >= body_range.end || token.kind == TokenKind::Eof {
+            break;
+        }
+        if token.kind == TokenKind::Identifier && token_text(source, token) == "for" {
+            let Some(header_open) = tokens
+                .get(cursor + 1)
+                .filter(|token| token.kind == TokenKind::LParen)
+            else {
+                cursor += 1;
+                continue;
+            };
+            let Some(header_close_index) =
+                matching_token_index(tokens, cursor + 1, TokenKind::LParen, TokenKind::RParen)
+            else {
+                cursor += 1;
+                continue;
+            };
+            let Some(body_open_index) = tokens
+                .get(header_close_index + 1)
+                .filter(|token| token.kind == TokenKind::LBrace)
+                .map(|_| header_close_index + 1)
+            else {
+                cursor += 1;
+                continue;
+            };
+            if let Some(body_close_index) = matching_token_index(
+                tokens,
+                body_open_index,
+                TokenKind::LBrace,
+                TokenKind::RBrace,
+            ) {
+                ranges.push(header_open.start..tokens[body_close_index].end);
+            }
+        }
+        cursor += 1;
+    }
+    ranges
+}
+
+fn matching_token_index(
+    tokens: &[Token],
+    open_index: usize,
+    open_kind: TokenKind,
+    close_kind: TokenKind,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, token) in tokens.iter().enumerate().skip(open_index) {
+        if token.kind == open_kind {
+            depth = depth.saturating_add(1);
+        } else if token.kind == close_kind {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1267,6 +1332,28 @@ function reset(): void {
             .find(|binding| binding.name == "damage")
             .expect("nested binding");
         assert!(damage.visibility_range.end < source.find("return speed").expect("return"));
+    }
+
+    #[test]
+    fn typed_for_initializer_is_visible_only_through_loop_body() {
+        let source = r#"
+function tick(): i32 {
+    for (let index: i32 = 0; index < 2; index += 1) {
+        let inside: i32 = index;
+    }
+    let after: i32 = 3;
+    return after;
+}
+"#;
+        let bindings = parse_typed_local_bindings(source).expect("typed locals");
+        let after_start = source.find("let after").expect("after binding");
+        for name in ["index", "inside"] {
+            let binding = bindings
+                .iter()
+                .find(|binding| binding.name == name)
+                .expect("loop binding");
+            assert!(binding.visibility_range.end < after_start);
+        }
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::frontend::lexer::{lex, Token, TokenKind};
-use crate::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
+use crate::frontend::parser::{
+    parse_top_level_functions, parse_top_level_struct_definitions, parse_top_level_type_layout,
+    parse_typed_local_bindings,
+};
 use crate::IncrementalCompileOutput;
 
 #[derive(
@@ -955,6 +958,32 @@ pub struct WorkshopSourceItem {
     pub source_hash: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopCompletionItem {
+    pub text: String,
+    pub kind: String,
+    pub detail: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<WorkshopCompletionScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopCompletionScope {
+    pub owner: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_end: Option<usize>,
+    pub visible_from: usize,
+    pub visible_to: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkshopSemanticEditOperation {
@@ -1091,6 +1120,419 @@ pub fn workshop_source_items(
         (item.file.clone(), order, start, item.name.clone())
     });
     Ok(items)
+}
+
+pub fn workshop_completion_items(
+    files: &[WorkshopSourceFile],
+) -> Result<Vec<WorkshopCompletionItem>, String> {
+    let mut items = Vec::new();
+    let mut struct_fields = BTreeMap::<String, Vec<(String, String)>>::new();
+    let parsed_files = files
+        .iter()
+        .map(|file| {
+            Ok((
+                file,
+                parse_top_level_type_layout(&file.source)?,
+                parse_top_level_functions(&file.source)?,
+                parse_typed_local_bindings(&file.source)?,
+                parse_top_level_struct_definitions(&file.source)?,
+            ))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut struct_scopes = BTreeMap::<(String, String), WorkshopCompletionScope>::new();
+    for (file, layout, _, _, ranges) in &parsed_files {
+        for definition in &layout.structs {
+            struct_fields.insert(
+                definition.name.clone(),
+                definition
+                    .fields
+                    .iter()
+                    .map(|field| (field.name.clone(), field.type_name.clone()))
+                    .collect(),
+            );
+        }
+        for definition in ranges {
+            struct_scopes.insert(
+                (file.path.clone(), definition.name.clone()),
+                WorkshopCompletionScope {
+                    owner: definition.name.clone(),
+                    file: file.path.clone(),
+                    owner_signature: Some(format!("struct {}", definition.name)),
+                    owner_end: Some(definition.definition_range.end),
+                    visible_from: definition.definition_range.start,
+                    visible_to: definition.definition_range.end,
+                },
+            );
+        }
+    }
+
+    let source_items = workshop_source_items(files)?;
+    let mut methods = BTreeMap::<String, Vec<(String, String, String)>>::new();
+    for item in source_items.iter().filter(|item| {
+        matches!(
+            item.kind,
+            WorkshopSourceItemKind::Struct
+                | WorkshopSourceItemKind::Function
+                | WorkshopSourceItemKind::Test
+        )
+    }) {
+        let kind = format!("{:?}", item.kind).to_ascii_lowercase();
+        items.push(completion_catalog_item(
+            &item.name,
+            &kind,
+            &format!("{} [{}]", item.signature, item.file),
+            &item.file,
+            item.owner.clone(),
+        ));
+        if item.kind == WorkshopSourceItemKind::Function {
+            if let Some(owner) = item
+                .owner
+                .as_ref()
+                .filter(|owner| struct_fields.contains_key(*owner))
+            {
+                methods.entry(owner.clone()).or_default().push((
+                    item.name.clone(),
+                    item.signature.clone(),
+                    item.file.clone(),
+                ));
+            }
+        }
+    }
+
+    let mut typed_bindings = Vec::<WorkshopTypedBinding>::new();
+    for (file, layout, functions, locals, _) in parsed_files {
+        for definition in layout.structs {
+            let struct_scope = struct_scopes
+                .get(&(file.path.clone(), definition.name.clone()))
+                .cloned();
+            for field in definition.fields {
+                items.push(scoped_completion_catalog_item(
+                    &field.name,
+                    "field",
+                    &format!(
+                        "{}.{}: {} [{}]",
+                        definition.name, field.name, field.type_name, file.path
+                    ),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    Some(&field.type_name),
+                    struct_scope
+                        .clone()
+                        .expect("parsed struct has a source range"),
+                ));
+                items.push(typed_completion_catalog_item(
+                    &format!("{}.{}", definition.name, field.name),
+                    "field",
+                    &format!("{} [{}]", field.type_name, file.path),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    &field.type_name,
+                ));
+            }
+        }
+        for definition in layout.enums {
+            items.push(typed_completion_catalog_item(
+                &definition.name,
+                "enum",
+                &format!("enum {} [{}]", definition.name, file.path),
+                &file.path,
+                None,
+                &definition.name,
+            ));
+            for variant in definition.variants {
+                items.push(typed_completion_catalog_item(
+                    &format!("{}.{}", definition.name, variant.name),
+                    "enum_variant",
+                    &format!("{} [{}]", definition.name, file.path),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    &definition.name,
+                ));
+            }
+        }
+        for global in layout.globals {
+            items.push(typed_completion_catalog_item(
+                &global.name,
+                "global",
+                &format!("{} [{}]", global.type_name, file.path),
+                &file.path,
+                None,
+                &global.type_name,
+            ));
+            typed_bindings.push(WorkshopTypedBinding {
+                name: global.name,
+                type_name: global.type_name,
+                kind: "global".to_string(),
+                scope_label: "global".to_string(),
+                file: file.path.clone(),
+                scope: None,
+            });
+        }
+        for block in layout.global_blocks {
+            for field in block.fields {
+                let path = format!("{}.{}", block.name, field.name);
+                items.push(typed_completion_catalog_item(
+                    &path,
+                    "state_path",
+                    &format!("{} [{}]", field.type_name, file.path),
+                    &file.path,
+                    Some(block.name.clone()),
+                    &field.type_name,
+                ));
+                typed_bindings.push(WorkshopTypedBinding {
+                    name: path,
+                    type_name: field.type_name,
+                    kind: "state_path".to_string(),
+                    scope_label: block.name.clone(),
+                    file: file.path.clone(),
+                    scope: None,
+                });
+            }
+        }
+        for constant in layout.constants {
+            items.push(typed_completion_catalog_item(
+                &constant.name,
+                "constant",
+                &format!("{} [{}]", constant.type_name, file.path),
+                &file.path,
+                None,
+                &constant.type_name,
+            ));
+        }
+        let function_scopes = functions
+            .iter()
+            .map(|function| {
+                (
+                    function.body_range.clone(),
+                    format_function_signature(
+                        &function.name,
+                        &function.params,
+                        &function.return_type_name,
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        for function in functions {
+            let owner_signature = format_function_signature(
+                &function.name,
+                &function.params,
+                &function.return_type_name,
+            );
+            for parameter in function.params {
+                let scope = WorkshopCompletionScope {
+                    owner: function.name.clone(),
+                    file: file.path.clone(),
+                    owner_signature: Some(owner_signature.clone()),
+                    owner_end: Some(function.body_range.end),
+                    visible_from: function.body_range.start,
+                    visible_to: function.body_range.end,
+                };
+                items.push(scoped_completion_catalog_item(
+                    &parameter.name,
+                    "parameter",
+                    &format!(
+                        "{} in {} [{}]",
+                        parameter.type_name, function.name, file.path
+                    ),
+                    &file.path,
+                    Some(function.name.clone()),
+                    Some(&parameter.type_name),
+                    scope.clone(),
+                ));
+                typed_bindings.push(WorkshopTypedBinding {
+                    name: parameter.name,
+                    type_name: parameter.type_name,
+                    kind: "parameter".to_string(),
+                    scope_label: function.name.clone(),
+                    file: file.path.clone(),
+                    scope: Some(scope),
+                });
+            }
+        }
+        for local in locals {
+            let (owner_range, owner_signature) = function_scopes
+                .iter()
+                .find(|(range, _)| {
+                    range.start <= local.visibility_range.start
+                        && local.visibility_range.start <= range.end
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "typed local {} has no containing function in {}",
+                        local.name, file.path
+                    )
+                })?;
+            let scope = WorkshopCompletionScope {
+                owner: local.function_name.clone(),
+                file: file.path.clone(),
+                owner_signature: Some(owner_signature.clone()),
+                owner_end: Some(owner_range.end),
+                visible_from: local.visibility_range.start,
+                visible_to: local.visibility_range.end,
+            };
+            items.push(scoped_completion_catalog_item(
+                &local.name,
+                "local",
+                &format!(
+                    "{} in {} [{}]",
+                    local.type_name, local.function_name, file.path
+                ),
+                &file.path,
+                Some(local.function_name.clone()),
+                Some(&local.type_name),
+                scope.clone(),
+            ));
+            typed_bindings.push(WorkshopTypedBinding {
+                name: local.name,
+                type_name: local.type_name,
+                kind: "local".to_string(),
+                scope_label: local.function_name,
+                file: file.path.clone(),
+                scope: Some(scope),
+            });
+        }
+    }
+
+    for binding in typed_bindings {
+        if let Some(fields) = struct_fields.get(&binding.type_name) {
+            for (field, field_type) in fields {
+                let text = format!("{}.{field}", binding.name);
+                let detail = format!(
+                    "{field_type} via {} {}: {} in {} [{}]",
+                    binding.kind,
+                    binding.name,
+                    binding.type_name,
+                    binding.scope_label,
+                    binding.file
+                );
+                let item = match binding.scope.clone() {
+                    Some(scope) => scoped_completion_catalog_item(
+                        &text,
+                        "field",
+                        &detail,
+                        &binding.file,
+                        Some(binding.type_name.clone()),
+                        Some(field_type),
+                        scope,
+                    ),
+                    None => typed_completion_catalog_item(
+                        &text,
+                        "field",
+                        &detail,
+                        &binding.file,
+                        Some(binding.type_name.clone()),
+                        field_type,
+                    ),
+                };
+                items.push(item);
+            }
+        }
+        if let Some(owner_methods) = methods.get(&binding.type_name) {
+            for (method, signature, method_file) in owner_methods {
+                let text = format!("{}.{method}", binding.name);
+                let detail = format!(
+                    "{signature} via {} {}: {} [{method_file}]",
+                    binding.kind, binding.name, binding.type_name
+                );
+                let item = match binding.scope.clone() {
+                    Some(scope) => scoped_completion_catalog_item(
+                        &text,
+                        "method",
+                        &detail,
+                        method_file,
+                        Some(binding.type_name.clone()),
+                        None,
+                        scope,
+                    ),
+                    None => completion_catalog_item(
+                        &text,
+                        "method",
+                        &detail,
+                        method_file,
+                        Some(binding.type_name.clone()),
+                    ),
+                };
+                items.push(item);
+            }
+        }
+    }
+
+    items.sort_by_key(|item| {
+        (
+            item.text.clone(),
+            item.kind.clone(),
+            item.detail.clone(),
+            item.file.clone(),
+            item.owner.clone(),
+        )
+    });
+    items.dedup();
+    Ok(items)
+}
+
+fn completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+) -> WorkshopCompletionItem {
+    let truncated = detail.chars().count() > 256;
+    let mut detail = if truncated {
+        detail.chars().take(253).collect::<String>()
+    } else {
+        detail.to_string()
+    };
+    if truncated {
+        detail.push_str("...");
+    }
+    WorkshopCompletionItem {
+        text: text.to_string(),
+        kind: kind.to_string(),
+        detail,
+        file: file.to_string(),
+        owner,
+        type_name: None,
+        scope: None,
+    }
+}
+
+fn typed_completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+    type_name: &str,
+) -> WorkshopCompletionItem {
+    let mut item = completion_catalog_item(text, kind, detail, file, owner);
+    item.type_name = Some(type_name.to_string());
+    item
+}
+
+fn scoped_completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+    type_name: Option<&str>,
+    scope: WorkshopCompletionScope,
+) -> WorkshopCompletionItem {
+    let mut item = completion_catalog_item(text, kind, detail, file, owner);
+    item.type_name = type_name.map(str::to_string);
+    item.scope = Some(scope);
+    item
+}
+
+#[derive(Debug, Clone)]
+struct WorkshopTypedBinding {
+    name: String,
+    type_name: String,
+    kind: String,
+    scope_label: String,
+    file: String,
+    scope: Option<WorkshopCompletionScope>,
 }
 
 fn source_item_from_ranges(
@@ -1758,11 +2200,7 @@ fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
         }) {
             if let Some(scope_start) = scope_at[index] {
                 if let Some(scope_end) = scope_ends.get(&scope_start) {
-                    local_bindings.push((
-                        token_text(source, token).to_string(),
-                        index,
-                        *scope_end,
-                    ));
+                    local_bindings.push((token_text(source, token).to_string(), index, *scope_end));
                 }
             }
         }
@@ -1777,9 +2215,10 @@ fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
                 return None;
             }
             let name = token_text(source, token);
-            if local_bindings.iter().any(|(binding, start, end)| {
-                binding == name && index >= *start && index <= *end
-            }) {
+            if local_bindings
+                .iter()
+                .any(|(binding, start, end)| binding == name && index >= *start && index <= *end)
+            {
                 return None;
             }
             let previous_is_dot = index.checked_sub(1).is_some_and(|index| {
@@ -2064,7 +2503,10 @@ fn write_workshop_semantic_plan_with(
             } else {
                 format!("; rollback incomplete: {}", rollback_errors.join("; "))
             };
-            return Err(format!("failed writing {}: {error}{rollback}", path.display()));
+            return Err(format!(
+                "failed writing {}: {error}{rollback}",
+                path.display()
+            ));
         }
         written.push(change.file.clone());
     }
@@ -3822,6 +4264,66 @@ mod workshop_compile_plan_tests {
         assert!(update.source.starts_with("// Advances the player."));
         assert!(!update.source.contains("Unrelated note"));
         assert!(update.source.ends_with("}\n"));
+    }
+
+    #[test]
+    fn completion_catalog_includes_scoped_bindings_fields_and_receiver_methods() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: r#"
+struct Player { hp: i32; speed: f32; }
+enum Mode { Playing, Paused }
+global state { player: Player; }
+function damage(player: Player, amount: i32): i32 { return player.hp - amount; }
+function tick(): i32 {
+    let hero: Player;
+    hero.hp = 7;
+    return damage(hero, 1);
+}
+"#
+            .to_string(),
+        }];
+        let items = workshop_completion_items(&files).expect("completion catalog");
+        let has = |text: &str, kind: &str| {
+            items
+                .iter()
+                .any(|item| item.text == text && item.kind == kind)
+        };
+        assert!(has("amount", "parameter"));
+        assert!(has("hero", "local"));
+        assert!(has("Player.hp", "field"));
+        assert!(has("player.hp", "field"));
+        assert!(has("player.damage", "method"));
+        assert!(has("hero.hp", "field"));
+        assert!(has("hero.damage", "method"));
+        assert!(has("state.player.hp", "field"));
+        assert!(has("Mode.Paused", "enum_variant"));
+        let hero_hp = items
+            .iter()
+            .find(|item| item.text == "hero.hp")
+            .expect("scoped receiver field");
+        assert_eq!(hero_hp.type_name.as_deref(), Some("i32"));
+        assert_eq!(
+            hero_hp.scope.as_ref().map(|scope| scope.owner.as_str()),
+            Some("tick")
+        );
+        let parameter = items
+            .iter()
+            .find(|item| item.text == "amount" && item.kind == "parameter")
+            .expect("parameter");
+        assert_eq!(
+            parameter.scope.as_ref().map(|scope| scope.owner.as_str()),
+            Some("damage")
+        );
+        assert!(items
+            .iter()
+            .find(|item| item.text == "state.player.hp")
+            .expect("global receiver field")
+            .scope
+            .is_none());
+        assert!(items
+            .iter()
+            .all(|item| item.detail.contains("[src/main.stasis]")));
     }
 
     #[test]

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -514,7 +514,8 @@ fn rank_indexed_completion_items(
     let bounded_limit = limit.min(256);
     let mut unscoped_match_count = 0usize;
     let mut best = Vec::<(CompletionRank<'_>, &CompletionItem)>::with_capacity(bounded_limit);
-    let mut scoped_matches = BTreeMap::<(&str, &str), (CompletionRank<'_>, &CompletionItem)>::new();
+    let mut scoped_matches =
+        BTreeMap::<(&str, &str, Option<&str>), (CompletionRank<'_>, &CompletionItem)>::new();
     for indexed in items {
         let Some(scope_distance) = completion_scope_distance(&indexed.item, context) else {
             continue;
@@ -537,7 +538,13 @@ fn rank_indexed_completion_items(
             detail: &indexed.item.detail,
         };
         if indexed.item.scope.is_some() {
-            let key = (indexed.item.text.as_str(), indexed.item.kind.as_str());
+            let overload_detail =
+                (indexed.item.kind == "method").then_some(indexed.item.detail.as_str());
+            let key = (
+                indexed.item.text.as_str(),
+                indexed.item.kind.as_str(),
+                overload_detail,
+            );
             match scoped_matches.get_mut(&key) {
                 Some(best) if rank < best.0 => *best = (rank, &indexed.item),
                 Some(_) => {}
@@ -1506,6 +1513,40 @@ mod tests {
         assert_eq!(result.items[0].detail, "inner");
         assert_eq!(result.items[1].text, "valid");
         assert!(!result.truncated);
+    }
+
+    #[test]
+    fn completion_query_preserves_scoped_method_overloads() {
+        let method = |detail: &str| CompletionItem {
+            text: "hero.damage".into(),
+            kind: "method".into(),
+            detail: detail.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "tick".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some("tick(): i32".into()),
+                owner_end: Some(100),
+                visible_from: 10,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            method("damage(hero: Player, amount: i32): i32"),
+            method("damage(hero: Player, amount: f32): i32"),
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("tick(): i32".into()),
+            source_offset: None,
+            expected_type: None,
+        };
+        let result = index.query_with_context("hrodam", 6, 10, &context);
+        assert_eq!(result.items.len(), 2);
+        assert_ne!(result.items[0].detail, result.items[1].detail);
     }
 
     #[test]

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -94,6 +94,18 @@ pub enum LiveCommand {
         cursor: usize,
         #[serde(default = "default_completion_limit")]
         limit: usize,
+        #[serde(default)]
+        context: CompletionContext,
+    },
+    Palette {
+        #[serde(default)]
+        query: String,
+        #[serde(default)]
+        page: u32,
+        #[serde(default = "default_completion_limit")]
+        limit: usize,
+        #[serde(default)]
+        context: CompletionContext,
     },
     Edit {
         operation: LiveEditOperation,
@@ -354,11 +366,58 @@ pub struct CompletionItem {
     pub text: String,
     pub kind: String,
     pub detail: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<CompletionScope>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_offset: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionScope {
+    pub owner: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_end: Option<usize>,
+    pub visible_from: usize,
+    pub visible_to: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionQuery {
+    pub replacement_start: usize,
+    pub replacement_end: usize,
+    pub page: u32,
+    pub truncated: bool,
+    pub items: Vec<CompletionItem>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct CompletionIndex {
-    items: BTreeMap<(String, String, String), CompletionItem>,
+    items: Vec<IndexedCompletionItem>,
+}
+
+#[derive(Debug, Clone)]
+struct IndexedCompletionItem {
+    normalized_text: String,
+    item: CompletionItem,
 }
 
 impl CompletionIndex {
@@ -366,42 +425,310 @@ impl CompletionIndex {
     where
         I: IntoIterator<Item = CompletionItem>,
     {
-        self.items.clear();
-        for item in items {
-            self.items.insert(
-                (item.text.clone(), item.kind.clone(), item.detail.clone()),
+        let mut items = items.into_iter().collect::<Vec<_>>();
+        items.sort_by(|left, right| completion_item_key(left).cmp(&completion_item_key(right)));
+        items.dedup();
+        self.items = items
+            .into_iter()
+            .map(|item| IndexedCompletionItem {
+                normalized_text: item.text.to_ascii_lowercase(),
                 item,
-            );
-        }
+            })
+            .collect();
     }
 
     pub fn complete(&self, buffer: &str, cursor: usize, limit: usize) -> Vec<CompletionItem> {
-        let mut cursor = cursor.min(buffer.len());
-        while !buffer.is_char_boundary(cursor) {
-            cursor -= 1;
+        self.query(buffer, cursor, limit).items
+    }
+
+    pub fn query(&self, buffer: &str, cursor: usize, limit: usize) -> CompletionQuery {
+        self.query_with_context(buffer, cursor, limit, &CompletionContext::default())
+    }
+
+    pub fn query_with_context(
+        &self,
+        buffer: &str,
+        cursor: usize,
+        limit: usize,
+        context: &CompletionContext,
+    ) -> CompletionQuery {
+        rank_indexed_completion_items(&self.items, buffer, cursor, limit, context)
+    }
+}
+
+pub fn rank_completion_items(
+    items: &[CompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+) -> CompletionQuery {
+    rank_completion_items_with_context(items, buffer, cursor, limit, &CompletionContext::default())
+}
+
+pub fn rank_completion_items_with_context(
+    items: &[CompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: &CompletionContext,
+) -> CompletionQuery {
+    let indexed = items
+        .iter()
+        .cloned()
+        .map(|item| IndexedCompletionItem {
+            normalized_text: item.text.to_ascii_lowercase(),
+            item,
+        })
+        .collect::<Vec<_>>();
+    rank_indexed_completion_items(&indexed, buffer, cursor, limit, context)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CompletionRank<'a> {
+    match_class: u8,
+    scope_distance: usize,
+    expected_type: u8,
+    kind: u8,
+    gaps: usize,
+    first: usize,
+    text_len: usize,
+    text: &'a str,
+    item_kind: &'a str,
+    detail: &'a str,
+}
+
+fn rank_indexed_completion_items(
+    items: &[IndexedCompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: &CompletionContext,
+) -> CompletionQuery {
+    let mut cursor = cursor.min(buffer.len());
+    while !buffer.is_char_boundary(cursor) {
+        cursor -= 1;
+    }
+    let replacement_start = completion_replacement_start(buffer, cursor);
+    let query = &buffer[replacement_start..cursor];
+    let normalized_query = query.to_ascii_lowercase();
+    let bounded_limit = limit.min(256);
+    let mut unscoped_match_count = 0usize;
+    let mut best = Vec::<(CompletionRank<'_>, &CompletionItem)>::with_capacity(bounded_limit);
+    let mut scoped_matches = BTreeMap::<(&str, &str), (CompletionRank<'_>, &CompletionItem)>::new();
+    for indexed in items {
+        let Some(scope_distance) = completion_scope_distance(&indexed.item, context) else {
+            continue;
+        };
+        let Some((match_class, gaps, first)) =
+            fuzzy_completion_score(&indexed.normalized_text, &normalized_query)
+        else {
+            continue;
+        };
+        let rank = CompletionRank {
+            match_class,
+            scope_distance,
+            expected_type: completion_expected_type_priority(&indexed.item, context),
+            kind: completion_kind_priority(&indexed.item.kind, query),
+            gaps,
+            first,
+            text_len: indexed.item.text.len(),
+            text: &indexed.item.text,
+            item_kind: &indexed.item.kind,
+            detail: &indexed.item.detail,
+        };
+        if indexed.item.scope.is_some() {
+            let key = (indexed.item.text.as_str(), indexed.item.kind.as_str());
+            match scoped_matches.get_mut(&key) {
+                Some(best) if rank < best.0 => *best = (rank, &indexed.item),
+                Some(_) => {}
+                None => {
+                    scoped_matches.insert(key, (rank, &indexed.item));
+                }
+            }
+        } else {
+            unscoped_match_count = unscoped_match_count.saturating_add(1);
+            retain_bounded_completion(&mut best, (rank, &indexed.item), bounded_limit);
         }
-        let prefix = buffer[..cursor]
-            .rsplit(|character: char| {
-                character.is_whitespace() || character == '(' || character == ','
-            })
-            .next()
-            .unwrap_or("");
-        let mut matches = self
-            .items
-            .values()
-            .filter(|item| item.text.starts_with(prefix))
-            .cloned()
-            .collect::<Vec<_>>();
-        matches.sort_by_key(|item| {
+    }
+    let total_matches = unscoped_match_count.saturating_add(scoped_matches.len());
+    for candidate in scoped_matches.into_values() {
+        retain_bounded_completion(&mut best, candidate, bounded_limit);
+    }
+    best.sort_by_key(|(rank, _)| *rank);
+    let items = best.into_iter().map(|(_, item)| item.clone()).collect();
+    CompletionQuery {
+        replacement_start,
+        replacement_end: cursor,
+        page: 0,
+        truncated: total_matches > bounded_limit,
+        items,
+    }
+}
+
+fn retain_bounded_completion<'a>(
+    best: &mut Vec<(CompletionRank<'a>, &'a CompletionItem)>,
+    candidate: (CompletionRank<'a>, &'a CompletionItem),
+    limit: usize,
+) {
+    if limit == 0 {
+        return;
+    }
+    if best.len() < limit {
+        best.push(candidate);
+        return;
+    }
+    let (worst_index, worst) = best
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, (rank, _))| *rank)
+        .expect("bounded completion set is not empty");
+    if candidate.0 < worst.0 {
+        best[worst_index] = candidate;
+    }
+}
+
+fn completion_item_key(
+    item: &CompletionItem,
+) -> (
+    &str,
+    &str,
+    &str,
+    Option<&str>,
+    Option<&str>,
+    Option<(&str, &str, Option<&str>, Option<usize>, usize, usize)>,
+) {
+    (
+        &item.text,
+        &item.kind,
+        &item.detail,
+        item.type_name.as_deref(),
+        item.source.as_deref(),
+        item.scope.as_ref().map(|scope| {
             (
-                item.text != prefix,
-                item.text.len().saturating_sub(prefix.len()),
-                item.text.clone(),
-                item.kind.clone(),
+                scope.owner.as_str(),
+                scope.file.as_str(),
+                scope.owner_signature.as_deref(),
+                scope.owner_end,
+                scope.visible_from,
+                scope.visible_to,
             )
-        });
-        matches.truncate(limit.min(256));
-        matches
+        }),
+    )
+}
+
+fn completion_replacement_start(buffer: &str, cursor: usize) -> usize {
+    buffer[..cursor]
+        .char_indices()
+        .rev()
+        .find(|(index, character)| {
+            character.is_whitespace()
+                || matches!(
+                    character,
+                    '(' | ')'
+                        | '['
+                        | ']'
+                        | ','
+                        | ';'
+                        | '{'
+                        | '}'
+                        | '='
+                        | '+'
+                        | '-'
+                        | '*'
+                        | '/'
+                        | '%'
+                        | '<'
+                        | '>'
+                        | '!'
+                )
+                || (*character == ':' && *index > 0)
+        })
+        .map_or(0, |(index, character)| index + character.len_utf8())
+}
+
+fn fuzzy_completion_score(text: &str, query: &str) -> Option<(u8, usize, usize)> {
+    if text == query {
+        return Some((0, 0, 0));
+    }
+    if text.starts_with(&query) {
+        return Some((1, 0, text.len().saturating_sub(query.len())));
+    }
+    if let Some(start) = text.find(&query) {
+        return Some((2, start, text.len().saturating_sub(query.len())));
+    }
+    let mut text_indices = text.char_indices();
+    let mut first = None;
+    let mut previous = None;
+    let mut gaps = 0usize;
+    for needle in query.chars() {
+        let (index, _) = text_indices.find(|(_, candidate)| *candidate == needle)?;
+        first.get_or_insert(index);
+        if let Some(previous) = previous {
+            gaps += index.saturating_sub(previous + 1);
+        }
+        previous = Some(index);
+    }
+    Some((3, gaps, first.unwrap_or(0)))
+}
+
+fn completion_scope_distance(item: &CompletionItem, context: &CompletionContext) -> Option<usize> {
+    let Some(scope) = item.scope.as_ref() else {
+        return Some(usize::MAX);
+    };
+    if context.owner.as_deref() != Some(scope.owner.as_str()) {
+        return None;
+    }
+    if context
+        .file
+        .as_deref()
+        .is_some_and(|file| file != scope.file)
+    {
+        return None;
+    }
+    if context
+        .owner_signature
+        .as_deref()
+        .is_some_and(|signature| scope.owner_signature.as_deref() != Some(signature))
+    {
+        return None;
+    }
+    let offset = context.source_offset.or(scope.owner_end)?;
+    if offset < scope.visible_from || offset > scope.visible_to {
+        return None;
+    }
+    Some(usize::MAX.saturating_sub(scope.visible_from))
+}
+
+fn completion_expected_type_priority(item: &CompletionItem, context: &CompletionContext) -> u8 {
+    match context.expected_type.as_deref() {
+        Some(expected) if item.type_name.as_deref() == Some(expected) => 0,
+        Some(_) => 1,
+        None => 0,
+    }
+}
+
+fn completion_kind_priority(kind: &str, query: &str) -> u8 {
+    if query.starts_with(':') {
+        return u8::from(kind != "command");
+    }
+    if query.contains('.') {
+        return match kind {
+            "field" | "state_path" => 0,
+            "method" => 1,
+            _ => 2,
+        };
+    }
+    match kind {
+        "local" => 0,
+        "parameter" => 1,
+        "field" => 2,
+        "method" => 3,
+        "function" => 4,
+        "global" | "constant" | "state_path" => 5,
+        "struct" | "enum" | "enum_variant" => 6,
+        "scratch_cell" => 7,
+        "command" => 8,
+        _ => 9,
     }
 }
 
@@ -609,6 +936,23 @@ impl TerminalBuffer {
     pub fn cancel_pending(&mut self) -> bool {
         self.pending.take().is_some()
     }
+
+    pub fn completion_context(&self) -> CompletionContext {
+        let Some(PendingMultiline {
+            command: PendingCommand::Edit { target, .. },
+            ..
+        }) = self.pending.as_ref()
+        else {
+            return CompletionContext::default();
+        };
+        CompletionContext {
+            owner: Some(target.name.clone()),
+            file: target.file.clone(),
+            owner_signature: target.signature.clone(),
+            source_offset: None,
+            expected_type: None,
+        }
+    }
 }
 
 enum ParsedTerminalCommand {
@@ -666,8 +1010,35 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
                 cursor: buffer.len(),
                 buffer,
                 limit: 32,
+                context: CompletionContext::default(),
             })
         }
+        ":palette" => ready(LiveCommand::Palette {
+            query: args
+                .get(1)
+                .filter(|value| !value.starts_with("--"))
+                .cloned()
+                .unwrap_or_default(),
+            page: terminal_selector_value(&args, "--page")
+                .map(|value| parse_u32("page", &value))
+                .transpose()?
+                .unwrap_or(0),
+            limit: terminal_selector_value(&args, "--limit")
+                .map(|value| parse_u32("limit", &value))
+                .transpose()?
+                .map(|value| value as usize)
+                .unwrap_or_else(default_completion_limit),
+            context: CompletionContext {
+                owner: terminal_selector_value(&args, "--owner"),
+                file: terminal_selector_value(&args, "--file"),
+                owner_signature: terminal_selector_value(&args, "--signature"),
+                source_offset: terminal_selector_value(&args, "--offset")
+                    .map(|value| parse_u32("offset", &value))
+                    .transpose()?
+                    .map(|value| value as usize),
+                expected_type: terminal_selector_value(&args, "--expected-type"),
+            },
+        }),
         ":preview" => ready(LiveCommand::Preview),
         ":apply" => ready(LiveCommand::Apply { run_tests: true }),
         ":changes" => ready(LiveCommand::Changes),
@@ -907,26 +1278,41 @@ mod tests {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(value: i32): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "ticker".into(),
                 kind: "global".into(),
                 detail: "i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "title".into(),
                 kind: "global".into(),
                 detail: "utf8[32]".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
         ]);
         let result = index.complete(":read tick", 10, 10);
@@ -935,6 +1321,287 @@ mod tests {
         assert_eq!(result[1].text, "tick");
         assert_eq!(result[2].text, "ticker");
         assert_eq!(index.complete("éti", 1, 10).len(), 4);
+    }
+
+    #[test]
+    fn completion_query_fuzzy_ranks_context_and_reports_replacement_range() {
+        let mut index = CompletionIndex::default();
+        index.replace([
+            CompletionItem {
+                text: "hero.hp".into(),
+                kind: "field".into(),
+                detail: "i32 via local hero: Player".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+            CompletionItem {
+                text: "hero.damage".into(),
+                kind: "method".into(),
+                detail: "damage(player: Player, amount: i32): i32".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+            CompletionItem {
+                text: ":help".into(),
+                kind: "command".into(),
+                detail: "live command".into(),
+                type_name: None,
+                source: None,
+                scope: None,
+            },
+        ]);
+        let member = index.query("call(hrohp", 10, 10);
+        assert_eq!(member.replacement_start, 5);
+        assert_eq!(member.replacement_end, 10);
+        assert_eq!(member.items[0].text, "hero.hp");
+        assert!(!member.truncated);
+
+        let commands = index.query(":h", 2, 1);
+        assert_eq!(commands.items[0].text, ":help");
+        assert!(!commands.truncated);
+
+        let bounded = index.query("hero.", 5, 1);
+        assert_eq!(bounded.items.len(), 1);
+        assert!(bounded.truncated);
+    }
+
+    #[test]
+    fn completion_query_filters_scopes_shadowing_and_expected_types() {
+        let scoped =
+            |detail: &str, owner: &str, from: usize, to: usize, owner_end: usize| CompletionItem {
+                text: "value".into(),
+                kind: "local".into(),
+                detail: detail.into(),
+                type_name: Some(if detail == "inner" { "i32" } else { "f32" }.into()),
+                source: Some("src/main.stasis".into()),
+                scope: Some(CompletionScope {
+                    owner: owner.into(),
+                    file: "src/main.stasis".into(),
+                    owner_signature: Some(format!("{owner}(): i32")),
+                    owner_end: Some(owner_end),
+                    visible_from: from,
+                    visible_to: to,
+                }),
+            };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            scoped("outer", "tick", 10, 100, 100),
+            scoped("inner", "tick", 50, 70, 100),
+            scoped("render local", "render", 20, 90, 90),
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: None,
+            source_offset: Some(60),
+            expected_type: Some("i32".into()),
+        };
+        let result = index.query_with_context("val", 3, 10, &context);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].detail, "inner");
+
+        let target_end = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            ..CompletionContext::default()
+        };
+        let result = index.query_with_context("val", 3, 10, &target_end);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].detail, "outer");
+
+        let mut nested_only = CompletionIndex::default();
+        nested_only.replace([scoped("inner", "tick", 50, 70, 100)]);
+        assert!(nested_only
+            .query_with_context("val", 3, 10, &target_end)
+            .items
+            .is_empty());
+
+        let render = CompletionContext {
+            owner: Some("render".into()),
+            source_offset: Some(50),
+            ..CompletionContext::default()
+        };
+        assert_eq!(
+            index.query_with_context("val", 3, 10, &render).items[0].detail,
+            "render local"
+        );
+        assert!(index.query("val", 3, 10).items.is_empty());
+    }
+
+    #[test]
+    fn completion_query_uses_signature_to_disambiguate_overload_scope() {
+        let local = |text: &str, signature: &str| CompletionItem {
+            text: text.into(),
+            kind: "local".into(),
+            detail: signature.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "update".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some(signature.into()),
+                owner_end: Some(100),
+                visible_from: 10,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            local("player_value", "update(player: Player): i32"),
+            local("enemy_value", "update(enemy: Enemy): i32"),
+        ]);
+        let context = CompletionContext {
+            owner: Some("update".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("update(player: Player): i32".into()),
+            source_offset: None,
+            expected_type: None,
+        };
+        let result = index.query_with_context("value", 5, 10, &context);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].text, "player_value");
+    }
+
+    #[test]
+    fn completion_query_deduplicates_shadowing_before_bounding() {
+        let scoped = |detail: &str, from: usize| CompletionItem {
+            text: "value".into(),
+            kind: "local".into(),
+            detail: detail.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "tick".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some("tick(): i32".into()),
+                owner_end: Some(100),
+                visible_from: from,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            scoped("outer", 10),
+            scoped("inner", 50),
+            CompletionItem {
+                text: "valid".into(),
+                kind: "function".into(),
+                detail: "valid(): i32".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("tick(): i32".into()),
+            source_offset: Some(60),
+            expected_type: None,
+        };
+        let result = index.query_with_context("va", 2, 2, &context);
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].detail, "inner");
+        assert_eq!(result.items[1].text, "valid");
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn completion_query_reaches_late_catalog_items_with_bounded_top_k() {
+        let mut items = (0..10_000)
+            .map(|index| CompletionItem {
+                text: format!("symbol_{index:05}"),
+                kind: "function".into(),
+                detail: format!("symbol_{index:05}(): i32"),
+                type_name: Some("i32".into()),
+                source: Some("src/generated.stasis".into()),
+                scope: None,
+            })
+            .collect::<Vec<_>>();
+        items.push(CompletionItem {
+            text: "very_late_target".into(),
+            kind: "function".into(),
+            detail: "very_late_target(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/late.stasis".into()),
+            scope: None,
+        });
+        let mut index = CompletionIndex::default();
+        index.replace(items);
+        let target = index.query("vltgt", 5, 8);
+        assert_eq!(target.items[0].text, "very_late_target");
+        let bounded = index.query("symbol", 6, 8);
+        assert_eq!(bounded.items.len(), 8);
+        assert!(bounded.truncated);
+    }
+
+    #[test]
+    fn completion_replacement_starts_after_unspaced_infix_operators() {
+        let mut index = CompletionIndex::default();
+        index.replace([CompletionItem {
+            text: "player".into(),
+            kind: "parameter".into(),
+            detail: "Player".into(),
+            type_name: Some("Player".into()),
+            source: None,
+            scope: None,
+        }]);
+        for buffer in ["score+pla", "x!=pla", "value*pla", "items[pla"] {
+            let result = index.query(buffer, buffer.len(), 4);
+            assert_eq!(result.items[0].text, "player", "{buffer}");
+            assert_eq!(&buffer[result.replacement_start..], "pla", "{buffer}");
+        }
+        assert_eq!(index.query(":hel", 4, 4).replacement_start, 0);
+    }
+
+    #[test]
+    fn terminal_palette_command_preserves_query_text() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(request) = terminal
+            .feed_line(
+                ":palette hero.hp --page 2 --limit 12 --owner tick --file src/main.stasis --offset 42 --expected-type i32",
+            )
+            .expect("palette command")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(
+            request.command,
+            LiveCommand::Palette {
+                query: "hero.hp".to_string(),
+                page: 2,
+                limit: 12,
+                context: CompletionContext {
+                    owner: Some("tick".into()),
+                    file: Some("src/main.stasis".into()),
+                    owner_signature: None,
+                    source_offset: Some(42),
+                    expected_type: Some("i32".into()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_completion_context_tracks_pending_semantic_owner() {
+        let mut terminal = TerminalBuffer::new();
+        terminal
+            .feed_line(":update function tick src/main.stasis")
+            .expect("start update");
+        assert_eq!(
+            terminal.completion_context(),
+            CompletionContext {
+                owner: Some("tick".into()),
+                file: Some("src/main.stasis".into()),
+                owner_signature: None,
+                source_offset: None,
+                expected_type: None,
+            }
+        );
+        assert!(terminal.cancel_pending());
+        assert_eq!(terminal.completion_context(), CompletionContext::default());
     }
 
     #[test]

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -26,6 +26,7 @@ The project must provide the graphical lifecycle entry points `main`, `tick`, an
 :symbols tick --page 0 --limit 50
 :read tick function --file src/main.stasis --owner Game --signature "tick(): i32"
 :complete ti
+:palette hrohp
 :preview
 :apply
 :inspect score
@@ -49,13 +50,26 @@ function tick(): i32 {
 :end
 ```
 
-The line editor provides session command history and compiler-backed Tab completion. Press
-Ctrl-C or enter `:abort` to discard a multiline buffer without submitting it. Symbol results are
-paged; selectors accept `--file`, `--owner`, and `--signature` for same-name overloads and receiver
-methods.
+The line editor provides session command history and a compiler-backed command palette. Press
+Ctrl-P at any prompt to open the fuzzy-ranked command and symbol list. Type or Backspace to filter;
+use Up/Down or PageUp/PageDown to select; Enter or Tab inserts the highlighted candidate; Esc
+cancels without changing the buffer. Inserted commands still require Enter at the normal prompt,
+so a palette selection never mutates the session by itself. Tab at the normal prompt queries the
+same live index for the current buffer and inserts a unique candidate.
 
-Add, update, delete, read, list, and completion operate on the compiler-owned symbol and type
-indexes. Edits use the same semantic selectors, expected source hashes, import reconciliation,
+The palette includes functions, structs, enum variants, globals, state paths, parameters,
+explicitly typed locals, fields, and receiver-qualified members such as `hero.hp` or
+`hero.damage`. Scoped candidates carry compiler-owned file, semantic-owner, visibility-span, and
+type metadata, so locals from another function or an out-of-scope block are excluded. Each row
+stays concise with kind and type/signature/source context. `:palette QUERY [--page N --limit N]
+[--owner OWNER --file FILE --signature SIGNATURE --offset N --expected-type TYPE]` exposes the same deterministic,
+bounded ranking to scripts and future desktop clients. Press Ctrl-C or enter `:abort` to discard a
+multiline buffer without submitting it. Symbol results are paged; selectors accept `--file`,
+`--owner`, and `--signature` for same-name overloads and receiver methods.
+
+Add, update, delete, read, list, and palette completion operate on compiler-owned symbol, scope,
+and type indexes. Successful edits refresh the palette atomically with the new runtime. Edits use
+the same semantic selectors, expected source hashes, import reconciliation,
 atomic source writes, test gate, and content-addressed receipts as `stasis symbol`. Successful
 edits are parsed, planned, compiled, and tested on a bounded background preparation worker. The
 graphics thread remains responsive and performs only the hash guard, atomic source/receipt write,

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -74,8 +74,9 @@ runnable `main()` and a real `.test.stasis` test.
   Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
 - `run --interactive`: keep the graphical runner and tick loop alive while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
-  typed between-tick inspection or mutation. The terminal includes history, compiler-backed Tab
-  completion, paging, multiline cancellation, and concise command-specific output. Use
+  typed between-tick inspection or mutation. The terminal includes history, a Ctrl-P command
+  palette with live fuzzy compiler-backed symbol/member completion, keyboard navigation and
+  insertion, Tab completion, paging, multiline cancellation, and concise command-specific output. Use
   `--live-json` for complete schema-v1 response envelopes or `--live-script PATH` for a
   deterministic command script. See
   [Interactive live workspace](live_cli_workspace.md).


### PR DESCRIPTION
Stacked on PR #284. Adds a real Ctrl-P command palette and Tab completion backed by compiler-owned function, struct, binding, type, source-span, and overload metadata. Provides fuzzy ranking, lexical-scope filtering, expected-type ranking, bounded top-K queries, paging, concise human output, keyboard navigation/insertion/cancel behavior, atomic completion refresh after semantic CRUD, and deterministic terminal-equivalent and graphical-boundary tests. Validation: stasis_compiler 297 passed/1 ignored; stasis app lib 158 passed/6 ignored; stasis_runner 33 passed; toolchain CLI unit 20 passed; toolchain CLI integration 8 passed. Repository validation reaches the known two Windows path-separator assertions in apps/stasis/src/main.rs after its app-lib phase passes.