### PR TITLE
fix: unify Android hot reload transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "serde_json",
  "stasis_assets",
  "stasis_compiler",
+ "stasis_dynload",
 ]
 
 [[package]]

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use stasis_compiler::backend::aot::{AotEngineBundle, AotProcess};
 use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess};
-use stasis_compiler::backend::state_layout::StateLayout;
+use stasis_compiler::backend::state_layout::{state_layout_digest, StateLayout};
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
 use stasis_compiler::frontend::parser::parse_top_level_functions;
 #[cfg(test)]
@@ -943,18 +943,14 @@ impl IncrementalCompilerBackend {
     }
 
     fn layout_hash_from_state_layout(&self) -> LayoutHash {
-        let serialized = serde_json::to_vec(
-            self.last_state_layout
-                .as_ref()
-                .expect("successful compiler result must have canonical state layout"),
+        LayoutHash(
+            state_layout_digest(
+                self.last_state_layout
+                    .as_ref()
+                    .expect("successful compiler result must have canonical state layout"),
+            )
+            .expect("canonical state layout serialization is infallible"),
         )
-        .expect("canonical state layout serialization is infallible");
-        let mut hasher = Sha256::new();
-        hasher.update(serialized);
-        let digest = hasher.finalize();
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&digest);
-        LayoutHash(bytes)
     }
 
     fn compile_jit_engine_package_from_cache(

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -7,7 +7,6 @@ mod host_set_registry;
 mod live_workspace;
 mod runtime_exec;
 mod stasis_test_runner;
-mod state_migration;
 mod watch;
 mod window_config;
 
@@ -27,6 +26,10 @@ use runtime_exec::RuntimeLauncher;
 use serde::Deserialize;
 use serde_json::Value;
 use stasis_compiler::backend::jit::JitProcess;
+use stasis_compiler::backend::state_migration::{
+    activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
+    MAX_STATE_SNAPSHOT_BYTES,
+};
 use stasis_compiler::backend::EngineEntrypoints;
 use stasis_jit::FunctionPointerTable;
 use stasis_runner::swap::contracts::{
@@ -36,10 +39,6 @@ use stasis_runner::swap::contracts::{
     TextSource,
 };
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
-use state_migration::{
-    activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
-    MAX_STATE_SNAPSHOT_BYTES,
-};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::Read;

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -24,7 +24,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 
-use crate::state_migration::{
+use stasis_compiler::backend::state_migration::{
     activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
     state_layout_version, StateMigrationPreview as LiveSwapPreview,
 };

--- a/crates/stasis_android_bridge/Cargo.toml
+++ b/crates/stasis_android_bridge/Cargo.toml
@@ -16,3 +16,6 @@ path = "src/android_workshop_compile.rs"
 stasis_compiler = { path = "../stasis_compiler" }
 stasis_assets = { path = "../stasis_assets" }
 serde_json.workspace = true
+
+[dev-dependencies]
+stasis_dynload = { path = "../stasis_dynload" }

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -575,6 +575,7 @@ fn with_initialized_runtime_session<R>(
         let session = session_slot
             .as_mut()
             .ok_or_else(|| "Android runtime session was not initialized".to_string())?;
+        activate_pending_runtime_candidate(session)?;
         if !session.initialized {
             execute_lifecycle_noarg(&session.jit, "main")?;
             session.initialized = true;
@@ -1630,6 +1631,48 @@ mod tests {
         fs::remove_dir_all(&root).ok();
         clear_runtime_session_for_test();
     }
+
+    #[test]
+    fn bridge_state_helper_activates_pending_candidate_before_write() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("state_set_pending_reload");
+        let source = root.join("src/main.stasis");
+        fs::write(
+            &source,
+            "global GameState { score: i32; }\nfunction main(): void { GameState.score = 1; }\nfunction tick(): void { return; }\n",
+        )
+        .expect("write active source");
+        run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+            .expect("initialize active runtime");
+
+        fs::write(
+            &source,
+            "global GameState { score: i32; bonus: i32; }\nfunction main(): void { GameState.score = 1; }\nfunction tick(): void { return; }\n",
+        )
+        .expect("write layout-changing source");
+        compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect("stage layout-changing candidate");
+
+        set_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "GameState.bonus", 42)
+            .expect("state helper should activate candidate before write");
+        assert_eq!(
+            get_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "GameState.bonus")
+                .expect("read migrated candidate state"),
+            42
+        );
+        run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+            .expect("run already-activated candidate");
+        assert_eq!(
+            get_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "GameState.bonus")
+                .expect("write should survive next frame"),
+            42
+        );
+
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
     #[test]
     fn bridge_run_tick_executes_real_void_lifecycle_functions() {
         let _guard = bridge_runtime_test_guard();

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -8,6 +8,11 @@ use std::path::{Path, PathBuf};
 
 use stasis_assets::{AssetFormat, AssetHandle, AssetLimits, ResolvedAssetManifest};
 use stasis_compiler::backend::jit::JitProcess;
+#[cfg(test)]
+use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
+use stasis_compiler::backend::state_migration::{
+    activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
+};
 use stasis_compiler::frontend::parser::rewrite_top_level_test_declarations;
 use stasis_compiler::frontend::workshop::{
     build_workshop_compile_plan, load_workshop_edit_workspace, load_workshop_project,
@@ -70,7 +75,7 @@ struct AndroidRuntimeSession {
     source_fingerprint: u64,
     jit: JitProcess,
     initialized: bool,
-    pending_code_swap: bool,
+    pending_candidate: Option<JitProcess>,
     tick_count: i32,
 }
 
@@ -381,6 +386,7 @@ pub fn compile_android_workshop_project(
 ) -> Result<AndroidBridgeCompileResult, String> {
     let project_root = project_root.as_ref();
     let entry_file = entry_file.as_ref();
+    discard_pending_runtime_candidate(project_root);
     let files = load_workshop_project(project_root, entry_file)?;
     let changed_files = files
         .iter()
@@ -493,11 +499,10 @@ pub fn run_android_workshop_tick(
         let session = session_slot
             .as_mut()
             .ok_or_else(|| "Android runtime session was not initialized".to_string())?;
-        let swapped_code = session.pending_code_swap;
+        let swapped_code = activate_pending_runtime_candidate(session)?;
         if swapped_code {
             recompiled = true;
         }
-        session.pending_code_swap = false;
         let initialized = if session.initialized {
             false
         } else {
@@ -505,9 +510,6 @@ pub fn run_android_workshop_tick(
             session.initialized = true;
             true
         };
-        if swapped_code && !initialized {
-            execute_optional_lifecycle_noarg(&session.jit, "on_code_swap")?;
-        }
         session
             .jit
             .write_i32_global_path("Input.touch_x", input.touch_x);
@@ -621,7 +623,7 @@ fn build_runtime_session(
         source_fingerprint,
         jit,
         initialized: false,
-        pending_code_swap: false,
+        pending_candidate: None,
         tick_count: 0,
     })
 }
@@ -636,7 +638,6 @@ fn warm_or_reload_runtime_session(
         match session_slot.as_mut() {
             Some(session) if session.project_root == project_root => {
                 recompile_runtime_session(session, project_root, files, source_fingerprint)?;
-                session.pending_code_swap = session.initialized;
             }
             _ => {
                 *session_slot = Some(build_runtime_session(
@@ -656,16 +657,62 @@ fn recompile_runtime_session(
     files: &[WorkshopSourceFile],
     source_fingerprint: u64,
 ) -> Result<(), String> {
-    configure_runtime_jit(&mut session.jit, project_root, files);
-    if let Err(error) = session.jit.compile() {
-        return Err(session
-            .jit
+    session.pending_candidate = None;
+    let mut candidate = session.jit.staged_candidate();
+    configure_runtime_jit(&mut candidate, project_root, files);
+    if let Err(error) = candidate.compile_staged() {
+        return Err(candidate
             .last_source_diagnostic()
             .map(|diagnostic| format_compiler_source_diagnostic(project_root, diagnostic))
             .unwrap_or_else(|| format!("Android JIT hot reload failed: {error:?}")));
     }
+    candidate.validate_on_code_swap_signature()?;
+    session.pending_candidate = Some(candidate);
     session.source_fingerprint = source_fingerprint;
     Ok(())
+}
+
+fn activate_pending_runtime_candidate(session: &mut AndroidRuntimeSession) -> Result<bool, String> {
+    let Some(candidate) = session.pending_candidate.take() else {
+        return Ok(false);
+    };
+    let mut preview = plan_state_migration(
+        &session.jit.state_layout(),
+        &candidate.state_layout(),
+        Vec::new(),
+        false,
+        None,
+    )?;
+    finalize_runtime_preview(&candidate, &mut preview);
+    let run_hook = session.initialized && candidate.has_on_code_swap();
+    activate_candidate_transactionally(
+        Some(&session.jit),
+        &candidate,
+        &preview,
+        run_hook,
+        || {
+            if run_hook {
+                candidate.execute_optional_on_code_swap()
+            } else {
+                Ok(())
+            }
+        },
+        Result::is_ok,
+    )??;
+    session.jit = candidate;
+    Ok(true)
+}
+
+fn discard_pending_runtime_candidate(project_root: &Path) {
+    RUNTIME_SESSION.with(|session_cell| {
+        let mut session_slot = session_cell.borrow_mut();
+        if let Some(session) = session_slot
+            .as_mut()
+            .filter(|session| session.project_root == project_root)
+        {
+            session.pending_candidate = None;
+        }
+    });
 }
 
 fn configure_runtime_jit(jit: &mut JitProcess, project_root: &Path, files: &[WorkshopSourceFile]) {
@@ -1642,7 +1689,7 @@ mod tests {
 
         fs::write(
             &source,
-            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 2; }\nfunction on_code_swap(): void { GameState.tick_count += 100; }\n",
+            "global GameState { tick_count: i32; bonus: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 2; }\nfunction on_code_swap(): void { GameState.tick_count += 100; GameState.bonus = 7; }\n",
         )
         .expect("write hot reload source");
         compile_android_workshop_project(&root, Path::new("src/main.stasis"))
@@ -1658,6 +1705,129 @@ mod tests {
 
         fs::remove_dir_all(&root).ok();
     }
+
+    #[test]
+    fn bridge_hot_reload_hook_rejection_restores_old_code_and_state() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("hot_reload_rejection");
+        let source = root.join("src/main.stasis");
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 1; }\n",
+        )
+        .expect("write first source");
+
+        let first =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("first real tick");
+        assert_eq!(first.observed_game_tick_count, 11);
+
+        fs::write(
+            &source,
+            "extern function reject_code_swap(): void;\nglobal GameState { tick_count: i32; added: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 2; }\nfunction on_code_swap(): void { GameState.tick_count = 99; reject_code_swap(); return; }\n",
+        )
+        .expect("write rejecting hot reload source");
+        compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect("stage rejecting hot reload source");
+
+        let error =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect_err("hook rejection should abort hot reload");
+        assert!(error.contains("hook requested rejection"));
+
+        let resumed =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("old runtime should remain usable");
+        assert!(!resumed.recompiled);
+        assert_eq!(resumed.observed_game_tick_count, 12);
+
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
+    fn bridge_code_only_reload_bypasses_oversized_state_snapshot() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "android_large.stasis",
+            "function main(): void { return; } function tick(): void { return; }",
+        );
+        active.compile().expect("compile active runtime");
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "android_large.stasis",
+            "function main(): void { return; } function tick(): void { let value: i32 = 1; return; }",
+        );
+        candidate
+            .compile_staged()
+            .expect("compile code-only candidate");
+        let oversized_len = MAX_STATE_SNAPSHOT_BYTES / std::mem::size_of::<i32>() + 1;
+        stasis_dynload::ensure_jit_i32_array_capacity(91_153, 0, oversized_len)
+            .expect("allocate oversized state fixture");
+        assert!(
+            stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES).is_err()
+        );
+        let mut session = AndroidRuntimeSession {
+            project_root: PathBuf::from("android-large-state"),
+            source_fingerprint: 1,
+            jit: active,
+            initialized: true,
+            pending_candidate: Some(candidate),
+            tick_count: 0,
+        };
+
+        assert!(activate_pending_runtime_candidate(&mut session)
+            .expect("hook-free activation should bypass snapshot limit"));
+
+        stasis_dynload::clear_registered_global_memory();
+        stasis_dynload::clear_jit_i32_array_global_table();
+    }
+
+    #[test]
+    fn bridge_failed_newer_compile_discards_older_pending_candidate() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("stale_pending_candidate");
+        let source = root.join("src/main.stasis");
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 1; }\n",
+        )
+        .expect("write active source");
+        let first =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("run active source");
+        assert_eq!(first.observed_game_tick_count, 11);
+
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 2; }\n",
+        )
+        .expect("write first candidate");
+        compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect("stage first candidate");
+
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { missing_target(); }\n",
+        )
+        .expect("write invalid newer candidate");
+        compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect_err("newer compile should fail");
+
+        let resumed =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("old runtime should remain active");
+        assert!(!resumed.recompiled);
+        assert_eq!(resumed.observed_game_tick_count, 12);
+
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
     #[test]
     fn bridge_run_tick_passes_input_to_stasis_and_exports_render_commands() {
         let _guard = bridge_runtime_test_guard();

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -930,6 +930,29 @@ impl JitProcess {
         Ok(())
     }
 
+    pub fn execute_optional_on_code_swap(&self) -> Result<(), String> {
+        self.validate_on_code_swap_signature()?;
+        let Some(function) = self
+            .compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == "on_code_swap")
+        else {
+            return Ok(());
+        };
+        let artifact = self
+            .artifact_for_function_id(function.id)
+            .ok_or_else(|| "compiled artifact missing for function 'on_code_swap'".to_string())?;
+        stasis_dynload::invoke_code_swap_hook(artifact.code_ptr as usize)
+    }
+
+    pub fn has_on_code_swap(&self) -> bool {
+        self.compiler
+            .functions()
+            .iter()
+            .any(|function| function.name == "on_code_swap")
+    }
+
     pub fn build_engine_package(
         &self,
         entrypoints: &EngineEntrypoints,

--- a/crates/stasis_compiler/src/backend/mod.rs
+++ b/crates/stasis_compiler/src/backend/mod.rs
@@ -4,6 +4,7 @@ pub mod jit;
 mod reachability;
 mod runtime_exports;
 pub mod state_layout;
+pub mod state_migration;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EngineEntrypoints {

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -2,6 +2,7 @@ use super::emit::{CollectionInfoMap, GlobalPathTypeMap};
 use crate::frontend::types::{
     TypeCategory, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
 };
+use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -36,6 +37,22 @@ pub struct StateCollectionFieldLayout {
 pub struct StateOpaqueLayout {
     pub path: String,
     pub type_name: String,
+}
+
+pub fn state_layout_digest(layout: &StateLayout) -> Result<[u8; 32], String> {
+    let serialized = serde_json::to_vec(layout)
+        .map_err(|error| format!("failed versioning compiler state layout: {error}"))?;
+    let digest = Sha256::digest(serialized);
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&digest);
+    Ok(bytes)
+}
+
+pub fn state_layout_version(layout: &StateLayout) -> Result<String, String> {
+    Ok(state_layout_digest(layout)?
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
 }
 
 pub(crate) fn build_state_layout(

--- a/crates/stasis_compiler/src/backend/state_migration.rs
+++ b/crates/stasis_compiler/src/backend/state_migration.rs
@@ -1,49 +1,49 @@
-use sha2::{Digest, Sha256};
-use stasis_compiler::backend::jit::{JitProcess, JitScalarValue, JitStateLayout};
+use super::jit::{JitProcess, JitScalarValue, JitStateLayout};
+pub use super::state_layout::state_layout_version;
 use std::collections::{BTreeMap, BTreeSet};
 
-pub(crate) const MAX_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_STATE_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub(crate) struct StateMigrationPreview {
-    pub(crate) schema_version: u16,
-    pub(crate) changed_functions: Vec<String>,
-    pub(crate) state_layout_compatible: bool,
-    pub(crate) layout_changed: bool,
-    pub(crate) from_layout_version: String,
-    pub(crate) to_layout_version: String,
-    pub(crate) migration_scope: StateMigrationScope,
-    pub(crate) migration_steps: Vec<StateMigrationStep>,
-    pub(crate) warnings: Vec<String>,
-    pub(crate) rejection: Option<String>,
-    pub(crate) estimated_commit_cost_us: u64,
-    pub(crate) requires_explicit_apply: bool,
+pub struct StateMigrationPreview {
+    pub schema_version: u16,
+    pub changed_functions: Vec<String>,
+    pub state_layout_compatible: bool,
+    pub layout_changed: bool,
+    pub from_layout_version: String,
+    pub to_layout_version: String,
+    pub migration_scope: StateMigrationScope,
+    pub migration_steps: Vec<StateMigrationStep>,
+    pub warnings: Vec<String>,
+    pub rejection: Option<String>,
+    pub estimated_commit_cost_us: u64,
+    pub requires_explicit_apply: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub(crate) struct StateMigrationScope {
-    kind: &'static str,
-    path: Option<String>,
+pub struct StateMigrationScope {
+    pub kind: &'static str,
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum StateMigrationStepKind {
+pub enum StateMigrationStepKind {
     Copy,
     Initialize,
     Remove,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-pub(crate) struct StateMigrationStep {
-    pub(crate) kind: StateMigrationStepKind,
-    pub(crate) path: String,
-    pub(crate) field: Option<String>,
-    pub(crate) type_name: String,
-    pub(crate) elements: u32,
-    pub(crate) start_index: u32,
-    pub(crate) from_capacity: Option<u32>,
-    pub(crate) to_capacity: Option<u32>,
+pub struct StateMigrationStep {
+    pub kind: StateMigrationStepKind,
+    pub path: String,
+    pub field: Option<String>,
+    pub type_name: String,
+    pub elements: u32,
+    pub start_index: u32,
+    pub from_capacity: Option<u32>,
+    pub to_capacity: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -58,7 +58,7 @@ struct CollectionFieldLayout {
     capacity: u32,
 }
 
-pub(crate) fn plan_state_migration(
+pub fn plan_state_migration(
     active: &JitStateLayout,
     incoming: &JitStateLayout,
     mut changed_functions: Vec<String>,
@@ -369,17 +369,7 @@ pub(crate) fn plan_state_migration(
     })
 }
 
-pub(crate) fn state_layout_version(layout: &JitStateLayout) -> Result<String, String> {
-    let serialized = serde_json::to_vec(layout)
-        .map_err(|error| format!("failed versioning compiler state layout: {error}"))?;
-    let digest = Sha256::digest(serialized);
-    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
-}
-
-pub(crate) fn finalize_runtime_preview(
-    candidate: &JitProcess,
-    preview: &mut StateMigrationPreview,
-) {
+pub fn finalize_runtime_preview(candidate: &JitProcess, preview: &mut StateMigrationPreview) {
     if !preview.state_layout_compatible {
         return;
     }
@@ -391,7 +381,7 @@ pub(crate) fn finalize_runtime_preview(
     }
 }
 
-pub(crate) fn activate_candidate_transactionally<T>(
+pub fn activate_candidate_transactionally<T>(
     active: Option<&JitProcess>,
     candidate: &JitProcess,
     preview: &StateMigrationPreview,
@@ -832,7 +822,7 @@ fn migration_type_bytes(type_name: &str) -> Result<usize, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stasis_compiler::backend::jit::{JitStateCollectionFieldLayout, JitStateCollectionLayout};
+    use crate::backend::jit::{JitStateCollectionFieldLayout, JitStateCollectionLayout};
 
     #[test]
     fn non_migratable_collection_shape_rejects_before_activation() {


### PR DESCRIPTION
Maddox Task #153 follow-up after PR #307 auto-merged before the Android caller convergence landed.

- move the shared state-layout migration/activation/rollback contract into stasis_compiler
- route Android Workshop hot reload through staged safe-point activation
- activate pending swaps before serialized JNI state reads and writes
- restore old code/state on hook rejection
- invalidate stale pending candidates before every newer compile request
- preserve the no-hook oversized-state snapshot bypass
- centralize canonical layout digest/version helpers

Validation:
- cargo test --workspace --all-targets -- --test-threads=1 (pass on merged main; zero failures)
- cargo test -p stasis_android_bridge --lib -- --test-threads=1 (33 passed, 1 intentional ignore)
- exact hook-rejection, stale-candidate, >8 MiB no-hook, and state-helper-before-frame regressions (pass)
- cargo fmt --all -- --check (pass)
- git diff --check (pass)
- python tools/ci/check_stasis_src_layout.py (pass)

Independent review iterated through false snapshot gating, stale pending-candidate activation, and state access before the next frame; all were fixed and final re-review found no issues.