### PR TITLE
fix: restore cross-platform nightly packaging

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -61,7 +61,15 @@ jobs:
           & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" "glew:$triplet" --recurse
 
           $buildDir = "runtime/build_ci"
-          cmake -S runtime -B $buildDir -G "Visual Studio 17 2022" -A x64 `
+          $cmakeHelp = cmake --help | Out-String
+          if ($cmakeHelp -match "Visual Studio 18 2026") {
+            $generator = "Visual Studio 18 2026"
+          } elseif ($cmakeHelp -match "Visual Studio 17 2022") {
+            $generator = "Visual Studio 17 2022"
+          } else {
+            throw "Supported Visual Studio CMake generator not found."
+          }
+          cmake -S runtime -B $buildDir -G $generator -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -124,7 +124,15 @@ jobs:
           & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" "glew:$triplet" --recurse
 
           $buildDir = "runtime/build_ci"
-          cmake -S runtime -B $buildDir -G "Visual Studio 17 2022" -A x64 `
+          $cmakeHelp = cmake --help | Out-String
+          if ($cmakeHelp -match "Visual Studio 18 2026") {
+            $generator = "Visual Studio 18 2026"
+          } elseif ($cmakeHelp -match "Visual Studio 17 2022") {
+            $generator = "Visual Studio 17 2022"
+          } else {
+            throw "Supported Visual Studio CMake generator not found."
+          }
+          cmake -S runtime -B $buildDir -G $generator -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `

--- a/crates/stasis_dynload/Cargo.toml
+++ b/crates/stasis_dynload/Cargo.toml
@@ -6,5 +6,5 @@ license.workspace = true
 
 [lib]
 path = "src/lib.rs"
-crate-type = ["rlib", "cdylib"]
+crate-type = ["rlib", "cdylib", "staticlib"]
 


### PR DESCRIPTION
## Summary

- publish `stasis_dynload` as an explicit static-library crate artifact
- restore Cargo's stable top-level release artifact path for Unix packaging
- select Visual Studio 2026 on current Windows runners with a Visual Studio 2022 fallback
- apply the generator selection to both nightly and bootstrap artifact workflows

## Root causes

After the Rust 1.97 compiler fix landed, all Unix nightly builds compiled successfully but packaging failed because the ad-hoc `--crate-type staticlib` output was placed under `release/deps`. Declaring `staticlib` in the crate manifest makes it an explicit, stable Cargo output.

The Windows build then failed because `windows-latest` now provides Visual Studio 2026 while the workflows hardcoded the Visual Studio 2022 CMake generator. The workflows now select the newest supported generator available on the runner.

Failed workflow: https://github.com/benwmaddox/StasisLang/actions/runs/29645237538

## Validation

- `cargo +1.97.1 build -p stasis_dynload --release --target x86_64-pc-windows-msvc`
- verified `target/x86_64-pc-windows-msvc/release/stasis_dynload.lib` exists
- `cargo +1.97.1 test -p stasis_dynload` (8 passed)
- `git diff --check`

The GitHub workflows provide the final Unix artifact-path and Windows Visual Studio 2026 verification.
