### PR TITLE
feat: add persistent live workspace TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
- "nix 0.30.1",
+ "nix",
  "rand",
 ]
 
@@ -121,12 +121,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -173,15 +167,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
 
 [[package]]
 name = "colorchoice"
@@ -432,12 +417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,12 +431,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fallible-iterator"
@@ -705,27 +678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,7 +685,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -833,16 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,26 +874,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustyline"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "clipboard-win",
- "libc",
- "log",
- "memchr",
- "nix 0.28.0",
- "radix_trie",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1089,7 +1011,6 @@ dependencies = [
  "crossterm",
  "notify",
  "object",
- "rustyline",
  "serde",
  "serde_json",
  "sha2",
@@ -1209,18 +1130,6 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio 1.2.2",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,10 +432,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "error-code"
@@ -578,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -590,7 +631,22 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -637,6 +693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +751,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -698,6 +775,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -733,6 +833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -803,6 +922,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustyline"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +947,7 @@ dependencies = [
  "log",
  "memchr",
  "nix 0.28.0",
+ "radix_trie",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -838,6 +971,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -894,6 +1033,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.2",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1086,7 @@ name = "stasis"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "crossterm",
  "notify",
  "object",
  "rustyline",
@@ -1101,6 +1272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1295,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -13,7 +13,6 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
-rustyline = { version = "14.0", default-features = false, features = ["custom-bindings"] }
 crossterm = "0.28"
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -13,7 +13,8 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
-rustyline = { version = "14.0", default-features = false }
+rustyline = { version = "14.0", default-features = false, features = ["custom-bindings"] }
+crossterm = "0.28"
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -17,7 +17,7 @@ use stasis_runner::live::{
     LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_TRACKS, MAX_LIVE_TRACK_TICKS,
     MAX_LIVE_WATCHES,
 };
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -673,7 +673,7 @@ impl LiveWorkspace {
                 }
             }
             LiveCommand::Inspect { path } => inspect_scalar(jit, &path),
-            LiveCommand::InspectAll { limit } => inspect_all_scalars(jit, limit),
+            LiveCommand::InspectAll { limit, concise } => inspect_all_scalars(jit, limit, concise),
             LiveCommand::Watch { path } => {
                 let value = jit.read_global_scalar(&path)?;
                 if !self.watches.contains_key(&path) && self.watches.len() >= MAX_LIVE_WATCHES {
@@ -1932,8 +1932,20 @@ fn inspect_scalar(jit: &JitProcess, path: &str) -> Result<(&'static str, Value),
     ))
 }
 
-fn inspect_all_scalars(jit: &JitProcess, limit: usize) -> Result<(&'static str, Value), String> {
+fn inspect_all_scalars(
+    jit: &JitProcess,
+    limit: usize,
+    concise: bool,
+) -> Result<(&'static str, Value), String> {
     let paths = jit.global_scalar_paths();
+    let path_names = paths
+        .iter()
+        .map(|(path, _)| path.clone())
+        .collect::<HashSet<_>>();
+    let paths = paths
+        .into_iter()
+        .filter(|(path, _)| !concise || concise_state_path_is_visible(path, &path_names))
+        .collect::<Vec<_>>();
     let total = paths.len();
     let limit = limit.clamp(1, 64);
     let items = paths
@@ -1946,8 +1958,29 @@ fn inspect_all_scalars(jit: &JitProcess, limit: usize) -> Result<(&'static str, 
         .collect::<Result<Vec<_>, String>>()?;
     Ok((
         "state_inspection",
-        json!({"total": total, "limit": limit, "truncated": total > limit, "items": items}),
+        json!({"total": total, "limit": limit, "truncated": total > limit, "concise": concise, "items": items}),
     ))
+}
+
+fn concise_state_path_is_visible(path: &str, all_paths: &HashSet<String>) -> bool {
+    let leaf = path.rsplit('.').next().unwrap_or(path);
+    if leaf == "max_length" {
+        return false;
+    }
+    if leaf == "length" {
+        let parent = path.strip_suffix(".length").unwrap_or_default();
+        if all_paths.contains(format!("{parent}.max_length").as_str()) {
+            return false;
+        }
+    }
+    let is_axis = matches!(leaf, "x" | "y" | "z")
+        || ["_x", "_y", "_z"]
+            .iter()
+            .any(|suffix| leaf.ends_with(suffix));
+    let is_position = path
+        .split('.')
+        .any(|segment| matches!(segment, "position" | "positions"));
+    !is_axis && !is_position
 }
 
 fn print_scalar(jit: &JitProcess, expression: &str) -> Result<(&'static str, Value), String> {
@@ -2216,13 +2249,38 @@ mod tests {
         let (root, config) = project();
         let (jit, _) = compile(&config);
         jit.execute_i32_noarg_by_name("main").expect("main");
-        let (kind, data) = inspect_all_scalars(&jit, 32).expect("state inspection");
+        let (kind, data) = inspect_all_scalars(&jit, 32, false).expect("state inspection");
         assert_eq!(kind, "state_inspection");
         assert_eq!(data["total"], 1);
         assert_eq!(data["items"][0]["path"], "score");
         assert_eq!(data["items"][0]["static_type"], "i32");
         assert_eq!(data["items"][0]["value"]["value"], 1);
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn concise_state_paths_hide_positions_and_proven_collection_metadata() {
+        let paths = HashSet::from([
+            "ball_x".to_string(),
+            "ball_y".to_string(),
+            "player.position.x".to_string(),
+            "commands.length".to_string(),
+            "commands.max_length".to_string(),
+            "snake.length".to_string(),
+            "score".to_string(),
+        ]);
+        for path in [
+            "ball_x",
+            "ball_y",
+            "player.position.x",
+            "commands.length",
+            "commands.max_length",
+        ] {
+            assert!(!concise_state_path_is_visible(path, &paths), "{path}");
+        }
+        for path in ["snake.length", "score"] {
+            assert!(concise_state_path_is_visible(path, &paths), "{path}");
+        }
     }
 
     #[test]

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -2,6 +2,7 @@ use serde_json::{json, Value};
 use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess, JitScalarValue};
 use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
+use stasis_compiler::frontend::lexer::{lex, TokenKind};
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
     workshop_completion_items, workshop_reachable_files, workshop_source_hash,
@@ -11,8 +12,10 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    CompletionIndex, CompletionItem, CompletionScope, LiveCommand, LiveEditOperation, LiveRequest,
-    LiveResponse, LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
+    CompletionContext, CompletionIndex, CompletionItem, CompletionQuery, CompletionScope,
+    LiveCommand, LiveEditOperation, LiveRequest, LiveResponse, LiveResponseSendError,
+    LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_TRACKS, MAX_LIVE_TRACK_TICKS,
+    MAX_LIVE_WATCHES,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
@@ -29,6 +32,13 @@ const MAX_LIVE_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
 const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
+const TRACK_PROGRESS_INTERVAL: usize = 10;
+
+struct LiveTrack {
+    total_ticks: u32,
+    samples: Vec<JitScalarValue>,
+    dropped_updates: u64,
+}
 
 #[derive(Debug, Clone)]
 pub struct LiveRunConfig {
@@ -72,6 +82,7 @@ struct PreparedEdit {
     package: JitEnginePackage,
     source_items: Vec<WorkshopSourceItem>,
     completion_items: Vec<WorkshopCompletionItem>,
+    source_files: Vec<WorkshopSourceFile>,
     input_hashes: BTreeMap<String, String>,
 }
 
@@ -80,6 +91,19 @@ struct EditPreparation {
     canceled: Arc<AtomicBool>,
     receiver: mpsc::Receiver<Result<PreparedEdit, String>>,
     worker: Option<std::thread::JoinHandle<()>>,
+}
+
+struct CompletionPreparation {
+    request_id: u64,
+    receiver: mpsc::Receiver<CompletionQuery>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+#[derive(Clone, Default)]
+struct CompletionSnapshot {
+    index: CompletionIndex,
+    source_items: Vec<WorkshopSourceItem>,
+    source_files: Vec<WorkshopSourceFile>,
 }
 
 #[derive(Debug, Clone)]
@@ -117,13 +141,17 @@ pub(crate) struct LiveWorkspace {
     completion: CompletionIndex,
     source_items: Vec<WorkshopSourceItem>,
     completion_items: Vec<WorkshopCompletionItem>,
+    source_files: Vec<WorkshopSourceFile>,
+    completion_snapshot: Arc<CompletionSnapshot>,
     scratch: ScratchWorkspace,
     watches: BTreeMap<String, Option<JitScalarValue>>,
+    tracks: BTreeMap<String, LiveTrack>,
     pending_plan: Option<WorkshopSemanticEditPlan>,
     pending_requests: VecDeque<LiveRequest>,
     pending_responses: VecDeque<LiveResponse>,
     self_write_hashes: BTreeMap<PathBuf, String>,
     edit_preparation: Option<EditPreparation>,
+    completion_preparation: Option<CompletionPreparation>,
     dropped_watch_events: u64,
 }
 
@@ -131,6 +159,11 @@ impl Drop for LiveWorkspace {
     fn drop(&mut self) {
         if let Some(mut preparation) = self.edit_preparation.take() {
             preparation.canceled.store(true, Ordering::Release);
+            if let Some(worker) = preparation.worker.take() {
+                let _ = worker.join();
+            }
+        }
+        if let Some(mut preparation) = self.completion_preparation.take() {
             if let Some(worker) = preparation.worker.take() {
                 let _ = worker.join();
             }
@@ -155,13 +188,17 @@ impl LiveWorkspace {
             completion: CompletionIndex::default(),
             source_items: Vec::new(),
             completion_items: Vec::new(),
+            source_files: Vec::new(),
+            completion_snapshot: Arc::new(CompletionSnapshot::default()),
             scratch: ScratchWorkspace::default(),
             watches: BTreeMap::new(),
+            tracks: BTreeMap::new(),
             pending_plan: None,
             pending_requests: VecDeque::new(),
             pending_responses: VecDeque::new(),
             self_write_hashes: BTreeMap::new(),
             edit_preparation: None,
+            completion_preparation: None,
             dropped_watch_events: 0,
         };
         workspace.refresh_completion(jit)?;
@@ -256,6 +293,9 @@ impl LiveWorkspace {
         {
             self.enqueue_response(response);
         }
+        if let Some(response) = self.finish_completion_preparation(tick) {
+            self.enqueue_response(response);
+        }
         for request in controls {
             let response = match request.command {
                 LiveCommand::Cancel {
@@ -339,6 +379,7 @@ impl LiveWorkspace {
     }
 
     pub(crate) fn publish_watches(&mut self, tick: u64, jit: &JitProcess) {
+        self.publish_tracks(tick, jit);
         if self.dropped_watch_events > 0 {
             let dropped = self.dropped_watch_events;
             match self.server.respond(LiveResponse::success(
@@ -383,6 +424,82 @@ impl LiveWorkspace {
         }
     }
 
+    fn publish_tracks(&mut self, tick: u64, jit: &JitProcess) {
+        let paths = self.tracks.keys().cloned().collect::<Vec<_>>();
+        for path in paths {
+            let value = match jit.read_global_scalar(&path) {
+                Ok(value) => value,
+                Err(error) => {
+                    self.tracks.remove(&path);
+                    let _ = self.server.respond(LiveResponse::success(
+                        0,
+                        tick,
+                        "track_failed",
+                        json!({"path": path, "error": error}),
+                    ));
+                    continue;
+                }
+            };
+            let Some(track) = self.tracks.get_mut(&path) else {
+                continue;
+            };
+            if track.samples.len() < track.total_ticks as usize {
+                track.samples.push(value);
+            }
+            let complete = track.samples.len() == track.total_ticks as usize;
+            if !complete && track.samples.len() % TRACK_PROGRESS_INTERVAL != 0 {
+                continue;
+            }
+            let kind = if complete {
+                "track_complete"
+            } else {
+                "track_progress"
+            };
+            let samples = if complete {
+                track.samples.clone()
+            } else {
+                track
+                    .samples
+                    .iter()
+                    .rev()
+                    .take(32)
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect()
+            };
+            let response = LiveResponse::success(
+                0,
+                tick,
+                kind,
+                json!({
+                    "path": path,
+                    "sample_count": track.samples.len(),
+                    "total_ticks": track.total_ticks,
+                    "latest": value,
+                    "samples": samples,
+                    "dropped_updates": track.dropped_updates,
+                }),
+            );
+            match self.server.respond(response) {
+                Ok(()) if complete => {
+                    self.tracks.remove(&path);
+                }
+                Ok(()) => {}
+                Err(LiveResponseSendError::Full(_)) => {
+                    if let Some(track) = self.tracks.get_mut(&path) {
+                        track.dropped_updates = track.dropped_updates.saturating_add(1);
+                    }
+                }
+                Err(LiveResponseSendError::Disconnected) => {
+                    self.quit = true;
+                    return;
+                }
+            }
+        }
+    }
+
     fn handle_request(
         &mut self,
         request: LiveRequest,
@@ -401,6 +518,7 @@ impl LiveWorkspace {
                     "history_length": self.history.len(),
                     "history_cursor": self.history_cursor,
                     "watches": self.watches.keys().collect::<Vec<_>>(),
+                    "tracks": self.tracks.keys().collect::<Vec<_>>(),
                     "scratch_cells": self.scratch.list(),
                     "dropped_watch_events": self.dropped_watch_events,
                     "preparing_request_id": self.edit_preparation.as_ref().map(|job| job.request_id),
@@ -456,12 +574,7 @@ impl LiveWorkspace {
                 cursor,
                 limit,
                 context,
-            } => Ok((
-                "completion",
-                json!(self
-                    .completion
-                    .query_with_context(&buffer, cursor, limit, &context)),
-            )),
+            } => self.start_completion_preparation(request_id, buffer, cursor, limit, context),
             LiveCommand::Palette {
                 query,
                 page,
@@ -560,12 +673,54 @@ impl LiveWorkspace {
                 }
             }
             LiveCommand::Inspect { path } => inspect_scalar(jit, &path),
+            LiveCommand::InspectAll { limit } => inspect_all_scalars(jit, limit),
             LiveCommand::Watch { path } => {
                 let value = jit.read_global_scalar(&path)?;
+                if !self.watches.contains_key(&path) && self.watches.len() >= MAX_LIVE_WATCHES {
+                    return Err(format!(
+                        "live watching is limited to {MAX_LIVE_WATCHES} paths"
+                    ));
+                }
                 self.watches.insert(path.clone(), Some(value));
                 Ok((
                     "watch_added",
                     json!({"path": path, "value": value, "tick": tick}),
+                ))
+            }
+            LiveCommand::Track { path, ticks } => {
+                if ticks == 0 || ticks > MAX_LIVE_TRACK_TICKS {
+                    return Err(format!(
+                        "track duration must be 1..={MAX_LIVE_TRACK_TICKS} ticks"
+                    ));
+                }
+                let value = jit.read_global_scalar(&path)?;
+                if !self.tracks.contains_key(&path) && self.tracks.len() >= MAX_LIVE_TRACKS {
+                    return Err(format!(
+                        "live tracking is limited to {MAX_LIVE_TRACKS} paths"
+                    ));
+                }
+                self.tracks.insert(
+                    path.clone(),
+                    LiveTrack {
+                        total_ticks: ticks,
+                        samples: Vec::with_capacity(ticks as usize),
+                        dropped_updates: 0,
+                    },
+                );
+                Ok((
+                    "track_started",
+                    json!({"path": path, "ticks": ticks, "value": value}),
+                ))
+            }
+            LiveCommand::Untrack { path } => {
+                if let Some(path) = path {
+                    self.tracks.remove(&path);
+                } else {
+                    self.tracks.clear();
+                }
+                Ok((
+                    "track_removed",
+                    json!({"tracks": self.tracks.keys().collect::<Vec<_>>()}),
                 ))
             }
             LiveCommand::Unwatch { path } => {
@@ -757,6 +912,78 @@ impl LiveWorkspace {
         ))
     }
 
+    fn start_completion_preparation(
+        &mut self,
+        request_id: u64,
+        buffer: String,
+        cursor: usize,
+        limit: usize,
+        context: CompletionContext,
+    ) -> Result<(&'static str, Value), String> {
+        if let Some(preparation) = self.completion_preparation.as_ref() {
+            return Err(format!(
+                "live completion request {} is still preparing; retry after it finishes",
+                preparation.request_id
+            ));
+        }
+        let snapshot = Arc::clone(&self.completion_snapshot);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name(format!("stasis-live-completion-{request_id}"))
+            .spawn(move || {
+                let query = completion_query_from_snapshot(
+                    snapshot.index.clone(),
+                    &snapshot.source_items,
+                    &snapshot.source_files,
+                    &buffer,
+                    cursor,
+                    limit,
+                    &context,
+                );
+                let _ = sender.send(query);
+            })
+            .map_err(|error| format!("failed starting live completion analysis: {error}"))?;
+        self.completion_preparation = Some(CompletionPreparation {
+            request_id,
+            receiver,
+            worker: Some(worker),
+        });
+        Ok((
+            "completion_preparing",
+            json!({"request_id": request_id, "background": true}),
+        ))
+    }
+
+    fn finish_completion_preparation(&mut self, tick: u64) -> Option<LiveResponse> {
+        let preparation = self.completion_preparation.as_ref()?;
+        let query = match preparation.receiver.try_recv() {
+            Ok(query) => query,
+            Err(mpsc::TryRecvError::Empty) => return None,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                let request_id = preparation.request_id;
+                self.completion_preparation = None;
+                return Some(LiveResponse::failure(
+                    request_id,
+                    tick,
+                    "live completion analysis worker disconnected",
+                ));
+            }
+        };
+        let mut preparation = self
+            .completion_preparation
+            .take()
+            .expect("completion preparation exists");
+        if let Some(worker) = preparation.worker.take() {
+            let _ = worker.join();
+        }
+        Some(LiveResponse::success(
+            preparation.request_id,
+            tick,
+            "completion",
+            json!(query),
+        ))
+    }
+
     fn finish_edit_preparation(
         &mut self,
         tick: u64,
@@ -867,6 +1094,7 @@ impl LiveWorkspace {
         let action = prepared.action.clone();
         let source_items = prepared.source_items;
         let completion_items = prepared.completion_items;
+        let source_files = prepared.source_files;
         let tests = if prepared.tests_ran {
             "passed"
         } else {
@@ -875,6 +1103,7 @@ impl LiveWorkspace {
         *jit = prepared.candidate;
         self.source_items = source_items;
         self.completion_items = completion_items;
+        self.source_files = source_files;
         self.remember_plan_hashes(&plan, prepared.restore);
         let (kind, data) = match action {
             PreparedAction::ApplyNew => {
@@ -951,27 +1180,14 @@ impl LiveWorkspace {
         let files = self.load_files()?;
         self.source_items = workshop_source_items(&files)?;
         self.completion_items = workshop_completion_items(&files)?;
+        self.source_files = files;
         self.rebuild_completion(jit);
         Ok(())
     }
 
     fn rebuild_completion(&mut self, jit: &JitProcess) {
         let mut items = live_command_completions();
-        items.extend(self.completion_items.iter().map(|item| CompletionItem {
-            text: item.text.clone(),
-            kind: item.kind.clone(),
-            detail: item.detail.clone(),
-            type_name: item.type_name.clone(),
-            source: Some(item.file.clone()),
-            scope: item.scope.as_ref().map(|scope| CompletionScope {
-                owner: scope.owner.clone(),
-                file: scope.file.clone(),
-                owner_signature: scope.owner_signature.clone(),
-                owner_end: scope.owner_end,
-                visible_from: scope.visible_from,
-                visible_to: scope.visible_to,
-            }),
-        }));
+        items.extend(self.completion_items.iter().map(live_completion_item));
         items.extend(
             jit.global_scalar_paths()
                 .into_iter()
@@ -981,6 +1197,7 @@ impl LiveWorkspace {
                     detail: type_name.to_string(),
                     type_name: Some(type_name.to_string()),
                     source: Some("runtime state".to_string()),
+                    selector: None,
                     scope: None,
                 }),
         );
@@ -990,10 +1207,147 @@ impl LiveWorkspace {
             detail: "session-only scratch cell".to_string(),
             type_name: None,
             source: Some("scratch workspace".to_string()),
+            selector: None,
             scope: None,
         }));
         self.completion.replace(items);
+        self.completion_snapshot = Arc::new(CompletionSnapshot {
+            index: self.completion.clone(),
+            source_items: self.source_items.clone(),
+            source_files: self.source_files.clone(),
+        });
     }
+
+    #[cfg(test)]
+    fn completion_query(
+        &self,
+        buffer: &str,
+        cursor: usize,
+        limit: usize,
+        context: &stasis_runner::live::CompletionContext,
+    ) -> stasis_runner::live::CompletionQuery {
+        completion_query_from_snapshot(
+            self.completion.clone(),
+            &self.source_items,
+            &self.source_files,
+            buffer,
+            cursor,
+            limit,
+            context,
+        )
+    }
+}
+
+fn completion_query_from_snapshot(
+    mut index: CompletionIndex,
+    source_items: &[WorkshopSourceItem],
+    source_files: &[WorkshopSourceFile],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: &CompletionContext,
+) -> CompletionQuery {
+    if let Some(items) = overlay_completion_items(source_items, source_files, buffer, context) {
+        index.retain(|item| !completion_item_belongs_to_context(item, context));
+        index.extend(items.into_iter().map(|item| live_completion_item(&item)));
+    }
+    index.query_with_context(buffer, cursor, limit, context)
+}
+
+fn overlay_completion_items(
+    source_items: &[WorkshopSourceItem],
+    source_files: &[WorkshopSourceFile],
+    buffer: &str,
+    context: &CompletionContext,
+) -> Option<Vec<WorkshopCompletionItem>> {
+    let file = context.file.as_deref()?;
+    let owner = context.owner.as_deref()?;
+    let item = source_items.iter().find(|item| {
+        item.file == file
+            && item.name == owner
+            && context
+                .owner_signature
+                .as_deref()
+                .is_none_or(|signature| item.signature == signature)
+    })?;
+    let span = item.source_spans.first()?;
+    let mut files = source_files.to_vec();
+    let source_file = files.iter_mut().find(|source| source.path == file)?;
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start > end || end > source_file.source.len() {
+        return None;
+    }
+    let overlay = balanced_definition(buffer)?;
+    source_file.source.replace_range(start..end, &overlay);
+    let mut items = workshop_completion_items(&files).ok()?;
+    for completion in &mut items {
+        if let Some(scope) = completion
+            .scope
+            .as_mut()
+            .filter(|scope| scope.owner == owner && scope.file == file)
+        {
+            scope.owner_signature = context.owner_signature.clone();
+        }
+    }
+    Some(items)
+}
+
+fn completion_item_belongs_to_context(
+    item: &CompletionItem,
+    context: &stasis_runner::live::CompletionContext,
+) -> bool {
+    let Some(scope) = item.scope.as_ref() else {
+        return false;
+    };
+    scope.owner == context.owner.as_deref().unwrap_or_default()
+        && scope.file == context.file.as_deref().unwrap_or_default()
+        && context
+            .owner_signature
+            .as_deref()
+            .is_none_or(|signature| scope.owner_signature.as_deref() == Some(signature))
+}
+
+fn live_completion_item(item: &WorkshopCompletionItem) -> CompletionItem {
+    CompletionItem {
+        text: item.text.clone(),
+        kind: item.kind.clone(),
+        detail: item.detail.clone(),
+        type_name: item.type_name.clone(),
+        source: Some(item.file.clone()),
+        selector: item.signature.as_ref().map(|signature| LiveSymbolTarget {
+            name: item.text.clone(),
+            kind: Some(item.kind.clone()),
+            file: Some(item.file.clone()),
+            owner: item.owner.clone(),
+            signature: Some(signature.clone()),
+        }),
+        scope: item.scope.as_ref().map(|scope| CompletionScope {
+            owner: scope.owner.clone(),
+            file: scope.file.clone(),
+            owner_signature: scope.owner_signature.clone(),
+            owner_end: scope.owner_end,
+            visible_from: scope.visible_from,
+            visible_to: scope.visible_to,
+        }),
+    }
+}
+
+fn balanced_definition(source: &str) -> Option<String> {
+    let tokens = lex(source).ok()?;
+    let mut depth = 0usize;
+    for token in tokens {
+        match token.kind {
+            TokenKind::LBrace => depth = depth.saturating_add(1),
+            TokenKind::RBrace => depth = depth.checked_sub(1)?,
+            _ => {}
+        }
+    }
+    let mut balanced = source.to_string();
+    for _ in 0..depth {
+        balanced.push('}');
+    }
+    Some(balanced)
 }
 
 fn paged_completion_query(
@@ -1121,6 +1475,7 @@ fn prepare_edit(
         package,
         source_items,
         completion_items,
+        source_files: candidate_files,
         input_hashes,
     })
 }
@@ -1437,10 +1792,12 @@ fn help_data() -> Value {
             ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
             ":symbols [query] [--page N --limit N]",
             ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
+            ":edit SYMBOL (interactive TUI)",
             ":complete BUFFER", ":palette [QUERY]",
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
-            ":inspect PATH", ":watch PATH", ":unwatch [PATH]", ":set PATH VALUE",
+            ":inspect [PATH]", ":watch PATH", ":unwatch [PATH]",
+            ":track PATH [ticks]", ":untrack [PATH]", ":set PATH VALUE",
             ":print VALUE_OR_PATH", ":do ... :end", ":cell put|run|list|clear"
         ],
         "multiline_terminator": ":end",
@@ -1462,6 +1819,7 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":symbols",
         ":find",
         ":read",
+        ":edit",
         ":complete",
         ":palette",
         ":add",
@@ -1475,6 +1833,8 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":inspect",
         ":watch",
         ":unwatch",
+        ":track",
+        ":untrack",
         ":set",
         ":print",
         ":do",
@@ -1487,6 +1847,7 @@ fn live_command_completions() -> Vec<CompletionItem> {
         detail: "live command".to_string(),
         type_name: None,
         source: Some("interactive workspace".to_string()),
+        selector: None,
         scope: None,
     })
     .collect()
@@ -1568,6 +1929,24 @@ fn inspect_scalar(jit: &JitProcess, path: &str) -> Result<(&'static str, Value),
     Ok((
         "inspection",
         json!({"path": path, "static_type": value.type_name(), "value": value}),
+    ))
+}
+
+fn inspect_all_scalars(jit: &JitProcess, limit: usize) -> Result<(&'static str, Value), String> {
+    let paths = jit.global_scalar_paths();
+    let total = paths.len();
+    let limit = limit.clamp(1, 64);
+    let items = paths
+        .into_iter()
+        .take(limit)
+        .map(|(path, static_type)| {
+            let value = jit.read_global_scalar(&path)?;
+            Ok(json!({"path": path, "static_type": static_type, "value": value}))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok((
+        "state_inspection",
+        json!({"total": total, "limit": limit, "truncated": total > limit, "items": items}),
     ))
 }
 
@@ -1769,7 +2148,12 @@ mod tests {
         for tick in 1..=500 {
             workspace.process_boundary(tick, jit, tick_ptr, render_ptr);
             if let Ok(response) = client.receive_timeout(std::time::Duration::from_millis(10)) {
-                if response.request_id == request_id && response.kind != "edit_preparing" {
+                if response.request_id == request_id
+                    && !matches!(
+                        response.kind.as_str(),
+                        "edit_preparing" | "completion_preparing"
+                    )
+                {
                     return response;
                 }
             }
@@ -1824,6 +2208,20 @@ mod tests {
         assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(9)));
         assert!(apply_scalar_transaction(&jit, "score = nope;", false).is_err());
         assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(9)));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn default_state_inspection_is_bounded_and_typed() {
+        let (root, config) = project();
+        let (jit, _) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (kind, data) = inspect_all_scalars(&jit, 32).expect("state inspection");
+        assert_eq!(kind, "state_inspection");
+        assert_eq!(data["total"], 1);
+        assert_eq!(data["items"][0]["path"], "score");
+        assert_eq!(data["items"][0]["static_type"], "i32");
+        assert_eq!(data["items"][0]["value"]["value"], 1);
         fs::remove_dir_all(root).ok();
     }
 
@@ -1953,6 +2351,53 @@ mod tests {
         assert!(workspace.should_run_tick());
         workspace.after_tick();
         assert!(!workspace.should_run_tick());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn per_tick_track_keeps_unchanged_samples_and_completes_exactly() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(32);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let started = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                44,
+                LiveCommand::Track {
+                    path: "score".into(),
+                    ticks: 3,
+                },
+            ),
+        );
+        assert!(started.ok, "{:?}", started.error);
+
+        jit.write_global_scalar("score", JitScalarValue::I32(5))
+            .expect("set score");
+        workspace.publish_watches(10, &jit);
+        workspace.publish_watches(11, &jit);
+        jit.write_global_scalar("score", JitScalarValue::I32(8))
+            .expect("set score");
+        workspace.publish_watches(12, &jit);
+
+        let complete = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("track complete");
+        assert_eq!(complete.kind, "track_complete");
+        assert_eq!(complete.tick, 12);
+        let data = complete.data.expect("track data");
+        assert_eq!(data["sample_count"], 3);
+        assert_eq!(data["samples"][0]["value"], 5);
+        assert_eq!(data["samples"][1]["value"], 5);
+        assert_eq!(data["samples"][2]["value"], 8);
+        assert!(workspace.tracks.is_empty());
         fs::remove_dir_all(root).ok();
     }
 
@@ -2192,6 +2637,176 @@ mod tests {
     }
 
     #[test]
+    fn dirty_unbalanced_definition_overlay_completes_new_typed_local() {
+        let (root, config) = project();
+        let (jit, _) = compile(&config);
+        let (_, server) = stasis_runner::live::live_session(8);
+        let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let tick = workspace
+            .source_items
+            .iter()
+            .find(|item| item.name == "tick")
+            .expect("tick item");
+        let buffer = "function tick(): i32 {\n    let local_speed: i32 = 2;\n    local_sp";
+        let context = stasis_runner::live::CompletionContext {
+            owner: Some("tick".into()),
+            file: Some(tick.file.clone()),
+            owner_signature: Some(tick.signature.clone()),
+            source_offset: Some(tick.source_spans[0].start as usize + buffer.len()),
+            expected_type: None,
+        };
+        let query = workspace.completion_query(buffer, buffer.len(), 10, &context);
+        assert_eq!(query.items[0].text, "local_speed");
+        assert_eq!(
+            balanced_definition(buffer)
+                .expect("balanced")
+                .matches('}')
+                .count(),
+            1
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn dirty_overlay_removes_deleted_locals_from_the_accepted_catalog() {
+        let (root, config) = project();
+        let path = root.join("src/main.stasis");
+        let source = fs::read_to_string(&path).expect("source").replace(
+            "function tick(): i32 { score += 1; return 0; }",
+            "function tick(): i32 { let stale_local: i32 = 1; score += stale_local; return 0; }",
+        );
+        fs::write(&path, source).expect("write local source");
+        let (jit, _) = compile(&config);
+        let (_, server) = stasis_runner::live::live_session(8);
+        let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let tick = workspace
+            .source_items
+            .iter()
+            .find(|item| item.name == "tick")
+            .expect("tick item");
+        let buffer = "function tick(): i32 {\n    score += 1;\n    stale";
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some(tick.file.clone()),
+            owner_signature: Some(tick.signature.clone()),
+            source_offset: Some(tick.source_spans[0].start as usize + buffer.len()),
+            expected_type: None,
+        };
+        let query = workspace.completion_query(buffer, buffer.len(), 10, &context);
+        assert!(query.items.iter().all(|item| item.text != "stale_local"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn dirty_overlay_keeps_scope_identity_when_a_parameter_is_renamed() {
+        let (root, config) = project();
+        let path = root.join("src/main.stasis");
+        let mut source = fs::read_to_string(&path).expect("source");
+        source.push_str("function helper(old_name: i32): i32 { return old_name; }\n");
+        fs::write(&path, source).expect("write helper source");
+        let (jit, _) = compile(&config);
+        let (_, server) = stasis_runner::live::live_session(8);
+        let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let helper = workspace
+            .source_items
+            .iter()
+            .find(|item| item.name == "helper")
+            .expect("helper item");
+        let buffer = "function helper(new_name: i32): i32 { return new_na";
+        let context = CompletionContext {
+            owner: Some("helper".into()),
+            file: Some(helper.file.clone()),
+            owner_signature: Some(helper.signature.clone()),
+            source_offset: Some(helper.source_spans[0].start as usize + buffer.len()),
+            expected_type: None,
+        };
+        let query = workspace.completion_query(buffer, buffer.len(), 10, &context);
+        assert_eq!(query.items[0].text, "new_name");
+        assert!(query.items.iter().all(|item| item.text != "old_name"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn completion_analysis_returns_preparing_before_the_background_result() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let tick = workspace
+            .source_items
+            .iter()
+            .find(|item| item.name == "tick")
+            .expect("tick item");
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some(tick.file.clone()),
+            owner_signature: Some(tick.signature.clone()),
+            source_offset: Some(tick.source_spans[0].start as usize),
+            expected_type: None,
+        };
+        let buffer = "function tick(): i32 { sco".to_string();
+        let cursor = buffer.len();
+        client
+            .submit(LiveRequest::new(
+                90,
+                LiveCommand::Complete {
+                    buffer,
+                    cursor,
+                    limit: 10,
+                    context,
+                },
+            ))
+            .expect("submit completion");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        workspace.process_boundary(1, &mut jit, &mut tick_ptr, &mut render_ptr);
+        let preparing = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("preparing response");
+        assert_eq!(preparing.kind, "completion_preparing");
+        let final_response = (2..=100)
+            .find_map(|boundary| {
+                workspace.process_boundary(boundary, &mut jit, &mut tick_ptr, &mut render_ptr);
+                client
+                    .receive_timeout(std::time::Duration::from_millis(10))
+                    .ok()
+            })
+            .expect("background completion response");
+        assert_eq!(final_response.kind, "completion");
+        assert!(final_response.ok);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn watch_paths_are_bounded() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        workspace.watches = (0..MAX_LIVE_WATCHES)
+            .map(|index| (format!("placeholder_{index}"), None))
+            .collect();
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                91,
+                LiveCommand::Watch {
+                    path: "score".into(),
+                },
+            ),
+        );
+        assert!(!response.ok);
+        assert!(response.error.expect("watch limit").contains("limited"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
     fn large_palette_query_stays_bounded_and_completes_in_one_graphics_boundary() {
         let (root, config) = project();
         let (mut jit, package) = compile(&config);
@@ -2204,6 +2819,7 @@ mod tests {
                 detail: format!("generated_{index:05}(): i32"),
                 type_name: Some("i32".into()),
                 source: Some("src/generated.stasis".into()),
+                selector: None,
                 scope: None,
             })
             .collect::<Vec<_>>();
@@ -2213,6 +2829,7 @@ mod tests {
             detail: "late_graphics_target(): i32".into(),
             type_name: Some("i32".into()),
             source: Some("src/late.stasis".into()),
+            selector: None,
             scope: None,
         });
         workspace.completion.replace(items);

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -4,15 +4,15 @@ use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
-    workshop_reachable_files, workshop_source_hash, workshop_source_items,
-    write_workshop_semantic_plan, write_workshop_semantic_receipt, ExpectedReload,
-    WorkshopSemanticEdit, WorkshopSemanticEditBatch, WorkshopSemanticEditOperation,
-    WorkshopSemanticEditPlan, WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind,
-    WorkshopSymbolSelector,
+    workshop_completion_items, workshop_reachable_files, workshop_source_hash,
+    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
+    ExpectedReload, WorkshopCompletionItem, WorkshopSemanticEdit, WorkshopSemanticEditBatch,
+    WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
+    WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    CompletionIndex, CompletionItem, LiveCommand, LiveEditOperation, LiveRequest, LiveResponse,
-    LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
+    CompletionIndex, CompletionItem, CompletionScope, LiveCommand, LiveEditOperation, LiveRequest,
+    LiveResponse, LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
@@ -71,6 +71,7 @@ struct PreparedEdit {
     candidate: JitProcess,
     package: JitEnginePackage,
     source_items: Vec<WorkshopSourceItem>,
+    completion_items: Vec<WorkshopCompletionItem>,
     input_hashes: BTreeMap<String, String>,
 }
 
@@ -115,6 +116,7 @@ pub(crate) struct LiveWorkspace {
     history_cursor: usize,
     completion: CompletionIndex,
     source_items: Vec<WorkshopSourceItem>,
+    completion_items: Vec<WorkshopCompletionItem>,
     scratch: ScratchWorkspace,
     watches: BTreeMap<String, Option<JitScalarValue>>,
     pending_plan: Option<WorkshopSemanticEditPlan>,
@@ -152,6 +154,7 @@ impl LiveWorkspace {
             history_cursor: 0,
             completion: CompletionIndex::default(),
             source_items: Vec::new(),
+            completion_items: Vec::new(),
             scratch: ScratchWorkspace::default(),
             watches: BTreeMap::new(),
             pending_plan: None,
@@ -452,9 +455,27 @@ impl LiveWorkspace {
                 buffer,
                 cursor,
                 limit,
+                context,
             } => Ok((
                 "completion",
-                json!({"items": self.completion.complete(&buffer, cursor, limit)}),
+                json!(self
+                    .completion
+                    .query_with_context(&buffer, cursor, limit, &context)),
+            )),
+            LiveCommand::Palette {
+                query,
+                page,
+                limit,
+                context,
+            } => Ok((
+                "palette",
+                json!(paged_completion_query(
+                    &self.completion,
+                    &query,
+                    page,
+                    limit,
+                    &context,
+                )),
             )),
             LiveCommand::Edit {
                 operation,
@@ -845,6 +866,7 @@ impl LiveWorkspace {
         let plan = prepared.plan.clone();
         let action = prepared.action.clone();
         let source_items = prepared.source_items;
+        let completion_items = prepared.completion_items;
         let tests = if prepared.tests_ran {
             "passed"
         } else {
@@ -852,6 +874,7 @@ impl LiveWorkspace {
         };
         *jit = prepared.candidate;
         self.source_items = source_items;
+        self.completion_items = completion_items;
         self.remember_plan_hashes(&plan, prepared.restore);
         let (kind, data) = match action {
             PreparedAction::ApplyNew => {
@@ -927,16 +950,27 @@ impl LiveWorkspace {
     fn refresh_completion(&mut self, jit: &JitProcess) -> Result<(), String> {
         let files = self.load_files()?;
         self.source_items = workshop_source_items(&files)?;
+        self.completion_items = workshop_completion_items(&files)?;
         self.rebuild_completion(jit);
         Ok(())
     }
 
     fn rebuild_completion(&mut self, jit: &JitProcess) {
         let mut items = live_command_completions();
-        items.extend(self.source_items.iter().map(|item| CompletionItem {
-            text: item.name.clone(),
-            kind: format!("{:?}", item.kind).to_ascii_lowercase(),
-            detail: item.signature.clone(),
+        items.extend(self.completion_items.iter().map(|item| CompletionItem {
+            text: item.text.clone(),
+            kind: item.kind.clone(),
+            detail: item.detail.clone(),
+            type_name: item.type_name.clone(),
+            source: Some(item.file.clone()),
+            scope: item.scope.as_ref().map(|scope| CompletionScope {
+                owner: scope.owner.clone(),
+                file: scope.file.clone(),
+                owner_signature: scope.owner_signature.clone(),
+                owner_end: scope.owner_end,
+                visible_from: scope.visible_from,
+                visible_to: scope.visible_to,
+            }),
         }));
         items.extend(
             jit.global_scalar_paths()
@@ -945,15 +979,36 @@ impl LiveWorkspace {
                     text: path,
                     kind: "state_path".to_string(),
                     detail: type_name.to_string(),
+                    type_name: Some(type_name.to_string()),
+                    source: Some("runtime state".to_string()),
+                    scope: None,
                 }),
         );
         items.extend(self.scratch.list().into_iter().map(|cell| CompletionItem {
             text: cell.name,
             kind: "scratch_cell".to_string(),
             detail: "session-only scratch cell".to_string(),
+            type_name: None,
+            source: Some("scratch workspace".to_string()),
+            scope: None,
         }));
         self.completion.replace(items);
     }
+}
+
+fn paged_completion_query(
+    index: &CompletionIndex,
+    query: &str,
+    page: u32,
+    limit: usize,
+    context: &stasis_runner::live::CompletionContext,
+) -> stasis_runner::live::CompletionQuery {
+    let start = (page as usize).saturating_mul(limit);
+    let requested = start.saturating_add(limit).min(256);
+    let mut result = index.query_with_context(query, query.len(), requested, context);
+    result.page = page;
+    result.items = result.items.into_iter().skip(start).take(limit).collect();
+    result
 }
 
 fn validate_edit_input_size(input: &EditPreparationInput) -> Result<(), String> {
@@ -1055,6 +1110,7 @@ fn prepare_edit(
     }
     check_preparation_canceled(canceled)?;
     let source_items = workshop_source_items(&candidate_files)?;
+    let completion_items = workshop_completion_items(&candidate_files)?;
     Ok(PreparedEdit {
         request_id,
         plan,
@@ -1064,6 +1120,7 @@ fn prepare_edit(
         candidate,
         package,
         source_items,
+        completion_items,
         input_hashes,
     })
 }
@@ -1379,7 +1436,8 @@ fn help_data() -> Value {
         "commands": [
             ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
             ":symbols [query] [--page N --limit N]",
-            ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]", ":complete BUFFER",
+            ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
+            ":complete BUFFER", ":palette [QUERY]",
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
             ":inspect PATH", ":watch PATH", ":unwatch [PATH]", ":set PATH VALUE",
@@ -1387,7 +1445,7 @@ fn help_data() -> Value {
         ],
         "multiline_terminator": ":end",
         "multiline_cancel": ":abort or Ctrl-C",
-        "line_editor": "session history and compiler-backed Tab completion",
+        "line_editor": "session history; Ctrl-P opens the compiler-backed palette; Tab completes",
         "durability": "semantic edits persist through code-aware receipts; scratch cells do not persist unless explicitly promoted",
     })
 }
@@ -1405,6 +1463,7 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":find",
         ":read",
         ":complete",
+        ":palette",
         ":add",
         ":update",
         ":delete",
@@ -1426,6 +1485,9 @@ fn live_command_completions() -> Vec<CompletionItem> {
         text: text.to_string(),
         kind: "command".to_string(),
         detail: "live command".to_string(),
+        type_name: None,
+        source: Some("interactive workspace".to_string()),
+        scope: None,
     })
     .collect()
 }
@@ -2033,7 +2095,10 @@ mod tests {
                 LiveCommand::Edit {
                     operation: LiveEditOperation::Add,
                     target: target.clone(),
-                    source: Some("function helper(): i32 { return 7; }".into()),
+                    source: Some(
+                        "function helper(value: i32): i32 { let local: i32 = value; return local; }"
+                            .into(),
+                    ),
                     expected_source_hash: None,
                     preview: false,
                     run_tests: false,
@@ -2044,6 +2109,19 @@ mod tests {
         assert_eq!(
             workspace.completion.complete(":read hel", 9, 10)[0].text,
             "helper"
+        );
+        let helper_context = stasis_runner::live::CompletionContext {
+            owner: Some("helper".into()),
+            file: Some("src/main.stasis".into()),
+            ..stasis_runner::live::CompletionContext::default()
+        };
+        assert_eq!(
+            workspace
+                .completion
+                .query_with_context("lcl", 3, 10, &helper_context)
+                .items[0]
+                .text,
+            "local"
         );
         assert!(workspace.consumes_self_write(&root.join("src/main.stasis")));
 
@@ -2058,7 +2136,10 @@ mod tests {
                 LiveCommand::Edit {
                     operation: LiveEditOperation::Update,
                     target: target.clone(),
-                    source: Some("function helper(): i32 { return 8; }".into()),
+                    source: Some(
+                        "function helper(value: i32): i32 { let local: i32 = value; return 8; }"
+                            .into(),
+                    ),
                     expected_source_hash: Some("stale".into()),
                     preview: false,
                     run_tests: false,
@@ -2068,7 +2149,7 @@ mod tests {
         assert!(!stale.ok);
         assert!(fs::read_to_string(root.join("src/main.stasis"))
             .expect("source")
-            .contains("return 7"));
+            .contains("return local"));
 
         let files = load_workshop_edit_workspace(&root, &config.entry).expect("files");
         let helper = find_workshop_symbols(&files, &selector(&target).expect("selector"))
@@ -2093,10 +2174,92 @@ mod tests {
             ),
         );
         assert!(deleted.ok, "{:?}", deleted.error);
-        assert!(workspace.completion.complete(":read hel", 9, 10).is_empty());
+        assert!(workspace
+            .completion
+            .complete(":read hel", 9, 10)
+            .iter()
+            .all(|item| item.text != "helper"));
+        assert!(workspace
+            .completion
+            .query_with_context("lcl", 3, 10, &helper_context)
+            .items
+            .iter()
+            .all(|item| item.text != "local"));
         assert!(!fs::read_to_string(root.join("src/main.stasis"))
             .expect("source")
             .contains("function helper"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn large_palette_query_stays_bounded_and_completes_in_one_graphics_boundary() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut items = (0..10_000)
+            .map(|index| CompletionItem {
+                text: format!("generated_{index:05}"),
+                kind: "function".into(),
+                detail: format!("generated_{index:05}(): i32"),
+                type_name: Some("i32".into()),
+                source: Some("src/generated.stasis".into()),
+                scope: None,
+            })
+            .collect::<Vec<_>>();
+        items.push(CompletionItem {
+            text: "late_graphics_target".into(),
+            kind: "function".into(),
+            detail: "late_graphics_target(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/late.stasis".into()),
+            scope: None,
+        });
+        workspace.completion.replace(items);
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                13,
+                LiveCommand::Palette {
+                    query: "lgt".into(),
+                    page: 0,
+                    limit: 8,
+                    context: stasis_runner::live::CompletionContext::default(),
+                },
+            ),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        assert_eq!(response.tick, 1);
+        assert_eq!(
+            response.data.expect("palette")["items"][0]["text"],
+            "late_graphics_target"
+        );
+        let page = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                14,
+                LiveCommand::Palette {
+                    query: "generated".into(),
+                    page: 2,
+                    limit: 8,
+                    context: stasis_runner::live::CompletionContext::default(),
+                },
+            ),
+        );
+        assert_eq!(
+            page.data.expect("page")["items"][0]["text"],
+            "generated_00016"
+        );
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,10 +1,22 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{
+    self, Event as TerminalEvent, KeyCode, KeyEvent as TerminalKeyEvent, KeyEventKind, KeyModifiers,
+};
+use crossterm::execute;
+use crossterm::style::Print;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use rustyline::completion::{Completer, Pair};
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::history::DefaultHistory;
 use rustyline::validate::Validator;
-use rustyline::{Context, Editor, Helper};
+use rustyline::{
+    Cmd, CompletionType, ConditionalEventHandler, Config, Context, Editor, Event as LineEvent,
+    EventContext, EventHandler, Helper, KeyEvent as LineKeyEvent, RepeatCount,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use stasis::{
@@ -12,6 +24,7 @@ use stasis::{
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
+use stasis_compiler::frontend::parser::completion_expected_type;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
     workshop_reachable_files, workshop_source_hash, workshop_source_items,
@@ -20,15 +33,17 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    live_session, CompletionItem, LiveCommand, LiveRequest, LiveResponse, TerminalBuffer,
-    TerminalInput,
+    live_session, CompletionContext, CompletionItem, LiveCommand, LiveRequest, LiveResponse,
+    LiveSessionClient, TerminalBuffer, TerminalInput,
 };
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -877,7 +892,60 @@ fn run_workspace_live(
 }
 
 struct LiveLineHelper {
-    items: Vec<CompletionItem>,
+    client: LiveSessionClient,
+    next_request_id: AtomicU64,
+    context: Mutex<CompletionContext>,
+    deferred_responses: Mutex<Vec<LiveResponse>>,
+}
+
+impl LiveLineHelper {
+    fn new(client: LiveSessionClient) -> Self {
+        Self {
+            client,
+            next_request_id: AtomicU64::new(1u64 << 63),
+            context: Mutex::new(CompletionContext::default()),
+            deferred_responses: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn set_context(&self, context: CompletionContext) {
+        *self.context.lock().expect("completion context lock") = context;
+    }
+
+    fn take_deferred_responses(&self) -> Vec<LiveResponse> {
+        std::mem::take(
+            &mut *self
+                .deferred_responses
+                .lock()
+                .expect("deferred response lock"),
+        )
+    }
+
+    fn query(
+        &self,
+        line: &str,
+        position: usize,
+        limit: usize,
+    ) -> Result<stasis_runner::live::CompletionQuery, String> {
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let mut context = self
+            .context
+            .lock()
+            .expect("completion context lock")
+            .clone();
+        if context.expected_type.is_none() {
+            context.expected_type = completion_expected_type(line, position).unwrap_or_default();
+        }
+        fetch_live_completion_query(
+            &self.client,
+            request_id,
+            line,
+            position,
+            limit,
+            context,
+            &self.deferred_responses,
+        )
+    }
 }
 
 impl Helper for LiveLineHelper {}
@@ -896,27 +964,295 @@ impl Completer for LiveLineHelper {
         position: usize,
         _context: &Context<'_>,
     ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        let mut position = position.min(line.len());
-        while !line.is_char_boundary(position) {
-            position -= 1;
-        }
-        let start = line[..position]
-            .rfind(|character: char| {
-                character.is_whitespace() || character == '(' || character == ','
-            })
-            .map_or(0, |index| index + 1);
-        let prefix = &line[start..position];
-        let candidates = self
+        let query = self
+            .query(line, position, 64)
+            .map_err(|error| rustyline::error::ReadlineError::Io(io::Error::other(error)))?;
+        let candidates = query
             .items
-            .iter()
-            .filter(|item| item.text.starts_with(prefix))
+            .into_iter()
             .map(|item| Pair {
-                display: format!("{}  {}", item.text, item.detail),
-                replacement: item.text.clone(),
+                display: format_completion_candidate(&item),
+                replacement: item.text,
             })
             .collect();
-        Ok((start, candidates))
+        Ok((query.replacement_start, candidates))
     }
+}
+
+fn format_completion_candidate(item: &CompletionItem) -> String {
+    let mut detail = item.detail.replace(['\r', '\n'], " ");
+    if detail.chars().count() > 48 {
+        detail = detail.chars().take(45).collect::<String>() + "...";
+    }
+    format!("{}  [{}]  {}", item.text, item.kind, detail)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PaletteOpen {
+    line: String,
+    cursor: usize,
+}
+
+struct PaletteTrigger {
+    pending: Arc<Mutex<Option<PaletteOpen>>>,
+}
+
+impl ConditionalEventHandler for PaletteTrigger {
+    fn handle(
+        &self,
+        _event: &LineEvent,
+        _repeat: RepeatCount,
+        _positive: bool,
+        context: &EventContext<'_>,
+    ) -> Option<Cmd> {
+        *self.pending.lock().expect("palette trigger lock") = Some(PaletteOpen {
+            line: context.line().to_string(),
+            cursor: context.pos(),
+        });
+        Some(Cmd::AcceptLine)
+    }
+}
+
+const PALETTE_PAGE_SIZE: usize = 8;
+
+struct PaletteState {
+    query: String,
+    items: Vec<CompletionItem>,
+    selected: usize,
+    truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaletteAction {
+    Cancel,
+    Move(isize),
+    Select,
+    Backspace,
+    Type(char),
+    Ignore,
+}
+
+fn palette_action(key: TerminalKeyEvent) -> PaletteAction {
+    match key.code {
+        KeyCode::Esc => PaletteAction::Cancel,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            PaletteAction::Cancel
+        }
+        KeyCode::Up => PaletteAction::Move(-1),
+        KeyCode::Down => PaletteAction::Move(1),
+        KeyCode::PageUp => PaletteAction::Move(-(PALETTE_PAGE_SIZE as isize)),
+        KeyCode::PageDown => PaletteAction::Move(PALETTE_PAGE_SIZE as isize),
+        KeyCode::Enter | KeyCode::Tab => PaletteAction::Select,
+        KeyCode::Backspace => PaletteAction::Backspace,
+        KeyCode::Char(character)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+        {
+            PaletteAction::Type(character)
+        }
+        _ => PaletteAction::Ignore,
+    }
+}
+
+impl PaletteState {
+    fn replace_results(&mut self, query: stasis_runner::live::CompletionQuery) {
+        self.items = query.items;
+        self.selected = 0;
+        self.truncated = query.truncated;
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.items.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        self.selected = self
+            .selected
+            .saturating_add_signed(delta)
+            .min(self.items.len() - 1);
+    }
+}
+
+struct PaletteTerminalGuard;
+
+impl PaletteTerminalGuard {
+    fn enter() -> Result<Self, String> {
+        enable_raw_mode().map_err(|error| format!("failed enabling palette input: {error}"))?;
+        if let Err(error) = execute!(io::stdout(), EnterAlternateScreen, Hide) {
+            let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            return Err(format!("failed opening palette screen: {error}"));
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for PaletteTerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+    }
+}
+
+fn run_live_palette(
+    helper: &LiveLineHelper,
+    open: PaletteOpen,
+) -> Result<(String, String), String> {
+    let initial = helper.query(&open.line, open.cursor, 64)?;
+    let replacement_start = initial.replacement_start;
+    let replacement_end = initial.replacement_end;
+    let mut state = PaletteState {
+        query: open.line[replacement_start..replacement_end].to_string(),
+        items: initial.items,
+        selected: 0,
+        truncated: initial.truncated,
+    };
+    let _guard = PaletteTerminalGuard::enter()?;
+    loop {
+        render_live_palette(&state)?;
+        let TerminalEvent::Key(key) =
+            event::read().map_err(|error| format!("failed reading palette input: {error}"))?
+        else {
+            continue;
+        };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        match palette_action(key) {
+            PaletteAction::Cancel => {
+                return Ok(split_palette_line(&open.line, open.cursor));
+            }
+            PaletteAction::Move(delta) => state.move_selection(delta),
+            PaletteAction::Select => {
+                if let Some(item) = state.items.get(state.selected) {
+                    return Ok(insert_palette_selection(
+                        &open.line,
+                        replacement_start,
+                        replacement_end,
+                        &item.text,
+                    ));
+                }
+            }
+            PaletteAction::Backspace => {
+                state.query.pop();
+                let query = query_live_palette(
+                    helper,
+                    &open.line,
+                    replacement_start,
+                    replacement_end,
+                    &state.query,
+                )?;
+                state.replace_results(query);
+            }
+            PaletteAction::Type(character) => {
+                state.query.push(character);
+                let query = query_live_palette(
+                    helper,
+                    &open.line,
+                    replacement_start,
+                    replacement_end,
+                    &state.query,
+                )?;
+                state.replace_results(query);
+            }
+            PaletteAction::Ignore => {}
+        }
+    }
+}
+
+fn query_live_palette(
+    helper: &LiveLineHelper,
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    query: &str,
+) -> Result<stasis_runner::live::CompletionQuery, String> {
+    let (line, cursor) = palette_query_input(line, replacement_start, replacement_end, query);
+    helper.query(&line, cursor, 64)
+}
+
+fn palette_query_input(
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    query: &str,
+) -> (String, usize) {
+    let mut line = line.to_string();
+    line.replace_range(replacement_start..replacement_end, query);
+    (line, replacement_start + query.len())
+}
+
+fn split_palette_line(line: &str, cursor: usize) -> (String, String) {
+    (line[..cursor].to_string(), line[cursor..].to_string())
+}
+
+fn insert_palette_selection(
+    line: &str,
+    replacement_start: usize,
+    replacement_end: usize,
+    selection: &str,
+) -> (String, String) {
+    let mut line = line.to_string();
+    line.replace_range(replacement_start..replacement_end, selection);
+    split_palette_line(&line, replacement_start + selection.len())
+}
+
+fn render_live_palette(state: &PaletteState) -> Result<(), String> {
+    let mut stdout = io::stdout();
+    let width = crossterm::terminal::size()
+        .map(|(width, _)| width as usize)
+        .unwrap_or(80)
+        .max(20);
+    execute!(
+        stdout,
+        MoveTo(0, 0),
+        Clear(ClearType::All),
+        Print(terminal_line("Stasis command palette", width)),
+        Print("\r\n"),
+        Print(terminal_line(&format!("> {}", state.query), width)),
+        Print("\r\n\r\n")
+    )
+    .map_err(|error| format!("failed drawing palette: {error}"))?;
+    let page_start = (state.selected / PALETTE_PAGE_SIZE) * PALETTE_PAGE_SIZE;
+    for index in page_start..page_start + PALETTE_PAGE_SIZE {
+        let line = state.items.get(index).map_or_else(String::new, |item| {
+            format!(
+                "{} {}  [{}]  {}",
+                if index == state.selected { ">" } else { " " },
+                item.text,
+                item.kind,
+                item.detail
+            )
+        });
+        execute!(stdout, Print(terminal_line(&line, width)), Print("\r\n"))
+            .map_err(|error| format!("failed drawing palette row: {error}"))?;
+    }
+    let more = if state.truncated {
+        " | more matches; keep typing"
+    } else {
+        ""
+    };
+    execute!(
+        stdout,
+        Print("\r\n"),
+        Print(terminal_line(
+            &format!(
+                "{} match(es){} | arrows/page select | Enter/Tab insert | Esc cancel",
+                state.items.len(),
+                more
+            ),
+            width
+        ))
+    )
+    .map_err(|error| format!("failed drawing palette footer: {error}"))?;
+    stdout
+        .flush()
+        .map_err(|error| format!("failed flushing palette: {error}"))
+}
+
+fn terminal_line(text: &str, width: usize) -> String {
+    text.chars().take(width.saturating_sub(1)).collect()
 }
 
 fn run_live_terminal(
@@ -960,20 +1296,31 @@ fn run_live_terminal_inner(
             );
         }
     } else {
-        println!("Stasis live workspace (:help, :quit, Tab completion, Ctrl-C cancels multiline)");
-        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::new()
+        println!(
+            "Stasis live workspace (:help, :quit, Ctrl-P palette, Tab completes, Ctrl-C cancels multiline)"
+        );
+        let config = live_editor_config();
+        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::with_config(config)
             .map_err(|error| format!("failed initializing live line editor: {error}"))?;
-        editor.set_helper(Some(LiveLineHelper { items: Vec::new() }));
+        let palette_pending = Arc::new(Mutex::new(None));
+        editor.bind_sequence(
+            live_palette_key(),
+            EventHandler::Conditional(Box::new(PaletteTrigger {
+                pending: Arc::clone(&palette_pending),
+            })),
+        );
+        editor.set_helper(Some(LiveLineHelper::new(client.clone())));
         let mut prompt = "stasis> ";
-        let mut completion_request_id = 1u64 << 63;
+        let mut initial = None::<(String, String)>;
         loop {
-            if let Ok(items) = fetch_live_completions(client, completion_request_id, json_lines) {
-                if let Some(helper) = editor.helper_mut() {
-                    helper.items = items;
-                }
+            if let Some(helper) = editor.helper() {
+                helper.set_context(terminal.completion_context());
             }
-            completion_request_id = completion_request_id.saturating_add(1);
-            let line = match editor.readline(prompt) {
+            let readline = match initial.take() {
+                Some((left, right)) => editor.readline_with_initial(prompt, (&left, &right)),
+                None => editor.readline(prompt),
+            };
+            let line = match readline {
                 Ok(line) => line,
                 Err(rustyline::error::ReadlineError::Interrupted) => {
                     if terminal.cancel_pending() {
@@ -985,6 +1332,17 @@ fn run_live_terminal_inner(
                 Err(rustyline::error::ReadlineError::Eof) => break,
                 Err(error) => return Err(format!("failed reading live terminal: {error}")),
             };
+            let palette_open = palette_pending.lock().expect("palette trigger lock").take();
+            if let Some(open) = palette_open {
+                let helper = editor.helper().expect("live line helper");
+                initial = Some(run_live_palette(helper, open)?);
+                continue;
+            }
+            if let Some(helper) = editor.helper() {
+                for response in helper.take_deferred_responses() {
+                    print_live_response(&response, json_lines)?;
+                }
+            }
             let _ = editor.add_history_entry(line.as_str());
             match terminal.feed_line(&line)? {
                 TerminalInput::Continue { prompt: next } => {
@@ -1016,23 +1374,42 @@ fn run_live_terminal_inner(
     }
 }
 
-fn fetch_live_completions(
-    client: &stasis_runner::live::LiveSessionClient,
+fn live_palette_key() -> LineKeyEvent {
+    LineKeyEvent::ctrl('P')
+}
+
+fn live_editor_config() -> Config {
+    Config::builder()
+        .completion_type(CompletionType::List)
+        .completion_prompt_limit(256)
+        .build()
+}
+
+fn fetch_live_completion_query(
+    client: &LiveSessionClient,
     request_id: u64,
-    json_lines: bool,
-) -> Result<Vec<CompletionItem>, String> {
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: CompletionContext,
+    deferred_responses: &Mutex<Vec<LiveResponse>>,
+) -> Result<stasis_runner::live::CompletionQuery, String> {
     client.submit(LiveRequest::new(
         request_id,
         LiveCommand::Complete {
-            buffer: String::new(),
-            cursor: 0,
-            limit: 256,
+            buffer: buffer.to_string(),
+            cursor,
+            limit,
+            context,
         },
     ))?;
     loop {
         let response = client.receive_timeout(Duration::from_secs(5))?;
         if response.request_id != request_id {
-            print_live_response(&response, json_lines)?;
+            deferred_responses
+                .lock()
+                .expect("deferred response lock")
+                .push(response);
             continue;
         }
         if !response.ok {
@@ -1040,13 +1417,11 @@ fn fetch_live_completions(
                 .error
                 .unwrap_or_else(|| "live completion failed".to_string()));
         }
-        return serde_json::from_value(
-            response
-                .data
-                .and_then(|data| data.get("items").cloned())
-                .unwrap_or_else(|| json!([])),
-        )
-        .map_err(|error| format!("invalid live completion response: {error}"));
+        if response.truncated {
+            return Err("live completion response exceeded the protocol output bound".to_string());
+        }
+        return serde_json::from_value(response.data.unwrap_or(Value::Null))
+            .map_err(|error| format!("invalid live completion response: {error}"));
     }
 }
 
@@ -1119,7 +1494,10 @@ fn format_live_response(response: &LiveResponse) -> String {
         ),
         "symbols" => format_live_symbols(data),
         "symbol" => format_live_symbol(data),
-        "completion" => format_live_completion(data),
+        "completion" | "palette" if response.truncated => {
+            "completion response exceeded the output bound; narrow the query".to_string()
+        }
+        "completion" | "palette" => format_live_completion(data),
         "inspection" => format!(
             "{}: {} = {}",
             string_field(data, "path", "value"),
@@ -1311,6 +1689,13 @@ fn format_live_completion(data: &Value) -> String {
                 string_field(item, "detail", "")
             ));
         }
+    }
+    if data
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        lines.push("... more matches; keep typing".to_string());
     }
     if lines.is_empty() {
         "no completions".to_string()
@@ -2584,22 +2969,110 @@ mod tests {
     use super::*;
 
     #[test]
-    fn live_line_helper_completes_current_token_with_compiler_detail() {
-        let helper = LiveLineHelper {
-            items: vec![CompletionItem {
-                text: "tick".into(),
-                kind: "function".into(),
-                detail: "tick(): i32".into(),
-            }],
+    fn live_palette_formats_compiler_detail_concisely() {
+        let display = format_completion_candidate(&CompletionItem {
+            text: "tick".into(),
+            kind: "function".into(),
+            detail: "tick(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: None,
+        });
+        assert_eq!(display, "tick  [function]  tick(): i32");
+    }
+
+    #[test]
+    fn live_palette_state_navigates_pages_and_preserves_cancel_buffer() {
+        let mut state = PaletteState {
+            query: "hero".into(),
+            items: (0..20)
+                .map(|index| CompletionItem {
+                    text: format!("hero.field_{index}"),
+                    kind: "field".into(),
+                    detail: "i32".into(),
+                    type_name: Some("i32".into()),
+                    source: Some("src/main.stasis".into()),
+                    scope: None,
+                })
+                .collect(),
+            selected: 0,
+            truncated: false,
         };
-        let history = DefaultHistory::new();
-        let context = Context::new(&history);
-        let (start, matches) = helper
-            .complete(":read ti", 8, &context)
-            .expect("completion");
-        assert_eq!(start, 6);
-        assert_eq!(matches[0].replacement, "tick");
-        assert!(matches[0].display.contains("tick(): i32"));
+        state.move_selection(PALETTE_PAGE_SIZE as isize);
+        assert_eq!(live_palette_key(), LineKeyEvent::ctrl('P'));
+        assert_eq!(live_editor_config().completion_type(), CompletionType::List);
+        assert_eq!(state.selected, PALETTE_PAGE_SIZE);
+        state.move_selection(-1);
+        assert_eq!(state.selected, PALETTE_PAGE_SIZE - 1);
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            PaletteAction::Move(PALETTE_PAGE_SIZE as isize)
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::NONE
+            )),
+            PaletteAction::Type('x')
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(
+                KeyCode::Backspace,
+                KeyModifiers::NONE
+            )),
+            PaletteAction::Backspace
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            PaletteAction::Select
+        );
+        assert_eq!(
+            palette_action(TerminalKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            PaletteAction::Cancel
+        );
+        assert_eq!(
+            insert_palette_selection("call(hrohp)", 5, 10, "hero.hp"),
+            ("call(hero.hp".to_string(), ")".to_string())
+        );
+        assert_eq!(
+            split_palette_line("call(hero)", 9),
+            ("call(hero".to_string(), ")".to_string())
+        );
+        assert_eq!(
+            palette_query_input("let next: i32 = he", 16, 18, "hero.hp"),
+            ("let next: i32 = hero.hp".to_string(), 23)
+        );
+    }
+
+    #[test]
+    fn human_palette_output_reports_bounded_truncation() {
+        let response = LiveResponse::success(
+            9,
+            44,
+            "palette",
+            json!({
+                "replacement_start": 0,
+                "replacement_end": 2,
+                "page": 0,
+                "truncated": true,
+                "items": [{"text": "tick", "kind": "function", "detail": "tick(): i32"}]
+            }),
+        );
+        assert_eq!(
+            format_live_response(&response),
+            "tick  function  tick(): i32\n... more matches; keep typing"
+        );
+        let bounded = LiveResponse::success(
+            10,
+            45,
+            "palette",
+            json!({"items": [{"text": "x".repeat(1024), "kind": "function", "detail": "x"}]}),
+        )
+        .bounded(256);
+        assert_eq!(
+            format_live_response(&bounded),
+            "completion response exceeded the output bound; narrow the query"
+        );
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1344,7 +1344,14 @@ fn run_live_terminal_inner(
                 }
             }
             let _ = editor.add_history_entry(line.as_str());
-            match terminal.feed_line(&line)? {
+            let input = match terminal.feed_line(&line) {
+                Ok(input) => input,
+                Err(error) => {
+                    eprintln!("error: {error}");
+                    continue;
+                }
+            };
+            match input {
                 TerminalInput::Continue { prompt: next } => {
                     prompt = next;
                     continue;
@@ -3042,6 +3049,22 @@ mod tests {
             palette_query_input("let next: i32 = he", 16, 18, "hero.hp"),
             ("let next: i32 = hero.hp".to_string(), 23)
         );
+    }
+
+    #[test]
+    fn invalid_interactive_command_does_not_poison_terminal_buffer() {
+        let mut terminal = TerminalBuffer::new();
+        assert_eq!(
+            terminal.feed_line("view render"),
+            Err("unknown live command 'view'; use :help".to_string())
+        );
+        let TerminalInput::Request(request) = terminal
+            .feed_line(":status")
+            .expect("valid command after invalid input")
+        else {
+            panic!("expected status request")
+        };
+        assert_eq!(request.command, LiveCommand::Status);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1,22 +1,4 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use crossterm::cursor::{Hide, MoveTo, Show};
-use crossterm::event::{
-    self, Event as TerminalEvent, KeyCode, KeyEvent as TerminalKeyEvent, KeyEventKind, KeyModifiers,
-};
-use crossterm::execute;
-use crossterm::style::Print;
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
-};
-use rustyline::completion::{Completer, Pair};
-use rustyline::highlight::Highlighter;
-use rustyline::hint::Hinter;
-use rustyline::history::DefaultHistory;
-use rustyline::validate::Validator;
-use rustyline::{
-    Cmd, CompletionType, ConditionalEventHandler, Config, Context, Editor, Event as LineEvent,
-    EventContext, EventHandler, Helper, KeyEvent as LineKeyEvent, RepeatCount,
-};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use stasis::{
@@ -24,7 +6,6 @@ use stasis::{
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
-use stasis_compiler::frontend::parser::completion_expected_type;
 use stasis_compiler::frontend::workshop::{
     find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
     workshop_reachable_files, workshop_source_hash, workshop_source_items,
@@ -33,19 +14,18 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    live_session, CompletionContext, CompletionItem, LiveCommand, LiveRequest, LiveResponse,
-    LiveSessionClient, TerminalBuffer, TerminalInput,
+    live_session, LiveCommand, LiveRequest, LiveResponse, TerminalBuffer, TerminalInput,
 };
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+
+mod live_tui;
 
 const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
@@ -891,370 +871,6 @@ fn run_workspace_live(
     ))
 }
 
-struct LiveLineHelper {
-    client: LiveSessionClient,
-    next_request_id: AtomicU64,
-    context: Mutex<CompletionContext>,
-    deferred_responses: Mutex<Vec<LiveResponse>>,
-}
-
-impl LiveLineHelper {
-    fn new(client: LiveSessionClient) -> Self {
-        Self {
-            client,
-            next_request_id: AtomicU64::new(1u64 << 63),
-            context: Mutex::new(CompletionContext::default()),
-            deferred_responses: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn set_context(&self, context: CompletionContext) {
-        *self.context.lock().expect("completion context lock") = context;
-    }
-
-    fn take_deferred_responses(&self) -> Vec<LiveResponse> {
-        std::mem::take(
-            &mut *self
-                .deferred_responses
-                .lock()
-                .expect("deferred response lock"),
-        )
-    }
-
-    fn query(
-        &self,
-        line: &str,
-        position: usize,
-        limit: usize,
-    ) -> Result<stasis_runner::live::CompletionQuery, String> {
-        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
-        let mut context = self
-            .context
-            .lock()
-            .expect("completion context lock")
-            .clone();
-        if context.expected_type.is_none() {
-            context.expected_type = completion_expected_type(line, position).unwrap_or_default();
-        }
-        fetch_live_completion_query(
-            &self.client,
-            request_id,
-            line,
-            position,
-            limit,
-            context,
-            &self.deferred_responses,
-        )
-    }
-}
-
-impl Helper for LiveLineHelper {}
-impl Highlighter for LiveLineHelper {}
-impl Validator for LiveLineHelper {}
-impl Hinter for LiveLineHelper {
-    type Hint = String;
-}
-
-impl Completer for LiveLineHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        position: usize,
-        _context: &Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        let query = self
-            .query(line, position, 64)
-            .map_err(|error| rustyline::error::ReadlineError::Io(io::Error::other(error)))?;
-        let candidates = query
-            .items
-            .into_iter()
-            .map(|item| Pair {
-                display: format_completion_candidate(&item),
-                replacement: item.text,
-            })
-            .collect();
-        Ok((query.replacement_start, candidates))
-    }
-}
-
-fn format_completion_candidate(item: &CompletionItem) -> String {
-    let mut detail = item.detail.replace(['\r', '\n'], " ");
-    if detail.chars().count() > 48 {
-        detail = detail.chars().take(45).collect::<String>() + "...";
-    }
-    format!("{}  [{}]  {}", item.text, item.kind, detail)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PaletteOpen {
-    line: String,
-    cursor: usize,
-}
-
-struct PaletteTrigger {
-    pending: Arc<Mutex<Option<PaletteOpen>>>,
-}
-
-impl ConditionalEventHandler for PaletteTrigger {
-    fn handle(
-        &self,
-        _event: &LineEvent,
-        _repeat: RepeatCount,
-        _positive: bool,
-        context: &EventContext<'_>,
-    ) -> Option<Cmd> {
-        *self.pending.lock().expect("palette trigger lock") = Some(PaletteOpen {
-            line: context.line().to_string(),
-            cursor: context.pos(),
-        });
-        Some(Cmd::AcceptLine)
-    }
-}
-
-const PALETTE_PAGE_SIZE: usize = 8;
-
-struct PaletteState {
-    query: String,
-    items: Vec<CompletionItem>,
-    selected: usize,
-    truncated: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PaletteAction {
-    Cancel,
-    Move(isize),
-    Select,
-    Backspace,
-    Type(char),
-    Ignore,
-}
-
-fn palette_action(key: TerminalKeyEvent) -> PaletteAction {
-    match key.code {
-        KeyCode::Esc => PaletteAction::Cancel,
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            PaletteAction::Cancel
-        }
-        KeyCode::Up => PaletteAction::Move(-1),
-        KeyCode::Down => PaletteAction::Move(1),
-        KeyCode::PageUp => PaletteAction::Move(-(PALETTE_PAGE_SIZE as isize)),
-        KeyCode::PageDown => PaletteAction::Move(PALETTE_PAGE_SIZE as isize),
-        KeyCode::Enter | KeyCode::Tab => PaletteAction::Select,
-        KeyCode::Backspace => PaletteAction::Backspace,
-        KeyCode::Char(character)
-            if !key
-                .modifiers
-                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
-        {
-            PaletteAction::Type(character)
-        }
-        _ => PaletteAction::Ignore,
-    }
-}
-
-impl PaletteState {
-    fn replace_results(&mut self, query: stasis_runner::live::CompletionQuery) {
-        self.items = query.items;
-        self.selected = 0;
-        self.truncated = query.truncated;
-    }
-
-    fn move_selection(&mut self, delta: isize) {
-        if self.items.is_empty() {
-            self.selected = 0;
-            return;
-        }
-        self.selected = self
-            .selected
-            .saturating_add_signed(delta)
-            .min(self.items.len() - 1);
-    }
-}
-
-struct PaletteTerminalGuard;
-
-impl PaletteTerminalGuard {
-    fn enter() -> Result<Self, String> {
-        enable_raw_mode().map_err(|error| format!("failed enabling palette input: {error}"))?;
-        if let Err(error) = execute!(io::stdout(), EnterAlternateScreen, Hide) {
-            let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
-            let _ = disable_raw_mode();
-            return Err(format!("failed opening palette screen: {error}"));
-        }
-        Ok(Self)
-    }
-}
-
-impl Drop for PaletteTerminalGuard {
-    fn drop(&mut self) {
-        let _ = execute!(io::stdout(), Show, LeaveAlternateScreen);
-        let _ = disable_raw_mode();
-    }
-}
-
-fn run_live_palette(
-    helper: &LiveLineHelper,
-    open: PaletteOpen,
-) -> Result<(String, String), String> {
-    let initial = helper.query(&open.line, open.cursor, 64)?;
-    let replacement_start = initial.replacement_start;
-    let replacement_end = initial.replacement_end;
-    let mut state = PaletteState {
-        query: open.line[replacement_start..replacement_end].to_string(),
-        items: initial.items,
-        selected: 0,
-        truncated: initial.truncated,
-    };
-    let _guard = PaletteTerminalGuard::enter()?;
-    loop {
-        render_live_palette(&state)?;
-        let TerminalEvent::Key(key) =
-            event::read().map_err(|error| format!("failed reading palette input: {error}"))?
-        else {
-            continue;
-        };
-        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
-            continue;
-        }
-        match palette_action(key) {
-            PaletteAction::Cancel => {
-                return Ok(split_palette_line(&open.line, open.cursor));
-            }
-            PaletteAction::Move(delta) => state.move_selection(delta),
-            PaletteAction::Select => {
-                if let Some(item) = state.items.get(state.selected) {
-                    return Ok(insert_palette_selection(
-                        &open.line,
-                        replacement_start,
-                        replacement_end,
-                        &item.text,
-                    ));
-                }
-            }
-            PaletteAction::Backspace => {
-                state.query.pop();
-                let query = query_live_palette(
-                    helper,
-                    &open.line,
-                    replacement_start,
-                    replacement_end,
-                    &state.query,
-                )?;
-                state.replace_results(query);
-            }
-            PaletteAction::Type(character) => {
-                state.query.push(character);
-                let query = query_live_palette(
-                    helper,
-                    &open.line,
-                    replacement_start,
-                    replacement_end,
-                    &state.query,
-                )?;
-                state.replace_results(query);
-            }
-            PaletteAction::Ignore => {}
-        }
-    }
-}
-
-fn query_live_palette(
-    helper: &LiveLineHelper,
-    line: &str,
-    replacement_start: usize,
-    replacement_end: usize,
-    query: &str,
-) -> Result<stasis_runner::live::CompletionQuery, String> {
-    let (line, cursor) = palette_query_input(line, replacement_start, replacement_end, query);
-    helper.query(&line, cursor, 64)
-}
-
-fn palette_query_input(
-    line: &str,
-    replacement_start: usize,
-    replacement_end: usize,
-    query: &str,
-) -> (String, usize) {
-    let mut line = line.to_string();
-    line.replace_range(replacement_start..replacement_end, query);
-    (line, replacement_start + query.len())
-}
-
-fn split_palette_line(line: &str, cursor: usize) -> (String, String) {
-    (line[..cursor].to_string(), line[cursor..].to_string())
-}
-
-fn insert_palette_selection(
-    line: &str,
-    replacement_start: usize,
-    replacement_end: usize,
-    selection: &str,
-) -> (String, String) {
-    let mut line = line.to_string();
-    line.replace_range(replacement_start..replacement_end, selection);
-    split_palette_line(&line, replacement_start + selection.len())
-}
-
-fn render_live_palette(state: &PaletteState) -> Result<(), String> {
-    let mut stdout = io::stdout();
-    let width = crossterm::terminal::size()
-        .map(|(width, _)| width as usize)
-        .unwrap_or(80)
-        .max(20);
-    execute!(
-        stdout,
-        MoveTo(0, 0),
-        Clear(ClearType::All),
-        Print(terminal_line("Stasis command palette", width)),
-        Print("\r\n"),
-        Print(terminal_line(&format!("> {}", state.query), width)),
-        Print("\r\n\r\n")
-    )
-    .map_err(|error| format!("failed drawing palette: {error}"))?;
-    let page_start = (state.selected / PALETTE_PAGE_SIZE) * PALETTE_PAGE_SIZE;
-    for index in page_start..page_start + PALETTE_PAGE_SIZE {
-        let line = state.items.get(index).map_or_else(String::new, |item| {
-            format!(
-                "{} {}  [{}]  {}",
-                if index == state.selected { ">" } else { " " },
-                item.text,
-                item.kind,
-                item.detail
-            )
-        });
-        execute!(stdout, Print(terminal_line(&line, width)), Print("\r\n"))
-            .map_err(|error| format!("failed drawing palette row: {error}"))?;
-    }
-    let more = if state.truncated {
-        " | more matches; keep typing"
-    } else {
-        ""
-    };
-    execute!(
-        stdout,
-        Print("\r\n"),
-        Print(terminal_line(
-            &format!(
-                "{} match(es){} | arrows/page select | Enter/Tab insert | Esc cancel",
-                state.items.len(),
-                more
-            ),
-            width
-        ))
-    )
-    .map_err(|error| format!("failed drawing palette footer: {error}"))?;
-    stdout
-        .flush()
-        .map_err(|error| format!("failed flushing palette: {error}"))
-}
-
-fn terminal_line(text: &str, width: usize) -> String {
-    text.chars().take(width.saturating_sub(1)).collect()
-}
-
 fn run_live_terminal(
     client: stasis_runner::live::LiveSessionClient,
     script: Option<&Path>,
@@ -1296,76 +912,7 @@ fn run_live_terminal_inner(
             );
         }
     } else {
-        println!(
-            "Stasis live workspace (:help, :quit, Ctrl-P palette, Tab completes, Ctrl-C cancels multiline)"
-        );
-        let config = live_editor_config();
-        let mut editor = Editor::<LiveLineHelper, DefaultHistory>::with_config(config)
-            .map_err(|error| format!("failed initializing live line editor: {error}"))?;
-        let palette_pending = Arc::new(Mutex::new(None));
-        editor.bind_sequence(
-            live_palette_key(),
-            EventHandler::Conditional(Box::new(PaletteTrigger {
-                pending: Arc::clone(&palette_pending),
-            })),
-        );
-        editor.set_helper(Some(LiveLineHelper::new(client.clone())));
-        let mut prompt = "stasis> ";
-        let mut initial = None::<(String, String)>;
-        loop {
-            if let Some(helper) = editor.helper() {
-                helper.set_context(terminal.completion_context());
-            }
-            let readline = match initial.take() {
-                Some((left, right)) => editor.readline_with_initial(prompt, (&left, &right)),
-                None => editor.readline(prompt),
-            };
-            let line = match readline {
-                Ok(line) => line,
-                Err(rustyline::error::ReadlineError::Interrupted) => {
-                    if terminal.cancel_pending() {
-                        println!("multiline command canceled");
-                        prompt = "stasis> ";
-                    }
-                    continue;
-                }
-                Err(rustyline::error::ReadlineError::Eof) => break,
-                Err(error) => return Err(format!("failed reading live terminal: {error}")),
-            };
-            let palette_open = palette_pending.lock().expect("palette trigger lock").take();
-            if let Some(open) = palette_open {
-                let helper = editor.helper().expect("live line helper");
-                initial = Some(run_live_palette(helper, open)?);
-                continue;
-            }
-            if let Some(helper) = editor.helper() {
-                for response in helper.take_deferred_responses() {
-                    print_live_response(&response, json_lines)?;
-                }
-            }
-            let _ = editor.add_history_entry(line.as_str());
-            let input = match terminal.feed_line(&line) {
-                Ok(input) => input,
-                Err(error) => {
-                    eprintln!("error: {error}");
-                    continue;
-                }
-            };
-            match input {
-                TerminalInput::Continue { prompt: next } => {
-                    prompt = next;
-                    continue;
-                }
-                TerminalInput::Request(request) => {
-                    prompt = "stasis> ";
-                    saw_quit |= matches!(&request.command, LiveCommand::Quit);
-                    submit_and_print_live_response(client, request, json_lines, false)?;
-                    if saw_quit {
-                        break;
-                    }
-                }
-            }
-        }
+        saw_quit = live_tui::run(client)?;
     }
     if !saw_quit {
         submit_and_print_live_response(
@@ -1378,57 +925,6 @@ fn run_live_terminal_inner(
     match script_failure {
         Some(error) => Err(error),
         None => Ok(()),
-    }
-}
-
-fn live_palette_key() -> LineKeyEvent {
-    LineKeyEvent::ctrl('P')
-}
-
-fn live_editor_config() -> Config {
-    Config::builder()
-        .completion_type(CompletionType::List)
-        .completion_prompt_limit(256)
-        .build()
-}
-
-fn fetch_live_completion_query(
-    client: &LiveSessionClient,
-    request_id: u64,
-    buffer: &str,
-    cursor: usize,
-    limit: usize,
-    context: CompletionContext,
-    deferred_responses: &Mutex<Vec<LiveResponse>>,
-) -> Result<stasis_runner::live::CompletionQuery, String> {
-    client.submit(LiveRequest::new(
-        request_id,
-        LiveCommand::Complete {
-            buffer: buffer.to_string(),
-            cursor,
-            limit,
-            context,
-        },
-    ))?;
-    loop {
-        let response = client.receive_timeout(Duration::from_secs(5))?;
-        if response.request_id != request_id {
-            deferred_responses
-                .lock()
-                .expect("deferred response lock")
-                .push(response);
-            continue;
-        }
-        if !response.ok {
-            return Err(response
-                .error
-                .unwrap_or_else(|| "live completion failed".to_string()));
-        }
-        if response.truncated {
-            return Err("live completion response exceeded the protocol output bound".to_string());
-        }
-        return serde_json::from_value(response.data.unwrap_or(Value::Null))
-            .map_err(|error| format!("invalid live completion response: {error}"));
     }
 }
 
@@ -1445,7 +941,12 @@ fn submit_and_print_live_response(
         let request_succeeded = response.ok;
         print_live_response(&response, json_lines)?;
         if response.request_id == request_id {
-            if wait_for_preparation && response.kind == "edit_preparing" {
+            if wait_for_preparation
+                && matches!(
+                    response.kind.as_str(),
+                    "edit_preparing" | "completion_preparing"
+                )
+            {
                 continue;
             }
             return Ok(request_succeeded);
@@ -1511,6 +1012,19 @@ fn format_live_response(response: &LiveResponse) -> String {
             string_field(data, "static_type", "unknown"),
             scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
+        "state_inspection" => format!(
+            "{} live state value(s){}",
+            data.get("total").and_then(Value::as_u64).unwrap_or(0),
+            if data
+                .get("truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                " (view bounded)"
+            } else {
+                ""
+            }
+        ),
         "print" => format!(
             "{} = {}",
             string_field(data, "static_type", "value"),
@@ -1526,6 +1040,27 @@ fn format_live_response(response: &LiveResponse) -> String {
             string_field(data, "path", "value"),
             scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
+        "track_started" => format!(
+            "tracking {} for {} tick(s) (~{} at 60 Hz)",
+            string_field(data, "path", "value"),
+            data.get("ticks").and_then(Value::as_u64).unwrap_or(0),
+            approximate_tick_duration(data.get("ticks").and_then(Value::as_u64).unwrap_or(0))
+        ),
+        "track_progress" => format_live_track(data, false),
+        "track_complete" => format_live_track(data, true),
+        "track_failed" => format!(
+            "track {} failed: {}",
+            string_field(data, "path", "value"),
+            string_field(data, "error", "unknown error")
+        ),
+        "track_removed" => {
+            let tracks = string_array(data.get("tracks"));
+            if tracks.is_empty() {
+                "no active traces".to_string()
+            } else {
+                format!("active traces: {tracks}")
+            }
+        }
         "watch_removed" => format_live_watch_removed(data),
         "watch_backpressure" => format!(
             "watch output dropped {} event(s)",
@@ -1584,6 +1119,76 @@ fn scalar_text(value: &Value) -> String {
     }
 }
 
+fn format_live_track(data: &Value, complete: bool) -> String {
+    let path = string_field(data, "path", "value");
+    let count = data
+        .get("sample_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total = data.get("total_ticks").and_then(Value::as_u64).unwrap_or(0);
+    let latest = scalar_text(data.get("latest").unwrap_or(&Value::Null));
+    let dropped = data
+        .get("dropped_updates")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let shape = format_track_shape(data.get("samples"));
+    format!(
+        "{}{}: {count}/{total} (~{} at 60 Hz), latest {latest}{}{}",
+        if complete { "trace complete " } else { "" },
+        path,
+        approximate_tick_duration(total),
+        shape,
+        if dropped > 0 {
+            format!(", {dropped} UI update(s) dropped")
+        } else {
+            String::new()
+        }
+    )
+}
+
+fn format_track_shape(samples: Option<&Value>) -> String {
+    let values = samples
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|sample| {
+            let value = sample.get("value").unwrap_or(sample);
+            value
+                .as_f64()
+                .or_else(|| value.as_bool().map(|value| f64::from(u8::from(value))))
+        })
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return String::new();
+    }
+    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let changes = values
+        .windows(2)
+        .filter(|window| window[0] != window[1])
+        .count();
+    let levels = ['.', ':', '-', '=', '+', '*', '#'];
+    let trend = values
+        .iter()
+        .rev()
+        .take(24)
+        .rev()
+        .map(|value| {
+            if max == min {
+                '-'
+            } else {
+                let normalized = (value - min) / (max - min);
+                levels[(normalized * (levels.len() - 1) as f64).round() as usize]
+            }
+        })
+        .collect::<String>();
+    format!(", range {min:.3}..{max:.3}, {changes} change(s), trend {trend}")
+}
+
+fn approximate_tick_duration(ticks: u64) -> String {
+    format!("{:.1}s", ticks as f64 / 60.0)
+}
+
 fn format_live_help(data: &Value) -> String {
     let commands = data
         .get("commands")
@@ -1620,6 +1225,7 @@ fn format_live_status(data: &Value) -> String {
         .and_then(Value::as_u64)
         .unwrap_or(0);
     let watches = string_array(data.get("watches"));
+    let tracks = string_array(data.get("tracks"));
     let cells = data
         .get("scratch_cells")
         .and_then(Value::as_array)
@@ -1634,6 +1240,9 @@ fn format_live_status(data: &Value) -> String {
     let mut line = format!("{state} | edits {cursor}/{history}");
     if !watches.is_empty() {
         line.push_str(&format!(" | watches {watches}"));
+    }
+    if !tracks.is_empty() {
+        line.push_str(&format!(" | traces {tracks}"));
     }
     if !cells.is_empty() {
         line.push_str(&format!(" | cells {cells}"));
@@ -2974,82 +2583,6 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn live_palette_formats_compiler_detail_concisely() {
-        let display = format_completion_candidate(&CompletionItem {
-            text: "tick".into(),
-            kind: "function".into(),
-            detail: "tick(): i32".into(),
-            type_name: Some("i32".into()),
-            source: Some("src/main.stasis".into()),
-            scope: None,
-        });
-        assert_eq!(display, "tick  [function]  tick(): i32");
-    }
-
-    #[test]
-    fn live_palette_state_navigates_pages_and_preserves_cancel_buffer() {
-        let mut state = PaletteState {
-            query: "hero".into(),
-            items: (0..20)
-                .map(|index| CompletionItem {
-                    text: format!("hero.field_{index}"),
-                    kind: "field".into(),
-                    detail: "i32".into(),
-                    type_name: Some("i32".into()),
-                    source: Some("src/main.stasis".into()),
-                    scope: None,
-                })
-                .collect(),
-            selected: 0,
-            truncated: false,
-        };
-        state.move_selection(PALETTE_PAGE_SIZE as isize);
-        assert_eq!(live_palette_key(), LineKeyEvent::ctrl('P'));
-        assert_eq!(live_editor_config().completion_type(), CompletionType::List);
-        assert_eq!(state.selected, PALETTE_PAGE_SIZE);
-        state.move_selection(-1);
-        assert_eq!(state.selected, PALETTE_PAGE_SIZE - 1);
-        assert_eq!(
-            palette_action(TerminalKeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
-            PaletteAction::Move(PALETTE_PAGE_SIZE as isize)
-        );
-        assert_eq!(
-            palette_action(TerminalKeyEvent::new(
-                KeyCode::Char('x'),
-                KeyModifiers::NONE
-            )),
-            PaletteAction::Type('x')
-        );
-        assert_eq!(
-            palette_action(TerminalKeyEvent::new(
-                KeyCode::Backspace,
-                KeyModifiers::NONE
-            )),
-            PaletteAction::Backspace
-        );
-        assert_eq!(
-            palette_action(TerminalKeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
-            PaletteAction::Select
-        );
-        assert_eq!(
-            palette_action(TerminalKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
-            PaletteAction::Cancel
-        );
-        assert_eq!(
-            insert_palette_selection("call(hrohp)", 5, 10, "hero.hp"),
-            ("call(hero.hp".to_string(), ")".to_string())
-        );
-        assert_eq!(
-            split_palette_line("call(hero)", 9),
-            ("call(hero".to_string(), ")".to_string())
-        );
-        assert_eq!(
-            palette_query_input("let next: i32 = he", 16, 18, "hero.hp"),
-            ("let next: i32 = hero.hp".to_string(), 23)
-        );
-    }
 
     #[test]
     fn invalid_interactive_command_does_not_poison_terminal_buffer() {

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1,0 +1,2191 @@
+use super::{format_live_response, scalar_text};
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::queue;
+use crossterm::style::{Attribute, Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+use crossterm::terminal::{
+    self, disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, Clear, ClearType,
+    EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use serde_json::Value;
+use stasis_compiler::frontend::parser::completion_expected_type;
+use stasis_compiler::frontend::workshop::{
+    workshop_source_hash, WorkshopSourceItem, WorkshopSourceItemKind,
+};
+use stasis_runner::live::{
+    CompletionContext, CompletionItem, CompletionQuery, LiveCommand, LiveEditOperation,
+    LiveRequest, LiveResponse, LiveSessionClient, LiveSymbolTarget, TerminalBuffer, TerminalInput,
+};
+use std::collections::{BTreeMap, VecDeque};
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
+
+const MAX_TRANSCRIPT_LINES: usize = 500;
+const MAX_UNDO_STATES: usize = 100;
+const COMPLETION_LIMIT: usize = 64;
+const TUI_REQUEST_START: u64 = 1u64 << 61;
+
+pub(super) fn run(client: &LiveSessionClient) -> Result<bool, String> {
+    let _guard = TerminalGuard::enter()?;
+    let mut app = LiveTui::new(client.clone());
+    app.request_default_inspection()?;
+    app.refresh_completion(false);
+    loop {
+        app.maybe_refresh_default_inspection()?;
+        app.drain_responses()?;
+        app.render()?;
+        if app.quit {
+            return Ok(true);
+        }
+        if !event::poll(Duration::from_millis(33))
+            .map_err(|error| format!("failed polling live TUI input: {error}"))?
+        {
+            continue;
+        }
+        match event::read().map_err(|error| format!("failed reading live TUI input: {error}"))? {
+            Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+                app.handle_key(key)?;
+            }
+            Event::Resize(_, _) => {}
+            _ => {}
+        }
+    }
+}
+
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> Result<Self, String> {
+        enable_raw_mode().map_err(|error| format!("failed enabling live TUI input: {error}"))?;
+        let mut stdout = io::stdout();
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide, Clear(ClearType::All)) {
+            let _ = execute!(stdout, Show, LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            return Err(format!("failed entering live TUI screen: {error}"));
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let mut stdout = io::stdout();
+        let _ = execute!(
+            stdout,
+            EndSynchronizedUpdate,
+            ResetColor,
+            SetAttribute(Attribute::Reset),
+            Show,
+            LeaveAlternateScreen
+        );
+        let _ = disable_raw_mode();
+    }
+}
+
+#[derive(Clone)]
+struct BufferSnapshot {
+    text: String,
+    cursor: usize,
+}
+
+#[derive(Default)]
+struct EditBuffer {
+    text: String,
+    cursor: usize,
+    selection_anchor: Option<usize>,
+    undo: Vec<BufferSnapshot>,
+    redo: Vec<BufferSnapshot>,
+    revision: u64,
+}
+
+impl EditBuffer {
+    fn from_text(text: String) -> Self {
+        let cursor = text.len();
+        Self {
+            text,
+            cursor,
+            ..Self::default()
+        }
+    }
+
+    fn snapshot(&self) -> BufferSnapshot {
+        BufferSnapshot {
+            text: self.text.clone(),
+            cursor: self.cursor,
+        }
+    }
+
+    fn remember(&mut self) {
+        self.undo.push(self.snapshot());
+        if self.undo.len() > MAX_UNDO_STATES {
+            self.undo.remove(0);
+        }
+        self.redo.clear();
+        self.revision = self.revision.saturating_add(1);
+    }
+
+    fn restore(&mut self, snapshot: BufferSnapshot) {
+        self.text = snapshot.text;
+        self.cursor = snapshot.cursor.min(self.text.len());
+        self.selection_anchor = None;
+        self.revision = self.revision.saturating_add(1);
+    }
+
+    fn undo(&mut self) {
+        if let Some(snapshot) = self.undo.pop() {
+            self.redo.push(self.snapshot());
+            self.restore(snapshot);
+        }
+    }
+
+    fn redo(&mut self) {
+        if let Some(snapshot) = self.redo.pop() {
+            self.undo.push(self.snapshot());
+            self.restore(snapshot);
+        }
+    }
+
+    fn selected_range(&self) -> Option<std::ops::Range<usize>> {
+        let anchor = self.selection_anchor?;
+        (anchor != self.cursor).then(|| anchor.min(self.cursor)..anchor.max(self.cursor))
+    }
+
+    fn selected_or_token(&self) -> String {
+        if let Some(range) = self.selected_range() {
+            return self.text[range].trim().to_string();
+        }
+        let is_token = |ch: char| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.');
+        let mut start = self.cursor;
+        while start > 0 {
+            let prior = previous_boundary(&self.text, start);
+            if !self.text[prior..start].chars().all(is_token) {
+                break;
+            }
+            start = prior;
+        }
+        let mut end = self.cursor;
+        while end < self.text.len() {
+            let next = next_boundary(&self.text, end);
+            if !self.text[end..next].chars().all(is_token) {
+                break;
+            }
+            end = next;
+        }
+        self.text[start..end].trim().to_string()
+    }
+
+    fn delete_selection(&mut self) -> bool {
+        let Some(range) = self.selected_range() else {
+            return false;
+        };
+        self.text.replace_range(range.clone(), "");
+        self.cursor = range.start;
+        self.selection_anchor = None;
+        true
+    }
+
+    fn insert_char(&mut self, ch: char) {
+        self.remember();
+        self.delete_selection();
+        self.text.insert(self.cursor, ch);
+        self.cursor += ch.len_utf8();
+    }
+
+    fn insert_newline(&mut self) {
+        self.remember();
+        self.delete_selection();
+        let line_start = self.text[..self.cursor]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        let line = &self.text[line_start..self.cursor];
+        let mut indent = line.chars().take_while(|ch| *ch == ' ').count();
+        if line.trim_end().ends_with('{') {
+            indent += 4;
+        }
+        let insertion = format!("\n{}", " ".repeat(indent));
+        self.text.insert_str(self.cursor, &insertion);
+        self.cursor += insertion.len();
+    }
+
+    fn backspace(&mut self) {
+        if self.cursor == 0 && self.selected_range().is_none() {
+            return;
+        }
+        self.remember();
+        if self.delete_selection() {
+            return;
+        }
+        let prior = previous_boundary(&self.text, self.cursor);
+        self.text.replace_range(prior..self.cursor, "");
+        self.cursor = prior;
+    }
+
+    fn delete(&mut self) {
+        if self.cursor == self.text.len() && self.selected_range().is_none() {
+            return;
+        }
+        self.remember();
+        if self.delete_selection() {
+            return;
+        }
+        let next = next_boundary(&self.text, self.cursor);
+        self.text.replace_range(self.cursor..next, "");
+    }
+
+    fn set_cursor(&mut self, cursor: usize, select: bool) {
+        if select {
+            self.selection_anchor.get_or_insert(self.cursor);
+        } else {
+            self.selection_anchor = None;
+        }
+        self.cursor = cursor.min(self.text.len());
+    }
+
+    fn move_left(&mut self, select: bool) {
+        self.set_cursor(previous_boundary(&self.text, self.cursor), select);
+    }
+
+    fn move_right(&mut self, select: bool) {
+        self.set_cursor(next_boundary(&self.text, self.cursor), select);
+    }
+
+    fn move_home(&mut self, select: bool) {
+        let line_start = self.text[..self.cursor]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        self.set_cursor(line_start, select);
+    }
+
+    fn move_end(&mut self, select: bool) {
+        let line_end = self.text[self.cursor..]
+            .find('\n')
+            .map_or(self.text.len(), |index| self.cursor + index);
+        self.set_cursor(line_end, select);
+    }
+
+    fn move_vertical(&mut self, delta: isize, select: bool) {
+        let (line, column) = line_column(&self.text, self.cursor);
+        let lines = line_ranges(&self.text);
+        let target = line
+            .saturating_add_signed(delta)
+            .min(lines.len().saturating_sub(1));
+        let range = &lines[target];
+        let cursor = self.text[range.clone()]
+            .char_indices()
+            .nth(column)
+            .map_or(range.end, |(offset, _)| range.start + offset);
+        self.set_cursor(cursor, select);
+    }
+
+    fn replace_completion(&mut self, start: usize, end: usize, text: &str) {
+        if start > end || end > self.text.len() {
+            return;
+        }
+        self.remember();
+        self.text.replace_range(start..end, text);
+        self.cursor = start + text.len();
+        self.selection_anchor = None;
+    }
+}
+
+fn previous_boundary(text: &str, cursor: usize) -> usize {
+    text[..cursor]
+        .char_indices()
+        .last()
+        .map_or(0, |(index, _)| index)
+}
+
+fn next_boundary(text: &str, cursor: usize) -> usize {
+    text[cursor..]
+        .chars()
+        .next()
+        .map_or(cursor, |ch| cursor + ch.len_utf8())
+}
+
+fn line_ranges(text: &str) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    for (index, ch) in text.char_indices() {
+        if ch == '\n' {
+            ranges.push(start..index);
+            start = index + 1;
+        }
+    }
+    ranges.push(start..text.len());
+    ranges
+}
+
+fn line_column(text: &str, cursor: usize) -> (usize, usize) {
+    let before = &text[..cursor];
+    let line = before.chars().filter(|ch| *ch == '\n').count();
+    let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+    (line, text[line_start..cursor].chars().count())
+}
+
+struct EditSession {
+    target: LiveSymbolTarget,
+    expected_source_hash: String,
+    accepted_source: String,
+    source_start: usize,
+    buffer: EditBuffer,
+    discard_confirm: bool,
+}
+
+enum InputMode {
+    Prompt(EditBuffer),
+    Definition(EditSession),
+}
+
+impl InputMode {
+    fn buffer(&self) -> &EditBuffer {
+        match self {
+            Self::Prompt(buffer) => buffer,
+            Self::Definition(edit) => &edit.buffer,
+        }
+    }
+
+    fn buffer_mut(&mut self) -> &mut EditBuffer {
+        match self {
+            Self::Prompt(buffer) => buffer,
+            Self::Definition(edit) => &mut edit.buffer,
+        }
+    }
+}
+
+#[derive(Default)]
+struct CompletionState {
+    items: Vec<CompletionItem>,
+    selected: usize,
+    replacement_start: usize,
+    replacement_end: usize,
+    armed: bool,
+    truncated: bool,
+}
+
+#[derive(Clone)]
+enum PendingAction {
+    OpenEdit,
+    ApplyEdit {
+        source: String,
+        revision: u64,
+    },
+    DefaultInspect,
+    Completion {
+        generation: u64,
+        arm: bool,
+        selected_key: Option<(String, String, String)>,
+    },
+    InspectorWatchLifecycle(InspectorWatchOperation),
+}
+
+#[derive(Clone)]
+enum InspectorWatchOperation {
+    Watch(String),
+    Unwatch(String),
+}
+
+struct QueuedCompletion {
+    generation: u64,
+    arm: bool,
+    selected_key: Option<(String, String, String)>,
+    command: LiveCommand,
+}
+
+struct InspectorState {
+    title: String,
+    lines: Vec<String>,
+    pinned: bool,
+}
+
+impl Default for InspectorState {
+    fn default() -> Self {
+        Self {
+            title: "Inspect / details".to_string(),
+            lines: vec!["Loading default live state...".to_string()],
+            pinned: false,
+        }
+    }
+}
+
+struct LiveTui {
+    client: LiveSessionClient,
+    terminal: TerminalBuffer,
+    input: InputMode,
+    command_bar: Option<EditBuffer>,
+    completion: CompletionState,
+    transcript: VecDeque<String>,
+    history: Vec<String>,
+    history_cursor: usize,
+    pending: BTreeMap<u64, PendingAction>,
+    next_request_id: u64,
+    completion_generation: u64,
+    completion_in_flight: Option<u64>,
+    queued_completion: Option<QueuedCompletion>,
+    inspector: InspectorState,
+    inspector_watch: Option<String>,
+    inspector_watch_target: Option<String>,
+    last_default_inspection: Instant,
+    status: String,
+    prompt: &'static str,
+    quit: bool,
+    last_regions: [Vec<u8>; 5],
+    last_size: Option<(u16, u16)>,
+}
+
+impl LiveTui {
+    fn new(client: LiveSessionClient) -> Self {
+        Self {
+            client,
+            terminal: TerminalBuffer::new(),
+            input: InputMode::Prompt(EditBuffer::default()),
+            command_bar: None,
+            completion: CompletionState::default(),
+            transcript: VecDeque::from([
+                "Stasis live workspace".to_string(),
+                "Type :help, :edit SYMBOL, or :inspect PATH. Ctrl+Space arms completion."
+                    .to_string(),
+            ]),
+            history: Vec::new(),
+            history_cursor: 0,
+            pending: BTreeMap::new(),
+            next_request_id: TUI_REQUEST_START,
+            completion_generation: 0,
+            completion_in_flight: None,
+            queued_completion: None,
+            inspector: InspectorState::default(),
+            inspector_watch: None,
+            inspector_watch_target: None,
+            last_default_inspection: Instant::now() - Duration::from_secs(1),
+            status: "running".to_string(),
+            prompt: "stasis> ",
+            quit: false,
+            last_regions: std::array::from_fn(|_| Vec::new()),
+            last_size: None,
+        }
+    }
+
+    fn active_buffer(&self) -> &EditBuffer {
+        self.command_bar
+            .as_ref()
+            .unwrap_or_else(|| self.input.buffer())
+    }
+
+    fn active_buffer_mut(&mut self) -> &mut EditBuffer {
+        if self.command_bar.is_none() {
+            if let InputMode::Definition(edit) = &mut self.input {
+                edit.discard_confirm = false;
+            }
+        }
+        self.command_bar
+            .as_mut()
+            .unwrap_or_else(|| self.input.buffer_mut())
+    }
+
+    fn next_request(&mut self) -> u64 {
+        let request = self.next_request_id;
+        self.next_request_id = self.next_request_id.saturating_add(1);
+        request
+    }
+
+    fn completion_context(&self) -> CompletionContext {
+        if self.command_bar.is_some() {
+            return CompletionContext::default();
+        }
+        match &self.input {
+            InputMode::Prompt(_) => self.terminal.completion_context(),
+            InputMode::Definition(edit) => CompletionContext {
+                owner: Some(edit.target.name.clone()),
+                file: edit.target.file.clone(),
+                owner_signature: edit.target.signature.clone(),
+                source_offset: Some(edit.source_start.saturating_add(edit.buffer.cursor)),
+                expected_type: None,
+            },
+        }
+    }
+
+    fn refresh_completion(&mut self, arm: bool) {
+        let buffer = self.active_buffer().text.clone();
+        let cursor = self.active_buffer().cursor;
+        let selected_key = self
+            .completion
+            .items
+            .get(self.completion.selected)
+            .map(completion_key);
+        let mut context = self.completion_context();
+        if context.expected_type.is_none() {
+            context.expected_type = completion_expected_type(&buffer, cursor).unwrap_or_default();
+        }
+        self.completion_generation = self.completion_generation.saturating_add(1);
+        self.queued_completion = Some(QueuedCompletion {
+            generation: self.completion_generation,
+            arm,
+            selected_key,
+            command: LiveCommand::Complete {
+                buffer,
+                cursor,
+                limit: COMPLETION_LIMIT,
+                context,
+            },
+        });
+        self.dispatch_completion();
+    }
+
+    fn dispatch_completion(&mut self) {
+        if self.completion_in_flight.is_some() {
+            return;
+        }
+        let Some(queued) = self.queued_completion.take() else {
+            return;
+        };
+        let request_id = self.next_request();
+        let action = PendingAction::Completion {
+            generation: queued.generation,
+            arm: queued.arm,
+            selected_key: queued.selected_key,
+        };
+        match self
+            .client
+            .submit(LiveRequest::new(request_id, queued.command))
+        {
+            Ok(()) => {
+                self.pending.insert(request_id, action);
+                self.completion_in_flight = Some(request_id);
+            }
+            Err(error) => {
+                self.completion.armed = false;
+                self.status = format!("completion unavailable: {error}");
+            }
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> Result<(), String> {
+        let control = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+
+        if control && key.code == KeyCode::Char('c') {
+            self.cancel_input();
+            return Ok(());
+        }
+        if control && key.code == KeyCode::Char('k') {
+            self.command_bar = Some(EditBuffer::from_text(":".to_string()));
+            self.refresh_completion(true);
+            return Ok(());
+        }
+        if control && matches!(key.code, KeyCode::Char(' ') | KeyCode::Char('p')) {
+            self.refresh_completion(true);
+            return Ok(());
+        }
+        if alt && matches!(key.code, KeyCode::Char('d' | 'p' | 'i')) {
+            return self.run_workspace_action(key.code);
+        }
+        if control && key.code == KeyCode::Char('z') {
+            self.active_buffer_mut().undo();
+            self.refresh_completion(false);
+            return Ok(());
+        }
+        if control && key.code == KeyCode::Char('y') {
+            self.active_buffer_mut().redo();
+            self.refresh_completion(false);
+            return Ok(());
+        }
+        if control && key.code == KeyCode::Char('w') {
+            self.close_definition();
+            return Ok(());
+        }
+        if control && key.code == KeyCode::Enter {
+            self.apply_definition()?;
+            return Ok(());
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                if self.command_bar.take().is_some() {
+                    self.status = "command bar closed".to_string();
+                } else {
+                    self.completion.armed = false;
+                }
+            }
+            KeyCode::Tab => self.accept_completion(),
+            KeyCode::Up if self.completion.armed => self.move_completion(-1),
+            KeyCode::Down if self.completion.armed => self.move_completion(1),
+            KeyCode::PageUp if self.completion.armed => self.move_completion(-8),
+            KeyCode::PageDown if self.completion.armed => self.move_completion(8),
+            KeyCode::Up => self.move_up(shift),
+            KeyCode::Down => self.move_down(shift),
+            KeyCode::Left => {
+                self.active_buffer_mut().move_left(shift);
+                self.completion.armed = false;
+            }
+            KeyCode::Right => {
+                self.active_buffer_mut().move_right(shift);
+                self.completion.armed = false;
+            }
+            KeyCode::Home => {
+                self.active_buffer_mut().move_home(shift);
+                self.completion.armed = false;
+            }
+            KeyCode::End => {
+                self.active_buffer_mut().move_end(shift);
+                self.completion.armed = false;
+            }
+            KeyCode::Backspace => {
+                self.active_buffer_mut().backspace();
+                let arm = !current_token(self.active_buffer()).is_empty();
+                self.refresh_completion(arm);
+            }
+            KeyCode::Delete => {
+                self.active_buffer_mut().delete();
+                self.refresh_completion(false);
+            }
+            KeyCode::Enter => self.enter()?,
+            KeyCode::Char(ch) if !control && !alt => {
+                self.active_buffer_mut().insert_char(ch);
+                let arm = ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | ':');
+                self.refresh_completion(arm);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn cancel_input(&mut self) {
+        if self.command_bar.take().is_some() {
+            self.status = "command bar canceled".to_string();
+        } else if self.terminal.cancel_pending() {
+            self.input = InputMode::Prompt(EditBuffer::default());
+            self.prompt = "stasis> ";
+            self.status = "multiline input canceled".to_string();
+        } else {
+            self.completion.armed = false;
+            self.status = "nothing pending to cancel".to_string();
+        }
+        self.refresh_completion(false);
+    }
+
+    fn enter(&mut self) -> Result<(), String> {
+        if self.command_bar.is_some() {
+            let command = self.command_bar.take().expect("command bar").text;
+            self.submit_line(command)?;
+            return Ok(());
+        }
+        match &mut self.input {
+            InputMode::Definition(_) => {
+                if let InputMode::Definition(edit) = &mut self.input {
+                    edit.discard_confirm = false;
+                }
+                self.input.buffer_mut().insert_newline();
+                self.refresh_completion(false);
+            }
+            InputMode::Prompt(_) => {
+                let line = std::mem::take(&mut self.input.buffer_mut().text);
+                self.input.buffer_mut().cursor = 0;
+                self.submit_line(line)?;
+                self.refresh_completion(false);
+            }
+        }
+        Ok(())
+    }
+
+    fn submit_line(&mut self, line: String) -> Result<(), String> {
+        let line = line.trim_end().to_string();
+        if line.trim().is_empty() {
+            return Ok(());
+        }
+        self.push_transcript(format!("{}{}", self.prompt, line));
+        self.history.push(line.clone());
+        self.history_cursor = self.history.len();
+        if line.trim() == ":inspect" {
+            self.replace_inspector_watch(None);
+            self.inspector.pinned = false;
+            self.request_default_inspection()?;
+            return Ok(());
+        }
+        if line.trim_start().starts_with(":edit") {
+            return self.open_definition(&line);
+        }
+        match self.terminal.feed_line(&line) {
+            Ok(TerminalInput::Continue { prompt }) => {
+                self.prompt = prompt;
+                self.status = "multiline compatibility input; finish with :end".to_string();
+            }
+            Ok(TerminalInput::Request(request)) => {
+                self.prompt = "stasis> ";
+                if let Err(error) = self.client.submit(request) {
+                    self.status = format!("live command queued failed: {error}");
+                    self.push_transcript(format!("error: {error}"));
+                }
+            }
+            Err(error) => self.push_transcript(format!("error: {error}")),
+        }
+        Ok(())
+    }
+
+    fn open_definition(&mut self, line: &str) -> Result<(), String> {
+        let args = line.split_ascii_whitespace().collect::<Vec<_>>();
+        if args.len() != 2 || args[0] != ":edit" {
+            self.push_transcript("error: use :edit SYMBOL".to_string());
+            return Ok(());
+        }
+        let target = edit_target_from_completion(args[1], &self.completion);
+        let request_id = self.next_request();
+        self.pending.insert(request_id, PendingAction::OpenEdit);
+        if let Err(error) = self.client.submit(LiveRequest::new(
+            request_id,
+            LiveCommand::Read {
+                name: target.name,
+                kind: target.kind,
+                file: target.file,
+                owner: target.owner,
+                signature: target.signature,
+            },
+        )) {
+            self.pending.remove(&request_id);
+            self.status = format!("definition open could not be queued: {error}");
+            return Ok(());
+        }
+        self.status = format!("opening {}...", args[1]);
+        Ok(())
+    }
+
+    fn apply_definition(&mut self) -> Result<(), String> {
+        let (source, revision, target, expected_source_hash) = match &self.input {
+            InputMode::Definition(edit) => (
+                edit.buffer.text.clone(),
+                edit.buffer.revision,
+                edit.target.clone(),
+                edit.expected_source_hash.clone(),
+            ),
+            InputMode::Prompt(_) => {
+                self.status = "Ctrl+Enter applies an open definition".to_string();
+                return Ok(());
+            }
+        };
+        let request_id = self.next_request();
+        let command = LiveCommand::Edit {
+            operation: LiveEditOperation::Update,
+            target,
+            source: Some(source.clone()),
+            expected_source_hash: Some(expected_source_hash),
+            preview: false,
+            run_tests: true,
+        };
+        self.pending
+            .insert(request_id, PendingAction::ApplyEdit { source, revision });
+        if let Err(error) = self.client.submit(LiveRequest::new(request_id, command)) {
+            self.pending.remove(&request_id);
+            self.status = format!("definition apply could not be queued: {error}");
+            return Ok(());
+        }
+        self.status = "validating snapshot in background; editing remains available".to_string();
+        Ok(())
+    }
+
+    fn close_definition(&mut self) {
+        let InputMode::Definition(edit) = &mut self.input else {
+            return;
+        };
+        if edit.buffer.text != edit.accepted_source && !edit.discard_confirm {
+            edit.discard_confirm = true;
+            self.status = "dirty definition: press Ctrl+W again to discard".to_string();
+            return;
+        }
+        self.input = InputMode::Prompt(EditBuffer::default());
+        self.status = "definition editor closed".to_string();
+        self.refresh_completion(false);
+    }
+
+    fn run_workspace_action(&mut self, code: KeyCode) -> Result<(), String> {
+        let expression = self.active_buffer().selected_or_token();
+        if expression.is_empty() {
+            self.status = "select text or place the cursor on an expression".to_string();
+            return Ok(());
+        }
+        let command = match code {
+            KeyCode::Char('d') => LiveCommand::Do {
+                code: expression,
+                preview: false,
+            },
+            KeyCode::Char('p') => LiveCommand::Print { expression },
+            KeyCode::Char('i') => LiveCommand::Inspect { path: expression },
+            _ => return Ok(()),
+        };
+        let request_id = self.next_request();
+        if let Err(error) = self.client.submit(LiveRequest::new(request_id, command)) {
+            self.status = format!("workspace action could not be queued: {error}");
+        }
+        Ok(())
+    }
+
+    fn move_completion(&mut self, delta: isize) {
+        if self.completion.items.is_empty() {
+            return;
+        }
+        self.completion.selected = self
+            .completion
+            .selected
+            .saturating_add_signed(delta)
+            .min(self.completion.items.len() - 1);
+    }
+
+    fn accept_completion(&mut self) {
+        if !self.completion.armed
+            || !suffix_is_whitespace(&self.active_buffer().text, self.active_buffer().cursor)
+        {
+            return;
+        }
+        let Some(item) = self.completion.items.get(self.completion.selected) else {
+            return;
+        };
+        let text = item.text.clone();
+        let start = self.completion.replacement_start;
+        let end = self.completion.replacement_end;
+        self.active_buffer_mut()
+            .replace_completion(start, end, &text);
+        self.completion.armed = false;
+        self.refresh_completion(false);
+    }
+
+    fn move_up(&mut self, select: bool) {
+        match &mut self.input {
+            InputMode::Definition(edit) if self.command_bar.is_none() => {
+                edit.buffer.move_vertical(-1, select)
+            }
+            _ if self.command_bar.is_none() => self.history_move(-1),
+            _ => self.active_buffer_mut().move_vertical(-1, select),
+        }
+    }
+
+    fn move_down(&mut self, select: bool) {
+        match &mut self.input {
+            InputMode::Definition(edit) if self.command_bar.is_none() => {
+                edit.buffer.move_vertical(1, select)
+            }
+            _ if self.command_bar.is_none() => self.history_move(1),
+            _ => self.active_buffer_mut().move_vertical(1, select),
+        }
+    }
+
+    fn history_move(&mut self, delta: isize) {
+        if self.history.is_empty() {
+            return;
+        }
+        self.history_cursor = self
+            .history_cursor
+            .saturating_add_signed(delta)
+            .min(self.history.len());
+        let text = self
+            .history
+            .get(self.history_cursor)
+            .cloned()
+            .unwrap_or_default();
+        self.input = InputMode::Prompt(EditBuffer::from_text(text));
+        self.refresh_completion(false);
+    }
+
+    fn drain_responses(&mut self) -> Result<(), String> {
+        while let Some(response) = self.client.try_receive()? {
+            self.handle_response(response);
+        }
+        Ok(())
+    }
+
+    fn request_default_inspection(&mut self) -> Result<(), String> {
+        if self.inspector.pinned
+            || self
+                .pending
+                .values()
+                .any(|action| matches!(action, PendingAction::DefaultInspect))
+        {
+            return Ok(());
+        }
+        let request_id = self.next_request();
+        self.pending
+            .insert(request_id, PendingAction::DefaultInspect);
+        self.last_default_inspection = Instant::now();
+        if let Err(error) = self.client.submit(LiveRequest::new(
+            request_id,
+            LiveCommand::InspectAll { limit: 32 },
+        )) {
+            self.pending.remove(&request_id);
+            self.status = format!("default inspection delayed by backpressure: {error}");
+        }
+        Ok(())
+    }
+
+    fn maybe_refresh_default_inspection(&mut self) -> Result<(), String> {
+        if !self.inspector.pinned
+            && self.last_default_inspection.elapsed() >= Duration::from_millis(250)
+        {
+            self.request_default_inspection()?;
+        }
+        Ok(())
+    }
+
+    fn handle_response(&mut self, response: LiveResponse) {
+        if let Some(action) = self.pending.get(&response.request_id).cloned() {
+            if matches!(
+                response.kind.as_str(),
+                "edit_preparing" | "completion_preparing"
+            ) {
+                if response.kind == "edit_preparing" {
+                    self.status = "snapshot compiling and testing...".to_string();
+                }
+                return;
+            }
+            match action {
+                PendingAction::OpenEdit => self.finish_open(response),
+                PendingAction::ApplyEdit { source, revision } => {
+                    self.finish_apply(response, source, revision);
+                }
+                PendingAction::DefaultInspect => self.finish_default_inspection(response),
+                PendingAction::Completion {
+                    generation,
+                    arm,
+                    selected_key,
+                } => self.finish_completion(response, generation, arm, selected_key),
+                PendingAction::InspectorWatchLifecycle(operation) => {
+                    self.pending.remove(&response.request_id);
+                    if response.ok {
+                        match operation {
+                            InspectorWatchOperation::Watch(path)
+                                if response.kind == "watch_added" =>
+                            {
+                                self.inspector_watch = Some(path);
+                            }
+                            InspectorWatchOperation::Unwatch(path)
+                                if response.kind == "watch_removed"
+                                    && self.inspector_watch.as_deref() == Some(path.as_str()) =>
+                            {
+                                self.inspector_watch = None;
+                            }
+                            _ => {
+                                self.inspector_watch_target = self.inspector_watch.clone();
+                                self.status = format!(
+                                    "inspector live refresh returned an unexpected response: {}",
+                                    format_live_response(&response)
+                                );
+                                return;
+                            }
+                        }
+                        self.advance_inspector_watch();
+                    } else {
+                        self.inspector_watch_target = self.inspector_watch.clone();
+                        self.status = format_live_response(&response);
+                    }
+                }
+            }
+            return;
+        }
+
+        if response.kind == "quitting" {
+            self.quit = true;
+        }
+        if response.kind == "inspection" && response.ok {
+            let path = response
+                .data
+                .as_ref()
+                .and_then(|data| data.get("path"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("inspection")
+                .to_string();
+            self.inspector.title = path.clone();
+            self.inspector.lines = vec![format_live_response(&response)];
+            self.inspector.pinned = true;
+            self.status = "live inspection pinned".to_string();
+            self.replace_inspector_watch(Some(path));
+            return;
+        }
+        if response.kind == "watch" && response.ok {
+            let path = response
+                .data
+                .as_ref()
+                .and_then(|data| data.get("path"))
+                .and_then(Value::as_str);
+            if path == self.inspector_watch.as_deref() {
+                self.inspector.lines = vec![format_live_response(&response)];
+                return;
+            }
+        }
+        if response.kind == "watch_removed" && response.ok {
+            let still_watched = response
+                .data
+                .as_ref()
+                .and_then(|data| data.get("watches"))
+                .and_then(Value::as_array)
+                .is_some_and(|paths| {
+                    paths
+                        .iter()
+                        .any(|path| path.as_str() == self.inspector_watch.as_deref())
+                });
+            if !still_watched && self.inspector_watch.take().is_some() {
+                self.inspector.pinned = false;
+                if let Err(error) = self.request_default_inspection() {
+                    self.status = format!("default inspection unavailable: {error}");
+                }
+            }
+        }
+        if matches!(
+            response.kind.as_str(),
+            "track_started" | "track_progress" | "track_complete" | "track_failed"
+        ) && response.ok
+        {
+            self.replace_inspector_watch(None);
+            self.inspector.title = response
+                .data
+                .as_ref()
+                .and_then(|data| data.get("path"))
+                .and_then(|value| value.as_str())
+                .unwrap_or("trace")
+                .to_string();
+            self.inspector.lines = vec![format_live_response(&response)];
+            self.inspector.pinned = true;
+            if response.kind == "track_complete" {
+                self.push_transcript(format_live_response(&response));
+            }
+            return;
+        }
+        self.push_transcript(format_live_response(&response));
+    }
+
+    fn replace_inspector_watch(&mut self, next: Option<String>) {
+        self.inspector_watch_target = next;
+        self.advance_inspector_watch();
+    }
+
+    fn advance_inspector_watch(&mut self) {
+        if self
+            .pending
+            .values()
+            .any(|action| matches!(action, PendingAction::InspectorWatchLifecycle(_)))
+            || self.inspector_watch == self.inspector_watch_target
+        {
+            return;
+        }
+        if let Some(previous) = self.inspector_watch.clone() {
+            self.submit_inspector_watch_command(
+                LiveCommand::Unwatch {
+                    path: Some(previous.clone()),
+                },
+                InspectorWatchOperation::Unwatch(previous),
+            );
+        } else if let Some(path) = self.inspector_watch_target.clone() {
+            self.submit_inspector_watch_command(
+                LiveCommand::Watch { path: path.clone() },
+                InspectorWatchOperation::Watch(path),
+            );
+        }
+    }
+
+    fn submit_inspector_watch_command(
+        &mut self,
+        command: LiveCommand,
+        operation: InspectorWatchOperation,
+    ) {
+        let request_id = self.next_request();
+        match self.client.submit(LiveRequest::new(request_id, command)) {
+            Ok(()) => {
+                self.pending.insert(
+                    request_id,
+                    PendingAction::InspectorWatchLifecycle(operation),
+                );
+            }
+            Err(error) => {
+                self.status = format!("inspector live refresh unavailable: {error}");
+            }
+        }
+    }
+
+    fn finish_completion(
+        &mut self,
+        response: LiveResponse,
+        generation: u64,
+        arm: bool,
+        selected_key: Option<(String, String, String)>,
+    ) {
+        self.pending.remove(&response.request_id);
+        if self.completion_in_flight == Some(response.request_id) {
+            self.completion_in_flight = None;
+        }
+        if generation == self.completion_generation {
+            if !response.ok || response.kind != "completion" || response.truncated {
+                self.completion.armed = false;
+                self.status = format!(
+                    "completion unavailable: {}",
+                    format_live_response(&response)
+                );
+            } else {
+                match serde_json::from_value::<CompletionQuery>(
+                    response.data.unwrap_or(Value::Null),
+                ) {
+                    Ok(query) => {
+                        self.completion.replacement_start = query.replacement_start;
+                        self.completion.replacement_end = query.replacement_end;
+                        self.completion.truncated = query.truncated;
+                        self.completion.items = query.items;
+                        self.completion.selected = selected_key
+                            .and_then(|key| {
+                                self.completion
+                                    .items
+                                    .iter()
+                                    .position(|item| completion_key(item) == key)
+                            })
+                            .unwrap_or(0);
+                        self.completion.armed =
+                            arm && suffix_is_whitespace(
+                                &self.active_buffer().text,
+                                self.active_buffer().cursor,
+                            ) && !self.completion.items.is_empty();
+                    }
+                    Err(error) => {
+                        self.completion.armed = false;
+                        self.status = format!("completion unavailable: {error}");
+                    }
+                }
+            }
+        }
+        self.dispatch_completion();
+    }
+
+    fn finish_default_inspection(&mut self, response: LiveResponse) {
+        self.pending.remove(&response.request_id);
+        if self.inspector.pinned {
+            return;
+        }
+        if !response.ok || response.kind != "state_inspection" {
+            self.inspector.lines = vec![format_live_response(&response)];
+            return;
+        }
+        let Some(items) = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("items"))
+            .and_then(|items| items.as_array())
+        else {
+            self.inspector.lines = vec!["Default state response omitted items.".to_string()];
+            return;
+        };
+        self.inspector.title = "Live state (default)".to_string();
+        self.inspector.lines = items.iter().map(format_state_item).collect();
+        if response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("truncated"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+        {
+            self.inspector
+                .lines
+                .push("... bounded view; use :inspect PATH".to_string());
+        }
+    }
+
+    fn finish_open(&mut self, response: LiveResponse) {
+        self.pending.remove(&response.request_id);
+        if !response.ok {
+            self.push_transcript(format_live_response(&response));
+            self.status = "definition open failed".to_string();
+            return;
+        }
+        let item = match response
+            .data
+            .clone()
+            .ok_or_else(|| "symbol response omitted data".to_string())
+            .and_then(|data| {
+                serde_json::from_value::<WorkshopSourceItem>(data)
+                    .map_err(|error| error.to_string())
+            }) {
+            Ok(item) => item,
+            Err(error) => {
+                self.push_transcript(format!("error: {error}"));
+                return;
+            }
+        };
+        let kind = match item.kind {
+            WorkshopSourceItemKind::Function => "function",
+            WorkshopSourceItemKind::Struct => "struct",
+            WorkshopSourceItemKind::Test => "test",
+            WorkshopSourceItemKind::Imports => "imports",
+            WorkshopSourceItemKind::Globals => "globals",
+        };
+        let source_start = item
+            .source_spans
+            .first()
+            .map_or(0, |span| span.start as usize);
+        let target = LiveSymbolTarget {
+            name: item.name.clone(),
+            kind: Some(kind.to_string()),
+            file: Some(item.file.clone()),
+            owner: item.owner.clone(),
+            signature: Some(item.signature.clone()),
+        };
+        self.input = InputMode::Definition(EditSession {
+            target,
+            expected_source_hash: item.source_hash,
+            accepted_source: item.source.clone(),
+            source_start,
+            buffer: EditBuffer::from_text(item.source),
+            discard_confirm: false,
+        });
+        self.status = format!("editing {} [{}]", item.name, item.file);
+        self.refresh_completion(false);
+    }
+
+    fn finish_apply(&mut self, response: LiveResponse, source: String, revision: u64) {
+        self.pending.remove(&response.request_id);
+        if !response.ok {
+            self.status = "apply failed; buffer remains open".to_string();
+            self.push_transcript(format_live_response(&response));
+            return;
+        }
+        if let InputMode::Definition(edit) = &mut self.input {
+            edit.accepted_source = source.clone();
+            edit.expected_source_hash = workshop_source_hash(&source);
+            edit.discard_confirm = false;
+            self.status = if edit.buffer.revision == revision && edit.buffer.text == source {
+                "snapshot applied; editor is clean".to_string()
+            } else {
+                "snapshot applied; later edits remain dirty".to_string()
+            };
+        }
+        self.push_transcript(format_live_response(&response));
+        self.refresh_completion(false);
+    }
+
+    fn push_transcript(&mut self, line: String) {
+        for line in line.lines() {
+            self.transcript.push_back(line.to_string());
+        }
+        while self.transcript.len() > MAX_TRANSCRIPT_LINES {
+            self.transcript.pop_front();
+        }
+    }
+
+    fn render(&mut self) -> Result<(), String> {
+        let (width, height) = terminal::size().unwrap_or((120, 40));
+        let layout = Layout::new(
+            width,
+            height,
+            matches!(self.input, InputMode::Definition(_)),
+        );
+        let mut regions: [Vec<u8>; 5] = std::array::from_fn(|_| Vec::new());
+        draw_box(&mut regions[0], layout.transcript, "Transcript")?;
+        draw_transcript(&mut regions[0], layout.transcript, &self.transcript)?;
+        draw_box(&mut regions[1], layout.editor, self.editor_title().as_str())?;
+        let cursor = draw_editor(
+            &mut regions[1],
+            layout.editor,
+            self.active_buffer(),
+            self.ghost_text(),
+            self.command_bar.is_some(),
+            matches!(self.input, InputMode::Definition(_)),
+            self.prompt,
+        )?;
+        draw_box(&mut regions[2], layout.right, "Completions / inspect")?;
+        draw_right_panel(
+            &mut regions[2],
+            layout.right,
+            &self.completion,
+            &self.inspector,
+        )?;
+        let status = format!(
+            "{} | Tab complete | Ctrl+Space arm | Ctrl+K commands | Ctrl+Enter apply",
+            self.status
+        );
+        write_at(
+            &mut regions[3],
+            0,
+            height.saturating_sub(1),
+            width,
+            &format!("{status:<width$}", width = width as usize),
+            Color::DarkGrey,
+        )?;
+        if let Some((x, y)) = cursor {
+            queue!(regions[4], MoveTo(x, y), Show)
+                .map_err(|error| format!("failed positioning live TUI cursor: {error}"))?;
+        } else {
+            queue!(regions[4], Hide)
+                .map_err(|error| format!("failed hiding live TUI cursor: {error}"))?;
+        }
+        let resized = self.last_size != Some((width, height));
+        let changed: [bool; 5] =
+            std::array::from_fn(|index| resized || regions[index] != self.last_regions[index]);
+        if !changed.iter().any(|changed| *changed) {
+            return Ok(());
+        }
+        let mut update = Vec::new();
+        queue!(update, BeginSynchronizedUpdate, Hide)
+            .map_err(|error| format!("failed starting live TUI update: {error}"))?;
+        if resized {
+            queue!(update, Clear(ClearType::All))
+                .map_err(|error| format!("failed resizing live TUI: {error}"))?;
+        }
+        for index in 0..4 {
+            if changed[index] {
+                update.extend_from_slice(&regions[index]);
+            }
+        }
+        update.extend_from_slice(&regions[4]);
+        queue!(update, EndSynchronizedUpdate)
+            .map_err(|error| format!("failed ending live TUI update: {error}"))?;
+        let mut stdout = io::stdout();
+        if let Err(error) = stdout.write_all(&update) {
+            let _ = execute!(stdout, EndSynchronizedUpdate);
+            return Err(format!("failed drawing live TUI update: {error}"));
+        }
+        if let Err(error) = stdout.flush() {
+            let _ = execute!(stdout, EndSynchronizedUpdate);
+            return Err(format!("failed flushing live TUI: {error}"));
+        }
+        self.last_regions = regions;
+        self.last_size = Some((width, height));
+        Ok(())
+    }
+
+    fn editor_title(&self) -> String {
+        if self.command_bar.is_some() {
+            return "Command bar".to_string();
+        }
+        match &self.input {
+            InputMode::Prompt(_) => "Input".to_string(),
+            InputMode::Definition(edit) => format!(
+                "Edit {}{}",
+                edit.target.name,
+                if edit.buffer.text == edit.accepted_source {
+                    ""
+                } else {
+                    " *"
+                }
+            ),
+        }
+    }
+
+    fn ghost_text(&self) -> String {
+        ghost_suffix(self.active_buffer(), &self.completion).unwrap_or_default()
+    }
+}
+
+fn completion_key(item: &CompletionItem) -> (String, String, String) {
+    (item.text.clone(), item.kind.clone(), item.detail.clone())
+}
+
+fn edit_target_from_completion(symbol: &str, completion: &CompletionState) -> LiveSymbolTarget {
+    let supported = |item: &&CompletionItem| {
+        item.text == symbol && matches!(item.kind.as_str(), "function" | "struct" | "test")
+    };
+    let matches = completion
+        .items
+        .iter()
+        .filter(supported)
+        .collect::<Vec<_>>();
+    let selected = completion
+        .items
+        .get(completion.selected)
+        .filter(|item| supported(item));
+    let item = selected.or_else(|| (matches.len() == 1).then_some(matches[0]));
+    let Some(item) = item else {
+        return LiveSymbolTarget {
+            name: symbol.to_string(),
+            kind: None,
+            file: None,
+            owner: None,
+            signature: None,
+        };
+    };
+    if let Some(selector) = item.selector.as_ref() {
+        return selector.clone();
+    }
+    LiveSymbolTarget {
+        name: symbol.to_string(),
+        kind: Some(item.kind.clone()),
+        file: item.source.clone(),
+        owner: None,
+        signature: None,
+    }
+}
+
+fn format_state_item(item: &Value) -> String {
+    let path = item.get("path").and_then(Value::as_str).unwrap_or("value");
+    let static_type = item
+        .get("static_type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let depth = path.matches('.').count();
+    let name = path.rsplit('.').next().unwrap_or(path);
+    format!(
+        "{}{}: {} = {}",
+        "  ".repeat(depth),
+        name,
+        static_type,
+        scalar_text(item.get("value").unwrap_or(&Value::Null))
+    )
+}
+
+fn current_token(buffer: &EditBuffer) -> &str {
+    let start = buffer.text[..buffer.cursor]
+        .rfind(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | ':')))
+        .map_or(0, |index| index + 1);
+    &buffer.text[start..buffer.cursor]
+}
+
+fn suffix_is_whitespace(text: &str, cursor: usize) -> bool {
+    text.get(cursor..)
+        .is_some_and(|suffix| suffix.chars().all(char::is_whitespace))
+}
+
+fn ghost_suffix(buffer: &EditBuffer, completion: &CompletionState) -> Option<String> {
+    if !completion.armed || !suffix_is_whitespace(&buffer.text, buffer.cursor) {
+        return None;
+    }
+    let item = completion.items.get(completion.selected)?;
+    let typed = buffer
+        .text
+        .get(completion.replacement_start..buffer.cursor)?;
+    item.text
+        .strip_prefix(typed)
+        .filter(|suffix| !suffix.is_empty())
+        .map(str::to_string)
+}
+
+#[derive(Clone, Copy)]
+struct Rect {
+    x: u16,
+    y: u16,
+    width: u16,
+    height: u16,
+}
+
+struct Layout {
+    transcript: Rect,
+    editor: Rect,
+    right: Rect,
+}
+
+impl Layout {
+    fn new(width: u16, height: u16, editing: bool) -> Self {
+        let usable_height = height.saturating_sub(1);
+        if usable_height < 6 || width < 20 {
+            return Self {
+                transcript: Rect {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 0,
+                },
+                editor: Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height: usable_height,
+                },
+                right: Rect {
+                    x: 0,
+                    y: usable_height,
+                    width: 0,
+                    height: 0,
+                },
+            };
+        }
+        if width >= 60 {
+            let left_width = (width * 3 / 5).max(40);
+            let preferred_editor_height = if editing {
+                (usable_height * 3 / 5).max(4)
+            } else {
+                5
+            };
+            let editor_height = preferred_editor_height.min(usable_height.saturating_sub(2));
+            let transcript_height = usable_height.saturating_sub(editor_height);
+            Self {
+                transcript: Rect {
+                    x: 0,
+                    y: 0,
+                    width: left_width,
+                    height: transcript_height,
+                },
+                editor: Rect {
+                    x: 0,
+                    y: transcript_height,
+                    width: left_width,
+                    height: editor_height,
+                },
+                right: Rect {
+                    x: left_width,
+                    y: 0,
+                    width: width.saturating_sub(left_width),
+                    height: usable_height,
+                },
+            }
+        } else {
+            let preferred_left_height = if editing {
+                usable_height * 2 / 3
+            } else {
+                usable_height / 2
+            };
+            let left_height = preferred_left_height.clamp(3, usable_height);
+            let preferred_editor_height = if editing {
+                (left_height * 3 / 5).max(3)
+            } else {
+                3
+            };
+            let editor_height = preferred_editor_height.min(left_height);
+            let transcript_height = left_height.saturating_sub(editor_height);
+            Self {
+                transcript: Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height: transcript_height,
+                },
+                editor: Rect {
+                    x: 0,
+                    y: left_height.saturating_sub(editor_height),
+                    width,
+                    height: editor_height,
+                },
+                right: Rect {
+                    x: 0,
+                    y: left_height,
+                    width,
+                    height: usable_height.saturating_sub(left_height),
+                },
+            }
+        }
+    }
+}
+
+fn draw_box(stdout: &mut impl Write, rect: Rect, title: &str) -> Result<(), String> {
+    if rect.width < 2 || rect.height < 2 {
+        return Ok(());
+    }
+    let horizontal = "-".repeat(rect.width.saturating_sub(2) as usize);
+    write_at(
+        stdout,
+        rect.x,
+        rect.y,
+        rect.width,
+        &format!("+{horizontal}+"),
+        Color::DarkGrey,
+    )?;
+    for row in 1..rect.height.saturating_sub(1) {
+        write_at(
+            stdout,
+            rect.x,
+            rect.y + row,
+            rect.width,
+            &format!("|{}|", " ".repeat(rect.width.saturating_sub(2) as usize)),
+            Color::DarkGrey,
+        )?;
+    }
+    write_at(
+        stdout,
+        rect.x,
+        rect.y + rect.height.saturating_sub(1),
+        rect.width,
+        &format!("+{horizontal}+"),
+        Color::DarkGrey,
+    )?;
+    write_at(
+        stdout,
+        rect.x + 2,
+        rect.y,
+        rect.width.saturating_sub(4),
+        title,
+        Color::Cyan,
+    )
+}
+
+fn draw_transcript(
+    stdout: &mut impl Write,
+    rect: Rect,
+    transcript: &VecDeque<String>,
+) -> Result<(), String> {
+    let rows = rect.height.saturating_sub(2) as usize;
+    let start = transcript.len().saturating_sub(rows);
+    for (row, line) in transcript.iter().skip(start).take(rows).enumerate() {
+        write_at(
+            stdout,
+            rect.x + 1,
+            rect.y + 1 + row as u16,
+            rect.width.saturating_sub(2),
+            line,
+            if line.starts_with("error:") {
+                Color::Red
+            } else {
+                Color::White
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn draw_editor(
+    stdout: &mut impl Write,
+    rect: Rect,
+    buffer: &EditBuffer,
+    ghost: String,
+    command_bar: bool,
+    definition: bool,
+    prompt: &str,
+) -> Result<Option<(u16, u16)>, String> {
+    if rect.width < 3 || rect.height < 3 {
+        return Ok(None);
+    }
+    let ranges = line_ranges(&buffer.text);
+    let (cursor_line, cursor_column) = line_column(&buffer.text, buffer.cursor);
+    let visible_rows = rect.height.saturating_sub(2) as usize;
+    let start_line = cursor_line.saturating_sub(visible_rows.saturating_sub(1));
+    let prefix = if definition || command_bar {
+        ""
+    } else {
+        prompt
+    };
+    for (screen_row, line_index) in (start_line..ranges.len()).take(visible_rows).enumerate() {
+        let range = ranges[line_index].clone();
+        let line = &buffer.text[range];
+        let y = rect.y + 1 + screen_row as u16;
+        if definition {
+            draw_syntax_line(stdout, rect.x + 1, y, rect.width.saturating_sub(2), line)?;
+        } else {
+            write_at(
+                stdout,
+                rect.x + 1,
+                y,
+                rect.width.saturating_sub(2),
+                &format!("{prefix}{line}"),
+                Color::White,
+            )?;
+        }
+        if line_index == cursor_line && !ghost.is_empty() {
+            write_at(
+                stdout,
+                rect.x + 1 + prefix.chars().count() as u16 + cursor_column as u16,
+                y,
+                rect.width.saturating_sub(2 + cursor_column as u16),
+                &ghost,
+                Color::DarkGrey,
+            )?;
+        }
+    }
+    let cursor_y = rect.y + 1 + cursor_line.saturating_sub(start_line) as u16;
+    let cursor_x = rect.x + 1 + prefix.chars().count() as u16 + cursor_column as u16;
+    Ok((cursor_x < rect.x + rect.width.saturating_sub(1)
+        && cursor_y < rect.y + rect.height.saturating_sub(1))
+    .then_some((cursor_x, cursor_y)))
+}
+
+fn draw_syntax_line(
+    stdout: &mut impl Write,
+    x: u16,
+    y: u16,
+    width: u16,
+    line: &str,
+) -> Result<(), String> {
+    let mut column = 0u16;
+    for (text, color) in syntax_segments(line) {
+        if column >= width {
+            break;
+        }
+        write_at(stdout, x + column, y, width - column, &text, color)?;
+        column = column.saturating_add(text.chars().count() as u16);
+    }
+    Ok(())
+}
+
+fn syntax_segments(line: &str) -> Vec<(String, Color)> {
+    let keywords = [
+        "function", "struct", "enum", "global", "const", "let", "return", "if", "else", "for",
+        "foreach", "while", "true", "false",
+    ];
+    let mut segments = Vec::<(String, Color)>::new();
+    let mut chars = line.char_indices().peekable();
+    while let Some((start, ch)) = chars.next() {
+        let end = if ch.is_ascii_alphabetic() || ch == '_' {
+            while chars
+                .peek()
+                .is_some_and(|(_, next)| next.is_ascii_alphanumeric() || *next == '_')
+            {
+                chars.next();
+            }
+            chars.peek().map_or(line.len(), |(index, _)| *index)
+        } else if ch.is_ascii_digit() {
+            while chars
+                .peek()
+                .is_some_and(|(_, next)| next.is_ascii_digit() || *next == '.')
+            {
+                chars.next();
+            }
+            chars.peek().map_or(line.len(), |(index, _)| *index)
+        } else {
+            chars.peek().map_or(line.len(), |(index, _)| *index)
+        };
+        let text = &line[start..end];
+        let color = if keywords.contains(&text) {
+            Color::Cyan
+        } else if ch.is_ascii_digit() {
+            Color::Yellow
+        } else {
+            Color::White
+        };
+        if let Some((prior, prior_color)) = segments.last_mut() {
+            if *prior_color == color {
+                prior.push_str(text);
+                continue;
+            }
+        }
+        segments.push((text.to_string(), color));
+    }
+    segments
+}
+
+fn draw_right_panel(
+    stdout: &mut impl Write,
+    rect: Rect,
+    completion: &CompletionState,
+    inspector: &InspectorState,
+) -> Result<(), String> {
+    if rect.width < 3 || rect.height < 3 {
+        return Ok(());
+    }
+    let inner_height = rect.height.saturating_sub(2);
+    let completion_rows = (inner_height / 2).max(2) as usize;
+    let page_start = completion
+        .selected
+        .saturating_sub(completion_rows.saturating_sub(1));
+    for (row, (index, item)) in completion
+        .items
+        .iter()
+        .enumerate()
+        .skip(page_start)
+        .take(completion_rows)
+        .enumerate()
+    {
+        let marker = if completion.armed && index == completion.selected {
+            ">"
+        } else {
+            " "
+        };
+        write_at(
+            stdout,
+            rect.x + 1,
+            rect.y + 1 + row as u16,
+            rect.width.saturating_sub(2),
+            &format!("{marker} {} [{}]", item.text, item.kind),
+            if index == completion.selected {
+                Color::Green
+            } else {
+                Color::White
+            },
+        )?;
+    }
+    let detail_y = rect.y + 1 + completion_rows as u16;
+    write_at(
+        stdout,
+        rect.x + 1,
+        detail_y,
+        rect.width.saturating_sub(2),
+        &format!("-- {} --", inspector.title),
+        Color::Cyan,
+    )?;
+    let detail = completion
+        .items
+        .get(completion.selected)
+        .map(|item| item.detail.clone());
+    let lines = detail.into_iter().chain(inspector.lines.iter().cloned());
+    for (row, line) in lines
+        .take(inner_height.saturating_sub(completion_rows as u16 + 1) as usize)
+        .enumerate()
+    {
+        write_at(
+            stdout,
+            rect.x + 1,
+            detail_y + 1 + row as u16,
+            rect.width.saturating_sub(2),
+            &line,
+            Color::DarkGrey,
+        )?;
+    }
+    Ok(())
+}
+
+fn write_at(
+    stdout: &mut impl Write,
+    x: u16,
+    y: u16,
+    width: u16,
+    text: &str,
+    color: Color,
+) -> Result<(), String> {
+    if width == 0 {
+        return Ok(());
+    }
+    let clipped = text.chars().take(width as usize).collect::<String>();
+    queue!(
+        stdout,
+        MoveTo(x, y),
+        SetForegroundColor(color),
+        Print(clipped),
+        ResetColor
+    )
+    .map_err(|error| format!("failed drawing live TUI: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multiline_editor_autoindents_and_moves_vertically() {
+        let mut buffer = EditBuffer::from_text("function tick(): i32 {".to_string());
+        buffer.insert_newline();
+        buffer.insert_char('r');
+        assert_eq!(buffer.text, "function tick(): i32 {\n    r");
+        buffer.move_vertical(-1, false);
+        assert_eq!(line_column(&buffer.text, buffer.cursor).0, 0);
+    }
+
+    #[test]
+    fn completion_requires_whitespace_document_tail() {
+        assert!(suffix_is_whitespace("hero.da\n   ", 7));
+        assert!(!suffix_is_whitespace("hero.da later", 7));
+    }
+
+    #[test]
+    fn ghost_is_only_a_real_prefix_suffix() {
+        let buffer = EditBuffer::from_text("hero.da".to_string());
+        let completion = CompletionState {
+            items: vec![CompletionItem {
+                text: "hero.damage".to_string(),
+                kind: "method".to_string(),
+                detail: String::new(),
+                type_name: None,
+                source: None,
+                selector: None,
+                scope: None,
+            }],
+            selected: 0,
+            replacement_start: 0,
+            replacement_end: 7,
+            armed: true,
+            truncated: false,
+        };
+        assert_eq!(ghost_suffix(&buffer, &completion).as_deref(), Some("mage"));
+    }
+
+    #[test]
+    fn very_narrow_layout_stacks_the_right_panel() {
+        let layout = Layout::new(50, 30, true);
+        assert_eq!(layout.right.x, 0);
+        assert!(layout.right.y > layout.editor.y);
+    }
+
+    #[test]
+    fn compact_desktop_keeps_the_right_panel_beside_the_editor() {
+        let layout = Layout::new(68, 30, true);
+        assert!(layout.right.x > 0);
+        assert_eq!(layout.right.y, 0);
+    }
+
+    #[test]
+    fn tiny_layout_never_draws_below_the_real_viewport() {
+        for (width, height) in [(80u16, 3u16), (40, 1), (10, 10)] {
+            let usable_height = height.saturating_sub(1);
+            let layout = Layout::new(width, height, true);
+            for rect in [layout.transcript, layout.editor, layout.right] {
+                assert!(rect.x.saturating_add(rect.width) <= width);
+                assert!(rect.y.saturating_add(rect.height) <= usable_height);
+            }
+        }
+    }
+
+    #[test]
+    fn syntax_segments_highlight_keywords_and_numbers() {
+        let segments = syntax_segments("let score: i32 = 12;");
+        assert!(segments
+            .iter()
+            .any(|(text, color)| text == "let" && *color == Color::Cyan));
+        assert!(segments
+            .iter()
+            .any(|(text, color)| text == "12" && *color == Color::Yellow));
+    }
+
+    #[test]
+    fn default_state_items_indent_dotted_paths() {
+        let item = serde_json::json!({
+            "path": "player.position.x",
+            "static_type": "f32",
+            "value": {"type": "f32", "value": 12.5}
+        });
+        assert_eq!(format_state_item(&item), "    x: f32 = 12.5");
+    }
+
+    #[test]
+    fn completion_requests_coalesce_and_stale_results_are_discarded() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        app.refresh_completion(false);
+        app.active_buffer_mut().insert_char('s');
+        app.refresh_completion(true);
+
+        let first = server.drain(8);
+        assert_eq!(first.len(), 1);
+        let first_id = first[0].request_id;
+        server
+            .respond(LiveResponse::success(
+                first_id,
+                1,
+                "completion",
+                serde_json::json!({
+                    "replacement_start": 0,
+                    "replacement_end": 0,
+                    "page": 0,
+                    "truncated": false,
+                    "items": [{"text": "stale", "kind": "global", "detail": "stale"}]
+                }),
+            ))
+            .expect("stale completion response");
+        app.drain_responses().expect("drain stale completion");
+        assert!(app.completion.items.is_empty());
+
+        let second = server.drain(8);
+        assert_eq!(second.len(), 1);
+        let second_id = second[0].request_id;
+        server
+            .respond(LiveResponse::success(
+                second_id,
+                2,
+                "completion",
+                serde_json::json!({
+                    "replacement_start": 0,
+                    "replacement_end": 1,
+                    "page": 0,
+                    "truncated": false,
+                    "items": [{"text": "score", "kind": "global", "detail": "i32"}]
+                }),
+            ))
+            .expect("current completion response");
+        app.drain_responses().expect("drain current completion");
+        assert_eq!(app.completion.items[0].text, "score");
+        assert!(app.completion.armed);
+    }
+
+    #[test]
+    fn editing_after_discard_warning_requires_a_fresh_confirmation() {
+        let (client, _server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        app.input = InputMode::Definition(EditSession {
+            target: LiveSymbolTarget {
+                name: "tick".to_string(),
+                kind: Some("function".to_string()),
+                file: Some("src/main.stasis".to_string()),
+                owner: None,
+                signature: Some("tick(): i32".to_string()),
+            },
+            expected_source_hash: workshop_source_hash("accepted"),
+            accepted_source: "accepted".to_string(),
+            source_start: 0,
+            buffer: EditBuffer::from_text("dirty".to_string()),
+            discard_confirm: false,
+        });
+        app.close_definition();
+        assert!(matches!(
+            &app.input,
+            InputMode::Definition(edit) if edit.discard_confirm
+        ));
+        app.active_buffer_mut().insert_char('!');
+        app.close_definition();
+        assert!(matches!(
+            &app.input,
+            InputMode::Definition(edit) if edit.discard_confirm
+        ));
+    }
+
+    #[test]
+    fn edit_uses_the_selected_overload_selector() {
+        let long_signature = format!("tick({}): i32", "value: i32, ".repeat(30));
+        let completion = CompletionState {
+            items: vec![
+                CompletionItem {
+                    text: "tick".to_string(),
+                    kind: "function".to_string(),
+                    detail: "tick(i32): i32 [src/a.stasis]".to_string(),
+                    type_name: None,
+                    source: Some("src/a.stasis".to_string()),
+                    selector: Some(LiveSymbolTarget {
+                        name: "tick".to_string(),
+                        kind: Some("function".to_string()),
+                        file: Some("src/a.stasis".to_string()),
+                        owner: None,
+                        signature: Some("tick(i32): i32".to_string()),
+                    }),
+                    scope: None,
+                },
+                CompletionItem {
+                    text: "tick".to_string(),
+                    kind: "function".to_string(),
+                    detail: "tick(...) [display text intentionally truncated]".to_string(),
+                    type_name: None,
+                    source: Some("src/b.stasis".to_string()),
+                    selector: Some(LiveSymbolTarget {
+                        name: "tick".to_string(),
+                        kind: Some("function".to_string()),
+                        file: Some("src/b.stasis".to_string()),
+                        owner: None,
+                        signature: Some(long_signature.clone()),
+                    }),
+                    scope: None,
+                },
+            ],
+            selected: 1,
+            ..CompletionState::default()
+        };
+        let target = edit_target_from_completion("tick", &completion);
+        assert_eq!(target.file.as_deref(), Some("src/b.stasis"));
+        assert_eq!(target.signature.as_deref(), Some(long_signature.as_str()));
+    }
+
+    #[test]
+    fn default_inspection_backpressure_does_not_exit_or_leave_pending_work() {
+        let (client, _server) = stasis_runner::live::live_session(1);
+        client
+            .submit(LiveRequest::new(99, LiveCommand::Pause))
+            .expect("fill request queue");
+        let mut app = LiveTui::new(client);
+
+        app.request_default_inspection()
+            .expect("backpressure stays inside the TUI");
+
+        assert!(!app
+            .pending
+            .values()
+            .any(|action| matches!(action, PendingAction::DefaultInspect)));
+        assert!(app.status.contains("delayed by backpressure"));
+    }
+
+    #[test]
+    fn replacing_a_pinned_inspection_unwatches_the_previous_path() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        app.handle_response(LiveResponse::success(
+            10,
+            1,
+            "inspection",
+            serde_json::json!({"path": "score", "static_type": "i32", "value": 1}),
+        ));
+        let first = server.drain(8);
+        assert!(matches!(
+            &first[0].command,
+            LiveCommand::Watch { path } if path == "score"
+        ));
+        server
+            .respond(LiveResponse::success(
+                first[0].request_id,
+                2,
+                "watch_added",
+                serde_json::json!({"path": "score", "value": 1}),
+            ))
+            .expect("confirm score watch");
+        app.drain_responses().expect("drain score watch");
+        assert_eq!(app.inspector_watch.as_deref(), Some("score"));
+        app.handle_response(LiveResponse::success(
+            11,
+            3,
+            "inspection",
+            serde_json::json!({"path": "speed", "static_type": "f32", "value": 2.0}),
+        ));
+        let replaced = server.drain(8);
+        assert_eq!(replaced.len(), 1);
+        assert!(matches!(
+            &replaced[0].command,
+            LiveCommand::Unwatch { path: Some(path) } if path == "score"
+        ));
+        server
+            .respond(LiveResponse::success(
+                replaced[0].request_id,
+                4,
+                "watch_removed",
+                serde_json::json!({"watches": []}),
+            ))
+            .expect("confirm score unwatch");
+        app.drain_responses().expect("drain score unwatch");
+        let watch = server.drain(8);
+        assert!(matches!(
+            &watch[0].command,
+            LiveCommand::Watch { path } if path == "speed"
+        ));
+        server
+            .respond(LiveResponse::success(
+                watch[0].request_id,
+                5,
+                "watch_added",
+                serde_json::json!({"path": "speed", "value": 2.0}),
+            ))
+            .expect("confirm speed watch");
+        app.drain_responses().expect("drain speed watch");
+        assert_eq!(app.inspector_watch.as_deref(), Some("speed"));
+    }
+
+    #[test]
+    fn watch_replacement_backpressure_keeps_truthful_retryable_state() {
+        let (client, server) = stasis_runner::live::live_session(1);
+        client
+            .submit(LiveRequest::new(99, LiveCommand::Pause))
+            .expect("fill request queue");
+        let mut app = LiveTui::new(client);
+        app.inspector_watch = Some("score".to_string());
+
+        app.replace_inspector_watch(Some("speed".to_string()));
+        assert_eq!(app.inspector_watch.as_deref(), Some("score"));
+        assert!(app.status.contains("unavailable"));
+
+        server.drain(1);
+        app.replace_inspector_watch(Some("speed".to_string()));
+        assert_eq!(app.inspector_watch.as_deref(), Some("score"));
+        let unwatch = server.drain(1);
+        assert!(matches!(
+            &unwatch[0].command,
+            LiveCommand::Unwatch { path: Some(path) } if path == "score"
+        ));
+        server
+            .respond(LiveResponse::success(
+                unwatch[0].request_id,
+                1,
+                "watch_removed",
+                serde_json::json!({"watches": []}),
+            ))
+            .expect("confirm unwatch");
+        app.drain_responses().expect("drain unwatch");
+        assert_eq!(app.inspector_watch, None);
+        let watch = server.drain(1);
+        assert!(matches!(
+            &watch[0].command,
+            LiveCommand::Watch { path } if path == "speed"
+        ));
+    }
+
+    #[test]
+    fn rejected_watch_does_not_create_a_ghost_or_suppress_retry() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        app.replace_inspector_watch(Some("score".to_string()));
+        let first = server.drain(1);
+        assert_eq!(app.inspector_watch, None);
+
+        server
+            .respond(LiveResponse::failure(
+                first[0].request_id,
+                1,
+                "live watch limit reached",
+            ))
+            .expect("reject watch");
+        app.drain_responses().expect("drain rejected watch");
+        assert_eq!(app.inspector_watch, None);
+
+        app.replace_inspector_watch(Some("score".to_string()));
+        let retry = server.drain(1);
+        assert!(matches!(
+            &retry[0].command,
+            LiveCommand::Watch { path } if path == "score"
+        ));
+    }
+}

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -906,7 +906,10 @@ impl LiveTui {
         self.last_default_inspection = Instant::now();
         if let Err(error) = self.client.submit(LiveRequest::new(
             request_id,
-            LiveCommand::InspectAll { limit: 32 },
+            LiveCommand::InspectAll {
+                limit: 32,
+                concise: true,
+            },
         )) {
             self.pending.remove(&request_id);
             self.status = format!("default inspection delayed by backpressure: {error}");
@@ -1168,6 +1171,9 @@ impl LiveTui {
         };
         self.inspector.title = "Live state (default)".to_string();
         self.inspector.lines = items.iter().map(format_state_item).collect();
+        if self.inspector.lines.is_empty() {
+            self.inspector.lines = vec!["No concise state values; use :inspect PATH.".to_string()];
+        }
         if response
             .data
             .as_ref()
@@ -1407,17 +1413,12 @@ fn edit_target_from_completion(symbol: &str, completion: &CompletionState) -> Li
 
 fn format_state_item(item: &Value) -> String {
     let path = item.get("path").and_then(Value::as_str).unwrap_or("value");
-    let static_type = item
-        .get("static_type")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
     let depth = path.matches('.').count();
     let name = path.rsplit('.').next().unwrap_or(path);
     format!(
-        "{}{}: {} = {}",
+        "{}{} = {}",
         "  ".repeat(depth),
         name,
-        static_type,
         scalar_text(item.get("value").unwrap_or(&Value::Null))
     )
 }
@@ -1910,13 +1911,13 @@ mod tests {
     }
 
     #[test]
-    fn default_state_items_indent_dotted_paths() {
+    fn default_state_items_are_concise_and_indent_dotted_paths() {
         let item = serde_json::json!({
-            "path": "player.position.x",
+            "path": "player.stats.score",
             "static_type": "f32",
             "value": {"type": "f32", "value": 12.5}
         });
-        assert_eq!(format_state_item(&item), "    x: f32 = 12.5");
+        assert_eq!(format_state_item(&item), "    score = 12.5");
     }
 
     #[test]

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1018,7 +1018,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     );
     fs::write(
         project.join("src/main.stasis"),
-        "global score: i32;\nglobal swaps: i32;\nfunction main(): i32 { score = 1; swaps = 0; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { swaps += 1; return; }\n",
+        "struct Player { hp: i32; }\nglobal score: i32;\nglobal swaps: i32;\nfunction main(): i32 { score = 1; swaps = 0; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { swaps += 1; return; }\nfunction damage(player: Player, amount: i32): i32 { let hero: Player; return amount; }\n",
     )
     .expect("write live project");
     fs::write(
@@ -1028,7 +1028,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write live test");
     fs::write(
         project.join("live.commands"),
-        ":pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
+        ":palette hrohp --owner damage --file src/main.stasis\n:palette :pa\n:pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
     )
     .expect("write live script");
 
@@ -1056,6 +1056,13 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
         .collect::<Vec<_>>();
     assert!(responses.iter().all(|response| response["ok"] == true));
     assert!(responses.iter().all(|response| response["tick"].is_u64()));
+    let palettes = responses
+        .iter()
+        .filter(|response| response["kind"] == "palette")
+        .collect::<Vec<_>>();
+    assert_eq!(palettes[0]["data"]["items"][0]["text"], "hero.hp");
+    assert_eq!(palettes[0]["data"]["items"][0]["kind"], "field");
+    assert_eq!(palettes[1]["data"]["items"][0]["text"], ":pause");
     let inspected = responses
         .iter()
         .filter(|response| response["kind"] == "inspection")
@@ -1100,7 +1107,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
 
     fs::write(
         project.join("human-live.commands"),
-        ":pause\n:inspect score\n:status\n:quit\n",
+        ":palette hrohp --owner damage --file src/main.stasis\n:pause\n:inspect score\n:status\n:quit\n",
     )
     .expect("write human live script");
     let human = stasis(
@@ -1121,6 +1128,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     );
     let human_stdout = String::from_utf8_lossy(&human.stdout);
     assert!(human_stdout.contains("paused"));
+    assert!(human_stdout.contains("hero.hp  field"));
     assert!(human_stdout.contains("score: i32 ="));
     assert!(human_stdout.contains("edits 0/0"));
     assert!(human_stdout.contains("session closed"));

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1028,7 +1028,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write live test");
     fs::write(
         project.join("live.commands"),
-        ":palette hrohp --owner damage --file src/main.stasis\n:palette :pa\n:pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
+        ":palette hrohp --owner damage --file src/main.stasis\n:palette :pa\n:complete sco\n:pause\n:update function tick src/main.stasis\nfunction tick(): i32 { score += 4; return 0; }\n:end\n:inspect swaps\n:set score 10\n:step 1\n:inspect score\n:undo\n:inspect swaps\n:step 1\n:inspect score\n:quit\n",
     )
     .expect("write live script");
 
@@ -1063,6 +1063,14 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     assert_eq!(palettes[0]["data"]["items"][0]["text"], "hero.hp");
     assert_eq!(palettes[0]["data"]["items"][0]["kind"], "field");
     assert_eq!(palettes[1]["data"]["items"][0]["text"], ":pause");
+    assert!(responses
+        .iter()
+        .any(|response| response["kind"] == "completion_preparing"));
+    let completion = responses
+        .iter()
+        .find(|response| response["kind"] == "completion")
+        .expect("background completion result");
+    assert_eq!(completion["data"]["items"][0]["text"], "score");
     let inspected = responses
         .iter()
         .filter(|response| response["kind"] == "inspection")

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -9,6 +9,14 @@ pub struct ParsedParam {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedLocalBinding {
+    pub function_name: String,
+    pub name: String,
+    pub type_name: String,
+    pub visibility_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedFunctionSignature {
     pub name: String,
     pub params: Vec<ParsedParam>,
@@ -82,6 +90,101 @@ pub struct ParsedTypeLayout {
     pub globals: Vec<ParsedGlobalDefinition>,
     pub global_blocks: Vec<ParsedGlobalBlockDefinition>,
     pub constants: Vec<ParsedConstDefinition>,
+}
+
+pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding>, String> {
+    let tokens = lex(source)?;
+    let mut bindings = Vec::new();
+    for function in parse_top_level_functions(source)? {
+        let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
+        let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
+        while let Some(token) = tokens.get(cursor).copied() {
+            if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
+                break;
+            }
+            if token.kind != TokenKind::Identifier || token_text(source, token) != "let" {
+                cursor += 1;
+                continue;
+            }
+            let Some(name) = tokens.get(cursor + 1).copied() else {
+                break;
+            };
+            let Some(colon) = tokens.get(cursor + 2).copied() else {
+                break;
+            };
+            if name.kind != TokenKind::Identifier || colon.kind != TokenKind::Colon {
+                cursor += 1;
+                continue;
+            }
+            let (type_name, next) = parse_type_name(source, &tokens, cursor + 3)?;
+            let scope_end = scope_ranges
+                .iter()
+                .filter(|range| range.start <= token.start && token.end <= range.end)
+                .min_by_key(|range| range.end.saturating_sub(range.start))
+                .map(|range| range.end)
+                .unwrap_or(function.body_range.end);
+            bindings.push(ParsedLocalBinding {
+                function_name: function.name.clone(),
+                name: token_text(source, name).to_string(),
+                type_name,
+                visibility_range: name.end..scope_end,
+            });
+            cursor = next;
+        }
+    }
+    bindings.sort_by_key(|binding| {
+        (
+            binding.function_name.clone(),
+            binding.name.clone(),
+            binding.type_name.clone(),
+            binding.visibility_range.start,
+            binding.visibility_range.end,
+        )
+    });
+    bindings.dedup();
+    Ok(bindings)
+}
+
+pub fn completion_expected_type(source: &str, cursor: usize) -> Result<Option<String>, String> {
+    let cursor = cursor.min(source.len());
+    let tokens = lex(source)?;
+    let Some(colon_index) = tokens
+        .iter()
+        .enumerate()
+        .take_while(|(_, token)| token.start < cursor)
+        .filter(|(_, token)| token.kind == TokenKind::Colon)
+        .map(|(index, _)| index)
+        .last()
+    else {
+        return Ok(None);
+    };
+    let (type_name, next) = parse_type_name(source, &tokens, colon_index + 1)?;
+    let has_assignment = tokens[colon_index + 1..]
+        .iter()
+        .take_while(|token| token.start < cursor)
+        .skip(next.saturating_sub(colon_index + 1))
+        .any(|token| token.kind == TokenKind::Other && token_text(source, *token) == "=");
+    Ok(has_assignment.then_some(type_name))
+}
+
+fn lexical_scope_ranges(tokens: &[Token], body_range: Range<usize>) -> Vec<Range<usize>> {
+    let mut starts = Vec::new();
+    let mut ranges = Vec::new();
+    for token in tokens
+        .iter()
+        .filter(|token| body_range.start <= token.start && token.end <= body_range.end)
+    {
+        match token.kind {
+            TokenKind::LBrace => starts.push(token.start),
+            TokenKind::RBrace => {
+                if let Some(start) = starts.pop() {
+                    ranges.push(start..token.end);
+                }
+            }
+            _ => {}
+        }
+    }
+    ranges
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1127,6 +1230,56 @@ mod tests {
         assert_eq!(parsed[0].return_type_name, "i32");
         assert_eq!(parsed[0].params.len(), 0);
         assert_eq!(&source[parsed[0].body_range.clone()], "{ return 0; }");
+    }
+
+    #[test]
+    fn parses_typed_locals_without_treating_foreach_bindings_as_typed() {
+        let source = r#"
+function move_player(player: Player, delta: f32): f32 {
+    let speed: f32 = delta;
+    foreach (let enemy in state.enemies) {
+        let damage: i32 = 1;
+    }
+    return speed;
+}
+function reset(): void {
+    let player: Player;
+}
+"#;
+        let bindings = parse_typed_local_bindings(source).expect("typed locals");
+        assert_eq!(
+            bindings
+                .iter()
+                .map(|binding| (
+                    binding.function_name.as_str(),
+                    binding.name.as_str(),
+                    binding.type_name.as_str(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("move_player", "damage", "i32"),
+                ("move_player", "speed", "f32"),
+                ("reset", "player", "Player"),
+            ]
+        );
+        let damage = bindings
+            .iter()
+            .find(|binding| binding.name == "damage")
+            .expect("nested binding");
+        assert!(damage.visibility_range.end < source.find("return speed").expect("return"));
+    }
+
+    #[test]
+    fn completion_expected_type_uses_typed_binding_before_cursor() {
+        let source = "let next_score: i32 = sco";
+        assert_eq!(
+            completion_expected_type(source, source.len()).expect("expected type"),
+            Some("i32".to_string())
+        );
+        assert_eq!(
+            completion_expected_type(":palette sco", 12).expect("command"),
+            None
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -97,6 +97,7 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
     let mut bindings = Vec::new();
     for function in parse_top_level_functions(source)? {
         let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
+        let loop_ranges = for_scope_ranges(source, &tokens, function.body_range.clone());
         let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
         while let Some(token) = tokens.get(cursor).copied() {
             if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
@@ -119,6 +120,7 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
             let (type_name, next) = parse_type_name(source, &tokens, cursor + 3)?;
             let scope_end = scope_ranges
                 .iter()
+                .chain(loop_ranges.iter())
                 .filter(|range| range.start <= token.start && token.end <= range.end)
                 .min_by_key(|range| range.end.saturating_sub(range.start))
                 .map(|range| range.end)
@@ -185,6 +187,69 @@ fn lexical_scope_ranges(tokens: &[Token], body_range: Range<usize>) -> Vec<Range
         }
     }
     ranges
+}
+
+fn for_scope_ranges(source: &str, tokens: &[Token], body_range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut cursor = tokens.partition_point(|token| token.start < body_range.start);
+    while let Some(token) = tokens.get(cursor).copied() {
+        if token.start >= body_range.end || token.kind == TokenKind::Eof {
+            break;
+        }
+        if token.kind == TokenKind::Identifier && token_text(source, token) == "for" {
+            let Some(header_open) = tokens
+                .get(cursor + 1)
+                .filter(|token| token.kind == TokenKind::LParen)
+            else {
+                cursor += 1;
+                continue;
+            };
+            let Some(header_close_index) =
+                matching_token_index(tokens, cursor + 1, TokenKind::LParen, TokenKind::RParen)
+            else {
+                cursor += 1;
+                continue;
+            };
+            let Some(body_open_index) = tokens
+                .get(header_close_index + 1)
+                .filter(|token| token.kind == TokenKind::LBrace)
+                .map(|_| header_close_index + 1)
+            else {
+                cursor += 1;
+                continue;
+            };
+            if let Some(body_close_index) = matching_token_index(
+                tokens,
+                body_open_index,
+                TokenKind::LBrace,
+                TokenKind::RBrace,
+            ) {
+                ranges.push(header_open.start..tokens[body_close_index].end);
+            }
+        }
+        cursor += 1;
+    }
+    ranges
+}
+
+fn matching_token_index(
+    tokens: &[Token],
+    open_index: usize,
+    open_kind: TokenKind,
+    close_kind: TokenKind,
+) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, token) in tokens.iter().enumerate().skip(open_index) {
+        if token.kind == open_kind {
+            depth = depth.saturating_add(1);
+        } else if token.kind == close_kind {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1267,6 +1332,28 @@ function reset(): void {
             .find(|binding| binding.name == "damage")
             .expect("nested binding");
         assert!(damage.visibility_range.end < source.find("return speed").expect("return"));
+    }
+
+    #[test]
+    fn typed_for_initializer_is_visible_only_through_loop_body() {
+        let source = r#"
+function tick(): i32 {
+    for (let index: i32 = 0; index < 2; index += 1) {
+        let inside: i32 = index;
+    }
+    let after: i32 = 3;
+    return after;
+}
+"#;
+        let bindings = parse_typed_local_bindings(source).expect("typed locals");
+        let after_start = source.find("let after").expect("after binding");
+        for name in ["index", "inside"] {
+            let binding = bindings
+                .iter()
+                .find(|binding| binding.name == name)
+                .expect("loop binding");
+            assert!(binding.visibility_range.end < after_start);
+        }
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::frontend::lexer::{lex, Token, TokenKind};
-use crate::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
+use crate::frontend::parser::{
+    parse_top_level_functions, parse_top_level_struct_definitions, parse_top_level_type_layout,
+    parse_typed_local_bindings,
+};
 use crate::IncrementalCompileOutput;
 
 #[derive(
@@ -955,6 +958,32 @@ pub struct WorkshopSourceItem {
     pub source_hash: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopCompletionItem {
+    pub text: String,
+    pub kind: String,
+    pub detail: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<WorkshopCompletionScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopCompletionScope {
+    pub owner: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_end: Option<usize>,
+    pub visible_from: usize,
+    pub visible_to: usize,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkshopSemanticEditOperation {
@@ -1091,6 +1120,419 @@ pub fn workshop_source_items(
         (item.file.clone(), order, start, item.name.clone())
     });
     Ok(items)
+}
+
+pub fn workshop_completion_items(
+    files: &[WorkshopSourceFile],
+) -> Result<Vec<WorkshopCompletionItem>, String> {
+    let mut items = Vec::new();
+    let mut struct_fields = BTreeMap::<String, Vec<(String, String)>>::new();
+    let parsed_files = files
+        .iter()
+        .map(|file| {
+            Ok((
+                file,
+                parse_top_level_type_layout(&file.source)?,
+                parse_top_level_functions(&file.source)?,
+                parse_typed_local_bindings(&file.source)?,
+                parse_top_level_struct_definitions(&file.source)?,
+            ))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let mut struct_scopes = BTreeMap::<(String, String), WorkshopCompletionScope>::new();
+    for (file, layout, _, _, ranges) in &parsed_files {
+        for definition in &layout.structs {
+            struct_fields.insert(
+                definition.name.clone(),
+                definition
+                    .fields
+                    .iter()
+                    .map(|field| (field.name.clone(), field.type_name.clone()))
+                    .collect(),
+            );
+        }
+        for definition in ranges {
+            struct_scopes.insert(
+                (file.path.clone(), definition.name.clone()),
+                WorkshopCompletionScope {
+                    owner: definition.name.clone(),
+                    file: file.path.clone(),
+                    owner_signature: Some(format!("struct {}", definition.name)),
+                    owner_end: Some(definition.definition_range.end),
+                    visible_from: definition.definition_range.start,
+                    visible_to: definition.definition_range.end,
+                },
+            );
+        }
+    }
+
+    let source_items = workshop_source_items(files)?;
+    let mut methods = BTreeMap::<String, Vec<(String, String, String)>>::new();
+    for item in source_items.iter().filter(|item| {
+        matches!(
+            item.kind,
+            WorkshopSourceItemKind::Struct
+                | WorkshopSourceItemKind::Function
+                | WorkshopSourceItemKind::Test
+        )
+    }) {
+        let kind = format!("{:?}", item.kind).to_ascii_lowercase();
+        items.push(completion_catalog_item(
+            &item.name,
+            &kind,
+            &format!("{} [{}]", item.signature, item.file),
+            &item.file,
+            item.owner.clone(),
+        ));
+        if item.kind == WorkshopSourceItemKind::Function {
+            if let Some(owner) = item
+                .owner
+                .as_ref()
+                .filter(|owner| struct_fields.contains_key(*owner))
+            {
+                methods.entry(owner.clone()).or_default().push((
+                    item.name.clone(),
+                    item.signature.clone(),
+                    item.file.clone(),
+                ));
+            }
+        }
+    }
+
+    let mut typed_bindings = Vec::<WorkshopTypedBinding>::new();
+    for (file, layout, functions, locals, _) in parsed_files {
+        for definition in layout.structs {
+            let struct_scope = struct_scopes
+                .get(&(file.path.clone(), definition.name.clone()))
+                .cloned();
+            for field in definition.fields {
+                items.push(scoped_completion_catalog_item(
+                    &field.name,
+                    "field",
+                    &format!(
+                        "{}.{}: {} [{}]",
+                        definition.name, field.name, field.type_name, file.path
+                    ),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    Some(&field.type_name),
+                    struct_scope
+                        .clone()
+                        .expect("parsed struct has a source range"),
+                ));
+                items.push(typed_completion_catalog_item(
+                    &format!("{}.{}", definition.name, field.name),
+                    "field",
+                    &format!("{} [{}]", field.type_name, file.path),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    &field.type_name,
+                ));
+            }
+        }
+        for definition in layout.enums {
+            items.push(typed_completion_catalog_item(
+                &definition.name,
+                "enum",
+                &format!("enum {} [{}]", definition.name, file.path),
+                &file.path,
+                None,
+                &definition.name,
+            ));
+            for variant in definition.variants {
+                items.push(typed_completion_catalog_item(
+                    &format!("{}.{}", definition.name, variant.name),
+                    "enum_variant",
+                    &format!("{} [{}]", definition.name, file.path),
+                    &file.path,
+                    Some(definition.name.clone()),
+                    &definition.name,
+                ));
+            }
+        }
+        for global in layout.globals {
+            items.push(typed_completion_catalog_item(
+                &global.name,
+                "global",
+                &format!("{} [{}]", global.type_name, file.path),
+                &file.path,
+                None,
+                &global.type_name,
+            ));
+            typed_bindings.push(WorkshopTypedBinding {
+                name: global.name,
+                type_name: global.type_name,
+                kind: "global".to_string(),
+                scope_label: "global".to_string(),
+                file: file.path.clone(),
+                scope: None,
+            });
+        }
+        for block in layout.global_blocks {
+            for field in block.fields {
+                let path = format!("{}.{}", block.name, field.name);
+                items.push(typed_completion_catalog_item(
+                    &path,
+                    "state_path",
+                    &format!("{} [{}]", field.type_name, file.path),
+                    &file.path,
+                    Some(block.name.clone()),
+                    &field.type_name,
+                ));
+                typed_bindings.push(WorkshopTypedBinding {
+                    name: path,
+                    type_name: field.type_name,
+                    kind: "state_path".to_string(),
+                    scope_label: block.name.clone(),
+                    file: file.path.clone(),
+                    scope: None,
+                });
+            }
+        }
+        for constant in layout.constants {
+            items.push(typed_completion_catalog_item(
+                &constant.name,
+                "constant",
+                &format!("{} [{}]", constant.type_name, file.path),
+                &file.path,
+                None,
+                &constant.type_name,
+            ));
+        }
+        let function_scopes = functions
+            .iter()
+            .map(|function| {
+                (
+                    function.body_range.clone(),
+                    format_function_signature(
+                        &function.name,
+                        &function.params,
+                        &function.return_type_name,
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        for function in functions {
+            let owner_signature = format_function_signature(
+                &function.name,
+                &function.params,
+                &function.return_type_name,
+            );
+            for parameter in function.params {
+                let scope = WorkshopCompletionScope {
+                    owner: function.name.clone(),
+                    file: file.path.clone(),
+                    owner_signature: Some(owner_signature.clone()),
+                    owner_end: Some(function.body_range.end),
+                    visible_from: function.body_range.start,
+                    visible_to: function.body_range.end,
+                };
+                items.push(scoped_completion_catalog_item(
+                    &parameter.name,
+                    "parameter",
+                    &format!(
+                        "{} in {} [{}]",
+                        parameter.type_name, function.name, file.path
+                    ),
+                    &file.path,
+                    Some(function.name.clone()),
+                    Some(&parameter.type_name),
+                    scope.clone(),
+                ));
+                typed_bindings.push(WorkshopTypedBinding {
+                    name: parameter.name,
+                    type_name: parameter.type_name,
+                    kind: "parameter".to_string(),
+                    scope_label: function.name.clone(),
+                    file: file.path.clone(),
+                    scope: Some(scope),
+                });
+            }
+        }
+        for local in locals {
+            let (owner_range, owner_signature) = function_scopes
+                .iter()
+                .find(|(range, _)| {
+                    range.start <= local.visibility_range.start
+                        && local.visibility_range.start <= range.end
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "typed local {} has no containing function in {}",
+                        local.name, file.path
+                    )
+                })?;
+            let scope = WorkshopCompletionScope {
+                owner: local.function_name.clone(),
+                file: file.path.clone(),
+                owner_signature: Some(owner_signature.clone()),
+                owner_end: Some(owner_range.end),
+                visible_from: local.visibility_range.start,
+                visible_to: local.visibility_range.end,
+            };
+            items.push(scoped_completion_catalog_item(
+                &local.name,
+                "local",
+                &format!(
+                    "{} in {} [{}]",
+                    local.type_name, local.function_name, file.path
+                ),
+                &file.path,
+                Some(local.function_name.clone()),
+                Some(&local.type_name),
+                scope.clone(),
+            ));
+            typed_bindings.push(WorkshopTypedBinding {
+                name: local.name,
+                type_name: local.type_name,
+                kind: "local".to_string(),
+                scope_label: local.function_name,
+                file: file.path.clone(),
+                scope: Some(scope),
+            });
+        }
+    }
+
+    for binding in typed_bindings {
+        if let Some(fields) = struct_fields.get(&binding.type_name) {
+            for (field, field_type) in fields {
+                let text = format!("{}.{field}", binding.name);
+                let detail = format!(
+                    "{field_type} via {} {}: {} in {} [{}]",
+                    binding.kind,
+                    binding.name,
+                    binding.type_name,
+                    binding.scope_label,
+                    binding.file
+                );
+                let item = match binding.scope.clone() {
+                    Some(scope) => scoped_completion_catalog_item(
+                        &text,
+                        "field",
+                        &detail,
+                        &binding.file,
+                        Some(binding.type_name.clone()),
+                        Some(field_type),
+                        scope,
+                    ),
+                    None => typed_completion_catalog_item(
+                        &text,
+                        "field",
+                        &detail,
+                        &binding.file,
+                        Some(binding.type_name.clone()),
+                        field_type,
+                    ),
+                };
+                items.push(item);
+            }
+        }
+        if let Some(owner_methods) = methods.get(&binding.type_name) {
+            for (method, signature, method_file) in owner_methods {
+                let text = format!("{}.{method}", binding.name);
+                let detail = format!(
+                    "{signature} via {} {}: {} [{method_file}]",
+                    binding.kind, binding.name, binding.type_name
+                );
+                let item = match binding.scope.clone() {
+                    Some(scope) => scoped_completion_catalog_item(
+                        &text,
+                        "method",
+                        &detail,
+                        method_file,
+                        Some(binding.type_name.clone()),
+                        None,
+                        scope,
+                    ),
+                    None => completion_catalog_item(
+                        &text,
+                        "method",
+                        &detail,
+                        method_file,
+                        Some(binding.type_name.clone()),
+                    ),
+                };
+                items.push(item);
+            }
+        }
+    }
+
+    items.sort_by_key(|item| {
+        (
+            item.text.clone(),
+            item.kind.clone(),
+            item.detail.clone(),
+            item.file.clone(),
+            item.owner.clone(),
+        )
+    });
+    items.dedup();
+    Ok(items)
+}
+
+fn completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+) -> WorkshopCompletionItem {
+    let truncated = detail.chars().count() > 256;
+    let mut detail = if truncated {
+        detail.chars().take(253).collect::<String>()
+    } else {
+        detail.to_string()
+    };
+    if truncated {
+        detail.push_str("...");
+    }
+    WorkshopCompletionItem {
+        text: text.to_string(),
+        kind: kind.to_string(),
+        detail,
+        file: file.to_string(),
+        owner,
+        type_name: None,
+        scope: None,
+    }
+}
+
+fn typed_completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+    type_name: &str,
+) -> WorkshopCompletionItem {
+    let mut item = completion_catalog_item(text, kind, detail, file, owner);
+    item.type_name = Some(type_name.to_string());
+    item
+}
+
+fn scoped_completion_catalog_item(
+    text: &str,
+    kind: &str,
+    detail: &str,
+    file: &str,
+    owner: Option<String>,
+    type_name: Option<&str>,
+    scope: WorkshopCompletionScope,
+) -> WorkshopCompletionItem {
+    let mut item = completion_catalog_item(text, kind, detail, file, owner);
+    item.type_name = type_name.map(str::to_string);
+    item.scope = Some(scope);
+    item
+}
+
+#[derive(Debug, Clone)]
+struct WorkshopTypedBinding {
+    name: String,
+    type_name: String,
+    kind: String,
+    scope_label: String,
+    file: String,
+    scope: Option<WorkshopCompletionScope>,
 }
 
 fn source_item_from_ranges(
@@ -1758,11 +2200,7 @@ fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
         }) {
             if let Some(scope_start) = scope_at[index] {
                 if let Some(scope_end) = scope_ends.get(&scope_start) {
-                    local_bindings.push((
-                        token_text(source, token).to_string(),
-                        index,
-                        *scope_end,
-                    ));
+                    local_bindings.push((token_text(source, token).to_string(), index, *scope_end));
                 }
             }
         }
@@ -1777,9 +2215,10 @@ fn source_identifiers(source: &str) -> Result<BTreeSet<String>, String> {
                 return None;
             }
             let name = token_text(source, token);
-            if local_bindings.iter().any(|(binding, start, end)| {
-                binding == name && index >= *start && index <= *end
-            }) {
+            if local_bindings
+                .iter()
+                .any(|(binding, start, end)| binding == name && index >= *start && index <= *end)
+            {
                 return None;
             }
             let previous_is_dot = index.checked_sub(1).is_some_and(|index| {
@@ -2064,7 +2503,10 @@ fn write_workshop_semantic_plan_with(
             } else {
                 format!("; rollback incomplete: {}", rollback_errors.join("; "))
             };
-            return Err(format!("failed writing {}: {error}{rollback}", path.display()));
+            return Err(format!(
+                "failed writing {}: {error}{rollback}",
+                path.display()
+            ));
         }
         written.push(change.file.clone());
     }
@@ -3822,6 +4264,66 @@ mod workshop_compile_plan_tests {
         assert!(update.source.starts_with("// Advances the player."));
         assert!(!update.source.contains("Unrelated note"));
         assert!(update.source.ends_with("}\n"));
+    }
+
+    #[test]
+    fn completion_catalog_includes_scoped_bindings_fields_and_receiver_methods() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: r#"
+struct Player { hp: i32; speed: f32; }
+enum Mode { Playing, Paused }
+global state { player: Player; }
+function damage(player: Player, amount: i32): i32 { return player.hp - amount; }
+function tick(): i32 {
+    let hero: Player;
+    hero.hp = 7;
+    return damage(hero, 1);
+}
+"#
+            .to_string(),
+        }];
+        let items = workshop_completion_items(&files).expect("completion catalog");
+        let has = |text: &str, kind: &str| {
+            items
+                .iter()
+                .any(|item| item.text == text && item.kind == kind)
+        };
+        assert!(has("amount", "parameter"));
+        assert!(has("hero", "local"));
+        assert!(has("Player.hp", "field"));
+        assert!(has("player.hp", "field"));
+        assert!(has("player.damage", "method"));
+        assert!(has("hero.hp", "field"));
+        assert!(has("hero.damage", "method"));
+        assert!(has("state.player.hp", "field"));
+        assert!(has("Mode.Paused", "enum_variant"));
+        let hero_hp = items
+            .iter()
+            .find(|item| item.text == "hero.hp")
+            .expect("scoped receiver field");
+        assert_eq!(hero_hp.type_name.as_deref(), Some("i32"));
+        assert_eq!(
+            hero_hp.scope.as_ref().map(|scope| scope.owner.as_str()),
+            Some("tick")
+        );
+        let parameter = items
+            .iter()
+            .find(|item| item.text == "amount" && item.kind == "parameter")
+            .expect("parameter");
+        assert_eq!(
+            parameter.scope.as_ref().map(|scope| scope.owner.as_str()),
+            Some("damage")
+        );
+        assert!(items
+            .iter()
+            .find(|item| item.text == "state.player.hp")
+            .expect("global receiver field")
+            .scope
+            .is_none());
+        assert!(items
+            .iter()
+            .all(|item| item.detail.contains("[src/main.stasis]")));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -967,6 +967,8 @@ pub struct WorkshopCompletionItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub type_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<WorkshopCompletionScope>,
@@ -1177,13 +1179,15 @@ pub fn workshop_completion_items(
         )
     }) {
         let kind = format!("{:?}", item.kind).to_ascii_lowercase();
-        items.push(completion_catalog_item(
+        let mut completion = completion_catalog_item(
             &item.name,
             &kind,
             &format!("{} [{}]", item.signature, item.file),
             &item.file,
             item.owner.clone(),
-        ));
+        );
+        completion.signature = Some(item.signature.clone());
+        items.push(completion);
         if item.kind == WorkshopSourceItemKind::Function {
             if let Some(owner) = item
                 .owner
@@ -1492,6 +1496,7 @@ fn completion_catalog_item(
         detail,
         file: file.to_string(),
         owner,
+        signature: None,
         type_name: None,
         scope: None,
     }

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -514,7 +514,8 @@ fn rank_indexed_completion_items(
     let bounded_limit = limit.min(256);
     let mut unscoped_match_count = 0usize;
     let mut best = Vec::<(CompletionRank<'_>, &CompletionItem)>::with_capacity(bounded_limit);
-    let mut scoped_matches = BTreeMap::<(&str, &str), (CompletionRank<'_>, &CompletionItem)>::new();
+    let mut scoped_matches =
+        BTreeMap::<(&str, &str, Option<&str>), (CompletionRank<'_>, &CompletionItem)>::new();
     for indexed in items {
         let Some(scope_distance) = completion_scope_distance(&indexed.item, context) else {
             continue;
@@ -537,7 +538,13 @@ fn rank_indexed_completion_items(
             detail: &indexed.item.detail,
         };
         if indexed.item.scope.is_some() {
-            let key = (indexed.item.text.as_str(), indexed.item.kind.as_str());
+            let overload_detail =
+                (indexed.item.kind == "method").then_some(indexed.item.detail.as_str());
+            let key = (
+                indexed.item.text.as_str(),
+                indexed.item.kind.as_str(),
+                overload_detail,
+            );
             match scoped_matches.get_mut(&key) {
                 Some(best) if rank < best.0 => *best = (rank, &indexed.item),
                 Some(_) => {}
@@ -1506,6 +1513,40 @@ mod tests {
         assert_eq!(result.items[0].detail, "inner");
         assert_eq!(result.items[1].text, "valid");
         assert!(!result.truncated);
+    }
+
+    #[test]
+    fn completion_query_preserves_scoped_method_overloads() {
+        let method = |detail: &str| CompletionItem {
+            text: "hero.damage".into(),
+            kind: "method".into(),
+            detail: detail.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "tick".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some("tick(): i32".into()),
+                owner_end: Some(100),
+                visible_from: 10,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            method("damage(hero: Player, amount: i32): i32"),
+            method("damage(hero: Player, amount: f32): i32"),
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("tick(): i32".into()),
+            source_offset: None,
+            expected_type: None,
+        };
+        let result = index.query_with_context("hrodam", 6, 10, &context);
+        assert_eq!(result.items.len(), 2);
+        assert_ne!(result.items[0].detail, result.items[1].detail);
     }
 
     #[test]

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -142,6 +142,8 @@ pub enum LiveCommand {
     InspectAll {
         #[serde(default = "default_inspect_limit")]
         limit: usize,
+        #[serde(default)]
+        concise: bool,
     },
     Watch {
         path: String,
@@ -1104,6 +1106,7 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         ":redo" => ready(LiveCommand::Redo { run_tests: true }),
         ":inspect" if args.len() == 1 => ready(LiveCommand::InspectAll {
             limit: default_inspect_limit(),
+            concise: false,
         }),
         ":inspect" => ready(LiveCommand::Inspect {
             path: required_arg(&args, 1, "state path")?.to_string(),
@@ -1743,7 +1746,13 @@ mod tests {
         else {
             panic!("expected request")
         };
-        assert_eq!(request.command, LiveCommand::InspectAll { limit: 32 });
+        assert_eq!(
+            request.command,
+            LiveCommand::InspectAll {
+                limit: 32,
+                concise: false,
+            }
+        );
     }
 
     #[test]

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -10,6 +10,9 @@ pub const DEFAULT_LIVE_OUTPUT_BYTES: usize = 64 * 1024;
 pub const MAX_LIVE_REQUEST_BYTES: usize = 512 * 1024;
 pub const MAX_LIVE_MULTILINE_BYTES: usize = 256 * 1024;
 pub const MAX_SCRATCH_CELLS: usize = 64;
+pub const MAX_LIVE_TRACKS: usize = 8;
+pub const MAX_LIVE_TRACK_TICKS: u32 = 600;
+pub const MAX_LIVE_WATCHES: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiveRequest {
@@ -136,8 +139,21 @@ pub enum LiveCommand {
     Inspect {
         path: String,
     },
+    InspectAll {
+        #[serde(default = "default_inspect_limit")]
+        limit: usize,
+    },
     Watch {
         path: String,
+    },
+    Track {
+        path: String,
+        #[serde(default = "default_track_ticks")]
+        ticks: u32,
+    },
+    Untrack {
+        #[serde(default)]
+        path: Option<String>,
     },
     Unwatch {
         #[serde(default)]
@@ -185,7 +201,15 @@ const fn one_tick() -> u32 {
     1
 }
 
+const fn default_track_ticks() -> u32 {
+    300
+}
+
 const fn default_completion_limit() -> usize {
+    32
+}
+
+const fn default_inspect_limit() -> usize {
     32
 }
 
@@ -333,6 +357,14 @@ impl LiveSessionClient {
             .recv_timeout(timeout)
             .map_err(|error| format!("live-session response unavailable: {error}"))
     }
+
+    pub fn try_receive(&self) -> Result<Option<LiveResponse>, String> {
+        match self.responses.try_recv() {
+            Ok(response) => Ok(Some(response)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err("live session has ended".to_string()),
+        }
+    }
 }
 
 impl LiveSessionServer {
@@ -370,6 +402,8 @@ pub struct CompletionItem {
     pub type_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<LiveSymbolTarget>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<CompletionScope>,
 }
@@ -435,6 +469,23 @@ impl CompletionIndex {
                 item,
             })
             .collect();
+    }
+
+    pub fn extend<I>(&mut self, items: I)
+    where
+        I: IntoIterator<Item = CompletionItem>,
+    {
+        let merged = self
+            .items
+            .iter()
+            .map(|indexed| indexed.item.clone())
+            .chain(items)
+            .collect::<Vec<_>>();
+        self.replace(merged);
+    }
+
+    pub fn retain(&mut self, mut keep: impl FnMut(&CompletionItem) -> bool) {
+        self.items.retain(|indexed| keep(&indexed.item));
     }
 
     pub fn complete(&self, buffer: &str, cursor: usize, limit: usize) -> Vec<CompletionItem> {
@@ -1051,11 +1102,25 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         ":changes" => ready(LiveCommand::Changes),
         ":undo" => ready(LiveCommand::Undo { run_tests: true }),
         ":redo" => ready(LiveCommand::Redo { run_tests: true }),
+        ":inspect" if args.len() == 1 => ready(LiveCommand::InspectAll {
+            limit: default_inspect_limit(),
+        }),
         ":inspect" => ready(LiveCommand::Inspect {
             path: required_arg(&args, 1, "state path")?.to_string(),
         }),
         ":watch" => ready(LiveCommand::Watch {
             path: required_arg(&args, 1, "state path")?.to_string(),
+        }),
+        ":track" => ready(LiveCommand::Track {
+            path: required_arg(&args, 1, "state path")?.to_string(),
+            ticks: args
+                .get(2)
+                .map(|value| parse_u32("ticks", value))
+                .transpose()?
+                .unwrap_or_else(default_track_ticks),
+        }),
+        ":untrack" => ready(LiveCommand::Untrack {
+            path: args.get(1).cloned(),
         }),
         ":unwatch" => ready(LiveCommand::Unwatch {
             path: args.get(1).cloned(),
@@ -1287,6 +1352,7 @@ mod tests {
                 detail: "tick(): i32".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1295,6 +1361,7 @@ mod tests {
                 detail: "tick(): i32".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1303,6 +1370,7 @@ mod tests {
                 detail: "tick(value: i32): i32".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1311,6 +1379,7 @@ mod tests {
                 detail: "i32".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1319,6 +1388,7 @@ mod tests {
                 detail: "utf8[32]".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
         ]);
@@ -1340,6 +1410,7 @@ mod tests {
                 detail: "i32 via local hero: Player".into(),
                 type_name: Some("i32".into()),
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1348,6 +1419,7 @@ mod tests {
                 detail: "damage(player: Player, amount: i32): i32".into(),
                 type_name: Some("i32".into()),
                 source: None,
+                selector: None,
                 scope: None,
             },
             CompletionItem {
@@ -1356,6 +1428,7 @@ mod tests {
                 detail: "live command".into(),
                 type_name: None,
                 source: None,
+                selector: None,
                 scope: None,
             },
         ]);
@@ -1383,6 +1456,7 @@ mod tests {
                 detail: detail.into(),
                 type_name: Some(if detail == "inner" { "i32" } else { "f32" }.into()),
                 source: Some("src/main.stasis".into()),
+                selector: None,
                 scope: Some(CompletionScope {
                     owner: owner.into(),
                     file: "src/main.stasis".into(),
@@ -1445,6 +1519,7 @@ mod tests {
             detail: signature.into(),
             type_name: Some("i32".into()),
             source: Some("src/main.stasis".into()),
+            selector: None,
             scope: Some(CompletionScope {
                 owner: "update".into(),
                 file: "src/main.stasis".into(),
@@ -1479,6 +1554,7 @@ mod tests {
             detail: detail.into(),
             type_name: Some("i32".into()),
             source: Some("src/main.stasis".into()),
+            selector: None,
             scope: Some(CompletionScope {
                 owner: "tick".into(),
                 file: "src/main.stasis".into(),
@@ -1498,6 +1574,7 @@ mod tests {
                 detail: "valid(): i32".into(),
                 type_name: Some("i32".into()),
                 source: None,
+                selector: None,
                 scope: None,
             },
         ]);
@@ -1523,6 +1600,7 @@ mod tests {
             detail: detail.into(),
             type_name: Some("i32".into()),
             source: Some("src/main.stasis".into()),
+            selector: None,
             scope: Some(CompletionScope {
                 owner: "tick".into(),
                 file: "src/main.stasis".into(),
@@ -1558,6 +1636,7 @@ mod tests {
                 detail: format!("symbol_{index:05}(): i32"),
                 type_name: Some("i32".into()),
                 source: Some("src/generated.stasis".into()),
+                selector: None,
                 scope: None,
             })
             .collect::<Vec<_>>();
@@ -1567,6 +1646,7 @@ mod tests {
             detail: "very_late_target(): i32".into(),
             type_name: Some("i32".into()),
             source: Some("src/late.stasis".into()),
+            selector: None,
             scope: None,
         });
         let mut index = CompletionIndex::default();
@@ -1587,6 +1667,7 @@ mod tests {
             detail: "Player".into(),
             type_name: Some("Player".into()),
             source: None,
+            selector: None,
             scope: None,
         }]);
         for buffer in ["score+pla", "x!=pla", "value*pla", "items[pla"] {
@@ -1623,6 +1704,46 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn terminal_track_command_defaults_and_accepts_tick_duration() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(default_request) =
+            terminal.feed_line(":track score").expect("default track")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(
+            default_request.command,
+            LiveCommand::Track {
+                path: "score".into(),
+                ticks: 300,
+            }
+        );
+        let TerminalInput::Request(explicit_request) = terminal
+            .feed_line(":track score 12")
+            .expect("explicit track")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(
+            explicit_request.command,
+            LiveCommand::Track {
+                path: "score".into(),
+                ticks: 12,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_bare_inspect_requests_the_default_state_view() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(request) = terminal.feed_line(":inspect").expect("inspect")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(request.command, LiveCommand::InspectAll { limit: 32 });
     }
 
     #[test]

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -94,6 +94,18 @@ pub enum LiveCommand {
         cursor: usize,
         #[serde(default = "default_completion_limit")]
         limit: usize,
+        #[serde(default)]
+        context: CompletionContext,
+    },
+    Palette {
+        #[serde(default)]
+        query: String,
+        #[serde(default)]
+        page: u32,
+        #[serde(default = "default_completion_limit")]
+        limit: usize,
+        #[serde(default)]
+        context: CompletionContext,
     },
     Edit {
         operation: LiveEditOperation,
@@ -354,11 +366,58 @@ pub struct CompletionItem {
     pub text: String,
     pub kind: String,
     pub detail: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<CompletionScope>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_offset: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionScope {
+    pub owner: String,
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_end: Option<usize>,
+    pub visible_from: usize,
+    pub visible_to: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionQuery {
+    pub replacement_start: usize,
+    pub replacement_end: usize,
+    pub page: u32,
+    pub truncated: bool,
+    pub items: Vec<CompletionItem>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct CompletionIndex {
-    items: BTreeMap<(String, String, String), CompletionItem>,
+    items: Vec<IndexedCompletionItem>,
+}
+
+#[derive(Debug, Clone)]
+struct IndexedCompletionItem {
+    normalized_text: String,
+    item: CompletionItem,
 }
 
 impl CompletionIndex {
@@ -366,42 +425,310 @@ impl CompletionIndex {
     where
         I: IntoIterator<Item = CompletionItem>,
     {
-        self.items.clear();
-        for item in items {
-            self.items.insert(
-                (item.text.clone(), item.kind.clone(), item.detail.clone()),
+        let mut items = items.into_iter().collect::<Vec<_>>();
+        items.sort_by(|left, right| completion_item_key(left).cmp(&completion_item_key(right)));
+        items.dedup();
+        self.items = items
+            .into_iter()
+            .map(|item| IndexedCompletionItem {
+                normalized_text: item.text.to_ascii_lowercase(),
                 item,
-            );
-        }
+            })
+            .collect();
     }
 
     pub fn complete(&self, buffer: &str, cursor: usize, limit: usize) -> Vec<CompletionItem> {
-        let mut cursor = cursor.min(buffer.len());
-        while !buffer.is_char_boundary(cursor) {
-            cursor -= 1;
+        self.query(buffer, cursor, limit).items
+    }
+
+    pub fn query(&self, buffer: &str, cursor: usize, limit: usize) -> CompletionQuery {
+        self.query_with_context(buffer, cursor, limit, &CompletionContext::default())
+    }
+
+    pub fn query_with_context(
+        &self,
+        buffer: &str,
+        cursor: usize,
+        limit: usize,
+        context: &CompletionContext,
+    ) -> CompletionQuery {
+        rank_indexed_completion_items(&self.items, buffer, cursor, limit, context)
+    }
+}
+
+pub fn rank_completion_items(
+    items: &[CompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+) -> CompletionQuery {
+    rank_completion_items_with_context(items, buffer, cursor, limit, &CompletionContext::default())
+}
+
+pub fn rank_completion_items_with_context(
+    items: &[CompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: &CompletionContext,
+) -> CompletionQuery {
+    let indexed = items
+        .iter()
+        .cloned()
+        .map(|item| IndexedCompletionItem {
+            normalized_text: item.text.to_ascii_lowercase(),
+            item,
+        })
+        .collect::<Vec<_>>();
+    rank_indexed_completion_items(&indexed, buffer, cursor, limit, context)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CompletionRank<'a> {
+    match_class: u8,
+    scope_distance: usize,
+    expected_type: u8,
+    kind: u8,
+    gaps: usize,
+    first: usize,
+    text_len: usize,
+    text: &'a str,
+    item_kind: &'a str,
+    detail: &'a str,
+}
+
+fn rank_indexed_completion_items(
+    items: &[IndexedCompletionItem],
+    buffer: &str,
+    cursor: usize,
+    limit: usize,
+    context: &CompletionContext,
+) -> CompletionQuery {
+    let mut cursor = cursor.min(buffer.len());
+    while !buffer.is_char_boundary(cursor) {
+        cursor -= 1;
+    }
+    let replacement_start = completion_replacement_start(buffer, cursor);
+    let query = &buffer[replacement_start..cursor];
+    let normalized_query = query.to_ascii_lowercase();
+    let bounded_limit = limit.min(256);
+    let mut unscoped_match_count = 0usize;
+    let mut best = Vec::<(CompletionRank<'_>, &CompletionItem)>::with_capacity(bounded_limit);
+    let mut scoped_matches = BTreeMap::<(&str, &str), (CompletionRank<'_>, &CompletionItem)>::new();
+    for indexed in items {
+        let Some(scope_distance) = completion_scope_distance(&indexed.item, context) else {
+            continue;
+        };
+        let Some((match_class, gaps, first)) =
+            fuzzy_completion_score(&indexed.normalized_text, &normalized_query)
+        else {
+            continue;
+        };
+        let rank = CompletionRank {
+            match_class,
+            scope_distance,
+            expected_type: completion_expected_type_priority(&indexed.item, context),
+            kind: completion_kind_priority(&indexed.item.kind, query),
+            gaps,
+            first,
+            text_len: indexed.item.text.len(),
+            text: &indexed.item.text,
+            item_kind: &indexed.item.kind,
+            detail: &indexed.item.detail,
+        };
+        if indexed.item.scope.is_some() {
+            let key = (indexed.item.text.as_str(), indexed.item.kind.as_str());
+            match scoped_matches.get_mut(&key) {
+                Some(best) if rank < best.0 => *best = (rank, &indexed.item),
+                Some(_) => {}
+                None => {
+                    scoped_matches.insert(key, (rank, &indexed.item));
+                }
+            }
+        } else {
+            unscoped_match_count = unscoped_match_count.saturating_add(1);
+            retain_bounded_completion(&mut best, (rank, &indexed.item), bounded_limit);
         }
-        let prefix = buffer[..cursor]
-            .rsplit(|character: char| {
-                character.is_whitespace() || character == '(' || character == ','
-            })
-            .next()
-            .unwrap_or("");
-        let mut matches = self
-            .items
-            .values()
-            .filter(|item| item.text.starts_with(prefix))
-            .cloned()
-            .collect::<Vec<_>>();
-        matches.sort_by_key(|item| {
+    }
+    let total_matches = unscoped_match_count.saturating_add(scoped_matches.len());
+    for candidate in scoped_matches.into_values() {
+        retain_bounded_completion(&mut best, candidate, bounded_limit);
+    }
+    best.sort_by_key(|(rank, _)| *rank);
+    let items = best.into_iter().map(|(_, item)| item.clone()).collect();
+    CompletionQuery {
+        replacement_start,
+        replacement_end: cursor,
+        page: 0,
+        truncated: total_matches > bounded_limit,
+        items,
+    }
+}
+
+fn retain_bounded_completion<'a>(
+    best: &mut Vec<(CompletionRank<'a>, &'a CompletionItem)>,
+    candidate: (CompletionRank<'a>, &'a CompletionItem),
+    limit: usize,
+) {
+    if limit == 0 {
+        return;
+    }
+    if best.len() < limit {
+        best.push(candidate);
+        return;
+    }
+    let (worst_index, worst) = best
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, (rank, _))| *rank)
+        .expect("bounded completion set is not empty");
+    if candidate.0 < worst.0 {
+        best[worst_index] = candidate;
+    }
+}
+
+fn completion_item_key(
+    item: &CompletionItem,
+) -> (
+    &str,
+    &str,
+    &str,
+    Option<&str>,
+    Option<&str>,
+    Option<(&str, &str, Option<&str>, Option<usize>, usize, usize)>,
+) {
+    (
+        &item.text,
+        &item.kind,
+        &item.detail,
+        item.type_name.as_deref(),
+        item.source.as_deref(),
+        item.scope.as_ref().map(|scope| {
             (
-                item.text != prefix,
-                item.text.len().saturating_sub(prefix.len()),
-                item.text.clone(),
-                item.kind.clone(),
+                scope.owner.as_str(),
+                scope.file.as_str(),
+                scope.owner_signature.as_deref(),
+                scope.owner_end,
+                scope.visible_from,
+                scope.visible_to,
             )
-        });
-        matches.truncate(limit.min(256));
-        matches
+        }),
+    )
+}
+
+fn completion_replacement_start(buffer: &str, cursor: usize) -> usize {
+    buffer[..cursor]
+        .char_indices()
+        .rev()
+        .find(|(index, character)| {
+            character.is_whitespace()
+                || matches!(
+                    character,
+                    '(' | ')'
+                        | '['
+                        | ']'
+                        | ','
+                        | ';'
+                        | '{'
+                        | '}'
+                        | '='
+                        | '+'
+                        | '-'
+                        | '*'
+                        | '/'
+                        | '%'
+                        | '<'
+                        | '>'
+                        | '!'
+                )
+                || (*character == ':' && *index > 0)
+        })
+        .map_or(0, |(index, character)| index + character.len_utf8())
+}
+
+fn fuzzy_completion_score(text: &str, query: &str) -> Option<(u8, usize, usize)> {
+    if text == query {
+        return Some((0, 0, 0));
+    }
+    if text.starts_with(&query) {
+        return Some((1, 0, text.len().saturating_sub(query.len())));
+    }
+    if let Some(start) = text.find(&query) {
+        return Some((2, start, text.len().saturating_sub(query.len())));
+    }
+    let mut text_indices = text.char_indices();
+    let mut first = None;
+    let mut previous = None;
+    let mut gaps = 0usize;
+    for needle in query.chars() {
+        let (index, _) = text_indices.find(|(_, candidate)| *candidate == needle)?;
+        first.get_or_insert(index);
+        if let Some(previous) = previous {
+            gaps += index.saturating_sub(previous + 1);
+        }
+        previous = Some(index);
+    }
+    Some((3, gaps, first.unwrap_or(0)))
+}
+
+fn completion_scope_distance(item: &CompletionItem, context: &CompletionContext) -> Option<usize> {
+    let Some(scope) = item.scope.as_ref() else {
+        return Some(usize::MAX);
+    };
+    if context.owner.as_deref() != Some(scope.owner.as_str()) {
+        return None;
+    }
+    if context
+        .file
+        .as_deref()
+        .is_some_and(|file| file != scope.file)
+    {
+        return None;
+    }
+    if context
+        .owner_signature
+        .as_deref()
+        .is_some_and(|signature| scope.owner_signature.as_deref() != Some(signature))
+    {
+        return None;
+    }
+    let offset = context.source_offset.or(scope.owner_end)?;
+    if offset < scope.visible_from || offset > scope.visible_to {
+        return None;
+    }
+    Some(usize::MAX.saturating_sub(scope.visible_from))
+}
+
+fn completion_expected_type_priority(item: &CompletionItem, context: &CompletionContext) -> u8 {
+    match context.expected_type.as_deref() {
+        Some(expected) if item.type_name.as_deref() == Some(expected) => 0,
+        Some(_) => 1,
+        None => 0,
+    }
+}
+
+fn completion_kind_priority(kind: &str, query: &str) -> u8 {
+    if query.starts_with(':') {
+        return u8::from(kind != "command");
+    }
+    if query.contains('.') {
+        return match kind {
+            "field" | "state_path" => 0,
+            "method" => 1,
+            _ => 2,
+        };
+    }
+    match kind {
+        "local" => 0,
+        "parameter" => 1,
+        "field" => 2,
+        "method" => 3,
+        "function" => 4,
+        "global" | "constant" | "state_path" => 5,
+        "struct" | "enum" | "enum_variant" => 6,
+        "scratch_cell" => 7,
+        "command" => 8,
+        _ => 9,
     }
 }
 
@@ -609,6 +936,23 @@ impl TerminalBuffer {
     pub fn cancel_pending(&mut self) -> bool {
         self.pending.take().is_some()
     }
+
+    pub fn completion_context(&self) -> CompletionContext {
+        let Some(PendingMultiline {
+            command: PendingCommand::Edit { target, .. },
+            ..
+        }) = self.pending.as_ref()
+        else {
+            return CompletionContext::default();
+        };
+        CompletionContext {
+            owner: Some(target.name.clone()),
+            file: target.file.clone(),
+            owner_signature: target.signature.clone(),
+            source_offset: None,
+            expected_type: None,
+        }
+    }
 }
 
 enum ParsedTerminalCommand {
@@ -666,8 +1010,35 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
                 cursor: buffer.len(),
                 buffer,
                 limit: 32,
+                context: CompletionContext::default(),
             })
         }
+        ":palette" => ready(LiveCommand::Palette {
+            query: args
+                .get(1)
+                .filter(|value| !value.starts_with("--"))
+                .cloned()
+                .unwrap_or_default(),
+            page: terminal_selector_value(&args, "--page")
+                .map(|value| parse_u32("page", &value))
+                .transpose()?
+                .unwrap_or(0),
+            limit: terminal_selector_value(&args, "--limit")
+                .map(|value| parse_u32("limit", &value))
+                .transpose()?
+                .map(|value| value as usize)
+                .unwrap_or_else(default_completion_limit),
+            context: CompletionContext {
+                owner: terminal_selector_value(&args, "--owner"),
+                file: terminal_selector_value(&args, "--file"),
+                owner_signature: terminal_selector_value(&args, "--signature"),
+                source_offset: terminal_selector_value(&args, "--offset")
+                    .map(|value| parse_u32("offset", &value))
+                    .transpose()?
+                    .map(|value| value as usize),
+                expected_type: terminal_selector_value(&args, "--expected-type"),
+            },
+        }),
         ":preview" => ready(LiveCommand::Preview),
         ":apply" => ready(LiveCommand::Apply { run_tests: true }),
         ":changes" => ready(LiveCommand::Changes),
@@ -907,26 +1278,41 @@ mod tests {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "tick".into(),
                 kind: "function".into(),
                 detail: "tick(value: i32): i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "ticker".into(),
                 kind: "global".into(),
                 detail: "i32".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
             CompletionItem {
                 text: "title".into(),
                 kind: "global".into(),
                 detail: "utf8[32]".into(),
+                type_name: None,
+                source: None,
+                scope: None,
             },
         ]);
         let result = index.complete(":read tick", 10, 10);
@@ -935,6 +1321,287 @@ mod tests {
         assert_eq!(result[1].text, "tick");
         assert_eq!(result[2].text, "ticker");
         assert_eq!(index.complete("éti", 1, 10).len(), 4);
+    }
+
+    #[test]
+    fn completion_query_fuzzy_ranks_context_and_reports_replacement_range() {
+        let mut index = CompletionIndex::default();
+        index.replace([
+            CompletionItem {
+                text: "hero.hp".into(),
+                kind: "field".into(),
+                detail: "i32 via local hero: Player".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+            CompletionItem {
+                text: "hero.damage".into(),
+                kind: "method".into(),
+                detail: "damage(player: Player, amount: i32): i32".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+            CompletionItem {
+                text: ":help".into(),
+                kind: "command".into(),
+                detail: "live command".into(),
+                type_name: None,
+                source: None,
+                scope: None,
+            },
+        ]);
+        let member = index.query("call(hrohp", 10, 10);
+        assert_eq!(member.replacement_start, 5);
+        assert_eq!(member.replacement_end, 10);
+        assert_eq!(member.items[0].text, "hero.hp");
+        assert!(!member.truncated);
+
+        let commands = index.query(":h", 2, 1);
+        assert_eq!(commands.items[0].text, ":help");
+        assert!(!commands.truncated);
+
+        let bounded = index.query("hero.", 5, 1);
+        assert_eq!(bounded.items.len(), 1);
+        assert!(bounded.truncated);
+    }
+
+    #[test]
+    fn completion_query_filters_scopes_shadowing_and_expected_types() {
+        let scoped =
+            |detail: &str, owner: &str, from: usize, to: usize, owner_end: usize| CompletionItem {
+                text: "value".into(),
+                kind: "local".into(),
+                detail: detail.into(),
+                type_name: Some(if detail == "inner" { "i32" } else { "f32" }.into()),
+                source: Some("src/main.stasis".into()),
+                scope: Some(CompletionScope {
+                    owner: owner.into(),
+                    file: "src/main.stasis".into(),
+                    owner_signature: Some(format!("{owner}(): i32")),
+                    owner_end: Some(owner_end),
+                    visible_from: from,
+                    visible_to: to,
+                }),
+            };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            scoped("outer", "tick", 10, 100, 100),
+            scoped("inner", "tick", 50, 70, 100),
+            scoped("render local", "render", 20, 90, 90),
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: None,
+            source_offset: Some(60),
+            expected_type: Some("i32".into()),
+        };
+        let result = index.query_with_context("val", 3, 10, &context);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].detail, "inner");
+
+        let target_end = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            ..CompletionContext::default()
+        };
+        let result = index.query_with_context("val", 3, 10, &target_end);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].detail, "outer");
+
+        let mut nested_only = CompletionIndex::default();
+        nested_only.replace([scoped("inner", "tick", 50, 70, 100)]);
+        assert!(nested_only
+            .query_with_context("val", 3, 10, &target_end)
+            .items
+            .is_empty());
+
+        let render = CompletionContext {
+            owner: Some("render".into()),
+            source_offset: Some(50),
+            ..CompletionContext::default()
+        };
+        assert_eq!(
+            index.query_with_context("val", 3, 10, &render).items[0].detail,
+            "render local"
+        );
+        assert!(index.query("val", 3, 10).items.is_empty());
+    }
+
+    #[test]
+    fn completion_query_uses_signature_to_disambiguate_overload_scope() {
+        let local = |text: &str, signature: &str| CompletionItem {
+            text: text.into(),
+            kind: "local".into(),
+            detail: signature.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "update".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some(signature.into()),
+                owner_end: Some(100),
+                visible_from: 10,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            local("player_value", "update(player: Player): i32"),
+            local("enemy_value", "update(enemy: Enemy): i32"),
+        ]);
+        let context = CompletionContext {
+            owner: Some("update".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("update(player: Player): i32".into()),
+            source_offset: None,
+            expected_type: None,
+        };
+        let result = index.query_with_context("value", 5, 10, &context);
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].text, "player_value");
+    }
+
+    #[test]
+    fn completion_query_deduplicates_shadowing_before_bounding() {
+        let scoped = |detail: &str, from: usize| CompletionItem {
+            text: "value".into(),
+            kind: "local".into(),
+            detail: detail.into(),
+            type_name: Some("i32".into()),
+            source: Some("src/main.stasis".into()),
+            scope: Some(CompletionScope {
+                owner: "tick".into(),
+                file: "src/main.stasis".into(),
+                owner_signature: Some("tick(): i32".into()),
+                owner_end: Some(100),
+                visible_from: from,
+                visible_to: 100,
+            }),
+        };
+        let mut index = CompletionIndex::default();
+        index.replace([
+            scoped("outer", 10),
+            scoped("inner", 50),
+            CompletionItem {
+                text: "valid".into(),
+                kind: "function".into(),
+                detail: "valid(): i32".into(),
+                type_name: Some("i32".into()),
+                source: None,
+                scope: None,
+            },
+        ]);
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some("src/main.stasis".into()),
+            owner_signature: Some("tick(): i32".into()),
+            source_offset: Some(60),
+            expected_type: None,
+        };
+        let result = index.query_with_context("va", 2, 2, &context);
+        assert_eq!(result.items.len(), 2);
+        assert_eq!(result.items[0].detail, "inner");
+        assert_eq!(result.items[1].text, "valid");
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn completion_query_reaches_late_catalog_items_with_bounded_top_k() {
+        let mut items = (0..10_000)
+            .map(|index| CompletionItem {
+                text: format!("symbol_{index:05}"),
+                kind: "function".into(),
+                detail: format!("symbol_{index:05}(): i32"),
+                type_name: Some("i32".into()),
+                source: Some("src/generated.stasis".into()),
+                scope: None,
+            })
+            .collect::<Vec<_>>();
+        items.push(CompletionItem {
+            text: "very_late_target".into(),
+            kind: "function".into(),
+            detail: "very_late_target(): i32".into(),
+            type_name: Some("i32".into()),
+            source: Some("src/late.stasis".into()),
+            scope: None,
+        });
+        let mut index = CompletionIndex::default();
+        index.replace(items);
+        let target = index.query("vltgt", 5, 8);
+        assert_eq!(target.items[0].text, "very_late_target");
+        let bounded = index.query("symbol", 6, 8);
+        assert_eq!(bounded.items.len(), 8);
+        assert!(bounded.truncated);
+    }
+
+    #[test]
+    fn completion_replacement_starts_after_unspaced_infix_operators() {
+        let mut index = CompletionIndex::default();
+        index.replace([CompletionItem {
+            text: "player".into(),
+            kind: "parameter".into(),
+            detail: "Player".into(),
+            type_name: Some("Player".into()),
+            source: None,
+            scope: None,
+        }]);
+        for buffer in ["score+pla", "x!=pla", "value*pla", "items[pla"] {
+            let result = index.query(buffer, buffer.len(), 4);
+            assert_eq!(result.items[0].text, "player", "{buffer}");
+            assert_eq!(&buffer[result.replacement_start..], "pla", "{buffer}");
+        }
+        assert_eq!(index.query(":hel", 4, 4).replacement_start, 0);
+    }
+
+    #[test]
+    fn terminal_palette_command_preserves_query_text() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(request) = terminal
+            .feed_line(
+                ":palette hero.hp --page 2 --limit 12 --owner tick --file src/main.stasis --offset 42 --expected-type i32",
+            )
+            .expect("palette command")
+        else {
+            panic!("expected request")
+        };
+        assert_eq!(
+            request.command,
+            LiveCommand::Palette {
+                query: "hero.hp".to_string(),
+                page: 2,
+                limit: 12,
+                context: CompletionContext {
+                    owner: Some("tick".into()),
+                    file: Some("src/main.stasis".into()),
+                    owner_signature: None,
+                    source_offset: Some(42),
+                    expected_type: Some("i32".into()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_completion_context_tracks_pending_semantic_owner() {
+        let mut terminal = TerminalBuffer::new();
+        terminal
+            .feed_line(":update function tick src/main.stasis")
+            .expect("start update");
+        assert_eq!(
+            terminal.completion_context(),
+            CompletionContext {
+                owner: Some("tick".into()),
+                file: Some("src/main.stasis".into()),
+                owner_signature: None,
+                source_offset: None,
+                expected_type: None,
+            }
+        );
+        assert!(terminal.cancel_pending());
+        assert_eq!(terminal.completion_context(), CompletionContext::default());
     }
 
     #[test]

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -26,6 +26,7 @@ The project must provide the graphical lifecycle entry points `main`, `tick`, an
 :symbols tick --page 0 --limit 50
 :read tick function --file src/main.stasis --owner Game --signature "tick(): i32"
 :complete ti
+:palette hrohp
 :preview
 :apply
 :inspect score
@@ -49,13 +50,26 @@ function tick(): i32 {
 :end
 ```
 
-The line editor provides session command history and compiler-backed Tab completion. Press
-Ctrl-C or enter `:abort` to discard a multiline buffer without submitting it. Symbol results are
-paged; selectors accept `--file`, `--owner`, and `--signature` for same-name overloads and receiver
-methods.
+The line editor provides session command history and a compiler-backed command palette. Press
+Ctrl-P at any prompt to open the fuzzy-ranked command and symbol list. Type or Backspace to filter;
+use Up/Down or PageUp/PageDown to select; Enter or Tab inserts the highlighted candidate; Esc
+cancels without changing the buffer. Inserted commands still require Enter at the normal prompt,
+so a palette selection never mutates the session by itself. Tab at the normal prompt queries the
+same live index for the current buffer and inserts a unique candidate.
 
-Add, update, delete, read, list, and completion operate on the compiler-owned symbol and type
-indexes. Edits use the same semantic selectors, expected source hashes, import reconciliation,
+The palette includes functions, structs, enum variants, globals, state paths, parameters,
+explicitly typed locals, fields, and receiver-qualified members such as `hero.hp` or
+`hero.damage`. Scoped candidates carry compiler-owned file, semantic-owner, visibility-span, and
+type metadata, so locals from another function or an out-of-scope block are excluded. Each row
+stays concise with kind and type/signature/source context. `:palette QUERY [--page N --limit N]
+[--owner OWNER --file FILE --signature SIGNATURE --offset N --expected-type TYPE]` exposes the same deterministic,
+bounded ranking to scripts and future desktop clients. Press Ctrl-C or enter `:abort` to discard a
+multiline buffer without submitting it. Symbol results are paged; selectors accept `--file`,
+`--owner`, and `--signature` for same-name overloads and receiver methods.
+
+Add, update, delete, read, list, and palette completion operate on compiler-owned symbol, scope,
+and type indexes. Successful edits refresh the palette atomically with the new runtime. Edits use
+the same semantic selectors, expected source hashes, import reconciliation,
 atomic source writes, test gate, and content-addressed receipts as `stasis symbol`. Successful
 edits are parsed, planned, compiled, and tested on a bounded background preparation worker. The
 graphics thread remains responsive and performs only the hash guard, atomic source/receipt write,

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -14,6 +14,124 @@ symbols/files and reload class. Routine human responses omit protocol request an
 The project must provide the graphical lifecycle entry points `main`, `tick`, and `render`.
 `on_code_swap` is optional. This mode is local-only and does not open a network listener.
 
+## Persistent TUI
+
+Status: the first desktop feel slice is implemented. Run `stasis run --interactive` in a Stasis
+project to open it. The deterministic `--live-script` and `--live-json` clients remain available
+without the TUI.
+
+The current key map is:
+
+```text
+type / :              progressively filter the always-visible completion pane
+Up / Down             choose a completion when armed; otherwise move/history
+Tab                   accept the selected safe completion; otherwise no-op
+Ctrl+Space or Ctrl+P  explicitly arm completion
+Ctrl+K                open the command bar without leaving a definition
+Enter                 run a prompt command or add an auto-indented editor line
+Ctrl+Enter             validate, test, and apply the current definition snapshot
+Ctrl+W                 close a definition (twice when discarding dirty text)
+Alt+D / Alt+P / Alt+I Do / Print / Inspect the selection or current token
+Ctrl+Z / Ctrl+Y       undo / redo text edits only
+```
+
+Pane-focus cycling with F6/Shift+F6 is intentionally still an open product question. This slice
+keeps keyboard focus in the input/editor and makes completion selection contextual instead.
+
+Implemented now are the persistent/adaptive panes, asynchronous coalesced completion, safe Tab and
+ghost insertion, multiline definition editing/apply, text undo/redo, command bar, concise default
+and pinned inspection, bounded per-tick traces, syntax colors, and guaranteed terminal restoration.
+Transcript scrollback with unread counts, visible selection styling, matching-delimiter feedback,
+diagnostic-span underlines, and a shared declarative command grammar remain planned polish; this
+slice does not claim them yet.
+
+The interactive human view becomes one long-lived terminal application rather than a line editor
+that temporarily opens a palette. The left side contains the transcript and an adaptive input
+area. The right side is always present and is split between ranked candidates and details or
+diagnostics for the highlighted item. When the terminal is too narrow for useful side-by-side
+panes, the right pane moves below the editor instead of squeezing or refusing to run. Normal REPL
+input keeps a short editor and a larger transcript; opening a function expands the editor and
+compresses the transcript.
+
+The right pane is useful even when completion is not armed. It shows commands and symbols ranked
+for the current semantic context, with signature, type, owner, and source details for the
+highlighted row. Typing an identifier, receiver dot, or a leading `:` query arms completion;
+Up/Down then changes the candidate and Tab accepts exactly that row. Esc disarms completion without
+changing text. Otherwise Up/Down retain normal meaning: history in the short REPL input and
+vertical cursor movement in the multiline editor. Ctrl+Space explicitly arms completion on a blank
+or indented line. Tab is reserved for completion and is a no-op when no safe candidate is armed; it
+never inserts indentation or changes focus.
+
+The selected candidate and inline ghost text are one model. The ghost renders only the untyped
+suffix of a genuine prefix match in dim gray. Fuzzy matches may remain visible in the pane, but do
+not produce misleading inline text. Async refresh retains selection by stable symbol or command
+identity and discards stale query results. Accepting a function or method inserts only its symbol;
+the signature remains visible in the details pane, and there is no snippet or Tab-stop mode.
+
+Completion insertion is permitted only when everything from the cursor to the end of the entire
+input buffer is whitespace or newlines. When that safety rule is not satisfied, the pane may still
+show context, but no candidate is armed, no ghost is drawn, and Tab is a no-op. Multiline dirty
+buffers need a bounded, tolerant compiler-owned overlay analysis so parameters, completed typed
+`let` bindings, receiver fields and methods, and expected types remain available before the edited
+definition is balanced or accepted. Overlay analysis is read-only and must never compile, write,
+or publish the dirty buffer. It augments the accepted project catalog rather than introducing a
+second language model.
+
+Enter inserts a newline and applies brace-aware auto-indentation. Ctrl+Enter snapshots the complete
+buffer, validates it, runs the normal test gate, and atomically hot-swaps it. Editing remains
+available while that immutable snapshot is prepared. A successful older snapshot becomes the new
+accepted base without erasing later keystrokes; those later edits remain dirty. Failed validation
+or apply keeps the editor open and reports diagnostics in the status/transcript; structured
+right-pane diagnostics with adaptive height remain planned polish. Stale results never overwrite a
+newer submitted snapshot. `:end` remains a compatibility escape hatch for the script and legacy
+line-input paths.
+
+`:edit SYMBOL` opens the complete current definition with its semantic selector and expected source
+hash. Overloads are disambiguated in the right pane using owner, file, and signature metadata. The
+user-facing command remains concise; storage-level selectors are generated internally. After a
+successful apply the editor stays open, its accepted source/hash advance to the applied snapshot,
+and the transcript records the swap. Ctrl+W closes an editor, requiring confirmation before a dirty
+buffer is discarded.
+
+A leading `:` in the normal REPL input progressively completes commands and valid arguments at the
+current position. Inside a Stasis definition, `:` always remains language syntax. Ctrl+K opens a
+temporary progressive command bar while editing; Enter executes the selected command and returns
+focus to the editor, while Esc closes the bar without changing code. Help, parsing, validation,
+preview, and progressive argument completion should be generated from one command grammar so their
+accepted forms cannot drift.
+
+Smalltalk-style workspace actions currently operate on the current selection, or on the current
+token when there is no selection: Alt+D performs Do, Alt+P performs Print, and Alt+I performs
+Inspect. A compiler-owned smallest-enclosing-expression selection is planned polish. The actions
+are available only for global/session expressions that can execute
+honestly in the current runtime. Expressions that depend on parameters or locals are disabled with
+an explicit explanation because the runtime does not expose a paused lexical stack. The TUI must
+not fake this context or instrument a future tick. Inspect pins a live structured view in the
+lower-right pane and refreshes it as the game runs until dismissed or replaced. Print writes an
+immutable one-time value to the transcript. Do does not add routine output beyond a minimal success
+state, but always surfaces failures and diagnostics. The default inspector refreshes visible values
+at a readable UI cadence and does not append each refresh to the transcript.
+
+Inspector nodes can be explicitly tracked for a bounded period. Tracking samples the selected
+values at every normalized between-tick boundary, including unchanged values, and stores them in a
+bounded ring owned by the live session. Duration is expressed canonically in ticks, with an
+approximate wall-time label for convenience; the initial default is 300 ticks and can be changed
+before starting a trace. The inspector shows the latest value, sample progress, min/max or change
+count where meaningful, and a compact trend. Completion, rendering, or a slow terminal must not
+block the game tick. Truncation or dropped samples are visible and never presented as a complete
+trace. Existing change-only watches remain useful for notifications and are not silently redefined
+as per-tick traces.
+
+Ctrl+Z/Ctrl+Y operate only on the current text buffer. `:undo` and `:redo` remain a separate history
+for accepted source/runtime swaps. The first TUI slice includes basic syntax coloring. Transcript
+scrollback/unread preservation, matching-delimiter feedback, and diagnostic span underlines are
+planned follow-up work; full semantic highlighting is not required.
+
+The interactive frontend should own terminal raw mode, alternate-screen entry, event dispatch,
+layout, rendering, and guaranteed restoration as one RAII-guarded lifecycle. The deterministic
+`--live-script` and `--live-json` paths remain non-TUI protocol clients with their current bounded,
+fail-fast behavior. Invalid human commands remain nonfatal and return focus to the current editor.
+
 ## Commands
 
 ```text
@@ -29,8 +147,12 @@ The project must provide the graphical lifecycle entry points `main`, `tick`, an
 :palette hrohp
 :preview
 :apply
+:edit tick
+:inspect
 :inspect score
 :watch score
+:track score 300
+:untrack score
 :set score 10
 :print score
 :changes
@@ -50,12 +172,11 @@ function tick(): i32 {
 :end
 ```
 
-The line editor provides session command history and a compiler-backed command palette. Press
-Ctrl-P at any prompt to open the fuzzy-ranked command and symbol list. Type or Backspace to filter;
-use Up/Down or PageUp/PageDown to select; Enter or Tab inserts the highlighted candidate; Esc
-cancels without changing the buffer. Inserted commands still require Enter at the normal prompt,
-so a palette selection never mutates the session by itself. Tab at the normal prompt queries the
-same live index for the current buffer and inserts a unique candidate.
+The TUI provides session command history and a compiler-backed command and symbol palette. Typing
+filters the persistent pane; Ctrl+Space or Ctrl+P explicitly arms it. Up/Down or PageUp/PageDown
+select, Tab inserts the highlighted candidate, and Esc disarms without changing the buffer.
+Inserted commands still require Enter, so a completion selection never mutates the session by
+itself.
 
 The palette includes functions, structs, enum variants, globals, state paths, parameters,
 explicitly typed locals, fields, and receiver-qualified members such as `hero.hp` or

--- a/docs/live_tui_recording.md
+++ b/docs/live_tui_recording.md
@@ -1,0 +1,38 @@
+# Recording the desktop live TUI
+
+This runbook describes a repeatable desktop capture for the persistent live TUI. It is intentionally separate from the runtime protocol: recording should observe the real process and must not replace the interactive workflow with JSON playback.
+
+## Prepare the session
+
+1. Build the debug runner with `cargo build -p stasis`.
+2. Start a small running game and the live workspace in two ordinary windows. Snap the TUI to the left and the game to the right with Win+Left and Win+Right.
+3. Use a monitor/display capture in OBS when OpenGL window capture is black. Run a short smoke recording first and inspect a frame before the full take.
+4. Keep OBS minimized. Do not click the classic console while recording; QuickEdit can suspend its input/output and make Stasis appear frozen. Bring it to the foreground with the window API or keyboard focus only.
+5. Stop and clean up the runner, terminal host, and OBS after every take. Reject any take containing an unrelated window, notification, JSON envelope, or a blank game surface.
+
+## Narrated walkthrough shape
+
+The opening must say, both aloud and on screen:
+
+> This demonstration was written, controlled, narrated, and recorded entirely by AI. The interactions are scripted for clarity, but the compiler, tests, live edits, and running game shown here are real.
+
+Then use a simple Pong-like game and make the experiment visible:
+
+- establish the baseline for several rallies;
+- try a speed increase, observe it, and undo it when it is less readable;
+- add a visible obstacle plus its matching tick behavior, validate, and observe the swap;
+- tune the obstacle once instead of endlessly adding features;
+- attempt one unsafe state-layout change and show deterministic rejection;
+- finish on the accepted version running unattended.
+
+Narration should name the hypothesis before each edit, explain that completion is compiler-backed, and distinguish visual evidence in the game from concise semantic live state. It should never imply that a human operator is typing off camera. Pause three seconds on completion choices, validation, swaps, undo, and rejection so a phone viewer can read them.
+
+## Capture acceptance
+
+- The TUI and game fill the capture together; no OBS chrome or unrelated desktop is visible.
+- The default live-state pane uses concise `name = value` rows. It omits source/type detail, spatial fields, and collection `length`/`max_length` bookkeeping; explicit `:inspect PATH` remains the detailed escape hatch.
+- The recording contains audible narration and the AI disclosure, not just an empty audio track.
+- Sample opening, experiment, rejection, and closing frames. Confirm the game changes and the TUI shows real completion, validation, and swap feedback.
+- Copy the accepted MP4 to a phone-share directory and verify it with the same LAN URL used by the viewer.
+
+For a fully scripted take, keep the action script and narration script beside the captured artifact, record the exact command sequence and model disclosure, and retain rejected takes only as local QA evidence.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -74,8 +74,9 @@ runnable `main()` and a real `.test.stasis` test.
   Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
 - `run --interactive`: keep the graphical runner and tick loop alive while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
-  typed between-tick inspection or mutation. The terminal includes history, compiler-backed Tab
-  completion, paging, multiline cancellation, and concise command-specific output. Use
+  typed between-tick inspection or mutation. The terminal includes history, a Ctrl-P command
+  palette with live fuzzy compiler-backed symbol/member completion, keyboard navigation and
+  insertion, Tab completion, paging, multiline cancellation, and concise command-specific output. Use
   `--live-json` for complete schema-v1 response envelopes or `--live-script PATH` for a
   deterministic command script. See
   [Interactive live workspace](live_cli_workspace.md).


### PR DESCRIPTION
## Summary

- replace the transient line editor with a persistent adaptive TUI and always-available completion/inspect pane
- add scope-aware dirty-buffer completion, multiline definition editing/apply, default inspection, pinned watches, and bounded per-tick traces
- use differential synchronized terminal updates, truthful watch acknowledgement, and bounded tiny-terminal layouts for Windows stability
- preserve deterministic script/JSON clients and nonfatal invalid-command behavior
- simplify the default live-state pane to concise `name = value` rows, filtering spatial fields and proven collection bookkeeping before the bounded result limit while keeping `:inspect PATH` detailed
- document the reproducible desktop/OBS recording workflow and AI-narrated Pong experiment storyboard in `docs/live_tui_recording.md`

This PR targets `main` directly because #285 was merged into the already-merged task-161 branch and did not reach `main`; it includes the complete task-162 history plus the persistent-TUI follow-up.

## Verification

- `cargo fmt -p stasis -p stasis_runner -- --check`: passed
- `cargo check -p stasis`: passed (existing `bindings_source` dead-code warning)
- `cargo test -p stasis_runner live::tests:: -- --test-threads=1`: 20 passed
- `cargo test -p stasis live_workspace::tests:: -- --test-threads=1`: 26 passed
- `cargo test -p stasis toolchain_cli::live_tui::tests -- --test-threads=1`: 15 passed
- `cargo test -p stasis --test toolchain_cli -- --test-threads=1`: 8 passed
- `python tools/ci/check_stasis_src_layout.py`: passed
- `git diff --check`: passed
- `tools/validate_repo.sh`: not runnable on this Windows host because `bash` is unavailable
- full workspace baseline remains: app library 165 passed / 6 ignored; binary 59 passed / 2 pre-existing Windows path-separator assertion failures
- manual Windows QA: classic Console Host + full running SDL game, progressive completion, multiline scope completion, FastReload apply, pinned inspect, and complete 120-tick trace; decoded video frames at 5s/35s/68s

## Recording workflow

Use a real interactive process, not `--live-json` playback. Build with `cargo build -p stasis`, start the TUI and game, snap them left/right with Win+Left/Win+Right, and use an OBS monitor capture if OpenGL window capture is black. Keep OBS minimized and never click the classic console while recording because QuickEdit can suspend I/O. Run a short smoke capture, inspect a frame, then record the full take and clean up Stasis, the console host, and OBS.

The narrated take should disclose on screen and aloud that it was written, controlled, narrated, and recorded entirely by AI. Start with simple Pong, establish a baseline, try and undo a speed hypothesis, add and tune an obstacle, show one deterministic unsafe-layout rejection, and end on the accepted game running unattended. Pause on completion choices, validation, swaps, undo, and rejection; reject any take with JSON, unrelated windows, notifications, or a blank game surface. Copy the accepted MP4 to a phone-share directory and verify its LAN URL. See `docs/live_tui_recording.md` for the full runbook.

## Cruft review

- removed Rustyline and its transitive lockfile entries
- kept human TUI, deterministic script client, and JSON protocol on one live command pipeline
- added no parser-shape detectors, fake compiler fallbacks, or alternate compilation path
