### PR TITLE
feat: unify Android preview rendering

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3687,6 +3687,7 @@ mod tests {
 
     #[test]
     fn shipping_renderers_share_one_versioned_sdl_command_process() {
+        let runtime_cmake = STASIS_RUNTIME_CMAKE.replace("\r\n", "\n");
         for required in [
             "STASIS_RENDER_V1_MAGIC 0x47584631",
             "STASIS_RENDER_V1_VERSION 1",
@@ -3702,9 +3703,9 @@ mod tests {
             );
         }
         assert!(
-            STASIS_RUNTIME_CMAKE.contains(
+            runtime_cmake.contains(
                 "Build the canonical SDL_Renderer runtime (disable only for legacy GL conformance)"
-            ) && STASIS_RUNTIME_CMAKE.contains("    ON\n)"),
+            ) && runtime_cmake.contains("    ON\n)"),
             "shipping runtime should default to the canonical SDL backend"
         );
         assert!(

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -18,7 +18,9 @@ use stasis::{
     run_self_host_aot_cli_with_options, run_with_default_backend, run_with_real_backend,
     RunnerConfig, StasisTestRunSession,
 };
-use stasis_assets::{load_project_asset_manifest, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH};
+use stasis_assets::{
+    load_project_asset_manifest, AssetFormat, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
+};
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
 use stasis_compiler::frontend::lexer::{lex, TokenKind};
@@ -1621,7 +1623,7 @@ fn write_mobile_aot_engine_bundle(
     let symbols_header = output_dir.join("published_aot_symbols.h");
     write_mobile_aot_symbols_header(&manifest_json, &symbols_header)?;
     let bindings_source = output_dir.join("published_aot_bindings.c");
-    write_mobile_aot_bindings_source(&manifest_json, &bindings_source)?;
+    write_mobile_aot_bindings_source(&manifest_json, project_dir, &bindings_source)?;
     let cmake_file = if target == MobileAotTarget::AndroidArm64 {
         let path = output_dir.join("published_aot_objects.cmake");
         write_android_aot_cmake_file(&bundle.object_paths_by_function, &path)?;
@@ -1968,6 +1970,7 @@ fn write_mobile_aot_symbols_header(
 
 fn write_mobile_aot_bindings_source(
     manifest: &serde_json::Value,
+    project_dir: &Path,
     output_path: &Path,
 ) -> Result<(), String> {
     let functions = manifest
@@ -1978,7 +1981,9 @@ fn write_mobile_aot_bindings_source(
         .get("string_literals")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
-    let mut out = String::from("#include <stdint.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n");
+    let mut out = String::from(
+        "#include <stdint.h>\n#include <string.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n",
+    );
     for function in functions {
         let symbol = function
             .get("symbol")
@@ -2022,6 +2027,33 @@ fn write_mobile_aot_bindings_source(
             escape_mobile_c_string_literal(value)
         ));
     }
+    let assets = load_project_asset_manifest(project_dir, AssetLimits::default())
+        .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
+    out.push_str("\ntypedef struct { const char *path; int32_t handle; } StasisPublishedSprite;\n");
+    out.push_str("static const StasisPublishedSprite stasis_published_sprites[] = {\n");
+    for asset in assets
+        .assets
+        .iter()
+        .filter(|asset| matches!(asset.entry.format, AssetFormat::Sprite { .. }))
+    {
+        out.push_str(&format!(
+            "    {{\"{}\", {}}},\n",
+            escape_mobile_c_string_literal(&asset.entry.path),
+            asset.handle.as_i32()
+        ));
+    }
+    out.push_str("    {0, 0},\n};\n");
+    out.push_str(
+        "int32_t stasis_published_sprite_handle_for_path(const char *path) {\n\
+         \x20   if (path == 0) return 0;\n\
+         \x20   while (path[0] == '.' && path[1] == '/') path += 2;\n\
+         \x20   while (path[0] == '.' && path[1] == '.' && path[2] == '/') path += 3;\n\
+         \x20   for (uintptr_t index = 0; index < sizeof(stasis_published_sprites) / sizeof(stasis_published_sprites[0]); index += 1) {\n\
+         \x20       if (stasis_published_sprites[index].path != 0 && strcmp(path, stasis_published_sprites[index].path) == 0) return stasis_published_sprites[index].handle;\n\
+         \x20   }\n\
+         \x20   return 0;\n\
+         }\n",
+    );
     out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
     for function in functions {
         let symbol = function
@@ -2767,9 +2799,11 @@ mod tests {
         let bindings =
             fs::read_to_string(&summary.bindings_source).expect("read mobile AOT bindings source");
         assert!(bindings.contains("extern void aot_fn_0(void);"));
-        assert!(bindings.contains("stasis_mobile_main_entry(void) { aot_fn_0(); return 0; }"));
+        assert!(bindings.contains("int32_t stasis_mobile_main_entry(void)"));
         assert!(bindings.contains("void stasis_aot_bind_runtime_globals(void)"));
         assert!(bindings.contains("stasis_jit_register_code_ptr(0"));
+        assert!(bindings.contains("stasis_published_sprite_handle_for_path"));
+        assert!(bindings.contains("{\"assets/ball.svg\","));
         assert!(header.contains("#define STASIS_AOT_BIND_RUNTIME_GLOBALS"));
         let engine_manifest: serde_json::Value = serde_json::from_str(
             &fs::read_to_string(output_dir.join("engine_bundle_manifest.json"))

--- a/crates/stasis_android_bridge/Cargo.toml
+++ b/crates/stasis_android_bridge/Cargo.toml
@@ -15,7 +15,5 @@ path = "src/android_workshop_compile.rs"
 [dependencies]
 stasis_compiler = { path = "../stasis_compiler" }
 stasis_assets = { path = "../stasis_assets" }
-serde_json.workspace = true
-
-[dev-dependencies]
 stasis_dynload = { path = "../stasis_dynload" }
+serde_json.workspace = true

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use stasis_assets::{AssetFormat, AssetHandle, AssetLimits, ResolvedAssetManifest};
 use stasis_compiler::backend::jit::JitProcess;
@@ -33,6 +34,9 @@ pub const ANDROID_RENDER_FRAME_HEADER_SIZE: usize = 6;
 pub const ANDROID_RENDER_COMMAND_STRIDE: usize = 13;
 pub const ANDROID_RENDER_FRAME_I32_CAPACITY: usize = ANDROID_RENDER_FRAME_HEADER_SIZE
     + ANDROID_RENDER_COMMAND_CAPACITY * ANDROID_RENDER_COMMAND_STRIDE;
+pub const ANDROID_RENDER_V1_I32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_I32_COUNT;
+pub const ANDROID_RENDER_V1_F32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_F32_COUNT;
+pub const ANDROID_RENDER_V1_U8_CAPACITY: usize = stasis_dynload::STASIS_RENDER_U8_COUNT;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndroidBridgeTickInput {
@@ -76,11 +80,14 @@ struct AndroidRuntimeSession {
     jit: JitProcess,
     initialized: bool,
     pending_candidate: Option<JitProcess>,
+    pending_resource_catalog: Option<EmbeddedResourceCatalog>,
     tick_count: i32,
+    previous_input: Option<AndroidBridgeTickInput>,
 }
 
 thread_local! {
     static RUNTIME_SESSION: RefCell<Option<AndroidRuntimeSession>> = const { RefCell::new(None) };
+    static LAST_FRAME_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -405,7 +412,38 @@ pub fn compile_android_workshop_project(
         }
     };
     let previous = read_previous_android_plan(project_root)?;
-    let plan = build_workshop_compile_plan(&files, &compile, previous.as_ref())?;
+    let mut plan = build_workshop_compile_plan(&files, &compile, previous.as_ref())?;
+    warm_or_reload_runtime_session(project_root, &files, fingerprint_workshop_sources(&files))?;
+
+    // The legacy artifact analyzer does not understand every production extern and can
+    // report detector errors for programs the real JIT has compiled successfully. The
+    // executable pipeline above is authoritative for Workshop; retain the artifact
+    // manifest for tooling, but derive its success/reload state from the source set.
+    let executable_project_hash = fingerprint_workshop_sources(&files) as i32;
+    let previous_hashes = previous
+        .as_ref()
+        .map(|previous| (previous.project_hash, previous.layout_hash));
+    plan.status = 0;
+    plan.errors.clear();
+    plan.project_hash = executable_project_hash;
+    (plan.reload, plan.reason) = match previous_hashes {
+        None => (
+            WorkshopReload::InitialCompile,
+            "Production JIT initialized the Workshop runtime.".to_string(),
+        ),
+        Some((project_hash, _)) if project_hash == executable_project_hash => (
+            WorkshopReload::NoChange,
+            "Production JIT source fingerprint is unchanged.".to_string(),
+        ),
+        Some((_, layout_hash)) if layout_hash == plan.layout_hash => (
+            WorkshopReload::FastReload,
+            "Production JIT accepted a layout-compatible source update.".to_string(),
+        ),
+        Some(_) => (
+            WorkshopReload::ResetRequired,
+            "Production JIT accepted a layout-changing source update.".to_string(),
+        ),
+    };
     let artifacts = render_workshop_artifacts(&plan);
 
     let manifest_path = project_root.join(&artifacts.manifest_path);
@@ -460,8 +498,6 @@ pub fn compile_android_workshop_project(
         })?;
     }
 
-    warm_or_reload_runtime_session(project_root, &files, fingerprint_workshop_sources(&files))?;
-
     Ok(AndroidBridgeCompileResult {
         status: plan.status,
         reload: plan.reload,
@@ -475,6 +511,340 @@ pub fn run_android_workshop_tick(
     project_root: impl AsRef<Path>,
     entry_file: impl AsRef<Path>,
     input: AndroidBridgeTickInput,
+) -> Result<AndroidBridgeRunTickResult, String> {
+    run_android_workshop_tick_internal(project_root, entry_file, input, true)
+}
+
+const MAX_EMBEDDED_FONTS: usize = 64;
+const MAX_EMBEDDED_TEXT_RUNS: usize = 4096;
+
+#[derive(Clone)]
+struct EmbeddedFont {
+    handle: i32,
+    path: PathBuf,
+    size: i32,
+}
+
+#[derive(Clone)]
+struct EmbeddedTextRun {
+    handle: i32,
+    font: i32,
+    text: String,
+    measured_width: f32,
+}
+
+struct EmbeddedResourceCatalog {
+    project_root: PathBuf,
+    assets: ResolvedAssetManifest,
+    fonts: Vec<EmbeddedFont>,
+    text_runs: Vec<EmbeddedTextRun>,
+    error: Option<String>,
+}
+
+fn embedded_resource_catalog() -> &'static Mutex<Option<EmbeddedResourceCatalog>> {
+    static CATALOG: OnceLock<Mutex<Option<EmbeddedResourceCatalog>>> = OnceLock::new();
+    CATALOG.get_or_init(|| Mutex::new(None))
+}
+
+fn install_embedded_resource_host(project_root: &Path) -> Result<(), String> {
+    let catalog = prepare_embedded_resource_catalog(project_root, false)?;
+    *embedded_resource_catalog()
+        .lock()
+        .map_err(|_| "embedded resource catalog mutex poisoned")? = Some(catalog);
+    stasis_dynload::set_embedded_graphics_host(Some(stasis_dynload::EmbeddedGraphicsHost {
+        load_sprite: embedded_load_sprite,
+        release_sprite: |_| {},
+        load_font: embedded_load_font,
+        measure_text: embedded_measure_text,
+        cache_text: embedded_cache_text,
+        measure_text_cached: embedded_measure_text_cached,
+        poll_reload: |_| 0,
+    }));
+    Ok(())
+}
+
+fn prepare_embedded_resource_catalog(
+    project_root: &Path,
+    preserve_loaded_resources: bool,
+) -> Result<EmbeddedResourceCatalog, String> {
+    let project_root = project_root
+        .canonicalize()
+        .map_err(|error| format!("failed to canonicalize embedded project root: {error}"))?;
+    let manifest_path = project_root.join(stasis_assets::DEFAULT_ASSET_MANIFEST_PATH);
+    let assets = if manifest_path.is_file() {
+        load_android_workshop_asset_manifest(&project_root)?
+    } else {
+        ResolvedAssetManifest {
+            manifest_path,
+            assets: Vec::new(),
+        }
+    };
+    let (fonts, text_runs) = if preserve_loaded_resources {
+        let slot = embedded_resource_catalog()
+            .lock()
+            .map_err(|_| "embedded resource catalog mutex poisoned")?;
+        slot.as_ref()
+            .filter(|catalog| catalog.project_root == project_root)
+            .map(|catalog| (catalog.fonts.clone(), catalog.text_runs.clone()))
+            .unwrap_or_else(|| {
+                (
+                    Vec::with_capacity(MAX_EMBEDDED_FONTS),
+                    Vec::with_capacity(MAX_EMBEDDED_TEXT_RUNS),
+                )
+            })
+    } else {
+        (
+            Vec::with_capacity(MAX_EMBEDDED_FONTS),
+            Vec::with_capacity(MAX_EMBEDDED_TEXT_RUNS),
+        )
+    };
+    Ok(EmbeddedResourceCatalog {
+        project_root,
+        assets,
+        fonts,
+        text_runs,
+        error: None,
+    })
+}
+
+fn embedded_path(catalog: &EmbeddedResourceCatalog, bytes: &[u8]) -> Option<PathBuf> {
+    let path = std::str::from_utf8(bytes).ok()?;
+    let absolute = catalog
+        .project_root
+        .join("src")
+        .join(path)
+        .canonicalize()
+        .ok()?;
+    absolute
+        .starts_with(&catalog.project_root)
+        .then_some(absolute)
+}
+
+fn set_embedded_resource_error(catalog: &mut EmbeddedResourceCatalog, message: String) {
+    if catalog.error.is_none() {
+        catalog.error = Some(message);
+    }
+}
+
+fn take_embedded_resource_error() -> Result<(), String> {
+    let mut slot = embedded_resource_catalog()
+        .lock()
+        .map_err(|_| "embedded resource catalog mutex poisoned".to_string())?;
+    let catalog = slot
+        .as_mut()
+        .ok_or_else(|| "embedded resource catalog is not initialized".to_string())?;
+    match catalog.error.take() {
+        Some(error) => Err(format!("render resource error: {error}")),
+        None => Ok(()),
+    }
+}
+
+fn embedded_load_sprite(path: &[u8], _max_w: i32, _max_h: i32) -> i32 {
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return 0;
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return 0;
+    };
+    let display_path = String::from_utf8_lossy(path);
+    let Some(absolute) = embedded_path(catalog, path) else {
+        set_embedded_resource_error(
+            catalog,
+            format!("sprite path is invalid or missing: {display_path}"),
+        );
+        return 0;
+    };
+    let handle = catalog
+        .assets
+        .assets
+        .iter()
+        .find(|asset| {
+            asset.absolute_path == absolute
+                && matches!(asset.entry.format, AssetFormat::Sprite { .. })
+        })
+        .map_or(0, |asset| asset.handle.as_i32());
+    if handle == 0 {
+        set_embedded_resource_error(
+            catalog,
+            format!("sprite is not declared in the asset manifest: {display_path}"),
+        );
+    }
+    handle
+}
+
+fn embedded_load_font(path: &[u8], size: i32) -> i32 {
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return 0;
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return 0;
+    };
+    let display_path = String::from_utf8_lossy(path);
+    if size <= 0 {
+        set_embedded_resource_error(
+            catalog,
+            format!("font size must be positive: {display_path}"),
+        );
+        return 0;
+    }
+    let Some(absolute) = embedded_path(catalog, path) else {
+        set_embedded_resource_error(
+            catalog,
+            format!("font path is invalid or missing: {display_path}"),
+        );
+        return 0;
+    };
+    if !absolute.is_file() {
+        set_embedded_resource_error(catalog, format!("font file is missing: {display_path}"));
+        return 0;
+    }
+    if let Some(font) = catalog
+        .fonts
+        .iter()
+        .find(|font| font.path == absolute && font.size == size)
+    {
+        return font.handle;
+    }
+    if catalog.fonts.len() >= MAX_EMBEDDED_FONTS {
+        set_embedded_resource_error(catalog, "font registry is full".to_string());
+        return 0;
+    }
+    let handle = catalog.fonts.len() as i32 + 1;
+    catalog.fonts.push(EmbeddedFont {
+        handle,
+        path: absolute,
+        size,
+    });
+    handle
+}
+
+fn embedded_measure_text(font: i32, text: &[u8]) -> f32 {
+    let Ok(slot) = embedded_resource_catalog().lock() else {
+        return 0.0;
+    };
+    let Some(catalog) = slot.as_ref() else {
+        return 0.0;
+    };
+    let Some(font) = catalog.fonts.iter().find(|entry| entry.handle == font) else {
+        return 0.0;
+    };
+    text.len() as f32 * font.size as f32 * 0.6
+}
+
+fn embedded_cache_text(font: i32, text: &[u8]) -> i32 {
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return 0;
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return 0;
+    };
+    let Ok(text) = std::str::from_utf8(text) else {
+        set_embedded_resource_error(catalog, "cached text is not valid UTF-8".to_string());
+        return 0;
+    };
+    let Some(font_entry) = catalog.fonts.iter().find(|entry| entry.handle == font) else {
+        set_embedded_resource_error(catalog, format!("font handle {font} was not loaded"));
+        return 0;
+    };
+    if let Some(run) = catalog
+        .text_runs
+        .iter()
+        .find(|run| run.font == font && run.text == text)
+    {
+        return run.handle;
+    }
+    if catalog.text_runs.len() >= MAX_EMBEDDED_TEXT_RUNS {
+        set_embedded_resource_error(catalog, "cached text registry is full".to_string());
+        return 0;
+    }
+    let handle = catalog.text_runs.len() as i32 + 1;
+    let measured_width = text.len() as f32 * font_entry.size as f32 * 0.6;
+    catalog.text_runs.push(EmbeddedTextRun {
+        handle,
+        font,
+        text: text.to_string(),
+        measured_width,
+    });
+    handle
+}
+
+fn embedded_measure_text_cached(handle: i32) -> f32 {
+    let Ok(slot) = embedded_resource_catalog().lock() else {
+        return 0.0;
+    };
+    slot.as_ref()
+        .and_then(|catalog| catalog.text_runs.iter().find(|run| run.handle == handle))
+        .map_or(0.0, |run| run.measured_width)
+}
+
+fn resolve_embedded_text_run(
+    project_root: &Path,
+    handle: i32,
+) -> Result<serde_json::Value, String> {
+    let root = project_root
+        .canonicalize()
+        .map_err(|error| format!("invalid project root: {error}"))?;
+    let slot = embedded_resource_catalog()
+        .lock()
+        .map_err(|_| "embedded resource catalog mutex poisoned")?;
+    let catalog = slot
+        .as_ref()
+        .ok_or_else(|| "embedded resource catalog is not initialized".to_string())?;
+    if catalog.project_root != root {
+        return Err("cached text belongs to a different project".to_string());
+    }
+    let run = catalog
+        .text_runs
+        .iter()
+        .find(|run| run.handle == handle)
+        .ok_or_else(|| format!("cached text handle {handle} was not loaded"))?;
+    let font = catalog
+        .fonts
+        .iter()
+        .find(|font| font.handle == run.font)
+        .ok_or_else(|| format!("font handle {} was not loaded", run.font))?;
+    Ok(serde_json::json!({
+        "status": "ok",
+        "handle": run.handle,
+        "font": font.handle,
+        "font_path": font.path,
+        "font_size": font.size,
+        "text": run.text,
+        "measured_width": run.measured_width,
+    }))
+}
+
+fn resolve_embedded_font(project_root: &Path, handle: i32) -> Result<serde_json::Value, String> {
+    let root = project_root
+        .canonicalize()
+        .map_err(|error| format!("invalid project root: {error}"))?;
+    let slot = embedded_resource_catalog()
+        .lock()
+        .map_err(|_| "embedded resource catalog mutex poisoned")?;
+    let catalog = slot
+        .as_ref()
+        .ok_or_else(|| "embedded resource catalog is not initialized".to_string())?;
+    if catalog.project_root != root {
+        return Err("font belongs to a different project".to_string());
+    }
+    let font = catalog
+        .fonts
+        .iter()
+        .find(|font| font.handle == handle)
+        .ok_or_else(|| format!("font handle {handle} was not loaded"))?;
+    Ok(serde_json::json!({
+        "status": "ok",
+        "handle": font.handle,
+        "font_path": font.path,
+        "font_size": font.size,
+    }))
+}
+
+fn run_android_workshop_tick_internal(
+    project_root: impl AsRef<Path>,
+    entry_file: impl AsRef<Path>,
+    input: AndroidBridgeTickInput,
+    read_legacy_render_commands: bool,
 ) -> Result<AndroidBridgeRunTickResult, String> {
     let project_root = project_root.as_ref();
     let entry_file = entry_file.as_ref();
@@ -503,10 +873,12 @@ pub fn run_android_workshop_tick(
         if swapped_code {
             recompiled = true;
         }
+        write_production_host_frame(session, input)?;
         let initialized = if session.initialized {
             false
         } else {
             execute_lifecycle_noarg(&session.jit, "main")?;
+            take_embedded_resource_error()?;
             session.initialized = true;
             true
         };
@@ -528,9 +900,19 @@ pub fn run_android_workshop_tick(
         execute_lifecycle_noarg(&session.jit, "tick")?;
         session.tick_count = session.tick_count.saturating_add(1);
         execute_optional_lifecycle_noarg(&session.jit, "render")?;
+        take_embedded_resource_error()?;
         let observed_game_tick_count = session.jit.read_i32_global_path("GameState.tick_count");
-        let render_command_count = session.jit.read_i32_global_path("Render.command_count");
-        let render_commands = read_render_commands(&session.jit);
+        let (render_command_count, render_commands) = if read_legacy_render_commands {
+            (
+                session.jit.read_i32_global_path("Render.command_count"),
+                read_render_commands(&session.jit),
+            )
+        } else {
+            (
+                0,
+                [AndroidBridgeRenderCommand::default(); ANDROID_RENDER_COMMAND_CAPACITY],
+            )
+        };
         if should_write_jit_runtime_state(session.tick_count, initialized, recompiled) {
             write_jit_runtime_state(
                 project_root,
@@ -550,6 +932,84 @@ pub fn run_android_workshop_tick(
             render_commands,
         })
     })
+}
+
+fn hash_global_path(path: &str) -> i32 {
+    let mut hash = 2_166_136_261u32;
+    for byte in path.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    hash as i32
+}
+
+fn write_production_host_frame(
+    session: &mut AndroidRuntimeSession,
+    input: AndroidBridgeTickInput,
+) -> Result<(), String> {
+    const HOST_I32_COUNT: i32 = 768;
+    const HOST_F32_COUNT: i32 = 64;
+    const POINTER_I32_BASE: usize = 544;
+    let host_i32_ptr = stasis_dynload::stasis_jit_global_i32_array_ptr(
+        hash_global_path("host_i32"),
+        0,
+        HOST_I32_COUNT,
+    );
+    let host_f32_ptr = stasis_dynload::stasis_jit_global_f32_array_ptr(
+        hash_global_path("host_f32"),
+        0,
+        HOST_F32_COUNT,
+    );
+    if host_i32_ptr.is_null() || host_f32_ptr.is_null() {
+        return Err("production host frame buffers were not registered".to_string());
+    }
+    let host_i32 = unsafe { std::slice::from_raw_parts_mut(host_i32_ptr, HOST_I32_COUNT as usize) };
+    let host_f32 = unsafe { std::slice::from_raw_parts_mut(host_f32_ptr, HOST_F32_COUNT as usize) };
+    let previous = session.previous_input;
+    let was_down = previous.is_some_and(|value| value.touch_active != 0);
+    let is_down = input.touch_active != 0;
+    host_i32[0] = stasis_dynload::stasis_get_time_ms();
+    host_i32[1] = input.screen_w;
+    host_i32[2] = input.screen_h;
+    host_i32[3] = 0;
+    host_i32[4] = 0;
+    host_i32[5] = input.screen_w;
+    host_i32[6] = input.screen_h;
+    host_i32[7] = 1;
+    host_i32[8] = 0;
+    host_i32[9] = 0;
+    host_i32[10] = session.tick_count;
+    host_i32[11] = 0;
+    host_i32[12] = input.screen_w;
+    host_i32[13] = input.screen_h;
+    host_i32[14] = 1;
+    host_i32[15] = 0;
+    host_i32[16] = 60;
+    host_i32[17] = 1;
+    host_i32[18] = 0;
+    host_i32[19] = stasis_dynload::stasis_get_time_us();
+    host_i32[POINTER_I32_BASE] = 0;
+    host_i32[POINTER_I32_BASE + 1] = i32::from(is_down);
+    host_i32[POINTER_I32_BASE + 2] = i32::from(is_down && !was_down);
+    host_i32[POINTER_I32_BASE + 3] = i32::from(!is_down && was_down);
+    let previous_x = previous.map_or(input.touch_x, |value| value.touch_x);
+    let previous_y = previous.map_or(input.touch_y, |value| value.touch_y);
+    host_f32[0] = input.touch_x as f32;
+    host_f32[1] = input.touch_y as f32;
+    host_f32[2] = (input.touch_x - previous_x) as f32;
+    host_f32[3] = (input.touch_y - previous_y) as f32;
+    host_f32[4] = if input.screen_w > 0 {
+        input.touch_x as f32 / input.screen_w as f32
+    } else {
+        0.0
+    };
+    host_f32[5] = if input.screen_h > 0 {
+        input.touch_y as f32 / input.screen_h as f32
+    } else {
+        0.0
+    };
+    session.previous_input = Some(input);
+    Ok(())
 }
 
 fn with_initialized_runtime_session<R>(
@@ -610,6 +1070,7 @@ fn build_runtime_session(
     files: &[WorkshopSourceFile],
     source_fingerprint: u64,
 ) -> Result<AndroidRuntimeSession, String> {
+    install_embedded_resource_host(project_root)?;
     let mut jit = JitProcess::new();
     jit.set_local_runtime_helper_trampolines(true);
     configure_runtime_jit(&mut jit, project_root, files);
@@ -625,7 +1086,9 @@ fn build_runtime_session(
         jit,
         initialized: false,
         pending_candidate: None,
+        pending_resource_catalog: None,
         tick_count: 0,
+        previous_input: None,
     })
 }
 
@@ -659,6 +1122,7 @@ fn recompile_runtime_session(
     source_fingerprint: u64,
 ) -> Result<(), String> {
     session.pending_candidate = None;
+    session.pending_resource_catalog = None;
     let mut candidate = session.jit.staged_candidate();
     configure_runtime_jit(&mut candidate, project_root, files);
     if let Err(error) = candidate.compile_staged() {
@@ -668,7 +1132,9 @@ fn recompile_runtime_session(
             .unwrap_or_else(|| format!("Android JIT hot reload failed: {error:?}")));
     }
     candidate.validate_on_code_swap_signature()?;
+    let resource_catalog = prepare_embedded_resource_catalog(project_root, true)?;
     session.pending_candidate = Some(candidate);
+    session.pending_resource_catalog = Some(resource_catalog);
     session.source_fingerprint = source_fingerprint;
     Ok(())
 }
@@ -677,6 +1143,7 @@ fn activate_pending_runtime_candidate(session: &mut AndroidRuntimeSession) -> Re
     let Some(candidate) = session.pending_candidate.take() else {
         return Ok(false);
     };
+    let pending_catalog = session.pending_resource_catalog.take();
     let mut preview = plan_state_migration(
         &session.jit.state_layout(),
         &candidate.state_layout(),
@@ -685,8 +1152,16 @@ fn activate_pending_runtime_candidate(session: &mut AndroidRuntimeSession) -> Re
         None,
     )?;
     finalize_runtime_preview(&candidate, &mut preview);
+    let previous_catalog = if let Some(catalog) = pending_catalog {
+        let mut slot = embedded_resource_catalog()
+            .lock()
+            .map_err(|_| "embedded resource catalog mutex poisoned")?;
+        Some(slot.replace(catalog))
+    } else {
+        None
+    };
     let run_hook = session.initialized && candidate.has_on_code_swap();
-    activate_candidate_transactionally(
+    let activation = activate_candidate_transactionally(
         Some(&session.jit),
         &candidate,
         &preview,
@@ -699,7 +1174,19 @@ fn activate_pending_runtime_candidate(session: &mut AndroidRuntimeSession) -> Re
             }
         },
         Result::is_ok,
-    )??;
+    );
+    let activation_error = match activation {
+        Ok(Ok(())) => None,
+        Ok(Err(error)) | Err(error) => Some(error),
+    };
+    if let Some(error) = activation_error {
+        if let Some(previous) = previous_catalog {
+            *embedded_resource_catalog()
+                .lock()
+                .map_err(|_| "embedded resource catalog mutex poisoned")? = previous;
+        }
+        return Err(error);
+    }
     session.jit = candidate;
     Ok(true)
 }
@@ -712,6 +1199,7 @@ fn discard_pending_runtime_candidate(project_root: &Path) {
             .filter(|session| session.project_root == project_root)
         {
             session.pending_candidate = None;
+            session.pending_resource_catalog = None;
         }
     });
 }
@@ -955,16 +1443,26 @@ pub extern "C" fn stasis_android_bridge_compile_project(
     project_root: *const c_char,
     entry_file: *const c_char,
 ) -> *mut c_char {
-    let result = unsafe { compile_project_from_c(project_root, entry_file) };
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        compile_project_from_c(project_root, entry_file)
+    }));
     let message = match result {
-        Ok(result) => format!(
+        Ok(Ok(result)) => format!(
             "CompilePlanned: reload={:?} status={} functions={} manifest={}",
             result.reload,
             result.status,
             result.function_artifact_count,
             result.manifest_path.display()
         ),
-        Err(error) => format!("CompileError: {error}"),
+        Ok(Err(error)) => format!("CompileError: {error}"),
+        Err(payload) => {
+            let panic_message = payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("unknown panic");
+            format!("CompileError: panic while compiling Android project: {panic_message}")
+        }
     };
     CString::new(message)
         .unwrap_or_else(|_| CString::new("CompileError: invalid bridge message").unwrap())
@@ -1315,6 +1813,94 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame(
 }
 
 #[no_mangle]
+pub extern "C" fn stasis_android_bridge_run_tick_frame_v1(
+    project_root: *const c_char,
+    entry_file: *const c_char,
+    touch_x: i32,
+    touch_y: i32,
+    touch_active: i32,
+    screen_w: i32,
+    screen_h: i32,
+    out_i32: *mut i32,
+    out_i32_len: usize,
+    out_f32: *mut f32,
+    out_f32_len: usize,
+    out_u8: *mut u8,
+    out_u8_len: usize,
+) -> i32 {
+    if out_i32.is_null()
+        || out_f32.is_null()
+        || out_u8.is_null()
+        || out_i32_len < ANDROID_RENDER_V1_I32_CAPACITY
+        || out_f32_len < ANDROID_RENDER_V1_F32_CAPACITY
+        || out_u8_len < ANDROID_RENDER_V1_U8_CAPACITY
+    {
+        return -1;
+    }
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        if project_root.is_null() || entry_file.is_null() {
+            return Err("null project root or entry file".to_string());
+        }
+        let project_root = CStr::from_ptr(project_root)
+            .to_str()
+            .map_err(|error| format!("project root was not UTF-8: {error}"))?;
+        let entry_file = CStr::from_ptr(entry_file)
+            .to_str()
+            .map_err(|error| format!("entry file was not UTF-8: {error}"))?;
+        run_android_workshop_tick_internal(
+            project_root,
+            entry_file,
+            AndroidBridgeTickInput {
+                touch_x,
+                touch_y,
+                touch_active,
+                screen_w,
+                screen_h,
+            },
+            false,
+        )?;
+        let i32_values = std::slice::from_raw_parts_mut(out_i32, out_i32_len);
+        let f32_values = std::slice::from_raw_parts_mut(out_f32, out_f32_len);
+        let u8_values = std::slice::from_raw_parts_mut(out_u8, out_u8_len);
+        stasis_dynload::copy_jit_render_v1_active(i32_values, f32_values, u8_values).map(|_| ())
+    }));
+    match result {
+        Ok(Ok(())) => {
+            LAST_FRAME_ERROR.with(|slot| *slot.borrow_mut() = None);
+            0
+        }
+        Ok(Err(error)) => {
+            LAST_FRAME_ERROR.with(|slot| *slot.borrow_mut() = Some(error));
+            unsafe {
+                *out_i32 = -1;
+            }
+            -1
+        }
+        Err(_) => {
+            LAST_FRAME_ERROR.with(|slot| {
+                *slot.borrow_mut() = Some("panic while running Android preview frame".to_string());
+            });
+            unsafe {
+                *out_i32 = -1;
+            }
+            -1
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_last_frame_error() -> *mut c_char {
+    let message = LAST_FRAME_ERROR.with(|slot| {
+        slot.borrow()
+            .clone()
+            .unwrap_or_else(|| "native preview frame failed".to_string())
+    });
+    CString::new(message)
+        .unwrap_or_else(|_| CString::new("native preview frame failed").unwrap())
+        .into_raw()
+}
+
+#[no_mangle]
 pub extern "C" fn stasis_android_bridge_run_tick(
     project_root: *const c_char,
     entry_file: *const c_char,
@@ -1387,6 +1973,56 @@ pub extern "C" fn stasis_android_bridge_resolve_sprite_asset(
         "{\"status\":\"error\",\"error\":\"invalid sprite response\"}".to_string()
     });
     CString::new(message)
+        .unwrap_or_else(|_| CString::new("{\"status\":\"error\"}").unwrap())
+        .into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_resolve_cached_text(
+    project_root: *const c_char,
+    handle: i32,
+) -> *mut c_char {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        if project_root.is_null() {
+            return Err("null project root".to_string());
+        }
+        let root = CStr::from_ptr(project_root)
+            .to_str()
+            .map_err(|error| format!("project root was not UTF-8: {error}"))?;
+        resolve_embedded_text_run(Path::new(root), handle)
+    }));
+    let value = match result {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => serde_json::json!({ "status": "error", "error": error }),
+        Err(_) => {
+            serde_json::json!({ "status": "error", "error": "panic while resolving cached text" })
+        }
+    };
+    CString::new(value.to_string())
+        .unwrap_or_else(|_| CString::new("{\"status\":\"error\"}").unwrap())
+        .into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_resolve_font(
+    project_root: *const c_char,
+    handle: i32,
+) -> *mut c_char {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        if project_root.is_null() {
+            return Err("null project root".to_string());
+        }
+        let root = CStr::from_ptr(project_root)
+            .to_str()
+            .map_err(|error| format!("project root was not UTF-8: {error}"))?;
+        resolve_embedded_font(Path::new(root), handle)
+    }));
+    let value = match result {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => serde_json::json!({ "status": "error", "error": error }),
+        Err(_) => serde_json::json!({ "status": "error", "error": "panic while resolving font" }),
+    };
+    CString::new(value.to_string())
         .unwrap_or_else(|_| CString::new("{\"status\":\"error\"}").unwrap())
         .into_raw()
 }
@@ -1568,6 +2204,28 @@ mod tests {
         assert!(state.contains("status=RuntimeStateReady"));
         assert!(state.contains("tick_count=0"));
         fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn bridge_uses_successful_jit_result_when_legacy_scan_misreads_from_field() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("production_jit_authoritative");
+        fs::write(
+            root.join("src/main.stasis"),
+            "global GameState { from_file: i32; }\nfunction main(): void { GameState.from_file = 3; }\nfunction tick(): void { GameState.from_file += 1; }\n",
+        )
+        .expect("write source");
+
+        let result = compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect("production JIT compile");
+        assert_eq!(result.status, 0);
+        let manifest = fs::read_to_string(root.join("build/native_compile_manifest.txt"))
+            .expect("read manifest");
+        assert!(manifest.contains("errors=0"));
+
+        fs::remove_dir_all(root).ok();
+        clear_runtime_session_for_test();
     }
 
     #[test]
@@ -1819,7 +2477,9 @@ mod tests {
             jit: active,
             initialized: true,
             pending_candidate: Some(candidate),
+            pending_resource_catalog: None,
             tick_count: 0,
+            previous_input: None,
         };
 
         assert!(activate_pending_runtime_candidate(&mut session)
@@ -2085,12 +2745,14 @@ mod tests {
     }
     #[test]
     fn android_bridge_runs_bundled_stasis_tests() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
         let root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../mobile/android/app/src/main/assets/workshop_sample")
             .canonicalize()
             .expect("bundled sample root");
         let result = run_android_workshop_stasis_tests(&root).expect("run bundled Stasis tests");
-        assert_eq!(result["passed"], 1);
+        assert_eq!(result["passed"], 1, "{result}");
         assert_eq!(result["failed"], 0);
         assert_eq!(result["all_passed"], true);
         assert_eq!(
@@ -2098,6 +2760,7 @@ mod tests {
             "tests/enemy_paddle_speed_schedule.test.stasis"
         );
         assert_eq!(result["results"][0]["line"], 3);
+        clear_runtime_session_for_test();
     }
 
     #[test]
@@ -2271,6 +2934,165 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
         assert_eq!(frame[ANDROID_RENDER_FRAME_HEADER_SIZE + 10], 0);
         assert_eq!(frame[ANDROID_RENDER_FRAME_HEADER_SIZE + 11], 0);
         assert_eq!(frame[ANDROID_RENDER_FRAME_HEADER_SIZE + 12], 0);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn c_bridge_run_tick_frame_v1_copies_only_production_active_spans() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("ffi_production_frame_tick");
+        fs::write(
+            root.join("src/main.stasis"),
+            "global host_i32: i32[768];
+global host_f32: f32[64];
+global gfx_cmd_i32: i32[34848];
+global gfx_cmd_f32: f32[92292];
+global gfx_cmd_u8: u8[65536];
+function main(): void {}
+function tick(): void {}
+function render(): void {
+  gfx_cmd_i32[0] = 1196967473;
+  gfx_cmd_i32[1] = 1;
+  gfx_cmd_i32[2] = 3;
+  gfx_cmd_i32[3] = 1;
+  gfx_cmd_i32[4] = 1;
+  gfx_cmd_i32[7] = 1;
+  gfx_cmd_i32[9] = 2;
+  gfx_cmd_f32[0] = 0.1;
+  gfx_cmd_f32[4] = host_f32[0];
+  gfx_cmd_f32[5] = host_f32[1];
+  gfx_cmd_f32[6] = 30.0;
+  gfx_cmd_f32[7] = 40.0;
+  gfx_cmd_f32[8] = 1.0;
+  gfx_cmd_i32[32] = 77;
+  gfx_cmd_i32[33] = 11;
+  gfx_cmd_i32[28704] = 5;
+  gfx_cmd_i32[28705] = 0;
+  gfx_cmd_i32[28706] = 1;
+  gfx_cmd_f32[80004] = 12.0;
+  gfx_cmd_u8[0] = 65;
+  gfx_cmd_u8[1] = 0;
+}
+",
+        )
+        .expect("write production source");
+        let root_c = CString::new(root.to_string_lossy().as_bytes()).expect("root cstr");
+        let entry_c = CString::new("src/main.stasis").expect("entry cstr");
+        let mut frame_i32 = vec![0i32; ANDROID_RENDER_V1_I32_CAPACITY];
+        let mut frame_f32 = vec![0.0f32; ANDROID_RENDER_V1_F32_CAPACITY];
+        let mut frame_u8 = vec![0u8; ANDROID_RENDER_V1_U8_CAPACITY];
+        let status = stasis_android_bridge_run_tick_frame_v1(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            17,
+            23,
+            1,
+            360,
+            640,
+            frame_i32.as_mut_ptr(),
+            frame_i32.len(),
+            frame_f32.as_mut_ptr(),
+            frame_f32.len(),
+            frame_u8.as_mut_ptr(),
+            frame_u8.len(),
+        );
+        assert_eq!(status, 0);
+        assert_eq!(&frame_i32[..5], &[1196967473, 1, 3, 1, 1]);
+        assert_eq!(frame_i32[32], 77);
+        assert_eq!(frame_i32[33], 11);
+        assert_eq!(&frame_i32[28704..28707], &[5, 0, 1]);
+        assert_eq!(frame_f32[4], 17.0);
+        assert_eq!(frame_f32[5], 23.0);
+        assert_eq!(frame_f32[80004], 12.0);
+        assert_eq!(&frame_u8[..2], &[65, 0]);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn c_bridge_reports_resource_load_failure_for_runtime_ui() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("ffi_resource_error");
+        fs::write(
+            root.join("src/main.stasis"),
+            "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+global host_i32: i32[768];
+global host_f32: f32[64];
+global gfx_cmd_i32: i32[34848];
+global gfx_cmd_f32: f32[92292];
+global gfx_cmd_u8: u8[65536];
+function main(): void { gfx_load_sprite(\"../assets/missing.svg\", 32, 32); }
+function tick(): void {}
+function render(): void {}
+",
+        )
+        .expect("write source");
+        let root_c = CString::new(root.to_string_lossy().as_bytes()).expect("root cstr");
+        let entry_c = CString::new("src/main.stasis").expect("entry cstr");
+        let mut i32_values = vec![0; ANDROID_RENDER_V1_I32_CAPACITY];
+        let mut f32_values = vec![0.0; ANDROID_RENDER_V1_F32_CAPACITY];
+        let mut u8_values = vec![0; ANDROID_RENDER_V1_U8_CAPACITY];
+        let status = stasis_android_bridge_run_tick_frame_v1(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            0,
+            0,
+            0,
+            360,
+            640,
+            i32_values.as_mut_ptr(),
+            i32_values.len(),
+            f32_values.as_mut_ptr(),
+            f32_values.len(),
+            u8_values.as_mut_ptr(),
+            u8_values.len(),
+        );
+        assert_eq!(status, -1);
+        let error_ptr = stasis_android_bridge_last_frame_error();
+        let error = unsafe { CStr::from_ptr(error_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        stasis_android_bridge_free_string(error_ptr);
+        assert!(
+            error.contains("render resource error"),
+            "unexpected error: {error}"
+        );
+        assert!(error.contains("missing.svg"), "unexpected error: {error}");
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
+    fn embedded_resource_refresh_preserves_loaded_font_handles() {
+        let _guard = bridge_runtime_test_guard();
+        let root = temp_project("embedded_resource_refresh");
+        install_embedded_resource_host(&root).expect("install embedded resource host");
+        {
+            let mut slot = embedded_resource_catalog()
+                .lock()
+                .expect("resource catalog lock");
+            let catalog = slot.as_mut().expect("installed resource catalog");
+            catalog.fonts.push(EmbeddedFont {
+                handle: 1,
+                path: root.join("assets/font.ttf"),
+                size: 18,
+            });
+            catalog.text_runs.push(EmbeddedTextRun {
+                handle: 1,
+                font: 1,
+                text: "refresh".to_string(),
+                measured_width: 75.6,
+            });
+        }
+
+        let refreshed = prepare_embedded_resource_catalog(&root, true)
+            .expect("prepare refreshed embedded resource catalog");
+
+        assert_eq!(refreshed.fonts.len(), 1);
+        assert_eq!(refreshed.fonts[0].handle, 1);
+        assert_eq!(refreshed.text_runs.len(), 1);
+        assert_eq!(refreshed.text_runs[0].text, "refresh");
         fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -413,8 +413,6 @@ pub fn compile_android_workshop_project(
     };
     let previous = read_previous_android_plan(project_root)?;
     let mut plan = build_workshop_compile_plan(&files, &compile, previous.as_ref())?;
-    warm_or_reload_runtime_session(project_root, &files, fingerprint_workshop_sources(&files))?;
-
     // The legacy artifact analyzer does not understand every production extern and can
     // report detector errors for programs the real JIT has compiled successfully. The
     // executable pipeline above is authoritative for Workshop; retain the artifact
@@ -497,6 +495,8 @@ pub fn compile_android_workshop_project(
             )
         })?;
     }
+
+    warm_or_reload_runtime_session(project_root, &files, fingerprint_workshop_sources(&files))?;
 
     Ok(AndroidBridgeCompileResult {
         status: plan.status,
@@ -882,21 +882,23 @@ fn run_android_workshop_tick_internal(
             session.initialized = true;
             true
         };
-        session
-            .jit
-            .write_i32_global_path("Input.touch_x", input.touch_x);
-        session
-            .jit
-            .write_i32_global_path("Input.touch_y", input.touch_y);
-        session
-            .jit
-            .write_i32_global_path("Input.touch_active", input.touch_active);
-        session
-            .jit
-            .write_i32_global_path("Input.screen_w", input.screen_w);
-        session
-            .jit
-            .write_i32_global_path("Input.screen_h", input.screen_h);
+        if read_legacy_render_commands {
+            session
+                .jit
+                .write_i32_global_path("Input.touch_x", input.touch_x);
+            session
+                .jit
+                .write_i32_global_path("Input.touch_y", input.touch_y);
+            session
+                .jit
+                .write_i32_global_path("Input.touch_active", input.touch_active);
+            session
+                .jit
+                .write_i32_global_path("Input.screen_w", input.screen_w);
+            session
+                .jit
+                .write_i32_global_path("Input.screen_h", input.screen_h);
+        }
         execute_lifecycle_noarg(&session.jit, "tick")?;
         session.tick_count = session.tick_count.saturating_add(1);
         execute_optional_lifecycle_noarg(&session.jit, "render")?;
@@ -2224,6 +2226,54 @@ mod tests {
             .expect("read manifest");
         assert!(manifest.contains("errors=0"));
 
+        fs::remove_dir_all(root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
+    fn artifact_write_failure_does_not_stage_runtime_candidate() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("artifact_write_rejection");
+        let source = root.join("src/main.stasis");
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 1; }\n",
+        )
+        .expect("write initial source");
+        compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect("initial compile");
+        let initial =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("initial tick");
+        assert_eq!(initial.observed_game_tick_count, 11);
+
+        fs::write(
+            &source,
+            "global GameState { tick_count: i32; }\nfunction main(): void { GameState.tick_count = 10; }\nfunction tick(): void { GameState.tick_count += 100; }\n",
+        )
+        .expect("write changed source");
+        fs::remove_dir_all(root.join("build/functions")).expect("remove artifact directory");
+        fs::write(root.join("build/functions"), b"blocks artifact directory")
+            .expect("block artifact directory");
+
+        let error = compile_android_workshop_project(&root, Path::new("src/main.stasis"))
+            .expect_err("artifact write must fail");
+        assert!(error.contains("function artifact directory"), "{error}");
+        RUNTIME_SESSION.with(|session| {
+            let session = session.borrow();
+            let session = session.as_ref().expect("active runtime preserved");
+            assert!(session.pending_candidate.is_none());
+            assert!(session.pending_resource_catalog.is_none());
+        });
+
+        let after_failure =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("old runtime tick");
+        assert!(!after_failure.recompiled);
+        assert_eq!(after_failure.observed_game_tick_count, 12);
+
+        fs::remove_file(root.join("build/functions")).ok();
         fs::remove_dir_all(root).ok();
         clear_runtime_session_for_test();
     }

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -1908,6 +1908,53 @@ pub extern "C" fn stasis_android_bridge_last_frame_error() -> *mut c_char {
 }
 
 #[no_mangle]
+pub extern "C" fn stasis_android_bridge_inspect_runtime_state(
+    project_root: *const c_char,
+) -> *mut c_char {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        if project_root.is_null() {
+            return Err("null project root".to_string());
+        }
+        let project_root = Path::new(
+            CStr::from_ptr(project_root)
+                .to_str()
+                .map_err(|error| format!("project root was not UTF-8: {error}"))?,
+        );
+        inspect_android_runtime_state(project_root)
+    }));
+    let value = match result {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => serde_json::json!({"status": "RuntimeStateError", "error": error}),
+        Err(_) => serde_json::json!({
+            "status": "RuntimeStateError",
+            "error": "panic while inspecting Android runtime state",
+        }),
+    };
+    CString::new(value.to_string())
+        .unwrap_or_else(|_| CString::new("{\"status\":\"RuntimeStateError\"}").unwrap())
+        .into_raw()
+}
+
+fn inspect_android_runtime_state(project_root: &Path) -> Result<serde_json::Value, String> {
+    RUNTIME_SESSION.with(|session_cell| {
+        let session_slot = session_cell.borrow();
+        let session = session_slot
+            .as_ref()
+            .filter(|session| session.project_root == project_root)
+            .ok_or_else(|| "Android runtime session was not initialized".to_string())?;
+        Ok(serde_json::json!({
+            "status": "RuntimeStateReady",
+            "mode": "JitExecuted",
+            "source": "live_session",
+            "tick_count": session.tick_count,
+            "game_tick_count": session.jit.read_i32_global_path("GameState.tick_count"),
+            "initialized": session.initialized,
+            "pending_candidate": session.pending_candidate.is_some(),
+        }))
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn stasis_android_bridge_run_tick(
     project_root: *const c_char,
     entry_file: *const c_char,
@@ -2411,6 +2458,11 @@ mod tests {
         assert!(!second.recompiled);
         assert!(!second.initialized);
         assert_eq!(second.observed_game_tick_count, 12);
+
+        let live_state = inspect_android_runtime_state(&root).expect("inspect live runtime state");
+        assert_eq!(live_state["source"], "live_session");
+        assert_eq!(live_state["tick_count"], 2);
+        assert_eq!(live_state["game_tick_count"], 12);
 
         let state = fs::read_to_string(root.join("build/runtime_state.txt"))
             .expect("read JIT runtime state");

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -903,7 +903,12 @@ fn run_android_workshop_tick_internal(
         session.tick_count = session.tick_count.saturating_add(1);
         execute_optional_lifecycle_noarg(&session.jit, "render")?;
         take_embedded_resource_error()?;
-        let observed_game_tick_count = session.jit.read_i32_global_path("GameState.tick_count");
+        let write_runtime_state = should_write_jit_runtime_state(initialized, recompiled);
+        let observed_game_tick_count = if read_legacy_render_commands || write_runtime_state {
+            session.jit.read_i32_global_path("GameState.tick_count")
+        } else {
+            0
+        };
         let (render_command_count, render_commands) = if read_legacy_render_commands {
             (
                 session.jit.read_i32_global_path("Render.command_count"),
@@ -915,7 +920,7 @@ fn run_android_workshop_tick_internal(
                 [AndroidBridgeRenderCommand::default(); ANDROID_RENDER_COMMAND_CAPACITY],
             )
         };
-        if should_write_jit_runtime_state(session.tick_count, initialized, recompiled) {
+        if write_runtime_state {
             write_jit_runtime_state(
                 project_root,
                 session.tick_count,
@@ -1368,8 +1373,8 @@ fn fingerprint_workshop_sources(files: &[WorkshopSourceFile]) -> u64 {
     hasher.finish()
 }
 
-fn should_write_jit_runtime_state(tick_count: i32, initialized: bool, recompiled: bool) -> bool {
-    initialized || recompiled || tick_count % 60 == 0
+fn should_write_jit_runtime_state(initialized: bool, recompiled: bool) -> bool {
+    initialized || recompiled
 }
 
 fn write_jit_runtime_state(
@@ -2311,10 +2316,9 @@ mod tests {
 
     #[test]
     fn jit_runtime_state_write_policy_skips_ordinary_frames() {
-        assert!(should_write_jit_runtime_state(1, true, false));
-        assert!(should_write_jit_runtime_state(7, false, true));
-        assert!(should_write_jit_runtime_state(60, false, false));
-        assert!(!should_write_jit_runtime_state(2, false, false));
+        assert!(should_write_jit_runtime_state(true, false));
+        assert!(should_write_jit_runtime_state(false, true));
+        assert!(!should_write_jit_runtime_state(false, false));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1811,8 +1811,12 @@ pub(crate) fn declare_runtime_helper(
                 return Err(format!("missing runtime helper address for {symbol}"));
             }
             let local_symbol = format!("__stasis_runtime_helper_{symbol}");
+            // Preemptible deliberately marks the helper as non-colocated. On AArch64,
+            // Cranelift then emits an address load plus an indirect call instead of a
+            // range-limited BL relocation. The helper is still defined in this private
+            // JIT module; the linkage only controls the generated call sequence.
             module
-                .declare_function(&local_symbol, Linkage::Local, &signature)
+                .declare_function(&local_symbol, Linkage::Preemptible, &signature)
                 .map_err(|error| {
                     format!("failed to declare runtime helper trampoline {symbol}: {error}")
                 })
@@ -2181,6 +2185,7 @@ pub(crate) fn declare_extern_call_imports(
     call_signatures: &CallSignatureMap,
     type_table: &TypeTable,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    linkage: RuntimeHelperLinkage<'_>,
 ) -> Result<BTreeMap<ExternImportKey, FuncId>, String> {
     let mut out = BTreeMap::new();
     for signatures in call_signatures.values() {
@@ -2213,14 +2218,14 @@ pub(crate) fn declare_extern_call_imports(
                         type_table,
                     )?));
             }
-            let func_id = module
-                .declare_function(symbol, Linkage::Import, &clif_signature)
-                .map_err(|error| {
+            let func_id = declare_runtime_helper(module, symbol, clif_signature, linkage).map_err(
+                |error| {
                     format!(
                         "failed to declare extern import '{}' with params {:?} return {}: {}",
                         symbol, signature.params, signature.return_type, error
                     )
-                })?;
+                },
+            )?;
             out.insert(key, func_id);
         }
     }
@@ -9840,6 +9845,7 @@ pub(crate) fn build_runtime_call_import_ids(
             call_signatures,
             type_table,
             named_struct_field_types,
+            linkage,
         )?,
     })
 }

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -13,6 +13,7 @@ use cranelift_codegen::settings::{self, Configurable};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{default_libcall_names, Module};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -290,19 +291,35 @@ impl JitProcess {
                 let mut type_table = lowered_types.clone();
                 type_table.ensure_utf8_view_id()?;
                 type_table.ensure_ascii_view_id()?;
-                let (module, code_ptr) = compile_function_to_jit_module(
-                    meta,
-                    hir,
-                    &symbol,
-                    &analysis.call_signatures,
-                    &mut type_table,
-                    &analysis.global_path_types,
-                    &analysis.constant_values,
-                    &analysis.collection_infos,
-                    &analysis.named_struct_field_types,
-                    &analysis.extern_symbol_addresses,
-                    local_runtime_helper_trampolines,
-                )?;
+                let compiled = catch_unwind(AssertUnwindSafe(|| {
+                    compile_function_to_jit_module(
+                        meta,
+                        hir,
+                        &symbol,
+                        &analysis.call_signatures,
+                        &mut type_table,
+                        &analysis.global_path_types,
+                        &analysis.constant_values,
+                        &analysis.collection_infos,
+                        &analysis.named_struct_field_types,
+                        &analysis.extern_symbol_addresses,
+                        local_runtime_helper_trampolines,
+                    )
+                }));
+                let (module, code_ptr) = match compiled {
+                    Ok(result) => result?,
+                    Err(payload) => {
+                        let message = payload
+                            .downcast_ref::<&str>()
+                            .copied()
+                            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("unknown panic");
+                        return Err(format!(
+                            "JIT backend panicked while compiling '{}': {message}",
+                            meta.name
+                        ));
+                    }
+                };
                 let slot = next_slot;
                 next_slot = next_slot.saturating_add(1);
                 staged_modules.push(module);
@@ -1290,6 +1307,9 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "gfx_dump_png" | "stasis_gfx_dump_png" => {
             function_address(stasis_dynload::stasis_jit_gfx_dump_png as *const ())
         }
+        "gfx_poll_reload" | "stasis_gfx_poll_reload" | "stasis_jit_gfx_poll_reload" => {
+            function_address(stasis_dynload::stasis_jit_gfx_poll_reload as *const ())
+        }
         "load_font" | "stasis_load_font" => {
             function_address(stasis_dynload::stasis_jit_load_font as *const ())
         }
@@ -1299,8 +1319,40 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "gfx_cache_text" | "stasis_gfx_cache_text" | "stasis_jit_gfx_cache_text" => {
             function_address(stasis_dynload::stasis_jit_gfx_cache_text as *const ())
         }
+        "gfx_measure_text_cached"
+        | "stasis_gfx_measure_text_cached"
+        | "stasis_jit_gfx_measure_text_cached" => {
+            function_address(stasis_dynload::stasis_jit_gfx_measure_text_cached as *const ())
+        }
+        "time" | "stasis_time" | "stasis_jit_time" | "stasis_get_time_ms" => {
+            function_address(stasis_dynload::stasis_get_time_ms as *const ())
+        }
+        "time_us" | "stasis_time_us" | "stasis_jit_time_us" | "stasis_get_time_us" => {
+            function_address(stasis_dynload::stasis_get_time_us as *const ())
+        }
+        "sleep_ms" | "stasis_sleep_ms" | "stasis_jit_sleep_ms" => {
+            function_address(stasis_dynload::stasis_jit_sleep_ms as *const ())
+        }
+        "audio_init" | "stasis_audio_init" => {
+            function_address(stasis_dynload::stasis_jit_audio_init as *const ())
+        }
+        "audio_shutdown" | "stasis_audio_shutdown" => {
+            function_address(stasis_dynload::stasis_jit_audio_shutdown as *const ())
+        }
         "audio_is_available" | "stasis_audio_is_available" => {
             function_address(stasis_dynload::stasis_jit_audio_is_available as *const ())
+        }
+        "audio_get_sample_rate" | "stasis_audio_get_sample_rate" => {
+            function_address(stasis_dynload::stasis_jit_audio_get_sample_rate as *const ())
+        }
+        "audio_get_channels" | "stasis_audio_get_channels" => {
+            function_address(stasis_dynload::stasis_jit_audio_get_channels as *const ())
+        }
+        "audio_get_queued_frames" | "stasis_audio_get_queued_frames" => {
+            function_address(stasis_dynload::stasis_jit_audio_get_queued_frames as *const ())
+        }
+        "audio_get_underruns" | "stasis_audio_get_underruns" => {
+            function_address(stasis_dynload::stasis_jit_audio_get_underruns as *const ())
         }
         "audio_push_f32_interleaved" | "stasis_audio_push_f32_interleaved" => {
             function_address(stasis_dynload::stasis_jit_audio_push_f32_interleaved as *const ())
@@ -1422,7 +1474,7 @@ fn new_stasis_jit_builder() -> Result<JITBuilder, String> {
     let mut flag_builder = settings::builder();
     flag_builder
         .set("is_pic", "false")
-        .map_err(|error| format!("failed to configure non-PIC JIT: {error}"))?;
+        .map_err(|error| format!("failed to configure JIT relocation model: {error}"))?;
     let isa_builder = cranelift_native::builder()
         .map_err(|message| format!("host machine is not supported by Cranelift: {message}"))?;
     let isa = isa_builder
@@ -1712,7 +1764,15 @@ fn compile_function_to_jit_module(
         }
         jit_builder.symbol(extern_symbol, *address as *const u8);
     }
-    let runtime_helper_addresses = local_runtime_helper_trampolines.then(runtime_helper_addresses);
+    let runtime_helper_addresses = local_runtime_helper_trampolines.then(|| {
+        let mut addresses = runtime_helper_addresses();
+        addresses.extend(
+            extern_symbol_addresses
+                .iter()
+                .map(|(symbol, address)| (symbol.clone(), *address)),
+        );
+        addresses
+    });
     let runtime_helper_linkage = runtime_helper_addresses
         .as_ref()
         .map_or(RuntimeHelperLinkage::Imported, |addresses| {
@@ -1796,6 +1856,22 @@ mod tests {
             crate::backend::emit::runtime_helper_trampoline_count_for_test(),
             2
         );
+    }
+
+    #[test]
+    fn local_runtime_resolves_production_preview_externs() {
+        crate::backend::emit::reset_runtime_helper_trampoline_count_for_test();
+        let mut process = JitProcess::new();
+        process.set_local_runtime_helper_trampolines(true);
+        process.upsert_file(
+            "sample.stasis",
+            "extern function time(): i32;\nextern function time_us(): i32;\nextern function gfx_poll_reload(handle: i32): bool;\nextern function gfx_measure_text_cached(handle: i32): f32;\nextern function audio_is_available(): bool;\nfunction main(): i32 { let ms: i32 = time(); let us: i32 = time_us(); let width: f32 = gfx_measure_text_cached(0); if (gfx_poll_reload(0) || audio_is_available() || width != 0.0) { return 2; } if (ms == 0 && us == 0) { return 0; } return 1; }\n",
+        );
+        process
+            .compile()
+            .expect("compile production preview externs");
+        assert_eq!(process.execute_i32_noarg_by_name("main").unwrap(), 1);
+        assert!(crate::backend::emit::runtime_helper_trampoline_count_for_test() >= 5);
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1807,9 +1807,104 @@ pub extern "C" fn stasis_jit_print_string(value_id: i32) {
     }
 }
 
-const STASIS_RENDER_I32_COUNT: i32 = 34_848;
-const STASIS_RENDER_F32_COUNT: i32 = 92_292;
-const STASIS_RENDER_U8_COUNT: i32 = 65_536;
+pub const STASIS_RENDER_I32_COUNT: usize = 34_848;
+pub const STASIS_RENDER_F32_COUNT: usize = 92_292;
+pub const STASIS_RENDER_U8_COUNT: usize = 65_536;
+const STASIS_RENDER_MAGIC: i32 = 0x4758_4631;
+const STASIS_RENDER_VERSION: i32 = 1;
+const STASIS_RENDER_HEADER_I32_COUNT: usize = 10;
+const STASIS_RENDER_SPRITE_BASE: usize = 32;
+const STASIS_RENDER_MAX_LINES: usize = 10_000;
+const STASIS_RENDER_LINE_STRIDE: usize = 8;
+const STASIS_RENDER_MAX_SPRITES: usize = 4_096;
+const STASIS_RENDER_SPRITE_STRIDE: usize = 7;
+const STASIS_RENDER_TEXT_BASE_I32: usize = 28_704;
+const STASIS_RENDER_TEXT_BASE_F32: usize = 80_004;
+const STASIS_RENDER_MAX_TEXT: usize = 2_048;
+const STASIS_RENDER_TEXT_STRIDE_I32: usize = 3;
+const STASIS_RENDER_TEXT_STRIDE_F32: usize = 6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenderV1ActiveCounts {
+    pub lines: usize,
+    pub sprites: usize,
+    pub text: usize,
+    pub text_bytes: usize,
+}
+
+fn global_path_hash(path: &str) -> i32 {
+    let mut hash = 2_166_136_261u32;
+    for byte in path.bytes() {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    hash as i32
+}
+
+/// Copies only the active spans of the canonical JIT render buffers.
+///
+/// The destination retains production offsets so the Android GLES adapter consumes the exact
+/// same ABI as the SDL renderer without copying unused command capacity.
+pub fn copy_jit_render_v1_active(
+    out_i32: &mut [i32],
+    out_f32: &mut [f32],
+    out_u8: &mut [u8],
+) -> Result<RenderV1ActiveCounts, String> {
+    if out_i32.len() < STASIS_RENDER_I32_COUNT
+        || out_f32.len() < STASIS_RENDER_F32_COUNT
+        || out_u8.len() < STASIS_RENDER_U8_COUNT
+    {
+        return Err("production render destination has the wrong capacity".to_string());
+    }
+    let i32_ptr = stasis_jit_global_i32_array_ptr(
+        global_path_hash("gfx_cmd_i32"),
+        0,
+        STASIS_RENDER_I32_COUNT as i32,
+    );
+    let f32_ptr = stasis_jit_global_f32_array_ptr(
+        global_path_hash("gfx_cmd_f32"),
+        0,
+        STASIS_RENDER_F32_COUNT as i32,
+    );
+    let u8_ptr = global_u8_array_ptr(
+        global_path_hash("gfx_cmd_u8"),
+        0,
+        STASIS_RENDER_U8_COUNT as i32,
+    );
+    if i32_ptr.is_null() || f32_ptr.is_null() || u8_ptr.is_null() {
+        return Err("production render buffers were not registered by the JIT".to_string());
+    }
+    let source_i32 = unsafe { std::slice::from_raw_parts(i32_ptr, STASIS_RENDER_I32_COUNT) };
+    let source_f32 = unsafe { std::slice::from_raw_parts(f32_ptr, STASIS_RENDER_F32_COUNT) };
+    let source_u8 = unsafe { std::slice::from_raw_parts(u8_ptr, STASIS_RENDER_U8_COUNT) };
+    if source_i32[0] != STASIS_RENDER_MAGIC || source_i32[1] != STASIS_RENDER_VERSION {
+        return Err("JIT frame is not production gfx_cmd v1".to_string());
+    }
+
+    let counts = RenderV1ActiveCounts {
+        lines: source_i32[3].clamp(0, STASIS_RENDER_MAX_LINES as i32) as usize,
+        sprites: source_i32[4].clamp(0, STASIS_RENDER_MAX_SPRITES as i32) as usize,
+        text: source_i32[7].clamp(0, STASIS_RENDER_MAX_TEXT as i32) as usize,
+        text_bytes: source_i32[9].clamp(0, STASIS_RENDER_U8_COUNT as i32) as usize,
+    };
+    out_i32[..STASIS_RENDER_HEADER_I32_COUNT]
+        .copy_from_slice(&source_i32[..STASIS_RENDER_HEADER_I32_COUNT]);
+    let sprite_end = STASIS_RENDER_SPRITE_BASE + counts.sprites * STASIS_RENDER_SPRITE_STRIDE;
+    out_i32[STASIS_RENDER_SPRITE_BASE..sprite_end]
+        .copy_from_slice(&source_i32[STASIS_RENDER_SPRITE_BASE..sprite_end]);
+    let text_i32_end = STASIS_RENDER_TEXT_BASE_I32 + counts.text * STASIS_RENDER_TEXT_STRIDE_I32;
+    out_i32[STASIS_RENDER_TEXT_BASE_I32..text_i32_end]
+        .copy_from_slice(&source_i32[STASIS_RENDER_TEXT_BASE_I32..text_i32_end]);
+
+    out_f32[..4].copy_from_slice(&source_f32[..4]);
+    let line_end = 4 + counts.lines * STASIS_RENDER_LINE_STRIDE;
+    out_f32[4..line_end].copy_from_slice(&source_f32[4..line_end]);
+    let text_f32_end = STASIS_RENDER_TEXT_BASE_F32 + counts.text * STASIS_RENDER_TEXT_STRIDE_F32;
+    out_f32[STASIS_RENDER_TEXT_BASE_F32..text_f32_end]
+        .copy_from_slice(&source_f32[STASIS_RENDER_TEXT_BASE_F32..text_f32_end]);
+    out_u8[..counts.text_bytes].copy_from_slice(&source_u8[..counts.text_bytes]);
+    Ok(counts)
+}
 
 unsafe extern "C" {
     fn stasis_render_v1_trace_native(
@@ -1828,15 +1923,15 @@ pub unsafe extern "C" fn stasis_jit_render_v1_trace(
     cmd_u8_id: i32,
     cmd_u8_len: i32,
 ) -> i32 {
-    if cmd_i32_len != STASIS_RENDER_I32_COUNT
-        || cmd_f32_len != STASIS_RENDER_F32_COUNT
-        || cmd_u8_len != STASIS_RENDER_U8_COUNT
+    if cmd_i32_len != STASIS_RENDER_I32_COUNT as i32
+        || cmd_f32_len != STASIS_RENDER_F32_COUNT as i32
+        || cmd_u8_len != STASIS_RENDER_U8_COUNT as i32
     {
         return 0;
     }
-    let cmd_i32 = stasis_jit_global_i32_array_ptr(cmd_i32_id, 0, STASIS_RENDER_I32_COUNT);
-    let cmd_f32 = stasis_jit_global_f32_array_ptr(cmd_f32_id, 0, STASIS_RENDER_F32_COUNT);
-    let cmd_u8 = global_u8_array_ptr(cmd_u8_id, 0, STASIS_RENDER_U8_COUNT);
+    let cmd_i32 = stasis_jit_global_i32_array_ptr(cmd_i32_id, 0, STASIS_RENDER_I32_COUNT as i32);
+    let cmd_f32 = stasis_jit_global_f32_array_ptr(cmd_f32_id, 0, STASIS_RENDER_F32_COUNT as i32);
+    let cmd_u8 = global_u8_array_ptr(cmd_u8_id, 0, STASIS_RENDER_U8_COUNT as i32);
     if cmd_i32.is_null() || cmd_f32.is_null() || cmd_u8.is_null() {
         return 0;
     }
@@ -1900,6 +1995,61 @@ fn jit_text_arg_bytes(value_id: i32) -> Option<Vec<u8>> {
     guard.get(&value_id).map(|text| text.as_bytes().to_vec())
 }
 
+thread_local! {
+    static JIT_TEXT_SCRATCH: std::cell::RefCell<Vec<u8>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+fn with_jit_text_arg_bytes<R>(value_id: i32, mut callback: impl FnMut(&[u8]) -> R) -> Option<R> {
+    if jit_text_buffer_is_registered(value_id) {
+        let byte_len = usize::try_from(stasis_jit_collection_i32_load(value_id, 1)).ok()?;
+        return JIT_TEXT_SCRATCH.with(|scratch| {
+            let mut bytes = scratch.borrow_mut();
+            bytes.clear();
+            bytes.try_reserve(byte_len).ok()?;
+            for index in 0..byte_len {
+                let byte = stasis_jit_global_i32_array_load(value_id, 0, index as i32);
+                bytes.push(u8::try_from(byte).ok()?);
+            }
+            Some(callback(&bytes))
+        });
+    }
+
+    let table = jit_string_literal_table();
+    let guard = table
+        .lock()
+        .expect("jit string literal table mutex poisoned");
+    guard.get(&value_id).map(|text| callback(text.as_bytes()))
+}
+
+#[derive(Clone, Copy)]
+pub struct EmbeddedGraphicsHost {
+    pub load_sprite: fn(&[u8], i32, i32) -> i32,
+    pub release_sprite: fn(i32),
+    pub load_font: fn(&[u8], i32) -> i32,
+    pub measure_text: fn(i32, &[u8]) -> f32,
+    pub cache_text: fn(i32, &[u8]) -> i32,
+    pub measure_text_cached: fn(i32) -> f32,
+    pub poll_reload: fn(i32) -> i32,
+}
+
+thread_local! {
+    static EMBEDDED_GRAPHICS_HOST: std::cell::Cell<Option<EmbeddedGraphicsHost>> =
+        const { std::cell::Cell::new(None) };
+}
+
+pub fn set_embedded_graphics_host(host: Option<EmbeddedGraphicsHost>) {
+    EMBEDDED_GRAPHICS_HOST.with(|slot| slot.set(host));
+}
+
+pub fn embedded_graphics_host_is_set() -> bool {
+    EMBEDDED_GRAPHICS_HOST.with(|slot| slot.get().is_some())
+}
+
+fn embedded_graphics_host() -> Option<EmbeddedGraphicsHost> {
+    EMBEDDED_GRAPHICS_HOST.with(|slot| slot.get())
+}
+
 #[cfg(windows)]
 fn jit_text_arg_to_cstring(value_id: i32) -> Result<CString, String> {
     let bytes = jit_text_arg_bytes(value_id).ok_or_else(|| {
@@ -1914,6 +2064,9 @@ fn jit_text_arg_to_cstring(value_id: i32) -> Result<CString, String> {
 // translate that into a stable `const char*` when calling the C runtime.
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i32) -> i32 {
+    if let (Some(host), Some(path)) = (embedded_graphics_host(), jit_text_arg_bytes(path_id)) {
+        return (host.load_sprite)(&path, max_w, max_h);
+    }
     #[cfg(windows)]
     {
         let Ok(path) = jit_text_arg_to_cstring(path_id) else {
@@ -1937,6 +2090,10 @@ pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i3
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_release_sprite(handle: i32) {
+    if let Some(host) = embedded_graphics_host() {
+        (host.release_sprite)(handle);
+        return;
+    }
     #[cfg(windows)]
     {
         let Ok(api) = stasis_graphics_assets_api() else {
@@ -1999,6 +2156,9 @@ pub extern "C" fn stasis_jit_gfx_dump_png(path_id: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_load_font(path_id: i32, size: i32) -> i32 {
+    if let (Some(host), Some(path)) = (embedded_graphics_host(), jit_text_arg_bytes(path_id)) {
+        return (host.load_font)(&path, size);
+    }
     #[cfg(windows)]
     {
         let Ok(path) = jit_text_arg_to_cstring(path_id) else {
@@ -2021,6 +2181,13 @@ pub extern "C" fn stasis_jit_load_font(path_id: i32, size: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
+    if let Some(host) = embedded_graphics_host() {
+        if let Some(width) =
+            with_jit_text_arg_bytes(text_id, |text| (host.measure_text)(font, text))
+        {
+            return width;
+        }
+    }
     #[cfg(windows)]
     {
         let Ok(text) = jit_text_arg_to_cstring(text_id) else {
@@ -2043,6 +2210,9 @@ pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
+    if let (Some(host), Some(text)) = (embedded_graphics_host(), jit_text_arg_bytes(text_id)) {
+        return (host.cache_text)(font, &text);
+    }
     #[cfg(windows)]
     {
         let Ok(text) = jit_text_arg_to_cstring(text_id) else {
@@ -2065,6 +2235,9 @@ pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_poll_reload(handle: i32) -> i32 {
+    if let Some(host) = embedded_graphics_host() {
+        return (host.poll_reload)(handle);
+    }
     #[cfg(windows)]
     {
         let Ok(api) = stasis_graphics_assets_api() else {
@@ -2083,6 +2256,9 @@ pub extern "C" fn stasis_jit_gfx_poll_reload(handle: i32) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_measure_text_cached(run_handle: i32) -> f32 {
+    if let Some(host) = embedded_graphics_host() {
+        return (host.measure_text_cached)(run_handle);
+    }
     #[cfg(windows)]
     {
         let Ok(api) = stasis_graphics_assets_api() else {
@@ -3567,9 +3743,9 @@ mod tests {
                 101,
                 i32::MAX,
                 102,
-                STASIS_RENDER_F32_COUNT,
+                STASIS_RENDER_F32_COUNT as i32,
                 103,
-                STASIS_RENDER_U8_COUNT,
+                STASIS_RENDER_U8_COUNT as i32,
             )
         };
 

--- a/mobile/android/app/src/main/assets/workshop_sample/assets/center_line.svg
+++ b/mobile/android/app/src/main/assets/workshop_sample/assets/center_line.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1">
+  <rect width="1" height="1" fill="#444444"/>
+</svg>

--- a/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
+++ b/mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json
@@ -13,6 +13,30 @@
         "height": 32
       },
       "dependencies": []
+    },
+    {
+      "id": "paddle",
+      "path": "assets/paddle.svg",
+      "content_sha256": "ffa8fd1dbbea0d4fccdb3dfff9d25cb0340a65b635f1081ea281b1b457a95177",
+      "format": {
+        "kind": "sprite",
+        "encoding": "svg",
+        "width": 1,
+        "height": 1
+      },
+      "dependencies": []
+    },
+    {
+      "id": "center_line",
+      "path": "assets/center_line.svg",
+      "content_sha256": "261f2e95d72e0d6cd08cb7414be56fe1212a27a5e4ddcffae8ec774b4611a5f3",
+      "format": {
+        "kind": "sprite",
+        "encoding": "svg",
+        "width": 1,
+        "height": 1
+      },
+      "dependencies": []
     }
   ]
 }

--- a/mobile/android/app/src/main/assets/workshop_sample/assets/paddle.svg
+++ b/mobile/android/app/src/main/assets/workshop_sample/assets/paddle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1">
+  <rect width="1" height="1" fill="#5bc17e"/>
+</svg>

--- a/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
@@ -77,7 +77,7 @@ global Render {
     command4_clip_x: i32; command4_clip_y: i32; command4_clip_w: i32; command4_clip_h: i32;
 }
 
-function main(): void {
+function pong_game_main(): void {
     init();
 }
 
@@ -97,7 +97,7 @@ function init(): void {
     GameState.ai_score = 0;
 }
 
-function tick(): void {
+function pong_game_tick(): void {
     GameState.tick_count += 1;
 
     update_input();
@@ -212,7 +212,7 @@ function reset_ball(): void {
     GameState.enemy_paddle_speed_x100 = 1500;
 }
 
-function render(): void {
+function pong_game_render(): void {
     Render.command_schema_version = 3;
     Render.command_count = 5;
 
@@ -273,6 +273,67 @@ function render(): void {
     Render.command4_clip_x = 0; Render.command4_clip_y = 0; Render.command4_clip_w = GameState.screen_w; Render.command4_clip_h = GameState.screen_h;
 }
 
-function on_code_swap(): void {
-    render();
+function pong_game_on_code_swap(): void {
+    pong_game_render();
 }
+
+@link("stasis_graphics");
+global host_i32: i32[768];
+global host_f32: f32[64];
+global gfx_cmd_i32: i32[34848];
+global gfx_cmd_f32: f32[92292];
+global gfx_cmd_u8: u8[65536];
+global PongHost { ball_sprite: i32; }
+extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+
+function pong_host_line(x1: i32, y1: i32, x2: i32, y2: i32, r: f32, g: f32, b: f32): void {
+    let index: i32 = gfx_cmd_i32[3];
+    if (index >= 10000) { return; }
+    let base: i32 = 4 + index * 8;
+    gfx_cmd_f32[base].from_i32(x1); gfx_cmd_f32[base + 1].from_i32(y1);
+    gfx_cmd_f32[base + 2].from_i32(x2); gfx_cmd_f32[base + 3].from_i32(y2);
+    gfx_cmd_f32[base + 4] = r; gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b; gfx_cmd_f32[base + 7] = 1.0;
+    gfx_cmd_i32[3] = index + 1;
+}
+
+function pong_host_filled_rect(x: i32, y: i32, w: i32, h: i32, r: f32, g: f32, b: f32): void {
+    let column: i32 = 0;
+    for (column = 0; column < w; column += 1) {
+        pong_host_line(x + column, y, x + column, y + h, r, g, b);
+    }
+}
+
+function pong_host_render(): void {
+    pong_game_render();
+    gfx_cmd_i32[0] = 1196967473; gfx_cmd_i32[1] = 1; gfx_cmd_i32[2] = 1;
+    gfx_cmd_i32[3] = 0; gfx_cmd_i32[4] = 0; gfx_cmd_i32[7] = 0; gfx_cmd_i32[9] = 0;
+    gfx_cmd_f32[0] = 0.0588; gfx_cmd_f32[1] = 0.0667;
+    gfx_cmd_f32[2] = 0.1098; gfx_cmd_f32[3] = 1.0;
+    pong_host_filled_rect(24, GameState.player_y - 36, 10, 72, 0.357, 0.749, 0.494);
+    pong_host_filled_rect(GameState.screen_w - 34, GameState.ai_y - 36, 10, 72, 0.357, 0.749, 0.494);
+    pong_host_filled_rect((GameState.screen_w / 2) - 1, 0, 2, GameState.screen_h, 0.267, 0.267, 0.267);
+    gfx_cmd_i32[32] = PongHost.ball_sprite;
+    gfx_cmd_i32[33] = GameState.ball_x - 7; gfx_cmd_i32[34] = GameState.ball_y - 7;
+    gfx_cmd_i32[35] = 14; gfx_cmd_i32[36] = 14;
+    gfx_cmd_i32[37] = (GameState.tick_count * 3) % 360; gfx_cmd_i32[38] = 255;
+    gfx_cmd_i32[4] = 1;
+    gfx_cmd_i32[2] = 3;
+}
+
+function main(): void {
+    pong_game_main();
+    PongHost.ball_sprite = gfx_load_sprite("../assets/ball.svg", 32, 32);
+    pong_host_render();
+}
+
+function tick(): void {
+    Input.screen_w = host_i32[5]; Input.screen_h = host_i32[6];
+    Input.touch_active = host_i32[545];
+    let touch_x: i32; touch_x.from_f32(host_f32[0]); Input.touch_x = touch_x;
+    let touch_y: i32; touch_y.from_f32(host_f32[1]); Input.touch_y = touch_y;
+    pong_game_tick();
+}
+
+function render(): void { pong_host_render(); }
+function on_code_swap(): void { pong_host_render(); }

--- a/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
@@ -1,3 +1,5 @@
+import "preview_adapter.stasis";
+
 global Input {
     touch_x: i32;
     touch_y: i32;
@@ -276,64 +278,3 @@ function pong_game_render(): void {
 function pong_game_on_code_swap(): void {
     pong_game_render();
 }
-
-@link("stasis_graphics");
-global host_i32: i32[768];
-global host_f32: f32[64];
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
-global gfx_cmd_u8: u8[65536];
-global PongHost { ball_sprite: i32; }
-extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
-
-function pong_host_line(x1: i32, y1: i32, x2: i32, y2: i32, r: f32, g: f32, b: f32): void {
-    let index: i32 = gfx_cmd_i32[3];
-    if (index >= 10000) { return; }
-    let base: i32 = 4 + index * 8;
-    gfx_cmd_f32[base].from_i32(x1); gfx_cmd_f32[base + 1].from_i32(y1);
-    gfx_cmd_f32[base + 2].from_i32(x2); gfx_cmd_f32[base + 3].from_i32(y2);
-    gfx_cmd_f32[base + 4] = r; gfx_cmd_f32[base + 5] = g;
-    gfx_cmd_f32[base + 6] = b; gfx_cmd_f32[base + 7] = 1.0;
-    gfx_cmd_i32[3] = index + 1;
-}
-
-function pong_host_filled_rect(x: i32, y: i32, w: i32, h: i32, r: f32, g: f32, b: f32): void {
-    let column: i32 = 0;
-    for (column = 0; column < w; column += 1) {
-        pong_host_line(x + column, y, x + column, y + h, r, g, b);
-    }
-}
-
-function pong_host_render(): void {
-    pong_game_render();
-    gfx_cmd_i32[0] = 1196967473; gfx_cmd_i32[1] = 1; gfx_cmd_i32[2] = 1;
-    gfx_cmd_i32[3] = 0; gfx_cmd_i32[4] = 0; gfx_cmd_i32[7] = 0; gfx_cmd_i32[9] = 0;
-    gfx_cmd_f32[0] = 0.0588; gfx_cmd_f32[1] = 0.0667;
-    gfx_cmd_f32[2] = 0.1098; gfx_cmd_f32[3] = 1.0;
-    pong_host_filled_rect(24, GameState.player_y - 36, 10, 72, 0.357, 0.749, 0.494);
-    pong_host_filled_rect(GameState.screen_w - 34, GameState.ai_y - 36, 10, 72, 0.357, 0.749, 0.494);
-    pong_host_filled_rect((GameState.screen_w / 2) - 1, 0, 2, GameState.screen_h, 0.267, 0.267, 0.267);
-    gfx_cmd_i32[32] = PongHost.ball_sprite;
-    gfx_cmd_i32[33] = GameState.ball_x - 7; gfx_cmd_i32[34] = GameState.ball_y - 7;
-    gfx_cmd_i32[35] = 14; gfx_cmd_i32[36] = 14;
-    gfx_cmd_i32[37] = (GameState.tick_count * 3) % 360; gfx_cmd_i32[38] = 255;
-    gfx_cmd_i32[4] = 1;
-    gfx_cmd_i32[2] = 3;
-}
-
-function main(): void {
-    pong_game_main();
-    PongHost.ball_sprite = gfx_load_sprite("../assets/ball.svg", 32, 32);
-    pong_host_render();
-}
-
-function tick(): void {
-    Input.screen_w = host_i32[5]; Input.screen_h = host_i32[6];
-    Input.touch_active = host_i32[545];
-    let touch_x: i32; touch_x.from_f32(host_f32[0]); Input.touch_x = touch_x;
-    let touch_y: i32; touch_y.from_f32(host_f32[1]); Input.touch_y = touch_y;
-    pong_game_tick();
-}
-
-function render(): void { pong_host_render(); }
-function on_code_swap(): void { pong_host_render(); }

--- a/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
@@ -1,0 +1,50 @@
+@link("stasis_graphics");
+global host_i32: i32[768];
+global host_f32: f32[64];
+global gfx_cmd_i32: i32[34848];
+global gfx_cmd_f32: f32[92292];
+global gfx_cmd_u8: u8[65536];
+global PongHost { ball_sprite: i32; paddle_sprite: i32; center_sprite: i32; }
+extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+
+function pong_host_sprite(index: i32, handle: i32, x: i32, y: i32, w: i32, h: i32): void {
+    let base: i32 = 32 + index * 7;
+    gfx_cmd_i32[base] = handle; gfx_cmd_i32[base + 1] = x; gfx_cmd_i32[base + 2] = y;
+    gfx_cmd_i32[base + 3] = w; gfx_cmd_i32[base + 4] = h;
+    gfx_cmd_i32[base + 5] = 0; gfx_cmd_i32[base + 6] = 255;
+}
+
+function pong_host_render(): void {
+    pong_game_render();
+    gfx_cmd_i32[0] = 1196967473; gfx_cmd_i32[1] = 1; gfx_cmd_i32[2] = 1;
+    gfx_cmd_i32[3] = 0; gfx_cmd_i32[4] = 0; gfx_cmd_i32[7] = 0; gfx_cmd_i32[9] = 0;
+    gfx_cmd_f32[0] = 0.0588; gfx_cmd_f32[1] = 0.0667;
+    gfx_cmd_f32[2] = 0.1098; gfx_cmd_f32[3] = 1.0;
+    pong_host_sprite(0, PongHost.paddle_sprite, Render.command1_x, Render.command1_y, Render.command1_w, Render.command1_h);
+    pong_host_sprite(1, PongHost.paddle_sprite, Render.command2_x, Render.command2_y, Render.command2_w, Render.command2_h);
+    pong_host_sprite(2, PongHost.center_sprite, Render.command4_x, Render.command4_y, Render.command4_w, Render.command4_h);
+    pong_host_sprite(3, PongHost.ball_sprite, Render.command3_x, Render.command3_y, Render.command3_w, Render.command3_h);
+    let ball_base: i32 = 53;
+    gfx_cmd_i32[ball_base + 5] = (GameState.tick_count * 3) % 360;
+    gfx_cmd_i32[4] = 4;
+    gfx_cmd_i32[2] = 3;
+}
+
+function main(): void {
+    pong_game_main();
+    PongHost.ball_sprite = gfx_load_sprite("../assets/ball.svg", 32, 32);
+    PongHost.paddle_sprite = gfx_load_sprite("../assets/paddle.svg", 1, 1);
+    PongHost.center_sprite = gfx_load_sprite("../assets/center_line.svg", 1, 1);
+    pong_host_render();
+}
+
+function tick(): void {
+    Input.screen_w = host_i32[5]; Input.screen_h = host_i32[6];
+    Input.touch_active = host_i32[545];
+    let touch_x: i32; touch_x.from_f32(host_f32[0]); Input.touch_x = touch_x;
+    let touch_y: i32; touch_y.from_f32(host_f32[1]); Input.touch_y = touch_y;
+    pong_game_tick();
+}
+
+function render(): void { pong_host_render(); }
+function on_code_swap(): void { pong_game_on_code_swap(); pong_host_render(); }

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,11 @@ if(STASIS_ANDROID_PUBLISHED_AOT)
         message(FATAL_ERROR "STASIS_PUBLISHED_AOT_DIR is required when STASIS_ANDROID_PUBLISHED_AOT=ON")
     endif()
     include("${STASIS_PUBLISHED_AOT_DIR}/published_aot_objects.cmake")
-    target_sources(stasis_mobile_smoke PRIVATE ${STASIS_PUBLISHED_AOT_OBJECTS})
+    target_sources(stasis_mobile_smoke PRIVATE
+        ${STASIS_PUBLISHED_AOT_OBJECTS}
+        "${STASIS_PUBLISHED_AOT_DIR}/published_aot_bindings.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime/stasis_mobile_aot_runtime.c")
     target_include_directories(stasis_mobile_smoke PRIVATE "${STASIS_PUBLISHED_AOT_DIR}")
-    target_compile_definitions(stasis_mobile_smoke PRIVATE STASIS_ANDROID_PUBLISHED_AOT=1)
+    target_compile_definitions(stasis_mobile_smoke PRIVATE
+        STASIS_ANDROID_PUBLISHED_AOT=1 STASIS_RENDER_V1_DIRECT=1)
 endif()

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -7,6 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
+#include "stasis_render_contract.h"
+#include "stasis_mobile_aot_runtime.h"
 #if STASIS_ANDROID_PUBLISHED_AOT
 #include "published_aot_symbols.h"
 #endif
@@ -26,10 +29,13 @@
 typedef char *(*stasis_android_bridge_compile_project_fn)(const char *project_root, const char *entry_file);
 typedef char *(*stasis_android_bridge_run_tests_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_run_tick_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h);
-typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_values, uintptr_t out_len);
+typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len);
+typedef char *(*stasis_android_bridge_last_frame_error_fn)(void);
 typedef char *(*stasis_android_bridge_set_i32_global_fn)(const char *project_root, const char *entry_file, const char *path, int value);
 typedef char *(*stasis_android_bridge_get_i32_global_fn)(const char *project_root, const char *entry_file, const char *path);
 typedef char *(*stasis_android_bridge_resolve_sprite_asset_fn)(const char *project_root, int handle);
+typedef char *(*stasis_android_bridge_resolve_cached_text_fn)(const char *project_root, int handle);
+typedef char *(*stasis_android_bridge_resolve_font_fn)(const char *project_root, int handle);
 typedef char *(*stasis_android_bridge_source_items_fn)(const char *project_root, const char *entry_file);
 typedef char *(*stasis_android_bridge_semantic_edit_fn)(const char *project_root, const char *entry_file, const char *request_json, int dry_run, int validate, int run_tests);
 typedef void (*stasis_android_bridge_free_string_fn)(char *value);
@@ -65,9 +71,12 @@ typedef struct RustBridgeApi {
     stasis_android_bridge_run_tests_fn run_tests;
     stasis_android_bridge_run_tick_fn run_tick;
     stasis_android_bridge_run_tick_frame_fn run_tick_frame;
+    stasis_android_bridge_last_frame_error_fn last_frame_error;
     stasis_android_bridge_set_i32_global_fn set_i32_global;
     stasis_android_bridge_get_i32_global_fn get_i32_global;
     stasis_android_bridge_resolve_sprite_asset_fn resolve_sprite_asset;
+    stasis_android_bridge_resolve_cached_text_fn resolve_cached_text;
+    stasis_android_bridge_resolve_font_fn resolve_font;
     stasis_android_bridge_source_items_fn source_items;
     stasis_android_bridge_semantic_edit_fn semantic_edit;
     stasis_android_bridge_free_string_fn free_string;
@@ -89,7 +98,7 @@ typedef struct CodexBridgeApi {
 } CodexBridgeApi;
 
 static CodexBridgeApi codex_bridge_api = {0};
-#if STASIS_ANDROID_PUBLISHED_AOT
+#if STASIS_ANDROID_PUBLISHED_AOT && !STASIS_RENDER_V1_DIRECT
 typedef struct PublishedRenderCommand {
     int32_t kind;
     int32_t x;
@@ -293,6 +302,287 @@ static int stasis_published_run_tick_frame(int touch_x, int touch_y, int touch_a
     published_runtime_tick_count += 1;
     stasis_published_pack_frame(out_values, out_len);
     return 0;
+}
+
+static int stasis_published_run_tick_frame_v1(
+        int touch_x, int touch_y, int touch_active, int screen_w, int screen_h,
+        int32_t *out_i32, float *out_f32, uint8_t *out_u8) {
+    int32_t legacy[STASIS_RENDER_FRAME_I32_CAPACITY] = {0};
+    int status = stasis_published_run_tick_frame(
+            touch_x, touch_y, touch_active, screen_w, screen_h,
+            legacy, STASIS_RENDER_FRAME_I32_CAPACITY);
+    if (status != 0) return status;
+    (void)out_u8;
+    out_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
+    out_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
+    out_i32[STASIS_RENDER_I_FLAGS] = STASIS_RENDER_FLAG_CLEAR | STASIS_RENDER_FLAG_PRESENT;
+    out_i32[STASIS_RENDER_I_LINE_COUNT] = 0;
+    out_i32[STASIS_RENDER_I_SPRITE_COUNT] = 0;
+    out_i32[STASIS_RENDER_I_TEXT_COUNT] = 0;
+    out_i32[STASIS_RENDER_I_TEXT_BYTES_USED] = 0;
+    out_f32[STASIS_RENDER_F_CLEAR_BASE + 0] = 15.0f / 255.0f;
+    out_f32[STASIS_RENDER_F_CLEAR_BASE + 1] = 20.0f / 255.0f;
+    out_f32[STASIS_RENDER_F_CLEAR_BASE + 2] = 28.0f / 255.0f;
+    out_f32[STASIS_RENDER_F_CLEAR_BASE + 3] = 1.0f;
+    int32_t command_count = stasis_render_clamp_count(
+            legacy[5], STASIS_RENDER_COMMAND_CAPACITY);
+    for (int32_t index = 0; index < command_count; index += 1) {
+        int32_t base = STASIS_RENDER_FRAME_HEADER_SIZE + index * STASIS_RENDER_COMMAND_STRIDE;
+        if (legacy[base] == 1) {
+            int32_t line = out_i32[STASIS_RENDER_I_LINE_COUNT];
+            if (line > STASIS_RENDER_MAX_LINES - 4) continue;
+            float x = (float)legacy[base + 1];
+            float y = (float)legacy[base + 2];
+            float right = x + (float)legacy[base + 3];
+            float bottom = y + (float)legacy[base + 4];
+            int32_t color = legacy[base + 5];
+            float r = (float)((color >> 16) & 255) / 255.0f;
+            float g = (float)((color >> 8) & 255) / 255.0f;
+            float b = (float)(color & 255) / 255.0f;
+            float a = (float)legacy[base + 8] / 255.0f;
+            const float points[16] = {
+                x, y, right, y, right, y, right, bottom,
+                right, bottom, x, bottom, x, bottom, x, y};
+            for (int edge = 0; edge < 4; edge += 1) {
+                int32_t line_base = STASIS_RENDER_F_LINE_BASE +
+                        (line + edge) * STASIS_RENDER_LINE_F32_STRIDE;
+                out_f32[line_base + 0] = points[edge * 4 + 0];
+                out_f32[line_base + 1] = points[edge * 4 + 1];
+                out_f32[line_base + 2] = points[edge * 4 + 2];
+                out_f32[line_base + 3] = points[edge * 4 + 3];
+                out_f32[line_base + 4] = r;
+                out_f32[line_base + 5] = g;
+                out_f32[line_base + 6] = b;
+                out_f32[line_base + 7] = a;
+            }
+            out_i32[STASIS_RENDER_I_LINE_COUNT] = line + 4;
+        } else if (legacy[base] == 2) {
+            int32_t sprite = out_i32[STASIS_RENDER_I_SPRITE_COUNT];
+            if (sprite >= STASIS_RENDER_MAX_SPRITES) continue;
+            int32_t sprite_base = STASIS_RENDER_I_SPRITE_BASE +
+                    sprite * STASIS_RENDER_SPRITE_I32_STRIDE;
+            out_i32[sprite_base + 0] = legacy[base + 6];
+            out_i32[sprite_base + 1] = legacy[base + 1];
+            out_i32[sprite_base + 2] = legacy[base + 2];
+            out_i32[sprite_base + 3] = legacy[base + 3];
+            out_i32[sprite_base + 4] = legacy[base + 4];
+            out_i32[sprite_base + 5] = legacy[base + 7];
+            out_i32[sprite_base + 6] = legacy[base + 8];
+            out_i32[STASIS_RENDER_I_SPRITE_COUNT] = sprite + 1;
+        }
+    }
+    return 0;
+}
+#endif
+
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+#define STASIS_PUBLISHED_MAX_FONTS 64
+#define STASIS_PUBLISHED_MAX_TEXT_RUNS 4096
+typedef struct PublishedFontResource { char path[256]; int32_t size; } PublishedFontResource;
+typedef struct PublishedTextResource { int32_t font; char text[1025]; float width; } PublishedTextResource;
+static PublishedFontResource published_fonts[STASIS_PUBLISHED_MAX_FONTS];
+static PublishedTextResource published_text_runs[STASIS_PUBLISHED_MAX_TEXT_RUNS];
+static int32_t published_font_count;
+static int32_t published_text_run_count;
+static char published_resource_error[256];
+
+extern int32_t stasis_published_sprite_handle_for_path(const char *path);
+
+int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) {
+    if (path == NULL || max_w <= 0 || max_h <= 0) {
+        snprintf(published_resource_error, sizeof(published_resource_error),
+                "sprite load rejected: invalid path or dimensions");
+        return 0;
+    }
+    int32_t handle = stasis_published_sprite_handle_for_path(path);
+    if (handle == 0) {
+        snprintf(published_resource_error, sizeof(published_resource_error),
+                "sprite is not declared in the packaged asset manifest: %.160s", path);
+    }
+    return handle;
+}
+void stasis_gfx_release_sprite(int handle) { (void)handle; }
+int stasis_gfx_dump_bmp(const char *path) { (void)path; return 0; }
+int stasis_gfx_dump_png(const char *path) { (void)path; return 0; }
+int stasis_gfx_poll_reload(int handle) { (void)handle; return 0; }
+
+int stasis_load_font(const char *path, int size) {
+    if (path == NULL || size <= 0) {
+        snprintf(published_resource_error, sizeof(published_resource_error),
+                "font load rejected: invalid path or size");
+        return 0;
+    }
+    for (int32_t index = 0; index < published_font_count; index += 1) {
+        if (published_fonts[index].size == size && strcmp(published_fonts[index].path, path) == 0) {
+            return index + 1;
+        }
+    }
+    if (published_font_count >= STASIS_PUBLISHED_MAX_FONTS || strlen(path) >= 256) {
+        snprintf(published_resource_error, sizeof(published_resource_error), "font registry full or path too long");
+        return 0;
+    }
+    PublishedFontResource *font = &published_fonts[published_font_count++];
+    snprintf(font->path, sizeof(font->path), "%s", path);
+    font->size = size;
+    return published_font_count;
+}
+
+float stasis_measure_text(int font, const char *text) {
+    if (font <= 0 || font > published_font_count || text == NULL) return 0.0f;
+    return (float)strlen(text) * (float)published_fonts[font - 1].size * 0.6f;
+}
+
+int stasis_gfx_cache_text(int font, const char *text) {
+    if (font <= 0 || font > published_font_count || text == NULL) {
+        snprintf(published_resource_error, sizeof(published_resource_error),
+                "cached text rejected: font handle was not loaded or text is null");
+        return 0;
+    }
+    for (int32_t index = 0; index < published_text_run_count; index += 1) {
+        if (published_text_runs[index].font == font && strcmp(published_text_runs[index].text, text) == 0) {
+            return index + 1;
+        }
+    }
+    if (published_text_run_count >= STASIS_PUBLISHED_MAX_TEXT_RUNS || strlen(text) >= 1025) {
+        snprintf(published_resource_error, sizeof(published_resource_error), "cached text registry full or text too long");
+        return 0;
+    }
+    PublishedTextResource *run = &published_text_runs[published_text_run_count++];
+    run->font = font;
+    snprintf(run->text, sizeof(run->text), "%s", text);
+    run->width = stasis_measure_text(font, text);
+    return published_text_run_count;
+}
+
+float stasis_gfx_measure_text_cached(int handle) {
+    return handle > 0 && handle <= published_text_run_count
+            ? published_text_runs[handle - 1].width : 0.0f;
+}
+
+int stasis_audio_init(int sample_rate, int channels, int target_latency_frames) {
+    (void)sample_rate; (void)channels; (void)target_latency_frames; return 0;
+}
+void stasis_audio_shutdown(void) {}
+int stasis_audio_is_available(void) { return 0; }
+int stasis_audio_get_sample_rate(void) { return 0; }
+int stasis_audio_get_channels(void) { return 0; }
+int stasis_audio_get_queued_frames(void) { return 0; }
+int stasis_audio_get_underruns(void) { return 0; }
+int stasis_audio_push_f32_interleaved(const float *samples, int frames) {
+    (void)samples; (void)frames; return 0;
+}
+void stasis_sleep_ms(int ms) {
+    if (ms <= 0) return;
+    struct timespec delay = { ms / 1000, (long)(ms % 1000) * 1000000L };
+    nanosleep(&delay, NULL);
+}
+int stasis_get_time_ms(void) {
+    struct timespec now;
+    return clock_gettime(CLOCK_MONOTONIC, &now) == 0
+            ? (int)(now.tv_sec * 1000 + now.tv_nsec / 1000000) : 0;
+}
+int stasis_get_time_us(void) {
+    struct timespec now;
+    return clock_gettime(CLOCK_MONOTONIC, &now) == 0
+            ? (int)(now.tv_sec * 1000000 + now.tv_nsec / 1000) : 0;
+}
+
+static int published_v1_initialized;
+static int32_t *published_v1_i32;
+static float *published_v1_f32;
+static uint8_t *published_v1_u8;
+static int32_t published_host_i32[768];
+static float published_host_f32[64];
+static int32_t published_previous_touch_x;
+static int32_t published_previous_touch_y;
+static int32_t published_previous_touch_active;
+static int32_t published_has_previous_input;
+
+static int32_t stasis_published_hash_path(const char *path) {
+    uint32_t hash = 2166136261U;
+    while (*path != '\0') {
+        hash ^= (uint8_t)*path++;
+        hash *= 16777619U;
+    }
+    return (int32_t)hash;
+}
+
+static void stasis_published_write_host_frame(
+        int touch_x, int touch_y, int touch_active, int screen_w, int screen_h) {
+    int32_t was_down = published_has_previous_input && published_previous_touch_active != 0;
+    int32_t is_down = touch_active != 0;
+    published_host_i32[0] = stasis_get_time_ms();
+    published_host_i32[1] = screen_w;
+    published_host_i32[2] = screen_h;
+    published_host_i32[5] = screen_w;
+    published_host_i32[6] = screen_h;
+    published_host_i32[7] = 1;
+    published_host_i32[12] = screen_w;
+    published_host_i32[13] = screen_h;
+    published_host_i32[14] = 1;
+    published_host_i32[16] = 60;
+    published_host_i32[17] = 1;
+    published_host_i32[19] = stasis_get_time_us();
+    published_host_i32[544] = 0;
+    published_host_i32[545] = is_down;
+    published_host_i32[546] = is_down && !was_down;
+    published_host_i32[547] = !is_down && was_down;
+    published_host_f32[0] = (float)touch_x;
+    published_host_f32[1] = (float)touch_y;
+    published_host_f32[2] = published_has_previous_input
+            ? (float)(touch_x - published_previous_touch_x) : 0.0f;
+    published_host_f32[3] = published_has_previous_input
+            ? (float)(touch_y - published_previous_touch_y) : 0.0f;
+    published_host_f32[4] = screen_w > 0 ? (float)touch_x / (float)screen_w : 0.0f;
+    published_host_f32[5] = screen_h > 0 ? (float)touch_y / (float)screen_h : 0.0f;
+    published_previous_touch_x = touch_x;
+    published_previous_touch_y = touch_y;
+    published_previous_touch_active = touch_active;
+    published_has_previous_input = 1;
+}
+
+static int stasis_published_run_tick_frame_v1(
+        int touch_x, int touch_y, int touch_active, int screen_w, int screen_h,
+        int32_t *out_i32, float *out_f32, uint8_t *out_u8) {
+    if (published_v1_initialized &&
+            (out_i32 != published_v1_i32 || out_f32 != published_v1_f32 || out_u8 != published_v1_u8)) {
+        published_v1_initialized = 0;
+        published_v1_i32 = NULL;
+        published_v1_f32 = NULL;
+        published_v1_u8 = NULL;
+        published_font_count = 0;
+        published_text_run_count = 0;
+        published_has_previous_input = 0;
+        memset(published_host_i32, 0, sizeof(published_host_i32));
+        memset(published_host_f32, 0, sizeof(published_host_f32));
+    }
+    if (!published_v1_initialized) {
+        published_resource_error[0] = '\0';
+        stasis_mobile_aot_reset();
+        STASIS_AOT_BIND_RUNTIME_GLOBALS();
+        stasis_jit_register_global_i32_array(
+                stasis_published_hash_path("host_i32"), 0, published_host_i32, 768);
+        stasis_jit_register_global_f32_array(
+                stasis_published_hash_path("host_f32"), 0, published_host_f32, 64);
+        stasis_jit_register_global_i32_array(
+                stasis_published_hash_path("gfx_cmd_i32"), 0, out_i32, STASIS_RENDER_I32_COUNT);
+        stasis_jit_register_global_f32_array(
+                stasis_published_hash_path("gfx_cmd_f32"), 0, out_f32, STASIS_RENDER_F32_COUNT);
+        stasis_jit_register_global_u8_array(
+                stasis_published_hash_path("gfx_cmd_u8"), 0, out_u8, STASIS_RENDER_U8_COUNT);
+        published_v1_i32 = out_i32;
+        published_v1_f32 = out_f32;
+        published_v1_u8 = out_u8;
+        stasis_published_write_host_frame(touch_x, touch_y, touch_active, screen_w, screen_h);
+        if (STASIS_AOT_MAIN() != 0) return -1;
+        if (published_resource_error[0] != '\0') return -1;
+        published_v1_initialized = 1;
+    }
+    stasis_published_write_host_frame(touch_x, touch_y, touch_active, screen_w, screen_h);
+    if (STASIS_AOT_TICK() != 0 || STASIS_AOT_RENDER() != 0) return -1;
+    if (published_resource_error[0] != '\0') return -1;
+    published_host_i32[10] += 1;
+    return stasis_render_v1_is_valid(out_i32) ? 0 : -1;
 }
 #endif
 static char *read_file_text(const char *path, long *size_out);
@@ -940,13 +1230,19 @@ static RustBridgeApi *load_rust_bridge_api(void) {
     rust_bridge_api.run_tick =
             (stasis_android_bridge_run_tick_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick");
     rust_bridge_api.run_tick_frame =
-            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame");
+            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v1");
+    rust_bridge_api.last_frame_error =
+            (stasis_android_bridge_last_frame_error_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_last_frame_error");
     rust_bridge_api.set_i32_global =
             (stasis_android_bridge_set_i32_global_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_set_i32_global");
     rust_bridge_api.get_i32_global =
             (stasis_android_bridge_get_i32_global_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_get_i32_global");
     rust_bridge_api.resolve_sprite_asset =
             (stasis_android_bridge_resolve_sprite_asset_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_sprite_asset");
+    rust_bridge_api.resolve_cached_text =
+            (stasis_android_bridge_resolve_cached_text_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_cached_text");
+    rust_bridge_api.resolve_font =
+            (stasis_android_bridge_resolve_font_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_font");
     rust_bridge_api.source_items =
             (stasis_android_bridge_source_items_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_source_items");
     rust_bridge_api.semantic_edit =
@@ -1164,12 +1460,14 @@ static int try_rust_bridge_get_i32_global(const char *project_root, const char *
     bridge->free_string(bridge_message);
     return 1;
 }
-static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_values, uintptr_t out_len) {
+static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
     RustBridgeApi *bridge = load_rust_bridge_api();
     if (bridge == NULL || bridge->run_tick_frame == NULL) {
         return -1;
     }
-    return bridge->run_tick_frame(project_root, "src/main.stasis", touch_x, touch_y, touch_active, screen_w, screen_h, out_values, out_len);
+    return bridge->run_tick_frame(project_root, "src/main.stasis", touch_x, touch_y, touch_active,
+            screen_w, screen_h, out_i32, out_i32_len, out_f32, out_f32_len,
+            out_u8, out_u8_len);
 }
 JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeSetRuntimeI32(JNIEnv *env, jclass activity_class, jstring project_root, jstring path, jint value) {
@@ -1260,6 +1558,99 @@ Java_com_stasislang_workshop_MainActivity_nativeResolveSpriteAsset(
 }
 
 JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeResolveCachedText(
+        JNIEnv *env, jclass activity_class, jstring project_root, jint handle) {
+    (void)activity_class;
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+    (void)project_root;
+    if (handle <= 0 || handle > published_text_run_count) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"cached text handle was not loaded\"}");
+    }
+    PublishedTextResource *run = &published_text_runs[handle - 1];
+    PublishedFontResource *font = &published_fonts[run->font - 1];
+    const char *asset_path = strstr(font->path, "assets/");
+    if (asset_path == NULL) asset_path = font->path;
+    char escaped_text[2050];
+    size_t out = 0;
+    for (const char *cursor = run->text; *cursor != '\0' && out + 2 < sizeof(escaped_text); cursor += 1) {
+        if (*cursor == '"' || *cursor == '\\') escaped_text[out++] = '\\';
+        escaped_text[out++] = *cursor;
+    }
+    escaped_text[out] = '\0';
+    char response[3072];
+    snprintf(response, sizeof(response),
+            "{\"status\":\"ok\",\"handle\":%d,\"font\":%d,\"font_asset\":\"stasis_game/%s\",\"font_size\":%d,\"text\":\"%s\",\"measured_width\":%.3f}",
+            (int)handle, (int)run->font, asset_path, (int)font->size,
+            escaped_text, (double)run->width);
+    return (*env)->NewStringUTF(env, response);
+#else
+    const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
+    if (root == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"unable to read project root\"}");
+    }
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->resolve_cached_text == NULL || bridge->free_string == NULL) {
+        (*env)->ReleaseStringUTFChars(env, project_root, root);
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"cached text resolver unavailable\"}");
+    }
+    char *message = bridge->resolve_cached_text(root, (int)handle);
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"cached text resolver returned no result\"}");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
+#endif
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeResolveFont(
+        JNIEnv *env, jclass activity_class, jstring project_root, jint handle) {
+    (void)activity_class;
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+    (void)project_root;
+    if (handle <= 0 || handle > published_font_count) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"font handle was not loaded\"}");
+    }
+    PublishedFontResource *font = &published_fonts[handle - 1];
+    const char *asset_path = strstr(font->path, "assets/");
+    if (asset_path == NULL) asset_path = font->path;
+    char response[768];
+    snprintf(response, sizeof(response),
+            "{\"status\":\"ok\",\"handle\":%d,\"font_asset\":\"stasis_game/%s\",\"font_size\":%d}",
+            (int)handle, asset_path, (int)font->size);
+    return (*env)->NewStringUTF(env, response);
+#else
+    const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
+    if (root == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"unable to read project root\"}");
+    }
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->resolve_font == NULL || bridge->free_string == NULL) {
+        (*env)->ReleaseStringUTFChars(env, project_root, root);
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"font resolver unavailable\"}");
+    }
+    char *message = bridge->resolve_font(root, (int)handle);
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"font resolver returned no result\"}");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
+#endif
+}
+
+JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeCodexBeginDeviceLogin(
         JNIEnv *env, jclass activity_class, jstring codex_home) {
     (void)activity_class;
@@ -1319,7 +1710,9 @@ Java_com_stasislang_workshop_MainActivity_nativeCompileProject(JNIEnv *env, jcla
     (void)activity_class;
 #if STASIS_ANDROID_PUBLISHED_AOT
     (void)project_root;
+#if !STASIS_RENDER_V1_DIRECT
     stasis_published_init_globals();
+#endif
     return (*env)->NewStringUTF(env, "CompilePlanned: reload=PublishedAot files=0 functions=0 hash=0000000000000000 manifest=published_aot state=compiled status=0");
 #else
 
@@ -1421,35 +1814,78 @@ Java_com_stasislang_workshop_MainActivity_nativeSemanticEdit(
     return response;
 }
 JNIEXPORT jint JNICALL
-Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h, jintArray frame_values) {
+Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h, jobject frame_i32, jobject frame_f32, jobject frame_u8) {
     (void)activity_class;
-    const int frame_len = STASIS_RENDER_FRAME_I32_CAPACITY;
-    int32_t values[STASIS_RENDER_FRAME_I32_CAPACITY];
-    memset(values, 0, sizeof(values));
-
-    if (frame_values == NULL || (*env)->GetArrayLength(env, frame_values) < frame_len) {
+    int32_t *values_i32 = (int32_t *)(*env)->GetDirectBufferAddress(env, frame_i32);
+    float *values_f32 = (float *)(*env)->GetDirectBufferAddress(env, frame_f32);
+    uint8_t *values_u8 = (uint8_t *)(*env)->GetDirectBufferAddress(env, frame_u8);
+    jlong bytes_i32 = (*env)->GetDirectBufferCapacity(env, frame_i32);
+    jlong bytes_f32 = (*env)->GetDirectBufferCapacity(env, frame_f32);
+    jlong bytes_u8 = (*env)->GetDirectBufferCapacity(env, frame_u8);
+    if (values_i32 == NULL || values_f32 == NULL || values_u8 == NULL
+            || bytes_i32 < (jlong)(STASIS_RENDER_I32_COUNT * sizeof(int32_t))
+            || bytes_f32 < (jlong)(STASIS_RENDER_F32_COUNT * sizeof(float))
+            || bytes_u8 < (jlong)STASIS_RENDER_U8_COUNT) {
         return -1;
     }
 
 #if STASIS_ANDROID_PUBLISHED_AOT
     (void)project_root;
-    int status = stasis_published_run_tick_frame((int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h, values, frame_len);
+    int status = stasis_published_run_tick_frame_v1(
+            (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h,
+            values_i32, values_f32, values_u8);
 #else
     const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
     if (root == NULL) {
-        values[0] = -1;
-        (*env)->SetIntArrayRegion(env, frame_values, 0, frame_len, (const jint *)values);
+        values_i32[0] = -1;
         return -1;
     }
 
-    int status = try_rust_bridge_run_tick_frame(root, (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h, values, frame_len);
+    int status = try_rust_bridge_run_tick_frame(
+            root, (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h,
+            values_i32, STASIS_RENDER_I32_COUNT, values_f32, STASIS_RENDER_F32_COUNT,
+            values_u8, STASIS_RENDER_U8_COUNT);
     (*env)->ReleaseStringUTFChars(env, project_root, root);
 #endif
     if (status != 0) {
-        values[0] = -1;
+        values_i32[0] = -1;
+    } else {
+        static int32_t *last_traced_frame;
+        if (last_traced_frame != values_i32) {
+            uint32_t trace = stasis_render_v1_trace(values_i32, values_f32, values_u8);
+            __android_log_print(ANDROID_LOG_INFO, STASIS_ANDROID_LOG_TAG,
+                    "Stasis preview gfx_cmd v1 trace=%u flags=%d lines=%d sprites=%d text=%d",
+                    trace, values_i32[STASIS_RENDER_I_FLAGS],
+                    values_i32[STASIS_RENDER_I_LINE_COUNT],
+                    values_i32[STASIS_RENDER_I_SPRITE_COUNT],
+                    values_i32[STASIS_RENDER_I_TEXT_COUNT]);
+            last_traced_frame = values_i32;
+        }
     }
-    (*env)->SetIntArrayRegion(env, frame_values, 0, frame_len, (const jint *)values);
     return (jint)status;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeLastFrameError(
+        JNIEnv *env, jclass activity_class) {
+    (void)activity_class;
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+    const char *message = published_resource_error[0] == '\0'
+            ? "native preview frame failed" : published_resource_error;
+    return (*env)->NewStringUTF(env, message);
+#else
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->last_frame_error == NULL || bridge->free_string == NULL) {
+        return (*env)->NewStringUTF(env, "native preview frame failed");
+    }
+    char *message = bridge->last_frame_error();
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env, "native preview frame failed");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
+#endif
 }
 JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeRunTick(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h) {

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -1571,14 +1571,12 @@ Java_com_stasislang_workshop_MainActivity_nativeResolveCachedText(
     PublishedFontResource *font = &published_fonts[run->font - 1];
     const char *asset_path = strstr(font->path, "assets/");
     if (asset_path == NULL) asset_path = font->path;
-    char escaped_text[2050];
-    size_t out = 0;
-    for (const char *cursor = run->text; *cursor != '\0' && out + 2 < sizeof(escaped_text); cursor += 1) {
-        if (*cursor == '"' || *cursor == '\\') escaped_text[out++] = '\\';
-        escaped_text[out++] = *cursor;
+    char escaped_text[(sizeof(run->text) - 1) * 6 + 1];
+    if (!stasis_mobile_json_escape(run->text, escaped_text, sizeof(escaped_text))) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"cached text could not be JSON encoded\"}");
     }
-    escaped_text[out] = '\0';
-    char response[3072];
+    char response[sizeof(escaped_text) + 1024];
     snprintf(response, sizeof(response),
             "{\"status\":\"ok\",\"handle\":%d,\"font\":%d,\"font_asset\":\"stasis_game/%s\",\"font_size\":%d,\"text\":\"%s\",\"measured_width\":%.3f}",
             (int)handle, (int)run->font, asset_path, (int)font->size,

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -31,6 +31,7 @@ typedef char *(*stasis_android_bridge_run_tests_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_run_tick_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h);
 typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len);
 typedef char *(*stasis_android_bridge_last_frame_error_fn)(void);
+typedef char *(*stasis_android_bridge_inspect_runtime_state_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_set_i32_global_fn)(const char *project_root, const char *entry_file, const char *path, int value);
 typedef char *(*stasis_android_bridge_get_i32_global_fn)(const char *project_root, const char *entry_file, const char *path);
 typedef char *(*stasis_android_bridge_resolve_sprite_asset_fn)(const char *project_root, int handle);
@@ -72,6 +73,7 @@ typedef struct RustBridgeApi {
     stasis_android_bridge_run_tick_fn run_tick;
     stasis_android_bridge_run_tick_frame_fn run_tick_frame;
     stasis_android_bridge_last_frame_error_fn last_frame_error;
+    stasis_android_bridge_inspect_runtime_state_fn inspect_runtime_state;
     stasis_android_bridge_set_i32_global_fn set_i32_global;
     stasis_android_bridge_get_i32_global_fn get_i32_global;
     stasis_android_bridge_resolve_sprite_asset_fn resolve_sprite_asset;
@@ -1233,6 +1235,8 @@ static RustBridgeApi *load_rust_bridge_api(void) {
             (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v1");
     rust_bridge_api.last_frame_error =
             (stasis_android_bridge_last_frame_error_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_last_frame_error");
+    rust_bridge_api.inspect_runtime_state =
+            (stasis_android_bridge_inspect_runtime_state_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_inspect_runtime_state");
     rust_bridge_api.set_i32_global =
             (stasis_android_bridge_set_i32_global_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_set_i32_global");
     rust_bridge_api.get_i32_global =
@@ -1885,6 +1889,28 @@ Java_com_stasislang_workshop_MainActivity_nativeLastFrameError(
     return result;
 #endif
 }
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeInspectRuntimeState(
+        JNIEnv *env, jclass activity_class, jstring project_root) {
+    (void)activity_class;
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->inspect_runtime_state == NULL || bridge->free_string == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"RuntimeStateError\",\"error\":\"live runtime inspection unavailable\"}");
+    }
+    const char *root = (*env)->GetStringUTFChars(env, project_root, NULL);
+    if (root == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"RuntimeStateError\",\"error\":\"unable to read project root\"}");
+    }
+    char *result = bridge->inspect_runtime_state(root);
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
+    if (result == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"RuntimeStateError\",\"error\":\"live runtime inspection returned null\"}");
+    }
+    jstring response = (*env)->NewStringUTF(env, result);
+    bridge->free_string(result);
+    return response;
+}
+
 JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeRunTick(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h) {
     (void)activity_class;

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -7,23 +7,67 @@ import android.opengl.GLSurfaceView;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 
 final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
-    static final int COMMAND_CAPACITY = 8;
-    static final int FRAME_HEADER_SIZE = 6;
-    static final int COMMAND_STRIDE = 13;
-    static final int FRAME_I32_CAPACITY = FRAME_HEADER_SIZE + COMMAND_CAPACITY * COMMAND_STRIDE;
+    static final int RENDER_MAGIC = 0x47584631;
+    static final int RENDER_VERSION = 1;
+    static final int FLAG_CLEAR = 1;
+    static final int FLAG_PRESENT = 2;
 
-    private static final int RECT_VERTICES = 6;
-    private static final int RECT_VERTEX_FLOATS = 6;
-    private static final int RECT_VERTEX_BYTES = RECT_VERTEX_FLOATS * 4;
-    private static final int SPRITE_VERTEX_FLOATS = 8;
-    private static final int SPRITE_VERTEX_BYTES = SPRITE_VERTEX_FLOATS * 4;
+    static final int I_FLAGS = 2;
+    static final int I_LINE_COUNT = 3;
+    static final int I_SPRITE_COUNT = 4;
+    static final int I_TEXT_COUNT = 7;
+    static final int I_TEXT_BYTES_USED = 9;
+    static final int I_SPRITE_BASE = 32;
+    static final int F_LINE_BASE = 4;
+    static final int MAX_LINES = 10_000;
+    static final int LINE_F32_STRIDE = 8;
+    static final int MAX_SPRITES = 4_096;
+    static final int SPRITE_I32_STRIDE = 7;
+    static final int MAX_TEXT = 2_048;
+    static final int TEXT_I32_STRIDE = 3;
+    static final int TEXT_F32_STRIDE = 6;
+    static final int TEXT_U8_CAPACITY = 65_536;
+    static final int I_TEXT_BASE = I_SPRITE_BASE + MAX_SPRITES * SPRITE_I32_STRIDE;
+    static final int F_TEXT_BASE = F_LINE_BASE + MAX_LINES * LINE_F32_STRIDE;
+    static final int FRAME_I32_CAPACITY = I_TEXT_BASE + MAX_TEXT * TEXT_I32_STRIDE;
+    static final int FRAME_F32_CAPACITY = F_TEXT_BASE + MAX_TEXT * TEXT_F32_STRIDE;
+
+    private static final int CAPTURE_HEADER_I32S = 10;
+    private static final int LINE_CHUNK_SIZE = 256;
+    private static final int SPRITE_CHUNK_SIZE = 128;
+    private static final int VERTICES_PER_QUAD = 6;
+    private static final int COLOR_VERTEX_FLOATS = 6;
+    private static final int TEXTURE_VERTEX_FLOATS = 8;
+    private static final int COLOR_VERTEX_BYTES = COLOR_VERTEX_FLOATS * 4;
+    private static final int TEXTURE_VERTEX_BYTES = TEXTURE_VERTEX_FLOATS * 4;
     private static final int MAX_CAPTURE_PIXELS = 8_000_000;
 
     interface TextureProvider {
         void onSurfaceCreated();
+
+        default void onFrameStart() {}
+
         int textureFor(int handle);
+
+        default int fallbackTexture() {
+            return 0;
+        }
+
+        default int filterFor(int handle) {
+            return GLES20.GL_LINEAR;
+        }
+
+        // Packed as texture:u32, width:u16, height:u16. Zero means unavailable.
+        default long textTextureFor(int font, ByteBuffer utf8, int offset, int length) {
+            return 0L;
+        }
+
+        default long cachedTextTextureFor(int runHandle) {
+            return 0L;
+        }
     }
 
     interface TimingListener {
@@ -31,7 +75,26 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     interface CaptureCallback {
-        void onCaptured(Bitmap bitmap, String error, int[] capturedFrame);
+        void onCaptured(Bitmap bitmap, String error, LogicalFrameSnapshot capturedFrame);
+    }
+
+    static final class LogicalFrameSnapshot {
+        final int[] header;
+        final float[] lines;
+        final int[] sprites;
+        final int[] textMetadata;
+        final float[] textValues;
+        final byte[] textBytes;
+
+        LogicalFrameSnapshot(int[] header, float[] lines, int[] sprites,
+                int[] textMetadata, float[] textValues, byte[] textBytes) {
+            this.header = header;
+            this.lines = lines;
+            this.sprites = sprites;
+            this.textMetadata = textMetadata;
+            this.textValues = textValues;
+            this.textBytes = textBytes;
+        }
     }
 
     private static final String VERTEX_SHADER =
@@ -39,48 +102,33 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             "attribute vec4 aColor;" +
             "uniform vec2 uResolution;" +
             "varying vec4 vColor;" +
-            "void main() {" +
-            "  vec2 zeroToOne = aPosition / uResolution;" +
-            "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-            "  vColor = aColor;" +
-            "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-            "}";
+            "void main(){vec2 p=aPosition/uResolution*2.0-1.0;vColor=aColor;" +
+            "gl_Position=vec4(p.x,-p.y,0.0,1.0);}";
     private static final String FRAGMENT_SHADER =
-            "precision mediump float;" +
-            "varying vec4 vColor;" +
-            "void main() { gl_FragColor = vColor; }";
+            "precision mediump float;varying vec4 vColor;" +
+            "void main(){gl_FragColor=vColor;}";
     private static final String TEXTURE_VERTEX_SHADER =
-            "attribute vec2 aPosition;" +
-            "attribute vec2 aTexCoord;" +
-            "attribute vec4 aColor;" +
-            "uniform vec2 uResolution;" +
-            "varying vec2 vTexCoord;" +
-            "varying vec4 vColor;" +
-            "void main() {" +
-            "  vec2 zeroToOne = aPosition / uResolution;" +
-            "  vec2 clip = zeroToOne * 2.0 - 1.0;" +
-            "  vTexCoord = aTexCoord;" +
-            "  vColor = aColor;" +
-            "  gl_Position = vec4(clip.x, -clip.y, 0.0, 1.0);" +
-            "}";
+            "attribute vec2 aPosition;attribute vec2 aTexCoord;attribute vec4 aColor;" +
+            "uniform vec2 uResolution;varying vec2 vTexCoord;varying vec4 vColor;" +
+            "void main(){vec2 p=aPosition/uResolution*2.0-1.0;vTexCoord=aTexCoord;" +
+            "vColor=aColor;gl_Position=vec4(p.x,-p.y,0.0,1.0);}";
     private static final String TEXTURE_FRAGMENT_SHADER =
-            "precision mediump float;" +
-            "uniform sampler2D uTexture;" +
-            "varying vec2 vTexCoord;" +
-            "varying vec4 vColor;" +
-            "void main() { gl_FragColor = texture2D(uTexture, vTexCoord) * vColor; }";
+            "precision mediump float;uniform sampler2D uTexture;varying vec2 vTexCoord;" +
+            "varying vec4 vColor;void main(){gl_FragColor=texture2D(uTexture,vTexCoord)*vColor;}";
 
     private final TextureProvider textures;
     private final TimingListener timing;
-    private final FloatBuffer rectVertices = ByteBuffer
-            .allocateDirect(COMMAND_CAPACITY * RECT_VERTICES * RECT_VERTEX_FLOATS * 4)
-            .order(ByteOrder.nativeOrder())
-            .asFloatBuffer();
-    private final FloatBuffer spriteVertices = ByteBuffer
-            .allocateDirect(COMMAND_CAPACITY * RECT_VERTICES * SPRITE_VERTEX_FLOATS * 4)
-            .order(ByteOrder.nativeOrder())
-            .asFloatBuffer();
-    private final int[] frame = new int[FRAME_I32_CAPACITY];
+    private final ByteBuffer frameI32Bytes = directBytes(FRAME_I32_CAPACITY * 4);
+    private final ByteBuffer frameF32Bytes = directBytes(FRAME_F32_CAPACITY * 4);
+    private final ByteBuffer frameU8Bytes = directBytes(TEXT_U8_CAPACITY);
+    private final IntBuffer frameI32 = frameI32Bytes.asIntBuffer();
+    private final FloatBuffer frameF32 = frameF32Bytes.asFloatBuffer();
+    private final FloatBuffer lineVertices = directBytes(
+            LINE_CHUNK_SIZE * 2 * COLOR_VERTEX_FLOATS * 4).asFloatBuffer();
+    private final FloatBuffer spriteVertices = directBytes(
+            SPRITE_CHUNK_SIZE * VERTICES_PER_QUAD * TEXTURE_VERTEX_FLOATS * 4).asFloatBuffer();
+    private final FloatBuffer textVertices = directBytes(
+            VERTICES_PER_QUAD * TEXTURE_VERTEX_FLOATS * 4).asFloatBuffer();
     private int colorProgram;
     private int colorPosition;
     private int colorValue;
@@ -100,22 +148,40 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         this.timing = timing;
     }
 
-    synchronized void setFrame(int[] values) {
-        if (values.length < FRAME_I32_CAPACITY) {
-            throw new IllegalArgumentException("render frame is smaller than schema v3");
+    // Callers fill these only while synchronized on this renderer. Native code writes
+    // active spans directly, so a frame does not copy the full production capacities.
+    ByteBuffer frameI32Bytes() {
+        return frameI32Bytes;
+    }
+
+    ByteBuffer frameF32Bytes() {
+        return frameF32Bytes;
+    }
+
+    ByteBuffer frameU8Bytes() {
+        return frameU8Bytes;
+    }
+
+    synchronized void copyFrameHeaderInto(int[] destination) {
+        if (destination.length < CAPTURE_HEADER_I32S) {
+            throw new IllegalArgumentException("render header destination is too small");
         }
-        System.arraycopy(values, 0, frame, 0, FRAME_I32_CAPACITY);
+        for (int index = 0; index < CAPTURE_HEADER_I32S; index += 1) {
+            destination[index] = frameI32.get(index);
+        }
     }
 
     synchronized void requestCapture(CaptureCallback callback) {
         if (pendingCapture != null) {
-            pendingCapture.onCaptured(null, "a newer preview capture replaced this request", new int[0]);
+            pendingCapture.onCaptured(null, "a newer preview capture replaced this request",
+                    new LogicalFrameSnapshot(new int[0], new float[0], new int[0],
+                            new int[0], new float[0], new byte[0]));
         }
         pendingCapture = callback;
     }
 
     @Override
-    public void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl,
+    public synchronized void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl,
             javax.microedition.khronos.egl.EGLConfig config) {
         colorProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
         colorPosition = GLES20.glGetAttribLocation(colorProgram, "aPosition");
@@ -131,10 +197,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         GLES20.glEnable(GLES20.GL_BLEND);
         GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
         GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
     }
 
     @Override
-    public void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl, int width, int height) {
+    public synchronized void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl,
+            int width, int height) {
         surfaceWidth = Math.max(1, width);
         surfaceHeight = Math.max(1, height);
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
@@ -143,194 +211,352 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     @Override
     public void onDrawFrame(javax.microedition.khronos.opengles.GL10 gl) {
         long started = System.nanoTime();
-        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
         CaptureCallback capture;
-        int[] capturedFrame;
+        LogicalFrameSnapshot capturedFrame;
         synchronized (this) {
-            drawCommands();
+            if (shouldPresent(frameI32)) {
+                drawFrame();
+            }
             capture = pendingCapture;
             pendingCapture = null;
-            capturedFrame = capture == null ? null : frame.clone();
+            capturedFrame = capture == null ? null : captureLogicalFrame();
         }
         captureIfRequested(capture, capturedFrame);
         timing.onRendered(System.nanoTime() - started);
     }
 
-    private void drawCommands() {
-        int commandCount = Math.max(0, Math.min(COMMAND_CAPACITY, frame[5]));
-        int index = 0;
-        while (index < commandCount) {
-            int base = FRAME_HEADER_SIZE + index * COMMAND_STRIDE;
-            int kind = frame[base];
-            if (kind == 1) {
-                rectVertices.clear();
-                int runEnd = index;
-                while (runEnd < commandCount) {
-                    int runBase = FRAME_HEADER_SIZE + runEnd * COMMAND_STRIDE;
-                    if (frame[runBase] != 1 || !sameClip(base, runBase)) break;
-                    appendRect(runBase);
-                    runEnd += 1;
-                }
-                rectVertices.flip();
-                applyClip(base);
-                drawRectBatch((runEnd - index) * RECT_VERTICES);
-                index = runEnd;
-            } else if (kind == 2) {
-                int texture = textures.textureFor(frame[base + 6]);
-                spriteVertices.clear();
-                appendSprite(base);
-                int runEnd = index + 1;
-                while (runEnd < commandCount) {
-                    int runBase = FRAME_HEADER_SIZE + runEnd * COMMAND_STRIDE;
-                    if (frame[runBase] != 2 || !sameClip(base, runBase)
-                            || textures.textureFor(frame[runBase + 6]) != texture) break;
-                    appendSprite(runBase);
-                    runEnd += 1;
-                }
-                spriteVertices.flip();
-                applyClip(base);
-                drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture);
-                index = runEnd;
-            } else {
-                index += 1;
-            }
-        }
+    private void drawFrame() {
+        textures.onFrameStart();
         GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+        int flags = frameI32.get(I_FLAGS);
+        if ((flags & FLAG_CLEAR) != 0) {
+            GLES20.glClearColor(frameF32.get(0), frameF32.get(1), frameF32.get(2), frameF32.get(3));
+            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+        }
+        drawLines(clampCount(frameI32.get(I_LINE_COUNT), MAX_LINES));
+        drawSprites(clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES));
+        drawText(clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT),
+                clampCount(frameI32.get(I_TEXT_BYTES_USED), TEXT_U8_CAPACITY));
     }
 
-    private void appendRect(int base) {
-        int color = frame[base + 5];
-        float red = ((color >> 16) & 255) / 255.0f;
-        float green = ((color >> 8) & 255) / 255.0f;
-        float blue = (color & 255) / 255.0f;
-        float alpha = Math.max(0, Math.min(255, frame[base + 8])) / 255.0f;
-        float left = frame[base + 1];
-        float top = frame[base + 2];
-        float right = left + frame[base + 3];
-        float bottom = top + frame[base + 4];
-        float centerX = (left + right) * 0.5f;
-        float centerY = (top + bottom) * 0.5f;
-        double radians = Math.toRadians(frame[base + 7] % 360);
-        float cosine = (float)Math.cos(radians);
-        float sine = (float)Math.sin(radians);
-        putRectVertex(left, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        putRectVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        putRectVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        putRectVertex(right, top, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        putRectVertex(right, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
-        putRectVertex(left, bottom, centerX, centerY, cosine, sine, red, green, blue, alpha);
+    private void drawLines(int count) {
+        int first = 0;
+        while (first < count) {
+            int horizontalRun = horizontalRunLength(frameF32, first, count);
+            if (horizontalRun >= 2) {
+                lineVertices.clear();
+                int quadCount = 0;
+                while (first < count && quadCount < LINE_CHUNK_SIZE / 3) {
+                    horizontalRun = horizontalRunLength(frameF32, first, count);
+                    if (horizontalRun < 2) break;
+                    int base = F_LINE_BASE + first * LINE_F32_STRIDE;
+                    appendColorQuad(lineVertices,
+                            frameF32.get(base), frameF32.get(base + 1), frameF32.get(base + 2),
+                            frameF32.get(base + 1) + horizontalRun,
+                            frameF32.get(base + 4), frameF32.get(base + 5),
+                            frameF32.get(base + 6), frameF32.get(base + 7));
+                    first += horizontalRun;
+                    quadCount += 1;
+                }
+                lineVertices.flip();
+                drawColorBatch(lineVertices,
+                        quadCount * VERTICES_PER_QUAD, GLES20.GL_TRIANGLES);
+                continue;
+            }
+            int chunk = Math.min(LINE_CHUNK_SIZE, count - first);
+            for (int offset = 1; offset < chunk; offset += 1) {
+                if (horizontalRunLength(frameF32, first + offset, count) >= 2) {
+                    chunk = offset;
+                    break;
+                }
+            }
+            lineVertices.clear();
+            for (int index = 0; index < chunk; index += 1) {
+                int base = F_LINE_BASE + (first + index) * LINE_F32_STRIDE;
+                putColorVertex(lineVertices, frameF32.get(base), frameF32.get(base + 1), base);
+                putColorVertex(lineVertices, frameF32.get(base + 2), frameF32.get(base + 3), base);
+            }
+            lineVertices.flip();
+            drawColorBatch(lineVertices, chunk * 2, GLES20.GL_LINES);
+            first += chunk;
+        }
+    }
+
+    static int horizontalRunLength(FloatBuffer values, int first, int count) {
+        if (values == null || first < 0 || first >= count) return 0;
+        int base = F_LINE_BASE + first * LINE_F32_STRIDE;
+        float left = values.get(base);
+        float top = values.get(base + 1);
+        float right = values.get(base + 2);
+        if (top != values.get(base + 3)) return 1;
+        int run = 1;
+        while (first + run < count) {
+            int next = F_LINE_BASE + (first + run) * LINE_F32_STRIDE;
+            if (values.get(next) != left || values.get(next + 2) != right
+                    || values.get(next + 1) != top + run || values.get(next + 3) != top + run
+                    || values.get(next + 4) != values.get(base + 4)
+                    || values.get(next + 5) != values.get(base + 5)
+                    || values.get(next + 6) != values.get(base + 6)
+                    || values.get(next + 7) != values.get(base + 7)) {
+                break;
+            }
+            run += 1;
+        }
+        return run;
+    }
+
+    private static void appendColorQuad(FloatBuffer output, float left, float top,
+            float right, float bottom, float red, float green, float blue, float alpha) {
+        putColorVertex(output, left, top, red, green, blue, alpha);
+        putColorVertex(output, right, top, red, green, blue, alpha);
+        putColorVertex(output, left, bottom, red, green, blue, alpha);
+        putColorVertex(output, right, top, red, green, blue, alpha);
+        putColorVertex(output, right, bottom, red, green, blue, alpha);
+        putColorVertex(output, left, bottom, red, green, blue, alpha);
+    }
+
+    private static void putColorVertex(FloatBuffer output, float x, float y,
+            float red, float green, float blue, float alpha) {
+        output.put(x).put(y).put(red).put(green).put(blue).put(alpha);
+    }
+
+    private void putColorVertex(FloatBuffer output, float x, float y, int lineBase) {
+        output.put(x).put(y)
+                .put(frameF32.get(lineBase + 4)).put(frameF32.get(lineBase + 5))
+                .put(frameF32.get(lineBase + 6)).put(frameF32.get(lineBase + 7));
+    }
+
+    private void drawSprites(int count) {
+        if (count == 0) return;
+        beginTextureBatches(spriteVertices);
+        int index = 0;
+        while (index < count) {
+            int base = I_SPRITE_BASE + index * SPRITE_I32_STRIDE;
+            int handle = frameI32.get(base);
+            int texture = spriteTextureFor(handle);
+            int filter = textures.filterFor(handle);
+            spriteVertices.clear();
+            appendSprite(base);
+            int chunk = 1;
+            while (index + chunk < count && chunk < SPRITE_CHUNK_SIZE) {
+                int next = I_SPRITE_BASE + (index + chunk) * SPRITE_I32_STRIDE;
+                int nextHandle = frameI32.get(next);
+                if (spriteTextureFor(nextHandle) != texture || textures.filterFor(nextHandle) != filter) break;
+                appendSprite(next);
+                chunk += 1;
+            }
+            spriteVertices.flip();
+            drawPreparedTextureBatch(chunk * VERTICES_PER_QUAD, texture);
+            index += chunk;
+        }
+        endTextureBatches();
     }
 
     private void appendSprite(int base) {
-        int color = frame[base + 5];
-        float red = ((color >> 16) & 255) / 255.0f;
-        float green = ((color >> 8) & 255) / 255.0f;
-        float blue = (color & 255) / 255.0f;
-        float alpha = Math.max(0, Math.min(255, frame[base + 8])) / 255.0f;
-        float left = frame[base + 1];
-        float top = frame[base + 2];
-        float right = left + frame[base + 3];
-        float bottom = top + frame[base + 4];
+        float left = frameI32.get(base + 1);
+        float top = frameI32.get(base + 2);
+        float right = left + frameI32.get(base + 3);
+        float bottom = top + frameI32.get(base + 4);
         float centerX = (left + right) * 0.5f;
         float centerY = (top + bottom) * 0.5f;
-        double radians = Math.toRadians(frame[base + 7] % 360);
+        double radians = Math.toRadians(frameI32.get(base + 5) % 360);
         float cosine = (float)Math.cos(radians);
         float sine = (float)Math.sin(radians);
-        putSpriteVertex(left, top, centerX, centerY, cosine, sine, 0.0f, 0.0f, red, green, blue, alpha);
-        putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-        putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
-        putSpriteVertex(right, top, centerX, centerY, cosine, sine, 1.0f, 0.0f, red, green, blue, alpha);
-        putSpriteVertex(right, bottom, centerX, centerY, cosine, sine, 1.0f, 1.0f, red, green, blue, alpha);
-        putSpriteVertex(left, bottom, centerX, centerY, cosine, sine, 0.0f, 1.0f, red, green, blue, alpha);
+        float alpha = clampUnit(frameI32.get(base + 6) / 255.0f);
+        putTextureVertex(spriteVertices, left, top, centerX, centerY, cosine, sine, 0, 0, 1, 1, 1, alpha);
+        putTextureVertex(spriteVertices, right, top, centerX, centerY, cosine, sine, 1, 0, 1, 1, 1, alpha);
+        putTextureVertex(spriteVertices, left, bottom, centerX, centerY, cosine, sine, 0, 1, 1, 1, 1, alpha);
+        putTextureVertex(spriteVertices, right, top, centerX, centerY, cosine, sine, 1, 0, 1, 1, 1, alpha);
+        putTextureVertex(spriteVertices, right, bottom, centerX, centerY, cosine, sine, 1, 1, 1, 1, 1, alpha);
+        putTextureVertex(spriteVertices, left, bottom, centerX, centerY, cosine, sine, 0, 1, 1, 1, 1, alpha);
     }
 
-    private void putRectVertex(float x, float y, float centerX, float centerY,
-            float cosine, float sine, float red, float green, float blue, float alpha) {
-        float offsetX = x - centerX;
-        float offsetY = y - centerY;
-        rectVertices.put(centerX + offsetX * cosine - offsetY * sine)
-                .put(centerY + offsetX * sine + offsetY * cosine)
-                .put(red).put(green).put(blue).put(alpha);
+    private int spriteTextureFor(int handle) {
+        int texture = textures.textureFor(handle);
+        return texture == 0 ? textures.fallbackTexture() : texture;
     }
 
-    private void putSpriteVertex(float x, float y, float centerX, float centerY,
-            float cosine, float sine, float u, float v, float red, float green, float blue,
-            float alpha) {
+    private void drawText(int count, int bytesUsed) {
+        if (count == 0) return;
+        beginTextureBatches(textVertices);
+        for (int index = 0; index < count; index += 1) {
+            int meta = I_TEXT_BASE + index * TEXT_I32_STRIDE;
+            int font = frameI32.get(meta);
+            int offset = frameI32.get(meta + 1);
+            int length = frameI32.get(meta + 2);
+            if (font <= 0) continue;
+            long packed;
+            if (offset < 0) {
+                packed = offset == Integer.MIN_VALUE ? 0L
+                        : textures.cachedTextTextureFor(-offset);
+            } else {
+                if (!isValidTextSpan(offset, length, bytesUsed)) continue;
+                packed = textures.textTextureFor(font, frameU8Bytes, offset, length);
+            }
+            int texture = (int)packed;
+            int width = (int)((packed >>> 32) & 0xffffL);
+            int height = (int)((packed >>> 48) & 0xffffL);
+            if (texture == 0 || width == 0 || height == 0) continue;
+            int values = F_TEXT_BASE + index * TEXT_F32_STRIDE;
+            float left = frameF32.get(values);
+            float top = frameF32.get(values + 1);
+            textVertices.clear();
+            appendAxisAlignedQuad(textVertices, left, top, left + width, top + height,
+                    clampUnit(frameF32.get(values + 2)), clampUnit(frameF32.get(values + 3)),
+                    clampUnit(frameF32.get(values + 4)), clampUnit(frameF32.get(values + 5)));
+            textVertices.flip();
+            drawPreparedTextureBatch(VERTICES_PER_QUAD, texture);
+        }
+        endTextureBatches();
+    }
+
+    private static void appendAxisAlignedQuad(FloatBuffer output, float left, float top,
+            float right, float bottom, float red, float green, float blue, float alpha) {
+        putTextureVertex(output, left, top, left, top, 1, 0, 0, 0, red, green, blue, alpha);
+        putTextureVertex(output, right, top, left, top, 1, 0, 1, 0, red, green, blue, alpha);
+        putTextureVertex(output, left, bottom, left, top, 1, 0, 0, 1, red, green, blue, alpha);
+        putTextureVertex(output, right, top, left, top, 1, 0, 1, 0, red, green, blue, alpha);
+        putTextureVertex(output, right, bottom, left, top, 1, 0, 1, 1, red, green, blue, alpha);
+        putTextureVertex(output, left, bottom, left, top, 1, 0, 0, 1, red, green, blue, alpha);
+    }
+
+    private static void putTextureVertex(FloatBuffer output, float x, float y,
+            float centerX, float centerY, float cosine, float sine, float u, float v,
+            float red, float green, float blue, float alpha) {
         float offsetX = x - centerX;
         float offsetY = y - centerY;
-        spriteVertices.put(centerX + offsetX * cosine - offsetY * sine)
+        output.put(centerX + offsetX * cosine - offsetY * sine)
                 .put(centerY + offsetX * sine + offsetY * cosine)
                 .put(u).put(v).put(red).put(green).put(blue).put(alpha);
     }
 
-    private boolean sameClip(int leftBase, int rightBase) {
-        return frame[leftBase + 9] == frame[rightBase + 9]
-                && frame[leftBase + 10] == frame[rightBase + 10]
-                && frame[leftBase + 11] == frame[rightBase + 11]
-                && frame[leftBase + 12] == frame[rightBase + 12];
-    }
-
-    private void applyClip(int base) {
-        int width = frame[base + 11];
-        int height = frame[base + 12];
-        if (width <= 0 || height <= 0) {
-            GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
-            return;
-        }
-        long sourceRight = (long)frame[base + 9] + width;
-        long sourceBottom = (long)frame[base + 10] + height;
-        int left = Math.max(0, Math.min(surfaceWidth, frame[base + 9]));
-        int top = Math.max(0, Math.min(surfaceHeight, frame[base + 10]));
-        int right = Math.max(left, (int)Math.max(0L, Math.min((long)surfaceWidth, sourceRight)));
-        int bottom = Math.max(top, (int)Math.max(0L, Math.min((long)surfaceHeight, sourceBottom)));
-        GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
-        GLES20.glScissor(left, surfaceHeight - bottom, right - left, bottom - top);
-    }
-
-    private void drawRectBatch(int vertexCount) {
+    private void drawColorBatch(FloatBuffer vertices, int vertexCount, int mode) {
         GLES20.glUseProgram(colorProgram);
-        GLES20.glUniform2f(colorResolution, (float)surfaceWidth, (float)surfaceHeight);
+        GLES20.glUniform2f(colorResolution, surfaceWidth, surfaceHeight);
         GLES20.glEnableVertexAttribArray(colorPosition);
         GLES20.glEnableVertexAttribArray(colorValue);
-        rectVertices.position(0);
-        GLES20.glVertexAttribPointer(colorPosition, 2, GLES20.GL_FLOAT, false,
-                RECT_VERTEX_BYTES, rectVertices);
-        rectVertices.position(2);
-        GLES20.glVertexAttribPointer(colorValue, 4, GLES20.GL_FLOAT, false,
-                RECT_VERTEX_BYTES, rectVertices);
-        GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-        rectVertices.position(0);
+        vertices.position(0);
+        GLES20.glVertexAttribPointer(colorPosition, 2, GLES20.GL_FLOAT, false, COLOR_VERTEX_BYTES, vertices);
+        vertices.position(2);
+        GLES20.glVertexAttribPointer(colorValue, 4, GLES20.GL_FLOAT, false, COLOR_VERTEX_BYTES, vertices);
+        GLES20.glDrawArrays(mode, 0, vertexCount);
+        vertices.position(0);
         GLES20.glDisableVertexAttribArray(colorValue);
         GLES20.glDisableVertexAttribArray(colorPosition);
     }
 
-    private void drawSpriteBatch(int vertexCount, int texture) {
+    private void beginTextureBatches(FloatBuffer vertices) {
         GLES20.glUseProgram(textureProgram);
-        GLES20.glUniform2f(textureResolution, (float)surfaceWidth, (float)surfaceHeight);
+        GLES20.glUniform2f(textureResolution, surfaceWidth, surfaceHeight);
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
         GLES20.glUniform1i(textureSampler, 0);
         GLES20.glEnableVertexAttribArray(texturePosition);
         GLES20.glEnableVertexAttribArray(textureCoordinate);
         GLES20.glEnableVertexAttribArray(textureColor);
-        spriteVertices.position(0);
-        GLES20.glVertexAttribPointer(texturePosition, 2, GLES20.GL_FLOAT, false,
-                SPRITE_VERTEX_BYTES, spriteVertices);
-        spriteVertices.position(2);
-        GLES20.glVertexAttribPointer(textureCoordinate, 2, GLES20.GL_FLOAT, false,
-                SPRITE_VERTEX_BYTES, spriteVertices);
-        spriteVertices.position(4);
-        GLES20.glVertexAttribPointer(textureColor, 4, GLES20.GL_FLOAT, false,
-                SPRITE_VERTEX_BYTES, spriteVertices);
+        vertices.position(0);
+        GLES20.glVertexAttribPointer(texturePosition, 2, GLES20.GL_FLOAT, false, TEXTURE_VERTEX_BYTES, vertices);
+        vertices.position(2);
+        GLES20.glVertexAttribPointer(textureCoordinate, 2, GLES20.GL_FLOAT, false, TEXTURE_VERTEX_BYTES, vertices);
+        vertices.position(4);
+        GLES20.glVertexAttribPointer(textureColor, 4, GLES20.GL_FLOAT, false, TEXTURE_VERTEX_BYTES, vertices);
+        vertices.position(0);
+    }
+
+    private void drawPreparedTextureBatch(int vertexCount, int texture) {
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
         GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
-        spriteVertices.position(0);
+    }
+
+    private void endTextureBatches() {
         GLES20.glDisableVertexAttribArray(textureColor);
         GLES20.glDisableVertexAttribArray(textureCoordinate);
         GLES20.glDisableVertexAttribArray(texturePosition);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
     }
 
-    private void captureIfRequested(CaptureCallback callback, int[] capturedFrame) {
+    static int clampCount(int value, int maximum) {
+        return Math.max(0, Math.min(maximum, value));
+    }
+
+    static boolean isValidFrame(IntBuffer values) {
+        return values != null && values.capacity() >= FRAME_I32_CAPACITY
+                && values.get(0) == RENDER_MAGIC && values.get(1) == RENDER_VERSION;
+    }
+
+    static boolean shouldPresent(IntBuffer values) {
+        return isValidFrame(values) && (values.get(I_FLAGS) & FLAG_PRESENT) != 0;
+    }
+
+    static boolean isValidTextSpan(int offset, int length, int bytesUsed) {
+        return offset >= 0 && length >= 0 && offset < bytesUsed
+                && length < bytesUsed - offset;
+    }
+
+    static int activeSpriteI32Count(int spriteCount) {
+        return clampCount(spriteCount, MAX_SPRITES) * SPRITE_I32_STRIDE;
+    }
+
+    static int activeTextI32Count(int textCount) {
+        return clampCount(textCount, MAX_TEXT) * TEXT_I32_STRIDE;
+    }
+
+    static int activeLineF32Count(int lineCount) {
+        return clampCount(lineCount, MAX_LINES) * LINE_F32_STRIDE;
+    }
+
+    static int activeTextF32Count(int textCount) {
+        return clampCount(textCount, MAX_TEXT) * TEXT_F32_STRIDE;
+    }
+
+    static int activeTextU8Count(int bytesUsed) {
+        return clampCount(bytesUsed, TEXT_U8_CAPACITY);
+    }
+
+    static long packTexture(int texture, int width, int height) {
+        if (texture == 0 || width <= 0 || height <= 0 || width > 0xffff || height > 0xffff) return 0L;
+        return (texture & 0xffffffffL) | ((long)width << 32) | ((long)height << 48);
+    }
+
+    private static float clampUnit(float value) {
+        return Math.max(0.0f, Math.min(1.0f, value));
+    }
+
+    synchronized LogicalFrameSnapshot captureLogicalFrame() {
+        int[] header = new int[CAPTURE_HEADER_I32S];
+        for (int index = 0; index < header.length; index += 1) header[index] = frameI32.get(index);
+        int lineCount = clampCount(header[I_LINE_COUNT], MAX_LINES);
+        int spriteCount = clampCount(header[I_SPRITE_COUNT], MAX_SPRITES);
+        int textCount = clampCount(header[I_TEXT_COUNT], MAX_TEXT);
+        int textByteCount = clampCount(header[I_TEXT_BYTES_USED], TEXT_U8_CAPACITY);
+        float[] lines = new float[activeLineF32Count(lineCount)];
+        for (int index = 0; index < lines.length; index += 1) {
+            lines[index] = frameF32.get(F_LINE_BASE + index);
+        }
+        int[] sprites = new int[activeSpriteI32Count(spriteCount)];
+        for (int index = 0; index < sprites.length; index += 1) {
+            sprites[index] = frameI32.get(I_SPRITE_BASE + index);
+        }
+        int[] textMetadata = new int[activeTextI32Count(textCount)];
+        for (int index = 0; index < textMetadata.length; index += 1) {
+            textMetadata[index] = frameI32.get(I_TEXT_BASE + index);
+        }
+        float[] textValues = new float[activeTextF32Count(textCount)];
+        for (int index = 0; index < textValues.length; index += 1) {
+            textValues[index] = frameF32.get(F_TEXT_BASE + index);
+        }
+        byte[] textBytes = new byte[textByteCount];
+        for (int index = 0; index < textBytes.length; index += 1) {
+            textBytes[index] = frameU8Bytes.get(index);
+        }
+        return new LogicalFrameSnapshot(
+                header, lines, sprites, textMetadata, textValues, textBytes);
+    }
+
+    private static ByteBuffer directBytes(int capacity) {
+        return ByteBuffer.allocateDirect(capacity).order(ByteOrder.nativeOrder());
+    }
+
+    private void captureIfRequested(CaptureCallback callback, LogicalFrameSnapshot capturedFrame) {
         if (callback == null) return;
         try {
             long pixelCount = (long)surfaceWidth * surfaceHeight;
@@ -338,15 +564,14 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                 callback.onCaptured(null, "preview framebuffer exceeds the 8 megapixel capture limit", capturedFrame);
                 return;
             }
-            java.nio.IntBuffer pixels = ByteBuffer.allocateDirect(surfaceWidth * surfaceHeight * 4)
-                    .order(ByteOrder.nativeOrder()).asIntBuffer();
+            java.nio.IntBuffer pixels = directBytes(surfaceWidth * surfaceHeight * 4).asIntBuffer();
             GLES20.glReadPixels(0, 0, surfaceWidth, surfaceHeight, GLES20.GL_RGBA,
                     GLES20.GL_UNSIGNED_BYTE, pixels);
             int[] flipped = new int[surfaceWidth * surfaceHeight];
-            for (int y = 0; y < surfaceHeight; y++) {
+            for (int y = 0; y < surfaceHeight; y += 1) {
                 int sourceRow = y * surfaceWidth;
                 int targetRow = (surfaceHeight - y - 1) * surfaceWidth;
-                for (int x = 0; x < surfaceWidth; x++) {
+                for (int x = 0; x < surfaceWidth; x += 1) {
                     int rgba = pixels.get(sourceRow + x);
                     flipped[targetRow + x] = (rgba & 0xff00ff00)
                             | ((rgba << 16) & 0x00ff0000) | ((rgba >> 16) & 0x000000ff);

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -15,6 +15,9 @@ import android.view.WindowInsets;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
 public final class MainActivity extends Activity {
     private static final String PUBLISHED_RUNTIME_ID = BuildConfig.STASIS_RUNTIME_ID;
     private static final long FRAME_DELAY_MS = 16L;
@@ -26,12 +29,12 @@ public final class MainActivity extends Activity {
     }
 
     private final Handler frameHandler = new Handler(Looper.getMainLooper());
-    private final int[] frameValues = new int[StasisPreviewRenderer.FRAME_I32_CAPACITY];
     private final RollingMetric tickMetric = new RollingMetric();
     private final RollingMetric renderMetric = new RollingMetric();
     private final StringBuilder hudText = new StringBuilder(80);
     private GameSurfaceView gameSurface;
     private TextView hud;
+    private TextView runtimeError;
     private Runnable frameLoop;
     private boolean compileAttempted;
     private boolean compileReady;
@@ -39,8 +42,12 @@ public final class MainActivity extends Activity {
 
     private static native String nativeCompileProject(String projectRoot);
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
-            int touchActive, int screenWidth, int screenHeight, int[] frameValues);
+            int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
+            ByteBuffer frameF32, ByteBuffer frameU8);
+    private static native String nativeLastFrameError();
     static native int[] nativeDecodeSvgSpriteBytes(byte[] bytes, int width, int height);
+    static native String nativeResolveCachedText(String projectRoot, int handle);
+    static native String nativeResolveFont(String projectRoot, int handle);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -61,16 +68,28 @@ public final class MainActivity extends Activity {
         hud = new TextView(this);
         hud.setTextColor(Color.WHITE);
         hud.setTextSize(12.0f);
-        hud.setSingleLine(true);
+        hud.setSingleLine(false);
         hud.setPadding(dp(10), dp(6), dp(10), dp(6));
         hud.setBackgroundColor(Color.argb(135, 20, 28, 38));
-        hud.setVisibility(View.GONE);
+        hud.setVisibility(BuildConfig.DEBUG ? View.VISIBLE : View.GONE);
         FrameLayout.LayoutParams hudParams = new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 Gravity.TOP | Gravity.START);
         hudParams.setMargins(dp(8), dp(8), dp(8), 0);
         root.addView(hud, hudParams);
+
+        runtimeError = new TextView(this);
+        runtimeError.setTextColor(Color.rgb(255, 180, 180));
+        runtimeError.setTextSize(12.0f);
+        runtimeError.setPadding(dp(10), dp(6), dp(10), dp(6));
+        runtimeError.setBackgroundColor(Color.argb(210, 80, 0, 0));
+        runtimeError.setVisibility(View.GONE);
+        FrameLayout.LayoutParams errorParams = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM | Gravity.START);
+        root.addView(runtimeError, errorParams);
 
         setContentView(root);
         startFrameLoop();
@@ -90,6 +109,13 @@ public final class MainActivity extends Activity {
 
     private void recordRenderTimeNanos(long durationNanos) {
         renderMetric.add(System.nanoTime(), durationNanos);
+    }
+
+    void reportPreviewResourceError(String message) {
+        runOnUiThread(() -> {
+            runtimeError.setText("Render resource error: " + message);
+            runtimeError.setVisibility(View.VISIBLE);
+        });
     }
 
     private void startFrameLoop() {
@@ -114,17 +140,13 @@ public final class MainActivity extends Activity {
         int width = gameSurface == null ? 0 : gameSurface.getWidth();
         int height = gameSurface == null ? 0 : gameSurface.getHeight();
         long started = System.nanoTime();
-        int status = nativeRunFrameInto(
-                PUBLISHED_RUNTIME_ID,
-                gameSurface == null ? 0 : gameSurface.touchX(),
-                gameSurface == null ? 0 : gameSurface.touchY(),
-                gameSurface == null ? 0 : gameSurface.touchActive(),
-                width,
-                height,
-                frameValues);
+        int status = gameSurface == null ? -1 : gameSurface.runNativeFrame(
+                PUBLISHED_RUNTIME_ID, gameSurface.touchX(), gameSurface.touchY(),
+                gameSurface.touchActive(), width, height);
         tickMetric.add(System.nanoTime(), System.nanoTime() - started);
-        if (status == 0 && frameValues[0] == 0 && gameSurface != null) {
-            gameSurface.setRenderFrameValues(frameValues);
+        if (status != 0) {
+            compileReady = false;
+            reportPreviewResourceError(nativeLastFrameError());
         }
         updateHud(false);
     }
@@ -136,13 +158,25 @@ public final class MainActivity extends Activity {
         lastHudUpdateNanos = now;
         double tickMillis = tickMetric.averageMillis();
         double renderMillis = renderMetric.averageMillis();
+        double tickP50Millis = tickMetric.percentileMillis(50);
+        double tickP95Millis = tickMetric.percentileMillis(95);
+        double renderP50Millis = renderMetric.percentileMillis(50);
+        double renderP95Millis = renderMetric.percentileMillis(95);
         int budgetPercent = Math.max(0,
                 (int)(((tickMillis + renderMillis) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
         hudText.setLength(0);
-        hudText.append("tick=");
+        hudText.append("tick avg=");
         appendMillis(hudText, tickMillis);
-        hudText.append(" ms  render=");
+        hudText.append(" p50=");
+        appendMillis(hudText, tickP50Millis);
+        hudText.append(" p95=");
+        appendMillis(hudText, tickP95Millis);
+        hudText.append(" ms\nrender avg=");
         appendMillis(hudText, renderMillis);
+        hudText.append(" p50=");
+        appendMillis(hudText, renderP50Millis);
+        hudText.append(" p95=");
+        appendMillis(hudText, renderP95Millis);
         hudText.append(" ms  budget=").append(budgetPercent).append('%');
         hud.setTextColor(debugColorForBudget(budgetPercent));
         hud.setText(hudText.toString());
@@ -203,7 +237,7 @@ public final class MainActivity extends Activity {
             this.activity = activity;
             setEGLContextClientVersion(2);
             renderer = new StasisPreviewRenderer(
-                    new PublishedSpriteCatalog(activity.getAssets()),
+                    new PublishedSpriteCatalog(activity, activity.getAssets()),
                     activity::recordRenderTimeNanos);
             setRenderer(renderer);
             setRenderMode(RENDERMODE_WHEN_DIRTY);
@@ -213,9 +247,16 @@ public final class MainActivity extends Activity {
         int touchY() { return touchY; }
         int touchActive() { return touchActive ? 1 : 0; }
 
-        void setRenderFrameValues(int[] values) {
-            renderer.setFrame(values);
-            requestRender();
+        int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,
+                int screenWidth, int screenHeight) {
+            int status;
+            synchronized (renderer) {
+                status = nativeRunFrameInto(projectRoot, inputX, inputY, inputActive,
+                        screenWidth, screenHeight, renderer.frameI32Bytes(),
+                        renderer.frameF32Bytes(), renderer.frameU8Bytes());
+            }
+            if (status == 0) requestRender();
+            return status;
         }
 
         @Override
@@ -236,6 +277,7 @@ public final class MainActivity extends Activity {
         private static final int CAPACITY = 360;
         private final long[] sampleTimes = new long[CAPACITY];
         private final long[] durations = new long[CAPACITY];
+        private final long[] orderedDurations = new long[CAPACITY];
         private int nextIndex;
         private int count;
 
@@ -258,6 +300,20 @@ public final class MainActivity extends Activity {
                 }
             }
             return samples == 0 ? 0.0 : (double)total / samples / 1_000_000.0;
+        }
+
+        double percentileMillis(int percentile) {
+            long now = System.nanoTime();
+            int samples = 0;
+            for (int index = 0; index < count; index += 1) {
+                if (now - sampleTimes[index] <= WINDOW_NANOS) {
+                    orderedDurations[samples++] = durations[index];
+                }
+            }
+            if (samples == 0) return 0.0;
+            Arrays.sort(orderedDurations, 0, samples);
+            int rank = Math.min(samples - 1, (samples * percentile + 99) / 100 - 1);
+            return orderedDurations[Math.max(0, rank)] / 1_000_000.0;
         }
     }
 }

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
@@ -3,6 +3,9 @@ package com.stasislang.workshop;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Typeface;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
 import android.util.SparseArray;
@@ -16,7 +19,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 
 final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvider {
     private static final String ROOT = "stasis_game/";
@@ -28,14 +33,19 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     private static final long MAX_PIXELS = 16_000_000L;
 
     private final AssetManager assets;
+    private final MainActivity activity;
     private final SparseArray<SpriteAsset> sprites = new SparseArray<>();
     private final SparseIntArray textures = new SparseIntArray();
     private final SparseBooleanArray failedHandles = new SparseBooleanArray();
+    private final SparseArray<TextTexture> textTextures = new SparseArray<>();
+    private final SparseArray<FontInfo> fonts = new SparseArray<>();
+    private final ArrayList<DynamicTextTexture> dynamicTextTextures = new ArrayList<>();
     private boolean manifestRead;
     private boolean manifestValid;
     private int fallbackTexture;
 
-    PublishedSpriteCatalog(AssetManager assets) {
+    PublishedSpriteCatalog(MainActivity activity, AssetManager assets) {
+        this.activity = activity;
         this.assets = assets;
     }
 
@@ -43,6 +53,9 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     public void onSurfaceCreated() {
         textures.clear();
         failedHandles.clear();
+        textTextures.clear();
+        fonts.clear();
+        dynamicTextTextures.clear();
         fallbackTexture = createFallbackTexture();
     }
 
@@ -68,8 +81,104 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
             return texture;
         } catch (Exception error) {
             failedHandles.put(handle, true);
+            activity.reportPreviewResourceError("sprite " + handle + ": " + error.getMessage());
             return fallbackTexture;
         }
+    }
+
+    @Override
+    public int fallbackTexture() {
+        return fallbackTexture;
+    }
+
+    @Override
+    public long cachedTextTextureFor(int runHandle) {
+        TextTexture cached = textTextures.get(runHandle);
+        if (cached != null) return StasisPreviewRenderer.packTexture(
+                cached.texture, cached.width, cached.height);
+        try {
+            JSONObject resolved = new JSONObject(MainActivity.nativeResolveCachedText("", runHandle));
+            if (!"ok".equals(resolved.optString("status"))) {
+                throw new IOException(resolved.optString("error", "cached text resolution failed"));
+            }
+            Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
+            paint.setColor(0xffffffff);
+            paint.setTextSize(resolved.getInt("font_size"));
+            paint.setTypeface(Typeface.createFromAsset(assets, resolved.getString("font_asset")));
+            String text = resolved.getString("text");
+            Paint.FontMetrics metrics = paint.getFontMetrics();
+            int width = Math.max(1, (int)Math.ceil(paint.measureText(text)));
+            int height = Math.max(1, (int)Math.ceil(metrics.descent - metrics.ascent));
+            Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            new Canvas(bitmap).drawText(text, 0.0f, -metrics.ascent, paint);
+            int texture;
+            try {
+                texture = upload(bitmap);
+            } finally {
+                bitmap.recycle();
+            }
+            cached = new TextTexture(texture, width, height);
+            textTextures.put(runHandle, cached);
+            return StasisPreviewRenderer.packTexture(texture, width, height);
+        } catch (Exception error) {
+            activity.reportPreviewResourceError("cached text " + runHandle + ": " + error.getMessage());
+            return 0L;
+        }
+    }
+
+    @Override
+    public long textTextureFor(int font, ByteBuffer utf8, int offset, int length) {
+        for (int index = 0; index < dynamicTextTextures.size(); index += 1) {
+            DynamicTextTexture cached = dynamicTextTextures.get(index);
+            if (cached.matches(font, utf8, offset, length)) {
+                return StasisPreviewRenderer.packTexture(
+                        cached.texture.texture, cached.texture.width, cached.texture.height);
+            }
+        }
+        try {
+            if (dynamicTextTextures.size() >= 4096) throw new IOException("dynamic text cache is full");
+            byte[] bytes = new byte[length];
+            for (int index = 0; index < length; index += 1) bytes[index] = utf8.get(offset + index);
+            FontInfo fontInfo = fontInfo(font);
+            TextTexture texture = rasterText(fontInfo, new String(bytes, StandardCharsets.UTF_8));
+            dynamicTextTextures.add(new DynamicTextTexture(font, bytes, texture));
+            return StasisPreviewRenderer.packTexture(texture.texture, texture.width, texture.height);
+        } catch (Exception error) {
+            activity.reportPreviewResourceError("text font " + font + ": " + error.getMessage());
+            return 0L;
+        }
+    }
+
+    private FontInfo fontInfo(int handle) throws Exception {
+        FontInfo cached = fonts.get(handle);
+        if (cached != null) return cached;
+        JSONObject resolved = new JSONObject(MainActivity.nativeResolveFont("", handle));
+        if (!"ok".equals(resolved.optString("status"))) {
+            throw new IOException(resolved.optString("error", "font resolution failed"));
+        }
+        cached = new FontInfo(Typeface.createFromAsset(
+                assets, resolved.getString("font_asset")), resolved.getInt("font_size"));
+        fonts.put(handle, cached);
+        return cached;
+    }
+
+    private static TextTexture rasterText(FontInfo font, String text) throws IOException {
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
+        paint.setColor(0xffffffff);
+        paint.setTextSize(font.size);
+        paint.setTypeface(font.typeface);
+        Paint.FontMetrics metrics = paint.getFontMetrics();
+        int width = Math.max(1, (int)Math.ceil(paint.measureText(text)));
+        int height = Math.max(1, (int)Math.ceil(metrics.descent - metrics.ascent));
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        new Canvas(bitmap).drawText(text, 0.0f, -metrics.ascent, paint);
+        int texture;
+        try {
+            texture = upload(bitmap);
+        } finally {
+            bitmap.recycle();
+        }
+        return new TextTexture(texture, width, height);
     }
 
     private void ensureManifest() throws Exception {
@@ -230,6 +339,48 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
             this.encoding = encoding;
             this.width = width;
             this.height = height;
+        }
+    }
+
+    private static final class TextTexture {
+        final int texture;
+        final int width;
+        final int height;
+
+        TextTexture(int texture, int width, int height) {
+            this.texture = texture;
+            this.width = width;
+            this.height = height;
+        }
+    }
+
+    private static final class FontInfo {
+        final Typeface typeface;
+        final int size;
+
+        FontInfo(Typeface typeface, int size) {
+            this.typeface = typeface;
+            this.size = size;
+        }
+    }
+
+    private static final class DynamicTextTexture {
+        final int font;
+        final byte[] text;
+        final TextTexture texture;
+
+        DynamicTextTexture(int font, byte[] text, TextTexture texture) {
+            this.font = font;
+            this.text = text;
+            this.texture = texture;
+        }
+
+        boolean matches(int candidateFont, ByteBuffer utf8, int offset, int length) {
+            if (font != candidateFont || text.length != length) return false;
+            for (int index = 0; index < length; index += 1) {
+                if (text[index] != utf8.get(offset + index)) return false;
+            }
+            return true;
         }
     }
 }

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -1,0 +1,138 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.IntBuffer;
+import java.nio.FloatBuffer;
+
+import org.junit.Test;
+
+public final class StasisPreviewRendererSchemaTest {
+    @Test
+    public void productionSchemaMatchesNativeContract() {
+        assertEquals(28_704, StasisPreviewRenderer.I_TEXT_BASE);
+        assertEquals(80_004, StasisPreviewRenderer.F_TEXT_BASE);
+        assertEquals(34_848, StasisPreviewRenderer.FRAME_I32_CAPACITY);
+        assertEquals(92_292, StasisPreviewRenderer.FRAME_F32_CAPACITY);
+        assertEquals(65_536, StasisPreviewRenderer.TEXT_U8_CAPACITY);
+    }
+
+    @Test
+    public void validationRequiresProductionMagicAndVersion() {
+        IntBuffer frame = IntBuffer.allocate(StasisPreviewRenderer.FRAME_I32_CAPACITY);
+        assertFalse(StasisPreviewRenderer.isValidFrame(frame));
+        frame.put(0, StasisPreviewRenderer.RENDER_MAGIC);
+        frame.put(1, StasisPreviewRenderer.RENDER_VERSION);
+        assertTrue(StasisPreviewRenderer.isValidFrame(frame));
+        assertFalse(StasisPreviewRenderer.shouldPresent(frame));
+        frame.put(StasisPreviewRenderer.I_FLAGS, StasisPreviewRenderer.FLAG_PRESENT);
+        assertTrue(StasisPreviewRenderer.shouldPresent(frame));
+        frame.put(1, 2);
+        assertFalse(StasisPreviewRenderer.isValidFrame(frame));
+        assertFalse(StasisPreviewRenderer.shouldPresent(frame));
+        assertFalse(StasisPreviewRenderer.isValidFrame(IntBuffer.allocate(10)));
+    }
+
+    @Test
+    public void countsAndActiveSpansAreBounded() {
+        assertEquals(0, StasisPreviewRenderer.clampCount(-1, 8));
+        assertEquals(5, StasisPreviewRenderer.clampCount(5, 8));
+        assertEquals(8, StasisPreviewRenderer.clampCount(20, 8));
+        assertEquals(StasisPreviewRenderer.MAX_SPRITES * StasisPreviewRenderer.SPRITE_I32_STRIDE,
+                StasisPreviewRenderer.activeSpriteI32Count(Integer.MAX_VALUE));
+        assertEquals(StasisPreviewRenderer.MAX_TEXT * StasisPreviewRenderer.TEXT_I32_STRIDE,
+                StasisPreviewRenderer.activeTextI32Count(Integer.MAX_VALUE));
+        assertEquals(StasisPreviewRenderer.MAX_LINES * StasisPreviewRenderer.LINE_F32_STRIDE,
+                StasisPreviewRenderer.activeLineF32Count(Integer.MAX_VALUE));
+        assertEquals(StasisPreviewRenderer.MAX_TEXT * StasisPreviewRenderer.TEXT_F32_STRIDE,
+                StasisPreviewRenderer.activeTextF32Count(Integer.MAX_VALUE));
+        assertEquals(StasisPreviewRenderer.TEXT_U8_CAPACITY,
+                StasisPreviewRenderer.activeTextU8Count(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void textSpanRequiresPayloadAndTrailingTerminator() {
+        assertTrue(StasisPreviewRenderer.isValidTextSpan(0, 3, 4));
+        assertTrue(StasisPreviewRenderer.isValidTextSpan(4, 0, 5));
+        assertFalse(StasisPreviewRenderer.isValidTextSpan(0, 4, 4));
+        assertFalse(StasisPreviewRenderer.isValidTextSpan(-1, 1, 4));
+        assertFalse(StasisPreviewRenderer.isValidTextSpan(0, -1, 4));
+        assertFalse(StasisPreviewRenderer.isValidTextSpan(4, 0, 4));
+    }
+
+    @Test
+    public void packedTextTextureRejectsOutOfRangeDimensions() {
+        long packed = StasisPreviewRenderer.packTexture(17, 640, 72);
+        assertEquals(17, (int)packed);
+        assertEquals(640, (int)((packed >>> 32) & 0xffffL));
+        assertEquals(72, (int)((packed >>> 48) & 0xffffL));
+        assertEquals(0L, StasisPreviewRenderer.packTexture(17, 65_536, 1));
+        assertEquals(0L, StasisPreviewRenderer.packTexture(0, 1, 1));
+    }
+
+    @Test
+    public void logicalSnapshotCopiesOnlyActiveProductionSpans() {
+        StasisPreviewRenderer renderer = new StasisPreviewRenderer(
+                new StasisPreviewRenderer.TextureProvider() {
+                    @Override public void onSurfaceCreated() {}
+                    @Override public int textureFor(int handle) { return 0; }
+                }, ignored -> {});
+        renderer.frameI32Bytes().asIntBuffer().put(0, StasisPreviewRenderer.RENDER_MAGIC);
+        renderer.frameI32Bytes().asIntBuffer().put(1, StasisPreviewRenderer.RENDER_VERSION);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_LINE_COUNT, 1);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_SPRITE_COUNT, 1);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_TEXT_COUNT, 1);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_TEXT_BYTES_USED, 4);
+        renderer.frameF32Bytes().asFloatBuffer().put(StasisPreviewRenderer.F_LINE_BASE, 12.5f);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_SPRITE_BASE, 77);
+        renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_TEXT_BASE, 5);
+        renderer.frameF32Bytes().asFloatBuffer().put(StasisPreviewRenderer.F_TEXT_BASE, 42.0f);
+        renderer.frameU8Bytes().put(0, (byte)'A');
+        renderer.frameU8Bytes().put(1, (byte)'B');
+        renderer.frameU8Bytes().put(2, (byte)'C');
+        renderer.frameU8Bytes().put(3, (byte)0);
+
+        StasisPreviewRenderer.LogicalFrameSnapshot snapshot = renderer.captureLogicalFrame();
+
+        assertEquals(StasisPreviewRenderer.LINE_F32_STRIDE, snapshot.lines.length);
+        assertEquals(12.5f, snapshot.lines[0], 0.0f);
+        assertEquals(StasisPreviewRenderer.SPRITE_I32_STRIDE, snapshot.sprites.length);
+        assertEquals(77, snapshot.sprites[0]);
+        assertEquals(StasisPreviewRenderer.TEXT_I32_STRIDE, snapshot.textMetadata.length);
+        assertEquals(5, snapshot.textMetadata[0]);
+        assertEquals(StasisPreviewRenderer.TEXT_F32_STRIDE, snapshot.textValues.length);
+        assertEquals(42.0f, snapshot.textValues[0], 0.0f);
+        assertEquals(4, snapshot.textBytes.length);
+        assertEquals('C', snapshot.textBytes[2]);
+    }
+
+    @Test
+    public void contiguousHorizontalLinesCoalesceWithoutCrossingColorOrGeometryChanges() {
+        FloatBuffer lines = FloatBuffer.allocate(
+                StasisPreviewRenderer.F_LINE_BASE + 4 * StasisPreviewRenderer.LINE_F32_STRIDE);
+        putLine(lines, 0, 10, 20, 30, 20, 1, 0, 0, 1);
+        putLine(lines, 1, 10, 21, 30, 21, 1, 0, 0, 1);
+        putLine(lines, 2, 10, 22, 30, 22, 0, 1, 0, 1);
+        putLine(lines, 3, 10, 23, 31, 23, 1, 0, 0, 1);
+
+        assertEquals(2, StasisPreviewRenderer.horizontalRunLength(lines, 0, 4));
+        assertEquals(1, StasisPreviewRenderer.horizontalRunLength(lines, 2, 4));
+        assertEquals(1, StasisPreviewRenderer.horizontalRunLength(lines, 3, 4));
+    }
+
+    private static void putLine(FloatBuffer lines, int index, float x1, float y1,
+            float x2, float y2, float r, float g, float b, float a) {
+        int base = StasisPreviewRenderer.F_LINE_BASE
+                + index * StasisPreviewRenderer.LINE_F32_STRIDE;
+        lines.put(base, x1);
+        lines.put(base + 1, y1);
+        lines.put(base + 2, x2);
+        lines.put(base + 3, y2);
+        lines.put(base + 4, r);
+        lines.put(base + 5, g);
+        lines.put(base + 6, b);
+        lines.put(base + 7, a);
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopBlockingErrorPolicyTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopBlockingErrorPolicyTest.java
@@ -1,0 +1,27 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopBlockingErrorPolicyTest {
+    @Test
+    public void compileAndFrameErrorsAreProminentOnlyWithoutRunningGame() {
+        assertTrue(WorkshopBlockingErrorPolicy.shouldShow(false, "CompileError: bad source"));
+        assertTrue(WorkshopBlockingErrorPolicy.shouldShow(false, "RunError: invalid frame"));
+        assertFalse(WorkshopBlockingErrorPolicy.shouldShow(true, "CompileError: stale edit"));
+        assertFalse(WorkshopBlockingErrorPolicy.shouldShow(false, "CompilePlanned: status=0"));
+    }
+
+    @Test
+    public void summaryRemovesPrivateRootAndFormatsSourceLocation() {
+        String status = "CompileError: /data/data/com.stasis/files/project/src/main.stasis: bad token"
+                + "|diagnostic_file=src/main.stasis|diagnostic_line=12|diagnostic_column=7";
+        String summary = WorkshopBlockingErrorPolicy.summary(
+                status, "/data/user/0/com.stasis/files/project");
+        assertFalse(summary.contains("/data/data"));
+        assertTrue(summary.contains("src/main.stasis: bad token"));
+        assertTrue(summary.contains("src/main.stasis:12:7"));
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopFrameBudgetTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopFrameBudgetTest.java
@@ -1,0 +1,15 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public final class WorkshopFrameBudgetTest {
+    @Test
+    public void reportsTickRenderAndCombinedSharesOfSixtyFpsFrame() {
+        assertEquals(5, WorkshopFrameBudget.percent(0.91));
+        assertEquals(3, WorkshopFrameBudget.percent(0.55));
+        assertEquals(9, WorkshopFrameBudget.percent(0.91 + 0.55));
+        assertEquals(0, WorkshopFrameBudget.percent(-1.0));
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopPongAssetManifestMigrationTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopPongAssetManifestMigrationTest.java
@@ -1,0 +1,31 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public final class WorkshopPongAssetManifestMigrationTest {
+    @Test
+    public void requiredSpritesMergeWithoutDroppingUserAssetsOrMetadata() throws Exception {
+        String current = "{\"schema\":\"stasis-assets\",\"version\":7,"
+                + "\"custom\":\"keep\",\"assets\":["
+                + "{\"id\":\"user_ship\",\"path\":\"assets/ship.svg\"},"
+                + "{\"id\":\"paddle\",\"path\":\"assets/old.svg\"}]}";
+        String packaged = "{\"assets\":["
+                + "{\"id\":\"ball\"},"
+                + "{\"id\":\"paddle\",\"path\":\"assets/paddle.svg\"},"
+                + "{\"id\":\"center_line\",\"path\":\"assets/center_line.svg\"}]}";
+
+        JSONObject merged = new JSONObject(
+                WorkshopPongAssetManifestMigration.mergeRequiredSprites(current, packaged));
+        JSONArray assets = merged.getJSONArray("assets");
+
+        assertEquals(7, merged.getInt("version"));
+        assertEquals("keep", merged.getString("custom"));
+        assertEquals("user_ship", assets.getJSONObject(0).getString("id"));
+        assertEquals("assets/paddle.svg", assets.getJSONObject(1).getString("path"));
+        assertEquals("assets/center_line.svg", assets.getJSONObject(2).getString("path"));
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopPongRendererMigrationTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopPongRendererMigrationTest.java
@@ -1,0 +1,43 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class WorkshopPongRendererMigrationTest {
+    @Test
+    public void migrationPreservesGameBodiesAndRenamesOnlyLifecycleDeclarations() {
+        String legacy = "global GameState { player_y: i32; }\n"
+                + "function main(): void { GameState.player_y = 72; }\n"
+                + "function tick(): void { GameState.player_y += 3; }\n"
+                + "function render(): void { GameState.player_y += 5; }\n"
+                + "function on_code_swap(): void { render(); }\n";
+
+        String migrated = WorkshopPongRendererMigration.migrateSource(legacy);
+
+        assertTrue(migrated.startsWith(WorkshopPongRendererMigration.ADAPTER_IMPORT));
+        assertTrue(migrated.contains("function pong_game_main(): void { GameState.player_y = 72; }"));
+        assertTrue(migrated.contains("function pong_game_tick(): void { GameState.player_y += 3; }"));
+        assertTrue(migrated.contains("function pong_game_render(): void { GameState.player_y += 5; }"));
+        assertTrue(migrated.contains("function pong_game_on_code_swap(): void { render(); }"));
+        assertFalse(migrated.contains("function main(): void"));
+        assertEquals(migrated, WorkshopPongRendererMigration.migrateSource(migrated));
+    }
+
+    @Test
+    public void migrationRejectsAmbiguousOrIncompleteLifecycleSets() {
+        String duplicateMain = "function main(): void {}\nfunction main(): void {}\n"
+                + "function tick(): void {}\nfunction render(): void {}\n"
+                + "function on_code_swap(): void {}\n";
+        assertThrows(IllegalArgumentException.class,
+                () -> WorkshopPongRendererMigration.migrateSource(duplicateMain));
+
+        String missingRender = "function main(): void {}\nfunction tick(): void {}\n"
+                + "function on_code_swap(): void {}\n";
+        assertThrows(IllegalArgumentException.class,
+                () -> WorkshopPongRendererMigration.migrateSource(missingRender));
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -90,8 +90,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -346,6 +350,7 @@ public final class MainActivity extends Activity {
             int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
             ByteBuffer frameF32, ByteBuffer frameU8);
     private static native String nativeLastFrameError();
+    private static native String nativeInspectRuntimeState(String projectRoot);
     private static native String nativeSetRuntimeI32(String projectRoot, String path, int value);
     private static native String nativeGetRuntimeI32(String projectRoot, String path);
     static native String nativeResolveSpriteAsset(String projectRoot, int handle);
@@ -7108,16 +7113,38 @@ public final class MainActivity extends Activity {
     }
     private JSONObject aiToolRunFrame() throws Exception {
         ensureAiTestCompileReady();
-        int status = gamePreview == null ? -1 : gamePreview.runNativeFrame(
-                projectRootPath(), aiSimTouchX, aiSimTouchY, aiSimTouchActive,
-                currentAiScreenWidth(), currentAiScreenHeight(), nativeFrameValues);
+        AiFrameResult frameResult = callOnGameThread(() -> {
+            int status = gamePreview == null ? -1 : gamePreview.runNativeFrame(
+                    projectRootPath(), aiSimTouchX, aiSimTouchY, aiSimTouchActive,
+                    currentAiScreenWidth(), currentAiScreenHeight(), nativeFrameValues);
+            String rawState = nativeInspectRuntimeState(projectRootPath());
+            JSONObject runtimeState = new JSONObject(rawState == null ? "{}" : rawState);
+            runtimeState.put("live", "live_session".equals(runtimeState.optString("source")));
+            String error = status == 0 ? null : nativeLastFrameError();
+            return new AiFrameResult(status, runtimeState, currentLogicalFrame(), error);
+        });
         JSONObject result = new JSONObject()
-                .put("status", status)
+                .put("status", frameResult.status)
                 .put("input", currentInputStateJson())
-                .put("frame", frameValuesToJson(currentLogicalFrame()))
-                .put("runtime_state", runtimeStateJson());
-        if (status != 0) result.put("error", nativeLastFrameError());
+                .put("frame", frameValuesToJson(frameResult.frame))
+                .put("runtime_state", frameResult.runtimeState);
+        if (frameResult.error != null) result.put("error", frameResult.error);
         return result;
+    }
+
+    private static final class AiFrameResult {
+        final int status;
+        final JSONObject runtimeState;
+        final StasisPreviewRenderer.LogicalFrameSnapshot frame;
+        final String error;
+
+        AiFrameResult(int status, JSONObject runtimeState,
+                StasisPreviewRenderer.LogicalFrameSnapshot frame, String error) {
+            this.status = status;
+            this.runtimeState = runtimeState;
+            this.frame = frame;
+            this.error = error;
+        }
     }
 
     private JSONObject aiToolInspectRuntimeState() throws Exception {
@@ -7163,24 +7190,32 @@ public final class MainActivity extends Activity {
     }
 
     private JSONObject runtimeStateJson() throws Exception {
-        File stateFile = new File(projectRoot(), "build/runtime_state.txt");
-        JSONObject values = new JSONObject();
-        String raw = "";
-        if (stateFile.isFile()) {
-            raw = readTextFile(stateFile);
-            String[] lines = raw.split("\\r?\\n");
-            for (String line : lines) {
-                int equals = line.indexOf('=');
-                if (equals > 0) {
-                    values.put(line.substring(0, equals), line.substring(equals + 1));
-                }
-            }
+        String raw = callOnGameThread(() -> nativeInspectRuntimeState(projectRootPath()));
+        JSONObject state = new JSONObject(raw == null ? "{}" : raw);
+        state.put("live", "live_session".equals(state.optString("source")));
+        return state;
+    }
+
+    private <T> T callOnGameThread(Callable<T> operation) throws Exception {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return operation.call();
         }
-        return new JSONObject()
-                .put("file", "build/runtime_state.txt")
-                .put("exists", stateFile.isFile())
-                .put("raw", raw)
-                .put("values", values);
+        FutureTask<T> task = new FutureTask<>(operation);
+        if (!gameLoopHandler.post(task)) {
+            throw new IOException("game thread is unavailable");
+        }
+        try {
+            return task.get(5, TimeUnit.SECONDS);
+        } catch (TimeoutException error) {
+            gameLoopHandler.removeCallbacks(task);
+            task.cancel(false);
+            throw new IOException("game thread operation timed out", error);
+        } catch (InterruptedException error) {
+            gameLoopHandler.removeCallbacks(task);
+            task.cancel(false);
+            Thread.currentThread().interrupt();
+            throw new IOException("game thread operation was interrupted", error);
+        }
     }
 
     private StasisPreviewRenderer.LogicalFrameSnapshot currentLogicalFrame() {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -73,6 +73,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -99,6 +102,7 @@ public final class MainActivity extends Activity {
     private static final String PROJECT_BASELINE_READY = ".ready";
     private static final String SAMPLE_MIGRATION_PREFS = "workshop_sample_migrations";
     private static final String PONG_SLOW_BALL_MIGRATION = "pong_slow_ball_v1";
+    private static final String PONG_GFX_CMD_MIGRATION = "pong_gfx_cmd_v6";
     private static final String AI_PREFS = "ai_settings";
     private static final String ONBOARDING_PREFS = "onboarding_settings";
     private static final String EXPLORATION_LESSON_PREFS = "exploration_lesson_progress";
@@ -139,7 +143,6 @@ public final class MainActivity extends Activity {
     private static final long AI_TRACE_RETENTION_MS = 24L * 60L * 60L * 1000L;
     private static final long DEFAULT_TICK_INTERVAL_MS = 16L;
     private static final long DEBUG_UPDATE_INTERVAL_NANOS = 250_000_000L;
-    private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
     private static final int MAX_AI_AGENT_TURNS = 25;
     private static final int MAX_AI_TOOL_CALLS_PER_BATCH = 12;
     private static final int MAX_AI_READ_ONLY_BATCHES = 2;
@@ -276,6 +279,8 @@ public final class MainActivity extends Activity {
     private AndroidEditRecoveryStore.Entry selectedRecoveryEntry;
     private TextView changeSummary;
     private TextView gameStatus;
+    private LinearLayout blockingErrorPanel;
+    private TextView blockingErrorBody;
     private GamePreviewView gamePreview;
     private boolean previewFocusabilityCaptured;
     private boolean previewFocusableWhenUncovered;
@@ -306,9 +311,11 @@ public final class MainActivity extends Activity {
     private final int[] nativeFrameValues = new int[RENDER_FRAME_HEADER_SIZE];
     private final StringBuilder debugTextBuilder = new StringBuilder(64);
     private final RollingMetric tickMetric = new RollingMetric();
+    private final RollingMetric syncMetric = new RollingMetric();
     private final RollingMetric renderMetric = new RollingMetric();
     private boolean compileReady;
     private boolean compileAttempted;
+    private boolean gameRuntimeActive;
     private String lastCompileResult = "CompileNotRun";
     private int aiSimTouchX;
     private int aiSimTouchY;
@@ -389,6 +396,7 @@ public final class MainActivity extends Activity {
         ProjectSnapshot project = loadBundledProject();
         try {
             if (migrateBundledPongBallSpeed()) project = loadBundledProject();
+            if (migrateBundledPongProductionRenderer()) project = loadBundledProject();
             ensureActiveProjectBaseline(project);
         } catch (IOException error) {
             projectRegistryError = "baseline: " + error.getMessage();
@@ -734,6 +742,7 @@ public final class MainActivity extends Activity {
 
         installGameStatusOverlay(root, true);
         installAiGameProgressOverlay(root);
+        installBlockingErrorPanel(root);
         LinearLayout content = new LinearLayout(this);
         content.setOrientation(LinearLayout.VERTICAL);
         content.setPadding(dp(14), dp(12), dp(14), dp(12));
@@ -922,7 +931,10 @@ public final class MainActivity extends Activity {
 
     private void installGameStatusOverlay(FrameLayout root, boolean visible) {
         gameStatus = new TextView(this);
-        gameStatus.setText("tick avg=-- p50=-- p95=-- ms\nrender avg=-- p50=-- p95=-- ms  budget=--%");
+        gameStatus.setText("tick avg=-- p50=-- p95=-- ms\n"
+                + "render avg=-- p50=-- p95=-- ms\n"
+                + "sync avg=-- p95=-- ms\n"
+                + "budget tick=--% render=--% sync=--% total=--%");
         gameStatus.setTextColor(Color.WHITE);
         gameStatus.setTextSize(12.0f);
         gameStatus.setSingleLine(false);
@@ -935,6 +947,60 @@ public final class MainActivity extends Activity {
                 Gravity.TOP | Gravity.START);
         statusParams.setMargins(dp(8), dp(8), dp(68), 0);
         root.addView(gameStatus, statusParams);
+    }
+
+    private void installBlockingErrorPanel(FrameLayout root) {
+        blockingErrorPanel = new LinearLayout(this);
+        blockingErrorPanel.setOrientation(LinearLayout.VERTICAL);
+        blockingErrorPanel.setPadding(dp(18), dp(16), dp(18), dp(16));
+        blockingErrorPanel.setBackground(createPanelBackground(
+                Color.rgb(66, 24, 30), Color.rgb(235, 105, 115)));
+        blockingErrorPanel.setElevation(dp(12));
+        blockingErrorPanel.setVisibility(View.GONE);
+
+        TextView title = new TextView(this);
+        title.setText("Game is not running");
+        title.setTextColor(Color.WHITE);
+        title.setTextSize(20.0f);
+        title.setTypeface(Typeface.DEFAULT_BOLD);
+        if (Build.VERSION.SDK_INT >= 28) title.setAccessibilityHeading(true);
+        blockingErrorPanel.addView(title, fullWidth());
+
+        blockingErrorBody = new TextView(this);
+        blockingErrorBody.setTextColor(Color.WHITE);
+        blockingErrorBody.setTextSize(14.0f);
+        blockingErrorBody.setTypeface(Typeface.MONOSPACE);
+        blockingErrorBody.setPadding(0, dp(10), 0, dp(12));
+        blockingErrorBody.setAccessibilityLiveRegion(View.ACCESSIBILITY_LIVE_REGION_ASSERTIVE);
+        blockingErrorPanel.addView(blockingErrorBody, fullWidth());
+
+        LinearLayout actions = new LinearLayout(this);
+        configureActionRow(actions, adaptiveLayoutProfile());
+        Button openDiagnostics = new Button(this);
+        openDiagnostics.setText("Open Diagnostics");
+        openDiagnostics.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) {
+                if (editorPanel != null && editorPanel.getVisibility() != View.VISIBLE) {
+                    toggleEditorPanel();
+                }
+                if (diagnosticBody != null) diagnosticBody.setVisibility(View.VISIBLE);
+            }
+        });
+        actions.addView(openDiagnostics, actionWidth(adaptiveLayoutProfile()));
+        Button retryCompile = new Button(this);
+        retryCompile.setText("Retry Compile");
+        retryCompile.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View view) { runNativeCompile(); }
+        });
+        actions.addView(retryCompile, actionWidth(adaptiveLayoutProfile()));
+        blockingErrorPanel.addView(actions, fullWidth());
+
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER);
+        params.setMargins(dp(24), dp(96), dp(24), dp(96));
+        root.addView(blockingErrorPanel, params);
     }
 
     private void installAiGameProgressOverlay(FrameLayout root) {
@@ -1261,7 +1327,7 @@ public final class MainActivity extends Activity {
                     compileAttempted = true;
                     setStatusText(compileResult);
                 }
-                if (compileReady) {
+                if (compileReady || gameRuntimeActive) {
                     runNativeTick();
                 }
                 gameLoopHandler.postDelayed(this, DEFAULT_TICK_INTERVAL_MS);
@@ -1277,6 +1343,16 @@ public final class MainActivity extends Activity {
     private void setStatusText(String status) {
         if (reloadStatus != null) {
             reloadStatus.setText(compactStatusText(status));
+        }
+        if (blockingErrorPanel != null) {
+            boolean visible = WorkshopBlockingErrorPolicy.shouldShow(gameRuntimeActive, status);
+            blockingErrorPanel.setVisibility(visible ? View.VISIBLE : View.GONE);
+            if (visible && blockingErrorBody != null) {
+                blockingErrorBody.setText(WorkshopBlockingErrorPolicy.summary(
+                        status, projectRootPath));
+                blockingErrorPanel.bringToFront();
+                if (editorToggle != null) editorToggle.bringToFront();
+            }
         }
     }
 
@@ -1448,12 +1524,17 @@ public final class MainActivity extends Activity {
         }
         lastDebugUpdateNanos = now;
         double tickMillis = tickMetric.averageMillis();
+        double syncMillis = syncMetric.averageMillis();
         double renderMillis = renderMetric.averageMillis();
         double tickP50Millis = tickMetric.percentileMillis(50);
         double tickP95Millis = tickMetric.percentileMillis(95);
+        double syncP95Millis = syncMetric.percentileMillis(95);
         double renderP50Millis = renderMetric.percentileMillis(50);
         double renderP95Millis = renderMetric.percentileMillis(95);
-        int budgetPercent = Math.max(0, (int)(((tickMillis + renderMillis) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
+        int tickBudgetPercent = WorkshopFrameBudget.percent(tickMillis);
+        int syncBudgetPercent = WorkshopFrameBudget.percent(syncMillis);
+        int renderBudgetPercent = WorkshopFrameBudget.percent(renderMillis);
+        int totalBudgetPercent = WorkshopFrameBudget.percent(tickMillis + syncMillis + renderMillis);
         debugTextBuilder.setLength(0);
         debugTextBuilder.append("tick avg=");
         appendMillis(debugTextBuilder, tickMillis);
@@ -1467,10 +1548,20 @@ public final class MainActivity extends Activity {
         appendMillis(debugTextBuilder, renderP50Millis);
         debugTextBuilder.append(" p95=");
         appendMillis(debugTextBuilder, renderP95Millis);
-        debugTextBuilder.append(" ms  budget=");
-        appendPercent(debugTextBuilder, budgetPercent);
+        debugTextBuilder.append(" ms\nsync avg=");
+        appendMillis(debugTextBuilder, syncMillis);
+        debugTextBuilder.append(" p95=");
+        appendMillis(debugTextBuilder, syncP95Millis);
+        debugTextBuilder.append(" ms\nbudget tick=");
+        appendPercent(debugTextBuilder, tickBudgetPercent);
+        debugTextBuilder.append(" render=");
+        appendPercent(debugTextBuilder, renderBudgetPercent);
+        debugTextBuilder.append(" sync=");
+        appendPercent(debugTextBuilder, syncBudgetPercent);
+        debugTextBuilder.append(" total=");
+        appendPercent(debugTextBuilder, totalBudgetPercent);
         appendExplorationProgress(debugTextBuilder);
-        gameStatus.setTextColor(debugColorForBudget(budgetPercent));
+        gameStatus.setTextColor(debugColorForBudget(totalBudgetPercent));
         gameStatus.setText(debugTextBuilder.toString());
         updateAiGameProgressOverlay();
     }
@@ -2626,6 +2717,7 @@ public final class MainActivity extends Activity {
             diagnosticSymbol = "";
             compileAttempted = false;
             compileReady = false;
+            gameRuntimeActive = false;
             lastCompileResult = "CompileNotRun";
             reviewedGitHubChangeFingerprint = "";
             ProjectSnapshot snapshot = loadBundledProject();
@@ -4787,19 +4879,26 @@ public final class MainActivity extends Activity {
         int touchActive = gamePreview == null ? 0 : gamePreview.touchActive();
         int screenWidth = gamePreview == null ? 0 : gamePreview.getWidth();
         int screenHeight = gamePreview == null ? 0 : gamePreview.getHeight();
-        long tickStartNanos = System.nanoTime();
         int frameStatus = gamePreview == null ? -1 : gamePreview.runNativeFrame(
                 projectRootPath(), touchX, touchY, touchActive, screenWidth, screenHeight,
                 nativeFrameValues);
         long tickEndNanos = System.nanoTime();
-        tickMetric.add(tickEndNanos, tickEndNanos - tickStartNanos);
+        tickMetric.add(tickEndNanos,
+                gamePreview == null ? 0L : gamePreview.lastNativeFrameDurationNanos());
+        syncMetric.add(tickEndNanos,
+                gamePreview == null ? 0L : gamePreview.lastRendererSyncWaitNanos());
         if (frameStatus != 0 || nativeFrameValues[0] != StasisPreviewRenderer.RENDER_MAGIC
                 || nativeFrameValues[1] != StasisPreviewRenderer.RENDER_VERSION) {
             compileReady = false;
             compileAttempted = true;
-            setStatusText("RunError: " + nativeLastFrameError());
+            gameRuntimeActive = false;
+            String frameError = "RunError: " + nativeLastFrameError();
+            setStatusText(frameError);
+            if (gameStatus != null) gameStatus.setText(frameError);
+            android.util.Log.e("StasisWorkshop", frameError);
             return;
         }
+        gameRuntimeActive = true;
         recordOnboardingProjectStep(WorkshopOnboardingPolicy.Step.PROJECT_RAN);
         updateGameDebugText();
     }
@@ -9715,7 +9814,8 @@ public final class MainActivity extends Activity {
         File readyFile = new File(baselineRoot, PROJECT_BASELINE_READY);
         String templateId = activeProject == null ? WorkshopTemplateCatalog.DEFAULT_TEMPLATE_ID
                 : activeProject.templateId;
-        String expectedReady = "format=3\ntemplate_id=" + templateId + "\n";
+        String expectedReady = "format=3\ntemplate_id=" + templateId
+                + "\nrenderer=gfx_cmd_v1\n";
         if (readyFile.isFile() && expectedReady.equals(readTextFile(readyFile))) return;
         ProjectSnapshot baseline = activeProject != null && "import".equals(activeProject.origin)
                 ? current : loadBundledAssetSnapshot();
@@ -10356,6 +10456,99 @@ public final class MainActivity extends Activity {
         return !after.equals(before);
     }
 
+    private boolean migrateBundledPongProductionRenderer() throws IOException {
+        if (activeProject == null || !"bundled-workshop".equals(activeProject.id)
+                || !"sample".equals(activeProject.origin)
+                || !WorkshopTemplateCatalog.LEGACY_TEMPLATE_ID.equals(activeProject.templateId)) {
+            return false;
+        }
+        SharedPreferences preferences = getSharedPreferences(SAMPLE_MIGRATION_PREFS, MODE_PRIVATE);
+        String key = activeProject.id + ":" + PONG_GFX_CMD_MIGRATION;
+        if (preferences.getBoolean(key, false)) return false;
+
+        File sourceFile = new File(projectRoot(), "src/main.stasis");
+        if (!sourceFile.isFile()) return false;
+        String before = readTextFile(sourceFile);
+        String after = before;
+        boolean sourceChanged = !WorkshopPongRendererMigration.isProductionSource(before);
+        if (sourceChanged) {
+            try {
+                after = WorkshopPongRendererMigration.migrateSource(before);
+            } catch (IllegalArgumentException error) {
+                throw new IOException("bundled Pong lifecycle could not be migrated safely", error);
+            }
+        }
+        File adapterFile = new File(projectRoot(), "src/preview_adapter.stasis");
+        boolean adapterExisted = adapterFile.isFile();
+        String previousAdapter = adapterExisted ? readTextFile(adapterFile) : "";
+        String packagedAdapter = readAsset(getAssets(),
+                "workshop_sample/src/preview_adapter.stasis");
+        boolean adapterChanged = !packagedAdapter.equals(previousAdapter);
+        File manifestFile = new File(projectRoot(), "assets/manifest.json");
+        boolean manifestExisted = manifestFile.isFile();
+        String previousManifest = manifestExisted ? readTextFile(manifestFile) : "";
+        String packagedManifest = readAsset(getAssets(),
+                "workshop_sample/assets/manifest.json");
+        String migratedManifest;
+        try {
+            migratedManifest = manifestExisted
+                    ? WorkshopPongAssetManifestMigration.mergeRequiredSprites(
+                            previousManifest, packagedManifest)
+                    : packagedManifest;
+        } catch (org.json.JSONException error) {
+            throw new IOException("bundled Pong asset manifest could not be migrated safely", error);
+        }
+        boolean manifestChanged = !migratedManifest.equals(previousManifest);
+        if (!sourceChanged && !adapterChanged && !manifestChanged) {
+            if (!preferences.edit().putBoolean(key, true).commit()) {
+                throw new IOException("unable to record bundled Pong renderer migration");
+            }
+            return false;
+        }
+
+        File backup = new File(projectRoot(),
+                "build/migrations/pong_gfx_cmd_v6/main.stasis");
+        File adapterBackup = new File(projectRoot(),
+                "build/migrations/pong_gfx_cmd_v6/preview_adapter.stasis");
+        File manifestBackup = new File(projectRoot(),
+                "build/migrations/pong_gfx_cmd_v6/manifest.json");
+        if (sourceChanged && !backup.isFile()) writeSyncedTextFile(backup, before);
+        if (adapterChanged && adapterExisted && !adapterBackup.isFile()) {
+            writeSyncedTextFile(adapterBackup, previousAdapter);
+        }
+        if (manifestChanged && manifestExisted && !manifestBackup.isFile()) {
+            writeSyncedTextFile(manifestBackup, previousManifest);
+        }
+        try {
+            if (sourceChanged) replaceTextFileAtomically(sourceFile, after);
+            if (adapterChanged) replaceTextFileAtomically(adapterFile, packagedAdapter);
+            if (manifestChanged) replaceTextFileAtomically(manifestFile, migratedManifest);
+            if (!preferences.edit().putBoolean(key, true).commit()) {
+                throw new IOException("unable to record bundled Pong renderer migration");
+            }
+        } catch (IOException error) {
+            try {
+                if (sourceChanged) replaceTextFileAtomically(sourceFile, before);
+                if (adapterChanged) {
+                    if (adapterExisted) replaceTextFileAtomically(adapterFile, previousAdapter);
+                    else if (!adapterFile.delete() && adapterFile.exists()) {
+                        throw new IOException("unable to remove migrated Pong renderer adapter");
+                    }
+                }
+                if (manifestChanged) {
+                    if (manifestExisted) replaceTextFileAtomically(manifestFile, previousManifest);
+                    else if (!manifestFile.delete() && manifestFile.exists()) {
+                        throw new IOException("unable to remove migrated Pong asset manifest");
+                    }
+                }
+            } catch (IOException rollback) {
+                error.addSuppressed(rollback);
+            }
+            throw error;
+        }
+        return true;
+    }
+
     private void ensureProjectFile(AssetManager assets, String assetPath, File diskFile) throws IOException {
         if (diskFile.isFile()) {
             return;
@@ -10459,6 +10652,35 @@ public final class MainActivity extends Activity {
             output.write(source.getBytes(StandardCharsets.UTF_8));
         } finally {
             output.close();
+        }
+    }
+
+    private void writeSyncedTextFile(File file, String source) throws IOException {
+        File parent = file.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("failed to create " + parent.getAbsolutePath());
+        }
+        FileOutputStream output = new FileOutputStream(file, false);
+        try {
+            output.write(source.getBytes(StandardCharsets.UTF_8));
+            output.getFD().sync();
+        } finally {
+            output.close();
+        }
+    }
+
+    private void replaceTextFileAtomically(File file, String source) throws IOException {
+        File temporary = new File(file.getParentFile(), file.getName() + ".gfx-cmd.tmp");
+        writeSyncedTextFile(temporary, source);
+        try {
+            try {
+                Files.move(temporary.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException unsupported) {
+                Files.move(temporary.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            if (temporary.exists()) temporary.delete();
         }
     }
 
@@ -11281,6 +11503,8 @@ public final class MainActivity extends Activity {
         private int touchX;
         private int touchY;
         private boolean touchActive;
+        private long lastNativeFrameDurationNanos;
+        private long lastRendererSyncWaitNanos;
 
         GamePreviewView(MainActivity activity) {
             super(activity);
@@ -11309,14 +11533,26 @@ public final class MainActivity extends Activity {
         int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,
                 int screenWidth, int screenHeight, int[] header) {
             int status;
+            long requested = System.nanoTime();
             synchronized (renderer) {
+                long started = System.nanoTime();
+                lastRendererSyncWaitNanos = started - requested;
                 status = nativeRunFrameInto(projectRoot, inputX, inputY, inputActive,
                         screenWidth, screenHeight, renderer.frameI32Bytes(),
                         renderer.frameF32Bytes(), renderer.frameU8Bytes());
+                lastNativeFrameDurationNanos = System.nanoTime() - started;
                 renderer.copyFrameHeaderInto(header);
             }
             if (status == 0) requestRender();
             return status;
+        }
+
+        long lastNativeFrameDurationNanos() {
+            return lastNativeFrameDurationNanos;
+        }
+
+        long lastRendererSyncWaitNanos() {
+            return lastRendererSyncWaitNanos;
         }
 
         void captureFrame(CaptureCallback callback) {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -71,6 +71,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -139,7 +140,6 @@ public final class MainActivity extends Activity {
     private static final long DEFAULT_TICK_INTERVAL_MS = 16L;
     private static final long DEBUG_UPDATE_INTERVAL_NANOS = 250_000_000L;
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
-    private static final int MAX_RENDER_COMMANDS = StasisPreviewRenderer.COMMAND_CAPACITY;
     private static final int MAX_AI_AGENT_TURNS = 25;
     private static final int MAX_AI_TOOL_CALLS_PER_BATCH = 12;
     private static final int MAX_AI_READ_ONLY_BATCHES = 2;
@@ -165,9 +165,7 @@ public final class MainActivity extends Activity {
     private static final int IMPORT_AUDIO_REQUEST = 74;
     private static final int EXPORT_SUPPORT_BUNDLE_REQUEST = 75;
     private static final double GPT_IMAGE_2_LOW_1024_USD = 0.006;
-    private static final int RENDER_FRAME_HEADER_SIZE = StasisPreviewRenderer.FRAME_HEADER_SIZE;
-    private static final int RENDER_COMMAND_STRIDE = StasisPreviewRenderer.COMMAND_STRIDE;
-    private static final int RENDER_FRAME_I32_CAPACITY = StasisPreviewRenderer.FRAME_I32_CAPACITY;
+    private static final int RENDER_FRAME_HEADER_SIZE = 10;
     private TextView sourceTitle;
     private LinearLayout selectedSourcePanel;
     private LinearLayout manualEditBody;
@@ -305,7 +303,7 @@ public final class MainActivity extends Activity {
     private final ExecutorService projectIoExecutor = Executors.newSingleThreadExecutor();
     private final ExecutorService codexExecutor = Executors.newSingleThreadExecutor();
     private Runnable gameLoop;
-    private final int[] nativeFrameValues = new int[RENDER_FRAME_I32_CAPACITY];
+    private final int[] nativeFrameValues = new int[RENDER_FRAME_HEADER_SIZE];
     private final StringBuilder debugTextBuilder = new StringBuilder(64);
     private final RollingMetric tickMetric = new RollingMetric();
     private final RollingMetric renderMetric = new RollingMetric();
@@ -337,11 +335,20 @@ public final class MainActivity extends Activity {
     private static native String nativeSemanticEdit(String projectRoot, String requestJson,
                                                     boolean dryRun, boolean validate, boolean runTests);
     private static native String nativeRunTick(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight);
-    private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight, int[] frameValues);
+    private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
+            int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
+            ByteBuffer frameF32, ByteBuffer frameU8);
+    private static native String nativeLastFrameError();
     private static native String nativeSetRuntimeI32(String projectRoot, String path, int value);
     private static native String nativeGetRuntimeI32(String projectRoot, String path);
     static native String nativeResolveSpriteAsset(String projectRoot, int handle);
+    static native String nativeResolveCachedText(String projectRoot, int handle);
+    static native String nativeResolveFont(String projectRoot, int handle);
     static native int[] nativeDecodeSvgSprite(String path, int width, int height);
+
+    void reportPreviewResourceError(String message) {
+        runOnUiThread(() -> setStatusText("RenderResourceError: " + message));
+    }
     private static native String nativeRunTests(String projectRoot);
     private static native String nativeCodexBeginDeviceLogin(String codexHome);
     private static native String nativeCodexAccountStatus(String codexHome);
@@ -915,10 +922,10 @@ public final class MainActivity extends Activity {
 
     private void installGameStatusOverlay(FrameLayout root, boolean visible) {
         gameStatus = new TextView(this);
-        gameStatus.setText("tick=-- ms  render=-- ms  budget=--%");
+        gameStatus.setText("tick avg=-- p50=-- p95=-- ms\nrender avg=-- p50=-- p95=-- ms  budget=--%");
         gameStatus.setTextColor(Color.WHITE);
         gameStatus.setTextSize(12.0f);
-        gameStatus.setSingleLine(true);
+        gameStatus.setSingleLine(false);
         gameStatus.setPadding(dp(10), dp(6), dp(10), dp(6));
         gameStatus.setBackgroundColor(Color.argb(150, 20, 28, 38));
         gameStatus.setVisibility(visible ? View.VISIBLE : View.GONE);
@@ -1442,12 +1449,24 @@ public final class MainActivity extends Activity {
         lastDebugUpdateNanos = now;
         double tickMillis = tickMetric.averageMillis();
         double renderMillis = renderMetric.averageMillis();
+        double tickP50Millis = tickMetric.percentileMillis(50);
+        double tickP95Millis = tickMetric.percentileMillis(95);
+        double renderP50Millis = renderMetric.percentileMillis(50);
+        double renderP95Millis = renderMetric.percentileMillis(95);
         int budgetPercent = Math.max(0, (int)(((tickMillis + renderMillis) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
         debugTextBuilder.setLength(0);
-        debugTextBuilder.append("tick=");
+        debugTextBuilder.append("tick avg=");
         appendMillis(debugTextBuilder, tickMillis);
-        debugTextBuilder.append(" ms  render=");
+        debugTextBuilder.append(" p50=");
+        appendMillis(debugTextBuilder, tickP50Millis);
+        debugTextBuilder.append(" p95=");
+        appendMillis(debugTextBuilder, tickP95Millis);
+        debugTextBuilder.append(" ms\nrender avg=");
         appendMillis(debugTextBuilder, renderMillis);
+        debugTextBuilder.append(" p50=");
+        appendMillis(debugTextBuilder, renderP50Millis);
+        debugTextBuilder.append(" p95=");
+        appendMillis(debugTextBuilder, renderP95Millis);
         debugTextBuilder.append(" ms  budget=");
         appendPercent(debugTextBuilder, budgetPercent);
         appendExplorationProgress(debugTextBuilder);
@@ -4769,24 +4788,17 @@ public final class MainActivity extends Activity {
         int screenWidth = gamePreview == null ? 0 : gamePreview.getWidth();
         int screenHeight = gamePreview == null ? 0 : gamePreview.getHeight();
         long tickStartNanos = System.nanoTime();
-        int frameStatus = nativeRunFrameInto(
-                projectRootPath(),
-                touchX,
-                touchY,
-                touchActive,
-                screenWidth,
-                screenHeight,
+        int frameStatus = gamePreview == null ? -1 : gamePreview.runNativeFrame(
+                projectRootPath(), touchX, touchY, touchActive, screenWidth, screenHeight,
                 nativeFrameValues);
         long tickEndNanos = System.nanoTime();
         tickMetric.add(tickEndNanos, tickEndNanos - tickStartNanos);
-        if (frameStatus != 0 || nativeFrameValues[0] != 0) {
+        if (frameStatus != 0 || nativeFrameValues[0] != StasisPreviewRenderer.RENDER_MAGIC
+                || nativeFrameValues[1] != StasisPreviewRenderer.RENDER_VERSION) {
             compileReady = false;
             compileAttempted = true;
-            setStatusText("RunError: native frame tick failed");
+            setStatusText("RunError: " + nativeLastFrameError());
             return;
-        }
-        if (gamePreview != null) {
-            gamePreview.setRenderFrameValues(nativeFrameValues);
         }
         recordOnboardingProjectStep(WorkshopOnboardingPolicy.Step.PROJECT_RAN);
         updateGameDebugText();
@@ -6997,31 +7009,23 @@ public final class MainActivity extends Activity {
     }
     private JSONObject aiToolRunFrame() throws Exception {
         ensureAiTestCompileReady();
-        int[] frame = new int[RENDER_FRAME_I32_CAPACITY];
-        int status = nativeRunFrameInto(
-                projectRootPath(),
-                aiSimTouchX,
-                aiSimTouchY,
-                aiSimTouchActive,
-                currentAiScreenWidth(),
-                currentAiScreenHeight(),
-                frame);
-        System.arraycopy(frame, 0, nativeFrameValues, 0, RENDER_FRAME_I32_CAPACITY);
-        if (gamePreview != null) {
-            gamePreview.setRenderFrameValues(nativeFrameValues);
-        }
-        return new JSONObject()
+        int status = gamePreview == null ? -1 : gamePreview.runNativeFrame(
+                projectRootPath(), aiSimTouchX, aiSimTouchY, aiSimTouchActive,
+                currentAiScreenWidth(), currentAiScreenHeight(), nativeFrameValues);
+        JSONObject result = new JSONObject()
                 .put("status", status)
                 .put("input", currentInputStateJson())
-                .put("frame", frameValuesToJson(frame))
+                .put("frame", frameValuesToJson(currentLogicalFrame()))
                 .put("runtime_state", runtimeStateJson());
+        if (status != 0) result.put("error", nativeLastFrameError());
+        return result;
     }
 
     private JSONObject aiToolInspectRuntimeState() throws Exception {
         return new JSONObject()
                 .put("input", currentInputStateJson())
                 .put("runtime_state", runtimeStateJson())
-                .put("frame", frameValuesToJson(nativeFrameValues));
+                .put("frame", frameValuesToJson(currentLogicalFrame()));
     }
 
     private void ensureAiTestCompileReady() throws Exception {
@@ -7080,49 +7084,55 @@ public final class MainActivity extends Activity {
                 .put("values", values);
     }
 
-    private static JSONObject frameValuesToJson(int[] frame) throws Exception {
-        JSONArray values = new JSONArray();
-        for (int index = 0; index < frame.length; index += 1) {
-            values.put(frame[index]);
-        }
-        JSONArray commands = new JSONArray();
-        int commandCount = frame.length > 5 ? Math.max(0, Math.min(MAX_RENDER_COMMANDS, frame[5])) : 0;
-        for (int index = 0; index < commandCount; index += 1) {
-            int base = RENDER_FRAME_HEADER_SIZE + index * RENDER_COMMAND_STRIDE;
-            commands.put(new JSONObject()
-                    .put("kind", frame[base])
-                    .put("x", frame[base + 1])
-                    .put("y", frame[base + 2])
-                    .put("w", frame[base + 3])
-                    .put("h", frame[base + 4])
-                     .put("color", frame[base + 5])
-                    .put("asset", frame[base + 6])
-                    .put("rotation_degrees", frame[base + 7])
-                    .put("alpha", frame[base + 8])
-                    .put("clip_x", frame[base + 9])
-                    .put("clip_y", frame[base + 10])
-                    .put("clip_w", frame[base + 11])
-                    .put("clip_h", frame[base + 12]));
-        }
-        return new JSONObject()
-                .put("status", frame.length > 0 ? frame[0] : -1)
-                .put("tick_count", frame.length > 1 ? frame[1] : 0)
-                .put("game_tick_count", frame.length > 2 ? frame[2] : 0)
-                .put("command_count", commandCount)
-                .put("commands", commands)
-                .put("raw_values", values);
-    }
-    private JSONObject aiToolTakeScreenshot() throws Exception {
-        return logicalRenderSnapshot(nativeFrameValues);
+    private StasisPreviewRenderer.LogicalFrameSnapshot currentLogicalFrame() {
+        return gamePreview == null ? null : gamePreview.logicalFrameSnapshot();
     }
 
-    private JSONObject logicalRenderSnapshot(int[] capturedFrame) throws Exception {
+    private static JSONObject frameValuesToJson(
+            StasisPreviewRenderer.LogicalFrameSnapshot frame) throws Exception {
+        if (frame == null) return new JSONObject().put("status", "unavailable");
+        JSONArray header = jsonArray(frame.header);
+        JSONArray lines = jsonArray(frame.lines);
+        JSONArray sprites = jsonArray(frame.sprites);
+        JSONArray textMetadata = jsonArray(frame.textMetadata);
+        JSONArray textValues = jsonArray(frame.textValues);
+        JSONArray textBytes = new JSONArray();
+        for (byte value : frame.textBytes) textBytes.put(value & 255);
+        return new JSONObject()
+                .put("magic", frame.header[0])
+                .put("version", frame.header[1])
+                .put("flags", frame.header[2])
+                .put("line_count", frame.header[3])
+                .put("sprite_count", frame.header[4])
+                .put("text_count", frame.header[7])
+                .put("text_bytes_used", frame.header[9])
+                .put("header_i32", header)
+                .put("line_f32", lines)
+                .put("sprite_i32", sprites)
+                .put("text_i32", textMetadata)
+                .put("text_f32", textValues)
+                .put("text_u8", textBytes);
+    }
+
+    private static JSONArray jsonArray(int[] values) {
+        JSONArray out = new JSONArray();
+        for (int value : values) out.put(value);
+        return out;
+    }
+
+    private static JSONArray jsonArray(float[] values) throws Exception {
+        JSONArray out = new JSONArray();
+        for (float value : values) out.put(value);
+        return out;
+    }
+    private JSONObject aiToolTakeScreenshot() throws Exception {
+        return logicalRenderSnapshot(currentLogicalFrame());
+    }
+
+    private JSONObject logicalRenderSnapshot(
+            StasisPreviewRenderer.LogicalFrameSnapshot capturedFrame) throws Exception {
         int width = gamePreview == null ? 0 : gamePreview.getWidth();
         int height = gamePreview == null ? 0 : gamePreview.getHeight();
-        JSONArray frame = new JSONArray();
-        for (int index = 0; index < capturedFrame.length; index += 1) {
-            frame.put(capturedFrame[index]);
-        }
         return new JSONObject()
                 .put("kind", "logical_render_snapshot")
                 .put("width", width)
@@ -7132,8 +7142,7 @@ public final class MainActivity extends Activity {
                 .put("touch_active", gamePreview != null && gamePreview.touchActive() == 1)
                 .put("input", currentInputStateJson())
                 .put("runtime_state", runtimeStateJson())
-                .put("frame", frameValuesToJson(capturedFrame))
-                .put("frame_values", frame);
+                .put("frame", frameValuesToJson(capturedFrame));
     }
 
     private static SourceFile findProjectFile(ProjectSnapshot project, String file) throws Exception {
@@ -9187,7 +9196,8 @@ public final class MainActivity extends Activity {
         }
         screenshotAttachmentStatus.setText("AI preview: capturing rendered pixels");
         gamePreview.captureFrame(new GamePreviewView.CaptureCallback() {
-            @Override public void onCaptured(final Bitmap bitmap, final String error, final int[] capturedFrame) {
+            @Override public void onCaptured(final Bitmap bitmap, final String error,
+                    final StasisPreviewRenderer.LogicalFrameSnapshot capturedFrame) {
                 runOnUiThread(new Runnable() {
                     @Override public void run() {
                         if (bitmap == null) {
@@ -11262,7 +11272,8 @@ public final class MainActivity extends Activity {
 
     private static final class GamePreviewView extends GLSurfaceView {
         interface CaptureCallback {
-            void onCaptured(Bitmap bitmap, String error, int[] capturedFrame);
+            void onCaptured(Bitmap bitmap, String error,
+                    StasisPreviewRenderer.LogicalFrameSnapshot capturedFrame);
         }
 
         private final MainActivity activity;
@@ -11295,14 +11306,26 @@ public final class MainActivity extends Activity {
             return touchActive ? 1 : 0;
         }
 
-        void setRenderFrameValues(int[] frameValues) {
-            renderer.setFrame(frameValues);
-            requestRender();
+        int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,
+                int screenWidth, int screenHeight, int[] header) {
+            int status;
+            synchronized (renderer) {
+                status = nativeRunFrameInto(projectRoot, inputX, inputY, inputActive,
+                        screenWidth, screenHeight, renderer.frameI32Bytes(),
+                        renderer.frameF32Bytes(), renderer.frameU8Bytes());
+                renderer.copyFrameHeaderInto(header);
+            }
+            if (status == 0) requestRender();
+            return status;
         }
 
         void captureFrame(CaptureCallback callback) {
             renderer.requestCapture(callback::onCaptured);
             requestRender();
+        }
+
+        StasisPreviewRenderer.LogicalFrameSnapshot logicalFrameSnapshot() {
+            return renderer.captureLogicalFrame();
         }
 
         @Override
@@ -11330,6 +11353,7 @@ public final class MainActivity extends Activity {
         private static final int CAPACITY = 600;
         private final long[] timestamps = new long[CAPACITY];
         private final long[] durations = new long[CAPACITY];
+        private final long[] orderedDurations = new long[CAPACITY];
         private int next;
         private int count;
 
@@ -11356,6 +11380,20 @@ public final class MainActivity extends Activity {
                 return 0.0;
             }
             return total / (samples * 1_000_000.0);
+        }
+
+        double percentileMillis(int percentile) {
+            long now = System.nanoTime();
+            int samples = 0;
+            for (int index = 0; index < count; index += 1) {
+                if (now - timestamps[index] <= WINDOW_NANOS) {
+                    orderedDurations[samples++] = durations[index];
+                }
+            }
+            if (samples == 0) return 0.0;
+            Arrays.sort(orderedDurations, 0, samples);
+            int rank = Math.min(samples - 1, (samples * percentile + 99) / 100 - 1);
+            return orderedDurations[Math.max(0, rank)] / 1_000_000.0;
         }
     }
 

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopBlockingErrorPolicy.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopBlockingErrorPolicy.java
@@ -1,0 +1,38 @@
+package com.stasislang.workshop;
+
+import java.io.File;
+
+final class WorkshopBlockingErrorPolicy {
+    private static final int MAX_SUMMARY_LENGTH = 1200;
+
+    private WorkshopBlockingErrorPolicy() {}
+
+    static boolean shouldShow(boolean gameRunning, String status) {
+        return !gameRunning && status != null
+                && (status.startsWith("CompileError") || status.startsWith("RunError"));
+    }
+
+    static String summary(String status, String projectRoot) {
+        if (status == null) return "Unknown game error";
+        int metadata = status.indexOf('|');
+        String summary = status.substring(0, metadata < 0 ? status.length() : metadata);
+        if (projectRoot != null && !projectRoot.isEmpty()) {
+            summary = summary.replace(projectRoot + File.separator, "")
+                    .replace(projectRoot.replace('\\', '/') + "/", "");
+            String projectMarker = "/files/" + new File(projectRoot).getName() + "/";
+            int marker = summary.indexOf(projectMarker);
+            int prefix = summary.indexOf(": ");
+            if (marker >= 0 && prefix >= 0 && prefix + 2 < marker) {
+                summary = summary.substring(0, prefix + 2)
+                        + summary.substring(marker + projectMarker.length());
+            }
+        }
+        WorkshopSourceDiagnostic diagnostic = WorkshopSourceDiagnostic.fromCompileResult(status);
+        if (diagnostic != null && diagnostic.line > 0) {
+            summary += "\n\n" + diagnostic.file + ":" + diagnostic.line
+                    + (diagnostic.column > 0 ? ":" + diagnostic.column : "");
+        }
+        return summary.length() <= MAX_SUMMARY_LENGTH
+                ? summary : summary.substring(0, MAX_SUMMARY_LENGTH - 3) + "...";
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopFrameBudget.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopFrameBudget.java
@@ -1,0 +1,11 @@
+package com.stasislang.workshop;
+
+final class WorkshopFrameBudget {
+    private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
+
+    private WorkshopFrameBudget() {}
+
+    static int percent(double millis) {
+        return Math.max(0, (int)((millis * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopPongAssetManifestMigration.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopPongAssetManifestMigration.java
@@ -1,0 +1,30 @@
+package com.stasislang.workshop;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+final class WorkshopPongAssetManifestMigration {
+    private WorkshopPongAssetManifestMigration() {}
+
+    static String mergeRequiredSprites(String current, String packaged) throws JSONException {
+        JSONObject mergedRoot = new JSONObject(current);
+        JSONArray currentAssets = mergedRoot.getJSONArray("assets");
+        JSONArray packagedAssets = new JSONObject(packaged).getJSONArray("assets");
+        JSONArray mergedAssets = new JSONArray();
+        for (int index = 0; index < currentAssets.length(); index += 1) {
+            JSONObject asset = currentAssets.getJSONObject(index);
+            if (!isRequiredSprite(asset.optString("id"))) mergedAssets.put(asset);
+        }
+        for (int index = 0; index < packagedAssets.length(); index += 1) {
+            JSONObject asset = packagedAssets.getJSONObject(index);
+            if (isRequiredSprite(asset.optString("id"))) mergedAssets.put(asset);
+        }
+        mergedRoot.put("assets", mergedAssets);
+        return mergedRoot.toString(2) + "\n";
+    }
+
+    private static boolean isRequiredSprite(String id) {
+        return "paddle".equals(id) || "center_line".equals(id);
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopPongRendererMigration.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopPongRendererMigration.java
@@ -1,0 +1,34 @@
+package com.stasislang.workshop;
+
+final class WorkshopPongRendererMigration {
+    static final String ADAPTER_IMPORT = "import \"preview_adapter.stasis\";";
+
+    private WorkshopPongRendererMigration() {}
+
+    static boolean isProductionSource(String source) {
+        return source != null && (source.contains(ADAPTER_IMPORT)
+                || source.contains("global gfx_cmd_i32:"));
+    }
+
+    static String migrateSource(String source) {
+        if (source == null || source.isEmpty()) {
+            throw new IllegalArgumentException("Pong source is empty");
+        }
+        if (isProductionSource(source)) return source;
+        String migrated = renameDeclaration(source, "main", "pong_game_main");
+        migrated = renameDeclaration(migrated, "tick", "pong_game_tick");
+        migrated = renameDeclaration(migrated, "render", "pong_game_render");
+        migrated = renameDeclaration(migrated, "on_code_swap", "pong_game_on_code_swap");
+        return ADAPTER_IMPORT + "\n\n" + migrated;
+    }
+
+    private static String renameDeclaration(String source, String from, String to) {
+        String needle = "function " + from + "(): void";
+        int first = source.indexOf(needle);
+        if (first < 0 || source.indexOf(needle, first + needle.length()) >= 0) {
+            throw new IllegalArgumentException("expected exactly one " + from + " lifecycle");
+        }
+        return source.substring(0, first) + "function " + to + "(): void"
+                + source.substring(first + needle.length());
+    }
+}

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTemplateCatalog.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTemplateCatalog.java
@@ -14,6 +14,7 @@ final class WorkshopTemplateCatalog {
             "workshop_sample/",
             new String[] {
                     "src/main.stasis",
+                    "src/preview_adapter.stasis",
                     "src/root.stasis",
                     "src/game_state.stasis",
                     "src/player.stasis",
@@ -23,7 +24,12 @@ final class WorkshopTemplateCatalog {
                     "src/systems/collision.stasis"
             },
             new String[] { "tests/enemy_paddle_speed_schedule.test.stasis" },
-            new String[] { "assets/manifest.json", "assets/ball.svg" });
+            new String[] {
+                    "assets/manifest.json",
+                    "assets/ball.svg",
+                    "assets/paddle.svg",
+                    "assets/center_line.svg"
+            });
 
     private static final Template EXPLORATION = new Template(
             "exploration",

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -1,6 +1,9 @@
 package com.stasislang.workshop;
 
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Typeface;
 import android.opengl.GLES20;
 import android.util.SparseArray;
 
@@ -9,15 +12,22 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 
 final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProvider {
+    private static final long MANIFEST_CHECK_INTERVAL_NANOS = 500_000_000L;
     private final MainActivity activity;
     private final SparseArray<SpriteTexture> textures = new SparseArray<>();
+    private final SparseArray<TextTexture> textTextures = new SparseArray<>();
+    private final SparseArray<FontInfo> fonts = new SparseArray<>();
+    private final ArrayList<DynamicTextTexture> dynamicTextTextures = new ArrayList<>();
     private final int[] deletedTexture = new int[1];
     private File manifest;
     private String projectRootPath;
     private int fallbackTexture;
     private long manifestStamp = Long.MIN_VALUE;
+    private long nextManifestCheckNanos;
 
     WorkshopTextureProvider(MainActivity activity) {
         this.activity = activity;
@@ -26,28 +36,35 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     @Override
     public void onSurfaceCreated() {
         textures.clear();
+        textTextures.clear();
+        fonts.clear();
+        dynamicTextTextures.clear();
         setProjectRoot(activity.projectRootPath());
         manifestStamp = Long.MIN_VALUE;
+        nextManifestCheckNanos = 0L;
         fallbackTexture = createFallbackTexture();
     }
 
     @Override
-    public int textureFor(int handle) {
-        String currentProjectRoot = activity.projectRootPath();
-        if (projectChanged(projectRootPath, currentProjectRoot)) {
-            clearTextures();
-            setProjectRoot(currentProjectRoot);
-        }
+    public void onFrameStart() {
+        ensureCurrentProject();
+        long now = System.nanoTime();
+        if (now < nextManifestCheckNanos) return;
+        nextManifestCheckNanos = now + MANIFEST_CHECK_INTERVAL_NANOS;
         long currentStamp = manifest.isFile()
                 ? manifest.lastModified() ^ (manifest.length() << 7) : 0L;
         if (currentStamp != manifestStamp) manifestStamp = currentStamp;
+    }
+
+    @Override
+    public int textureFor(int handle) {
         SpriteTexture cached = textures.get(handle);
         if (cached != null && cached.checkedManifestStamp == manifestStamp) {
             return cached.texture;
         }
         try {
             JSONObject resolved = new JSONObject(MainActivity.nativeResolveSpriteAsset(
-                    currentProjectRoot, handle));
+                    projectRootPath, handle));
             if (!"ok".equals(resolved.optString("status"))) {
                 throw new IOException(resolved.optString("error", "sprite resolution failed"));
             }
@@ -67,12 +84,122 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             if (cached != null) deleteTexture(cached.texture);
             return uploaded;
         } catch (Exception error) {
+            activity.reportPreviewResourceError("sprite " + handle + ": " + error.getMessage());
             if (cached != null) {
                 cached.checkedManifestStamp = manifestStamp;
                 return cached.texture;
             }
             return fallbackTexture;
         }
+    }
+
+    @Override
+    public int fallbackTexture() {
+        return fallbackTexture;
+    }
+
+    @Override
+    public long cachedTextTextureFor(int runHandle) {
+        ensureCurrentProject();
+        TextTexture cached = textTextures.get(runHandle);
+        if (cached != null) return StasisPreviewRenderer.packTexture(
+                cached.texture, cached.width, cached.height);
+        try {
+            JSONObject resolved = new JSONObject(MainActivity.nativeResolveCachedText(
+                    activity.projectRootPath(), runHandle));
+            if (!"ok".equals(resolved.optString("status"))) {
+                throw new IOException(resolved.optString("error", "cached text resolution failed"));
+            }
+            Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
+            paint.setColor(0xffffffff);
+            paint.setTextSize(resolved.getInt("font_size"));
+            paint.setTypeface(Typeface.createFromFile(resolved.getString("font_path")));
+            String text = resolved.getString("text");
+            Paint.FontMetrics metrics = paint.getFontMetrics();
+            int width = Math.max(1, (int)Math.ceil(paint.measureText(text)));
+            int height = Math.max(1, (int)Math.ceil(metrics.descent - metrics.ascent));
+            Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            new Canvas(bitmap).drawText(text, 0.0f, -metrics.ascent, paint);
+            int texture;
+            try {
+                texture = upload(bitmap);
+            } finally {
+                bitmap.recycle();
+            }
+            cached = new TextTexture(texture, width, height);
+            textTextures.put(runHandle, cached);
+            return StasisPreviewRenderer.packTexture(texture, width, height);
+        } catch (Exception error) {
+            activity.reportPreviewResourceError("cached text " + runHandle + ": " + error.getMessage());
+            return 0L;
+        }
+    }
+
+    @Override
+    public long textTextureFor(int font, ByteBuffer utf8, int offset, int length) {
+        ensureCurrentProject();
+        for (int index = 0; index < dynamicTextTextures.size(); index += 1) {
+            DynamicTextTexture cached = dynamicTextTextures.get(index);
+            if (cached.matches(font, utf8, offset, length)) {
+                return StasisPreviewRenderer.packTexture(
+                        cached.texture.texture, cached.texture.width, cached.texture.height);
+            }
+        }
+        try {
+            if (dynamicTextTextures.size() >= 4096) throw new IOException("dynamic text cache is full");
+            byte[] bytes = new byte[length];
+            for (int index = 0; index < length; index += 1) bytes[index] = utf8.get(offset + index);
+            FontInfo fontInfo = fontInfo(font);
+            TextTexture texture = rasterText(fontInfo, new String(bytes, StandardCharsets.UTF_8));
+            dynamicTextTextures.add(new DynamicTextTexture(font, bytes, texture));
+            return StasisPreviewRenderer.packTexture(texture.texture, texture.width, texture.height);
+        } catch (Exception error) {
+            activity.reportPreviewResourceError("text font " + font + ": " + error.getMessage());
+            return 0L;
+        }
+    }
+
+    private String ensureCurrentProject() {
+        String currentProjectRoot = activity.projectRootPath();
+        if (projectChanged(projectRootPath, currentProjectRoot)) {
+            clearTextures();
+            setProjectRoot(currentProjectRoot);
+        }
+        return currentProjectRoot;
+    }
+
+    private FontInfo fontInfo(int handle) throws Exception {
+        FontInfo cached = fonts.get(handle);
+        if (cached != null) return cached;
+        JSONObject resolved = new JSONObject(MainActivity.nativeResolveFont(projectRootPath, handle));
+        if (!"ok".equals(resolved.optString("status"))) {
+            throw new IOException(resolved.optString("error", "font resolution failed"));
+        }
+        cached = new FontInfo(Typeface.createFromFile(resolved.getString("font_path")),
+                resolved.getInt("font_size"));
+        fonts.put(handle, cached);
+        return cached;
+    }
+
+    private static TextTexture rasterText(FontInfo font, String text) {
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
+        paint.setColor(0xffffffff);
+        paint.setTextSize(font.size);
+        paint.setTypeface(font.typeface);
+        Paint.FontMetrics metrics = paint.getFontMetrics();
+        int width = Math.max(1, (int)Math.ceil(paint.measureText(text)));
+        int height = Math.max(1, (int)Math.ceil(metrics.descent - metrics.ascent));
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        new Canvas(bitmap).drawText(text, 0.0f, -metrics.ascent, paint);
+        int texture;
+        try {
+            texture = upload(bitmap);
+        } catch (IOException error) {
+            throw new IllegalStateException(error);
+        } finally {
+            bitmap.recycle();
+        }
+        return new TextTexture(texture, width, height);
     }
 
     static boolean projectChanged(String boundRoot, String currentRoot) {
@@ -83,6 +210,7 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         projectRootPath = root;
         manifest = new File(root, WorkshopAssetManifest.RELATIVE_PATH);
         manifestStamp = Long.MIN_VALUE;
+        nextManifestCheckNanos = 0L;
     }
 
     private void clearTextures() {
@@ -90,6 +218,15 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             deleteTexture(textures.valueAt(index).texture);
         }
         textures.clear();
+        for (int index = 0; index < textTextures.size(); index++) {
+            deleteTexture(textTextures.valueAt(index).texture);
+        }
+        textTextures.clear();
+        for (DynamicTextTexture texture : dynamicTextTextures) {
+            deleteTexture(texture.texture.texture);
+        }
+        dynamicTextTextures.clear();
+        fonts.clear();
     }
 
     private void deleteTexture(int texture) {
@@ -183,6 +320,48 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             this.texture = texture;
             this.contentHash = contentHash;
             this.checkedManifestStamp = checkedManifestStamp;
+        }
+    }
+
+    private static final class TextTexture {
+        final int texture;
+        final int width;
+        final int height;
+
+        TextTexture(int texture, int width, int height) {
+            this.texture = texture;
+            this.width = width;
+            this.height = height;
+        }
+    }
+
+    private static final class FontInfo {
+        final Typeface typeface;
+        final int size;
+
+        FontInfo(Typeface typeface, int size) {
+            this.typeface = typeface;
+            this.size = size;
+        }
+    }
+
+    private static final class DynamicTextTexture {
+        final int font;
+        final byte[] text;
+        final TextTexture texture;
+
+        DynamicTextTexture(int font, byte[] text, TextTexture texture) {
+            this.font = font;
+            this.text = text;
+            this.texture = texture;
+        }
+
+        boolean matches(int candidateFont, ByteBuffer utf8, int offset, int length) {
+            if (font != candidateFont || text.length != length) return false;
+            for (int index = 0; index < length; index += 1) {
+                if (text[index] != utf8.get(offset + index)) return false;
+            }
+            return true;
         }
     }
 }

--- a/mobile/android/build_rust_bridge.ps1
+++ b/mobile/android/build_rust_bridge.ps1
@@ -44,6 +44,8 @@ if ($installedTargets -notcontains "aarch64-linux-android") {
 }
 
 $env:CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = $linker
+$env:CC_aarch64_linux_android = $linker
+$env:AR_aarch64_linux_android = Join-Path $prebuilt "bin\llvm-ar.exe"
 $env:CARGO_INCREMENTAL = "0"
 $profileArgs = @()
 $profileDir = "debug"

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -80,6 +80,55 @@ static size_t code_ptr_count;
 static StasisStringLiteral strings[STASIS_MOBILE_MAX_STRINGS];
 static size_t string_count;
 
+int stasis_mobile_json_escape(const char *input, char *output, size_t capacity) {
+    static const char hex[] = "0123456789abcdef";
+    size_t out = 0;
+    if (input == NULL || output == NULL || capacity == 0) return 0;
+    output[0] = '\0';
+    while (*input != '\0') {
+        unsigned char value = (unsigned char)*input++;
+        const char *escape = NULL;
+        size_t escape_length = 0;
+        switch (value) {
+            case '"': escape = "\\\""; escape_length = 2; break;
+            case '\\': escape = "\\\\"; escape_length = 2; break;
+            case '\b': escape = "\\b"; escape_length = 2; break;
+            case '\f': escape = "\\f"; escape_length = 2; break;
+            case '\n': escape = "\\n"; escape_length = 2; break;
+            case '\r': escape = "\\r"; escape_length = 2; break;
+            case '\t': escape = "\\t"; escape_length = 2; break;
+            default: break;
+        }
+        if (escape != NULL) {
+            if (out + escape_length >= capacity) {
+                output[0] = '\0';
+                return 0;
+            }
+            memcpy(output + out, escape, escape_length);
+            out += escape_length;
+        } else if (value < 0x20) {
+            if (out + 6 >= capacity) {
+                output[0] = '\0';
+                return 0;
+            }
+            output[out++] = '\\';
+            output[out++] = 'u';
+            output[out++] = '0';
+            output[out++] = '0';
+            output[out++] = hex[value >> 4];
+            output[out++] = hex[value & 0x0f];
+        } else {
+            if (out + 1 >= capacity) {
+                output[0] = '\0';
+                return 0;
+            }
+            output[out++] = (char)value;
+        }
+    }
+    output[out] = '\0';
+    return 1;
+}
+
 static size_t value_size(int kind) {
     if (kind == STASIS_VALUE_I32) return sizeof(int32_t);
     if (kind == STASIS_VALUE_F32) return sizeof(float);

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -501,25 +501,35 @@ float stasis_jit_sin_fast(float value) { return sinf(value); }
 float stasis_jit_cos_fast(float value) { return cosf(value); }
 
 static void copy_i32_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
-    int32_t *values;
     int32_t index;
     if (count <= 0 || di < 0 || si < 0) return;
-    values = (int32_t *)malloc((size_t)count * sizeof(int32_t));
-    if (values == NULL) return;
-    for (index = 0; index < count; index += 1) values[index] = stasis_jit_global_i32_array_load(src, 0, si + index);
-    for (index = 0; index < count; index += 1) stasis_jit_global_i32_array_store(dst, 0, di + index, values[index]);
-    free(values);
+    if (dst == src && di > si && di < si + count) {
+        for (index = count; index > 0; index -= 1) {
+            int32_t value = stasis_jit_global_i32_array_load(src, 0, si + index - 1);
+            stasis_jit_global_i32_array_store(dst, 0, di + index - 1, value);
+        }
+        return;
+    }
+    for (index = 0; index < count; index += 1) {
+        int32_t value = stasis_jit_global_i32_array_load(src, 0, si + index);
+        stasis_jit_global_i32_array_store(dst, 0, di + index, value);
+    }
 }
 
 static void copy_f32_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
-    float *values;
     int32_t index;
     if (count <= 0 || di < 0 || si < 0) return;
-    values = (float *)malloc((size_t)count * sizeof(float));
-    if (values == NULL) return;
-    for (index = 0; index < count; index += 1) values[index] = stasis_jit_global_f32_array_load(src, 0, si + index);
-    for (index = 0; index < count; index += 1) stasis_jit_global_f32_array_store(dst, 0, di + index, values[index]);
-    free(values);
+    if (dst == src && di > si && di < si + count) {
+        for (index = count; index > 0; index -= 1) {
+            float value = stasis_jit_global_f32_array_load(src, 0, si + index - 1);
+            stasis_jit_global_f32_array_store(dst, 0, di + index - 1, value);
+        }
+        return;
+    }
+    for (index = 0; index < count; index += 1) {
+        float value = stasis_jit_global_f32_array_load(src, 0, si + index);
+        stasis_jit_global_f32_array_store(dst, 0, di + index, value);
+    }
 }
 
 void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -1,6 +1,7 @@
 #ifndef STASIS_MOBILE_AOT_RUNTIME_H
 #define STASIS_MOBILE_AOT_RUNTIME_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -91,6 +92,7 @@ float stasis_jit_gfx_measure_text_cached(int32_t handle);
 int stasis_jit_load_font(int32_t path, int32_t size);
 float stasis_jit_measure_text(int32_t font, int32_t text);
 void stasis_jit_sleep_ms(int32_t ms);
+int stasis_mobile_json_escape(const char *input, char *output, size_t capacity);
 void stasis_mobile_aot_reset(void);
 
 #ifdef __cplusplus

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -57,6 +57,13 @@ int main(void) {
     uint8_t external_u8[4] = {1, 2, 3, 4};
     uint8_t dynamic_path[] = "sprite.bmp";
     int32_t *owned;
+    char escaped_json[64];
+    const char json_controls[] = {'"', '\\', '\b', '\f', '\n', '\r', '\t', 1, 'A', 0};
+
+    CHECK(stasis_mobile_json_escape(json_controls, escaped_json, sizeof(escaped_json)) == 1);
+    CHECK(strcmp(escaped_json, "\\\"\\\\\\b\\f\\n\\r\\t\\u0001A") == 0);
+    CHECK(stasis_mobile_json_escape("too long", escaped_json, 2) == 0);
+    CHECK(escaped_json[0] == '\0');
 
     stasis_mobile_aot_reset();
     stasis_jit_global_i32_store(10, 42);

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -52,6 +52,8 @@ void stasis_sleep_ms(int ms) { (void)ms; }
 int main(void) {
     int32_t external = 4;
     int32_t external_array[3] = {7, 8, 9};
+    int32_t overlapping_i32[5] = {1, 2, 3, 4, 5};
+    float overlapping_f32[5] = {1, 2, 3, 4, 5};
     uint8_t external_u8[4] = {1, 2, 3, 4};
     uint8_t dynamic_path[] = "sprite.bmp";
     int32_t *owned;
@@ -75,6 +77,15 @@ int main(void) {
     CHECK(stasis_jit_global_i32_array_load(22, 0, 1) == 2);
     stasis_jit_sys_memcpy_u8(22, 2, 22, 0, 2);
     CHECK(external_u8[2] == 1 && external_u8[3] == 2);
+
+    stasis_jit_register_global_i32_array(24, 0, overlapping_i32, 5);
+    stasis_jit_sys_memmove_i32(24, 1, 24, 0, 4);
+    CHECK(overlapping_i32[0] == 1 && overlapping_i32[1] == 1 &&
+            overlapping_i32[2] == 2 && overlapping_i32[3] == 3 && overlapping_i32[4] == 4);
+    stasis_jit_register_global_f32_array(25, 0, overlapping_f32, 5);
+    stasis_jit_sys_memmove_f32(25, 1, 25, 0, 4);
+    CHECK(overlapping_f32[0] == 1 && overlapping_f32[1] == 1 &&
+            overlapping_f32[2] == 2 && overlapping_f32[3] == 3 && overlapping_f32[4] == 4);
 
     stasis_jit_register_global_u8_array(23, 0, dynamic_path, sizeof(dynamic_path) - 1);
     stasis_jit_collection_i32_store(23, 1, sizeof(dynamic_path) - 1);

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -19,6 +19,8 @@ REQUIRED_FILES = [
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/AndroidDraftStore.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopProjectRegistry.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTemplateCatalog.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopFrameBudget.java",
+    "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopPongAssetManifestMigration.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopProjectFormatPolicy.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopProjectArchive.java",
     "mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopOnboardingPolicy.java",
@@ -60,6 +62,7 @@ REQUIRED_FILES = [
     "mobile/android/codex_native/src/lib.rs",
     "mobile/android/app/src/main/res/values/styles.xml",
     "mobile/android/app/src/main/assets/workshop_sample/src/main.stasis",
+    "mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis",
     "mobile/android/app/src/main/assets/workshop_sample/src/root.stasis",
     "mobile/android/app/src/main/assets/workshop_sample/src/game_state.stasis",
     "mobile/android/app/src/main/assets/workshop_sample/src/player.stasis",
@@ -68,6 +71,8 @@ REQUIRED_FILES = [
     "mobile/android/app/src/main/assets/workshop_sample/src/assets.stasis",
     "mobile/android/app/src/main/assets/workshop_sample/src/systems/collision.stasis",
     "mobile/android/app/src/main/assets/workshop_sample/assets/ball.svg",
+    "mobile/android/app/src/main/assets/workshop_sample/assets/paddle.svg",
+    "mobile/android/app/src/main/assets/workshop_sample/assets/center_line.svg",
     "mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json",
     "mobile/android/app/src/main/assets/exploration_sample/src/main.stasis",
     "mobile/android/app/src/main/assets/exploration_sample/src/host.stasis",
@@ -355,7 +360,10 @@ def main() -> int:
     assert "MAX_TOOL_CALLS_PER_BATCH = 12" in host_agent
     assert 'DEFAULT_MODELS = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")' in host_comparison
     assert "private static native String nativeRunTick(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight)" in activity
-    assert "private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight, int[] frameValues)" in activity
+    assert "private static native int nativeRunFrameInto(String projectRoot" in activity
+    assert "ByteBuffer frameI32" in activity
+    assert "ByteBuffer frameF32" in activity
+    assert "ByteBuffer frameU8" in activity
     assert 'assetRoot = "workshop_sample/"' not in template_catalog
     assert '"workshop_sample/"' in template_catalog
     assert "activeWorkshopTemplate" in activity
@@ -371,16 +379,17 @@ def main() -> int:
     assert "GLSurfaceView" in activity
     assert "new StasisPreviewRenderer(" in activity
     assert "onDrawFrame" in preview_renderer
-    assert "drawCommands" in preview_renderer
-    draw_loop = preview_renderer.split("private void drawCommands()", 1)[1].split(
-        "private void appendRect", 1
+    assert "drawFrame" in preview_renderer
+    draw_loop = preview_renderer.split("private void drawFrame()", 1)[1].split(
+        "private void drawLines", 1
     )[0]
     assert "new " not in draw_loop
     assert "allocate" not in draw_loop
-    assert "appendSprite(base);" in draw_loop
-    assert "int runEnd = index + 1;" in draw_loop
+    assert "drawLines" in draw_loop
+    assert "drawSprites" in draw_loop
+    assert "drawText" in draw_loop
     assert "GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA)" in preview_renderer
-    assert "GLES20.glScissor" in preview_renderer
+    assert "GLES20.glDisable(GLES20.GL_SCISSOR_TEST)" in preview_renderer
     assert "WorkshopTextureProvider" in activity
     assert "implements StasisPreviewRenderer.TextureProvider" in workshop_textures
     assert "SparseArray<SpriteTexture>" in workshop_textures
@@ -388,9 +397,9 @@ def main() -> int:
     assert "clearTextures();" in workshop_textures
     assert "private final int[] deletedTexture = new int[1]" in workshop_textures
     assert "extractIntField" in activity
-    assert "private final int[] nativeFrameValues = new int[RENDER_FRAME_I32_CAPACITY]" in activity
-    assert "FRAME_BUDGET_MILLIS = 1000.0 / 60.0" in activity
-    assert "budget=--%" in activity
+    assert "private final int[] nativeFrameValues = new int[RENDER_FRAME_HEADER_SIZE]" in activity
+    assert "WorkshopFrameBudget.percent" in activity
+    assert "budget tick=--% render=--% sync=--% total=--%" in activity
     assert "debugColorForBudget" in activity
     assert "appendExplorationProgress(debugTextBuilder)" in activity
     assert '"GameState.collected_count"' in activity
@@ -399,7 +408,7 @@ def main() -> int:
     assert "String projectRootPath" in activity
     assert "nativeCompileProject(projectRootPath())" in activity
     assert "String.format" not in activity
-    assert "gamePreview.setRenderFrameValues(nativeFrameValues)" in activity
+    assert "gamePreview.runNativeFrame(" in activity
     assert "RenderFrame.fromNativeFrame" not in activity
     assert "new RenderCommand" not in activity
     assert "ProjectSnapshot.from" in activity
@@ -522,7 +531,7 @@ def main() -> int:
     assert "Attach logical render/runtime/input snapshot" in activity
     assert "Nothing is sent until selected here and Queue AI Change is pressed" in activity
     assert "GLES20.glReadPixels" in preview_renderer
-    assert "capturedFrame = capture == null ? null : frame.clone()" in preview_renderer
+    assert "capturedFrame = capture == null ? null : captureLogicalFrame()" in preview_renderer
     assert "lastDrawnFrame" not in preview_renderer
     assert "MAX_CAPTURE_PIXELS = 8_000_000" in preview_renderer
     assert "preview framebuffer exceeds the 8 megapixel capture limit" in preview_renderer
@@ -1244,13 +1253,14 @@ def main() -> int:
     assert "gamePreview.touchY()" in activity
     assert "gamePreview.touchActive()" in activity
     assert "MotionEvent" in activity
-    assert "COMMAND_STRIDE = 13" in preview_renderer
-    assert "drawRectBatch((runEnd - index) * RECT_VERTICES)" in preview_renderer
-    assert "drawSpriteBatch((runEnd - index) * RECT_VERTICES, texture)" in preview_renderer
-    assert "GLES20.glScissor" in preview_renderer
-    assert "sameClip(base, runBase)" in preview_renderer
-    assert "frame[5]" in preview_renderer
-    assert "frame[base + 6]" in preview_renderer
+    assert "LINE_F32_STRIDE = 8" in preview_renderer
+    assert "SPRITE_I32_STRIDE = 7" in preview_renderer
+    assert "TEXT_I32_STRIDE = 3" in preview_renderer
+    assert "drawColorBatch" in preview_renderer
+    assert "drawPreparedTextureBatch" in preview_renderer
+    assert "frameI32" in preview_renderer
+    assert "frameF32" in preview_renderer
+    assert "frameU8Bytes" in preview_renderer
     assert "GLES20.glDrawArrays" in preview_renderer
     assert "GL_TRIANGLES" in preview_renderer
     assert "glUniform4f" not in preview_renderer
@@ -1295,7 +1305,7 @@ def main() -> int:
     assert "gameLoopHandler.postDelayed(this, DEFAULT_TICK_INTERVAL_MS)" in activity
     assert "compileReady = isRunnableCompile(compileResult)" in activity
     assert "compileAttempted = true" in activity
-    assert "RunError: native frame tick failed" in activity
+    assert 'String frameError = "RunError: " + nativeLastFrameError()' in activity
     assert "!compileReady && !compileAttempted" in activity
     assert "compileResult.contains(\"status=0\")" in activity
     assert "if (resetProject)" in activity
@@ -1328,7 +1338,7 @@ def main() -> int:
     assert "event.getPointerCount() >= 3" in published_activity
     assert "PUBLISHED_RUNTIME_ID = BuildConfig.STASIS_RUNTIME_ID" in published_activity
     assert "PublishedSpriteCatalog" in published_activity
-    assert "drawSpriteBatch" in preview_renderer
+    assert "drawSprites" in preview_renderer
     assert "nativeDecodeSvgSpriteBytes" in published_activity
     assert 'MANIFEST = ROOT + "assets/manifest.json"' in published_sprites
     assert "MessageDigest.getInstance(\"SHA-256\")" in published_sprites
@@ -1368,7 +1378,8 @@ def main() -> int:
     assert "stasis_android_bridge_free_string" in native
     assert "Java_com_stasislang_workshop_MainActivity_nativeRunTick" in native
     assert "Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto" in native
-    assert "const int frame_len = STASIS_RENDER_FRAME_I32_CAPACITY" in native
+    assert "bytes_i32 < (jlong)(STASIS_RENDER_I32_COUNT * sizeof(int32_t))" in native
+    assert 'dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v1")' in native
     assert "#define STASIS_RENDER_COMMAND_STRIDE 13" in native
     assert '"Render.command_schema_version"' in native
     assert '"Render.command" #index "_rotation_degrees"' in native
@@ -1446,6 +1457,10 @@ def main() -> int:
     assert "Render.command3_clip_w = GameState.screen_w" in sample_main
     pong_manifest = read("mobile/android/app/src/main/assets/workshop_sample/assets/manifest.json")
     assert '"id": "ball"' in pong_manifest
+    assert '"id": "paddle"' in pong_manifest
+    assert '"id": "center_line"' in pong_manifest
+    preview_adapter = read("mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis")
+    assert "function on_code_swap(): void { pong_game_on_code_swap(); pong_host_render(); }" in preview_adapter
     assert '"encoding": "svg"' in pong_manifest
 
     collision = read("mobile/android/app/src/main/assets/workshop_sample/src/systems/collision.stasis")


### PR DESCRIPTION
## Summary
- route Workshop JIT and Published AOT through one canonical production `gfx_cmd` v1 preview schema
- render clear, sprites/SVG, cached font text, rotation, alpha, filtering, fallback resources, and present through the shared GLES path
- migrate bundled Pong safely to production sprite commands while preserving user source, `on_code_swap`, custom manifest entries, and rollback backups
- preserve the active runtime after failed hot reloads; show centered compile/runtime diagnostics when no game is running
- reuse fixed direct buffers and active spans, avoid allocation/line expansion in Pong hot loops, and report separate tick/render/sync budgets
- remove periodic filesystem persistence and diagnostic global reads from ordinary Workshop frames
- inspect live runtime state on demand on the owning game thread; AI frame/state/error snapshots are coherent and bounded
- harden runtime staging order and cached-text JSON escaping

## Verification
- `python tools/ci/check_stasis_src_layout.py`
- `python tools/ci/check_android_shell.py`
- `cargo test -p stasis_android_bridge` (38 passed, 1 ignored)
- `cargo test --workspace --all-targets -- --test-threads=1` (passed in 88.4s)
- `gradle :app:testWorkshopDebugUnitTest :app:assembleWorkshopDebug :app:assemblePublishedDebug --no-daemon --max-workers=1` (BUILD SUCCESSFUL on final head)
- native Windows CMake/CTest runtime contract suite (5/5 passed)
- physical Galaxy S21: Workshop Pong, Published Pong, Workshop ChessTD, compile-error overlay, and recovery verified; all apps force-stopped
- independent code review: clean after all findings fixed

## Device performance
- Workshop Pong: tick p50 0.41 ms / p95 0.46 ms; render p50 0.44 ms / p95 0.56 ms; sync p95 0.00 ms; total 5%
- Published Pong: tick p50 0.10 ms / p95 0.19 ms; render p50 0.36 ms / p95 0.54 ms; total 3%
- Workshop ChessTD: tick p50 0.99 ms / p95 1.13 ms; render p50 0.94 ms / p95 1.16 ms; sync p95 0.01 ms; total 12%
- production traces: Pong `lines=0 sprites=4 text=0`; ChessTD `lines=0 sprites=6 text=8`

## Follow-up
- Maddox #172 (priority 1, Next) owns direct core JIT scalar/collection memory lowering with immutable per-execution bindings and rebinding only at between-tick commit points. No renderer/Pong special case is added here.

## Validation note
`tools/validate_repo.sh` could not find `python3` in Git Bash on this Windows host, so its two exact gates were run directly with Windows Python and Cargo; both passed.

Maddox task #171.