### PR TITLE
fix: deduplicate project-relative imports in mobile AOT bundles

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1443,6 +1443,7 @@ fn write_mobile_aot_engine_bundle(
     output_dir: &Path,
 ) -> Result<MobileAotBundleSummary, String> {
     let mut process = AotProcess::with_optimization_profile(AotOptimizationProfile::SpeedAndSize);
+    process.set_import_base_dir(project_dir);
     process.set_target(target.aot_target());
     for (path, source) in collect_mobile_aot_sources(project_dir, entry_file)? {
         process.upsert_file(path, source);
@@ -2543,6 +2544,65 @@ mod tests {
         assert_eq!(paths, vec!["src/helper.stasis", "src/main.stasis"]);
 
         std::fs::remove_dir_all(&project_dir).ok();
+    }
+
+    #[test]
+    fn mobile_aot_bundle_deduplicates_cyclic_import_graph() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project_dir = std::env::temp_dir().join(format!("stasis_mobile_imports_{stamp}"));
+        let src_dir = project_dir.join("src");
+        let asset_dir = project_dir.join("assets");
+        let output_dir = std::env::temp_dir().join(format!("stasis_mobile_imports_out_{stamp}"));
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::create_dir_all(&asset_dir).expect("mkdir assets");
+        std::fs::write(
+            src_dir.join("main.stasis"),
+            r#"import "window.stasis";
+function main(): i32 { return 0; }
+function tick(): i32 { return 0; }
+function render(): i32 { return window_width(); }
+"#,
+        )
+        .expect("write main");
+        std::fs::write(
+            src_dir.join("window.stasis"),
+            r#"import "frame.stasis";
+function window_width(): i32 { return frame_width(); }
+"#,
+        )
+        .expect("write window");
+        std::fs::write(
+            src_dir.join("frame.stasis"),
+            r#"import "window.stasis";
+function frame_width(): i32 { return 360; }
+"#,
+        )
+        .expect("write frame");
+        std::fs::write(
+            asset_dir.join("manifest.json"),
+            r#"{
+  "schema": "stasis-assets",
+  "version": 1,
+  "assets": []
+}
+"#,
+        )
+        .expect("write manifest");
+
+        let summary = write_mobile_aot_engine_bundle(
+            MobileAotTarget::AndroidArm64,
+            &project_dir,
+            Some(Path::new("src/main.stasis")),
+            &output_dir,
+        )
+        .expect("cyclic imports should compile each canonical file once");
+        assert!(summary.package_manifest.is_file());
+
+        std::fs::remove_dir_all(&project_dir).ok();
+        std::fs::remove_dir_all(&output_dir).ok();
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -27,6 +27,7 @@ pub struct AotArtifact {
 #[derive(Debug, Default)]
 pub struct AotProcess {
     compiler: Compiler,
+    import_base_dir: Option<PathBuf>,
     optimization_profile: AotOptimizationProfile,
     target: stasis_jit::AotTarget,
     next_object_index: u32,
@@ -54,6 +55,7 @@ impl AotProcess {
     pub fn with_optimization_profile(optimization_profile: AotOptimizationProfile) -> Self {
         Self {
             compiler: Compiler::new(),
+            import_base_dir: None,
             optimization_profile,
             target: stasis_jit::AotTarget::default(),
             next_object_index: 0,
@@ -68,6 +70,11 @@ impl AotProcess {
 
     pub fn upsert_file(&mut self, path: impl Into<String>, content: impl Into<String>) {
         self.compiler.upsert_file(path, content);
+    }
+
+    pub fn set_import_base_dir(&mut self, path: impl Into<PathBuf>) {
+        let path = path.into();
+        self.import_base_dir = Some(fs::canonicalize(&path).unwrap_or(path));
     }
 
     pub fn set_target(&mut self, target: stasis_jit::AotTarget) {
@@ -212,7 +219,8 @@ impl AotProcess {
             .compiler
             .files()
             .iter()
-            .map(|file| file.path.clone())
+            .map(|file| self.resolve_import_source_path(&file.path))
+            .map(|path| normalize_path_for_compiler_key(&path))
             .collect();
         let mut queue: Vec<String> = self
             .compiler
@@ -233,7 +241,8 @@ impl AotProcess {
             };
             let imports = parse_import_paths(&source);
             for import_path in imports {
-                let resolved = resolve_import_path(&path, &import_path);
+                let resolved =
+                    self.resolve_import_source_path(&resolve_import_path(&path, &import_path));
                 let normalized = normalize_path_for_compiler_key(&resolved);
                 if known_paths.contains(&normalized) {
                     continue;
@@ -251,6 +260,16 @@ impl AotProcess {
         }
 
         Ok(())
+    }
+
+    fn resolve_import_source_path(&self, path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
+        if path.is_absolute() {
+            return path.to_path_buf();
+        }
+        self.import_base_dir
+            .as_ref()
+            .map_or_else(|| path.to_path_buf(), |base| base.join(path))
     }
 
     pub fn artifacts(&self) -> &[AotArtifact] {


### PR DESCRIPTION
## Summary
- anchor mobile AOT import resolution to the project root
- canonicalize preloaded and discovered source identities before deduplication
- add a cyclic multi-file mobile packaging regression test

## Problem
`package-mobile` preloads the entry import closure with project-relative compiler keys, while `AotProcess` previously resolved filesystem imports relative to the process working directory. The same source could therefore enter under relative and canonical identities, producing duplicate declarations for cyclic or aliased imports.

## Verification
- `rustfmt --check apps/stasis/src/main.rs crates/stasis_compiler/src/backend/aot.rs`
- `python tools/ci/check_stasis_src_layout.py`
- `cargo test -p stasis --bin stasis mobile_aot_bundle_ -- --nocapture` — 4 passed
- `cargo test -p stasis --test toolchain_cli package_mobile_builds_android_and_ios_projects_from_one_entry -- --exact --test-threads=1` — 1 passed
- `cargo test -p stasis_compiler backend::aot::tests -- --nocapture` — 30 passed, 1 ignored
- ChessTD `package-mobile --target android-arm64` — 97 AOT objects, APK build passed

Repository-wide baseline observations on current `main`:
- `cargo fmt --all -- --check` reports an unrelated formatting diff in `crates/stasis_compiler/src/backend/runtime_exports.rs`; this PR does not touch that file.
- `cargo test --workspace --all-targets -- --test-threads=1` completed 163 passed, 2 failed, 6 ignored. Both failures are existing Brickout JIT/runtime smoke tests (`jit_dev_brickout_v1_builds_engine_package_with_render_pointer`, `real_backend_smoke_compiles_and_commits_brickout_v1`), outside the touched mobile AOT path.

## Scope and risk
Only the mobile bundle caller sets an import base; existing `AotProcess` callers retain prior behavior. No language, ABI, runtime, overload-resolution, or release-layout changes. User documentation is unchanged because this restores intended `package-mobile` behavior.

## Reflection
- **Good:** one project-root identity fixes relative/canonical aliases without changing compiler semantics.
- **Bad:** source collection and AOT import loading previously used different path identity domains.
- **Adjustment:** mobile packaging regressions should include nested and cyclic imports, not only single-file smoke projects.