### PR TITLE
fix: restore nightly release on Rust 1.97

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1369,6 +1369,10 @@ fn try_run_android_aot_bundle_subcommand() -> Option<i32> {
                 "android_aot_symbols_header={}",
                 summary.symbols_header.display()
             );
+            println!(
+                "android_aot_bindings_source={}",
+                summary.bindings_source.display()
+            );
             println!("android_aot_cmake_file={}", summary.cmake_file.display());
             println!("android_aot_asset_dir={}", summary.asset_dir.display());
             Some(0)

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1026,201 +1026,66 @@ fn new_stasis_jit_builder() -> Result<JITBuilder, String> {
 }
 fn runtime_helper_addresses() -> BTreeMap<String, usize> {
     let mut out = BTreeMap::new();
-    out.insert(
-        "stasis_jit_call_i32_0".to_string(),
-        stasis_dynload::stasis_jit_call_i32_0 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_1".to_string(),
-        stasis_dynload::stasis_jit_call_i32_1 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_2".to_string(),
-        stasis_dynload::stasis_jit_call_i32_2 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_3".to_string(),
-        stasis_dynload::stasis_jit_call_i32_3 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_4".to_string(),
-        stasis_dynload::stasis_jit_call_i32_4 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_5".to_string(),
-        stasis_dynload::stasis_jit_call_i32_5 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_6".to_string(),
-        stasis_dynload::stasis_jit_call_i32_6 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_7".to_string(),
-        stasis_dynload::stasis_jit_call_i32_7 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_8".to_string(),
-        stasis_dynload::stasis_jit_call_i32_8 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_1".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_1 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_2".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_2 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_3".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_3 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_4".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_4 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_5".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_5 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_6".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_6 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_7".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_7 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_i32_f32_8".to_string(),
-        stasis_dynload::stasis_jit_call_i32_f32_8 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_0".to_string(),
-        stasis_dynload::stasis_jit_call_f32_0 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_1".to_string(),
-        stasis_dynload::stasis_jit_call_f32_1 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_2".to_string(),
-        stasis_dynload::stasis_jit_call_f32_2 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_3".to_string(),
-        stasis_dynload::stasis_jit_call_f32_3 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_4".to_string(),
-        stasis_dynload::stasis_jit_call_f32_4 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_5".to_string(),
-        stasis_dynload::stasis_jit_call_f32_5 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_6".to_string(),
-        stasis_dynload::stasis_jit_call_f32_6 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_7".to_string(),
-        stasis_dynload::stasis_jit_call_f32_7 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_8".to_string(),
-        stasis_dynload::stasis_jit_call_f32_8 as usize,
-    );
-    out.insert(
-        "stasis_jit_call_f32_i32_1".to_string(),
-        stasis_dynload::stasis_jit_call_f32_i32_1 as usize,
-    );
-    out.insert(
-        "stasis_jit_print_i32".to_string(),
-        stasis_dynload::stasis_jit_print_i32 as usize,
-    );
-    out.insert(
-        "stasis_jit_print_string".to_string(),
-        stasis_dynload::stasis_jit_print_string as usize,
-    );
-    out.insert(
-        "stasis_jit_lookup_code_ptr".to_string(),
-        stasis_dynload::stasis_jit_lookup_code_ptr as usize,
-    );
-    out.insert(
-        "stasis_jit_sin_fast".to_string(),
-        stasis_dynload::stasis_jit_sin_fast as usize,
-    );
-    out.insert(
-        "stasis_jit_cos_fast".to_string(),
-        stasis_dynload::stasis_jit_cos_fast as usize,
-    );
-    out.insert(
-        "stasis_jit_global_i32_load".to_string(),
-        stasis_dynload::stasis_jit_global_i32_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_i32_store".to_string(),
-        stasis_dynload::stasis_jit_global_i32_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f32_load".to_string(),
-        stasis_dynload::stasis_jit_global_f32_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f32_store".to_string(),
-        stasis_dynload::stasis_jit_global_f32_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f64_load".to_string(),
-        stasis_dynload::stasis_jit_global_f64_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f64_store".to_string(),
-        stasis_dynload::stasis_jit_global_f64_store as usize,
-    );
-    out.insert(
-        "stasis_jit_collection_i32_load".to_string(),
-        stasis_dynload::stasis_jit_collection_i32_load as usize,
-    );
-    out.insert(
-        "stasis_jit_collection_i32_store".to_string(),
-        stasis_dynload::stasis_jit_collection_i32_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_i32_array_load".to_string(),
-        stasis_dynload::stasis_jit_global_i32_array_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_i32_array_store".to_string(),
-        stasis_dynload::stasis_jit_global_i32_array_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_i32_array_ptr".to_string(),
-        stasis_dynload::stasis_jit_global_i32_array_ptr as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f32_array_load".to_string(),
-        stasis_dynload::stasis_jit_global_f32_array_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f32_array_store".to_string(),
-        stasis_dynload::stasis_jit_global_f32_array_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f32_array_ptr".to_string(),
-        stasis_dynload::stasis_jit_global_f32_array_ptr as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f64_array_load".to_string(),
-        stasis_dynload::stasis_jit_global_f64_array_load as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f64_array_store".to_string(),
-        stasis_dynload::stasis_jit_global_f64_array_store as usize,
-    );
-    out.insert(
-        "stasis_jit_global_f64_array_ptr".to_string(),
-        stasis_dynload::stasis_jit_global_f64_array_ptr as usize,
+    macro_rules! insert_helpers {
+        ($($name:ident),+ $(,)?) => {
+            $(
+                out.insert(
+                    stringify!($name).to_string(),
+                    function_address(stasis_dynload::$name as *const ()),
+                );
+            )+
+        };
+    }
+    insert_helpers!(
+        stasis_jit_call_i32_0,
+        stasis_jit_call_i32_1,
+        stasis_jit_call_i32_2,
+        stasis_jit_call_i32_3,
+        stasis_jit_call_i32_4,
+        stasis_jit_call_i32_5,
+        stasis_jit_call_i32_6,
+        stasis_jit_call_i32_7,
+        stasis_jit_call_i32_8,
+        stasis_jit_call_i32_f32_1,
+        stasis_jit_call_i32_f32_2,
+        stasis_jit_call_i32_f32_3,
+        stasis_jit_call_i32_f32_4,
+        stasis_jit_call_i32_f32_5,
+        stasis_jit_call_i32_f32_6,
+        stasis_jit_call_i32_f32_7,
+        stasis_jit_call_i32_f32_8,
+        stasis_jit_call_f32_0,
+        stasis_jit_call_f32_1,
+        stasis_jit_call_f32_2,
+        stasis_jit_call_f32_3,
+        stasis_jit_call_f32_4,
+        stasis_jit_call_f32_5,
+        stasis_jit_call_f32_6,
+        stasis_jit_call_f32_7,
+        stasis_jit_call_f32_8,
+        stasis_jit_call_f32_i32_1,
+        stasis_jit_print_i32,
+        stasis_jit_print_string,
+        stasis_jit_lookup_code_ptr,
+        stasis_jit_sin_fast,
+        stasis_jit_cos_fast,
+        stasis_jit_global_i32_load,
+        stasis_jit_global_i32_store,
+        stasis_jit_global_f32_load,
+        stasis_jit_global_f32_store,
+        stasis_jit_global_f64_load,
+        stasis_jit_global_f64_store,
+        stasis_jit_collection_i32_load,
+        stasis_jit_collection_i32_store,
+        stasis_jit_global_i32_array_load,
+        stasis_jit_global_i32_array_store,
+        stasis_jit_global_i32_array_ptr,
+        stasis_jit_global_f32_array_load,
+        stasis_jit_global_f32_array_store,
+        stasis_jit_global_f32_array_ptr,
+        stasis_jit_global_f64_array_load,
+        stasis_jit_global_f64_array_store,
+        stasis_jit_global_f64_array_ptr,
     );
     out
 }


### PR DESCRIPTION
## Summary

- convert JIT runtime helper function items to pointers before storing integer addresses
- consolidate helper registration so new entries use the Rust 1.97-compatible conversion path
- report the generated Android AOT bindings source, preventing a release-only dead-code error

## Root cause

Rust 1.97.1 rejects direct function-item-to-integer casts. The compiler crate denies warnings in release builds, so all four nightly release targets failed while compiling `stasis_compiler`. After correcting those casts, the release build exposed an unused Android bundle summary field that was only read by tests.

Failed workflow: https://github.com/benwmaddox/StasisLang/actions/runs/29630220137

## Validation

- `cargo +1.97.1 build -p stasis --release --target x86_64-pc-windows-msvc`
- `cargo +1.97.1 test -p stasis_compiler --lib` (298 passed, 1 ignored)
- `cargo +1.97.1 test -p stasis --bin stasis tests::android_aot_bundle_writes_pong_symbols_header -- --exact`

The full `stasis` binary test suite also ran: 60 passed and 2 existing Windows path-separator assertions failed (`nested\\helper.stasis` versus `nested/helper.stasis`).
