### PR TITLE
fix: normalize lookup output paths

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -408,8 +408,8 @@ fn lookup_name_matches(name: &str, query_lower: &str) -> bool {
 fn lookup_display_path(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
-        .display()
-        .to_string()
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 fn collect_lookup_matches_in_source(


### PR DESCRIPTION
## What

Normalize lookup result paths to forward slashes before rendering them.

## Why

The lookup CLI formatted relative paths with `Path::display()`, which emits host-native separators. On Windows, imported definitions were reported as `nested\helper.stasis` while the CLI contract and existing tests expect stable `nested/helper.stasis` output.

## Impact

Lookup/search output is now consistent across Windows, macOS, and Linux. Filesystem resolution is unchanged; only user-facing lookup result paths are normalized.

## Root cause

`lookup_display_path` stripped the workspace root correctly, but then delegated formatting to the host OS.

## Checks

- `cargo test -p stasis --bin stasis -- --test-threads=1` — 79 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Self-reflection

- **Good:** Fixed the output boundary rather than weakening Windows-specific assertions.
- **Bad:** The platform-dependent formatter was hidden behind a helper whose name implied stable display behavior.
- **Adjustment:** Keep machine-readable and snapshot-tested path output explicitly normalized at rendering boundaries.