### PR TITLE
feat: add built-in deterministic framebuffer screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ Notes:
 - `play` is currently Windows-focused (graphics runtime integration).
 - If `--watch-dir` is omitted, `play` watches the entry file's parent directory by default.
 - You can cap runtime for smoke testing with `--ticks N`.
+- Capture the rendered framebuffer with `--screenshot artifacts\frame.png`. PNG is
+  selected by the `.png` extension; other extensions preserve the existing BMP output.
+  `--screenshot-frame N` selects a 1-based frame (default `1`). The capture happens
+  after queued drawing and post-effects, immediately before present. PNG bytes are
+  deterministic for identical input pixels, but rasterization can differ between
+  graphics backends, drivers, and platforms.
+- The CLI creates missing parent directories and replaces an existing output file.
+  With `--exit-after-screenshot`, a write failure also stops the game and returns a
+  nonzero exit code instead of leaving screenshot automation running indefinitely.
+
+For example:
+
+```powershell
+cargo run -p stasis --release -- play samples\brickout_revenge\brickout_revenge_v1.stasis --screenshot artifacts\frame-12.png --screenshot-frame 12 --exit-after-screenshot
+```
+
+The equivalent runtime environment variables are `STASIS_SCREENSHOT_ONCE`,
+`STASIS_SCREENSHOT_FRAME`, and `STASIS_EXIT_AFTER_SCREENSHOT=1`.
 
 ## Tests (In Stasis, Run via JIT)
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -111,6 +111,9 @@ struct PlayCliArgs {
     data_bind_struct_meta: Option<PathBuf>,
     tick_sleep_micros: u64,
     ticks: Option<u64>,
+    screenshot: Option<PathBuf>,
+    screenshot_frame: u64,
+    exit_after_screenshot: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -526,6 +529,10 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
     let mut data_bind_struct_meta: Option<PathBuf> = None;
     let mut tick_sleep_micros: u64 = 16000;
     let mut ticks: Option<u64> = None;
+    let mut screenshot: Option<PathBuf> = None;
+    let mut screenshot_frame: u64 = 1;
+    let mut screenshot_frame_explicit = false;
+    let mut exit_after_screenshot = false;
     let mut i: usize = 0;
     while i < args.len() {
         let arg = args[i].as_str();
@@ -584,6 +591,33 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
             i += 2;
             continue;
         }
+        if arg == "--screenshot" {
+            if i + 1 >= args.len() {
+                return Err("missing value for --screenshot".to_string());
+            }
+            screenshot = Some(PathBuf::from(args[i + 1].clone()));
+            i += 2;
+            continue;
+        }
+        if arg == "--screenshot-frame" {
+            if i + 1 >= args.len() {
+                return Err("missing value for --screenshot-frame".to_string());
+            }
+            screenshot_frame = args[i + 1]
+                .parse::<u64>()
+                .map_err(|error| format!("invalid value for --screenshot-frame: {error}"))?;
+            if screenshot_frame == 0 || screenshot_frame > i32::MAX as u64 {
+                return Err("--screenshot-frame must be between 1 and 2147483647".to_string());
+            }
+            screenshot_frame_explicit = true;
+            i += 2;
+            continue;
+        }
+        if arg == "--exit-after-screenshot" {
+            exit_after_screenshot = true;
+            i += 1;
+            continue;
+        }
         i += 1;
     }
     let Some(watch_file) = watch_file else {
@@ -592,6 +626,15 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
                 .to_string(),
         );
     };
+    if screenshot.is_none() && (screenshot_frame_explicit || exit_after_screenshot) {
+        return Err(
+            "--screenshot-frame and --exit-after-screenshot require --screenshot <path>"
+                .to_string(),
+        );
+    }
+    if screenshot.is_some() && ticks.is_some_and(|count| count < screenshot_frame) {
+        return Err("--ticks must be at least --screenshot-frame when capturing".to_string());
+    }
     Ok(PlayCliArgs {
         watch_file,
         watch_dir,
@@ -599,7 +642,85 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         data_bind_struct_meta,
         tick_sleep_micros,
         ticks,
+        screenshot,
+        screenshot_frame,
+        exit_after_screenshot,
     })
+}
+
+struct PlayScreenshotEnvironment {
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    output_path: Option<PathBuf>,
+}
+
+impl Drop for PlayScreenshotEnvironment {
+    fn drop(&mut self) {
+        for (name, value) in self.previous.drain(..).rev() {
+            if let Some(value) = value {
+                env::set_var(name, value);
+            } else {
+                env::remove_var(name);
+            }
+        }
+    }
+}
+
+fn configure_play_screenshot_environment(
+    parsed: &PlayCliArgs,
+) -> Result<PlayScreenshotEnvironment, String> {
+    let Some(path) = parsed.screenshot.as_ref() else {
+        return Ok(PlayScreenshotEnvironment {
+            previous: Vec::new(),
+            output_path: None,
+        });
+    };
+    let resolved = if path.is_absolute() {
+        path.clone()
+    } else {
+        env::current_dir()
+            .map_err(|error| format!("failed to resolve --screenshot path: {error}"))?
+            .join(path)
+    };
+    let names = [
+        "STASIS_SCREENSHOT_ONCE",
+        "STASIS_SCREENSHOT_FRAME",
+        "STASIS_EXIT_AFTER_SCREENSHOT",
+    ];
+    let parent = resolved
+        .parent()
+        .ok_or_else(|| "--screenshot path has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "failed to create screenshot directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    if resolved.exists() {
+        fs::remove_file(&resolved).map_err(|error| {
+            format!(
+                "failed to replace screenshot output {}: {error}",
+                resolved.display()
+            )
+        })?;
+    }
+    let guard = PlayScreenshotEnvironment {
+        previous: names
+            .into_iter()
+            .map(|name| (name, env::var_os(name)))
+            .collect(),
+        output_path: Some(resolved.clone()),
+    };
+    env::set_var("STASIS_SCREENSHOT_ONCE", resolved);
+    env::set_var(
+        "STASIS_SCREENSHOT_FRAME",
+        parsed.screenshot_frame.to_string(),
+    );
+    if parsed.exit_after_screenshot {
+        env::set_var("STASIS_EXIT_AFTER_SCREENSHOT", "1");
+    } else {
+        env::remove_var("STASIS_EXIT_AFTER_SCREENSHOT");
+    }
+    Ok(guard)
 }
 
 fn try_run_play_subcommand() -> Option<i32> {
@@ -616,16 +737,39 @@ fn try_run_play_subcommand() -> Option<i32> {
             return Some(2);
         }
     };
+    let screenshot_environment = match configure_play_screenshot_environment(&parsed) {
+        Ok(value) => value,
+        Err(message) => {
+            eprintln!("{message}");
+            return Some(2);
+        }
+    };
 
-    match run_play_in_process(
+    let play_result = run_play_in_process(
         &parsed.watch_file,
         parsed.watch_dir.as_deref(),
         parsed.data_bind_json.as_deref(),
         parsed.data_bind_struct_meta.as_deref(),
         parsed.tick_sleep_micros,
         parsed.ticks,
-    ) {
-        Ok(()) => Some(0),
+    );
+    match play_result {
+        Ok(()) => {
+            if let Some(path) = screenshot_environment.output_path.as_ref() {
+                match fs::metadata(path) {
+                    Ok(metadata) if metadata.len() > 0 => {}
+                    Ok(_) => {
+                        eprintln!("screenshot output is empty: {}", path.display());
+                        return Some(1);
+                    }
+                    Err(error) => {
+                        eprintln!("screenshot was not captured at {}: {error}", path.display());
+                        return Some(1);
+                    }
+                }
+            }
+            Some(0)
+        }
         Err(message) => {
             eprintln!("{message}");
             Some(1)
@@ -2036,6 +2180,63 @@ mod tests {
         ];
         let error = parse_play_cli_args(&args).expect_err("parse should fail");
         assert!(error.contains("missing values for --data-bind"));
+    }
+
+    #[test]
+    fn parse_play_cli_args_accepts_screenshot_configuration() {
+        let args = vec![
+            "samples/brickout_revenge/brickout_revenge_v1.stasis".to_string(),
+            "--screenshot".to_string(),
+            "artifacts/frame-12.png".to_string(),
+            "--screenshot-frame".to_string(),
+            "12".to_string(),
+            "--exit-after-screenshot".to_string(),
+        ];
+        let parsed = parse_play_cli_args(&args).expect("parse should succeed");
+        assert_eq!(
+            parsed.screenshot,
+            Some(PathBuf::from("artifacts/frame-12.png"))
+        );
+        assert_eq!(parsed.screenshot_frame, 12);
+        assert!(parsed.exit_after_screenshot);
+    }
+
+    #[test]
+    fn parse_play_cli_args_rejects_zero_screenshot_frame() {
+        let args = vec![
+            "samples/brickout_revenge/brickout_revenge_v1.stasis".to_string(),
+            "--screenshot".to_string(),
+            "frame.png".to_string(),
+            "--screenshot-frame".to_string(),
+            "0".to_string(),
+        ];
+        let error = parse_play_cli_args(&args).expect_err("parse should fail");
+        assert!(error.contains("between 1 and 2147483647"));
+    }
+
+    #[test]
+    fn parse_play_cli_args_requires_screenshot_for_capture_options() {
+        let args = vec![
+            "samples/brickout_revenge/brickout_revenge_v1.stasis".to_string(),
+            "--exit-after-screenshot".to_string(),
+        ];
+        let error = parse_play_cli_args(&args).expect_err("parse should fail");
+        assert!(error.contains("require --screenshot"));
+    }
+
+    #[test]
+    fn parse_play_cli_args_rejects_ticks_before_screenshot_frame() {
+        let args = vec![
+            "samples/brickout_revenge/brickout_revenge_v1.stasis".to_string(),
+            "--ticks".to_string(),
+            "11".to_string(),
+            "--screenshot".to_string(),
+            "frame.png".to_string(),
+            "--screenshot-frame".to_string(),
+            "12".to_string(),
+        ];
+        let error = parse_play_cli_args(&args).expect_err("parse should fail");
+        assert!(error.contains("--ticks must be at least --screenshot-frame"));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -894,6 +894,9 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "gfx_dump_bmp" | "stasis_gfx_dump_bmp" => {
             function_address(stasis_dynload::stasis_jit_gfx_dump_bmp as *const ())
         }
+        "gfx_dump_png" | "stasis_gfx_dump_png" => {
+            function_address(stasis_dynload::stasis_jit_gfx_dump_png as *const ())
+        }
         "load_font" | "stasis_load_font" => {
             function_address(stasis_dynload::stasis_jit_load_font as *const ())
         }

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -17,6 +17,7 @@ pub(crate) const AOT_RUNTIME_EXPORT_SYMBOLS: &[&str] = &[
     "stasis_jit_cos_fast",
     "stasis_jit_gfx_cache_text",
     "stasis_jit_gfx_dump_bmp",
+    "stasis_jit_gfx_dump_png",
     "stasis_jit_gfx_load_sprite",
     "stasis_jit_gfx_release_sprite",
     "stasis_jit_gfx_measure_text_cached",
@@ -61,7 +62,9 @@ mod tests {
     #[test]
     fn aot_runtime_export_contract_requires_exact_symbol_matches() {
         assert!(is_aot_runtime_export_symbol("stasis_jit_gfx_load_sprite"));
-        assert!(is_aot_runtime_export_symbol("stasis_jit_gfx_release_sprite"));
+        assert!(is_aot_runtime_export_symbol(
+            "stasis_jit_gfx_release_sprite"
+        ));
         assert!(!is_aot_runtime_export_symbol(
             "stasis_jit_gfx_totally_missing"
         ));

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -425,6 +425,7 @@ struct StasisGraphicsAssetsApi {
     stasis_gfx_load_sprite: usize,
     stasis_gfx_release_sprite: usize,
     stasis_gfx_dump_bmp: usize,
+    stasis_gfx_dump_png: Option<usize>,
     stasis_gfx_poll_reload: usize,
     stasis_load_font: usize,
     stasis_measure_text: usize,
@@ -452,6 +453,9 @@ impl StasisGraphicsAssetsApi {
             stasis_gfx_load_sprite: lib.symbol_address("stasis_gfx_load_sprite")?,
             stasis_gfx_release_sprite: lib.symbol_address("stasis_gfx_release_sprite")?,
             stasis_gfx_dump_bmp: lib.symbol_address("stasis_gfx_dump_bmp")?,
+            // PNG capture was added after the original asset ABI. Keep older runtime
+            // DLLs usable for all pre-existing calls and report PNG as unsupported.
+            stasis_gfx_dump_png: lib.symbol_address("stasis_gfx_dump_png").ok(),
             stasis_gfx_poll_reload: lib.symbol_address("stasis_gfx_poll_reload")?,
             stasis_load_font: lib.symbol_address("stasis_load_font")?,
             stasis_measure_text: lib.symbol_address("stasis_measure_text")?,
@@ -1499,6 +1503,30 @@ pub extern "C" fn stasis_jit_gfx_dump_bmp(path_id: i32) -> i32 {
         };
         let callback: extern "system" fn(*const c_char) -> i32 =
             unsafe { std::mem::transmute(api.stasis_gfx_dump_bmp) };
+        return callback(path.as_ptr());
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = path_id;
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_gfx_dump_png(path_id: i32) -> i32 {
+    #[cfg(windows)]
+    {
+        let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+            return 0;
+        };
+        let Ok(api) = stasis_graphics_assets_api() else {
+            return 0;
+        };
+        let Some(address) = api.stasis_gfx_dump_png else {
+            return 0;
+        };
+        let callback: extern "system" fn(*const c_char) -> i32 =
+            unsafe { std::mem::transmute(address) };
         return callback(path.as_ptr());
     }
     #[cfg(not(windows))]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2,6 +2,20 @@
 
 Native SDL2+OpenGL graphics library for Stasis programs.
 
+## Framebuffer capture
+
+`stasis_gfx_dump_png(path)` writes the current framebuffer as an RGBA PNG and
+returns `1` on success or `0` on failure. `stasis_gfx_dump_bmp(path)` provides
+the existing BMP equivalent. Relative runtime paths resolve through the asset
+root; callers that need a specific output location should pass an absolute path.
+
+For automated captures, set `STASIS_SCREENSHOT_ONCE` to an output path and
+optionally set the 1-based `STASIS_SCREENSHOT_FRAME` and
+`STASIS_EXIT_AFTER_SCREENSHOT=1`. Scheduled capture occurs after queued drawing
+and post-effects and before the frame is presented. A `.png` suffix selects PNG;
+other suffixes use BMP. PNG bytes are deterministic for identical framebuffer
+pixels, though pixels can vary across backends, drivers, and platforms.
+
 ## Prerequisites
 
 - CMake 3.16+

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -88,6 +88,7 @@ static bool g_postfx_applied_this_frame = false;
 static bool g_screenshot_taken = false;
 static char g_screenshot_path[1024] = {0};
 static int g_screenshot_exit_after = 0;
+static int g_screenshot_frame = 1;
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
 static GLuint g_postfx_program = 0;
 static GLint g_postfx_time_loc = -1;
@@ -2536,7 +2537,139 @@ static int write_bmp_bgra32(const char* path, int w, int h, const uint8_t* bgra,
     return 1;
 }
 
-STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
+static void write_u32_be(uint8_t* out, uint32_t value) {
+    out[0] = (uint8_t)(value >> 24);
+    out[1] = (uint8_t)(value >> 16);
+    out[2] = (uint8_t)(value >> 8);
+    out[3] = (uint8_t)value;
+}
+
+static uint32_t png_crc32_update(uint32_t crc, const uint8_t* data, size_t length) {
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (int bit = 0; bit < 8; bit++) {
+            uint32_t mask = (uint32_t)(-(int32_t)(crc & 1u));
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return crc;
+}
+
+static int write_png_chunk(FILE* f, const char type[4], const uint8_t* data, uint32_t length) {
+    uint8_t size_bytes[4];
+    uint8_t crc_bytes[4];
+    write_u32_be(size_bytes, length);
+    uint32_t crc = png_crc32_update(0xFFFFFFFFu, (const uint8_t*)type, 4);
+    if (length > 0) crc = png_crc32_update(crc, data, length);
+    write_u32_be(crc_bytes, crc ^ 0xFFFFFFFFu);
+    return fwrite(size_bytes, 1, 4, f) == 4 &&
+           fwrite(type, 1, 4, f) == 4 &&
+           (length == 0 || fwrite(data, 1, length, f) == length) &&
+           fwrite(crc_bytes, 1, 4, f) == 4;
+}
+
+static uint32_t png_adler32(const uint8_t* data, size_t length) {
+    uint32_t a = 1;
+    uint32_t b = 0;
+    for (size_t offset = 0; offset < length;) {
+        size_t block = length - offset;
+        if (block > 5552) block = 5552;
+        for (size_t i = 0; i < block; i++) {
+            a += data[offset + i];
+            b += a;
+        }
+        a %= 65521u;
+        b %= 65521u;
+        offset += block;
+    }
+    return (b << 16) | a;
+}
+
+/* Deterministic PNG writer using zlib's uncompressed DEFLATE blocks. */
+static int write_png_bgra32(const char* path, int w, int h, const uint8_t* bgra, int is_bottom_up) {
+    if (!path || !*path || w <= 0 || h <= 0 || !bgra) return 0;
+    if ((size_t)w > (SIZE_MAX - 1u) / 4u) return 0;
+    const size_t pixel_row_bytes = (size_t)w * 4u;
+    const size_t png_row_bytes = pixel_row_bytes + 1u;
+    if ((size_t)h > SIZE_MAX / png_row_bytes) return 0;
+    const size_t raw_size = png_row_bytes * (size_t)h;
+    if (raw_size > UINT32_MAX) return 0;
+
+    uint8_t* raw = (uint8_t*)malloc(raw_size);
+    if (!raw) return 0;
+    for (int y = 0; y < h; y++) {
+        const int source_y = is_bottom_up ? (h - 1 - y) : y;
+        const uint8_t* source = bgra + (size_t)source_y * pixel_row_bytes;
+        uint8_t* target = raw + (size_t)y * png_row_bytes;
+        target[0] = 0;
+        for (int x = 0; x < w; x++) {
+            target[1 + x * 4 + 0] = source[x * 4 + 2];
+            target[1 + x * 4 + 1] = source[x * 4 + 1];
+            target[1 + x * 4 + 2] = source[x * 4 + 0];
+            target[1 + x * 4 + 3] = source[x * 4 + 3];
+        }
+    }
+
+    const size_t block_count = (raw_size + 65534u) / 65535u;
+    if (raw_size > SIZE_MAX - 6u ||
+        block_count > (SIZE_MAX - raw_size - 6u) / 5u) {
+        free(raw);
+        return 0;
+    }
+    const size_t zlib_size = 2u + raw_size + block_count * 5u + 4u;
+    if (zlib_size > UINT32_MAX) {
+        free(raw);
+        return 0;
+    }
+    uint8_t* zlib = (uint8_t*)malloc(zlib_size);
+    if (!zlib) {
+        free(raw);
+        return 0;
+    }
+
+    size_t input_offset = 0;
+    size_t output_offset = 0;
+    zlib[output_offset++] = 0x78;
+    zlib[output_offset++] = 0x01;
+    while (input_offset < raw_size) {
+        size_t remaining = raw_size - input_offset;
+        uint16_t block_length = (uint16_t)(remaining > 65535u ? 65535u : remaining);
+        uint16_t inverse_length = (uint16_t)~block_length;
+        zlib[output_offset++] = remaining <= 65535u ? 1u : 0u;
+        zlib[output_offset++] = (uint8_t)block_length;
+        zlib[output_offset++] = (uint8_t)(block_length >> 8);
+        zlib[output_offset++] = (uint8_t)inverse_length;
+        zlib[output_offset++] = (uint8_t)(inverse_length >> 8);
+        memcpy(zlib + output_offset, raw + input_offset, block_length);
+        output_offset += block_length;
+        input_offset += block_length;
+    }
+    write_u32_be(zlib + output_offset, png_adler32(raw, raw_size));
+    output_offset += 4;
+
+    uint8_t ihdr[13];
+    write_u32_be(ihdr, (uint32_t)w);
+    write_u32_be(ihdr + 4, (uint32_t)h);
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    ihdr[10] = 0;
+    ihdr[11] = 0;
+    ihdr[12] = 0;
+    static const uint8_t signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+
+    FILE* f = fopen(path, "wb");
+    int ok = f && fwrite(signature, 1, sizeof(signature), f) == sizeof(signature) &&
+             write_png_chunk(f, "IHDR", ihdr, sizeof(ihdr)) &&
+             write_png_chunk(f, "IDAT", zlib, (uint32_t)output_offset) &&
+             write_png_chunk(f, "IEND", NULL, 0);
+    if (f && fclose(f) != 0) ok = 0;
+    if (!ok) remove(path);
+    free(zlib);
+    free(raw);
+    return ok;
+}
+
+static int stasis_gfx_dump_image(const char* path, int png, int render_queued_lines) {
     if (!path || !*path) return 0;
     if (!g_window) return 0;
     if (g_window_width <= 0 || g_window_height <= 0) return 0;
@@ -2561,23 +2694,26 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
 
     if (g_use_sdl_renderer) {
         if (g_renderer) {
-            /* Match end_frame() behavior so the screenshot includes queued lines. */
-            SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
-            SDL_Color color;
-            for (int i = 0; i < g_line_count; i++) {
-                color.r = (Uint8)(g_lines[i].r * 255.0f);
-                color.g = (Uint8)(g_lines[i].g * 255.0f);
-                color.b = (Uint8)(g_lines[i].b * 255.0f);
-                color.a = (Uint8)(g_lines[i].a * 255.0f);
-                SDL_SetRenderDrawColor(g_renderer, color.r, color.g, color.b, color.a);
-                SDL_RenderDrawLineF(g_renderer, g_lines[i].x1, g_lines[i].y1, g_lines[i].x2, g_lines[i].y2);
+            if (render_queued_lines) {
+                /* Direct API calls may happen before end_frame(), so flush pending lines once. */
+                SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
+                SDL_Color color;
+                for (int i = 0; i < g_line_count; i++) {
+                    color.r = (Uint8)(g_lines[i].r * 255.0f);
+                    color.g = (Uint8)(g_lines[i].g * 255.0f);
+                    color.b = (Uint8)(g_lines[i].b * 255.0f);
+                    color.a = (Uint8)(g_lines[i].a * 255.0f);
+                    SDL_SetRenderDrawColor(g_renderer, color.r, color.g, color.b, color.a);
+                    SDL_RenderDrawLineF(g_renderer, g_lines[i].x1, g_lines[i].y1, g_lines[i].x2, g_lines[i].y2);
+                }
+                g_line_count = 0;
             }
-            g_line_count = 0;
 
-            /* SDL_RenderReadPixels reads from the current render target. Call before stasis_end_frame(). */
+            /* SDL_RenderReadPixels reads from the current render target before present. */
             int rc = SDL_RenderReadPixels(g_renderer, NULL, SDL_PIXELFORMAT_BGRA32, pixels, w * 4);
             if (rc == 0) {
-                ok = write_bmp_bgra32(out_path, w, h, pixels, 0);
+                ok = png ? write_png_bgra32(out_path, w, h, pixels, 0)
+                         : write_bmp_bgra32(out_path, w, h, pixels, 0);
             }
         }
         free(pixels);
@@ -2603,8 +2739,9 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
         glReadPixels(0, 0, w, h, GL_BGRA, GL_UNSIGNED_BYTE, pixels);
         GLenum err = glGetError();
         if (err == GL_NO_ERROR) {
-            /* glReadPixels returns bottom-up; BMP header uses top-down (negative height). Flip by writing bottom-up rows and marking as bottom-up. */
-            ok = write_bmp_bgra32(out_path, w, h, pixels, 1);
+            /* glReadPixels returns rows from the bottom of the framebuffer first. */
+            ok = png ? write_png_bgra32(out_path, w, h, pixels, 1)
+                     : write_bmp_bgra32(out_path, w, h, pixels, 1);
         }
         free(pixels);
         return ok;
@@ -2613,6 +2750,32 @@ STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
 
     free(pixels);
     return 0;
+}
+
+STASIS_EXPORT int stasis_gfx_dump_bmp(const char* path) {
+    return stasis_gfx_dump_image(path, 0, 1);
+}
+
+STASIS_EXPORT int stasis_gfx_dump_png(const char* path) {
+    return stasis_gfx_dump_image(path, 1, 1);
+}
+
+static void capture_scheduled_screenshot(void) {
+    if (g_screenshot_taken || g_screenshot_path[0] == 0 ||
+        g_debug_frame_counter + 1 != g_screenshot_frame) {
+        return;
+    }
+    int ok = stasis_gfx_dump_image(
+        g_screenshot_path,
+        ends_with_ci(g_screenshot_path, ".png"),
+        0);
+    if (!ok) {
+        SDL_Log("failed to capture screenshot: %s", g_screenshot_path);
+        if (g_screenshot_exit_after) g_should_quit = true;
+        return;
+    }
+    g_screenshot_taken = true;
+    if (g_screenshot_exit_after) g_should_quit = true;
 }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -3147,6 +3310,8 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     /* Optional screenshot automation via environment variables. */
     g_screenshot_taken = false;
     g_screenshot_exit_after = 0;
+    g_screenshot_frame = 1;
+    g_debug_frame_counter = 0;
     g_screenshot_path[0] = 0;
     const char* screenshot = SDL_getenv("STASIS_SCREENSHOT_ONCE");
     if (screenshot && *screenshot) {
@@ -3155,6 +3320,15 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
         const char* exit_after = SDL_getenv("STASIS_EXIT_AFTER_SCREENSHOT");
         if (exit_after && exit_after[0] == '1') {
             g_screenshot_exit_after = 1;
+        }
+        const char* screenshot_frame = SDL_getenv("STASIS_SCREENSHOT_FRAME");
+        if (screenshot_frame && *screenshot_frame) {
+            char* end = NULL;
+            long parsed_frame = strtol(screenshot_frame, &end, 10);
+            if (end != screenshot_frame && *end == 0 &&
+                parsed_frame >= 1 && parsed_frame <= INT_MAX) {
+                g_screenshot_frame = (int)parsed_frame;
+            }
         }
     }
 
@@ -3515,14 +3689,8 @@ STASIS_EXPORT void stasis_end_frame(void) {
             SDL_RenderDrawLineF(g_renderer, g_lines[i].x1, g_lines[i].y1, g_lines[i].x2, g_lines[i].y2);
         }
 
-        if (!g_screenshot_taken && g_screenshot_path[0] != 0) {
-            /* Capture before present so we read the current render target. */
-            stasis_gfx_dump_bmp(g_screenshot_path);
-            g_screenshot_taken = true;
-            if (g_screenshot_exit_after) {
-                g_should_quit = true;
-            }
-        }
+        /* Capture before present so we read the current render target. */
+        capture_scheduled_screenshot();
         SDL_RenderPresent(g_renderer);
         g_line_count = 0;
     } else {
@@ -3533,14 +3701,8 @@ STASIS_EXPORT void stasis_end_frame(void) {
             render_postfx();
             g_postfx_applied_this_frame = true;
         }
-        if (!g_screenshot_taken && g_screenshot_path[0] != 0) {
-            /* Capture after all draws (including postfx) but before swap. */
-            stasis_gfx_dump_bmp(g_screenshot_path);
-            g_screenshot_taken = true;
-            if (g_screenshot_exit_after) {
-                g_should_quit = true;
-            }
-        }
+        /* Capture after all draws (including postfx) but before swap. */
+        capture_scheduled_screenshot();
         SDL_GL_SwapWindow(g_window);
 #else
         /* STASIS_GRAPHICS_SDL_ONLY should never create a GL context. */

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -58,6 +58,7 @@ EXPORTS
     stasis_gfx_debug_enable_hash
     stasis_gfx_debug_get_frame_hash
     stasis_gfx_dump_bmp
+    stasis_gfx_dump_png
     stasis_load_font
     stasis_draw_text
     stasis_measure_text

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -23,6 +23,7 @@ int stasis_audio_push_f32_interleaved(const float *samples, int frames);
 int stasis_gfx_load_sprite(const char *path, int max_w, int max_h);
 void stasis_gfx_release_sprite(int handle);
 int stasis_gfx_dump_bmp(const char *path);
+int stasis_gfx_dump_png(const char *path);
 int stasis_gfx_cache_text(int font, const char *text);
 int stasis_gfx_poll_reload(int handle);
 float stasis_gfx_measure_text_cached(int handle);
@@ -360,6 +361,12 @@ void stasis_jit_gfx_release_sprite(int32_t handle) { stasis_gfx_release_sprite(h
 int stasis_jit_gfx_dump_bmp(int32_t path) {
     char *value = resolve_text(path);
     int result = value == NULL ? 0 : stasis_gfx_dump_bmp(value);
+    free(value);
+    return result;
+}
+int stasis_jit_gfx_dump_png(int32_t path) {
+    char *value = resolve_text(path);
+    int result = value == NULL ? 0 : stasis_gfx_dump_png(value);
     free(value);
     return result;
 }

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -83,6 +83,7 @@ int stasis_jit_audio_push_f32_interleaved(int32_t samples, int32_t frames);
 int stasis_jit_gfx_load_sprite(int32_t path, int32_t max_w, int32_t max_h);
 void stasis_jit_gfx_release_sprite(int32_t handle);
 int stasis_jit_gfx_dump_bmp(int32_t path);
+int stasis_jit_gfx_dump_png(int32_t path);
 int stasis_jit_gfx_cache_text(int32_t font, int32_t text);
 int stasis_jit_gfx_poll_reload(int32_t handle);
 float stasis_jit_gfx_measure_text_cached(int32_t handle);

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -39,6 +39,7 @@ int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) {
 }
 void stasis_gfx_release_sprite(int handle) { (void)handle; }
 int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
+int stasis_gfx_dump_png(const char *path) { return path != NULL; }
 int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
 int stasis_gfx_poll_reload(int handle) { return handle; }
 float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
@@ -79,6 +80,7 @@ int main(void) {
     stasis_jit_collection_i32_store(23, 1, sizeof(dynamic_path) - 1);
     CHECK(stasis_jit_gfx_load_sprite(23, 32, 32) == 1);
     CHECK(strcmp(last_sprite_path, "sprite.bmp") == 0);
+    CHECK(stasis_jit_gfx_dump_png(23) == 1);
 
     owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
     CHECK(owned != NULL);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -108,6 +108,7 @@ int stasis_audio_push_f32_interleaved(const float *samples, int frames) { return
 int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) { return path && max_w && max_h; }
 void stasis_gfx_release_sprite(int handle) { (void)handle; }
 int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
+int stasis_gfx_dump_png(const char *path) { return path != NULL; }
 int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
 int stasis_gfx_poll_reload(int handle) { return handle; }
 float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -23,6 +23,7 @@ extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 extern function gfx_release_sprite(handle: i32): void;
 extern function gfx_poll_reload(handle: i32): bool;
 extern function gfx_dump_bmp(path: string): i32;
+extern function gfx_dump_png(path: string): i32;
 extern function load_font(path: string, size: i32): i32;
 extern function measure_text(font: i32, text: string): f32;
 


### PR DESCRIPTION
## Summary
- add deterministic PNG framebuffer encoding alongside BMP capture
- add 1-based scheduled capture and reliable exit/failure behavior
- expose gfx_dump_png through stdlib, JIT, AOT, mobile, and Windows exports
- add stasis play --screenshot/--screenshot-frame/--exit-after-screenshot
- preserve compatibility with runtime DLLs that predate PNG support
- document backend/platform determinism scope and runtime API

## Validation
- cargo fmt --all -- --check
- screenshot CLI parser tests: 6 passed
- stasis_compiler: 300 passed, 1 ignored
- stasis_dynload: 8 passed
- mobile AOT coverage test passed
- native stasis_graphics + stasis_runner built with MSVC/VS 2022
- native mobile lifecycle/AOT CTest: 2 passed
- real ChessTD PNG captures decoded at frames 1 and 3 (800x600, valid PNG signature)
- Brickout engine smoke tests pass with the matching newly-built runtime DLL