### PR TITLE
feat: add layout-aware hot reload migrations

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use stasis_compiler::backend::aot::{AotEngineBundle, AotProcess};
 use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess};
+use stasis_compiler::backend::state_layout::StateLayout;
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
-use stasis_compiler::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
+use stasis_compiler::frontend::parser::parse_top_level_functions;
 #[cfg(test)]
 use stasis_compiler::{SimpleI32Condition, SimpleI32ReturnExpr};
 use stasis_jit::{
@@ -11,12 +12,18 @@ use stasis_jit::{
 };
 use stasis_runner::swap::contracts::{
     AotFunctionSymbol, CompileRequest, CompileResult, Diagnostic, DiagnosticSeverity, FnId,
-    FunctionPatch, FunctionPatchSet, JitCodePtrOverride, LayoutHash, StateMapEntry, TargetMode,
+    FunctionPatch, FunctionPatchSet, JitCodePtrOverride, LayoutHash, RequestId, TargetMode,
 };
 use stasis_runner::swap::pipeline::CompilerBackend;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::SyncSender;
+
+pub(crate) struct PreparedJitSwap {
+    pub(crate) request_id: stasis_runner::swap::contracts::RequestId,
+    pub(crate) candidate: JitProcess,
+}
 
 pub struct IncrementalCompilerBackend {
     source_by_path: BTreeMap<String, String>,
@@ -30,6 +37,9 @@ pub struct IncrementalCompilerBackend {
     enable_aot_link_step: bool,
     last_jit_engine_package: Option<JitEnginePackage>,
     last_aot_engine_bundle: Option<AotEngineBundle>,
+    prepared_jit_swap_tx: Option<SyncSender<PreparedJitSwap>>,
+    pending_jit_candidate: Option<JitProcess>,
+    last_state_layout: Option<StateLayout>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -72,12 +82,6 @@ struct SelfHostObjectBundle {
 struct EngineFunctionEntry {
     path: String,
     name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct StructFieldType {
-    field_name: String,
-    type_name: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -213,7 +217,18 @@ impl IncrementalCompilerBackend {
                 .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true")),
             last_jit_engine_package: None,
             last_aot_engine_bundle: None,
+            prepared_jit_swap_tx: None,
+            pending_jit_candidate: None,
+            last_state_layout: None,
         }
+    }
+
+    pub(crate) fn new_with_prepared_jit_swaps(
+        prepared_jit_swap_tx: SyncSender<PreparedJitSwap>,
+    ) -> Self {
+        let mut backend = Self::new();
+        backend.prepared_jit_swap_tx = Some(prepared_jit_swap_tx);
+        backend
     }
 
     pub fn new_self_host_aot_cli(aot_artifact_root: PathBuf) -> Self {
@@ -244,6 +259,9 @@ impl IncrementalCompilerBackend {
             enable_aot_link_step: false,
             last_jit_engine_package: None,
             last_aot_engine_bundle: None,
+            prepared_jit_swap_tx: None,
+            pending_jit_candidate: None,
+            last_state_layout: None,
         }
     }
 
@@ -266,6 +284,9 @@ impl IncrementalCompilerBackend {
             enable_aot_link_step,
             last_jit_engine_package: None,
             last_aot_engine_bundle: None,
+            prepared_jit_swap_tx: None,
+            pending_jit_candidate: None,
+            last_state_layout: None,
         }
     }
 
@@ -291,8 +312,34 @@ impl Default for IncrementalCompilerBackend {
 
 impl CompilerBackend for IncrementalCompilerBackend {
     fn compile(&mut self, request: CompileRequest) -> CompileResult {
+        let request_id = request.request_id;
+        let mut result = self.compile_request(request);
+        if result.status == stasis_runner::swap::contracts::CompileStatus::Success {
+            if let Err(message) = self.publish_prepared_jit_candidate(request_id) {
+                result = CompileResult::failed(
+                    request_id,
+                    vec![Diagnostic {
+                        severity: DiagnosticSeverity::Error,
+                        message,
+                        path: None,
+                        line: None,
+                        column: None,
+                    }],
+                );
+            }
+        } else {
+            self.pending_jit_candidate = None;
+        }
+        result
+    }
+}
+
+impl IncrementalCompilerBackend {
+    fn compile_request(&mut self, request: CompileRequest) -> CompileResult {
         self.last_jit_engine_package = None;
         self.last_aot_engine_bundle = None;
+        self.pending_jit_candidate = None;
+        self.last_state_layout = None;
         let source_delta = match self.refresh_cached_sources(&request.changed_files) {
             Ok(delta) => delta,
             Err(message) => {
@@ -640,7 +687,7 @@ impl IncrementalCompilerBackend {
 
         let mut result = CompileResult::success_with_host_set_metadata(
             request.request_id,
-            self.layout_hash_from_source_cache(),
+            self.layout_hash_from_state_layout(),
             FunctionPatchSet { functions },
             request.host_set_id.clone(),
             request.host_set_hash,
@@ -652,22 +699,6 @@ impl IncrementalCompilerBackend {
             aot_function_symbols,
         );
         result.jit_code_ptr_overrides = jit_code_ptr_overrides;
-        let state_map = match self.state_map_from_source_cache() {
-            Ok(map) => map,
-            Err(message) => {
-                return CompileResult::failed(
-                    request.request_id,
-                    vec![Diagnostic {
-                        severity: DiagnosticSeverity::Error,
-                        message,
-                        path: request.changed_files.first().cloned(),
-                        line: None,
-                        column: None,
-                    }],
-                );
-            }
-        };
-        result.state_map = Some(state_map);
         result
     }
 
@@ -727,7 +758,7 @@ impl IncrementalCompilerBackend {
 
         let mut result = CompileResult::success_with_host_set_metadata(
             request.request_id,
-            self.layout_hash_from_source_cache(),
+            self.layout_hash_from_state_layout(),
             FunctionPatchSet { functions },
             request.host_set_id.clone(),
             request.host_set_hash,
@@ -739,7 +770,6 @@ impl IncrementalCompilerBackend {
             None,
         );
         result.jit_code_ptr_overrides = Some(jit_code_ptr_overrides);
-        result.state_map = Some(self.state_map_from_source_cache()?);
         Ok(result)
     }
 
@@ -784,9 +814,9 @@ impl IncrementalCompilerBackend {
             );
         }
 
-        let mut result = CompileResult::success_with_host_set_metadata(
+        let result = CompileResult::success_with_host_set_metadata(
             request.request_id,
-            self.layout_hash_from_source_cache(),
+            self.layout_hash_from_state_layout(),
             FunctionPatchSet { functions },
             request.host_set_id.clone(),
             request.host_set_hash,
@@ -797,7 +827,6 @@ impl IncrementalCompilerBackend {
             compile.linked_image_sha256,
             Some(aot_function_symbols),
         );
-        result.state_map = Some(self.state_map_from_source_cache()?);
         Ok(result)
     }
 
@@ -847,6 +876,28 @@ impl IncrementalCompilerBackend {
         }
     }
 
+    fn publish_prepared_jit_candidate(&mut self, request_id: RequestId) -> Result<(), String> {
+        let Some(candidate) = self.pending_jit_candidate.take() else {
+            return Ok(());
+        };
+        let Some(sender) = self.prepared_jit_swap_tx.as_ref() else {
+            self.jit_process = candidate;
+            return Ok(());
+        };
+        self.jit_process = candidate.staged_candidate();
+        sender
+            .send(PreparedJitSwap {
+                request_id,
+                candidate,
+            })
+            .map_err(|_| {
+                format!(
+                    "failed publishing staged JIT candidate for request {}",
+                    request_id.0
+                )
+            })
+    }
+
     fn source_cache_has_function(&self, function_name: &str) -> bool {
         let needle = format!("function {function_name}(");
         self.source_by_path
@@ -891,113 +942,19 @@ impl IncrementalCompilerBackend {
         })
     }
 
-    fn layout_hash_from_source_cache(&self) -> LayoutHash {
+    fn layout_hash_from_state_layout(&self) -> LayoutHash {
+        let serialized = serde_json::to_vec(
+            self.last_state_layout
+                .as_ref()
+                .expect("successful compiler result must have canonical state layout"),
+        )
+        .expect("canonical state layout serialization is infallible");
         let mut hasher = Sha256::new();
-        for (path, source) in &self.source_by_path {
-            hasher.update(path.as_bytes());
-            hasher.update([0u8]);
-            hasher.update(source.as_bytes());
-            hasher.update([0xffu8]);
-        }
+        hasher.update(serialized);
         let digest = hasher.finalize();
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(&digest);
         LayoutHash(bytes)
-    }
-
-    fn state_map_from_source_cache(&self) -> Result<Vec<StateMapEntry>, String> {
-        let mut struct_fields_by_name: BTreeMap<String, Vec<StructFieldType>> = BTreeMap::new();
-        for (path, source) in &self.source_by_path {
-            let parsed = parse_top_level_type_layout(source).map_err(|error| {
-                format!(
-                    "failed parsing top-level type layout in {} for state map extraction: {error}",
-                    path
-                )
-            })?;
-            for struct_def in parsed.structs {
-                let mut fields = Vec::new();
-                for field in struct_def.fields {
-                    fields.push(StructFieldType {
-                        field_name: field.name,
-                        type_name: field.type_name,
-                    });
-                }
-                struct_fields_by_name.insert(struct_def.name, fields);
-            }
-        }
-
-        let mut leaf_by_path: BTreeMap<String, StateMapEntry> = BTreeMap::new();
-        for (path, source) in &self.source_by_path {
-            let parsed = parse_top_level_type_layout(source).map_err(|error| {
-                format!(
-                    "failed parsing top-level type layout in {} for state map extraction: {error}",
-                    path
-                )
-            })?;
-            for global in parsed.globals {
-                Self::collect_state_map_leaf_entries(
-                    &global.name,
-                    &global.type_name,
-                    &struct_fields_by_name,
-                    &mut Vec::new(),
-                    &mut leaf_by_path,
-                )?;
-            }
-            for block in parsed.global_blocks {
-                for field in block.fields {
-                    let field_path = format!("{}.{}", block.name, field.name);
-                    Self::collect_state_map_leaf_entries(
-                        &field_path,
-                        &field.type_name,
-                        &struct_fields_by_name,
-                        &mut Vec::new(),
-                        &mut leaf_by_path,
-                    )?;
-                }
-            }
-        }
-
-        Ok(leaf_by_path.into_values().collect())
-    }
-
-    fn collect_state_map_leaf_entries(
-        path: &str,
-        type_name: &str,
-        struct_fields_by_name: &BTreeMap<String, Vec<StructFieldType>>,
-        struct_stack: &mut Vec<String>,
-        leaf_by_path: &mut BTreeMap<String, StateMapEntry>,
-    ) -> Result<(), String> {
-        if let Some(fields) = struct_fields_by_name.get(type_name) {
-            if struct_stack.iter().any(|name| name == type_name) {
-                return Err(format!(
-                    "state-map extraction rejected recursive struct '{}' in path '{}'",
-                    type_name, path
-                ));
-            }
-            struct_stack.push(type_name.to_string());
-            for field in fields {
-                let child_path = format!("{}.{}", path, field.field_name);
-                Self::collect_state_map_leaf_entries(
-                    &child_path,
-                    &field.type_name,
-                    struct_fields_by_name,
-                    struct_stack,
-                    leaf_by_path,
-                )?;
-            }
-            struct_stack.pop();
-            return Ok(());
-        }
-
-        leaf_by_path.insert(
-            path.to_string(),
-            StateMapEntry {
-                path: path.to_string(),
-                path_hash: crate::hash_global_path(path),
-                type_name: type_name.to_string(),
-            },
-        );
-        Ok(())
     }
 
     fn compile_jit_engine_package_from_cache(
@@ -1006,15 +963,24 @@ impl IncrementalCompilerBackend {
         source_delta: &SourceCacheDelta,
     ) -> Result<(), String> {
         self.sync_jit_process_sources(source_delta);
-        self.jit_process
-            .compile()
-            .map_err(|error| format!("rust-native JIT engine compile failed: {error:?}"))?;
-        self.jit_process.validate_on_code_swap_signature()?;
-        let package = self
-            .jit_process
+        let mut candidate = if self.prepared_jit_swap_tx.is_some() {
+            self.jit_process.staged_candidate()
+        } else {
+            std::mem::take(&mut self.jit_process)
+        };
+        if let Err(error) = candidate.compile_staged() {
+            if self.prepared_jit_swap_tx.is_none() {
+                self.jit_process = candidate;
+            }
+            return Err(format!("rust-native JIT engine compile failed: {error:?}"));
+        }
+        candidate.validate_on_code_swap_signature()?;
+        let package = candidate
             .build_engine_package(&Self::engine_entrypoints(include_on_code_swap))
             .map_err(|error| format!("failed to build JIT engine package: {error}"))?;
+        self.last_state_layout = Some(candidate.state_layout());
         self.last_jit_engine_package = Some(package);
+        self.pending_jit_candidate = Some(candidate);
         Ok(())
     }
 
@@ -1023,11 +989,22 @@ impl IncrementalCompilerBackend {
         source_delta: &SourceCacheDelta,
     ) -> Result<BTreeMap<String, u64>, String> {
         self.sync_jit_process_sources(source_delta);
-        self.jit_process
-            .compile()
-            .map_err(|error| format!("rust-native JIT compile failed: {error:?}"))?;
-        self.jit_process.validate_on_code_swap_signature()?;
-        Ok(self.jit_process.symbol_code_ptrs())
+        let mut candidate = if self.prepared_jit_swap_tx.is_some() {
+            self.jit_process.staged_candidate()
+        } else {
+            std::mem::take(&mut self.jit_process)
+        };
+        if let Err(error) = candidate.compile_staged() {
+            if self.prepared_jit_swap_tx.is_none() {
+                self.jit_process = candidate;
+            }
+            return Err(format!("rust-native JIT compile failed: {error:?}"));
+        }
+        candidate.validate_on_code_swap_signature()?;
+        let symbol_code_ptrs = candidate.symbol_code_ptrs();
+        self.last_state_layout = Some(candidate.state_layout());
+        self.pending_jit_candidate = Some(candidate);
+        Ok(symbol_code_ptrs)
     }
 
     fn compile_aot_engine_bundle_from_cache(
@@ -1036,6 +1013,7 @@ impl IncrementalCompilerBackend {
         include_on_code_swap: bool,
     ) -> Result<AotEngineBundle, String> {
         let process = self.compile_aot_process_from_source_cache()?;
+        self.last_state_layout = Some(process.state_layout());
 
         let bundle_output_dir = self
             .aot_artifact_root
@@ -1073,10 +1051,11 @@ impl IncrementalCompilerBackend {
     }
 
     fn compile_aot_non_engine_artifacts_from_cache(
-        &self,
+        &mut self,
         request_id: u64,
     ) -> Result<DirectAotArtifactBundle, String> {
         let process = self.compile_aot_process_from_source_cache()?;
+        self.last_state_layout = Some(process.state_layout());
         let output_dir = self
             .aot_artifact_root
             .join("non_engine")
@@ -7280,6 +7259,48 @@ mod tests {
     }
 
     #[test]
+    fn jit_layout_hash_ignores_function_body_only_edits() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_layout_hash_body_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let source = temp_root.join("main.stasis");
+        fs::write(
+            &source,
+            "global score: i32;\nfunction main(): i32 { return score + 1; }\n",
+        )
+        .expect("write source");
+
+        let mut backend = IncrementalCompilerBackend::new();
+        let first = backend.compile(CompileRequest::new(
+            RequestId(9_113),
+            vec![source.clone()],
+            TargetMode::JitDev,
+        ));
+        assert_eq!(first.status, CompileStatus::Success);
+
+        fs::write(
+            &source,
+            "global score: i32;\nfunction main(): i32 { return score + 2; }\n",
+        )
+        .expect("rewrite source");
+        let second = backend.compile(CompileRequest::new(
+            RequestId(9_114),
+            vec![source],
+            TargetMode::JitDev,
+        ));
+        assert_eq!(second.status, CompileStatus::Success);
+        assert_eq!(
+            first.layout_hash, second.layout_hash,
+            "function body changes must not create a parallel layout identity"
+        );
+
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[test]
     fn jit_dev_non_engine_source_emits_jit_code_ptr_overrides() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -7330,70 +7351,6 @@ mod tests {
         assert!(backend.last_jit_engine_package().is_none());
         assert!(backend.last_aot_engine_bundle().is_none());
         fs::remove_dir_all(&temp_root).ok();
-    }
-
-    #[test]
-    fn jit_dev_non_engine_result_includes_flattened_state_map_entries() {
-        let stamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let temp_root = std::env::temp_dir().join(format!("stasis_jit_state_map_{stamp}"));
-        fs::create_dir_all(&temp_root).expect("create temp root");
-        let source = temp_root.join("game_logic.stasis");
-        fs::write(
-            &source,
-            "struct Enemy { hp: i32; speed: f32; }\nglobal Game { score: i32; first_enemy: Enemy; }\nfunction main(): i32 { return Game.score; }\n",
-        )
-        .expect("write source");
-
-        let mut backend = IncrementalCompilerBackend::new();
-        let result = backend.compile(CompileRequest::new(
-            RequestId(9_103),
-            vec![source],
-            TargetMode::JitDev,
-        ));
-        assert_eq!(result.status, CompileStatus::Success);
-        let state_map = result
-            .state_map
-            .as_ref()
-            .expect("state map should be populated on successful compile");
-        assert!(
-            state_map
-                .iter()
-                .any(|entry| entry.path == "Game.score" && entry.type_name == "i32"),
-            "expected scalar global block entry in state map"
-        );
-        assert!(
-            state_map
-                .iter()
-                .any(|entry| entry.path == "Game.first_enemy.hp" && entry.type_name == "i32"),
-            "expected flattened struct field entry in state map"
-        );
-        assert!(
-            state_map
-                .iter()
-                .any(|entry| entry.path == "Game.first_enemy.speed" && entry.type_name == "f32"),
-            "expected flattened struct field entry in state map"
-        );
-        fs::remove_dir_all(&temp_root).ok();
-    }
-
-    #[test]
-    fn state_map_extraction_rejects_recursive_structs() {
-        let mut backend = IncrementalCompilerBackend::new();
-        backend.source_by_path.insert(
-            "recursive.stasis".to_string(),
-            "struct Node { next: Node; }\nglobal root: Node;\nfunction main(): i32 { return 0; }\n"
-                .to_string(),
-        );
-        let result = backend.state_map_from_source_cache();
-        assert!(
-            result.is_err(),
-            "recursive struct layout should be rejected"
-        );
-        let message = result.expect_err("state map extraction should fail");
-        assert!(message.contains("recursive struct"));
     }
 
     #[test]

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1836,7 +1836,8 @@ fn run_play_in_process_inner(
                                 let t_hook = Instant::now();
                                 // Run the hook against the newly compiled code. If it fails, abort the swap attempt
                                 // and keep running last-known-good code/data.
-                                if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize)
+                                if let Err(error) =
+                                    stasis_dynload::invoke_code_swap_hook(hook as usize)
                                 {
                                     hook_ms = t_hook.elapsed().as_millis();
                                     hook_failed = Some(error);
@@ -2832,7 +2833,7 @@ fn apply_commit_request(
                     swap_failure_reasons.push(hook_error.clone());
                     return SwapCommitResult::failed(request.request_id, hook_error);
                 }
-                if let Err(error) = stasis_dynload::invoke_noarg_void(code_ptr as usize) {
+                if let Err(error) = stasis_dynload::invoke_code_swap_hook(code_ptr as usize) {
                     *hook_failures += 1;
                     let hook_error = format!("{hook_symbol} failed: {error}");
                     hook_failure_reasons.push(hook_error.clone());
@@ -3000,7 +3001,7 @@ fn apply_commit_request(
                 }
             };
 
-            if let Err(error) = stasis_dynload::invoke_noarg_void(address) {
+            if let Err(error) = stasis_dynload::invoke_code_swap_hook(address) {
                 *hook_failures += 1;
                 let hook_error = format!("{hook_symbol} failed: {error}");
                 hook_failure_reasons.push(hook_error.clone());

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -7,6 +7,7 @@ mod host_set_registry;
 mod live_workspace;
 mod runtime_exec;
 mod stasis_test_runner;
+mod state_migration;
 mod watch;
 mod window_config;
 
@@ -20,7 +21,7 @@ pub use stasis_test_runner::{
 };
 pub use window_config::WindowConfig;
 
-use compiler_backend::IncrementalCompilerBackend;
+use compiler_backend::{IncrementalCompilerBackend, PreparedJitSwap};
 use live_workspace::LiveWorkspace;
 use runtime_exec::RuntimeLauncher;
 use serde::Deserialize;
@@ -31,10 +32,14 @@ use stasis_jit::FunctionPointerTable;
 use stasis_runner::swap::contracts::{
     AotFunctionSymbol, CompileRequest, CompileResult, CompileStatus, Diagnostic,
     DiagnosticSeverity, FileChangeEvent, FileChangeKind, FnId, FunctionPatch, FunctionPatchSet,
-    JitCodePtrOverride, LayoutHash, RequestId, StateMapEntry, SwapCommitResult, SwapCommitStatus,
-    TargetMode, TextSource,
+    JitCodePtrOverride, LayoutHash, RequestId, SwapCommitResult, SwapCommitStatus, TargetMode,
+    TextSource,
 };
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
+use state_migration::{
+    activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
+    MAX_STATE_SNAPSHOT_BYTES,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Read;
@@ -45,7 +50,6 @@ use std::time::Instant;
 use watch::WatchService;
 
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
-const MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, Default)]
 struct PendingAotCompileMetadata {
@@ -1832,15 +1836,36 @@ fn run_play_in_process_inner(
                             let candidate_on_code_swap_code_ptr =
                                 next_package.on_code_swap_code_ptr;
 
+                            let mut migration_preview = match plan_state_migration(
+                                &jit.state_layout(),
+                                &candidate.state_layout(),
+                                next_package.symbol_code_ptrs.keys().cloned().collect(),
+                                false,
+                                None,
+                            ) {
+                                Ok(preview) => preview,
+                                Err(error) => {
+                                    println!("[swap] aborted before activation: {error}");
+                                    continue;
+                                }
+                            };
+                            finalize_runtime_preview(&candidate, &mut migration_preview);
                             let t_hook = Instant::now();
-                            // Activate and run the candidate hook transactionally. Rejection restores the
-                            // active process's dispatch, literals, headers, and runtime state.
-                            let hook_failed = activate_candidate_runtime_transactionally(
-                                &jit,
+                            let hook_failed = match activate_candidate_transactionally(
+                                Some(&jit),
                                 &candidate,
-                                candidate_on_code_swap_code_ptr,
-                            )
-                            .err();
+                                &migration_preview,
+                                candidate_on_code_swap_code_ptr.is_some(),
+                                || {
+                                    candidate_on_code_swap_code_ptr.map_or(Ok(()), |code_ptr| {
+                                        stasis_dynload::invoke_code_swap_hook(code_ptr as usize)
+                                    })
+                                },
+                                Result::is_ok,
+                            ) {
+                                Ok(Ok(())) => None,
+                                Ok(Err(error)) | Err(error) => Some(error),
+                            };
                             let hook_ms = t_hook.elapsed().as_millis();
 
                             let t_deps = Instant::now();
@@ -1946,8 +1971,9 @@ fn run_play_in_process_inner(
 }
 
 pub fn run_with_real_backend(config: RunnerConfig) -> RunnerSummary {
-    let backend = IncrementalCompilerBackend::new();
-    run_with_backend(config, backend)
+    let (prepared_tx, prepared_rx) = std::sync::mpsc::sync_channel(1);
+    let backend = IncrementalCompilerBackend::new_with_prepared_jit_swaps(prepared_tx);
+    run_with_backend_and_prepared_swaps(config, backend, Some(prepared_rx))
 }
 
 fn is_stasis_source_file(path: &Path) -> bool {
@@ -2138,6 +2164,14 @@ fn resolve_initial_source_file(config: &RunnerConfig) -> Option<PathBuf> {
 }
 
 pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) -> RunnerSummary {
+    run_with_backend_and_prepared_swaps(config, backend, None)
+}
+
+fn run_with_backend_and_prepared_swaps<B: CompilerBackend>(
+    config: RunnerConfig,
+    backend: B,
+    prepared_jit_swap_rx: Option<std::sync::mpsc::Receiver<PreparedJitSwap>>,
+) -> RunnerSummary {
     let mut watcher = config
         .watch_directory
         .as_deref()
@@ -2213,8 +2247,10 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
     let mut pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
     let mut pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
         BTreeMap::new();
+    let requires_prepared_jit = prepared_jit_swap_rx.is_some();
+    let mut pending_jit_candidates: BTreeMap<RequestId, JitProcess> = BTreeMap::new();
+    let mut active_jit_candidate: Option<JitProcess> = None;
     let mut active_layout_hash: Option<LayoutHash> = None;
-    let mut active_state_map: Option<Vec<StateMapEntry>> = None;
     let mut aot_linked_image_activations: u32 = 0;
     let mut active_aot_linked_image_path: Option<PathBuf> = None;
     let mut active_aot_linked_image_size_bytes: Option<u64> = None;
@@ -2272,10 +2308,10 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         pipeline.pump_coordinator();
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
+        capture_prepared_jit_swaps(prepared_jit_swap_rx.as_ref(), &mut pending_jit_candidates);
         pipeline.process_commits_at_safe_point(|request| {
             let request_id = request.request_id;
             let request_layout_hash = request.layout_hash;
-            let request_state_map = request.state_map.clone();
             let hook_may_mutate_state = commit_request_may_execute_runtime_hook(
                 &request,
                 &config,
@@ -2283,32 +2319,44 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
                 &pending_aot_metadata,
                 &pending_jit_code_ptr_overrides,
             );
-            let result = apply_runtime_state_transaction(
-                active_layout_hash,
-                request_layout_hash,
-                active_state_map.as_deref(),
-                request_state_map.as_deref(),
-                hook_may_mutate_state,
-                || {
-                    apply_commit_request(
-                        request,
-                        &mut pointer_table,
-                        &config,
-                        &host_set_contract,
-                        &mut hook_runs,
-                        &mut hook_failures,
-                        &mut hook_failure_reasons,
-                        &mut swap_commit_successes,
-                        &mut swap_commit_failures,
-                        &mut swap_failure_reasons,
-                        &mut events,
-                        hook_failure_reason.as_ref(),
-                        swap_failure_reason.as_ref(),
-                        &pending_aot_metadata,
-                        &pending_jit_code_ptr_overrides,
-                    )
-                },
-            );
+            let prepared_candidate = pending_jit_candidates.remove(&request_id);
+            let commit = || {
+                apply_commit_request(
+                    request,
+                    &mut pointer_table,
+                    &config,
+                    &host_set_contract,
+                    &mut hook_runs,
+                    &mut hook_failures,
+                    &mut hook_failure_reasons,
+                    &mut swap_commit_successes,
+                    &mut swap_commit_failures,
+                    &mut swap_failure_reasons,
+                    &mut events,
+                    hook_failure_reason.as_ref(),
+                    swap_failure_reason.as_ref(),
+                    &pending_aot_metadata,
+                    &pending_jit_code_ptr_overrides,
+                )
+            };
+            let result = if config.target_mode == TargetMode::JitDev
+                && (requires_prepared_jit || prepared_candidate.is_some())
+            {
+                apply_prepared_jit_transaction(
+                    request_id,
+                    prepared_candidate,
+                    &mut active_jit_candidate,
+                    hook_may_mutate_state,
+                    commit,
+                )
+            } else {
+                apply_runtime_state_transaction(
+                    active_layout_hash,
+                    request_layout_hash,
+                    hook_may_mutate_state,
+                    commit,
+                )
+            };
             let result = match result {
                 Ok(result) => result,
                 Err(message) => {
@@ -2322,9 +2370,6 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
             };
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
-                if let Some(state_map) = request_state_map {
-                    active_state_map = Some(state_map);
-                }
             }
             result
         });
@@ -2399,10 +2444,10 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         pipeline.pump_coordinator();
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
+        capture_prepared_jit_swaps(prepared_jit_swap_rx.as_ref(), &mut pending_jit_candidates);
         pipeline.process_commits_at_safe_point(|request| {
             let request_id = request.request_id;
             let request_layout_hash = request.layout_hash;
-            let request_state_map = request.state_map.clone();
             let hook_may_mutate_state = commit_request_may_execute_runtime_hook(
                 &request,
                 &config,
@@ -2410,32 +2455,44 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
                 &pending_aot_metadata,
                 &pending_jit_code_ptr_overrides,
             );
-            let result = apply_runtime_state_transaction(
-                active_layout_hash,
-                request_layout_hash,
-                active_state_map.as_deref(),
-                request_state_map.as_deref(),
-                hook_may_mutate_state,
-                || {
-                    apply_commit_request(
-                        request,
-                        &mut pointer_table,
-                        &config,
-                        &host_set_contract,
-                        &mut hook_runs,
-                        &mut hook_failures,
-                        &mut hook_failure_reasons,
-                        &mut swap_commit_successes,
-                        &mut swap_commit_failures,
-                        &mut swap_failure_reasons,
-                        &mut events,
-                        hook_failure_reason.as_ref(),
-                        swap_failure_reason.as_ref(),
-                        &pending_aot_metadata,
-                        &pending_jit_code_ptr_overrides,
-                    )
-                },
-            );
+            let prepared_candidate = pending_jit_candidates.remove(&request_id);
+            let commit = || {
+                apply_commit_request(
+                    request,
+                    &mut pointer_table,
+                    &config,
+                    &host_set_contract,
+                    &mut hook_runs,
+                    &mut hook_failures,
+                    &mut hook_failure_reasons,
+                    &mut swap_commit_successes,
+                    &mut swap_commit_failures,
+                    &mut swap_failure_reasons,
+                    &mut events,
+                    hook_failure_reason.as_ref(),
+                    swap_failure_reason.as_ref(),
+                    &pending_aot_metadata,
+                    &pending_jit_code_ptr_overrides,
+                )
+            };
+            let result = if config.target_mode == TargetMode::JitDev
+                && (requires_prepared_jit || prepared_candidate.is_some())
+            {
+                apply_prepared_jit_transaction(
+                    request_id,
+                    prepared_candidate,
+                    &mut active_jit_candidate,
+                    hook_may_mutate_state,
+                    commit,
+                )
+            } else {
+                apply_runtime_state_transaction(
+                    active_layout_hash,
+                    request_layout_hash,
+                    hook_may_mutate_state,
+                    commit,
+                )
+            };
             let result = match result {
                 Ok(result) => result,
                 Err(message) => {
@@ -2449,9 +2506,6 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
             };
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
-                if let Some(state_map) = request_state_map {
-                    active_state_map = Some(state_map);
-                }
             }
             result
         });
@@ -2607,6 +2661,18 @@ fn capture_pending_jit_compile_metadata(
         .or_insert(overrides);
 }
 
+fn capture_prepared_jit_swaps(
+    receiver: Option<&std::sync::mpsc::Receiver<PreparedJitSwap>>,
+    pending: &mut BTreeMap<RequestId, JitProcess>,
+) {
+    let Some(receiver) = receiver else {
+        return;
+    };
+    while let Ok(prepared) = receiver.try_recv() {
+        pending.insert(prepared.request_id, prepared.candidate);
+    }
+}
+
 fn format_layout_hash_hex(layout_hash: LayoutHash) -> String {
     let mut out = String::with_capacity(64);
     for byte in layout_hash.0 {
@@ -2624,119 +2690,6 @@ fn record_swap_failure(
 ) {
     *swap_commit_failures += 1;
     swap_failure_reasons.push(message.to_string());
-}
-
-fn normalize_state_map(
-    entries: &[StateMapEntry],
-    label: &str,
-) -> Result<BTreeMap<String, StateMapEntry>, String> {
-    let mut by_path: BTreeMap<String, StateMapEntry> = BTreeMap::new();
-    for entry in entries {
-        if entry.path.trim().is_empty() {
-            return Err(format!(
-                "{label} state-map contains empty path entry (restart required)"
-            ));
-        }
-        if let Some(previous) = by_path.insert(entry.path.clone(), entry.clone()) {
-            if previous.type_name != entry.type_name || previous.path_hash != entry.path_hash {
-                return Err(format!(
-                    "{label} state-map contains conflicting duplicate path '{}' (restart required)",
-                    entry.path
-                ));
-            }
-        }
-    }
-    Ok(by_path)
-}
-
-fn validate_layout_transition(
-    active_layout_hash: Option<LayoutHash>,
-    request_layout_hash: LayoutHash,
-    active_state_map: Option<&[StateMapEntry]>,
-    request_state_map: Option<&[StateMapEntry]>,
-) -> Result<(), String> {
-    let Some(active_layout_hash) = active_layout_hash else {
-        return Ok(());
-    };
-    if active_layout_hash == request_layout_hash {
-        return Ok(());
-    }
-    let Some(active_state_map) = active_state_map else {
-        return Err(format!(
-            "layout hash changed from {} to {}, but active state-map metadata is missing (restart required)",
-            format_layout_hash_hex(active_layout_hash),
-            format_layout_hash_hex(request_layout_hash)
-        ));
-    };
-    let Some(request_state_map) = request_state_map else {
-        return Err(format!(
-            "layout hash changed from {} to {}, but incoming state-map metadata is missing (restart required)",
-            format_layout_hash_hex(active_layout_hash),
-            format_layout_hash_hex(request_layout_hash)
-        ));
-    };
-
-    let active_by_path = normalize_state_map(active_state_map, "active")?;
-    let request_by_path = normalize_state_map(request_state_map, "incoming")?;
-    for (path, request_entry) in &request_by_path {
-        if let Some(active_entry) = active_by_path.get(path) {
-            if active_entry.type_name != request_entry.type_name {
-                return Err(format!(
-                    "layout hash changed from {} to {} and state-map path '{}' changed type '{}' -> '{}' (restart required)",
-                    format_layout_hash_hex(active_layout_hash),
-                    format_layout_hash_hex(request_layout_hash),
-                    path,
-                    active_entry.type_name,
-                    request_entry.type_name
-                ));
-            }
-        }
-    }
-    Ok(())
-}
-
-fn type_name_is_f32(type_name: &str) -> bool {
-    type_name.trim() == "f32"
-}
-
-fn type_name_is_f64(type_name: &str) -> bool {
-    type_name.trim() == "f64"
-}
-
-fn type_name_is_collection_like(type_name: &str) -> bool {
-    let normalized = type_name.trim();
-    normalized.contains('[') || normalized == "ascii" || normalized == "utf8"
-}
-
-fn activate_candidate_runtime_transactionally(
-    active: &JitProcess,
-    candidate: &JitProcess,
-    hook_code_ptr: Option<u64>,
-) -> Result<(), String> {
-    let snapshot = hook_code_ptr
-        .map(|_| {
-            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES)
-        })
-        .transpose()?;
-    let result = candidate.activate_staged_runtime().and_then(|()| {
-        hook_code_ptr.map_or(Ok(()), |code_ptr| {
-            stasis_dynload::invoke_code_swap_hook(code_ptr as usize)
-        })
-    });
-    if let Err(error) = result {
-        let Some(snapshot) = snapshot else {
-            return Err(error);
-        };
-        let reactivation = active.activate_staged_runtime();
-        stasis_dynload::restore_jit_runtime_state(&snapshot);
-        return match reactivation {
-            Ok(()) => Err(error),
-            Err(rollback_error) => Err(format!(
-                "{error}; failed restoring active JIT runtime after rejected candidate: {rollback_error}"
-            )),
-        };
-    }
-    Ok(())
 }
 
 fn commit_request_may_execute_runtime_hook(
@@ -2761,73 +2714,64 @@ fn commit_request_may_execute_runtime_hook(
     }
 }
 
-fn apply_runtime_state_transaction(
-    active_layout_hash: Option<LayoutHash>,
-    request_layout_hash: LayoutHash,
-    active_state_map: Option<&[StateMapEntry]>,
-    request_state_map: Option<&[StateMapEntry]>,
+fn apply_prepared_jit_transaction(
+    request_id: RequestId,
+    candidate: Option<JitProcess>,
+    active: &mut Option<JitProcess>,
     hook_may_mutate_state: bool,
     apply: impl FnOnce() -> SwapCommitResult,
 ) -> Result<SwapCommitResult, String> {
-    validate_layout_transition(
-        active_layout_hash,
-        request_layout_hash,
-        active_state_map,
-        request_state_map,
+    let candidate = candidate.ok_or_else(|| {
+        format!(
+            "JIT commit {} is missing its staged runtime candidate",
+            request_id.0
+        )
+    })?;
+    let incoming_layout = candidate.state_layout();
+    let active_layout = active
+        .as_ref()
+        .map(JitProcess::state_layout)
+        .unwrap_or_else(|| incoming_layout.clone());
+    let mut preview =
+        plan_state_migration(&active_layout, &incoming_layout, Vec::new(), false, None)?;
+    finalize_runtime_preview(&candidate, &mut preview);
+    let result = activate_candidate_transactionally(
+        active.as_ref(),
+        &candidate,
+        &preview,
+        hook_may_mutate_state,
+        apply,
+        |result| result.status == SwapCommitStatus::Success,
     )?;
+    if result.status == SwapCommitStatus::Success {
+        *active = Some(candidate);
+    }
+    Ok(result)
+}
+
+fn apply_runtime_state_transaction(
+    active_layout_hash: Option<LayoutHash>,
+    request_layout_hash: LayoutHash,
+    hook_may_mutate_state: bool,
+    apply: impl FnOnce() -> SwapCommitResult,
+) -> Result<SwapCommitResult, String> {
     let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
-    if !layout_changed && !hook_may_mutate_state {
+    if layout_changed {
+        return Err(format!(
+            "layout-changing commit from {} to {} requires a staged JIT candidate; restart required for this backend",
+            format_layout_hash_hex(active_layout_hash.expect("layout change has active hash")),
+            format_layout_hash_hex(request_layout_hash)
+        ));
+    }
+    if !hook_may_mutate_state {
         return Ok(apply());
     }
-    let snapshot =
-        stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES)?;
-    if layout_changed {
-        if let (Some(from), Some(to)) = (active_state_map, request_state_map) {
-            if let Err(error) = migrate_state_map_fields(from, to) {
-                stasis_dynload::restore_jit_runtime_state(&snapshot);
-                return Err(error);
-            }
-        }
-    }
+    let snapshot = stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES)?;
     let result = apply();
     if result.status != SwapCommitStatus::Success {
         stasis_dynload::restore_jit_runtime_state(&snapshot);
     }
     Ok(result)
-}
-
-fn migrate_state_map_fields(
-    active_state_map: &[StateMapEntry],
-    request_state_map: &[StateMapEntry],
-) -> Result<(), String> {
-    let active_by_path = normalize_state_map(active_state_map, "active")?;
-    let request_by_path = normalize_state_map(request_state_map, "incoming")?;
-
-    for (path, request_entry) in &request_by_path {
-        let Some(active_entry) = active_by_path.get(path) else {
-            continue;
-        };
-        if active_entry.type_name != request_entry.type_name {
-            continue;
-        }
-        if type_name_is_collection_like(&request_entry.type_name) {
-            continue;
-        }
-        if type_name_is_f32(&request_entry.type_name) {
-            let value = stasis_dynload::stasis_jit_global_f32_load(active_entry.path_hash);
-            stasis_dynload::stasis_jit_global_f32_store(request_entry.path_hash, value);
-            continue;
-        }
-        if type_name_is_f64(&request_entry.type_name) {
-            let value = stasis_dynload::stasis_jit_global_f64_load(active_entry.path_hash);
-            stasis_dynload::stasis_jit_global_f64_store(request_entry.path_hash, value);
-            continue;
-        }
-        let value = stasis_dynload::stasis_jit_global_i32_load(active_entry.path_hash);
-        stasis_dynload::stasis_jit_global_i32_store(request_entry.path_hash, value);
-    }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3809,30 +3753,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_layout_transition_rejects_type_change_for_existing_path() {
-        let active_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: 11,
-            type_name: "i32".to_string(),
-        }];
-        let incoming_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: 11,
-            type_name: "f32".to_string(),
-        }];
-        let result = validate_layout_transition(
-            Some(LayoutHash([1; 32])),
-            LayoutHash([2; 32]),
-            Some(active_map.as_slice()),
-            Some(incoming_map.as_slice()),
-        );
-        assert!(result.is_err());
-        let message = result.expect_err("transition should fail");
-        assert!(message.contains("changed type"));
-        assert!(message.contains("restart required"));
-    }
-
-    #[test]
     fn apply_play_data_binding_value_populates_registered_scalars_and_strings() {
         let _global_lock = jit_global_table_lock()
             .lock()
@@ -4366,63 +4286,177 @@ mod tests {
     }
 
     #[test]
-    fn validate_layout_transition_allows_added_and_removed_paths_when_types_match() {
-        let active_map = vec![
-            StateMapEntry {
-                path: "State.score".to_string(),
-                path_hash: 11,
-                type_name: "i32".to_string(),
-            },
-            StateMapEntry {
-                path: "State.removed".to_string(),
-                path_hash: 12,
-                type_name: "i32".to_string(),
-            },
-        ];
-        let incoming_map = vec![
-            StateMapEntry {
-                path: "State.score".to_string(),
-                path_hash: 21,
-                type_name: "i32".to_string(),
-            },
-            StateMapEntry {
-                path: "State.added".to_string(),
-                path_hash: 22,
-                type_name: "i32".to_string(),
-            },
-        ];
-        let result = validate_layout_transition(
-            Some(LayoutHash([3; 32])),
-            LayoutHash([4; 32]),
-            Some(active_map.as_slice()),
-            Some(incoming_map.as_slice()),
-        );
-        assert!(result.is_ok(), "expected migration-compatible transition");
-    }
-
-    #[test]
-    fn migrate_state_map_fields_copies_i32_for_matching_paths() {
+    fn compiler_thread_stages_jit_candidate_without_activating_runtime() {
         let _global_lock = jit_global_table_lock()
             .lock()
             .expect("jit global lock should be acquired");
         stasis_dynload::clear_jit_i32_global_table();
-        stasis_dynload::stasis_jit_global_i32_store(11, 777);
-        stasis_dynload::stasis_jit_global_i32_store(22, 0);
 
-        let active_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: 11,
-            type_name: "i32".to_string(),
-        }];
-        let incoming_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: 22,
-            type_name: "i32".to_string(),
-        }];
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_staged_candidate_{stamp}"));
+        fs::create_dir_all(&temp_root).expect("create temp root");
+        let source = temp_root.join("main.stasis");
+        fs::write(
+            &source,
+            "global values: i32[4];\nfunction main(): i32 { return values.max_length; }\n",
+        )
+        .expect("write source");
 
-        migrate_state_map_fields(&active_map, &incoming_map).expect("migration should succeed");
-        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(22), 777);
+        let max_length_hash = hash_global_path("values.max_length");
+        stasis_dynload::stasis_jit_global_i32_store(max_length_hash, 99);
+        let (prepared_tx, prepared_rx) = std::sync::mpsc::sync_channel(1);
+        let mut backend = IncrementalCompilerBackend::new_with_prepared_jit_swaps(prepared_tx);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(89),
+            vec![source],
+            TargetMode::JitDev,
+        ));
+
+        assert_eq!(result.status, CompileStatus::Success);
+        assert_eq!(
+            stasis_dynload::stasis_jit_global_i32_load(max_length_hash),
+            99,
+            "background compilation must not seed the active runtime"
+        );
+        let prepared = prepared_rx
+            .try_recv()
+            .expect("successful compile should stage a candidate");
+        assert_eq!(prepared.request_id, RequestId(89));
+        prepared
+            .candidate
+            .activate_staged_runtime()
+            .expect("safe-point activation should succeed");
+        assert_eq!(
+            stasis_dynload::stasis_jit_global_i32_load(max_length_hash),
+            4
+        );
+
         stasis_dynload::clear_jit_i32_global_table();
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[test]
+    fn runner_collection_growth_uses_shared_migration_transaction() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_jit_i32_global_table();
+        stasis_dynload::clear_jit_i32_array_global_table();
+
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "runner_collection.stasis",
+            "global values: i32[2]; function main(): i32 { return values[0]; }",
+        );
+        active.compile().expect("active compile");
+        active
+            .write_global_collection_scalar(
+                "values",
+                "",
+                0,
+                stasis_compiler::backend::jit::JitScalarValue::I32(11),
+            )
+            .expect("seed first value");
+        active
+            .write_global_collection_scalar(
+                "values",
+                "",
+                1,
+                stasis_compiler::backend::jit::JitScalarValue::I32(22),
+            )
+            .expect("seed second value");
+
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "runner_collection.stasis",
+            "global values: i32[4]; function main(): i32 { return values[0]; }",
+        );
+        candidate.compile_staged().expect("candidate compile");
+        let mut active_candidate = Some(active);
+        let result = apply_prepared_jit_transaction(
+            RequestId(90),
+            Some(candidate),
+            &mut active_candidate,
+            false,
+            || {
+                SwapCommitResult::success(
+                    RequestId(90),
+                    Vec::new(),
+                    stasis_runner::swap::contracts::CodeGeneration(1),
+                )
+            },
+        )
+        .expect("shared transaction should apply collection migration");
+
+        assert_eq!(result.status, SwapCommitStatus::Success);
+        let active = active_candidate.expect("candidate should become active");
+        assert_eq!(
+            active.read_global_collection_scalar("values", "", 0),
+            Ok(stasis_compiler::backend::jit::JitScalarValue::I32(11))
+        );
+        assert_eq!(
+            active.read_global_collection_scalar("values", "", 1),
+            Ok(stasis_compiler::backend::jit::JitScalarValue::I32(22))
+        );
+        assert_eq!(
+            active.read_global_collection_scalar("values", "", 2),
+            Ok(stasis_compiler::backend::jit::JitScalarValue::I32(0))
+        );
+
+        stasis_dynload::clear_jit_i32_global_table();
+        stasis_dynload::clear_jit_i32_array_global_table();
+    }
+
+    #[test]
+    fn runner_rejects_missing_jit_candidate_without_mutating_state() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_jit_i32_global_table();
+        let score_hash = hash_global_path("score");
+        stasis_dynload::stasis_jit_global_i32_store(score_hash, 7);
+        let mut active = None;
+        let mut applied = false;
+
+        let error = apply_prepared_jit_transaction(RequestId(91), None, &mut active, false, || {
+            applied = true;
+            SwapCommitResult::success(
+                RequestId(91),
+                Vec::new(),
+                stasis_runner::swap::contracts::CodeGeneration(1),
+            )
+        })
+        .expect_err("missing candidate must reject");
+
+        assert!(error.contains("missing its staged runtime candidate"));
+        assert!(!applied, "commit callback must not run");
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(score_hash), 7);
+        stasis_dynload::clear_jit_i32_global_table();
+    }
+
+    #[test]
+    fn layout_change_without_jit_candidate_requires_restart() {
+        let mut applied = false;
+        let error = apply_runtime_state_transaction(
+            Some(LayoutHash([1; 32])),
+            LayoutHash([2; 32]),
+            false,
+            || {
+                applied = true;
+                SwapCommitResult::success(
+                    RequestId(92),
+                    Vec::new(),
+                    stasis_runner::swap::contracts::CodeGeneration(1),
+                )
+            },
+        )
+        .expect_err("layout-changing fallback backend must reject");
+
+        assert!(error.contains("requires a staged JIT candidate"));
+        assert!(!applied, "commit callback must not run");
     }
 
     #[test]
@@ -4443,11 +4477,23 @@ mod tests {
         REJECTING_HOOK_PATH_HASH.store(path_hash, std::sync::atomic::Ordering::Relaxed);
         stasis_dynload::stasis_jit_global_i32_store(path_hash, 7);
 
-        let error = activate_candidate_runtime_transactionally(
-            &active,
-            &candidate,
-            Some(mutating_rejecting_hook as usize as u64),
+        let preview = plan_state_migration(
+            &active.state_layout(),
+            &candidate.state_layout(),
+            Vec::new(),
+            false,
+            None,
         )
+        .expect("plan");
+        let error = activate_candidate_transactionally(
+            Some(&active),
+            &candidate,
+            &preview,
+            true,
+            || stasis_dynload::invoke_code_swap_hook(mutating_rejecting_hook as usize),
+            Result::is_ok,
+        )
+        .expect("runtime transaction should execute")
         .expect_err("hook should reject");
 
         assert!(error.contains("rejection"));
@@ -4466,16 +4512,31 @@ mod tests {
         let mut candidate = active.staged_candidate();
         candidate.upsert_file("watch_large.stasis", "function main(): i32 { return 1; }");
         candidate.compile_staged().expect("candidate compile");
-        let oversized_len = MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
+        let oversized_len = MAX_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
         stasis_dynload::ensure_jit_i32_array_capacity(9002, 0, oversized_len)
             .expect("oversized test storage should allocate");
-        assert!(stasis_dynload::snapshot_jit_runtime_state_bounded(
-            MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES
-        )
-        .is_err());
+        assert!(
+            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES).is_err()
+        );
 
-        activate_candidate_runtime_transactionally(&active, &candidate, None)
-            .expect("hook-free candidate activation should not snapshot state");
+        let preview = plan_state_migration(
+            &active.state_layout(),
+            &candidate.state_layout(),
+            Vec::new(),
+            false,
+            None,
+        )
+        .expect("plan");
+        activate_candidate_transactionally(
+            Some(&active),
+            &candidate,
+            &preview,
+            false,
+            || Ok::<(), String>(()),
+            Result::is_ok,
+        )
+        .expect("hook-free candidate activation should not snapshot state")
+        .expect("commit should succeed");
 
         stasis_dynload::clear_registered_global_memory();
         stasis_dynload::clear_jit_i32_array_global_table();
@@ -4487,22 +4548,27 @@ mod tests {
             .lock()
             .expect("jit global lock should be acquired");
         stasis_dynload::clear_jit_i32_global_table();
-        let active_hash = hash_global_path("RunnerRollback.active_score");
-        let incoming_hash = hash_global_path("RunnerRollback.incoming_score");
-        stasis_dynload::stasis_jit_global_i32_store(active_hash, 7);
-        stasis_dynload::stasis_jit_global_i32_store(incoming_hash, 3);
-        REJECTING_HOOK_PATH_HASH.store(incoming_hash, std::sync::atomic::Ordering::Relaxed);
-
-        let active_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: active_hash,
-            type_name: "i32".to_string(),
-        }];
-        let incoming_map = vec![StateMapEntry {
-            path: "State.score".to_string(),
-            path_hash: incoming_hash,
-            type_name: "i32".to_string(),
-        }];
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "runner_rollback.stasis",
+            "global score: i32; function main(): i32 { return score; }",
+        );
+        active.compile().expect("active compile");
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "runner_rollback.stasis",
+            "global score: i32; global added: i32; function main(): i32 { return score + added; }",
+        );
+        candidate.compile_staged().expect("candidate compile");
+        active
+            .write_global_scalar(
+                "score",
+                stasis_compiler::backend::jit::JitScalarValue::I32(7),
+            )
+            .expect("seed active score");
+        let added_hash = hash_global_path("added");
+        stasis_dynload::stasis_jit_global_i32_store(added_hash, 3);
+        REJECTING_HOOK_PATH_HASH.store(added_hash, std::sync::atomic::Ordering::Relaxed);
         let request_id = RequestId(90);
         let hook_fn_id = FnId(2);
         let mut request = stasis_runner::swap::contracts::SwapCommitRequest::new(
@@ -4514,7 +4580,6 @@ mod tests {
             Some("on_code_swap".to_string()),
         );
         request.hook_fn_id = Some(hook_fn_id);
-        request.state_map = Some(incoming_map.clone());
         let config = RunnerConfig::default();
         let host_set_contract = expected_host_set(&config);
         attach_host_set(&mut request, &host_set_contract);
@@ -4535,11 +4600,11 @@ mod tests {
             }],
         )]);
 
-        let result = apply_runtime_state_transaction(
-            Some(LayoutHash([1; 32])),
-            LayoutHash([2; 32]),
-            Some(&active_map),
-            Some(&incoming_map),
+        let mut active_candidate = Some(active);
+        let result = apply_prepared_jit_transaction(
+            request_id,
+            Some(candidate),
+            &mut active_candidate,
             true,
             || {
                 apply_commit_request(
@@ -4564,8 +4629,14 @@ mod tests {
         .expect("runtime transaction should execute");
 
         assert_eq!(result.status, SwapCommitStatus::Failed);
-        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(active_hash), 7);
-        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(incoming_hash), 3);
+        assert_eq!(
+            active_candidate
+                .as_ref()
+                .expect("active candidate retained")
+                .read_global_scalar("score"),
+            Ok(stasis_compiler::backend::jit::JitScalarValue::I32(7))
+        );
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(added_hash), 3);
         assert_eq!(pointer_table.generation().0, 0);
         assert_eq!(hook_runs, 1);
         assert_eq!(hook_failures, 1);
@@ -4580,19 +4651,16 @@ mod tests {
             .lock()
             .expect("jit global lock should be acquired");
         let _jit = JitProcess::new();
-        let oversized_len = MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
+        let oversized_len = MAX_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
         stasis_dynload::ensure_jit_i32_array_capacity(9001, 0, oversized_len)
             .expect("oversized test storage should allocate");
-        assert!(stasis_dynload::snapshot_jit_runtime_state_bounded(
-            MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES
-        )
-        .is_err());
+        assert!(
+            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES).is_err()
+        );
 
         let result = apply_runtime_state_transaction(
             Some(LayoutHash([1; 32])),
             LayoutHash([1; 32]),
-            None,
-            None,
             false,
             || {
                 SwapCommitResult::success(
@@ -6381,7 +6449,8 @@ mod tests {
         let game = temp_root.join("game.stasis");
         fs::copy(&fixture, &game).expect("copy hook fixture");
 
-        let backend = IncrementalCompilerBackend::new();
+        let (prepared_tx, prepared_rx) = std::sync::mpsc::sync_channel(1);
+        let backend = IncrementalCompilerBackend::new_with_prepared_jit_swaps(prepared_tx);
         let mut pipeline = DevHotSwapPipeline::with_target_mode(backend, TargetMode::JitDev);
         let mut pointer_table = FunctionPointerTable::new();
         let config = RunnerConfig {
@@ -6409,6 +6478,8 @@ mod tests {
         let pending_aot_metadata: BTreeMap<RequestId, PendingAotCompileMetadata> = BTreeMap::new();
         let mut pending_jit_code_ptr_overrides: BTreeMap<RequestId, Vec<JitCodePtrOverride>> =
             BTreeMap::new();
+        let mut pending_jit_candidates = BTreeMap::new();
+        let mut active_jit_candidate = None;
 
         pipeline.submit_file_change(FileChangeEvent::new(
             game.clone(),
@@ -6423,24 +6494,36 @@ mod tests {
         while start.elapsed() < timeout {
             pipeline.pump_coordinator();
             capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
+            capture_prepared_jit_swaps(Some(&prepared_rx), &mut pending_jit_candidates);
             pipeline.process_commits_at_safe_point(|request| {
-                apply_commit_request(
-                    request,
-                    &mut pointer_table,
-                    &config,
-                    &host_set_contract,
-                    &mut hook_runs,
-                    &mut hook_failures,
-                    &mut hook_failure_reasons,
-                    &mut swap_commit_successes,
-                    &mut swap_commit_failures,
-                    &mut swap_failure_reasons,
-                    &mut events,
-                    None,
-                    None,
-                    &pending_aot_metadata,
-                    &pending_jit_code_ptr_overrides,
+                let request_id = request.request_id;
+                let candidate = pending_jit_candidates.remove(&request_id);
+                apply_prepared_jit_transaction(
+                    request_id,
+                    candidate,
+                    &mut active_jit_candidate,
+                    true,
+                    || {
+                        apply_commit_request(
+                            request,
+                            &mut pointer_table,
+                            &config,
+                            &host_set_contract,
+                            &mut hook_runs,
+                            &mut hook_failures,
+                            &mut hook_failure_reasons,
+                            &mut swap_commit_successes,
+                            &mut swap_commit_failures,
+                            &mut swap_failure_reasons,
+                            &mut events,
+                            None,
+                            None,
+                            &pending_aot_metadata,
+                            &pending_jit_code_ptr_overrides,
+                        )
+                    },
                 )
+                .unwrap_or_else(|error| SwapCommitResult::failed(request_id, error))
             });
             pipeline.pump_coordinator();
 
@@ -6479,24 +6562,36 @@ mod tests {
         while start.elapsed() < timeout {
             pipeline.pump_coordinator();
             capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
+            capture_prepared_jit_swaps(Some(&prepared_rx), &mut pending_jit_candidates);
             pipeline.process_commits_at_safe_point(|request| {
-                apply_commit_request(
-                    request,
-                    &mut pointer_table,
-                    &config,
-                    &host_set_contract,
-                    &mut hook_runs,
-                    &mut hook_failures,
-                    &mut hook_failure_reasons,
-                    &mut swap_commit_successes,
-                    &mut swap_commit_failures,
-                    &mut swap_failure_reasons,
-                    &mut events,
-                    None,
-                    None,
-                    &pending_aot_metadata,
-                    &pending_jit_code_ptr_overrides,
+                let request_id = request.request_id;
+                let candidate = pending_jit_candidates.remove(&request_id);
+                apply_prepared_jit_transaction(
+                    request_id,
+                    candidate,
+                    &mut active_jit_candidate,
+                    true,
+                    || {
+                        apply_commit_request(
+                            request,
+                            &mut pointer_table,
+                            &config,
+                            &host_set_contract,
+                            &mut hook_runs,
+                            &mut hook_failures,
+                            &mut hook_failure_reasons,
+                            &mut swap_commit_successes,
+                            &mut swap_commit_failures,
+                            &mut swap_failure_reasons,
+                            &mut events,
+                            None,
+                            None,
+                            &pending_aot_metadata,
+                            &pending_jit_code_ptr_overrides,
+                        )
+                    },
                 )
+                .unwrap_or_else(|error| SwapCommitResult::failed(request_id, error))
             });
             pipeline.pump_coordinator();
 

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -45,6 +45,7 @@ use std::time::Instant;
 use watch::WatchService;
 
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
+const MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, Default)]
 struct PendingAotCompileMetadata {
@@ -1808,19 +1809,20 @@ fn run_play_in_process_inner(
             println!("[watch] change detected: {changed}");
 
             let t_total = Instant::now();
-            // Ensure the root file is refreshed (imports are pulled by the JIT process).
+            let mut candidate = jit.staged_candidate();
+            // Ensure the root file is refreshed (imports are pulled by the candidate process).
             if let Ok(next_root_source) = fs::read_to_string(&root_path) {
-                jit.upsert_file(root_path_str.clone(), next_root_source);
+                candidate.upsert_file(root_path_str.clone(), next_root_source);
             }
-            let _ = jit.refresh_imported_sources_from_disk(&root_path_str);
+            let _ = candidate.refresh_imported_sources_from_disk(&root_path_str);
 
             let t_compile = Instant::now();
-            match jit.compile() {
+            match candidate.compile_staged() {
                 Ok(_) => {
                     let compile_ms = t_compile.elapsed().as_millis();
 
                     let t_pkg = Instant::now();
-                    match jit.build_engine_package(&EngineEntrypoints::runtime_default()) {
+                    match candidate.build_engine_package(&EngineEntrypoints::runtime_default()) {
                         Ok(next_package) => {
                             let package_ms = t_pkg.elapsed().as_millis();
 
@@ -1830,21 +1832,16 @@ fn run_play_in_process_inner(
                             let candidate_on_code_swap_code_ptr =
                                 next_package.on_code_swap_code_ptr;
 
-                            let mut hook_ms: u128 = 0;
-                            let mut hook_failed: Option<String> = None;
-                            if let Some(hook) = candidate_on_code_swap_code_ptr {
-                                let t_hook = Instant::now();
-                                // Run the hook against the newly compiled code. If it fails, abort the swap attempt
-                                // and keep running last-known-good code/data.
-                                if let Err(error) =
-                                    stasis_dynload::invoke_code_swap_hook(hook as usize)
-                                {
-                                    hook_ms = t_hook.elapsed().as_millis();
-                                    hook_failed = Some(error);
-                                } else {
-                                    hook_ms = t_hook.elapsed().as_millis();
-                                }
-                            }
+                            let t_hook = Instant::now();
+                            // Activate and run the candidate hook transactionally. Rejection restores the
+                            // active process's dispatch, literals, headers, and runtime state.
+                            let hook_failed = activate_candidate_runtime_transactionally(
+                                &jit,
+                                &candidate,
+                                candidate_on_code_swap_code_ptr,
+                            )
+                            .err();
+                            let hook_ms = t_hook.elapsed().as_millis();
 
                             let t_deps = Instant::now();
                             if let Ok(next_graph) = collect_watch_dependency_paths(&root_path) {
@@ -1860,6 +1857,7 @@ fn run_play_in_process_inner(
                                 );
                             } else {
                                 // Commit the swap (all-or-nothing).
+                                jit.accept_staged_candidate(candidate);
                                 tick_code_ptr = candidate_tick_code_ptr;
                                 render_code_ptr = candidate_render_code_ptr;
                                 if let Some(live) = live.as_mut() {
@@ -2275,53 +2273,53 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
         pipeline.process_commits_at_safe_point(|request| {
+            let request_id = request.request_id;
             let request_layout_hash = request.layout_hash;
             let request_state_map = request.state_map.clone();
-            if let Err(message) = validate_layout_transition(
+            let hook_may_mutate_state = commit_request_may_execute_runtime_hook(
+                &request,
+                &config,
+                hook_failure_reason.is_some(),
+                &pending_aot_metadata,
+                &pending_jit_code_ptr_overrides,
+            );
+            let result = apply_runtime_state_transaction(
                 active_layout_hash,
                 request_layout_hash,
                 active_state_map.as_deref(),
                 request_state_map.as_deref(),
-            ) {
-                record_swap_failure(
-                    &message,
-                    &mut swap_commit_failures,
-                    &mut swap_failure_reasons,
-                );
-                return SwapCommitResult::failed(request.request_id, message);
-            }
-            let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
-            if layout_changed {
-                if let (Some(from), Some(to)) =
-                    (active_state_map.as_deref(), request_state_map.as_deref())
-                {
-                    if let Err(message) = migrate_state_map_fields(from, to) {
-                        record_swap_failure(
-                            &message,
-                            &mut swap_commit_failures,
-                            &mut swap_failure_reasons,
-                        );
-                        return SwapCommitResult::failed(request.request_id, message);
-                    }
-                }
-            }
-            let result = apply_commit_request(
-                request,
-                &mut pointer_table,
-                &config,
-                &host_set_contract,
-                &mut hook_runs,
-                &mut hook_failures,
-                &mut hook_failure_reasons,
-                &mut swap_commit_successes,
-                &mut swap_commit_failures,
-                &mut swap_failure_reasons,
-                &mut events,
-                hook_failure_reason.as_ref(),
-                swap_failure_reason.as_ref(),
-                &pending_aot_metadata,
-                &pending_jit_code_ptr_overrides,
+                hook_may_mutate_state,
+                || {
+                    apply_commit_request(
+                        request,
+                        &mut pointer_table,
+                        &config,
+                        &host_set_contract,
+                        &mut hook_runs,
+                        &mut hook_failures,
+                        &mut hook_failure_reasons,
+                        &mut swap_commit_successes,
+                        &mut swap_commit_failures,
+                        &mut swap_failure_reasons,
+                        &mut events,
+                        hook_failure_reason.as_ref(),
+                        swap_failure_reason.as_ref(),
+                        &pending_aot_metadata,
+                        &pending_jit_code_ptr_overrides,
+                    )
+                },
             );
+            let result = match result {
+                Ok(result) => result,
+                Err(message) => {
+                    record_swap_failure(
+                        &message,
+                        &mut swap_commit_failures,
+                        &mut swap_failure_reasons,
+                    );
+                    return SwapCommitResult::failed(request_id, message);
+                }
+            };
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
                 if let Some(state_map) = request_state_map {
@@ -2402,53 +2400,53 @@ pub fn run_with_backend<B: CompilerBackend>(config: RunnerConfig, backend: B) ->
         capture_pending_aot_compile_metadata(&pipeline, &mut pending_aot_metadata);
         capture_pending_jit_compile_metadata(&pipeline, &mut pending_jit_code_ptr_overrides);
         pipeline.process_commits_at_safe_point(|request| {
+            let request_id = request.request_id;
             let request_layout_hash = request.layout_hash;
             let request_state_map = request.state_map.clone();
-            if let Err(message) = validate_layout_transition(
+            let hook_may_mutate_state = commit_request_may_execute_runtime_hook(
+                &request,
+                &config,
+                hook_failure_reason.is_some(),
+                &pending_aot_metadata,
+                &pending_jit_code_ptr_overrides,
+            );
+            let result = apply_runtime_state_transaction(
                 active_layout_hash,
                 request_layout_hash,
                 active_state_map.as_deref(),
                 request_state_map.as_deref(),
-            ) {
-                record_swap_failure(
-                    &message,
-                    &mut swap_commit_failures,
-                    &mut swap_failure_reasons,
-                );
-                return SwapCommitResult::failed(request.request_id, message);
-            }
-            let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
-            if layout_changed {
-                if let (Some(from), Some(to)) =
-                    (active_state_map.as_deref(), request_state_map.as_deref())
-                {
-                    if let Err(message) = migrate_state_map_fields(from, to) {
-                        record_swap_failure(
-                            &message,
-                            &mut swap_commit_failures,
-                            &mut swap_failure_reasons,
-                        );
-                        return SwapCommitResult::failed(request.request_id, message);
-                    }
-                }
-            }
-            let result = apply_commit_request(
-                request,
-                &mut pointer_table,
-                &config,
-                &host_set_contract,
-                &mut hook_runs,
-                &mut hook_failures,
-                &mut hook_failure_reasons,
-                &mut swap_commit_successes,
-                &mut swap_commit_failures,
-                &mut swap_failure_reasons,
-                &mut events,
-                hook_failure_reason.as_ref(),
-                swap_failure_reason.as_ref(),
-                &pending_aot_metadata,
-                &pending_jit_code_ptr_overrides,
+                hook_may_mutate_state,
+                || {
+                    apply_commit_request(
+                        request,
+                        &mut pointer_table,
+                        &config,
+                        &host_set_contract,
+                        &mut hook_runs,
+                        &mut hook_failures,
+                        &mut hook_failure_reasons,
+                        &mut swap_commit_successes,
+                        &mut swap_commit_failures,
+                        &mut swap_failure_reasons,
+                        &mut events,
+                        hook_failure_reason.as_ref(),
+                        swap_failure_reason.as_ref(),
+                        &pending_aot_metadata,
+                        &pending_jit_code_ptr_overrides,
+                    )
+                },
             );
+            let result = match result {
+                Ok(result) => result,
+                Err(message) => {
+                    record_swap_failure(
+                        &message,
+                        &mut swap_commit_failures,
+                        &mut swap_failure_reasons,
+                    );
+                    return SwapCommitResult::failed(request_id, message);
+                }
+            };
             if result.status == SwapCommitStatus::Success {
                 active_layout_hash = Some(request_layout_hash);
                 if let Some(state_map) = request_state_map {
@@ -2708,6 +2706,94 @@ fn type_name_is_f64(type_name: &str) -> bool {
 fn type_name_is_collection_like(type_name: &str) -> bool {
     let normalized = type_name.trim();
     normalized.contains('[') || normalized == "ascii" || normalized == "utf8"
+}
+
+fn activate_candidate_runtime_transactionally(
+    active: &JitProcess,
+    candidate: &JitProcess,
+    hook_code_ptr: Option<u64>,
+) -> Result<(), String> {
+    let snapshot = hook_code_ptr
+        .map(|_| {
+            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES)
+        })
+        .transpose()?;
+    let result = candidate.activate_staged_runtime().and_then(|()| {
+        hook_code_ptr.map_or(Ok(()), |code_ptr| {
+            stasis_dynload::invoke_code_swap_hook(code_ptr as usize)
+        })
+    });
+    if let Err(error) = result {
+        let Some(snapshot) = snapshot else {
+            return Err(error);
+        };
+        let reactivation = active.activate_staged_runtime();
+        stasis_dynload::restore_jit_runtime_state(&snapshot);
+        return match reactivation {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(format!(
+                "{error}; failed restoring active JIT runtime after rejected candidate: {rollback_error}"
+            )),
+        };
+    }
+    Ok(())
+}
+
+fn commit_request_may_execute_runtime_hook(
+    request: &stasis_runner::swap::contracts::SwapCommitRequest,
+    config: &RunnerConfig,
+    has_forced_hook_failure: bool,
+    pending_aot_metadata: &BTreeMap<RequestId, PendingAotCompileMetadata>,
+    pending_jit_code_ptr_overrides: &BTreeMap<RequestId, Vec<JitCodePtrOverride>>,
+) -> bool {
+    if config.disable_on_code_swap_hook || has_forced_hook_failure || request.hook_symbol.is_none()
+    {
+        return false;
+    }
+    match config.target_mode {
+        TargetMode::JitDev => pending_jit_code_ptr_overrides.contains_key(&request.request_id),
+        TargetMode::AotProd => {
+            pending_aot_metadata.contains_key(&request.request_id)
+                && std::env::var("STASIS_AOT_EXECUTE_NATIVE_HOOK")
+                    .ok()
+                    .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        }
+    }
+}
+
+fn apply_runtime_state_transaction(
+    active_layout_hash: Option<LayoutHash>,
+    request_layout_hash: LayoutHash,
+    active_state_map: Option<&[StateMapEntry]>,
+    request_state_map: Option<&[StateMapEntry]>,
+    hook_may_mutate_state: bool,
+    apply: impl FnOnce() -> SwapCommitResult,
+) -> Result<SwapCommitResult, String> {
+    validate_layout_transition(
+        active_layout_hash,
+        request_layout_hash,
+        active_state_map,
+        request_state_map,
+    )?;
+    let layout_changed = active_layout_hash.is_some_and(|hash| hash != request_layout_hash);
+    if !layout_changed && !hook_may_mutate_state {
+        return Ok(apply());
+    }
+    let snapshot =
+        stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES)?;
+    if layout_changed {
+        if let (Some(from), Some(to)) = (active_state_map, request_state_map) {
+            if let Err(error) = migrate_state_map_fields(from, to) {
+                stasis_dynload::restore_jit_runtime_state(&snapshot);
+                return Err(error);
+            }
+        }
+    }
+    let result = apply();
+    if result.status != SwapCommitStatus::Success {
+        stasis_dynload::restore_jit_runtime_state(&snapshot);
+    }
+    Ok(result)
 }
 
 fn migrate_state_map_fields(
@@ -3239,6 +3325,15 @@ mod tests {
     fn jit_global_table_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    static REJECTING_HOOK_PATH_HASH: std::sync::atomic::AtomicI32 =
+        std::sync::atomic::AtomicI32::new(0);
+
+    extern "C" fn mutating_rejecting_hook() {
+        let path_hash = REJECTING_HOOK_PATH_HASH.load(std::sync::atomic::Ordering::Relaxed);
+        stasis_dynload::stasis_jit_global_i32_store(path_hash, 99);
+        stasis_dynload::stasis_jit_reject_code_swap();
     }
 
     fn process_env_lock() -> &'static std::sync::Mutex<()> {
@@ -4328,6 +4423,190 @@ mod tests {
         migrate_state_map_fields(&active_map, &incoming_map).expect("migration should succeed");
         assert_eq!(stasis_dynload::stasis_jit_global_i32_load(22), 777);
         stasis_dynload::clear_jit_i32_global_table();
+    }
+
+    #[test]
+    fn watched_hook_rejection_restores_mutated_runtime_state() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "watch_rollback.stasis",
+            "function main(): i32 { return 0; }",
+        );
+        active.compile().expect("active compile");
+        let mut candidate = active.staged_candidate();
+        candidate.compile_staged().expect("candidate compile");
+        stasis_dynload::clear_jit_i32_global_table();
+        let path_hash = hash_global_path("WatchRollback.score");
+        REJECTING_HOOK_PATH_HASH.store(path_hash, std::sync::atomic::Ordering::Relaxed);
+        stasis_dynload::stasis_jit_global_i32_store(path_hash, 7);
+
+        let error = activate_candidate_runtime_transactionally(
+            &active,
+            &candidate,
+            Some(mutating_rejecting_hook as usize as u64),
+        )
+        .expect_err("hook should reject");
+
+        assert!(error.contains("rejection"));
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(path_hash), 7);
+        stasis_dynload::clear_jit_i32_global_table();
+    }
+
+    #[test]
+    fn watched_code_only_candidate_bypasses_state_snapshot_limit() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        let mut active = JitProcess::new();
+        active.upsert_file("watch_large.stasis", "function main(): i32 { return 0; }");
+        active.compile().expect("active compile");
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file("watch_large.stasis", "function main(): i32 { return 1; }");
+        candidate.compile_staged().expect("candidate compile");
+        let oversized_len = MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
+        stasis_dynload::ensure_jit_i32_array_capacity(9002, 0, oversized_len)
+            .expect("oversized test storage should allocate");
+        assert!(stasis_dynload::snapshot_jit_runtime_state_bounded(
+            MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES
+        )
+        .is_err());
+
+        activate_candidate_runtime_transactionally(&active, &candidate, None)
+            .expect("hook-free candidate activation should not snapshot state");
+
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_array_global_table();
+    }
+
+    #[test]
+    fn runner_commit_hook_rejection_restores_migrated_and_hook_state() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        stasis_dynload::clear_jit_i32_global_table();
+        let active_hash = hash_global_path("RunnerRollback.active_score");
+        let incoming_hash = hash_global_path("RunnerRollback.incoming_score");
+        stasis_dynload::stasis_jit_global_i32_store(active_hash, 7);
+        stasis_dynload::stasis_jit_global_i32_store(incoming_hash, 3);
+        REJECTING_HOOK_PATH_HASH.store(incoming_hash, std::sync::atomic::Ordering::Relaxed);
+
+        let active_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: active_hash,
+            type_name: "i32".to_string(),
+        }];
+        let incoming_map = vec![StateMapEntry {
+            path: "State.score".to_string(),
+            path_hash: incoming_hash,
+            type_name: "i32".to_string(),
+        }];
+        let request_id = RequestId(90);
+        let hook_fn_id = FnId(2);
+        let mut request = stasis_runner::swap::contracts::SwapCommitRequest::new(
+            request_id,
+            LayoutHash([2; 32]),
+            FunctionPatchSet {
+                functions: vec![FunctionPatch { fn_id: FnId(1) }],
+            },
+            Some("on_code_swap".to_string()),
+        );
+        request.hook_fn_id = Some(hook_fn_id);
+        request.state_map = Some(incoming_map.clone());
+        let config = RunnerConfig::default();
+        let host_set_contract = expected_host_set(&config);
+        attach_host_set(&mut request, &host_set_contract);
+        let mut pointer_table = FunctionPointerTable::new();
+        let mut hook_runs = 0;
+        let mut hook_failures = 0;
+        let mut hook_failure_reasons = Vec::new();
+        let mut swap_commit_successes = 0;
+        let mut swap_commit_failures = 0;
+        let mut swap_failure_reasons = Vec::new();
+        let mut events = Vec::new();
+        let pending_aot_metadata = BTreeMap::new();
+        let pending_jit_code_ptr_overrides = BTreeMap::from([(
+            request_id,
+            vec![JitCodePtrOverride {
+                fn_id: hook_fn_id,
+                code_ptr: mutating_rejecting_hook as usize as u64,
+            }],
+        )]);
+
+        let result = apply_runtime_state_transaction(
+            Some(LayoutHash([1; 32])),
+            LayoutHash([2; 32]),
+            Some(&active_map),
+            Some(&incoming_map),
+            true,
+            || {
+                apply_commit_request(
+                    request,
+                    &mut pointer_table,
+                    &config,
+                    &host_set_contract,
+                    &mut hook_runs,
+                    &mut hook_failures,
+                    &mut hook_failure_reasons,
+                    &mut swap_commit_successes,
+                    &mut swap_commit_failures,
+                    &mut swap_failure_reasons,
+                    &mut events,
+                    None,
+                    None,
+                    &pending_aot_metadata,
+                    &pending_jit_code_ptr_overrides,
+                )
+            },
+        )
+        .expect("runtime transaction should execute");
+
+        assert_eq!(result.status, SwapCommitStatus::Failed);
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(active_hash), 7);
+        assert_eq!(stasis_dynload::stasis_jit_global_i32_load(incoming_hash), 3);
+        assert_eq!(pointer_table.generation().0, 0);
+        assert_eq!(hook_runs, 1);
+        assert_eq!(hook_failures, 1);
+        assert_eq!(swap_commit_successes, 0);
+        assert_eq!(swap_commit_failures, 1);
+        stasis_dynload::clear_jit_i32_global_table();
+    }
+
+    #[test]
+    fn code_only_commit_without_hook_bypasses_state_snapshot_limit() {
+        let _global_lock = jit_global_table_lock()
+            .lock()
+            .expect("jit global lock should be acquired");
+        let _jit = JitProcess::new();
+        let oversized_len = MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
+        stasis_dynload::ensure_jit_i32_array_capacity(9001, 0, oversized_len)
+            .expect("oversized test storage should allocate");
+        assert!(stasis_dynload::snapshot_jit_runtime_state_bounded(
+            MAX_HOT_SWAP_STATE_SNAPSHOT_BYTES
+        )
+        .is_err());
+
+        let result = apply_runtime_state_transaction(
+            Some(LayoutHash([1; 32])),
+            LayoutHash([1; 32]),
+            None,
+            None,
+            false,
+            || {
+                SwapCommitResult::success(
+                    RequestId(91),
+                    Vec::new(),
+                    stasis_runner::swap::contracts::CodeGeneration(1),
+                )
+            },
+        )
+        .expect("code-only transaction should not snapshot state");
+
+        assert_eq!(result.status, SwapCommitStatus::Success);
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_array_global_table();
     }
 
     #[test]

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1,5 +1,5 @@
 use serde_json::{json, Value};
-use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess, JitScalarValue};
+use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess, JitScalarValue, JitStateLayout};
 use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::lexer::{lex, TokenKind};
@@ -51,7 +51,62 @@ impl LiveRunConfig {
 #[derive(Debug, Clone)]
 struct HistoryEntry {
     plan: WorkshopSemanticEditPlan,
+    swap_preview: LiveSwapPreview,
     receipt: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct PendingEdit {
+    plan: WorkshopSemanticEditPlan,
+    swap_preview: LiveSwapPreview,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct LiveSwapPreview {
+    schema_version: u16,
+    changed_functions: Vec<String>,
+    state_layout_compatible: bool,
+    layout_changed: bool,
+    from_layout_version: String,
+    to_layout_version: String,
+    migration_scope: LiveMigrationScope,
+    migration_steps: Vec<LiveMigrationStep>,
+    warnings: Vec<String>,
+    rejection: Option<String>,
+    estimated_commit_cost_us: u64,
+    requires_explicit_apply: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct LiveMigrationScope {
+    kind: &'static str,
+    path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LiveMigrationStepKind {
+    Copy,
+    Initialize,
+    Remove,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+struct LiveMigrationStep {
+    kind: LiveMigrationStepKind,
+    path: String,
+    field: Option<String>,
+    type_name: String,
+    elements: u32,
+    start_index: u32,
+    from_capacity: Option<u32>,
+    to_capacity: Option<u32>,
+}
+
+#[derive(Debug)]
+struct CapturedMigrationState {
+    scalars: Vec<(String, JitScalarValue)>,
+    collections: Vec<(String, String, Vec<JitScalarValue>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +121,8 @@ enum PreparedAction {
 struct PreparedEdit {
     request_id: u64,
     plan: WorkshopSemanticEditPlan,
+    swap_preview: LiveSwapPreview,
+    expected_swap_preview: Option<LiveSwapPreview>,
     restore: bool,
     action: PreparedAction,
     tests_ran: bool,
@@ -109,6 +166,7 @@ enum EditPreparationInput {
     },
     Plan {
         plan: WorkshopSemanticEditPlan,
+        expected_swap_preview: Option<LiveSwapPreview>,
         restore: bool,
         run_tests: bool,
         action: PreparedAction,
@@ -136,7 +194,7 @@ pub(crate) struct LiveWorkspace {
     completion_snapshot: Arc<CompletionSnapshot>,
     scratch: ScratchWorkspace,
     watches: BTreeMap<String, Option<JitScalarValue>>,
-    pending_plan: Option<WorkshopSemanticEditPlan>,
+    pending_plan: Option<PendingEdit>,
     pending_requests: VecDeque<LiveRequest>,
     pending_responses: VecDeque<LiveResponse>,
     self_write_hashes: BTreeMap<PathBuf, String>,
@@ -518,25 +576,37 @@ impl LiveWorkspace {
                     preview,
                     run_tests,
                 },
+                jit,
             ),
             LiveCommand::Preview => self
                 .pending_plan
                 .as_ref()
-                .map(|plan| ("edit_preview", json!({"validated": true, "plan": plan})))
+                .map(|pending| {
+                    (
+                        "edit_preview",
+                        json!({
+                            "validated": pending.swap_preview.state_layout_compatible,
+                            "plan": pending.plan,
+                            "swap": pending.swap_preview,
+                        }),
+                    )
+                })
                 .ok_or_else(|| "no validated live semantic preview is pending".to_string()),
             LiveCommand::Apply { run_tests } => {
-                let plan = self
+                let pending = self
                     .pending_plan
                     .clone()
                     .ok_or_else(|| "no validated live semantic preview is pending".to_string())?;
                 self.start_edit_preparation(
                     request_id,
                     EditPreparationInput::Plan {
-                        plan,
+                        plan: pending.plan,
+                        expected_swap_preview: Some(pending.swap_preview),
                         restore: false,
                         run_tests,
                         action: PreparedAction::ApplyPending,
                     },
+                    jit,
                 )
             }
             LiveCommand::Changes => Ok((
@@ -549,6 +619,7 @@ impl LiveWorkspace {
                         "receipt": entry.receipt,
                         "changed_files": entry.plan.changed_files.iter().map(|change| &change.file).collect::<Vec<_>>(),
                         "changed_symbols": entry.plan.reload.changed_symbols,
+                        "swap": entry.swap_preview,
                     })).collect::<Vec<_>>()
                 }),
             )),
@@ -561,10 +632,12 @@ impl LiveWorkspace {
                     request_id,
                     EditPreparationInput::Plan {
                         plan: self.history[index].plan.clone(),
+                        expected_swap_preview: None,
                         restore: true,
                         run_tests,
                         action: PreparedAction::Undo { index },
                     },
+                    jit,
                 )
             }
             LiveCommand::Redo { run_tests } => {
@@ -576,10 +649,12 @@ impl LiveWorkspace {
                         request_id,
                         EditPreparationInput::Plan {
                             plan: self.history[index].plan.clone(),
+                            expected_swap_preview: None,
                             restore: false,
                             run_tests,
                             action: PreparedAction::Redo { index },
                         },
+                        jit,
                     )
                 }
             }
@@ -661,6 +736,7 @@ impl LiveWorkspace {
                         preview,
                         run_tests,
                     },
+                    jit,
                 )
             }
         })();
@@ -756,6 +832,7 @@ impl LiveWorkspace {
         &mut self,
         request_id: u64,
         input: EditPreparationInput,
+        active: &JitProcess,
     ) -> Result<(&'static str, Value), String> {
         if let Some(preparation) = self.edit_preparation.as_ref() {
             return Err(format!(
@@ -765,13 +842,15 @@ impl LiveWorkspace {
         }
         validate_edit_input_size(&input)?;
         let config = self.config.clone();
+        let active_layout = active.state_layout();
         let canceled = Arc::new(AtomicBool::new(false));
         let worker_canceled = Arc::clone(&canceled);
         let (sender, receiver) = mpsc::sync_channel(1);
         let worker = std::thread::Builder::new()
             .name(format!("stasis-live-edit-{request_id}"))
             .spawn(move || {
-                let result = prepare_edit(request_id, &config, input, &worker_canceled);
+                let result =
+                    prepare_edit(request_id, &config, input, &active_layout, &worker_canceled);
                 let _ = sender.send(result);
             })
             .map_err(|error| format!("failed starting live edit preparation: {error}"))?;
@@ -885,19 +964,38 @@ impl LiveWorkspace {
                 "live edit preparation canceled",
             ));
         }
-        let prepared = match result {
+        let mut prepared = match result {
             Ok(prepared) => prepared,
             Err(error) => {
                 return Some(LiveResponse::failure(preparation.request_id, tick, error));
             }
         };
+        finalize_runtime_preview(&prepared.candidate, &mut prepared.swap_preview);
+        if prepared
+            .expected_swap_preview
+            .as_ref()
+            .is_some_and(|expected| expected != &prepared.swap_preview)
+        {
+            return Some(LiveResponse::failure(
+                prepared.request_id,
+                tick,
+                "refusing live commit because the regenerated swap preview differs from the validated preview",
+            ));
+        }
         if matches!(prepared.action, PreparedAction::Preview) {
-            self.pending_plan = Some(prepared.plan.clone());
+            self.pending_plan = Some(PendingEdit {
+                plan: prepared.plan.clone(),
+                swap_preview: prepared.swap_preview.clone(),
+            });
             return Some(LiveResponse::success(
                 prepared.request_id,
                 tick,
                 "edit_preview",
-                json!({"validated": true, "plan": prepared.plan}),
+                json!({
+                    "validated": prepared.swap_preview.state_layout_compatible,
+                    "plan": prepared.plan,
+                    "swap": prepared.swap_preview,
+                }),
             ));
         }
         let request_id = prepared.request_id;
@@ -915,8 +1013,26 @@ impl LiveWorkspace {
         render_code_ptr: &mut u64,
     ) -> Result<(&'static str, Value), String> {
         verify_prepared_input_hashes(&self.config, &prepared.input_hashes)?;
+        let active_layout = jit.state_layout();
+        let active_version = state_layout_version(&active_layout)?;
+        if active_version != prepared.swap_preview.from_layout_version {
+            return Err(format!(
+                "refusing live commit because active state layout changed after preview (expected {}, found {})",
+                prepared.swap_preview.from_layout_version, active_version
+            ));
+        }
+        if !prepared.swap_preview.state_layout_compatible {
+            return Err(prepared
+                .swap_preview
+                .rejection
+                .clone()
+                .unwrap_or_else(|| "incoming state layout is incompatible".to_string()));
+        }
+        preflight_collection_growth(&prepared.candidate, &prepared.swap_preview)?;
         let snapshot =
             stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_LIVE_STATE_SNAPSHOT_BYTES)?;
+        let migration_state =
+            capture_migration_state(jit, &prepared.swap_preview, MAX_LIVE_STATE_SNAPSHOT_BYTES)?;
         let receipt_directory = self.config.output.join("live-edits");
         let serialized_plan = serde_json::to_string(&prepared.plan)
             .map_err(|error| format!("failed serializing live receipt: {error}"))?;
@@ -954,8 +1070,33 @@ impl LiveWorkspace {
             ));
         }
         stasis_dynload::restore_jit_runtime_state(&snapshot);
+        if let Err(error) = prepare_collection_growth(&prepared.candidate, &prepared.swap_preview) {
+            self.rollback_prepared(&prepared, jit, &snapshot)?;
+            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+            return Err(format!(
+                "collection growth failed after state restore; disk/code/state remained unchanged: {error}"
+            ));
+        }
+        if let Err(error) = prepared.candidate.activate_staged_runtime() {
+            self.rollback_prepared(&prepared, jit, &snapshot)?;
+            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+            return Err(format!(
+                "live runtime reactivation failed after state restore; disk/code/state remained unchanged: {error}"
+            ));
+        }
+        if let Err(error) = apply_migration_state(
+            &prepared.candidate,
+            &prepared.swap_preview,
+            &migration_state,
+        ) {
+            self.rollback_prepared(&prepared, jit, &snapshot)?;
+            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+            return Err(format!(
+                "state migration failed; disk/code/state remained on the prior version: {error}"
+            ));
+        }
         if let Some(hook) = prepared.package.on_code_swap_code_ptr {
-            if let Err(error) = stasis_dynload::invoke_noarg_void(hook as usize) {
+            if let Err(error) = stasis_dynload::invoke_code_swap_hook(hook as usize) {
                 self.rollback_prepared(&prepared, jit, &snapshot)?;
                 cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
                 return Err(format!(
@@ -966,6 +1107,7 @@ impl LiveWorkspace {
         *tick_code_ptr = prepared.package.tick_code_ptr;
         *render_code_ptr = prepared.package.render_code_ptr;
         let plan = prepared.plan.clone();
+        let swap_preview = prepared.swap_preview.clone();
         let action = prepared.action.clone();
         let source_items = prepared.source_items;
         let completion_items = prepared.completion_items;
@@ -985,39 +1127,41 @@ impl LiveWorkspace {
                 self.history.truncate(self.history_cursor);
                 self.history.push(HistoryEntry {
                     plan: plan.clone(),
+                    swap_preview: swap_preview.clone(),
                     receipt: receipt.clone(),
                 });
                 self.history_cursor = self.history.len();
                 (
                     "edit_applied",
-                    json!({"plan": plan, "receipt": receipt, "tests": tests}),
+                    json!({"plan": plan, "swap": swap_preview, "receipt": receipt, "tests": tests}),
                 )
             }
             PreparedAction::ApplyPending => {
                 self.history.truncate(self.history_cursor);
                 self.history.push(HistoryEntry {
                     plan: plan.clone(),
+                    swap_preview: swap_preview.clone(),
                     receipt: receipt.clone(),
                 });
                 self.history_cursor = self.history.len();
                 self.pending_plan = None;
                 (
                     "edit_applied",
-                    json!({"plan": plan, "receipt": receipt, "tests": tests}),
+                    json!({"plan": plan, "swap": swap_preview, "receipt": receipt, "tests": tests}),
                 )
             }
             PreparedAction::Undo { index } => {
                 self.history_cursor = index;
                 (
                     "edit_undone",
-                    json!({"index": index, "receipt": receipt, "tests": tests}),
+                    json!({"index": index, "swap": swap_preview, "receipt": receipt, "tests": tests}),
                 )
             }
             PreparedAction::Redo { index } => {
                 self.history_cursor = index + 1;
                 (
                     "edit_redone",
-                    json!({"index": index, "receipt": receipt, "tests": tests}),
+                    json!({"index": index, "swap": swap_preview, "receipt": receipt, "tests": tests}),
                 )
             }
             PreparedAction::Preview => unreachable!("preview never commits"),
@@ -1258,6 +1402,7 @@ fn prepare_edit(
     request_id: u64,
     config: &LiveRunConfig,
     input: EditPreparationInput,
+    active_layout: &JitStateLayout,
     canceled: &AtomicBool,
 ) -> Result<PreparedEdit, String> {
     check_preparation_canceled(canceled)?;
@@ -1266,7 +1411,8 @@ fn prepare_edit(
         .iter()
         .map(|file| (file.path.clone(), workshop_source_hash(&file.source)))
         .collect::<BTreeMap<_, _>>();
-    let (candidate_files, plan, restore, run_tests, action) = match input {
+    let (candidate_files, plan, restore, run_tests, mut action, expected_swap_preview) = match input
+    {
         EditPreparationInput::Edit {
             operation,
             target,
@@ -1287,6 +1433,7 @@ fn prepare_edit(
                 } else {
                     PreparedAction::ApplyNew
                 },
+                None,
             )
         }
         EditPreparationInput::Persist {
@@ -1311,26 +1458,45 @@ fn prepare_edit(
                 } else {
                     PreparedAction::ApplyNew
                 },
+                None,
             )
         }
         EditPreparationInput::Plan {
             plan,
+            expected_swap_preview,
             restore,
             run_tests,
             action,
         } => {
             let candidate_files = files_for_plan(&files, &plan, restore)?;
-            (candidate_files, plan, restore, run_tests, action)
+            (
+                candidate_files,
+                plan,
+                restore,
+                run_tests,
+                action,
+                expected_swap_preview,
+            )
         }
     };
-    if plan.reload.expected_reload == ExpectedReload::ResetRequired {
-        return Err(format!(
-            "live edit rejected until layout migration support lands in Maddox #153: {}",
-            plan.reload.reason
-        ));
-    }
     check_preparation_canceled(canceled)?;
     let (candidate, package) = compile_candidate(config, &candidate_files)?;
+    let changed_functions = candidate.symbol_code_ptrs().into_keys().collect();
+    let swap_preview = plan_live_swap(
+        active_layout,
+        &candidate.state_layout(),
+        &plan,
+        changed_functions,
+    )?;
+    if matches!(action, PreparedAction::ApplyNew) && swap_preview.requires_explicit_apply {
+        action = PreparedAction::Preview;
+    }
+    if !matches!(action, PreparedAction::Preview) && !swap_preview.state_layout_compatible {
+        return Err(swap_preview
+            .rejection
+            .clone()
+            .unwrap_or_else(|| "incoming state layout is incompatible".to_string()));
+    }
     check_preparation_canceled(canceled)?;
     if run_tests {
         run_staged_tests(config, &candidate_files, request_id, canceled).map_err(|error| {
@@ -1343,6 +1509,8 @@ fn prepare_edit(
     Ok(PreparedEdit {
         request_id,
         plan,
+        swap_preview,
+        expected_swap_preview,
         restore,
         action,
         tests_ran: run_tests,
@@ -1353,6 +1521,364 @@ fn prepare_edit(
         source_files: candidate_files,
         input_hashes,
     })
+}
+
+fn plan_live_swap(
+    active: &JitStateLayout,
+    incoming: &JitStateLayout,
+    plan: &WorkshopSemanticEditPlan,
+    mut changed_functions: Vec<String>,
+) -> Result<LiveSwapPreview, String> {
+    let from_layout_version = state_layout_version(active)?;
+    let to_layout_version = state_layout_version(incoming)?;
+    let layout_changed = from_layout_version != to_layout_version;
+    changed_functions.sort();
+    changed_functions.dedup();
+
+    let active_scalars = active
+        .scalars
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let incoming_scalars = incoming
+        .scalars
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let active_collections = collection_field_layouts(active)?;
+    let incoming_collections = collection_field_layouts(incoming)?;
+    let active_opaque = active
+        .opaque
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let incoming_opaque = incoming
+        .opaque
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut steps = Vec::new();
+    let mut warnings = Vec::new();
+    let mut rejections = Vec::new();
+    let mut affected_roots = BTreeSet::new();
+
+    if layout_changed {
+        for (path, incoming_type) in &incoming_scalars {
+            if path.ends_with(".max_length") {
+                continue;
+            }
+            match active_scalars.get(path) {
+                Some(active_type) if active_type == incoming_type => {
+                    steps.push(scalar_migration_step(
+                        LiveMigrationStepKind::Copy,
+                        path,
+                        incoming_type,
+                    ));
+                }
+                Some(active_type) => {
+                    rejections.push(format!(
+                        "state path '{path}' changed type '{active_type}' -> '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    steps.push(scalar_migration_step(
+                        LiveMigrationStepKind::Initialize,
+                        path,
+                        incoming_type,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for (path, active_type) in &active_scalars {
+            if path.ends_with(".max_length") || incoming_scalars.contains_key(path) {
+                continue;
+            }
+            steps.push(scalar_migration_step(
+                LiveMigrationStepKind::Remove,
+                path,
+                active_type,
+            ));
+            warnings.push(format!("removed state path '{path}' will be discarded"));
+            affected_roots.insert(migration_root(path));
+        }
+
+        for ((path, field), incoming_field) in &incoming_collections {
+            match active_collections.get(&(path.clone(), field.clone())) {
+                Some(active_field) if active_field.type_name == incoming_field.type_name => {
+                    let elements = active_field.capacity.min(incoming_field.capacity);
+                    steps.push(collection_migration_step(
+                        LiveMigrationStepKind::Copy,
+                        path,
+                        field,
+                        &incoming_field.type_name,
+                        0,
+                        elements,
+                        active_field.capacity,
+                        incoming_field.capacity,
+                    ));
+                    if incoming_field.capacity < active_field.capacity {
+                        warnings.push(format!(
+                            "collection '{}' shrinks from {} to {}; elements [{}..{}) will be discarded",
+                            display_collection_path(path, field),
+                            active_field.capacity,
+                            incoming_field.capacity,
+                            incoming_field.capacity,
+                            active_field.capacity,
+                        ));
+                        affected_roots.insert(migration_root(path));
+                    } else if incoming_field.capacity > active_field.capacity {
+                        steps.push(collection_migration_step(
+                            LiveMigrationStepKind::Initialize,
+                            path,
+                            field,
+                            &incoming_field.type_name,
+                            active_field.capacity,
+                            incoming_field.capacity - active_field.capacity,
+                            active_field.capacity,
+                            incoming_field.capacity,
+                        ));
+                        affected_roots.insert(migration_root(path));
+                    }
+                }
+                Some(active_field) => {
+                    rejections.push(format!(
+                        "collection state path '{}' changed type '{}' -> '{}'",
+                        display_collection_path(path, field),
+                        active_field.type_name,
+                        incoming_field.type_name,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    steps.push(collection_migration_step(
+                        LiveMigrationStepKind::Initialize,
+                        path,
+                        field,
+                        &incoming_field.type_name,
+                        0,
+                        incoming_field.capacity,
+                        0,
+                        incoming_field.capacity,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for ((path, field), active_field) in &active_collections {
+            if incoming_collections.contains_key(&(path.clone(), field.clone())) {
+                continue;
+            }
+            steps.push(collection_migration_step(
+                LiveMigrationStepKind::Remove,
+                path,
+                field,
+                &active_field.type_name,
+                0,
+                active_field.capacity,
+                active_field.capacity,
+                0,
+            ));
+            warnings.push(format!(
+                "removed collection state path '{}' will be discarded",
+                display_collection_path(path, field)
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+        for (path, incoming_type) in &incoming_opaque {
+            match active_opaque.get(path) {
+                Some(active_type) if active_type == incoming_type => {}
+                Some(active_type) => {
+                    rejections.push(format!(
+                        "state path '{path}' changed non-migratable type '{active_type}' -> '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    rejections.push(format!(
+                        "new state path '{path}' uses non-migratable type '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for (path, active_type) in &active_opaque {
+            if incoming_opaque.contains_key(path) {
+                continue;
+            }
+            rejections.push(format!(
+                "removed state path '{path}' uses non-migratable type '{active_type}'"
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+    }
+
+    if plan.reload.expected_reload == ExpectedReload::ResetRequired
+        && plan
+            .reload
+            .reason
+            .to_ascii_lowercase()
+            .contains("signature changed")
+    {
+        rejections.push(format!(
+            "{} Hot reload cannot migrate function ABI changes.",
+            plan.reload.reason
+        ));
+    }
+
+    let state_layout_compatible = rejections.is_empty();
+    let rejection = (!state_layout_compatible).then(|| {
+        format!(
+            "hot reload rejected: {}. Old code and state remain active.",
+            rejections.join("; ")
+        )
+    });
+    let migration_scope = if affected_roots.len() == 1 {
+        let path = affected_roots
+            .into_iter()
+            .next()
+            .expect("one affected root");
+        let top_level_global = active_scalars.contains_key(&path)
+            || incoming_scalars.contains_key(&path)
+            || active_opaque.contains_key(&path)
+            || incoming_opaque.contains_key(&path)
+            || active_collections
+                .keys()
+                .any(|(collection, _)| collection == &path)
+            || incoming_collections
+                .keys()
+                .any(|(collection, _)| collection == &path);
+        LiveMigrationScope {
+            kind: if top_level_global {
+                "whole_state"
+            } else {
+                "struct"
+            },
+            path: (!top_level_global).then_some(path),
+        }
+    } else if affected_roots.is_empty() {
+        LiveMigrationScope {
+            kind: "none",
+            path: None,
+        }
+    } else {
+        LiveMigrationScope {
+            kind: "whole_state",
+            path: None,
+        }
+    };
+    let state_values = steps
+        .iter()
+        .filter(|step| step.kind != LiveMigrationStepKind::Remove)
+        .map(|step| u64::from(step.elements))
+        .sum::<u64>();
+    let estimated_commit_cost_us = 20u64
+        .saturating_add((changed_functions.len() as u64).saturating_mul(5))
+        .saturating_add(state_values.saturating_mul(8).div_ceil(256));
+
+    Ok(LiveSwapPreview {
+        schema_version: 1,
+        changed_functions,
+        state_layout_compatible,
+        layout_changed,
+        from_layout_version,
+        to_layout_version,
+        migration_scope,
+        migration_steps: steps,
+        warnings,
+        rejection,
+        estimated_commit_cost_us,
+        requires_explicit_apply: plan.reload.expected_reload == ExpectedReload::ResetRequired,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct CollectionFieldLayout {
+    type_name: String,
+    capacity: u32,
+}
+
+fn collection_field_layouts(
+    layout: &JitStateLayout,
+) -> Result<BTreeMap<(String, String), CollectionFieldLayout>, String> {
+    let mut fields = BTreeMap::new();
+    for collection in &layout.collections {
+        let capacity = u32::try_from(collection.capacity).map_err(|_| {
+            format!(
+                "collection '{}' has negative capacity {}",
+                collection.path, collection.capacity
+            )
+        })?;
+        for field in &collection.fields {
+            fields.insert(
+                (collection.path.clone(), field.field.clone()),
+                CollectionFieldLayout {
+                    type_name: field.type_name.clone(),
+                    capacity,
+                },
+            );
+        }
+    }
+    Ok(fields)
+}
+
+fn state_layout_version(layout: &JitStateLayout) -> Result<String, String> {
+    serde_json::to_string(layout)
+        .map(|serialized| workshop_source_hash(&serialized))
+        .map_err(|error| format!("failed versioning JIT state layout: {error}"))
+}
+
+fn scalar_migration_step(
+    kind: LiveMigrationStepKind,
+    path: &str,
+    type_name: &str,
+) -> LiveMigrationStep {
+    LiveMigrationStep {
+        kind,
+        path: path.to_string(),
+        field: None,
+        type_name: type_name.to_string(),
+        elements: 1,
+        start_index: 0,
+        from_capacity: None,
+        to_capacity: None,
+    }
+}
+
+fn collection_migration_step(
+    kind: LiveMigrationStepKind,
+    path: &str,
+    field: &str,
+    type_name: &str,
+    start_index: u32,
+    elements: u32,
+    from_capacity: u32,
+    to_capacity: u32,
+) -> LiveMigrationStep {
+    LiveMigrationStep {
+        kind,
+        path: path.to_string(),
+        field: Some(field.to_string()),
+        type_name: type_name.to_string(),
+        elements,
+        start_index,
+        from_capacity: Some(from_capacity),
+        to_capacity: Some(to_capacity),
+    }
+}
+
+fn migration_root(path: &str) -> String {
+    path.split('.').next().unwrap_or(path).to_string()
+}
+
+fn display_collection_path(path: &str, field: &str) -> String {
+    if field.is_empty() {
+        format!("{path}[]")
+    } else {
+        format!("{path}[].{field}")
+    }
 }
 
 fn plan_live_edit(
@@ -1610,6 +2136,307 @@ fn check_preparation_canceled(canceled: &AtomicBool) -> Result<(), String> {
         Err("live edit preparation canceled".to_string())
     } else {
         Ok(())
+    }
+}
+
+fn capture_migration_state(
+    active: &JitProcess,
+    preview: &LiveSwapPreview,
+    max_bytes: usize,
+) -> Result<CapturedMigrationState, String> {
+    let copied_values = preview
+        .migration_steps
+        .iter()
+        .filter(|step| step.kind == LiveMigrationStepKind::Copy)
+        .map(|step| step.elements as usize)
+        .try_fold(0usize, |total, count| total.checked_add(count))
+        .ok_or_else(|| "state migration value count overflow".to_string())?;
+    let required_bytes = copied_values
+        .checked_mul(std::mem::size_of::<JitScalarValue>())
+        .ok_or_else(|| "state migration snapshot size overflow".to_string())?;
+    if required_bytes > max_bytes {
+        return Err(format!(
+            "state migration requires {required_bytes} bytes, exceeding the {max_bytes}-byte live limit"
+        ));
+    }
+
+    let mut scalars = Vec::new();
+    let mut collections = Vec::new();
+    for step in &preview.migration_steps {
+        if step.kind != LiveMigrationStepKind::Copy {
+            continue;
+        }
+        if let Some(field) = step.field.as_deref() {
+            let mut values = Vec::with_capacity(step.elements as usize);
+            for index in step.start_index..step.start_index.saturating_add(step.elements) {
+                values.push(active.read_global_collection_scalar(
+                    &step.path,
+                    field,
+                    index as i32,
+                )?);
+            }
+            collections.push((step.path.clone(), field.to_string(), values));
+        } else {
+            scalars.push((step.path.clone(), active.read_global_scalar(&step.path)?));
+        }
+    }
+    Ok(CapturedMigrationState {
+        scalars,
+        collections,
+    })
+}
+
+fn apply_migration_state(
+    incoming: &JitProcess,
+    preview: &LiveSwapPreview,
+    captured: &CapturedMigrationState,
+) -> Result<(), String> {
+    let scalars = captured
+        .scalars
+        .iter()
+        .map(|(path, value)| (path.as_str(), *value))
+        .collect::<BTreeMap<_, _>>();
+    let collections = captured
+        .collections
+        .iter()
+        .map(|(path, field, values)| ((path.as_str(), field.as_str()), values.as_slice()))
+        .collect::<BTreeMap<_, _>>();
+
+    for step in &preview.migration_steps {
+        match (step.kind, step.field.as_deref()) {
+            (LiveMigrationStepKind::Copy, None) => {
+                let value = scalars.get(step.path.as_str()).copied().ok_or_else(|| {
+                    format!("migration copy source '{}' was not captured", step.path)
+                })?;
+                incoming.write_global_scalar(&step.path, value)?;
+            }
+            (LiveMigrationStepKind::Initialize, None) => {
+                incoming.write_global_scalar(&step.path, default_scalar_value(&step.type_name)?)?;
+            }
+            (LiveMigrationStepKind::Copy, Some(field)) => {
+                let values = collections
+                    .get(&(step.path.as_str(), field))
+                    .copied()
+                    .ok_or_else(|| {
+                        format!(
+                            "migration copy source '{}' was not captured",
+                            display_collection_path(&step.path, field)
+                        )
+                    })?;
+                if values.len() != step.elements as usize {
+                    return Err(format!(
+                        "migration copy source '{}' expected {} elements, captured {}",
+                        display_collection_path(&step.path, field),
+                        step.elements,
+                        values.len()
+                    ));
+                }
+                for (offset, value) in values.iter().copied().enumerate() {
+                    incoming.write_global_collection_scalar(
+                        &step.path,
+                        field,
+                        step.start_index as i32 + offset as i32,
+                        value,
+                    )?;
+                }
+            }
+            (LiveMigrationStepKind::Initialize, Some(field)) => {
+                let value = default_scalar_value(&step.type_name)?;
+                for index in step.start_index..step.start_index.saturating_add(step.elements) {
+                    incoming.write_global_collection_scalar(
+                        &step.path,
+                        field,
+                        index as i32,
+                        value,
+                    )?;
+                }
+            }
+            (LiveMigrationStepKind::Remove, _) => {}
+        }
+    }
+
+    let mut shrunken = BTreeSet::new();
+    for step in &preview.migration_steps {
+        let (Some(from_capacity), Some(to_capacity)) = (step.from_capacity, step.to_capacity)
+        else {
+            continue;
+        };
+        if to_capacity >= from_capacity {
+            continue;
+        }
+        shrunken.insert((step.path.as_str(), to_capacity));
+    }
+    for (path, capacity) in shrunken {
+        normalize_collection_lengths(incoming, path, capacity)?;
+    }
+    Ok(())
+}
+
+fn normalize_collection_lengths(
+    incoming: &JitProcess,
+    path: &str,
+    capacity: u32,
+) -> Result<(), String> {
+    let capacity = capacity as i32;
+    if incoming.global_fixed_text_encoding(path) == Some("utf8") {
+        let byte_length = read_i32_header(incoming, path, "length")?
+            .or(read_i32_header(incoming, path, "byte_length")?)
+            .unwrap_or(0)
+            .clamp(0, capacity);
+        let mut bytes = Vec::with_capacity(byte_length as usize);
+        for index in 0..byte_length {
+            let JitScalarValue::U8(value) =
+                incoming.read_global_collection_scalar(path, "", index)?
+            else {
+                return Err(format!("UTF-8 collection '{path}' payload is not u8"));
+            };
+            bytes.push(value);
+        }
+        let valid_bytes = std::str::from_utf8(&bytes)
+            .map(|_| bytes.len())
+            .unwrap_or_else(|error| error.valid_up_to());
+        let char_length = std::str::from_utf8(&bytes[..valid_bytes])
+            .expect("valid UTF-8 prefix")
+            .chars()
+            .count() as i32;
+        for index in valid_bytes..bytes.len() {
+            incoming.write_global_collection_scalar(
+                path,
+                "",
+                index as i32,
+                JitScalarValue::U8(0),
+            )?;
+        }
+        write_i32_header(incoming, path, "length", valid_bytes as i32)?;
+        write_i32_header(incoming, path, "byte_length", valid_bytes as i32)?;
+        write_i32_header(incoming, path, "char_length", char_length)?;
+        return Ok(());
+    }
+    for suffix in ["length", "byte_length", "char_length"] {
+        if let Some(length) = read_i32_header(incoming, path, suffix)? {
+            write_i32_header(incoming, path, suffix, length.clamp(0, capacity))?;
+        }
+    }
+    Ok(())
+}
+
+fn read_i32_header(incoming: &JitProcess, path: &str, suffix: &str) -> Result<Option<i32>, String> {
+    let header = format!("{path}.{suffix}");
+    if incoming.global_scalar_type(&header) != Some("i32") {
+        return Ok(None);
+    }
+    let JitScalarValue::I32(value) = incoming.read_global_scalar(&header)? else {
+        return Err(format!("collection length path '{header}' is not i32"));
+    };
+    Ok(Some(value))
+}
+
+fn write_i32_header(
+    incoming: &JitProcess,
+    path: &str,
+    suffix: &str,
+    value: i32,
+) -> Result<(), String> {
+    let header = format!("{path}.{suffix}");
+    if incoming.global_scalar_type(&header) == Some("i32") {
+        incoming.write_global_scalar(&header, JitScalarValue::I32(value))?;
+    }
+    Ok(())
+}
+
+fn default_scalar_value(type_name: &str) -> Result<JitScalarValue, String> {
+    match type_name {
+        "i32" => Ok(JitScalarValue::I32(0)),
+        "f32" => Ok(JitScalarValue::F32(0.0)),
+        "f64" => Ok(JitScalarValue::F64(0.0)),
+        "bool" => Ok(JitScalarValue::Bool(false)),
+        "u8" => Ok(JitScalarValue::U8(0)),
+        _ => Err(format!(
+            "state migration cannot initialize unsupported scalar type '{type_name}'"
+        )),
+    }
+}
+
+fn finalize_runtime_preview(candidate: &JitProcess, preview: &mut LiveSwapPreview) {
+    if !preview.state_layout_compatible {
+        return;
+    }
+    if let Err(error) = preflight_collection_growth(candidate, preview) {
+        preview.state_layout_compatible = false;
+        preview.rejection = Some(format!(
+            "hot reload rejected: {error}. Old code and state remain active."
+        ));
+    }
+}
+
+fn preflight_collection_growth(
+    candidate: &JitProcess,
+    preview: &LiveSwapPreview,
+) -> Result<Vec<(String, String, u32)>, String> {
+    let mut prepared = BTreeSet::new();
+    let mut total_bytes = 0usize;
+    for step in &preview.migration_steps {
+        let (Some(field), Some(from_capacity), Some(to_capacity)) =
+            (step.field.as_deref(), step.from_capacity, step.to_capacity)
+        else {
+            continue;
+        };
+        if to_capacity <= from_capacity
+            || !prepared.insert((step.path.clone(), field.to_string(), to_capacity))
+        {
+            continue;
+        }
+        let value_bytes = migration_type_bytes(&step.type_name)?;
+        total_bytes = total_bytes
+            .checked_add(
+                (to_capacity as usize)
+                    .checked_mul(value_bytes)
+                    .ok_or_else(|| "collection growth allocation size overflow".to_string())?,
+            )
+            .ok_or_else(|| "collection growth allocation size overflow".to_string())?;
+        if total_bytes > MAX_LIVE_STATE_SNAPSHOT_BYTES {
+            return Err(format!(
+                "collection growth requires {total_bytes} bytes, exceeding the {MAX_LIVE_STATE_SNAPSHOT_BYTES}-byte live limit"
+            ));
+        }
+    }
+    for (path, field, capacity) in &prepared {
+        candidate
+            .preflight_global_collection_capacity(path, field, *capacity)
+            .map_err(|error| {
+                format!(
+                    "failed preparing collection growth for '{}': {error}",
+                    display_collection_path(path, field)
+                )
+            })?;
+    }
+    Ok(prepared.into_iter().collect())
+}
+
+fn prepare_collection_growth(
+    candidate: &JitProcess,
+    preview: &LiveSwapPreview,
+) -> Result<(), String> {
+    for (path, field, capacity) in preflight_collection_growth(candidate, preview)? {
+        candidate
+            .ensure_global_collection_capacity(&path, &field, capacity)
+            .map_err(|error| {
+                format!(
+                    "failed preparing collection growth for '{}': {error}",
+                    display_collection_path(&path, &field)
+                )
+            })?;
+    }
+    Ok(())
+}
+
+fn migration_type_bytes(type_name: &str) -> Result<usize, String> {
+    match type_name {
+        "i32" | "f32" | "bool" | "u8" => Ok(4),
+        "f64" => Ok(8),
+        _ => Err(format!(
+            "unsupported collection migration type '{type_name}'"
+        )),
     }
 }
 
@@ -1927,6 +2754,10 @@ fn parse_scalar_value(
             "false" => Ok(JitScalarValue::Bool(false)),
             _ => Err(format!("invalid bool expression '{expression}'")),
         },
+        JitScalarValue::U8(_) => expression
+            .parse::<u8>()
+            .map(JitScalarValue::U8)
+            .map_err(|error| format!("invalid u8 expression '{expression}': {error}")),
     }
 }
 
@@ -2068,6 +2899,9 @@ mod tests {
     }
 
     fn prepared_tick_edit(config: &LiveRunConfig, request_id: u64) -> PreparedEdit {
+        let (active, _) = compile(config);
+        let active_layout = active.state_layout();
+        drop(active);
         prepare_edit(
             request_id,
             config,
@@ -2085,6 +2919,7 @@ mod tests {
                 preview: false,
                 run_tests: false,
             },
+            &active_layout,
             &AtomicBool::new(false),
         )
         .expect("prepare edit")
@@ -2357,9 +3192,10 @@ mod tests {
     }
 
     #[test]
-    fn layout_edit_is_rejected_before_disk_or_runtime_change() {
+    fn layout_edit_previews_then_preserves_state_and_initializes_new_field() {
         let (root, config) = project();
         let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
         let (client, server) = stasis_runner::live::live_session(4);
         let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
         let mut tick_ptr = package.tick_code_ptr;
@@ -2389,12 +3225,732 @@ mod tests {
                 },
             ),
         );
-        assert!(!response.ok);
-        assert!(response.error.expect("error").contains("#153"));
+        assert!(response.ok, "{:?}", response.error);
+        assert_eq!(response.kind, "edit_preview");
+        let data = response.data.expect("preview data");
+        assert_eq!(data["validated"], true);
+        assert_eq!(data["swap"]["layout_changed"], true);
+        assert_eq!(data["swap"]["requires_explicit_apply"], true);
+        assert_eq!(data["swap"]["migration_scope"]["kind"], "whole_state");
+        assert!(data["swap"]["changed_functions"]
+            .as_array()
+            .is_some_and(|functions| !functions.is_empty()));
+        assert!(data["swap"]["migration_steps"]
+            .as_array()
+            .expect("migration steps")
+            .iter()
+            .any(|step| step["kind"] == "initialize" && step["path"] == "extra"));
         assert_eq!(
             fs::read_to_string(root.join("src/main.stasis")).expect("after"),
             before
         );
+
+        let applied = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(2, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(applied.ok, "{:?}", applied.error);
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(1)));
+        assert_eq!(jit.read_global_scalar("extra"), Ok(JitScalarValue::I32(0)));
+        assert!(fs::read_to_string(root.join("src/main.stasis"))
+            .expect("source")
+            .contains("global extra: i32;"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn collection_capacity_shrink_warns_and_copies_only_retained_elements() {
+        let (root, config) = project();
+        let sample = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("samples/layout_migration_preview.stasis");
+        fs::write(
+            root.join("src/main.stasis"),
+            fs::read_to_string(sample).expect("migration sample"),
+        )
+        .expect("array source");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                10,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global score: i32;\nglobal values: i32[2];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        let swap = &response.data.expect("preview")["swap"];
+        assert!(swap["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|text| text.contains("shrinks from 4 to 2"))));
+
+        let applied = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(11, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(applied.ok, "{:?}", applied.error);
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 0),
+            Ok(JitScalarValue::I32(11))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 1),
+            Ok(JitScalarValue::I32(22))
+        );
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
+        assert_eq!(
+            stasis_dynload::invoke_noarg_i32(tick_ptr as usize).expect("migrated tick"),
+            19
+        );
+        assert!(jit
+            .read_global_collection_scalar("values", "", 2)
+            .expect_err("new capacity should reject index 2")
+            .contains("outside capacity 2"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn collection_capacity_growth_preserves_prefix_and_initializes_tail() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global values: i32[2];\nfunction main(): i32 { values[0] = 11; values[1] = 22; return 0; }\nfunction tick(): i32 { return values[0] + values[1]; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("array source");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                12,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global values: i32[4];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        assert!(preview.data.expect("preview")["swap"]["migration_steps"]
+            .as_array()
+            .expect("steps")
+            .iter()
+            .any(|step| {
+                step["kind"] == "initialize" && step["start_index"] == 2 && step["elements"] == 2
+            }));
+
+        let applied = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(13, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(applied.ok, "{:?}", applied.error);
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 0),
+            Ok(JitScalarValue::I32(11))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 1),
+            Ok(JitScalarValue::I32(22))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 2),
+            Ok(JitScalarValue::I32(0))
+        );
+        jit.write_global_collection_scalar("values", "", 3, JitScalarValue::I32(44))
+            .expect("expanded storage accepts the new tail");
+        assert_eq!(
+            jit.read_global_collection_scalar("values", "", 3),
+            Ok(JitScalarValue::I32(44))
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn collection_growth_preview_rejects_host_owned_storage() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global values: i32[2];\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return values[0]; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("array source");
+        let (mut jit, package) = compile(&config);
+        let mut host_values = vec![11, 22];
+        stasis_dynload::register_global_i32_array(
+            crate::hash_global_path("values"),
+            0,
+            host_values.as_mut_ptr(),
+            host_values.len(),
+        );
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                18,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global values: i32[4];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let data = preview.data.expect("preview");
+        assert_eq!(data["validated"], false);
+        assert!(data["swap"]["rejection"]
+            .as_str()
+            .is_some_and(|error| error.contains("host-owned")));
+        assert_eq!(host_values, [11, 22]);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn collection_growth_preview_rejects_unbounded_allocation() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global values: i32[2];\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return values[0]; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("array source");
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                19,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global values: i32[3000000];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let data = preview.data.expect("preview");
+        assert_eq!(data["validated"], false);
+        assert!(data["swap"]["rejection"]
+            .as_str()
+            .is_some_and(|error| error.contains("8") && error.contains("live limit")));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn new_collection_commit_allocates_and_initializes_storage() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global score: i32;\nfunction main(): i32 { score = 7; return 0; }\nfunction tick(): i32 { return score; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("scalar source");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                20,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global score: i32;\nglobal fresh_values: i32[4];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        assert_eq!(preview.data.expect("preview")["validated"], true);
+
+        let applied = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(21, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(applied.ok, "{:?}", applied.error);
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
+        assert_eq!(
+            jit.read_global_collection_scalar("fresh_values", "", 3),
+            Ok(JitScalarValue::I32(0))
+        );
+        jit.write_global_collection_scalar("fresh_values", "", 3, JitScalarValue::I32(44))
+            .expect("new storage accepts writes");
+        assert_eq!(
+            jit.read_global_collection_scalar("fresh_values", "", 3),
+            Ok(JitScalarValue::I32(44))
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn new_collection_preview_rejects_unbounded_allocation() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global score: i32;\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return score; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("scalar source");
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                22,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global score: i32;\nglobal huge_values: i32[3000000];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let data = preview.data.expect("preview");
+        assert_eq!(data["validated"], false);
+        assert!(data["swap"]["rejection"]
+            .as_str()
+            .is_some_and(|error| error.contains("8") && error.contains("live limit")));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn text_capacity_shrink_copies_bytes_and_clamps_lengths() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global label: ascii[4];\nglobal glyphs: utf8[3];\nglobal word: utf8[3];\nfunction main(): i32 { label[0] = 65; label[1] = 66; label[2] = 67; label.length = 4; label.byte_length = 4; glyphs[0] = 195; glyphs[1] = 169; glyphs[2] = 65; glyphs.length = 3; glyphs.byte_length = 3; glyphs.char_length = 2; word[0] = 195; word[1] = 169; word[2] = 65; word.length = 3; word.char_length = 2; return 0; }\nfunction tick(): i32 { return label.length + glyphs.length + word.length; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("text source");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                14,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some(
+                        "global label: ascii[2];\nglobal glyphs: utf8[1];\nglobal word: utf8[2];"
+                            .into(),
+                    ),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let preview_data = preview.data.expect("preview");
+        let swap = &preview_data["swap"];
+        let warnings = swap["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>();
+        assert!(
+            warnings.iter().any(|warning| warning.contains("label[]")),
+            "{swap:#}\nactive={:#?}",
+            jit.state_layout()
+        );
+        assert!(
+            warnings.iter().any(|warning| warning.contains("glyphs[]")),
+            "{swap:#}\nactive={:#?}",
+            jit.state_layout()
+        );
+        assert!(warnings.iter().any(|warning| warning.contains("word[]")));
+
+        let applied = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(15, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(applied.ok, "{:?}", applied.error);
+        assert_eq!(
+            jit.read_global_scalar("label.length"),
+            Ok(JitScalarValue::I32(2))
+        );
+        assert_eq!(
+            jit.read_global_scalar("glyphs.length"),
+            Ok(JitScalarValue::I32(0))
+        );
+        assert_eq!(
+            jit.read_global_scalar("label.byte_length"),
+            Ok(JitScalarValue::I32(2))
+        );
+        assert_eq!(
+            jit.read_global_scalar("glyphs.byte_length"),
+            Ok(JitScalarValue::I32(0))
+        );
+        assert_eq!(
+            jit.read_global_scalar("glyphs.char_length"),
+            Ok(JitScalarValue::I32(0))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("label", "", 0),
+            Ok(JitScalarValue::U8(65))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("glyphs", "", 1),
+            Err("global collection path 'glyphs' index 1 is outside capacity 1".to_string())
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("glyphs", "", 0),
+            Ok(JitScalarValue::U8(0))
+        );
+        assert_eq!(
+            jit.read_global_scalar("word.length"),
+            Ok(JitScalarValue::I32(2))
+        );
+        assert_eq!(
+            jit.read_global_scalar("word.byte_length"),
+            Ok(JitScalarValue::I32(2))
+        );
+        assert_eq!(
+            jit.read_global_scalar("word.char_length"),
+            Ok(JitScalarValue::I32(1))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("word", "", 0),
+            Ok(JitScalarValue::U8(195))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("word", "", 1),
+            Ok(JitScalarValue::U8(169))
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn hook_rejection_rolls_back_hook_mutation_code_and_disk() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "extern function reject_code_swap(): void;\nglobal score: i32;\nfunction main(): i32 { score = 7; return 0; }\nfunction tick(): i32 { return score; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("hook source");
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let old_tick_ptr = package.tick_code_ptr;
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                16,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "on_code_swap".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some(
+                        "function on_code_swap(): void { score = 99; reject_code_swap(); return; }"
+                            .into(),
+                    ),
+                    expected_source_hash: None,
+                    preview: true,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let rejected = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(17, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(!rejected.ok);
+        assert!(rejected
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("hook requested rejection")));
+        assert_eq!(tick_ptr, old_tick_ptr);
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn hook_rejection_after_growth_restores_old_collection_registration() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "extern function reject_code_swap(): void;\nglobal rollback_values: i32[2];\nfunction main(): i32 { rollback_values[0] = 11; rollback_values[1] = 22; return 0; }\nfunction tick(): i32 { return rollback_values[0] + rollback_values[1]; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { rollback_values[0] = 99; reject_code_swap(); return; }\n",
+        )
+        .expect("hook source");
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let preview = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                22,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global rollback_values: i32[4];".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(preview.ok, "{:?}", preview.error);
+        let rejected = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(23, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(!rejected.ok);
+        assert_eq!(
+            jit.read_global_collection_scalar("rollback_values", "", 0),
+            Ok(JitScalarValue::I32(11))
+        );
+        assert_eq!(
+            jit.read_global_collection_scalar("rollback_values", "", 1),
+            Ok(JitScalarValue::I32(22))
+        );
+        assert!(jit
+            .read_global_collection_scalar("rollback_values", "", 2)
+            .expect_err("old capacity restored")
+            .contains("outside capacity 2"));
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn incompatible_state_type_preview_cannot_commit() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "global score: i32;\nglobal spare: i32;\nfunction main(): i32 { score = 7; return 0; }\nfunction tick(): i32 { return score; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("source");
+        let before = fs::read_to_string(root.join("src/main.stasis")).expect("before");
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(4);
+        let mut workspace = LiveWorkspace::new(server, config.clone(), &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                20,
+                LiveCommand::Edit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "globals".into(),
+                        kind: Some("globals".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("global score: i32;\nglobal spare: f32;".into()),
+                    expected_source_hash: None,
+                    preview: false,
+                    run_tests: false,
+                },
+            ),
+        );
+        assert!(response.ok, "{:?}", response.error);
+        let data = response.data.expect("preview");
+        assert_eq!(data["validated"], false);
+        assert!(data["swap"]["rejection"]
+            .as_str()
+            .is_some_and(|text| text.contains("spare")
+                && text.contains("i32")
+                && text.contains("f32")));
+
+        let rejected = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(21, LiveCommand::Apply { run_tests: false }),
+        );
+        assert!(!rejected.ok);
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.stasis")).expect("after"),
+            before
+        );
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -24,10 +24,14 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 
+use crate::state_migration::{
+    activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
+    state_layout_version, StateMigrationPreview as LiveSwapPreview,
+};
+
 const REQUESTS_PER_TICK: usize = 8;
 const MAX_PENDING_LIVE_REQUESTS: usize = 64;
 const MAX_LIVE_EDIT_SOURCE_BYTES: usize = 256 * 1024;
-const MAX_LIVE_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
 const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
@@ -59,54 +63,6 @@ struct HistoryEntry {
 struct PendingEdit {
     plan: WorkshopSemanticEditPlan,
     swap_preview: LiveSwapPreview,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-struct LiveSwapPreview {
-    schema_version: u16,
-    changed_functions: Vec<String>,
-    state_layout_compatible: bool,
-    layout_changed: bool,
-    from_layout_version: String,
-    to_layout_version: String,
-    migration_scope: LiveMigrationScope,
-    migration_steps: Vec<LiveMigrationStep>,
-    warnings: Vec<String>,
-    rejection: Option<String>,
-    estimated_commit_cost_us: u64,
-    requires_explicit_apply: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-struct LiveMigrationScope {
-    kind: &'static str,
-    path: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-enum LiveMigrationStepKind {
-    Copy,
-    Initialize,
-    Remove,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-struct LiveMigrationStep {
-    kind: LiveMigrationStepKind,
-    path: String,
-    field: Option<String>,
-    type_name: String,
-    elements: u32,
-    start_index: u32,
-    from_capacity: Option<u32>,
-    to_capacity: Option<u32>,
-}
-
-#[derive(Debug)]
-struct CapturedMigrationState {
-    scalars: Vec<(String, JitScalarValue)>,
-    collections: Vec<(String, String, Vec<JitScalarValue>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -1028,11 +984,6 @@ impl LiveWorkspace {
                 .clone()
                 .unwrap_or_else(|| "incoming state layout is incompatible".to_string()));
         }
-        preflight_collection_growth(&prepared.candidate, &prepared.swap_preview)?;
-        let snapshot =
-            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_LIVE_STATE_SNAPSHOT_BYTES)?;
-        let migration_state =
-            capture_migration_state(jit, &prepared.swap_preview, MAX_LIVE_STATE_SNAPSHOT_BYTES)?;
         let receipt_directory = self.config.output.join("live-edits");
         let serialized_plan = serde_json::to_string(&prepared.plan)
             .map_err(|error| format!("failed serializing live receipt: {error}"))?;
@@ -1055,54 +1006,42 @@ impl LiveWorkspace {
         ) {
             Ok(receipt) => receipt,
             Err(error) => {
-                self.rollback_prepared(&prepared, jit, &snapshot)?;
+                self.rollback_prepared(&prepared)?;
                 return Err(format!(
                     "live receipt failed; disk/runtime remained unchanged: {error}"
                 ));
             }
         };
 
-        if let Err(error) = prepared.candidate.activate_staged_runtime() {
-            self.rollback_prepared(&prepared, jit, &snapshot)?;
-            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
-            return Err(format!(
-                "live runtime activation failed; disk/code/state remained unchanged: {error}"
-            ));
-        }
-        stasis_dynload::restore_jit_runtime_state(&snapshot);
-        if let Err(error) = prepare_collection_growth(&prepared.candidate, &prepared.swap_preview) {
-            self.rollback_prepared(&prepared, jit, &snapshot)?;
-            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
-            return Err(format!(
-                "collection growth failed after state restore; disk/code/state remained unchanged: {error}"
-            ));
-        }
-        if let Err(error) = prepared.candidate.activate_staged_runtime() {
-            self.rollback_prepared(&prepared, jit, &snapshot)?;
-            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
-            return Err(format!(
-                "live runtime reactivation failed after state restore; disk/code/state remained unchanged: {error}"
-            ));
-        }
-        if let Err(error) = apply_migration_state(
+        let hook = prepared.package.on_code_swap_code_ptr;
+        let runtime_result = activate_candidate_transactionally(
+            Some(jit),
             &prepared.candidate,
             &prepared.swap_preview,
-            &migration_state,
-        ) {
-            self.rollback_prepared(&prepared, jit, &snapshot)?;
-            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
-            return Err(format!(
-                "state migration failed; disk/code/state remained on the prior version: {error}"
-            ));
-        }
-        if let Some(hook) = prepared.package.on_code_swap_code_ptr {
-            if let Err(error) = stasis_dynload::invoke_code_swap_hook(hook as usize) {
-                self.rollback_prepared(&prepared, jit, &snapshot)?;
+            hook.is_some(),
+            || {
+                hook.map_or(Ok(()), |code_ptr| {
+                    stasis_dynload::invoke_code_swap_hook(code_ptr as usize)
+                })
+            },
+            Result::is_ok,
+        );
+        let runtime_result = match runtime_result {
+            Ok(result) => result,
+            Err(error) => {
+                self.rollback_prepared(&prepared)?;
                 cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
                 return Err(format!(
-                    "on_code_swap failed; disk/code/state remained on the prior version: {error}"
+                    "live runtime transaction failed; disk/code/state remained on the prior version: {error}"
                 ));
             }
+        };
+        if let Err(error) = runtime_result {
+            self.rollback_prepared(&prepared)?;
+            cleanup_new_receipt(&self.config, &receipt, receipt_existed)?;
+            return Err(format!(
+                "on_code_swap failed; disk/code/state remained on the prior version: {error}"
+            ));
         }
         *tick_code_ptr = prepared.package.tick_code_ptr;
         *render_code_ptr = prepared.package.render_code_ptr;
@@ -1170,13 +1109,8 @@ impl LiveWorkspace {
         Ok((kind, data))
     }
 
-    fn rollback_prepared(
-        &mut self,
-        prepared: &PreparedEdit,
-        active: &JitProcess,
-        snapshot: &stasis_dynload::JitRuntimeStateSnapshot,
-    ) -> Result<(), String> {
-        let result = rollback_prepared_disk(&self.config, prepared, active, snapshot);
+    fn rollback_prepared(&mut self, prepared: &PreparedEdit) -> Result<(), String> {
+        let result = rollback_prepared_disk(&self.config, prepared);
         self.remember_plan_hashes(&prepared.plan, !prepared.restore);
         result
     }
@@ -1482,11 +1416,24 @@ fn prepare_edit(
     check_preparation_canceled(canceled)?;
     let (candidate, package) = compile_candidate(config, &candidate_files)?;
     let changed_functions = candidate.symbol_code_ptrs().into_keys().collect();
-    let swap_preview = plan_live_swap(
+    let abi_rejection = (plan.reload.expected_reload == ExpectedReload::ResetRequired
+        && plan
+            .reload
+            .reason
+            .to_ascii_lowercase()
+            .contains("signature changed"))
+    .then(|| {
+        format!(
+            "{} Hot reload cannot migrate function ABI changes.",
+            plan.reload.reason
+        )
+    });
+    let swap_preview = plan_state_migration(
         active_layout,
         &candidate.state_layout(),
-        &plan,
         changed_functions,
+        plan.reload.expected_reload == ExpectedReload::ResetRequired,
+        abi_rejection,
     )?;
     if matches!(action, PreparedAction::ApplyNew) && swap_preview.requires_explicit_apply {
         action = PreparedAction::Preview;
@@ -1521,364 +1468,6 @@ fn prepare_edit(
         source_files: candidate_files,
         input_hashes,
     })
-}
-
-fn plan_live_swap(
-    active: &JitStateLayout,
-    incoming: &JitStateLayout,
-    plan: &WorkshopSemanticEditPlan,
-    mut changed_functions: Vec<String>,
-) -> Result<LiveSwapPreview, String> {
-    let from_layout_version = state_layout_version(active)?;
-    let to_layout_version = state_layout_version(incoming)?;
-    let layout_changed = from_layout_version != to_layout_version;
-    changed_functions.sort();
-    changed_functions.dedup();
-
-    let active_scalars = active
-        .scalars
-        .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
-        .collect::<BTreeMap<_, _>>();
-    let incoming_scalars = incoming
-        .scalars
-        .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
-        .collect::<BTreeMap<_, _>>();
-    let active_collections = collection_field_layouts(active)?;
-    let incoming_collections = collection_field_layouts(incoming)?;
-    let active_opaque = active
-        .opaque
-        .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
-        .collect::<BTreeMap<_, _>>();
-    let incoming_opaque = incoming
-        .opaque
-        .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
-        .collect::<BTreeMap<_, _>>();
-
-    let mut steps = Vec::new();
-    let mut warnings = Vec::new();
-    let mut rejections = Vec::new();
-    let mut affected_roots = BTreeSet::new();
-
-    if layout_changed {
-        for (path, incoming_type) in &incoming_scalars {
-            if path.ends_with(".max_length") {
-                continue;
-            }
-            match active_scalars.get(path) {
-                Some(active_type) if active_type == incoming_type => {
-                    steps.push(scalar_migration_step(
-                        LiveMigrationStepKind::Copy,
-                        path,
-                        incoming_type,
-                    ));
-                }
-                Some(active_type) => {
-                    rejections.push(format!(
-                        "state path '{path}' changed type '{active_type}' -> '{incoming_type}'"
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-                None => {
-                    steps.push(scalar_migration_step(
-                        LiveMigrationStepKind::Initialize,
-                        path,
-                        incoming_type,
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-            }
-        }
-        for (path, active_type) in &active_scalars {
-            if path.ends_with(".max_length") || incoming_scalars.contains_key(path) {
-                continue;
-            }
-            steps.push(scalar_migration_step(
-                LiveMigrationStepKind::Remove,
-                path,
-                active_type,
-            ));
-            warnings.push(format!("removed state path '{path}' will be discarded"));
-            affected_roots.insert(migration_root(path));
-        }
-
-        for ((path, field), incoming_field) in &incoming_collections {
-            match active_collections.get(&(path.clone(), field.clone())) {
-                Some(active_field) if active_field.type_name == incoming_field.type_name => {
-                    let elements = active_field.capacity.min(incoming_field.capacity);
-                    steps.push(collection_migration_step(
-                        LiveMigrationStepKind::Copy,
-                        path,
-                        field,
-                        &incoming_field.type_name,
-                        0,
-                        elements,
-                        active_field.capacity,
-                        incoming_field.capacity,
-                    ));
-                    if incoming_field.capacity < active_field.capacity {
-                        warnings.push(format!(
-                            "collection '{}' shrinks from {} to {}; elements [{}..{}) will be discarded",
-                            display_collection_path(path, field),
-                            active_field.capacity,
-                            incoming_field.capacity,
-                            incoming_field.capacity,
-                            active_field.capacity,
-                        ));
-                        affected_roots.insert(migration_root(path));
-                    } else if incoming_field.capacity > active_field.capacity {
-                        steps.push(collection_migration_step(
-                            LiveMigrationStepKind::Initialize,
-                            path,
-                            field,
-                            &incoming_field.type_name,
-                            active_field.capacity,
-                            incoming_field.capacity - active_field.capacity,
-                            active_field.capacity,
-                            incoming_field.capacity,
-                        ));
-                        affected_roots.insert(migration_root(path));
-                    }
-                }
-                Some(active_field) => {
-                    rejections.push(format!(
-                        "collection state path '{}' changed type '{}' -> '{}'",
-                        display_collection_path(path, field),
-                        active_field.type_name,
-                        incoming_field.type_name,
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-                None => {
-                    steps.push(collection_migration_step(
-                        LiveMigrationStepKind::Initialize,
-                        path,
-                        field,
-                        &incoming_field.type_name,
-                        0,
-                        incoming_field.capacity,
-                        0,
-                        incoming_field.capacity,
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-            }
-        }
-        for ((path, field), active_field) in &active_collections {
-            if incoming_collections.contains_key(&(path.clone(), field.clone())) {
-                continue;
-            }
-            steps.push(collection_migration_step(
-                LiveMigrationStepKind::Remove,
-                path,
-                field,
-                &active_field.type_name,
-                0,
-                active_field.capacity,
-                active_field.capacity,
-                0,
-            ));
-            warnings.push(format!(
-                "removed collection state path '{}' will be discarded",
-                display_collection_path(path, field)
-            ));
-            affected_roots.insert(migration_root(path));
-        }
-        for (path, incoming_type) in &incoming_opaque {
-            match active_opaque.get(path) {
-                Some(active_type) if active_type == incoming_type => {}
-                Some(active_type) => {
-                    rejections.push(format!(
-                        "state path '{path}' changed non-migratable type '{active_type}' -> '{incoming_type}'"
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-                None => {
-                    rejections.push(format!(
-                        "new state path '{path}' uses non-migratable type '{incoming_type}'"
-                    ));
-                    affected_roots.insert(migration_root(path));
-                }
-            }
-        }
-        for (path, active_type) in &active_opaque {
-            if incoming_opaque.contains_key(path) {
-                continue;
-            }
-            rejections.push(format!(
-                "removed state path '{path}' uses non-migratable type '{active_type}'"
-            ));
-            affected_roots.insert(migration_root(path));
-        }
-    }
-
-    if plan.reload.expected_reload == ExpectedReload::ResetRequired
-        && plan
-            .reload
-            .reason
-            .to_ascii_lowercase()
-            .contains("signature changed")
-    {
-        rejections.push(format!(
-            "{} Hot reload cannot migrate function ABI changes.",
-            plan.reload.reason
-        ));
-    }
-
-    let state_layout_compatible = rejections.is_empty();
-    let rejection = (!state_layout_compatible).then(|| {
-        format!(
-            "hot reload rejected: {}. Old code and state remain active.",
-            rejections.join("; ")
-        )
-    });
-    let migration_scope = if affected_roots.len() == 1 {
-        let path = affected_roots
-            .into_iter()
-            .next()
-            .expect("one affected root");
-        let top_level_global = active_scalars.contains_key(&path)
-            || incoming_scalars.contains_key(&path)
-            || active_opaque.contains_key(&path)
-            || incoming_opaque.contains_key(&path)
-            || active_collections
-                .keys()
-                .any(|(collection, _)| collection == &path)
-            || incoming_collections
-                .keys()
-                .any(|(collection, _)| collection == &path);
-        LiveMigrationScope {
-            kind: if top_level_global {
-                "whole_state"
-            } else {
-                "struct"
-            },
-            path: (!top_level_global).then_some(path),
-        }
-    } else if affected_roots.is_empty() {
-        LiveMigrationScope {
-            kind: "none",
-            path: None,
-        }
-    } else {
-        LiveMigrationScope {
-            kind: "whole_state",
-            path: None,
-        }
-    };
-    let state_values = steps
-        .iter()
-        .filter(|step| step.kind != LiveMigrationStepKind::Remove)
-        .map(|step| u64::from(step.elements))
-        .sum::<u64>();
-    let estimated_commit_cost_us = 20u64
-        .saturating_add((changed_functions.len() as u64).saturating_mul(5))
-        .saturating_add(state_values.saturating_mul(8).div_ceil(256));
-
-    Ok(LiveSwapPreview {
-        schema_version: 1,
-        changed_functions,
-        state_layout_compatible,
-        layout_changed,
-        from_layout_version,
-        to_layout_version,
-        migration_scope,
-        migration_steps: steps,
-        warnings,
-        rejection,
-        estimated_commit_cost_us,
-        requires_explicit_apply: plan.reload.expected_reload == ExpectedReload::ResetRequired,
-    })
-}
-
-#[derive(Debug, Clone)]
-struct CollectionFieldLayout {
-    type_name: String,
-    capacity: u32,
-}
-
-fn collection_field_layouts(
-    layout: &JitStateLayout,
-) -> Result<BTreeMap<(String, String), CollectionFieldLayout>, String> {
-    let mut fields = BTreeMap::new();
-    for collection in &layout.collections {
-        let capacity = u32::try_from(collection.capacity).map_err(|_| {
-            format!(
-                "collection '{}' has negative capacity {}",
-                collection.path, collection.capacity
-            )
-        })?;
-        for field in &collection.fields {
-            fields.insert(
-                (collection.path.clone(), field.field.clone()),
-                CollectionFieldLayout {
-                    type_name: field.type_name.clone(),
-                    capacity,
-                },
-            );
-        }
-    }
-    Ok(fields)
-}
-
-fn state_layout_version(layout: &JitStateLayout) -> Result<String, String> {
-    serde_json::to_string(layout)
-        .map(|serialized| workshop_source_hash(&serialized))
-        .map_err(|error| format!("failed versioning JIT state layout: {error}"))
-}
-
-fn scalar_migration_step(
-    kind: LiveMigrationStepKind,
-    path: &str,
-    type_name: &str,
-) -> LiveMigrationStep {
-    LiveMigrationStep {
-        kind,
-        path: path.to_string(),
-        field: None,
-        type_name: type_name.to_string(),
-        elements: 1,
-        start_index: 0,
-        from_capacity: None,
-        to_capacity: None,
-    }
-}
-
-fn collection_migration_step(
-    kind: LiveMigrationStepKind,
-    path: &str,
-    field: &str,
-    type_name: &str,
-    start_index: u32,
-    elements: u32,
-    from_capacity: u32,
-    to_capacity: u32,
-) -> LiveMigrationStep {
-    LiveMigrationStep {
-        kind,
-        path: path.to_string(),
-        field: Some(field.to_string()),
-        type_name: type_name.to_string(),
-        elements,
-        start_index,
-        from_capacity: Some(from_capacity),
-        to_capacity: Some(to_capacity),
-    }
-}
-
-fn migration_root(path: &str) -> String {
-    path.split('.').next().unwrap_or(path).to_string()
-}
-
-fn display_collection_path(path: &str, field: &str) -> String {
-    if field.is_empty() {
-        format!("{path}[]")
-    } else {
-        format!("{path}[].{field}")
-    }
 }
 
 fn plan_live_edit(
@@ -2139,319 +1728,9 @@ fn check_preparation_canceled(canceled: &AtomicBool) -> Result<(), String> {
     }
 }
 
-fn capture_migration_state(
-    active: &JitProcess,
-    preview: &LiveSwapPreview,
-    max_bytes: usize,
-) -> Result<CapturedMigrationState, String> {
-    let copied_values = preview
-        .migration_steps
-        .iter()
-        .filter(|step| step.kind == LiveMigrationStepKind::Copy)
-        .map(|step| step.elements as usize)
-        .try_fold(0usize, |total, count| total.checked_add(count))
-        .ok_or_else(|| "state migration value count overflow".to_string())?;
-    let required_bytes = copied_values
-        .checked_mul(std::mem::size_of::<JitScalarValue>())
-        .ok_or_else(|| "state migration snapshot size overflow".to_string())?;
-    if required_bytes > max_bytes {
-        return Err(format!(
-            "state migration requires {required_bytes} bytes, exceeding the {max_bytes}-byte live limit"
-        ));
-    }
-
-    let mut scalars = Vec::new();
-    let mut collections = Vec::new();
-    for step in &preview.migration_steps {
-        if step.kind != LiveMigrationStepKind::Copy {
-            continue;
-        }
-        if let Some(field) = step.field.as_deref() {
-            let mut values = Vec::with_capacity(step.elements as usize);
-            for index in step.start_index..step.start_index.saturating_add(step.elements) {
-                values.push(active.read_global_collection_scalar(
-                    &step.path,
-                    field,
-                    index as i32,
-                )?);
-            }
-            collections.push((step.path.clone(), field.to_string(), values));
-        } else {
-            scalars.push((step.path.clone(), active.read_global_scalar(&step.path)?));
-        }
-    }
-    Ok(CapturedMigrationState {
-        scalars,
-        collections,
-    })
-}
-
-fn apply_migration_state(
-    incoming: &JitProcess,
-    preview: &LiveSwapPreview,
-    captured: &CapturedMigrationState,
-) -> Result<(), String> {
-    let scalars = captured
-        .scalars
-        .iter()
-        .map(|(path, value)| (path.as_str(), *value))
-        .collect::<BTreeMap<_, _>>();
-    let collections = captured
-        .collections
-        .iter()
-        .map(|(path, field, values)| ((path.as_str(), field.as_str()), values.as_slice()))
-        .collect::<BTreeMap<_, _>>();
-
-    for step in &preview.migration_steps {
-        match (step.kind, step.field.as_deref()) {
-            (LiveMigrationStepKind::Copy, None) => {
-                let value = scalars.get(step.path.as_str()).copied().ok_or_else(|| {
-                    format!("migration copy source '{}' was not captured", step.path)
-                })?;
-                incoming.write_global_scalar(&step.path, value)?;
-            }
-            (LiveMigrationStepKind::Initialize, None) => {
-                incoming.write_global_scalar(&step.path, default_scalar_value(&step.type_name)?)?;
-            }
-            (LiveMigrationStepKind::Copy, Some(field)) => {
-                let values = collections
-                    .get(&(step.path.as_str(), field))
-                    .copied()
-                    .ok_or_else(|| {
-                        format!(
-                            "migration copy source '{}' was not captured",
-                            display_collection_path(&step.path, field)
-                        )
-                    })?;
-                if values.len() != step.elements as usize {
-                    return Err(format!(
-                        "migration copy source '{}' expected {} elements, captured {}",
-                        display_collection_path(&step.path, field),
-                        step.elements,
-                        values.len()
-                    ));
-                }
-                for (offset, value) in values.iter().copied().enumerate() {
-                    incoming.write_global_collection_scalar(
-                        &step.path,
-                        field,
-                        step.start_index as i32 + offset as i32,
-                        value,
-                    )?;
-                }
-            }
-            (LiveMigrationStepKind::Initialize, Some(field)) => {
-                let value = default_scalar_value(&step.type_name)?;
-                for index in step.start_index..step.start_index.saturating_add(step.elements) {
-                    incoming.write_global_collection_scalar(
-                        &step.path,
-                        field,
-                        index as i32,
-                        value,
-                    )?;
-                }
-            }
-            (LiveMigrationStepKind::Remove, _) => {}
-        }
-    }
-
-    let mut shrunken = BTreeSet::new();
-    for step in &preview.migration_steps {
-        let (Some(from_capacity), Some(to_capacity)) = (step.from_capacity, step.to_capacity)
-        else {
-            continue;
-        };
-        if to_capacity >= from_capacity {
-            continue;
-        }
-        shrunken.insert((step.path.as_str(), to_capacity));
-    }
-    for (path, capacity) in shrunken {
-        normalize_collection_lengths(incoming, path, capacity)?;
-    }
-    Ok(())
-}
-
-fn normalize_collection_lengths(
-    incoming: &JitProcess,
-    path: &str,
-    capacity: u32,
-) -> Result<(), String> {
-    let capacity = capacity as i32;
-    if incoming.global_fixed_text_encoding(path) == Some("utf8") {
-        let byte_length = read_i32_header(incoming, path, "length")?
-            .or(read_i32_header(incoming, path, "byte_length")?)
-            .unwrap_or(0)
-            .clamp(0, capacity);
-        let mut bytes = Vec::with_capacity(byte_length as usize);
-        for index in 0..byte_length {
-            let JitScalarValue::U8(value) =
-                incoming.read_global_collection_scalar(path, "", index)?
-            else {
-                return Err(format!("UTF-8 collection '{path}' payload is not u8"));
-            };
-            bytes.push(value);
-        }
-        let valid_bytes = std::str::from_utf8(&bytes)
-            .map(|_| bytes.len())
-            .unwrap_or_else(|error| error.valid_up_to());
-        let char_length = std::str::from_utf8(&bytes[..valid_bytes])
-            .expect("valid UTF-8 prefix")
-            .chars()
-            .count() as i32;
-        for index in valid_bytes..bytes.len() {
-            incoming.write_global_collection_scalar(
-                path,
-                "",
-                index as i32,
-                JitScalarValue::U8(0),
-            )?;
-        }
-        write_i32_header(incoming, path, "length", valid_bytes as i32)?;
-        write_i32_header(incoming, path, "byte_length", valid_bytes as i32)?;
-        write_i32_header(incoming, path, "char_length", char_length)?;
-        return Ok(());
-    }
-    for suffix in ["length", "byte_length", "char_length"] {
-        if let Some(length) = read_i32_header(incoming, path, suffix)? {
-            write_i32_header(incoming, path, suffix, length.clamp(0, capacity))?;
-        }
-    }
-    Ok(())
-}
-
-fn read_i32_header(incoming: &JitProcess, path: &str, suffix: &str) -> Result<Option<i32>, String> {
-    let header = format!("{path}.{suffix}");
-    if incoming.global_scalar_type(&header) != Some("i32") {
-        return Ok(None);
-    }
-    let JitScalarValue::I32(value) = incoming.read_global_scalar(&header)? else {
-        return Err(format!("collection length path '{header}' is not i32"));
-    };
-    Ok(Some(value))
-}
-
-fn write_i32_header(
-    incoming: &JitProcess,
-    path: &str,
-    suffix: &str,
-    value: i32,
-) -> Result<(), String> {
-    let header = format!("{path}.{suffix}");
-    if incoming.global_scalar_type(&header) == Some("i32") {
-        incoming.write_global_scalar(&header, JitScalarValue::I32(value))?;
-    }
-    Ok(())
-}
-
-fn default_scalar_value(type_name: &str) -> Result<JitScalarValue, String> {
-    match type_name {
-        "i32" => Ok(JitScalarValue::I32(0)),
-        "f32" => Ok(JitScalarValue::F32(0.0)),
-        "f64" => Ok(JitScalarValue::F64(0.0)),
-        "bool" => Ok(JitScalarValue::Bool(false)),
-        "u8" => Ok(JitScalarValue::U8(0)),
-        _ => Err(format!(
-            "state migration cannot initialize unsupported scalar type '{type_name}'"
-        )),
-    }
-}
-
-fn finalize_runtime_preview(candidate: &JitProcess, preview: &mut LiveSwapPreview) {
-    if !preview.state_layout_compatible {
-        return;
-    }
-    if let Err(error) = preflight_collection_growth(candidate, preview) {
-        preview.state_layout_compatible = false;
-        preview.rejection = Some(format!(
-            "hot reload rejected: {error}. Old code and state remain active."
-        ));
-    }
-}
-
-fn preflight_collection_growth(
-    candidate: &JitProcess,
-    preview: &LiveSwapPreview,
-) -> Result<Vec<(String, String, u32)>, String> {
-    let mut prepared = BTreeSet::new();
-    let mut total_bytes = 0usize;
-    for step in &preview.migration_steps {
-        let (Some(field), Some(from_capacity), Some(to_capacity)) =
-            (step.field.as_deref(), step.from_capacity, step.to_capacity)
-        else {
-            continue;
-        };
-        if to_capacity <= from_capacity
-            || !prepared.insert((step.path.clone(), field.to_string(), to_capacity))
-        {
-            continue;
-        }
-        let value_bytes = migration_type_bytes(&step.type_name)?;
-        total_bytes = total_bytes
-            .checked_add(
-                (to_capacity as usize)
-                    .checked_mul(value_bytes)
-                    .ok_or_else(|| "collection growth allocation size overflow".to_string())?,
-            )
-            .ok_or_else(|| "collection growth allocation size overflow".to_string())?;
-        if total_bytes > MAX_LIVE_STATE_SNAPSHOT_BYTES {
-            return Err(format!(
-                "collection growth requires {total_bytes} bytes, exceeding the {MAX_LIVE_STATE_SNAPSHOT_BYTES}-byte live limit"
-            ));
-        }
-    }
-    for (path, field, capacity) in &prepared {
-        candidate
-            .preflight_global_collection_capacity(path, field, *capacity)
-            .map_err(|error| {
-                format!(
-                    "failed preparing collection growth for '{}': {error}",
-                    display_collection_path(path, field)
-                )
-            })?;
-    }
-    Ok(prepared.into_iter().collect())
-}
-
-fn prepare_collection_growth(
-    candidate: &JitProcess,
-    preview: &LiveSwapPreview,
-) -> Result<(), String> {
-    for (path, field, capacity) in preflight_collection_growth(candidate, preview)? {
-        candidate
-            .ensure_global_collection_capacity(&path, &field, capacity)
-            .map_err(|error| {
-                format!(
-                    "failed preparing collection growth for '{}': {error}",
-                    display_collection_path(&path, &field)
-                )
-            })?;
-    }
-    Ok(())
-}
-
-fn migration_type_bytes(type_name: &str) -> Result<usize, String> {
-    match type_name {
-        "i32" | "f32" | "bool" | "u8" => Ok(4),
-        "f64" => Ok(8),
-        _ => Err(format!(
-            "unsupported collection migration type '{type_name}'"
-        )),
-    }
-}
-
-fn rollback_prepared_disk(
-    config: &LiveRunConfig,
-    prepared: &PreparedEdit,
-    active: &JitProcess,
-    snapshot: &stasis_dynload::JitRuntimeStateSnapshot,
-) -> Result<(), String> {
-    let rollback =
-        write_workshop_semantic_plan(&config.project_root, &prepared.plan, !prepared.restore);
-    let activation = active.activate_staged_runtime();
-    stasis_dynload::restore_jit_runtime_state(snapshot);
-    rollback.map_err(|error| format!("disk rollback failed: {error}"))?;
-    activation.map_err(|error| format!("runtime rollback failed: {error}"))
+fn rollback_prepared_disk(config: &LiveRunConfig, prepared: &PreparedEdit) -> Result<(), String> {
+    write_workshop_semantic_plan(&config.project_root, &prepared.plan, !prepared.restore)
+        .map_err(|error| format!("disk rollback failed: {error}"))
 }
 
 fn verify_prepared_input_hashes(

--- a/apps/stasis/src/state_migration.rs
+++ b/apps/stasis/src/state_migration.rs
@@ -1,0 +1,869 @@
+use sha2::{Digest, Sha256};
+use stasis_compiler::backend::jit::{JitProcess, JitScalarValue, JitStateLayout};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) const MAX_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct StateMigrationPreview {
+    pub(crate) schema_version: u16,
+    pub(crate) changed_functions: Vec<String>,
+    pub(crate) state_layout_compatible: bool,
+    pub(crate) layout_changed: bool,
+    pub(crate) from_layout_version: String,
+    pub(crate) to_layout_version: String,
+    pub(crate) migration_scope: StateMigrationScope,
+    pub(crate) migration_steps: Vec<StateMigrationStep>,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) rejection: Option<String>,
+    pub(crate) estimated_commit_cost_us: u64,
+    pub(crate) requires_explicit_apply: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct StateMigrationScope {
+    kind: &'static str,
+    path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum StateMigrationStepKind {
+    Copy,
+    Initialize,
+    Remove,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct StateMigrationStep {
+    pub(crate) kind: StateMigrationStepKind,
+    pub(crate) path: String,
+    pub(crate) field: Option<String>,
+    pub(crate) type_name: String,
+    pub(crate) elements: u32,
+    pub(crate) start_index: u32,
+    pub(crate) from_capacity: Option<u32>,
+    pub(crate) to_capacity: Option<u32>,
+}
+
+#[derive(Debug)]
+struct CapturedMigrationState {
+    scalars: Vec<(String, JitScalarValue)>,
+    collections: Vec<(String, String, Vec<JitScalarValue>)>,
+}
+
+#[derive(Debug, Clone)]
+struct CollectionFieldLayout {
+    type_name: String,
+    capacity: u32,
+}
+
+pub(crate) fn plan_state_migration(
+    active: &JitStateLayout,
+    incoming: &JitStateLayout,
+    mut changed_functions: Vec<String>,
+    requires_explicit_apply: bool,
+    abi_rejection: Option<String>,
+) -> Result<StateMigrationPreview, String> {
+    let from_layout_version = state_layout_version(active)?;
+    let to_layout_version = state_layout_version(incoming)?;
+    let layout_changed = from_layout_version != to_layout_version;
+    changed_functions.sort();
+    changed_functions.dedup();
+
+    let active_scalars = active
+        .scalars
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let incoming_scalars = incoming
+        .scalars
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let active_collections = collection_field_layouts(active)?;
+    let incoming_collections = collection_field_layouts(incoming)?;
+    let active_collection_layouts = active
+        .collections
+        .iter()
+        .map(|collection| (collection.path.as_str(), collection))
+        .collect::<BTreeMap<_, _>>();
+    let incoming_collection_layouts = incoming
+        .collections
+        .iter()
+        .map(|collection| (collection.path.as_str(), collection))
+        .collect::<BTreeMap<_, _>>();
+    let active_opaque = active
+        .opaque
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let incoming_opaque = incoming
+        .opaque
+        .iter()
+        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut steps = Vec::new();
+    let mut warnings = Vec::new();
+    let mut rejections = Vec::new();
+    let mut affected_roots = BTreeSet::new();
+
+    if layout_changed {
+        for (path, incoming_collection) in &incoming_collection_layouts {
+            let active_collection = active_collection_layouts.get(path).copied();
+            if incoming_collection.fully_migratable
+                && active_collection.is_none_or(|collection| collection.fully_migratable)
+            {
+                continue;
+            }
+            let detail = active_collection.map_or_else(
+                || format!("new shape '{}'", incoming_collection.element_shape),
+                |collection| {
+                    if collection.element_shape == incoming_collection.element_shape
+                        && collection.capacity == incoming_collection.capacity
+                    {
+                        format!("shape '{}'", incoming_collection.element_shape)
+                    } else {
+                        format!(
+                            "shape '{}' capacity {} -> shape '{}' capacity {}",
+                            collection.element_shape,
+                            collection.capacity,
+                            incoming_collection.element_shape,
+                            incoming_collection.capacity
+                        )
+                    }
+                },
+            );
+            rejections.push(format!(
+                "collection state path '{path}' has non-migratable {detail}"
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+        for (path, active_collection) in &active_collection_layouts {
+            if incoming_collection_layouts.contains_key(path) || active_collection.fully_migratable
+            {
+                continue;
+            }
+            rejections.push(format!(
+                "removed collection state path '{path}' has non-migratable shape '{}'",
+                active_collection.element_shape
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+        for (path, incoming_type) in &incoming_scalars {
+            if path.ends_with(".max_length") {
+                continue;
+            }
+            match active_scalars.get(path) {
+                Some(active_type) if active_type == incoming_type => steps.push(scalar_step(
+                    StateMigrationStepKind::Copy,
+                    path,
+                    incoming_type,
+                )),
+                Some(active_type) => {
+                    rejections.push(format!(
+                        "state path '{path}' changed type '{active_type}' -> '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    steps.push(scalar_step(
+                        StateMigrationStepKind::Initialize,
+                        path,
+                        incoming_type,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for (path, active_type) in &active_scalars {
+            if path.ends_with(".max_length") || incoming_scalars.contains_key(path) {
+                continue;
+            }
+            steps.push(scalar_step(
+                StateMigrationStepKind::Remove,
+                path,
+                active_type,
+            ));
+            warnings.push(format!("removed state path '{path}' will be discarded"));
+            affected_roots.insert(migration_root(path));
+        }
+
+        for ((path, field), incoming_field) in &incoming_collections {
+            match active_collections.get(&(path.clone(), field.clone())) {
+                Some(active_field) if active_field.type_name == incoming_field.type_name => {
+                    let elements = active_field.capacity.min(incoming_field.capacity);
+                    steps.push(collection_step(
+                        StateMigrationStepKind::Copy,
+                        path,
+                        field,
+                        &incoming_field.type_name,
+                        0,
+                        elements,
+                        active_field.capacity,
+                        incoming_field.capacity,
+                    ));
+                    if incoming_field.capacity < active_field.capacity {
+                        warnings.push(format!(
+                            "collection '{}' shrinks from {} to {}; elements [{}..{}) will be discarded",
+                            display_collection_path(path, field),
+                            active_field.capacity,
+                            incoming_field.capacity,
+                            incoming_field.capacity,
+                            active_field.capacity,
+                        ));
+                        affected_roots.insert(migration_root(path));
+                    } else if incoming_field.capacity > active_field.capacity {
+                        steps.push(collection_step(
+                            StateMigrationStepKind::Initialize,
+                            path,
+                            field,
+                            &incoming_field.type_name,
+                            active_field.capacity,
+                            incoming_field.capacity - active_field.capacity,
+                            active_field.capacity,
+                            incoming_field.capacity,
+                        ));
+                        affected_roots.insert(migration_root(path));
+                    }
+                }
+                Some(active_field) => {
+                    rejections.push(format!(
+                        "collection state path '{}' changed type '{}' -> '{}'",
+                        display_collection_path(path, field),
+                        active_field.type_name,
+                        incoming_field.type_name,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    steps.push(collection_step(
+                        StateMigrationStepKind::Initialize,
+                        path,
+                        field,
+                        &incoming_field.type_name,
+                        0,
+                        incoming_field.capacity,
+                        0,
+                        incoming_field.capacity,
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for ((path, field), active_field) in &active_collections {
+            if incoming_collections.contains_key(&(path.clone(), field.clone())) {
+                continue;
+            }
+            steps.push(collection_step(
+                StateMigrationStepKind::Remove,
+                path,
+                field,
+                &active_field.type_name,
+                0,
+                active_field.capacity,
+                active_field.capacity,
+                0,
+            ));
+            warnings.push(format!(
+                "removed collection state path '{}' will be discarded",
+                display_collection_path(path, field)
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+        for (path, incoming_type) in &incoming_opaque {
+            match active_opaque.get(path) {
+                Some(active_type) if active_type == incoming_type => {}
+                Some(active_type) => {
+                    rejections.push(format!(
+                        "state path '{path}' changed non-migratable type '{active_type}' -> '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+                None => {
+                    rejections.push(format!(
+                        "new state path '{path}' uses non-migratable type '{incoming_type}'"
+                    ));
+                    affected_roots.insert(migration_root(path));
+                }
+            }
+        }
+        for (path, active_type) in &active_opaque {
+            if incoming_opaque.contains_key(path) {
+                continue;
+            }
+            rejections.push(format!(
+                "removed state path '{path}' uses non-migratable type '{active_type}'"
+            ));
+            affected_roots.insert(migration_root(path));
+        }
+    }
+    if let Some(rejection) = abi_rejection {
+        rejections.push(rejection);
+    }
+
+    let state_layout_compatible = rejections.is_empty();
+    let rejection = (!state_layout_compatible).then(|| {
+        format!(
+            "hot reload rejected: {}. Old code and state remain active.",
+            rejections.join("; ")
+        )
+    });
+    let migration_scope = if affected_roots.len() == 1 {
+        let path = affected_roots
+            .into_iter()
+            .next()
+            .expect("one affected root");
+        let top_level_global = active_scalars.contains_key(&path)
+            || incoming_scalars.contains_key(&path)
+            || active_opaque.contains_key(&path)
+            || incoming_opaque.contains_key(&path)
+            || active_collections
+                .keys()
+                .any(|(collection, _)| collection == &path)
+            || incoming_collections
+                .keys()
+                .any(|(collection, _)| collection == &path);
+        StateMigrationScope {
+            kind: if top_level_global {
+                "whole_state"
+            } else {
+                "struct"
+            },
+            path: (!top_level_global).then_some(path),
+        }
+    } else if affected_roots.is_empty() {
+        StateMigrationScope {
+            kind: "none",
+            path: None,
+        }
+    } else {
+        StateMigrationScope {
+            kind: "whole_state",
+            path: None,
+        }
+    };
+    let state_values = steps
+        .iter()
+        .filter(|step| step.kind != StateMigrationStepKind::Remove)
+        .map(|step| u64::from(step.elements))
+        .sum::<u64>();
+    let estimated_commit_cost_us = 20u64
+        .saturating_add((changed_functions.len() as u64).saturating_mul(5))
+        .saturating_add(state_values.saturating_mul(8).div_ceil(256));
+
+    Ok(StateMigrationPreview {
+        schema_version: 1,
+        changed_functions,
+        state_layout_compatible,
+        layout_changed,
+        from_layout_version,
+        to_layout_version,
+        migration_scope,
+        migration_steps: steps,
+        warnings,
+        rejection,
+        estimated_commit_cost_us,
+        requires_explicit_apply,
+    })
+}
+
+pub(crate) fn state_layout_version(layout: &JitStateLayout) -> Result<String, String> {
+    let serialized = serde_json::to_vec(layout)
+        .map_err(|error| format!("failed versioning compiler state layout: {error}"))?;
+    let digest = Sha256::digest(serialized);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+pub(crate) fn finalize_runtime_preview(
+    candidate: &JitProcess,
+    preview: &mut StateMigrationPreview,
+) {
+    if !preview.state_layout_compatible {
+        return;
+    }
+    if let Err(error) = preflight_collection_growth(candidate, preview) {
+        preview.state_layout_compatible = false;
+        preview.rejection = Some(format!(
+            "hot reload rejected: {error}. Old code and state remain active."
+        ));
+    }
+}
+
+pub(crate) fn activate_candidate_transactionally<T>(
+    active: Option<&JitProcess>,
+    candidate: &JitProcess,
+    preview: &StateMigrationPreview,
+    hook_may_mutate_state: bool,
+    apply: impl FnOnce() -> T,
+    accepted: impl FnOnce(&T) -> bool,
+) -> Result<T, String> {
+    if !preview.state_layout_compatible {
+        return Err(preview
+            .rejection
+            .clone()
+            .unwrap_or_else(|| "incoming state layout is incompatible".to_string()));
+    }
+    preflight_collection_growth(candidate, preview)?;
+    let needs_snapshot = preview.layout_changed || hook_may_mutate_state;
+    let snapshot = needs_snapshot
+        .then(|| stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES))
+        .transpose()?;
+    let migration_state = if preview.layout_changed {
+        let active = active.ok_or_else(|| {
+            "layout migration requires an active JIT candidate at the safe point".to_string()
+        })?;
+        Some(capture_migration_state(
+            active,
+            preview,
+            MAX_STATE_SNAPSHOT_BYTES,
+        )?)
+    } else {
+        None
+    };
+
+    let transaction = (|| {
+        candidate.activate_staged_runtime()?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            if preview.layout_changed {
+                stasis_dynload::restore_jit_runtime_state(snapshot);
+                prepare_collection_growth(candidate, preview)?;
+                candidate.activate_staged_runtime()?;
+                apply_migration_state(
+                    candidate,
+                    preview,
+                    migration_state
+                        .as_ref()
+                        .expect("layout changes capture migration state"),
+                )?;
+            }
+        }
+        Ok(apply())
+    })();
+    let result = match transaction {
+        Ok(result) => result,
+        Err(error) => {
+            rollback_runtime(active, snapshot.as_ref())?;
+            return Err(error);
+        }
+    };
+    if !accepted(&result) {
+        rollback_runtime(active, snapshot.as_ref())?;
+    }
+    Ok(result)
+}
+
+fn rollback_runtime(
+    active: Option<&JitProcess>,
+    snapshot: Option<&stasis_dynload::JitRuntimeStateSnapshot>,
+) -> Result<(), String> {
+    if let Some(active) = active {
+        active.activate_staged_runtime().map_err(|error| {
+            format!("failed restoring active JIT runtime after rejected candidate: {error}")
+        })?;
+    }
+    if let Some(snapshot) = snapshot {
+        stasis_dynload::restore_jit_runtime_state(snapshot);
+    }
+    Ok(())
+}
+
+fn collection_field_layouts(
+    layout: &JitStateLayout,
+) -> Result<BTreeMap<(String, String), CollectionFieldLayout>, String> {
+    let mut fields = BTreeMap::new();
+    for collection in &layout.collections {
+        let capacity = u32::try_from(collection.capacity).map_err(|_| {
+            format!(
+                "collection '{}' has negative capacity {}",
+                collection.path, collection.capacity
+            )
+        })?;
+        for field in &collection.fields {
+            fields.insert(
+                (collection.path.clone(), field.field.clone()),
+                CollectionFieldLayout {
+                    type_name: field.type_name.clone(),
+                    capacity,
+                },
+            );
+        }
+    }
+    Ok(fields)
+}
+
+fn scalar_step(kind: StateMigrationStepKind, path: &str, type_name: &str) -> StateMigrationStep {
+    StateMigrationStep {
+        kind,
+        path: path.to_string(),
+        field: None,
+        type_name: type_name.to_string(),
+        elements: 1,
+        start_index: 0,
+        from_capacity: None,
+        to_capacity: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collection_step(
+    kind: StateMigrationStepKind,
+    path: &str,
+    field: &str,
+    type_name: &str,
+    start_index: u32,
+    elements: u32,
+    from_capacity: u32,
+    to_capacity: u32,
+) -> StateMigrationStep {
+    StateMigrationStep {
+        kind,
+        path: path.to_string(),
+        field: Some(field.to_string()),
+        type_name: type_name.to_string(),
+        elements,
+        start_index,
+        from_capacity: Some(from_capacity),
+        to_capacity: Some(to_capacity),
+    }
+}
+
+fn migration_root(path: &str) -> String {
+    path.split('.').next().unwrap_or(path).to_string()
+}
+
+fn display_collection_path(path: &str, field: &str) -> String {
+    if field.is_empty() {
+        format!("{path}[]")
+    } else {
+        format!("{path}[].{field}")
+    }
+}
+
+fn capture_migration_state(
+    active: &JitProcess,
+    preview: &StateMigrationPreview,
+    max_bytes: usize,
+) -> Result<CapturedMigrationState, String> {
+    let copied_values = preview
+        .migration_steps
+        .iter()
+        .filter(|step| step.kind == StateMigrationStepKind::Copy)
+        .map(|step| step.elements as usize)
+        .try_fold(0usize, |total, count| total.checked_add(count))
+        .ok_or_else(|| "state migration value count overflow".to_string())?;
+    let required_bytes = copied_values
+        .checked_mul(std::mem::size_of::<JitScalarValue>())
+        .ok_or_else(|| "state migration snapshot size overflow".to_string())?;
+    if required_bytes > max_bytes {
+        return Err(format!(
+            "state migration requires {required_bytes} bytes, exceeding the {max_bytes}-byte live limit"
+        ));
+    }
+
+    let mut scalars = Vec::new();
+    let mut collections = Vec::new();
+    for step in &preview.migration_steps {
+        if step.kind != StateMigrationStepKind::Copy {
+            continue;
+        }
+        if let Some(field) = step.field.as_deref() {
+            let mut values = Vec::with_capacity(step.elements as usize);
+            for index in step.start_index..step.start_index.saturating_add(step.elements) {
+                values.push(active.read_global_collection_scalar(
+                    &step.path,
+                    field,
+                    index as i32,
+                )?);
+            }
+            collections.push((step.path.clone(), field.to_string(), values));
+        } else {
+            scalars.push((step.path.clone(), active.read_global_scalar(&step.path)?));
+        }
+    }
+    Ok(CapturedMigrationState {
+        scalars,
+        collections,
+    })
+}
+
+fn apply_migration_state(
+    incoming: &JitProcess,
+    preview: &StateMigrationPreview,
+    captured: &CapturedMigrationState,
+) -> Result<(), String> {
+    let scalars = captured
+        .scalars
+        .iter()
+        .map(|(path, value)| (path.as_str(), *value))
+        .collect::<BTreeMap<_, _>>();
+    let collections = captured
+        .collections
+        .iter()
+        .map(|(path, field, values)| ((path.as_str(), field.as_str()), values.as_slice()))
+        .collect::<BTreeMap<_, _>>();
+
+    for step in &preview.migration_steps {
+        match (step.kind, step.field.as_deref()) {
+            (StateMigrationStepKind::Copy, None) => {
+                let value = scalars.get(step.path.as_str()).copied().ok_or_else(|| {
+                    format!("migration copy source '{}' was not captured", step.path)
+                })?;
+                incoming.write_global_scalar(&step.path, value)?;
+            }
+            (StateMigrationStepKind::Initialize, None) => {
+                incoming.write_global_scalar(&step.path, default_scalar_value(&step.type_name)?)?;
+            }
+            (StateMigrationStepKind::Copy, Some(field)) => {
+                let values = collections
+                    .get(&(step.path.as_str(), field))
+                    .copied()
+                    .ok_or_else(|| {
+                        format!(
+                            "migration copy source '{}' was not captured",
+                            display_collection_path(&step.path, field)
+                        )
+                    })?;
+                if values.len() != step.elements as usize {
+                    return Err(format!(
+                        "migration copy source '{}' expected {} elements, captured {}",
+                        display_collection_path(&step.path, field),
+                        step.elements,
+                        values.len()
+                    ));
+                }
+                for (offset, value) in values.iter().copied().enumerate() {
+                    incoming.write_global_collection_scalar(
+                        &step.path,
+                        field,
+                        step.start_index as i32 + offset as i32,
+                        value,
+                    )?;
+                }
+            }
+            (StateMigrationStepKind::Initialize, Some(field)) => {
+                let value = default_scalar_value(&step.type_name)?;
+                for index in step.start_index..step.start_index.saturating_add(step.elements) {
+                    incoming.write_global_collection_scalar(
+                        &step.path,
+                        field,
+                        index as i32,
+                        value,
+                    )?;
+                }
+            }
+            (StateMigrationStepKind::Remove, _) => {}
+        }
+    }
+
+    let mut shrunken = BTreeSet::new();
+    for step in &preview.migration_steps {
+        let (Some(from_capacity), Some(to_capacity)) = (step.from_capacity, step.to_capacity)
+        else {
+            continue;
+        };
+        if to_capacity < from_capacity {
+            shrunken.insert((step.path.as_str(), to_capacity));
+        }
+    }
+    for (path, capacity) in shrunken {
+        normalize_collection_lengths(incoming, path, capacity)?;
+    }
+    Ok(())
+}
+
+fn normalize_collection_lengths(
+    incoming: &JitProcess,
+    path: &str,
+    capacity: u32,
+) -> Result<(), String> {
+    let capacity = capacity as i32;
+    if incoming.global_fixed_text_encoding(path) == Some("utf8") {
+        let byte_length = read_i32_header(incoming, path, "length")?
+            .or(read_i32_header(incoming, path, "byte_length")?)
+            .unwrap_or(0)
+            .clamp(0, capacity);
+        let mut bytes = Vec::with_capacity(byte_length as usize);
+        for index in 0..byte_length {
+            let JitScalarValue::U8(value) =
+                incoming.read_global_collection_scalar(path, "", index)?
+            else {
+                return Err(format!("UTF-8 collection '{path}' payload is not u8"));
+            };
+            bytes.push(value);
+        }
+        let valid_bytes = std::str::from_utf8(&bytes)
+            .map(|_| bytes.len())
+            .unwrap_or_else(|error| error.valid_up_to());
+        let char_length = std::str::from_utf8(&bytes[..valid_bytes])
+            .expect("valid UTF-8 prefix")
+            .chars()
+            .count() as i32;
+        for index in valid_bytes..bytes.len() {
+            incoming.write_global_collection_scalar(
+                path,
+                "",
+                index as i32,
+                JitScalarValue::U8(0),
+            )?;
+        }
+        write_i32_header(incoming, path, "length", valid_bytes as i32)?;
+        write_i32_header(incoming, path, "byte_length", valid_bytes as i32)?;
+        write_i32_header(incoming, path, "char_length", char_length)?;
+        return Ok(());
+    }
+    for suffix in ["length", "byte_length", "char_length"] {
+        if let Some(length) = read_i32_header(incoming, path, suffix)? {
+            write_i32_header(incoming, path, suffix, length.clamp(0, capacity))?;
+        }
+    }
+    Ok(())
+}
+
+fn read_i32_header(incoming: &JitProcess, path: &str, suffix: &str) -> Result<Option<i32>, String> {
+    let header = format!("{path}.{suffix}");
+    if incoming.global_scalar_type(&header) != Some("i32") {
+        return Ok(None);
+    }
+    let JitScalarValue::I32(value) = incoming.read_global_scalar(&header)? else {
+        return Err(format!("collection length path '{header}' is not i32"));
+    };
+    Ok(Some(value))
+}
+
+fn write_i32_header(
+    incoming: &JitProcess,
+    path: &str,
+    suffix: &str,
+    value: i32,
+) -> Result<(), String> {
+    let header = format!("{path}.{suffix}");
+    if incoming.global_scalar_type(&header) == Some("i32") {
+        incoming.write_global_scalar(&header, JitScalarValue::I32(value))?;
+    }
+    Ok(())
+}
+
+fn default_scalar_value(type_name: &str) -> Result<JitScalarValue, String> {
+    match type_name {
+        "i32" => Ok(JitScalarValue::I32(0)),
+        "f32" => Ok(JitScalarValue::F32(0.0)),
+        "f64" => Ok(JitScalarValue::F64(0.0)),
+        "bool" => Ok(JitScalarValue::Bool(false)),
+        "u8" => Ok(JitScalarValue::U8(0)),
+        _ => Err(format!(
+            "state migration cannot initialize unsupported scalar type '{type_name}'"
+        )),
+    }
+}
+
+fn preflight_collection_growth(
+    candidate: &JitProcess,
+    preview: &StateMigrationPreview,
+) -> Result<Vec<(String, String, u32)>, String> {
+    let mut prepared = BTreeSet::new();
+    let mut total_bytes = 0usize;
+    for step in &preview.migration_steps {
+        let (Some(field), Some(from_capacity), Some(to_capacity)) =
+            (step.field.as_deref(), step.from_capacity, step.to_capacity)
+        else {
+            continue;
+        };
+        if to_capacity <= from_capacity
+            || !prepared.insert((step.path.clone(), field.to_string(), to_capacity))
+        {
+            continue;
+        }
+        let value_bytes = migration_type_bytes(&step.type_name)?;
+        total_bytes = total_bytes
+            .checked_add(
+                (to_capacity as usize)
+                    .checked_mul(value_bytes)
+                    .ok_or_else(|| "collection growth allocation size overflow".to_string())?,
+            )
+            .ok_or_else(|| "collection growth allocation size overflow".to_string())?;
+        if total_bytes > MAX_STATE_SNAPSHOT_BYTES {
+            return Err(format!(
+                "collection growth requires {total_bytes} bytes, exceeding the {MAX_STATE_SNAPSHOT_BYTES}-byte live limit"
+            ));
+        }
+    }
+    for (path, field, capacity) in &prepared {
+        candidate
+            .preflight_global_collection_capacity(path, field, *capacity)
+            .map_err(|error| {
+                format!(
+                    "failed preparing collection growth for '{}': {error}",
+                    display_collection_path(path, field)
+                )
+            })?;
+    }
+    Ok(prepared.into_iter().collect())
+}
+
+fn prepare_collection_growth(
+    candidate: &JitProcess,
+    preview: &StateMigrationPreview,
+) -> Result<(), String> {
+    for (path, field, capacity) in preflight_collection_growth(candidate, preview)? {
+        candidate
+            .ensure_global_collection_capacity(&path, &field, capacity)
+            .map_err(|error| {
+                format!(
+                    "failed preparing collection growth for '{}': {error}",
+                    display_collection_path(&path, &field)
+                )
+            })?;
+    }
+    Ok(())
+}
+
+fn migration_type_bytes(type_name: &str) -> Result<usize, String> {
+    match type_name {
+        "i32" | "f32" | "bool" | "u8" => Ok(4),
+        "f64" => Ok(8),
+        _ => Err(format!(
+            "unsupported collection migration type '{type_name}'"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stasis_compiler::backend::jit::{JitStateCollectionFieldLayout, JitStateCollectionLayout};
+
+    #[test]
+    fn non_migratable_collection_shape_rejects_before_activation() {
+        let collection = |capacity| JitStateCollectionLayout {
+            path: "rows".to_string(),
+            capacity,
+            element_shape: "{value:i32,samples:f32[2]}".to_string(),
+            fully_migratable: false,
+            fields: vec![JitStateCollectionFieldLayout {
+                field: "value".to_string(),
+                type_name: "i32".to_string(),
+            }],
+        };
+        let active = JitStateLayout {
+            scalars: Vec::new(),
+            collections: vec![collection(4)],
+            opaque: Vec::new(),
+        };
+        let incoming = JitStateLayout {
+            scalars: Vec::new(),
+            collections: vec![collection(8)],
+            opaque: Vec::new(),
+        };
+
+        let preview = plan_state_migration(&active, &incoming, Vec::new(), false, None)
+            .expect("plan deterministic rejection");
+
+        assert!(!preview.state_layout_compatible);
+        assert!(preview
+            .rejection
+            .as_deref()
+            .is_some_and(|message| message.contains("non-migratable")));
+    }
+}

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1300,10 +1300,105 @@ fn format_live_plan(data: &Value) -> String {
         .pointer("/reload/expected_reload")
         .and_then(Value::as_str)
         .unwrap_or("reload unknown");
-    if symbols.is_empty() {
+    let mut summary = if symbols.is_empty() {
         format!("{file_count} file(s), {reload}")
     } else {
         format!("{symbols}; {file_count} file(s), {reload}")
+    };
+    if let Some(swap) = data.get("swap") {
+        let compatible = if swap
+            .get("state_layout_compatible")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "compatible"
+        } else {
+            "incompatible"
+        };
+        let migration_steps = swap
+            .get("migration_steps")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        let estimated_us = swap
+            .get("estimated_commit_cost_us")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        summary.push_str(&format!(
+            "; state layout {compatible}, {migration_steps} migration step(s), estimated commit {estimated_us} us"
+        ));
+        if let Some(functions) = swap.get("changed_functions").and_then(Value::as_array) {
+            let functions = functions
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            summary.push_str(&format!(
+                "\nchanged functions: {}",
+                if functions.is_empty() {
+                    "none"
+                } else {
+                    &functions
+                }
+            ));
+        }
+        if let (Some(from), Some(to)) = (
+            swap.get("from_layout_version").and_then(Value::as_str),
+            swap.get("to_layout_version").and_then(Value::as_str),
+        ) {
+            summary.push_str(&format!("\nlayout version: {from} -> {to}"));
+        }
+        if let Some(scope) = swap.get("migration_scope") {
+            let kind = string_field(scope, "kind", "none");
+            let path = scope.get("path").and_then(Value::as_str);
+            summary.push_str(&format!(
+                "\nmigration scope: {kind}{}",
+                path.map_or_else(String::new, |path| format!(" ({path})"))
+            ));
+        }
+        if let Some(steps) = swap.get("migration_steps").and_then(Value::as_array) {
+            for step in steps {
+                let path = string_field(step, "path", "state");
+                let field = step.get("field").and_then(Value::as_str);
+                let start = step.get("start_index").and_then(Value::as_u64).unwrap_or(0);
+                let elements = step.get("elements").and_then(Value::as_u64).unwrap_or(1);
+                let target = field.map_or_else(
+                    || path.to_string(),
+                    |field| {
+                        if field.is_empty() {
+                            path.to_string()
+                        } else {
+                            display_live_collection_path(path, field)
+                        }
+                    },
+                );
+                let range = field
+                    .is_some()
+                    .then(|| format!("[{start}..{})", start.saturating_add(elements)))
+                    .unwrap_or_default();
+                summary.push_str(&format!(
+                    "\nmigration: {} {target}{range} ({})",
+                    string_field(step, "kind", "unknown"),
+                    string_field(step, "type_name", "unknown")
+                ));
+            }
+        }
+        if let Some(warnings) = swap.get("warnings").and_then(Value::as_array) {
+            for warning in warnings.iter().filter_map(Value::as_str) {
+                summary.push_str(&format!("\nwarning: {warning}"));
+            }
+        }
+        if let Some(rejection) = swap.get("rejection").and_then(Value::as_str) {
+            summary.push_str(&format!("\nrejected: {rejection}"));
+        }
+    }
+    summary
+}
+
+fn display_live_collection_path(path: &str, field: &str) -> String {
+    if field.is_empty() {
+        format!("{path}[]")
+    } else {
+        format!("{path}[].{field}")
     }
 }
 
@@ -2582,6 +2677,41 @@ mod tests {
         assert!(!output.contains("source"));
         assert!(!output.contains("receipt"));
         assert!(!output.contains('{'));
+    }
+
+    #[test]
+    fn human_live_preview_shows_layout_migration_cost_and_warning() {
+        let response = LiveResponse::success(
+            9,
+            44,
+            "edit_preview",
+            json!({
+                "plan": {
+                    "changed_files": [{"file": "src/main.stasis"}],
+                    "reload": {
+                        "changed_symbols": [{"name": "State"}],
+                        "expected_reload": "ResetRequired"
+                    }
+                },
+                "swap": {
+                    "state_layout_compatible": true,
+                    "changed_functions": ["tick"],
+                    "from_layout_version": "layout-v1",
+                    "to_layout_version": "layout-v2",
+                    "migration_scope": {"kind": "struct", "path": "State"},
+                    "migration_steps": [
+                        {"kind": "copy", "path": "State.score", "type_name": "i32", "elements": 1, "start_index": 0},
+                        {"kind": "initialize", "path": "State.items", "field": "", "type_name": "i32", "elements": 4, "start_index": 4}
+                    ],
+                    "estimated_commit_cost_us": 37,
+                    "warnings": ["collection 'State.items' shrinks from 8 to 4"]
+                }
+            }),
+        );
+        assert_eq!(
+            format_live_response(&response),
+            "preview ready: State; 1 file(s), ResetRequired; state layout compatible, 2 migration step(s), estimated commit 37 us\nchanged functions: tick\nlayout version: layout-v1 -> layout-v2\nmigration scope: struct (State)\nmigration: copy State.score (i32)\nmigration: initialize State.items[4..8) (i32)\nwarning: collection 'State.items' shrinks from 8 to 4"
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1,4 +1,5 @@
 use crate::backend::emit::*;
+use crate::backend::state_layout::{build_state_layout, StateLayout};
 use crate::backend::{AotOptimizationProfile, EngineEntrypoints};
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
 use crate::frontend::types::{TypeCategory, TypeTable, TYPE_ID_I32};
@@ -212,6 +213,18 @@ impl AotProcess {
         compact_active_artifact_storage(artifacts, object_bytes);
         self.next_object_index = u32::try_from(self.object_bytes.len()).unwrap_or(u32::MAX);
         Ok(CompileReport { index, emit })
+    }
+
+    pub fn state_layout(&self) -> StateLayout {
+        self.compile_analysis_cache
+            .as_ref()
+            .map_or_else(StateLayout::default, |analysis| {
+                build_state_layout(
+                    &analysis.global_path_types,
+                    &analysis.collection_infos,
+                    self.compiler.types(),
+                )
+            })
     }
 
     fn load_import_graph_sources(&mut self) -> Result<(), String> {

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -99,6 +99,8 @@ pub(crate) struct ForeachCollectionInfo {
     pub(crate) len: i32,
     pub(crate) element_type: Option<TypeId>,
     pub(crate) field_types: BTreeMap<String, TypeId>,
+    pub(crate) element_shape: String,
+    pub(crate) fully_migratable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1042,12 +1044,15 @@ pub(crate) fn collect_foreach_collections_from_type(
             element_type_name,
             struct_fields_by_name,
             type_table,
+            constant_values,
             visiting_structs,
         )?;
         let info = ForeachCollectionInfo {
             len,
             element_type: collection.element_type,
             field_types: collection.field_types,
+            element_shape: collection.element_shape,
+            fully_migratable: collection.fully_migratable,
         };
         if let Some(existing) = out.get(path) {
             if existing != &info {
@@ -1094,13 +1099,22 @@ pub(crate) fn build_collection_info_for_element_type(
     element_type_name: &str,
     struct_fields_by_name: &BTreeMap<String, Vec<ParsedField>>,
     type_table: &mut TypeTable,
+    constant_values: &ConstantValueMap,
     visiting_structs: &mut Vec<String>,
 ) -> Result<ForeachCollectionInfo, String> {
+    let (element_shape, fully_migratable) = collection_element_shape(
+        element_type_name,
+        struct_fields_by_name,
+        constant_values,
+        visiting_structs,
+    )?;
     if let Some(type_id) = resolve_primitive_scalar_type_id(element_type_name, type_table) {
         return Ok(ForeachCollectionInfo {
             len: 0,
             element_type: Some(type_id),
             field_types: BTreeMap::new(),
+            element_shape,
+            fully_migratable,
         });
     }
     if !struct_fields_by_name.contains_key(element_type_name) {
@@ -1109,6 +1123,8 @@ pub(crate) fn build_collection_info_for_element_type(
             len: 0,
             element_type: Some(element_type),
             field_types: BTreeMap::new(),
+            element_shape,
+            fully_migratable,
         });
     }
     let mut field_types = BTreeMap::new();
@@ -1124,7 +1140,77 @@ pub(crate) fn build_collection_info_for_element_type(
         len: 0,
         element_type: None,
         field_types,
+        element_shape,
+        fully_migratable,
     })
+}
+
+fn collection_element_shape(
+    type_name: &str,
+    struct_fields_by_name: &BTreeMap<String, Vec<ParsedField>>,
+    constant_values: &ConstantValueMap,
+    visiting_structs: &mut Vec<String>,
+) -> Result<(String, bool), String> {
+    let type_name = type_name.trim();
+    if matches!(
+        type_name,
+        "i32" | "f32" | "f64" | "bool" | "u8" | "ascii" | "utf8"
+    ) {
+        return Ok((type_name.to_string(), true));
+    }
+    let Some(fields) = struct_fields_by_name.get(type_name) else {
+        return Ok((type_name.to_string(), false));
+    };
+    if visiting_structs
+        .iter()
+        .any(|existing| existing == type_name)
+    {
+        return Err(format!(
+            "recursive collection element shape is unsupported for '{type_name}'"
+        ));
+    }
+    visiting_structs.push(type_name.to_string());
+    let mut shape = String::from("{");
+    let mut fully_migratable = true;
+    for field in fields {
+        if shape.len() > 1 {
+            shape.push(',');
+        }
+        shape.push_str(&field.name);
+        shape.push(':');
+        let field_type = field.type_name.trim();
+        if let Some((element, extent)) = parse_array_type_parts(field_type) {
+            let (element_shape, _) = collection_element_shape(
+                element,
+                struct_fields_by_name,
+                constant_values,
+                visiting_structs,
+            )?;
+            let extent = resolve_fixed_array_extent(extent, constant_values).ok_or_else(|| {
+                format!(
+                    "collection element field '{}.{}' has unresolved fixed extent '{}'",
+                    type_name, field.name, extent
+                )
+            })?;
+            shape.push_str(&element_shape);
+            shape.push('[');
+            shape.push_str(&extent.to_string());
+            shape.push(']');
+            fully_migratable = false;
+        } else {
+            let (field_shape, field_migratable) = collection_element_shape(
+                field_type,
+                struct_fields_by_name,
+                constant_values,
+                visiting_structs,
+            )?;
+            shape.push_str(&field_shape);
+            fully_migratable &= field_migratable;
+        }
+    }
+    shape.push('}');
+    visiting_structs.pop();
+    Ok((shape, fully_migratable))
 }
 
 pub(crate) fn collect_struct_primitive_leaf_fields(
@@ -7629,12 +7715,20 @@ pub(crate) fn build_local_foreach_collection_info(
             len,
             element_type: None,
             field_types: field_types.clone(),
+            element_shape: type_table
+                .type_info(element_type)
+                .map_or_else(|| format!("type#{element_type}"), |info| info.name.clone()),
+            fully_migratable: true,
         });
     }
     Ok(ForeachCollectionInfo {
         len,
         element_type: Some(element_type),
         field_types: BTreeMap::new(),
+        element_shape: type_table
+            .type_info(element_type)
+            .map_or_else(|| format!("type#{element_type}"), |info| info.name.clone()),
+        fully_migratable: true,
     })
 }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1,4 +1,5 @@
 use crate::backend::emit::RuntimeHelperLinkage;
+use crate::backend::state_layout::build_state_layout;
 use crate::backend::EngineEntrypoints;
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
 use crate::frontend::indexer::hash_text;
@@ -16,6 +17,12 @@ use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::SystemTime;
+
+pub use crate::backend::state_layout::{
+    StateCollectionFieldLayout as JitStateCollectionFieldLayout,
+    StateCollectionLayout as JitStateCollectionLayout, StateLayout as JitStateLayout,
+    StateOpaqueLayout as JitStateOpaqueLayout, StateScalarLayout as JitStateScalarLayout,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
@@ -45,38 +52,6 @@ pub struct JitArtifact {
     pub slot: u32,
     pub body_hash: u64,
     pub code_ptr: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct JitStateLayout {
-    pub scalars: Vec<JitStateScalarLayout>,
-    pub collections: Vec<JitStateCollectionLayout>,
-    pub opaque: Vec<JitStateOpaqueLayout>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct JitStateScalarLayout {
-    pub path: String,
-    pub type_name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct JitStateCollectionLayout {
-    pub path: String,
-    pub capacity: i32,
-    pub fields: Vec<JitStateCollectionFieldLayout>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct JitStateCollectionFieldLayout {
-    pub field: String,
-    pub type_name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct JitStateOpaqueLayout {
-    pub path: String,
-    pub type_name: String,
 }
 
 pub struct JitProcess {
@@ -490,116 +465,15 @@ impl JitProcess {
     }
 
     pub fn state_layout(&self) -> JitStateLayout {
-        let scalars = self
-            .global_scalar_paths()
-            .into_iter()
-            .map(|(path, type_name)| JitStateScalarLayout {
-                path,
-                type_name: type_name.to_string(),
-            })
-            .collect();
-        let mut collections: Vec<JitStateCollectionLayout> = self
-            .compile_analysis_cache
+        self.compile_analysis_cache
             .as_ref()
-            .map(|analysis| {
-                analysis
-                    .collection_infos
-                    .iter()
-                    .map(|(path, info)| {
-                        let mut fields = Vec::new();
-                        if let Some(type_name) = info.element_type.and_then(|type_id| {
-                            collection_type_name(self.compiler.types(), type_id)
-                        }) {
-                            fields.push(JitStateCollectionFieldLayout {
-                                field: String::new(),
-                                type_name: type_name.to_string(),
-                            });
-                        }
-                        fields.extend(info.field_types.iter().filter_map(|(field, type_id)| {
-                            collection_type_name(self.compiler.types(), *type_id).map(|type_name| {
-                                JitStateCollectionFieldLayout {
-                                    field: field.clone(),
-                                    type_name: type_name.to_string(),
-                                }
-                            })
-                        }));
-                        JitStateCollectionLayout {
-                            path: path.clone(),
-                            capacity: info.len,
-                            fields,
-                        }
-                    })
-                    .collect()
+            .map_or_else(JitStateLayout::default, |analysis| {
+                build_state_layout(
+                    &analysis.global_path_types,
+                    &analysis.collection_infos,
+                    self.compiler.types(),
+                )
             })
-            .unwrap_or_default();
-        if let Some(analysis) = self.compile_analysis_cache.as_ref() {
-            for path in analysis.global_path_types.keys() {
-                let Some(capacity) = self.global_fixed_text_capacity(path) else {
-                    continue;
-                };
-                if let Some(collection) = collections
-                    .iter_mut()
-                    .find(|collection| collection.path == *path)
-                {
-                    if !collection.fields.iter().any(|field| field.field.is_empty()) {
-                        collection.fields.push(JitStateCollectionFieldLayout {
-                            field: String::new(),
-                            type_name: "u8".to_string(),
-                        });
-                    }
-                    continue;
-                }
-                collections.push(JitStateCollectionLayout {
-                    path: path.clone(),
-                    capacity,
-                    fields: vec![JitStateCollectionFieldLayout {
-                        field: String::new(),
-                        type_name: "u8".to_string(),
-                    }],
-                });
-            }
-        }
-        collections.sort_by(|left, right| left.path.cmp(&right.path));
-        let collection_paths = collections
-            .iter()
-            .map(|collection| collection.path.as_str())
-            .collect::<BTreeSet<_>>();
-        let opaque = self
-            .compile_analysis_cache
-            .as_ref()
-            .map(|analysis| {
-                analysis
-                    .global_path_types
-                    .iter()
-                    .filter_map(|(path, type_id)| {
-                        if scalar_type_name(*type_id).is_some()
-                            || collection_paths.contains(path.as_str())
-                        {
-                            return None;
-                        }
-                        let info = self.compiler.types().type_info(*type_id)?;
-                        let prefix = format!("{path}.");
-                        if info.category == TypeCategory::Named
-                            && analysis
-                                .global_path_types
-                                .keys()
-                                .any(|candidate| candidate.starts_with(&prefix))
-                        {
-                            return None;
-                        }
-                        Some(JitStateOpaqueLayout {
-                            path: path.clone(),
-                            type_name: info.name.clone(),
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        JitStateLayout {
-            scalars,
-            collections,
-            opaque,
-        }
     }
 
     pub fn read_global_collection_scalar(
@@ -1251,14 +1125,6 @@ fn scalar_type_name(type_id: u16) -> Option<&'static str> {
         TYPE_ID_F64 => Some("f64"),
         TYPE_ID_BOOL => Some("bool"),
         _ => None,
-    }
-}
-
-fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
-    if is_u8_type(type_table, type_id) {
-        Some("u8")
-    } else {
-        scalar_type_name(type_id)
     }
 }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -95,7 +95,7 @@ pub struct JitProcess {
     required_emit_roots: Vec<String>,
     local_runtime_helper_trampolines: bool,
     #[cfg(test)]
-    _test_guard: MutexGuard<'static, ()>,
+    _test_guard: Option<MutexGuard<'static, ()>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,6 +124,13 @@ impl JitProcess {
             stasis_dynload::clear_registered_global_memory();
         }
 
+        Self::new_inner(
+            #[cfg(test)]
+            Some(_test_guard),
+        )
+    }
+
+    fn new_inner(#[cfg(test)] _test_guard: Option<MutexGuard<'static, ()>>) -> Self {
         Self {
             compiler: Compiler::new(),
             next_slot: 0,
@@ -142,6 +149,29 @@ impl JitProcess {
             #[cfg(test)]
             _test_guard,
         }
+    }
+
+    pub fn staged_candidate(&self) -> Self {
+        let mut candidate = Self::new_inner(
+            #[cfg(test)]
+            None,
+        );
+        for file in self.compiler.files() {
+            candidate.upsert_file(file.path.clone(), file.content.clone());
+        }
+        candidate.required_emit_roots = self.required_emit_roots.clone();
+        candidate.local_runtime_helper_trampolines = self.local_runtime_helper_trampolines;
+        candidate
+    }
+
+    pub fn accept_staged_candidate(&mut self, candidate: Self) {
+        #[cfg(test)]
+        let candidate = {
+            let mut candidate = candidate;
+            candidate._test_guard = self._test_guard.take();
+            candidate
+        };
+        *self = candidate;
     }
 
     pub fn upsert_file(&mut self, path: impl Into<String>, content: impl Into<String>) {
@@ -1415,6 +1445,7 @@ fn seed_fixed_collection_max_length_headers(
     global_path_types: &GlobalPathTypeMap,
     type_table: &TypeTable,
 ) -> Result<(), String> {
+    let mut headers = Vec::new();
     for (path, type_id) in global_path_types {
         let Some(type_info) = type_table.type_info(*type_id) else {
             continue;
@@ -1430,7 +1461,7 @@ fn seed_fixed_collection_max_length_headers(
                         path, payload_bytes
                     )
                 })?;
-                seed_collection_max_length(path, max_length);
+                headers.push((path, max_length));
             }
             TypeCategory::Utf8Fixed => {
                 let Some(payload_bytes) = type_info.layout.payload_size_bytes else {
@@ -1442,16 +1473,19 @@ fn seed_fixed_collection_max_length_headers(
                         path, payload_bytes
                     )
                 })?;
-                seed_collection_max_length(path, max_length);
+                headers.push((path, max_length));
             }
             TypeCategory::ArrayFixed => {
                 let Some(max_length) = type_table.fixed_collection_len(*type_id) else {
                     continue;
                 };
-                seed_collection_max_length(path, max_length);
+                headers.push((path, max_length));
             }
             _ => {}
         }
+    }
+    for (path, max_length) in headers {
+        seed_collection_max_length(path, max_length);
     }
     Ok(())
 }

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -24,6 +24,7 @@ pub enum JitScalarValue {
     F32(f32),
     F64(f64),
     Bool(bool),
+    U8(u8),
 }
 
 impl JitScalarValue {
@@ -33,6 +34,7 @@ impl JitScalarValue {
             Self::F32(_) => "f32",
             Self::F64(_) => "f64",
             Self::Bool(_) => "bool",
+            Self::U8(_) => "u8",
         }
     }
 }
@@ -43,6 +45,38 @@ pub struct JitArtifact {
     pub slot: u32,
     pub body_hash: u64,
     pub code_ptr: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JitStateLayout {
+    pub scalars: Vec<JitStateScalarLayout>,
+    pub collections: Vec<JitStateCollectionLayout>,
+    pub opaque: Vec<JitStateOpaqueLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JitStateScalarLayout {
+    pub path: String,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JitStateCollectionLayout {
+    pub path: String,
+    pub capacity: i32,
+    pub fields: Vec<JitStateCollectionFieldLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JitStateCollectionFieldLayout {
+    pub field: String,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct JitStateOpaqueLayout {
+    pub path: String,
+    pub type_name: String,
 }
 
 pub struct JitProcess {
@@ -425,6 +459,259 @@ impl JitProcess {
             .collect()
     }
 
+    pub fn state_layout(&self) -> JitStateLayout {
+        let scalars = self
+            .global_scalar_paths()
+            .into_iter()
+            .map(|(path, type_name)| JitStateScalarLayout {
+                path,
+                type_name: type_name.to_string(),
+            })
+            .collect();
+        let mut collections: Vec<JitStateCollectionLayout> = self
+            .compile_analysis_cache
+            .as_ref()
+            .map(|analysis| {
+                analysis
+                    .collection_infos
+                    .iter()
+                    .map(|(path, info)| {
+                        let mut fields = Vec::new();
+                        if let Some(type_name) = info.element_type.and_then(|type_id| {
+                            collection_type_name(self.compiler.types(), type_id)
+                        }) {
+                            fields.push(JitStateCollectionFieldLayout {
+                                field: String::new(),
+                                type_name: type_name.to_string(),
+                            });
+                        }
+                        fields.extend(info.field_types.iter().filter_map(|(field, type_id)| {
+                            collection_type_name(self.compiler.types(), *type_id).map(|type_name| {
+                                JitStateCollectionFieldLayout {
+                                    field: field.clone(),
+                                    type_name: type_name.to_string(),
+                                }
+                            })
+                        }));
+                        JitStateCollectionLayout {
+                            path: path.clone(),
+                            capacity: info.len,
+                            fields,
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if let Some(analysis) = self.compile_analysis_cache.as_ref() {
+            for path in analysis.global_path_types.keys() {
+                let Some(capacity) = self.global_fixed_text_capacity(path) else {
+                    continue;
+                };
+                if let Some(collection) = collections
+                    .iter_mut()
+                    .find(|collection| collection.path == *path)
+                {
+                    if !collection.fields.iter().any(|field| field.field.is_empty()) {
+                        collection.fields.push(JitStateCollectionFieldLayout {
+                            field: String::new(),
+                            type_name: "u8".to_string(),
+                        });
+                    }
+                    continue;
+                }
+                collections.push(JitStateCollectionLayout {
+                    path: path.clone(),
+                    capacity,
+                    fields: vec![JitStateCollectionFieldLayout {
+                        field: String::new(),
+                        type_name: "u8".to_string(),
+                    }],
+                });
+            }
+        }
+        collections.sort_by(|left, right| left.path.cmp(&right.path));
+        let collection_paths = collections
+            .iter()
+            .map(|collection| collection.path.as_str())
+            .collect::<BTreeSet<_>>();
+        let opaque = self
+            .compile_analysis_cache
+            .as_ref()
+            .map(|analysis| {
+                analysis
+                    .global_path_types
+                    .iter()
+                    .filter_map(|(path, type_id)| {
+                        if scalar_type_name(*type_id).is_some()
+                            || collection_paths.contains(path.as_str())
+                        {
+                            return None;
+                        }
+                        let info = self.compiler.types().type_info(*type_id)?;
+                        let prefix = format!("{path}.");
+                        if info.category == TypeCategory::Named
+                            && analysis
+                                .global_path_types
+                                .keys()
+                                .any(|candidate| candidate.starts_with(&prefix))
+                        {
+                            return None;
+                        }
+                        Some(JitStateOpaqueLayout {
+                            path: path.clone(),
+                            type_name: info.name.clone(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        JitStateLayout {
+            scalars,
+            collections,
+            opaque,
+        }
+    }
+
+    pub fn read_global_collection_scalar(
+        &self,
+        path: &str,
+        field: &str,
+        index: i32,
+    ) -> Result<JitScalarValue, String> {
+        let (type_id, capacity) = self.global_collection_value_type(path, field)?;
+        if index < 0 || index >= capacity {
+            return Err(format!(
+                "global collection path '{path}' index {index} is outside capacity {capacity}"
+            ));
+        }
+        let collection_hash = hash_global_path(path);
+        let field_hash = hash_foreach_field_suffix(field);
+        if field.is_empty() && self.global_fixed_text_capacity(path).is_some() {
+            return Ok(JitScalarValue::U8(
+                stasis_dynload::stasis_jit_global_i32_array_load(collection_hash, field_hash, index)
+                    as u8,
+            ));
+        }
+        match type_id {
+            TYPE_ID_I32 => Ok(JitScalarValue::I32(
+                stasis_dynload::stasis_jit_global_i32_array_load(
+                    collection_hash,
+                    field_hash,
+                    index,
+                ),
+            )),
+            TYPE_ID_F32 => Ok(JitScalarValue::F32(
+                stasis_dynload::stasis_jit_global_f32_array_load(
+                    collection_hash,
+                    field_hash,
+                    index,
+                ),
+            )),
+            TYPE_ID_F64 => Ok(JitScalarValue::F64(
+                stasis_dynload::stasis_jit_global_f64_array_load(
+                    collection_hash,
+                    field_hash,
+                    index,
+                ),
+            )),
+            TYPE_ID_BOOL => Ok(JitScalarValue::Bool(
+                stasis_dynload::stasis_jit_global_i32_array_load(
+                    collection_hash,
+                    field_hash,
+                    index,
+                ) != 0,
+            )),
+            type_id if is_u8_type(self.compiler.types(), type_id) => Ok(JitScalarValue::U8(
+                stasis_dynload::stasis_jit_global_i32_array_load(collection_hash, field_hash, index)
+                    as u8,
+            )),
+            _ => Err(format!(
+                "global collection path '{path}' field '{field}' is not a supported scalar"
+            )),
+        }
+    }
+
+    pub fn write_global_collection_scalar(
+        &self,
+        path: &str,
+        field: &str,
+        index: i32,
+        value: JitScalarValue,
+    ) -> Result<(), String> {
+        let (type_id, capacity) = self.global_collection_value_type(path, field)?;
+        if index < 0 || index >= capacity {
+            return Err(format!(
+                "global collection path '{path}' index {index} is outside capacity {capacity}"
+            ));
+        }
+        let collection_hash = hash_global_path(path);
+        let field_hash = hash_foreach_field_suffix(field);
+        if field.is_empty() && self.global_fixed_text_capacity(path).is_some() {
+            let JitScalarValue::U8(value) = value else {
+                return Err(format!(
+                    "global text path '{path}' does not accept {}",
+                    value.type_name()
+                ));
+            };
+            stasis_dynload::stasis_jit_global_i32_array_store(
+                collection_hash,
+                field_hash,
+                index,
+                i32::from(value),
+            );
+            return Ok(());
+        }
+        match (type_id, value) {
+            (TYPE_ID_I32, JitScalarValue::I32(value)) => {
+                stasis_dynload::stasis_jit_global_i32_array_store(
+                    collection_hash,
+                    field_hash,
+                    index,
+                    value,
+                )
+            }
+            (TYPE_ID_F32, JitScalarValue::F32(value)) => {
+                stasis_dynload::stasis_jit_global_f32_array_store(
+                    collection_hash,
+                    field_hash,
+                    index,
+                    value,
+                )
+            }
+            (TYPE_ID_F64, JitScalarValue::F64(value)) => {
+                stasis_dynload::stasis_jit_global_f64_array_store(
+                    collection_hash,
+                    field_hash,
+                    index,
+                    value,
+                )
+            }
+            (TYPE_ID_BOOL, JitScalarValue::Bool(value)) => {
+                stasis_dynload::stasis_jit_global_i32_array_store(
+                    collection_hash,
+                    field_hash,
+                    index,
+                    i32::from(value),
+                )
+            }
+            (type_id, JitScalarValue::U8(value)) if is_u8_type(self.compiler.types(), type_id) => {
+                stasis_dynload::stasis_jit_global_i32_array_store(
+                    collection_hash,
+                    field_hash,
+                    index,
+                    i32::from(value),
+                )
+            }
+            (_, value) => {
+                return Err(format!(
+                    "global collection path '{path}' field '{field}' does not accept {}",
+                    value.type_name()
+                ))
+            }
+        }
+        Ok(())
+    }
+
     pub fn read_global_scalar(&self, path: &str) -> Result<JitScalarValue, String> {
         let type_id = self.global_path_type(path)?;
         let path_hash = hash_global_path(path);
@@ -497,6 +784,120 @@ impl JitProcess {
             .as_ref()
             .and_then(|analysis| analysis.global_path_types.get(path).copied())
             .ok_or_else(|| format!("global path '{path}' was not found in compiler metadata"))
+    }
+
+    fn global_collection_value_type(&self, path: &str, field: &str) -> Result<(u16, i32), String> {
+        let analysis = self
+            .compile_analysis_cache
+            .as_ref()
+            .ok_or_else(|| "JIT collection metadata is unavailable".to_string())?;
+        if let Some(info) = analysis.collection_infos.get(path) {
+            let type_id = if field.is_empty() {
+                info.element_type
+            } else {
+                info.field_types.get(field).copied()
+            }
+            .ok_or_else(|| {
+                format!("global collection path '{path}' field '{field}' was not found")
+            })?;
+            return Ok((type_id, info.len));
+        }
+        if field.is_empty() {
+            if let Some(capacity) = self.global_fixed_text_capacity(path) {
+                let type_id = analysis
+                    .global_path_types
+                    .get(path)
+                    .and_then(|type_id| self.compiler.types().indexed_element_type_id(*type_id))
+                    .ok_or_else(|| format!("global text path '{path}' has no payload type"))?;
+                return Ok((type_id, capacity));
+            }
+        }
+        Err(format!("global collection path '{path}' was not found"))
+    }
+
+    fn global_fixed_text_capacity(&self, path: &str) -> Option<i32> {
+        let type_id = self
+            .compile_analysis_cache
+            .as_ref()?
+            .global_path_types
+            .get(path)?;
+        let category = self.compiler.types().type_info(*type_id)?.category;
+        matches!(category, TypeCategory::AsciiFixed | TypeCategory::Utf8Fixed)
+            .then(|| self.compiler.types().fixed_collection_len(*type_id))
+            .flatten()
+    }
+
+    pub fn global_fixed_text_encoding(&self, path: &str) -> Option<&'static str> {
+        let type_id = self
+            .compile_analysis_cache
+            .as_ref()?
+            .global_path_types
+            .get(path)?;
+        match self.compiler.types().type_info(*type_id)?.category {
+            TypeCategory::AsciiFixed => Some("ascii"),
+            TypeCategory::Utf8Fixed => Some("utf8"),
+            _ => None,
+        }
+    }
+
+    pub fn preflight_global_collection_capacity(
+        &self,
+        path: &str,
+        field: &str,
+        capacity: u32,
+    ) -> Result<(), String> {
+        self.collection_capacity_operation(path, field, capacity, false)
+    }
+
+    pub fn ensure_global_collection_capacity(
+        &self,
+        path: &str,
+        field: &str,
+        capacity: u32,
+    ) -> Result<(), String> {
+        self.collection_capacity_operation(path, field, capacity, true)
+    }
+
+    fn collection_capacity_operation(
+        &self,
+        path: &str,
+        field: &str,
+        capacity: u32,
+        grow: bool,
+    ) -> Result<(), String> {
+        let (type_id, _) = self.global_collection_value_type(path, field)?;
+        let capacity = capacity as usize;
+        let collection_hash = hash_global_path(path);
+        let field_hash = hash_foreach_field_suffix(field);
+        let i32_capacity = if grow {
+            stasis_dynload::ensure_jit_i32_array_capacity
+        } else {
+            stasis_dynload::preflight_jit_i32_array_capacity
+        };
+        let f32_capacity = if grow {
+            stasis_dynload::ensure_jit_f32_array_capacity
+        } else {
+            stasis_dynload::preflight_jit_f32_array_capacity
+        };
+        let f64_capacity = if grow {
+            stasis_dynload::ensure_jit_f64_array_capacity
+        } else {
+            stasis_dynload::preflight_jit_f64_array_capacity
+        };
+        if field.is_empty() && self.global_fixed_text_capacity(path).is_some() {
+            return i32_capacity(collection_hash, field_hash, capacity);
+        }
+        match type_id {
+            TYPE_ID_I32 | TYPE_ID_BOOL => i32_capacity(collection_hash, field_hash, capacity),
+            TYPE_ID_F32 => f32_capacity(collection_hash, field_hash, capacity),
+            TYPE_ID_F64 => f64_capacity(collection_hash, field_hash, capacity),
+            type_id if is_u8_type(self.compiler.types(), type_id) => {
+                i32_capacity(collection_hash, field_hash, capacity)
+            }
+            _ => Err(format!(
+                "global collection path '{path}' field '{field}' is not resizable"
+            )),
+        }
     }
 
     pub fn write_i32_global_path(&self, path: &str, value: i32) {
@@ -823,6 +1224,20 @@ fn scalar_type_name(type_id: u16) -> Option<&'static str> {
     }
 }
 
+fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
+    if is_u8_type(type_table, type_id) {
+        Some("u8")
+    } else {
+        scalar_type_name(type_id)
+    }
+}
+
+fn is_u8_type(type_table: &TypeTable, type_id: u16) -> bool {
+    type_table
+        .type_info(type_id)
+        .is_some_and(|info| info.name == "u8")
+}
+
 fn collect_current_string_literals(compiler: &Compiler) -> Result<HashMap<i32, String>, String> {
     let mut literals = HashMap::new();
     for file in compiler.files() {
@@ -988,6 +1403,9 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "sys_memmove_f32" | "stasis_jit_sys_memmove_f32" => {
             function_address(stasis_dynload::stasis_jit_sys_memmove_f32 as *const ())
         }
+        "reject_code_swap" | "stasis_jit_reject_code_swap" => {
+            function_address(stasis_dynload::stasis_jit_reject_code_swap as *const ())
+        }
         _ => return None,
     };
     Some(address)
@@ -1117,6 +1535,7 @@ fn runtime_helper_addresses() -> BTreeMap<String, usize> {
         stasis_jit_global_f64_array_load,
         stasis_jit_global_f64_array_store,
         stasis_jit_global_f64_array_ptr,
+        stasis_jit_reject_code_swap,
     );
     out
 }

--- a/crates/stasis_compiler/src/backend/mod.rs
+++ b/crates/stasis_compiler/src/backend/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod emit;
 pub mod jit;
 mod reachability;
 mod runtime_exports;
+pub mod state_layout;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EngineEntrypoints {

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -41,6 +41,7 @@ pub(crate) const AOT_RUNTIME_EXPORT_SYMBOLS: &[&str] = &[
     "stasis_jit_measure_text",
     "stasis_jit_print_i32",
     "stasis_jit_print_string",
+    "stasis_jit_reject_code_swap",
     "stasis_jit_sin_fast",
     "stasis_jit_sleep_ms",
     "stasis_jit_sys_memcpy_f32",

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -1,0 +1,230 @@
+use super::emit::{CollectionInfoMap, GlobalPathTypeMap};
+use crate::frontend::types::{
+    TypeCategory, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
+};
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateLayout {
+    pub scalars: Vec<StateScalarLayout>,
+    pub collections: Vec<StateCollectionLayout>,
+    pub opaque: Vec<StateOpaqueLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateScalarLayout {
+    pub path: String,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateCollectionLayout {
+    pub path: String,
+    pub capacity: i32,
+    pub element_shape: String,
+    pub fully_migratable: bool,
+    pub fields: Vec<StateCollectionFieldLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateCollectionFieldLayout {
+    pub field: String,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateOpaqueLayout {
+    pub path: String,
+    pub type_name: String,
+}
+
+pub(crate) fn build_state_layout(
+    global_path_types: &GlobalPathTypeMap,
+    collection_infos: &CollectionInfoMap,
+    type_table: &TypeTable,
+) -> StateLayout {
+    let scalars = global_path_types
+        .iter()
+        .filter_map(|(path, type_id)| {
+            scalar_type_name(*type_id).map(|type_name| StateScalarLayout {
+                path: path.clone(),
+                type_name: type_name.to_string(),
+            })
+        })
+        .collect();
+    let mut collections: Vec<StateCollectionLayout> = collection_infos
+        .iter()
+        .map(|(path, info)| {
+            let mut fields = Vec::new();
+            if let Some(type_name) = info
+                .element_type
+                .and_then(|type_id| collection_type_name(type_table, type_id))
+            {
+                fields.push(StateCollectionFieldLayout {
+                    field: String::new(),
+                    type_name: type_name.to_string(),
+                });
+            }
+            fields.extend(info.field_types.iter().filter_map(|(field, type_id)| {
+                collection_type_name(type_table, *type_id).map(|type_name| {
+                    StateCollectionFieldLayout {
+                        field: field.clone(),
+                        type_name: type_name.to_string(),
+                    }
+                })
+            }));
+            StateCollectionLayout {
+                path: path.clone(),
+                capacity: info.len,
+                element_shape: info.element_shape.clone(),
+                fully_migratable: info.fully_migratable,
+                fields,
+            }
+        })
+        .collect();
+    for (path, type_id) in global_path_types {
+        let Some(info) = type_table.type_info(*type_id) else {
+            continue;
+        };
+        if !matches!(
+            info.category,
+            TypeCategory::AsciiFixed | TypeCategory::Utf8Fixed
+        ) {
+            continue;
+        }
+        let Some(capacity) = type_table.fixed_collection_len(*type_id) else {
+            continue;
+        };
+        if let Some(collection) = collections
+            .iter_mut()
+            .find(|collection| collection.path == *path)
+        {
+            if !collection.fields.iter().any(|field| field.field.is_empty()) {
+                collection.fields.push(StateCollectionFieldLayout {
+                    field: String::new(),
+                    type_name: "u8".to_string(),
+                });
+            }
+            collection.fully_migratable = true;
+            continue;
+        }
+        collections.push(StateCollectionLayout {
+            path: path.clone(),
+            capacity,
+            element_shape: info.name.clone(),
+            fully_migratable: true,
+            fields: vec![StateCollectionFieldLayout {
+                field: String::new(),
+                type_name: "u8".to_string(),
+            }],
+        });
+    }
+    collections.sort_by(|left, right| left.path.cmp(&right.path));
+    let collection_paths = collections
+        .iter()
+        .map(|collection| collection.path.as_str())
+        .collect::<BTreeSet<_>>();
+    let opaque = global_path_types
+        .iter()
+        .filter_map(|(path, type_id)| {
+            if scalar_type_name(*type_id).is_some() || collection_paths.contains(path.as_str()) {
+                return None;
+            }
+            let info = type_table.type_info(*type_id)?;
+            let prefix = format!("{path}.");
+            if info.category == TypeCategory::Named
+                && global_path_types
+                    .keys()
+                    .any(|candidate| candidate.starts_with(&prefix))
+            {
+                return None;
+            }
+            Some(StateOpaqueLayout {
+                path: path.clone(),
+                type_name: info.name.clone(),
+            })
+        })
+        .collect();
+    StateLayout {
+        scalars,
+        collections,
+        opaque,
+    }
+}
+
+fn scalar_type_name(type_id: u16) -> Option<&'static str> {
+    match type_id {
+        TYPE_ID_I32 => Some("i32"),
+        TYPE_ID_F32 => Some("f32"),
+        TYPE_ID_F64 => Some("f64"),
+        TYPE_ID_BOOL => Some("bool"),
+        _ => None,
+    }
+}
+
+fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
+    if type_table
+        .type_info(type_id)
+        .is_some_and(|info| info.name == "u8")
+    {
+        Some("u8")
+    } else {
+        scalar_type_name(type_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::aot::AotProcess;
+    use crate::backend::jit::JitProcess;
+
+    #[test]
+    fn jit_and_aot_share_canonical_state_layout() {
+        let source = "const SAMPLE_COUNT: i32 = 2;\n\
+                      struct Row { value: i32; samples: f32[SAMPLE_COUNT]; }\n\
+                      global rows: Row[4];\n\
+                      global score: i32;\n\
+                      global title: utf8[8];\n\
+                      global samples: f32[4];\n\
+                      function main(): i32 { return score; }\n";
+
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile_staged().expect("compile JIT fixture");
+
+        let mut aot = AotProcess::new();
+        aot.upsert_file("main.stasis", source);
+        aot.compile().expect("compile AOT fixture");
+
+        let layout = jit.state_layout();
+        assert_eq!(layout, aot.state_layout());
+        assert!(layout.scalars.iter().any(|field| field.path == "score"));
+        assert!(layout
+            .collections
+            .iter()
+            .any(|collection| collection.path == "title" && collection.capacity == 8));
+        assert!(layout
+            .collections
+            .iter()
+            .any(|collection| collection.path == "samples" && collection.capacity == 4));
+        let rows = layout
+            .collections
+            .iter()
+            .find(|collection| collection.path == "rows")
+            .expect("rows collection layout");
+        assert!(!rows.fully_migratable);
+        assert!(rows.element_shape.contains("samples:f32[2]"));
+
+        let original_shape = rows.element_shape.clone();
+        jit.upsert_file("main.stasis", source.replace("= 2", "= 3"));
+        jit.compile_staged().expect("recompile changed extent");
+        let changed_rows = jit
+            .state_layout()
+            .collections
+            .into_iter()
+            .find(|collection| collection.path == "rows")
+            .expect("changed rows collection layout");
+        assert!(changed_rows.element_shape.contains("samples:f32[3]"));
+        assert_ne!(original_shape, changed_rows.element_shape);
+    }
+}

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -136,6 +136,23 @@ pub fn invoke_noarg_void(address: usize) -> Result<(), String> {
     }
 }
 
+thread_local! {
+    static CODE_SWAP_REJECTION: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+pub fn invoke_code_swap_hook(address: usize) -> Result<(), String> {
+    let _ = CODE_SWAP_REJECTION.with(|rejection| rejection.borrow_mut().take());
+    invoke_noarg_void(address)?;
+    CODE_SWAP_REJECTION.with(|rejection| rejection.borrow_mut().take().map_or(Ok(()), Err))
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_reject_code_swap() {
+    CODE_SWAP_REJECTION.with(|rejection| {
+        *rejection.borrow_mut() = Some("hook requested rejection".to_string());
+    });
+}
+
 pub fn invoke_i32_to_void(address: usize, arg0: i32) -> Result<(), String> {
     if address == 0 {
         return Err("cannot invoke null function pointer".to_string());
@@ -759,6 +776,202 @@ fn owned_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f64>>> {
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn ensure_owned_array_capacity<T: Copy>(
+    key: ArrayKey,
+    requested_len: usize,
+    default: T,
+    owned: &Mutex<HashMap<ArrayKey, Vec<T>>>,
+    registered: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
+) -> Result<(), String> {
+    let mut owned_guard = owned.lock().expect("owned array table mutex poisoned");
+    if let Some(array) = owned_guard.get_mut(&key) {
+        if let Some((registered_ptr, registered_len)) = registered
+            .lock()
+            .expect("registered array table mutex poisoned")
+            .get(&key)
+            .copied()
+        {
+            if registered_ptr != array.as_mut_ptr() as usize {
+                return (registered_len >= requested_len)
+                    .then_some(())
+                    .ok_or_else(|| {
+                        format!(
+                            "cannot grow host-owned collection storage from {registered_len} to {requested_len}"
+                        )
+                    });
+            }
+        }
+        array.resize(array.len().max(requested_len), default);
+        let mut registered_guard = registered
+            .lock()
+            .expect("registered array table mutex poisoned");
+        registered_guard.insert(key, (array.as_mut_ptr() as usize, array.len()));
+        return Ok(());
+    }
+    if let Some((_, registered_len)) = registered
+        .lock()
+        .expect("registered array table mutex poisoned")
+        .get(&key)
+        .copied()
+    {
+        return (registered_len >= requested_len)
+            .then_some(())
+            .ok_or_else(|| {
+                format!(
+                "cannot grow host-owned collection storage from {registered_len} to {requested_len}"
+            )
+            });
+    }
+    let mut array = vec![default; requested_len];
+    let ptr = array.as_mut_ptr() as usize;
+    owned_guard.insert(key, array);
+    registered
+        .lock()
+        .expect("registered array table mutex poisoned")
+        .insert(key, (ptr, requested_len));
+    Ok(())
+}
+
+fn preflight_owned_array_capacity<T>(
+    key: ArrayKey,
+    requested_len: usize,
+    owned: &Mutex<HashMap<ArrayKey, Vec<T>>>,
+    registered: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
+) -> Result<(), String> {
+    let owned_guard = owned.lock().expect("owned array table mutex poisoned");
+    let registered_entry = registered
+        .lock()
+        .expect("registered array table mutex poisoned")
+        .get(&key)
+        .copied();
+    if let Some(array) = owned_guard.get(&key) {
+        if registered_entry
+            .is_none_or(|(registered_ptr, _)| registered_ptr == array.as_ptr() as usize)
+        {
+            return Ok(());
+        }
+    }
+    if let Some((_, registered_len)) = registered_entry {
+        return (registered_len >= requested_len)
+            .then_some(())
+            .ok_or_else(|| {
+                format!(
+                    "cannot grow host-owned collection storage from {registered_len} to {requested_len}"
+                )
+            });
+    }
+    Ok(())
+}
+
+pub fn preflight_jit_i32_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    preflight_owned_array_capacity(
+        (collection_hash, field_hash),
+        requested_len,
+        owned_i32_arrays(),
+        registered_i32_arrays(),
+    )
+}
+
+pub fn preflight_jit_f32_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    preflight_owned_array_capacity(
+        (collection_hash, field_hash),
+        requested_len,
+        owned_f32_arrays(),
+        registered_f32_arrays(),
+    )
+}
+
+pub fn preflight_jit_f64_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    preflight_owned_array_capacity(
+        (collection_hash, field_hash),
+        requested_len,
+        owned_f64_arrays(),
+        registered_f64_arrays(),
+    )
+}
+
+fn migrate_fallback_array<T: Copy>(
+    key: ArrayKey,
+    owned: &Mutex<HashMap<ArrayKey, Vec<T>>>,
+    fallback: &Mutex<HashMap<(i32, i32, i32), T>>,
+) {
+    let mut owned_guard = owned.lock().expect("owned array table mutex poisoned");
+    let Some(array) = owned_guard.get_mut(&key) else {
+        return;
+    };
+    let mut fallback = fallback
+        .lock()
+        .expect("fallback array table mutex poisoned");
+    for (index, slot) in array.iter_mut().enumerate() {
+        if let Some(value) = fallback.remove(&(key.0, key.1, index as i32)) {
+            *slot = value;
+        }
+    }
+}
+
+pub fn ensure_jit_i32_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let key = (collection_hash, field_hash);
+    ensure_owned_array_capacity(
+        key,
+        requested_len,
+        0,
+        owned_i32_arrays(),
+        registered_i32_arrays(),
+    )?;
+    migrate_fallback_array(key, owned_i32_arrays(), jit_i32_array_global_table());
+    Ok(())
+}
+
+pub fn ensure_jit_f32_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let key = (collection_hash, field_hash);
+    ensure_owned_array_capacity(
+        key,
+        requested_len,
+        0.0,
+        owned_f32_arrays(),
+        registered_f32_arrays(),
+    )?;
+    migrate_fallback_array(key, owned_f32_arrays(), jit_f32_array_global_table());
+    Ok(())
+}
+
+pub fn ensure_jit_f64_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let key = (collection_hash, field_hash);
+    ensure_owned_array_capacity(
+        key,
+        requested_len,
+        0.0,
+        owned_f64_arrays(),
+        registered_f64_arrays(),
+    )?;
+    migrate_fallback_array(key, owned_f64_arrays(), jit_f64_array_global_table());
+    Ok(())
+}
+
 pub fn clear_registered_global_memory() {
     registered_i32_ptrs()
         .lock()
@@ -814,10 +1027,18 @@ pub struct JitRuntimeStateSnapshot {
     i32_ptrs: Vec<(usize, i32)>,
     f32_ptrs: Vec<(usize, f32)>,
     f64_ptrs: Vec<(usize, f64)>,
-    i32_arrays: Vec<(usize, Vec<i32>)>,
-    f32_arrays: Vec<(usize, Vec<f32>)>,
-    f64_arrays: Vec<(usize, Vec<f64>)>,
-    u8_arrays: Vec<(usize, Vec<u8>)>,
+    i32_arrays: Vec<RegisteredArraySnapshot<i32>>,
+    f32_arrays: Vec<RegisteredArraySnapshot<f32>>,
+    f64_arrays: Vec<RegisteredArraySnapshot<f64>>,
+    u8_arrays: Vec<RegisteredArraySnapshot<u8>>,
+}
+
+#[derive(Debug, Clone)]
+struct RegisteredArraySnapshot<T> {
+    key: ArrayKey,
+    address: usize,
+    values: Vec<T>,
+    owned: bool,
 }
 
 pub fn snapshot_jit_runtime_state() -> JitRuntimeStateSnapshot {
@@ -862,10 +1083,13 @@ pub fn snapshot_jit_runtime_state_bounded(
         i32_ptrs: snapshot_registered_ptrs(registered_i32_ptrs()),
         f32_ptrs: snapshot_registered_ptrs(registered_f32_ptrs()),
         f64_ptrs: snapshot_registered_ptrs(registered_f64_ptrs()),
-        i32_arrays: snapshot_registered_arrays(registered_i32_arrays()),
-        f32_arrays: snapshot_registered_arrays(registered_f32_arrays()),
-        f64_arrays: snapshot_registered_arrays(registered_f64_arrays()),
-        u8_arrays: snapshot_registered_arrays(registered_u8_arrays()),
+        i32_arrays: snapshot_registered_arrays(registered_i32_arrays(), Some(owned_i32_arrays())),
+        f32_arrays: snapshot_registered_arrays(registered_f32_arrays(), Some(owned_f32_arrays())),
+        f64_arrays: snapshot_registered_arrays(registered_f64_arrays(), Some(owned_f64_arrays())),
+        u8_arrays: snapshot_registered_arrays(
+            registered_u8_arrays(),
+            None::<&Mutex<HashMap<ArrayKey, Vec<u8>>>>,
+        ),
     })
 }
 
@@ -998,10 +1222,26 @@ pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
     restore_registered_ptrs(&snapshot.i32_ptrs);
     restore_registered_ptrs(&snapshot.f32_ptrs);
     restore_registered_ptrs(&snapshot.f64_ptrs);
-    restore_registered_arrays(&snapshot.i32_arrays);
-    restore_registered_arrays(&snapshot.f32_arrays);
-    restore_registered_arrays(&snapshot.f64_arrays);
-    restore_registered_arrays(&snapshot.u8_arrays);
+    restore_registered_arrays(
+        &snapshot.i32_arrays,
+        registered_i32_arrays(),
+        Some(owned_i32_arrays()),
+    );
+    restore_registered_arrays(
+        &snapshot.f32_arrays,
+        registered_f32_arrays(),
+        Some(owned_f32_arrays()),
+    );
+    restore_registered_arrays(
+        &snapshot.f64_arrays,
+        registered_f64_arrays(),
+        Some(owned_f64_arrays()),
+    );
+    restore_registered_arrays(
+        &snapshot.u8_arrays,
+        registered_u8_arrays(),
+        None::<&Mutex<HashMap<ArrayKey, Vec<u8>>>>,
+    );
 }
 
 fn snapshot_registered_ptrs<T: Copy>(table: &Mutex<HashMap<i32, usize>>) -> Vec<(usize, T)> {
@@ -1027,27 +1267,69 @@ fn restore_registered_ptrs<T: Copy>(values: &[(usize, T)]) {
 
 fn snapshot_registered_arrays<T: Copy>(
     table: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
-) -> Vec<(usize, Vec<T>)> {
+    owned: Option<&Mutex<HashMap<ArrayKey, Vec<T>>>>,
+) -> Vec<RegisteredArraySnapshot<T>> {
+    let owned_addresses = owned
+        .map(|owned| {
+            owned
+                .lock()
+                .expect("owned array table mutex poisoned")
+                .iter()
+                .map(|(key, values)| (*key, values.as_ptr() as usize))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
     table
         .lock()
         .expect("registered global array table mutex poisoned")
-        .values()
-        .copied()
-        .map(|(address, len)| {
+        .iter()
+        .map(|(key, (address, len))| {
             // Registered array memory remains valid until the in-process runner unregisters it.
-            let values = unsafe { std::slice::from_raw_parts(address as *const T, len) }.to_vec();
-            (address, values)
+            let values = unsafe { std::slice::from_raw_parts(*address as *const T, *len) }.to_vec();
+            RegisteredArraySnapshot {
+                key: *key,
+                address: *address,
+                values,
+                owned: owned_addresses.contains_key(key),
+            }
         })
         .collect()
 }
 
-fn restore_registered_arrays<T: Copy>(arrays: &[(usize, Vec<T>)]) {
-    for (address, values) in arrays {
-        // Restoration is serialized with guest execution at the between-tick boundary.
-        unsafe {
-            std::slice::from_raw_parts_mut(*address as *mut T, values.len()).copy_from_slice(values)
-        };
+fn restore_registered_arrays<T: Copy + Default>(
+    arrays: &[RegisteredArraySnapshot<T>],
+    registered: &Mutex<HashMap<ArrayKey, (usize, usize)>>,
+    owned: Option<&Mutex<HashMap<ArrayKey, Vec<T>>>>,
+) {
+    let mut restored = HashMap::new();
+    let mut owned_guard =
+        owned.map(|owned| owned.lock().expect("owned array table mutex poisoned"));
+    if let Some(owned) = owned_guard.as_mut() {
+        owned.retain(|key, _| arrays.iter().any(|array| array.owned && array.key == *key));
     }
+    for array in arrays {
+        let address = if array.owned {
+            let values = owned_guard
+                .as_mut()
+                .expect("owned snapshot requires owned storage")
+                .entry(array.key)
+                .or_default();
+            values.clear();
+            values.extend_from_slice(&array.values);
+            values.as_mut_ptr() as usize
+        } else {
+            // Restoration is serialized with guest execution at the between-tick boundary.
+            unsafe {
+                std::slice::from_raw_parts_mut(array.address as *mut T, array.values.len())
+                    .copy_from_slice(&array.values)
+            };
+            array.address
+        };
+        restored.insert(array.key, (address, array.values.len()));
+    }
+    *registered
+        .lock()
+        .expect("registered array table mutex poisoned") = restored;
 }
 
 pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
@@ -1087,33 +1369,53 @@ pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mu
     if ptr.is_null() {
         return;
     }
+    let key = (collection_hash, field_hash);
+    remove_replaced_owned_array(key, ptr as usize, owned_i32_arrays());
     let table = registered_i32_arrays();
     let mut guard = table
         .lock()
         .expect("registered i32 array table mutex poisoned");
-    guard.insert((collection_hash, field_hash), (ptr as usize, len));
+    guard.insert(key, (ptr as usize, len));
 }
 
 pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mut f32, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let key = (collection_hash, field_hash);
+    remove_replaced_owned_array(key, ptr as usize, owned_f32_arrays());
     let table = registered_f32_arrays();
     let mut guard = table
         .lock()
         .expect("registered f32 array table mutex poisoned");
-    guard.insert((collection_hash, field_hash), (ptr as usize, len));
+    guard.insert(key, (ptr as usize, len));
 }
 
 pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mut f64, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let key = (collection_hash, field_hash);
+    remove_replaced_owned_array(key, ptr as usize, owned_f64_arrays());
     let table = registered_f64_arrays();
     let mut guard = table
         .lock()
         .expect("registered f64 array table mutex poisoned");
-    guard.insert((collection_hash, field_hash), (ptr as usize, len));
+    guard.insert(key, (ptr as usize, len));
+}
+
+fn remove_replaced_owned_array<T>(
+    key: ArrayKey,
+    registered_ptr: usize,
+    owned: &Mutex<HashMap<ArrayKey, Vec<T>>>,
+) {
+    let mut guard = owned.lock().expect("owned array table mutex poisoned");
+    if guard
+        .get(&key)
+        .is_some_and(|values| values.as_ptr() as usize != registered_ptr)
+    {
+        guard.remove(&key);
+    }
 }
 
 pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut u8, len: usize) {
@@ -1205,14 +1507,30 @@ pub extern "C" fn stasis_jit_global_i32_array_ptr(
     }
 
     // Fast path: already registered (host-owned or previously allocated).
-    {
+    let registered_len = {
         let table = registered_i32_arrays();
         let guard = table
             .lock()
             .expect("registered i32 array table mutex poisoned");
-        if let Some((ptr, _)) = guard.get(&(collection_hash, field_hash)).copied() {
-            return ptr as *mut i32;
+        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
+            if registered_len >= len as usize {
+                return ptr as *mut i32;
+            }
+            Some(registered_len)
+        } else {
+            None
         }
+    };
+
+    if registered_len.is_some() {
+        if ensure_jit_i32_array_capacity(collection_hash, field_hash, len as usize).is_err() {
+            return std::ptr::null_mut();
+        }
+        return registered_i32_arrays()
+            .lock()
+            .expect("registered i32 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut i32);
     }
 
     let requested_len = len as usize;
@@ -1266,14 +1584,30 @@ pub extern "C" fn stasis_jit_global_f32_array_ptr(
     }
 
     // Fast path: already registered (host-owned or previously allocated).
-    {
+    let registered_len = {
         let table = registered_f32_arrays();
         let guard = table
             .lock()
             .expect("registered f32 array table mutex poisoned");
-        if let Some((ptr, _)) = guard.get(&(collection_hash, field_hash)).copied() {
-            return ptr as *mut f32;
+        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
+            if registered_len >= len as usize {
+                return ptr as *mut f32;
+            }
+            Some(registered_len)
+        } else {
+            None
         }
+    };
+
+    if registered_len.is_some() {
+        if ensure_jit_f32_array_capacity(collection_hash, field_hash, len as usize).is_err() {
+            return std::ptr::null_mut();
+        }
+        return registered_f32_arrays()
+            .lock()
+            .expect("registered f32 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f32);
     }
 
     let requested_len = len as usize;
@@ -1330,14 +1664,30 @@ pub extern "C" fn stasis_jit_global_f64_array_ptr(
     }
 
     // Fast path: already registered (host-owned or previously allocated).
-    {
+    let registered_len = {
         let table = registered_f64_arrays();
         let guard = table
             .lock()
             .expect("registered f64 array table mutex poisoned");
-        if let Some((ptr, _)) = guard.get(&(collection_hash, field_hash)).copied() {
-            return ptr as *mut f64;
+        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
+            if registered_len >= len as usize {
+                return ptr as *mut f64;
+            }
+            Some(registered_len)
+        } else {
+            None
         }
+    };
+
+    if registered_len.is_some() {
+        if ensure_jit_f64_array_capacity(collection_hash, field_hash, len as usize).is_err() {
+            return std::ptr::null_mut();
+        }
+        return registered_f64_arrays()
+            .lock()
+            .expect("registered f64 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f64);
     }
 
     let requested_len = len as usize;

--- a/crates/stasis_runner/src/swap/contracts.rs
+++ b/crates/stasis_runner/src/swap/contracts.rs
@@ -128,13 +128,6 @@ pub struct JitCodePtrOverride {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StateMapEntry {
-    pub path: String,
-    pub path_hash: i32,
-    pub type_name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompileStatus {
     Success,
     Failed,
@@ -165,8 +158,6 @@ pub struct CompileResult {
     pub aot_function_symbols: Option<Vec<AotFunctionSymbol>>,
     #[serde(default)]
     pub jit_code_ptr_overrides: Option<Vec<JitCodePtrOverride>>,
-    #[serde(default)]
-    pub state_map: Option<Vec<StateMapEntry>>,
 }
 
 impl CompileResult {
@@ -229,7 +220,6 @@ impl CompileResult {
             aot_linked_image_sha256,
             aot_function_symbols,
             jit_code_ptr_overrides: None,
-            state_map: None,
         }
     }
 
@@ -250,7 +240,6 @@ impl CompileResult {
             aot_linked_image_sha256: None,
             aot_function_symbols: None,
             jit_code_ptr_overrides: None,
-            state_map: None,
         }
     }
 }
@@ -268,8 +257,6 @@ pub struct SwapCommitRequest {
     pub host_set_hash: Option<[u8; 32]>,
     #[serde(default)]
     pub hook_fn_id: Option<FnId>,
-    #[serde(default)]
-    pub state_map: Option<Vec<StateMapEntry>>,
 }
 
 impl SwapCommitRequest {
@@ -288,7 +275,6 @@ impl SwapCommitRequest {
             host_set_id: None,
             host_set_hash: None,
             hook_fn_id: None,
-            state_map: None,
         }
     }
 }

--- a/crates/stasis_runner/src/swap/pipeline.rs
+++ b/crates/stasis_runner/src/swap/pipeline.rs
@@ -251,7 +251,6 @@ impl DevHotSwapPipeline {
                                 result.host_set_id.clone(),
                                 result.host_set_hash,
                                 result.hook_fn_id,
-                                result.state_map.clone(),
                             );
                         }
                     }
@@ -270,7 +269,6 @@ impl DevHotSwapPipeline {
         host_set_id: Option<String>,
         host_set_hash: Option<[u8; 32]>,
         hook_fn_id: Option<FnId>,
-        state_map: Option<Vec<crate::swap::contracts::StateMapEntry>>,
     ) {
         let Some(layout_hash) = layout_hash else {
             return;
@@ -291,7 +289,6 @@ impl DevHotSwapPipeline {
             host_set_id,
             host_set_hash,
             hook_fn_id,
-            state_map,
         };
         let _ = self.commit_request_tx.send(request);
         self.in_flight_commit = Some(request_id);

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -398,7 +398,7 @@ Rules:
 When a source file changes during development, ownership is:
 
 - Runtime/Main Thread: owns tick loop, safe-point detection, and final swap commit; never performs parsing/semantic/codegen work inline with tick execution.
-- Compiler Service Thread: owns lex/parse/index/semantic/hash analysis for changed files and produces either diagnostics or a swap candidate patch.
+- Compiler Service Thread: owns lex/parse/index/semantic/hash analysis for changed files and produces either diagnostics or a staged swap candidate; it never activates candidate runtime state.
 - Codegen Service (Cranelift): owns JIT code emission for dev mode and AOT emission for prod mode; never mutates runtime state directly.
 - Swap Coordinator: owns two-phase commit transaction boundaries, all-or-nothing swap rules, and generation retirement scheduling after successful commit.
 
@@ -417,11 +417,11 @@ Interfaces are message-based and versioned. No cross-thread shared mutable compi
 1. Watcher emits `FileChangeEvent`.
 2. Swap coordinator coalesces pending events and emits `CompileRequest`.
 3. Compiler service runs full-file semantic pass.
-4. Compiler/codegen returns `CompileResult` with diagnostics or patch.
+4. Compiler/codegen returns `CompileResult` with diagnostics or a patch plus its staged JIT candidate.
 5. If diagnostics exist, patch is discarded and old code remains active.
 6. If eligible, coordinator waits for between-ticks safe point.
-7. Main thread runs `on_code_swap()` (if present) using old pointers.
-8. Main thread atomically applies pointer-table update and records new generation.
+7. Main thread runs the shared bounded state-migration transaction and `on_code_swap()` (if present).
+8. Main thread atomically activates the candidate runtime and pointer-table update, then records the new generation.
 9. Runtime publishes `SwapCommitResult`; debug UI updates swap indicator only on success.
 
 Failure at any sequence step aborts commit and preserves old code/data.

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -198,10 +198,22 @@ Add `--preview` to an inline `:add`, `:update`, or `:delete` to compile and reta
 plan without writing. `:preview` displays that staged plan and `:apply` commits it only if its
 source hashes are still current.
 
-Layout-changing edits return a deterministic diagnostic until the first-class migration contract
-tracked by Maddox #153 is available. Compiler, test, stale-hash, receipt, or `on_code_swap`
-invocation failure restores the prior disk sources, dispatch table, and bounded typed runtime
-state. The current `on_code_swap(): void` ABI has no application-level rejection return value.
+Layout-affecting edits always stop at a versioned swap preview, even when the original edit did
+not pass `--preview`. The preview lists candidate dispatch-patch functions, source and target state-layout versions,
+struct-scoped or whole-state migration steps, compatibility, capacity-shrink data-loss warnings,
+and a deterministic commit-cost estimate. `:apply` regenerates the preview and refuses the commit
+if it differs from the validated version.
+
+Compatible scalar and fixed-collection fields are copied by compiler-owned path/type metadata.
+New fields and expanded collection capacity are explicitly initialized to the type default before
+`on_code_swap`; removed fields are reported, and collection lengths are clamped when capacity
+shrinks. Growth is preflighted against runtime storage ownership and the bounded live-state budget.
+UTF-8 shrink retains only the largest valid code-point prefix and recomputes byte and character
+counts. Type changes at an existing state path and function ABI changes reject deterministically.
+Compiler, migration, test, stale-hash, receipt, or `on_code_swap` failure restores the prior disk
+sources, dispatch table, fixed-capacity headers, and bounded typed runtime state with no partial
+commit. `on_code_swap(): void` can call the stdlib `reject_code_swap()` helper to reject after
+validating or adjusting migrated state; the runtime then restores the prior disk, code, and state.
 
 ## Scratch and state transactions
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -688,15 +688,20 @@ Swap is rejected if:
 - `on_code_swap()` fails.
 
 Current policy (pre-1.0):
-- Layout-hash changes are rejected deterministically with a `restart required` error.
-- Automatic blob state migration (`state-map` old->new layout copy) is planned but not yet implemented.
+- Layout-affecting semantic edits produce a versioned preview and require explicit apply.
+- The preview reports candidate dispatch-patch functions, state-layout compatibility, struct or whole-state scope, migration steps, capacity-shrink warnings, and estimated commit cost.
+- Apply regenerates the preview; any preview/commit mismatch rejects the swap.
 
 On rejection, old code and old data remain active.
 
 Current migration policy (pre-1.0):
-- Layout hash changes can commit only when both active and incoming builds provide deterministic state-map metadata.
-- Migration compatibility is path-based: overlapping paths must keep compatible type shape; added/removed paths are allowed.
-- Incompatible or missing state-map metadata fails commit deterministically with actionable `restart required` diagnostics.
+- Layout hash changes can commit only when both active and incoming builds provide deterministic state metadata.
+- Migration compatibility is path-based: overlapping paths must keep compatible scalar or collection-element type shape.
+- Compatible scalar and fixed-collection fields are copied; new fields are initialized to their type default; removed fields are discarded with an explicit preview warning.
+- Fixed-collection growth is storage-ownership preflighted and bounded before allocation, preserves the old prefix, and initializes the expanded tail.
+- Shrink copies the retained prefix, warns about the discarded range, and clamps logical lengths; UTF-8 shrink retains the largest valid code-point prefix and recomputes byte and character counts.
+- Incompatible or missing state metadata fails deterministically with an actionable diagnostic.
+- Migration, `on_code_swap`, or pointer commit failure restores the old code and complete bounded runtime snapshot; partial migration is forbidden.
 
 ### 14.4 Development File-Change Boundary Contracts
 
@@ -736,6 +741,7 @@ Rules:
 - Runs between ticks.
 - Runs before new code executes.
 - May mutate global data.
+- May call `reject_code_swap()` to abort; the runtime restores the old code and complete bounded state snapshot.
 - Must not invoke gameplay entrypoints.
 
 ## 16. Diagnostics
@@ -770,4 +776,3 @@ Rules:
 
 This document defines the current direction.
 Legacy bootstrap/tooling details from prior repository generations are intentionally excluded.
-

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -695,7 +695,10 @@ Current policy (pre-1.0):
 On rejection, old code and old data remain active.
 
 Current migration policy (pre-1.0):
-- Layout hash changes can commit only when both active and incoming builds provide deterministic state metadata.
+- JIT and AOT derive layout identity from the same canonical compiler-owned state-layout model; source text and function bodies are not layout identity inputs.
+- Development JIT compilation produces a staged runtime candidate and never activates dispatch, literals, collection headers, or state from the compiler thread.
+- Every JIT entry point uses the same migration planner and bounded transactional activation at the runtime safe point. There is no scalar-only runner migration path.
+- Layout-changing commits without a staged JIT candidate, including current AOT runtime swaps, reject with a restart-required diagnostic.
 - Migration compatibility is path-based: overlapping paths must keep compatible scalar or collection-element type shape.
 - Compatible scalar and fixed-collection fields are copied; new fields are initialized to their type default; removed fields are discarded with an explicit preview warning.
 - Fixed-collection growth is storage-ownership preflighted and bounded before allocation, preserves the old prefix, and initializes the expanded tail.
@@ -716,8 +719,8 @@ Role ownership:
 Required high-level message contracts:
 - `FileChangeEvent(path, revision, text_source, change_kind)`
 - `CompileRequest(request_id, changed_files[], target_mode)`
-- `CompileResult(request_id, status, diagnostics[], layout_hash, fn_patch_set, hook_symbol?, state_map?)`
-- `SwapCommitRequest(request_id, layout_hash, fn_patch_set, hook_symbol, state_map?)`
+- `CompileResult(request_id, status, diagnostics[], layout_hash, fn_patch_set, hook_symbol?, staged_candidate?)`
+- `SwapCommitRequest(request_id, layout_hash, fn_patch_set, hook_symbol)`
 - `SwapCommitResult(request_id, status, swapped_fn_ids[], new_generation, error)`
 
 Rules:

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -525,6 +525,9 @@ static void copy_f32_values(int32_t dst, int32_t di, int32_t src, int32_t si, in
 void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memcpy_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memcpy_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }
+
+/* Mobile AOT has no live swap coordinator; retain the shared import contract as a no-op. */
+void stasis_jit_reject_code_swap(void) {}
 void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memmove_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memmove_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -69,6 +69,7 @@ float stasis_jit_call_f32_i32_1(int32_t fn, int32_t a0);
 void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
 void stasis_jit_sys_memcpy_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
 void stasis_jit_sys_memcpy_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
+void stasis_jit_reject_code_swap(void);
 void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
 void stasis_jit_sys_memmove_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);
 void stasis_jit_sys_memmove_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n);

--- a/samples/layout_migration_preview.stasis
+++ b/samples/layout_migration_preview.stasis
@@ -1,0 +1,24 @@
+global score: i32;
+global values: i32[4];
+
+function main(): i32 {
+    score = 7;
+    values[0] = 11;
+    values[1] = 22;
+    values[2] = 33;
+    values[3] = 44;
+    return 0;
+}
+
+function tick(): i32 {
+    score += 1;
+    return score + values[0];
+}
+
+function render(): i32 {
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -4,6 +4,9 @@
 
 import "memory.stasis";
 
+// Abort the current hot swap after on_code_swap restores any application invariants it can.
+extern function reject_code_swap(): void;
+
 // Rewrite V1 canonical integer print name.
 // Bootstrap currently provides `print_int`; this wrapper keeps source-level API aligned.
 function print_i32(value: i32): void {


### PR DESCRIPTION
Maddox Task #153: StasisLang: Make hot reload layout-aware with migration previews

Summary:
- derive one canonical compiler-owned state layout for JIT and AOT, including complete collection element shapes and resolved constant-backed extents
- expose one compiler-owned planner, bounded preflight, migration executor, candidate activation, and rollback transaction
- route LiveWorkspace edits, ordinary watched reloads, runner JIT commits, and Android Workshop reloads through that shared transaction
- stage candidates without activating runtime state before the main-thread/tick safe point; failed newer Android compiles invalidate older pending candidates
- snapshot only when layout migration or an actual `on_code_swap` hook can mutate state, preserving code-only >8 MiB bypasses
- deterministically reject non-migratable collection shapes and layout-changing commits without a staged candidate
- remove the obsolete scalar `state_map` transport/copy path and document the single layout authority

Tests:
- `cargo test --workspace --all-targets -- --test-threads=1` (pass on final Android-inclusive head; all workspace targets)
- `cargo test -p stasis --lib -- --test-threads=1` (200 passed, 6 ignored on convergence head)
- `cargo test -p stasis_compiler --lib -- --test-threads=1` (301 passed, 1 ignored on convergence head)
- `cargo test -p stasis_runner -- --test-threads=1` (35 passed)
- `cargo test -p stasis_android_bridge --lib -- --test-threads=1` (32 passed, 1 intentional ignore)
- exact Android regressions for hook rejection rollback, oversized no-hook snapshot bypass, and stale pending-candidate invalidation (pass)
- isolated rerun of the timing-sensitive interactive live CLI test (pass), followed by a clean full workspace rerun
- `cargo fmt --all -- --check` (pass)
- `git diff --check` (pass)
- `python tools/ci/check_stasis_src_layout.py` (pass)

Validation note:
- `tools/validate_repo.sh` could not be launched because Bash is unavailable on this Windows host; the direct full workspace/all-targets gate passed.

Review:
- independent sub-agent review iterated through unsupported collection shapes, constant-backed extents, Android false snapshot gating, and stale pending candidates; every finding was fixed and final re-reviews found no issues.

Compiler-slice reflection:
- Good: converging every JIT caller on one compiler-owned plan/transaction and adding adversarial shape/hash/lifecycle tests removed architectural ambiguity.
- Bad: the first convergence drafts missed unsupported collection fields, resolved nested extents, Android’s separate reload path, and pending-candidate ordering.
- Adjustment: inventory every activation caller before extraction; canonical metadata must prove complete representability, and each caller needs stale-candidate, no-hook, hook-failure, and layout-change tests before completion.