### PR TITLE
fix: unify shipping renderer process

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -79,8 +79,8 @@ jobs:
             -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test
-          ctest --test-dir $buildDir -C Release -R stasis_render_command_contract --output-on-failure
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test stasis_asset_path_test
+          ctest --test-dir $buildDir -C Release -R "stasis_(render_command|asset_path)_contract" --output-on-failure
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -98,7 +98,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/stasis-release-${{ runner.os }}.tar.gz" "stasis-release-${{ runner.os }}"
@@ -134,7 +134,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
           Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
-          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
           Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/stasis-release-${{ runner.os }}.zip" -Force

--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
           }
 
           $triplet = "x64-windows-static"
-          & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" "glew:$triplet" --recurse
+          & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" --recurse
 
           $buildDir = "runtime/build_ci"
           $cmakeHelp = cmake --help | Out-String
@@ -74,10 +74,13 @@ jobs:
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
+            -DSTASIS_GRAPHICS_SDL_ONLY=ON `
+            -DSTASIS_MOBILE_RUNTIME_BUILD_TESTS=ON `
             -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test
+          ctest --test-dir $buildDir -C Release -R stasis_render_command_contract --output-on-failure
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -95,7 +98,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/stasis-release-${{ runner.os }}.tar.gz" "stasis-release-${{ runner.os }}"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -121,7 +121,7 @@ jobs:
           }
 
           $triplet = "x64-windows-static"
-          & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" "glew:$triplet" --recurse
+          & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" --recurse
 
           $buildDir = "runtime/build_ci"
           $cmakeHelp = cmake --help | Out-String
@@ -137,10 +137,13 @@ jobs:
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
+            -DSTASIS_GRAPHICS_SDL_ONLY=ON `
+            -DSTASIS_MOBILE_RUNTIME_BUILD_TESTS=ON `
             -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test
+          ctest --test-dir $buildDir -C Release -R stasis_render_command_contract --output-on-failure
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -159,7 +162,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/${{ matrix.archive }}.${{ matrix.ext }}" "${{ matrix.archive }}"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -142,8 +142,8 @@ jobs:
             -DSTASIS_BUILD_RUNNER=ON `
             -DSTASIS_BUILD_SYS=OFF
 
-          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test
-          ctest --test-dir $buildDir -C Release -R stasis_render_command_contract --output-on-failure
+          cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test stasis_asset_path_test
+          ctest --test-dir $buildDir -C Release -R "stasis_(render_command|asset_path)_contract" --output-on-failure
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -162,7 +162,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/${{ matrix.archive }}.${{ matrix.ext }}" "${{ matrix.archive }}"
@@ -199,7 +199,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
           Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
-          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
           Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/${{ matrix.archive }}.${{ matrix.ext }}" -Force

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +458,12 @@ dependencies = [
  "libc",
  "libredox",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -955,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1085,9 @@ dependencies = [
 [[package]]
 name = "stasis_dynload"
 version = "0.1.0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "stasis_jit"

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3307,6 +3307,10 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/CMakeLists.txt"
     ));
+    const STASIS_RENDER_CONTRACT_HEADER: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_render_contract.h"
+    ));
 
     fn jit_global_table_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
@@ -3678,6 +3682,47 @@ mod tests {
                 && STASIS_GRAPHICS_SOURCE
                     .contains("SDL_PauseAudioDevice(g_audio_device, paused ? 1 : 0)"),
             "mobile pause should continue polling events and pause the audio device"
+        );
+    }
+
+    #[test]
+    fn shipping_renderers_share_one_versioned_sdl_command_process() {
+        for required in [
+            "STASIS_RENDER_V1_MAGIC 0x47584631",
+            "STASIS_RENDER_V1_VERSION 1",
+            "STASIS_RENDER_V1_TRACE_VERSION 1",
+            "STASIS_RENDER_I32_COUNT",
+            "STASIS_RENDER_F32_COUNT",
+            "stasis_render_v1_is_valid",
+            "stasis_render_v1_trace",
+        ] {
+            assert!(
+                STASIS_RENDER_CONTRACT_HEADER.contains(required),
+                "shared renderer contract should contain {required}"
+            );
+        }
+        assert!(
+            STASIS_RUNTIME_CMAKE.contains(
+                "Build the canonical SDL_Renderer runtime (disable only for legacy GL conformance)"
+            ) && STASIS_RUNTIME_CMAKE.contains("    ON\n)"),
+            "shipping runtime should default to the canonical SDL backend"
+        );
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains("stasis_render_v1_is_valid(cmd_i32)")
+                && STASIS_GRAPHICS_SOURCE.contains("STASIS_RENDER_FLAG_PRESENT")
+                && STASIS_GRAPHICS_SOURCE
+                    .contains("SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, \"linear\")")
+                && STASIS_GRAPHICS_SOURCE.contains("SDL_RenderSetClipRect(g_renderer, NULL)")
+                && STASIS_GRAPHICS_SOURCE.contains("if (a < 0) a = 0;")
+                && STASIS_GRAPHICS_SOURCE.contains("if (a > 255) a = 255;")
+                && STASIS_GRAPHICS_SOURCE.contains("SDL_BLENDMODE_BLEND")
+                && STASIS_GRAPHICS_SOURCE.contains("SDL_RenderCopyEx"),
+            "desktop and mobile should enter the shared versioned command interpreter"
+        );
+        assert!(
+            STASIS_MOBILE_RUNTIME_SOURCE.contains("STASIS_RENDER_I32_COUNT")
+                && STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_gfx_submit_u8("),
+            "mobile AOT should bind and submit the same command representation"
         );
     }
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1929,24 +1929,24 @@ fn write_mobile_aot_symbols_header(
     manifest: &serde_json::Value,
     output_path: &Path,
 ) -> Result<(), String> {
-    let main = mobile_aot_symbol_for(manifest, "main")?;
-    let tick = mobile_aot_symbol_for(manifest, "tick")?;
-    let render = mobile_aot_symbol_for(manifest, "render")?;
+    mobile_aot_function_for(manifest, "main")?;
+    mobile_aot_function_for(manifest, "tick")?;
+    mobile_aot_function_for(manifest, "render")?;
     let on_code_swap = mobile_aot_symbol_for(manifest, "on_code_swap").ok();
     let mut out = String::new();
     out.push_str("#pragma once\n\n#include <stdint.h>\n\n");
     out.push_str("extern void stasis_aot_bind_runtime_globals(void);\n");
-    for symbol in [&main, &tick, &render] {
-        out.push_str(&format!("extern int32_t {symbol}(void);\n"));
-    }
+    out.push_str("extern int32_t stasis_mobile_main_entry(void);\n");
+    out.push_str("extern int32_t stasis_mobile_tick_entry(void);\n");
+    out.push_str("extern int32_t stasis_mobile_render_entry(void);\n");
     if let Some(symbol) = on_code_swap.as_ref() {
         out.push_str(&format!("extern void {symbol}(void);\n"));
     }
     out.push_str("\n");
     out.push_str("#define STASIS_AOT_BIND_RUNTIME_GLOBALS stasis_aot_bind_runtime_globals\n");
-    out.push_str(&format!("#define STASIS_AOT_MAIN {main}\n"));
-    out.push_str(&format!("#define STASIS_AOT_TICK {tick}\n"));
-    out.push_str(&format!("#define STASIS_AOT_RENDER {render}\n"));
+    out.push_str("#define STASIS_AOT_MAIN stasis_mobile_main_entry\n");
+    out.push_str("#define STASIS_AOT_TICK stasis_mobile_tick_entry\n");
+    out.push_str("#define STASIS_AOT_RENDER stasis_mobile_render_entry\n");
     if let Some(symbol) = on_code_swap.as_ref() {
         out.push_str(&format!("#define STASIS_AOT_ON_CODE_SWAP {symbol}\n"));
     }
@@ -1980,20 +1980,32 @@ fn write_mobile_aot_bindings_source(
         .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
     let mut out = String::from("#include <stdint.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n");
     for function in functions {
-        let name = function
-            .get("name")
-            .and_then(serde_json::Value::as_str)
-            .ok_or_else(|| "mobile AOT function missing name".to_string())?;
         let symbol = function
             .get("symbol")
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
-        let return_type = if matches!(name, "main" | "tick" | "render") {
-            "int32_t"
-        } else {
-            "void"
-        };
+        let return_type = mobile_aot_c_return_type(function)?;
         out.push_str(&format!("extern {return_type} {symbol}(void);\n"));
+    }
+    for (name, wrapper) in [
+        ("main", "stasis_mobile_main_entry"),
+        ("tick", "stasis_mobile_tick_entry"),
+        ("render", "stasis_mobile_render_entry"),
+    ] {
+        let (symbol, return_type) = mobile_aot_function_for(manifest, name)?;
+        if return_type == 0 {
+            out.push_str(&format!(
+                "int32_t {wrapper}(void) {{ {symbol}(); return 0; }}\n"
+            ));
+        } else if return_type == 1 {
+            out.push_str(&format!(
+                "int32_t {wrapper}(void) {{ return {symbol}(); }}\n"
+            ));
+        } else {
+            return Err(format!(
+                "mobile AOT entry '{name}' must return void or i32, found type id {return_type}"
+            ));
+        }
     }
     for literal in literals {
         let id = literal
@@ -2074,6 +2086,42 @@ fn mobile_aot_symbol_for(
         .and_then(|entry| entry.get("symbol").and_then(serde_json::Value::as_str))
         .map(str::to_string)
         .ok_or_else(|| format!("mobile AOT manifest missing symbol for function '{function_name}'"))
+}
+
+fn mobile_aot_function_for(
+    manifest: &serde_json::Value,
+    function_name: &str,
+) -> Result<(String, u64), String> {
+    let functions = manifest
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
+    let function = functions
+        .iter()
+        .find(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(function_name))
+        .ok_or_else(|| format!("mobile AOT manifest missing function '{function_name}'"))?;
+    let symbol = function
+        .get("symbol")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing symbol"))?;
+    let return_type = function
+        .get("return_type")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing return_type"))?;
+    Ok((symbol.to_string(), return_type))
+}
+
+fn mobile_aot_c_return_type(function: &serde_json::Value) -> Result<&'static str, String> {
+    match function
+        .get("return_type")
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(0) => Ok("void"),
+        Some(2) => Ok("float"),
+        Some(4) => Ok("double"),
+        Some(_) => Ok("int32_t"),
+        None => Err("mobile AOT function missing return_type".to_string()),
+    }
 }
 
 fn write_mobile_aot_package_manifest(
@@ -2703,29 +2751,40 @@ mod tests {
 
         assert!(summary.object_count >= 3, "expected lifecycle objects");
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
-        assert!(
-            header
-                .lines()
-                .filter(
-                    |line| line.starts_with("extern int32_t aot_fn_") && line.ends_with("(void);")
-                )
-                .count()
-                >= 3,
-            "mobile AOT lifecycle symbols must match StasisMobileI32Entry callbacks"
-        );
+        for entry in ["main", "tick", "render"] {
+            assert!(header.contains(&format!(
+                "extern int32_t stasis_mobile_{entry}_entry(void);"
+            )));
+            assert!(header.contains(&format!(
+                "#define STASIS_AOT_{} stasis_mobile_{entry}_entry",
+                entry.to_ascii_uppercase()
+            )));
+        }
         let mobile_runtime_header =
             fs::read_to_string(repo_root.join("runtime/stasis_mobile_runtime.h"))
                 .expect("read mobile runtime header");
         assert!(mobile_runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         let bindings =
             fs::read_to_string(&summary.bindings_source).expect("read mobile AOT bindings source");
-        assert!(bindings.contains("extern int32_t aot_fn_"));
+        assert!(bindings.contains("extern void aot_fn_0(void);"));
+        assert!(bindings.contains("stasis_mobile_main_entry(void) { aot_fn_0(); return 0; }"));
         assert!(bindings.contains("void stasis_aot_bind_runtime_globals(void)"));
         assert!(bindings.contains("stasis_jit_register_code_ptr(0"));
-        assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
         assert!(header.contains("#define STASIS_AOT_BIND_RUNTIME_GLOBALS"));
-        assert!(header.contains("#define STASIS_AOT_TICK aot_fn_"));
-        assert!(header.contains("#define STASIS_AOT_RENDER aot_fn_"));
+        let engine_manifest: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(output_dir.join("engine_bundle_manifest.json"))
+                .expect("read engine manifest"),
+        )
+        .expect("parse engine manifest");
+        assert!(engine_manifest["functions"]
+            .as_array()
+            .expect("functions")
+            .iter()
+            .filter(|function| matches!(
+                function["name"].as_str(),
+                Some("main" | "tick" | "render")
+            ))
+            .all(|function| function["return_type"] == 0));
         let cmake = fs::read_to_string(&summary.cmake_file).expect("read cmake file");
         assert!(cmake.contains("set(STASIS_PUBLISHED_AOT_OBJECTS"));
         assert!(cmake.contains("${CMAKE_CURRENT_LIST_DIR}/"));
@@ -3030,10 +3089,12 @@ function frame_width(): i32 { return 360; }
         )
         .expect("missing on_code_swap should be accepted for mobile");
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
+        let bindings = fs::read_to_string(&summary.bindings_source).expect("read bindings source");
 
-        assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
-        assert!(header.contains("#define STASIS_AOT_TICK aot_fn_"));
-        assert!(header.contains("#define STASIS_AOT_RENDER aot_fn_"));
+        assert!(header.contains("#define STASIS_AOT_MAIN stasis_mobile_main_entry"));
+        assert!(header.contains("#define STASIS_AOT_TICK stasis_mobile_tick_entry"));
+        assert!(header.contains("#define STASIS_AOT_RENDER stasis_mobile_render_entry"));
+        assert!(bindings.contains("stasis_mobile_main_entry(void) { return aot_fn_0(); }"));
         assert!(!header.contains("STASIS_AOT_ON_CODE_SWAP"));
 
         std::fs::remove_dir_all(&project_dir).ok();
@@ -3091,7 +3152,7 @@ function frame_width(): i32 { return 360; }
                 .as_str()
                 .is_some_and(|path| { path.ends_with(".o") && !Path::new(path).is_absolute() })));
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
-        assert!(header.contains("#define STASIS_AOT_MAIN aot_fn_"));
+        assert!(header.contains("#define STASIS_AOT_MAIN stasis_mobile_main_entry"));
 
         std::fs::remove_dir_all(&output_dir).ok();
     }

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1662,7 +1662,7 @@ fn package_mobile_workspace(
                 String::from_utf8_lossy(&child.stderr).trim()
             ));
         }
-        assemble_mobile_shell(workspace, target, entry, &aot_root, &staging_root)?;
+        assemble_mobile_shell(workspace, target, &aot_root, &staging_root)?;
         Ok(())
     })();
     if let Err(error) = child_result {
@@ -1694,7 +1694,6 @@ fn package_mobile_workspace(
 fn assemble_mobile_shell(
     workspace: &Workspace,
     target: PackageTarget,
-    entry: &Path,
     aot_root: &Path,
     staging_root: &Path,
 ) -> Result<(), String> {
@@ -1723,29 +1722,17 @@ fn assemble_mobile_shell(
     };
     let package_id = mobile_package_id(&workspace.manifest.name);
     let jni_package = package_id.replace('.', "_");
-    let asset_base = entry
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let asset_base_token = asset_base.to_string_lossy().replace('\\', "/");
     let replacements = [
         ("@STASIS_APP_NAME@", workspace.manifest.name.as_str()),
         ("@STASIS_PACKAGE_ID@", package_id.as_str()),
         ("@STASIS_JNI_PACKAGE@", jni_package.as_str()),
-        ("@STASIS_ASSET_BASE@", asset_base_token.as_str()),
+        ("@STASIS_ASSET_BASE@", "."),
     ];
     replace_shell_tokens(&common_destination, &replacements)?;
     replace_shell_tokens(&platform_destination, &replacements)?;
     copy_required_dir(&asset_source, &asset_destination)?;
-    let packaged_asset_base = asset_destination.join(asset_base);
-    fs::create_dir_all(&packaged_asset_base).map_err(|error| {
-        format!(
-            "failed to create packaged asset base {}: {error}",
-            packaged_asset_base.display()
-        )
-    })?;
     fs::write(
-        packaged_asset_base.join("stasis_asset_base.marker"),
+        asset_destination.join("stasis_asset_base.marker"),
         b"stasis.mobile.asset_base.v1\n",
     )
     .map_err(|error| format!("failed to write packaged asset base marker: {error}"))?;
@@ -1808,6 +1795,7 @@ fn copy_mobile_runtime(source: &Path, destination: &Path) -> Result<(), String> 
         "nanosvg.h",
         "nanosvgrast.h",
         "stasis_display_scale.h",
+        "stasis_asset_path.h",
         "stasis_render_contract.h",
         "stasis_graphics.c",
         "stasis_mobile_aot_runtime.c",
@@ -2930,14 +2918,8 @@ mod tests {
 
         let android = root.join("android-package");
         fs::create_dir_all(&android).expect("create Android staging");
-        assemble_mobile_shell(
-            &workspace,
-            PackageTarget::AndroidArm64,
-            Path::new("src/main.stasis"),
-            &aot,
-            &android,
-        )
-        .expect("assemble Android shell");
+        assemble_mobile_shell(&workspace, PackageTarget::AndroidArm64, &aot, &android)
+            .expect("assemble Android shell");
         let android_cmake =
             fs::read_to_string(android.join("android/app/src/main/cpp/CMakeLists.txt"))
                 .expect("read Android CMake");
@@ -2951,12 +2933,13 @@ mod tests {
             .expect("read shared mobile runtime header");
         assert!(runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         assert!(android.join("runtime/stasis_display_scale.h").is_file());
+        assert!(android.join("runtime/stasis_asset_path.h").is_file());
         assert!(android.join("runtime/stasis_render_contract.h").is_file());
         assert!(android
             .join("android/app/src/main/assets/stasis_game/assets/manifest.json")
             .is_file());
         assert!(android
-            .join("android/app/src/main/assets/stasis_game/src/stasis_asset_base.marker")
+            .join("android/app/src/main/assets/stasis_game/stasis_asset_base.marker")
             .is_file());
         assert_eq!(
             fs::read_to_string(
@@ -2970,7 +2953,7 @@ mod tests {
         )
         .expect("read Android activity");
         assert!(java.contains(".stasis_game.staging"));
-        assert!(java.contains("new File(root, \"src\")"));
+        assert!(java.contains("new File(root, \".\")"));
         let jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
                 .expect("read Android asset bridge");
@@ -2981,14 +2964,8 @@ mod tests {
 
         let ios = root.join("ios-package");
         fs::create_dir_all(&ios).expect("create iOS staging");
-        assemble_mobile_shell(
-            &workspace,
-            PackageTarget::IosArm64,
-            Path::new("src/main.stasis"),
-            &aot,
-            &ios,
-        )
-        .expect("assemble iOS shell");
+        assemble_mobile_shell(&workspace, PackageTarget::IosArm64, &aot, &ios)
+            .expect("assemble iOS shell");
         let project = fs::read_to_string(ios.join("ios/StasisMobile.xcodeproj/project.pbxproj"))
             .expect("read Xcode project");
         let config =
@@ -2997,6 +2974,7 @@ mod tests {
         assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
         assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
         assert!(ios.join("runtime/stasis_display_scale.h").is_file());
+        assert!(ios.join("runtime/stasis_asset_path.h").is_file());
         assert!(ios.join("runtime/stasis_render_contract.h").is_file());
         assert!(config.contains("@executable_path/Frameworks"));
         assert!(project.contains("Embed SDL frameworks"));
@@ -3004,7 +2982,7 @@ mod tests {
             .join("ios/StasisMobile/stasis_game/assets/manifest.json")
             .is_file());
         assert!(ios
-            .join("ios/StasisMobile/stasis_game/src/stasis_asset_base.marker")
+            .join("ios/StasisMobile/stasis_game/stasis_asset_base.marker")
             .is_file());
         assert!(!project.contains("@STASIS_"));
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1662,7 +1662,7 @@ fn package_mobile_workspace(
                 String::from_utf8_lossy(&child.stderr).trim()
             ));
         }
-        assemble_mobile_shell(workspace, target, &aot_root, &staging_root)?;
+        assemble_mobile_shell(workspace, target, entry, &aot_root, &staging_root)?;
         Ok(())
     })();
     if let Err(error) = child_result {
@@ -1694,6 +1694,7 @@ fn package_mobile_workspace(
 fn assemble_mobile_shell(
     workspace: &Workspace,
     target: PackageTarget,
+    entry: &Path,
     aot_root: &Path,
     staging_root: &Path,
 ) -> Result<(), String> {
@@ -1722,14 +1723,32 @@ fn assemble_mobile_shell(
     };
     let package_id = mobile_package_id(&workspace.manifest.name);
     let jni_package = package_id.replace('.', "_");
+    let asset_base = entry
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let asset_base_token = asset_base.to_string_lossy().replace('\\', "/");
     let replacements = [
         ("@STASIS_APP_NAME@", workspace.manifest.name.as_str()),
         ("@STASIS_PACKAGE_ID@", package_id.as_str()),
         ("@STASIS_JNI_PACKAGE@", jni_package.as_str()),
+        ("@STASIS_ASSET_BASE@", asset_base_token.as_str()),
     ];
     replace_shell_tokens(&common_destination, &replacements)?;
     replace_shell_tokens(&platform_destination, &replacements)?;
     copy_required_dir(&asset_source, &asset_destination)?;
+    let packaged_asset_base = asset_destination.join(asset_base);
+    fs::create_dir_all(&packaged_asset_base).map_err(|error| {
+        format!(
+            "failed to create packaged asset base {}: {error}",
+            packaged_asset_base.display()
+        )
+    })?;
+    fs::write(
+        packaged_asset_base.join("stasis_asset_base.marker"),
+        b"stasis.mobile.asset_base.v1\n",
+    )
+    .map_err(|error| format!("failed to write packaged asset base marker: {error}"))?;
     if !asset_destination.join("assets/manifest.json").is_file() {
         return Err(format!(
             "mobile AOT bundle is missing asset manifest: {}",
@@ -1789,6 +1808,7 @@ fn copy_mobile_runtime(source: &Path, destination: &Path) -> Result<(), String> 
         "nanosvg.h",
         "nanosvgrast.h",
         "stasis_display_scale.h",
+        "stasis_render_contract.h",
         "stasis_graphics.c",
         "stasis_mobile_aot_runtime.c",
         "stasis_mobile_aot_runtime.h",
@@ -2910,8 +2930,14 @@ mod tests {
 
         let android = root.join("android-package");
         fs::create_dir_all(&android).expect("create Android staging");
-        assemble_mobile_shell(&workspace, PackageTarget::AndroidArm64, &aot, &android)
-            .expect("assemble Android shell");
+        assemble_mobile_shell(
+            &workspace,
+            PackageTarget::AndroidArm64,
+            Path::new("src/main.stasis"),
+            &aot,
+            &android,
+        )
+        .expect("assemble Android shell");
         let android_cmake =
             fs::read_to_string(android.join("android/app/src/main/cpp/CMakeLists.txt"))
                 .expect("read Android CMake");
@@ -2925,8 +2951,12 @@ mod tests {
             .expect("read shared mobile runtime header");
         assert!(runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         assert!(android.join("runtime/stasis_display_scale.h").is_file());
+        assert!(android.join("runtime/stasis_render_contract.h").is_file());
         assert!(android
             .join("android/app/src/main/assets/stasis_game/assets/manifest.json")
+            .is_file());
+        assert!(android
+            .join("android/app/src/main/assets/stasis_game/src/stasis_asset_base.marker")
             .is_file());
         assert_eq!(
             fs::read_to_string(
@@ -2940,6 +2970,7 @@ mod tests {
         )
         .expect("read Android activity");
         assert!(java.contains(".stasis_game.staging"));
+        assert!(java.contains("new File(root, \"src\")"));
         let jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
                 .expect("read Android asset bridge");
@@ -2950,8 +2981,14 @@ mod tests {
 
         let ios = root.join("ios-package");
         fs::create_dir_all(&ios).expect("create iOS staging");
-        assemble_mobile_shell(&workspace, PackageTarget::IosArm64, &aot, &ios)
-            .expect("assemble iOS shell");
+        assemble_mobile_shell(
+            &workspace,
+            PackageTarget::IosArm64,
+            Path::new("src/main.stasis"),
+            &aot,
+            &ios,
+        )
+        .expect("assemble iOS shell");
         let project = fs::read_to_string(ios.join("ios/StasisMobile.xcodeproj/project.pbxproj"))
             .expect("read Xcode project");
         let config =
@@ -2960,10 +2997,14 @@ mod tests {
         assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
         assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
         assert!(ios.join("runtime/stasis_display_scale.h").is_file());
+        assert!(ios.join("runtime/stasis_render_contract.h").is_file());
         assert!(config.contains("@executable_path/Frameworks"));
         assert!(project.contains("Embed SDL frameworks"));
         assert!(ios
             .join("ios/StasisMobile/stasis_game/assets/manifest.json")
+            .is_file());
+        assert!(ios
+            .join("ios/StasisMobile/stasis_game/src/stasis_asset_base.marker")
             .is_file());
         assert!(!project.contains("@STASIS_"));
 

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1041,6 +1041,18 @@ mod tests {
                 expected_clif_markers: &[("main", &["call", "iadd"])],
             },
             ParityCorpusCase {
+                label: "renderer_command_trace",
+                source: "global cmd: i32[15];\nfunction emit_renderer_trace(): i32 {\n    cmd[0] = 1196967473;\n    cmd[1] = 1;\n    cmd[2] = 3;\n    cmd[3] = 1;\n    cmd[4] = 1;\n    cmd[5] = 1;\n    cmd[6] = 17;\n    cmd[7] = 10;\n    cmd[8] = 20;\n    cmd[9] = 30;\n    cmd[10] = 40;\n    cmd[11] = 45;\n    cmd[12] = 192;\n    cmd[13] = 4;\n    cmd[14] = 6;\n    let trace: i32 = 0;\n    for (let i: i32 = 0; i < 15; i += 1) {\n        trace = (trace * 17 + cmd[i]) % 251;\n    }\n    return trace;\n}\nfunction main(): i32 { return emit_renderer_trace(); }\n",
+                expected_exit: 189,
+                expected_extern_symbols: &[],
+                expected_string_literals: &[],
+                expected_collection_max_lengths: &[("cmd", 15)],
+                expected_clif_markers: &[
+                    ("main", &["call"]),
+                    ("emit_renderer_trace", &["call", "brif", "jump"]),
+                ],
+            },
+            ParityCorpusCase {
                 label: "control_flow_branching",
                 source: "function main(): i32 {\n    let sum: i32 = 0;\n    for (let i: i32 = 0; i < 3; i += 1) {\n        sum += i;\n    }\n    if (sum == 3) {\n        return 1;\n    }\n    return 0;\n}\n",
                 expected_exit: 1,
@@ -1611,7 +1623,7 @@ mod tests {
         );
         assert_eq!(
             resolved.get("gfx_cache_text").copied(),
-            Some("stasis_gfx_cache_text")
+            Some("stasis_jit_gfx_cache_text")
         );
     }
 

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1030,6 +1030,46 @@ function main(): i32 {
 "#;
 
     #[cfg(windows)]
+    fn ensure_test_dynload_artifacts(deps_dir: &Path) -> (PathBuf, PathBuf) {
+        let find_artifacts = || {
+            [
+                deps_dir,
+                deps_dir.parent().expect("Cargo profile directory"),
+            ]
+            .into_iter()
+            .find_map(|directory| {
+                let import_library = directory.join("stasis_dynload.dll.lib");
+                let runtime_dll = directory.join("stasis_dynload.dll");
+                (import_library.is_file() && runtime_dll.is_file())
+                    .then_some((import_library, runtime_dll))
+            })
+        };
+        if let Some(artifacts) = find_artifacts() {
+            return artifacts;
+        }
+
+        let profile_dir = deps_dir.parent().expect("Cargo profile directory");
+        let target_dir = profile_dir.parent().expect("Cargo target directory");
+        let mut command = Command::new("cargo");
+        command.arg("build").arg("-p").arg("stasis_dynload");
+        if profile_dir.file_name().and_then(|name| name.to_str()) == Some("release") {
+            command.arg("--release");
+        }
+        let output = command
+            .current_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+            .env("CARGO_TARGET_DIR", target_dir)
+            .output()
+            .expect("build stasis_dynload test runtime");
+        assert!(
+            output.status.success(),
+            "failed to build stasis_dynload test runtime\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        find_artifacts().expect("stasis_dynload build did not produce DLL and import library")
+    }
+
+    #[cfg(windows)]
     fn run_linked_i32_noarg_fixture(
         process: &AotProcess,
         function_name: &str,
@@ -1044,19 +1084,12 @@ function main(): i32 {
         fs::create_dir_all(&temp_root).expect("create temp root");
         let exe_path = temp_root.join(format!("{function_name}_{label}.exe"));
         let mut effective_config = link_config.clone();
-        let debug_dir = std::env::current_exe()
+        let deps_dir = std::env::current_exe()
             .expect("current test executable")
             .parent()
-            .expect("target debug deps directory")
+            .expect("Cargo deps directory")
             .to_path_buf();
-        let import_library = debug_dir.join("stasis_dynload.dll.lib");
-        let runtime_dll = debug_dir.join("stasis_dynload.dll");
-        assert!(
-            import_library.is_file(),
-            "missing {}",
-            import_library.display()
-        );
-        assert!(runtime_dll.is_file(), "missing {}", runtime_dll.display());
+        let (import_library, runtime_dll) = ensure_test_dynload_artifacts(&deps_dir);
         effective_config.runtime_lib_paths.push(import_library);
         fs::copy(&runtime_dll, temp_root.join("stasis_dynload.dll"))
             .expect("copy AOT test runtime");

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -411,7 +411,7 @@ impl AotProcess {
         })?;
 
         let mut object_paths_by_function: BTreeMap<String, PathBuf> = BTreeMap::new();
-        let mut manifest_rows: Vec<(String, String, String)> = Vec::new();
+        let mut manifest_rows: Vec<(String, String, String, u16)> = Vec::new();
         for artifact in &self.artifacts {
             let function = self
                 .compiler
@@ -451,6 +451,7 @@ impl AotProcess {
                 function.name.clone(),
                 artifact.symbol_name.clone(),
                 object_file_name,
+                function.return_type,
             ));
         }
 
@@ -880,7 +881,7 @@ fn json_escape(value: &str) -> String {
 fn build_engine_bundle_manifest(
     optimization_profile: AotOptimizationProfile,
     entrypoints: &EngineEntrypoints,
-    rows: &[(String, String, String)],
+    rows: &[(String, String, String, u16)],
     string_literals: &BTreeMap<i32, String>,
     collection_max_lengths: &BTreeMap<String, i32>,
 ) -> String {
@@ -909,13 +910,14 @@ fn build_engine_bundle_manifest(
     }
     out.push_str("  },\n");
     out.push_str("  \"functions\": [\n");
-    for (index, (name, symbol, object_file)) in rows.iter().enumerate() {
+    for (index, (name, symbol, object_file, return_type)) in rows.iter().enumerate() {
         let comma = if index + 1 < rows.len() { "," } else { "" };
         out.push_str(&format!(
-            "    {{\"name\":\"{}\",\"symbol\":\"{}\",\"object\":\"{}\"}}{}\n",
+            "    {{\"name\":\"{}\",\"symbol\":\"{}\",\"object\":\"{}\",\"return_type\":{}}}{}\n",
             json_escape(name),
             json_escape(symbol),
             json_escape(object_file),
+            return_type,
             comma
         ));
     }
@@ -969,6 +971,64 @@ mod tests {
         expected_clif_markers: &'static [(&'static str, &'static [&'static str])],
     }
 
+    const RENDER_TRACE_FIXTURE: &str = r#"
+function @extern("stasis_jit_render_v1_trace") native_render_trace(
+    cmd_i32: i32[], cmd_i32_len: i32,
+    cmd_f32: f32[], cmd_f32_len: i32,
+    cmd_u8: u8[], cmd_u8_len: i32
+): i32;
+
+global cmd_i32: i32[34848];
+global cmd_f32: f32[92292];
+global cmd_u8: u8[65536];
+
+function main(): i32 {
+    cmd_i32[0] = 1196967473;
+    cmd_i32[1] = 1;
+    cmd_i32[2] = 3;
+    cmd_i32[3] = 1;
+    cmd_i32[4] = 1;
+    cmd_i32[7] = 1;
+    cmd_i32[9] = 3;
+
+    cmd_f32[0] = 0.05;
+    cmd_f32[1] = 0.10;
+    cmd_f32[2] = 0.15;
+    cmd_f32[3] = 1.0;
+    cmd_f32[4] = 10.0;
+    cmd_f32[5] = 20.0;
+    cmd_f32[6] = 30.0;
+    cmd_f32[7] = 40.0;
+    cmd_f32[8] = 0.25;
+    cmd_f32[9] = 0.50;
+    cmd_f32[10] = 0.75;
+    cmd_f32[11] = 1.0;
+
+    cmd_i32[32] = 17;
+    cmd_i32[33] = 50;
+    cmd_i32[34] = 60;
+    cmd_i32[35] = 70;
+    cmd_i32[36] = 80;
+    cmd_i32[37] = 45;
+    cmd_i32[38] = 192;
+
+    cmd_i32[28704] = 4;
+    cmd_i32[28705] = 0;
+    cmd_i32[28706] = 2;
+    cmd_f32[80004] = 90.0;
+    cmd_f32[80005] = 100.0;
+    cmd_f32[80006] = 1.0;
+    cmd_f32[80007] = 0.5;
+    cmd_f32[80008] = 0.25;
+    cmd_f32[80009] = 1.0;
+    cmd_u8[0] = 79;
+    cmd_u8[1] = 75;
+    cmd_u8[2] = 0;
+
+    return native_render_trace(cmd_i32, 34848, cmd_f32, 92292, cmd_u8, 65536);
+}
+"#;
+
     #[cfg(windows)]
     fn run_linked_i32_noarg_fixture(
         process: &AotProcess,
@@ -983,8 +1043,28 @@ mod tests {
         let temp_root = std::env::temp_dir().join(format!("stasis_aot_fixture_{label}_{stamp}"));
         fs::create_dir_all(&temp_root).expect("create temp root");
         let exe_path = temp_root.join(format!("{function_name}_{label}.exe"));
-        let link_result =
-            process.link_executable_for_i32_noarg_function(function_name, &exe_path, link_config);
+        let mut effective_config = link_config.clone();
+        let debug_dir = std::env::current_exe()
+            .expect("current test executable")
+            .parent()
+            .expect("target debug deps directory")
+            .to_path_buf();
+        let import_library = debug_dir.join("stasis_dynload.dll.lib");
+        let runtime_dll = debug_dir.join("stasis_dynload.dll");
+        assert!(
+            import_library.is_file(),
+            "missing {}",
+            import_library.display()
+        );
+        assert!(runtime_dll.is_file(), "missing {}", runtime_dll.display());
+        effective_config.runtime_lib_paths.push(import_library);
+        fs::copy(&runtime_dll, temp_root.join("stasis_dynload.dll"))
+            .expect("copy AOT test runtime");
+        let link_result = process.link_executable_for_i32_noarg_function(
+            function_name,
+            &exe_path,
+            &effective_config,
+        );
         if let Err(ref message) = link_result {
             if message.contains("undefined symbol") {
                 eprintln!(
@@ -1042,15 +1122,19 @@ mod tests {
             },
             ParityCorpusCase {
                 label: "renderer_command_trace",
-                source: "global cmd: i32[15];\nfunction emit_renderer_trace(): i32 {\n    cmd[0] = 1196967473;\n    cmd[1] = 1;\n    cmd[2] = 3;\n    cmd[3] = 1;\n    cmd[4] = 1;\n    cmd[5] = 1;\n    cmd[6] = 17;\n    cmd[7] = 10;\n    cmd[8] = 20;\n    cmd[9] = 30;\n    cmd[10] = 40;\n    cmd[11] = 45;\n    cmd[12] = 192;\n    cmd[13] = 4;\n    cmd[14] = 6;\n    let trace: i32 = 0;\n    for (let i: i32 = 0; i < 15; i += 1) {\n        trace = (trace * 17 + cmd[i]) % 251;\n    }\n    return trace;\n}\nfunction main(): i32 { return emit_renderer_trace(); }\n",
-                expected_exit: 189,
-                expected_extern_symbols: &[],
+                source: RENDER_TRACE_FIXTURE,
+                expected_exit: 975_559_585,
+                expected_extern_symbols: &[(
+                    "native_render_trace",
+                    "stasis_jit_render_v1_trace",
+                )],
                 expected_string_literals: &[],
-                expected_collection_max_lengths: &[("cmd", 15)],
-                expected_clif_markers: &[
-                    ("main", &["call"]),
-                    ("emit_renderer_trace", &["call", "brif", "jump"]),
+                expected_collection_max_lengths: &[
+                    ("cmd_i32", 34_848),
+                    ("cmd_f32", 92_292),
+                    ("cmd_u8", 65_536),
                 ],
+                expected_clif_markers: &[("main", &["call"])],
             },
             ParityCorpusCase {
                 label: "control_flow_branching",

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -313,12 +313,15 @@ pub(crate) fn build_extern_call_signature(
         params.push(type_id);
     }
     let return_type = type_table.resolve_or_intern(&declaration.return_type_name)?;
+    let symbol_name = match declaration.symbol_name.as_str() {
+        // Stasis strings are stable integer IDs. Keep legacy stdlib declarations on the
+        // adapter that resolves the ID before entering the native renderer.
+        "stasis_gfx_cache_text" => "stasis_jit_gfx_cache_text",
+        symbol_name => symbol_name,
+    };
     Ok(ExternCallSignature {
         name: declaration.name,
-        symbol_candidates: build_extern_symbol_candidates(
-            &declaration.symbol_name,
-            declaration.explicit_symbol,
-        ),
+        symbol_candidates: build_extern_symbol_candidates(symbol_name, declaration.explicit_symbol),
         params,
         return_type,
     })

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1356,6 +1356,9 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "reject_code_swap" | "stasis_jit_reject_code_swap" => {
             function_address(stasis_dynload::stasis_jit_reject_code_swap as *const ())
         }
+        "stasis_jit_render_v1_trace" => {
+            function_address(stasis_dynload::stasis_jit_render_v1_trace as *const ())
+        }
         _ => return None,
     };
     Some(address)

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1296,7 +1296,7 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "measure_text" | "stasis_measure_text" => {
             function_address(stasis_dynload::stasis_jit_measure_text as *const ())
         }
-        "gfx_cache_text" | "stasis_gfx_cache_text" => {
+        "gfx_cache_text" | "stasis_gfx_cache_text" | "stasis_jit_gfx_cache_text" => {
             function_address(stasis_dynload::stasis_jit_gfx_cache_text as *const ())
         }
         "audio_is_available" | "stasis_audio_is_available" => {

--- a/crates/stasis_dynload/Cargo.toml
+++ b/crates/stasis_dynload/Cargo.toml
@@ -8,3 +8,6 @@ license.workspace = true
 path = "src/lib.rs"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
+[build-dependencies]
+cc = "1.2"
+

--- a/crates/stasis_dynload/build.rs
+++ b/crates/stasis_dynload/build.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+fn main() {
+    let runtime = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../runtime");
+    cc::Build::new()
+        .file(runtime.join("stasis_render_trace.c"))
+        .include(&runtime)
+        .compile("stasis_render_trace_native");
+    println!(
+        "cargo:rerun-if-changed={}",
+        runtime.join("stasis_render_trace.c").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        runtime.join("stasis_render_contract.h").display()
+    );
+}

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -771,6 +771,11 @@ fn owned_i32_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<i32>>> {
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn owned_u8_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<u8>>> {
+    static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<u8>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 fn owned_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f64>>> {
     static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<f64>>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
@@ -1014,6 +1019,10 @@ pub fn clear_registered_global_memory() {
         .lock()
         .expect("owned f64 array table mutex poisoned")
         .clear();
+    owned_u8_arrays()
+        .lock()
+        .expect("owned u8 array table mutex poisoned")
+        .clear();
 }
 
 #[derive(Debug, Clone)]
@@ -1086,10 +1095,7 @@ pub fn snapshot_jit_runtime_state_bounded(
         i32_arrays: snapshot_registered_arrays(registered_i32_arrays(), Some(owned_i32_arrays())),
         f32_arrays: snapshot_registered_arrays(registered_f32_arrays(), Some(owned_f32_arrays())),
         f64_arrays: snapshot_registered_arrays(registered_f64_arrays(), Some(owned_f64_arrays())),
-        u8_arrays: snapshot_registered_arrays(
-            registered_u8_arrays(),
-            None::<&Mutex<HashMap<ArrayKey, Vec<u8>>>>,
-        ),
+        u8_arrays: snapshot_registered_arrays(registered_u8_arrays(), Some(owned_u8_arrays())),
     })
 }
 
@@ -1240,7 +1246,7 @@ pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
     restore_registered_arrays(
         &snapshot.u8_arrays,
         registered_u8_arrays(),
-        None::<&Mutex<HashMap<ArrayKey, Vec<u8>>>>,
+        Some(owned_u8_arrays()),
     );
 }
 
@@ -1653,6 +1659,53 @@ pub extern "C" fn stasis_jit_global_f32_array_ptr(
     ptr
 }
 
+fn global_u8_array_ptr(collection_hash: i32, field_hash: i32, len: i32) -> *mut u8 {
+    if len <= 0 {
+        return std::ptr::null_mut();
+    }
+
+    let requested_len = len as usize;
+    let key = (collection_hash, field_hash);
+    if let Some((ptr, registered_len)) = registered_u8_arrays()
+        .lock()
+        .expect("registered u8 array table mutex poisoned")
+        .get(&key)
+        .copied()
+    {
+        return if registered_len >= requested_len {
+            ptr as *mut u8
+        } else {
+            std::ptr::null_mut()
+        };
+    }
+
+    let ptr = {
+        let mut owned_guard = owned_u8_arrays()
+            .lock()
+            .expect("owned u8 array table mutex poisoned");
+        let array = owned_guard
+            .entry(key)
+            .or_insert_with(|| vec![0; requested_len]);
+        if array.len() < requested_len {
+            array.resize(requested_len, 0);
+        }
+        let mut fallback = jit_i32_array_global_table()
+            .lock()
+            .expect("jit global table mutex poisoned");
+        for (index, value) in array.iter_mut().enumerate() {
+            if let Some(stored) = fallback.remove(&(collection_hash, field_hash, index as i32)) {
+                *value = stored as u8;
+            }
+        }
+        array.as_mut_ptr()
+    };
+    registered_u8_arrays()
+        .lock()
+        .expect("registered u8 array table mutex poisoned")
+        .insert(key, (ptr as usize, requested_len));
+    ptr
+}
+
 #[no_mangle]
 pub extern "C" fn stasis_jit_global_f64_array_ptr(
     collection_hash: i32,
@@ -1752,6 +1805,42 @@ pub extern "C" fn stasis_jit_print_string(value_id: i32) {
         print!("{text}");
         let _ = std::io::stdout().flush();
     }
+}
+
+const STASIS_RENDER_I32_COUNT: i32 = 34_848;
+const STASIS_RENDER_F32_COUNT: i32 = 92_292;
+const STASIS_RENDER_U8_COUNT: i32 = 65_536;
+
+unsafe extern "C" {
+    fn stasis_render_v1_trace_native(
+        cmd_i32: *const i32,
+        cmd_f32: *const f32,
+        cmd_u8: *const u8,
+    ) -> u32;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn stasis_jit_render_v1_trace(
+    cmd_i32_id: i32,
+    cmd_i32_len: i32,
+    cmd_f32_id: i32,
+    cmd_f32_len: i32,
+    cmd_u8_id: i32,
+    cmd_u8_len: i32,
+) -> i32 {
+    if cmd_i32_len != STASIS_RENDER_I32_COUNT
+        || cmd_f32_len != STASIS_RENDER_F32_COUNT
+        || cmd_u8_len != STASIS_RENDER_U8_COUNT
+    {
+        return 0;
+    }
+    let cmd_i32 = stasis_jit_global_i32_array_ptr(cmd_i32_id, 0, STASIS_RENDER_I32_COUNT);
+    let cmd_f32 = stasis_jit_global_f32_array_ptr(cmd_f32_id, 0, STASIS_RENDER_F32_COUNT);
+    let cmd_u8 = global_u8_array_ptr(cmd_u8_id, 0, STASIS_RENDER_U8_COUNT);
+    if cmd_i32.is_null() || cmd_f32.is_null() || cmd_u8.is_null() {
+        return 0;
+    }
+    stasis_render_v1_trace_native(cmd_i32, cmd_f32, cmd_u8) as i32
 }
 
 fn jit_text_buffer_is_registered(value_id: i32) -> bool {
@@ -3465,6 +3554,38 @@ mod tests {
 
         let ptr2 = stasis_jit_global_i32_array_ptr(collection_hash, field_hash, 4);
         assert_eq!(ptr, ptr2);
+    }
+
+    #[test]
+    fn render_trace_rejects_non_contract_lengths_before_allocating() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+
+        // Safety: invalid lengths must be rejected before any pointer is resolved.
+        let trace = unsafe {
+            stasis_jit_render_v1_trace(
+                101,
+                i32::MAX,
+                102,
+                STASIS_RENDER_F32_COUNT,
+                103,
+                STASIS_RENDER_U8_COUNT,
+            )
+        };
+
+        assert_eq!(trace, 0);
+        assert!(registered_i32_arrays()
+            .lock()
+            .expect("registered i32 array table mutex poisoned")
+            .is_empty());
+        assert!(registered_f32_arrays()
+            .lock()
+            .expect("registered f32 array table mutex poisoned")
+            .is_empty());
+        assert!(registered_u8_arrays()
+            .lock()
+            .expect("registered u8 array table mutex poisoned")
+            .is_empty());
     }
 
     #[test]

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -21,6 +21,10 @@ Each output contains the same pieces:
 - `stasis_mobile_package.json`: the versioned package receipt
 - `android/` or `ios/`: a thin platform-native app project
 
+The packaged runtime is the same canonical SDL command interpreter used by the
+desktop distribution. The versioned guest buffer and deterministic trace
+contract are documented in `shared_renderer_process.md`.
+
 No package contains the Stasis compiler, JIT, watcher, dynamic game loader, or
 writable Stasis source.
 

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -25,6 +25,12 @@ The packaged runtime is the same canonical SDL command interpreter used by the
 desktop distribution. The versioned guest buffer and deterministic trace
 contract are documented in `shared_renderer_process.md`.
 
+The runtime asset root is always the packaged `stasis_game` project root.
+Canonical game paths therefore start with `assets/`. For compatibility with
+older source-relative literals such as `../assets/foo.svg`, an explicit
+packaged asset root normalizes `.` and leading parent segments without allowing
+the resolved path to escape `stasis_game`.
+
 No package contains the Stasis compiler, JIT, watcher, dynamic game loader, or
 writable Stasis source.
 

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -40,11 +40,19 @@ Shipping CMake builds set `STASIS_GRAPHICS_SDL_ONLY=ON`. Android and iOS shells
 add only lifecycle, asset-root, input/surface, and package glue. Windows CI
 builds this same SDL-only target and runs the portable trace contract test.
 
-The Android Workshop and its bundled Published preview flavor retain an embedded
-GLES development adapter. They are tested on-device for preview correctness, but
-they do not yet share the SDL resource lifecycle and are not evidence of pixel
-parity with a shipping package. Published game artifacts use
-`stasis package-mobile` and the SDL runtime. The old desktop GL adapter is
-available only when CMake is explicitly configured with
-`STASIS_GRAPHICS_SDL_ONLY=OFF`; it is not packaged or exercised as the canonical
-process.
+The Android Workshop menus remain native Android UI. Its embedded game canvas
+cannot use SDL's single Android window without handing the editor activity and
+surface lifecycle to SDL, so Workshop and the bundled Published preview flavor
+share one thin `StasisPreviewRenderer` GLES adapter instead. Both flavors use the
+same command interpreter, batching, clipping, rotation, alpha, filtering, and
+fallback behavior; only their texture sources differ. The steady-state draw loop
+uses fixed command arrays and direct vertex buffers. Texture uploads happen on
+first use or an explicit Workshop asset change, and framebuffer allocations
+happen only for an explicit screenshot capture.
+
+Published shipping artifacts use `stasis package-mobile` and the SDL runtime.
+The preview adapter is therefore an embedded-editor boundary, not a competing
+shipping renderer. It performs no per-command JNI calls and adds no additional
+full-frame copy. The old desktop GL adapter is available only when CMake is
+explicitly configured with `STASIS_GRAPHICS_SDL_ONLY=OFF`; it is not packaged or
+exercised as the canonical process.

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -1,0 +1,50 @@
+# Shared renderer process
+
+Stasis shipping packages use one renderer process on desktop, Android, and iOS:
+
+1. JIT or AOT game code writes the `gfx_cmd` v1 guest buffers.
+2. `stasis_gfx_submit_u8` validates and interprets that versioned buffer.
+3. `stasis_graphics.c` owns frame order, resources, blending, filtering,
+   clipping state, fallback sprites, and renderer shutdown.
+4. SDL owns platform surface creation, texture upload/draw, input adaptation,
+   and present.
+
+`runtime/stasis_render_contract.h` is the C source of truth for magic, version,
+flags, capacities, offsets, and the backend-independent trace. The Stasis
+modules `src/runtime/gfx_cmd.stasis` and `src/stdlib/gfx_cmd.stasis` use the same
+layout. Unsupported magic or versions are rejected without drawing.
+
+## Command contract
+
+Schema v1 has one fixed order: optional clear, lines, sprites, text or cached
+text, then optional present. The trace mixes an explicit kind marker and every
+consumed value in that order. Counts are clamped to the contract capacities;
+invalid text ranges contribute metadata but never read outside the byte buffer.
+JIT and AOT traces must match exactly for the representative conformance frame.
+
+Coordinates are logical top-left pixels. Colors and alpha are straight alpha;
+SDL uses source-alpha over destination. Sprite alpha is clamped to `0..255`,
+linear filtering is used for normal sprite textures, rotation is clockwise
+around the destination center, and an invalid sprite handle resolves to the
+procedural magenta checker. Schema v1 has no clip command; the interpreter
+resets the SDL clip rectangle at each frame boundary. Text and SVG rasterization,
+cache keys, and resource replacement live in `stasis_graphics.c`, so platform
+shells cannot redefine them.
+
+Schema v1 does not allow games to interleave command categories. Flexible
+cross-category ordering is tracked separately and requires a schema bump.
+
+## Platform boundary
+
+Shipping CMake builds set `STASIS_GRAPHICS_SDL_ONLY=ON`. Android and iOS shells
+add only lifecycle, asset-root, input/surface, and package glue. Windows CI
+builds this same SDL-only target and runs the portable trace contract test.
+
+The Android Workshop and its bundled Published preview flavor retain an embedded
+GLES development adapter. They are tested on-device for preview correctness, but
+they do not yet share the SDL resource lifecycle and are not evidence of pixel
+parity with a shipping package. Published game artifacts use
+`stasis package-mobile` and the SDL runtime. The old desktop GL adapter is
+available only when CMake is explicitly configured with
+`STASIS_GRAPHICS_SDL_ONLY=OFF`; it is not packaged or exercised as the canonical
+process.

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -1,0 +1,406 @@
+package com.stasislang.workshop;
+
+import android.graphics.Bitmap;
+import android.opengl.GLES20;
+import android.opengl.GLSurfaceView;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+
+final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
+    static final int COMMAND_CAPACITY = 8;
+    static final int FRAME_HEADER_SIZE = 6;
+    static final int COMMAND_STRIDE = 13;
+    static final int FRAME_I32_CAPACITY = FRAME_HEADER_SIZE + COMMAND_CAPACITY * COMMAND_STRIDE;
+
+    private static final int RECT_VERTICES = 6;
+    private static final int RECT_VERTEX_FLOATS = 6;
+    private static final int RECT_VERTEX_BYTES = RECT_VERTEX_FLOATS * 4;
+    private static final int SPRITE_VERTEX_FLOATS = 8;
+    private static final int SPRITE_VERTEX_BYTES = SPRITE_VERTEX_FLOATS * 4;
+    private static final int MAX_CAPTURE_PIXELS = 8_000_000;
+
+    interface TextureProvider {
+        void onSurfaceCreated();
+        int textureFor(int handle);
+    }
+
+    interface TimingListener {
+        void onRendered(long durationNanos);
+    }
+
+    interface CaptureCallback {
+        void onCaptured(Bitmap bitmap, String error, int[] capturedFrame);
+    }
+
+    private static final String VERTEX_SHADER =
+            "attribute vec2 aPosition;" +
+            "attribute vec4 aColor;" +
+            "uniform vec2 uResolution;" +
+            "varying vec4 vColor;" +
+            "void main() {" +
+            "  vec2 zeroToOne = aPosition / uResolution;" +
+            "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
+            "  vColor = aColor;" +
+            "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
+            "}";
+    private static final String FRAGMENT_SHADER =
+            "precision mediump float;" +
+            "varying vec4 vColor;" +
+            "void main() { gl_FragColor = vColor; }";
+    private static final String TEXTURE_VERTEX_SHADER =
+            "attribute vec2 aPosition;" +
+            "attribute vec2 aTexCoord;" +
+            "attribute vec4 aColor;" +
+            "uniform vec2 uResolution;" +
+            "varying vec2 vTexCoord;" +
+            "varying vec4 vColor;" +
+            "void main() {" +
+            "  vec2 zeroToOne = aPosition / uResolution;" +
+            "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
+            "  vTexCoord = aTexCoord;" +
+            "  vColor = aColor;" +
+            "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
+            "}";
+    private static final String TEXTURE_FRAGMENT_SHADER =
+            "precision mediump float;" +
+            "uniform sampler2D uTexture;" +
+            "varying vec2 vTexCoord;" +
+            "varying vec4 vColor;" +
+            "void main() { gl_FragColor = texture2D(uTexture, vTexCoord) * vColor; }";
+
+    private final TextureProvider textures;
+    private final TimingListener timing;
+    private final FloatBuffer rectVertices = ByteBuffer
+            .allocateDirect(COMMAND_CAPACITY * RECT_VERTICES * RECT_VERTEX_FLOATS * 4)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer();
+    private final FloatBuffer spriteVertices = ByteBuffer
+            .allocateDirect(COMMAND_CAPACITY * RECT_VERTICES * SPRITE_VERTEX_FLOATS * 4)
+            .order(ByteOrder.nativeOrder())
+            .asFloatBuffer();
+    private final int[] frame = new int[FRAME_I32_CAPACITY];
+    private int colorProgram;
+    private int colorPosition;
+    private int colorValue;
+    private int colorResolution;
+    private int textureProgram;
+    private int texturePosition;
+    private int textureCoordinate;
+    private int textureColor;
+    private int textureResolution;
+    private int textureSampler;
+    private int surfaceWidth = 1;
+    private int surfaceHeight = 1;
+    private CaptureCallback pendingCapture;
+
+    StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
+        this.textures = textures;
+        this.timing = timing;
+    }
+
+    synchronized void setFrame(int[] values) {
+        if (values.length < FRAME_I32_CAPACITY) {
+            throw new IllegalArgumentException("render frame is smaller than schema v3");
+        }
+        System.arraycopy(values, 0, frame, 0, FRAME_I32_CAPACITY);
+    }
+
+    synchronized void requestCapture(CaptureCallback callback) {
+        if (pendingCapture != null) {
+            pendingCapture.onCaptured(null, "a newer preview capture replaced this request", new int[0]);
+        }
+        pendingCapture = callback;
+    }
+
+    @Override
+    public void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl,
+            javax.microedition.khronos.egl.EGLConfig config) {
+        colorProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        colorPosition = GLES20.glGetAttribLocation(colorProgram, "aPosition");
+        colorValue = GLES20.glGetAttribLocation(colorProgram, "aColor");
+        colorResolution = GLES20.glGetUniformLocation(colorProgram, "uResolution");
+        textureProgram = createProgram(TEXTURE_VERTEX_SHADER, TEXTURE_FRAGMENT_SHADER);
+        texturePosition = GLES20.glGetAttribLocation(textureProgram, "aPosition");
+        textureCoordinate = GLES20.glGetAttribLocation(textureProgram, "aTexCoord");
+        textureColor = GLES20.glGetAttribLocation(textureProgram, "aColor");
+        textureResolution = GLES20.glGetUniformLocation(textureProgram, "uResolution");
+        textureSampler = GLES20.glGetUniformLocation(textureProgram, "uTexture");
+        textures.onSurfaceCreated();
+        GLES20.glEnable(GLES20.GL_BLEND);
+        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
+        GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
+    }
+
+    @Override
+    public void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl, int width, int height) {
+        surfaceWidth = Math.max(1, width);
+        surfaceHeight = Math.max(1, height);
+        GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
+    }
+
+    @Override
+    public void onDrawFrame(javax.microedition.khronos.opengles.GL10 gl) {
+        long started = System.nanoTime();
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+        CaptureCallback capture;
+        int[] capturedFrame;
+        synchronized (this) {
+            drawCommands();
+            capture = pendingCapture;
+            pendingCapture = null;
+            capturedFrame = capture == null ? null : frame.clone();
+        }
+        captureIfRequested(capture, capturedFrame);
+        timing.onRendered(System.nanoTime() - started);
+    }
+
+    private void drawCommands() {
+        int commandCount = Math.max(0, Math.min(COMMAND_CAPACITY, frame[5]));
+        int index = 0;
+        while (index < commandCount) {
+            int base = FRAME_HEADER_SIZE + index * COMMAND_STRIDE;
+            int kind = frame[base];
+            if (kind == 1) {
+                rectVertices.clear();
+                int runEnd = index;
+                while (runEnd < commandCount) {
+                    int runBase = FRAME_HEADER_SIZE + runEnd * COMMAND_STRIDE;
+                    if (frame[runBase] != 1 || !sameClip(base, runBase)) break;
+                    appendRect(runBase);
+                    runEnd += 1;
+                }
+                rectVertices.flip();
+                applyClip(base);
+                drawRectBatch((runEnd - index) * RECT_VERTICES);
+                index = runEnd;
+            } else if (kind == 2) {
+                int texture = textures.textureFor(frame[base + 6]);
+                spriteVertices.clear();
+                appendSprite(base);
+                int runEnd = index + 1;
+                while (runEnd < commandCount) {
+                    int runBase = FRAME_HEADER_SIZE + runEnd * COMMAND_STRIDE;
+                    if (frame[runBase] != 2 || !sameClip(base, runBase)
+                            || textures.textureFor(frame[runBase + 6]) != texture) break;
+                    appendSprite(runBase);
+                    runEnd += 1;
+                }
+                spriteVertices.flip();
+                applyClip(base);
+                drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture);
+                index = runEnd;
+            } else {
+                index += 1;
+            }
+        }
+        GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+    }
+
+    private void appendRect(int base) {
+        int color = frame[base + 5];
+        float red = ((color >> 16) & 255) / 255.0f;
+        float green = ((color >> 8) & 255) / 255.0f;
+        float blue = (color & 255) / 255.0f;
+        float alpha = Math.max(0, Math.min(255, frame[base + 8])) / 255.0f;
+        float left = frame[base + 1];
+        float top = frame[base + 2];
+        float right = left + frame[base + 3];
+        float bottom = top + frame[base + 4];
+        float centerX = (left + right) * 0.5f;
+        float centerY = (top + bottom) * 0.5f;
+        double radians = Math.toRadians(frame[base + 7] % 360);
+        float cosine = (float)Math.cos(radians);
+        float sine = (float)Math.sin(radians);
+        putRectVertex(left, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
+        putRectVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
+        putRectVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
+        putRectVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
+        putRectVertex(right, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
+        putRectVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
+    }
+
+    private void appendSprite(int base) {
+        int color = frame[base + 5];
+        float red = ((color >> 16) & 255) / 255.0f;
+        float green = ((color >> 8) & 255) / 255.0f;
+        float blue = (color & 255) / 255.0f;
+        float alpha = Math.max(0, Math.min(255, frame[base + 8])) / 255.0f;
+        float left = frame[base + 1];
+        float top = frame[base + 2];
+        float right = left + frame[base + 3];
+        float bottom = top + frame[base + 4];
+        float centerX = (left + right) * 0.5f;
+        float centerY = (top + bottom) * 0.5f;
+        double radians = Math.toRadians(frame[base + 7] % 360);
+        float cosine = (float)Math.cos(radians);
+        float sine = (float)Math.sin(radians);
+        putSpriteVertex(left, top, centerX, centerY, cosine, sine, 0.0f, 0.0f, red, green, blue, alpha);
+        putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
+        putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
+        putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
+        putSpriteVertex(right, bottom, centerX, centerY, cosine, sine, 1.0f, 1.0f, red, green, blue, alpha);
+        putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
+    }
+
+    private void putRectVertex(float x, float y, float centerX, float centerY,
+            float cosine, float sine, float red, float green, float blue, float alpha) {
+        float offsetX = x - centerX;
+        float offsetY = y - centerY;
+        rectVertices.put(centerX + offsetX * cosine - offsetY * sine)
+                .put(centerY + offsetX * sine + offsetY * cosine)
+                .put(red).put(green).put(blue).put(alpha);
+    }
+
+    private void putSpriteVertex(float x, float y, float centerX, float centerY,
+            float cosine, float sine, float u, float v, float red, float green, float blue,
+            float alpha) {
+        float offsetX = x - centerX;
+        float offsetY = y - centerY;
+        spriteVertices.put(centerX + offsetX * cosine - offsetY * sine)
+                .put(centerY + offsetX * sine + offsetY * cosine)
+                .put(u).put(v).put(red).put(green).put(blue).put(alpha);
+    }
+
+    private boolean sameClip(int leftBase, int rightBase) {
+        return frame[leftBase + 9] == frame[rightBase + 9]
+                && frame[leftBase + 10] == frame[rightBase + 10]
+                && frame[leftBase + 11] == frame[rightBase + 11]
+                && frame[leftBase + 12] == frame[rightBase + 12];
+    }
+
+    private void applyClip(int base) {
+        int width = frame[base + 11];
+        int height = frame[base + 12];
+        if (width <= 0 || height <= 0) {
+            GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+            return;
+        }
+        long sourceRight = (long)frame[base + 9] + width;
+        long sourceBottom = (long)frame[base + 10] + height;
+        int left = Math.max(0, Math.min(surfaceWidth, frame[base + 9]));
+        int top = Math.max(0, Math.min(surfaceHeight, frame[base + 10]));
+        int right = Math.max(left, (int)Math.max(0L, Math.min((long)surfaceWidth, sourceRight)));
+        int bottom = Math.max(top, (int)Math.max(0L, Math.min((long)surfaceHeight, sourceBottom)));
+        GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
+        GLES20.glScissor(left, surfaceHeight - bottom, right - left, bottom - top);
+    }
+
+    private void drawRectBatch(int vertexCount) {
+        GLES20.glUseProgram(colorProgram);
+        GLES20.glUniform2f(colorResolution, (float)surfaceWidth, (float)surfaceHeight);
+        GLES20.glEnableVertexAttribArray(colorPosition);
+        GLES20.glEnableVertexAttribArray(colorValue);
+        rectVertices.position(0);
+        GLES20.glVertexAttribPointer(colorPosition, 2, GLES20.GL_FLOAT, false,
+                RECT_VERTEX_BYTES, rectVertices);
+        rectVertices.position(2);
+        GLES20.glVertexAttribPointer(colorValue, 4, GLES20.GL_FLOAT, false,
+                RECT_VERTEX_BYTES, rectVertices);
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
+        rectVertices.position(0);
+        GLES20.glDisableVertexAttribArray(colorValue);
+        GLES20.glDisableVertexAttribArray(colorPosition);
+    }
+
+    private void drawSpriteBatch(int vertexCount, int texture) {
+        GLES20.glUseProgram(textureProgram);
+        GLES20.glUniform2f(textureResolution, (float)surfaceWidth, (float)surfaceHeight);
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
+        GLES20.glUniform1i(textureSampler, 0);
+        GLES20.glEnableVertexAttribArray(texturePosition);
+        GLES20.glEnableVertexAttribArray(textureCoordinate);
+        GLES20.glEnableVertexAttribArray(textureColor);
+        spriteVertices.position(0);
+        GLES20.glVertexAttribPointer(texturePosition, 2, GLES20.GL_FLOAT, false,
+                SPRITE_VERTEX_BYTES, spriteVertices);
+        spriteVertices.position(2);
+        GLES20.glVertexAttribPointer(textureCoordinate, 2, GLES20.GL_FLOAT, false,
+                SPRITE_VERTEX_BYTES, spriteVertices);
+        spriteVertices.position(4);
+        GLES20.glVertexAttribPointer(textureColor, 4, GLES20.GL_FLOAT, false,
+                SPRITE_VERTEX_BYTES, spriteVertices);
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
+        spriteVertices.position(0);
+        GLES20.glDisableVertexAttribArray(textureColor);
+        GLES20.glDisableVertexAttribArray(textureCoordinate);
+        GLES20.glDisableVertexAttribArray(texturePosition);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+    }
+
+    private void captureIfRequested(CaptureCallback callback, int[] capturedFrame) {
+        if (callback == null) return;
+        try {
+            long pixelCount = (long)surfaceWidth * surfaceHeight;
+            if (pixelCount > MAX_CAPTURE_PIXELS) {
+                callback.onCaptured(null, "preview framebuffer exceeds the 8 megapixel capture limit", capturedFrame);
+                return;
+            }
+            java.nio.IntBuffer pixels = ByteBuffer.allocateDirect(surfaceWidth * surfaceHeight * 4)
+                    .order(ByteOrder.nativeOrder()).asIntBuffer();
+            GLES20.glReadPixels(0, 0, surfaceWidth, surfaceHeight, GLES20.GL_RGBA,
+                    GLES20.GL_UNSIGNED_BYTE, pixels);
+            int[] flipped = new int[surfaceWidth * surfaceHeight];
+            for (int y = 0; y < surfaceHeight; y++) {
+                int sourceRow = y * surfaceWidth;
+                int targetRow = (surfaceHeight - y - 1) * surfaceWidth;
+                for (int x = 0; x < surfaceWidth; x++) {
+                    int rgba = pixels.get(sourceRow + x);
+                    flipped[targetRow + x] = (rgba & 0xff00ff00)
+                            | ((rgba << 16) & 0x00ff0000) | ((rgba >> 16) & 0x000000ff);
+                }
+            }
+            Bitmap full = Bitmap.createBitmap(flipped, surfaceWidth, surfaceHeight, Bitmap.Config.ARGB_8888);
+            int largest = Math.max(surfaceWidth, surfaceHeight);
+            if (largest <= 1024) {
+                callback.onCaptured(full, "", capturedFrame);
+                return;
+            }
+            float scale = 1024.0f / largest;
+            Bitmap bounded = Bitmap.createScaledBitmap(full,
+                    Math.max(1, Math.round(surfaceWidth * scale)),
+                    Math.max(1, Math.round(surfaceHeight * scale)), true);
+            full.recycle();
+            callback.onCaptured(bounded, "", capturedFrame);
+        } catch (OutOfMemoryError error) {
+            callback.onCaptured(null, "not enough memory for bounded pixel capture", capturedFrame);
+        } catch (RuntimeException error) {
+            callback.onCaptured(null, error.getMessage(), capturedFrame);
+        }
+    }
+
+    private static int createProgram(String vertexSource, String fragmentSource) {
+        int vertex = compileShader(GLES20.GL_VERTEX_SHADER, vertexSource);
+        int fragment = compileShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource);
+        int program = GLES20.glCreateProgram();
+        GLES20.glAttachShader(program, vertex);
+        GLES20.glAttachShader(program, fragment);
+        GLES20.glLinkProgram(program);
+        GLES20.glDeleteShader(vertex);
+        GLES20.glDeleteShader(fragment);
+        int[] linked = new int[1];
+        GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, linked, 0);
+        if (linked[0] == 0) {
+            String log = GLES20.glGetProgramInfoLog(program);
+            GLES20.glDeleteProgram(program);
+            throw new IllegalStateException("OpenGL program link failed: " + log);
+        }
+        return program;
+    }
+
+    private static int compileShader(int type, String source) {
+        int shader = GLES20.glCreateShader(type);
+        GLES20.glShaderSource(shader, source);
+        GLES20.glCompileShader(shader);
+        int[] compiled = new int[1];
+        GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0);
+        if (compiled[0] == 0) {
+            String log = GLES20.glGetShaderInfoLog(shader);
+            GLES20.glDeleteShader(shader);
+            throw new IllegalStateException("OpenGL shader compile failed: " + log);
+        }
+        return shader;
+    }
+}

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -2,8 +2,6 @@ package com.stasislang.workshop;
 
 import android.app.Activity;
 import android.graphics.Color;
-import android.opengl.GLES20;
-import android.opengl.GLSurfaceView;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -17,33 +15,18 @@ import android.view.WindowInsets;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
-
 public final class MainActivity extends Activity {
     private static final String PUBLISHED_RUNTIME_ID = BuildConfig.STASIS_RUNTIME_ID;
-
     private static final long FRAME_DELAY_MS = 16L;
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
     private static final long DEBUG_UPDATE_INTERVAL_NANOS = 200_000_000L;
-    private static final int MAX_RENDER_COMMANDS = 8;
-    private static final int RENDER_FRAME_HEADER_SIZE = 6;
-    private static final int RENDER_COMMAND_STRIDE = 13;
-    private static final int RENDER_FRAME_I32_CAPACITY = RENDER_FRAME_HEADER_SIZE + MAX_RENDER_COMMANDS * RENDER_COMMAND_STRIDE;
-    private static final int RECT_VERTICES = 6;
-    private static final int RECT_VERTEX_FLOATS = 6;
-    private static final int RENDER_VERTEX_BUFFER_FLOATS = MAX_RENDER_COMMANDS * RECT_VERTICES * RECT_VERTEX_FLOATS;
-    private static final int SPRITE_VERTEX_FLOATS = 8;
-    private static final int SPRITE_VERTEX_BYTES = SPRITE_VERTEX_FLOATS * 4;
-    private static final int SPRITE_VERTEX_BUFFER_FLOATS = MAX_RENDER_COMMANDS * RECT_VERTICES * SPRITE_VERTEX_FLOATS;
 
     static {
         System.loadLibrary("stasis_mobile_smoke");
     }
 
     private final Handler frameHandler = new Handler(Looper.getMainLooper());
-    private final int[] frameValues = new int[RENDER_FRAME_I32_CAPACITY];
+    private final int[] frameValues = new int[StasisPreviewRenderer.FRAME_I32_CAPACITY];
     private final RollingMetric tickMetric = new RollingMetric();
     private final RollingMetric renderMetric = new RollingMetric();
     private final StringBuilder hudText = new StringBuilder(80);
@@ -55,7 +38,8 @@ public final class MainActivity extends Activity {
     private long lastHudUpdateNanos;
 
     private static native String nativeCompileProject(String projectRoot);
-    private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight, int[] frameValues);
+    private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
+            int touchActive, int screenWidth, int screenHeight, int[] frameValues);
     static native int[] nativeDecodeSvgSpriteBytes(byte[] bytes, int width, int height);
 
     @Override
@@ -94,39 +78,32 @@ public final class MainActivity extends Activity {
 
     @Override
     protected void onDestroy() {
-        if (frameLoop != null) {
-            frameHandler.removeCallbacks(frameLoop);
-        }
+        if (frameLoop != null) frameHandler.removeCallbacks(frameLoop);
         super.onDestroy();
     }
 
-    void toggleHud() {
-        if (hud == null) {
-            return;
-        }
+    private void toggleHud() {
+        if (hud == null) return;
         hud.setVisibility(hud.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
         updateHud(true);
     }
 
-    void recordRenderTimeNanos(long durationNanos) {
+    private void recordRenderTimeNanos(long durationNanos) {
         renderMetric.add(System.nanoTime(), durationNanos);
     }
 
     private void startFrameLoop() {
-        if (frameLoop != null) {
-            return;
-        }
+        if (frameLoop != null) return;
         frameLoop = new Runnable() {
             @Override
             public void run() {
                 if (!compileAttempted) {
                     String result = nativeCompileProject(PUBLISHED_RUNTIME_ID);
-                    compileReady = result != null && result.startsWith("CompilePlanned") && result.contains("status=0");
+                    compileReady = result != null && result.startsWith("CompilePlanned")
+                            && result.contains("status=0");
                     compileAttempted = true;
                 }
-                if (compileReady) {
-                    runFrame();
-                }
+                if (compileReady) runFrame();
                 frameHandler.postDelayed(this, FRAME_DELAY_MS);
             }
         };
@@ -136,7 +113,7 @@ public final class MainActivity extends Activity {
     private void runFrame() {
         int width = gameSurface == null ? 0 : gameSurface.getWidth();
         int height = gameSurface == null ? 0 : gameSurface.getHeight();
-        long start = System.nanoTime();
+        long started = System.nanoTime();
         int status = nativeRunFrameInto(
                 PUBLISHED_RUNTIME_ID,
                 gameSurface == null ? 0 : gameSurface.touchX(),
@@ -145,7 +122,7 @@ public final class MainActivity extends Activity {
                 width,
                 height,
                 frameValues);
-        tickMetric.add(System.nanoTime(), System.nanoTime() - start);
+        tickMetric.add(System.nanoTime(), System.nanoTime() - started);
         if (status == 0 && frameValues[0] == 0 && gameSurface != null) {
             gameSurface.setRenderFrameValues(frameValues);
         }
@@ -153,17 +130,14 @@ public final class MainActivity extends Activity {
     }
 
     private void updateHud(boolean force) {
-        if (hud == null || hud.getVisibility() != View.VISIBLE) {
-            return;
-        }
+        if (hud == null || hud.getVisibility() != View.VISIBLE) return;
         long now = System.nanoTime();
-        if (!force && now - lastHudUpdateNanos < DEBUG_UPDATE_INTERVAL_NANOS) {
-            return;
-        }
+        if (!force && now - lastHudUpdateNanos < DEBUG_UPDATE_INTERVAL_NANOS) return;
         lastHudUpdateNanos = now;
         double tickMillis = tickMetric.averageMillis();
         double renderMillis = renderMetric.averageMillis();
-        int budgetPercent = Math.max(0, (int)(((tickMillis + renderMillis) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
+        int budgetPercent = Math.max(0,
+                (int)(((tickMillis + renderMillis) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
         hudText.setLength(0);
         hudText.append("tick=");
         appendMillis(hudText, tickMillis);
@@ -175,15 +149,9 @@ public final class MainActivity extends Activity {
     }
 
     private static int debugColorForBudget(int budgetPercent) {
-        if (budgetPercent >= 100) {
-            return Color.rgb(186, 104, 255);
-        }
-        if (budgetPercent >= 80) {
-            return Color.rgb(255, 91, 91);
-        }
-        if (budgetPercent >= 50) {
-            return Color.rgb(255, 214, 102);
-        }
+        if (budgetPercent >= 100) return Color.rgb(186, 104, 255);
+        if (budgetPercent >= 80) return Color.rgb(255, 91, 91);
+        if (budgetPercent >= 50) return Color.rgb(255, 214, 102);
         return Color.WHITE;
     }
 
@@ -191,9 +159,7 @@ public final class MainActivity extends Activity {
         int hundredths = Math.max(0, (int)(millis * 100.0 + 0.5));
         builder.append(hundredths / 100).append('.');
         int fraction = hundredths % 100;
-        if (fraction < 10) {
-            builder.append('0');
-        }
+        if (fraction < 10) builder.append('0');
         builder.append(fraction);
     }
 
@@ -225,9 +191,9 @@ public final class MainActivity extends Activity {
         return Math.round(value * getResources().getDisplayMetrics().density);
     }
 
-    private static final class GameSurfaceView extends GLSurfaceView {
+    private static final class GameSurfaceView extends android.opengl.GLSurfaceView {
         private final MainActivity activity;
-        private final PreviewRenderer renderer;
+        private final StasisPreviewRenderer renderer;
         private int touchX;
         private int touchY;
         private boolean touchActive;
@@ -236,25 +202,19 @@ public final class MainActivity extends Activity {
             super(activity);
             this.activity = activity;
             setEGLContextClientVersion(2);
-            renderer = new PreviewRenderer(activity);
+            renderer = new StasisPreviewRenderer(
+                    new PublishedSpriteCatalog(activity.getAssets()),
+                    activity::recordRenderTimeNanos);
             setRenderer(renderer);
-            setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
+            setRenderMode(RENDERMODE_WHEN_DIRTY);
         }
 
-        int touchX() {
-            return touchX;
-        }
-
-        int touchY() {
-            return touchY;
-        }
-
-        int touchActive() {
-            return touchActive ? 1 : 0;
-        }
+        int touchX() { return touchX; }
+        int touchY() { return touchY; }
+        int touchActive() { return touchActive ? 1 : 0; }
 
         void setRenderFrameValues(int[] values) {
-            renderer.setFrameValues(values);
+            renderer.setFrame(values);
             requestRender();
         }
 
@@ -271,305 +231,6 @@ public final class MainActivity extends Activity {
         }
     }
 
-    private static final class PreviewRenderer implements GLSurfaceView.Renderer {
-        private static final String VERTEX_SHADER =
-                "attribute vec2 aPosition;" +
-                "attribute vec4 aColor;" +
-                "uniform vec2 uResolution;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  vec2 zeroToOne = aPosition / uResolution;" +
-                "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-                "  vColor = aColor;" +
-                "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-                "}";
-        private static final String FRAGMENT_SHADER =
-                "precision mediump float;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  gl_FragColor = vColor;" +
-                "}";
-        private static final String TEXTURE_VERTEX_SHADER =
-                "attribute vec2 aPosition;" +
-                "attribute vec2 aTexCoord;" +
-                "attribute vec4 aColor;" +
-                "uniform vec2 uResolution;" +
-                "varying vec2 vTexCoord;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  vec2 zeroToOne = aPosition / uResolution;" +
-                "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-                "  vTexCoord = aTexCoord;" +
-                "  vColor = aColor;" +
-                "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-                "}";
-        private static final String TEXTURE_FRAGMENT_SHADER =
-                "precision mediump float;" +
-                "uniform sampler2D uTexture;" +
-                "varying vec2 vTexCoord;" +
-                "varying vec4 vColor;" +
-                "void main() { gl_FragColor = texture2D(uTexture, vTexCoord) * vColor; }";
-
-        private final MainActivity activity;
-        private final FloatBuffer vertexBuffer = ByteBuffer
-                .allocateDirect(RENDER_VERTEX_BUFFER_FLOATS * 4)
-                .order(ByteOrder.nativeOrder())
-                .asFloatBuffer();
-        private final FloatBuffer spriteVertexBuffer = ByteBuffer
-                .allocateDirect(SPRITE_VERTEX_BUFFER_FLOATS * 4)
-                .order(ByteOrder.nativeOrder())
-                .asFloatBuffer();
-        private final int[] frameValues = new int[RENDER_FRAME_I32_CAPACITY];
-        private final PublishedSpriteCatalog spriteCatalog;
-        private int program;
-        private int positionHandle;
-        private int colorHandle;
-        private int resolutionHandle;
-        private int textureProgram;
-        private int texturePositionHandle;
-        private int textureCoordHandle;
-        private int textureColorHandle;
-        private int textureResolutionHandle;
-        private int textureSamplerHandle;
-        private int surfaceWidth = 1;
-        private int surfaceHeight = 1;
-
-        PreviewRenderer(MainActivity activity) {
-            this.activity = activity;
-            spriteCatalog = new PublishedSpriteCatalog(activity.getAssets());
-        }
-
-        synchronized void setFrameValues(int[] values) {
-            System.arraycopy(values, 0, frameValues, 0, RENDER_FRAME_I32_CAPACITY);
-        }
-
-        @Override
-        public void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl, javax.microedition.khronos.egl.EGLConfig config) {
-            program = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
-            positionHandle = GLES20.glGetAttribLocation(program, "aPosition");
-            colorHandle = GLES20.glGetAttribLocation(program, "aColor");
-            resolutionHandle = GLES20.glGetUniformLocation(program, "uResolution");
-            textureProgram = createProgram(TEXTURE_VERTEX_SHADER, TEXTURE_FRAGMENT_SHADER);
-            texturePositionHandle = GLES20.glGetAttribLocation(textureProgram, "aPosition");
-            textureCoordHandle = GLES20.glGetAttribLocation(textureProgram, "aTexCoord");
-            textureColorHandle = GLES20.glGetAttribLocation(textureProgram, "aColor");
-            textureResolutionHandle = GLES20.glGetUniformLocation(textureProgram, "uResolution");
-            textureSamplerHandle = GLES20.glGetUniformLocation(textureProgram, "uTexture");
-            spriteCatalog.onSurfaceCreated();
-            GLES20.glEnable(GLES20.GL_BLEND);
-            GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
-            GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
-        }
-
-        @Override
-        public void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl, int width, int height) {
-            surfaceWidth = Math.max(1, width);
-            surfaceHeight = Math.max(1, height);
-            GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
-        }
-
-        @Override
-        public void onDrawFrame(javax.microedition.khronos.opengles.GL10 gl) {
-            long start = System.nanoTime();
-            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
-            GLES20.glUseProgram(program);
-            GLES20.glUniform2f(resolutionHandle, (float)surfaceWidth, (float)surfaceHeight);
-            synchronized (this) {
-                int commandCount = Math.max(0, Math.min(MAX_RENDER_COMMANDS, frameValues[5]));
-                int index = 0;
-                while (index < commandCount) {
-                    int base = RENDER_FRAME_HEADER_SIZE + index * RENDER_COMMAND_STRIDE;
-                    int kind = frameValues[base];
-                    if (kind == 1) {
-                        vertexBuffer.clear();
-                        int runEnd = index;
-                        while (runEnd < commandCount) {
-                            int runBase = RENDER_FRAME_HEADER_SIZE + runEnd * RENDER_COMMAND_STRIDE;
-                            int runKind = frameValues[runBase];
-                            if (runKind != 1 || !sameClip(base, runBase)) break;
-                            appendRect(runBase);
-                            runEnd += 1;
-                        }
-                        vertexBuffer.flip();
-                        applyClip(base);
-                        drawBatch((runEnd - index) * RECT_VERTICES);
-                        index = runEnd;
-                    } else if (kind == 2) {
-                        int texture = spriteCatalog.textureFor(frameValues[base + 6]);
-                        spriteVertexBuffer.clear();
-                        int runEnd = index;
-                        while (runEnd < commandCount) {
-                            int runBase = RENDER_FRAME_HEADER_SIZE + runEnd * RENDER_COMMAND_STRIDE;
-                            if (frameValues[runBase] != 2 || !sameClip(base, runBase)) break;
-                            int runTexture = spriteCatalog.textureFor(frameValues[runBase + 6]);
-                            if (runTexture != texture) break;
-                            appendSprite(runBase);
-                            runEnd += 1;
-                        }
-                        spriteVertexBuffer.flip();
-                        applyClip(base);
-                        drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture);
-                        index = runEnd;
-                    } else {
-                        index += 1;
-                    }
-                }
-                GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-            }
-            activity.recordRenderTimeNanos(System.nanoTime() - start);
-        }
-
-        private void drawBatch(int vertexCount) {
-            GLES20.glUseProgram(program);
-            GLES20.glUniform2f(resolutionHandle, (float)surfaceWidth, (float)surfaceHeight);
-            GLES20.glEnableVertexAttribArray(positionHandle);
-            GLES20.glEnableVertexAttribArray(colorHandle);
-            vertexBuffer.position(0);
-            GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false,
-                    RECT_VERTEX_FLOATS * 4, vertexBuffer);
-            vertexBuffer.position(2);
-            GLES20.glVertexAttribPointer(colorHandle, 4, GLES20.GL_FLOAT, false,
-                    RECT_VERTEX_FLOATS * 4, vertexBuffer);
-            GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-            GLES20.glDisableVertexAttribArray(positionHandle);
-            GLES20.glDisableVertexAttribArray(colorHandle);
-        }
-
-        private void appendSprite(int base) {
-            int color = frameValues[base + 5];
-            float red = ((color >> 16) & 255) / 255.0f;
-            float green = ((color >> 8) & 255) / 255.0f;
-            float blue = (color & 255) / 255.0f;
-            float alpha = Math.max(0, Math.min(255, frameValues[base + 8])) / 255.0f;
-            float left = frameValues[base + 1];
-            float top = frameValues[base + 2];
-            float right = left + frameValues[base + 3];
-            float bottom = top + frameValues[base + 4];
-            float centerX = (left + right) * 0.5f;
-            float centerY = (top + bottom) * 0.5f;
-            double radians = Math.toRadians(frameValues[base + 7] % 360);
-            float cosine = (float)Math.cos(radians);
-            float sine = (float)Math.sin(radians);
-            putSpriteVertex(left, top, centerX, centerY, cosine, sine, 0.0f, 0.0f, red, green, blue, alpha);
-            putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-            putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
-            putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-            putSpriteVertex(right, bottom, centerX, centerY, cosine, sine, 1.0f, 1.0f, red, green, blue, alpha);
-            putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
-        }
-
-        private void putSpriteVertex(float x, float y, float centerX, float centerY,
-                float cosine, float sine, float u, float v, float red, float green, float blue,
-                float alpha) {
-            float offsetX = x - centerX;
-            float offsetY = y - centerY;
-            float rotatedX = centerX + offsetX * cosine - offsetY * sine;
-            float rotatedY = centerY + offsetX * sine + offsetY * cosine;
-            spriteVertexBuffer.put(rotatedX).put(rotatedY).put(u).put(v)
-                    .put(red).put(green).put(blue).put(alpha);
-        }
-
-        private void drawSpriteBatch(int vertexCount, int texture) {
-            GLES20.glUseProgram(textureProgram);
-            GLES20.glUniform2f(textureResolutionHandle, (float)surfaceWidth, (float)surfaceHeight);
-            GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
-            GLES20.glUniform1i(textureSamplerHandle, 0);
-            GLES20.glEnableVertexAttribArray(texturePositionHandle);
-            GLES20.glEnableVertexAttribArray(textureCoordHandle);
-            GLES20.glEnableVertexAttribArray(textureColorHandle);
-            spriteVertexBuffer.position(0);
-            GLES20.glVertexAttribPointer(texturePositionHandle, 2, GLES20.GL_FLOAT, false,
-                    SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            spriteVertexBuffer.position(2);
-            GLES20.glVertexAttribPointer(textureCoordHandle, 2, GLES20.GL_FLOAT, false,
-                    SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            spriteVertexBuffer.position(4);
-            GLES20.glVertexAttribPointer(textureColorHandle, 4, GLES20.GL_FLOAT, false,
-                    SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-            GLES20.glDisableVertexAttribArray(textureColorHandle);
-            GLES20.glDisableVertexAttribArray(textureCoordHandle);
-            GLES20.glDisableVertexAttribArray(texturePositionHandle);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
-        }
-
-        private void appendRect(int base) {
-            int color = frameValues[base + 5];
-            float red = ((color >> 16) & 255) / 255.0f;
-            float green = ((color >> 8) & 255) / 255.0f;
-            float blue = (color & 255) / 255.0f;
-            float alpha = Math.max(0, Math.min(255, frameValues[base + 8])) / 255.0f;
-            float left = frameValues[base + 1];
-            float top = frameValues[base + 2];
-            float right = frameValues[base + 1] + frameValues[base + 3];
-            float bottom = frameValues[base + 2] + frameValues[base + 4];
-            float centerX = (left + right) * 0.5f;
-            float centerY = (top + bottom) * 0.5f;
-            double radians = Math.toRadians(frameValues[base + 7] % 360);
-            float cosine = (float)Math.cos(radians);
-            float sine = (float)Math.sin(radians);
-            putVertex(left, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        }
-
-        private boolean sameClip(int leftBase, int rightBase) {
-            return frameValues[leftBase + 9] == frameValues[rightBase + 9]
-                    && frameValues[leftBase + 10] == frameValues[rightBase + 10]
-                    && frameValues[leftBase + 11] == frameValues[rightBase + 11]
-                    && frameValues[leftBase + 12] == frameValues[rightBase + 12];
-        }
-
-        private void applyClip(int base) {
-            int width = frameValues[base + 11];
-            int height = frameValues[base + 12];
-            if (width <= 0 || height <= 0) {
-                GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-                return;
-            }
-            long sourceRight = (long)frameValues[base + 9] + width;
-            long sourceBottom = (long)frameValues[base + 10] + height;
-            int left = Math.max(0, Math.min(surfaceWidth, frameValues[base + 9]));
-            int top = Math.max(0, Math.min(surfaceHeight, frameValues[base + 10]));
-            int right = Math.max(left, (int)Math.max(0L, Math.min((long)surfaceWidth, sourceRight)));
-            int bottom = Math.max(top, (int)Math.max(0L, Math.min((long)surfaceHeight, sourceBottom)));
-            GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
-            GLES20.glScissor(left, surfaceHeight - bottom, right - left, bottom - top);
-        }
-
-        private void putVertex(float x, float y, float centerX, float centerY,
-                float cosine, float sine, float red, float green, float blue, float alpha) {
-            float offsetX = x - centerX;
-            float offsetY = y - centerY;
-            float rotatedX = centerX + offsetX * cosine - offsetY * sine;
-            float rotatedY = centerY + offsetX * sine + offsetY * cosine;
-            vertexBuffer.put(rotatedX).put(rotatedY).put(red).put(green).put(blue).put(alpha);
-        }
-
-        private static int createProgram(String vertexSource, String fragmentSource) {
-            int vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, vertexSource);
-            int fragmentShader = loadShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource);
-            int program = GLES20.glCreateProgram();
-            GLES20.glAttachShader(program, vertexShader);
-            GLES20.glAttachShader(program, fragmentShader);
-            GLES20.glLinkProgram(program);
-            GLES20.glDeleteShader(vertexShader);
-            GLES20.glDeleteShader(fragmentShader);
-            return program;
-        }
-
-        private static int loadShader(int type, String source) {
-            int shader = GLES20.glCreateShader(type);
-            GLES20.glShaderSource(shader, source);
-            GLES20.glCompileShader(shader);
-            return shader;
-        }
-    }
-
     private static final class RollingMetric {
         private static final long WINDOW_NANOS = 5_000_000_000L;
         private static final int CAPACITY = 360;
@@ -582,15 +243,11 @@ public final class MainActivity extends Activity {
             sampleTimes[nextIndex] = now;
             durations[nextIndex] = durationNanos;
             nextIndex = (nextIndex + 1) % CAPACITY;
-            if (count < CAPACITY) {
-                count += 1;
-            }
+            if (count < CAPACITY) count += 1;
         }
 
         double averageMillis() {
-            if (count == 0) {
-                return 0.0;
-            }
+            if (count == 0) return 0.0;
             long now = System.nanoTime();
             long total = 0L;
             int samples = 0;
@@ -600,10 +257,7 @@ public final class MainActivity extends Activity {
                     samples += 1;
                 }
             }
-            if (samples == 0) {
-                return 0.0;
-            }
-            return (double)total / (double)samples / 1_000_000.0;
+            return samples == 0 ? 0.0 : (double)total / samples / 1_000_000.0;
         }
     }
 }

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
@@ -5,6 +5,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
+import android.util.SparseArray;
+import android.util.SparseBooleanArray;
+import android.util.SparseIntArray;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -14,12 +17,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
-final class PublishedSpriteCatalog {
+final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvider {
     private static final String ROOT = "stasis_game/";
     private static final String MANIFEST = ROOT + "assets/manifest.json";
     private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
@@ -29,9 +28,9 @@ final class PublishedSpriteCatalog {
     private static final long MAX_PIXELS = 16_000_000L;
 
     private final AssetManager assets;
-    private final Map<Integer, SpriteAsset> sprites = new HashMap<>();
-    private final Map<Integer, Integer> textures = new HashMap<>();
-    private final Set<Integer> failedHandles = new HashSet<>();
+    private final SparseArray<SpriteAsset> sprites = new SparseArray<>();
+    private final SparseIntArray textures = new SparseIntArray();
+    private final SparseBooleanArray failedHandles = new SparseBooleanArray();
     private boolean manifestRead;
     private boolean manifestValid;
     private int fallbackTexture;
@@ -40,16 +39,18 @@ final class PublishedSpriteCatalog {
         this.assets = assets;
     }
 
-    void onSurfaceCreated() {
+    @Override
+    public void onSurfaceCreated() {
         textures.clear();
         failedHandles.clear();
         fallbackTexture = createFallbackTexture();
     }
 
-    int textureFor(int handle) {
-        Integer cached = textures.get(handle);
-        if (cached != null) return cached;
-        if (failedHandles.contains(handle)) return fallbackTexture;
+    @Override
+    public int textureFor(int handle) {
+        int cached = textures.get(handle, 0);
+        if (cached != 0) return cached;
+        if (failedHandles.get(handle)) return fallbackTexture;
         try {
             ensureManifest();
             SpriteAsset sprite = sprites.get(handle);
@@ -66,7 +67,7 @@ final class PublishedSpriteCatalog {
             textures.put(handle, texture);
             return texture;
         } catch (Exception error) {
-            failedHandles.add(handle);
+            failedHandles.put(handle, true);
             return fallbackTexture;
         }
     }
@@ -96,9 +97,10 @@ final class PublishedSpriteCatalog {
                 throw new IOException("invalid packaged sprite metadata");
             }
             int handle = stableHandle("sprite:" + id);
-            if (sprites.put(handle, new SpriteAsset(path, hash, encoding, width, height)) != null) {
+            if (sprites.get(handle) != null) {
                 throw new IOException("packaged sprite handle collision");
             }
+            sprites.put(handle, new SpriteAsset(path, hash, encoding, width, height));
         }
         manifestValid = true;
     }

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopTextureProviderTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopTextureProviderTest.java
@@ -1,0 +1,15 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopTextureProviderTest {
+    @Test
+    public void projectIdentityInvalidatesTextureCache() {
+        assertTrue(WorkshopTextureProvider.projectChanged(null, "projects/one"));
+        assertFalse(WorkshopTextureProvider.projectChanged("projects/one", "projects/one"));
+        assertTrue(WorkshopTextureProvider.projectChanged("projects/one", "projects/two"));
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -69,10 +69,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -143,7 +139,7 @@ public final class MainActivity extends Activity {
     private static final long DEFAULT_TICK_INTERVAL_MS = 16L;
     private static final long DEBUG_UPDATE_INTERVAL_NANOS = 250_000_000L;
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
-    private static final int MAX_RENDER_COMMANDS = 8;
+    private static final int MAX_RENDER_COMMANDS = StasisPreviewRenderer.COMMAND_CAPACITY;
     private static final int MAX_AI_AGENT_TURNS = 25;
     private static final int MAX_AI_TOOL_CALLS_PER_BATCH = 12;
     private static final int MAX_AI_READ_ONLY_BATCHES = 2;
@@ -151,7 +147,6 @@ public final class MainActivity extends Activity {
     private static final int MAX_AI_IMAGE_ATTACHMENTS = 4;
     private static final int MAX_AI_IMAGE_ATTACHMENT_BYTES = 12 * 1024 * 1024;
     private static final int MAX_AI_GENERATED_BASE64_CHARS = ((8 * 1024 * 1024 + 2) / 3) * 4 + 16;
-    private static final long MAX_PREVIEW_CAPTURE_PIXELS = 8_000_000L;
     private static final int MAX_COMMAND_HISTORY = 20;
     private static final long GITHUB_AUTO_SYNC_DEBOUNCE_MS = 2_000L;
     private static final int MAX_GITHUB_BACKUP_BYTES = 32 * 1024 * 1024;
@@ -170,19 +165,9 @@ public final class MainActivity extends Activity {
     private static final int IMPORT_AUDIO_REQUEST = 74;
     private static final int EXPORT_SUPPORT_BUNDLE_REQUEST = 75;
     private static final double GPT_IMAGE_2_LOW_1024_USD = 0.006;
-    private static final int RENDER_FRAME_HEADER_SIZE = 6;
-    private static final int RENDER_COMMAND_STRIDE = 13;
-    private static final int RENDER_FRAME_I32_CAPACITY =
-            RENDER_FRAME_HEADER_SIZE + MAX_RENDER_COMMANDS * RENDER_COMMAND_STRIDE;
-    private static final int RECT_VERTICES = 6;
-    private static final int RENDER_VERTEX_FLOATS = 6;
-    private static final int RENDER_VERTEX_BYTES = RENDER_VERTEX_FLOATS * 4;
-    private static final int RENDER_VERTEX_BUFFER_FLOATS =
-            MAX_RENDER_COMMANDS * RECT_VERTICES * RENDER_VERTEX_FLOATS;
-    private static final int SPRITE_VERTEX_FLOATS = 8;
-    private static final int SPRITE_VERTEX_BYTES = SPRITE_VERTEX_FLOATS * 4;
-    private static final int SPRITE_VERTEX_BUFFER_FLOATS =
-            MAX_RENDER_COMMANDS * RECT_VERTICES * SPRITE_VERTEX_FLOATS;
+    private static final int RENDER_FRAME_HEADER_SIZE = StasisPreviewRenderer.FRAME_HEADER_SIZE;
+    private static final int RENDER_COMMAND_STRIDE = StasisPreviewRenderer.COMMAND_STRIDE;
+    private static final int RENDER_FRAME_I32_CAPACITY = StasisPreviewRenderer.FRAME_I32_CAPACITY;
     private TextView sourceTitle;
     private LinearLayout selectedSourcePanel;
     private LinearLayout manualEditBody;
@@ -355,8 +340,8 @@ public final class MainActivity extends Activity {
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight, int[] frameValues);
     private static native String nativeSetRuntimeI32(String projectRoot, String path, int value);
     private static native String nativeGetRuntimeI32(String projectRoot, String path);
-    private static native String nativeResolveSpriteAsset(String projectRoot, int handle);
-    private static native int[] nativeDecodeSvgSprite(String path, int width, int height);
+    static native String nativeResolveSpriteAsset(String projectRoot, int handle);
+    static native int[] nativeDecodeSvgSprite(String path, int width, int height);
     private static native String nativeRunTests(String projectRoot);
     private static native String nativeCodexBeginDeviceLogin(String codexHome);
     private static native String nativeCodexAccountStatus(String codexHome);
@@ -10155,7 +10140,7 @@ public final class MainActivity extends Activity {
         return trimmed.substring("function ".length(), bodyStart).trim();
     }
 
-    private File projectRoot() {
+    File projectRoot() {
         return projectRootFile;
     }
 
@@ -10246,7 +10231,7 @@ public final class MainActivity extends Activity {
             out.add(new SourceFile(path, file, readTextFile(file)));
         }
     }
-    private String projectRootPath() {
+    String projectRootPath() {
         return projectRootPath;
     }
     private ProjectSnapshot loadBundledProject() {
@@ -11281,7 +11266,7 @@ public final class MainActivity extends Activity {
         }
 
         private final MainActivity activity;
-        private final PreviewRenderer renderer;
+        private final StasisPreviewRenderer renderer;
         private int touchX;
         private int touchY;
         private boolean touchActive;
@@ -11290,7 +11275,9 @@ public final class MainActivity extends Activity {
             super(activity);
             this.activity = activity;
             setEGLContextClientVersion(2);
-            renderer = new PreviewRenderer(activity);
+            renderer = new StasisPreviewRenderer(
+                    new WorkshopTextureProvider(activity),
+                    activity::recordRenderTimeNanos);
             setRenderer(renderer);
             setRenderMode(GLSurfaceView.RENDERMODE_WHEN_DIRTY);
             setFocusable(true);
@@ -11309,12 +11296,12 @@ public final class MainActivity extends Activity {
         }
 
         void setRenderFrameValues(int[] frameValues) {
-            renderer.setFrameValues(frameValues);
+            renderer.setFrame(frameValues);
             requestRender();
         }
 
         void captureFrame(CaptureCallback callback) {
-            renderer.requestCapture(callback);
+            renderer.requestCapture(callback::onCaptured);
             requestRender();
         }
 
@@ -11323,505 +11310,12 @@ public final class MainActivity extends Activity {
             touchX = Math.round(event.getX());
             touchY = Math.round(event.getY());
             int action = event.getActionMasked();
-            if (BuildConfig.STASIS_PUBLISHED_BUILD && action == MotionEvent.ACTION_POINTER_DOWN && event.getPointerCount() >= 3) {
+            if (BuildConfig.STASIS_PUBLISHED_BUILD && action == MotionEvent.ACTION_POINTER_DOWN
+                    && event.getPointerCount() >= 3) {
                 activity.toggleBenchmarkHudFromPreview();
             }
             touchActive = action != MotionEvent.ACTION_UP && action != MotionEvent.ACTION_CANCEL;
             return true;
-        }
-    }
-
-    private static final class PreviewRenderer implements GLSurfaceView.Renderer {
-        private static final String VERTEX_SHADER =
-                "attribute vec2 aPosition;" +
-                "attribute vec4 aColor;" +
-                "uniform vec2 uResolution;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  vec2 zeroToOne = aPosition / uResolution;" +
-                "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-                "  vColor = aColor;" +
-                "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-                "}";
-        private static final String FRAGMENT_SHADER =
-                "precision mediump float;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  gl_FragColor = vColor;" +
-                "}";
-        private static final String TEXTURE_VERTEX_SHADER =
-                "attribute vec2 aPosition;" +
-                "attribute vec2 aTexCoord;" +
-                "attribute vec4 aColor;" +
-                "uniform vec2 uResolution;" +
-                "varying vec2 vTexCoord;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  vec2 zeroToOne = aPosition / uResolution;" +
-                "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-                "  vTexCoord = aTexCoord;" +
-                "  vColor = aColor;" +
-                "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-                "}";
-        private static final String TEXTURE_FRAGMENT_SHADER =
-                "precision mediump float;" +
-                "uniform sampler2D uTexture;" +
-                "varying vec2 vTexCoord;" +
-                "varying vec4 vColor;" +
-                "void main() {" +
-                "  gl_FragColor = texture2D(uTexture, vTexCoord) * vColor;" +
-                "}";
-
-        private final MainActivity activity;
-        private final FloatBuffer vertexBuffer = ByteBuffer
-                .allocateDirect(RENDER_VERTEX_BUFFER_FLOATS * 4)
-                .order(ByteOrder.nativeOrder())
-                .asFloatBuffer();
-        private final FloatBuffer spriteVertexBuffer = ByteBuffer
-                .allocateDirect(SPRITE_VERTEX_BUFFER_FLOATS * 4)
-                .order(ByteOrder.nativeOrder())
-                .asFloatBuffer();
-        private final int[] frameValues = new int[RENDER_FRAME_I32_CAPACITY];
-        private final int[] lastDrawnFrame = new int[RENDER_FRAME_I32_CAPACITY];
-        private int program;
-        private int positionHandle;
-        private int resolutionHandle;
-        private int colorHandle;
-        private int textureProgram;
-        private int texturePositionHandle;
-        private int textureCoordHandle;
-        private int textureColorHandle;
-        private int textureResolutionHandle;
-        private int textureSamplerHandle;
-        private final Map<Integer, SpriteTexture> spriteTextures = new LinkedHashMap<>();
-        private int fallbackTexture;
-        private long manifestStamp = Long.MIN_VALUE;
-        private int surfaceWidth = 1;
-        private int surfaceHeight = 1;
-        private GamePreviewView.CaptureCallback pendingCapture;
-
-        PreviewRenderer(MainActivity activity) {
-            this.activity = activity;
-        }
-
-        synchronized void setFrameValues(int[] values) {
-            System.arraycopy(values, 0, frameValues, 0, RENDER_FRAME_I32_CAPACITY);
-        }
-
-        synchronized void requestCapture(GamePreviewView.CaptureCallback callback) {
-            if (pendingCapture != null) {
-                pendingCapture.onCaptured(null, "a newer preview capture replaced this request", new int[0]);
-            }
-            pendingCapture = callback;
-        }
-
-        @Override
-        public void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl, javax.microedition.khronos.egl.EGLConfig config) {
-            spriteTextures.clear();
-            manifestStamp = Long.MIN_VALUE;
-            program = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
-            positionHandle = GLES20.glGetAttribLocation(program, "aPosition");
-            resolutionHandle = GLES20.glGetUniformLocation(program, "uResolution");
-            colorHandle = GLES20.glGetAttribLocation(program, "aColor");
-            textureProgram = createProgram(TEXTURE_VERTEX_SHADER, TEXTURE_FRAGMENT_SHADER);
-            texturePositionHandle = GLES20.glGetAttribLocation(textureProgram, "aPosition");
-            textureCoordHandle = GLES20.glGetAttribLocation(textureProgram, "aTexCoord");
-            textureColorHandle = GLES20.glGetAttribLocation(textureProgram, "aColor");
-            textureResolutionHandle = GLES20.glGetUniformLocation(textureProgram, "uResolution");
-            textureSamplerHandle = GLES20.glGetUniformLocation(textureProgram, "uTexture");
-            fallbackTexture = createFallbackTexture();
-            GLES20.glEnable(GLES20.GL_BLEND);
-            GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
-            GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
-        }
-
-        @Override
-        public void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl, int width, int height) {
-            surfaceWidth = Math.max(1, width);
-            surfaceHeight = Math.max(1, height);
-            GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
-        }
-
-        @Override
-        public void onDrawFrame(javax.microedition.khronos.opengles.GL10 gl) {
-            long renderStartNanos = System.nanoTime();
-            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
-            synchronized (this) {
-                System.arraycopy(frameValues, 0, lastDrawnFrame, 0, lastDrawnFrame.length);
-                int commandCount = Math.max(0, Math.min(MAX_RENDER_COMMANDS, frameValues[5]));
-                int index = 0;
-                while (index < commandCount) {
-                    int base = RENDER_FRAME_HEADER_SIZE + index * RENDER_COMMAND_STRIDE;
-                    int kind = frameValues[base];
-                    if (kind == 1) {
-                        vertexBuffer.clear();
-                        int runEnd = index;
-                        while (runEnd < commandCount) {
-                            int runBase = RENDER_FRAME_HEADER_SIZE + runEnd * RENDER_COMMAND_STRIDE;
-                            if (frameValues[runBase] != 1 || !sameClip(base, runBase)) break;
-                            appendRect(runBase);
-                            runEnd += 1;
-                        }
-                        vertexBuffer.flip();
-                        applyClip(base);
-                        drawBatch((runEnd - index) * RECT_VERTICES);
-                        index = runEnd;
-                    } else if (kind == 2) {
-                        int texture = spriteTexture(frameValues[base + 6]);
-                        spriteVertexBuffer.clear();
-                        int runEnd = index;
-                        while (runEnd < commandCount) {
-                            int runBase = RENDER_FRAME_HEADER_SIZE + runEnd * RENDER_COMMAND_STRIDE;
-                            if (frameValues[runBase] != 2 || !sameClip(base, runBase)) break;
-                            int runTexture = spriteTexture(frameValues[runBase + 6]);
-                            if (runTexture != texture) break;
-                            appendSprite(runBase);
-                            runEnd += 1;
-                        }
-                        spriteVertexBuffer.flip();
-                        applyClip(base);
-                        drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture);
-                        index = runEnd;
-                    } else {
-                        index += 1;
-                    }
-                }
-                GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-            }
-            captureRenderedPixelsIfRequested();
-            activity.recordRenderTimeNanos(System.nanoTime() - renderStartNanos);
-        }
-
-        private void captureRenderedPixelsIfRequested() {
-            GamePreviewView.CaptureCallback callback;
-            synchronized (this) {
-                callback = pendingCapture;
-                pendingCapture = null;
-            }
-            if (callback == null) return;
-            int[] capturedFrame = new int[RENDER_FRAME_I32_CAPACITY];
-            synchronized (this) {
-                System.arraycopy(lastDrawnFrame, 0, capturedFrame, 0, capturedFrame.length);
-            }
-            try {
-                long pixelCount = (long)surfaceWidth * (long)surfaceHeight;
-                if (pixelCount > MAX_PREVIEW_CAPTURE_PIXELS) {
-                    callback.onCaptured(null, "preview framebuffer exceeds the 8 megapixel capture limit", capturedFrame);
-                    return;
-                }
-                IntBuffer pixels = ByteBuffer.allocateDirect(surfaceWidth * surfaceHeight * 4)
-                        .order(ByteOrder.nativeOrder()).asIntBuffer();
-                GLES20.glReadPixels(0, 0, surfaceWidth, surfaceHeight, GLES20.GL_RGBA,
-                        GLES20.GL_UNSIGNED_BYTE, pixels);
-                int[] flipped = new int[surfaceWidth * surfaceHeight];
-                for (int y = 0; y < surfaceHeight; y++) {
-                    int sourceRow = y * surfaceWidth;
-                    int targetRow = (surfaceHeight - y - 1) * surfaceWidth;
-                    for (int x = 0; x < surfaceWidth; x++) {
-                        int rgba = pixels.get(sourceRow + x);
-                        int redBlueSwapped = (rgba & 0xff00ff00)
-                                | ((rgba << 16) & 0x00ff0000) | ((rgba >> 16) & 0x000000ff);
-                        flipped[targetRow + x] = redBlueSwapped;
-                    }
-                }
-                Bitmap full = Bitmap.createBitmap(flipped, surfaceWidth, surfaceHeight, Bitmap.Config.ARGB_8888);
-                int largest = Math.max(surfaceWidth, surfaceHeight);
-                if (largest <= 1024) {
-                    callback.onCaptured(full, "", capturedFrame);
-                    return;
-                }
-                float scale = 1024.0f / largest;
-                Bitmap bounded = Bitmap.createScaledBitmap(full, Math.max(1, Math.round(surfaceWidth * scale)),
-                        Math.max(1, Math.round(surfaceHeight * scale)), true);
-                full.recycle();
-                callback.onCaptured(bounded, "", capturedFrame);
-            } catch (OutOfMemoryError error) {
-                callback.onCaptured(null, "not enough memory for bounded pixel capture", capturedFrame);
-            } catch (RuntimeException error) {
-                callback.onCaptured(null, error.getMessage(), capturedFrame);
-            }
-        }
-
-        private void appendRect(int base) {
-            int color = frameValues[base + 5];
-            float red = ((color >> 16) & 255) / 255.0f;
-            float green = ((color >> 8) & 255) / 255.0f;
-            float blue = (color & 255) / 255.0f;
-            float alpha = Math.max(0, Math.min(255, frameValues[base + 8])) / 255.0f;
-            float left = frameValues[base + 1];
-            float top = frameValues[base + 2];
-            float right = frameValues[base + 1] + frameValues[base + 3];
-            float bottom = frameValues[base + 2] + frameValues[base + 4];
-            float centerX = (left + right) * 0.5f;
-            float centerY = (top + bottom) * 0.5f;
-            double radians = Math.toRadians(frameValues[base + 7] % 360);
-            float cosine = (float)Math.cos(radians);
-            float sine = (float)Math.sin(radians);
-            putVertex(left, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(right, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-            putVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        }
-
-        private boolean sameClip(int leftBase, int rightBase) {
-            return frameValues[leftBase + 9] == frameValues[rightBase + 9]
-                    && frameValues[leftBase + 10] == frameValues[rightBase + 10]
-                    && frameValues[leftBase + 11] == frameValues[rightBase + 11]
-                    && frameValues[leftBase + 12] == frameValues[rightBase + 12];
-        }
-
-        private void applyClip(int base) {
-            int width = frameValues[base + 11];
-            int height = frameValues[base + 12];
-            if (width <= 0 || height <= 0) {
-                GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-                return;
-            }
-            long sourceRight = (long)frameValues[base + 9] + width;
-            long sourceBottom = (long)frameValues[base + 10] + height;
-            int left = Math.max(0, Math.min(surfaceWidth, frameValues[base + 9]));
-            int top = Math.max(0, Math.min(surfaceHeight, frameValues[base + 10]));
-            int right = Math.max(left, (int)Math.max(0L, Math.min((long)surfaceWidth, sourceRight)));
-            int bottom = Math.max(top, (int)Math.max(0L, Math.min((long)surfaceHeight, sourceBottom)));
-            GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
-            GLES20.glScissor(left, surfaceHeight - bottom, right - left, bottom - top);
-        }
-
-        private void putVertex(float x, float y, float centerX, float centerY,
-                float cosine, float sine, float red, float green, float blue, float alpha) {
-            float offsetX = x - centerX;
-            float offsetY = y - centerY;
-            float rotatedX = centerX + offsetX * cosine - offsetY * sine;
-            float rotatedY = centerY + offsetX * sine + offsetY * cosine;
-            vertexBuffer.put(rotatedX).put(rotatedY).put(red).put(green).put(blue).put(alpha);
-        }
-
-        private void appendSprite(int base) {
-            int color = frameValues[base + 5];
-            float red = ((color >> 16) & 255) / 255.0f;
-            float green = ((color >> 8) & 255) / 255.0f;
-            float blue = (color & 255) / 255.0f;
-            float alpha = Math.max(0, Math.min(255, frameValues[base + 8])) / 255.0f;
-            float left = frameValues[base + 1];
-            float top = frameValues[base + 2];
-            float right = frameValues[base + 1] + frameValues[base + 3];
-            float bottom = frameValues[base + 2] + frameValues[base + 4];
-            float centerX = (left + right) * 0.5f;
-            float centerY = (top + bottom) * 0.5f;
-            double radians = Math.toRadians(frameValues[base + 7] % 360);
-            float cosine = (float)Math.cos(radians);
-            float sine = (float)Math.sin(radians);
-            putRotatedSpriteVertex(left, top, centerX, centerY, cosine, sine, 0.0f, 0.0f, red, green, blue, alpha);
-            putRotatedSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-            putRotatedSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
-            putRotatedSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-            putRotatedSpriteVertex(right, bottom, centerX, centerY, cosine, sine, 1.0f, 1.0f, red, green, blue, alpha);
-            putRotatedSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
-        }
-
-        private void putRotatedSpriteVertex(float x, float y, float centerX, float centerY,
-                float cosine, float sine, float u, float v, float red, float green, float blue,
-                float alpha) {
-            float offsetX = x - centerX;
-            float offsetY = y - centerY;
-            float rotatedX = centerX + offsetX * cosine - offsetY * sine;
-            float rotatedY = centerY + offsetX * sine + offsetY * cosine;
-            spriteVertexBuffer.put(rotatedX).put(rotatedY).put(u).put(v)
-                    .put(red).put(green).put(blue).put(alpha);
-        }
-        private void drawBatch(int vertexCount) {
-            GLES20.glUseProgram(program);
-            GLES20.glUniform2f(resolutionHandle, (float)surfaceWidth, (float)surfaceHeight);
-            GLES20.glEnableVertexAttribArray(positionHandle);
-            GLES20.glEnableVertexAttribArray(colorHandle);
-            vertexBuffer.position(0);
-            GLES20.glVertexAttribPointer(positionHandle, 2, GLES20.GL_FLOAT, false, RENDER_VERTEX_BYTES, vertexBuffer);
-            vertexBuffer.position(2);
-            GLES20.glVertexAttribPointer(colorHandle, 4, GLES20.GL_FLOAT, false, RENDER_VERTEX_BYTES, vertexBuffer);
-            GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-            vertexBuffer.position(0);
-            GLES20.glDisableVertexAttribArray(colorHandle);
-            GLES20.glDisableVertexAttribArray(positionHandle);
-        }
-
-        private void drawSpriteBatch(int vertexCount, int texture) {
-            GLES20.glUseProgram(textureProgram);
-            GLES20.glUniform2f(textureResolutionHandle, (float)surfaceWidth, (float)surfaceHeight);
-            GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
-            GLES20.glUniform1i(textureSamplerHandle, 0);
-            GLES20.glEnableVertexAttribArray(texturePositionHandle);
-            GLES20.glEnableVertexAttribArray(textureCoordHandle);
-            GLES20.glEnableVertexAttribArray(textureColorHandle);
-            spriteVertexBuffer.position(0);
-            GLES20.glVertexAttribPointer(texturePositionHandle, 2, GLES20.GL_FLOAT, false, SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            spriteVertexBuffer.position(2);
-            GLES20.glVertexAttribPointer(textureCoordHandle, 2, GLES20.GL_FLOAT, false, SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            spriteVertexBuffer.position(4);
-            GLES20.glVertexAttribPointer(textureColorHandle, 4, GLES20.GL_FLOAT, false, SPRITE_VERTEX_BYTES, spriteVertexBuffer);
-            GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-            spriteVertexBuffer.position(0);
-            GLES20.glDisableVertexAttribArray(textureColorHandle);
-            GLES20.glDisableVertexAttribArray(textureCoordHandle);
-            GLES20.glDisableVertexAttribArray(texturePositionHandle);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
-        }
-
-        private int spriteTexture(int handle) {
-            File manifest = new File(activity.projectRoot(), WorkshopAssetManifest.RELATIVE_PATH);
-            long currentStamp = manifest.isFile()
-                    ? manifest.lastModified() ^ (manifest.length() << 7) : 0L;
-            if (currentStamp != manifestStamp) manifestStamp = currentStamp;
-            SpriteTexture cached = spriteTextures.get(handle);
-            if (cached != null && cached.checkedManifestStamp == manifestStamp) return cached.texture;
-            try {
-                JSONObject resolved = new JSONObject(nativeResolveSpriteAsset(
-                        activity.projectRootPath(), handle));
-                if (!"ok".equals(resolved.optString("status"))) {
-                    throw new IOException(resolved.optString("error", "sprite resolution failed"));
-                }
-                String hash = resolved.getString("content_sha256");
-                if (cached != null && hash.equals(cached.contentHash)) {
-                    cached.checkedManifestStamp = manifestStamp;
-                    return cached.texture;
-                }
-                String encoding = resolved.getString("encoding");
-                int width = resolved.getInt("width");
-                int height = resolved.getInt("height");
-                long pixels = (long)width * (long)height;
-                if (width <= 0 || height <= 0 || width > 16384 || height > 16384
-                        || pixels > 16_000_000L) {
-                    throw new IOException("sprite dimensions exceed Android decode limits");
-                }
-                File file = new File(resolved.getString("path"));
-                if (!file.isFile() || file.length() > 64L * 1024L * 1024L) {
-                    throw new IOException("sprite file exceeds Android decode limits");
-                }
-                Bitmap bitmap;
-                if ("svg".equals(encoding)) {
-                    int[] argb = nativeDecodeSvgSprite(file.getAbsolutePath(), width, height);
-                    if (argb == null || argb.length != width * height) {
-                        throw new IOException("Android could not decode the SVG sprite");
-                    }
-                    bitmap = Bitmap.createBitmap(argb, width, height, Bitmap.Config.ARGB_8888);
-                } else if ("png".equals(encoding) || "jpeg".equals(encoding)
-                        || "webp".equals(encoding)) {
-                    android.graphics.BitmapFactory.Options bounds = new android.graphics.BitmapFactory.Options();
-                    bounds.inJustDecodeBounds = true;
-                    android.graphics.BitmapFactory.decodeFile(file.getAbsolutePath(), bounds);
-                    if (bounds.outWidth != width || bounds.outHeight != height) {
-                        throw new IOException("decoded sprite dimensions do not match the manifest");
-                    }
-                    android.graphics.BitmapFactory.Options options = new android.graphics.BitmapFactory.Options();
-                    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                    options.inScaled = false;
-                    bitmap = android.graphics.BitmapFactory.decodeFile(file.getAbsolutePath(), options);
-                    if (bitmap == null) throw new IOException("Android could not decode the sprite");
-                } else {
-                    throw new IOException("unsupported Android sprite encoding " + encoding);
-                }
-                int uploaded;
-                try {
-                    uploaded = uploadBitmapTexture(bitmap);
-                } finally {
-                    bitmap.recycle();
-                }
-                SpriteTexture replacement = new SpriteTexture(uploaded, hash, manifestStamp);
-                spriteTextures.put(handle, replacement);
-                if (cached != null) GLES20.glDeleteTextures(1, new int[]{cached.texture}, 0);
-                return uploaded;
-            } catch (Exception error) {
-                if (cached != null) {
-                    cached.checkedManifestStamp = manifestStamp;
-                    return cached.texture;
-                }
-                return fallbackTexture;
-            }
-        }
-
-        private static int uploadBitmapTexture(Bitmap bitmap) throws IOException {
-            int[] textures = new int[1];
-            GLES20.glGenTextures(1, textures, 0);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textures[0]);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
-            while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
-            android.opengl.GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0);
-            int error = GLES20.glGetError();
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
-            if (error != GLES20.GL_NO_ERROR) {
-                GLES20.glDeleteTextures(1, textures, 0);
-                throw new IOException("Android texture upload failed with GL error " + error);
-            }
-            return textures[0];
-        }
-
-        private static int createFallbackTexture() {
-            ByteBuffer pixels = ByteBuffer.allocateDirect(16);
-            pixels.put(new byte[]{
-                    (byte)255, 0, (byte)255, (byte)255,
-                    35, 35, 35, (byte)255,
-                    35, 35, 35, (byte)255,
-                    (byte)255, 0, (byte)255, (byte)255});
-            pixels.flip();
-            int[] textures = new int[1];
-            GLES20.glGenTextures(1, textures, 0);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textures[0]);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
-            GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
-            GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, 2, 2, 0,
-                    GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels);
-            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
-            return textures[0];
-        }
-
-        private static final class SpriteTexture {
-            final int texture;
-            final String contentHash;
-            long checkedManifestStamp;
-
-            SpriteTexture(int texture, String contentHash, long checkedManifestStamp) {
-                this.texture = texture;
-                this.contentHash = contentHash;
-                this.checkedManifestStamp = checkedManifestStamp;
-            }
-        }
-
-        private static int createProgram(String vertexSource, String fragmentSource) {
-            int vertexShader = compileShader(GLES20.GL_VERTEX_SHADER, vertexSource);
-            int fragmentShader = compileShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource);
-            int program = GLES20.glCreateProgram();
-            GLES20.glAttachShader(program, vertexShader);
-            GLES20.glAttachShader(program, fragmentShader);
-            GLES20.glLinkProgram(program);
-            int[] linked = new int[1];
-            GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, linked, 0);
-            if (linked[0] == 0) {
-                String log = GLES20.glGetProgramInfoLog(program);
-                GLES20.glDeleteProgram(program);
-                throw new IllegalStateException("OpenGL program link failed: " + log);
-            }
-            return program;
-        }
-
-        private static int compileShader(int type, String source) {
-            int shader = GLES20.glCreateShader(type);
-            GLES20.glShaderSource(shader, source);
-            GLES20.glCompileShader(shader);
-            int[] compiled = new int[1];
-            GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0);
-            if (compiled[0] == 0) {
-                String log = GLES20.glGetShaderInfoLog(shader);
-                GLES20.glDeleteShader(shader);
-                throw new IllegalStateException("OpenGL shader compile failed: " + log);
-            }
-            return shader;
         }
     }
 

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -1,0 +1,188 @@
+package com.stasislang.workshop;
+
+import android.graphics.Bitmap;
+import android.opengl.GLES20;
+import android.util.SparseArray;
+
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProvider {
+    private final MainActivity activity;
+    private final SparseArray<SpriteTexture> textures = new SparseArray<>();
+    private final int[] deletedTexture = new int[1];
+    private File manifest;
+    private String projectRootPath;
+    private int fallbackTexture;
+    private long manifestStamp = Long.MIN_VALUE;
+
+    WorkshopTextureProvider(MainActivity activity) {
+        this.activity = activity;
+    }
+
+    @Override
+    public void onSurfaceCreated() {
+        textures.clear();
+        setProjectRoot(activity.projectRootPath());
+        manifestStamp = Long.MIN_VALUE;
+        fallbackTexture = createFallbackTexture();
+    }
+
+    @Override
+    public int textureFor(int handle) {
+        String currentProjectRoot = activity.projectRootPath();
+        if (projectChanged(projectRootPath, currentProjectRoot)) {
+            clearTextures();
+            setProjectRoot(currentProjectRoot);
+        }
+        long currentStamp = manifest.isFile()
+                ? manifest.lastModified() ^ (manifest.length() << 7) : 0L;
+        if (currentStamp != manifestStamp) manifestStamp = currentStamp;
+        SpriteTexture cached = textures.get(handle);
+        if (cached != null && cached.checkedManifestStamp == manifestStamp) {
+            return cached.texture;
+        }
+        try {
+            JSONObject resolved = new JSONObject(MainActivity.nativeResolveSpriteAsset(
+                    currentProjectRoot, handle));
+            if (!"ok".equals(resolved.optString("status"))) {
+                throw new IOException(resolved.optString("error", "sprite resolution failed"));
+            }
+            String hash = resolved.getString("content_sha256");
+            if (cached != null && hash.equals(cached.contentHash)) {
+                cached.checkedManifestStamp = manifestStamp;
+                return cached.texture;
+            }
+            Bitmap bitmap = decode(resolved);
+            int uploaded;
+            try {
+                uploaded = upload(bitmap);
+            } finally {
+                bitmap.recycle();
+            }
+            textures.put(handle, new SpriteTexture(uploaded, hash, manifestStamp));
+            if (cached != null) deleteTexture(cached.texture);
+            return uploaded;
+        } catch (Exception error) {
+            if (cached != null) {
+                cached.checkedManifestStamp = manifestStamp;
+                return cached.texture;
+            }
+            return fallbackTexture;
+        }
+    }
+
+    static boolean projectChanged(String boundRoot, String currentRoot) {
+        return boundRoot == null || !boundRoot.equals(currentRoot);
+    }
+
+    private void setProjectRoot(String root) {
+        projectRootPath = root;
+        manifest = new File(root, WorkshopAssetManifest.RELATIVE_PATH);
+        manifestStamp = Long.MIN_VALUE;
+    }
+
+    private void clearTextures() {
+        for (int index = 0; index < textures.size(); index++) {
+            deleteTexture(textures.valueAt(index).texture);
+        }
+        textures.clear();
+    }
+
+    private void deleteTexture(int texture) {
+        deletedTexture[0] = texture;
+        GLES20.glDeleteTextures(1, deletedTexture, 0);
+    }
+
+    private static Bitmap decode(JSONObject resolved) throws Exception {
+        String encoding = resolved.getString("encoding");
+        int width = resolved.getInt("width");
+        int height = resolved.getInt("height");
+        long pixels = (long)width * height;
+        if (width <= 0 || height <= 0 || width > 16384 || height > 16384
+                || pixels > 16_000_000L) {
+            throw new IOException("sprite dimensions exceed Android decode limits");
+        }
+        File file = new File(resolved.getString("path"));
+        if (!file.isFile() || file.length() > 64L * 1024L * 1024L) {
+            throw new IOException("sprite file exceeds Android decode limits");
+        }
+        if ("svg".equals(encoding)) {
+            int[] argb = MainActivity.nativeDecodeSvgSprite(file.getAbsolutePath(), width, height);
+            if (argb == null || argb.length != width * height) {
+                throw new IOException("Android could not decode the SVG sprite");
+            }
+            return Bitmap.createBitmap(argb, width, height, Bitmap.Config.ARGB_8888);
+        }
+        if (!"png".equals(encoding) && !"jpeg".equals(encoding) && !"webp".equals(encoding)) {
+            throw new IOException("unsupported Android sprite encoding " + encoding);
+        }
+        android.graphics.BitmapFactory.Options bounds = new android.graphics.BitmapFactory.Options();
+        bounds.inJustDecodeBounds = true;
+        android.graphics.BitmapFactory.decodeFile(file.getAbsolutePath(), bounds);
+        if (bounds.outWidth != width || bounds.outHeight != height) {
+            throw new IOException("decoded sprite dimensions do not match the manifest");
+        }
+        android.graphics.BitmapFactory.Options options = new android.graphics.BitmapFactory.Options();
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+        options.inScaled = false;
+        Bitmap bitmap = android.graphics.BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+        if (bitmap == null) throw new IOException("Android could not decode the sprite");
+        return bitmap;
+    }
+
+    private static int upload(Bitmap bitmap) throws IOException {
+        int[] names = new int[1];
+        GLES20.glGenTextures(1, names, 0);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, names[0]);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
+        while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
+        android.opengl.GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmap, 0);
+        int error = GLES20.glGetError();
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+        if (error != GLES20.GL_NO_ERROR) {
+            GLES20.glDeleteTextures(1, names, 0);
+            throw new IOException("Android texture upload failed with GL error " + error);
+        }
+        return names[0];
+    }
+
+    private static int createFallbackTexture() {
+        ByteBuffer pixels = ByteBuffer.allocateDirect(16);
+        pixels.put(new byte[]{
+                (byte)255, 0, (byte)255, (byte)255,
+                35, 35, 35, (byte)255,
+                35, 35, 35, (byte)255,
+                (byte)255, 0, (byte)255, (byte)255});
+        pixels.flip();
+        int[] names = new int[1];
+        GLES20.glGenTextures(1, names, 0);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, names[0]);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
+        GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, 2, 2, 0,
+                GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+        return names[0];
+    }
+
+    private static final class SpriteTexture {
+        final int texture;
+        final String contentHash;
+        long checkedManifestStamp;
+
+        SpriteTexture(int texture, String contentHash, long checkedManifestStamp) {
+            this.texture = texture;
+            this.contentHash = contentHash;
+            this.checkedManifestStamp = checkedManifestStamp;
+        }
+    }
+}

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -28,7 +28,11 @@ public final class MainActivity extends SDLActivity {
         } catch (IOException error) {
             throw new IllegalStateException("Unable to install bundled Stasis assets", error);
         }
-        nativeSetAssetRoot(root.getAbsolutePath());
+        File assetBase = new File(root, "@STASIS_ASSET_BASE@");
+        if (!assetBase.isDirectory()) {
+            throw new IllegalStateException("Bundled Stasis asset base is missing: " + assetBase);
+        }
+        nativeSetAssetRoot(assetBase.getAbsolutePath());
         super.onCreate(state);
     }
 

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -14,7 +14,12 @@ static int configure_asset_root(void) {
         return -1;
     }
     char path[1024];
-    int written = snprintf(path, sizeof(path), "%sstasis_game", base);
+    int written = snprintf(
+        path,
+        sizeof(path),
+        "%sstasis_game/@STASIS_ASSET_BASE@",
+        base
+    );
     SDL_free(base);
     if (written < 0 || (size_t)written >= sizeof(path)) {
         return -1;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -33,8 +33,8 @@ option(STASIS_MOBILE_RUNTIME_BUILD_TESTS "Build mobile runtime lifecycle tests" 
 # Android and other restricted platforms do not support the OpenGL 2.1 + GLEW path.
 option(
     STASIS_GRAPHICS_SDL_ONLY
-    "Build SDL_Renderer-only runtime (no OpenGL/GLEW backend)"
-    ${STASIS_MOBILE_PLATFORM}
+    "Build the canonical SDL_Renderer runtime (disable only for legacy GL conformance)"
+    ON
 )
 
 # Prefer static CRT when possible (for single-exe bundling)
@@ -155,6 +155,12 @@ endif()
 
 if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
     enable_testing()
+    add_executable(
+        stasis_render_contract_test
+        tests/stasis_render_contract_test.c
+    )
+    target_include_directories(stasis_render_contract_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_render_command_contract COMMAND stasis_render_contract_test)
     add_executable(
         stasis_display_scale_test
         tests/stasis_display_scale_test.c

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -148,7 +148,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
     )
     install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
     install(
-        FILES stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
+        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
         DESTINATION include
     )
 endif()
@@ -170,6 +170,12 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         target_link_libraries(stasis_display_scale_test PRIVATE m)
     endif()
     add_test(NAME stasis_display_scale_contract COMMAND stasis_display_scale_test)
+    add_executable(
+        stasis_asset_path_test
+        tests/stasis_asset_path_test.c
+    )
+    target_include_directories(stasis_asset_path_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_asset_path_contract COMMAND stasis_asset_path_test)
     add_executable(
         stasis_mobile_runtime_test
         tests/stasis_mobile_runtime_test.c

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,6 +1,8 @@
 # Stasis Graphics Runtime
 
-Native SDL2+OpenGL graphics library for Stasis programs.
+Native SDL2 graphics library for Stasis programs. Shipping desktop, Android,
+and iOS builds compile the same `stasis_graphics.c` command interpreter and SDL
+resource lifecycle. See `docs/shared_renderer_process.md` for the contract.
 
 ## Framebuffer capture
 
@@ -65,10 +67,9 @@ captures use the drawable resolution.
 
 ## Android (NDK)
 
-Android builds currently use the SDL_Renderer backend only (no OpenGL 2.1/GLEW path):
-
-- Configure `runtime/CMakeLists.txt` with `-DSTASIS_GRAPHICS_SDL_ONLY=ON`
-- Use an NDK toolchain (direct CMake toolchain or vcpkg Android triplets)
+Android uses the canonical SDL renderer process. `STASIS_GRAPHICS_SDL_ONLY`
+defaults to `ON` on every platform; release automation passes it explicitly.
+Use an NDK toolchain through direct CMake or vcpkg Android triplets.
 
 Build helper:
 - `runtime/build_android.ps1` (requires `ANDROID_NDK_HOME` and vcpkg via `VCPKG_ROOT` or `C:\vcpkg`)
@@ -95,9 +96,15 @@ If you prefer to build manually or vcpkg is unavailable:
    cmake --build . --config Release
    ```
 
-## Sprite Atlas Runtime Settings
+## Legacy GL conformance
 
-The OpenGL sprite path now uses a multi-page atlas instead of one fixed texture.
+`-DSTASIS_GRAPHICS_SDL_ONLY=OFF` retains the old desktop GL adapter for bounded
+conformance investigation. It is not a shipping renderer. `STASIS_USE_SDL=1`
+selects the canonical path in such a legacy build.
+
+## Legacy GL atlas settings
+
+The opt-in GL adapter uses a multi-page atlas instead of one fixed texture.
 
 - `STASIS_GFX_ATLAS_W` and `STASIS_GFX_ATLAS_H` set the per-page atlas size.
 - The default page size is `2048x2048`, clamped to the runtime `GL_MAX_TEXTURE_SIZE`.
@@ -111,7 +118,7 @@ The library exports these functions for Stasis programs:
 
 | Function | Description |
 |----------|-------------|
-| `stasis_init_window(w, h, title)` | Create window with OpenGL context |
+| `stasis_init_window(w, h, title)` | Create the SDL window and renderer |
 | `stasis_begin_frame()` | Start a new frame |
 | `stasis_end_frame()` | Render queued lines, swap buffers |
 | `stasis_clear(r, g, b, a)` | Clear screen with color |
@@ -143,9 +150,9 @@ Guest code should read keyboard/pointer/quit state through `src/runtime/host_fra
 directly or via the HostFrame-backed stdlib wrappers in `src/stdlib/graphics.stasis` and
 `src/stdlib/game_input.stasis`.
 
-## Sprite Atlas Configuration
+## Legacy GL atlas configuration
 
-The OpenGL sprite path now uses paged atlases with region reuse instead of one fixed compile-time atlas.
+The opt-in GL adapter uses paged atlases with region reuse instead of one fixed compile-time atlas.
 The runtime creates new atlas pages on demand, reuses freed regions on reload/resize, and keeps sprite
 handles in a growable table.
 

--- a/runtime/build.bat
+++ b/runtime/build.bat
@@ -41,9 +41,9 @@ if "%VCPKG_TRIPLET%"=="" (
     set VCPKG_TRIPLET=x64-windows-static
 )
 
-:: Install SDL2 + SDL2_image + GLEW for the chosen triplet
-echo Checking for SDL2/SDL2_image/GLEW with triplet %VCPKG_TRIPLET%...
-%VCPKG_ROOT%\vcpkg install sdl2:%VCPKG_TRIPLET% sdl2-image:%VCPKG_TRIPLET% glew:%VCPKG_TRIPLET% --recurse
+:: Shipping builds use the same SDL renderer process on desktop and mobile.
+echo Checking for SDL2/SDL2_image with triplet %VCPKG_TRIPLET%...
+%VCPKG_ROOT%\vcpkg install sdl2:%VCPKG_TRIPLET% sdl2-image:%VCPKG_TRIPLET% --recurse
 if %ERRORLEVEL% neq 0 (
     echo Error: vcpkg install failed.
     exit /b 1
@@ -129,7 +129,7 @@ echo.
 echo Copying static dependency libs to build\\Release for single-exe links...
 set "STATIC_LIB_DIR=%VCPKG_ROOT%\\installed\\%VCPKG_TRIPLET%\\lib"
 set "MANUAL_LIB_DIR=%STATIC_LIB_DIR%\\manual-link"
-for %%F in (SDL2-static.lib libglew32.lib OpenGL32.Lib GlU32.Lib) do (
+for %%F in (SDL2-static.lib) do (
     if exist "%STATIC_LIB_DIR%\\%%F" (
         copy /Y "%STATIC_LIB_DIR%\\%%F" "%BUILD_DIR%\\Release" >NUL
     ) else (

--- a/runtime/stasis_asset_path.h
+++ b/runtime/stasis_asset_path.h
@@ -1,0 +1,48 @@
+#ifndef STASIS_ASSET_PATH_H
+#define STASIS_ASSET_PATH_H
+
+#include <stddef.h>
+#include <string.h>
+
+static int stasis_asset_normalize_relative_path(
+    const char *path,
+    char *out,
+    size_t out_size
+) {
+    const char *cursor = path;
+    size_t used = 0;
+    if (path == NULL || out == NULL || out_size < 2) return 0;
+    if (path[0] == '/' || path[0] == '\\') return 0;
+    if (((path[0] >= 'A' && path[0] <= 'Z') ||
+         (path[0] >= 'a' && path[0] <= 'z')) &&
+        path[1] == ':' && (path[2] == '/' || path[2] == '\\')) {
+        return 0;
+    }
+
+    while (*cursor != '\0') {
+        while (*cursor == '/' || *cursor == '\\') cursor += 1;
+        if (*cursor == '\0') break;
+
+        const char *segment = cursor;
+        while (*cursor != '\0' && *cursor != '/' && *cursor != '\\') cursor += 1;
+        size_t segment_len = (size_t)(cursor - segment);
+        if (segment_len == 1 && segment[0] == '.') continue;
+        if (segment_len == 2 && segment[0] == '.' && segment[1] == '.') {
+            while (used > 0 && out[used - 1] != '/') used -= 1;
+            if (used > 0) used -= 1;
+            continue;
+        }
+
+        size_t separator = used > 0 ? 1 : 0;
+        if (used + separator + segment_len + 1 > out_size) return 0;
+        if (separator != 0) out[used++] = '/';
+        memcpy(out + used, segment, segment_len);
+        used += segment_len;
+    }
+
+    if (used == 0) return 0;
+    out[used] = '\0';
+    return 1;
+}
+
+#endif

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -22,6 +22,10 @@
 #include <limits.h>
 #include <ctype.h>
 #include <time.h>
+#if defined(__ANDROID__)
+#include <android/log.h>
+#endif
+#include "stasis_render_contract.h"
 #include "stasis_display_scale.h"
 #if defined(_WIN32)
 #include <sys/types.h>
@@ -54,8 +58,12 @@ static void stasis_sdl_log_output(void* userdata, int category, SDL_LogPriority 
     (void)category;
     (void)priority;
     if (!message) return;
+#if defined(__ANDROID__)
+    __android_log_write(ANDROID_LOG_INFO, "Stasis", message);
+#else
     fprintf(stderr, "%s\n", message);
     fflush(stderr);
+#endif
 }
 
 #if defined(STASIS_GRAPHICS_STATIC)
@@ -3373,6 +3381,7 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
 
     SDL_LogSetOutputFunction(stasis_sdl_log_output, NULL);
     SDL_LogSetAllPriority(SDL_LOG_PRIORITY_INFO);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) < 0) {
         SDL_Log("SDL_Init failed: %s", SDL_GetError());
         return 0;
@@ -3768,6 +3777,7 @@ STASIS_EXPORT void stasis_begin_frame(void) {
     g_line_count = 0;
     if (g_use_sdl_renderer) {
         SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
+        SDL_RenderSetClipRect(g_renderer, NULL);
     } else {
         (void)g_force_debug_overlay;
     }
@@ -3946,19 +3956,25 @@ static void flush_sprites_before_text(void) {
 }
 
 static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
+    static int contract_logged = 0;
     if (!cmd_i32 || !cmd_f32) return;
 
-    const int32_t magic = cmd_i32[0];
-    const int32_t version = cmd_i32[1];
-    if (magic != 0x47584631 || version != 1) {
+    if (!stasis_render_v1_is_valid(cmd_i32)) {
+        if (!contract_logged) {
+            SDL_Log(
+                "Stasis render contract rejected: magic=%d version=%d",
+                cmd_i32[STASIS_RENDER_I_MAGIC],
+                cmd_i32[STASIS_RENDER_I_VERSION]);
+            contract_logged = 1;
+        }
         return;
     }
 
-    const int32_t flags = cmd_i32[2];
-    const int32_t gfx_cmd_max_lines = MAX_LINES;
-    const int32_t gfx_cmd_max_sprites = 4096;  /* must match MAX_SPRITE_VERTS/6 */
-    const int32_t gfx_cmd_max_text = 2048;
-    const int32_t gfx_cmd_max_text_bytes = 65536;
+    const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
+    const int32_t gfx_cmd_max_lines = STASIS_RENDER_MAX_LINES;
+    const int32_t gfx_cmd_max_sprites = STASIS_RENDER_MAX_SPRITES;
+    const int32_t gfx_cmd_max_text = STASIS_RENDER_MAX_TEXT;
+    const int32_t gfx_cmd_max_text_bytes = STASIS_RENDER_TEXT_MAX_BYTES;
 
     int32_t line_count = cmd_i32[3];
     int32_t sprite_count = cmd_i32[4];
@@ -3975,9 +3991,21 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     if (text_count > gfx_cmd_max_text) text_count = gfx_cmd_max_text;
     if (text_bytes_used > gfx_cmd_max_text_bytes) text_bytes_used = gfx_cmd_max_text_bytes;
 
+    if (!contract_logged) {
+        SDL_Log(
+            "Stasis render contract v%d trace=%u flags=%d lines=%d sprites=%d text=%d",
+            STASIS_RENDER_V1_VERSION,
+            (unsigned int)stasis_render_v1_trace(cmd_i32, cmd_f32, cmd_u8),
+            flags,
+            line_count,
+            sprite_count,
+            text_count);
+        contract_logged = 1;
+    }
+
     stasis_begin_frame();
 
-    if ((flags & 1) != 0) {
+    if ((flags & STASIS_RENDER_FLAG_CLEAR) != 0) {
         stasis_clear(cmd_f32[0], cmd_f32[1], cmd_f32[2], cmd_f32[3]);
     }
 
@@ -3992,7 +4020,7 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
 
     /* sprites: i32 header is 32, then sprite payload */
     if (sprite_count > 0) {
-        const int32_t* sprites = cmd_i32 + 32;
+        const int32_t* sprites = cmd_i32 + STASIS_RENDER_I_SPRITE_BASE;
         if (!g_debug_hash_enabled && !g_use_sdl_renderer) {
             stasis_gfx_draw_sprites_i32_fast(sprites, sprite_count);
         } else {
@@ -4018,8 +4046,8 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     /* text: payload is split between i32 metadata + u8 bytes + f32 color/pos */
     /* byte_off < 0 encodes cached text run handle (no cmd_u8 access). */
     if (text_count > 0) {
-        const int32_t text_i32_base = 32 + gfx_cmd_max_sprites * 7;
-        const int32_t text_f32_base = 4 + gfx_cmd_max_lines * 8;
+        const int32_t text_i32_base = STASIS_RENDER_I_TEXT_BASE;
+        const int32_t text_f32_base = STASIS_RENDER_F_TEXT_BASE;
         const int32_t* text_meta = cmd_i32 + text_i32_base;
 
         for (int i = 0; i < text_count; i++) {
@@ -4042,9 +4070,8 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
                 continue;
             }
             if (!cmd_u8 || text_bytes_used <= 0) continue;
-            if (byte_off >= text_bytes_used) continue;
-            if (byte_len < 0) continue;
-            if (byte_off + byte_len >= text_bytes_used) continue;
+            if (!stasis_render_v1_text_span_is_valid(
+                    byte_off, byte_len, text_bytes_used)) continue;
 
             const char* text = (const char*)(cmd_u8 + byte_off);
 
@@ -4061,7 +4088,7 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     }
 
     /* Present only if requested (lets benchmarks exclude swap/vsync). */
-    if ((flags & 2) != 0) {
+    if ((flags & STASIS_RENDER_FLAG_PRESENT) != 0) {
         stasis_end_frame();
     }
 }
@@ -4492,6 +4519,8 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
     if (!e) return;
 
     if (w <= 0 || h <= 0) return;
+    if (a < 0) a = 0;
+    if (a > 255) a = 255;
 
     /* Re-rasterize only when explicitly invalidated (resize/reload).
      *

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -15,6 +15,7 @@
 #endif
 #include <stdbool.h>
 #include <string.h>
+#include "stasis_asset_path.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -1283,10 +1284,19 @@ static int resolve_asset_path(const char* path, char* out, size_t out_size) {
     if (!out || out_size < 2 || !path || !*path) return 0;
     ensure_asset_base();
     if (is_absolute_path(path)) {
+        if (g_asset_env[0] != 0) return 0;
         strncpy(out, path, out_size - 1);
         out[out_size - 1] = 0;
     } else {
-        snprintf(out, out_size, "%s/%s", g_asset_base, path);
+        char normalized[1024];
+        const char* relative = path;
+        if (g_asset_env[0] != 0) {
+            if (!stasis_asset_normalize_relative_path(path, normalized, sizeof(normalized))) {
+                return 0;
+            }
+            relative = normalized;
+        }
+        snprintf(out, out_size, "%s/%s", g_asset_base, relative);
         out[out_size - 1] = 0;
     }
     for (char* p = out; *p; ++p) {

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -1,5 +1,6 @@
 #include "stasis_mobile_runtime.h"
 #include "stasis_mobile_aot_runtime.h"
+#include "stasis_render_contract.h"
 
 #include <stddef.h>
 #include <string.h>
@@ -25,9 +26,9 @@ void stasis_shutdown(void);
 
 static int32_t host_i32[768];
 static float host_f32[64];
-static int32_t gfx_cmd_i32[34848];
-static float gfx_cmd_f32[92292];
-static uint8_t gfx_cmd_u8[65536];
+static int32_t gfx_cmd_i32[STASIS_RENDER_I32_COUNT];
+static float gfx_cmd_f32[STASIS_RENDER_F32_COUNT];
+static uint8_t gfx_cmd_u8[STASIS_RENDER_U8_COUNT];
 static int32_t host_req_seq;
 static int32_t host_req_flags;
 static int32_t host_req_window_w_px;
@@ -63,9 +64,12 @@ static void bind_host_globals(void) {
     host_req_window_h_px = 0;
     stasis_jit_register_global_i32_array(hash_global_path("host_i32"), 0, host_i32, 768);
     stasis_jit_register_global_f32_array(hash_global_path("host_f32"), 0, host_f32, 64);
-    stasis_jit_register_global_i32_array(hash_global_path("gfx_cmd_i32"), 0, gfx_cmd_i32, 34848);
-    stasis_jit_register_global_f32_array(hash_global_path("gfx_cmd_f32"), 0, gfx_cmd_f32, 92292);
-    stasis_jit_register_global_u8_array(hash_global_path("gfx_cmd_u8"), 0, gfx_cmd_u8, 65536);
+    stasis_jit_register_global_i32_array(
+        hash_global_path("gfx_cmd_i32"), 0, gfx_cmd_i32, STASIS_RENDER_I32_COUNT);
+    stasis_jit_register_global_f32_array(
+        hash_global_path("gfx_cmd_f32"), 0, gfx_cmd_f32, STASIS_RENDER_F32_COUNT);
+    stasis_jit_register_global_u8_array(
+        hash_global_path("gfx_cmd_u8"), 0, gfx_cmd_u8, STASIS_RENDER_U8_COUNT);
     stasis_jit_register_global_i32_ptr(hash_global_path("host_req_seq"), &host_req_seq);
     stasis_jit_register_global_i32_ptr(hash_global_path("host_req_flags"), &host_req_flags);
     stasis_jit_register_global_i32_ptr(

--- a/runtime/stasis_render_contract.h
+++ b/runtime/stasis_render_contract.h
@@ -1,0 +1,176 @@
+#ifndef STASIS_RENDER_CONTRACT_H
+#define STASIS_RENDER_CONTRACT_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Canonical guest-to-renderer command ABI used by JIT and AOT runtimes. */
+#define STASIS_RENDER_V1_MAGIC 0x47584631
+#define STASIS_RENDER_V1_VERSION 1
+#define STASIS_RENDER_V1_TRACE_VERSION 1
+
+#define STASIS_RENDER_FLAG_CLEAR 1
+#define STASIS_RENDER_FLAG_PRESENT 2
+
+#define STASIS_RENDER_I_MAGIC 0
+#define STASIS_RENDER_I_VERSION 1
+#define STASIS_RENDER_I_FLAGS 2
+#define STASIS_RENDER_I_LINE_COUNT 3
+#define STASIS_RENDER_I_SPRITE_COUNT 4
+#define STASIS_RENDER_I_TEXT_COUNT 7
+#define STASIS_RENDER_I_TEXT_BYTES_USED 9
+#define STASIS_RENDER_I_SPRITE_BASE 32
+
+#define STASIS_RENDER_F_CLEAR_BASE 0
+#define STASIS_RENDER_F_LINE_BASE 4
+
+#define STASIS_RENDER_MAX_LINES 10000
+#define STASIS_RENDER_LINE_F32_STRIDE 8
+#define STASIS_RENDER_MAX_SPRITES 4096
+#define STASIS_RENDER_SPRITE_I32_STRIDE 7
+#define STASIS_RENDER_MAX_TEXT 2048
+#define STASIS_RENDER_TEXT_I32_STRIDE 3
+#define STASIS_RENDER_TEXT_F32_STRIDE 6
+#define STASIS_RENDER_TEXT_MAX_BYTES 65536
+
+#define STASIS_RENDER_I_TEXT_BASE \
+    (STASIS_RENDER_I_SPRITE_BASE + \
+     STASIS_RENDER_MAX_SPRITES * STASIS_RENDER_SPRITE_I32_STRIDE)
+#define STASIS_RENDER_F_TEXT_BASE \
+    (STASIS_RENDER_F_LINE_BASE + \
+     STASIS_RENDER_MAX_LINES * STASIS_RENDER_LINE_F32_STRIDE)
+#define STASIS_RENDER_I32_COUNT \
+    (STASIS_RENDER_I_TEXT_BASE + \
+     STASIS_RENDER_MAX_TEXT * STASIS_RENDER_TEXT_I32_STRIDE)
+#define STASIS_RENDER_F32_COUNT \
+    (STASIS_RENDER_F_TEXT_BASE + \
+     STASIS_RENDER_MAX_TEXT * STASIS_RENDER_TEXT_F32_STRIDE)
+#define STASIS_RENDER_U8_COUNT STASIS_RENDER_TEXT_MAX_BYTES
+
+static inline int32_t stasis_render_clamp_count(int32_t value, int32_t maximum) {
+    if (value < 0) return 0;
+    return value > maximum ? maximum : value;
+}
+
+static inline int stasis_render_v1_is_valid(const int32_t *cmd_i32) {
+    return cmd_i32 != NULL &&
+        cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V1_MAGIC &&
+        cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V1_VERSION;
+}
+
+static inline int stasis_render_v1_text_span_is_valid(
+    int32_t byte_offset,
+    int32_t byte_length,
+    int32_t text_bytes_used
+) {
+    return byte_offset >= 0 && byte_length >= 0 &&
+        byte_offset < text_bytes_used &&
+        byte_length < text_bytes_used - byte_offset;
+}
+
+static inline uint32_t stasis_render_trace_mix_u32(uint32_t hash, uint32_t value) {
+    hash ^= (value >> 0) & 0xffu; hash *= 16777619u;
+    hash ^= (value >> 8) & 0xffu; hash *= 16777619u;
+    hash ^= (value >> 16) & 0xffu; hash *= 16777619u;
+    hash ^= (value >> 24) & 0xffu; hash *= 16777619u;
+    return hash;
+}
+
+static inline uint32_t stasis_render_trace_mix_f32(uint32_t hash, float value) {
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return stasis_render_trace_mix_u32(hash, bits);
+}
+
+static inline uint32_t stasis_render_trace_mix_bytes(
+    uint32_t hash,
+    const uint8_t *bytes,
+    int32_t length
+) {
+    if (bytes == NULL || length <= 0) return hash;
+    for (int32_t index = 0; index < length; index++) {
+        hash ^= bytes[index];
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+/*
+ * Returns a backend-independent trace of the interpreted v1 frame. The trace
+ * includes command kind markers, normalized counts, every consumed value, and
+ * the fixed clear -> line -> sprite -> cached/text -> present order.
+ */
+static inline uint32_t stasis_render_v1_trace(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8
+) {
+    if (!stasis_render_v1_is_valid(cmd_i32) || cmd_f32 == NULL) return 0;
+
+    const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
+    const int32_t line_count = stasis_render_clamp_count(
+        cmd_i32[STASIS_RENDER_I_LINE_COUNT], STASIS_RENDER_MAX_LINES);
+    const int32_t sprite_count = stasis_render_clamp_count(
+        cmd_i32[STASIS_RENDER_I_SPRITE_COUNT], STASIS_RENDER_MAX_SPRITES);
+    const int32_t text_count = stasis_render_clamp_count(
+        cmd_i32[STASIS_RENDER_I_TEXT_COUNT], STASIS_RENDER_MAX_TEXT);
+    const int32_t text_bytes_used = stasis_render_clamp_count(
+        cmd_i32[STASIS_RENDER_I_TEXT_BYTES_USED], STASIS_RENDER_TEXT_MAX_BYTES);
+
+    uint32_t hash = 2166136261u;
+    hash = stasis_render_trace_mix_u32(hash, STASIS_RENDER_V1_TRACE_VERSION);
+    if ((flags & STASIS_RENDER_FLAG_CLEAR) != 0) {
+        hash = stasis_render_trace_mix_u32(hash, 1u);
+        for (int index = 0; index < 4; index++) {
+            hash = stasis_render_trace_mix_f32(
+                hash, cmd_f32[STASIS_RENDER_F_CLEAR_BASE + index]);
+        }
+    }
+
+    for (int32_t index = 0; index < line_count; index++) {
+        hash = stasis_render_trace_mix_u32(hash, 2u);
+        const int32_t base = STASIS_RENDER_F_LINE_BASE +
+            index * STASIS_RENDER_LINE_F32_STRIDE;
+        for (int field = 0; field < STASIS_RENDER_LINE_F32_STRIDE; field++) {
+            hash = stasis_render_trace_mix_f32(hash, cmd_f32[base + field]);
+        }
+    }
+
+    for (int32_t index = 0; index < sprite_count; index++) {
+        hash = stasis_render_trace_mix_u32(hash, 3u);
+        const int32_t base = STASIS_RENDER_I_SPRITE_BASE +
+            index * STASIS_RENDER_SPRITE_I32_STRIDE;
+        for (int field = 0; field < STASIS_RENDER_SPRITE_I32_STRIDE; field++) {
+            hash = stasis_render_trace_mix_u32(hash, (uint32_t)cmd_i32[base + field]);
+        }
+    }
+
+    for (int32_t index = 0; index < text_count; index++) {
+        const int32_t meta_base = STASIS_RENDER_I_TEXT_BASE +
+            index * STASIS_RENDER_TEXT_I32_STRIDE;
+        const int32_t float_base = STASIS_RENDER_F_TEXT_BASE +
+            index * STASIS_RENDER_TEXT_F32_STRIDE;
+        const int32_t byte_offset = cmd_i32[meta_base + 1];
+        const int32_t byte_length = cmd_i32[meta_base + 2];
+        hash = stasis_render_trace_mix_u32(hash, byte_offset < 0 ? 4u : 5u);
+        for (int field = 0; field < STASIS_RENDER_TEXT_I32_STRIDE; field++) {
+            hash = stasis_render_trace_mix_u32(hash, (uint32_t)cmd_i32[meta_base + field]);
+        }
+        for (int field = 0; field < STASIS_RENDER_TEXT_F32_STRIDE; field++) {
+            hash = stasis_render_trace_mix_f32(hash, cmd_f32[float_base + field]);
+        }
+        if (byte_length > 0 && stasis_render_v1_text_span_is_valid(
+                byte_offset, byte_length, text_bytes_used)) {
+            hash = stasis_render_trace_mix_bytes(
+                hash, cmd_u8 == NULL ? NULL : cmd_u8 + byte_offset, byte_length);
+        }
+    }
+
+    if ((flags & STASIS_RENDER_FLAG_PRESENT) != 0) {
+        hash = stasis_render_trace_mix_u32(hash, 6u);
+    }
+    return hash;
+}
+
+#endif

--- a/runtime/stasis_render_trace.c
+++ b/runtime/stasis_render_trace.c
@@ -1,0 +1,9 @@
+#include "stasis_render_contract.h"
+
+uint32_t stasis_render_v1_trace_native(
+    const int32_t *cmd_i32,
+    const float *cmd_f32,
+    const uint8_t *cmd_u8
+) {
+    return stasis_render_v1_trace(cmd_i32, cmd_f32, cmd_u8);
+}

--- a/runtime/tests/stasis_asset_path_test.c
+++ b/runtime/tests/stasis_asset_path_test.c
@@ -1,0 +1,36 @@
+#include "stasis_asset_path.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define CHECK_PATH(input, expected) do { \
+    char resolved[128] = {0}; \
+    if (!stasis_asset_normalize_relative_path(input, resolved, sizeof(resolved)) || \
+        strcmp(resolved, expected) != 0) { \
+        fprintf(stderr, "asset path mismatch: %s -> %s (expected %s)\n", \
+            input, resolved, expected); \
+        return 1; \
+    } \
+} while (0)
+
+int main(void) {
+    CHECK_PATH("assets/ball.svg", "assets/ball.svg");
+    CHECK_PATH("../assets/fonts/ui.ttf", "assets/fonts/ui.ttf");
+    CHECK_PATH("../../assets/sprites/unit.svg", "assets/sprites/unit.svg");
+    CHECK_PATH("src/../assets/ball.svg", "assets/ball.svg");
+    CHECK_PATH("./assets\\ball.svg", "assets/ball.svg");
+
+    char too_small[4] = {0};
+    if (stasis_asset_normalize_relative_path("assets/ball.svg", too_small, sizeof(too_small))) {
+        fprintf(stderr, "asset path unexpectedly fit in bounded output\n");
+        return 1;
+    }
+    char absolute[128] = {0};
+    if (stasis_asset_normalize_relative_path("/tmp/ball.svg", absolute, sizeof(absolute)) ||
+        stasis_asset_normalize_relative_path("C:\\tmp\\ball.svg", absolute, sizeof(absolute)) ||
+        stasis_asset_normalize_relative_path("\\\\server\\share\\ball.svg", absolute, sizeof(absolute))) {
+        fprintf(stderr, "absolute asset path unexpectedly accepted\n");
+        return 1;
+    }
+    return 0;
+}

--- a/runtime/tests/stasis_render_contract_test.c
+++ b/runtime/tests/stasis_render_contract_test.c
@@ -1,0 +1,80 @@
+#include "stasis_render_contract.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void build_representative_frame(
+    int32_t *i32s,
+    float *f32s,
+    uint8_t *u8s
+) {
+    i32s[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
+    i32s[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
+    i32s[STASIS_RENDER_I_FLAGS] =
+        STASIS_RENDER_FLAG_CLEAR | STASIS_RENDER_FLAG_PRESENT;
+    i32s[STASIS_RENDER_I_LINE_COUNT] = 1;
+    i32s[STASIS_RENDER_I_SPRITE_COUNT] = 1;
+    i32s[STASIS_RENDER_I_TEXT_COUNT] = 2;
+    i32s[STASIS_RENDER_I_TEXT_BYTES_USED] = 5;
+
+    f32s[0] = 0.1f; f32s[1] = 0.2f; f32s[2] = 0.3f; f32s[3] = 1.0f;
+    const float line[] = {1.0f, 2.0f, 3.0f, 4.0f, 0.5f, 0.6f, 0.7f, 0.8f};
+    memcpy(f32s + STASIS_RENDER_F_LINE_BASE, line, sizeof(line));
+
+    const int32_t sprite[] = {17, 10, 20, 30, 40, 45, 192};
+    memcpy(i32s + STASIS_RENDER_I_SPRITE_BASE, sprite, sizeof(sprite));
+
+    int32_t *text = i32s + STASIS_RENDER_I_TEXT_BASE;
+    text[0] = 3; text[1] = 0; text[2] = 4;
+    text[3] = 3; text[4] = -9; text[5] = 0;
+    memcpy(u8s, "test", 5);
+    for (int index = 0; index < 12; index++) {
+        f32s[STASIS_RENDER_F_TEXT_BASE + index] = (float)(index + 1) * 0.25f;
+    }
+}
+
+int main(void) {
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "render contract check failed at line %d: %s\n", \
+            __LINE__, #condition); \
+        return 1; \
+    } \
+} while (0)
+    int32_t *first_i32 = calloc(STASIS_RENDER_I32_COUNT, sizeof(*first_i32));
+    float *first_f32 = calloc(STASIS_RENDER_F32_COUNT, sizeof(*first_f32));
+    uint8_t *first_u8 = calloc(STASIS_RENDER_U8_COUNT, sizeof(*first_u8));
+    int32_t *second_i32 = calloc(STASIS_RENDER_I32_COUNT, sizeof(*second_i32));
+    float *second_f32 = calloc(STASIS_RENDER_F32_COUNT, sizeof(*second_f32));
+    uint8_t *second_u8 = calloc(STASIS_RENDER_U8_COUNT, sizeof(*second_u8));
+    CHECK(first_i32 && first_f32 && first_u8);
+    CHECK(second_i32 && second_f32 && second_u8);
+
+    build_representative_frame(first_i32, first_f32, first_u8);
+    build_representative_frame(second_i32, second_f32, second_u8);
+    CHECK(stasis_render_v1_is_valid(first_i32));
+    uint32_t first_trace = stasis_render_v1_trace(first_i32, first_f32, first_u8);
+    uint32_t second_trace = stasis_render_v1_trace(second_i32, second_f32, second_u8);
+    CHECK(first_trace != 0);
+    CHECK(first_trace == second_trace);
+
+    second_i32[STASIS_RENDER_I_SPRITE_BASE + 1] += 1;
+    CHECK(first_trace != stasis_render_v1_trace(second_i32, second_f32, second_u8));
+    second_i32[STASIS_RENDER_I_VERSION] = 99;
+    CHECK(!stasis_render_v1_is_valid(second_i32));
+    CHECK(stasis_render_v1_trace(second_i32, second_f32, second_u8) == 0);
+
+    build_representative_frame(second_i32, second_f32, second_u8);
+    second_i32[STASIS_RENDER_I_TEXT_BASE + 1] = 1;
+    second_i32[STASIS_RENDER_I_TEXT_BASE + 2] = INT32_MAX;
+    CHECK(!stasis_render_v1_text_span_is_valid(1, INT32_MAX, 5));
+    CHECK(stasis_render_v1_text_span_is_valid(0, 4, 5));
+    CHECK(!stasis_render_v1_text_span_is_valid(0, 5, 5));
+    CHECK(stasis_render_v1_trace(second_i32, second_f32, second_u8) != 0);
+
+    free(first_i32); free(first_f32); free(first_u8);
+    free(second_i32); free(second_f32); free(second_u8);
+#undef CHECK
+    return 0;
+}

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -28,7 +28,7 @@ extern function load_font(path: string, size: i32): i32;
 extern function measure_text(font: i32, text: string): f32;
 
 // Cache text into a host-side glyph run; intended for startup/init, not per-tick.
-function @extern("stasis_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
+function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
 function @extern("stasis_gfx_measure_text_cached") gfx_measure_text_cached(run_handle: i32): f32;
 
 // Deprecated controls/debug: kept as stubs so older samples compile; host-owned behavior should move to snapshot/commands.

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -13,6 +13,7 @@ REQUIRED_FILES = [
     "mobile/android/app/src/main/AndroidManifest.xml",
     "mobile/android/app/src/workshop/AndroidManifest.xml",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/AndroidSecretStore.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/AndroidEditRecoveryStore.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/AndroidDraftStore.java",
@@ -52,6 +53,7 @@ REQUIRED_FILES = [
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiResumePolicy.java",
     "mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java",
     "mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java",
+    "mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java",
     "mobile/android/app/src/main/cpp/CMakeLists.txt",
     "mobile/android/app/src/main/cpp/stasis_android_sprite.c",
     "mobile/android/app/src/main/cpp/stasis_mobile_smoke.c",
@@ -206,6 +208,8 @@ def main() -> int:
     assert '<item name="android:textColorPrimary">#161B22</item>' in styles
 
     activity = read("mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java")
+    preview_renderer = read("mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java")
+    workshop_textures = read("mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java")
     onboarding_policy = read(
         "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopOnboardingPolicy.java"
     )
@@ -365,7 +369,24 @@ def main() -> int:
     assert "startGameLoop();" in activity
     assert "GamePreviewView" in activity
     assert "GLSurfaceView" in activity
-    assert "onDrawFrame" in activity
+    assert "new StasisPreviewRenderer(" in activity
+    assert "onDrawFrame" in preview_renderer
+    assert "drawCommands" in preview_renderer
+    draw_loop = preview_renderer.split("private void drawCommands()", 1)[1].split(
+        "private void appendRect", 1
+    )[0]
+    assert "new " not in draw_loop
+    assert "allocate" not in draw_loop
+    assert "appendSprite(base);" in draw_loop
+    assert "int runEnd = index + 1;" in draw_loop
+    assert "GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA)" in preview_renderer
+    assert "GLES20.glScissor" in preview_renderer
+    assert "WorkshopTextureProvider" in activity
+    assert "implements StasisPreviewRenderer.TextureProvider" in workshop_textures
+    assert "SparseArray<SpriteTexture>" in workshop_textures
+    assert "projectChanged(projectRootPath, currentProjectRoot)" in workshop_textures
+    assert "clearTextures();" in workshop_textures
+    assert "private final int[] deletedTexture = new int[1]" in workshop_textures
     assert "extractIntField" in activity
     assert "private final int[] nativeFrameValues = new int[RENDER_FRAME_I32_CAPACITY]" in activity
     assert "FRAME_BUDGET_MILLIS = 1000.0 / 60.0" in activity
@@ -375,7 +396,7 @@ def main() -> int:
     assert '"GameState.collected_count"' in activity
     assert '"keepsakes="' in activity
     assert "garden complete" in activity
-    assert "private String projectRootPath" in activity
+    assert "String projectRootPath" in activity
     assert "nativeCompileProject(projectRootPath())" in activity
     assert "String.format" not in activity
     assert "gamePreview.setRenderFrameValues(nativeFrameValues)" in activity
@@ -500,11 +521,12 @@ def main() -> int:
     assert "Attach these rendered pixels" in activity
     assert "Attach logical render/runtime/input snapshot" in activity
     assert "Nothing is sent until selected here and Queue AI Change is pressed" in activity
-    assert "GLES20.glReadPixels" in activity
-    assert "lastDrawnFrame" in activity
-    assert "MAX_PREVIEW_CAPTURE_PIXELS = 8_000_000L" in activity
-    assert "preview framebuffer exceeds the 8 megapixel capture limit" in activity
-    assert "Bitmap.createScaledBitmap" in activity
+    assert "GLES20.glReadPixels" in preview_renderer
+    assert "capturedFrame = capture == null ? null : frame.clone()" in preview_renderer
+    assert "lastDrawnFrame" not in preview_renderer
+    assert "MAX_CAPTURE_PIXELS = 8_000_000" in preview_renderer
+    assert "preview framebuffer exceeds the 8 megapixel capture limit" in preview_renderer
+    assert "Bitmap.createScaledBitmap" in preview_renderer
     assert "selected_preview_logical_snapshot" in activity
     assert '"captured-preview.png"' in activity
     assert "clearPendingPreviewCapture();" in activity
@@ -1222,23 +1244,23 @@ def main() -> int:
     assert "gamePreview.touchY()" in activity
     assert "gamePreview.touchActive()" in activity
     assert "MotionEvent" in activity
-    assert "RENDER_COMMAND_STRIDE = 13" in activity
-    assert "drawBatch((runEnd - index) * RECT_VERTICES)" in activity
-    assert "drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture)" in activity
-    assert "GLES20.glScissor" in activity
-    assert "sameClip(base, runBase)" in activity
-    assert "frameValues[5]" in activity
-    assert "frameValues[base + 6]" in activity
-    assert "GLES20.glDrawArrays" in activity
-    assert "GL_TRIANGLES" in activity
-    assert "glUniform4f" not in activity
-    assert "attribute vec4 aColor" in activity
-    assert "TEXTURE_FRAGMENT_SHADER" in activity
-    assert "nativeResolveSpriteAsset" in activity
-    assert "nativeDecodeSvgSprite" in activity
-    assert "createFallbackTexture" in activity
-    assert "decoded sprite dimensions do not match the manifest" in activity
-    assert "glTexImage2D" in activity
+    assert "COMMAND_STRIDE = 13" in preview_renderer
+    assert "drawRectBatch((runEnd - index) * RECT_VERTICES)" in preview_renderer
+    assert "drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture)" in preview_renderer
+    assert "GLES20.glScissor" in preview_renderer
+    assert "sameClip(base, runBase)" in preview_renderer
+    assert "frame[5]" in preview_renderer
+    assert "frame[base + 6]" in preview_renderer
+    assert "GLES20.glDrawArrays" in preview_renderer
+    assert "GL_TRIANGLES" in preview_renderer
+    assert "glUniform4f" not in preview_renderer
+    assert "attribute vec4 aColor" in preview_renderer
+    assert "TEXTURE_FRAGMENT_SHADER" in preview_renderer
+    assert "nativeResolveSpriteAsset" in workshop_textures
+    assert "nativeDecodeSvgSprite" in workshop_textures
+    assert "createFallbackTexture" in workshop_textures
+    assert "decoded sprite dimensions do not match the manifest" in workshop_textures
+    assert "glTexImage2D" in workshop_textures
     assert "applySelectedEdit" in activity
     assert "persistSelectedEdit" in activity
     assert "getFilesDir()" in activity
@@ -1300,16 +1322,20 @@ def main() -> int:
     assert "Manual Symbols and Source" not in published_activity
     assert "GameSurfaceView" in published_activity
     assert "GLSurfaceView" in published_activity
-    assert "onDrawFrame" in published_activity
+    assert "new StasisPreviewRenderer(" in published_activity
+    assert "onDrawFrame" not in published_activity
     assert "FRAME_BUDGET_MILLIS = 1000.0 / 60.0" in published_activity
     assert "event.getPointerCount() >= 3" in published_activity
     assert "PUBLISHED_RUNTIME_ID = BuildConfig.STASIS_RUNTIME_ID" in published_activity
     assert "PublishedSpriteCatalog" in published_activity
-    assert "drawSpriteBatch" in published_activity
+    assert "drawSpriteBatch" in preview_renderer
     assert "nativeDecodeSvgSpriteBytes" in published_activity
     assert 'MANIFEST = ROOT + "assets/manifest.json"' in published_sprites
     assert "MessageDigest.getInstance(\"SHA-256\")" in published_sprites
-    assert "spriteCatalog.textureFor" in published_activity
+    assert "implements StasisPreviewRenderer.TextureProvider" in published_sprites
+    assert "textureFor(int handle)" in published_sprites
+    assert "SparseIntArray textures" in published_sprites
+    assert "SparseBooleanArray failedHandles" in published_sprites
     assert '"com.stasislang.pong"' in device_script
     assert "ensureBundledProject" not in published_activity
     workshop = read("crates/stasis_compiler/src/frontend/workshop.rs")


### PR DESCRIPTION
## Summary

- establish one versioned `gfx_cmd` render contract and deterministic native trace shared by Windows and Android shipping runtimes
- make SDL the canonical shipping renderer, with contract validation and consistent filter/clip/alpha semantics
- make Workshop and the bundled Published preview use one allocation-stable GLES adapter and texture lifecycle
- fix mobile AOT entry wrappers so `void` lifecycle functions return status 0 instead of garbage
- fix mobile asset-root resolution and the cached-text string ABI used by JIT/AOT

## Root cause

Desktop and mobile shipping paths had diverged in command interpretation and lifecycle behavior. The two embedded Android previews also maintained independent GLES renderers. Android AOT packaging additionally declared `void` guest lifecycle functions as `int32_t`, which could request immediate shutdown with a garbage result.

## Validation

- `python tools/ci/check_stasis_src_layout.py` - passed
- `python tools/ci/check_android_shell.py` - passed
- `cargo test --workspace --all-targets -- --test-threads=1` - passed
- `cargo test -p stasis_dynload -- --test-threads=1` - 9 passed
- `cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --test-threads=1 --nocapture` with the real MSVC linker - passed exact JIT/AOT trace `975559585`
- `cargo test --release --target-dir target/task165-compiler-release-clean -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture` - 1 passed from a clean release target in 169.3s; release dynload DLL/import library produced
- focused mobile-shell unit and `package_mobile_builds_android_and_ios_projects_from_one_entry` integration tests - 2 passed
- focused mobile AOT wrapper tests - passed
- `cargo fmt --all -- --check` and `git diff --check` - passed
- Windows SDL `ctest` - 5/5 passed, including render-command and confined asset-path contracts
- Workshop JVM regression for project-switch texture invalidation - passed
- Workshop full JVM task plus Published Java compilation - passed
- generated `package-mobile` Android app built through Gradle/CMake/SDL, installed on Galaxy S21, stayed alive, and visibly rendered the canonical clear/line probe
- Galaxy S21 Workshop and bundled Published preview both rendered; every tested app was force-stopped afterward
- Workshop device metrics improved from the recorded 2.11 ms render baseline to 1.16-1.37 ms (8-9% frame budget)

The Bash validation wrapper is unavailable on this Windows host; its source-layout and full-workspace Cargo commands passed directly.

## Follow-up boundary

Workshop and the bundled Published preview now share one low-allocation GLES implementation, while their native bridge still supplies the legacy eight-command rectangle/sprite preview schema. Shipping `package-mobile` consumes the complete `gfx_cmd` v1 clear/line/sprite/text/present stream through SDL. Per product decision, migrating the embedded previews to that exact production stream is the separate priority-1 Next Maddox task #171; it is not remaining #165 scope.

## Review

Independent and GitHub review found unsafe oversized trace lengths, stale cross-project textures, an avoidable hot-loop copy, a mixed-root race, an incorrect packaged asset root, missing CI coverage for its contract, and profile-sensitive dynload test artifacts. All concrete findings were fixed and re-reviewed clean.
