### PR TITLE
feat: integrate Codex AI into live TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,11 +1036,20 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "stasis_ai",
  "stasis_assets",
  "stasis_compiler",
  "stasis_dynload",
  "stasis_jit",
  "stasis_runner",
+]
+
+[[package]]
+name = "stasis_ai"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/stasis_android_bridge",
   "crates/stasis_jit",
   "crates/stasis_runner",
+  "crates/stasis_ai",
 ]
 
 [workspace.package]

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = "0.10"
 crossterm = "0.28"
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }
+stasis_ai = { path = "../../crates/stasis_ai" }
 
 [dev-dependencies]
 object = "0.36"

--- a/apps/stasis/examples/engine_overhead_bench.rs
+++ b/apps/stasis/examples/engine_overhead_bench.rs
@@ -151,7 +151,7 @@ fn print_help() {
 }
 
 fn render_fixture_source() -> &'static str {
-    "function tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n"
+    "function tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n"
 }
 
 fn write_fixture(path: &Path) -> Result<(), String> {

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1762,7 +1762,7 @@ fn run_play_in_process_inner(
         || gfx.host_bulk_init(&host_req_seq),
         || {
             jit.execute_i32_noarg_by_name("main")
-                .map_err(|error| format!("guest main() failed: {error}"))
+                .map_err(format_live_main_error)
         },
         || {
             gfx.host_bulk_apply_requests(
@@ -2010,6 +2010,14 @@ fn run_play_in_process_inner(
     }
 
     Ok(())
+}
+
+fn format_live_main_error(error: String) -> String {
+    if error.contains("not i32-returning") || error.contains("not a no-argument function") {
+        format!("interactive entry signature mismatch: expected `function main(): i32`; {error}")
+    } else {
+        format!("guest main() failed: {error}")
+    }
 }
 
 pub fn run_with_real_backend(config: RunnerConfig) -> RunnerSummary {
@@ -3392,6 +3400,14 @@ mod tests {
 
         assert_eq!(result, 0);
         assert_eq!(&*phases.borrow(), &["init", "main", "apply"]);
+    }
+
+    #[test]
+    fn live_main_signature_error_names_the_required_signature() {
+        let error =
+            format_live_main_error("function 'main' is not i32-returning (type id 0)".to_string());
+        assert!(error.contains("expected `function main(): i32`"));
+        assert!(error.contains("not i32-returning"));
     }
 
     #[test]

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -487,9 +487,21 @@ impl LiveWorkspace {
                 self.quit = true;
                 Ok(("quitting", json!({"tick": tick})))
             }
-            LiveCommand::Symbols { query, page, limit } => {
-                self.symbols(query.as_deref(), page, limit)
-            }
+            LiveCommand::Symbols {
+                query,
+                kind,
+                file,
+                owner,
+                page,
+                limit,
+            } => self.symbols(
+                query.as_deref(),
+                kind.as_deref(),
+                file.as_deref(),
+                owner.as_deref(),
+                page,
+                limit,
+            ),
             LiveCommand::Read {
                 name,
                 kind,
@@ -760,38 +772,53 @@ impl LiveWorkspace {
     fn symbols(
         &self,
         query: Option<&str>,
+        kind: Option<&str>,
+        file: Option<&str>,
+        owner: Option<&str>,
         page: u32,
         limit: usize,
     ) -> Result<(&'static str, Value), String> {
         let query = query.unwrap_or("").to_ascii_lowercase();
-        let matching = self
-            .source_items
-            .iter()
-            .filter(|item| {
-                query.is_empty()
+        let kind = kind.map(parse_kind).transpose()?;
+        let file = file.map(normalize_file);
+        let matches = |item: &WorkshopSourceItem| {
+            item.kind != WorkshopSourceItemKind::Imports
+                && !(item.kind == WorkshopSourceItemKind::Globals && item.source.trim().is_empty())
+                && (query.is_empty()
                     || item.name.to_ascii_lowercase().contains(&query)
-                    || item.signature.to_ascii_lowercase().contains(&query)
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+                    || item.signature.to_ascii_lowercase().contains(&query))
+                && kind.is_none_or(|kind| item.kind == kind)
+                && file
+                    .as_deref()
+                    .is_none_or(|file| normalize_file(&item.file) == file)
+                && owner.is_none_or(|owner| item.owner.as_deref() == Some(owner))
+        };
         let limit = limit.clamp(1, 200);
         let offset = usize::try_from(page)
             .unwrap_or(usize::MAX)
             .saturating_mul(limit);
-        let total = matching.len();
-        let items = matching
-            .into_iter()
+        let total = self
+            .source_items
+            .iter()
+            .filter(|item| matches(item))
+            .count();
+        let items = self
+            .source_items
+            .iter()
+            .filter(|item| matches(item))
             .skip(offset)
             .take(limit)
             .map(|item| {
-                json!({
+                let mut value = json!({
                     "kind": item.kind,
                     "name": item.name,
-                    "owner": item.owner,
                     "file": item.file,
                     "signature": item.signature,
-                    "source_hash": item.source_hash,
-                })
+                });
+                if let Some(owner) = &item.owner {
+                    value["owner"] = Value::String(owner.clone());
+                }
+                value
             })
             .collect::<Vec<_>>();
         Ok((
@@ -2608,6 +2635,40 @@ mod tests {
         assert!(references
             .iter()
             .all(|reference| reference.get("source").is_none()));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn symbol_search_is_filtered_compact_and_hash_free() {
+        let (root, config) = project();
+        let (jit, _package) = compile(&config);
+        let (_client, server) = stasis_runner::live::live_session(8);
+        let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+
+        let (_, all) = workspace
+            .symbols(None, None, None, None, 0, 32)
+            .expect("symbols");
+        let items = all["items"].as_array().expect("items");
+        assert!(items.iter().all(|item| item["kind"] != "imports"));
+        assert!(items.iter().all(|item| item.get("source_hash").is_none()));
+        assert!(items.iter().all(|item| item.get("source").is_none()));
+        assert!(items
+            .iter()
+            .all(|item| { matches!(item.as_object().map(|object| object.len()), Some(4 | 5)) }));
+
+        let (_, filtered) = workspace
+            .symbols(
+                Some("tick"),
+                Some("function"),
+                Some("src/main.stasis"),
+                None,
+                0,
+                1,
+            )
+            .expect("filtered symbols");
+        assert_eq!(filtered["total"], 1);
+        assert_eq!(filtered["items"][0]["name"], "tick");
+        assert!(filtered["items"][0].get("owner").is_none());
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1,15 +1,16 @@
 use serde_json::{json, Value};
 use stasis_compiler::backend::jit::{JitEnginePackage, JitProcess, JitScalarValue, JitStateLayout};
+use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
 use stasis_compiler::backend::EngineEntrypoints;
 use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::lexer::{lex, TokenKind};
 use stasis_compiler::frontend::workshop::{
-    find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
-    workshop_completion_items, workshop_reachable_files, workshop_source_hash,
-    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
-    ExpectedReload, WorkshopCompletionItem, WorkshopSemanticEdit, WorkshopSemanticEditBatch,
-    WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
-    WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
+    find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
+    plan_workshop_semantic_edits, workshop_completion_items, workshop_reachable_files,
+    workshop_source_hash, workshop_source_items, write_workshop_semantic_plan,
+    write_workshop_semantic_receipt, ExpectedReload, WorkshopCompletionItem, WorkshopSemanticEdit,
+    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
+    WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
     CompletionContext, CompletionIndex, CompletionItem, CompletionQuery, CompletionScope,
@@ -163,6 +164,7 @@ pub(crate) struct LiveWorkspace {
     edit_preparation: Option<EditPreparation>,
     completion_preparation: Option<CompletionPreparation>,
     dropped_watch_events: u64,
+    validation_snapshot: Option<stasis_dynload::JitRuntimeStateSnapshot>,
 }
 
 impl Drop for LiveWorkspace {
@@ -209,6 +211,7 @@ impl LiveWorkspace {
             edit_preparation: None,
             completion_preparation: None,
             dropped_watch_events: 0,
+            validation_snapshot: None,
         };
         workspace.refresh_completion(jit)?;
         Ok(workspace)
@@ -500,6 +503,31 @@ impl LiveWorkspace {
                 owner,
                 signature,
             }),
+            LiveCommand::References { symbol, limit } => Ok((
+                "references",
+                json!({
+                    "symbol": symbol,
+                    "references": find_workshop_references(&self.source_files, &symbol, limit)?,
+                }),
+            )),
+            LiveCommand::ValidationSnapshot => {
+                self.validation_snapshot = Some(
+                    stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES)?,
+                );
+                Ok(("validation_snapshot", json!({"captured": true})))
+            }
+            LiveCommand::ValidationRestore => {
+                let snapshot = self
+                    .validation_snapshot
+                    .as_ref()
+                    .ok_or_else(|| "no AI validation baseline is available".to_string())?;
+                stasis_dynload::restore_jit_runtime_state(snapshot);
+                Ok(("validation_restored", json!({"restored": true})))
+            }
+            LiveCommand::ValidationClear => {
+                self.validation_snapshot = None;
+                Ok(("validation_cleared", json!({"cleared": true})))
+            }
             LiveCommand::Complete {
                 buffer,
                 cursor,
@@ -1469,6 +1497,7 @@ fn prepare_edit(
             )
         }
     };
+    require_semantic_changes(&plan)?;
     check_preparation_canceled(canceled)?;
     let (candidate, package) = compile_candidate(config, &candidate_files)?;
     let changed_functions = candidate.symbol_code_ptrs().into_keys().collect();
@@ -1524,6 +1553,14 @@ fn prepare_edit(
         source_files: candidate_files,
         input_hashes,
     })
+}
+
+fn require_semantic_changes(plan: &WorkshopSemanticEditPlan) -> Result<(), String> {
+    if plan.reload.changed_symbols.is_empty() {
+        Err("live edit has no semantic changes; disk and runtime were left unchanged".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 fn plan_live_edit(
@@ -2474,6 +2511,127 @@ mod tests {
         stasis_dynload::invoke_noarg_i32(package.tick_code_ptr as usize).expect("tick");
         assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(7)));
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn reference_request_returns_compact_containing_symbols() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                39,
+                LiveCommand::References {
+                    symbol: "score".into(),
+                    limit: 16,
+                },
+            ),
+        );
+
+        assert!(response.ok);
+        let references = response.data.expect("reference data")["references"]
+            .as_array()
+            .expect("references")
+            .clone();
+        assert!(references
+            .iter()
+            .any(|reference| reference["containing_name"] == "tick"));
+        assert!(references
+            .iter()
+            .all(|reference| reference.get("source").is_none()));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn validation_snapshot_restores_the_same_runtime_baseline() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(40, LiveCommand::ValidationSnapshot),
+            )
+            .ok
+        );
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    41,
+                    LiveCommand::Set {
+                        path: "score".into(),
+                        expression: "9".into(),
+                        preview: false,
+                    },
+                ),
+            )
+            .ok
+        );
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(9)));
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(42, LiveCommand::ValidationRestore),
+            )
+            .ok
+        );
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(1)));
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(43, LiveCommand::ValidationClear),
+            )
+            .ok
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn semantic_noop_edit_is_rejected_without_writing() {
+        let plan = WorkshopSemanticEditPlan {
+            schema_version: 1,
+            edits: Vec::new(),
+            changed_files: Vec::new(),
+            reload: stasis_compiler::frontend::workshop::WorkshopReloadClassification {
+                expected_reload: ExpectedReload::FastReload,
+                reason: "No symbol changes detected.".into(),
+                changed_symbols: Vec::new(),
+            },
+        };
+        let error = require_semantic_changes(&plan).expect_err("semantic no-op");
+
+        assert!(error.contains("disk and runtime were left unchanged"));
     }
 
     #[test]

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -32,6 +32,7 @@ use stasis_compiler::backend::state_migration::{
 const REQUESTS_PER_TICK: usize = 8;
 const MAX_PENDING_LIVE_REQUESTS: usize = 64;
 const MAX_LIVE_EDIT_SOURCE_BYTES: usize = 256 * 1024;
+const MAX_LIVE_EDIT_BATCH: usize = 64;
 const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
 const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
@@ -117,6 +118,11 @@ enum EditPreparationInput {
         target: LiveSymbolTarget,
         source: Option<String>,
         expected_source_hash: Option<String>,
+        preview: bool,
+        run_tests: bool,
+    },
+    EditBatch {
+        edits: Vec<stasis_runner::live::LiveEdit>,
         preview: bool,
         run_tests: bool,
     },
@@ -529,6 +535,19 @@ impl LiveWorkspace {
                     target,
                     source,
                     expected_source_hash,
+                    preview,
+                    run_tests,
+                },
+                jit,
+            ),
+            LiveCommand::EditBatch {
+                edits,
+                preview,
+                run_tests,
+            } => self.start_edit_preparation(
+                request_id,
+                EditPreparationInput::EditBatch {
+                    edits,
                     preview,
                     run_tests,
                 },
@@ -1321,6 +1340,24 @@ fn paged_completion_query(
 fn validate_edit_input_size(input: &EditPreparationInput) -> Result<(), String> {
     let source = match input {
         EditPreparationInput::Edit { source, .. } => source.as_deref(),
+        EditPreparationInput::EditBatch { edits, .. } => {
+            if edits.len() > MAX_LIVE_EDIT_BATCH {
+                return Err(format!(
+                    "live edit batch exceeds {MAX_LIVE_EDIT_BATCH} edits"
+                ));
+            }
+            let bytes = edits
+                .iter()
+                .filter_map(|edit| edit.source.as_deref())
+                .map(str::len)
+                .sum::<usize>();
+            if bytes > MAX_LIVE_EDIT_SOURCE_BYTES {
+                return Err(format!(
+                    "live edit source exceeds {MAX_LIVE_EDIT_SOURCE_BYTES} bytes"
+                ));
+            }
+            None
+        }
         EditPreparationInput::Persist { source, .. } => Some(source.as_str()),
         EditPreparationInput::Plan { .. } => None,
     };
@@ -1357,6 +1394,25 @@ fn prepare_edit(
         } => {
             let (after, plan) =
                 plan_live_edit(&files, operation, target, source, expected_source_hash)?;
+            (
+                after,
+                plan,
+                false,
+                run_tests && !preview,
+                if preview {
+                    PreparedAction::Preview
+                } else {
+                    PreparedAction::ApplyNew
+                },
+                None,
+            )
+        }
+        EditPreparationInput::EditBatch {
+            edits,
+            preview,
+            run_tests,
+        } => {
+            let (after, plan) = plan_live_edit_batch(&files, edits)?;
             (
                 after,
                 plan,
@@ -1506,6 +1562,50 @@ fn plan_live_edit(
                 new_source: source,
                 expected_source_hash,
             }],
+        },
+    )
+}
+
+fn plan_live_edit_batch(
+    files: &[WorkshopSourceFile],
+    edits: Vec<stasis_runner::live::LiveEdit>,
+) -> Result<(Vec<WorkshopSourceFile>, WorkshopSemanticEditPlan), String> {
+    if edits.is_empty() {
+        return Err("live edit batch must contain at least one edit".to_string());
+    }
+    let mut semantic_edits = Vec::with_capacity(edits.len());
+    for edit in edits {
+        let mut target = selector(&edit.target)?;
+        let operation = match edit.operation {
+            LiveEditOperation::Add => WorkshopSemanticEditOperation::Add,
+            LiveEditOperation::Update => WorkshopSemanticEditOperation::Update,
+            LiveEditOperation::Delete => WorkshopSemanticEditOperation::Delete,
+        };
+        if operation == WorkshopSemanticEditOperation::Add && target.file.is_none() {
+            return Err("code-aware live add requires a project src/ or tests/ file".to_string());
+        }
+        if operation != WorkshopSemanticEditOperation::Add && target.file.is_none() {
+            let matches = find_workshop_symbols(files, &target)?;
+            if matches.len() != 1 {
+                return Err(format!(
+                    "code-aware live edit requires one target; found {}",
+                    matches.len()
+                ));
+            }
+            target.file = Some(matches[0].file.clone());
+        }
+        semantic_edits.push(WorkshopSemanticEdit {
+            operation,
+            target,
+            new_source: edit.source,
+            expected_source_hash: edit.expected_source_hash,
+        });
+    }
+    plan_workshop_semantic_edits(
+        files,
+        &WorkshopSemanticEditBatch {
+            schema_version: 1,
+            edits: semantic_edits,
         },
     )
 }
@@ -1774,6 +1874,7 @@ fn help_data() -> Value {
             ":symbols [query] [--page N --limit N]",
             ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
             ":edit SYMBOL (interactive TUI)",
+            ":ai PROMPT | :ai status | :ai cancel (interactive TUI; installed Codex subscription)",
             ":complete BUFFER", ":palette [QUERY]",
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
@@ -1801,6 +1902,7 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":find",
         ":read",
         ":edit",
+        ":ai",
         ":complete",
         ":palette",
         ":add",
@@ -2149,6 +2251,51 @@ mod tests {
             .build_engine_package(&EngineEntrypoints::runtime_default())
             .expect("package");
         (jit, package)
+    }
+
+    #[test]
+    fn live_edit_batch_plans_all_symbols_as_one_transaction() {
+        let (root, config) = project();
+        let files = load_workshop_edit_workspace(&root, &config.entry).expect("files");
+        let (after, plan) = plan_live_edit_batch(
+            &files,
+            vec![
+                stasis_runner::live::LiveEdit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): i32 { score += 3; return 0; }".into()),
+                    expected_source_hash: None,
+                },
+                stasis_runner::live::LiveEdit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "render".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function render(): i32 { return score; }".into()),
+                    expected_source_hash: None,
+                },
+            ],
+        )
+        .expect("batch plan");
+        assert_eq!(plan.edits.len(), 2);
+        assert_eq!(plan.changed_files.len(), 1);
+        let main = after
+            .iter()
+            .find(|file| file.path == "src/main.stasis")
+            .expect("main");
+        assert!(main.source.contains("score += 3"));
+        assert!(main.source.contains("return score"));
+        fs::remove_dir_all(root).ok();
     }
 
     fn run_request(

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -13,9 +13,9 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
-    CompletionContext, CompletionIndex, CompletionItem, CompletionQuery, CompletionScope,
-    LiveCommand, LiveEditOperation, LiveRequest, LiveResponse, LiveResponseSendError,
-    LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_WATCHES,
+    compare_live_validation_values, CompletionContext, CompletionIndex, CompletionItem,
+    CompletionQuery, CompletionScope, LiveCommand, LiveEditOperation, LiveRequest, LiveResponse,
+    LiveResponseSendError, LiveSessionServer, LiveSymbolTarget, ScratchWorkspace, MAX_LIVE_WATCHES,
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::fs;
@@ -510,6 +510,10 @@ impl LiveWorkspace {
                     "references": find_workshop_references(&self.source_files, &symbol, limit)?,
                 }),
             )),
+            LiveCommand::Validate {
+                requirement,
+                frames,
+            } => validate_live_runtime(jit, &requirement, frames),
             LiveCommand::ValidationSnapshot => {
                 self.validation_snapshot = Some(
                     stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES)?,
@@ -1911,6 +1915,7 @@ fn help_data() -> Value {
             ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
             ":symbols [query] [--page N --limit N]",
             ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
+            ":references SYMBOL [--limit N]", ":validate PATH OP VALUE [--frames N]",
             ":edit SYMBOL (interactive TUI)",
             ":ai PROMPT | :ai status | :ai cancel (interactive TUI; installed Codex subscription)",
             ":complete BUFFER", ":palette [QUERY]",
@@ -1939,6 +1944,8 @@ fn live_command_completions() -> Vec<CompletionItem> {
         ":symbols",
         ":find",
         ":read",
+        ":references",
+        ":validate",
         ":edit",
         ":ai",
         ":complete",
@@ -2049,6 +2056,59 @@ fn inspect_scalar(jit: &JitProcess, path: &str) -> Result<(&'static str, Value),
         "inspection",
         json!({"path": path, "static_type": value.type_name(), "value": value}),
     ))
+}
+
+fn validate_live_runtime(
+    jit: &JitProcess,
+    requirement: &stasis_runner::live::LiveValidationRequirement,
+    frames: u32,
+) -> Result<(&'static str, Value), String> {
+    if frames > 600 {
+        return Err("frames exceeds the 600-frame limit".to_string());
+    }
+    let snapshot = stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES)?;
+    let result = (|| {
+        for _ in 0..frames {
+            execute_validation_entry(jit, "tick")?;
+        }
+        execute_validation_entry(jit, "render")?;
+        let actual = serde_json::to_value(jit.read_global_scalar(&requirement.path)?)
+            .map_err(|error| format!("failed encoding {}: {error}", requirement.path))?
+            .get("value")
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "inspection for {} returned no scalar value",
+                    requirement.path
+                )
+            })?;
+        let passed = compare_live_validation_values(&actual, &requirement.op, &requirement.value)?;
+        Ok((
+            "runtime_validation",
+            json!({
+                "baseline": "live",
+                "frames": frames,
+                "requirements_met": passed,
+                "checks": [{
+                    "path": requirement.path,
+                    "op": requirement.op,
+                    "expected": requirement.value,
+                    "actual": actual,
+                    "passed": passed,
+                }],
+            }),
+        ))
+    })();
+    stasis_dynload::restore_jit_runtime_state(&snapshot);
+    result
+}
+
+fn execute_validation_entry(jit: &JitProcess, name: &str) -> Result<(), String> {
+    match jit.execute_i32_noarg_by_name(name) {
+        Ok(_) => Ok(()),
+        Err(error) if error.contains("not i32-returning") => jit.execute_void_noarg_by_name(name),
+        Err(error) => Err(error),
+    }
 }
 
 fn inspect_all_scalars(
@@ -2614,6 +2674,41 @@ mod tests {
             )
             .ok
         );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn human_runtime_validation_restores_live_state_after_frames() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                44,
+                LiveCommand::Validate {
+                    requirement: stasis_runner::live::LiveValidationRequirement {
+                        path: "score".into(),
+                        op: "eq".into(),
+                        value: json!(3),
+                    },
+                    frames: 2,
+                },
+            ),
+        );
+
+        assert!(response.ok);
+        assert_eq!(response.data.expect("validation")["requirements_met"], true);
+        assert_eq!(jit.read_global_scalar("score"), Ok(JitScalarValue::I32(1)));
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1624,6 +1624,7 @@ fn compile_candidate(
     ]);
     for file in runtime_files {
         let path = config.project_root.join(&file.path);
+        let path = path.canonicalize().unwrap_or(path);
         candidate.upsert_file(path.to_string_lossy().to_string(), file.source);
     }
     candidate
@@ -2295,6 +2296,26 @@ mod tests {
             .expect("main");
         assert!(main.source.contains("score += 3"));
         assert!(main.source.contains("return score"));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn compile_candidate_does_not_reload_imports_under_a_second_path() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "import \"adapter.stasis\";\nfunction main(): i32 { return helper(1); }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return helper(2); }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("main");
+        fs::write(
+            root.join("src/adapter.stasis"),
+            "function helper(value: i32): i32 { return value; }\n",
+        )
+        .expect("adapter");
+        let files = load_workshop_edit_workspace(&root, &config.entry).expect("files");
+
+        compile_candidate(&config, &files).expect("candidate with imported helper");
+
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -2818,7 +2818,7 @@ mod tests {
                 function["name"].as_str(),
                 Some("main" | "tick" | "render")
             ))
-            .all(|function| function["return_type"] == 0));
+            .all(|function| function["return_type"] == 1));
         let cmake = fs::read_to_string(&summary.cmake_file).expect("read cmake file");
         assert!(cmake.contains("set(STASIS_PUBLISHED_AOT_OBJECTS"));
         assert!(cmake.contains("${CMAKE_CURRENT_LIST_DIR}/"));

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -22,6 +22,8 @@ use std::fs;
 use std::io::{self, BufRead};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -854,8 +856,11 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
     let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
     let ai_root = workspace.root.clone();
     let prompt = prompt.to_string();
+    let canceled = Arc::new(AtomicBool::new(false));
+    let ai_canceled = Arc::clone(&canceled);
     let ai = thread::spawn(move || {
-        let result = live_tui::run_scripted_ai(&client, &ai_root, &prompt);
+        let result =
+            live_tui::run_scripted_ai_with_cancel(&client, &ai_root, &prompt, &ai_canceled);
         let _ = client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
         result
     });
@@ -866,10 +871,14 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
     );
     let run_result =
         run_live_in_process(&entry, Some(&workspace.root), 16_000, None, server, config);
+    if let Err(error) = run_result {
+        canceled.store(true, Ordering::Release);
+        let _ = ai.join();
+        return Err(error);
+    }
     let (summary, trace) = ai
         .join()
         .map_err(|_| "live AI thread panicked".to_string())??;
-    run_result?;
     Ok(CommandResult::success(
         format!("AI complete: {summary}\nAI trace: {}", trace.display()),
         json!({

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -203,12 +203,18 @@ enum ToolchainCommand {
 enum SymbolCommand {
     /// List symbols in deterministic source order.
     List {
+        #[arg(long)]
+        query: Option<String>,
         #[arg(long, value_enum)]
         kind: Option<SymbolKindArg>,
         #[arg(long)]
         file: Option<String>,
         #[arg(long)]
         owner: Option<String>,
+        #[arg(long, default_value_t = 0)]
+        page: usize,
+        #[arg(long, default_value_t = 32)]
+        limit: usize,
     },
     /// Find symbol metadata without returning its source.
     Find(SymbolSelectorArgs),
@@ -1080,16 +1086,21 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
         let _ = ai.join();
         return Err(error);
     }
-    let (summary, trace) = ai
+    let (summary, trace, usage_trace) = ai
         .join()
         .map_err(|_| "live AI thread panicked".to_string())??;
     Ok(CommandResult::success(
-        format!("AI complete: {summary}\nAI trace: {}", trace.display()),
+        format!(
+            "AI complete: {summary}\nAI trace: {}\nAI usage: {}",
+            trace.display(),
+            usage_trace.display()
+        ),
         json!({
             "backend": "jit",
             "provider": "installed_codex_subscription",
             "summary": summary,
             "trace": trace,
+            "usage_trace": usage_trace,
         }),
     ))
 }
@@ -1158,7 +1169,8 @@ fn run_live_terminal_inner(
         for line in io::BufReader::new(file).lines() {
             let line = line.map_err(|error| format!("failed reading live script: {error}"))?;
             if let Some(prompt) = line.trim().strip_prefix(":ai ") {
-                let (summary, trace) = live_tui::run_scripted_ai(client, project_root, prompt)?;
+                let (summary, trace, usage_trace) =
+                    live_tui::run_scripted_ai(client, project_root, prompt)?;
                 if json_lines {
                     println!(
                         "{}",
@@ -1168,11 +1180,13 @@ fn run_live_terminal_inner(
                             "ok": true,
                             "summary": summary,
                             "trace": trace,
+                            "usage_trace": usage_trace,
                         })
                     );
                 } else {
                     println!("AI complete: {summary}");
                     println!("AI trace: {}", trace.display());
+                    println!("AI usage: {}", usage_trace.display());
                 }
                 continue;
             }
@@ -2245,10 +2259,26 @@ fn symbol_workspace(
         .cloned()
         .collect::<Vec<_>>();
     match command {
-        SymbolCommand::List { kind, file, owner } => {
+        SymbolCommand::List {
+            query,
+            kind,
+            file,
+            owner,
+            page,
+            limit,
+        } => {
+            let limit = limit.clamp(1, 200);
             let mut items = workshop_source_items(&editable_files)?;
             items.retain(|item| {
-                kind.is_none_or(|kind| item.kind == kind.into())
+                item.kind != WorkshopSourceItemKind::Imports
+                    && !(item.kind == WorkshopSourceItemKind::Globals
+                        && item.source.trim().is_empty())
+                    && query.as_deref().is_none_or(|query| {
+                        let query = query.to_ascii_lowercase();
+                        item.name.to_ascii_lowercase().contains(&query)
+                            || item.signature.to_ascii_lowercase().contains(&query)
+                    })
+                    && kind.is_none_or(|kind| item.kind == kind.into())
                     && file.as_deref().is_none_or(|file| {
                         normalize_symbol_file(&item.file) == normalize_symbol_file(file)
                     })
@@ -2256,6 +2286,12 @@ fn symbol_workspace(
                         .as_deref()
                         .is_none_or(|owner| item.owner.as_deref() == Some(owner))
             });
+            let total = items.len();
+            let items = items
+                .into_iter()
+                .skip(page.saturating_mul(limit))
+                .take(limit)
+                .collect::<Vec<_>>();
             let human = items
                 .iter()
                 .map(|item| {
@@ -2269,9 +2305,24 @@ fn symbol_workspace(
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
+            let metadata = items
+                .into_iter()
+                .map(|item| {
+                    let mut value = json!({
+                        "kind": item.kind,
+                        "name": item.name,
+                        "file": item.file,
+                        "signature": item.signature,
+                    });
+                    if let Some(owner) = item.owner {
+                        value["owner"] = Value::String(owner);
+                    }
+                    value
+                })
+                .collect::<Vec<_>>();
             Ok(CommandResult::success(
                 human,
-                json!({"schema_version": 1, "items": items}),
+                json!({"schema_version": 1, "page": page, "limit": limit, "total": total, "items": metadata}),
             ))
         }
         SymbolCommand::Find(args) => {

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -49,7 +49,20 @@ const COMMANDS: &[&str] = &[
     "env",
     "symbol",
     "help",
+    "__validate-runtime",
 ];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(super) struct RuntimeValidationRequirement {
+    pub path: String,
+    #[serde(default = "default_validation_operator")]
+    pub op: String,
+    pub value: Value,
+}
+
+fn default_validation_operator() -> String {
+    "eq".to_string()
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -109,6 +122,19 @@ enum ToolchainCommand {
     Ai {
         #[arg(value_name = "PROMPT")]
         prompt: String,
+    },
+    #[command(name = "__validate-runtime", hide = true)]
+    ValidateRuntime {
+        #[arg(long, default_value_t = 0)]
+        frames: u32,
+        #[arg(long)]
+        requirements_json: String,
+        #[arg(long, default_value = "main")]
+        setup: String,
+        #[arg(long, default_value = "tick")]
+        tick: String,
+        #[arg(long, default_value = "render")]
+        render: String,
     },
     /// JIT-compile and run main() in the headless toolchain runtime.
     Run {
@@ -499,6 +525,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Check => "check",
         ToolchainCommand::Test { .. } => "test",
         ToolchainCommand::Ai { .. } => "ai",
+        ToolchainCommand::ValidateRuntime { .. } => "__validate-runtime",
         ToolchainCommand::Run { .. } => "run",
         ToolchainCommand::Build { .. } => "build",
         ToolchainCommand::Package { .. } => "package",
@@ -548,6 +575,20 @@ fn execute(
                     test_workspace(&workspace, path.as_deref())
                 }
                 ToolchainCommand::Ai { prompt } => run_workspace_ai(&workspace, &prompt),
+                ToolchainCommand::ValidateRuntime {
+                    frames,
+                    requirements_json,
+                    setup,
+                    tick,
+                    render,
+                } => validate_fresh_runtime(
+                    &workspace,
+                    frames,
+                    &requirements_json,
+                    &setup,
+                    &tick,
+                    &render,
+                ),
                 ToolchainCommand::Run {
                     watch,
                     headless,
@@ -788,6 +829,92 @@ fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
         }
     })?;
     Ok(jit)
+}
+
+fn validate_fresh_runtime(
+    workspace: &Workspace,
+    frames: u32,
+    requirements_json: &str,
+    setup: &str,
+    tick: &str,
+    render: &str,
+) -> Result<CommandResult, String> {
+    if frames > 600 {
+        return Err("frames exceeds the 600-frame limit".to_string());
+    }
+    let requirements = serde_json::from_str::<Vec<RuntimeValidationRequirement>>(requirements_json)
+        .map_err(|error| format!("invalid runtime validation requirements: {error}"))?;
+    if requirements.is_empty() || requirements.len() > 16 {
+        return Err("requirements must contain 1..=16 checks".to_string());
+    }
+    for (label, name) in [("setup", setup), ("tick", tick), ("render", render)] {
+        if name.is_empty()
+            || !name.bytes().enumerate().all(|(index, byte)| {
+                byte == b'_' || byte.is_ascii_alphabetic() || (index > 0 && byte.is_ascii_digit())
+            })
+        {
+            return Err(format!(
+                "fresh validation {label} must be a Stasis identifier"
+            ));
+        }
+    }
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    validate_workspace_destination(workspace, "entry", &entry)?;
+    let source = fs::read_to_string(&entry)
+        .map_err(|error| format!("failed to read entry {}: {error}", entry.display()))?;
+    let mut jit = JitProcess::new();
+    jit.set_required_emit_roots(&[setup.to_string(), tick.to_string(), render.to_string()]);
+    jit.upsert_file(display_path(&entry), source);
+    jit.compile()
+        .map_err(|error| format!("fresh validation compile failed: {error:?}"))?;
+    execute_noarg_entry(&jit, setup)?;
+    for _ in 0..frames {
+        execute_noarg_entry(&jit, tick)?;
+    }
+    execute_noarg_entry(&jit, render)?;
+
+    let mut requirements_met = true;
+    let mut checks = Vec::with_capacity(requirements.len());
+    for requirement in requirements {
+        let actual = serde_json::to_value(jit.read_global_scalar(&requirement.path)?)
+            .map_err(|error| format!("failed encoding {}: {error}", requirement.path))?
+            .get("value")
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "inspection for {} returned no scalar value",
+                    requirement.path
+                )
+            })?;
+        let passed =
+            live_tui::compare_validation_values(&actual, &requirement.op, &requirement.value)?;
+        requirements_met &= passed;
+        checks.push(json!({
+            "path": requirement.path,
+            "op": requirement.op,
+            "expected": requirement.value,
+            "actual": actual,
+            "passed": passed,
+        }));
+    }
+    Ok(CommandResult::success(
+        "fresh runtime validation complete",
+        json!({
+            "baseline": "fresh",
+            "entrypoints": {"setup": setup, "tick": tick, "render": render},
+            "frames": frames,
+            "requirements_met": requirements_met,
+            "checks": checks,
+        }),
+    ))
+}
+
+fn execute_noarg_entry(jit: &JitProcess, name: &str) -> Result<(), String> {
+    match jit.execute_i32_noarg_by_name(name) {
+        Ok(_) => Ok(()),
+        Err(error) if error.contains("not i32-returning") => jit.execute_void_noarg_by_name(name),
+        Err(error) => Err(error),
+    }
 }
 
 fn test_workspace(workspace: &Workspace, path: Option<&Path>) -> Result<CommandResult, String> {
@@ -2867,6 +2994,44 @@ mod tests {
 
     fn remove_temp(path: &Path) {
         let _ = fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn fresh_runtime_validation_boots_ticks_renders_and_checks_state() {
+        let root = temp_dir("fresh_validation");
+        fs::create_dir_all(root.join("src")).expect("src");
+        fs::write(
+            root.join(MANIFEST_NAME),
+            serde_json::to_vec(&ProjectManifest::new("fresh_validation".into())).expect("manifest"),
+        )
+        .expect("write manifest");
+        fs::write(
+            root.join("src/main.stasis"),
+            "global State { value: i32; rendered: i32; }\nfunction main(): i32 { State.value = 1; State.rendered = 0; return 0; }\nfunction tick(): i32 { State.value += 1; return 0; }\nfunction render(): i32 { State.rendered = 1; return 0; }\n",
+        )
+        .expect("write source");
+        let workspace = load_workspace(Some(&root)).expect("workspace");
+        let requirements = serde_json::to_string(&vec![
+            RuntimeValidationRequirement {
+                path: "State.value".into(),
+                op: "eq".into(),
+                value: json!(3),
+            },
+            RuntimeValidationRequirement {
+                path: "State.rendered".into(),
+                op: "eq".into(),
+                value: json!(1),
+            },
+        ])
+        .expect("requirements");
+
+        let result = validate_fresh_runtime(&workspace, 2, &requirements, "main", "tick", "render")
+            .expect("validation");
+
+        assert_eq!(result.data["baseline"], "fresh");
+        assert_eq!(result.data["requirements_met"], true);
+        assert_eq!(result.data["checks"].as_array().expect("checks").len(), 2);
+        remove_temp(&root);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -846,7 +846,10 @@ fn run_workspace_live(
     let entry = workspace.root.join(&workspace.manifest.entry);
     let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
     let script = script.map(|path| workspace.root.join(path));
-    let terminal = thread::spawn(move || run_live_terminal(client, script.as_deref(), json_lines));
+    let terminal_root = workspace.root.clone();
+    let terminal = thread::spawn(move || {
+        run_live_terminal(client, script.as_deref(), json_lines, &terminal_root)
+    });
     let config = LiveRunConfig::new(
         workspace.root.clone(),
         PathBuf::from(&workspace.manifest.entry),
@@ -875,8 +878,9 @@ fn run_live_terminal(
     client: stasis_runner::live::LiveSessionClient,
     script: Option<&Path>,
     json_lines: bool,
+    project_root: &Path,
 ) -> Result<(), String> {
-    let result = run_live_terminal_inner(&client, script, json_lines);
+    let result = run_live_terminal_inner(&client, script, json_lines, project_root);
     if result.is_err() {
         let _ = client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
     }
@@ -887,6 +891,7 @@ fn run_live_terminal_inner(
     client: &stasis_runner::live::LiveSessionClient,
     script: Option<&Path>,
     json_lines: bool,
+    project_root: &Path,
 ) -> Result<(), String> {
     let mut terminal = TerminalBuffer::new();
     let mut saw_quit = false;
@@ -912,7 +917,7 @@ fn run_live_terminal_inner(
             );
         }
     } else {
-        saw_quit = live_tui::run(client)?;
+        saw_quit = live_tui::run(client, project_root)?;
     }
     if !saw_quit {
         submit_and_print_live_response(

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -35,6 +35,7 @@ const COMMANDS: &[&str] = &[
     "fmt",
     "check",
     "test",
+    "ai",
     "run",
     "build",
     "package",
@@ -101,6 +102,11 @@ enum ToolchainCommand {
     Test {
         #[arg(value_name = "PATH")]
         path: Option<PathBuf>,
+    },
+    /// Run one subscription-backed AI change against the live workspace.
+    Ai {
+        #[arg(value_name = "PROMPT")]
+        prompt: String,
     },
     /// JIT-compile and run main() in the headless toolchain runtime.
     Run {
@@ -490,6 +496,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Fmt { .. } => "fmt",
         ToolchainCommand::Check => "check",
         ToolchainCommand::Test { .. } => "test",
+        ToolchainCommand::Ai { .. } => "ai",
         ToolchainCommand::Run { .. } => "run",
         ToolchainCommand::Build { .. } => "build",
         ToolchainCommand::Package { .. } => "package",
@@ -538,6 +545,7 @@ fn execute(
                     validate_optional_workspace_path(&workspace, "test path", path.as_deref())?;
                     test_workspace(&workspace, path.as_deref())
                 }
+                ToolchainCommand::Ai { prompt } => run_workspace_ai(&workspace, &prompt),
                 ToolchainCommand::Run {
                     watch,
                     headless,
@@ -838,6 +846,41 @@ fn run_workspace_watch(workspace: &Workspace) -> Result<CommandResult, String> {
     ))
 }
 
+fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult, String> {
+    if prompt.trim().is_empty() {
+        return Err("AI prompt must not be empty".to_string());
+    }
+    let entry = workspace.root.join(&workspace.manifest.entry);
+    let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
+    let ai_root = workspace.root.clone();
+    let prompt = prompt.to_string();
+    let ai = thread::spawn(move || {
+        let result = live_tui::run_scripted_ai(&client, &ai_root, &prompt);
+        let _ = client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
+        result
+    });
+    let config = LiveRunConfig::new(
+        workspace.root.clone(),
+        PathBuf::from(&workspace.manifest.entry),
+        PathBuf::from(&workspace.manifest.output),
+    );
+    let run_result =
+        run_live_in_process(&entry, Some(&workspace.root), 16_000, None, server, config);
+    let (summary, trace) = ai
+        .join()
+        .map_err(|_| "live AI thread panicked".to_string())??;
+    run_result?;
+    Ok(CommandResult::success(
+        format!("AI complete: {summary}\nAI trace: {}", trace.display()),
+        json!({
+            "backend": "jit",
+            "provider": "installed_codex_subscription",
+            "summary": summary,
+            "trace": trace,
+        }),
+    ))
+}
+
 fn run_workspace_live(
     workspace: &Workspace,
     script: Option<&Path>,
@@ -901,6 +944,28 @@ fn run_live_terminal_inner(
             .map_err(|error| format!("failed to open live script {}: {error}", script.display()))?;
         for line in io::BufReader::new(file).lines() {
             let line = line.map_err(|error| format!("failed reading live script: {error}"))?;
+            if let Some(prompt) = line.trim().strip_prefix(":ai ") {
+                let (summary, trace) = live_tui::run_scripted_ai(client, project_root, prompt)?;
+                if json_lines {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "schema_version": 1,
+                            "kind": "ai_completed",
+                            "ok": true,
+                            "summary": summary,
+                            "trace": trace,
+                        })
+                    );
+                } else {
+                    println!("AI complete: {summary}");
+                    println!("AI trace: {}", trace.display());
+                }
+                continue;
+            }
+            if line.trim() == ":ai" {
+                return Err("live script :ai requires a prompt".to_string());
+            }
             if let TerminalInput::Request(request) = terminal.feed_line(&line)? {
                 saw_quit |= matches!(&request.command, LiveCommand::Quit);
                 let request_id = request.request_id;
@@ -2843,6 +2908,23 @@ mod tests {
                 headless: true,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn ai_command_accepts_one_prompt() {
+        let parsed = ToolchainCli::try_parse_from([
+            "stasis",
+            "--workspace",
+            "demo",
+            "ai",
+            "make the paddle twice as long",
+        ])
+        .expect("parse AI command");
+        assert!(matches!(
+            parsed.command,
+            ToolchainCommand::Ai { ref prompt }
+                if prompt == "make the paddle twice as long"
         ));
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7,14 +7,16 @@ use stasis::{
 };
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::frontend::workshop::{
-    find_workshop_symbols, load_workshop_edit_workspace, plan_workshop_semantic_edits,
-    workshop_reachable_files, workshop_source_hash, workshop_source_items,
-    write_workshop_semantic_plan, write_workshop_semantic_receipt, WorkshopSemanticEdit,
-    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
-    WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
+    find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
+    plan_workshop_semantic_edits, workshop_reachable_files, workshop_source_hash,
+    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
+    WorkshopSemanticEdit, WorkshopSemanticEditBatch, WorkshopSemanticEditOperation,
+    WorkshopSemanticEditPlan, WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
+pub(super) use stasis_runner::live::LiveValidationRequirement as RuntimeValidationRequirement;
 use stasis_runner::live::{
-    live_session, LiveCommand, LiveRequest, LiveResponse, TerminalBuffer, TerminalInput,
+    compare_live_validation_values, live_session, LiveCommand, LiveRequest, LiveResponse,
+    TerminalBuffer, TerminalInput,
 };
 use std::env;
 use std::ffi::OsString;
@@ -38,6 +40,7 @@ const COMMANDS: &[&str] = &[
     "check",
     "test",
     "ai",
+    "validate",
     "run",
     "build",
     "package",
@@ -51,18 +54,6 @@ const COMMANDS: &[&str] = &[
     "help",
     "__validate-runtime",
 ];
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub(super) struct RuntimeValidationRequirement {
-    pub path: String,
-    #[serde(default = "default_validation_operator")]
-    pub op: String,
-    pub value: Value,
-}
-
-fn default_validation_operator() -> String {
-    "eq".to_string()
-}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -122,6 +113,20 @@ enum ToolchainCommand {
     Ai {
         #[arg(value_name = "PROMPT")]
         prompt: String,
+    },
+    /// Boot a fresh isolated runtime and validate one scalar requirement.
+    Validate {
+        path: String,
+        op: String,
+        value: String,
+        #[arg(long, default_value_t = 0)]
+        frames: u32,
+        #[arg(long, default_value = "main")]
+        setup: String,
+        #[arg(long, default_value = "tick")]
+        tick: String,
+        #[arg(long, default_value = "render")]
+        render: String,
     },
     #[command(name = "__validate-runtime", hide = true)]
     ValidateRuntime {
@@ -209,6 +214,12 @@ enum SymbolCommand {
     Find(SymbolSelectorArgs),
     /// Read one unambiguous symbol and its source.
     Read(SymbolSelectorArgs),
+    /// Find compact definitions, reads, writes, and calls for a symbol or field.
+    References {
+        symbol: String,
+        #[arg(long, default_value_t = 128)]
+        limit: usize,
+    },
     /// Add one declaration to an existing imported file.
     Add {
         #[command(flatten)]
@@ -525,6 +536,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Check => "check",
         ToolchainCommand::Test { .. } => "test",
         ToolchainCommand::Ai { .. } => "ai",
+        ToolchainCommand::Validate { .. } => "validate",
         ToolchainCommand::ValidateRuntime { .. } => "__validate-runtime",
         ToolchainCommand::Run { .. } => "run",
         ToolchainCommand::Build { .. } => "build",
@@ -575,6 +587,17 @@ fn execute(
                     test_workspace(&workspace, path.as_deref())
                 }
                 ToolchainCommand::Ai { prompt } => run_workspace_ai(&workspace, &prompt),
+                ToolchainCommand::Validate {
+                    path,
+                    op,
+                    value,
+                    frames,
+                    setup,
+                    tick,
+                    render,
+                } => validate_runtime_command(
+                    &workspace, path, op, value, frames, setup, tick, render,
+                ),
                 ToolchainCommand::ValidateRuntime {
                     frames,
                     requirements_json,
@@ -886,8 +909,7 @@ fn validate_fresh_runtime(
                     requirement.path
                 )
             })?;
-        let passed =
-            live_tui::compare_validation_values(&actual, &requirement.op, &requirement.value)?;
+        let passed = compare_live_validation_values(&actual, &requirement.op, &requirement.value)?;
         requirements_met &= passed;
         checks.push(json!({
             "path": requirement.path,
@@ -906,6 +928,61 @@ fn validate_fresh_runtime(
             "requirements_met": requirements_met,
             "checks": checks,
         }),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_runtime_command(
+    workspace: &Workspace,
+    path: String,
+    op: String,
+    value: String,
+    frames: u32,
+    setup: String,
+    tick: String,
+    render: String,
+) -> Result<CommandResult, String> {
+    let expected = serde_json::from_str(&value).unwrap_or(Value::String(value));
+    let requirements = serde_json::to_string(&[RuntimeValidationRequirement {
+        path: path.clone(),
+        op: op.clone(),
+        value: expected,
+    }])
+    .map_err(|error| format!("failed encoding runtime requirement: {error}"))?;
+    let result = validate_fresh_runtime(workspace, frames, &requirements, &setup, &tick, &render)?;
+    if !result
+        .data
+        .get("requirements_met")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let check = result
+            .data
+            .get("checks")
+            .and_then(Value::as_array)
+            .and_then(|checks| checks.first())
+            .cloned()
+            .unwrap_or(Value::Null);
+        return Err(format!(
+            "runtime validation failed: {path} {op} {}; actual {}",
+            scalar_text(check.get("expected").unwrap_or(&Value::Null)),
+            scalar_text(check.get("actual").unwrap_or(&Value::Null)),
+        ));
+    }
+    let check = result
+        .data
+        .get("checks")
+        .and_then(Value::as_array)
+        .and_then(|checks| checks.first())
+        .cloned()
+        .unwrap_or(Value::Null);
+    Ok(CommandResult::success(
+        format!(
+            "runtime validation passed: {path} {op} {} (actual {}, {frames} frame(s))",
+            scalar_text(check.get("expected").unwrap_or(&Value::Null)),
+            scalar_text(check.get("actual").unwrap_or(&Value::Null)),
+        ),
+        result.data,
     ))
 }
 
@@ -1208,6 +1285,7 @@ fn format_live_response(response: &LiveResponse) -> String {
         ),
         "symbols" => format_live_symbols(data),
         "symbol" => format_live_symbol(data),
+        "references" => format_live_references(data),
         "completion" | "palette" if response.truncated => {
             "completion response exceeded the output bound; narrow the query".to_string()
         }
@@ -1231,6 +1309,7 @@ fn format_live_response(response: &LiveResponse) -> String {
                 ""
             }
         ),
+        "runtime_validation" => format_live_runtime_validation(data),
         "print" => format!(
             "{} = {}",
             string_field(data, "static_type", "value"),
@@ -1403,6 +1482,60 @@ fn format_live_symbol(data: &Value) -> String {
         Some(source) => format!("{header}\n{}", source.trim()),
         None => header,
     }
+}
+
+fn format_live_references(data: &Value) -> String {
+    let references = data
+        .get("references")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if references.is_empty() {
+        return format!(
+            "no references found for {}",
+            string_field(data, "symbol", "symbol")
+        );
+    }
+    references
+        .iter()
+        .map(|reference| {
+            format!(
+                "{}  {}  {}  {}",
+                string_field(reference, "kind", "read"),
+                string_field(reference, "file", "unknown"),
+                string_field(reference, "containing_name", "unknown"),
+                string_field(reference, "containing_signature", ""),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_live_runtime_validation(data: &Value) -> String {
+    let Some(check) = data
+        .get("checks")
+        .and_then(Value::as_array)
+        .and_then(|checks| checks.first())
+    else {
+        return "runtime validation returned no check".to_string();
+    };
+    format!(
+        "{}: {} {} {} (actual {}, {} frame(s))",
+        if check
+            .get("passed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "PASS"
+        } else {
+            "FAIL"
+        },
+        string_field(check, "path", "value"),
+        string_field(check, "op", "eq"),
+        scalar_text(check.get("expected").unwrap_or(&Value::Null)),
+        scalar_text(check.get("actual").unwrap_or(&Value::Null)),
+        data.get("frames").and_then(Value::as_u64).unwrap_or(0),
+    )
 }
 
 fn format_live_completion(data: &Value) -> String {
@@ -2176,6 +2309,26 @@ fn symbol_workspace(
                 json!({"schema_version": 1, "item": item}),
             ))
         }
+        SymbolCommand::References { symbol, limit } => {
+            let references = find_workshop_references(&editable_files, &symbol, limit)?;
+            let human = references
+                .iter()
+                .map(|reference| {
+                    format!(
+                        "{:?}\t{}\t{}\t{}",
+                        reference.kind,
+                        reference.file,
+                        reference.containing_name,
+                        reference.containing_signature,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Ok(CommandResult::success(
+                human,
+                json!({"schema_version": 1, "symbol": symbol, "references": references}),
+            ))
+        }
         SymbolCommand::Add {
             target,
             source,
@@ -2798,6 +2951,8 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stasis_ai::live_tool_specs;
+    use std::collections::BTreeMap;
 
     #[test]
     fn invalid_interactive_command_does_not_poison_terminal_buffer() {
@@ -2859,6 +3014,71 @@ mod tests {
             }),
         );
         assert_eq!(format_live_response(&response), "player.score: i32 = 12");
+    }
+
+    #[test]
+    fn human_live_output_formats_references_and_validation_evidence() {
+        let references = LiveResponse::success(
+            12,
+            42,
+            "references",
+            json!({
+                "symbol": "GameState.player_y",
+                "references": [{
+                    "kind": "write",
+                    "file": "src/main.stasis",
+                    "containing_name": "update_player_paddle",
+                    "containing_signature": "update_player_paddle(): void"
+                }]
+            }),
+        );
+        assert_eq!(
+            format_live_response(&references),
+            "write  src/main.stasis  update_player_paddle  update_player_paddle(): void"
+        );
+
+        let validation = LiveResponse::success(
+            13,
+            42,
+            "runtime_validation",
+            json!({
+                "frames": 2,
+                "checks": [{
+                    "path": "Render.command1_h",
+                    "op": "eq",
+                    "expected": 144,
+                    "actual": 144,
+                    "passed": true
+                }]
+            }),
+        );
+        assert_eq!(
+            format_live_response(&validation),
+            "PASS: Render.command1_h eq 144 (actual 144, 2 frame(s))"
+        );
+    }
+
+    #[test]
+    fn every_live_ai_tool_has_a_human_command_surface() {
+        let mappings = BTreeMap::from([
+            ("list_symbols", "stasis symbol list / :symbols"),
+            ("find_references", "stasis symbol references / :references"),
+            ("read_symbol", "stasis symbol read / :read"),
+            ("write_symbol", "stasis symbol update / :update"),
+            ("delete_symbol", "stasis symbol delete / :delete"),
+            ("inspect_runtime_state", ":inspect"),
+            ("validate_runtime_state", "stasis validate / :validate"),
+            ("run_frame", ":step / stasis validate --frames"),
+            ("run_tests", "stasis test / tested TUI apply"),
+        ]);
+
+        for tool in live_tool_specs() {
+            assert!(
+                mappings.contains_key(tool.tool.as_str()),
+                "live AI tool '{}' needs a useful CLI/TUI mapping",
+                tool.tool
+            );
+        }
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -19,8 +19,9 @@ use stasis_compiler::frontend::workshop::{
     workshop_source_hash, WorkshopSourceItem, WorkshopSourceItemKind,
 };
 use stasis_runner::live::{
-    CompletionContext, CompletionItem, CompletionQuery, LiveCommand, LiveEdit, LiveEditOperation,
-    LiveRequest, LiveResponse, LiveSessionClient, LiveSymbolTarget, TerminalBuffer, TerminalInput,
+    compare_live_validation_values, CompletionContext, CompletionItem, CompletionQuery,
+    LiveCommand, LiveEdit, LiveEditOperation, LiveRequest, LiveResponse, LiveSessionClient,
+    LiveSymbolTarget, TerminalBuffer, TerminalInput,
 };
 use std::collections::{BTreeMap, VecDeque};
 use std::fs::{self, OpenOptions};
@@ -2061,7 +2062,7 @@ impl LiveAiTools {
                     .and_then(|value| value.get("value"))
                     .cloned()
                     .ok_or_else(|| format!("inspection for {path} returned no scalar value"))?;
-                let passed = compare_validation_values(&actual, &operator, &expected)?;
+                let passed = compare_live_validation_values(&actual, &operator, &expected)?;
                 requirements_met &= passed;
                 checks.push(serde_json::json!({
                     "path": path,
@@ -2420,36 +2421,6 @@ fn usize_arg(args: &serde_json::Map<String, Value>, name: &str) -> Option<usize>
     args.get(name)
         .and_then(Value::as_u64)
         .and_then(|value| usize::try_from(value).ok())
-}
-
-pub(super) fn compare_validation_values(
-    actual: &Value,
-    operator: &str,
-    expected: &Value,
-) -> Result<bool, String> {
-    if matches!(operator, "eq" | "ne") {
-        let equal = actual == expected
-            || actual
-                .as_f64()
-                .zip(expected.as_f64())
-                .is_some_and(|(actual, expected)| actual == expected);
-        return Ok(if operator == "eq" { equal } else { !equal });
-    }
-    let actual = actual
-        .as_f64()
-        .ok_or_else(|| format!("operator '{operator}' requires a numeric actual value"))?;
-    let expected = expected
-        .as_f64()
-        .ok_or_else(|| format!("operator '{operator}' requires a numeric expected value"))?;
-    match operator {
-        "lt" => Ok(actual < expected),
-        "lte" => Ok(actual <= expected),
-        "gt" => Ok(actual > expected),
-        "gte" => Ok(actual >= expected),
-        _ => Err(format!(
-            "unsupported validation operator '{operator}'; use eq, ne, lt, lte, gt, or gte"
-        )),
-    }
 }
 
 fn read_bounded_process_output(mut reader: impl Read) -> Result<String, String> {
@@ -3033,13 +3004,13 @@ mod tests {
 
     #[test]
     fn runtime_validation_comparisons_cover_scalar_requirements() {
-        assert!(compare_validation_values(&json!(144), "eq", &json!(144)).expect("eq"));
-        assert!(compare_validation_values(&json!(72), "ne", &json!(144)).expect("ne"));
-        assert!(compare_validation_values(&json!(2.5), "lt", &json!(15)).expect("lt"));
-        assert!(compare_validation_values(&json!(true), "eq", &json!(true)).expect("bool"));
-        assert!(compare_validation_values(&json!(7), "gte", &json!(7)).expect("gte"));
-        assert!(compare_validation_values(&json!(9), "gt", &json!(7)).expect("gt"));
-        assert!(compare_validation_values(&json!(7), "lte", &json!(7)).expect("lte"));
+        assert!(compare_live_validation_values(&json!(144), "eq", &json!(144)).expect("eq"));
+        assert!(compare_live_validation_values(&json!(72), "ne", &json!(144)).expect("ne"));
+        assert!(compare_live_validation_values(&json!(2.5), "lt", &json!(15)).expect("lt"));
+        assert!(compare_live_validation_values(&json!(true), "eq", &json!(true)).expect("bool"));
+        assert!(compare_live_validation_values(&json!(7), "gte", &json!(7)).expect("gte"));
+        assert!(compare_live_validation_values(&json!(9), "gt", &json!(7)).expect("gt"));
+        assert!(compare_live_validation_values(&json!(7), "lte", &json!(7)).expect("lte"));
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1,4 +1,4 @@
-use super::{format_live_response, scalar_text};
+use super::{format_live_response, scalar_text, RuntimeValidationRequirement};
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::execute;
@@ -24,8 +24,9 @@ use stasis_runner::live::{
 };
 use std::collections::{BTreeMap, VecDeque};
 use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -59,7 +60,7 @@ pub(super) fn run_scripted_ai_with_cancel(
     let mut audit = AiAuditLog::create(project_root, prompt)?;
     let trace_path = audit.path.clone();
     let mut provider = CodexExecProvider::default();
-    let mut tools = LiveAiTools::new(client.clone());
+    let mut tools = LiveAiTools::new(client.clone(), project_root.to_path_buf());
     let mut audit_error = None;
     let result = run_agent(
         &mut provider,
@@ -1170,12 +1171,13 @@ impl LiveTui {
             }
         }
         let client = self.client.clone();
+        let project_root = self.project_root.clone();
         let canceled = Arc::new(AtomicBool::new(false));
         let worker_canceled = canceled.clone();
         let (events_tx, events_rx) = mpsc::channel();
         let worker = thread::spawn(move || {
             let mut provider = CodexExecProvider::default();
-            let mut tools = LiveAiTools::new(client);
+            let mut tools = LiveAiTools::new(client, project_root);
             let progress = events_tx.clone();
             let result = run_agent(
                 &mut provider,
@@ -1825,18 +1827,40 @@ fn completion_key(item: &CompletionItem) -> (String, String, String) {
     (item.text.clone(), item.kind.clone(), item.detail.clone())
 }
 
+#[derive(Clone, PartialEq)]
+struct AiValidationContract {
+    requirements: Value,
+    frames: usize,
+    baseline: String,
+    setup: String,
+    tick: String,
+    render: String,
+}
+
 struct LiveAiTools {
     client: LiveSessionClient,
+    project_root: PathBuf,
     next_request_id: u64,
     last_write: Option<LiveResponse>,
+    validation_baseline_active: bool,
+    validation_was_paused: bool,
+    red_validation_contract: Option<AiValidationContract>,
+    write_needs_green_validation: bool,
+    reference_search_ready: bool,
 }
 
 impl LiveAiTools {
-    fn new(client: LiveSessionClient) -> Self {
+    fn new(client: LiveSessionClient, project_root: PathBuf) -> Self {
         Self {
             client,
+            project_root,
             next_request_id: AI_REQUEST_START,
             last_write: None,
+            validation_baseline_active: false,
+            validation_was_paused: false,
+            red_validation_contract: None,
+            write_needs_green_validation: false,
+            reference_search_ready: false,
         }
     }
 
@@ -1890,6 +1914,10 @@ impl LiveAiTools {
                 owner: string_arg(args, "owner"),
                 signature: string_arg(args, "signature"),
             },
+            "find_references" => LiveCommand::References {
+                symbol: string_arg(args, "symbol").unwrap_or_default(),
+                limit: usize_arg(args, "limit").unwrap_or(128).min(256),
+            },
             "inspect_runtime_state" => LiveCommand::InspectAll {
                 limit: 64,
                 concise: true,
@@ -1907,10 +1935,14 @@ impl LiveAiTools {
                     ),
                 };
             }
+            "validate_runtime_state" => return self.execute_validation(call, canceled),
             _ => return ToolObservation::error(&call.tool, "tool is not a read operation"),
         };
         match self.request(command, canceled) {
             Ok(response) if response.ok => {
+                if call.tool == "find_references" {
+                    self.reference_search_ready = true;
+                }
                 ToolObservation::result(&call.tool, response.data.unwrap_or(Value::Null))
             }
             Ok(response) => ToolObservation::error(&call.tool, format_live_response(&response)),
@@ -1918,11 +1950,349 @@ impl LiveAiTools {
         }
     }
 
+    fn execute_validation(&mut self, call: &ToolCall, canceled: &AtomicBool) -> ToolObservation {
+        let args = call.args.as_object().expect("validated tool args");
+        let expected_outcome = string_arg(args, "expected_outcome").unwrap_or_default();
+        if !matches!(expected_outcome.as_str(), "pass" | "fail") {
+            return ToolObservation::error(&call.tool, "expected_outcome must be 'pass' or 'fail'");
+        }
+        let Some(requirements) = args.get("requirements").and_then(Value::as_array) else {
+            return ToolObservation::error(&call.tool, "requirements must be an array");
+        };
+        if requirements.is_empty() || requirements.len() > 16 {
+            return ToolObservation::error(&call.tool, "requirements must contain 1..=16 checks");
+        }
+        let frames = usize_arg(args, "frames").unwrap_or(0);
+        if frames > 600 {
+            return ToolObservation::error(&call.tool, "frames exceeds the 600-frame limit");
+        }
+        let baseline = string_arg(args, "baseline").unwrap_or_else(|| "live".to_string());
+        if !matches!(baseline.as_str(), "live" | "fresh") {
+            return ToolObservation::error(&call.tool, "baseline must be 'live' or 'fresh'");
+        }
+        let setup = string_arg(args, "setup").unwrap_or_else(|| "main".to_string());
+        let tick = string_arg(args, "tick").unwrap_or_else(|| "tick".to_string());
+        let render = string_arg(args, "render").unwrap_or_else(|| "render".to_string());
+        let validation_contract = AiValidationContract {
+            requirements: Value::Array(requirements.clone()),
+            frames,
+            baseline: baseline.clone(),
+            setup,
+            tick,
+            render,
+        };
+        if expected_outcome == "pass"
+            && self.write_needs_green_validation
+            && self.red_validation_contract.as_ref() != Some(&validation_contract)
+        {
+            return ToolObservation::error(
+                &call.tool,
+                "green validation must use the same baseline, requirements, and frame count as the accepted red validation",
+            );
+        }
+        if baseline == "fresh" {
+            let result = self.execute_fresh_validation(&validation_contract, canceled);
+            return self.finish_validation_observation(
+                &call.tool,
+                expected_outcome,
+                validation_contract,
+                result,
+            );
+        }
+        if !self.validation_baseline_active {
+            self.validation_was_paused = match self.request(LiveCommand::Status, canceled) {
+                Ok(response) if response.ok => response
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.get("paused"))
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                Ok(response) => {
+                    return ToolObservation::error(&call.tool, format_live_response(&response))
+                }
+                Err(error) => return ToolObservation::error(&call.tool, error),
+            };
+        }
+        let mut validation_pause_acquired = false;
+        let result = (|| -> Result<Value, String> {
+            let response = self.request(LiveCommand::Pause, canceled)?;
+            if !response.ok {
+                return Err(format_live_response(&response));
+            }
+            validation_pause_acquired = true;
+            let baseline_command = if self.validation_baseline_active {
+                LiveCommand::ValidationRestore
+            } else {
+                LiveCommand::ValidationSnapshot
+            };
+            let response = self.request(baseline_command, canceled)?;
+            if !response.ok {
+                return Err(format_live_response(&response));
+            }
+            self.validation_baseline_active = true;
+            for _ in 0..frames {
+                let response = self.request(LiveCommand::Step { ticks: 1 }, canceled)?;
+                if !response.ok {
+                    return Err(format_live_response(&response));
+                }
+            }
+            let mut checks = Vec::new();
+            let mut requirements_met = true;
+            for requirement in requirements {
+                let object = requirement
+                    .as_object()
+                    .ok_or_else(|| "each requirement must be an object".to_string())?;
+                let path = string_arg(object, "path")
+                    .ok_or_else(|| "each requirement needs a path".to_string())?;
+                let operator = string_arg(object, "op").unwrap_or_else(|| "eq".to_string());
+                let expected = object
+                    .get("value")
+                    .cloned()
+                    .ok_or_else(|| format!("requirement for {path} needs a value"))?;
+                let response =
+                    self.request(LiveCommand::Inspect { path: path.clone() }, canceled)?;
+                if !response.ok {
+                    return Err(format_live_response(&response));
+                }
+                let actual = response
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.get("value"))
+                    .and_then(|value| value.get("value"))
+                    .cloned()
+                    .ok_or_else(|| format!("inspection for {path} returned no scalar value"))?;
+                let passed = compare_validation_values(&actual, &operator, &expected)?;
+                requirements_met &= passed;
+                checks.push(serde_json::json!({
+                    "path": path,
+                    "op": operator,
+                    "expected": expected,
+                    "actual": actual,
+                    "passed": passed,
+                }));
+            }
+            let expected_met = expected_outcome == "pass";
+            Ok(serde_json::json!({
+                "status": if requirements_met == expected_met { "accepted" } else { "unexpected" },
+                "expected_outcome": expected_outcome,
+                "requirements_met": requirements_met,
+                "validation_passed": requirements_met == expected_met,
+                "frames": frames,
+                "checks": checks,
+            }))
+        })();
+        let requirements_met = result
+            .as_ref()
+            .ok()
+            .and_then(|value| value.get("requirements_met"))
+            .and_then(Value::as_bool);
+        let should_finish = result.is_err()
+            || expected_outcome == "pass"
+            || (expected_outcome == "fail" && requirements_met == Some(true));
+        if should_finish {
+            if self.validation_baseline_active {
+                self.finish_validation();
+            } else if validation_pause_acquired && !self.validation_was_paused {
+                let _ = self.request(LiveCommand::Resume, &AtomicBool::new(false));
+            }
+        } else if self.validation_baseline_active {
+            let _ = self.request(LiveCommand::ValidationRestore, canceled);
+        }
+        self.finish_validation_observation(
+            &call.tool,
+            expected_outcome,
+            validation_contract,
+            result,
+        )
+    }
+
+    fn execute_fresh_validation(
+        &self,
+        contract: &AiValidationContract,
+        canceled: &AtomicBool,
+    ) -> Result<Value, String> {
+        let requirements = contract
+            .requirements
+            .as_array()
+            .expect("validated requirements array")
+            .iter()
+            .cloned()
+            .map(serde_json::from_value::<RuntimeValidationRequirement>)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| format!("invalid fresh validation requirement: {error}"))?;
+        let executable = std::env::current_exe()
+            .map_err(|error| format!("failed locating stasis executable: {error}"))?;
+        let mut child = Command::new(executable)
+            .arg("--json")
+            .arg("--workspace")
+            .arg(&self.project_root)
+            .arg("__validate-runtime")
+            .arg("--frames")
+            .arg(contract.frames.to_string())
+            .arg("--requirements-json")
+            .arg(
+                serde_json::to_string(&requirements)
+                    .map_err(|error| format!("failed encoding validation requirements: {error}"))?,
+            )
+            .arg("--setup")
+            .arg(&contract.setup)
+            .arg("--tick")
+            .arg(&contract.tick)
+            .arg("--render")
+            .arg(&contract.render)
+            .current_dir(&self.project_root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("failed starting fresh validation process: {error}"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "fresh validation stdout was unavailable".to_string())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "fresh validation stderr was unavailable".to_string())?;
+        let stdout_worker = thread::spawn(move || read_bounded_process_output(stdout));
+        let stderr_worker = thread::spawn(move || read_bounded_process_output(stderr));
+        let started = Instant::now();
+        let status = loop {
+            if canceled.load(Ordering::Acquire) {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_worker.join();
+                let _ = stderr_worker.join();
+                return Err("AI request canceled".to_string());
+            }
+            if let Some(status) = child
+                .try_wait()
+                .map_err(|error| format!("fresh validation process failed: {error}"))?
+            {
+                break status;
+            }
+            if started.elapsed() >= Duration::from_secs(60) {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_worker.join();
+                let _ = stderr_worker.join();
+                return Err("fresh validation exceeded 60 seconds".to_string());
+            }
+            thread::sleep(Duration::from_millis(20));
+        };
+        let stdout = stdout_worker
+            .join()
+            .map_err(|_| "fresh validation stdout reader panicked".to_string())??;
+        let stderr = stderr_worker
+            .join()
+            .map_err(|_| "fresh validation stderr reader panicked".to_string())??;
+        if !status.success() {
+            return Err(format!(
+                "fresh validation failed: {}",
+                stderr.lines().last().unwrap_or("child process failed")
+            ));
+        }
+        if !stderr.trim().is_empty() {
+            return Err(format!(
+                "fresh validation reported diagnostics: {}",
+                stderr.lines().last().unwrap_or("unknown diagnostic")
+            ));
+        }
+        let envelope = stdout
+            .lines()
+            .rev()
+            .find_map(|line| serde_json::from_str::<Value>(line).ok())
+            .ok_or_else(|| "fresh validation returned no JSON result".to_string())?;
+        envelope
+            .get("result")
+            .cloned()
+            .ok_or_else(|| "fresh validation JSON omitted result".to_string())
+    }
+
+    fn finish_validation_observation(
+        &mut self,
+        tool: &str,
+        expected_outcome: String,
+        validation_contract: AiValidationContract,
+        result: Result<Value, String>,
+    ) -> ToolObservation {
+        match result {
+            Ok(mut result) => {
+                let requirements_met = result
+                    .get("requirements_met")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let validation_passed = requirements_met == (expected_outcome == "pass");
+                let object = result.as_object_mut().expect("validation result object");
+                object.insert(
+                    "expected_outcome".into(),
+                    Value::String(expected_outcome.clone()),
+                );
+                object.insert("validation_passed".into(), Value::Bool(validation_passed));
+                object.insert(
+                    "status".into(),
+                    Value::String(
+                        if validation_passed {
+                            "accepted"
+                        } else {
+                            "unexpected"
+                        }
+                        .into(),
+                    ),
+                );
+                if validation_passed && expected_outcome == "fail" {
+                    self.red_validation_contract = Some(validation_contract);
+                }
+                if validation_passed && expected_outcome == "pass" && self.last_write.is_some() {
+                    self.write_needs_green_validation = false;
+                    self.red_validation_contract = None;
+                }
+                ToolObservation::result(tool, result)
+            }
+            Err(error) => ToolObservation::error(tool, error),
+        }
+    }
+
+    fn finish_validation(&mut self) {
+        if !self.validation_baseline_active {
+            return;
+        }
+        let cleanup_canceled = AtomicBool::new(false);
+        let _ = self.request(LiveCommand::ValidationRestore, &cleanup_canceled);
+        let _ = self.request(LiveCommand::ValidationClear, &cleanup_canceled);
+        if !self.validation_was_paused {
+            let _ = self.request(LiveCommand::Resume, &cleanup_canceled);
+        }
+        self.validation_baseline_active = false;
+    }
+
     fn execute_writes(
         &mut self,
         calls: &[&ToolCall],
         canceled: &AtomicBool,
     ) -> Vec<ToolObservation> {
+        if self.red_validation_contract.is_none() {
+            return calls
+                .iter()
+                .map(|call| {
+                    ToolObservation::error(
+                        &call.tool,
+                        "run validate_runtime_state with expected_outcome=fail before a live AI write",
+                    )
+                })
+                .collect();
+        }
+        if !self.reference_search_ready {
+            return calls
+                .iter()
+                .map(|call| {
+                    ToolObservation::error(
+                        &call.tool,
+                        "run find_references for a behavior-bearing symbol before a live AI write",
+                    )
+                })
+                .collect();
+        }
         let edits = calls
             .iter()
             .map(|call| {
@@ -1960,6 +2330,8 @@ impl LiveAiTools {
                 let applied = response.ok && response.kind == "edit_applied";
                 if applied {
                     self.last_write = Some(response.clone());
+                    self.write_needs_green_validation = true;
+                    self.reference_search_ready = false;
                 }
                 calls
                     .iter()
@@ -1992,6 +2364,14 @@ impl LiveAiTools {
     }
 }
 
+impl Drop for LiveAiTools {
+    fn drop(&mut self) {
+        if self.validation_baseline_active {
+            self.finish_validation();
+        }
+    }
+}
+
 impl ToolExecutor for LiveAiTools {
     fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation> {
         let writes = calls
@@ -2003,7 +2383,7 @@ impl ToolExecutor for LiveAiTools {
             .filter(|call| {
                 !matches!(
                     call.tool.as_str(),
-                    "write_symbol" | "delete_symbol" | "run_tests"
+                    "write_symbol" | "delete_symbol" | "run_tests" | "validate_runtime_state"
                 )
             })
             .map(|call| self.execute_read(call, canceled))
@@ -2014,10 +2394,18 @@ impl ToolExecutor for LiveAiTools {
         observations.extend(
             calls
                 .iter()
-                .filter(|call| call.tool == "run_tests")
+                .filter(|call| matches!(call.tool.as_str(), "run_tests" | "validate_runtime_state"))
                 .map(|call| self.execute_read(call, canceled)),
         );
         observations
+    }
+
+    fn validate_completion(&self) -> Result<(), String> {
+        if self.write_needs_green_validation {
+            Err("the applied live edit still requires validate_runtime_state with expected_outcome=pass".to_string())
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -2026,6 +2414,59 @@ fn string_arg(args: &serde_json::Map<String, Value>, name: &str) -> Option<Strin
         .and_then(Value::as_str)
         .map(str::to_string)
         .filter(|value| !value.trim().is_empty())
+}
+
+fn usize_arg(args: &serde_json::Map<String, Value>, name: &str) -> Option<usize> {
+    args.get(name)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+}
+
+pub(super) fn compare_validation_values(
+    actual: &Value,
+    operator: &str,
+    expected: &Value,
+) -> Result<bool, String> {
+    if matches!(operator, "eq" | "ne") {
+        let equal = actual == expected
+            || actual
+                .as_f64()
+                .zip(expected.as_f64())
+                .is_some_and(|(actual, expected)| actual == expected);
+        return Ok(if operator == "eq" { equal } else { !equal });
+    }
+    let actual = actual
+        .as_f64()
+        .ok_or_else(|| format!("operator '{operator}' requires a numeric actual value"))?;
+    let expected = expected
+        .as_f64()
+        .ok_or_else(|| format!("operator '{operator}' requires a numeric expected value"))?;
+    match operator {
+        "lt" => Ok(actual < expected),
+        "lte" => Ok(actual <= expected),
+        "gt" => Ok(actual > expected),
+        "gte" => Ok(actual >= expected),
+        _ => Err(format!(
+            "unsupported validation operator '{operator}'; use eq, ne, lt, lte, gt, or gte"
+        )),
+    }
+}
+
+fn read_bounded_process_output(mut reader: impl Read) -> Result<String, String> {
+    const CAPTURE_LIMIT: usize = 65_536;
+    let mut captured = Vec::with_capacity(CAPTURE_LIMIT);
+    let mut buffer = [0u8; 8_192];
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|error| format!("failed reading validation process output: {error}"))?;
+        if count == 0 {
+            break;
+        }
+        let remaining = CAPTURE_LIMIT.saturating_sub(captured.len());
+        captured.extend_from_slice(&buffer[..count.min(remaining)]);
+    }
+    Ok(String::from_utf8_lossy(&captured).into_owned())
 }
 
 fn audit_tool_call(call: &ToolCall) -> Value {
@@ -2588,6 +3029,146 @@ fn write_at(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn runtime_validation_comparisons_cover_scalar_requirements() {
+        assert!(compare_validation_values(&json!(144), "eq", &json!(144)).expect("eq"));
+        assert!(compare_validation_values(&json!(72), "ne", &json!(144)).expect("ne"));
+        assert!(compare_validation_values(&json!(2.5), "lt", &json!(15)).expect("lt"));
+        assert!(compare_validation_values(&json!(true), "eq", &json!(true)).expect("bool"));
+        assert!(compare_validation_values(&json!(7), "gte", &json!(7)).expect("gte"));
+        assert!(compare_validation_values(&json!(9), "gt", &json!(7)).expect("gt"));
+        assert!(compare_validation_values(&json!(7), "lte", &json!(7)).expect("lte"));
+    }
+
+    #[test]
+    fn runtime_validation_runs_bounded_red_green_requirements() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let worker = thread::spawn(move || {
+            let mut handled = 0;
+            let mut inspections = 0;
+            while handled < 11 {
+                for request in server.drain(8) {
+                    let (kind, data) = match request.command {
+                        LiveCommand::Status => ("status", json!({"paused": false})),
+                        LiveCommand::Pause => ("paused", json!({"paused": true})),
+                        LiveCommand::ValidationSnapshot => {
+                            ("validation_snapshot", json!({"captured": true}))
+                        }
+                        LiveCommand::ValidationRestore => {
+                            ("validation_restored", json!({"restored": true}))
+                        }
+                        LiveCommand::ValidationClear => {
+                            ("validation_cleared", json!({"cleared": true}))
+                        }
+                        LiveCommand::Inspect { path } => {
+                            inspections += 1;
+                            let value = if inspections == 1 { 72 } else { 144 };
+                            (
+                                "inspection",
+                                json!({"path": path, "value": {"type": "i32", "value": value}}),
+                            )
+                        }
+                        LiveCommand::Resume => ("resumed", json!({"paused": false})),
+                        command => panic!("unexpected validation command: {command:?}"),
+                    };
+                    server
+                        .respond(LiveResponse::success(request.request_id, 0, kind, data))
+                        .expect("respond");
+                    handled += 1;
+                }
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
+        let red = tools.execute(
+            &[ToolCall {
+                tool: "validate_runtime_state".into(),
+                args: json!({
+                    "expected_outcome": "fail",
+                    "requirements": [{"path": "Render.command1_h", "op": "eq", "value": 144}]
+                }),
+            }],
+            &AtomicBool::new(false),
+        );
+        let green = tools.execute(
+            &[ToolCall {
+                tool: "validate_runtime_state".into(),
+                args: json!({
+                    "expected_outcome": "pass",
+                    "requirements": [{"path": "Render.command1_h", "op": "eq", "value": 144}]
+                }),
+            }],
+            &AtomicBool::new(false),
+        );
+
+        worker.join().expect("validation server");
+        assert_eq!(red.len(), 1);
+        assert_eq!(
+            red[0].result.as_ref().expect("red")["validation_passed"],
+            true
+        );
+        assert!(tools.red_validation_contract.is_some());
+        assert_eq!(
+            green[0].result.as_ref().expect("green")["validation_passed"],
+            true
+        );
+    }
+
+    #[test]
+    fn live_ai_write_is_rejected_until_red_validation_exists() {
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
+
+        let observations = tools.execute(
+            &[ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({
+                    "file": "src/main.stasis",
+                    "name": "tick",
+                    "new_source": "function tick(): void { return; }"
+                }),
+            }],
+            &AtomicBool::new(false),
+        );
+
+        assert!(observations[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("expected_outcome=fail")));
+    }
+
+    #[test]
+    fn live_ai_write_is_rejected_until_references_were_checked() {
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
+        tools.red_validation_contract = Some(AiValidationContract {
+            requirements: json!([{"path": "State.value", "op": "eq", "value": 2}]),
+            frames: 0,
+            baseline: "live".into(),
+            setup: "main".into(),
+            tick: "tick".into(),
+            render: "render".into(),
+        });
+
+        let observations = tools.execute(
+            &[ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({
+                    "file": "src/main.stasis",
+                    "name": "tick",
+                    "new_source": "function tick(): void { return; }"
+                }),
+            }],
+            &AtomicBool::new(false),
+        );
+
+        assert!(observations[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("find_references")));
+    }
 
     #[test]
     fn ai_audit_redacts_source_bodies_but_keeps_action_identity() {

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -9,7 +9,6 @@ use crossterm::terminal::{
     EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use stasis_ai::{
     live_tool_specs, run_agent, AgentEvent, CodexExecProvider, ToolCall, ToolExecutor,
     ToolObservation, DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT,
@@ -165,7 +164,7 @@ impl AiAuditLog {
             "reasoning_effort": std::env::var("STASIS_AI_REASONING_EFFORT")
                 .unwrap_or_else(|_| DEFAULT_REASONING_EFFORT.to_string()),
             "prompt": prompt,
-            "payload_logging": "bounded meaningful fields; source bodies hashed",
+            "payload_logging": "exact agent tool calls and observations; Codex transport envelope omitted",
         }))?;
         Ok(log)
     }
@@ -2441,61 +2440,11 @@ fn read_bounded_process_output(mut reader: impl Read) -> Result<String, String> 
 }
 
 fn audit_tool_call(call: &ToolCall) -> Value {
-    serde_json::json!({
-        "tool": call.tool,
-        "args": audit_value(&call.args, None),
-    })
+    serde_json::to_value(call).expect("tool calls serialize")
 }
 
 fn audit_observation(observation: &ToolObservation) -> Value {
-    serde_json::json!({
-        "tool": observation.tool,
-        "result": observation.result.as_ref().map(|value| audit_value(value, None)),
-        "error": observation.error.as_deref().map(bounded_audit_text),
-    })
-}
-
-fn audit_value(value: &Value, key: Option<&str>) -> Value {
-    let sensitive = key.is_some_and(|key| {
-        matches!(
-            key,
-            "source" | "new_source" | "before_source" | "after_source" | "request_json" | "payload"
-        )
-    });
-    if sensitive {
-        let text = value.as_str().unwrap_or_default();
-        let hash = Sha256::digest(text.as_bytes());
-        return serde_json::json!({
-            "redacted": true,
-            "bytes": text.len(),
-            "sha256": format!("{hash:x}"),
-        });
-    }
-    match value {
-        Value::Object(object) => Value::Object(
-            object
-                .iter()
-                .map(|(key, value)| (key.clone(), audit_value(value, Some(key))))
-                .collect(),
-        ),
-        Value::Array(values) => Value::Array(
-            values
-                .iter()
-                .take(64)
-                .map(|value| audit_value(value, key))
-                .collect(),
-        ),
-        Value::String(text) => Value::String(bounded_audit_text(text)),
-        other => other.clone(),
-    }
-}
-
-fn bounded_audit_text(text: &str) -> String {
-    const MAX: usize = 1_000;
-    if text.chars().count() <= MAX {
-        return text.to_string();
-    }
-    text.chars().take(MAX).collect::<String>() + "..."
+    serde_json::to_value(observation).expect("tool observations serialize")
 }
 
 fn edit_target_from_completion(symbol: &str, completion: &CompletionState) -> LiveSymbolTarget {
@@ -3142,7 +3091,7 @@ mod tests {
     }
 
     #[test]
-    fn ai_audit_redacts_source_bodies_but_keeps_action_identity() {
+    fn ai_audit_records_the_exact_tool_payload_seen_by_the_agent() {
         let call = ToolCall {
             tool: "write_symbol".into(),
             args: serde_json::json!({
@@ -3152,19 +3101,29 @@ mod tests {
             }),
         };
         let logged = audit_tool_call(&call);
-        assert_eq!(logged["tool"], "write_symbol");
-        assert_eq!(logged["args"]["file"], "src/main.stasis");
-        assert_eq!(logged["args"]["name"], "tick");
-        assert_eq!(logged["args"]["new_source"]["redacted"], true);
-        assert_eq!(logged["args"]["new_source"]["bytes"], 33);
         assert_eq!(
-            logged["args"]["new_source"]["sha256"]
-                .as_str()
-                .unwrap()
-                .len(),
-            64
+            logged,
+            serde_json::json!({
+                "tool": "write_symbol",
+                "args": {
+                    "file": "src/main.stasis",
+                    "name": "tick",
+                    "new_source": "function tick(): void { return; }"
+                }
+            })
         );
-        assert!(!logged.to_string().contains("function tick"));
+
+        let observation = ToolObservation::result(
+            "read_symbol",
+            serde_json::json!({
+                "name": "tick",
+                "source": "function tick(): void { return; }"
+            }),
+        );
+        assert_eq!(
+            audit_observation(&observation),
+            serde_json::to_value(observation).unwrap()
+        );
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -47,9 +47,17 @@ pub(super) fn run_scripted_ai(
     project_root: &Path,
     prompt: &str,
 ) -> Result<(String, PathBuf), String> {
+    run_scripted_ai_with_cancel(client, project_root, prompt, &AtomicBool::new(false))
+}
+
+pub(super) fn run_scripted_ai_with_cancel(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    prompt: &str,
+    canceled: &AtomicBool,
+) -> Result<(String, PathBuf), String> {
     let mut audit = AiAuditLog::create(project_root, prompt)?;
     let trace_path = audit.path.clone();
-    let canceled = AtomicBool::new(false);
     let mut provider = CodexExecProvider::default();
     let mut tools = LiveAiTools::new(client.clone());
     let mut audit_error = None;
@@ -59,7 +67,7 @@ pub(super) fn run_scripted_ai(
         prompt,
         ai_initial_context(),
         live_tool_specs(),
-        &canceled,
+        canceled,
         |event| {
             if audit_error.is_none() {
                 audit_error = audit.write(audit_agent_event(&event)).err();

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -9,26 +9,103 @@ use crossterm::terminal::{
     EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+use stasis_ai::{
+    live_tool_specs, run_agent, AgentEvent, CodexExecProvider, ToolCall, ToolExecutor,
+    ToolObservation, DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT,
+};
 use stasis_compiler::frontend::parser::completion_expected_type;
 use stasis_compiler::frontend::workshop::{
     workshop_source_hash, WorkshopSourceItem, WorkshopSourceItemKind,
 };
 use stasis_runner::live::{
-    CompletionContext, CompletionItem, CompletionQuery, LiveCommand, LiveEditOperation,
+    CompletionContext, CompletionItem, CompletionQuery, LiveCommand, LiveEdit, LiveEditOperation,
     LiveRequest, LiveResponse, LiveSessionClient, LiveSymbolTarget, TerminalBuffer, TerminalInput,
 };
 use std::collections::{BTreeMap, VecDeque};
+use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::time::{Duration, Instant};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const MAX_TRANSCRIPT_LINES: usize = 500;
 const MAX_UNDO_STATES: usize = 100;
 const COMPLETION_LIMIT: usize = 64;
 const TUI_REQUEST_START: u64 = 1u64 << 61;
+const AI_REQUEST_START: u64 = 1u64 << 62;
 
-pub(super) fn run(client: &LiveSessionClient) -> Result<bool, String> {
+enum AiUiEvent {
+    Progress(AgentEvent),
+    Finished(Result<String, String>),
+}
+
+struct AiRun {
+    canceled: Arc<AtomicBool>,
+    events: mpsc::Receiver<AiUiEvent>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+struct AiAuditLog {
+    path: PathBuf,
+    file: fs::File,
+}
+
+impl AiAuditLog {
+    fn create(project_root: &Path, prompt: &str) -> Result<Self, String> {
+        let directory = project_root.join("build/ai-traces");
+        fs::create_dir_all(&directory)
+            .map_err(|error| format!("failed creating AI trace directory: {error}"))?;
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let path = directory.join(format!("tui-ai-{stamp}.jsonl"));
+        let file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .map_err(|error| format!("failed creating AI trace: {error}"))?;
+        let mut log = Self { path, file };
+        log.write(serde_json::json!({
+            "event": "request",
+            "provider": "installed_codex_subscription",
+            "model": std::env::var("STASIS_AI_MODEL")
+                .unwrap_or_else(|_| DEFAULT_CODEX_MODEL.to_string()),
+            "reasoning_effort": std::env::var("STASIS_AI_REASONING_EFFORT")
+                .unwrap_or_else(|_| DEFAULT_REASONING_EFFORT.to_string()),
+            "prompt": prompt,
+            "payload_logging": "bounded meaningful fields; source bodies hashed",
+        }))?;
+        Ok(log)
+    }
+
+    fn write(&mut self, value: Value) -> Result<(), String> {
+        serde_json::to_writer(&mut self.file, &value)
+            .map_err(|error| format!("failed encoding AI trace: {error}"))?;
+        self.file
+            .write_all(b"\n")
+            .map_err(|error| format!("failed writing AI trace: {error}"))?;
+        self.file
+            .flush()
+            .map_err(|error| format!("failed flushing AI trace: {error}"))
+    }
+}
+
+impl Drop for AiRun {
+    fn drop(&mut self) {
+        self.canceled.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+pub(super) fn run(client: &LiveSessionClient, project_root: &Path) -> Result<bool, String> {
     let _guard = TerminalGuard::enter()?;
-    let mut app = LiveTui::new(client.clone());
+    let mut app = LiveTui::new(client.clone(), project_root.to_path_buf());
     app.request_default_inspection()?;
     app.refresh_completion(false);
     loop {
@@ -416,6 +493,7 @@ impl Default for InspectorState {
 
 struct LiveTui {
     client: LiveSessionClient,
+    project_root: PathBuf,
     terminal: TerminalBuffer,
     input: InputMode,
     command_bar: Option<EditBuffer>,
@@ -434,6 +512,9 @@ struct LiveTui {
     inspector_watch_target: Option<String>,
     last_default_inspection: Instant,
     status: String,
+    queued_ai_prompt: Option<String>,
+    ai_run: Option<AiRun>,
+    ai_audit: Option<AiAuditLog>,
     prompt: &'static str,
     quit: bool,
     last_regions: [Vec<u8>; 5],
@@ -441,9 +522,10 @@ struct LiveTui {
 }
 
 impl LiveTui {
-    fn new(client: LiveSessionClient) -> Self {
+    fn new(client: LiveSessionClient, project_root: PathBuf) -> Self {
         Self {
             client,
+            project_root,
             terminal: TerminalBuffer::new(),
             input: InputMode::Prompt(EditBuffer::default()),
             command_bar: None,
@@ -466,6 +548,9 @@ impl LiveTui {
             inspector_watch_target: None,
             last_default_inspection: Instant::now() - Duration::from_secs(1),
             status: "running".to_string(),
+            queued_ai_prompt: None,
+            ai_run: None,
+            ai_audit: None,
             prompt: "stasis> ",
             quit: false,
             last_regions: std::array::from_fn(|_| Vec::new()),
@@ -517,6 +602,9 @@ impl LiveTui {
     }
 
     fn refresh_completion(&mut self, arm: bool) {
+        if self.queued_ai_prompt.is_some() || self.ai_run.is_some() {
+            return;
+        }
         let buffer = self.active_buffer().text.clone();
         let cursor = self.active_buffer().cursor;
         let selected_key = self
@@ -544,6 +632,9 @@ impl LiveTui {
     }
 
     fn dispatch_completion(&mut self) {
+        if self.queued_ai_prompt.is_some() || self.ai_run.is_some() {
+            return;
+        }
         if self.completion_in_flight.is_some() {
             return;
         }
@@ -577,6 +668,15 @@ impl LiveTui {
         let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
         if control && key.code == KeyCode::Char('c') {
+            if let Some(run) = &self.ai_run {
+                run.canceled.store(true, Ordering::Release);
+                self.status = "canceling AI request...".to_string();
+                return Ok(());
+            }
+            if self.queued_ai_prompt.take().is_some() {
+                self.status = "queued AI request canceled".to_string();
+                return Ok(());
+            }
             self.cancel_input();
             return Ok(());
         }
@@ -694,7 +794,9 @@ impl LiveTui {
                 let line = std::mem::take(&mut self.input.buffer_mut().text);
                 self.input.buffer_mut().cursor = 0;
                 self.submit_line(line)?;
-                self.refresh_completion(false);
+                if self.queued_ai_prompt.is_none() && self.ai_run.is_none() {
+                    self.refresh_completion(false);
+                }
             }
         }
         Ok(())
@@ -708,6 +810,9 @@ impl LiveTui {
         self.push_transcript(format!("{}{}", self.prompt, line));
         self.history.push(line.clone());
         self.history_cursor = self.history.len();
+        if line.trim_start().starts_with(":ai") {
+            return self.handle_ai_command(&line);
+        }
         if line.trim() == ":inspect" {
             self.replace_inspector_watch(None);
             self.inspector.pinned = false;
@@ -906,13 +1011,205 @@ impl LiveTui {
     }
 
     fn drain_responses(&mut self) -> Result<(), String> {
+        self.drain_ai_events();
+        if self.ai_run.is_some() {
+            return Ok(());
+        }
         while let Some(response) = self.client.try_receive()? {
             self.handle_response(response);
         }
+        self.maybe_start_queued_ai();
         Ok(())
     }
 
+    fn handle_ai_command(&mut self, line: &str) -> Result<(), String> {
+        let argument = line
+            .trim_start()
+            .strip_prefix(":ai")
+            .unwrap_or_default()
+            .trim();
+        if argument.eq_ignore_ascii_case("cancel") {
+            if let Some(run) = &self.ai_run {
+                run.canceled.store(true, Ordering::Release);
+                self.status = "canceling AI request...".to_string();
+            } else if self.queued_ai_prompt.take().is_some() {
+                self.status = "queued AI request canceled".to_string();
+            } else {
+                self.status = "no AI request is active".to_string();
+            }
+            return Ok(());
+        }
+        if argument.eq_ignore_ascii_case("status") {
+            self.push_transcript(if self.ai_run.is_some() {
+                "AI: running through the installed Codex subscription".to_string()
+            } else if self.queued_ai_prompt.is_some() {
+                "AI: waiting for outstanding live responses".to_string()
+            } else {
+                "AI: idle; use :ai PROMPT".to_string()
+            });
+            return Ok(());
+        }
+        if argument.is_empty() {
+            self.push_transcript("error: use :ai PROMPT, :ai status, or :ai cancel".to_string());
+            return Ok(());
+        }
+        if self.ai_run.is_some() || self.queued_ai_prompt.is_some() {
+            self.push_transcript("error: one AI request is already active".to_string());
+            return Ok(());
+        }
+        self.completion.armed = false;
+        self.queued_completion = None;
+        self.queued_ai_prompt = Some(argument.to_string());
+        self.status = "AI request queued; draining live UI responses...".to_string();
+        self.maybe_start_queued_ai();
+        Ok(())
+    }
+
+    fn maybe_start_queued_ai(&mut self) {
+        if self.ai_run.is_some() || !self.pending.is_empty() {
+            return;
+        }
+        let Some(prompt) = self.queued_ai_prompt.take() else {
+            return;
+        };
+        match AiAuditLog::create(&self.project_root, &prompt) {
+            Ok(log) => {
+                self.push_transcript(format!("AI trace: {}", log.path.display()));
+                self.ai_audit = Some(log);
+            }
+            Err(error) => {
+                self.status = format!("AI trace unavailable: {error}");
+                self.push_transcript(format!("error: {error}"));
+                return;
+            }
+        }
+        let client = self.client.clone();
+        let canceled = Arc::new(AtomicBool::new(false));
+        let worker_canceled = canceled.clone();
+        let (events_tx, events_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let mut provider = CodexExecProvider::default();
+            let mut tools = LiveAiTools::new(client);
+            let progress = events_tx.clone();
+            let result = run_agent(
+                &mut provider,
+                &mut tools,
+                &prompt,
+                serde_json::json!({
+                    "language": "Stasis",
+                    "runtime": "live in-process JIT",
+                    "commit_boundary": "between deterministic ticks",
+                    "write_policy": "all writes in one model batch compile, test, and commit atomically",
+                }),
+                live_tool_specs(),
+                &worker_canceled,
+                move |event| {
+                    let _ = progress.send(AiUiEvent::Progress(event));
+                },
+            );
+            let _ = events_tx.send(AiUiEvent::Finished(result));
+        });
+        self.ai_run = Some(AiRun {
+            canceled,
+            events: events_rx,
+            worker: Some(worker),
+        });
+        self.status = "AI: starting installed Codex... Ctrl+C cancels".to_string();
+        self.inspector.title = "AI working notes".to_string();
+        self.inspector.lines = vec!["Starting a subscription-backed Codex turn...".to_string()];
+        self.inspector.pinned = true;
+    }
+
+    fn drain_ai_events(&mut self) {
+        let mut events = Vec::new();
+        if let Some(run) = &self.ai_run {
+            while let Ok(event) = run.events.try_recv() {
+                events.push(event);
+            }
+        }
+        let mut finished = None;
+        for event in events {
+            match event {
+                AiUiEvent::Progress(AgentEvent::Turn { current, maximum }) => {
+                    self.status = format!("AI turn {current}/{maximum}; Ctrl+C cancels");
+                    self.audit(serde_json::json!({"event": "turn", "current": current, "maximum": maximum}));
+                }
+                AiUiEvent::Progress(AgentEvent::WorkingNotes(notes)) => {
+                    self.inspector.title = "AI working notes".to_string();
+                    self.inspector.lines = notes.lines().map(str::to_string).collect();
+                    if self.inspector.lines.is_empty() {
+                        self.inspector
+                            .lines
+                            .push("AI supplied no displayable notes".to_string());
+                    }
+                    self.audit(serde_json::json!({"event": "working_notes", "text": notes}));
+                }
+                AiUiEvent::Progress(AgentEvent::ToolBatch(calls)) => {
+                    let tools = calls
+                        .iter()
+                        .map(|call| call.tool.as_str())
+                        .collect::<Vec<_>>();
+                    self.status = format!("AI tools: {}", tools.join(", "));
+                    self.push_transcript(format!("AI tools: {}", tools.join(", ")));
+                    self.audit(serde_json::json!({
+                        "event": "tool_calls",
+                        "calls": calls.iter().map(audit_tool_call).collect::<Vec<_>>(),
+                    }));
+                }
+                AiUiEvent::Progress(AgentEvent::Observations(observations)) => {
+                    self.audit(serde_json::json!({
+                        "event": "tool_observations",
+                        "observations": observations.iter().map(audit_observation).collect::<Vec<_>>(),
+                    }));
+                }
+                AiUiEvent::Progress(AgentEvent::Completed(summary)) => {
+                    self.push_transcript(format!("AI: {summary}"));
+                    self.audit(serde_json::json!({"event": "model_completed", "summary": summary}));
+                }
+                AiUiEvent::Finished(result) => finished = Some(result),
+            }
+        }
+        if let Some(result) = finished {
+            let mut run = self.ai_run.take().expect("finished AI run exists");
+            if let Some(worker) = run.worker.take() {
+                let _ = worker.join();
+            }
+            match result {
+                Ok(summary) => {
+                    self.status = "AI request completed and verified".to_string();
+                    self.push_transcript(format!("AI complete: {summary}"));
+                    self.audit(
+                        serde_json::json!({"event": "finished", "ok": true, "summary": summary}),
+                    );
+                }
+                Err(error) => {
+                    self.status = "AI request failed".to_string();
+                    self.push_transcript(format!("AI error: {error}"));
+                    self.audit(
+                        serde_json::json!({"event": "finished", "ok": false, "error": error}),
+                    );
+                }
+            }
+            self.ai_audit = None;
+            self.inspector.pinned = false;
+            let _ = self.request_default_inspection();
+            self.refresh_completion(false);
+        }
+    }
+
+    fn audit(&mut self, value: Value) {
+        if let Some(log) = &mut self.ai_audit {
+            if let Err(error) = log.write(value) {
+                self.status = error;
+                self.ai_audit = None;
+            }
+        }
+    }
+
     fn request_default_inspection(&mut self) -> Result<(), String> {
+        if self.queued_ai_prompt.is_some() || self.ai_run.is_some() {
+            return Ok(());
+        }
         if self.inspector.pinned
             || self
                 .pending
@@ -1447,6 +1744,267 @@ fn completion_key(item: &CompletionItem) -> (String, String, String) {
     (item.text.clone(), item.kind.clone(), item.detail.clone())
 }
 
+struct LiveAiTools {
+    client: LiveSessionClient,
+    next_request_id: u64,
+    last_write: Option<LiveResponse>,
+}
+
+impl LiveAiTools {
+    fn new(client: LiveSessionClient) -> Self {
+        Self {
+            client,
+            next_request_id: AI_REQUEST_START,
+            last_write: None,
+        }
+    }
+
+    fn request(
+        &mut self,
+        command: LiveCommand,
+        canceled: &AtomicBool,
+    ) -> Result<LiveResponse, String> {
+        let request_id = self.next_request_id;
+        self.next_request_id = self.next_request_id.saturating_add(1);
+        self.client.submit(LiveRequest::new(request_id, command))?;
+        loop {
+            if canceled.load(Ordering::Acquire) {
+                let _ = self.client.submit(LiveRequest::new(
+                    self.next_request_id,
+                    LiveCommand::Cancel { request_id },
+                ));
+                return Err("AI request canceled".to_string());
+            }
+            let response = self.client.receive_timeout(Duration::from_millis(100));
+            let response = match response {
+                Ok(response) => response,
+                Err(error) if error.contains("timed out") => continue,
+                Err(error) => return Err(error),
+            };
+            if response.request_id != request_id {
+                continue;
+            }
+            if matches!(
+                response.kind.as_str(),
+                "edit_preparing" | "completion_preparing"
+            ) {
+                continue;
+            }
+            return Ok(response);
+        }
+    }
+
+    fn execute_read(&mut self, call: &ToolCall, canceled: &AtomicBool) -> ToolObservation {
+        let args = call.args.as_object().expect("validated tool args");
+        let command = match call.tool.as_str() {
+            "list_symbols" => LiveCommand::Symbols {
+                query: None,
+                page: 0,
+                limit: 256,
+            },
+            "read_symbol" => LiveCommand::Read {
+                name: string_arg(args, "name").unwrap_or_default(),
+                kind: string_arg(args, "kind"),
+                file: string_arg(args, "file"),
+                owner: string_arg(args, "owner"),
+                signature: string_arg(args, "signature"),
+            },
+            "inspect_runtime_state" => LiveCommand::InspectAll {
+                limit: 64,
+                concise: true,
+            },
+            "run_frame" => LiveCommand::Step { ticks: 1 },
+            "run_tests" => {
+                return match &self.last_write {
+                    Some(response) if response.ok => ToolObservation::result(
+                        "run_tests",
+                        serde_json::json!({"status": "passed_with_latest_atomic_write", "edit": response.data}),
+                    ),
+                    _ => ToolObservation::error(
+                        "run_tests",
+                        "live AI tests run as part of each atomic write batch; no successful write batch is available",
+                    ),
+                };
+            }
+            _ => return ToolObservation::error(&call.tool, "tool is not a read operation"),
+        };
+        match self.request(command, canceled) {
+            Ok(response) if response.ok => {
+                ToolObservation::result(&call.tool, response.data.unwrap_or(Value::Null))
+            }
+            Ok(response) => ToolObservation::error(&call.tool, format_live_response(&response)),
+            Err(error) => ToolObservation::error(&call.tool, error),
+        }
+    }
+
+    fn execute_writes(
+        &mut self,
+        calls: &[&ToolCall],
+        canceled: &AtomicBool,
+    ) -> Vec<ToolObservation> {
+        let edits = calls
+            .iter()
+            .map(|call| {
+                let args = call.args.as_object().expect("validated tool args");
+                let operation = if call.tool == "delete_symbol" {
+                    LiveEditOperation::Delete
+                } else if string_arg(args, "operation").as_deref() == Some("add") {
+                    LiveEditOperation::Add
+                } else {
+                    LiveEditOperation::Update
+                };
+                LiveEdit {
+                    operation,
+                    target: LiveSymbolTarget {
+                        name: string_arg(args, "name").unwrap_or_default(),
+                        kind: string_arg(args, "kind"),
+                        file: string_arg(args, "file"),
+                        owner: string_arg(args, "owner"),
+                        signature: string_arg(args, "signature"),
+                    },
+                    source: string_arg(args, "new_source"),
+                    expected_source_hash: string_arg(args, "expected_source_hash"),
+                }
+            })
+            .collect();
+        match self.request(
+            LiveCommand::EditBatch {
+                edits,
+                preview: false,
+                run_tests: true,
+            },
+            canceled,
+        ) {
+            Ok(response) => {
+                let applied = response.ok && response.kind == "edit_applied";
+                if applied {
+                    self.last_write = Some(response.clone());
+                }
+                calls
+                    .iter()
+                    .map(|call| {
+                        if applied {
+                            ToolObservation::result(
+                                &call.tool,
+                                serde_json::json!({
+                                    "status": "compiled_tested_applied",
+                                    "transaction": response.data,
+                                }),
+                            )
+                        } else {
+                            let error = if response.ok && response.kind == "edit_preview" {
+                                "layout-changing AI edit was validated but requires explicit user :apply approval"
+                                    .to_string()
+                            } else {
+                                format_live_response(&response)
+                            };
+                            ToolObservation::error(&call.tool, error)
+                        }
+                    })
+                    .collect()
+            }
+            Err(error) => calls
+                .iter()
+                .map(|call| ToolObservation::error(&call.tool, error.clone()))
+                .collect(),
+        }
+    }
+}
+
+impl ToolExecutor for LiveAiTools {
+    fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation> {
+        let writes = calls
+            .iter()
+            .filter(|call| matches!(call.tool.as_str(), "write_symbol" | "delete_symbol"))
+            .collect::<Vec<_>>();
+        let mut observations = calls
+            .iter()
+            .filter(|call| {
+                !matches!(
+                    call.tool.as_str(),
+                    "write_symbol" | "delete_symbol" | "run_tests"
+                )
+            })
+            .map(|call| self.execute_read(call, canceled))
+            .collect::<Vec<_>>();
+        if !writes.is_empty() {
+            observations.extend(self.execute_writes(&writes, canceled));
+        }
+        observations.extend(
+            calls
+                .iter()
+                .filter(|call| call.tool == "run_tests")
+                .map(|call| self.execute_read(call, canceled)),
+        );
+        observations
+    }
+}
+
+fn string_arg(args: &serde_json::Map<String, Value>, name: &str) -> Option<String> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn audit_tool_call(call: &ToolCall) -> Value {
+    serde_json::json!({
+        "tool": call.tool,
+        "args": audit_value(&call.args, None),
+    })
+}
+
+fn audit_observation(observation: &ToolObservation) -> Value {
+    serde_json::json!({
+        "tool": observation.tool,
+        "result": observation.result.as_ref().map(|value| audit_value(value, None)),
+        "error": observation.error.as_deref().map(bounded_audit_text),
+    })
+}
+
+fn audit_value(value: &Value, key: Option<&str>) -> Value {
+    let sensitive = key.is_some_and(|key| {
+        matches!(
+            key,
+            "source" | "new_source" | "before_source" | "after_source" | "request_json" | "payload"
+        )
+    });
+    if sensitive {
+        let text = value.as_str().unwrap_or_default();
+        let hash = Sha256::digest(text.as_bytes());
+        return serde_json::json!({
+            "redacted": true,
+            "bytes": text.len(),
+            "sha256": format!("{hash:x}"),
+        });
+    }
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .iter()
+                .map(|(key, value)| (key.clone(), audit_value(value, Some(key))))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .take(64)
+                .map(|value| audit_value(value, key))
+                .collect(),
+        ),
+        Value::String(text) => Value::String(bounded_audit_text(text)),
+        other => other.clone(),
+    }
+}
+
+fn bounded_audit_text(text: &str) -> String {
+    const MAX: usize = 1_000;
+    if text.chars().count() <= MAX {
+        return text.to_string();
+    }
+    text.chars().take(MAX).collect::<String>() + "..."
+}
+
 fn edit_target_from_completion(symbol: &str, completion: &CompletionState) -> LiveSymbolTarget {
     let supported = |item: &&CompletionItem| {
         item.text == symbol && matches!(item.kind.as_str(), "function" | "struct" | "test")
@@ -1951,6 +2509,32 @@ mod tests {
     use super::*;
 
     #[test]
+    fn ai_audit_redacts_source_bodies_but_keeps_action_identity() {
+        let call = ToolCall {
+            tool: "write_symbol".into(),
+            args: serde_json::json!({
+                "file": "src/main.stasis",
+                "name": "tick",
+                "new_source": "function tick(): void { return; }"
+            }),
+        };
+        let logged = audit_tool_call(&call);
+        assert_eq!(logged["tool"], "write_symbol");
+        assert_eq!(logged["args"]["file"], "src/main.stasis");
+        assert_eq!(logged["args"]["name"], "tick");
+        assert_eq!(logged["args"]["new_source"]["redacted"], true);
+        assert_eq!(logged["args"]["new_source"]["bytes"], 33);
+        assert_eq!(
+            logged["args"]["new_source"]["sha256"]
+                .as_str()
+                .unwrap()
+                .len(),
+            64
+        );
+        assert!(!logged.to_string().contains("function tick"));
+    }
+
+    #[test]
     fn multiline_editor_autoindents_and_moves_vertically() {
         let mut buffer = EditBuffer::from_text("function tick(): i32 {".to_string());
         buffer.insert_newline();
@@ -2118,7 +2702,7 @@ mod tests {
     #[test]
     fn successful_clean_apply_closes_definition_editor() {
         let (client, _server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         let target = LiveSymbolTarget {
             name: "tick".to_string(),
             kind: Some("function".to_string()),
@@ -2164,7 +2748,7 @@ mod tests {
     #[test]
     fn completed_apply_does_not_mutate_a_different_open_definition() {
         let (client, _server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         let submitted_target = LiveSymbolTarget {
             name: "tick".to_string(),
             kind: Some("function".to_string()),
@@ -2222,7 +2806,7 @@ mod tests {
     #[test]
     fn completed_apply_does_not_mutate_a_reopened_same_definition() {
         let (client, _server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         let target = LiveSymbolTarget {
             name: "obstacle_enabled".to_string(),
             kind: Some("function".to_string()),
@@ -2275,7 +2859,7 @@ mod tests {
     #[test]
     fn completion_requests_coalesce_and_stale_results_are_discarded() {
         let (client, server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.refresh_completion(false);
         app.active_buffer_mut().insert_char('s');
         app.refresh_completion(true);
@@ -2325,7 +2909,7 @@ mod tests {
     #[test]
     fn editing_after_discard_warning_requires_a_fresh_confirmation() {
         let (client, _server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.input = InputMode::Definition(EditSession {
             id: 1,
             target: LiveSymbolTarget {
@@ -2357,7 +2941,7 @@ mod tests {
     #[test]
     fn rendering_buffer_access_preserves_discard_confirmation() {
         let (client, _server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.input = InputMode::Definition(EditSession {
             id: 1,
             target: LiveSymbolTarget {
@@ -2431,7 +3015,7 @@ mod tests {
         client
             .submit(LiveRequest::new(99, LiveCommand::Pause))
             .expect("fill request queue");
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
 
         app.request_default_inspection()
             .expect("backpressure stays inside the TUI");
@@ -2446,7 +3030,7 @@ mod tests {
     #[test]
     fn replacing_a_pinned_inspection_unwatches_the_previous_path() {
         let (client, server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.handle_response(LiveResponse::success(
             10,
             1,
@@ -2512,7 +3096,7 @@ mod tests {
         client
             .submit(LiveRequest::new(99, LiveCommand::Pause))
             .expect("fill request queue");
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.inspector_watch = Some("score".to_string());
 
         app.replace_inspector_watch(Some("speed".to_string()));
@@ -2547,7 +3131,7 @@ mod tests {
     #[test]
     fn rejected_watch_does_not_create_a_ghost_or_suppress_retry() {
         let (client, server) = stasis_runner::live::live_session(8);
-        let mut app = LiveTui::new(client);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
         app.replace_inspector_watch(Some("score".to_string()));
         let first = server.drain(1);
         assert_eq!(app.inspector_watch, None);

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -47,7 +47,7 @@ pub(super) fn run_scripted_ai(
     client: &LiveSessionClient,
     project_root: &Path,
     prompt: &str,
-) -> Result<(String, PathBuf), String> {
+) -> Result<(String, PathBuf, PathBuf), String> {
     run_scripted_ai_with_cancel(client, project_root, prompt, &AtomicBool::new(false))
 }
 
@@ -56,9 +56,10 @@ pub(super) fn run_scripted_ai_with_cancel(
     project_root: &Path,
     prompt: &str,
     canceled: &AtomicBool,
-) -> Result<(String, PathBuf), String> {
+) -> Result<(String, PathBuf, PathBuf), String> {
     let mut audit = AiAuditLog::create(project_root, prompt)?;
     let trace_path = audit.path.clone();
+    let usage_path = audit.usage_path.clone();
     let mut provider = CodexExecProvider::default();
     let mut tools = LiveAiTools::new(client.clone(), project_root.to_path_buf());
     let mut audit_error = None;
@@ -71,7 +72,10 @@ pub(super) fn run_scripted_ai_with_cancel(
         canceled,
         |event| {
             if audit_error.is_none() {
-                audit_error = audit.write(audit_agent_event(&event)).err();
+                audit_error = match &event {
+                    AgentEvent::ProviderUsage(usage) => audit.write_usage(usage).err(),
+                    _ => audit.write(audit_agent_event(&event)).err(),
+                };
             }
         },
     );
@@ -85,7 +89,7 @@ pub(super) fn run_scripted_ai_with_cancel(
                 "ok": true,
                 "summary": summary,
             }))?;
-            Ok((summary, trace_path))
+            Ok((summary, trace_path, usage_path))
         }
         Err(error) => {
             audit.write(serde_json::json!({
@@ -112,6 +116,7 @@ fn audit_agent_event(event: &AgentEvent) -> Value {
         AgentEvent::Turn { current, maximum } => {
             serde_json::json!({"event": "turn", "current": current, "maximum": maximum})
         }
+        AgentEvent::ProviderUsage(_) => unreachable!("provider usage has a separate log"),
         AgentEvent::WorkingNotes(notes) => {
             serde_json::json!({"event": "working_notes", "text": notes})
         }
@@ -138,6 +143,8 @@ struct AiRun {
 struct AiAuditLog {
     path: PathBuf,
     file: fs::File,
+    usage_path: PathBuf,
+    usage_file: fs::File,
 }
 
 impl AiAuditLog {
@@ -150,12 +157,23 @@ impl AiAuditLog {
             .unwrap_or_default()
             .as_millis();
         let path = directory.join(format!("tui-ai-{stamp}.jsonl"));
+        let usage_path = directory.join(format!("tui-ai-{stamp}.usage.jsonl"));
         let file = OpenOptions::new()
             .create_new(true)
             .write(true)
             .open(&path)
             .map_err(|error| format!("failed creating AI trace: {error}"))?;
-        let mut log = Self { path, file };
+        let usage_file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&usage_path)
+            .map_err(|error| format!("failed creating AI usage trace: {error}"))?;
+        let mut log = Self {
+            path,
+            file,
+            usage_path,
+            usage_file,
+        };
         log.write(serde_json::json!({
             "event": "request",
             "provider": "installed_codex_subscription",
@@ -178,6 +196,17 @@ impl AiAuditLog {
         self.file
             .flush()
             .map_err(|error| format!("failed flushing AI trace: {error}"))
+    }
+
+    fn write_usage(&mut self, usage: &Value) -> Result<(), String> {
+        serde_json::to_writer(&mut self.usage_file, usage)
+            .map_err(|error| format!("failed encoding AI usage trace: {error}"))?;
+        self.usage_file
+            .write_all(b"\n")
+            .map_err(|error| format!("failed writing AI usage trace: {error}"))?;
+        self.usage_file
+            .flush()
+            .map_err(|error| format!("failed flushing AI usage trace: {error}"))
     }
 }
 
@@ -1162,6 +1191,7 @@ impl LiveTui {
         match AiAuditLog::create(&self.project_root, &prompt) {
             Ok(log) => {
                 self.push_transcript(format!("AI trace: {}", log.path.display()));
+                self.push_transcript(format!("AI usage: {}", log.usage_path.display()));
                 self.ai_audit = Some(log);
             }
             Err(error) => {
@@ -1216,6 +1246,13 @@ impl LiveTui {
                 AiUiEvent::Progress(AgentEvent::Turn { current, maximum }) => {
                     self.status = format!("AI turn {current}/{maximum}; Ctrl+C cancels");
                     self.audit(serde_json::json!({"event": "turn", "current": current, "maximum": maximum}));
+                }
+                AiUiEvent::Progress(AgentEvent::ProviderUsage(usage)) => {
+                    if let Some(log) = &mut self.ai_audit {
+                        if let Err(error) = log.write_usage(&usage) {
+                            self.status = format!("AI usage trace disabled: {error}");
+                        }
+                    }
                 }
                 AiUiEvent::Progress(AgentEvent::WorkingNotes(notes)) => {
                     self.inspector.title = "AI working notes".to_string();
@@ -1903,9 +1940,12 @@ impl LiveAiTools {
         let args = call.args.as_object().expect("validated tool args");
         let command = match call.tool.as_str() {
             "list_symbols" => LiveCommand::Symbols {
-                query: None,
-                page: 0,
-                limit: 256,
+                query: string_arg(args, "query"),
+                kind: string_arg(args, "kind"),
+                file: string_arg(args, "file"),
+                owner: string_arg(args, "owner"),
+                page: usize_arg(args, "page").unwrap_or(0).min(u32::MAX as usize) as u32,
+                limit: usize_arg(args, "limit").unwrap_or(32).min(64),
             },
             "read_symbol" => LiveCommand::Read {
                 name: string_arg(args, "name").unwrap_or_default(),
@@ -3124,6 +3164,28 @@ mod tests {
             audit_observation(&observation),
             serde_json::to_value(observation).unwrap()
         );
+
+        let root = std::env::temp_dir().join(format!(
+            "stasis_ai_usage_log_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let usage = serde_json::json!({
+            "input_tokens": 100,
+            "cached_input_tokens": 80,
+            "output_tokens": 20,
+        });
+        let mut log = AiAuditLog::create(&root, "test prompt").expect("audit log");
+        let usage_path = log.usage_path.clone();
+        log.write_usage(&usage).expect("usage log");
+        drop(log);
+        assert_eq!(
+            fs::read_to_string(&usage_path).expect("usage contents"),
+            format!("{}\n", serde_json::to_string(&usage).unwrap())
+        );
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -42,6 +42,84 @@ enum AiUiEvent {
     Finished(Result<String, String>),
 }
 
+pub(super) fn run_scripted_ai(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    prompt: &str,
+) -> Result<(String, PathBuf), String> {
+    let mut audit = AiAuditLog::create(project_root, prompt)?;
+    let trace_path = audit.path.clone();
+    let canceled = AtomicBool::new(false);
+    let mut provider = CodexExecProvider::default();
+    let mut tools = LiveAiTools::new(client.clone());
+    let mut audit_error = None;
+    let result = run_agent(
+        &mut provider,
+        &mut tools,
+        prompt,
+        ai_initial_context(),
+        live_tool_specs(),
+        &canceled,
+        |event| {
+            if audit_error.is_none() {
+                audit_error = audit.write(audit_agent_event(&event)).err();
+            }
+        },
+    );
+    if let Some(error) = audit_error {
+        return Err(error);
+    }
+    match result {
+        Ok(summary) => {
+            audit.write(serde_json::json!({
+                "event": "finished",
+                "ok": true,
+                "summary": summary,
+            }))?;
+            Ok((summary, trace_path))
+        }
+        Err(error) => {
+            audit.write(serde_json::json!({
+                "event": "finished",
+                "ok": false,
+                "error": error,
+            }))?;
+            Err(error)
+        }
+    }
+}
+
+fn ai_initial_context() -> Value {
+    serde_json::json!({
+        "language": "Stasis",
+        "runtime": "live in-process JIT",
+        "commit_boundary": "between deterministic ticks",
+        "write_policy": "all writes in one model batch compile, test, and commit atomically",
+    })
+}
+
+fn audit_agent_event(event: &AgentEvent) -> Value {
+    match event {
+        AgentEvent::Turn { current, maximum } => {
+            serde_json::json!({"event": "turn", "current": current, "maximum": maximum})
+        }
+        AgentEvent::WorkingNotes(notes) => {
+            serde_json::json!({"event": "working_notes", "text": notes})
+        }
+        AgentEvent::ToolBatch(calls) => serde_json::json!({
+            "event": "tool_calls",
+            "calls": calls.iter().map(audit_tool_call).collect::<Vec<_>>(),
+        }),
+        AgentEvent::Observations(observations) => serde_json::json!({
+            "event": "tool_observations",
+            "observations": observations.iter().map(audit_observation).collect::<Vec<_>>(),
+        }),
+        AgentEvent::Completed(summary) => {
+            serde_json::json!({"event": "model_completed", "summary": summary})
+        }
+    }
+}
+
 struct AiRun {
     canceled: Arc<AtomicBool>,
     events: mpsc::Receiver<AiUiEvent>,
@@ -1095,12 +1173,7 @@ impl LiveTui {
                 &mut provider,
                 &mut tools,
                 &prompt,
-                serde_json::json!({
-                    "language": "Stasis",
-                    "runtime": "live in-process JIT",
-                    "commit_boundary": "between deterministic ticks",
-                    "write_policy": "all writes in one model batch compile, test, and commit atomically",
-                }),
+                ai_initial_context(),
                 live_tool_specs(),
                 &worker_canceled,
                 move |event| {

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -107,6 +107,30 @@ fn fresh_runtime_validation_runs_in_a_separate_cli_process() {
     assert_eq!(result["command"], "__validate-runtime");
     assert_eq!(result["result"]["baseline"], "fresh");
     assert_eq!(result["result"]["requirements_met"], true);
+
+    let human_validation = stasis(
+        &[
+            "--json",
+            "validate",
+            "State.value",
+            "eq",
+            "3",
+            "--frames",
+            "2",
+        ],
+        &project,
+    );
+    assert_eq!(human_validation.status.code(), Some(0));
+    assert_eq!(
+        json_stdout(&human_validation)["result"]["requirements_met"],
+        true
+    );
+
+    let references = stasis(&["--json", "symbol", "references", "State.value"], &project);
+    assert_eq!(references.status.code(), Some(0));
+    assert!(json_stdout(&references)["result"]["references"]
+        .as_array()
+        .is_some_and(|references| references.len() >= 2));
     fs::remove_dir_all(&parent).ok();
 }
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -73,6 +73,44 @@ fn project_commands_emit_stable_json_from_nested_directories() {
 }
 
 #[test]
+fn fresh_runtime_validation_runs_in_a_separate_cli_process() {
+    let parent = temp_dir("fresh_validation");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    fs::write(
+        project.join("src/main.stasis"),
+        "global State { value: i32; rendered: i32; }\nfunction main(): i32 { State.value = 1; return 0; }\nfunction tick(): i32 { State.value += 1; return 0; }\nfunction render(): i32 { State.rendered = 1; return 0; }\n",
+    )
+    .expect("write validation game");
+    let requirements = r#"[{"path":"State.value","op":"eq","value":3},{"path":"State.rendered","op":"eq","value":1}]"#;
+
+    let output = stasis(
+        &[
+            "--json",
+            "__validate-runtime",
+            "--frames",
+            "2",
+            "--requirements-json",
+            requirements,
+        ],
+        &project,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let result = json_stdout(&output);
+    assert_eq!(result["command"], "__validate-runtime");
+    assert_eq!(result["result"]["baseline"], "fresh");
+    assert_eq!(result["result"]["requirements_met"], true);
+    fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
 fn usage_compile_test_and_guest_exit_codes_are_stable() {
     let parent = temp_dir("failures");
     fs::create_dir_all(&parent).expect("create temp parent");

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -222,11 +222,14 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
     let listed = stasis(&["--json", "symbol", "list"], &project);
     assert_eq!(listed.status.code(), Some(0));
     let listed_json = json_stdout(&listed);
-    assert!(listed_json["result"]["items"]
-        .as_array()
-        .expect("items")
+    let listed_items = listed_json["result"]["items"].as_array().expect("items");
+    assert!(listed_items.iter().all(|item| item["kind"] != "imports"));
+    assert!(listed_items
         .iter()
-        .any(|item| item["kind"] == "imports" && item["file"] == "src/main.stasis"));
+        .all(|item| item.get("source").is_none() && item.get("source_hash").is_none()));
+    assert!(listed_items
+        .iter()
+        .any(|item| item["name"] == "tick" && item["file"] == "src/main.stasis"));
 
     let preview = stasis(
         &[

--- a/crates/stasis_ai/Cargo.toml
+++ b/crates/stasis_ai/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "stasis_ai"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -100,6 +100,10 @@ pub trait ModelProvider {
 
 pub trait ToolExecutor {
     fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation>;
+
+    fn validate_completion(&self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 pub fn run_agent<P, T, E>(
@@ -134,7 +138,7 @@ where
         });
         let request = json!({
             "role": "Stasis live-workspace coding agent",
-            "instruction": "Use only the supplied Stasis tools. Inspect narrowly, make the requested change, and return done only after the edit response reports that compilation and tests passed. Return exactly one JSON object matching the response contract.",
+            "instruction": "Use only the supplied Stasis tools. Inspect narrowly and call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
             "user_prompt": user_prompt,
             "initial_context": initial_context,
             "tool_specs": tool_specs,
@@ -148,6 +152,11 @@ where
         ));
         match response {
             ModelResponse::Done { summary, .. } => {
+                if let Err(error) = executor.validate_completion() {
+                    observations = vec![ToolObservation::error("completion_gate", error)];
+                    emit(AgentEvent::Observations(observations.clone()));
+                    continue;
+                }
                 let summary = if summary.trim().is_empty() {
                     "AI request completed".to_string()
                 } else {
@@ -258,6 +267,7 @@ pub fn model_response_schema() -> Value {
 pub fn workshop_tool_specs() -> Vec<ToolSpec> {
     vec![
         spec("list_symbols", "List editable Stasis symbols.", &[], &[]),
+        spec("find_references", "Find compact compiler-owned definitions, reads, writes, and calls for a function, global, or dot-qualified field.", &["symbol"], &["limit"]),
         spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
         spec("read_symbol", "Read one Stasis symbol.", &["name"], &["kind", "file", "owner", "signature"]),
         spec("write_symbol", "Atomically add or replace a symbol; set operation=add for a new symbol. A write batch compiles and tests together.", &["file", "name", "new_source"], &["operation", "kind", "owner", "signature", "expected_source_hash"]),
@@ -267,6 +277,7 @@ pub fn workshop_tool_specs() -> Vec<ToolSpec> {
         spec("get_diagnostics", "Read the latest compiler diagnostics.", &[], &[]),
         spec("set_input_state", "Set simulated input state.", &[], &["x", "y", "active", "screen_w", "screen_h"]),
         spec("inspect_runtime_state", "Read bounded live scalar state.", &[], &[]),
+        spec("validate_runtime_state", "Evaluate 1..=16 scalar requirements shaped as {path, op, value}, where op is eq, ne, lt, lte, gt, or gte. baseline=live pauses and restores the running game; baseline=fresh boots an isolated child process for an integration-style check. Fresh defaults to main/tick/render; use setup, tick, and render to select game-level entrypoints when host adapters have side effects. Use expected_outcome=fail before an edit and pass afterward with an identical contract.", &["requirements", "expected_outcome"], &["frames", "baseline", "setup", "tick", "render"]),
         spec("run_frame", "Advance the live runtime by one deterministic tick.", &[], &[]),
         spec("take_screenshot", "Capture a logical render snapshot and runtime state.", &[], &[]),
         spec("list_tests", "List Stasis test files.", &[], &[]),
@@ -280,10 +291,12 @@ pub fn workshop_tool_specs() -> Vec<ToolSpec> {
 pub fn live_tool_specs() -> Vec<ToolSpec> {
     const LIVE_TOOLS: &[&str] = &[
         "list_symbols",
+        "find_references",
         "read_symbol",
         "write_symbol",
         "delete_symbol",
         "inspect_runtime_state",
+        "validate_runtime_state",
         "run_frame",
         "run_tests",
     ];
@@ -556,6 +569,77 @@ mod tests {
     }
 
     #[test]
+    fn completion_gate_returns_evidence_to_the_agent_before_finishing() {
+        #[derive(Default)]
+        struct GatedTools {
+            ready: bool,
+        }
+        impl ToolExecutor for GatedTools {
+            fn execute(
+                &mut self,
+                calls: &[ToolCall],
+                _canceled: &AtomicBool,
+            ) -> Vec<ToolObservation> {
+                self.ready = true;
+                calls
+                    .iter()
+                    .map(|call| ToolObservation::result(&call.tool, json!({"ok": true})))
+                    .collect()
+            }
+
+            fn validate_completion(&self) -> Result<(), String> {
+                self.ready
+                    .then_some(())
+                    .ok_or_else(|| "green validation required".to_string())
+            }
+        }
+
+        let mut provider = Responses(vec![
+            ModelResponse::Done {
+                working_notes: "Intent: finish. Observed: edit. Next: none. Blocker: none."
+                    .to_string(),
+                summary: "too early".to_string(),
+            },
+            ModelResponse::ToolCalls {
+                working_notes: "Intent: validate. Observed: gate. Next: check. Blocker: none."
+                    .to_string(),
+                summary: String::new(),
+                tool_calls: vec![ToolCall {
+                    tool: "run_tests".to_string(),
+                    args: json!({}),
+                }],
+            },
+            ModelResponse::Done {
+                working_notes: "Intent: finish. Observed: green. Next: none. Blocker: none."
+                    .to_string(),
+                summary: "verified".to_string(),
+            },
+        ]);
+        let mut tools = GatedTools::default();
+        let mut saw_gate = false;
+
+        let result = run_agent(
+            &mut provider,
+            &mut tools,
+            "change",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |event| {
+                if let AgentEvent::Observations(observations) = event {
+                    saw_gate |= observations
+                        .iter()
+                        .any(|observation| observation.tool == "completion_gate");
+                }
+            },
+        )
+        .expect("agent");
+
+        assert_eq!(result, "verified");
+        assert!(saw_gate);
+    }
+
+    #[test]
     fn rejects_unknown_tools_before_execution() {
         let mut provider = Responses(vec![ModelResponse::ToolCalls {
             working_notes: "Intent: act. Observed: none. Next: shell. Blocker: none.".to_string(),
@@ -588,6 +672,10 @@ mod tests {
             .iter()
             .all(|tool| workshop.iter().any(|candidate| candidate.tool == tool.tool)));
         assert!(live.iter().any(|tool| tool.tool == "write_symbol"));
+        assert!(live.iter().any(|tool| tool.tool == "find_references"));
+        assert!(live
+            .iter()
+            .any(|tool| tool.tool == "validate_runtime_state"));
         assert!(!live.iter().any(|tool| tool.tool == "capture_screenshot"));
     }
 

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -88,6 +88,7 @@ impl ModelResponse {
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentEvent {
     Turn { current: usize, maximum: usize },
+    ProviderUsage(Value),
     WorkingNotes(String),
     ToolBatch(Vec<ToolCall>),
     Observations(Vec<ToolObservation>),
@@ -96,6 +97,10 @@ pub enum AgentEvent {
 
 pub trait ModelProvider {
     fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String>;
+
+    fn take_usage(&mut self) -> Option<Value> {
+        None
+    }
 }
 
 pub trait ToolExecutor {
@@ -148,6 +153,9 @@ where
             "response_contract": response_contract(),
         });
         let response = provider.respond(&request, canceled)?;
+        if let Some(usage) = provider.take_usage() {
+            emit(AgentEvent::ProviderUsage(usage));
+        }
         validate_working_notes(response.working_notes())?;
         emit(AgentEvent::WorkingNotes(
             response.working_notes().to_string(),
@@ -274,7 +282,7 @@ pub fn model_response_schema() -> Value {
 
 pub fn workshop_tool_specs() -> Vec<ToolSpec> {
     vec![
-        spec("list_symbols", "List editable Stasis symbols.", &[], &[]),
+        spec("list_symbols", "Search compact editable Stasis symbols. Results exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["query", "kind", "file", "owner", "page", "limit"]),
         spec("find_references", "Find compact compiler-owned definitions, reads, writes, and calls for a function, global, or dot-qualified field.", &["symbol"], &["limit"]),
         spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
         spec("read_symbol", "Read one Stasis symbol.", &["name"], &["kind", "file", "owner", "signature"]),
@@ -327,6 +335,7 @@ pub struct CodexExecProvider {
     executable: PathBuf,
     model: String,
     reasoning_effort: String,
+    last_usage: Option<Value>,
 }
 
 impl Default for CodexExecProvider {
@@ -343,6 +352,7 @@ impl Default for CodexExecProvider {
                 .ok()
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or_else(|| DEFAULT_REASONING_EFFORT.to_string()),
+            last_usage: None,
         }
     }
 }
@@ -363,6 +373,7 @@ fn default_codex_executable() -> PathBuf {
 
 impl ModelProvider for CodexExecProvider {
     fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String> {
+        self.last_usage = None;
         let run = TemporaryRun::create()?;
         fs::write(
             &run.schema,
@@ -383,6 +394,7 @@ impl ModelProvider for CodexExecProvider {
             .arg("--skip-git-repo-check")
             .arg("--color")
             .arg("never")
+            .arg("--json")
             .arg("--cd")
             .arg(&run.root)
             .arg("--output-schema")
@@ -397,7 +409,7 @@ impl ModelProvider for CodexExecProvider {
         command
             .arg("-")
             .stdin(Stdio::piped())
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
             .stderr(Stdio::from(stderr));
         #[cfg(windows)]
         {
@@ -409,6 +421,11 @@ impl ModelProvider for CodexExecProvider {
                 "failed starting Codex; install/sign in to Codex or set STASIS_CODEX_EXE: {error}"
             )
         })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Codex stdout was unavailable".to_string())?;
+        let usage_worker = std::thread::spawn(move || read_codex_usage(stdout));
         let encoded = serde_json::to_vec(request).map_err(|error| error.to_string())?;
         child
             .stdin
@@ -420,6 +437,7 @@ impl ModelProvider for CodexExecProvider {
             if canceled.load(Ordering::Acquire) {
                 let _ = child.kill();
                 let _ = child.wait();
+                let _ = usage_worker.join();
                 return Err("AI request canceled".to_string());
             }
             match child
@@ -428,15 +446,37 @@ impl ModelProvider for CodexExecProvider {
             {
                 Some(status) if status.success() => break,
                 Some(status) => {
+                    let _ = usage_worker.join();
                     return Err(codex_failure_message(&run.stderr, status));
                 }
                 None => std::thread::sleep(Duration::from_millis(50)),
             }
         }
+        self.last_usage = usage_worker
+            .join()
+            .map_err(|_| "Codex usage reader panicked".to_string())??;
         let source = fs::read_to_string(&run.output)
             .map_err(|error| format!("Codex did not produce a final response: {error}"))?;
         decode_codex_response(&source)
     }
+
+    fn take_usage(&mut self) -> Option<Value> {
+        self.last_usage.take()
+    }
+}
+
+fn read_codex_usage(stdout: impl Read) -> Result<Option<Value>, String> {
+    let mut usage = None;
+    for line in BufReader::new(stdout).lines() {
+        let line = line.map_err(|error| format!("failed reading Codex JSON events: {error}"))?;
+        let Ok(event) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if event.get("type").and_then(Value::as_str) == Some("turn.completed") {
+            usage = event.get("usage").cloned();
+        }
+    }
+    Ok(usage)
 }
 
 fn decode_codex_response(source: &str) -> Result<ModelResponse, String> {
@@ -756,6 +796,31 @@ mod tests {
             panic!("tool calls");
         };
         assert_eq!(tool_calls[0].args, json!({"name": "tick"}));
+    }
+
+    #[test]
+    fn codex_json_stream_keeps_only_the_exact_reported_usage() {
+        let stream = concat!(
+            "{\"type\":\"thread.started\",\"thread_id\":\"hidden\"}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"text\":\"not retained\"}}\n",
+            "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":24763,\"cached_input_tokens\":24448,\"output_tokens\":122,\"reasoning_output_tokens\":7}}\n"
+        );
+
+        let usage = read_codex_usage(std::io::Cursor::new(stream))
+            .expect("stream")
+            .expect("usage");
+
+        assert_eq!(
+            usage,
+            json!({
+                "input_tokens": 24763,
+                "cached_input_tokens": 24448,
+                "output_tokens": 122,
+                "reasoning_output_tokens": 7,
+            })
+        );
+        assert!(!usage.to_string().contains("not retained"));
+        assert!(!usage.to_string().contains("hidden"));
     }
 
     #[test]

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -1,0 +1,623 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub const MAX_AGENT_TURNS: usize = 25;
+pub const MAX_TOOL_CALLS_PER_TURN: usize = 12;
+pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
+pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
+pub const DEFAULT_REASONING_EFFORT: &str = "medium";
+pub const MAX_OBSERVATION_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub tool: String,
+    #[serde(default)]
+    pub args: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolObservation {
+    pub tool: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ToolObservation {
+    pub fn result(tool: impl Into<String>, result: Value) -> Self {
+        Self {
+            tool: tool.into(),
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(tool: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            tool: tool.into(),
+            result: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    pub tool: String,
+    pub purpose: String,
+    #[serde(default)]
+    pub required_args: Vec<String>,
+    #[serde(default)]
+    pub optional_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ModelResponse {
+    ToolCalls {
+        working_notes: String,
+        #[serde(default)]
+        summary: String,
+        tool_calls: Vec<ToolCall>,
+    },
+    Done {
+        working_notes: String,
+        #[serde(default)]
+        summary: String,
+    },
+}
+
+impl ModelResponse {
+    pub fn working_notes(&self) -> &str {
+        match self {
+            Self::ToolCalls { working_notes, .. } | Self::Done { working_notes, .. } => {
+                working_notes
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentEvent {
+    Turn { current: usize, maximum: usize },
+    WorkingNotes(String),
+    ToolBatch(Vec<ToolCall>),
+    Observations(Vec<ToolObservation>),
+    Completed(String),
+}
+
+pub trait ModelProvider {
+    fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String>;
+}
+
+pub trait ToolExecutor {
+    fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation>;
+}
+
+pub fn run_agent<P, T, E>(
+    provider: &mut P,
+    executor: &mut T,
+    user_prompt: &str,
+    initial_context: Value,
+    tool_specs: Vec<ToolSpec>,
+    canceled: &AtomicBool,
+    mut emit: E,
+) -> Result<String, String>
+where
+    P: ModelProvider,
+    T: ToolExecutor,
+    E: FnMut(AgentEvent),
+{
+    if user_prompt.trim().is_empty() {
+        return Err("AI request must not be empty".to_string());
+    }
+    let known_tools = tool_specs
+        .iter()
+        .map(|spec| spec.tool.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut observations = Vec::<ToolObservation>::new();
+    for turn in 1..=MAX_AGENT_TURNS {
+        if canceled.load(Ordering::Acquire) {
+            return Err("AI request canceled".to_string());
+        }
+        emit(AgentEvent::Turn {
+            current: turn,
+            maximum: MAX_AGENT_TURNS,
+        });
+        let request = json!({
+            "role": "Stasis live-workspace coding agent",
+            "instruction": "Use only the supplied Stasis tools. Inspect narrowly, make the requested change, and return done only after the edit response reports that compilation and tests passed. Return exactly one JSON object matching the response contract.",
+            "user_prompt": user_prompt,
+            "initial_context": initial_context,
+            "tool_specs": tool_specs,
+            "observations": observations,
+            "response_contract": response_contract(),
+        });
+        let response = provider.respond(&request, canceled)?;
+        validate_working_notes(response.working_notes())?;
+        emit(AgentEvent::WorkingNotes(
+            response.working_notes().to_string(),
+        ));
+        match response {
+            ModelResponse::Done { summary, .. } => {
+                let summary = if summary.trim().is_empty() {
+                    "AI request completed".to_string()
+                } else {
+                    summary
+                };
+                emit(AgentEvent::Completed(summary.clone()));
+                return Ok(summary);
+            }
+            ModelResponse::ToolCalls { tool_calls, .. } => {
+                if tool_calls.is_empty() {
+                    return Err("model returned an empty tool-call batch".to_string());
+                }
+                if tool_calls.len() > MAX_TOOL_CALLS_PER_TURN {
+                    return Err(format!(
+                        "model returned {} tool calls; limit is {MAX_TOOL_CALLS_PER_TURN}",
+                        tool_calls.len()
+                    ));
+                }
+                for call in &tool_calls {
+                    validate_tool_call(call, &tool_specs, &known_tools)?;
+                }
+                emit(AgentEvent::ToolBatch(tool_calls.clone()));
+                observations = bound_observations(executor.execute(&tool_calls, canceled));
+                emit(AgentEvent::Observations(observations.clone()));
+            }
+        }
+    }
+    Err(format!("AI agent reached the {MAX_AGENT_TURNS}-turn limit"))
+}
+
+fn validate_working_notes(notes: &str) -> Result<(), String> {
+    let count = notes.chars().count();
+    if notes.trim().is_empty() || count > MAX_WORKING_NOTES_CHARS {
+        return Err(format!(
+            "working_notes must contain 1..={MAX_WORKING_NOTES_CHARS} characters"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_tool_call(
+    call: &ToolCall,
+    specs: &[ToolSpec],
+    known_tools: &BTreeSet<&str>,
+) -> Result<(), String> {
+    if !known_tools.contains(call.tool.as_str()) {
+        return Err(format!("unsupported AI tool: {}", call.tool));
+    }
+    let args = call
+        .args
+        .as_object()
+        .ok_or_else(|| format!("AI tool {} requires an object args value", call.tool))?;
+    let spec = specs
+        .iter()
+        .find(|spec| spec.tool == call.tool)
+        .expect("known tool has spec");
+    for required in &spec.required_args {
+        if !args.contains_key(required) {
+            return Err(format!("AI tool {} requires arg: {required}", call.tool));
+        }
+    }
+    Ok(())
+}
+
+fn bound_observations(observations: Vec<ToolObservation>) -> Vec<ToolObservation> {
+    if serde_json::to_vec(&observations).is_ok_and(|encoded| encoded.len() <= MAX_OBSERVATION_BYTES)
+    {
+        return observations;
+    }
+    vec![ToolObservation::error(
+        "observation_batch",
+        format!("tool observations exceeded {MAX_OBSERVATION_BYTES} bytes"),
+    )]
+}
+
+pub fn response_contract() -> Value {
+    json!({
+        "accepted_modes": ["tool_calls", "done"],
+        "working_notes": format!("required non-empty string, maximum {MAX_WORKING_NOTES_CHARS} characters"),
+        "tool_calls": {"maximum": MAX_TOOL_CALLS_PER_TURN, "shape": {"tool": "name", "args": "JSON object encoded as a string"}},
+    })
+}
+
+pub fn model_response_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["mode", "working_notes", "summary", "tool_calls"],
+        "properties": {
+            "mode": {"type": "string", "enum": ["tool_calls", "done"]},
+            "working_notes": {"type": "string", "minLength": 1, "maxLength": MAX_WORKING_NOTES_CHARS},
+            "summary": {"type": "string"},
+            "tool_calls": {
+                "type": "array",
+                "maxItems": MAX_TOOL_CALLS_PER_TURN,
+                "items": {
+                    "type": "object",
+                    "required": ["tool", "args"],
+                    "properties": {"tool": {"type": "string"}, "args": {"type": "string"}},
+                    "additionalProperties": false
+                }
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+pub fn workshop_tool_specs() -> Vec<ToolSpec> {
+    vec![
+        spec("list_symbols", "List editable Stasis symbols.", &[], &[]),
+        spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
+        spec("read_symbol", "Read one Stasis symbol.", &["name"], &["kind", "file", "owner", "signature"]),
+        spec("write_symbol", "Atomically add or replace a symbol; set operation=add for a new symbol. A write batch compiles and tests together.", &["file", "name", "new_source"], &["operation", "kind", "owner", "signature", "expected_source_hash"]),
+        spec("delete_symbol", "Atomically delete a symbol.", &["name"], &["file", "kind", "owner", "signature", "expected_source_hash"]),
+        spec("read_imports", "Read one source file's imports.", &["file"], &[]),
+        spec("write_imports", "Atomically replace one source file's imports.", &["file", "imports"], &[]),
+        spec("get_diagnostics", "Read the latest compiler diagnostics.", &[], &[]),
+        spec("set_input_state", "Set simulated input state.", &[], &["x", "y", "active", "screen_w", "screen_h"]),
+        spec("inspect_runtime_state", "Read bounded live scalar state.", &[], &[]),
+        spec("run_frame", "Advance the live runtime by one deterministic tick.", &[], &[]),
+        spec("take_screenshot", "Capture a logical render snapshot and runtime state.", &[], &[]),
+        spec("list_tests", "List Stasis test files.", &[], &[]),
+        spec("read_test_file", "Read one Stasis test file.", &["file"], &[]),
+        spec("write_test_file", "Create or replace one Stasis test file.", &["file", "source"], &[]),
+        spec("delete_test_file", "Delete one Stasis test file.", &["file"], &[]),
+        spec("run_tests", "Confirm the latest atomic write batch compiled and passed tests.", &[], &[]),
+    ]
+}
+
+pub fn live_tool_specs() -> Vec<ToolSpec> {
+    const LIVE_TOOLS: &[&str] = &[
+        "list_symbols",
+        "read_symbol",
+        "write_symbol",
+        "delete_symbol",
+        "inspect_runtime_state",
+        "run_frame",
+        "run_tests",
+    ];
+    workshop_tool_specs()
+        .into_iter()
+        .filter(|spec| LIVE_TOOLS.contains(&spec.tool.as_str()))
+        .collect()
+}
+
+fn spec(tool: &str, purpose: &str, required: &[&str], optional: &[&str]) -> ToolSpec {
+    ToolSpec {
+        tool: tool.to_string(),
+        purpose: purpose.to_string(),
+        required_args: required.iter().map(|value| (*value).to_string()).collect(),
+        optional_args: optional.iter().map(|value| (*value).to_string()).collect(),
+    }
+}
+
+pub struct CodexExecProvider {
+    executable: PathBuf,
+    model: String,
+    reasoning_effort: String,
+}
+
+impl Default for CodexExecProvider {
+    fn default() -> Self {
+        Self {
+            executable: std::env::var_os("STASIS_CODEX_EXE")
+                .map(PathBuf::from)
+                .unwrap_or_else(default_codex_executable),
+            model: std::env::var("STASIS_AI_MODEL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
+            reasoning_effort: std::env::var("STASIS_AI_REASONING_EFFORT")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_REASONING_EFFORT.to_string()),
+        }
+    }
+}
+
+fn default_codex_executable() -> PathBuf {
+    #[cfg(windows)]
+    if let Some(app_data) = std::env::var_os("APPDATA") {
+        let npm = PathBuf::from(app_data).join(
+            "npm/node_modules/@openai/codex/node_modules/@openai/codex-win32-x64/\
+             vendor/x86_64-pc-windows-msvc/bin/codex.exe",
+        );
+        if npm.is_file() {
+            return npm;
+        }
+    }
+    PathBuf::from("codex")
+}
+
+impl ModelProvider for CodexExecProvider {
+    fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String> {
+        let run = TemporaryRun::create()?;
+        fs::write(
+            &run.schema,
+            serde_json::to_vec_pretty(&model_response_schema())
+                .map_err(|error| error.to_string())?,
+        )
+        .map_err(|error| format!("failed writing Codex output schema: {error}"))?;
+        let mut command = Command::new(&self.executable);
+        let stderr = fs::File::create(&run.stderr)
+            .map_err(|error| format!("failed creating Codex error capture: {error}"))?;
+        command
+            .arg("exec")
+            .arg("--ephemeral")
+            .arg("--ignore-user-config")
+            .arg("--ignore-rules")
+            .arg("--sandbox")
+            .arg("read-only")
+            .arg("--skip-git-repo-check")
+            .arg("--color")
+            .arg("never")
+            .arg("--cd")
+            .arg(&run.root)
+            .arg("--output-schema")
+            .arg(&run.schema)
+            .arg("--output-last-message")
+            .arg(&run.output);
+        command.arg("--model").arg(&self.model);
+        command.arg("--config").arg(format!(
+            "model_reasoning_effort=\"{}\"",
+            self.reasoning_effort
+        ));
+        command
+            .arg("-")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(stderr));
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x08000000);
+        }
+        let mut child = command.spawn().map_err(|error| {
+            format!(
+                "failed starting Codex; install/sign in to Codex or set STASIS_CODEX_EXE: {error}"
+            )
+        })?;
+        let encoded = serde_json::to_vec(request).map_err(|error| error.to_string())?;
+        child
+            .stdin
+            .take()
+            .ok_or_else(|| "Codex stdin was unavailable".to_string())?
+            .write_all(&encoded)
+            .map_err(|error| format!("failed sending Codex request: {error}"))?;
+        loop {
+            if canceled.load(Ordering::Acquire) {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("AI request canceled".to_string());
+            }
+            match child
+                .try_wait()
+                .map_err(|error| format!("failed waiting for Codex: {error}"))?
+            {
+                Some(status) if status.success() => break,
+                Some(status) => {
+                    return Err(codex_failure_message(&run.stderr, status));
+                }
+                None => std::thread::sleep(Duration::from_millis(50)),
+            }
+        }
+        let source = fs::read_to_string(&run.output)
+            .map_err(|error| format!("Codex did not produce a final response: {error}"))?;
+        decode_codex_response(&source)
+    }
+}
+
+fn decode_codex_response(source: &str) -> Result<ModelResponse, String> {
+    let mut value: Value = serde_json::from_str(source)
+        .map_err(|error| format!("Codex returned invalid agent JSON: {error}"))?;
+    if let Some(calls) = value.get_mut("tool_calls").and_then(Value::as_array_mut) {
+        for call in calls {
+            let Some(args) = call.get_mut("args") else {
+                continue;
+            };
+            if let Some(encoded) = args.as_str() {
+                *args = serde_json::from_str(encoded)
+                    .map_err(|error| format!("Codex returned invalid tool args JSON: {error}"))?;
+            }
+        }
+    }
+    serde_json::from_value(value)
+        .map_err(|error| format!("Codex returned invalid agent response: {error}"))
+}
+
+struct TemporaryRun {
+    root: PathBuf,
+    schema: PathBuf,
+    output: PathBuf,
+    stderr: PathBuf,
+}
+
+impl TemporaryRun {
+    fn create() -> Result<Self, String> {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_ai_{}_{}", std::process::id(), stamp));
+        fs::create_dir(&root)
+            .map_err(|error| format!("failed creating isolated AI directory: {error}"))?;
+        Ok(Self {
+            schema: root.join("response.schema.json"),
+            output: root.join("response.json"),
+            stderr: root.join("stderr.log"),
+            root,
+        })
+    }
+}
+
+fn codex_failure_message(stderr: &Path, status: std::process::ExitStatus) -> String {
+    let detail = fs::read_to_string(stderr).ok().and_then(|text| {
+        let start = text.rfind("ERROR:").or_else(|| text.rfind("error:"))?;
+        let detail = text[start..]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        Some(detail.chars().take(500).collect::<String>())
+    });
+    match detail {
+        Some(detail) => format!("Codex exited with status {status}: {detail}"),
+        None => format!("Codex exited with status {status}; verify `codex login` and the model"),
+    }
+}
+
+impl Drop for TemporaryRun {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+pub fn contract_json() -> Value {
+    json!({
+        "schema_version": 1,
+        "limits": {
+            "agent_turns": MAX_AGENT_TURNS,
+            "tool_calls_per_turn": MAX_TOOL_CALLS_PER_TURN,
+            "working_notes_characters": MAX_WORKING_NOTES_CHARS,
+        },
+        "tool_specs": workshop_tool_specs(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    struct Responses(Vec<ModelResponse>);
+    impl ModelProvider for Responses {
+        fn respond(
+            &mut self,
+            _request: &Value,
+            _canceled: &AtomicBool,
+        ) -> Result<ModelResponse, String> {
+            Ok(self.0.remove(0))
+        }
+    }
+
+    #[derive(Default)]
+    struct Tools(usize);
+    impl ToolExecutor for Tools {
+        fn execute(&mut self, calls: &[ToolCall], _canceled: &AtomicBool) -> Vec<ToolObservation> {
+            self.0 += calls.len();
+            calls
+                .iter()
+                .map(|call| ToolObservation::result(&call.tool, json!({"ok": true})))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn bounded_loop_executes_tools_then_finishes() {
+        let mut provider = Responses(vec![
+            ModelResponse::ToolCalls {
+                working_notes: "Intent: inspect. Observed: none. Next: list. Blocker: none."
+                    .to_string(),
+                summary: String::new(),
+                tool_calls: vec![ToolCall {
+                    tool: "list_symbols".to_string(),
+                    args: json!({}),
+                }],
+            },
+            ModelResponse::Done {
+                working_notes: "Intent: finish. Observed: verified. Next: none. Blocker: none."
+                    .to_string(),
+                summary: "verified".to_string(),
+            },
+        ]);
+        let mut tools = Tools::default();
+        let result = run_agent(
+            &mut provider,
+            &mut tools,
+            "inspect",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .expect("agent");
+        assert_eq!(result, "verified");
+        assert_eq!(tools.0, 1);
+    }
+
+    #[test]
+    fn rejects_unknown_tools_before_execution() {
+        let mut provider = Responses(vec![ModelResponse::ToolCalls {
+            working_notes: "Intent: act. Observed: none. Next: shell. Blocker: none.".to_string(),
+            summary: String::new(),
+            tool_calls: vec![ToolCall {
+                tool: "shell".to_string(),
+                args: json!({}),
+            }],
+        }]);
+        let error = run_agent(
+            &mut provider,
+            &mut Tools::default(),
+            "change",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .expect_err("unknown tool");
+        assert_eq!(error, "unsupported AI tool: shell");
+    }
+
+    #[test]
+    fn live_contract_is_a_strict_subset_of_the_workshop_contract() {
+        let workshop = workshop_tool_specs();
+        let live = live_tool_specs();
+        assert!(!live.is_empty());
+        assert!(live.len() < workshop.len());
+        assert!(live
+            .iter()
+            .all(|tool| workshop.iter().any(|candidate| candidate.tool == tool.tool)));
+        assert!(live.iter().any(|tool| tool.tool == "write_symbol"));
+        assert!(!live.iter().any(|tool| tool.tool == "capture_screenshot"));
+    }
+
+    #[test]
+    fn codex_transport_decodes_json_encoded_tool_args() {
+        let response = decode_codex_response(
+            r#"{"mode":"tool_calls","working_notes":"Inspect next.","summary":"","tool_calls":[{"tool":"read_symbol","args":"{\"name\":\"tick\"}"}]}"#,
+        )
+        .expect("response");
+        let ModelResponse::ToolCalls { tool_calls, .. } = response else {
+            panic!("tool calls");
+        };
+        assert_eq!(tool_calls[0].args, json!({"name": "tick"}));
+    }
+
+    #[test]
+    #[ignore = "requires an installed, signed-in Codex CLI"]
+    fn installed_codex_provider_accepts_the_shared_response_schema() {
+        let mut provider = CodexExecProvider::default();
+        let response = provider
+            .respond(
+                &json!({
+                    "system": "Return a done response without calling tools.",
+                    "user_prompt": "Confirm the Stasis AI provider is connected.",
+                    "tool_specs": [],
+                    "observations": [],
+                }),
+                &AtomicBool::new(false),
+            )
+            .expect("signed-in Codex response");
+        assert!(matches!(response, ModelResponse::Done { .. }));
+    }
+}

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -8,7 +8,7 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub const MAX_AGENT_TURNS: usize = 25;
+pub const MAX_AGENT_TURNS: usize = 12;
 pub const MAX_TOOL_CALLS_PER_TURN: usize = 12;
 pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
@@ -128,6 +128,7 @@ where
         .map(|spec| spec.tool.as_str())
         .collect::<BTreeSet<_>>();
     let mut observations = Vec::<ToolObservation>::new();
+    let mut conversation_history = Vec::<Value>::new();
     for turn in 1..=MAX_AGENT_TURNS {
         if canceled.load(Ordering::Acquire) {
             return Err("AI request canceled".to_string());
@@ -138,10 +139,11 @@ where
         });
         let request = json!({
             "role": "Stasis live-workspace coding agent",
-            "instruction": "Use only the supplied Stasis tools. Inspect narrowly and call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
+            "instruction": "Use only the supplied Stasis tools. Treat conversation_history as the authoritative record of your earlier tool calls and their results; do not repeat completed inspection or validation. Inspect narrowly and call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
             "user_prompt": user_prompt,
             "initial_context": initial_context,
             "tool_specs": tool_specs,
+            "conversation_history": conversation_history,
             "observations": observations,
             "response_contract": response_contract(),
         });
@@ -150,6 +152,8 @@ where
         emit(AgentEvent::WorkingNotes(
             response.working_notes().to_string(),
         ));
+        let response_record = serde_json::to_value(&response)
+            .map_err(|error| format!("failed recording AI response: {error}"))?;
         match response {
             ModelResponse::Done { summary, .. } => {
                 if let Err(error) = executor.validate_completion() {
@@ -181,6 +185,10 @@ where
                 emit(AgentEvent::ToolBatch(tool_calls.clone()));
                 observations = bound_observations(executor.execute(&tool_calls, canceled));
                 emit(AgentEvent::Observations(observations.clone()));
+                conversation_history.push(json!({
+                    "response": response_record,
+                    "observations": observations,
+                }));
             }
         }
     }
@@ -566,6 +574,65 @@ mod tests {
         .expect("agent");
         assert_eq!(result, "verified");
         assert_eq!(tools.0, 1);
+    }
+
+    #[test]
+    fn later_turns_receive_prior_calls_and_observations() {
+        struct RecordingResponses {
+            responses: Vec<ModelResponse>,
+            requests: Vec<Value>,
+        }
+        impl ModelProvider for RecordingResponses {
+            fn respond(
+                &mut self,
+                request: &Value,
+                _canceled: &AtomicBool,
+            ) -> Result<ModelResponse, String> {
+                self.requests.push(request.clone());
+                Ok(self.responses.remove(0))
+            }
+        }
+
+        let mut provider = RecordingResponses {
+            responses: vec![
+                ModelResponse::ToolCalls {
+                    working_notes: "Inspect the relevant symbol once.".to_string(),
+                    summary: String::new(),
+                    tool_calls: vec![ToolCall {
+                        tool: "read_symbol".to_string(),
+                        args: json!({"name": "tick"}),
+                    }],
+                },
+                ModelResponse::Done {
+                    working_notes: "The prior inspection is visible and complete.".to_string(),
+                    summary: "verified".to_string(),
+                },
+            ],
+            requests: Vec::new(),
+        };
+
+        run_agent(
+            &mut provider,
+            &mut Tools::default(),
+            "inspect",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .expect("agent");
+
+        assert_eq!(provider.requests.len(), 2);
+        assert_eq!(provider.requests[0]["conversation_history"], json!([]));
+        assert_eq!(
+            provider.requests[1]["conversation_history"][0]["response"]["tool_calls"][0]["args"]
+                ["name"],
+            "tick"
+        );
+        assert_eq!(
+            provider.requests[1]["conversation_history"][0]["observations"][0]["result"]["ok"],
+            true
+        );
     }
 
     #[test]

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -679,15 +679,17 @@ fn prepare_embedded_resource_catalog(
 
 fn embedded_path(catalog: &EmbeddedResourceCatalog, bytes: &[u8]) -> Option<PathBuf> {
     let path = std::str::from_utf8(bytes).ok()?;
-    let absolute = catalog
-        .project_root
-        .join("src")
-        .join(path)
-        .canonicalize()
-        .ok()?;
-    absolute
-        .starts_with(&catalog.project_root)
-        .then_some(absolute)
+    [
+        catalog.project_root.join(path),
+        catalog.project_root.join("src").join(path),
+    ]
+    .into_iter()
+    .find_map(|candidate| {
+        let absolute = candidate.canonicalize().ok()?;
+        absolute
+            .starts_with(&catalog.project_root)
+            .then_some(absolute)
+    })
 }
 
 fn set_embedded_resource_error(catalog: &mut EmbeddedResourceCatalog, message: String) {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -398,6 +398,12 @@ impl JitProcess {
                 function.return_type
             ));
         }
+        if !function.params.is_empty() {
+            return Err(format!(
+                "function '{name}' is not a no-argument function (param count {})",
+                function.params.len()
+            ));
+        }
         let artifact = self
             .artifact_for_function_id(function.id)
             .ok_or_else(|| format!("compiled artifact missing for function '{name}'"))?;
@@ -974,9 +980,10 @@ impl JitProcess {
         &self,
         entrypoints: &EngineEntrypoints,
     ) -> Result<JitEnginePackage, String> {
-        let tick_code_ptr = self.code_ptr_for_function_name(&entrypoints.tick)?;
-        let render_code_ptr = self.code_ptr_for_function_name(&entrypoints.render)?;
+        let tick_code_ptr = self.code_ptr_for_i32_noarg_entrypoint(&entrypoints.tick)?;
+        let render_code_ptr = self.code_ptr_for_i32_noarg_entrypoint(&entrypoints.render)?;
         let on_code_swap_code_ptr = if let Some(name) = entrypoints.on_code_swap.as_ref() {
+            self.validate_on_code_swap_signature()?;
             Some(self.code_ptr_for_function_name(name)?)
         } else {
             None
@@ -1001,6 +1008,25 @@ impl JitProcess {
             .artifact_for_function_id(function.id)
             .ok_or_else(|| format!("compiled artifact missing for required entrypoint '{name}'"))?;
         Ok(artifact.code_ptr)
+    }
+
+    fn code_ptr_for_i32_noarg_entrypoint(&self, name: &str) -> Result<u64, String> {
+        let function = self
+            .compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == name)
+            .ok_or_else(|| format!("required engine entrypoint '{name}' not found"))?;
+        if function.return_type != TYPE_ID_I32 || !function.params.is_empty() {
+            return Err(format!(
+                "engine entrypoint signature mismatch for '{name}': expected `function {name}(): i32`; actual return type id {}, parameter count {}",
+                function.return_type,
+                function.params.len()
+            ));
+        }
+        self.artifact_for_function_id(function.id)
+            .map(|artifact| artifact.code_ptr)
+            .ok_or_else(|| format!("compiled artifact missing for required entrypoint '{name}'"))
     }
 
     fn refresh_runtime_dispatch_table(&self) {
@@ -4574,7 +4600,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "function tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n",
+            "function tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
         );
         process.compile().expect("compile");
         let package = process
@@ -4602,7 +4628,7 @@ mod tests {
     #[test]
     fn jit_engine_package_errors_when_required_entrypoint_missing() {
         let mut process = JitProcess::new();
-        process.upsert_file("sample.stasis", "function tick(): void { return; }\n");
+        process.upsert_file("sample.stasis", "function tick(): i32 { return 0; }\n");
         process.compile().expect("compile");
         let error = process
             .build_engine_package(&EngineEntrypoints::runtime_default())
@@ -4611,5 +4637,20 @@ mod tests {
             error.contains("required engine entrypoint 'render' not found"),
             "unexpected message: {error}"
         );
+    }
+
+    #[test]
+    fn jit_engine_package_reports_signature_mismatch() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function tick(): void { return; }\nfunction render(): i32 { return 0; }\n",
+        );
+        process.compile().expect("compile");
+        let error = process
+            .build_engine_package(&EngineEntrypoints::runtime_default())
+            .expect_err("void tick should fail");
+        assert!(error.contains("expected `function tick(): i32`"));
+        assert!(error.contains("actual return type id"));
     }
 }

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -958,6 +958,27 @@ pub struct WorkshopSourceItem {
     pub source_hash: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkshopReferenceKind {
+    Definition,
+    Read,
+    Write,
+    Call,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WorkshopReference {
+    pub symbol: String,
+    pub kind: WorkshopReferenceKind,
+    pub file: String,
+    pub source_span: WorkshopSourceSpan,
+    pub containing_kind: WorkshopSourceItemKind,
+    pub containing_name: String,
+    pub containing_signature: String,
+    pub containing_source_hash: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WorkshopCompletionItem {
     pub text: String,
@@ -1122,6 +1143,151 @@ pub fn workshop_source_items(
         (item.file.clone(), order, start, item.name.clone())
     });
     Ok(items)
+}
+
+pub fn find_workshop_references(
+    files: &[WorkshopSourceFile],
+    symbol: &str,
+    limit: usize,
+) -> Result<Vec<WorkshopReference>, String> {
+    let segments = symbol.split('.').collect::<Vec<_>>();
+    if segments.is_empty()
+        || segments.len() > 8
+        || segments
+            .iter()
+            .any(|segment| !is_workshop_identifier(segment))
+    {
+        return Err("reference symbol must be 1..=8 dot-separated identifiers".to_string());
+    }
+    let limit = limit.clamp(1, 256);
+    let items = workshop_source_items(files)?;
+    let mut references = Vec::new();
+    for file in files {
+        let tokens = lex(&file.source)?;
+        for start_index in 0..tokens.len() {
+            let Some(end_index) =
+                reference_match_end(&file.source, &tokens, start_index, &segments)
+            else {
+                continue;
+            };
+            let start = tokens[start_index].start;
+            let end = tokens[end_index].end;
+            let Some(item) = items
+                .iter()
+                .filter(|item| {
+                    item.file == file.path
+                        && item
+                            .source_spans
+                            .iter()
+                            .any(|span| span.start as usize <= start && end <= span.end as usize)
+                })
+                .min_by_key(|item| {
+                    item.source_spans
+                        .iter()
+                        .map(|span| span.end.saturating_sub(span.start))
+                        .min()
+                        .unwrap_or(u32::MAX)
+                })
+            else {
+                continue;
+            };
+            let kind =
+                classify_workshop_reference(&file.source, &tokens, end_index, item, symbol, start);
+            references.push(WorkshopReference {
+                symbol: symbol.to_string(),
+                kind,
+                file: file.path.clone(),
+                source_span: WorkshopSourceSpan {
+                    start: u32::try_from(start)
+                        .map_err(|_| "reference start exceeds u32".to_string())?,
+                    end: u32::try_from(end).map_err(|_| "reference end exceeds u32".to_string())?,
+                },
+                containing_kind: item.kind,
+                containing_name: item.name.clone(),
+                containing_signature: item.signature.clone(),
+                containing_source_hash: item.source_hash.clone(),
+            });
+            if references.len() >= limit {
+                return Ok(references);
+            }
+        }
+    }
+    Ok(references)
+}
+
+fn is_workshop_identifier(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn reference_match_end(
+    source: &str,
+    tokens: &[Token],
+    start: usize,
+    segments: &[&str],
+) -> Option<usize> {
+    let mut cursor = start;
+    for (index, segment) in segments.iter().enumerate() {
+        let token = *tokens.get(cursor)?;
+        if token.kind != TokenKind::Identifier || token_text(source, token) != *segment {
+            return None;
+        }
+        if index + 1 < segments.len() {
+            let dot = *tokens.get(cursor + 1)?;
+            if dot.kind != TokenKind::Other || token_text(source, dot) != "." {
+                return None;
+            }
+            cursor += 2;
+        }
+    }
+    Some(cursor)
+}
+
+fn classify_workshop_reference(
+    source: &str,
+    tokens: &[Token],
+    end_index: usize,
+    item: &WorkshopSourceItem,
+    symbol: &str,
+    start: usize,
+) -> WorkshopReferenceKind {
+    if !symbol.contains('.')
+        && item.name == symbol
+        && matches!(
+            item.kind,
+            WorkshopSourceItemKind::Function
+                | WorkshopSourceItemKind::Struct
+                | WorkshopSourceItemKind::Test
+        )
+        && item
+            .source_spans
+            .first()
+            .is_some_and(|span| start < span.start as usize + item.signature.len() + 16)
+    {
+        return WorkshopReferenceKind::Definition;
+    }
+    let next = tokens.get(end_index + 1).copied();
+    if next.is_some_and(|token| token.kind == TokenKind::LParen) {
+        return WorkshopReferenceKind::Call;
+    }
+    let next_text = next.map(|token| token_text(source, token));
+    let following_text = tokens
+        .get(end_index + 2)
+        .copied()
+        .map(|token| token_text(source, token));
+    if next_text == Some("=")
+        || (matches!(
+            next_text,
+            Some("+") | Some("-") | Some("*") | Some("/") | Some("%")
+        ) && following_text == Some("="))
+    {
+        WorkshopReferenceKind::Write
+    } else {
+        WorkshopReferenceKind::Read
+    }
 }
 
 pub fn workshop_completion_items(
@@ -4269,6 +4435,25 @@ mod workshop_compile_plan_tests {
         assert!(update.source.starts_with("// Advances the player."));
         assert!(!update.source.contains("Unrelated note"));
         assert!(update.source.ends_with("}\n"));
+    }
+
+    #[test]
+    fn references_find_dot_qualified_reads_and_writes_by_containing_function() {
+        let files = vec![WorkshopSourceFile {
+            path: "src/main.stasis".to_string(),
+            source: "global Game { score: i32; }\nfunction bump(): void { Game.score += 1; }\nfunction current(): i32 { return Game.score; }\n"
+                .to_string(),
+        }];
+
+        let references = find_workshop_references(&files, "Game.score", 16).expect("references");
+
+        assert_eq!(references.len(), 2);
+        assert!(references.iter().any(|reference| {
+            reference.kind == WorkshopReferenceKind::Write && reference.containing_name == "bump"
+        }));
+        assert!(references.iter().any(|reference| {
+            reference.kind == WorkshopReferenceKind::Read && reference.containing_name == "current"
+        }));
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -2070,14 +2070,23 @@ pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i3
     #[cfg(windows)]
     {
         let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+            eprintln!("gfx_load_sprite failed: unknown string handle {path_id}");
             return 0;
         };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
+        let api = match stasis_graphics_assets_api() {
+            Ok(api) => api,
+            Err(error) => {
+                eprintln!("gfx_load_sprite failed: {error}");
+                return 0;
+            }
         };
         let callback: extern "system" fn(*const c_char, i32, i32) -> i32 =
             unsafe { std::mem::transmute(api.stasis_gfx_load_sprite) };
-        return callback(path.as_ptr(), max_w, max_h);
+        let handle = callback(path.as_ptr(), max_w, max_h);
+        if handle == 0 {
+            eprintln!("gfx_load_sprite failed for {}", path.to_string_lossy());
+        }
+        return handle;
     }
     #[cfg(not(windows))]
     {

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -120,6 +120,13 @@ pub enum LiveCommand {
         #[serde(default = "default_true")]
         run_tests: bool,
     },
+    EditBatch {
+        edits: Vec<LiveEdit>,
+        #[serde(default)]
+        preview: bool,
+        #[serde(default = "default_true")]
+        run_tests: bool,
+    },
     Preview,
     Apply {
         #[serde(default = "default_true")]
@@ -214,6 +221,16 @@ pub enum LiveEditOperation {
     Add,
     Update,
     Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveEdit {
+    pub operation: LiveEditOperation,
+    pub target: LiveSymbolTarget,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub expected_source_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1245,6 +1262,37 @@ fn split_terminal_args(line: &str) -> Result<Vec<String>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn edit_batch_has_a_stable_json_contract() {
+        let request = LiveRequest::new(
+            7,
+            LiveCommand::EditBatch {
+                edits: vec![LiveEdit {
+                    operation: LiveEditOperation::Update,
+                    target: LiveSymbolTarget {
+                        name: "tick".into(),
+                        kind: Some("function".into()),
+                        file: Some("src/main.stasis".into()),
+                        owner: None,
+                        signature: None,
+                    },
+                    source: Some("function tick(): void {}".into()),
+                    expected_source_hash: Some("before".into()),
+                }],
+                preview: false,
+                run_tests: true,
+            },
+        );
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(json["type"], "edit_batch");
+        assert_eq!(json["edits"][0]["operation"], "update");
+        assert_eq!(json["edits"][0]["target"]["name"], "tick");
+        assert_eq!(
+            serde_json::from_value::<LiveRequest>(json).expect("round trip"),
+            request
+        );
+    }
 
     #[test]
     fn bounded_queue_reports_backpressure_without_blocking() {

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -95,6 +95,11 @@ pub enum LiveCommand {
         #[serde(default = "default_reference_limit")]
         limit: usize,
     },
+    Validate {
+        requirement: LiveValidationRequirement,
+        #[serde(default)]
+        frames: u32,
+    },
     ValidationSnapshot,
     ValidationRestore,
     ValidationClear,
@@ -203,6 +208,44 @@ pub enum LiveCommand {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveValidationRequirement {
+    pub path: String,
+    #[serde(default = "default_validation_operator")]
+    pub op: String,
+    pub value: serde_json::Value,
+}
+
+pub fn compare_live_validation_values(
+    actual: &serde_json::Value,
+    operator: &str,
+    expected: &serde_json::Value,
+) -> Result<bool, String> {
+    if matches!(operator, "eq" | "ne") {
+        let equal = actual == expected
+            || actual
+                .as_f64()
+                .zip(expected.as_f64())
+                .is_some_and(|(actual, expected)| actual == expected);
+        return Ok(if operator == "eq" { equal } else { !equal });
+    }
+    let actual = actual
+        .as_f64()
+        .ok_or_else(|| format!("operator '{operator}' requires a numeric actual value"))?;
+    let expected = expected
+        .as_f64()
+        .ok_or_else(|| format!("operator '{operator}' requires a numeric expected value"))?;
+    match operator {
+        "lt" => Ok(actual < expected),
+        "lte" => Ok(actual <= expected),
+        "gt" => Ok(actual > expected),
+        "gte" => Ok(actual >= expected),
+        _ => Err(format!(
+            "unsupported validation operator '{operator}'; use eq, ne, lt, lte, gt, or gte"
+        )),
+    }
+}
+
 const fn one_tick() -> u32 {
     1
 }
@@ -221,6 +264,10 @@ const fn default_symbol_page_limit() -> usize {
 
 const fn default_reference_limit() -> usize {
     128
+}
+
+fn default_validation_operator() -> String {
+    "eq".to_string()
 }
 
 const fn default_true() -> bool {
@@ -1078,6 +1125,25 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
             owner: terminal_selector_value(&args, "--owner"),
             signature: terminal_selector_value(&args, "--signature"),
         }),
+        ":references" | ":refs" => ready(LiveCommand::References {
+            symbol: required_arg(&args, 1, "symbol")?.to_string(),
+            limit: terminal_selector_value(&args, "--limit")
+                .map(|value| parse_u32("limit", &value))
+                .transpose()?
+                .map(|value| value as usize)
+                .unwrap_or_else(default_reference_limit),
+        }),
+        ":validate" => ready(LiveCommand::Validate {
+            requirement: LiveValidationRequirement {
+                path: required_arg(&args, 1, "state path")?.to_string(),
+                op: required_arg(&args, 2, "operator")?.to_string(),
+                value: parse_terminal_scalar(required_arg(&args, 3, "expected value")?),
+            },
+            frames: terminal_selector_value(&args, "--frames")
+                .map(|value| parse_u32("frames", &value))
+                .transpose()?
+                .unwrap_or(0),
+        }),
         ":complete" => {
             let buffer = args.get(1).cloned().unwrap_or_default();
             ready(LiveCommand::Complete {
@@ -1206,6 +1272,10 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         }
         _ => Err(format!("unknown live command '{command}'; use :help")),
     }
+}
+
+fn parse_terminal_scalar(value: &str) -> serde_json::Value {
+    serde_json::from_str(value).unwrap_or_else(|_| serde_json::Value::String(value.to_string()))
 }
 
 fn terminal_selector_value(args: &[String], option: &str) -> Option<String> {
@@ -1885,5 +1955,41 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn terminal_exposes_reference_and_runtime_validation_commands() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(references) = terminal
+            .feed_line(":references GameState.player_y --limit 24")
+            .expect("references")
+        else {
+            panic!("expected reference request");
+        };
+        assert_eq!(
+            references.command,
+            LiveCommand::References {
+                symbol: "GameState.player_y".into(),
+                limit: 24,
+            }
+        );
+
+        let TerminalInput::Request(validation) = terminal
+            .feed_line(":validate Render.command1_h eq 144 --frames 2")
+            .expect("validation")
+        else {
+            panic!("expected validation request");
+        };
+        assert_eq!(
+            validation.command,
+            LiveCommand::Validate {
+                requirement: LiveValidationRequirement {
+                    path: "Render.command1_h".into(),
+                    op: "eq".into(),
+                    value: serde_json::json!(144),
+                },
+                frames: 2,
+            }
+        );
     }
 }

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -90,6 +90,14 @@ pub enum LiveCommand {
         #[serde(default)]
         signature: Option<String>,
     },
+    References {
+        symbol: String,
+        #[serde(default = "default_reference_limit")]
+        limit: usize,
+    },
+    ValidationSnapshot,
+    ValidationRestore,
+    ValidationClear,
     Complete {
         buffer: String,
         cursor: usize,
@@ -209,6 +217,10 @@ const fn default_inspect_limit() -> usize {
 
 const fn default_symbol_page_limit() -> usize {
     50
+}
+
+const fn default_reference_limit() -> usize {
+    128
 }
 
 const fn default_true() -> bool {

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -75,6 +75,12 @@ pub enum LiveCommand {
         #[serde(default)]
         query: Option<String>,
         #[serde(default)]
+        kind: Option<String>,
+        #[serde(default)]
+        file: Option<String>,
+        #[serde(default)]
+        owner: Option<String>,
+        #[serde(default)]
         page: u32,
         #[serde(default = "default_symbol_page_limit")]
         limit: usize,
@@ -259,7 +265,7 @@ const fn default_inspect_limit() -> usize {
 }
 
 const fn default_symbol_page_limit() -> usize {
-    50
+    32
 }
 
 const fn default_reference_limit() -> usize {
@@ -1107,6 +1113,9 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         }),
         ":symbols" | ":find" => ready(LiveCommand::Symbols {
             query: args.get(1).filter(|arg| !arg.starts_with("--")).cloned(),
+            kind: terminal_selector_value(&args, "--kind"),
+            file: terminal_selector_value(&args, "--file"),
+            owner: terminal_selector_value(&args, "--owner"),
             page: terminal_selector_value(&args, "--page")
                 .map(|value| parse_u32("page", &value))
                 .transpose()?
@@ -1942,7 +1951,7 @@ mod tests {
         assert_eq!(signature.as_deref(), Some("update(i32): void"));
 
         let TerminalInput::Request(request) = terminal
-            .feed_line(":symbols update --page 2 --limit 10")
+            .feed_line(":symbols update --kind function --file src/game.stasis --owner Enemy --page 2 --limit 10")
             .expect("page")
         else {
             panic!("expected request")
@@ -1950,10 +1959,16 @@ mod tests {
         assert!(matches!(
             request.command,
             LiveCommand::Symbols {
+                query: Some(ref query),
+                kind: Some(ref kind),
+                file: Some(ref file),
+                owner: Some(ref owner),
                 page: 2,
                 limit: 10,
-                ..
-            }
+            } if query == "update"
+                && kind == "function"
+                && file == "src/game.stasis"
+                && owner == "Enemy"
         ));
     }
 

--- a/docs/android_workshop_codex_harness.md
+++ b/docs/android_workshop_codex_harness.md
@@ -86,6 +86,12 @@ The current first slice provides:
 
 ## Workshop tool harness
 
+The provider-neutral agent loop, turn limits, and Workshop tool-name catalog live in the shared
+Rust `stasis_ai` crate. The Android Codex native build copies that crate beside its pinned upstream
+Codex wrapper and exports the versioned contract to Java. Android retains its platform-specific
+tool handlers, queue, foreground-service lifecycle, image tools, and richer descriptions; the
+desktop TUI uses the same Rust contract with the smaller set supported by the live protocol.
+
 The agent turn layer should expose only controlled Workshop operations, not a
 general Android shell:
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -20,6 +20,29 @@ Status: the first desktop feel slice is implemented. Run `stasis run --interacti
 project to open it. The deterministic `--live-script` and `--live-json` clients remain available
 without the TUI.
 
+### Subscription-backed AI
+
+`:ai PROMPT` runs a bounded coding turn through the locally installed `codex` executable and its
+existing ChatGPT/Codex subscription sign-in. Stasis does not request, store, or infer an API key.
+On Windows, the provider prefers the current npm-installed native Codex binary over older desktop
+shims on `PATH`. It defaults to `gpt-5.6-sol` with medium reasoning. Set `STASIS_CODEX_EXE`,
+`STASIS_AI_MODEL`, or `STASIS_AI_REASONING_EFFORT` to override those selections. `:ai status`,
+`:ai cancel`, and Ctrl+C expose status and cancellation without stopping the live runtime.
+
+Each model turn runs ephemerally in an empty read-only temporary directory. The project is not
+mounted into that directory. Codex receives only the user request, bounded Stasis tool catalog,
+and bounded observations returned by the live workspace. Symbol reads, runtime inspection, and
+deterministic ticks pass through `stasis_runner::live`; model write batches become one
+`WorkshopSemanticEditBatch`, compile and test on the normal preparation worker, and commit at a
+between-tick boundary. A layout-changing edit remains a validated preview and requires explicit
+user `:apply` approval.
+
+Every run creates `build/ai-traces/tui-ai-<timestamp>.jsonl`. The trace records the user request,
+turns, user-visible working notes, tool calls, and bounded observation/outcome summaries. It never
+stores the complete provider payload. Source-bearing fields and before/after source snapshots are
+replaced by their byte count and SHA-256 digest before writing; long strings and arrays are also
+bounded.
+
 The current key map is:
 
 ```text

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -22,12 +22,17 @@ without the TUI.
 
 ### Subscription-backed AI
 
+`stasis ai "PROMPT"` starts the live runtime, executes one AI change, and exits after the atomic
+result. It is the simplest form for automation and repeatable evaluations.
+
 `:ai PROMPT` runs a bounded coding turn through the locally installed `codex` executable and its
 existing ChatGPT/Codex subscription sign-in. Stasis does not request, store, or infer an API key.
 On Windows, the provider prefers the current npm-installed native Codex binary over older desktop
 shims on `PATH`. It defaults to `gpt-5.6-sol` with medium reasoning. Set `STASIS_CODEX_EXE`,
 `STASIS_AI_MODEL`, or `STASIS_AI_REASONING_EFFORT` to override those selections. `:ai status`,
 `:ai cancel`, and Ctrl+C expose status and cancellation without stopping the live runtime.
+Deterministic `--live-script` files may also contain `:ai PROMPT`; each line runs through the same
+provider, live tools, atomic transaction boundary, and trace policy as the interactive TUI.
 
 Each model turn runs ephemerally in an empty read-only temporary directory. The project is not
 mounted into that directory. Codex receives only the user request, bounded Stasis tool catalog,

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -79,6 +79,17 @@ with the agent. Tool source arguments and results therefore appear verbatim when
 or received from the agent. The trace does not store the complete Codex transport request, response
 schema, tool catalog, repeated conversation envelope, or CLI transport output.
 
+Provider-reported token usage is written separately to
+`build/ai-traces/tui-ai-<timestamp>.usage.jsonl`. Each line is the exact `usage` object from a
+Codex `turn.completed` event; Stasis does not estimate or add missing token categories. The Codex
+JSON event stream is consumed in memory and all non-usage transport events are discarded.
+
+AI `list_symbols` calls return at most 32 entries by default and accept `query`, `kind`, `file`,
+`owner`, `page`, and `limit` filters. Listings omit imports, empty global groups, source bodies, and
+source hashes. Each item contains only its name, kind, signature, file, and owner when applicable.
+`read_symbol` returns the selected source and its hash so a later write can use that hash solely as
+a stale-write guard.
+
 The current key map is:
 
 ```text

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -42,6 +42,20 @@ deterministic ticks pass through `stasis_runner::live`; model write batches beco
 between-tick boundary. A layout-changing edit remains a validated preview and requires explicit
 user `:apply` approval.
 
+Before changing a behavior-bearing symbol, the AI must use compiler-backed `find_references` to
+locate its definition, reads, writes, and calls without receiving unrelated source bodies. For an
+observable game change it uses AI-only `validate_runtime_state` acceptance checks: the requested
+condition must fail before the edit (red), the atomic edit must compile and pass project tests, and
+the same condition must pass afterward (green). The default `live` baseline pauses and restores the
+same bounded runtime snapshot, so normal game progression cannot manufacture a pass. The optional
+`fresh` baseline boots `main`, advances bounded `tick` frames, renders, and inspects state in a
+separate Stasis child process for integration-style red/green checks without changing the running
+game. Projects with host adapters can select game-level `setup`, `tick`, and `render` entrypoints so
+the isolated check exercises logical gameplay without opening a second window or duplicating host
+resource side effects. These acceptance checks are ephemeral and do not create or replace project `.test.stasis`
+files; durable regression tests remain the appropriate place for behavior that should be protected
+after the AI turn.
+
 Every run creates `build/ai-traces/tui-ai-<timestamp>.jsonl`. The trace records the user request,
 turns, user-visible working notes, tool calls, and bounded observation/outcome summaries. It never
 stores the complete provider payload. Source-bearing fields and before/after source snapshots are

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -74,10 +74,10 @@ and `--render`. TUI `:validate` uses a snapshot of the live game, runs the reque
 PASS/FAIL with expected and actual values, and restores the snapshot before returning.
 
 Every run creates `build/ai-traces/tui-ai-<timestamp>.jsonl`. The trace records the user request,
-turns, user-visible working notes, tool calls, and bounded observation/outcome summaries. It never
-stores the complete provider payload. Source-bearing fields and before/after source snapshots are
-replaced by their byte count and SHA-256 digest before writing; long strings and arrays are also
-bounded.
+turns, user-visible working notes, and the exact tool calls and bounded tool observations exchanged
+with the agent. Tool source arguments and results therefore appear verbatim when they were sent to
+or received from the agent. The trace does not store the complete Codex transport request, response
+schema, tool catalog, repeated conversation envelope, or CLI transport output.
 
 The current key map is:
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -56,6 +56,23 @@ resource side effects. These acceptance checks are ephemeral and do not create o
 files; durable regression tests remain the appropriate place for behavior that should be protected
 after the AI turn.
 
+Human commands intentionally cover every useful live AI capability:
+
+| AI tool | CLI / TUI equivalent |
+| --- | --- |
+| `list_symbols` | `stasis symbol list` / `:symbols` |
+| `find_references` | `stasis symbol references SYMBOL` / `:references SYMBOL` |
+| `read_symbol` | `stasis symbol read SYMBOL` / `:read SYMBOL` |
+| `write_symbol`, `delete_symbol` | `stasis symbol add|update|delete` / `:add`, `:update`, `:delete` |
+| `inspect_runtime_state` | `:inspect`; `stasis validate` exposes fresh-run scalar evidence |
+| `validate_runtime_state` | `stasis validate PATH OP VALUE` / `:validate PATH OP VALUE` |
+| `run_frame` | `:step`; `stasis validate --frames N` in an isolated CLI run |
+| `run_tests` | `stasis test`; live `:apply`, `:undo`, `:redo`, and definition apply run tests automatically |
+
+`stasis validate` uses the isolated `fresh` baseline and accepts `--frames`, `--setup`, `--tick`,
+and `--render`. TUI `:validate` uses a snapshot of the live game, runs the requested frames, reports
+PASS/FAIL with expected and actual values, and restores the snapshot before returning.
+
 Every run creates `build/ai-traces/tui-ai-<timestamp>.jsonl`. The trace records the user request,
 turns, user-visible working notes, tool calls, and bounded observation/outcome summaries. It never
 stores the complete provider payload. Source-bearing fields and before/after source snapshots are

--- a/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
@@ -30,21 +30,23 @@ function pong_host_render(): void {
     gfx_cmd_i32[2] = 3;
 }
 
-function main(): void {
+function main(): i32 {
     pong_game_main();
-    PongHost.ball_sprite = gfx_load_sprite("../assets/ball.svg", 32, 32);
-    PongHost.paddle_sprite = gfx_load_sprite("../assets/paddle.svg", 1, 1);
-    PongHost.center_sprite = gfx_load_sprite("../assets/center_line.svg", 1, 1);
+    PongHost.ball_sprite = gfx_load_sprite("assets/ball.svg", 32, 32);
+    PongHost.paddle_sprite = gfx_load_sprite("assets/paddle.svg", 1, 1);
+    PongHost.center_sprite = gfx_load_sprite("assets/center_line.svg", 1, 1);
     pong_host_render();
+    return 0;
 }
 
-function tick(): void {
+function tick(): i32 {
     Input.screen_w = host_i32[5]; Input.screen_h = host_i32[6];
     Input.touch_active = host_i32[545];
     let touch_x: i32; touch_x.from_f32(host_f32[0]); Input.touch_x = touch_x;
     let touch_y: i32; touch_y.from_f32(host_f32[1]); Input.touch_y = touch_y;
     pong_game_tick();
+    return 0;
 }
 
-function render(): void { pong_host_render(); }
+function render(): i32 { pong_host_render(); return 0; }
 function on_code_swap(): void { pong_game_on_code_swap(); pong_host_render(); }

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -45,6 +45,7 @@ typedef char *(*stasis_codex_android_string_fn)(const char *codex_home);
 typedef uint64_t (*stasis_codex_android_begin_response_fn)(void);
 typedef void (*stasis_codex_android_cancel_response_fn)(void);
 typedef char *(*stasis_codex_android_response_fn)(const char *codex_home, const char *request_json, uint64_t generation);
+typedef char *(*stasis_codex_android_ai_contract_fn)(void);
 typedef int (*stasis_codex_android_initialize_fn)(void *env, void *context);
 typedef void (*stasis_codex_android_free_string_fn)(char *value);
 typedef struct CompileStats {
@@ -96,6 +97,7 @@ typedef struct CodexBridgeApi {
     stasis_codex_android_begin_response_fn begin_response;
     stasis_codex_android_cancel_response_fn cancel_response;
     stasis_codex_android_response_fn response;
+    stasis_codex_android_ai_contract_fn ai_contract;
     stasis_codex_android_free_string_fn free_string;
     int attempted;
 } CodexBridgeApi;
@@ -1362,6 +1364,8 @@ static CodexBridgeApi *load_codex_bridge_api(void) {
             codex_bridge_api.handle, "stasis_codex_android_cancel_response");
     codex_bridge_api.response = (stasis_codex_android_response_fn)dlsym(
             codex_bridge_api.handle, "stasis_codex_android_response");
+    codex_bridge_api.ai_contract = (stasis_codex_android_ai_contract_fn)dlsym(
+            codex_bridge_api.handle, "stasis_codex_android_ai_contract");
     codex_bridge_api.free_string = (stasis_codex_android_free_string_fn)dlsym(
             codex_bridge_api.handle, "stasis_codex_android_free_string");
     if (codex_bridge_api.initialize == NULL ||
@@ -1753,6 +1757,25 @@ Java_com_stasislang_workshop_MainActivity_nativeCodexAccountRateLimits(
         JNIEnv *env, jclass activity_class, jstring codex_home) {
     (void)activity_class;
     return call_codex_rate_limits(env, codex_home);
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeSharedAiContract(
+        JNIEnv *env, jclass activity_class) {
+    (void)activity_class;
+    CodexBridgeApi *bridge = load_codex_bridge_api();
+    if (bridge == NULL || bridge->ai_contract == NULL || bridge->free_string == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"shared AI contract unavailable\"}");
+    }
+    char *message = bridge->ai_contract();
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env,
+                "{\"status\":\"error\",\"error\":\"shared AI contract returned no result\"}");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
 }
 
 JNIEXPORT jstring JNICALL

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -369,6 +369,7 @@ public final class MainActivity extends Activity {
     private static native void nativeCodexCancelResponse();
     private static native String nativeCodexResponse(String codexHome, String requestJson,
                                                      long generation);
+    private static native String nativeSharedAiContract();
     private static native int nativeCodexInitialize(Object applicationContext);
 
     @Override
@@ -5450,6 +5451,8 @@ public final class MainActivity extends Activity {
             request.put("response_contract", aiResponseContract());
             request.put("available_tools", supportedAiTools());
             request.put("tool_specs", aiToolSpecs());
+            JSONObject sharedContract = sharedAiContract();
+            if (sharedContract != null) request.put("shared_rust_ai_contract", sharedContract);
             request.put("stasis_style_rules", rules);
             request.put("game_design_rules", gameRules);
             request.put("architecture_recommendations", architectureRecommendations);
@@ -6396,6 +6399,17 @@ public final class MainActivity extends Activity {
     }
 
     private static JSONArray supportedAiTools() {
+        JSONObject shared = sharedAiContract();
+        JSONArray sharedSpecs = shared == null ? null : shared.optJSONArray("tool_specs");
+        if (sharedSpecs != null && sharedSpecs.length() > 0) {
+            JSONArray tools = new JSONArray();
+            for (int index = 0; index < sharedSpecs.length(); index += 1) {
+                JSONObject spec = sharedSpecs.optJSONObject(index);
+                String tool = spec == null ? "" : spec.optString("tool", "");
+                if (!tool.isEmpty()) tools.put(tool);
+            }
+            if (tools.length() > 0) return tools;
+        }
         return new JSONArray()
                 .put("list_symbols")
                 .put("list_owner_symbols")
@@ -6414,6 +6428,15 @@ public final class MainActivity extends Activity {
                 .put("write_test_file")
                 .put("delete_test_file")
                 .put("run_tests");
+    }
+
+    private static JSONObject sharedAiContract() {
+        try {
+            JSONObject contract = new JSONObject(nativeSharedAiContract());
+            return contract.optInt("schema_version", 0) == 1 ? contract : null;
+        } catch (Throwable ignored) {
+            return null;
+        }
     }
 
     private static JSONArray aiToolSpecs() throws Exception {

--- a/mobile/android/build_codex_native.ps1
+++ b/mobile/android/build_codex_native.ps1
@@ -14,6 +14,7 @@ $buildRoot = Join-Path $repoRoot "build\android_codex_native"
 $upstreamRoot = Join-Path $buildRoot "codex"
 $codexRustRoot = Join-Path $upstreamRoot "codex-rs"
 $wrapperRoot = Join-Path $codexRustRoot "stasis-codex-android"
+$sharedAiRoot = Join-Path $codexRustRoot "stasis-ai"
 $patchPath = Join-Path $scriptRoot "patches\codex-android-rustls.patch"
 
 if (-not $AndroidHome) {
@@ -60,6 +61,21 @@ if ($LASTEXITCODE -eq 0) {
 New-Item -ItemType Directory -Force (Join-Path $wrapperRoot "src") | Out-Null
 Copy-Item -Force (Join-Path $scriptRoot "codex_native\Cargo.toml") (Join-Path $wrapperRoot "Cargo.toml")
 Copy-Item -Force (Join-Path $scriptRoot "codex_native\src\lib.rs") (Join-Path $wrapperRoot "src\lib.rs")
+New-Item -ItemType Directory -Force (Join-Path $sharedAiRoot "src") | Out-Null
+Copy-Item -Force (Join-Path $repoRoot "crates\stasis_ai\Cargo.toml") (Join-Path $sharedAiRoot "Cargo.toml")
+Copy-Item -Force (Join-Path $repoRoot "crates\stasis_ai\src\lib.rs") (Join-Path $sharedAiRoot "src\lib.rs")
+$sharedManifest = Join-Path $sharedAiRoot "Cargo.toml"
+$sharedCargo = Get-Content -Raw $sharedManifest
+$sharedCargo = $sharedCargo.Replace('version.workspace = true', 'version = "0.1.0"')
+$sharedCargo = $sharedCargo.Replace('edition.workspace = true', 'edition = "2021"')
+$sharedCargo = $sharedCargo.Replace('license.workspace = true', 'license = "MIT"')
+$sharedCargo = $sharedCargo.Replace('serde.workspace = true', 'serde = { version = "1", features = ["derive"] }')
+$sharedCargo = $sharedCargo.Replace('serde_json.workspace = true', 'serde_json = "1"')
+Set-Content -NoNewline -Path $sharedManifest -Value $sharedCargo
+$wrapperManifest = Join-Path $wrapperRoot "Cargo.toml"
+$wrapperCargo = Get-Content -Raw $wrapperManifest
+$wrapperCargo = $wrapperCargo.Replace('../../../crates/stasis_ai', '../stasis-ai')
+Set-Content -NoNewline -Path $wrapperManifest -Value $wrapperCargo
 
 $installedTargets = & rustup target list --installed --toolchain 1.95.0
 if ($installedTargets -notcontains "aarch64-linux-android") {

--- a/mobile/android/codex_native/Cargo.toml
+++ b/mobile/android/codex_native/Cargo.toml
@@ -15,3 +15,4 @@ rustls-platform-verifier = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+stasis_ai = { path = "../../../crates/stasis_ai" }

--- a/mobile/android/codex_native/src/lib.rs
+++ b/mobile/android/codex_native/src/lib.rs
@@ -610,6 +610,14 @@ pub extern "C" fn stasis_codex_android_cancel_response() {
 }
 
 #[no_mangle]
+pub extern "C" fn stasis_codex_android_ai_contract() -> *mut c_char {
+    match catch_unwind(AssertUnwindSafe(|| Ok(stasis_ai::contract_json()))) {
+        Ok(result) => into_c_json(result),
+        Err(_) => into_c_json(Err("shared AI contract bridge panicked".to_string())),
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn stasis_codex_android_response(
     codex_home: *const c_char,
     request_json: *const c_char,


### PR DESCRIPTION
## Summary

- add a shared Rust `stasis_ai` agent loop, bounded tool contract, and installed-Codex provider
- add `:ai PROMPT` plus `stasis ai PROMPT`, cancellation, progress, and atomic edit batches to the live workspace
- prefer the current npm Codex native binary on Windows and default to `gpt-5.6-sol` with medium reasoning, using the existing ChatGPT/Codex subscription (no API key)
- record the exact agent tool calls and observations, including source actually exchanged through tools, under `build/ai-traces` without persisting the full Codex transport envelope
- preserve bounded tool-call/result context across stateless `codex exec` turns so the agent does not repeat completed inspection and validation
- write each exact provider-reported Codex usage object to a separate `.usage.jsonl` file while discarding non-usage transport events
- make symbol discovery filtered and paged, exclude imports/empty globals, and omit source bodies and hashes until `read_symbol`
- export the shared Rust tool/limit contract through the Android native bridge while retaining Android-specific handlers
- fix the bundled Pong preview adapter and enforce exact lifecycle signatures with explicit diagnostics
- canonicalize Windows hot-edit source identities so imported helpers are not loaded twice after an AI edit
- add compiler-backed `find_references` for definitions, reads, writes, and calls, including dot-qualified fields
- require AI writes to establish reference context and red runtime evidence before editing, then pass the identical green contract before completion
- reject semantic no-op edits explicitly instead of reporting whitespace-only rewrites as applied changes

## Behavior and safety

Codex runs ephemerally in an empty read-only temporary directory. It cannot browse the project directly; all inspection and mutation goes through the bounded live protocol. Writes in one model batch are planned, compiled, tested, and committed as one transaction between ticks. Layout-changing edits remain previews requiring explicit `:apply`.

`validate_runtime_state` supports two bounded red/green baselines:

- `live` pauses the current game, retains an 8 MiB-bounded state snapshot, restores that exact baseline before both checks, and resumes the user's prior pause state afterward.
- `fresh` starts a separate Stasis child process, boots configurable setup/tick/render entrypoints, advances up to 600 frames, and inspects scalar results without mutating or opening a second copy of the live game.

The same baseline, requirements, frame count, and entrypoints must be used for red and green. Cancellation restores retained live state. AI completion is rejected while an applied write still needs green evidence.

Useful live AI capabilities also have direct human surfaces: `stasis symbol references`, TUI `:references`, isolated CLI `stasis validate`, and snapshot-restored TUI `:validate`. A catalog coverage test fails if a future live AI tool lacks an explicit CLI/TUI mapping.

## Fresh Pong AI evaluation

Both prompts were rerun through the signed-in npm Codex installation against separate clean Pong copies with `gpt-5.6-sol` and medium reasoning.

- Long-paddle run: completed in 93 seconds. It called `find_references` four times, established a fresh red contract, atomically changed both render heights/offsets, both movement clamps, and collision reach, ran tests, and passed the matching fresh green contract. The clean-copy test still passed.
- Enemy-speed run: completed in 84 seconds. It called `find_references` three times and proved with a fresh runtime check that the existing speed falls from 15.00 toward 2.50 and resets at a new rally. It correctly reported the request already satisfied and made no source change.

An initial long-paddle run exposed that separate `codex exec` calls were losing earlier tool context: its bounded audit trace showed 102 repetitive events and no write before the five-minute limit. The agent now carries prior calls and observations in bounded in-memory conversation history and uses a 12-turn ceiling. The successful traces contained 25 and 21 meaningful events respectively. Traces now preserve the exact tool-level source the agent saw while omitting the larger internal Codex request envelope.

A follow-up real Codex run verified the streamlined protocol. Its filtered symbol response was 895 JSON characters versus 8,414 for the earlier Pong listing, contained no imports or source hashes, and the trace contained full `read_symbol` source with no redaction markers. The separate usage log retained six exact provider objects, including `input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`, `output_tokens`, and `reasoning_output_tokens`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- focused `stasis_ai` context-retention test
- compiler reference classification and compact live reference response tests
- live validation comparison, snapshot/restore, cancellation cleanup, red gate, reference gate, and completion gate tests
- isolated child-process integration test for fresh setup/tick/render validation
- fresh-copy Pong `check` and `.stasis` tests before/after AI runs
- direct Pong fresh-runtime validation of doubled paddle height
- exact lifecycle signature diagnostic tests
- `cargo test --workspace -- --test-threads=1`
- real signed-in Codex smoke for exact source trace, compact symbol response, and separate usage JSONL

## Reflection

- Good: exact tool transcripts plus separate provider usage objects make context quality and token cost directly reviewable without retaining the full Codex transport stream.
- Bad: the first external loop repeatedly rediscovered symbols because only the latest observation batch reached each stateless Codex invocation.
- Adjustment: retain a bounded authoritative history of prior model actions and tool outcomes, and cap the agent at 12 turns so regressions fail within the repository test budget.
