### PR TITLE
fix: keep focus inside compact Workshop menu

### DIFF
--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -279,6 +279,9 @@ public final class MainActivity extends Activity {
     private TextView changeSummary;
     private TextView gameStatus;
     private GamePreviewView gamePreview;
+    private boolean previewFocusabilityCaptured;
+    private boolean previewFocusableWhenUncovered;
+    private boolean previewFocusableInTouchModeWhenUncovered;
     private LinearLayout symbolList;
     private File projectRootFile;
     private String projectRootPath;
@@ -1165,7 +1168,7 @@ public final class MainActivity extends Activity {
         boolean opening = editorPanel.getVisibility() != View.VISIBLE;
         editorPanel.setVisibility(opening ? View.VISIBLE : View.GONE);
         boolean coverPreview = opening && adaptiveLayoutProfile().fullWidthEditor;
-        setPreviewAccessibilityHidden(coverPreview);
+        setPreviewCovered(coverPreview);
         updateAiGameProgressOverlay();
         if (opening) {
             editorPanel.bringToFront();
@@ -1196,10 +1199,25 @@ public final class MainActivity extends Activity {
         }
     }
 
-    private void setPreviewAccessibilityHidden(boolean hidden) {
-        int importance = hidden ? View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+    private void setPreviewCovered(boolean covered) {
+        int importance = covered ? View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
                 : View.IMPORTANT_FOR_ACCESSIBILITY_AUTO;
-        if (gamePreview != null) gamePreview.setImportantForAccessibility(importance);
+        if (gamePreview != null) {
+            gamePreview.setImportantForAccessibility(importance);
+            if (covered && !previewFocusabilityCaptured) {
+                previewFocusableWhenUncovered = gamePreview.isFocusable();
+                previewFocusableInTouchModeWhenUncovered = gamePreview.isFocusableInTouchMode();
+                previewFocusabilityCaptured = true;
+            }
+            if (covered) {
+                gamePreview.setFocusable(false);
+                gamePreview.setFocusableInTouchMode(false);
+            } else if (previewFocusabilityCaptured) {
+                gamePreview.setFocusable(previewFocusableWhenUncovered);
+                gamePreview.setFocusableInTouchMode(previewFocusableInTouchModeWhenUncovered);
+                previewFocusabilityCaptured = false;
+            }
+        }
         if (gameStatus != null) gameStatus.setImportantForAccessibility(importance);
     }
 

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -569,6 +569,9 @@ def main() -> int:
     assert "SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR" in activity
     assert 'announceForAccessibility("Workshop menu opened")' in activity
     assert "createFocusableControlBackground" in activity
+    assert "setPreviewCovered(coverPreview)" in activity
+    assert "gamePreview.setFocusable(false)" in activity
+    assert "gamePreview.setFocusable(previewFocusableWhenUncovered)" in activity
     assert "voiceActionRow, layout" in activity
     assert "configuration.fontScale" in activity
     assert "MEDIUM_WIDTH_DP = 600" in adaptive_layout


### PR DESCRIPTION
## Summary
- keep keyboard focus out of the gameplay preview while the compact full-width Workshop menu covers it
- restore the preview prior focus settings when the menu closes
- add a structural regression assertion

Follow-up to #291 after its original head auto-merged while review feedback was being addressed.

## Verification
- `python tools\\ci\\check_android_shell.py`
- `gradle :app:testWorkshopDebugUnitTest --no-daemon --max-workers=1` (72 tests)
- `gradle :app:lintWorkshopDebug --no-daemon --max-workers=1`
- `gradle :app:assembleWorkshopDebug --no-daemon --max-workers=1`
- `git diff --check origin/main...HEAD`