### PR TITLE
fix: polish persistent live editing

### DIFF
--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -14,8 +14,7 @@ use stasis_compiler::frontend::workshop::{
 use stasis_runner::live::{
     CompletionContext, CompletionIndex, CompletionItem, CompletionQuery, CompletionScope,
     LiveCommand, LiveEditOperation, LiveRequest, LiveResponse, LiveResponseSendError,
-    LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_TRACKS, MAX_LIVE_TRACK_TICKS,
-    MAX_LIVE_WATCHES,
+    LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_WATCHES,
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::fs;
@@ -32,14 +31,6 @@ const MAX_LIVE_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
 const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
-const TRACK_PROGRESS_INTERVAL: usize = 10;
-
-struct LiveTrack {
-    total_ticks: u32,
-    samples: Vec<JitScalarValue>,
-    dropped_updates: u64,
-}
-
 #[derive(Debug, Clone)]
 pub struct LiveRunConfig {
     pub project_root: PathBuf,
@@ -145,7 +136,6 @@ pub(crate) struct LiveWorkspace {
     completion_snapshot: Arc<CompletionSnapshot>,
     scratch: ScratchWorkspace,
     watches: BTreeMap<String, Option<JitScalarValue>>,
-    tracks: BTreeMap<String, LiveTrack>,
     pending_plan: Option<WorkshopSemanticEditPlan>,
     pending_requests: VecDeque<LiveRequest>,
     pending_responses: VecDeque<LiveResponse>,
@@ -192,7 +182,6 @@ impl LiveWorkspace {
             completion_snapshot: Arc::new(CompletionSnapshot::default()),
             scratch: ScratchWorkspace::default(),
             watches: BTreeMap::new(),
-            tracks: BTreeMap::new(),
             pending_plan: None,
             pending_requests: VecDeque::new(),
             pending_responses: VecDeque::new(),
@@ -379,7 +368,6 @@ impl LiveWorkspace {
     }
 
     pub(crate) fn publish_watches(&mut self, tick: u64, jit: &JitProcess) {
-        self.publish_tracks(tick, jit);
         if self.dropped_watch_events > 0 {
             let dropped = self.dropped_watch_events;
             match self.server.respond(LiveResponse::success(
@@ -424,82 +412,6 @@ impl LiveWorkspace {
         }
     }
 
-    fn publish_tracks(&mut self, tick: u64, jit: &JitProcess) {
-        let paths = self.tracks.keys().cloned().collect::<Vec<_>>();
-        for path in paths {
-            let value = match jit.read_global_scalar(&path) {
-                Ok(value) => value,
-                Err(error) => {
-                    self.tracks.remove(&path);
-                    let _ = self.server.respond(LiveResponse::success(
-                        0,
-                        tick,
-                        "track_failed",
-                        json!({"path": path, "error": error}),
-                    ));
-                    continue;
-                }
-            };
-            let Some(track) = self.tracks.get_mut(&path) else {
-                continue;
-            };
-            if track.samples.len() < track.total_ticks as usize {
-                track.samples.push(value);
-            }
-            let complete = track.samples.len() == track.total_ticks as usize;
-            if !complete && track.samples.len() % TRACK_PROGRESS_INTERVAL != 0 {
-                continue;
-            }
-            let kind = if complete {
-                "track_complete"
-            } else {
-                "track_progress"
-            };
-            let samples = if complete {
-                track.samples.clone()
-            } else {
-                track
-                    .samples
-                    .iter()
-                    .rev()
-                    .take(32)
-                    .copied()
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect()
-            };
-            let response = LiveResponse::success(
-                0,
-                tick,
-                kind,
-                json!({
-                    "path": path,
-                    "sample_count": track.samples.len(),
-                    "total_ticks": track.total_ticks,
-                    "latest": value,
-                    "samples": samples,
-                    "dropped_updates": track.dropped_updates,
-                }),
-            );
-            match self.server.respond(response) {
-                Ok(()) if complete => {
-                    self.tracks.remove(&path);
-                }
-                Ok(()) => {}
-                Err(LiveResponseSendError::Full(_)) => {
-                    if let Some(track) = self.tracks.get_mut(&path) {
-                        track.dropped_updates = track.dropped_updates.saturating_add(1);
-                    }
-                }
-                Err(LiveResponseSendError::Disconnected) => {
-                    self.quit = true;
-                    return;
-                }
-            }
-        }
-    }
-
     fn handle_request(
         &mut self,
         request: LiveRequest,
@@ -518,7 +430,6 @@ impl LiveWorkspace {
                     "history_length": self.history.len(),
                     "history_cursor": self.history_cursor,
                     "watches": self.watches.keys().collect::<Vec<_>>(),
-                    "tracks": self.tracks.keys().collect::<Vec<_>>(),
                     "scratch_cells": self.scratch.list(),
                     "dropped_watch_events": self.dropped_watch_events,
                     "preparing_request_id": self.edit_preparation.as_ref().map(|job| job.request_id),
@@ -685,42 +596,6 @@ impl LiveWorkspace {
                 Ok((
                     "watch_added",
                     json!({"path": path, "value": value, "tick": tick}),
-                ))
-            }
-            LiveCommand::Track { path, ticks } => {
-                if ticks == 0 || ticks > MAX_LIVE_TRACK_TICKS {
-                    return Err(format!(
-                        "track duration must be 1..={MAX_LIVE_TRACK_TICKS} ticks"
-                    ));
-                }
-                let value = jit.read_global_scalar(&path)?;
-                if !self.tracks.contains_key(&path) && self.tracks.len() >= MAX_LIVE_TRACKS {
-                    return Err(format!(
-                        "live tracking is limited to {MAX_LIVE_TRACKS} paths"
-                    ));
-                }
-                self.tracks.insert(
-                    path.clone(),
-                    LiveTrack {
-                        total_ticks: ticks,
-                        samples: Vec::with_capacity(ticks as usize),
-                        dropped_updates: 0,
-                    },
-                );
-                Ok((
-                    "track_started",
-                    json!({"path": path, "ticks": ticks, "value": value}),
-                ))
-            }
-            LiveCommand::Untrack { path } => {
-                if let Some(path) = path {
-                    self.tracks.remove(&path);
-                } else {
-                    self.tracks.clear();
-                }
-                Ok((
-                    "track_removed",
-                    json!({"tracks": self.tracks.keys().collect::<Vec<_>>()}),
                 ))
             }
             LiveCommand::Unwatch { path } => {
@@ -1797,7 +1672,7 @@ fn help_data() -> Value {
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
             ":inspect [PATH]", ":watch PATH", ":unwatch [PATH]",
-            ":track PATH [ticks]", ":untrack [PATH]", ":set PATH VALUE",
+            ":set PATH VALUE",
             ":print VALUE_OR_PATH", ":do ... :end", ":cell put|run|list|clear"
         ],
         "multiline_terminator": ":end",
@@ -1833,8 +1708,6 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":inspect",
         ":watch",
         ":unwatch",
-        ":track",
-        ":untrack",
         ":set",
         ":print",
         ":do",
@@ -2409,53 +2282,6 @@ mod tests {
         assert!(workspace.should_run_tick());
         workspace.after_tick();
         assert!(!workspace.should_run_tick());
-        fs::remove_dir_all(root).ok();
-    }
-
-    #[test]
-    fn per_tick_track_keeps_unchanged_samples_and_completes_exactly() {
-        let (root, config) = project();
-        let (mut jit, package) = compile(&config);
-        jit.execute_i32_noarg_by_name("main").expect("main");
-        let (client, server) = stasis_runner::live::live_session(32);
-        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
-        let mut tick_ptr = package.tick_code_ptr;
-        let mut render_ptr = package.render_code_ptr;
-        let started = run_request(
-            &client,
-            &mut workspace,
-            &mut jit,
-            &mut tick_ptr,
-            &mut render_ptr,
-            LiveRequest::new(
-                44,
-                LiveCommand::Track {
-                    path: "score".into(),
-                    ticks: 3,
-                },
-            ),
-        );
-        assert!(started.ok, "{:?}", started.error);
-
-        jit.write_global_scalar("score", JitScalarValue::I32(5))
-            .expect("set score");
-        workspace.publish_watches(10, &jit);
-        workspace.publish_watches(11, &jit);
-        jit.write_global_scalar("score", JitScalarValue::I32(8))
-            .expect("set score");
-        workspace.publish_watches(12, &jit);
-
-        let complete = client
-            .receive_timeout(std::time::Duration::from_secs(1))
-            .expect("track complete");
-        assert_eq!(complete.kind, "track_complete");
-        assert_eq!(complete.tick, 12);
-        let data = complete.data.expect("track data");
-        assert_eq!(data["sample_count"], 3);
-        assert_eq!(data["samples"][0]["value"], 5);
-        assert_eq!(data["samples"][1]["value"], 5);
-        assert_eq!(data["samples"][2]["value"], 8);
-        assert!(workspace.tracks.is_empty());
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1040,27 +1040,6 @@ fn format_live_response(response: &LiveResponse) -> String {
             string_field(data, "path", "value"),
             scalar_text(data.get("value").unwrap_or(&Value::Null))
         ),
-        "track_started" => format!(
-            "tracking {} for {} tick(s) (~{} at 60 Hz)",
-            string_field(data, "path", "value"),
-            data.get("ticks").and_then(Value::as_u64).unwrap_or(0),
-            approximate_tick_duration(data.get("ticks").and_then(Value::as_u64).unwrap_or(0))
-        ),
-        "track_progress" => format_live_track(data, false),
-        "track_complete" => format_live_track(data, true),
-        "track_failed" => format!(
-            "track {} failed: {}",
-            string_field(data, "path", "value"),
-            string_field(data, "error", "unknown error")
-        ),
-        "track_removed" => {
-            let tracks = string_array(data.get("tracks"));
-            if tracks.is_empty() {
-                "no active traces".to_string()
-            } else {
-                format!("active traces: {tracks}")
-            }
-        }
         "watch_removed" => format_live_watch_removed(data),
         "watch_backpressure" => format!(
             "watch output dropped {} event(s)",
@@ -1119,76 +1098,6 @@ fn scalar_text(value: &Value) -> String {
     }
 }
 
-fn format_live_track(data: &Value, complete: bool) -> String {
-    let path = string_field(data, "path", "value");
-    let count = data
-        .get("sample_count")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let total = data.get("total_ticks").and_then(Value::as_u64).unwrap_or(0);
-    let latest = scalar_text(data.get("latest").unwrap_or(&Value::Null));
-    let dropped = data
-        .get("dropped_updates")
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let shape = format_track_shape(data.get("samples"));
-    format!(
-        "{}{}: {count}/{total} (~{} at 60 Hz), latest {latest}{}{}",
-        if complete { "trace complete " } else { "" },
-        path,
-        approximate_tick_duration(total),
-        shape,
-        if dropped > 0 {
-            format!(", {dropped} UI update(s) dropped")
-        } else {
-            String::new()
-        }
-    )
-}
-
-fn format_track_shape(samples: Option<&Value>) -> String {
-    let values = samples
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|sample| {
-            let value = sample.get("value").unwrap_or(sample);
-            value
-                .as_f64()
-                .or_else(|| value.as_bool().map(|value| f64::from(u8::from(value))))
-        })
-        .collect::<Vec<_>>();
-    if values.is_empty() {
-        return String::new();
-    }
-    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
-    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-    let changes = values
-        .windows(2)
-        .filter(|window| window[0] != window[1])
-        .count();
-    let levels = ['.', ':', '-', '=', '+', '*', '#'];
-    let trend = values
-        .iter()
-        .rev()
-        .take(24)
-        .rev()
-        .map(|value| {
-            if max == min {
-                '-'
-            } else {
-                let normalized = (value - min) / (max - min);
-                levels[(normalized * (levels.len() - 1) as f64).round() as usize]
-            }
-        })
-        .collect::<String>();
-    format!(", range {min:.3}..{max:.3}, {changes} change(s), trend {trend}")
-}
-
-fn approximate_tick_duration(ticks: u64) -> String {
-    format!("{:.1}s", ticks as f64 / 60.0)
-}
-
 fn format_live_help(data: &Value) -> String {
     let commands = data
         .get("commands")
@@ -1225,7 +1134,6 @@ fn format_live_status(data: &Value) -> String {
         .and_then(Value::as_u64)
         .unwrap_or(0);
     let watches = string_array(data.get("watches"));
-    let tracks = string_array(data.get("tracks"));
     let cells = data
         .get("scratch_cells")
         .and_then(Value::as_array)
@@ -1240,9 +1148,6 @@ fn format_live_status(data: &Value) -> String {
     let mut line = format!("{state} | edits {cursor}/{history}");
     if !watches.is_empty() {
         line.push_str(&format!(" | watches {watches}"));
-    }
-    if !tracks.is_empty() {
-        line.push_str(&format!(" | traces {tracks}"));
     }
     if !cells.is_empty() {
         line.push_str(&format!(" | cells {cells}"));

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -485,6 +485,10 @@ impl LiveTui {
                 edit.discard_confirm = false;
             }
         }
+        self.active_buffer_for_render_mut()
+    }
+
+    fn active_buffer_for_render_mut(&mut self) -> &mut EditBuffer {
         self.command_bar
             .as_mut()
             .unwrap_or_else(|| self.input.buffer_mut())
@@ -1321,7 +1325,7 @@ impl LiveTui {
         let cursor = draw_editor(
             &mut regions[1],
             layout.editor,
-            self.active_buffer_mut(),
+            self.active_buffer_for_render_mut(),
             ghost,
             command_bar,
             definition,
@@ -2348,6 +2352,33 @@ mod tests {
             &app.input,
             InputMode::Definition(edit) if edit.discard_confirm
         ));
+    }
+
+    #[test]
+    fn rendering_buffer_access_preserves_discard_confirmation() {
+        let (client, _server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        app.input = InputMode::Definition(EditSession {
+            id: 1,
+            target: LiveSymbolTarget {
+                name: "tick".to_string(),
+                kind: Some("function".to_string()),
+                file: Some("src/main.stasis".to_string()),
+                owner: None,
+                signature: Some("tick(): i32".to_string()),
+            },
+            expected_source_hash: workshop_source_hash("accepted"),
+            accepted_source: "accepted".to_string(),
+            source_start: 0,
+            buffer: EditBuffer::from_text("dirty".to_string()),
+            discard_confirm: false,
+        });
+
+        app.close_definition();
+        let _ = app.active_buffer_for_render_mut();
+        app.close_definition();
+
+        assert!(matches!(app.input, InputMode::Prompt(_)));
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -93,6 +93,8 @@ struct BufferSnapshot {
 struct EditBuffer {
     text: String,
     cursor: usize,
+    scroll_top: usize,
+    last_rendered_cursor_line: usize,
     selection_anchor: Option<usize>,
     undo: Vec<BufferSnapshot>,
     redo: Vec<BufferSnapshot>,
@@ -324,6 +326,7 @@ fn line_column(text: &str, cursor: usize) -> (usize, usize) {
 }
 
 struct EditSession {
+    id: u64,
     target: LiveSymbolTarget,
     expected_source_hash: String,
     accepted_source: String,
@@ -369,6 +372,9 @@ enum PendingAction {
     ApplyEdit {
         source: String,
         revision: u64,
+        session_id: u64,
+        target: LiveSymbolTarget,
+        submitted_at: Instant,
     },
     DefaultInspect,
     Completion {
@@ -419,6 +425,7 @@ struct LiveTui {
     history_cursor: usize,
     pending: BTreeMap<u64, PendingAction>,
     next_request_id: u64,
+    next_edit_session_id: u64,
     completion_generation: u64,
     completion_in_flight: Option<u64>,
     queued_completion: Option<QueuedCompletion>,
@@ -450,6 +457,7 @@ impl LiveTui {
             history_cursor: 0,
             pending: BTreeMap::new(),
             next_request_id: TUI_REQUEST_START,
+            next_edit_session_id: 0,
             completion_generation: 0,
             completion_in_flight: None,
             queued_completion: None,
@@ -750,10 +758,11 @@ impl LiveTui {
     }
 
     fn apply_definition(&mut self) -> Result<(), String> {
-        let (source, revision, target, expected_source_hash) = match &self.input {
+        let (source, revision, session_id, target, expected_source_hash) = match &self.input {
             InputMode::Definition(edit) => (
                 edit.buffer.text.clone(),
                 edit.buffer.revision,
+                edit.id,
                 edit.target.clone(),
                 edit.expected_source_hash.clone(),
             ),
@@ -765,14 +774,22 @@ impl LiveTui {
         let request_id = self.next_request();
         let command = LiveCommand::Edit {
             operation: LiveEditOperation::Update,
-            target,
+            target: target.clone(),
             source: Some(source.clone()),
             expected_source_hash: Some(expected_source_hash),
             preview: false,
             run_tests: true,
         };
-        self.pending
-            .insert(request_id, PendingAction::ApplyEdit { source, revision });
+        self.pending.insert(
+            request_id,
+            PendingAction::ApplyEdit {
+                source,
+                revision,
+                session_id,
+                target,
+                submitted_at: Instant::now(),
+            },
+        );
         if let Err(error) = self.client.submit(LiveRequest::new(request_id, command)) {
             self.pending.remove(&request_id);
             self.status = format!("definition apply could not be queued: {error}");
@@ -939,8 +956,14 @@ impl LiveTui {
             }
             match action {
                 PendingAction::OpenEdit => self.finish_open(response),
-                PendingAction::ApplyEdit { source, revision } => {
-                    self.finish_apply(response, source, revision);
+                PendingAction::ApplyEdit {
+                    source,
+                    revision,
+                    session_id,
+                    target,
+                    submitted_at,
+                } => {
+                    self.finish_apply(response, source, revision, session_id, target, submitted_at);
                 }
                 PendingAction::DefaultInspect => self.finish_default_inspection(response),
                 PendingAction::Completion {
@@ -1028,26 +1051,6 @@ impl LiveTui {
                     self.status = format!("default inspection unavailable: {error}");
                 }
             }
-        }
-        if matches!(
-            response.kind.as_str(),
-            "track_started" | "track_progress" | "track_complete" | "track_failed"
-        ) && response.ok
-        {
-            self.replace_inspector_watch(None);
-            self.inspector.title = response
-                .data
-                .as_ref()
-                .and_then(|data| data.get("path"))
-                .and_then(|value| value.as_str())
-                .unwrap_or("trace")
-                .to_string();
-            self.inspector.lines = vec![format_live_response(&response)];
-            self.inspector.pinned = true;
-            if response.kind == "track_complete" {
-                self.push_transcript(format_live_response(&response));
-            }
-            return;
         }
         self.push_transcript(format_live_response(&response));
     }
@@ -1226,7 +1229,9 @@ impl LiveTui {
             owner: item.owner.clone(),
             signature: Some(item.signature.clone()),
         };
+        self.next_edit_session_id = self.next_edit_session_id.saturating_add(1);
         self.input = InputMode::Definition(EditSession {
+            id: self.next_edit_session_id,
             target,
             expected_source_hash: item.source_hash,
             accepted_source: item.source.clone(),
@@ -1238,24 +1243,54 @@ impl LiveTui {
         self.refresh_completion(false);
     }
 
-    fn finish_apply(&mut self, response: LiveResponse, source: String, revision: u64) {
+    fn finish_apply(
+        &mut self,
+        response: LiveResponse,
+        source: String,
+        revision: u64,
+        session_id: u64,
+        target: LiveSymbolTarget,
+        submitted_at: Instant,
+    ) {
         self.pending.remove(&response.request_id);
         if !response.ok {
-            self.status = "apply failed; buffer remains open".to_string();
-            self.push_transcript(format_live_response(&response));
+            self.status = match &self.input {
+                InputMode::Definition(edit) if edit.id == session_id && edit.target == target => {
+                    "apply failed; buffer remains open".to_string()
+                }
+                _ => format!("apply failed for {}; current editor unchanged", target.name),
+            };
+            self.push_transcript(format_apply_error(&response));
             return;
         }
-        if let InputMode::Definition(edit) = &mut self.input {
+        let mut close_editor = false;
+        let same_editor = matches!(
+            &self.input,
+            InputMode::Definition(edit) if edit.id == session_id && edit.target == target
+        );
+        if same_editor {
+            let InputMode::Definition(edit) = &mut self.input else {
+                unreachable!("same_editor requires a definition");
+            };
             edit.accepted_source = source.clone();
             edit.expected_source_hash = workshop_source_hash(&source);
             edit.discard_confirm = false;
-            self.status = if edit.buffer.revision == revision && edit.buffer.text == source {
-                "snapshot applied; editor is clean".to_string()
+            close_editor = edit.buffer.revision == revision && edit.buffer.text == source;
+            self.status = if close_editor {
+                "snapshot applied; editor closed".to_string()
             } else {
                 "snapshot applied; later edits remain dirty".to_string()
             };
+        } else {
+            self.status = format!(
+                "snapshot applied for {}; current editor unchanged",
+                target.name
+            );
         }
-        self.push_transcript(format_live_response(&response));
+        if close_editor {
+            self.input = InputMode::Prompt(EditBuffer::default());
+        }
+        self.push_transcript(format_apply_confirmation(&response, submitted_at.elapsed()));
         self.refresh_completion(false);
     }
 
@@ -1279,14 +1314,18 @@ impl LiveTui {
         draw_box(&mut regions[0], layout.transcript, "Transcript")?;
         draw_transcript(&mut regions[0], layout.transcript, &self.transcript)?;
         draw_box(&mut regions[1], layout.editor, self.editor_title().as_str())?;
+        let ghost = self.ghost_text();
+        let command_bar = self.command_bar.is_some();
+        let definition = matches!(self.input, InputMode::Definition(_));
+        let prompt = self.prompt;
         let cursor = draw_editor(
             &mut regions[1],
             layout.editor,
-            self.active_buffer(),
-            self.ghost_text(),
-            self.command_bar.is_some(),
-            matches!(self.input, InputMode::Definition(_)),
-            self.prompt,
+            self.active_buffer_mut(),
+            ghost,
+            command_bar,
+            definition,
+            prompt,
         )?;
         draw_box(&mut regions[2], layout.right, "Completions / inspect")?;
         draw_right_panel(
@@ -1370,6 +1409,34 @@ impl LiveTui {
     fn ghost_text(&self) -> String {
         ghost_suffix(self.active_buffer(), &self.completion).unwrap_or_default()
     }
+}
+
+fn format_apply_confirmation(response: &LiveResponse, elapsed: Duration) -> String {
+    let elapsed_ms = elapsed.as_nanos().saturating_add(999_999) / 1_000_000;
+    let Some(data) = response.data.as_ref() else {
+        return format!(
+            "Hot swapped <= {elapsed_ms} ms | {}",
+            format_live_response(response)
+        );
+    };
+    let tests = data
+        .get("tests")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    format!("Hot swapped <= {elapsed_ms} ms | tests {tests}")
+}
+
+fn format_apply_error(response: &LiveResponse) -> String {
+    let Some(error) = response.error.as_deref() else {
+        return format_live_response(response);
+    };
+    let message = error
+        .lines()
+        .next()
+        .unwrap_or(error)
+        .rsplit_once(": ")
+        .map_or(error, |(_, message)| message);
+    format!("error: {message}")
 }
 
 fn completion_key(item: &CompletionItem) -> (String, String, String) {
@@ -1623,7 +1690,7 @@ fn draw_transcript(
 fn draw_editor(
     stdout: &mut impl Write,
     rect: Rect,
-    buffer: &EditBuffer,
+    buffer: &mut EditBuffer,
     ghost: String,
     command_bar: bool,
     definition: bool,
@@ -1635,7 +1702,7 @@ fn draw_editor(
     let ranges = line_ranges(&buffer.text);
     let (cursor_line, cursor_column) = line_column(&buffer.text, buffer.cursor);
     let visible_rows = rect.height.saturating_sub(2) as usize;
-    let start_line = cursor_line.saturating_sub(visible_rows.saturating_sub(1));
+    let start_line = update_editor_scroll(buffer, cursor_line, ranges.len(), visible_rows);
     let prefix = if definition || command_bar {
         ""
     } else {
@@ -1673,6 +1740,50 @@ fn draw_editor(
     Ok((cursor_x < rect.x + rect.width.saturating_sub(1)
         && cursor_y < rect.y + rect.height.saturating_sub(1))
     .then_some((cursor_x, cursor_y)))
+}
+
+fn update_editor_scroll(
+    buffer: &mut EditBuffer,
+    cursor_line: usize,
+    total_lines: usize,
+    visible_rows: usize,
+) -> usize {
+    if visible_rows == 0 {
+        return 0;
+    }
+    let max_start = total_lines.saturating_sub(visible_rows);
+    buffer.scroll_top = buffer.scroll_top.min(max_start);
+    let margin = (visible_rows / 4)
+        .max(1)
+        .min(visible_rows.saturating_sub(1) / 2);
+
+    if cursor_line < buffer.last_rendered_cursor_line {
+        let upper_trigger = buffer.scroll_top.saturating_add(margin);
+        if cursor_line <= upper_trigger && buffer.scroll_top > 0 {
+            buffer.scroll_top = cursor_line.saturating_sub(margin);
+        }
+    } else if cursor_line > buffer.last_rendered_cursor_line {
+        let lower_trigger = buffer
+            .scroll_top
+            .saturating_add(visible_rows.saturating_sub(1 + margin));
+        if cursor_line >= lower_trigger && buffer.scroll_top < max_start {
+            buffer.scroll_top = cursor_line
+                .saturating_add(1 + margin)
+                .saturating_sub(visible_rows)
+                .min(max_start);
+        }
+    }
+
+    if cursor_line < buffer.scroll_top {
+        buffer.scroll_top = cursor_line;
+    } else if cursor_line >= buffer.scroll_top.saturating_add(visible_rows) {
+        buffer.scroll_top = cursor_line
+            .saturating_add(1)
+            .saturating_sub(visible_rows)
+            .min(max_start);
+    }
+    buffer.last_rendered_cursor_line = cursor_line;
+    buffer.scroll_top
 }
 
 fn draw_syntax_line(
@@ -1846,6 +1957,40 @@ mod tests {
     }
 
     #[test]
+    fn editor_scrolls_down_inside_the_lower_quarter_margin() {
+        let mut buffer =
+            EditBuffer::from_text((0..20).map(|line| format!("line {line}\n")).collect());
+        buffer.set_cursor(0, false);
+        assert_eq!(update_editor_scroll(&mut buffer, 0, 21, 8), 0);
+
+        for line in 1..=6 {
+            buffer.move_vertical(1, false);
+            let cursor_line = line_column(&buffer.text, buffer.cursor).0;
+            update_editor_scroll(&mut buffer, cursor_line, 21, 8);
+            if line < 5 {
+                assert_eq!(buffer.scroll_top, 0);
+            }
+        }
+
+        assert_eq!(buffer.scroll_top, 1);
+    }
+
+    #[test]
+    fn editor_scrolls_up_inside_the_upper_quarter_margin() {
+        let mut buffer =
+            EditBuffer::from_text((0..20).map(|line| format!("line {line}\n")).collect());
+        buffer.scroll_top = 8;
+        let line_ten = line_ranges(&buffer.text)[10].start;
+        buffer.set_cursor(line_ten, false);
+        buffer.last_rendered_cursor_line = 11;
+        assert_eq!(update_editor_scroll(&mut buffer, 10, 21, 8), 8);
+
+        buffer.move_vertical(-1, false);
+        let cursor_line = line_column(&buffer.text, buffer.cursor).0;
+        assert_eq!(update_editor_scroll(&mut buffer, cursor_line, 21, 8), 7);
+    }
+
+    #[test]
     fn completion_requires_whitespace_document_tail() {
         assert!(suffix_is_whitespace("hero.da\n   ", 7));
         assert!(!suffix_is_whitespace("hero.da later", 7));
@@ -1921,6 +2066,209 @@ mod tests {
     }
 
     #[test]
+    fn apply_confirmation_reports_active_confirmation_bound_in_transcript() {
+        let response = LiveResponse::success(
+            8,
+            43,
+            "edit_applied",
+            serde_json::json!({
+                "plan": {
+                    "changed_files": [{"file": "src/main.stasis"}],
+                    "reload": {
+                        "expected_reload": "FastReload",
+                        "changed_symbols": [{"name": "tick"}]
+                    }
+                },
+                "tests": "passed"
+            }),
+        );
+
+        assert_eq!(
+            format_apply_confirmation(&response, Duration::from_millis(18)),
+            "Hot swapped <= 18 ms | tests passed"
+        );
+        assert!(
+            format_apply_confirmation(&response, Duration::from_micros(900))
+                .starts_with("Hot swapped <= 1 ms")
+        );
+        assert!(
+            format_apply_confirmation(&response, Duration::from_micros(18_900))
+                .starts_with("Hot swapped <= 19 ms")
+        );
+    }
+
+    #[test]
+    fn apply_error_omits_the_workspace_path_on_narrow_transcripts() {
+        let response = LiveResponse::failure(
+            8,
+            43,
+            r"C:\workspace\src\main.stasis:4514-4544: unknown identifier 'missing_symbol'",
+        );
+
+        assert_eq!(
+            format_apply_error(&response),
+            "error: unknown identifier 'missing_symbol'"
+        );
+    }
+
+    #[test]
+    fn successful_clean_apply_closes_definition_editor() {
+        let (client, _server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        let target = LiveSymbolTarget {
+            name: "tick".to_string(),
+            kind: Some("function".to_string()),
+            file: Some("src/main.stasis".to_string()),
+            owner: None,
+            signature: Some("tick(): i32".to_string()),
+        };
+        app.input = InputMode::Definition(EditSession {
+            id: 1,
+            target: target.clone(),
+            expected_source_hash: workshop_source_hash("accepted"),
+            accepted_source: "accepted".to_string(),
+            source_start: 0,
+            buffer: EditBuffer::from_text("accepted".to_string()),
+            discard_confirm: false,
+        });
+        let response = LiveResponse::success(
+            8,
+            43,
+            "edit_applied",
+            serde_json::json!({
+                "plan": {
+                    "changed_files": [{"file": "src/main.stasis"}],
+                    "reload": {"expected_reload": "FastReload"}
+                },
+                "tests": "passed"
+            }),
+        );
+
+        app.finish_apply(
+            response,
+            "accepted".to_string(),
+            0,
+            1,
+            target,
+            Instant::now(),
+        );
+
+        assert!(matches!(app.input, InputMode::Prompt(_)));
+        assert_eq!(app.status, "snapshot applied; editor closed");
+    }
+
+    #[test]
+    fn completed_apply_does_not_mutate_a_different_open_definition() {
+        let (client, _server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        let submitted_target = LiveSymbolTarget {
+            name: "tick".to_string(),
+            kind: Some("function".to_string()),
+            file: Some("src/main.stasis".to_string()),
+            owner: None,
+            signature: Some("tick(): i32".to_string()),
+        };
+        let current_target = LiveSymbolTarget {
+            name: "render".to_string(),
+            signature: Some("render(): i32".to_string()),
+            ..submitted_target.clone()
+        };
+        app.input = InputMode::Definition(EditSession {
+            id: 2,
+            target: current_target.clone(),
+            expected_source_hash: workshop_source_hash("render source"),
+            accepted_source: "render source".to_string(),
+            source_start: 0,
+            buffer: EditBuffer::from_text("render source".to_string()),
+            discard_confirm: false,
+        });
+        let response = LiveResponse::success(
+            8,
+            43,
+            "edit_applied",
+            serde_json::json!({
+                "plan": {
+                    "changed_files": [{"file": "src/main.stasis"}],
+                    "reload": {"expected_reload": "FastReload"}
+                },
+                "tests": "passed"
+            }),
+        );
+
+        app.finish_apply(
+            response,
+            "tick source".to_string(),
+            0,
+            1,
+            submitted_target,
+            Instant::now(),
+        );
+
+        let InputMode::Definition(edit) = &app.input else {
+            panic!("current definition must remain open");
+        };
+        assert_eq!(edit.target, current_target);
+        assert_eq!(edit.accepted_source, "render source");
+        assert_eq!(
+            app.status,
+            "snapshot applied for tick; current editor unchanged"
+        );
+    }
+
+    #[test]
+    fn completed_apply_does_not_mutate_a_reopened_same_definition() {
+        let (client, _server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client);
+        let target = LiveSymbolTarget {
+            name: "obstacle_enabled".to_string(),
+            kind: Some("function".to_string()),
+            file: Some("src/main.stasis".to_string()),
+            owner: None,
+            signature: Some("obstacle_enabled(): bool".to_string()),
+        };
+        app.input = InputMode::Definition(EditSession {
+            id: 2,
+            target: target.clone(),
+            expected_source_hash: workshop_source_hash("reopened source"),
+            accepted_source: "reopened source".to_string(),
+            source_start: 0,
+            buffer: EditBuffer::from_text("reopened source".to_string()),
+            discard_confirm: false,
+        });
+        let response = LiveResponse::success(
+            8,
+            43,
+            "edit_applied",
+            serde_json::json!({
+                "plan": {
+                    "changed_files": [{"file": "src/main.stasis"}],
+                    "reload": {"expected_reload": "FastReload"}
+                },
+                "tests": "passed"
+            }),
+        );
+
+        app.finish_apply(
+            response,
+            "old submitted source".to_string(),
+            0,
+            1,
+            target,
+            Instant::now(),
+        );
+
+        let InputMode::Definition(edit) = &app.input else {
+            panic!("reopened definition must remain open");
+        };
+        assert_eq!(edit.id, 2);
+        assert_eq!(edit.accepted_source, "reopened source");
+        assert_eq!(
+            app.status,
+            "snapshot applied for obstacle_enabled; current editor unchanged"
+        );
+    }
+
+    #[test]
     fn completion_requests_coalesce_and_stale_results_are_discarded() {
         let (client, server) = stasis_runner::live::live_session(8);
         let mut app = LiveTui::new(client);
@@ -1975,6 +2323,7 @@ mod tests {
         let (client, _server) = stasis_runner::live::live_session(8);
         let mut app = LiveTui::new(client);
         app.input = InputMode::Definition(EditSession {
+            id: 1,
             target: LiveSymbolTarget {
                 name: "tick".to_string(),
                 kind: Some("function".to_string()),

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -404,6 +404,9 @@ pub(crate) fn are_assignment_types_compatible(
     if target_type == expression_type {
         return true;
     }
+    if target_type == TYPE_ID_BOOL || expression_type == TYPE_ID_BOOL {
+        return false;
+    }
     is_i32_abi_compatible_type(target_type, type_table)
         && is_i32_abi_compatible_type(expression_type, type_table)
 }
@@ -2470,7 +2473,9 @@ pub(crate) fn parse_let_statement(
             })?;
             let expression = if let Some(expression_text) = initializer {
                 parse_value_expression(expression_text)?
-            } else if resolved_type_id == TYPE_ID_I32 || resolved_type_id == TYPE_ID_BOOL {
+            } else if resolved_type_id == TYPE_ID_BOOL {
+                SimpleExpr::Bool(false)
+            } else if resolved_type_id == TYPE_ID_I32 {
                 SimpleExpr::Int(0)
             } else {
                 SimpleExpr::Float(0.0)
@@ -4772,9 +4777,14 @@ pub(crate) fn emit_simple_statements(
                         binding.type_id,
                         type_table,
                     ) {
+                        let expected = type_table
+                            .type_info(declared_type_id)
+                            .map_or_else(|| declared_type_id.to_string(), |info| info.name.clone());
+                        let found = type_table
+                            .type_info(binding.type_id)
+                            .map_or_else(|| binding.type_id.to_string(), |info| info.name.clone());
                         return Err(format!(
-                            "let binding '{}' expected type {} expression but found {}",
-                            name, declared_type_id, binding.type_id
+                            "let binding '{name}' expected {expected} expression but found {found}"
                         ));
                     }
                     declared_type_id
@@ -5704,9 +5714,15 @@ pub(crate) fn emit_simple_statements(
                     binding.type_id,
                     type_table,
                 ) {
+                    let expected = type_table.type_info(expected_return_type).map_or_else(
+                        || expected_return_type.to_string(),
+                        |info| info.name.clone(),
+                    );
+                    let found = type_table
+                        .type_info(binding.type_id)
+                        .map_or_else(|| binding.type_id.to_string(), |info| info.name.clone());
                     return Err(format!(
-                        "return expression expected type {} but found {}",
-                        expected_return_type, binding.type_id
+                        "return expression expected {expected} but found {found}"
                     ));
                 }
                 builder.ins().return_(&[binding.value]);

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3298,6 +3298,46 @@ mod tests {
     }
 
     #[test]
+    fn jit_process_rejects_i32_return_from_bool_function() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function enabled(): bool { return 1; }\nfunction main(): i32 { if (enabled()) { return 1; } return 0; }\n",
+        );
+        let error = process.compile().expect_err("expected return type error");
+        match error {
+            crate::compiler::CompileError::Backend(message) => {
+                assert!(
+                    message.contains("return expression expected bool but found i32"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected backend error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn jit_process_rejects_i32_initializer_for_bool_binding() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function main(): i32 { let ready: bool = 1; if (ready) { return 1; } return 0; }\n",
+        );
+        let error = process
+            .compile()
+            .expect_err("expected assignment type error");
+        match error {
+            crate::compiler::CompileError::Backend(message) => {
+                assert!(
+                    message.contains("let binding 'ready' expected bool expression but found i32"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected backend error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn jit_process_rejects_f32_condition_expression() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -10,8 +10,6 @@ pub const DEFAULT_LIVE_OUTPUT_BYTES: usize = 64 * 1024;
 pub const MAX_LIVE_REQUEST_BYTES: usize = 512 * 1024;
 pub const MAX_LIVE_MULTILINE_BYTES: usize = 256 * 1024;
 pub const MAX_SCRATCH_CELLS: usize = 64;
-pub const MAX_LIVE_TRACKS: usize = 8;
-pub const MAX_LIVE_TRACK_TICKS: u32 = 600;
 pub const MAX_LIVE_WATCHES: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -148,15 +146,6 @@ pub enum LiveCommand {
     Watch {
         path: String,
     },
-    Track {
-        path: String,
-        #[serde(default = "default_track_ticks")]
-        ticks: u32,
-    },
-    Untrack {
-        #[serde(default)]
-        path: Option<String>,
-    },
     Unwatch {
         #[serde(default)]
         path: Option<String>,
@@ -201,10 +190,6 @@ pub enum LiveCommand {
 
 const fn one_tick() -> u32 {
     1
-}
-
-const fn default_track_ticks() -> u32 {
-    300
 }
 
 const fn default_completion_limit() -> usize {
@@ -1114,17 +1099,6 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         ":watch" => ready(LiveCommand::Watch {
             path: required_arg(&args, 1, "state path")?.to_string(),
         }),
-        ":track" => ready(LiveCommand::Track {
-            path: required_arg(&args, 1, "state path")?.to_string(),
-            ticks: args
-                .get(2)
-                .map(|value| parse_u32("ticks", value))
-                .transpose()?
-                .unwrap_or_else(default_track_ticks),
-        }),
-        ":untrack" => ready(LiveCommand::Untrack {
-            path: args.get(1).cloned(),
-        }),
         ":unwatch" => ready(LiveCommand::Unwatch {
             path: args.get(1).cloned(),
         }),
@@ -1705,36 +1679,6 @@ mod tests {
                     source_offset: Some(42),
                     expected_type: Some("i32".into()),
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn terminal_track_command_defaults_and_accepts_tick_duration() {
-        let mut terminal = TerminalBuffer::new();
-        let TerminalInput::Request(default_request) =
-            terminal.feed_line(":track score").expect("default track")
-        else {
-            panic!("expected request")
-        };
-        assert_eq!(
-            default_request.command,
-            LiveCommand::Track {
-                path: "score".into(),
-                ticks: 300,
-            }
-        );
-        let TerminalInput::Request(explicit_request) = terminal
-            .feed_line(":track score 12")
-            .expect("explicit track")
-        else {
-            panic!("expected request")
-        };
-        assert_eq!(
-            explicit_request.command,
-            LiveCommand::Track {
-                path: "score".into(),
-                ticks: 12,
             }
         );
     }

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -40,7 +40,7 @@ keeps keyboard focus in the input/editor and makes completion selection contextu
 
 Implemented now are the persistent/adaptive panes, asynchronous coalesced completion, safe Tab and
 ghost insertion, multiline definition editing/apply, text undo/redo, command bar, concise default
-and pinned inspection, bounded per-tick traces, syntax colors, and guaranteed terminal restoration.
+and pinned inspection, syntax colors, and guaranteed terminal restoration.
 Transcript scrollback with unread counts, visible selection styling, matching-delimiter feedback,
 diagnostic-span underlines, and a shared declarative command grammar remain planned polish; this
 slice does not claim them yet.
@@ -79,8 +79,9 @@ second language model.
 
 Enter inserts a newline and applies brace-aware auto-indentation. Ctrl+Enter snapshots the complete
 buffer, validates it, runs the normal test gate, and atomically hot-swaps it. Editing remains
-available while that immutable snapshot is prepared. A successful older snapshot becomes the new
-accepted base without erasing later keystrokes; those later edits remain dirty. Failed validation
+available while that immutable snapshot is prepared. A successful current snapshot closes the
+editor and returns to the prompt. If the user typed after submission, the accepted snapshot becomes
+the new base without erasing those later keystrokes, and the editor stays open with them dirty. Failed validation
 or apply keeps the editor open and reports diagnostics in the status/transcript; structured
 right-pane diagnostics with adaptive height remain planned polish. Stale results never overwrite a
 newer submitted snapshot. `:end` remains a compatibility escape hatch for the script and legacy
@@ -89,9 +90,8 @@ line-input paths.
 `:edit SYMBOL` opens the complete current definition with its semantic selector and expected source
 hash. Overloads are disambiguated in the right pane using owner, file, and signature metadata. The
 user-facing command remains concise; storage-level selectors are generated internally. After a
-successful apply the editor stays open, its accepted source/hash advance to the applied snapshot,
-and the transcript records the swap. Ctrl+W closes an editor, requiring confirmation before a dirty
-buffer is discarded.
+successful clean apply the transcript records the swap and the editor closes. Ctrl+W closes an
+editor manually, requiring confirmation before a dirty buffer is discarded.
 
 A leading `:` in the normal REPL input progressively completes commands and valid arguments at the
 current position. Inside a Stasis definition, `:` always remains language syntax. Ctrl+K opens a
@@ -112,15 +112,9 @@ immutable one-time value to the transcript. Do does not add routine output beyon
 state, but always surfaces failures and diagnostics. The default inspector refreshes visible values
 at a readable UI cadence and does not append each refresh to the transcript.
 
-Inspector nodes can be explicitly tracked for a bounded period. Tracking samples the selected
-values at every normalized between-tick boundary, including unchanged values, and stores them in a
-bounded ring owned by the live session. Duration is expressed canonically in ticks, with an
-approximate wall-time label for convenience; the initial default is 300 ticks and can be changed
-before starting a trace. The inspector shows the latest value, sample progress, min/max or change
-count where meaningful, and a compact trend. Completion, rendering, or a slow terminal must not
-block the game tick. Truncation or dropped samples are visible and never presented as a complete
-trace. Existing change-only watches remain useful for notifications and are not silently redefined
-as per-tick traces.
+The concise default inspector is the primary continuous observation surface. Explicit inspections
+can pin one value, while change-only watches remain available for notifications. Inspector refresh,
+completion, rendering, or a slow terminal must not block the game tick.
 
 Ctrl+Z/Ctrl+Y operate only on the current text buffer. `:undo` and `:redo` remain a separate history
 for accepted source/runtime swaps. The first TUI slice includes basic syntax coloring. Transcript
@@ -151,8 +145,6 @@ fail-fast behavior. Invalid human commands remain nonfatal and return focus to t
 :inspect
 :inspect score
 :watch score
-:track score 300
-:untrack score
 :set score 10
 :print score
 :changes

--- a/docs/live_tui_recording.md
+++ b/docs/live_tui_recording.md
@@ -5,34 +5,45 @@ This runbook describes a repeatable desktop capture for the persistent live TUI.
 ## Prepare the session
 
 1. Build the debug runner with `cargo build -p stasis`.
-2. Start a small running game and the live workspace in two ordinary windows. Snap the TUI to the left and the game to the right with Win+Left and Win+Right.
-3. Use a monitor/display capture in OBS when OpenGL window capture is black. Run a short smoke recording first and inspect a frame before the full take.
+2. Start a small running game and the live workspace in two ordinary windows. Size the real TUI window entirely above the taskbar, with the game beside it.
+3. Capture the TUI and game as direct window sources on a fixed canvas. Crop and scale those sources to fill the frame without capturing the desktop or taskbar. Use display capture only as a diagnosed fallback, with an explicit crop that excludes the taskbar. Run a short smoke recording first and inspect a frame before the full take.
 4. Keep OBS minimized. Do not click the classic console while recording; QuickEdit can suspend its input/output and make Stasis appear frozen. Bring it to the foreground with the window API or keyboard focus only.
 5. Stop and clean up the runner, terminal host, and OBS after every take. Reject any take containing an unrelated window, notification, JSON envelope, or a blank game surface.
 
-## Narrated walkthrough shape
+## Walkthrough shape
 
-The opening must say, both aloud and on screen:
+Say this disclosure at the opening and show it briefly on screen:
 
 > This demonstration was written, controlled, narrated, and recorded entirely by AI. The interactions are scripted for clarity, but the compiler, tests, live edits, and running game shown here are real.
 
-Then use a simple Pong-like game and make the experiment visible:
+The story is not merely that source can be edited while a window is open. Make four Stasis-specific claims visible and falsifiable:
 
-- establish the baseline for several rallies;
-- try a speed increase, observe it, and undo it when it is less readable;
-- add a visible obstacle plus its matching tick behavior, validate, and observe the swap;
-- tune the obstacle once instead of endlessly adding features;
-- attempt one unsafe state-layout change and show deterministic rejection;
-- finish on the accepted version running unattended.
+1. A changed function becomes active in the existing native process without restarting the match.
+2. Compiler validation and project tests gate the swap, and the accepted pointer change commits between ticks.
+3. Runtime state such as the current score and rally count survives the function replacement.
+4. Concise live values and visible gameplay distinguish the old behavior from the new behavior, while an invalid or incompatible edit leaves the accepted game running.
 
-Narration should name the hypothesis before each edit, explain that completion is compiler-backed, and distinguish visual evidence in the game from concise semantic live state. It should never imply that a human operator is typing off camera. Pause three seconds on completion choices, validation, swaps, undo, and rejection so a phone viewer can read them.
+Use a real autonomous Pong baseline with aligned ball/paddle collision bounds, visible `0-0` score digits, scoring, and a small `obstacle_enabled()` function. The baseline returns `false`. The tick and render functions both call it, so replacing this one function can add two smaller center bumpers with a passable gap, plus their collision behavior, without changing state layout. Keep `left_score`, `right_score`, `rally_hits`, `obstacle_hits`, `speed`, and `swaps` visible in the concise state pane.
+
+Record this sequence:
+
+1. Let Pong play unattended until a point or several paddle contacts establish that the match is real. Point out that `obstacle_hits` remains zero in the concise live-state pane before the obstacle exists.
+2. Open `obstacle_enabled` through completion. Change its return expression from `false` to `true`.
+3. Press Ctrl+Enter once. Hold on the concise transcript confirmation, `Hot swapped <= N ms | tests passed`. A clean successful apply closes the editor automatically. Keep the game visible so the viewer can see that the obstacle appears while the ball and score do not reset.
+4. Hold on the live game and concise state. The counter must advance after the ball visibly rebounds from a horizontal or vertical bumper face. Abort or revise the take if it remains zero.
+5. Reopen `obstacle_enabled`, replace `return true;` with `return 1;`, and submit it. Show the deterministic bool-versus-i32 diagnostic while the last accepted game continues and its counters still advance. Discard the rejected buffer before finishing.
+6. End on the accepted obstacle version running unattended, with the preserved match score and incremented `swaps` count visible.
+
+Narrate each hypothesis before its action. The displayed duration is an end-to-end upper bound from Ctrl+Enter submission until the TUI processes the response confirming that the pointer is active; the replacement runs on the next tick. Do not present it as compiler-only or exact first-execution time. Connect visible gameplay to the concise live values, and do not use one-off `:inspect` calls as filler. Type briskly, while pausing long enough on completion choices, apply timing, live-state evidence, and rejection for a phone viewer to read them.
 
 ## Capture acceptance
 
-- The TUI and game fill the capture together; no OBS chrome or unrelated desktop is visible.
+- The TUI and game fill the capture together; no OBS chrome, unrelated desktop, or taskbar is visible. The real TUI window does not overlap the taskbar.
 - The default live-state pane uses concise `name = value` rows. It omits source/type detail, spatial fields, and collection `length`/`max_length` bookkeeping; explicit `:inspect PATH` remains the detailed escape hatch.
-- The recording contains audible narration and the AI disclosure, not just an empty audio track.
+- The accepted apply line includes the measured active-confirmation upper bound. The score/rally state visibly survives that apply.
+- `obstacle_hits` remains zero before the swap and advances only after a visible bumper collision.
+- The accepted recording contains audible narration and the AI disclosure. Generate one cached audio section per beat, keyed by text, voice, model, and settings; unchanged sections must not consume API credits again.
 - Sample opening, experiment, rejection, and closing frames. Confirm the game changes and the TUI shows real completion, validation, and swap feedback.
 - Copy the accepted MP4 to a phone-share directory and verify it with the same LAN URL used by the viewer.
 
-For a fully scripted take, keep the action script and narration script beside the captured artifact, record the exact command sequence and model disclosure, and retain rejected takes only as local QA evidence.
+For a fully scripted take, keep the action and narration scripts beside the captured artifact, record the exact command sequence and model disclosure, and retain rejected takes only as local QA evidence.


### PR DESCRIPTION
## Summary
- make Ctrl+Enter apply immutable edit snapshots, report `Hot swapped <= N ms | tests passed`, close only the successful clean editor, and ignore stale responses for reopened/different definitions
- add directional quarter-viewport editor scrolling, concise diagnostics, and strict bool-vs-i32 assignment/return validation
- remove track/untrack from the live protocol and human TUI while retaining concise default state, explicit watch, and detailed inspect
- document the taskbar-free direct-window OBS workflow, cached segmented narration, and the functional Pong hot-swap/rejection evidence

## Tests
- `cargo test -p stasis_compiler --lib -- --test-threads=1` ? 300 passed, 1 ignored
- `cargo test -p stasis toolchain_cli::live_tui::tests:: -- --test-threads=1` ? 23 passed
- `cargo test -p stasis live_workspace::tests --lib -- --test-threads=1` ? 25 passed
- `cargo test -p stasis_runner live::tests -- --test-threads=1` ? 19 passed
- `cargo test -p stasis --test toolchain_cli -- --test-threads=1` ? 8 passed
- functional Pong fixture via `stasis test --workspace . --json` ? 13 passed
- `python tools/ci/check_stasis_src_layout.py` ? passed
- standalone rustfmt and `git diff --check` ? passed
- `cargo test --workspace --all-targets -- --test-threads=1` ? library phase 165 passed/6 ignored; stopped only on the two existing Windows slash-normalization assertions in `apps/stasis/src/main.rs`

## Verification and recording
- independent review and fix re-review completed with no remaining findings
- addressed the post-open P2 render/discard-confirmation review in `472eb33d`; thread resolved and updated TUI suite passes 23/23
- decoded opening/edit/apply/rejection/closing frames from the 1280x720 take; only TUI and game are captured, with the real terminal above the taskbar
- narrated final is 60.455 seconds with H.264 video and mono AAC; George clips are cached by text, voice, model, and settings so unchanged beats do not use credits again
- `docs/live_tui_recording.md` contains the repeatable workflow and acceptance gates

Maddox #162.
