### PR TITLE
perf: target AI discovery and reduce coding cost

### DIFF
--- a/apps/stasis/examples/engine_overhead_bench.rs
+++ b/apps/stasis/examples/engine_overhead_bench.rs
@@ -151,7 +151,7 @@ fn print_help() {
 }
 
 fn render_fixture_source() -> &'static str {
-    "function tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n"
+    "function tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n"
 }
 
 fn write_fixture(path: &Path) -> Result<(), String> {

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -490,14 +490,14 @@ impl LiveWorkspace {
             LiveCommand::Symbols {
                 query,
                 kind,
-                file,
+                files,
                 owner,
                 page,
                 limit,
             } => self.symbols(
                 query.as_deref(),
                 kind.as_deref(),
-                file.as_deref(),
+                &files,
                 owner.as_deref(),
                 page,
                 limit,
@@ -773,14 +773,32 @@ impl LiveWorkspace {
         &self,
         query: Option<&str>,
         kind: Option<&str>,
-        file: Option<&str>,
+        files: &[String],
         owner: Option<&str>,
         page: u32,
         limit: usize,
     ) -> Result<(&'static str, Value), String> {
         let query = query.unwrap_or("").to_ascii_lowercase();
         let kind = kind.map(parse_kind).transpose()?;
-        let file = file.map(normalize_file);
+        if files.len() > 16 {
+            return Err("symbol search accepts at most 16 starting files".to_string());
+        }
+        let scope_files = if files.is_empty() {
+            vec![normalize_file(&self.config.entry.to_string_lossy())]
+        } else {
+            files.iter().map(|file| normalize_file(file)).collect()
+        };
+        let available_files = self
+            .source_items
+            .iter()
+            .map(|item| normalize_file(&item.file))
+            .collect::<BTreeSet<_>>();
+        for file in &scope_files {
+            if !available_files.contains(file) {
+                return Err(format!("symbol search file is not in the project: {file}"));
+            }
+        }
+        let scope_files = scope_files.into_iter().collect::<BTreeSet<_>>();
         let matches = |item: &WorkshopSourceItem| {
             item.kind != WorkshopSourceItemKind::Imports
                 && !(item.kind == WorkshopSourceItemKind::Globals && item.source.trim().is_empty())
@@ -788,9 +806,7 @@ impl LiveWorkspace {
                     || item.name.to_ascii_lowercase().contains(&query)
                     || item.signature.to_ascii_lowercase().contains(&query))
                 && kind.is_none_or(|kind| item.kind == kind)
-                && file
-                    .as_deref()
-                    .is_none_or(|file| normalize_file(&item.file) == file)
+                && scope_files.contains(&normalize_file(&item.file))
                 && owner.is_none_or(|owner| item.owner.as_deref() == Some(owner))
         };
         let limit = limit.clamp(1, 200);
@@ -823,7 +839,7 @@ impl LiveWorkspace {
             .collect::<Vec<_>>();
         Ok((
             "symbols",
-            json!({"schema_version": 1, "page": page, "limit": limit, "total": total, "items": items}),
+            json!({"schema_version": 1, "files": scope_files, "page": page, "limit": limit, "total": total, "items": items}),
         ))
     }
 
@@ -1940,7 +1956,7 @@ fn help_data() -> Value {
     json!({
         "commands": [
             ":help", ":status", ":pause", ":resume", ":step [ticks]", ":cancel REQUEST_ID", ":quit",
-            ":symbols [query] [--page N --limit N]",
+            ":symbols [query] [--file PATH ... --kind KIND --owner OWNER --page N --limit N]",
             ":read NAME [KIND] [--file FILE --owner OWNER --signature SIGNATURE]",
             ":references SYMBOL [--limit N]", ":validate PATH OP VALUE [--frames N]",
             ":edit SYMBOL (interactive TUI)",
@@ -2646,7 +2662,7 @@ mod tests {
         let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
 
         let (_, all) = workspace
-            .symbols(None, None, None, None, 0, 32)
+            .symbols(None, None, &[], None, 0, 32)
             .expect("symbols");
         let items = all["items"].as_array().expect("items");
         assert!(items.iter().all(|item| item["kind"] != "imports"));
@@ -2660,7 +2676,7 @@ mod tests {
             .symbols(
                 Some("tick"),
                 Some("function"),
-                Some("src/main.stasis"),
+                &["src/main.stasis".to_string()],
                 None,
                 0,
                 1,
@@ -2669,6 +2685,19 @@ mod tests {
         assert_eq!(filtered["total"], 1);
         assert_eq!(filtered["items"][0]["name"], "tick");
         assert!(filtered["items"][0].get("owner").is_none());
+
+        let (_, tests) = workspace
+            .symbols(
+                None,
+                Some("test"),
+                &["tests/main.test.stasis".to_string()],
+                None,
+                0,
+                32,
+            )
+            .expect("test symbols");
+        assert_eq!(tests["total"], 1);
+        assert_eq!(tests["files"], json!(["tests/main.test.stasis"]));
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -6,11 +6,12 @@ use stasis_compiler::compiler::CompileError;
 use stasis_compiler::frontend::lexer::{lex, TokenKind};
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
-    plan_workshop_semantic_edits, workshop_completion_items, workshop_reachable_files,
-    workshop_source_hash, workshop_source_items, write_workshop_semantic_plan,
-    write_workshop_semantic_receipt, ExpectedReload, WorkshopCompletionItem, WorkshopSemanticEdit,
-    WorkshopSemanticEditBatch, WorkshopSemanticEditOperation, WorkshopSemanticEditPlan,
-    WorkshopSourceFile, WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
+    plan_workshop_semantic_edits, workshop_completion_items, workshop_direct_import_files,
+    workshop_reachable_files, workshop_source_hash, workshop_source_items,
+    write_workshop_semantic_plan, write_workshop_semantic_receipt, ExpectedReload,
+    WorkshopCompletionItem, WorkshopSemanticEdit, WorkshopSemanticEditBatch,
+    WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
+    WorkshopSourceItem, WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 use stasis_runner::live::{
     compare_live_validation_values, CompletionContext, CompletionIndex, CompletionItem,
@@ -783,11 +784,19 @@ impl LiveWorkspace {
         if files.len() > 16 {
             return Err("symbol search accepts at most 16 starting files".to_string());
         }
-        let scope_files = if files.is_empty() {
+        let loaded_files = &self.source_files;
+        let default_scope = files.is_empty();
+        let mut scope_files = if default_scope {
             vec![normalize_file(&self.config.entry.to_string_lossy())]
         } else {
             files.iter().map(|file| normalize_file(file)).collect()
         };
+        if default_scope {
+            scope_files.extend(workshop_direct_import_files(
+                loaded_files,
+                &self.config.entry,
+            )?);
+        }
         let available_files = self
             .source_items
             .iter()
@@ -799,6 +808,15 @@ impl LiveWorkspace {
             }
         }
         let scope_files = scope_files.into_iter().collect::<BTreeSet<_>>();
+        let imports = scope_files
+            .iter()
+            .map(|file| {
+                Ok((
+                    file.clone(),
+                    workshop_direct_import_files(loaded_files, Path::new(file))?,
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, String>>()?;
         let matches = |item: &WorkshopSourceItem| {
             item.kind != WorkshopSourceItemKind::Imports
                 && !(item.kind == WorkshopSourceItemKind::Globals && item.source.trim().is_empty())
@@ -839,7 +857,7 @@ impl LiveWorkspace {
             .collect::<Vec<_>>();
         Ok((
             "symbols",
-            json!({"schema_version": 1, "files": scope_files, "page": page, "limit": limit, "total": total, "items": items}),
+            json!({"schema_version": 1, "files": scope_files, "imports": imports, "page": page, "limit": limit, "total": total, "items": items}),
         ))
     }
 
@@ -2657,6 +2675,16 @@ mod tests {
     #[test]
     fn symbol_search_is_filtered_compact_and_hash_free() {
         let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "import \"helper.stasis\";\nglobal score: i32;\nfunction main(): i32 { score = 1; return 0; }\nfunction tick(): i32 { score += 1; return 0; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("source with import");
+        fs::write(
+            root.join("src/helper.stasis"),
+            "function direct_import_value(): i32 { return 1; }\n",
+        )
+        .expect("helper source");
         let (jit, _package) = compile(&config);
         let (_client, server) = stasis_runner::live::live_session(8);
         let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
@@ -2671,6 +2699,17 @@ mod tests {
         assert!(items
             .iter()
             .all(|item| { matches!(item.as_object().map(|object| object.len()), Some(4 | 5)) }));
+        assert_eq!(
+            all["files"],
+            json!(["src/helper.stasis", "src/main.stasis"])
+        );
+        assert_eq!(
+            all["imports"],
+            json!({"src/helper.stasis": [], "src/main.stasis": ["src/helper.stasis"]})
+        );
+        assert!(items
+            .iter()
+            .any(|item| item["name"] == "direct_import_value"));
 
         let (_, filtered) = workspace
             .symbols(

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -18,6 +18,7 @@ use stasis_runner::live::{
     compare_live_validation_values, live_session, LiveCommand, LiveRequest, LiveResponse,
     TerminalBuffer, TerminalInput,
 };
+use std::collections::BTreeSet;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -208,7 +209,7 @@ enum SymbolCommand {
         #[arg(long, value_enum)]
         kind: Option<SymbolKindArg>,
         #[arg(long)]
-        file: Option<String>,
+        file: Vec<String>,
         #[arg(long)]
         owner: Option<String>,
         #[arg(long, default_value_t = 0)]
@@ -2262,13 +2263,34 @@ fn symbol_workspace(
         SymbolCommand::List {
             query,
             kind,
-            file,
+            file: files,
             owner,
             page,
             limit,
         } => {
             let limit = limit.clamp(1, 200);
             let mut items = workshop_source_items(&editable_files)?;
+            if files.len() > 16 {
+                return Err("symbol list accepts at most 16 --file values".to_string());
+            }
+            let scope_files = if files.is_empty() {
+                vec![normalize_symbol_file(&workspace.manifest.entry)]
+            } else {
+                files
+                    .iter()
+                    .map(|file| normalize_symbol_file(file))
+                    .collect::<Vec<_>>()
+            };
+            let available_files = items
+                .iter()
+                .map(|item| normalize_symbol_file(&item.file))
+                .collect::<BTreeSet<_>>();
+            for file in &scope_files {
+                if !available_files.contains(file) {
+                    return Err(format!("symbol list file is not in the project: {file}"));
+                }
+            }
+            let scope_files = scope_files.into_iter().collect::<BTreeSet<_>>();
             items.retain(|item| {
                 item.kind != WorkshopSourceItemKind::Imports
                     && !(item.kind == WorkshopSourceItemKind::Globals
@@ -2279,9 +2301,7 @@ fn symbol_workspace(
                             || item.signature.to_ascii_lowercase().contains(&query)
                     })
                     && kind.is_none_or(|kind| item.kind == kind.into())
-                    && file.as_deref().is_none_or(|file| {
-                        normalize_symbol_file(&item.file) == normalize_symbol_file(file)
-                    })
+                    && scope_files.contains(&normalize_symbol_file(&item.file))
                     && owner
                         .as_deref()
                         .is_none_or(|owner| item.owner.as_deref() == Some(owner))
@@ -2322,7 +2342,7 @@ fn symbol_workspace(
                 .collect::<Vec<_>>();
             Ok(CommandResult::success(
                 human,
-                json!({"schema_version": 1, "page": page, "limit": limit, "total": total, "items": metadata}),
+                json!({"schema_version": 1, "files": scope_files, "page": page, "limit": limit, "total": total, "items": metadata}),
             ))
         }
         SymbolCommand::Find(args) => {

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -8,17 +8,18 @@ use stasis::{
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
-    plan_workshop_semantic_edits, workshop_reachable_files, workshop_source_hash,
-    workshop_source_items, write_workshop_semantic_plan, write_workshop_semantic_receipt,
-    WorkshopSemanticEdit, WorkshopSemanticEditBatch, WorkshopSemanticEditOperation,
-    WorkshopSemanticEditPlan, WorkshopSourceFile, WorkshopSourceItemKind, WorkshopSymbolSelector,
+    plan_workshop_semantic_edits, workshop_direct_import_files, workshop_reachable_files,
+    workshop_source_hash, workshop_source_items, write_workshop_semantic_plan,
+    write_workshop_semantic_receipt, WorkshopSemanticEdit, WorkshopSemanticEditBatch,
+    WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
+    WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
 pub(super) use stasis_runner::live::LiveValidationRequirement as RuntimeValidationRequirement;
 use stasis_runner::live::{
     compare_live_validation_values, live_session, LiveCommand, LiveRequest, LiveResponse,
     TerminalBuffer, TerminalInput,
 };
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -2273,7 +2274,8 @@ fn symbol_workspace(
             if files.len() > 16 {
                 return Err("symbol list accepts at most 16 --file values".to_string());
             }
-            let scope_files = if files.is_empty() {
+            let default_scope = files.is_empty();
+            let mut scope_files = if default_scope {
                 vec![normalize_symbol_file(&workspace.manifest.entry)]
             } else {
                 files
@@ -2281,6 +2283,12 @@ fn symbol_workspace(
                     .map(|file| normalize_symbol_file(file))
                     .collect::<Vec<_>>()
             };
+            if default_scope {
+                scope_files.extend(workshop_direct_import_files(
+                    &editable_files,
+                    Path::new(&workspace.manifest.entry),
+                )?);
+            }
             let available_files = items
                 .iter()
                 .map(|item| normalize_symbol_file(&item.file))
@@ -2291,6 +2299,15 @@ fn symbol_workspace(
                 }
             }
             let scope_files = scope_files.into_iter().collect::<BTreeSet<_>>();
+            let imports = scope_files
+                .iter()
+                .map(|file| {
+                    Ok((
+                        file.clone(),
+                        workshop_direct_import_files(&editable_files, Path::new(file))?,
+                    ))
+                })
+                .collect::<Result<BTreeMap<_, _>, String>>()?;
             items.retain(|item| {
                 item.kind != WorkshopSourceItemKind::Imports
                     && !(item.kind == WorkshopSourceItemKind::Globals
@@ -2342,7 +2359,7 @@ fn symbol_workspace(
                 .collect::<Vec<_>>();
             Ok(CommandResult::success(
                 human,
-                json!({"schema_version": 1, "files": scope_files, "page": page, "limit": limit, "total": total, "items": metadata}),
+                json!({"schema_version": 1, "files": scope_files, "imports": imports, "page": page, "limit": limit, "total": total, "items": metadata}),
             ))
         }
         SymbolCommand::Find(args) => {

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -34,11 +34,13 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const MAX_TRANSCRIPT_LINES: usize = 500;
 const MAX_UNDO_STATES: usize = 100;
+const MAX_AI_DIAGNOSTIC_CHARS: usize = 4096;
 const COMPLETION_LIMIT: usize = 64;
 const TUI_REQUEST_START: u64 = 1u64 << 61;
 const AI_REQUEST_START: u64 = 1u64 << 62;
 
 enum AiUiEvent {
+    InitialContext(Value),
     Progress(AgentEvent),
     Finished(Result<String, String>),
 }
@@ -62,12 +64,17 @@ pub(super) fn run_scripted_ai_with_cancel(
     let usage_path = audit.usage_path.clone();
     let mut provider = CodexExecProvider::default();
     let mut tools = LiveAiTools::new(client.clone(), project_root.to_path_buf());
+    let initial_context = load_ai_initial_context(&mut tools, canceled)?;
+    audit.write(serde_json::json!({
+        "event": "initial_context",
+        "value": initial_context.clone(),
+    }))?;
     let mut audit_error = None;
     let result = run_agent(
         &mut provider,
         &mut tools,
         prompt,
-        ai_initial_context(),
+        initial_context,
         live_tool_specs(),
         canceled,
         |event| {
@@ -102,13 +109,38 @@ pub(super) fn run_scripted_ai_with_cancel(
     }
 }
 
-fn ai_initial_context() -> Value {
+fn ai_initial_context(initial_symbols: Value) -> Value {
     serde_json::json!({
         "language": "Stasis",
         "runtime": "live in-process JIT",
         "commit_boundary": "between deterministic ticks",
         "write_policy": "all writes in one model batch compile, test, and commit atomically",
+        "initial_symbols": initial_symbols,
+        "initial_symbols_instruction": "This is the completed default list_symbols result. Use it before requesting filtered or paged follow-up discovery.",
     })
+}
+
+fn load_ai_initial_context(
+    tools: &mut LiveAiTools,
+    canceled: &AtomicBool,
+) -> Result<Value, String> {
+    let observations = tools.execute(
+        &[ToolCall {
+            tool: "list_symbols".to_string(),
+            args: serde_json::json!({}),
+        }],
+        canceled,
+    );
+    let observation = observations
+        .into_iter()
+        .next()
+        .ok_or_else(|| "initial symbol discovery returned no observation".to_string())?;
+    if let Some(error) = observation.error {
+        return Err(format!("initial symbol discovery failed: {error}"));
+    }
+    Ok(ai_initial_context(
+        observation.result.unwrap_or(Value::Null),
+    ))
 }
 
 fn audit_agent_event(event: &AgentEvent) -> Value {
@@ -1209,17 +1241,21 @@ impl LiveTui {
             let mut provider = CodexExecProvider::default();
             let mut tools = LiveAiTools::new(client, project_root);
             let progress = events_tx.clone();
-            let result = run_agent(
-                &mut provider,
-                &mut tools,
-                &prompt,
-                ai_initial_context(),
-                live_tool_specs(),
-                &worker_canceled,
-                move |event| {
-                    let _ = progress.send(AiUiEvent::Progress(event));
-                },
-            );
+            let result =
+                load_ai_initial_context(&mut tools, &worker_canceled).and_then(|initial_context| {
+                    let _ = progress.send(AiUiEvent::InitialContext(initial_context.clone()));
+                    run_agent(
+                        &mut provider,
+                        &mut tools,
+                        &prompt,
+                        initial_context,
+                        live_tool_specs(),
+                        &worker_canceled,
+                        move |event| {
+                            let _ = progress.send(AiUiEvent::Progress(event));
+                        },
+                    )
+                });
             let _ = events_tx.send(AiUiEvent::Finished(result));
         });
         self.ai_run = Some(AiRun {
@@ -1243,6 +1279,16 @@ impl LiveTui {
         let mut finished = None;
         for event in events {
             match event {
+                AiUiEvent::InitialContext(initial_context) => {
+                    if let Some(audit) = self.ai_audit.as_mut() {
+                        if let Err(error) = audit.write(serde_json::json!({
+                            "event": "initial_context",
+                            "value": initial_context,
+                        })) {
+                            self.status = format!("AI trace failed: {error}");
+                        }
+                    }
+                }
                 AiUiEvent::Progress(AgentEvent::Turn { current, maximum }) => {
                     self.status = format!("AI turn {current}/{maximum}; Ctrl+C cancels");
                     self.audit(serde_json::json!({"event": "turn", "current": current, "maximum": maximum}));
@@ -1970,7 +2016,10 @@ impl LiveAiTools {
                 return match &self.last_write {
                     Some(response) if response.ok => ToolObservation::result(
                         "run_tests",
-                        serde_json::json!({"status": "passed_with_latest_atomic_write", "edit": response.data}),
+                        serde_json::json!({
+                            "status": "passed_with_latest_atomic_write",
+                            "write": compact_write_transaction(response.data.as_ref()),
+                        }),
                     ),
                     _ => ToolObservation::error(
                         "run_tests",
@@ -2235,21 +2284,24 @@ impl LiveAiTools {
                 stderr.lines().last().unwrap_or("child process failed")
             ));
         }
-        if !stderr.trim().is_empty() {
-            return Err(format!(
-                "fresh validation reported diagnostics: {}",
-                stderr.lines().last().unwrap_or("unknown diagnostic")
-            ));
-        }
         let envelope = stdout
             .lines()
             .rev()
             .find_map(|line| serde_json::from_str::<Value>(line).ok())
             .ok_or_else(|| "fresh validation returned no JSON result".to_string())?;
-        envelope
+        let mut result = envelope
             .get("result")
             .cloned()
-            .ok_or_else(|| "fresh validation JSON omitted result".to_string())
+            .ok_or_else(|| "fresh validation JSON omitted result".to_string())?;
+        if !stderr.trim().is_empty() {
+            result["diagnostics"] = Value::String(
+                stderr
+                    .chars()
+                    .take(MAX_AI_DIAGNOSTIC_CHARS)
+                    .collect::<String>(),
+            );
+        }
+        Ok(result)
     }
 
     fn finish_validation_observation(
@@ -2413,20 +2465,57 @@ fn applied_write_observation(
     batch_size: usize,
     transaction: &Option<Value>,
 ) -> ToolObservation {
+    let transaction = compact_write_transaction(transaction.as_ref());
     let result = if index == 0 {
         serde_json::json!({
             "status": "compiled_tested_applied",
             "batch_size": batch_size,
-            "transaction": transaction,
+            "write": transaction,
         })
     } else {
         serde_json::json!({
             "status": "compiled_tested_applied",
             "batch_size": batch_size,
-            "transaction_observation": 0,
+            "write_receipt": transaction.get("receipt").cloned().unwrap_or(Value::Null),
         })
     };
     ToolObservation::result(&call.tool, result)
+}
+
+fn compact_write_transaction(transaction: Option<&Value>) -> Value {
+    let Some(transaction) = transaction else {
+        return Value::Null;
+    };
+    serde_json::json!({
+        "receipt": transaction.get("receipt").cloned().unwrap_or(Value::Null),
+        "tests": transaction.get("tests").cloned().unwrap_or(Value::Null),
+        "changed_symbols": transaction.pointer("/plan/reload/changed_symbols").cloned().unwrap_or_else(|| serde_json::json!([])),
+        "expected_reload": transaction.pointer("/plan/reload/expected_reload").cloned().unwrap_or(Value::Null),
+        "state_layout_compatible": transaction.pointer("/swap/state_layout_compatible").cloned().unwrap_or(Value::Null),
+        "requires_explicit_apply": transaction.pointer("/swap/requires_explicit_apply").cloned().unwrap_or(Value::Null),
+        "warnings": transaction.pointer("/swap/warnings").cloned().unwrap_or_else(|| serde_json::json!([])),
+    })
+}
+
+fn contiguous_write_range(calls: &[ToolCall]) -> Result<Option<std::ops::Range<usize>>, String> {
+    let write_indexes = calls
+        .iter()
+        .enumerate()
+        .filter_map(|(index, call)| {
+            matches!(call.tool.as_str(), "write_symbol" | "delete_symbol").then_some(index)
+        })
+        .collect::<Vec<_>>();
+    let Some(first) = write_indexes.first().copied() else {
+        return Ok(None);
+    };
+    let last = write_indexes.last().copied().expect("write index");
+    if write_indexes.len() != last - first + 1 {
+        return Err(
+            "write_symbol and delete_symbol calls must be contiguous so their atomic order is unambiguous"
+                .to_string(),
+        );
+    }
+    Ok(Some(first..last + 1))
 }
 
 impl Drop for LiveAiTools {
@@ -2439,29 +2528,55 @@ impl Drop for LiveAiTools {
 
 impl ToolExecutor for LiveAiTools {
     fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation> {
-        let writes = calls
-            .iter()
-            .filter(|call| matches!(call.tool.as_str(), "write_symbol" | "delete_symbol"))
-            .collect::<Vec<_>>();
-        let mut observations = calls
-            .iter()
-            .filter(|call| {
-                !matches!(
-                    call.tool.as_str(),
-                    "write_symbol" | "delete_symbol" | "run_tests" | "validate_runtime_state"
-                )
-            })
-            .map(|call| self.execute_read(call, canceled))
-            .collect::<Vec<_>>();
-        if !writes.is_empty() {
-            observations.extend(self.execute_writes(&writes, canceled));
+        let write_range = match contiguous_write_range(calls) {
+            Ok(range) => range,
+            Err(error) => {
+                return calls
+                    .iter()
+                    .map(|call| ToolObservation::error(&call.tool, error.clone()))
+                    .collect()
+            }
+        };
+        let mut observations = Vec::with_capacity(calls.len() + 1);
+        let mut index = 0;
+        while index < calls.len() {
+            if write_range
+                .as_ref()
+                .is_some_and(|range| range.start == index)
+            {
+                let range = write_range.as_ref().expect("write range");
+                let writes = calls[range.clone()].iter().collect::<Vec<_>>();
+                let write_observations = self.execute_writes(&writes, canceled);
+                let applied = write_observations
+                    .iter()
+                    .all(|observation| observation.error.is_none())
+                    && self.write_needs_green_validation;
+                observations.extend(write_observations);
+                if applied {
+                    let contract = self
+                        .red_validation_contract
+                        .clone()
+                        .expect("applied AI write has red validation contract");
+                    let green_call = ToolCall {
+                        tool: "validate_runtime_state".to_string(),
+                        args: serde_json::json!({
+                            "requirements": contract.requirements,
+                            "expected_outcome": "pass",
+                            "frames": contract.frames,
+                            "baseline": contract.baseline,
+                            "setup": contract.setup,
+                            "tick": contract.tick,
+                            "render": contract.render,
+                        }),
+                    };
+                    observations.push(self.execute_validation(&green_call, canceled));
+                }
+                index = range.end;
+            } else {
+                observations.push(self.execute_read(&calls[index], canceled));
+                index += 1;
+            }
         }
-        observations.extend(
-            calls
-                .iter()
-                .filter(|call| matches!(call.tool.as_str(), "run_tests" | "validate_runtime_state"))
-                .map(|call| self.execute_read(call, canceled)),
-        );
         observations
     }
 
@@ -3179,7 +3294,7 @@ mod tests {
     }
 
     #[test]
-    fn atomic_write_batch_returns_the_full_transaction_once() {
+    fn atomic_write_batch_returns_one_compact_receipt() {
         let calls = [
             ToolCall {
                 tool: "write_symbol".into(),
@@ -3190,20 +3305,57 @@ mod tests {
                 args: json!({"name": "render"}),
             },
         ];
-        let transaction = Some(json!({"source": "full transaction payload"}));
+        let transaction = Some(json!({
+            "receipt": "build/live-edits/receipt.json",
+            "tests": "passed",
+            "plan": {"reload": {
+                "changed_symbols": [{"name": "tick", "kind": "function"}],
+                "expected_reload": "FastReload"
+            }},
+            "swap": {
+                "state_layout_compatible": true,
+                "requires_explicit_apply": false,
+                "warnings": []
+            },
+            "large_source": "must not be returned"
+        }));
 
         let first = applied_write_observation(&calls[0], 0, calls.len(), &transaction);
         let second = applied_write_observation(&calls[1], 1, calls.len(), &transaction);
 
         assert_eq!(
-            first.result.as_ref().unwrap()["transaction"],
-            transaction.clone().unwrap()
+            first.result.as_ref().unwrap()["write"]["receipt"],
+            "build/live-edits/receipt.json"
         );
-        assert!(second.result.as_ref().unwrap().get("transaction").is_none());
+        assert!(first.result.as_ref().unwrap()["write"]
+            .get("large_source")
+            .is_none());
         assert_eq!(
-            second.result.as_ref().unwrap()["transaction_observation"],
-            0
+            second.result.as_ref().unwrap()["write_receipt"],
+            "build/live-edits/receipt.json"
         );
+    }
+
+    #[test]
+    fn write_batches_must_be_contiguous_to_preserve_call_order() {
+        let calls = [
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({}),
+            },
+            ToolCall {
+                tool: "read_symbol".into(),
+                args: json!({}),
+            },
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({}),
+            },
+        ];
+
+        assert!(contiguous_write_range(&calls)
+            .expect_err("split writes")
+            .contains("must be contiguous"));
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -2378,14 +2378,14 @@ impl LiveAiTools {
                 }
                 calls
                     .iter()
-                    .map(|call| {
+                    .enumerate()
+                    .map(|(index, call)| {
                         if applied {
-                            ToolObservation::result(
-                                &call.tool,
-                                serde_json::json!({
-                                    "status": "compiled_tested_applied",
-                                    "transaction": response.data,
-                                }),
+                            applied_write_observation(
+                                call,
+                                index,
+                                calls.len(),
+                                &response.data,
                             )
                         } else {
                             let error = if response.ok && response.kind == "edit_preview" {
@@ -2405,6 +2405,28 @@ impl LiveAiTools {
                 .collect(),
         }
     }
+}
+
+fn applied_write_observation(
+    call: &ToolCall,
+    index: usize,
+    batch_size: usize,
+    transaction: &Option<Value>,
+) -> ToolObservation {
+    let result = if index == 0 {
+        serde_json::json!({
+            "status": "compiled_tested_applied",
+            "batch_size": batch_size,
+            "transaction": transaction,
+        })
+    } else {
+        serde_json::json!({
+            "status": "compiled_tested_applied",
+            "batch_size": batch_size,
+            "transaction_observation": 0,
+        })
+    };
+    ToolObservation::result(&call.tool, result)
 }
 
 impl Drop for LiveAiTools {
@@ -3154,6 +3176,34 @@ mod tests {
             .error
             .as_deref()
             .is_some_and(|error| error.contains("find_references")));
+    }
+
+    #[test]
+    fn atomic_write_batch_returns_the_full_transaction_once() {
+        let calls = [
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({"name": "tick"}),
+            },
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({"name": "render"}),
+            },
+        ];
+        let transaction = Some(json!({"source": "full transaction payload"}));
+
+        let first = applied_write_observation(&calls[0], 0, calls.len(), &transaction);
+        let second = applied_write_observation(&calls[1], 1, calls.len(), &transaction);
+
+        assert_eq!(
+            first.result.as_ref().unwrap()["transaction"],
+            transaction.clone().unwrap()
+        );
+        assert!(second.result.as_ref().unwrap().get("transaction").is_none());
+        assert_eq!(
+            second.result.as_ref().unwrap()["transaction_observation"],
+            0
+        );
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1942,7 +1942,10 @@ impl LiveAiTools {
             "list_symbols" => LiveCommand::Symbols {
                 query: string_arg(args, "query"),
                 kind: string_arg(args, "kind"),
-                file: string_arg(args, "file"),
+                files: match string_array_arg(args, "files") {
+                    Ok(files) => files,
+                    Err(error) => return ToolObservation::error(&call.tool, error),
+                },
                 owner: string_arg(args, "owner"),
                 page: usize_arg(args, "page").unwrap_or(0).min(u32::MAX as usize) as u32,
                 limit: usize_arg(args, "limit").unwrap_or(32).min(64),
@@ -2460,6 +2463,29 @@ fn usize_arg(args: &serde_json::Map<String, Value>, name: &str) -> Option<usize>
     args.get(name)
         .and_then(Value::as_u64)
         .and_then(|value| usize::try_from(value).ok())
+}
+
+fn string_array_arg(
+    args: &serde_json::Map<String, Value>,
+    name: &str,
+) -> Result<Vec<String>, String> {
+    let Some(value) = args.get(name) else {
+        return Ok(Vec::new());
+    };
+    let values = value
+        .as_array()
+        .ok_or_else(|| format!("{name} must be an array of project-relative paths"))?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| format!("{name} must contain non-empty strings"))
+        })
+        .collect()
 }
 
 fn read_bounded_process_output(mut reader: impl Read) -> Result<String, String> {

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -230,6 +230,32 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
     assert!(listed_items
         .iter()
         .any(|item| item["name"] == "tick" && item["file"] == "src/main.stasis"));
+    assert_eq!(listed_json["result"]["files"], json!(["src/main.stasis"]));
+    assert!(!listed_items.iter().any(|item| item["name"] == "old_value"));
+
+    let widened = stasis(
+        &[
+            "--json",
+            "symbol",
+            "list",
+            "--file",
+            "src/main.stasis",
+            "--file",
+            "src/old.stasis",
+        ],
+        &project,
+    );
+    assert_eq!(widened.status.code(), Some(0));
+    let widened_json = json_stdout(&widened);
+    assert_eq!(
+        widened_json["result"]["files"],
+        json!(["src/main.stasis", "src/old.stasis"])
+    );
+    assert!(widened_json["result"]["items"]
+        .as_array()
+        .expect("widened items")
+        .iter()
+        .any(|item| item["name"] == "old_value"));
 
     let preview = stasis(
         &[

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -230,8 +230,15 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
     assert!(listed_items
         .iter()
         .any(|item| item["name"] == "tick" && item["file"] == "src/main.stasis"));
-    assert_eq!(listed_json["result"]["files"], json!(["src/main.stasis"]));
-    assert!(!listed_items.iter().any(|item| item["name"] == "old_value"));
+    assert_eq!(
+        listed_json["result"]["files"],
+        json!(["src/main.stasis", "src/old.stasis"])
+    );
+    assert_eq!(
+        listed_json["result"]["imports"],
+        json!({"src/main.stasis": ["src/old.stasis"], "src/old.stasis": []})
+    );
+    assert!(listed_items.iter().any(|item| item["name"] == "old_value"));
 
     let widened = stasis(
         &[
@@ -250,6 +257,10 @@ fn semantic_symbol_cli_previews_applies_runs_and_reverts() {
     assert_eq!(
         widened_json["result"]["files"],
         json!(["src/main.stasis", "src/old.stasis"])
+    );
+    assert_eq!(
+        widened_json["result"]["imports"],
+        json!({"src/main.stasis": ["src/old.stasis"], "src/old.stasis": []})
     );
     assert!(widened_json["result"]["items"]
         .as_array()

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -282,7 +282,7 @@ pub fn model_response_schema() -> Value {
 
 pub fn workshop_tool_specs() -> Vec<ToolSpec> {
     vec![
-        spec("list_symbols", "Search compact editable Stasis symbols. Results exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["query", "kind", "file", "owner", "page", "limit"]),
+        spec("list_symbols", "Search compact editable Stasis symbols within explicit starting files. Without files, only the project entry file is searched. Pass files as an array of up to 16 project-relative paths to widen the scope. Results exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["files", "query", "kind", "owner", "page", "limit"]),
         spec("find_references", "Find compact compiler-owned definitions, reads, writes, and calls for a function, global, or dot-qualified field.", &["symbol"], &["limit"]),
         spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
         spec("read_symbol", "Read one Stasis symbol.", &["name"], &["kind", "file", "owner", "signature"]),

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -8,12 +8,12 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub const MAX_AGENT_TURNS: usize = 12;
-pub const MAX_TOOL_CALLS_PER_TURN: usize = 12;
+pub const MAX_AGENT_TURNS: usize = 15;
+pub const MAX_TOOL_CALLS_PER_TURN: usize = 50;
 pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 pub const DEFAULT_REASONING_EFFORT: &str = "medium";
-pub const MAX_OBSERVATION_BYTES: usize = 64 * 1024;
+pub const MAX_OBSERVATION_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -144,7 +144,7 @@ where
         });
         let request = json!({
             "role": "Stasis live-workspace coding agent",
-            "instruction": "Use only the supplied Stasis tools. Treat conversation_history as the authoritative record of your earlier tool calls and their results; do not repeat completed inspection or validation. Inspect narrowly and call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
+            "instruction": "Use only the supplied Stasis tools. Treat conversation_history as the authoritative record of your earlier tool calls and their results; do not repeat completed inspection or validation. Start discovery narrowly instead of enumerating the whole project. Once relevant symbols are identified, batch related read_symbol or other independent tool calls in one turn when useful. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
             "user_prompt": user_prompt,
             "initial_context": initial_context,
             "tool_specs": tool_specs,
@@ -285,7 +285,7 @@ pub fn workshop_tool_specs() -> Vec<ToolSpec> {
         spec("list_symbols", "Search compact editable Stasis symbols within explicit starting files. Without files, only the project entry file is searched. Pass files as an array of up to 16 project-relative paths to widen the scope. Results exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["files", "query", "kind", "owner", "page", "limit"]),
         spec("find_references", "Find compact compiler-owned definitions, reads, writes, and calls for a function, global, or dot-qualified field.", &["symbol"], &["limit"]),
         spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
-        spec("read_symbol", "Read one Stasis symbol.", &["name"], &["kind", "file", "owner", "signature"]),
+        spec("read_symbol", "Read one Stasis symbol. Up to 50 deliberate symbol reads may be batched as separate tool calls in one turn.", &["name"], &["kind", "file", "owner", "signature"]),
         spec("write_symbol", "Atomically add or replace a symbol; set operation=add for a new symbol. A write batch compiles and tests together.", &["file", "name", "new_source"], &["operation", "kind", "owner", "signature", "expected_source_hash"]),
         spec("delete_symbol", "Atomically delete a symbol.", &["name"], &["file", "kind", "owner", "signature", "expected_source_hash"]),
         spec("read_imports", "Read one source file's imports.", &["file"], &[]),
@@ -614,6 +614,71 @@ mod tests {
         .expect("agent");
         assert_eq!(result, "verified");
         assert_eq!(tools.0, 1);
+    }
+
+    #[test]
+    fn fifty_tool_calls_execute_in_one_turn() {
+        let calls = (0..MAX_TOOL_CALLS_PER_TURN)
+            .map(|index| ToolCall {
+                tool: "read_symbol".to_string(),
+                args: json!({"name": format!("function_{index}")}),
+            })
+            .collect();
+        let mut provider = Responses(vec![
+            ModelResponse::ToolCalls {
+                working_notes: "Read the explicitly selected related functions together."
+                    .to_string(),
+                summary: String::new(),
+                tool_calls: calls,
+            },
+            ModelResponse::Done {
+                working_notes: "The requested symbol batch is available for review.".to_string(),
+                summary: "verified".to_string(),
+            },
+        ]);
+        let mut tools = Tools::default();
+
+        run_agent(
+            &mut provider,
+            &mut tools,
+            "inspect selected functions",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .expect("fifty-call batch");
+
+        assert_eq!(MAX_AGENT_TURNS, 15);
+        assert_eq!(tools.0, 50);
+        assert_eq!(contract_json()["limits"]["agent_turns"], 15);
+        assert_eq!(contract_json()["limits"]["tool_calls_per_turn"], 50);
+    }
+
+    #[test]
+    fn substantial_full_source_observations_fit_the_batch_budget() {
+        let source = "x".repeat(18 * 1024);
+        let observations = (0..MAX_TOOL_CALLS_PER_TURN)
+            .map(|index| {
+                ToolObservation::result(
+                    "read_symbol",
+                    json!({"name": format!("function_{index}"), "source": source}),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            serde_json::to_vec(&observations)
+                .expect("observations")
+                .len()
+                > 64 * 1024
+        );
+
+        let bounded = bound_observations(observations);
+
+        assert_eq!(bounded.len(), 50);
+        assert!(bounded
+            .iter()
+            .all(|observation| observation.error.is_none()));
     }
 
     #[test]

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -363,6 +363,7 @@ pub struct CodexExecProvider {
     model: String,
     reasoning_effort: String,
     last_usage: Option<Value>,
+    run: Option<TemporaryRun>,
 }
 
 impl Default for CodexExecProvider {
@@ -380,6 +381,7 @@ impl Default for CodexExecProvider {
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or_else(|| DEFAULT_REASONING_EFFORT.to_string()),
             last_usage: None,
+            run: None,
         }
     }
 }
@@ -401,7 +403,10 @@ fn default_codex_executable() -> PathBuf {
 impl ModelProvider for CodexExecProvider {
     fn respond(&mut self, request: &str, canceled: &AtomicBool) -> Result<ModelResponse, String> {
         self.last_usage = None;
-        let run = TemporaryRun::create()?;
+        if self.run.is_none() {
+            self.run = Some(TemporaryRun::create()?);
+        }
+        let run = self.run.as_ref().expect("AI temporary run initialized");
         fs::write(
             &run.schema,
             serde_json::to_vec_pretty(&model_response_schema())

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -14,6 +14,7 @@ pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 pub const DEFAULT_REASONING_EFFORT: &str = "medium";
 pub const MAX_OBSERVATION_BYTES: usize = 1024 * 1024;
+const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection or validation. Start discovery narrowly instead of enumerating the whole project. Once relevant symbols are identified, batch related read_symbol or other independent tool calls in one turn when useful. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -95,8 +96,20 @@ pub enum AgentEvent {
     Completed(String),
 }
 
+#[derive(Serialize)]
+struct ModelRequestHeader<'a> {
+    record: &'static str,
+    schema_version: u32,
+    role: &'static str,
+    instruction: &'static str,
+    user_prompt: &'a str,
+    initial_context: &'a Value,
+    tool_specs: &'a [ToolSpec],
+    response_contract: &'a Value,
+}
+
 pub trait ModelProvider {
-    fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String>;
+    fn respond(&mut self, request: &str, canceled: &AtomicBool) -> Result<ModelResponse, String>;
 
     fn take_usage(&mut self) -> Option<Value> {
         None
@@ -132,8 +145,18 @@ where
         .iter()
         .map(|spec| spec.tool.as_str())
         .collect::<BTreeSet<_>>();
-    let mut observations = Vec::<ToolObservation>::new();
-    let mut conversation_history = Vec::<Value>::new();
+    let response_contract = response_contract();
+    let mut request = serde_json::to_string(&ModelRequestHeader {
+        record: "request",
+        schema_version: 1,
+        role: "Stasis live-workspace coding agent",
+        instruction: AGENT_INSTRUCTION,
+        user_prompt,
+        initial_context: &initial_context,
+        tool_specs: &tool_specs,
+        response_contract: &response_contract,
+    })
+    .map_err(|error| format!("failed encoding append-only AI request header: {error}"))?;
     for turn in 1..=MAX_AGENT_TURNS {
         if canceled.load(Ordering::Acquire) {
             return Err("AI request canceled".to_string());
@@ -141,16 +164,6 @@ where
         emit(AgentEvent::Turn {
             current: turn,
             maximum: MAX_AGENT_TURNS,
-        });
-        let request = json!({
-            "role": "Stasis live-workspace coding agent",
-            "instruction": "Use only the supplied Stasis tools. Treat conversation_history as the authoritative record of your earlier tool calls and their results; do not repeat completed inspection or validation. Start discovery narrowly instead of enumerating the whole project. Once relevant symbols are identified, batch related read_symbol or other independent tool calls in one turn when useful. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.",
-            "user_prompt": user_prompt,
-            "initial_context": initial_context,
-            "tool_specs": tool_specs,
-            "conversation_history": conversation_history,
-            "observations": observations,
-            "response_contract": response_contract(),
         });
         let response = provider.respond(&request, canceled)?;
         if let Some(usage) = provider.take_usage() {
@@ -165,8 +178,9 @@ where
         match response {
             ModelResponse::Done { summary, .. } => {
                 if let Err(error) = executor.validate_completion() {
-                    observations = vec![ToolObservation::error("completion_gate", error)];
+                    let observations = vec![ToolObservation::error("completion_gate", error)];
                     emit(AgentEvent::Observations(observations.clone()));
+                    append_transcript_entry(&mut request, &response_record, &observations)?;
                     continue;
                 }
                 let summary = if summary.trim().is_empty() {
@@ -191,16 +205,29 @@ where
                     validate_tool_call(call, &tool_specs, &known_tools)?;
                 }
                 emit(AgentEvent::ToolBatch(tool_calls.clone()));
-                observations = bound_observations(executor.execute(&tool_calls, canceled));
+                let observations = bound_observations(executor.execute(&tool_calls, canceled));
                 emit(AgentEvent::Observations(observations.clone()));
-                conversation_history.push(json!({
-                    "response": response_record,
-                    "observations": observations,
-                }));
+                append_transcript_entry(&mut request, &response_record, &observations)?;
             }
         }
     }
     Err(format!("AI agent reached the {MAX_AGENT_TURNS}-turn limit"))
+}
+
+fn append_transcript_entry(
+    request: &mut String,
+    response: &Value,
+    observations: &[ToolObservation],
+) -> Result<(), String> {
+    let entry = serde_json::to_string(&json!({
+        "record": "turn_result",
+        "response": response,
+        "observations": observations,
+    }))
+    .map_err(|error| format!("failed encoding append-only AI transcript entry: {error}"))?;
+    request.push('\n');
+    request.push_str(&entry);
+    Ok(())
 }
 
 fn validate_working_notes(notes: &str) -> Result<(), String> {
@@ -372,7 +399,7 @@ fn default_codex_executable() -> PathBuf {
 }
 
 impl ModelProvider for CodexExecProvider {
-    fn respond(&mut self, request: &Value, canceled: &AtomicBool) -> Result<ModelResponse, String> {
+    fn respond(&mut self, request: &str, canceled: &AtomicBool) -> Result<ModelResponse, String> {
         self.last_usage = None;
         let run = TemporaryRun::create()?;
         fs::write(
@@ -426,12 +453,11 @@ impl ModelProvider for CodexExecProvider {
             .take()
             .ok_or_else(|| "Codex stdout was unavailable".to_string())?;
         let usage_worker = std::thread::spawn(move || read_codex_usage(stdout));
-        let encoded = serde_json::to_vec(request).map_err(|error| error.to_string())?;
         child
             .stdin
             .take()
             .ok_or_else(|| "Codex stdin was unavailable".to_string())?
-            .write_all(&encoded)
+            .write_all(request.as_bytes())
             .map_err(|error| format!("failed sending Codex request: {error}"))?;
         loop {
             if canceled.load(Ordering::Acquire) {
@@ -564,7 +590,7 @@ mod tests {
     impl ModelProvider for Responses {
         fn respond(
             &mut self,
-            _request: &Value,
+            _request: &str,
             _canceled: &AtomicBool,
         ) -> Result<ModelResponse, String> {
             Ok(self.0.remove(0))
@@ -685,15 +711,15 @@ mod tests {
     fn later_turns_receive_prior_calls_and_observations() {
         struct RecordingResponses {
             responses: Vec<ModelResponse>,
-            requests: Vec<Value>,
+            requests: Vec<String>,
         }
         impl ModelProvider for RecordingResponses {
             fn respond(
                 &mut self,
-                request: &Value,
+                request: &str,
                 _canceled: &AtomicBool,
             ) -> Result<ModelResponse, String> {
-                self.requests.push(request.clone());
+                self.requests.push(request.to_string());
                 Ok(self.responses.remove(0))
             }
         }
@@ -706,6 +732,14 @@ mod tests {
                     tool_calls: vec![ToolCall {
                         tool: "read_symbol".to_string(),
                         args: json!({"name": "tick"}),
+                    }],
+                },
+                ModelResponse::ToolCalls {
+                    working_notes: "Inspect one related symbol in the next batch.".to_string(),
+                    summary: String::new(),
+                    tool_calls: vec![ToolCall {
+                        tool: "read_symbol".to_string(),
+                        args: json!({"name": "render"}),
                     }],
                 },
                 ModelResponse::Done {
@@ -727,21 +761,44 @@ mod tests {
         )
         .expect("agent");
 
-        assert_eq!(provider.requests.len(), 2);
-        assert_eq!(provider.requests[0]["conversation_history"], json!([]));
+        assert_eq!(provider.requests.len(), 3);
+        let header = serde_json::from_str::<Value>(&provider.requests[0]).expect("request header");
+        assert_eq!(header["record"], "request");
+        assert!(header.get("observations").is_none());
+        let first_entry = serde_json::from_str::<Value>(
+            provider.requests[1]
+                .lines()
+                .nth(1)
+                .expect("first transcript entry"),
+        )
+        .expect("transcript JSON");
         assert_eq!(
-            provider.requests[1]["conversation_history"][0]["response"]["tool_calls"][0]["args"]
-                ["name"],
+            first_entry["response"]["tool_calls"][0]["args"]["name"],
             "tick"
         );
-        assert_eq!(
-            provider.requests[1]["conversation_history"][0]["observations"][0]["result"]["ok"],
-            true
-        );
+        assert_eq!(first_entry["observations"][0]["result"]["ok"], true);
+        assert_eq!(provider.requests[2].lines().count(), 3);
+        assert!(provider.requests[1].starts_with(&format!("{}\n", provider.requests[0])));
+        assert!(provider.requests[2].starts_with(&format!("{}\n", provider.requests[1])));
     }
 
     #[test]
     fn completion_gate_returns_evidence_to_the_agent_before_finishing() {
+        struct RecordingResponses {
+            responses: Vec<ModelResponse>,
+            requests: Vec<String>,
+        }
+        impl ModelProvider for RecordingResponses {
+            fn respond(
+                &mut self,
+                request: &str,
+                _canceled: &AtomicBool,
+            ) -> Result<ModelResponse, String> {
+                self.requests.push(request.to_string());
+                Ok(self.responses.remove(0))
+            }
+        }
+
         #[derive(Default)]
         struct GatedTools {
             ready: bool,
@@ -766,27 +823,30 @@ mod tests {
             }
         }
 
-        let mut provider = Responses(vec![
-            ModelResponse::Done {
-                working_notes: "Intent: finish. Observed: edit. Next: none. Blocker: none."
-                    .to_string(),
-                summary: "too early".to_string(),
-            },
-            ModelResponse::ToolCalls {
-                working_notes: "Intent: validate. Observed: gate. Next: check. Blocker: none."
-                    .to_string(),
-                summary: String::new(),
-                tool_calls: vec![ToolCall {
-                    tool: "run_tests".to_string(),
-                    args: json!({}),
-                }],
-            },
-            ModelResponse::Done {
-                working_notes: "Intent: finish. Observed: green. Next: none. Blocker: none."
-                    .to_string(),
-                summary: "verified".to_string(),
-            },
-        ]);
+        let mut provider = RecordingResponses {
+            responses: vec![
+                ModelResponse::Done {
+                    working_notes: "Intent: finish. Observed: edit. Next: none. Blocker: none."
+                        .to_string(),
+                    summary: "too early".to_string(),
+                },
+                ModelResponse::ToolCalls {
+                    working_notes: "Intent: validate. Observed: gate. Next: check. Blocker: none."
+                        .to_string(),
+                    summary: String::new(),
+                    tool_calls: vec![ToolCall {
+                        tool: "run_tests".to_string(),
+                        args: json!({}),
+                    }],
+                },
+                ModelResponse::Done {
+                    working_notes: "Intent: finish. Observed: green. Next: none. Blocker: none."
+                        .to_string(),
+                    summary: "verified".to_string(),
+                },
+            ],
+            requests: Vec::new(),
+        };
         let mut tools = GatedTools::default();
         let mut saw_gate = false;
 
@@ -809,6 +869,17 @@ mod tests {
 
         assert_eq!(result, "verified");
         assert!(saw_gate);
+        let gate_entry = serde_json::from_str::<Value>(
+            provider.requests[1]
+                .lines()
+                .nth(1)
+                .expect("completion gate entry"),
+        )
+        .expect("completion gate JSON");
+        assert_eq!(gate_entry["observations"][0]["tool"], "completion_gate");
+        let header = serde_json::from_str::<Value>(provider.requests[1].lines().next().unwrap())
+            .expect("request header");
+        assert!(header.get("observations").is_none());
     }
 
     #[test]
@@ -894,12 +965,7 @@ mod tests {
         let mut provider = CodexExecProvider::default();
         let response = provider
             .respond(
-                &json!({
-                    "system": "Return a done response without calling tools.",
-                    "user_prompt": "Confirm the Stasis AI provider is connected.",
-                    "tool_specs": [],
-                    "observations": [],
-                }),
+                r#"{"system":"Return a done response without calling tools.","user_prompt":"Confirm the Stasis AI provider is connected.","tool_specs":[],"transcript":[]}"#,
                 &AtomicBool::new(false),
             )
             .expect("signed-in Codex response");

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -14,7 +14,7 @@ pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 pub const DEFAULT_REASONING_EFFORT: &str = "medium";
 pub const MAX_OBSERVATION_BYTES: usize = 1024 * 1024;
-const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection or validation. Start discovery narrowly instead of enumerating the whole project. Once relevant symbols are identified, batch related read_symbol or other independent tool calls in one turn when useful. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing, then the identical baseline, requirements, and frames with expected_outcome=pass after writing. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Return done after any edit reports compilation/tests passed and the green validation passes. Return exactly one JSON object matching the response contract.";
+const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection or validation. Start with initial_context.initial_symbols, which is the completed compact default list_symbols result for the entry file and its direct imports. Treat every listed function whose name directly contains the requested behavior noun as a candidate: batch read_symbol and find_references for all of them before editing. Do not skip update, movement, collision, or render candidates merely because one function exposes the visible value. If relevant symbols are missing, batch multiple narrow list_symbols searches directly suggested by the request, such as the behavior noun plus render or update terms; never enumerate the whole project. A reference lookup does not require a prior source read. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing. Never guess setup, tick, or render names: omit optional entrypoints unless a tool observation established the exact function. When source edits are ready, place red validation immediately before one contiguous atomic write batch in the same turn; writes run only when the red contract is accepted. The runtime automatically applies the identical green validation after a successful write, so do not request it again. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Do not claim an affected behavior is consistent unless you inspected its source or validated it. Return done after the edit reports compilation/tests passed and automatic green validation passes. Return exactly one JSON object matching the response contract.";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -265,14 +265,34 @@ fn validate_tool_call(
 }
 
 fn bound_observations(observations: Vec<ToolObservation>) -> Vec<ToolObservation> {
-    if serde_json::to_vec(&observations).is_ok_and(|encoded| encoded.len() <= MAX_OBSERVATION_BYTES)
-    {
+    if observation_bytes(&observations) <= MAX_OBSERVATION_BYTES {
         return observations;
     }
-    vec![ToolObservation::error(
-        "observation_batch",
-        format!("tool observations exceeded {MAX_OBSERVATION_BYTES} bytes"),
-    )]
+    let mut bounded = observations
+        .iter()
+        .map(|observation| omitted_observation(observation))
+        .collect::<Vec<_>>();
+    for (index, observation) in observations.into_iter().enumerate() {
+        let omitted = std::mem::replace(&mut bounded[index], observation);
+        if observation_bytes(&bounded) > MAX_OBSERVATION_BYTES {
+            bounded[index] = omitted;
+        }
+    }
+    bounded
+}
+
+fn omitted_observation(observation: &ToolObservation) -> ToolObservation {
+    let bytes = serde_json::to_vec(observation).map_or(0, |encoded| encoded.len());
+    ToolObservation::error(
+        &observation.tool,
+        format!(
+            "observation omitted because its {bytes} bytes would exceed the {MAX_OBSERVATION_BYTES}-byte turn budget; narrow or page the request"
+        ),
+    )
+}
+
+fn observation_bytes(observations: &[ToolObservation]) -> usize {
+    serde_json::to_vec(observations).map_or(usize::MAX, |encoded| encoded.len())
 }
 
 pub fn response_contract() -> Value {
@@ -309,7 +329,7 @@ pub fn model_response_schema() -> Value {
 
 pub fn workshop_tool_specs() -> Vec<ToolSpec> {
     vec![
-        spec("list_symbols", "Search compact editable Stasis symbols within explicit starting files. Without files, only the project entry file is searched. Pass files as an array of up to 16 project-relative paths to widen the scope. Results exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["files", "query", "kind", "owner", "page", "limit"]),
+        spec("list_symbols", "Search compact editable Stasis symbols within explicit starting files. Without files, the project entry file and its direct imports are searched. The response maps every searched file to its direct imports. Pass files as an array of up to 16 project-relative paths to choose a different scope. Symbol items exclude imports and empty global groups, default to 32 items, and never include source or source hashes.", &[], &["files", "query", "kind", "owner", "page", "limit"]),
         spec("find_references", "Find compact compiler-owned definitions, reads, writes, and calls for a function, global, or dot-qualified field.", &["symbol"], &["limit"]),
         spec("list_owner_symbols", "List compact symbols owned by one type or group.", &["owner"], &[]),
         spec("read_symbol", "Read one Stasis symbol. Up to 50 deliberate symbol reads may be batched as separate tool calls in one turn.", &["name"], &["kind", "file", "owner", "signature"]),
@@ -320,7 +340,7 @@ pub fn workshop_tool_specs() -> Vec<ToolSpec> {
         spec("get_diagnostics", "Read the latest compiler diagnostics.", &[], &[]),
         spec("set_input_state", "Set simulated input state.", &[], &["x", "y", "active", "screen_w", "screen_h"]),
         spec("inspect_runtime_state", "Read bounded live scalar state.", &[], &[]),
-        spec("validate_runtime_state", "Evaluate 1..=16 scalar requirements shaped as {path, op, value}, where op is eq, ne, lt, lte, gt, or gte. baseline=live pauses and restores the running game; baseline=fresh boots an isolated child process for an integration-style check. Fresh defaults to main/tick/render; use setup, tick, and render to select game-level entrypoints when host adapters have side effects. Use expected_outcome=fail before an edit and pass afterward with an identical contract.", &["requirements", "expected_outcome"], &["frames", "baseline", "setup", "tick", "render"]),
+        spec("validate_runtime_state", "Evaluate 1..=16 scalar requirements shaped as {path, op, value}, where op is eq, ne, lt, lte, gt, or gte. baseline=live pauses and restores the running game; baseline=fresh boots an isolated child process for an integration-style check. Fresh defaults to main/tick/render. Omit setup, tick, or render unless an earlier tool result established the exact game-level function; never infer an entrypoint name. Use expected_outcome=fail immediately before a contiguous write batch; the runtime automatically repeats the identical contract as green validation after a successful write.", &["requirements", "expected_outcome"], &["frames", "baseline", "setup", "tick", "render"]),
         spec("run_frame", "Advance the live runtime by one deterministic tick.", &[], &[]),
         spec("take_screenshot", "Capture a logical render snapshot and runtime state.", &[], &[]),
         spec("list_tests", "List Stasis test files.", &[], &[]),
@@ -710,6 +730,32 @@ mod tests {
         assert!(bounded
             .iter()
             .all(|observation| observation.error.is_none()));
+    }
+
+    #[test]
+    fn oversized_observation_batches_preserve_results_that_fit() {
+        let observations = vec![
+            ToolObservation::result("large_a", json!({"source": "a".repeat(700 * 1024)})),
+            ToolObservation::result("large_b", json!({"source": "b".repeat(700 * 1024)})),
+            ToolObservation::result("small", json!({"value": 7})),
+        ];
+
+        let bounded = bound_observations(observations);
+
+        assert_eq!(bounded.len(), 3);
+        assert!(observation_bytes(&bounded) <= MAX_OBSERVATION_BYTES);
+        assert_eq!(
+            bounded[0].result.as_ref().unwrap()["source"]
+                .as_str()
+                .unwrap()
+                .len(),
+            700 * 1024
+        );
+        assert!(bounded[1]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("omitted")));
+        assert_eq!(bounded[2].result.as_ref().unwrap()["value"], 7);
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -569,6 +569,24 @@ pub fn workshop_reachable_files(
     Ok(out)
 }
 
+pub fn workshop_direct_import_files(
+    files: &[WorkshopSourceFile],
+    file_path: &Path,
+) -> Result<Vec<String>, String> {
+    let normalized = normalize_project_path_text(&file_path.to_string_lossy());
+    let file = files
+        .iter()
+        .find(|file| normalize_project_path_text(&file.path) == normalized)
+        .ok_or_else(|| format!("import graph file is not loaded: {normalized}"))?;
+    let mut imports = parse_workshop_import_paths(&file.source)?
+        .into_iter()
+        .map(|import| resolve_project_import_path(&file.path, &import))
+        .collect::<Vec<_>>();
+    imports.sort();
+    imports.dedup();
+    Ok(imports)
+}
+
 fn collect_workshop_source_files(
     project_root: &Path,
     directory: &Path,

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -77,7 +77,7 @@ pub enum LiveCommand {
         #[serde(default)]
         kind: Option<String>,
         #[serde(default)]
-        file: Option<String>,
+        files: Vec<String>,
         #[serde(default)]
         owner: Option<String>,
         #[serde(default)]
@@ -1114,7 +1114,7 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
         ":symbols" | ":find" => ready(LiveCommand::Symbols {
             query: args.get(1).filter(|arg| !arg.starts_with("--")).cloned(),
             kind: terminal_selector_value(&args, "--kind"),
-            file: terminal_selector_value(&args, "--file"),
+            files: terminal_selector_values(&args, "--file"),
             owner: terminal_selector_value(&args, "--owner"),
             page: terminal_selector_value(&args, "--page")
                 .map(|value| parse_u32("page", &value))
@@ -1291,6 +1291,13 @@ fn terminal_selector_value(args: &[String], option: &str) -> Option<String> {
     args.windows(2)
         .find(|pair| pair[0] == option)
         .map(|pair| pair[1].clone())
+}
+
+fn terminal_selector_values(args: &[String], option: &str) -> Vec<String> {
+    args.windows(2)
+        .filter(|pair| pair[0] == option)
+        .map(|pair| pair[1].clone())
+        .collect()
 }
 
 fn required_arg<'a>(args: &'a [String], index: usize, name: &str) -> Result<&'a str, String> {
@@ -1951,7 +1958,7 @@ mod tests {
         assert_eq!(signature.as_deref(), Some("update(i32): void"));
 
         let TerminalInput::Request(request) = terminal
-            .feed_line(":symbols update --kind function --file src/game.stasis --owner Enemy --page 2 --limit 10")
+            .feed_line(":symbols update --kind function --file src/game.stasis --file src/enemy.stasis --owner Enemy --page 2 --limit 10")
             .expect("page")
         else {
             panic!("expected request")
@@ -1961,13 +1968,13 @@ mod tests {
             LiveCommand::Symbols {
                 query: Some(ref query),
                 kind: Some(ref kind),
-                file: Some(ref file),
+                ref files,
                 owner: Some(ref owner),
                 page: 2,
                 limit: 10,
             } if query == "update"
                 && kind == "function"
-                && file == "src/game.stasis"
+                && files == &["src/game.stasis", "src/enemy.stasis"]
                 && owner == "Enemy"
         ));
     }

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -84,11 +84,13 @@ Provider-reported token usage is written separately to
 Codex `turn.completed` event; Stasis does not estimate or add missing token categories. The Codex
 JSON event stream is consumed in memory and all non-usage transport events are discarded.
 
-AI `list_symbols` calls return at most 32 entries by default and accept `query`, `kind`, `file`,
-`owner`, `page`, and `limit` filters. Listings omit imports, empty global groups, source bodies, and
-source hashes. Each item contains only its name, kind, signature, file, and owner when applicable.
-`read_symbol` returns the selected source and its hash so a later write can use that hash solely as
-a stale-write guard.
+AI `list_symbols` calls search only the project entry file by default. The agent can pass `files` as
+an array of up to 16 project-relative paths to widen that starting scope, and can further narrow it
+with `query`, `kind`, `owner`, `page`, and `limit`. Human `stasis symbol list` and TUI `:symbols`
+accept repeated `--file` options and use the same entry-file default. Listings return at most 32
+entries by default and omit imports, empty global groups, source bodies, and source hashes. Each
+item contains only its name, kind, signature, file, and owner when applicable. `read_symbol` returns
+the selected source and its hash so a later write can use that hash solely as a stale-write guard.
 
 The current key map is:
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -39,22 +39,32 @@ mounted into that directory. Codex receives only the user request, bounded Stasi
 and bounded observations returned by the live workspace. Symbol reads, runtime inspection, and
 deterministic ticks pass through `stasis_runner::live`; model write batches become one
 `WorkshopSemanticEditBatch`, compile and test on the normal preparation worker, and commit at a
-between-tick boundary. A layout-changing edit remains a validated preview and requires explicit
-user `:apply` approval.
+between-tick boundary. Successful writes return a compact receipt and changed-symbol summary rather
+than echoing whole before/after files into later model turns. A layout-changing edit remains a
+validated preview and requires explicit user `:apply` approval.
+
+`list_symbols` starts with the entry file and its direct imports when no file is supplied. Its
+compact response includes the direct imports for every searched file, allowing the next search to
+expand deliberately without enumerating the project. Each AI request preloads this default result
+in `initial_context`, avoiding a provider round trip while retaining filtered and paged follow-up
+searches. Explicit file arguments remain an exact scope.
 
 Before changing a behavior-bearing symbol, the AI must use compiler-backed `find_references` to
 locate its definition, reads, writes, and calls without receiving unrelated source bodies. For an
 observable game change it uses AI-only `validate_runtime_state` acceptance checks: the requested
 condition must fail before the edit (red), the atomic edit must compile and pass project tests, and
-the same condition must pass afterward (green). The default `live` baseline pauses and restores the
-same bounded runtime snapshot, so normal game progression cannot manufacture a pass. The optional
-`fresh` baseline boots `main`, advances bounded `tick` frames, renders, and inspects state in a
-separate Stasis child process for integration-style red/green checks without changing the running
-game. Projects with host adapters can select game-level `setup`, `tick`, and `render` entrypoints so
-the isolated check exercises logical gameplay without opening a second window or duplicating host
-resource side effects. These acceptance checks are ephemeral and do not create or replace project `.test.stasis`
-files; durable regression tests remain the appropriate place for behavior that should be protected
-after the AI turn.
+the runtime automatically evaluates the same condition afterward (green). Red validation may be
+immediately followed by one contiguous write batch in the same model turn, reducing provider turns
+without allowing writes when the red contract is not accepted. The default `live` baseline pauses
+and restores the same bounded runtime snapshot, so normal game progression cannot manufacture a
+pass. The optional `fresh` baseline boots `main`, advances bounded `tick` frames, renders, and
+inspects state in a separate Stasis child process for integration-style red/green checks without
+changing the running game. Successful fresh checks retain bounded stderr diagnostics as evidence
+instead of discarding otherwise valid results. Projects with host adapters can select game-level
+`setup`, `tick`, and `render` entrypoints so the isolated check exercises logical gameplay without
+opening a second window or duplicating host resource side effects. These acceptance checks are
+ephemeral and do not create or replace project `.test.stasis` files; durable regression tests remain
+the appropriate place for behavior that should be protected after the AI turn.
 
 Human commands intentionally cover every useful live AI capability:
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -96,6 +96,12 @@ in each turn, such as reading a related set of functions after targeted discover
 observations are bounded to 1 MiB; this supports substantial explicit source reads without making
 whole-project enumeration the default behavior.
 
+Provider requests use JSONL: one immutable request-header record followed by append-only
+`turn_result` records. Each model response and its tool observations appear exactly once, including
+completion-gate feedback. Every later payload is the complete previous payload byte-for-byte plus
+one newline and one new record, so provider prefix caching can reuse the stable instruction,
+context, tools, contract, and prior interactions.
+
 The current key map is:
 
 ```text

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -91,6 +91,10 @@ accept repeated `--file` options and use the same entry-file default. Listings r
 entries by default and omit imports, empty global groups, source bodies, and source hashes. Each
 item contains only its name, kind, signature, file, and owner when applicable. `read_symbol` returns
 the selected source and its hash so a later write can use that hash solely as a stale-write guard.
+An AI request may use up to 15 provider turns. The agent may batch up to 50 deliberate tool calls
+in each turn, such as reading a related set of functions after targeted discovery. Combined
+observations are bounded to 1 MiB; this supports substantial explicit source reads without making
+whole-project enumeration the default behavior.
 
 The current key map is:
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -100,7 +100,10 @@ Provider requests use JSONL: one immutable request-header record followed by app
 `turn_result` records. Each model response and its tool observations appear exactly once, including
 completion-gate feedback. Every later payload is the complete previous payload byte-for-byte plus
 one newline and one new record, so provider prefix caching can reuse the stable instruction,
-context, tools, contract, and prior interactions.
+context, tools, contract, and prior interactions. All provider turns in one AI request also reuse
+the same isolated temporary working directory so Codex does not see a changing path before this
+stable payload. An atomic multi-symbol write returns its full transaction once; the remaining
+per-symbol observations point to that first result instead of repeating the same source-heavy plan.
 
 The current key map is:
 


### PR DESCRIPTION
## Summary
- preload the compact default symbol index into every CLI/TUI AI request
- search the entry file plus its direct imports when no file is specified
- include a compact file-to-direct-import map while keeping symbol rows source/hash-free
- preserve explicit file scopes and expose identical behavior through CLI and TUI
- batch independent reads and reference searches, preserve declared tool order, and require contiguous atomic writes
- place red validation immediately before ready writes and run the identical green contract automatically after commit
- return compact write receipts instead of whole before/after files
- preserve observations that fit when a large batch exceeds its byte budget
- retain bounded successful fresh-validation diagnostics instead of discarding valid results
- log the exact preloaded `initial_context` before the first model turn
- align the engine-overhead benchmark fixture with the enforced `tick(): i32` and `render(): i32` host contracts

## Cost model and fresh Pong results
Weighted input cost is calculated as `uncached input + 0.1 * cached input`.

Earlier stable fresh-edit baseline:
- 9 turns, 18 tool calls
- 236,490 input / 73,472 cached / 163,018 uncached
- 170,365 weighted input-token equivalents
- 43,457 observation bytes

Two final pristine runs under the exact quality-adjusted contract:
- run 1: 4 turns, 17 calls, 76,626 input / 34,048 cached / 42,578 uncached, 45,983 weighted, 18,713 observation bytes
- run 2: 4 turns, 16 calls, 77,653 input / 22,016 cached / 55,637 uncached, 57,839 weighted, 18,583 observation bytes

Final average:
- 4 turns and 16.5 tool calls
- 51,911 weighted input-token equivalents, 69.5% below baseline
- 18,648 observation bytes, 57.1% below baseline

Both final runs produced byte-identical source, compiled, passed the Pong test, and automatically validated both rendered paddle heights at 144. Rendering offsets, player/enemy movement bounds, and collision reach were all updated consistently.

An exploratory preload run changed rendering and collision but missed movement bounds; the height-only green contract did not catch that. The final agent contract therefore requires reading and reference-checking every initially listed function whose name directly matches the requested behavior noun. Both subsequent quality-adjusted runs made the complete change.

## Validation
- `python tools/ci/check_stasis_src_layout.py`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p stasis_ai`
- targeted symbol-list, compact-receipt, ordering, and CLI workflow tests
- `cargo test --workspace --all-targets -- --test-threads=1`
- explicit `stasis test` against both final fresh Pong projects
- `cargo run --target-dir F:\StasisLang\target -p stasis --example engine_overhead_bench -- --mode both --samples 3 --ticks 240`

## Dependency
Stacked on #312 because this tightens the AI symbol-discovery interface introduced there. Merge #312 first, then retarget this PR to `main` if GitHub does not do so automatically.

Persistent `codex exec resume` retained the response schema in a controlled experiment, but it also creates a second durable Codex session containing the full payload. This PR keeps bounded ephemeral turns; an in-memory app-server transport can be evaluated separately if stronger session-level caching is worth adopting an experimental interface.
