### PR TITLE
Make project data convention-based in JIT and AOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,21 @@ That keeps the common Windows command simple:
 
 ## Project Data
 
-Put editable runtime data in the project-level `data/` directory. Every
-`data/<name>.json` file with a matching `data/<name>.struct-meta.json` mapping is
-bound automatically; normal development commands do not need `--data-bind`.
+Put editable runtime data in the project-level `data/` directory. Every JSON or
+CSV file with a matching `<name>.struct-meta.json` mapping is bound
+automatically; normal development commands do not need `--data-bind`.
+
+JSON supports nested metadata paths. CSV is deliberately flat: headers map to
+metadata paths without dots, one row supplies scalar/string fields, and multiple
+rows supply primitive arrays with one value per row. Quoted fields, escaped
+quotes, commas, CRLF, and embedded newlines are supported. A JSON and CSV file
+cannot share the same stem because their metadata mapping would be ambiguous.
 
 While `stasis play` is running, changes to either file are validated and rebound
 between ticks. An invalid edit is rejected without partially applying the set.
 For AOT output, the same files are staged with the package and their values are
 compiled into the runtime bridge, so mobile and desktop builds start with the
-data even when no loose development JSON is available.
+data even when no loose development data file is available.
 
 The older entry-specific `<entry-name>/data/` layout remains supported for
 existing projects. `--data-bind` is reserved for intentionally overriding the

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ That keeps the common Windows command simple:
 .\stasis.exe play samples\bucket_catcher.stasis
 ```
 
+## Project Data
+
+Put editable runtime data in the project-level `data/` directory. Every
+`data/<name>.json` file with a matching `data/<name>.struct-meta.json` mapping is
+bound automatically; normal development commands do not need `--data-bind`.
+
+While `stasis play` is running, changes to either file are validated and rebound
+between ticks. An invalid edit is rejected without partially applying the set.
+For AOT output, the same files are staged with the package and their values are
+compiled into the runtime bridge, so mobile and desktop builds start with the
+data even when no loose development JSON is available.
+
+The older entry-specific `<entry-name>/data/` layout remains supported for
+existing projects. `--data-bind` is reserved for intentionally overriding the
+project convention with an external pair.
+
 On Windows, SmartScreen may warn on unsigned binaries.
 
 ## Hello, World

--- a/README.md
+++ b/README.md
@@ -68,17 +68,42 @@ Put editable runtime data in the project-level `data/` directory. Every JSON or
 CSV file with a matching `<name>.struct-meta.json` mapping is bound
 automatically; normal development commands do not need `--data-bind`.
 
-JSON supports nested metadata paths. CSV is deliberately flat: headers map to
-metadata paths without dots, one row supplies scalar/string fields, and multiple
-rows supply primitive arrays with one value per row. Quoted fields, escaped
-quotes, commas, CRLF, and embedded newlines are supported. A JSON and CSV file
-cannot share the same stem because their metadata mapping would be ambiguous.
+JSON supports nested metadata paths. CSV headers are deliberately flat. The
+basic form maps one row to scalar/string fields or an exact number of rows to
+primitive arrays. The table form maps variable rows into a fixed-capacity struct
+array, writes `row_count` automatically, clears unused slots, and requires one
+or more non-blank unique key columns. For example:
+
+```json
+{
+  "version": 1,
+  "globalName": "level",
+  "csvTable": {
+    "rowsPath": "waves",
+    "rowCountPath": "wave_count",
+    "capacity": 64,
+    "keyColumns": ["id"]
+  },
+  "fields": [
+    { "jsonPath": "waves.id", "csvColumn": "id", "type": "i32", "arrayCount": 64 },
+    { "jsonPath": "waves.tick", "csvColumn": "tick", "type": "i32", "arrayCount": 64 },
+    { "jsonPath": "waves.enemy_kind", "csvColumn": "enemy", "type": "i32", "arrayCount": 64 }
+  ]
+}
+```
+
+This binds `id,tick,enemy` rows to the fields of `level.waves: Wave[64]`
+and maintains `level.wave_count`. Row fields are flat primitive values; CSV does
+not represent nested row properties. Quoted fields, escaped quotes, commas,
+CRLF, and embedded newlines are supported. A JSON and CSV file cannot share the
+same stem because their metadata mapping would be ambiguous.
 
 Binding is schema-strict in both directions. Every JSON property or CSV column
 must exist in the metadata, every metadata path must exist in the data file, and
 development binding fails if the resulting global path is absent from the
 compiled program. Misspellings never create fallback globals or disappear
-silently.
+silently. Table CSV additionally rejects row counts above capacity, mismatched
+field capacities, blank keys, and duplicate (including composite) keys.
 
 While `stasis play` is running, changes to either file are validated and rebound
 between ticks. An invalid edit is rejected without partially applying the set.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ rows supply primitive arrays with one value per row. Quoted fields, escaped
 quotes, commas, CRLF, and embedded newlines are supported. A JSON and CSV file
 cannot share the same stem because their metadata mapping would be ambiguous.
 
+Binding is schema-strict in both directions. Every JSON property or CSV column
+must exist in the metadata, every metadata path must exist in the data file, and
+development binding fails if the resulting global path is absent from the
+compiled program. Misspellings never create fallback globals or disappear
+silently.
+
 While `stasis play` is running, changes to either file are validated and rebound
 between ticks. An invalid edit is rejected without partially applying the set.
 For AOT output, the same files are staged with the package and their values are

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2605,6 +2605,22 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
             } else {
                 None
             };
+            if let Some(root) = data_root.as_ref() {
+                let paths: Vec<String> = meta
+                    .fields
+                    .iter()
+                    .map(|field| field.json_path.clone())
+                    .collect();
+                crate::validate_binding_source_paths(root, &paths).map_err(|error| {
+                    format!(
+                        "data file {} does not match target metadata: {error}",
+                        data_path
+                            .as_ref()
+                            .expect("data root requires data path")
+                            .display()
+                    )
+                })?;
+            }
             for field in meta.fields {
                 let field_name = match field.name {
                     Some(name) if !name.is_empty() => name,

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2557,15 +2557,51 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
             let data_name = name
                 .strip_suffix(".struct-meta.json")
                 .expect("metadata suffix checked");
-            let data_path = path.with_file_name(format!("{data_name}.json"));
-            let data_root = if data_path.is_file() {
+            let json_path = path.with_file_name(format!("{data_name}.json"));
+            let csv_path = path.with_file_name(format!("{data_name}.csv"));
+            if json_path.is_file() && csv_path.is_file() {
+                return Err(format!(
+                    "data files {} and {} cannot share metadata {}",
+                    json_path.display(),
+                    csv_path.display(),
+                    path.display()
+                ));
+            }
+            let data_path = if json_path.is_file() {
+                Some(json_path)
+            } else if csv_path.is_file() {
+                Some(csv_path)
+            } else {
+                None
+            };
+            let data_root = if let Some(data_path) = data_path.as_ref() {
                 let data_text = std::fs::read_to_string(&data_path)
                     .map_err(|error| format!("failed to read {}: {error}", data_path.display()))?;
-                Some(
-                    serde_json::from_str::<serde_json::Value>(&data_text).map_err(|error| {
-                        format!("failed to parse {}: {error}", data_path.display())
-                    })?,
-                )
+                if data_path
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("csv"))
+                {
+                    let fields: Vec<crate::CsvBindingField> = meta
+                        .fields
+                        .iter()
+                        .map(|field| crate::CsvBindingField {
+                            path: field.json_path.clone(),
+                            type_name: field.field_type.clone(),
+                            array_count: field.array_count,
+                        })
+                        .collect();
+                    Some(
+                        crate::parse_flat_csv_binding(&data_text, &fields).map_err(|error| {
+                            format!("failed to parse {}: {error}", data_path.display())
+                        })?,
+                    )
+                } else {
+                    Some(
+                        serde_json::from_str::<serde_json::Value>(&data_text).map_err(|error| {
+                            format!("failed to parse {}: {error}", data_path.display())
+                        })?,
+                    )
+                }
             } else {
                 None
             };
@@ -2594,7 +2630,10 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                 if data_root.is_some() && initial_value.is_none() {
                     return Err(format!(
                         "data file {} is missing metadata path {}",
-                        data_path.display(),
+                        data_path
+                            .as_ref()
+                            .expect("data root requires data path")
+                            .display(),
                         field.json_path
                     ));
                 }
@@ -2632,7 +2671,7 @@ fn is_bundleable_asset_extension(path: &Path) -> bool {
     };
     matches!(
         ext.to_ascii_lowercase().as_str(),
-        "json" | "svg" | "png" | "jpg" | "jpeg" | "gif" | "bmp" | "webp"
+        "json" | "csv" | "svg" | "png" | "jpg" | "jpeg" | "gif" | "bmp" | "webp"
     )
 }
 
@@ -3770,11 +3809,28 @@ mod tests {
             }"#,
         )
         .expect("write metadata");
+        fs::write(
+            data_dir.join("enemy.csv"),
+            "cadence,damage\n90,9\n60,6\n120,18\n",
+        )
+        .expect("write CSV data");
+        fs::write(
+            data_dir.join("enemy.struct-meta.json"),
+            r#"{
+                "globalName":"enemy",
+                "fields":[
+                    {"jsonPath":"cadence","size":12,"type":"i32","arrayCount":3},
+                    {"jsonPath":"damage","size":12,"type":"i32","arrayCount":3}
+                ]
+            }"#,
+        )
+        .expect("write CSV metadata");
 
         let support = stage_entry_support_files(&project_dir, Some(&entry_file), &output_dir)
             .expect("stage project data");
         assert!(output_dir.join("data").join("balance.json").is_file());
-        assert_eq!(support.runtime_fields.len(), 2);
+        assert!(output_dir.join("data").join("enemy.csv").is_file());
+        assert_eq!(support.runtime_fields.len(), 4);
 
         let source = build_engine_bundle_runtime_bridge_source(
             &stasis_jit::AotTarget::Native,
@@ -3786,6 +3842,8 @@ mod tests {
         .expect("build embedded data bridge");
         assert!(source.contains("int32_t balance__hp[3] = {70, 110, 85};"));
         assert!(source.contains("int32_t balance__enabled = 1;"));
+        assert!(source.contains("int32_t enemy__cadence[3] = {90, 60, 120};"));
+        assert!(source.contains("int32_t enemy__damage[3] = {9, 6, 18};"));
 
         let _ = fs::remove_dir_all(&temp_root);
     }

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -115,6 +115,8 @@ struct StructMetaFieldExportRow {
     name: Option<String>,
     #[serde(default, rename = "jsonPath")]
     json_path: String,
+    #[serde(default, rename = "csvColumn")]
+    csv_column: Option<String>,
     size: usize,
     #[serde(rename = "type")]
     field_type: String,
@@ -126,6 +128,8 @@ struct StructMetaFieldExportRow {
 struct StructMetaExportFile {
     #[serde(default, rename = "globalName")]
     global_name: String,
+    #[serde(default, rename = "csvTable")]
+    csv_table: Option<crate::CsvTableMetadata>,
     fields: Vec<StructMetaFieldExportRow>,
 }
 
@@ -144,13 +148,15 @@ struct PackagedFunctionAlias {
     returns_i32: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct PackagedRuntimeField {
     name: String,
     size: usize,
     field_type: String,
     array_count: usize,
     initial_value: Option<serde_json::Value>,
+    collection_path: Option<String>,
+    collection_field: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2554,6 +2560,61 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                 .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
             let meta: StructMetaExportFile = serde_json::from_str(&text)
                 .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+            if let Some(table) = &meta.csv_table {
+                if table.rows_path.is_empty()
+                    || table.row_count_path.is_empty()
+                    || table.rows_path.contains('.')
+                    || table.row_count_path.contains('.')
+                    || table.capacity == 0
+                    || table.key_columns.is_empty()
+                {
+                    return Err(format!("invalid csvTable schema in {}", path.display()));
+                }
+                let prefix = format!("{}.", table.rows_path);
+                let mut columns = BTreeSet::new();
+                for field in &meta.fields {
+                    let suffix = field.json_path.strip_prefix(&prefix).ok_or_else(|| {
+                        format!(
+                            "CSV table target {} in {} must be below rowsPath {}",
+                            field.json_path,
+                            path.display(),
+                            table.rows_path
+                        )
+                    })?;
+                    if suffix.is_empty()
+                        || suffix.contains('.')
+                        || field.array_count != table.capacity
+                    {
+                        return Err(format!(
+                            "invalid CSV table target {} in {}",
+                            field.json_path,
+                            path.display()
+                        ));
+                    }
+                    let column = field.csv_column.as_deref().unwrap_or(&field.json_path);
+                    if column.is_empty() || column.contains('.') || !columns.insert(column) {
+                        return Err(format!(
+                            "invalid or duplicate CSV table column {column} in {}",
+                            path.display()
+                        ));
+                    }
+                }
+                let mut keys = BTreeSet::new();
+                for key in &table.key_columns {
+                    if !keys.insert(key) {
+                        return Err(format!(
+                            "duplicate CSV table key column {key} in {}",
+                            path.display()
+                        ));
+                    }
+                    if !columns.contains(key.as_str()) {
+                        return Err(format!(
+                            "CSV table key column {key} in {} has no target field",
+                            path.display()
+                        ));
+                    }
+                }
+            }
             let data_name = name
                 .strip_suffix(".struct-meta.json")
                 .expect("metadata suffix checked");
@@ -2586,16 +2647,28 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                         .iter()
                         .map(|field| crate::CsvBindingField {
                             path: field.json_path.clone(),
+                            csv_column: field.csv_column.clone(),
                             type_name: field.field_type.clone(),
                             array_count: field.array_count,
                         })
                         .collect();
                     Some(
-                        crate::parse_flat_csv_binding(&data_text, &fields).map_err(|error| {
+                        if let Some(table) = &meta.csv_table {
+                            crate::parse_csv_table_binding(&data_text, &fields, table)
+                        } else {
+                            crate::parse_flat_csv_binding(&data_text, &fields)
+                        }
+                        .map_err(|error| {
                             format!("failed to parse {}: {error}", data_path.display())
                         })?,
                     )
                 } else {
+                    if meta.csv_table.is_some() {
+                        return Err(format!(
+                            "csvTable metadata requires a CSV data file: {}",
+                            data_path.display()
+                        ));
+                    }
                     Some(
                         serde_json::from_str::<serde_json::Value>(&data_text).map_err(|error| {
                             format!("failed to parse {}: {error}", data_path.display())
@@ -2606,11 +2679,14 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                 None
             };
             if let Some(root) = data_root.as_ref() {
-                let paths: Vec<String> = meta
+                let mut paths: Vec<String> = meta
                     .fields
                     .iter()
                     .map(|field| field.json_path.clone())
                     .collect();
+                if let Some(table) = &meta.csv_table {
+                    paths.push(table.row_count_path.clone());
+                }
                 crate::validate_binding_source_paths(root, &paths).map_err(|error| {
                     format!(
                         "data file {} does not match target metadata: {error}",
@@ -2621,6 +2697,7 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                     )
                 })?;
             }
+            let csv_table = meta.csv_table.clone();
             for field in meta.fields {
                 let field_name = match field.name {
                     Some(name) if !name.is_empty() => name,
@@ -2653,15 +2730,63 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                         field.json_path
                     ));
                 }
+                let collection_field = if let Some(table) = &csv_table {
+                    Some(
+                        field
+                            .json_path
+                            .strip_prefix(&format!("{}.", table.rows_path))
+                            .ok_or_else(|| {
+                                format!(
+                                    "CSV table target {} in {} must be below rowsPath {}",
+                                    field.json_path,
+                                    path.display(),
+                                    table.rows_path
+                                )
+                            })?
+                            .to_string(),
+                    )
+                } else {
+                    None
+                };
                 let next = PackagedRuntimeField {
                     name: field_name.clone(),
                     size: field.size,
                     field_type: field.field_type,
                     array_count: field.array_count,
                     initial_value,
+                    collection_path: csv_table
+                        .as_ref()
+                        .map(|table| format!("{}.{}", meta.global_name, table.rows_path)),
+                    collection_field,
                 };
                 if let Some(existing) = out.get(&field_name) {
-                    if existing.initial_value != next.initial_value {
+                    if existing != &next {
+                        return Err(format!(
+                            "conflicting packaged data values for runtime field {field_name}"
+                        ));
+                    }
+                } else {
+                    out.insert(field_name, next);
+                }
+            }
+            if let Some(table) = csv_table {
+                let path_suffix = table.row_count_path.replace('.', "__");
+                let field_name = format!("{}__{path_suffix}", meta.global_name);
+                let initial_value = data_root
+                    .as_ref()
+                    .and_then(|root| json_value_by_path(root, &table.row_count_path))
+                    .cloned();
+                let next = PackagedRuntimeField {
+                    name: field_name.clone(),
+                    size: 4,
+                    field_type: "i32".to_string(),
+                    array_count: 1,
+                    initial_value,
+                    collection_path: None,
+                    collection_field: None,
+                };
+                if let Some(existing) = out.get(&field_name) {
+                    if existing != &next {
                         return Err(format!(
                             "conflicting packaged data values for runtime field {field_name}"
                         ));
@@ -2909,7 +3034,7 @@ fn stage_entry_support_files(
     for root in staged_roots {
         for field in collect_struct_meta_fields(&root)? {
             if let Some(existing) = fields_by_name.get(&field.name) {
-                if existing.initial_value != field.initial_value {
+                if existing != &field {
                     return Err(format!(
                         "conflicting packaged data values for runtime field {}",
                         field.name
@@ -2999,7 +3124,17 @@ fn append_runtime_bridge_field_source(
     }
 
     let runtime_path = field.name.replace("__", ".");
-    let field_hash = crate::hash_global_path(&runtime_path);
+    let scalar_hash = crate::hash_global_path(&runtime_path);
+    let collection_hash = field
+        .collection_path
+        .as_deref()
+        .map(crate::hash_global_path)
+        .unwrap_or_else(|| crate::hash_global_path(&runtime_path));
+    let field_hash = field
+        .collection_field
+        .as_deref()
+        .map(crate::hash_global_path)
+        .unwrap_or(0);
     match field.field_type.as_str() {
         "bool" | "u8" | "u16" | "u32" | "i32" => {
             let values = values_for_field(field)?;
@@ -3018,7 +3153,7 @@ fn append_runtime_bridge_field_source(
                     field.name, field.array_count,
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_i32_array({field_hash}, 0, {name}, {len});",
+                    "stasis_jit_register_global_i32_array({collection_hash}, {field_hash}, {name}, {len});",
                     name = field.name,
                     len = field.array_count
                 ));
@@ -3033,7 +3168,7 @@ fn append_runtime_bridge_field_source(
                     field.name
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_i32_ptr({field_hash}, &{name});",
+                    "stasis_jit_register_global_i32_ptr({scalar_hash}, &{name});",
                     name = field.name
                 ));
             }
@@ -3055,7 +3190,7 @@ fn append_runtime_bridge_field_source(
                     field.name, field.array_count,
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_f32_array({field_hash}, 0, {name}, {len});",
+                    "stasis_jit_register_global_f32_array({collection_hash}, {field_hash}, {name}, {len});",
                     name = field.name,
                     len = field.array_count
                 ));
@@ -3070,7 +3205,7 @@ fn append_runtime_bridge_field_source(
                     field.name
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_f32_ptr({field_hash}, &{name});",
+                    "stasis_jit_register_global_f32_ptr({scalar_hash}, &{name});",
                     name = field.name
                 ));
             }
@@ -3092,7 +3227,7 @@ fn append_runtime_bridge_field_source(
                     field.name, field.array_count,
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_f64_array({field_hash}, 0, {name}, {len});",
+                    "stasis_jit_register_global_f64_array({collection_hash}, {field_hash}, {name}, {len});",
                     name = field.name,
                     len = field.array_count
                 ));
@@ -3107,7 +3242,7 @@ fn append_runtime_bridge_field_source(
                     field.name
                 ));
                 register_lines.push(format!(
-                    "stasis_jit_register_global_f64_ptr({field_hash}, &{name});",
+                    "stasis_jit_register_global_f64_ptr({scalar_hash}, &{name});",
                     name = field.name
                 ));
             }
@@ -3181,7 +3316,7 @@ fn append_runtime_bridge_field_source(
                 ));
             }
             register_lines.push(format!(
-                "stasis_jit_register_global_u8_array({field_hash}, 0, {name} + {header_bytes}, {payload_len});",
+                "stasis_jit_register_global_u8_array({scalar_hash}, 0, {name} + {header_bytes}, {payload_len});",
                 name = field.name,
                 header_bytes = header_bytes,
                 payload_len = payload_len
@@ -3841,12 +3976,31 @@ mod tests {
             }"#,
         )
         .expect("write CSV metadata");
+        fs::write(data_dir.join("waves.csv"), "id,hp\n10,70\n20,110\n")
+            .expect("write table CSV data");
+        fs::write(
+            data_dir.join("waves.struct-meta.json"),
+            r#"{
+                "globalName":"level",
+                "csvTable":{
+                    "rowsPath":"rows",
+                    "rowCountPath":"row_count",
+                    "capacity":4,
+                    "keyColumns":["id"]
+                },
+                "fields":[
+                    {"jsonPath":"rows.id","csvColumn":"id","size":16,"type":"i32","arrayCount":4},
+                    {"jsonPath":"rows.hp","csvColumn":"hp","size":16,"type":"i32","arrayCount":4}
+                ]
+            }"#,
+        )
+        .expect("write table CSV metadata");
 
         let support = stage_entry_support_files(&project_dir, Some(&entry_file), &output_dir)
             .expect("stage project data");
         assert!(output_dir.join("data").join("balance.json").is_file());
         assert!(output_dir.join("data").join("enemy.csv").is_file());
-        assert_eq!(support.runtime_fields.len(), 4);
+        assert_eq!(support.runtime_fields.len(), 7);
 
         let source = build_engine_bundle_runtime_bridge_source(
             &stasis_jit::AotTarget::Native,
@@ -3860,6 +4014,14 @@ mod tests {
         assert!(source.contains("int32_t balance__enabled = 1;"));
         assert!(source.contains("int32_t enemy__cadence[3] = {90, 60, 120};"));
         assert!(source.contains("int32_t enemy__damage[3] = {9, 6, 18};"));
+        assert!(source.contains("int32_t level__rows__id[4] = {10, 20, 0, 0};"));
+        assert!(source.contains("int32_t level__rows__hp[4] = {70, 110, 0, 0};"));
+        assert!(source.contains("int32_t level__row_count = 2;"));
+        let rows_hash = crate::hash_global_path("level.rows");
+        let id_hash = crate::hash_global_path("id");
+        assert!(source.contains(&format!(
+            "stasis_jit_register_global_i32_array({rows_hash}, {id_hash}, level__rows__id, 4);"
+        )));
 
         let _ = fs::remove_dir_all(&temp_root);
     }
@@ -3912,6 +4074,8 @@ mod tests {
             field_type: "i32".to_string(),
             array_count: 3,
             initial_value: Some(serde_json::json!([70, 110, 85])),
+            collection_path: None,
+            collection_field: None,
         }];
         let source = build_engine_bundle_runtime_bridge_source(
             &stasis_jit::AotTarget::Native,

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -111,7 +111,10 @@ struct EngineBundleManifest {
 
 #[derive(Debug, Clone, Deserialize)]
 struct StructMetaFieldExportRow {
-    name: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, rename = "jsonPath")]
+    json_path: String,
     size: usize,
     #[serde(rename = "type")]
     field_type: String,
@@ -121,6 +124,8 @@ struct StructMetaFieldExportRow {
 
 #[derive(Debug, Clone, Deserialize)]
 struct StructMetaExportFile {
+    #[serde(default, rename = "globalName")]
+    global_name: String,
     fields: Vec<StructMetaFieldExportRow>,
 }
 
@@ -145,6 +150,7 @@ struct PackagedRuntimeField {
     size: usize,
     field_type: String,
     array_count: usize,
+    initial_value: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -2506,6 +2512,20 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
 }
 
 fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, String> {
+    fn json_value_by_path<'a>(
+        root: &'a serde_json::Value,
+        path: &str,
+    ) -> Option<&'a serde_json::Value> {
+        if path.is_empty() {
+            return Some(root);
+        }
+        let mut value = root;
+        for segment in path.split('.') {
+            value = value.get(segment)?;
+        }
+        Some(value)
+    }
+
     fn walk(dir: &Path, out: &mut BTreeMap<String, PackagedRuntimeField>) -> Result<(), String> {
         let entries = std::fs::read_dir(dir)
             .map_err(|error| format!("failed to read directory {}: {error}", dir.display()))?;
@@ -2534,14 +2554,66 @@ fn collect_struct_meta_fields(root: &Path) -> Result<Vec<PackagedRuntimeField>, 
                 .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
             let meta: StructMetaExportFile = serde_json::from_str(&text)
                 .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+            let data_name = name
+                .strip_suffix(".struct-meta.json")
+                .expect("metadata suffix checked");
+            let data_path = path.with_file_name(format!("{data_name}.json"));
+            let data_root = if data_path.is_file() {
+                let data_text = std::fs::read_to_string(&data_path)
+                    .map_err(|error| format!("failed to read {}: {error}", data_path.display()))?;
+                Some(
+                    serde_json::from_str::<serde_json::Value>(&data_text).map_err(|error| {
+                        format!("failed to parse {}: {error}", data_path.display())
+                    })?,
+                )
+            } else {
+                None
+            };
             for field in meta.fields {
-                out.entry(field.name.clone())
-                    .or_insert(PackagedRuntimeField {
-                        name: field.name,
-                        size: field.size,
-                        field_type: field.field_type,
-                        array_count: field.array_count,
-                    });
+                let field_name = match field.name {
+                    Some(name) if !name.is_empty() => name,
+                    _ if !meta.global_name.is_empty() => {
+                        let path_suffix = field.json_path.replace('.', "__");
+                        if path_suffix.is_empty() {
+                            meta.global_name.clone()
+                        } else {
+                            format!("{}__{path_suffix}", meta.global_name)
+                        }
+                    }
+                    _ => {
+                        return Err(format!(
+                            "metadata field in {} requires name or globalName",
+                            path.display()
+                        ));
+                    }
+                };
+                let initial_value = data_root
+                    .as_ref()
+                    .and_then(|root| json_value_by_path(root, &field.json_path))
+                    .cloned();
+                if data_root.is_some() && initial_value.is_none() {
+                    return Err(format!(
+                        "data file {} is missing metadata path {}",
+                        data_path.display(),
+                        field.json_path
+                    ));
+                }
+                let next = PackagedRuntimeField {
+                    name: field_name.clone(),
+                    size: field.size,
+                    field_type: field.field_type,
+                    array_count: field.array_count,
+                    initial_value,
+                };
+                if let Some(existing) = out.get(&field_name) {
+                    if existing.initial_value != next.initial_value {
+                        return Err(format!(
+                            "conflicting packaged data values for runtime field {field_name}"
+                        ));
+                    }
+                } else {
+                    out.insert(field_name, next);
+                }
             }
         }
         Ok(())
@@ -2736,23 +2808,64 @@ fn stage_entry_support_files(
         .ok_or_else(|| format!("invalid entry file name {}", entry_file.display()))?
         .to_string();
     let source_bundle_dir = entry_root.join(&package_dir_name);
-    if !source_bundle_dir.exists() {
-        return Ok(PackagedAotSupportFiles::default());
-    }
-
     let staged_bundle_dir = output_root.join(&package_dir_name);
-    if staged_bundle_dir.exists() {
-        std::fs::remove_dir_all(&staged_bundle_dir).map_err(|error| {
-            format!(
-                "failed to clear existing staged asset directory {}: {error}",
-                staged_bundle_dir.display()
-            )
-        })?;
+    let mut staged_roots = Vec::new();
+    if source_bundle_dir.exists() {
+        if staged_bundle_dir.exists() {
+            std::fs::remove_dir_all(&staged_bundle_dir).map_err(|error| {
+                format!(
+                    "failed to clear existing staged asset directory {}: {error}",
+                    staged_bundle_dir.display()
+                )
+            })?;
+        }
+        copy_dir_recursive(&source_bundle_dir, &staged_bundle_dir)?;
+        rewrite_packaged_json_asset_paths(&staged_bundle_dir, &package_dir_name)?;
+        staged_roots.push(staged_bundle_dir.clone());
     }
-    copy_dir_recursive(&source_bundle_dir, &staged_bundle_dir)?;
-    rewrite_packaged_json_asset_paths(&staged_bundle_dir, &package_dir_name)?;
 
-    let runtime_fields = collect_struct_meta_fields(&staged_bundle_dir)?;
+    let project_data_dir = project_dir.join("data");
+    let staged_data_dir = output_root.join("data");
+    if project_data_dir.exists() {
+        let source_data_abs = project_data_dir
+            .canonicalize()
+            .unwrap_or_else(|_| project_data_dir.clone());
+        let staged_data_abs = staged_data_dir
+            .canonicalize()
+            .unwrap_or_else(|_| staged_data_dir.clone());
+        if source_data_abs == staged_data_abs {
+            staged_roots.push(project_data_dir);
+        } else {
+            if staged_data_dir.exists() {
+                std::fs::remove_dir_all(&staged_data_dir).map_err(|error| {
+                    format!(
+                        "failed to clear existing staged data directory {}: {error}",
+                        staged_data_dir.display()
+                    )
+                })?;
+            }
+            copy_dir_recursive(&project_data_dir, &staged_data_dir)?;
+            rewrite_packaged_json_asset_paths(&staged_data_dir, "data")?;
+            staged_roots.push(staged_data_dir);
+        }
+    }
+
+    let mut fields_by_name: BTreeMap<String, PackagedRuntimeField> = BTreeMap::new();
+    for root in staged_roots {
+        for field in collect_struct_meta_fields(&root)? {
+            if let Some(existing) = fields_by_name.get(&field.name) {
+                if existing.initial_value != field.initial_value {
+                    return Err(format!(
+                        "conflicting packaged data values for runtime field {}",
+                        field.name
+                    ));
+                }
+            } else {
+                fields_by_name.insert(field.name.clone(), field);
+            }
+        }
+    }
+    let runtime_fields: Vec<_> = fields_by_name.into_values().collect();
     let mut support = PackagedAotSupportFiles {
         export_symbols: runtime_fields
             .iter()
@@ -2780,14 +2893,74 @@ fn append_runtime_bridge_field_source(
     register_lines: &mut Vec<String>,
     field: &PackagedRuntimeField,
 ) -> Result<(), String> {
+    fn values_for_field<'a>(
+        field: &'a PackagedRuntimeField,
+    ) -> Result<Vec<&'a serde_json::Value>, String> {
+        let Some(value) = field.initial_value.as_ref() else {
+            return Ok(Vec::new());
+        };
+        if field.array_count > 1 {
+            let values = value.as_array().ok_or_else(|| {
+                format!("packaged data field {} must be a JSON array", field.name)
+            })?;
+            if values.len() != field.array_count {
+                return Err(format!(
+                    "packaged data field {} requires {} values, found {}",
+                    field.name,
+                    field.array_count,
+                    values.len()
+                ));
+            }
+            Ok(values.iter().collect())
+        } else {
+            Ok(vec![value])
+        }
+    }
+
+    fn i32_literal(value: &serde_json::Value, field_name: &str) -> Result<String, String> {
+        if let Some(value) = value.as_bool() {
+            return Ok(if value { "1" } else { "0" }.to_string());
+        }
+        let value = value.as_i64().ok_or_else(|| {
+            format!("packaged data field {field_name} requires an integer or boolean")
+        })?;
+        i32::try_from(value)
+            .map(|value| value.to_string())
+            .map_err(|_| format!("packaged data field {field_name} is outside i32 range"))
+    }
+
+    fn float_literal(
+        value: &serde_json::Value,
+        field_name: &str,
+        suffix: &str,
+    ) -> Result<String, String> {
+        let value = value
+            .as_f64()
+            .ok_or_else(|| format!("packaged data field {field_name} requires a number"))?;
+        if !value.is_finite() {
+            return Err(format!("packaged data field {field_name} must be finite"));
+        }
+        Ok(format!("{value:.17}{suffix}"))
+    }
+
     let runtime_path = field.name.replace("__", ".");
     let field_hash = crate::hash_global_path(&runtime_path);
     match field.field_type.as_str() {
         "bool" | "u8" | "u16" | "u32" | "i32" => {
+            let values = values_for_field(field)?;
             if field.array_count > 1 {
+                let initializer = if values.is_empty() {
+                    "0".to_string()
+                } else {
+                    values
+                        .iter()
+                        .map(|value| i32_literal(value, &field.name))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join(", ")
+                };
                 source.push_str(&format!(
-                    "STASIS_EXPORT int32_t {}[{}] = {{0}};\n",
-                    field.name, field.array_count
+                    "STASIS_EXPORT int32_t {}[{}] = {{{initializer}}};\n",
+                    field.name, field.array_count,
                 ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_i32_array({field_hash}, 0, {name}, {len});",
@@ -2795,7 +2968,15 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!("STASIS_EXPORT int32_t {} = 0;\n", field.name));
+                let initializer = values
+                    .first()
+                    .map(|value| i32_literal(value, &field.name))
+                    .transpose()?
+                    .unwrap_or_else(|| "0".to_string());
+                source.push_str(&format!(
+                    "STASIS_EXPORT int32_t {} = {initializer};\n",
+                    field.name
+                ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_i32_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2803,10 +2984,20 @@ fn append_runtime_bridge_field_source(
             }
         }
         "f32" => {
+            let values = values_for_field(field)?;
             if field.array_count > 1 {
+                let initializer = if values.is_empty() {
+                    "0.0f".to_string()
+                } else {
+                    values
+                        .iter()
+                        .map(|value| float_literal(value, &field.name, "f"))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join(", ")
+                };
                 source.push_str(&format!(
-                    "STASIS_EXPORT float {}[{}] = {{0}};\n",
-                    field.name, field.array_count
+                    "STASIS_EXPORT float {}[{}] = {{{initializer}}};\n",
+                    field.name, field.array_count,
                 ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f32_array({field_hash}, 0, {name}, {len});",
@@ -2814,7 +3005,15 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!("STASIS_EXPORT float {} = 0.0f;\n", field.name));
+                let initializer = values
+                    .first()
+                    .map(|value| float_literal(value, &field.name, "f"))
+                    .transpose()?
+                    .unwrap_or_else(|| "0.0f".to_string());
+                source.push_str(&format!(
+                    "STASIS_EXPORT float {} = {initializer};\n",
+                    field.name
+                ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f32_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2822,10 +3021,20 @@ fn append_runtime_bridge_field_source(
             }
         }
         "f64" => {
+            let values = values_for_field(field)?;
             if field.array_count > 1 {
+                let initializer = if values.is_empty() {
+                    "0.0".to_string()
+                } else {
+                    values
+                        .iter()
+                        .map(|value| float_literal(value, &field.name, ""))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join(", ")
+                };
                 source.push_str(&format!(
-                    "STASIS_EXPORT double {}[{}] = {{0}};\n",
-                    field.name, field.array_count
+                    "STASIS_EXPORT double {}[{}] = {{{initializer}}};\n",
+                    field.name, field.array_count,
                 ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f64_array({field_hash}, 0, {name}, {len});",
@@ -2833,7 +3042,15 @@ fn append_runtime_bridge_field_source(
                     len = field.array_count
                 ));
             } else {
-                source.push_str(&format!("STASIS_EXPORT double {} = 0.0;\n", field.name));
+                let initializer = values
+                    .first()
+                    .map(|value| float_literal(value, &field.name, ""))
+                    .transpose()?
+                    .unwrap_or_else(|| "0.0".to_string());
+                source.push_str(&format!(
+                    "STASIS_EXPORT double {} = {initializer};\n",
+                    field.name
+                ));
                 register_lines.push(format!(
                     "stasis_jit_register_global_f64_ptr({field_hash}, &{name});",
                     name = field.name
@@ -2848,6 +3065,39 @@ fn append_runtime_bridge_field_source(
                 "STASIS_EXPORT uint8_t {}[{}] = {{0}};\n",
                 field.name, len
             ));
+            if let Some(value) = field.initial_value.as_ref() {
+                let text = value.as_str().ok_or_else(|| {
+                    format!("packaged data field {} requires a string", field.name)
+                })?;
+                let bytes = text.as_bytes();
+                if bytes.len() > payload_len {
+                    return Err(format!(
+                        "packaged data field {} exceeds string capacity {}",
+                        field.name, payload_len
+                    ));
+                }
+                if header_bytes >= 8 {
+                    register_lines.push(format!(
+                        "*((int32_t*){name}) = {len};",
+                        name = field.name,
+                        len = bytes.len()
+                    ));
+                }
+                if header_bytes >= 12 {
+                    register_lines.push(format!(
+                        "*((int32_t*)({name} + 8)) = {len};",
+                        name = field.name,
+                        len = text.chars().count()
+                    ));
+                }
+                for (index, byte) in bytes.iter().enumerate() {
+                    register_lines.push(format!(
+                        "{name}[{offset}] = {byte};",
+                        name = field.name,
+                        offset = header_bytes + index
+                    ));
+                }
+            }
             if header_bytes >= 8 {
                 let max_length_hash =
                     crate::hash_global_path(&format!("{}.max_length", runtime_path));
@@ -3490,6 +3740,57 @@ mod tests {
     }
 
     #[test]
+    fn project_data_is_staged_and_embedded_in_aot_runtime_fields() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_project_data_{stamp}"));
+        let project_dir = temp_root.join("project");
+        let output_dir = temp_root.join("output");
+        let entry_file = project_dir.join("src").join("main.stasis");
+        let data_dir = project_dir.join("data");
+        fs::create_dir_all(entry_file.parent().expect("entry parent")).expect("create src");
+        fs::create_dir_all(&data_dir).expect("create data");
+        fs::create_dir_all(&output_dir).expect("create output");
+        fs::write(&entry_file, "function main(): i32 { return 0; }\n").expect("write entry");
+        fs::write(
+            data_dir.join("balance.json"),
+            r#"{"hp":[70,110,85],"enabled":true}"#,
+        )
+        .expect("write data");
+        fs::write(
+            data_dir.join("balance.struct-meta.json"),
+            r#"{
+                "globalName":"balance",
+                "fields":[
+                    {"jsonPath":"hp","size":12,"type":"i32","arrayCount":3},
+                    {"jsonPath":"enabled","size":1,"type":"bool","arrayCount":1}
+                ]
+            }"#,
+        )
+        .expect("write metadata");
+
+        let support = stage_entry_support_files(&project_dir, Some(&entry_file), &output_dir)
+            .expect("stage project data");
+        assert!(output_dir.join("data").join("balance.json").is_file());
+        assert_eq!(support.runtime_fields.len(), 2);
+
+        let source = build_engine_bundle_runtime_bridge_source(
+            &stasis_jit::AotTarget::Native,
+            &support.runtime_fields,
+            &[],
+            &[],
+            &[],
+        )
+        .expect("build embedded data bridge");
+        assert!(source.contains("int32_t balance__hp[3] = {70, 110, 85};"));
+        assert!(source.contains("int32_t balance__enabled = 1;"));
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
     fn engine_bundle_runtime_bridge_source_includes_android_entry_exports() {
         let source = build_engine_bundle_runtime_bridge_source(
             &stasis_jit::AotTarget::android_arm64_default(),
@@ -3531,9 +3832,16 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_runtime_bridge_object_has_no_default_library_directives() {
+        let runtime_fields = vec![PackagedRuntimeField {
+            name: "balance__hp".to_string(),
+            size: 12,
+            field_type: "i32".to_string(),
+            array_count: 3,
+            initial_value: Some(serde_json::json!([70, 110, 85])),
+        }];
         let source = build_engine_bundle_runtime_bridge_source(
             &stasis_jit::AotTarget::Native,
-            &[],
+            &runtime_fields,
             &["aot_fn_1".to_string()],
             &[PackagedFunctionAlias {
                 alias: "main",
@@ -3544,6 +3852,7 @@ mod tests {
         )
         .expect("build bridge source");
         assert!(source.contains("typedef signed int int32_t;"));
+        assert!(source.contains("int32_t balance__hp[3] = {70, 110, 85};"));
         assert!(!source.starts_with("#include <stdint.h>"));
 
         let stamp = SystemTime::now()

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -232,6 +232,191 @@ struct PlayStructFieldMetadata {
     array_count: i32,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CsvBindingField {
+    pub(crate) path: String,
+    pub(crate) type_name: String,
+    pub(crate) array_count: usize,
+}
+
+fn parse_csv_records(source: &str) -> Result<Vec<Vec<String>>, String> {
+    let mut records = Vec::new();
+    let mut row = Vec::new();
+    let mut field = String::new();
+    let mut chars = source.chars().peekable();
+    let mut in_quotes = false;
+    let mut closed_quote = false;
+
+    while let Some(ch) = chars.next() {
+        if in_quotes {
+            if ch == '"' {
+                if chars.peek() == Some(&'"') {
+                    chars.next();
+                    field.push('"');
+                } else {
+                    in_quotes = false;
+                    closed_quote = true;
+                }
+            } else {
+                field.push(ch);
+            }
+            continue;
+        }
+        if closed_quote && !matches!(ch, ',' | '\r' | '\n') {
+            return Err("unexpected character after closing quote".to_string());
+        }
+        match ch {
+            '"' if field.is_empty() && !closed_quote => in_quotes = true,
+            '"' => return Err("quote must begin a CSV field".to_string()),
+            ',' => {
+                row.push(std::mem::take(&mut field));
+                closed_quote = false;
+            }
+            '\n' => {
+                row.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut row));
+                closed_quote = false;
+            }
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                row.push(std::mem::take(&mut field));
+                records.push(std::mem::take(&mut row));
+                closed_quote = false;
+            }
+            _ => field.push(ch),
+        }
+    }
+    if in_quotes {
+        return Err("unterminated quoted CSV field".to_string());
+    }
+    if !field.is_empty() || !row.is_empty() || closed_quote {
+        row.push(field);
+        records.push(row);
+    }
+    Ok(records)
+}
+
+fn parse_csv_cell(value: &str, field: &CsvBindingField) -> Result<Value, String> {
+    let trimmed = value.trim();
+    match field.type_name.as_str() {
+        "string" => Ok(Value::String(value.to_string())),
+        "bool" => match trimmed.to_ascii_lowercase().as_str() {
+            "true" | "1" => Ok(Value::Bool(true)),
+            "false" | "0" => Ok(Value::Bool(false)),
+            _ => Err(format!(
+                "field {} requires true, false, 1, or 0",
+                field.path
+            )),
+        },
+        "u8" | "u16" | "u32" | "i32" => {
+            let number = trimmed
+                .parse::<i64>()
+                .map_err(|error| format!("field {} requires an integer: {error}", field.path))?;
+            i32::try_from(number)
+                .map_err(|_| format!("field {} is outside i32 range", field.path))?;
+            Ok(Value::Number(number.into()))
+        }
+        "f32" | "f64" => {
+            let number = trimmed
+                .parse::<f64>()
+                .map_err(|error| format!("field {} requires a number: {error}", field.path))?;
+            let number = serde_json::Number::from_f64(number)
+                .ok_or_else(|| format!("field {} must be finite", field.path))?;
+            Ok(Value::Number(number))
+        }
+        other => Err(format!(
+            "field {} has unsupported CSV type {other}",
+            field.path
+        )),
+    }
+}
+
+pub(crate) fn parse_flat_csv_binding(
+    source: &str,
+    fields: &[CsvBindingField],
+) -> Result<Value, String> {
+    let records = parse_csv_records(source)?;
+    let Some(headers) = records.first() else {
+        return Err("CSV data requires a header row".to_string());
+    };
+    if records.len() == 1 {
+        return Err("CSV data requires at least one data row".to_string());
+    }
+    let mut header_indices = BTreeMap::new();
+    for (index, header) in headers.iter().enumerate() {
+        let header = if index == 0 {
+            header.strip_prefix('\u{feff}').unwrap_or(header)
+        } else {
+            header
+        };
+        if header.is_empty() {
+            return Err("CSV headers must not be empty".to_string());
+        }
+        if header.contains('.') {
+            return Err(format!(
+                "CSV header {header} cannot contain nested path separators"
+            ));
+        }
+        if header_indices.insert(header.to_string(), index).is_some() {
+            return Err(format!("duplicate CSV header {header}"));
+        }
+    }
+    for (row_index, row) in records.iter().enumerate().skip(1) {
+        if row.len() != headers.len() {
+            return Err(format!(
+                "CSV row {} has {} columns; expected {}",
+                row_index + 1,
+                row.len(),
+                headers.len()
+            ));
+        }
+    }
+
+    let data_rows = &records[1..];
+    let mut object = serde_json::Map::new();
+    for field in fields {
+        if field.path.is_empty() || field.path.contains('.') {
+            return Err(format!(
+                "CSV metadata path {} must name one flat column",
+                field.path
+            ));
+        }
+        let column = header_indices
+            .get(&field.path)
+            .copied()
+            .ok_or_else(|| format!("CSV is missing metadata column {}", field.path))?;
+        let is_array = field.type_name != "string" && field.array_count > 1;
+        let value = if is_array {
+            if data_rows.len() != field.array_count {
+                return Err(format!(
+                    "CSV column {} requires {} rows, found {}",
+                    field.path,
+                    field.array_count,
+                    data_rows.len()
+                ));
+            }
+            Value::Array(
+                data_rows
+                    .iter()
+                    .map(|row| parse_csv_cell(&row[column], field))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        } else {
+            if data_rows.len() != 1 {
+                return Err(format!(
+                    "scalar CSV column {} requires exactly one data row",
+                    field.path
+                ));
+            }
+            parse_csv_cell(&data_rows[0][column], field)?
+        };
+        object.insert(field.path.clone(), value);
+    }
+    Ok(Value::Object(object))
+}
+
 fn resolve_play_sidecar_path(path: &Path, launch_dir: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();
@@ -257,7 +442,7 @@ fn resolve_play_data_binding_paths(
     }
 
     fn discover_pairs(data_dir: &Path) -> Result<Vec<(PathBuf, PathBuf)>, String> {
-        fn collect_json_paths(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+        fn collect_data_paths(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
             for entry in fs::read_dir(dir).map_err(|error| {
                 format!("failed to read data directory {}: {error}", dir.display())
             })? {
@@ -266,11 +451,11 @@ fn resolve_play_data_binding_paths(
                 })?;
                 let path = entry.path();
                 if path.is_dir() {
-                    collect_json_paths(&path, out)?;
+                    collect_data_paths(&path, out)?;
                 } else if path.is_file()
-                    && path
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+                    && path.extension().is_some_and(|ext| {
+                        ext.eq_ignore_ascii_case("json") || ext.eq_ignore_ascii_case("csv")
+                    })
                     && !path
                         .file_name()
                         .and_then(|name| name.to_str())
@@ -285,24 +470,33 @@ fn resolve_play_data_binding_paths(
         if !data_dir.is_dir() {
             return Ok(Vec::new());
         }
-        let mut json_paths = Vec::new();
-        collect_json_paths(data_dir, &mut json_paths)?;
-        json_paths.sort();
+        let mut data_paths = Vec::new();
+        collect_data_paths(data_dir, &mut data_paths)?;
+        data_paths.sort();
         let mut out = Vec::new();
-        for json_path in json_paths {
-            let stem = json_path
+        let mut metadata_owners = BTreeMap::new();
+        for data_path in data_paths {
+            let stem = data_path
                 .file_stem()
                 .and_then(|value| value.to_str())
-                .ok_or_else(|| format!("invalid data file name {}", json_path.display()))?;
-            let meta_path = data_dir.join(format!("{stem}.struct-meta.json"));
+                .ok_or_else(|| format!("invalid data file name {}", data_path.display()))?;
+            let meta_path = data_path.with_file_name(format!("{stem}.struct-meta.json"));
             if !meta_path.is_file() {
                 return Err(format!(
                     "data file {} requires matching metadata {}",
-                    json_path.display(),
+                    data_path.display(),
                     meta_path.display()
                 ));
             }
-            out.push((json_path, meta_path));
+            if let Some(owner) = metadata_owners.insert(meta_path.clone(), data_path.clone()) {
+                return Err(format!(
+                    "data files {} and {} cannot share metadata {}",
+                    owner.display(),
+                    data_path.display(),
+                    meta_path.display()
+                ));
+            }
+            out.push((data_path, meta_path));
         }
         Ok(out)
     }
@@ -519,19 +713,7 @@ fn apply_play_data_binding_value(
 
 fn load_and_apply_play_data_bindings(paths: &[(PathBuf, PathBuf)]) -> Result<(), String> {
     let mut loaded = Vec::new();
-    for (json_path, meta_path) in paths {
-        let json_source = fs::read_to_string(json_path).map_err(|error| {
-            format!(
-                "failed to read data-bind json {}: {error}",
-                json_path.display()
-            )
-        })?;
-        let json_root: Value = serde_json::from_str(&json_source).map_err(|error| {
-            format!(
-                "failed to parse data-bind json {}: {error}",
-                json_path.display()
-            )
-        })?;
+    for (data_path, meta_path) in paths {
         let meta_source = fs::read_to_string(meta_path).map_err(|error| {
             format!(
                 "failed to read data-bind struct-meta {}: {error}",
@@ -544,7 +726,31 @@ fn load_and_apply_play_data_bindings(paths: &[(PathBuf, PathBuf)]) -> Result<(),
                 meta_path.display()
             )
         })?;
-        loaded.push((json_root, metadata));
+        let data_source = fs::read_to_string(data_path).map_err(|error| {
+            format!("failed to read data file {}: {error}", data_path.display())
+        })?;
+        let is_csv = data_path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("csv"));
+        let data_root = if is_csv {
+            let fields: Vec<CsvBindingField> = metadata
+                .fields
+                .iter()
+                .map(|field| CsvBindingField {
+                    path: field.json_path.clone(),
+                    type_name: field.type_name.clone(),
+                    array_count: usize::try_from(field.array_count.max(0)).unwrap_or(0),
+                })
+                .collect();
+            parse_flat_csv_binding(&data_source, &fields).map_err(|error| {
+                format!("failed to parse data CSV {}: {error}", data_path.display())
+            })?
+        } else {
+            serde_json::from_str(&data_source).map_err(|error| {
+                format!("failed to parse data JSON {}: {error}", data_path.display())
+            })?
+        };
+        loaded.push((data_root, metadata));
     }
     for (_, metadata) in &loaded {
         if metadata.version != 1 {
@@ -3204,6 +3410,104 @@ mod tests {
     }
 
     #[test]
+    fn parse_flat_csv_binding_supports_scalar_and_columnar_data() {
+        let scalar = parse_flat_csv_binding(
+            "enabled,label\r\ntrue,\"Fast, tough\"\r\n",
+            &[
+                CsvBindingField {
+                    path: "enabled".to_string(),
+                    type_name: "bool".to_string(),
+                    array_count: 1,
+                },
+                CsvBindingField {
+                    path: "label".to_string(),
+                    type_name: "string".to_string(),
+                    array_count: 32,
+                },
+            ],
+        )
+        .expect("scalar CSV should parse");
+        assert_eq!(
+            scalar,
+            serde_json::json!({"enabled": true, "label": "Fast, tough"})
+        );
+
+        let arrays = parse_flat_csv_binding(
+            "hp,speed\n70,1.5\n110,2.25\n85,3\n",
+            &[
+                CsvBindingField {
+                    path: "hp".to_string(),
+                    type_name: "i32".to_string(),
+                    array_count: 3,
+                },
+                CsvBindingField {
+                    path: "speed".to_string(),
+                    type_name: "f32".to_string(),
+                    array_count: 3,
+                },
+            ],
+        )
+        .expect("columnar CSV should parse");
+        assert_eq!(
+            arrays,
+            serde_json::json!({"hp": [70, 110, 85], "speed": [1.5, 2.25, 3.0]})
+        );
+    }
+
+    #[test]
+    fn parse_flat_csv_binding_rejects_nested_metadata_paths() {
+        let error = parse_flat_csv_binding(
+            "screen_width\n800\n",
+            &[CsvBindingField {
+                path: "config.screen_width".to_string(),
+                type_name: "i32".to_string(),
+                array_count: 1,
+            }],
+        )
+        .expect_err("nested CSV metadata should fail");
+        assert!(error.contains("flat column"));
+    }
+
+    #[test]
+    fn load_play_data_bindings_applies_columnar_csv_arrays() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let mut hp = [0i32; 3];
+        stasis_dynload::register_global_i32_array(
+            hash_global_path("state.hp"),
+            0,
+            hp.as_mut_ptr(),
+            hp.len(),
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_play_bind_csv_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let data_path = temp_root.join("balance.csv");
+        let meta_path = temp_root.join("balance.struct-meta.json");
+        fs::write(&data_path, "hp\n70\n110\n85\n").expect("write CSV");
+        fs::write(
+            &meta_path,
+            r#"{"version":1,"globalName":"state","fields":[{"jsonPath":"hp","type":"i32","arrayCount":3}]}"#,
+        )
+        .expect("write metadata");
+
+        load_and_apply_play_data_bindings(&[(data_path, meta_path)])
+            .expect("CSV binding should apply");
+        assert_eq!(hp, [70, 110, 85]);
+
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
     fn load_play_data_bindings_rejects_set_before_mutating_runtime() {
         let _global_lock = jit_global_table_lock()
             .lock()
@@ -3241,7 +3545,7 @@ mod tests {
             (second_json, second_meta),
         ])
         .expect_err("invalid set should be rejected");
-        assert!(error.contains("failed to parse data-bind json"));
+        assert!(error.contains("failed to parse data JSON"));
         assert_eq!(
             value, 5,
             "the earlier valid file must not be partially applied"
@@ -3298,6 +3602,11 @@ mod tests {
             fs::write(data_dir.join(format!("{stem}.struct-meta.json")), "{}\n")
                 .expect("write metadata");
         }
+        let nested_data_dir = data_dir.join("tables");
+        fs::create_dir_all(&nested_data_dir).expect("create nested data dir");
+        fs::write(nested_data_dir.join("tuning.csv"), "hp\n70\n").expect("write CSV");
+        fs::write(nested_data_dir.join("tuning.struct-meta.json"), "{}\n")
+            .expect("write CSV metadata");
 
         let resolved = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
             .expect("project data discovery should succeed");
@@ -3312,6 +3621,10 @@ mod tests {
                 (
                     data_dir.join("pieces.json"),
                     data_dir.join("pieces.struct-meta.json")
+                ),
+                (
+                    nested_data_dir.join("tuning.csv"),
+                    nested_data_dir.join("tuning.struct-meta.json")
                 )
             ]
         );
@@ -3336,6 +3649,28 @@ mod tests {
         let error = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
             .expect_err("partial sidecars should fail");
         assert!(error.contains("requires matching metadata"));
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn resolve_play_data_binding_paths_rejects_json_csv_stem_collision() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_play_bind_collision_{stamp}"));
+        let data_dir = temp_root.join("data");
+        let watch_file = temp_root.join("main.stasis");
+        fs::create_dir_all(&data_dir).expect("create data dir");
+        fs::write(&watch_file, "function main(): i32 { return 0; }\n").expect("write entry");
+        fs::write(data_dir.join("balance.json"), "{}\n").expect("write JSON");
+        fs::write(data_dir.join("balance.csv"), "hp\n70\n").expect("write CSV");
+        fs::write(data_dir.join("balance.struct-meta.json"), "{}\n").expect("write metadata");
+
+        let error = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
+            .expect_err("shared JSON/CSV metadata should fail");
+        assert!(error.contains("cannot share metadata"));
 
         let _ = fs::remove_dir_all(&temp_root);
     }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -244,38 +244,87 @@ fn resolve_play_data_binding_paths(
     launch_dir: &Path,
     data_bind_json: Option<&Path>,
     data_bind_struct_meta: Option<&Path>,
-) -> Result<Option<(PathBuf, PathBuf)>, String> {
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
     match (data_bind_json, data_bind_struct_meta) {
         (Some(json_path), Some(struct_meta_path)) => {
-            return Ok(Some((
+            return Ok(vec![(
                 resolve_play_sidecar_path(json_path, launch_dir),
                 resolve_play_sidecar_path(struct_meta_path, launch_dir),
-            )));
+            )]);
         }
         (None, None) => {}
         _ => return Err("play data binding requires both json and struct-meta paths".to_string()),
     }
 
+    fn discover_pairs(data_dir: &Path) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+        fn collect_json_paths(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+            for entry in fs::read_dir(dir).map_err(|error| {
+                format!("failed to read data directory {}: {error}", dir.display())
+            })? {
+                let entry = entry.map_err(|error| {
+                    format!("failed to read data directory {}: {error}", dir.display())
+                })?;
+                let path = entry.path();
+                if path.is_dir() {
+                    collect_json_paths(&path, out)?;
+                } else if path.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+                    && !path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.ends_with(".struct-meta.json"))
+                {
+                    out.push(path);
+                }
+            }
+            Ok(())
+        }
+
+        if !data_dir.is_dir() {
+            return Ok(Vec::new());
+        }
+        let mut json_paths = Vec::new();
+        collect_json_paths(data_dir, &mut json_paths)?;
+        json_paths.sort();
+        let mut out = Vec::new();
+        for json_path in json_paths {
+            let stem = json_path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| format!("invalid data file name {}", json_path.display()))?;
+            let meta_path = data_dir.join(format!("{stem}.struct-meta.json"));
+            if !meta_path.is_file() {
+                return Err(format!(
+                    "data file {} requires matching metadata {}",
+                    json_path.display(),
+                    meta_path.display()
+                ));
+            }
+            out.push((json_path, meta_path));
+        }
+        Ok(out)
+    }
+
     let watch_file_path = resolve_play_sidecar_path(watch_file, launch_dir);
+    let mut roots = vec![launch_dir.join("data")];
     let Some(file_stem) = watch_file_path.file_stem() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let base_dir = watch_file_path.parent().unwrap_or(launch_dir);
-    let auto_root = base_dir.join(file_stem);
-    let json_path = auto_root.join("data").join("config.json");
-    let struct_meta_path = auto_root.join("data").join("config.struct-meta.json");
-
-    if json_path.exists() && struct_meta_path.exists() {
-        return Ok(Some((json_path, struct_meta_path)));
+    roots.push(base_dir.join(file_stem).join("data"));
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for root in roots {
+        for pair in discover_pairs(&root)? {
+            let key = normalize_watch_path_for_log(&pair.0);
+            if seen.insert(key) {
+                out.push(pair);
+            }
+        }
     }
-    if !json_path.exists() && !struct_meta_path.exists() {
-        return Ok(None);
-    }
-    Err(format!(
-        "play auto data binding requires both sidecars; looked for {} and {}",
-        json_path.display(),
-        struct_meta_path.display()
-    ))
+    Ok(out)
 }
 fn json_value_by_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
     if path.is_empty() {
@@ -468,37 +517,47 @@ fn apply_play_data_binding_value(
     Ok(())
 }
 
-fn load_and_apply_play_data_binding(
-    json_path: &Path,
-    struct_meta_path: &Path,
-) -> Result<(), String> {
-    let json_source = fs::read_to_string(json_path).map_err(|error| {
-        format!(
-            "failed to read data-bind json {}: {error}",
-            json_path.display()
-        )
-    })?;
-    let json_root: Value = serde_json::from_str(&json_source).map_err(|error| {
-        format!(
-            "failed to parse data-bind json {}: {error}",
-            json_path.display()
-        )
-    })?;
-
-    let meta_source = fs::read_to_string(struct_meta_path).map_err(|error| {
-        format!(
-            "failed to read data-bind struct-meta {}: {error}",
-            struct_meta_path.display()
-        )
-    })?;
-    let metadata: PlayStructMetadata = serde_json::from_str(&meta_source).map_err(|error| {
-        format!(
-            "failed to parse data-bind struct-meta {}: {error}",
-            struct_meta_path.display()
-        )
-    })?;
-
-    apply_play_data_binding_value(&json_root, &metadata)
+fn load_and_apply_play_data_bindings(paths: &[(PathBuf, PathBuf)]) -> Result<(), String> {
+    let mut loaded = Vec::new();
+    for (json_path, meta_path) in paths {
+        let json_source = fs::read_to_string(json_path).map_err(|error| {
+            format!(
+                "failed to read data-bind json {}: {error}",
+                json_path.display()
+            )
+        })?;
+        let json_root: Value = serde_json::from_str(&json_source).map_err(|error| {
+            format!(
+                "failed to parse data-bind json {}: {error}",
+                json_path.display()
+            )
+        })?;
+        let meta_source = fs::read_to_string(meta_path).map_err(|error| {
+            format!(
+                "failed to read data-bind struct-meta {}: {error}",
+                meta_path.display()
+            )
+        })?;
+        let metadata: PlayStructMetadata = serde_json::from_str(&meta_source).map_err(|error| {
+            format!(
+                "failed to parse data-bind struct-meta {}: {error}",
+                meta_path.display()
+            )
+        })?;
+        loaded.push((json_root, metadata));
+    }
+    for (_, metadata) in &loaded {
+        if metadata.version != 1 {
+            return Err(format!(
+                "unsupported struct-meta version {}; expected 1",
+                metadata.version
+            ));
+        }
+    }
+    for (json_root, metadata) in loaded {
+        apply_play_data_binding_value(&json_root, &metadata)?;
+    }
+    Ok(())
 }
 
 fn resolve_play_watch_dir(watch_file: &Path, watch_dir: Option<&Path>) -> PathBuf {
@@ -899,6 +958,28 @@ fn run_play_in_process_inner(
             watch_dir.display()
         )
     })?;
+    let mut data_watchers = Vec::new();
+    let mut watched_data_dirs = BTreeSet::new();
+    for (json_path, _) in &data_binding_paths {
+        let Some(parent) = json_path.parent() else {
+            continue;
+        };
+        let parent_abs = parent
+            .canonicalize()
+            .unwrap_or_else(|_| parent.to_path_buf());
+        if parent_abs.starts_with(&watch_dir_abs) {
+            continue;
+        }
+        let key = normalize_watch_path_for_log(&parent_abs);
+        if watched_data_dirs.insert(key) {
+            data_watchers.push(WatchService::start(&parent_abs).map_err(|error| {
+                format!(
+                    "failed to watch data directory {}: {error}",
+                    parent_abs.display()
+                )
+            })?);
+        }
+    }
 
     let root_path = watch_file
         .canonicalize()
@@ -987,9 +1068,7 @@ fn run_play_in_process_inner(
     let _ = jit
         .compile()
         .map_err(|error| format!("initial JIT compile failed: {error:?}"))?;
-    if let Some((json_path, struct_meta_path)) = data_binding_paths.as_ref() {
-        load_and_apply_play_data_binding(json_path, struct_meta_path)?;
-    }
+    load_and_apply_play_data_bindings(&data_binding_paths)?;
     let package = jit
         .build_engine_package(&EngineEntrypoints::runtime_default())
         .map_err(|error| format!("failed to build engine package: {error}"))?;
@@ -1042,12 +1121,26 @@ fn run_play_in_process_inner(
         let mut needs_recompile = false;
         let mut ignored_changes: u32 = 0;
         let mut triggered_paths: Vec<String> = Vec::new();
-        for event in watcher.drain_stasis_changes() {
+        let mut watch_events = watcher.drain_stasis_changes();
+        for data_watcher in &mut data_watchers {
+            watch_events.extend(data_watcher.drain_stasis_changes());
+        }
+        let mut needs_data_reload = false;
+        for event in watch_events {
             if live
                 .as_mut()
                 .is_some_and(|workspace| workspace.consumes_self_write(&event.path))
             {
                 ignored_changes = ignored_changes.saturating_add(1);
+                continue;
+            }
+            let event_path = normalize_watch_path_for_log(&event.path);
+            let is_data_event = data_binding_paths.iter().any(|(json_path, meta_path)| {
+                event_path == normalize_watch_path_for_log(json_path)
+                    || event_path == normalize_watch_path_for_log(meta_path)
+            });
+            if is_data_event {
+                needs_data_reload = true;
                 continue;
             }
             let submit = should_submit_watch_event(
@@ -1060,6 +1153,12 @@ fn run_play_in_process_inner(
                 triggered_paths.push(normalize_watch_path_for_log(&event.path));
             } else {
                 ignored_changes = ignored_changes.saturating_add(1);
+            }
+        }
+        if needs_data_reload {
+            match load_and_apply_play_data_bindings(&data_binding_paths) {
+                Ok(()) => println!("[data] rebound {} file(s)", data_binding_paths.len()),
+                Err(error) => println!("[data] reload rejected: {error}"),
             }
         }
         if ignored_changes > 0 && !needs_recompile {
@@ -3105,6 +3204,55 @@ mod tests {
     }
 
     #[test]
+    fn load_play_data_bindings_rejects_set_before_mutating_runtime() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let mut value = 5i32;
+        stasis_dynload::register_global_i32_ptr(hash_global_path("state.value"), &mut value);
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_play_bind_atomic_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let first_json = temp_root.join("first.json");
+        let first_meta = temp_root.join("first.struct-meta.json");
+        let second_json = temp_root.join("second.json");
+        let second_meta = temp_root.join("second.struct-meta.json");
+        fs::write(&first_json, r#"{"value":9}"#).expect("write first json");
+        fs::write(
+            &first_meta,
+            r#"{"version":1,"globalName":"state","fields":[{"jsonPath":"value","type":"i32","arrayCount":1}]}"#,
+        )
+        .expect("write first metadata");
+        fs::write(&second_json, "{invalid").expect("write invalid json");
+        fs::write(
+            &second_meta,
+            r#"{"version":1,"globalName":"other","fields":[]}"#,
+        )
+        .expect("write second metadata");
+
+        let error = load_and_apply_play_data_bindings(&[
+            (first_json, first_meta),
+            (second_json, second_meta),
+        ])
+        .expect_err("invalid set should be rejected");
+        assert!(error.contains("failed to parse data-bind json"));
+        assert_eq!(
+            value, 5,
+            "the earlier valid file must not be partially applied"
+        );
+
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
     fn resolve_play_data_binding_paths_auto_discovers_bucket_layout() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -3120,11 +3268,53 @@ mod tests {
         fs::write(data_dir.join("config.struct-meta.json"), "{}\n").expect("write struct meta");
 
         let resolved = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
-            .expect("auto discovery should succeed")
-            .expect("expected auto binding paths");
+            .expect("auto discovery should succeed");
 
-        assert_eq!(resolved.0, data_dir.join("config.json"));
-        assert_eq!(resolved.1, data_dir.join("config.struct-meta.json"));
+        assert_eq!(
+            resolved,
+            vec![(
+                data_dir.join("config.json"),
+                data_dir.join("config.struct-meta.json")
+            )]
+        );
+
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn resolve_play_data_binding_paths_discovers_all_project_data_in_name_order() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_play_bind_project_{stamp}"));
+        let data_dir = temp_root.join("data");
+        let watch_file = temp_root.join("src").join("main.stasis");
+        fs::create_dir_all(watch_file.parent().expect("source parent")).expect("create src");
+        fs::create_dir_all(&data_dir).expect("create data dir");
+        fs::write(&watch_file, "function main(): i32 { return 0; }\n").expect("write entry");
+        for stem in ["pieces", "enemies"] {
+            fs::write(data_dir.join(format!("{stem}.json")), "{}\n").expect("write json");
+            fs::write(data_dir.join(format!("{stem}.struct-meta.json")), "{}\n")
+                .expect("write metadata");
+        }
+
+        let resolved = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
+            .expect("project data discovery should succeed");
+
+        assert_eq!(
+            resolved,
+            vec![
+                (
+                    data_dir.join("enemies.json"),
+                    data_dir.join("enemies.struct-meta.json")
+                ),
+                (
+                    data_dir.join("pieces.json"),
+                    data_dir.join("pieces.struct-meta.json")
+                )
+            ]
+        );
 
         let _ = fs::remove_dir_all(&temp_root);
     }
@@ -3145,7 +3335,7 @@ mod tests {
 
         let error = resolve_play_data_binding_paths(&watch_file, &temp_root, None, None)
             .expect_err("partial sidecars should fail");
-        assert!(error.contains("play auto data binding requires both sidecars"));
+        assert!(error.contains("requires matching metadata"));
 
         let _ = fs::remove_dir_all(&temp_root);
     }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -219,13 +219,28 @@ struct PlayStructMetadata {
     version: i32,
     #[serde(rename = "globalName")]
     global_name: String,
+    #[serde(default, rename = "csvTable")]
+    csv_table: Option<CsvTableMetadata>,
     fields: Vec<PlayStructFieldMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct CsvTableMetadata {
+    #[serde(rename = "rowsPath")]
+    pub(crate) rows_path: String,
+    #[serde(rename = "rowCountPath")]
+    pub(crate) row_count_path: String,
+    pub(crate) capacity: usize,
+    #[serde(rename = "keyColumns")]
+    pub(crate) key_columns: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 struct PlayStructFieldMetadata {
     #[serde(rename = "jsonPath")]
     json_path: String,
+    #[serde(default, rename = "csvColumn")]
+    csv_column: Option<String>,
     #[serde(rename = "type")]
     type_name: String,
     #[serde(rename = "arrayCount")]
@@ -235,8 +250,13 @@ struct PlayStructFieldMetadata {
 #[derive(Debug, Clone)]
 pub(crate) struct CsvBindingField {
     pub(crate) path: String,
+    pub(crate) csv_column: Option<String>,
     pub(crate) type_name: String,
     pub(crate) array_count: usize,
+}
+
+fn csv_column_name<'a>(field: &'a CsvBindingField) -> &'a str {
+    field.csv_column.as_deref().unwrap_or(&field.path)
 }
 
 fn parse_csv_records(source: &str) -> Result<Vec<Vec<String>>, String> {
@@ -339,6 +359,9 @@ pub(crate) fn parse_flat_csv_binding(
 ) -> Result<Value, String> {
     let mut metadata_paths = BTreeSet::new();
     for field in fields {
+        if field.csv_column.is_some() {
+            return Err("csvColumn metadata requires csvTable".to_string());
+        }
         if field.path.is_empty() || field.path.contains('.') {
             return Err(format!(
                 "CSV metadata path {} must name one flat column",
@@ -426,6 +449,170 @@ pub(crate) fn parse_flat_csv_binding(
         object.insert(field.path.clone(), value);
     }
     Ok(Value::Object(object))
+}
+
+pub(crate) fn parse_csv_table_binding(
+    source: &str,
+    fields: &[CsvBindingField],
+    table: &CsvTableMetadata,
+) -> Result<Value, String> {
+    if table.rows_path.is_empty()
+        || table.row_count_path.is_empty()
+        || table.rows_path.contains('.')
+        || table.row_count_path.contains('.')
+    {
+        return Err("CSV table rowsPath and rowCountPath must be flat properties".to_string());
+    }
+    if table.capacity == 0 {
+        return Err("CSV table capacity must be greater than zero".to_string());
+    }
+    if table.key_columns.is_empty() {
+        return Err("CSV table requires at least one stable key column".to_string());
+    }
+
+    let prefix = format!("{}.", table.rows_path);
+    let mut columns = BTreeMap::new();
+    for field in fields {
+        let suffix = field.path.strip_prefix(&prefix).ok_or_else(|| {
+            format!(
+                "CSV table target {} must be below rowsPath {}",
+                field.path, table.rows_path
+            )
+        })?;
+        if suffix.is_empty() {
+            return Err(format!("CSV table target {} has no row field", field.path));
+        }
+        if suffix.contains('.') {
+            return Err(format!(
+                "CSV table target {} must name one flat row field",
+                field.path
+            ));
+        }
+        if field.array_count != table.capacity {
+            return Err(format!(
+                "CSV table target {} capacity {} does not match table capacity {}",
+                field.path, field.array_count, table.capacity
+            ));
+        }
+        let column = csv_column_name(field);
+        if column.is_empty() || column.contains('.') {
+            return Err(format!("CSV table column {column} must be a flat header"));
+        }
+        if columns.insert(column.to_string(), field).is_some() {
+            return Err(format!("duplicate CSV table column {column}"));
+        }
+    }
+    let mut key_columns = BTreeSet::new();
+    for key in &table.key_columns {
+        if !key_columns.insert(key) {
+            return Err(format!("duplicate CSV table key column {key}"));
+        }
+        if !columns.contains_key(key) {
+            return Err(format!("CSV table key column {key} has no target field"));
+        }
+    }
+
+    let records = parse_csv_records(source)?;
+    let Some(headers) = records.first() else {
+        return Err("CSV table requires a header row".to_string());
+    };
+    let mut header_indices = BTreeMap::new();
+    for (index, raw_header) in headers.iter().enumerate() {
+        let header = if index == 0 {
+            raw_header.strip_prefix('\u{feff}').unwrap_or(raw_header)
+        } else {
+            raw_header
+        };
+        if header.is_empty() || header.contains('.') {
+            return Err(format!(
+                "CSV table header {header} must be flat and non-empty"
+            ));
+        }
+        if !columns.contains_key(header) {
+            return Err(format!(
+                "CSV column {header} does not exist in target metadata"
+            ));
+        }
+        if header_indices.insert(header.to_string(), index).is_some() {
+            return Err(format!("duplicate CSV header {header}"));
+        }
+    }
+    for column in columns.keys() {
+        if !header_indices.contains_key(column) {
+            return Err(format!("CSV is missing metadata column {column}"));
+        }
+    }
+
+    let data_rows = &records[1..];
+    if data_rows.len() > table.capacity {
+        return Err(format!(
+            "CSV table has {} rows; capacity is {}",
+            data_rows.len(),
+            table.capacity
+        ));
+    }
+    let mut stable_keys = BTreeSet::new();
+    for (row_index, row) in data_rows.iter().enumerate() {
+        if row.len() != headers.len() {
+            return Err(format!(
+                "CSV row {} has {} columns; expected {}",
+                row_index + 2,
+                row.len(),
+                headers.len()
+            ));
+        }
+        let mut parts = Vec::new();
+        for key in &table.key_columns {
+            let raw_value = &row[*header_indices.get(key).expect("key header validated")];
+            if raw_value.trim().is_empty() {
+                return Err(format!(
+                    "CSV table key column {key} is blank on row {}",
+                    row_index + 2
+                ));
+            }
+            let field = columns.get(key).expect("key target validated");
+            parts.push(parse_csv_cell(raw_value, field)?.to_string());
+        }
+        let stable_key = parts.join("\u{1f}");
+        if !stable_keys.insert(stable_key) {
+            return Err(format!("duplicate CSV table key on row {}", row_index + 2));
+        }
+    }
+
+    let mut rows = serde_json::Map::new();
+    for (column, field) in columns {
+        let column_index = *header_indices
+            .get(&column)
+            .expect("column header validated");
+        let mut values = data_rows
+            .iter()
+            .map(|row| parse_csv_cell(&row[column_index], field))
+            .collect::<Result<Vec<_>, _>>()?;
+        let default = match field.type_name.as_str() {
+            "bool" => Value::Bool(false),
+            "u8" | "u16" | "u32" | "i32" => Value::Number(0.into()),
+            "f32" | "f64" => serde_json::json!(0.0),
+            other => {
+                return Err(format!(
+                    "CSV table target {} has unsupported column type {other}",
+                    field.path
+                ));
+            }
+        };
+        values.resize(table.capacity, default);
+        let suffix = field
+            .path
+            .strip_prefix(&prefix)
+            .expect("field prefix validated");
+        rows.insert(suffix.to_string(), Value::Array(values));
+    }
+    let mut root = serde_json::Map::new();
+    root.insert(table.rows_path.clone(), Value::Object(rows));
+    root.insert(
+        table.row_count_path.clone(),
+        Value::Number((data_rows.len() as u64).into()),
+    );
+    Ok(Value::Object(root))
 }
 
 fn resolve_play_sidecar_path(path: &Path, launch_dir: &Path) -> PathBuf {
@@ -544,11 +731,14 @@ fn json_value_by_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
 }
 
 fn validate_play_binding_source(root: &Value, metadata: &PlayStructMetadata) -> Result<(), String> {
-    let paths: Vec<String> = metadata
+    let mut paths: Vec<String> = metadata
         .fields
         .iter()
         .map(|field| field.json_path.clone())
         .collect();
+    if let Some(table) = &metadata.csv_table {
+        paths.push(table.row_count_path.clone());
+    }
     validate_binding_source_paths(root, &paths)
 }
 
@@ -599,6 +789,54 @@ fn validate_play_binding_targets(
     metadata: &PlayStructMetadata,
     jit: &JitProcess,
 ) -> Result<(), String> {
+    if let Some(table) = &metadata.csv_table {
+        let collection_path = format!("{}.{}", metadata.global_name, table.rows_path);
+        let capacity = jit
+            .global_collection_capacity(&collection_path)
+            .ok_or_else(|| {
+                format!(
+                    "binding target property {collection_path} does not exist in compiled globals"
+                )
+            })?;
+        if usize::try_from(capacity).ok() != Some(table.capacity) {
+            return Err(format!(
+                "binding target collection {collection_path} has capacity {capacity}; metadata requires {}",
+                table.capacity
+            ));
+        }
+        let row_count_path = format!("{}.{}", metadata.global_name, table.row_count_path);
+        let row_count_type = jit.global_scalar_type(&row_count_path).ok_or_else(|| {
+            format!("binding target property {row_count_path} does not exist in compiled globals")
+        })?;
+        if row_count_type != "i32" {
+            return Err(format!(
+                "binding target property {row_count_path} has type {row_count_type}; CSV row count requires i32"
+            ));
+        }
+        let prefix = format!("{}.", table.rows_path);
+        for field in &metadata.fields {
+            let suffix = field.json_path.strip_prefix(&prefix).ok_or_else(|| {
+                format!(
+                    "CSV table target {} must be below rowsPath {}",
+                    field.json_path, table.rows_path
+                )
+            })?;
+            let target_type = jit
+                .global_collection_field_type(&collection_path, suffix)
+                .ok_or_else(|| {
+                    format!(
+                        "binding target property {collection_path}[].{suffix} does not exist in compiled globals"
+                    )
+                })?;
+            if target_type != field.type_name {
+                return Err(format!(
+                    "binding target property {collection_path}[].{suffix} has type {target_type}; metadata requires {}",
+                    field.type_name
+                ));
+            }
+        }
+        return Ok(());
+    }
     for field in &metadata.fields {
         let full_path = format!("{}.{}", metadata.global_name, field.json_path);
         if !jit.has_global_path(&full_path) {
@@ -607,6 +845,95 @@ fn validate_play_binding_targets(
             ));
         }
     }
+    Ok(())
+}
+
+fn apply_play_bound_table_array(
+    field: &PlayStructFieldMetadata,
+    collection_hash: i32,
+    field_hash: i32,
+    value: &Value,
+) {
+    let Some(items) = value.as_array() else {
+        return;
+    };
+    match field.type_name.as_str() {
+        "bool" | "u8" | "u16" | "u32" | "i32" => {
+            for (index, item) in items.iter().enumerate() {
+                let value = if field.type_name == "bool" {
+                    item.as_bool().map(|flag| i32::from(flag))
+                } else {
+                    item.as_i64().and_then(|number| i32::try_from(number).ok())
+                };
+                if let Some(value) = value {
+                    stasis_dynload::stasis_jit_global_i32_array_store(
+                        collection_hash,
+                        field_hash,
+                        index as i32,
+                        value,
+                    );
+                }
+            }
+        }
+        "f32" => {
+            for (index, item) in items.iter().enumerate() {
+                if let Some(value) = item.as_f64() {
+                    stasis_dynload::stasis_jit_global_f32_array_store(
+                        collection_hash,
+                        field_hash,
+                        index as i32,
+                        value as f32,
+                    );
+                }
+            }
+        }
+        "f64" => {
+            for (index, item) in items.iter().enumerate() {
+                if let Some(value) = item.as_f64() {
+                    stasis_dynload::stasis_jit_global_f64_array_store(
+                        collection_hash,
+                        field_hash,
+                        index as i32,
+                        value,
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn apply_play_csv_table_value(
+    root: &Value,
+    metadata: &PlayStructMetadata,
+    table: &CsvTableMetadata,
+) -> Result<(), String> {
+    let collection_path = format!("{}.{}", metadata.global_name, table.rows_path);
+    let collection_hash = hash_global_path(&collection_path);
+    let prefix = format!("{}.", table.rows_path);
+    for field in &metadata.fields {
+        let suffix = field.json_path.strip_prefix(&prefix).ok_or_else(|| {
+            format!(
+                "CSV table target {} must be below rowsPath {}",
+                field.json_path, table.rows_path
+            )
+        })?;
+        let value = json_value_by_path(root, &field.json_path)
+            .ok_or_else(|| format!("CSV table is missing target {}", field.json_path))?;
+        apply_play_bound_table_array(field, collection_hash, hash_global_path(suffix), value);
+    }
+    let row_count = json_value_by_path(root, &table.row_count_path)
+        .and_then(Value::as_u64)
+        .and_then(|value| i32::try_from(value).ok())
+        .ok_or_else(|| "CSV table row_count is invalid".to_string())?;
+    stasis_dynload::stasis_jit_collection_i32_store(collection_hash, 1, row_count);
+    stasis_dynload::stasis_jit_collection_i32_store(
+        collection_hash,
+        2,
+        i32::try_from(table.capacity).map_err(|_| "CSV table capacity exceeds i32".to_string())?,
+    );
+    let row_count_path = format!("{}.{}", metadata.global_name, table.row_count_path);
+    stasis_dynload::stasis_jit_global_i32_store(hash_global_path(&row_count_path), row_count);
     Ok(())
 }
 
@@ -774,6 +1101,10 @@ fn apply_play_data_binding_value(
         ));
     }
 
+    if let Some(table) = &metadata.csv_table {
+        return apply_play_csv_table_value(root, metadata, table);
+    }
+
     for field in &metadata.fields {
         let Some(value) = json_value_by_path(root, &field.json_path) else {
             continue;
@@ -819,14 +1150,26 @@ fn load_and_apply_play_data_bindings(
                 .iter()
                 .map(|field| CsvBindingField {
                     path: field.json_path.clone(),
+                    csv_column: field.csv_column.clone(),
                     type_name: field.type_name.clone(),
                     array_count: usize::try_from(field.array_count.max(0)).unwrap_or(0),
                 })
                 .collect();
-            parse_flat_csv_binding(&data_source, &fields).map_err(|error| {
+            let parsed = if let Some(table) = &metadata.csv_table {
+                parse_csv_table_binding(&data_source, &fields, table)
+            } else {
+                parse_flat_csv_binding(&data_source, &fields)
+            };
+            parsed.map_err(|error| {
                 format!("failed to parse data CSV {}: {error}", data_path.display())
             })?
         } else {
+            if metadata.csv_table.is_some() {
+                return Err(format!(
+                    "csvTable metadata requires a CSV data file: {}",
+                    data_path.display()
+                ));
+            }
             serde_json::from_str(&data_source).map_err(|error| {
                 format!("failed to parse data JSON {}: {error}", data_path.display())
             })?
@@ -3426,24 +3769,29 @@ mod tests {
         let metadata = PlayStructMetadata {
             version: 1,
             global_name: "state".to_string(),
+            csv_table: None,
             fields: vec![
                 PlayStructFieldMetadata {
                     json_path: "config.json_loaded".to_string(),
+                    csv_column: None,
                     type_name: "bool".to_string(),
                     array_count: 1,
                 },
                 PlayStructFieldMetadata {
                     json_path: "config.screen_width".to_string(),
+                    csv_column: None,
                     type_name: "i32".to_string(),
                     array_count: 1,
                 },
                 PlayStructFieldMetadata {
                     json_path: "config.background_red".to_string(),
+                    csv_column: None,
                     type_name: "f32".to_string(),
                     array_count: 1,
                 },
                 PlayStructFieldMetadata {
                     json_path: "config.font_path".to_string(),
+                    csv_column: None,
                     type_name: "string".to_string(),
                     array_count: 64,
                 },
@@ -3487,6 +3835,7 @@ mod tests {
         let metadata = PlayStructMetadata {
             version: 2,
             global_name: "state".to_string(),
+            csv_table: None,
             fields: Vec::new(),
         };
         let root = serde_json::json!({});
@@ -3503,11 +3852,13 @@ mod tests {
             &[
                 CsvBindingField {
                     path: "enabled".to_string(),
+                    csv_column: None,
                     type_name: "bool".to_string(),
                     array_count: 1,
                 },
                 CsvBindingField {
                     path: "label".to_string(),
+                    csv_column: None,
                     type_name: "string".to_string(),
                     array_count: 32,
                 },
@@ -3524,11 +3875,13 @@ mod tests {
             &[
                 CsvBindingField {
                     path: "hp".to_string(),
+                    csv_column: None,
                     type_name: "i32".to_string(),
                     array_count: 3,
                 },
                 CsvBindingField {
                     path: "speed".to_string(),
+                    csv_column: None,
                     type_name: "f32".to_string(),
                     array_count: 3,
                 },
@@ -3547,6 +3900,7 @@ mod tests {
             "screen_width\n800\n",
             &[CsvBindingField {
                 path: "config.screen_width".to_string(),
+                csv_column: None,
                 type_name: "i32".to_string(),
                 array_count: 1,
             }],
@@ -3561,6 +3915,7 @@ mod tests {
             "hp,typo\n70,99\n",
             &[CsvBindingField {
                 path: "hp".to_string(),
+                csv_column: None,
                 type_name: "i32".to_string(),
                 array_count: 1,
             }],
@@ -3570,12 +3925,105 @@ mod tests {
     }
 
     #[test]
+    fn parse_csv_table_binding_tracks_count_pads_capacity_and_validates_keys() {
+        let fields = vec![
+            CsvBindingField {
+                path: "rows.id".to_string(),
+                csv_column: Some("id".to_string()),
+                type_name: "i32".to_string(),
+                array_count: 4,
+            },
+            CsvBindingField {
+                path: "rows.hp".to_string(),
+                csv_column: Some("health".to_string()),
+                type_name: "i32".to_string(),
+                array_count: 4,
+            },
+        ];
+        let table = CsvTableMetadata {
+            rows_path: "rows".to_string(),
+            row_count_path: "row_count".to_string(),
+            capacity: 4,
+            key_columns: vec!["id".to_string()],
+        };
+        let parsed = parse_csv_table_binding("id,health\n10,70\n20,110\n", &fields, &table)
+            .expect("table should parse");
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "rows": {"id": [10, 20, 0, 0], "hp": [70, 110, 0, 0]},
+                "row_count": 2
+            })
+        );
+
+        let duplicate = parse_csv_table_binding("id,health\n10,70\n10,110\n", &fields, &table)
+            .expect_err("duplicate stable keys should fail");
+        assert!(duplicate.contains("duplicate CSV table key"));
+    }
+
+    #[test]
+    fn load_play_data_bindings_applies_struct_array_csv_table() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let collection_hash = hash_global_path("level.rows");
+        let mut ids = [99i32; 4];
+        let mut hp = [99i32; 4];
+        let mut row_count = 0i32;
+        stasis_dynload::register_global_i32_array(
+            collection_hash,
+            hash_global_path("id"),
+            ids.as_mut_ptr(),
+            ids.len(),
+        );
+        stasis_dynload::register_global_i32_array(
+            collection_hash,
+            hash_global_path("hp"),
+            hp.as_mut_ptr(),
+            hp.len(),
+        );
+        stasis_dynload::register_global_i32_ptr(
+            hash_global_path("level.row_count"),
+            &mut row_count,
+        );
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_play_bind_table_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let data_path = temp_root.join("waves.csv");
+        let meta_path = temp_root.join("waves.struct-meta.json");
+        fs::write(&data_path, "id,hp\n10,70\n20,110\n").expect("write CSV");
+        fs::write(
+            &meta_path,
+            r#"{"version":1,"globalName":"level","csvTable":{"rowsPath":"rows","rowCountPath":"row_count","capacity":4,"keyColumns":["id"]},"fields":[{"jsonPath":"rows.id","csvColumn":"id","type":"i32","arrayCount":4},{"jsonPath":"rows.hp","csvColumn":"hp","type":"i32","arrayCount":4}]}"#,
+        )
+        .expect("write metadata");
+
+        load_and_apply_play_data_bindings(&[(data_path, meta_path)], None)
+            .expect("CSV table binding should apply");
+        assert_eq!(ids, [10, 20, 0, 0]);
+        assert_eq!(hp, [70, 110, 0, 0]);
+        assert_eq!(row_count, 2);
+
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_global_table();
+        let _ = fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
     fn validate_play_binding_source_requires_an_exact_property_set() {
         let metadata = PlayStructMetadata {
             version: 1,
             global_name: "state".to_string(),
+            csv_table: None,
             fields: vec![PlayStructFieldMetadata {
                 json_path: "config.width".to_string(),
+                csv_column: None,
                 type_name: "i32".to_string(),
                 array_count: 1,
             }],
@@ -3601,8 +4049,10 @@ mod tests {
         let metadata = PlayStructMetadata {
             version: 1,
             global_name: "state".to_string(),
+            csv_table: None,
             fields: vec![PlayStructFieldMetadata {
                 json_path: "typo".to_string(),
+                csv_column: None,
                 type_name: "i32".to_string(),
                 array_count: 1,
             }],

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -337,6 +337,18 @@ pub(crate) fn parse_flat_csv_binding(
     source: &str,
     fields: &[CsvBindingField],
 ) -> Result<Value, String> {
+    let mut metadata_paths = BTreeSet::new();
+    for field in fields {
+        if field.path.is_empty() || field.path.contains('.') {
+            return Err(format!(
+                "CSV metadata path {} must name one flat column",
+                field.path
+            ));
+        }
+        if !metadata_paths.insert(field.path.as_str()) {
+            return Err(format!("duplicate CSV metadata path {}", field.path));
+        }
+    }
     let records = parse_csv_records(source)?;
     let Some(headers) = records.first() else {
         return Err("CSV data requires a header row".to_string());
@@ -359,6 +371,11 @@ pub(crate) fn parse_flat_csv_binding(
                 "CSV header {header} cannot contain nested path separators"
             ));
         }
+        if !metadata_paths.contains(header) {
+            return Err(format!(
+                "CSV column {header} does not exist in target metadata"
+            ));
+        }
         if header_indices.insert(header.to_string(), index).is_some() {
             return Err(format!("duplicate CSV header {header}"));
         }
@@ -377,12 +394,6 @@ pub(crate) fn parse_flat_csv_binding(
     let data_rows = &records[1..];
     let mut object = serde_json::Map::new();
     for field in fields {
-        if field.path.is_empty() || field.path.contains('.') {
-            return Err(format!(
-                "CSV metadata path {} must name one flat column",
-                field.path
-            ));
-        }
         let column = header_indices
             .get(&field.path)
             .copied()
@@ -530,6 +541,73 @@ fn json_value_by_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
         current = current.get(segment)?;
     }
     Some(current)
+}
+
+fn validate_play_binding_source(root: &Value, metadata: &PlayStructMetadata) -> Result<(), String> {
+    let paths: Vec<String> = metadata
+        .fields
+        .iter()
+        .map(|field| field.json_path.clone())
+        .collect();
+    validate_binding_source_paths(root, &paths)
+}
+
+pub(crate) fn validate_binding_source_paths(root: &Value, paths: &[String]) -> Result<(), String> {
+    let mut field_paths = BTreeSet::new();
+    for path in paths {
+        if path.is_empty() {
+            return Err("binding metadata paths must not be empty".to_string());
+        }
+        if !field_paths.insert(path.as_str()) {
+            return Err(format!("duplicate binding metadata path {path}"));
+        }
+        if json_value_by_path(root, path).is_none() {
+            return Err(format!("binding source is missing target property {path}"));
+        }
+    }
+
+    fn walk(value: &Value, path: &str, field_paths: &BTreeSet<&str>) -> Result<(), String> {
+        let Value::Object(properties) = value else {
+            return Ok(());
+        };
+        for (name, child) in properties {
+            let child_path = if path.is_empty() {
+                name.clone()
+            } else {
+                format!("{path}.{name}")
+            };
+            let exact = field_paths.contains(child_path.as_str());
+            let prefix = field_paths
+                .iter()
+                .any(|field| field.starts_with(&format!("{child_path}.")));
+            if !exact && !prefix {
+                return Err(format!(
+                    "binding source property {child_path} does not exist in target metadata"
+                ));
+            }
+            if prefix {
+                walk(child, &child_path, field_paths)?;
+            }
+        }
+        Ok(())
+    }
+
+    walk(root, "", &field_paths)
+}
+
+fn validate_play_binding_targets(
+    metadata: &PlayStructMetadata,
+    jit: &JitProcess,
+) -> Result<(), String> {
+    for field in &metadata.fields {
+        let full_path = format!("{}.{}", metadata.global_name, field.json_path);
+        if !jit.has_global_path(&full_path) {
+            return Err(format!(
+                "binding target property {full_path} does not exist in compiled globals"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn truncate_utf8_to_capacity(value: &str, max_bytes: usize) -> (Vec<u8>, i32) {
@@ -711,7 +789,10 @@ fn apply_play_data_binding_value(
     Ok(())
 }
 
-fn load_and_apply_play_data_bindings(paths: &[(PathBuf, PathBuf)]) -> Result<(), String> {
+fn load_and_apply_play_data_bindings(
+    paths: &[(PathBuf, PathBuf)],
+    jit: Option<&JitProcess>,
+) -> Result<(), String> {
     let mut loaded = Vec::new();
     for (data_path, meta_path) in paths {
         let meta_source = fs::read_to_string(meta_path).map_err(|error| {
@@ -758,6 +839,12 @@ fn load_and_apply_play_data_bindings(paths: &[(PathBuf, PathBuf)]) -> Result<(),
                 "unsupported struct-meta version {}; expected 1",
                 metadata.version
             ));
+        }
+    }
+    for (data_root, metadata) in &loaded {
+        validate_play_binding_source(data_root, metadata)?;
+        if let Some(jit) = jit {
+            validate_play_binding_targets(metadata, jit)?;
         }
     }
     for (json_root, metadata) in loaded {
@@ -1274,7 +1361,7 @@ fn run_play_in_process_inner(
     let _ = jit
         .compile()
         .map_err(|error| format!("initial JIT compile failed: {error:?}"))?;
-    load_and_apply_play_data_bindings(&data_binding_paths)?;
+    load_and_apply_play_data_bindings(&data_binding_paths, Some(&jit))?;
     let package = jit
         .build_engine_package(&EngineEntrypoints::runtime_default())
         .map_err(|error| format!("failed to build engine package: {error}"))?;
@@ -1362,7 +1449,7 @@ fn run_play_in_process_inner(
             }
         }
         if needs_data_reload {
-            match load_and_apply_play_data_bindings(&data_binding_paths) {
+            match load_and_apply_play_data_bindings(&data_binding_paths, Some(&jit)) {
                 Ok(()) => println!("[data] rebound {} file(s)", data_binding_paths.len()),
                 Err(error) => println!("[data] reload rejected: {error}"),
             }
@@ -3469,6 +3556,63 @@ mod tests {
     }
 
     #[test]
+    fn parse_flat_csv_binding_rejects_columns_missing_from_target_metadata() {
+        let error = parse_flat_csv_binding(
+            "hp,typo\n70,99\n",
+            &[CsvBindingField {
+                path: "hp".to_string(),
+                type_name: "i32".to_string(),
+                array_count: 1,
+            }],
+        )
+        .expect_err("extra CSV columns should fail");
+        assert!(error.contains("column typo does not exist in target metadata"));
+    }
+
+    #[test]
+    fn validate_play_binding_source_requires_an_exact_property_set() {
+        let metadata = PlayStructMetadata {
+            version: 1,
+            global_name: "state".to_string(),
+            fields: vec![PlayStructFieldMetadata {
+                json_path: "config.width".to_string(),
+                type_name: "i32".to_string(),
+                array_count: 1,
+            }],
+        };
+        validate_play_binding_source(&serde_json::json!({"config": {"width": 800}}), &metadata)
+            .expect("exact JSON properties should pass");
+
+        let extra = validate_play_binding_source(
+            &serde_json::json!({"config": {"width": 800, "widht": 600}}),
+            &metadata,
+        )
+        .expect_err("extra JSON properties should fail");
+        assert!(extra.contains("config.widht does not exist in target metadata"));
+
+        let missing = validate_play_binding_source(&serde_json::json!({"config": {}}), &metadata)
+            .expect_err("missing JSON properties should fail");
+        assert!(missing.contains("missing target property config.width"));
+    }
+
+    #[test]
+    fn validate_play_binding_targets_rejects_missing_compiled_global() {
+        let jit = JitProcess::new();
+        let metadata = PlayStructMetadata {
+            version: 1,
+            global_name: "state".to_string(),
+            fields: vec![PlayStructFieldMetadata {
+                json_path: "typo".to_string(),
+                type_name: "i32".to_string(),
+                array_count: 1,
+            }],
+        };
+        let error = validate_play_binding_targets(&metadata, &jit)
+            .expect_err("missing runtime targets should fail");
+        assert!(error.contains("state.typo does not exist in compiled globals"));
+    }
+
+    #[test]
     fn load_play_data_bindings_applies_columnar_csv_arrays() {
         let _global_lock = jit_global_table_lock()
             .lock()
@@ -3498,7 +3642,7 @@ mod tests {
         )
         .expect("write metadata");
 
-        load_and_apply_play_data_bindings(&[(data_path, meta_path)])
+        load_and_apply_play_data_bindings(&[(data_path, meta_path)], None)
             .expect("CSV binding should apply");
         assert_eq!(hp, [70, 110, 85]);
 
@@ -3540,10 +3684,10 @@ mod tests {
         )
         .expect("write second metadata");
 
-        let error = load_and_apply_play_data_bindings(&[
-            (first_json, first_meta),
-            (second_json, second_meta),
-        ])
+        let error = load_and_apply_play_data_bindings(
+            &[(first_json, first_meta), (second_json, second_meta)],
+            None,
+        )
         .expect_err("invalid set should be rejected");
         assert!(error.contains("failed to parse data JSON"));
         assert_eq!(

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -564,7 +564,7 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         if arg == "--data-bind" {
             if i + 2 >= args.len() {
                 return Err(
-                    "missing values for --data-bind <json_path> <struct_meta_path>".to_string(),
+                    "missing values for --data-bind <data_path> <struct_meta_path>".to_string(),
                 );
             }
             data_bind_json = Some(PathBuf::from(args[i + 1].clone()));

--- a/apps/stasis/src/watch.rs
+++ b/apps/stasis/src/watch.rs
@@ -50,7 +50,7 @@ fn map_notify_event(event: Event, next_revision: &mut u64) -> Vec<FileChangeEven
 
     let mut out = Vec::new();
     for path in event.paths {
-        if is_stasis_path(&path) {
+        if is_watchable_path(&path) {
             let revision = *next_revision;
             *next_revision = revision.saturating_add(1);
             out.push(FileChangeEvent::new(
@@ -73,9 +73,9 @@ fn map_event_kind(kind: &EventKind) -> Option<FileChangeKind> {
     }
 }
 
-fn is_stasis_path(path: &Path) -> bool {
+fn is_watchable_path(path: &Path) -> bool {
     path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("stasis"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("stasis") || ext.eq_ignore_ascii_case("json"))
 }
 
 #[cfg(test)]
@@ -85,12 +85,16 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn maps_create_modify_remove_and_filters_non_stasis() {
+    fn maps_create_modify_remove_and_filters_unwatched_extensions() {
         let mut revision = 10;
 
         let create = Event {
             kind: EventKind::Create(CreateKind::File),
-            paths: vec![PathBuf::from("a.stasis"), PathBuf::from("note.txt")],
+            paths: vec![
+                PathBuf::from("a.stasis"),
+                PathBuf::from("data.json"),
+                PathBuf::from("note.txt"),
+            ],
             attrs: Default::default(),
         };
         let modify = Event {
@@ -108,17 +112,17 @@ mod tests {
         let modify_events = map_notify_event(modify, &mut revision);
         let remove_events = map_notify_event(remove, &mut revision);
 
-        assert_eq!(create_events.len(), 1);
+        assert_eq!(create_events.len(), 2);
         assert_eq!(create_events[0].change_kind, FileChangeKind::Created);
         assert_eq!(create_events[0].revision, 10);
 
         assert_eq!(modify_events.len(), 1);
         assert_eq!(modify_events[0].change_kind, FileChangeKind::Modified);
-        assert_eq!(modify_events[0].revision, 11);
+        assert_eq!(modify_events[0].revision, 12);
 
         assert_eq!(remove_events.len(), 1);
         assert_eq!(remove_events[0].change_kind, FileChangeKind::Deleted);
-        assert_eq!(remove_events[0].revision, 12);
+        assert_eq!(remove_events[0].revision, 13);
     }
 
     #[test]

--- a/apps/stasis/src/watch.rs
+++ b/apps/stasis/src/watch.rs
@@ -74,8 +74,11 @@ fn map_event_kind(kind: &EventKind) -> Option<FileChangeKind> {
 }
 
 fn is_watchable_path(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("stasis") || ext.eq_ignore_ascii_case("json"))
+    path.extension().is_some_and(|ext| {
+        ext.eq_ignore_ascii_case("stasis")
+            || ext.eq_ignore_ascii_case("json")
+            || ext.eq_ignore_ascii_case("csv")
+    })
 }
 
 #[cfg(test)]
@@ -93,6 +96,7 @@ mod tests {
             paths: vec![
                 PathBuf::from("a.stasis"),
                 PathBuf::from("data.json"),
+                PathBuf::from("data.csv"),
                 PathBuf::from("note.txt"),
             ],
             attrs: Default::default(),
@@ -112,17 +116,17 @@ mod tests {
         let modify_events = map_notify_event(modify, &mut revision);
         let remove_events = map_notify_event(remove, &mut revision);
 
-        assert_eq!(create_events.len(), 2);
+        assert_eq!(create_events.len(), 3);
         assert_eq!(create_events[0].change_kind, FileChangeKind::Created);
         assert_eq!(create_events[0].revision, 10);
 
         assert_eq!(modify_events.len(), 1);
         assert_eq!(modify_events[0].change_kind, FileChangeKind::Modified);
-        assert_eq!(modify_events[0].revision, 12);
+        assert_eq!(modify_events[0].revision, 13);
 
         assert_eq!(remove_events.len(), 1);
         assert_eq!(remove_events[0].change_kind, FileChangeKind::Deleted);
-        assert_eq!(remove_events[0].revision, 13);
+        assert_eq!(remove_events[0].revision, 14);
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -384,6 +384,34 @@ impl JitProcess {
             .is_some_and(|analysis| analysis.global_path_types.contains_key(path))
     }
 
+    pub fn global_scalar_type(&self, path: &str) -> Option<&'static str> {
+        let type_id = self
+            .compile_analysis_cache
+            .as_ref()?
+            .global_path_types
+            .get(path)?;
+        scalar_type_name(*type_id)
+    }
+
+    pub fn global_collection_capacity(&self, path: &str) -> Option<i32> {
+        self.compile_analysis_cache
+            .as_ref()?
+            .collection_infos
+            .get(path)
+            .map(|info| info.len)
+    }
+
+    pub fn global_collection_field_type(&self, path: &str, field: &str) -> Option<&'static str> {
+        let type_id = self
+            .compile_analysis_cache
+            .as_ref()?
+            .collection_infos
+            .get(path)?
+            .field_types
+            .get(field)?;
+        scalar_type_name(*type_id)
+    }
+
     pub fn global_scalar_paths(&self) -> Vec<(String, &'static str)> {
         let Some(analysis) = self.compile_analysis_cache.as_ref() else {
             return Vec::new();

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -207,7 +207,7 @@ Examples:
 
 - Editable runtime data lives under the project-level `data/` directory.
 - Every JSON or CSV file has a same-name `.struct-meta.json` mapping and is discovered automatically; ordinary development does not require binding flags or project-specific loader code.
-- JSON may map nested properties. CSV mappings are flat and bind columns to scalar fields or primitive arrays.
+- JSON may map nested properties. CSV headers are flat and bind either scalar/primitive-array data or variable rows into a fixed-capacity struct array. Table mappings automatically expose `row_count`, clear unused slots, and validate non-blank unique key columns (including composite keys).
 - Binding rejects extra source properties/columns, missing metadata paths, duplicate mappings, and paths absent from compiled globals before mutating runtime data.
 - Development watches both files and applies a validated set between ticks. Rejected edits preserve the last accepted runtime data.
 - Production AOT packages stage the same data and compile its accepted values into the runtime bridge, so startup never depends on loose development files.

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -206,7 +206,8 @@ Examples:
 ### First-Class Project Data
 
 - Editable runtime data lives under the project-level `data/` directory.
-- Every JSON file has a same-name `.struct-meta.json` mapping and is discovered automatically; ordinary development does not require binding flags or project-specific loader code.
+- Every JSON or CSV file has a same-name `.struct-meta.json` mapping and is discovered automatically; ordinary development does not require binding flags or project-specific loader code.
+- JSON may map nested properties. CSV mappings are flat and bind columns to scalar fields or primitive arrays.
 - Development watches both files and applies a validated set between ticks. Rejected edits preserve the last accepted runtime data.
 - Production AOT packages stage the same data and compile its accepted values into the runtime bridge, so startup never depends on loose development files.
 - The JIT and AOT paths use the same global names, field types, array bounds, and JSON-path mapping.

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -203,6 +203,15 @@ Examples:
 - rendering commands
 - audio events
 
+### First-Class Project Data
+
+- Editable runtime data lives under the project-level `data/` directory.
+- Every JSON file has a same-name `.struct-meta.json` mapping and is discovered automatically; ordinary development does not require binding flags or project-specific loader code.
+- Development watches both files and applies a validated set between ticks. Rejected edits preserve the last accepted runtime data.
+- Production AOT packages stage the same data and compile its accepted values into the runtime bridge, so startup never depends on loose development files.
+- The JIT and AOT paths use the same global names, field types, array bounds, and JSON-path mapping.
+- Explicit binding paths are compatibility overrides, not the standard project workflow.
+
 ### First-Class Sprite and Audio Assets
 
 Sprite and audio support is a cross-platform runtime contract, not an editor-only feature.
@@ -495,4 +504,3 @@ This system is intentionally:
 - developer-trust-focused
 
 It provides a robust, file-level hot reload pipeline with per-function efficiency, an explicit swap hook, and a deterministic tick-based UI confirmation mechanism.
-

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -208,6 +208,7 @@ Examples:
 - Editable runtime data lives under the project-level `data/` directory.
 - Every JSON or CSV file has a same-name `.struct-meta.json` mapping and is discovered automatically; ordinary development does not require binding flags or project-specific loader code.
 - JSON may map nested properties. CSV mappings are flat and bind columns to scalar fields or primitive arrays.
+- Binding rejects extra source properties/columns, missing metadata paths, duplicate mappings, and paths absent from compiled globals before mutating runtime data.
 - Development watches both files and applies a validated set between ticks. Rejected edits preserve the last accepted runtime data.
 - Production AOT packages stage the same data and compile its accepted values into the runtime bridge, so startup never depends on loose development files.
 - The JIT and AOT paths use the same global names, field types, array bounds, and JSON-path mapping.

--- a/samples/bucket_catcher.stasis
+++ b/samples/bucket_catcher.stasis
@@ -14,15 +14,13 @@ import "../src/stdlib/sdl_scancodes.stasis";
 // - Use SVG sprites for the bucket/ball to show asset binding.
 //
 // Config binding:
-// - A JSON file at samples/bucket_catcher/data/config.json can populate state.config.
-// - The runtime runner auto-binds matching sidecars from bucket_catcher/data/.
-// - Use --data-bind only to override the default sidecar paths.
+// - A JSON file at samples/bucket_catcher/data/config.json populates state.config.
+// - The runtime auto-binds and watches matching files under data/.
+// - Project data is also embedded when the sample is built AOT.
 // - We require JSON binding; json_loaded must be true.
 // - json_loaded stays false unless the JSON file explicitly sets it to true.
 // - Example (auto-discovery):
 //   stasis.exe play samples/bucket_catcher.stasis --watch-dir samples
-// - Example (explicit override):
-//   stasis.exe play samples/bucket_catcher.stasis --watch-dir samples --data-bind samples/bucket_catcher/data/config.json samples/bucket_catcher/data/config.struct-meta.json
 
 const MAX_BALLS: i32 = 500;
 


### PR DESCRIPTION
## What changed

- Discover every paired `data/**/*.{json,csv}` and same-stem `.struct-meta.json` file automatically during `stasis play`.
- Watch JSON, CSV, and metadata files and atomically rebind accepted edits between ticks.
- Bind flat CSV scalars/primitive arrays and first-class CSV tables into fixed-capacity struct arrays.
- CSV tables accept variable row counts up to capacity, maintain a configured `row_count` target automatically, zero unused slots, and require non-blank unique stable keys (including composite keys).
- Map CSV headers to flat struct fields with optional `csvColumn` aliases, while using the existing collection-path/field-hash ABI in both JIT and AOT.
- Enforce an exact schema: reject extra JSON properties/CSV columns, missing or duplicate mappings, over-capacity tables, blank/duplicate keys, mismatched capacities/types, nonexistent compiled table fields, and JSON/CSV stem collisions.
- Stage JSON and CSV data for AOT and initialize generated runtime-bridge globals from the same accepted values.
- Keep the legacy entry-specific directory and explicit `--data-bind` pair as compatibility paths.
- Document project data as a first-class JIT/AOT convention.

## Why

Projects should treat `data/` as editable input without repeating paths in commands or writing project-specific loaders. JSON covers nested configuration. CSV should be comfortable for level and balance design: designers can add or remove rows without resizing source arrays, while stable keys and strict column validation catch accidental data drift.

## Validation

- `cargo check -p stasis --release --no-default-features`
- `cargo check -p stasis --tests --no-default-features` (compiled all test targets; Windows denied cleanup of some incremental-cache working directories, but the check completed)
- deterministic tests added for variable row counts, capacity padding, duplicate keys, struct-array JIT application, and AOT field-hash registration/initializers
- previously completed focused discovery, JSON/CSV parsing, exact-property validation, runtime-target validation, atomic rejection, watcher, live binding, AOT staging/initializer, CLI, and bridge-object tests
- real CSV runner smoke automatically loaded `70`, then emitted `[data] rebound 1 file(s)` after an edit
- Chess TD: formatter/checker pass and all 59 tests pass on pinned nightly 20260719-131
- `git diff --check`

Windows Device Guard blocked a later repeated launch of the Rust test harness. Further local Rust test execution was stopped rather than bypassing security policy. New CSV-table tests were compiled but not launched; release compilation remains green.

The earlier broad `cargo test -p stasis --lib --no-default-features` run was also not green in this worktree: 164 passed, 11 failed, and 6 were ignored. Those failures include shared JIT/global-state tests, signer-environment tests, a repository-path assertion requiring `/StasisLang`, and an existing Brickout JIT fixture failure. This PR remains draft while the broader gate is separated from this slice.

## Slice reflection

- Good: CSV now has a level-design-friendly table contract without adding a second runtime representation; JIT and AOT both use the existing struct-array ABI.
- Bad: exact-length parallel arrays forced designers to edit source/metadata for ordinary row-count changes, and array-level target checks could not detect misspelled struct fields.
- Adjustment: declare table capacity once, derive logical row count from accepted rows, validate stable keys and every compiled row-field name/type before mutation, and pad unused AOT/JIT slots deterministically.