### PR TITLE
fix: restore renderer resources across lifecycle changes

### DIFF
--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -1,0 +1,63 @@
+# Renderer resource lifecycle
+
+Stasis keeps game-visible renderer handles stable while device-local resources are
+recreated. CPU source data survives the transition; GPU and SDL objects never do.
+
+## State machine
+
+Every renderer moves through the same states:
+
+- `Unavailable`: no renderer exists.
+- `Ready`: resource generations match the active surface and frames may present.
+- `Paused`: the host is in the background; ticks may poll events but no frame presents.
+- `RestorePending`: a surface or renderer generation changed.
+- `Restoring`: the renderer is rebuilding every active device-local resource.
+- `RestoreFailed`: the frame is withheld and the complete restore is retried on the
+  next frame.
+
+Surface resize and orientation advance `surface_generation`. Renderer/context
+creation, foreground recovery, `SDL_RENDER_TARGETS_RESET`, and
+`SDL_RENDER_DEVICE_RESET` advance both `surface_generation` and
+`renderer_generation`. Generations skip zero. A sprite, fallback texture, font
+atlas, or text texture can be submitted only when both generations match.
+
+The native SDL runtime retains sprite paths, logical raster requests, decoded font
+bytes, font metrics, and cached text bytes/quads. Android Workshop and Published
+previews retain their project or packaged manifest, asset identities, content
+hashes, and font sources. Lost-context handles are discarded without calling a
+destructor in the invalid context. Resize-only invalidation deletes still-valid
+handles before rebuilding them.
+
+## Restore transaction
+
+Before the first post-transition frame is presented, the native renderer rebuilds
+all active sprites, the procedural fallback, every active font atlas, and cached
+text geometry. A failure keeps the lifecycle retryable and withholds presentation.
+The Android GLES adapter restores from the complete production command frame; every
+referenced sprite, fallback, cached-text, and direct-text texture is resolved during
+that frame. A provider or GL failure marks the restore failed and retries it on the
+next requested frame.
+
+This path covers desktop/mobile resize, orientation, Android background/resume,
+Activity recreation, SDL target reset, and SDL device reset. The legacy desktop GL
+backend remains a conformance-only adapter; its supported resize path resets GL
+program state, while shipping desktop and mobile packages use SDL.
+
+## Diagnostics
+
+Native restore messages contain `stage`, resource handle/path, logical and raster
+dimensions, backend, surface generation, renderer generation, transition reason,
+and failure. `stasis_gfx_get_resource_lifecycle` exposes state, both generations,
+attempt/failure counters, and the last reason for build audits. Android preview
+errors expose the same fields in the visible resource error and under the
+`StasisRenderer` log tag.
+
+## Verification
+
+- `ctest --test-dir <runtime-build> -C Release --output-on-failure` exercises the
+  bounded lifecycle transition/retry contract and existing render/mobile contracts.
+- `gradle testWorkshopDebugUnitTest` covers Android lifecycle generations, schema,
+  and provider behavior.
+- `mobile/android/test_emulator.ps1` installs Workshop, launches it, rotates it,
+  backgrounds/resumes it, forces Activity/process recreation, requires multiple
+  successful restoration markers with no restore failure, and force-stops the app.

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -55,6 +55,11 @@ uses fixed command arrays and direct vertex buffers. Texture uploads happen on
 first use or an explicit Workshop asset change, and framebuffer allocations
 happen only for an explicit screenshot capture.
 
+Surface/context loss, resize, orientation, background/resume, and renderer reset
+follow the generation-based state machine in `renderer_resource_lifecycle.md`.
+Both adapters retain CPU source metadata, reject stale GPU generations, and restore
+through their normal resource providers before accepting the next valid frame.
+
 Published shipping artifacts use `stasis package-mobile` and the SDL runtime.
 The preview adapter is therefore an embedded-editor boundary, not a competing
 shipping renderer. It performs no per-command JNI calls and adds no additional

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -119,7 +119,7 @@ Then build, install, launch, and record the normal Workshop acceptance check wit
 .\test_emulator.ps1
 ```
 
-Pass `-Headless` for unattended runs or `-SkipBuild` to relaunch and validate an APK that is already installed. `start_emulator.ps1` can also be used independently. Workshop validation prefers an attached emulator when both an emulator and phone are connected; pass `-Serial` to `validate_device.ps1` to select explicitly.
+Pass `-Headless` for unattended runs or `-SkipBuild` to relaunch and validate an APK that is already installed. The emulator gate rotates, backgrounds/resumes, and force-recreates Workshop, requires successful `StasisRenderer` resource restoration markers, and force-stops the app when finished. Pass `-Lifecycle` to `validate_device.ps1` for the same lifecycle matrix on an attached device. `start_emulator.ps1` can also be used independently. Workshop validation prefers an attached emulator when both an emulator and phone are connected; pass `-Serial` to `validate_device.ps1` to select explicitly.
 
 ## Host AI Run Review
 

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
@@ -1,0 +1,80 @@
+package com.stasislang.workshop;
+
+final class RendererResourceLifecycle {
+    enum State { UNAVAILABLE, READY, PAUSED, RESTORE_PENDING, RESTORING, RESTORE_FAILED }
+
+    private int surfaceGeneration;
+    private int rendererGeneration;
+    private int restoreAttempts;
+    private int restoreFailures;
+    private State state = State.UNAVAILABLE;
+    private String reason = "none";
+
+    void onRendererCreated() {
+        surfaceGeneration = nextGeneration(surfaceGeneration);
+        rendererGeneration = nextGeneration(rendererGeneration);
+        state = State.RESTORE_PENDING;
+        reason = "renderer_created";
+    }
+
+    void onSurfaceChanged() {
+        if (state == State.UNAVAILABLE) return;
+        surfaceGeneration = nextGeneration(surfaceGeneration);
+        state = State.RESTORE_PENDING;
+        reason = "surface_changed";
+    }
+
+    void onPause() {
+        if (state == State.UNAVAILABLE) return;
+        state = State.PAUSED;
+        reason = "background";
+    }
+
+    void onResume() {
+        if (state != State.PAUSED) return;
+        surfaceGeneration = nextGeneration(surfaceGeneration);
+        rendererGeneration = nextGeneration(rendererGeneration);
+        state = State.RESTORE_PENDING;
+        reason = "foreground";
+    }
+
+    boolean beginRestore() {
+        if (state != State.RESTORE_PENDING && state != State.RESTORE_FAILED) return false;
+        restoreAttempts = nextCounter(restoreAttempts);
+        state = State.RESTORING;
+        return true;
+    }
+
+    void finishRestore(boolean succeeded) {
+        if (state != State.RESTORING) return;
+        if (succeeded) {
+            state = State.READY;
+        } else {
+            restoreFailures = nextCounter(restoreFailures);
+            state = State.RESTORE_FAILED;
+        }
+    }
+
+    void resourceFailed() {
+        if (state == State.UNAVAILABLE || state == State.PAUSED) return;
+        restoreFailures = nextCounter(restoreFailures);
+        state = State.RESTORE_FAILED;
+    }
+
+    boolean canPresent() { return state == State.READY; }
+    int surfaceGeneration() { return surfaceGeneration; }
+    int rendererGeneration() { return rendererGeneration; }
+    int restoreAttempts() { return restoreAttempts; }
+    int restoreFailures() { return restoreFailures; }
+    State state() { return state; }
+    String reason() { return reason; }
+
+    private static int nextGeneration(int value) {
+        value += 1;
+        return value == 0 ? 1 : value;
+    }
+
+    private static int nextCounter(int value) {
+        return value == Integer.MAX_VALUE ? Integer.MAX_VALUE : value + 1;
+    }
+}

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -60,7 +60,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final int MAX_CAPTURE_PIXELS = 8_000_000;
 
     interface TextureProvider {
-        void onSurfaceCreated();
+        void onResourceGenerationChanged(int surfaceGeneration, int rendererGeneration,
+                boolean discardGpuHandles, String transitionReason);
+
+        default void beginRestoreAttempt() {}
+
+        default String consumeFailure() { return null; }
 
         default void onFrameStart() {}
 
@@ -153,6 +158,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
 
     private final TextureProvider textures;
     private final TimingListener timing;
+    private final RendererResourceLifecycle resourceLifecycle = new RendererResourceLifecycle();
     private final ByteBuffer frameI32Bytes = directBytes(FRAME_I32_CAPACITY * 4);
     private final ByteBuffer frameF32Bytes = directBytes(FRAME_F32_CAPACITY * 4);
     private final ByteBuffer frameU8Bytes = directBytes(TEXT_U8_CAPACITY);
@@ -220,9 +226,24 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         pendingCapture = callback;
     }
 
+    synchronized void onHostPaused() {
+        resourceLifecycle.onPause();
+    }
+
+    synchronized void onHostResumed() {
+        RendererResourceLifecycle.State before = resourceLifecycle.state();
+        resourceLifecycle.onResume();
+        if (before == RendererResourceLifecycle.State.PAUSED) {
+            textures.onResourceGenerationChanged(
+                    resourceLifecycle.surfaceGeneration(),
+                    resourceLifecycle.rendererGeneration(), false, resourceLifecycle.reason());
+        }
+    }
+
     @Override
     public synchronized void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl,
             javax.microedition.khronos.egl.EGLConfig config) {
+        resourceLifecycle.onRendererCreated();
         colorProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
         colorPosition = GLES20.glGetAttribLocation(colorProgram, "aPosition");
         colorValue = GLES20.glGetAttribLocation(colorProgram, "aColor");
@@ -233,7 +254,9 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         textureColor = GLES20.glGetAttribLocation(textureProgram, "aColor");
         textureResolution = GLES20.glGetUniformLocation(textureProgram, "uResolution");
         textureSampler = GLES20.glGetUniformLocation(textureProgram, "uTexture");
-        textures.onSurfaceCreated();
+        textures.onResourceGenerationChanged(
+                resourceLifecycle.surfaceGeneration(),
+                resourceLifecycle.rendererGeneration(), true, resourceLifecycle.reason());
         GLES20.glEnable(GLES20.GL_BLEND);
         GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
         GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
@@ -243,8 +266,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     @Override
     public synchronized void onSurfaceChanged(javax.microedition.khronos.opengles.GL10 gl,
             int width, int height) {
+        resourceLifecycle.onSurfaceChanged();
         surfaceWidth = Math.max(1, width);
         surfaceHeight = Math.max(1, height);
+        textures.onResourceGenerationChanged(
+                resourceLifecycle.surfaceGeneration(),
+                resourceLifecycle.rendererGeneration(), false, resourceLifecycle.reason());
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
         GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
@@ -258,9 +285,34 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         CaptureCallback capture;
         LogicalFrameSnapshot capturedFrame;
         synchronized (this) {
-            if (shouldPresent(frameI32)) {
-                drawFrame();
+            boolean restoring = resourceLifecycle.beginRestore();
+            textures.beginRestoreAttempt();
+            while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
+            boolean hasFrame = shouldPresent(frameI32);
+            if (hasFrame) prepareFrameResources();
+            String resourceFailure = textures.consumeFailure();
+            int glError = GLES20.glGetError();
+            boolean restored = resourceFailure == null && glError == GLES20.GL_NO_ERROR;
+            if (restoring) {
+                resourceLifecycle.finishRestore(restored);
+            } else if (!restored) {
+                resourceLifecycle.resourceFailed();
             }
+            if (restoring) {
+                if (restored) {
+                    Log.i(LOG_TAG, "resources restored backend=gles surface_generation="
+                            + resourceLifecycle.surfaceGeneration() + " renderer_generation="
+                            + resourceLifecycle.rendererGeneration() + " reason="
+                            + resourceLifecycle.reason());
+                } else {
+                    Log.e(LOG_TAG, "resource restore failed backend=gles surface_generation="
+                            + resourceLifecycle.surfaceGeneration() + " renderer_generation="
+                            + resourceLifecycle.rendererGeneration() + " reason="
+                            + resourceLifecycle.reason() + " failure="
+                            + (resourceFailure == null ? "gl_error_" + glError : resourceFailure));
+                }
+            }
+            if (hasFrame && restored && resourceLifecycle.canPresent()) drawFrame();
             capture = pendingCapture;
             pendingCapture = null;
             capturedFrame = capture == null ? null : captureLogicalFrame();
@@ -270,8 +322,6 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void drawFrame() {
-        updateDisplayMetrics();
-        textures.onFrameStart();
         GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
         clearLetterboxBars();
@@ -292,6 +342,30 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         drawSprites(clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES));
         drawText(clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT),
                 clampCount(frameI32.get(I_TEXT_BYTES_USED), TEXT_U8_CAPACITY));
+    }
+
+    private void prepareFrameResources() {
+        updateDisplayMetrics();
+        textures.onFrameStart();
+        int spriteCount = clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES);
+        for (int index = 0; index < spriteCount; index += 1) {
+            int base = I_SPRITE_BASE + index * SPRITE_I32_STRIDE;
+            spriteTextureFor(frameI32.get(base));
+        }
+        int textCount = clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT);
+        int bytesUsed = clampCount(frameI32.get(I_TEXT_BYTES_USED), TEXT_U8_CAPACITY);
+        for (int index = 0; index < textCount; index += 1) {
+            int meta = I_TEXT_BASE + index * TEXT_I32_STRIDE;
+            int font = frameI32.get(meta);
+            int offset = frameI32.get(meta + 1);
+            int length = frameI32.get(meta + 2);
+            if (font <= 0) continue;
+            if (offset < 0) {
+                if (offset != Integer.MIN_VALUE) textures.cachedTextTextureFor(-offset);
+            } else if (isValidTextSpan(offset, length, bytesUsed)) {
+                textures.textTextureFor(font, frameU8Bytes, offset, length);
+            }
+        }
     }
 
     private void clearLetterboxBars() {
@@ -357,6 +431,22 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                 (float)height / logicalHeight);
         return new DisplayViewport(x, y, width, height, contentScale,
                 Math.max(1.0f, Math.min(8.0f, contentScale)));
+    }
+
+    static String formatResourceFailure(String stage, int handle, String path,
+            int logicalWidth, int logicalHeight, int rasterWidth, int rasterHeight,
+            int surfaceGeneration, int rendererGeneration, String transitionReason,
+            String failure) {
+        return "stage=" + stage + " handle=" + handle + " path=" + path
+                + " logical=" + logicalWidth + "x" + logicalHeight
+                + " raster=" + rasterWidth + "x" + rasterHeight + " backend=gles"
+                + " surface_generation=" + surfaceGeneration
+                + " renderer_generation=" + rendererGeneration
+                + " reason=" + transitionReason + " failure=" + failure;
+    }
+
+    static boolean textureCreationSucceeded(int texture, int glError) {
+        return texture != 0 && glError == GLES20.GL_NO_ERROR;
     }
 
     private void drawLines(int count) {

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -92,7 +92,20 @@ public final class MainActivity extends Activity {
         root.addView(runtimeError, errorParams);
 
         setContentView(root);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (gameSurface != null) gameSurface.onHostResume();
         startFrameLoop();
+    }
+
+    @Override
+    protected void onPause() {
+        if (frameLoop != null) frameHandler.removeCallbacks(frameLoop);
+        if (gameSurface != null) gameSurface.onHostPause();
+        super.onPause();
     }
 
     @Override
@@ -246,6 +259,17 @@ public final class MainActivity extends Activity {
         int touchX() { return touchX; }
         int touchY() { return touchY; }
         int touchActive() { return touchActive ? 1 : 0; }
+
+        void onHostPause() {
+            renderer.onHostPaused();
+            onPause();
+        }
+
+        void onHostResume() {
+            onResume();
+            queueEvent(renderer::onHostResumed);
+            requestRender();
+        }
 
         int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,
                 int screenWidth, int screenHeight) {

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -103,14 +103,14 @@ public final class MainActivity extends Activity {
 
     @Override
     protected void onPause() {
-        if (frameLoop != null) frameHandler.removeCallbacks(frameLoop);
+        stopFrameLoop();
         if (gameSurface != null) gameSurface.onHostPause();
         super.onPause();
     }
 
     @Override
     protected void onDestroy() {
-        if (frameLoop != null) frameHandler.removeCallbacks(frameLoop);
+        stopFrameLoop();
         super.onDestroy();
     }
 
@@ -147,6 +147,12 @@ public final class MainActivity extends Activity {
             }
         };
         frameHandler.post(frameLoop);
+    }
+
+    private void stopFrameLoop() {
+        if (frameLoop == null) return;
+        frameHandler.removeCallbacks(frameLoop);
+        frameLoop = null;
     }
 
     private void runFrame() {

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/PublishedSpriteCatalog.java
@@ -10,7 +10,6 @@ import android.opengl.GLES20;
 import android.opengl.GLUtils;
 import android.util.SparseArray;
 import android.util.SparseBooleanArray;
-import android.util.SparseIntArray;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -35,7 +34,7 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     private final AssetManager assets;
     private final MainActivity activity;
     private final SparseArray<SpriteAsset> sprites = new SparseArray<>();
-    private final SparseIntArray textures = new SparseIntArray();
+    private final SparseArray<SpriteTexture> textures = new SparseArray<>();
     private final SparseBooleanArray failedHandles = new SparseBooleanArray();
     private final SparseArray<TextTexture> textTextures = new SparseArray<>();
     private final SparseArray<FontInfo> fonts = new SparseArray<>();
@@ -46,6 +45,12 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     private float rasterScale = 1.0f;
     private int densityGeneration = -1;
     private final int[] deletedTexture = new int[1];
+    private int surfaceGeneration;
+    private int rendererGeneration;
+    private int fallbackSurfaceGeneration;
+    private int fallbackRendererGeneration;
+    private String lastFailure;
+    private String transitionReason = "none";
 
     PublishedSpriteCatalog(MainActivity activity, AssetManager assets) {
         this.activity = activity;
@@ -53,32 +58,49 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     }
 
     @Override
-    public void onSurfaceCreated() {
-        textures.clear();
+    public void onResourceGenerationChanged(int nextSurfaceGeneration,
+            int nextRendererGeneration, boolean discardGpuHandles,
+            String nextTransitionReason) {
+        clearDensityTextures(!discardGpuHandles);
+        surfaceGeneration = nextSurfaceGeneration;
+        rendererGeneration = nextRendererGeneration;
+        transitionReason = nextTransitionReason;
+    }
+
+    @Override
+    public void beginRestoreAttempt() {
+        lastFailure = null;
         failedHandles.clear();
-        textTextures.clear();
-        fonts.clear();
-        dynamicTextTextures.clear();
-        fallbackTexture = createFallbackTexture();
+    }
+
+    @Override
+    public String consumeFailure() {
+        String failure = lastFailure;
+        lastFailure = null;
+        return failure;
     }
 
     @Override
     public void onDisplayMetricsChanged(float nextRasterScale, int nextDensityGeneration) {
         if (densityGeneration == nextDensityGeneration
                 && Math.abs(rasterScale - nextRasterScale) < 0.001f) return;
-        clearDensityTextures();
+        clearDensityTextures(true);
         rasterScale = nextRasterScale;
         densityGeneration = nextDensityGeneration;
     }
 
     @Override
     public int textureFor(int handle) {
-        int cached = textures.get(handle, 0);
-        if (cached != 0) return cached;
-        if (failedHandles.get(handle)) return fallbackTexture;
+        SpriteTexture cached = textures.get(handle);
+        if (cached != null && cached.matches(surfaceGeneration, rendererGeneration)) {
+            return cached.texture;
+        }
+        if (cached != null) textures.remove(handle);
+        if (failedHandles.get(handle)) return fallbackTexture();
+        SpriteAsset sprite = null;
         try {
             ensureManifest();
-            SpriteAsset sprite = sprites.get(handle);
+            sprite = sprites.get(handle);
             if (!manifestValid || sprite == null) throw new IOException("sprite handle is not packaged");
             byte[] bytes = readAsset(ROOT + sprite.path, MAX_ASSET_BYTES);
             if (!sprite.sha256.equals(sha256(bytes))) throw new IOException("sprite content hash mismatch");
@@ -89,25 +111,44 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
             } finally {
                 bitmap.recycle();
             }
-            textures.put(handle, texture);
+            textures.put(handle, new SpriteTexture(
+                    texture, surfaceGeneration, rendererGeneration));
             return texture;
         } catch (Exception error) {
             failedHandles.put(handle, true);
-            activity.reportPreviewResourceError("sprite " + handle + ": " + error.getMessage());
-            return fallbackTexture;
+            recordFailure("sprite", handle,
+                    sprite == null ? ROOT : ROOT + sprite.path,
+                    sprite == null ? 0 : sprite.width,
+                    sprite == null ? 0 : sprite.height, error);
+            return fallbackTexture();
         }
     }
 
     @Override
     public int fallbackTexture() {
+        if (fallbackTexture == 0 || fallbackSurfaceGeneration != surfaceGeneration
+                || fallbackRendererGeneration != rendererGeneration) {
+            try {
+                fallbackTexture = createFallbackTexture();
+            } catch (IOException error) {
+                fallbackTexture = 0;
+                recordFailure("fallback", 0, "<procedural>", 2, 2, error);
+                return 0;
+            }
+            fallbackSurfaceGeneration = surfaceGeneration;
+            fallbackRendererGeneration = rendererGeneration;
+        }
         return fallbackTexture;
     }
 
     @Override
     public long cachedTextTextureFor(int runHandle) {
         TextTexture cached = textTextures.get(runHandle);
-        if (cached != null) return StasisPreviewRenderer.packTexture(
+        if (cached != null && cached.matches(surfaceGeneration, rendererGeneration)) {
+            return StasisPreviewRenderer.packTexture(
                 cached.texture, cached.width, cached.height);
+        }
+        if (cached != null) textTextures.remove(runHandle);
         try {
             JSONObject resolved = new JSONObject(MainActivity.nativeResolveCachedText("", runHandle));
             if (!"ok".equals(resolved.optString("status"))) {
@@ -131,11 +172,12 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
             }
             cached = new TextTexture(texture,
                     Math.max(1, Math.round(width / rasterScale)),
-                    Math.max(1, Math.round(height / rasterScale)));
+                    Math.max(1, Math.round(height / rasterScale)),
+                    surfaceGeneration, rendererGeneration);
             textTextures.put(runHandle, cached);
             return StasisPreviewRenderer.packTexture(texture, cached.width, cached.height);
         } catch (Exception error) {
-            activity.reportPreviewResourceError("cached text " + runHandle + ": " + error.getMessage());
+            recordFailure("cached_text", runHandle, ROOT + "manifest.json", 0, 0, error);
             return 0L;
         }
     }
@@ -144,7 +186,8 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     public long textTextureFor(int font, ByteBuffer utf8, int offset, int length) {
         for (int index = 0; index < dynamicTextTextures.size(); index += 1) {
             DynamicTextTexture cached = dynamicTextTextures.get(index);
-            if (cached.matches(font, utf8, offset, length)) {
+            if (cached.texture.matches(surfaceGeneration, rendererGeneration)
+                    && cached.matches(font, utf8, offset, length)) {
                 return StasisPreviewRenderer.packTexture(
                         cached.texture.texture, cached.texture.width, cached.texture.height);
             }
@@ -155,11 +198,12 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
             for (int index = 0; index < length; index += 1) bytes[index] = utf8.get(offset + index);
             FontInfo fontInfo = fontInfo(font);
             TextTexture texture = rasterText(
-                    fontInfo, new String(bytes, StandardCharsets.UTF_8), rasterScale);
+                    fontInfo, new String(bytes, StandardCharsets.UTF_8), rasterScale,
+                    surfaceGeneration, rendererGeneration);
             dynamicTextTextures.add(new DynamicTextTexture(font, bytes, texture));
             return StasisPreviewRenderer.packTexture(texture.texture, texture.width, texture.height);
         } catch (Exception error) {
-            activity.reportPreviewResourceError("text font " + font + ": " + error.getMessage());
+            recordFailure("text", font, ROOT + "manifest.json", 0, 0, error);
             return 0L;
         }
     }
@@ -178,7 +222,8 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
     }
 
     private static TextTexture rasterText(
-            FontInfo font, String text, float rasterScale) throws IOException {
+            FontInfo font, String text, float rasterScale,
+            int surfaceGeneration, int rendererGeneration) throws IOException {
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
         paint.setColor(0xffffffff);
         paint.setTextSize(font.size * rasterScale);
@@ -196,24 +241,38 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
         }
         return new TextTexture(texture,
                 Math.max(1, Math.round(width / rasterScale)),
-                Math.max(1, Math.round(height / rasterScale)));
+                Math.max(1, Math.round(height / rasterScale)),
+                surfaceGeneration, rendererGeneration);
     }
 
-    private void clearDensityTextures() {
+    private void clearDensityTextures(boolean deleteGpuHandles) {
         for (int index = 0; index < textures.size(); index += 1) {
-            deleteTexture(textures.valueAt(index));
+            if (deleteGpuHandles) deleteTexture(textures.valueAt(index).texture);
         }
         textures.clear();
         failedHandles.clear();
         for (int index = 0; index < textTextures.size(); index += 1) {
-            deleteTexture(textTextures.valueAt(index).texture);
+            if (deleteGpuHandles) deleteTexture(textTextures.valueAt(index).texture);
         }
         textTextures.clear();
         for (DynamicTextTexture texture : dynamicTextTextures) {
-            deleteTexture(texture.texture.texture);
+            if (deleteGpuHandles) deleteTexture(texture.texture.texture);
         }
         dynamicTextTextures.clear();
-        fonts.clear();
+        if (fallbackTexture != 0 && deleteGpuHandles) deleteTexture(fallbackTexture);
+        fallbackTexture = 0;
+        fallbackSurfaceGeneration = 0;
+        fallbackRendererGeneration = 0;
+    }
+
+    private void recordFailure(String stage, int handle, String path,
+            int logicalWidth, int logicalHeight, Exception error) {
+        lastFailure = StasisPreviewRenderer.formatResourceFailure(stage, handle, path,
+                logicalWidth, logicalHeight,
+                Math.max(0, Math.round(logicalWidth * rasterScale)),
+                Math.max(0, Math.round(logicalHeight * rasterScale)),
+                surfaceGeneration, rendererGeneration, transitionReason, error.getMessage());
+        activity.reportPreviewResourceError(lastFailure);
     }
 
     private void deleteTexture(int texture) {
@@ -301,7 +360,7 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
         return names[0];
     }
 
-    private static int createFallbackTexture() {
+    private static int createFallbackTexture() throws IOException {
         ByteBuffer pixels = ByteBuffer.allocateDirect(16);
         pixels.put(new byte[]{(byte)255, 0, (byte)255, (byte)255, 35, 35, 35, (byte)255,
                 35, 35, 35, (byte)255, (byte)255, 0, (byte)255, (byte)255});
@@ -315,7 +374,12 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
         GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, 2, 2, 0,
                 GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels);
+        int error = GLES20.glGetError();
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+        if (!StasisPreviewRenderer.textureCreationSucceeded(names[0], error)) {
+            if (names[0] != 0) GLES20.glDeleteTextures(1, names, 0);
+            throw new IOException("fallback texture upload failed with GL error " + error);
+        }
         return names[0];
     }
 
@@ -388,15 +452,40 @@ final class PublishedSpriteCatalog implements StasisPreviewRenderer.TextureProvi
         }
     }
 
+    private static final class SpriteTexture {
+        final int texture;
+        final int surfaceGeneration;
+        final int rendererGeneration;
+
+        SpriteTexture(int texture, int surfaceGeneration, int rendererGeneration) {
+            this.texture = texture;
+            this.surfaceGeneration = surfaceGeneration;
+            this.rendererGeneration = rendererGeneration;
+        }
+
+        boolean matches(int surface, int renderer) {
+            return surfaceGeneration == surface && rendererGeneration == renderer;
+        }
+    }
+
     private static final class TextTexture {
         final int texture;
         final int width;
         final int height;
+        final int surfaceGeneration;
+        final int rendererGeneration;
 
-        TextTexture(int texture, int width, int height) {
+        TextTexture(int texture, int width, int height,
+                int surfaceGeneration, int rendererGeneration) {
             this.texture = texture;
             this.width = width;
             this.height = height;
+            this.surfaceGeneration = surfaceGeneration;
+            this.rendererGeneration = rendererGeneration;
+        }
+
+        boolean matches(int surface, int renderer) {
+            return surfaceGeneration == surface && rendererGeneration == renderer;
         }
     }
 

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
@@ -1,0 +1,44 @@
+package com.stasislang.workshop;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class RendererResourceLifecycleTest {
+    @Test
+    public void restoreFailureRetriesWithoutPresentingStaleResources() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+        lifecycle.onSurfaceChanged();
+        assertEquals(2, lifecycle.surfaceGeneration());
+        assertEquals(1, lifecycle.rendererGeneration());
+        assertFalse(lifecycle.canPresent());
+
+        assertTrue(lifecycle.beginRestore());
+        lifecycle.finishRestore(false);
+        assertFalse(lifecycle.canPresent());
+        assertTrue(lifecycle.beginRestore());
+        lifecycle.finishRestore(true);
+        assertTrue(lifecycle.canPresent());
+        assertEquals(2, lifecycle.restoreAttempts());
+        assertEquals(1, lifecycle.restoreFailures());
+    }
+
+    @Test
+    public void repeatedPauseResumeAndRecreationAdvanceGenerations() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+        lifecycle.onPause();
+        assertEquals(RendererResourceLifecycle.State.PAUSED, lifecycle.state());
+        lifecycle.onResume();
+        assertEquals(2, lifecycle.surfaceGeneration());
+        assertEquals(2, lifecycle.rendererGeneration());
+        assertEquals("foreground", lifecycle.reason());
+        lifecycle.onRendererCreated();
+        assertEquals(3, lifecycle.surfaceGeneration());
+        assertEquals(3, lifecycle.rendererGeneration());
+        assertFalse(lifecycle.canPresent());
+    }
+}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -1,5 +1,7 @@
 package com.stasislang.workshop;
 
+import android.opengl.GLES20;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -17,6 +19,24 @@ public final class StasisPreviewRendererSchemaTest {
         assertEquals(34_848, StasisPreviewRenderer.FRAME_I32_CAPACITY);
         assertEquals(92_292, StasisPreviewRenderer.FRAME_F32_CAPACITY);
         assertEquals(65_536, StasisPreviewRenderer.TEXT_U8_CAPACITY);
+    }
+
+    @Test
+    public void resourceFailureDiagnosticIncludesLifecycleContext() {
+        String diagnostic = StasisPreviewRenderer.formatResourceFailure(
+                "sprite", 7, "sprites/ball.svg", 24, 16, 72, 48,
+                3, 4, "surface_changed", "upload_failed");
+        assertTrue(diagnostic.contains("stage=sprite handle=7 path=sprites/ball.svg"));
+        assertTrue(diagnostic.contains("logical=24x16 raster=72x48 backend=gles"));
+        assertTrue(diagnostic.contains("surface_generation=3 renderer_generation=4"));
+        assertTrue(diagnostic.contains("reason=surface_changed failure=upload_failed"));
+    }
+
+    @Test
+    public void failedTextureCreationCannotBecomeCachedRestoreSuccess() {
+        assertFalse(StasisPreviewRenderer.textureCreationSucceeded(0, GLES20.GL_NO_ERROR));
+        assertFalse(StasisPreviewRenderer.textureCreationSucceeded(23, GLES20.GL_OUT_OF_MEMORY));
+        assertTrue(StasisPreviewRenderer.textureCreationSucceeded(23, GLES20.GL_NO_ERROR));
     }
 
     @Test
@@ -123,7 +143,9 @@ public final class StasisPreviewRendererSchemaTest {
     public void logicalSnapshotCopiesOnlyActiveProductionSpans() {
         StasisPreviewRenderer renderer = new StasisPreviewRenderer(
                 new StasisPreviewRenderer.TextureProvider() {
-                    @Override public void onSurfaceCreated() {}
+                    @Override public void onResourceGenerationChanged(
+                            int surfaceGeneration, int rendererGeneration,
+                            boolean discardGpuHandles, String transitionReason) {}
                     @Override public int textureFor(int handle) { return 0; }
                 }, ignored -> {});
         renderer.frameI32Bytes().asIntBuffer().put(0, StasisPreviewRenderer.RENDER_MAGIC);

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -439,6 +439,7 @@ public final class MainActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
+        if (gamePreview != null) gamePreview.onHostResume();
         codexLoginLifecycle.onResume();
         refreshPhoneNativeCodexStatus();
         startNextQueuedAiIfIdle();
@@ -449,6 +450,7 @@ public final class MainActivity extends Activity {
 
     @Override
     protected void onPause() {
+        if (gamePreview != null) gamePreview.onHostPause();
         codexLoginLifecycle.onPause();
         gameLoopHandler.removeCallbacks(codexStatusPoll);
         gameLoopHandler.removeCallbacks(githubAutoSyncRequest);
@@ -11563,6 +11565,17 @@ public final class MainActivity extends Activity {
 
         int touchActive() {
             return touchActive ? 1 : 0;
+        }
+
+        void onHostPause() {
+            renderer.onHostPaused();
+            onPause();
+        }
+
+        void onHostResume() {
+            onResume();
+            queueEvent(renderer::onHostResumed);
+            requestRender();
         }
 
         int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -30,21 +30,40 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     private long nextManifestCheckNanos;
     private float rasterScale = 1.0f;
     private int densityGeneration = -1;
+    private int surfaceGeneration;
+    private int rendererGeneration;
+    private int fallbackSurfaceGeneration;
+    private int fallbackRendererGeneration;
+    private String lastFailure;
+    private String transitionReason = "none";
 
     WorkshopTextureProvider(MainActivity activity) {
         this.activity = activity;
     }
 
     @Override
-    public void onSurfaceCreated() {
-        textures.clear();
-        textTextures.clear();
-        fonts.clear();
-        dynamicTextTextures.clear();
+    public void onResourceGenerationChanged(int nextSurfaceGeneration,
+            int nextRendererGeneration, boolean discardGpuHandles,
+            String nextTransitionReason) {
+        clearTextures(!discardGpuHandles);
+        surfaceGeneration = nextSurfaceGeneration;
+        rendererGeneration = nextRendererGeneration;
+        transitionReason = nextTransitionReason;
         setProjectRoot(activity.projectRootPath());
         manifestStamp = Long.MIN_VALUE;
         nextManifestCheckNanos = 0L;
-        fallbackTexture = createFallbackTexture();
+    }
+
+    @Override
+    public void beginRestoreAttempt() {
+        lastFailure = null;
+    }
+
+    @Override
+    public String consumeFailure() {
+        String failure = lastFailure;
+        lastFailure = null;
+        return failure;
     }
 
     @Override
@@ -70,11 +89,17 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     @Override
     public int textureFor(int handle) {
         SpriteTexture cached = textures.get(handle);
-        if (cached != null && cached.checkedManifestStamp == manifestStamp) {
+        if (cached != null && cached.matches(surfaceGeneration, rendererGeneration)
+                && cached.checkedManifestStamp == manifestStamp) {
             return cached.texture;
         }
+        if (cached != null && !cached.matches(surfaceGeneration, rendererGeneration)) {
+            textures.remove(handle);
+            cached = null;
+        }
+        JSONObject resolved = null;
         try {
-            JSONObject resolved = new JSONObject(MainActivity.nativeResolveSpriteAsset(
+            resolved = new JSONObject(MainActivity.nativeResolveSpriteAsset(
                     projectRootPath, handle));
             if (!"ok".equals(resolved.optString("status"))) {
                 throw new IOException(resolved.optString("error", "sprite resolution failed"));
@@ -91,21 +116,37 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             } finally {
                 bitmap.recycle();
             }
-            textures.put(handle, new SpriteTexture(uploaded, hash, manifestStamp));
+            textures.put(handle, new SpriteTexture(uploaded, hash, manifestStamp,
+                    surfaceGeneration, rendererGeneration));
             if (cached != null) deleteTexture(cached.texture);
             return uploaded;
         } catch (Exception error) {
-            activity.reportPreviewResourceError("sprite " + handle + ": " + error.getMessage());
+            recordFailure("sprite", handle,
+                    resolved == null ? "<unresolved>" : resolved.optString("path", "<unresolved>"),
+                    resolved == null ? 0 : resolved.optInt("width"),
+                    resolved == null ? 0 : resolved.optInt("height"), error);
             if (cached != null) {
                 cached.checkedManifestStamp = manifestStamp;
                 return cached.texture;
             }
-            return fallbackTexture;
+            return fallbackTexture();
         }
     }
 
     @Override
     public int fallbackTexture() {
+        if (fallbackTexture == 0 || fallbackSurfaceGeneration != surfaceGeneration
+                || fallbackRendererGeneration != rendererGeneration) {
+            try {
+                fallbackTexture = createFallbackTexture();
+            } catch (IOException error) {
+                fallbackTexture = 0;
+                recordFailure("fallback", 0, "<procedural>", 2, 2, error);
+                return 0;
+            }
+            fallbackSurfaceGeneration = surfaceGeneration;
+            fallbackRendererGeneration = rendererGeneration;
+        }
         return fallbackTexture;
     }
 
@@ -113,8 +154,11 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     public long cachedTextTextureFor(int runHandle) {
         ensureCurrentProject();
         TextTexture cached = textTextures.get(runHandle);
-        if (cached != null) return StasisPreviewRenderer.packTexture(
+        if (cached != null && cached.matches(surfaceGeneration, rendererGeneration)) {
+            return StasisPreviewRenderer.packTexture(
                 cached.texture, cached.width, cached.height);
+        }
+        if (cached != null) textTextures.remove(runHandle);
         try {
             JSONObject resolved = new JSONObject(MainActivity.nativeResolveCachedText(
                     activity.projectRootPath(), runHandle));
@@ -139,11 +183,12 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             }
             cached = new TextTexture(texture,
                     Math.max(1, Math.round(width / rasterScale)),
-                    Math.max(1, Math.round(height / rasterScale)));
+                    Math.max(1, Math.round(height / rasterScale)),
+                    surfaceGeneration, rendererGeneration);
             textTextures.put(runHandle, cached);
             return StasisPreviewRenderer.packTexture(texture, cached.width, cached.height);
         } catch (Exception error) {
-            activity.reportPreviewResourceError("cached text " + runHandle + ": " + error.getMessage());
+            recordFailure("cached_text", runHandle, "<resolved-cached-text>", 0, 0, error);
             return 0L;
         }
     }
@@ -153,7 +198,8 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         ensureCurrentProject();
         for (int index = 0; index < dynamicTextTextures.size(); index += 1) {
             DynamicTextTexture cached = dynamicTextTextures.get(index);
-            if (cached.matches(font, utf8, offset, length)) {
+            if (cached.texture.matches(surfaceGeneration, rendererGeneration)
+                    && cached.matches(font, utf8, offset, length)) {
                 return StasisPreviewRenderer.packTexture(
                         cached.texture.texture, cached.texture.width, cached.texture.height);
             }
@@ -164,11 +210,12 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
             for (int index = 0; index < length; index += 1) bytes[index] = utf8.get(offset + index);
             FontInfo fontInfo = fontInfo(font);
             TextTexture texture = rasterText(
-                    fontInfo, new String(bytes, StandardCharsets.UTF_8), rasterScale);
+                    fontInfo, new String(bytes, StandardCharsets.UTF_8), rasterScale,
+                    surfaceGeneration, rendererGeneration);
             dynamicTextTextures.add(new DynamicTextTexture(font, bytes, texture));
             return StasisPreviewRenderer.packTexture(texture.texture, texture.width, texture.height);
         } catch (Exception error) {
-            activity.reportPreviewResourceError("text font " + font + ": " + error.getMessage());
+            recordFailure("text", font, "<resolved-font>", 0, 0, error);
             return 0L;
         }
     }
@@ -195,7 +242,8 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         return cached;
     }
 
-    private static TextTexture rasterText(FontInfo font, String text, float rasterScale) {
+    private static TextTexture rasterText(FontInfo font, String text, float rasterScale,
+            int surfaceGeneration, int rendererGeneration) {
         Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.SUBPIXEL_TEXT_FLAG);
         paint.setColor(0xffffffff);
         paint.setTextSize(font.size * rasterScale);
@@ -215,7 +263,8 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         }
         return new TextTexture(texture,
                 Math.max(1, Math.round(width / rasterScale)),
-                Math.max(1, Math.round(height / rasterScale)));
+                Math.max(1, Math.round(height / rasterScale)),
+                surfaceGeneration, rendererGeneration);
     }
 
     static boolean projectChanged(String boundRoot, String currentRoot) {
@@ -230,19 +279,37 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     }
 
     private void clearTextures() {
+        clearTextures(true);
+    }
+
+    private void clearTextures(boolean deleteGpuHandles) {
         for (int index = 0; index < textures.size(); index++) {
-            deleteTexture(textures.valueAt(index).texture);
+            if (deleteGpuHandles) deleteTexture(textures.valueAt(index).texture);
         }
         textures.clear();
         for (int index = 0; index < textTextures.size(); index++) {
-            deleteTexture(textTextures.valueAt(index).texture);
+            if (deleteGpuHandles) deleteTexture(textTextures.valueAt(index).texture);
         }
         textTextures.clear();
         for (DynamicTextTexture texture : dynamicTextTextures) {
-            deleteTexture(texture.texture.texture);
+            if (deleteGpuHandles) deleteTexture(texture.texture.texture);
         }
         dynamicTextTextures.clear();
         fonts.clear();
+        if (fallbackTexture != 0 && deleteGpuHandles) deleteTexture(fallbackTexture);
+        fallbackTexture = 0;
+        fallbackSurfaceGeneration = 0;
+        fallbackRendererGeneration = 0;
+    }
+
+    private void recordFailure(String stage, int handle, String path,
+            int logicalWidth, int logicalHeight, Exception error) {
+        lastFailure = StasisPreviewRenderer.formatResourceFailure(stage, handle, path,
+                logicalWidth, logicalHeight,
+                Math.max(0, Math.round(logicalWidth * rasterScale)),
+                Math.max(0, Math.round(logicalHeight * rasterScale)),
+                surfaceGeneration, rendererGeneration, transitionReason, error.getMessage());
+        activity.reportPreviewResourceError(lastFailure);
     }
 
     private void deleteTexture(int texture) {
@@ -310,7 +377,7 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         return names[0];
     }
 
-    private static int createFallbackTexture() {
+    private static int createFallbackTexture() throws IOException {
         ByteBuffer pixels = ByteBuffer.allocateDirect(16);
         pixels.put(new byte[]{
                 (byte)255, 0, (byte)255, (byte)255,
@@ -327,7 +394,12 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
         GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, 2, 2, 0,
                 GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels);
+        int error = GLES20.glGetError();
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+        if (!StasisPreviewRenderer.textureCreationSucceeded(names[0], error)) {
+            if (names[0] != 0) GLES20.glDeleteTextures(1, names, 0);
+            throw new IOException("fallback texture upload failed with GL error " + error);
+        }
         return names[0];
     }
 
@@ -336,10 +408,20 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         final String contentHash;
         long checkedManifestStamp;
 
-        SpriteTexture(int texture, String contentHash, long checkedManifestStamp) {
+        final int surfaceGeneration;
+        final int rendererGeneration;
+
+        SpriteTexture(int texture, String contentHash, long checkedManifestStamp,
+                int surfaceGeneration, int rendererGeneration) {
             this.texture = texture;
             this.contentHash = contentHash;
             this.checkedManifestStamp = checkedManifestStamp;
+            this.surfaceGeneration = surfaceGeneration;
+            this.rendererGeneration = rendererGeneration;
+        }
+
+        boolean matches(int surface, int renderer) {
+            return surfaceGeneration == surface && rendererGeneration == renderer;
         }
     }
 
@@ -347,11 +429,20 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         final int texture;
         final int width;
         final int height;
+        final int surfaceGeneration;
+        final int rendererGeneration;
 
-        TextTexture(int texture, int width, int height) {
+        TextTexture(int texture, int width, int height,
+                int surfaceGeneration, int rendererGeneration) {
             this.texture = texture;
             this.width = width;
             this.height = height;
+            this.surfaceGeneration = surfaceGeneration;
+            this.rendererGeneration = rendererGeneration;
+        }
+
+        boolean matches(int surface, int renderer) {
+            return surfaceGeneration == surface && rendererGeneration == renderer;
         }
     }
 

--- a/mobile/android/test_emulator.ps1
+++ b/mobile/android/test_emulator.ps1
@@ -17,7 +17,7 @@ try {
         & (Join-Path $scriptRoot "build_debug.ps1") -Install
         if ($LASTEXITCODE -ne 0) { throw "Workshop emulator build/install failed with exit code $LASTEXITCODE" }
     }
-    & (Join-Path $scriptRoot "validate_device.ps1") -RequireDevice -Serial $serial
+    & (Join-Path $scriptRoot "validate_device.ps1") -RequireDevice -Serial $serial -Lifecycle
     if ($LASTEXITCODE -ne 0) { throw "Workshop emulator acceptance failed with exit code $LASTEXITCODE" }
 } finally {
     $env:ANDROID_SERIAL = $previousSerial

--- a/mobile/android/validate_device.ps1
+++ b/mobile/android/validate_device.ps1
@@ -1,6 +1,7 @@
 param(
     [switch]$Published,
     [switch]$Install,
+    [switch]$Lifecycle,
     [switch]$RequireDevice,
     [string]$Serial = "",
     [string]$OutputPath = ""
@@ -69,6 +70,8 @@ function Invoke-Adb([string[]]$Arguments) {
     return $result
 }
 
+$originalAutoRotation = $null
+$originalRotation = $null
 try {
     $model = (Invoke-Adb @("shell", "getprop", "ro.product.model") | Select-Object -First 1).Trim()
     $sdk = (Invoke-Adb @("shell", "getprop", "ro.build.version.sdk") | Select-Object -First 1).Trim()
@@ -81,6 +84,7 @@ try {
         Invoke-Adb @("install", "-r", $apk) | Out-Null
     }
 
+    Invoke-Adb @("logcat", "-c") | Out-Null
     Invoke-Adb @("shell", "am", "force-stop", $package) | Out-Null
     $launchOutput = Invoke-Adb @("shell", "am", "start", "-W", "-n", "$package/com.stasislang.workshop.MainActivity")
     Start-Sleep -Seconds 2
@@ -88,6 +92,34 @@ try {
     if (-not $appPid) { throw "Android package did not remain running after launch: $package" }
     $packageInfo = Invoke-Adb @("shell", "dumpsys", "package", $package)
     $versionName = ($packageInfo | Select-String -Pattern 'versionName=' | Select-Object -First 1).Line.Trim()
+
+    $lifecycleLog = @()
+    $restoreCount = 0
+    if ($Lifecycle) {
+        $originalAutoRotation = (Invoke-Adb @("shell", "settings", "get", "system", "accelerometer_rotation") | Select-Object -First 1).Trim()
+        $originalRotation = (Invoke-Adb @("shell", "settings", "get", "system", "user_rotation") | Select-Object -First 1).Trim()
+        Invoke-Adb @("shell", "settings", "put", "system", "accelerometer_rotation", "0") | Out-Null
+        Invoke-Adb @("shell", "settings", "put", "system", "user_rotation", "1") | Out-Null
+        Start-Sleep -Seconds 2
+        Invoke-Adb @("shell", "input", "keyevent", "KEYCODE_HOME") | Out-Null
+        Start-Sleep -Seconds 1
+        Invoke-Adb @("shell", "am", "start", "-W", "-n", "$package/com.stasislang.workshop.MainActivity") | Out-Null
+        Start-Sleep -Seconds 2
+        Invoke-Adb @("shell", "settings", "put", "system", "user_rotation", "0") | Out-Null
+        Start-Sleep -Seconds 2
+        Invoke-Adb @("shell", "am", "start", "-S", "-W", "-n", "$package/com.stasislang.workshop.MainActivity") | Out-Null
+        Start-Sleep -Seconds 2
+        $appPid = (Invoke-Adb @("shell", "pidof", $package) | Select-Object -First 1).Trim()
+        if (-not $appPid) { throw "Android package did not survive lifecycle acceptance: $package" }
+        $lifecycleLog = @(Invoke-Adb @("logcat", "-d", "-s", "StasisRenderer:I", "*:S"))
+        $restoreCount = @($lifecycleLog | Select-String -SimpleMatch "resources restored").Count
+        if ($restoreCount -lt 2) {
+            throw "renderer lifecycle emitted only $restoreCount successful restoration markers"
+        }
+        if ($lifecycleLog | Select-String -SimpleMatch "resource restore failed") {
+            throw "renderer lifecycle reported a restoration failure"
+        }
+    }
 
     Write-Report @{
         status = "passed"
@@ -99,6 +131,9 @@ try {
         pid = $appPid
         version = $versionName
         launch = @($launchOutput)
+        lifecycle = [bool]$Lifecycle
+        restoration_markers = $restoreCount
+        lifecycle_log = $lifecycleLog
     }
 } catch {
     Write-Report @{
@@ -108,4 +143,14 @@ try {
         reason = $_.Exception.Message
     }
     exit 1
+} finally {
+    if ($serial) {
+        if ($null -ne $originalAutoRotation) {
+            & $adb -s $serial shell settings put system accelerometer_rotation $originalAutoRotation | Out-Null
+        }
+        if ($null -ne $originalRotation) {
+            & $adb -s $serial shell settings put system user_rotation $originalRotation | Out-Null
+        }
+        & $adb -s $serial shell am force-stop $package | Out-Null
+    }
 }

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -171,6 +171,12 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
     endif()
     add_test(NAME stasis_display_scale_contract COMMAND stasis_display_scale_test)
     add_executable(
+        stasis_renderer_lifecycle_test
+        tests/stasis_renderer_lifecycle_test.c
+    )
+    target_include_directories(stasis_renderer_lifecycle_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_renderer_lifecycle_contract COMMAND stasis_renderer_lifecycle_test)
+    add_executable(
         stasis_asset_path_test
         tests/stasis_asset_path_test.c
     )

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -28,6 +28,7 @@
 #endif
 #include "stasis_render_contract.h"
 #include "stasis_display_scale.h"
+#include "stasis_renderer_lifecycle.h"
 #if defined(_WIN32)
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -99,6 +100,8 @@ static StasisDisplayMetrics g_display_metrics;
 static int g_display_generation = 0;
 static int g_density_generation = 0;
 static bool g_window_resized = false;
+static StasisRendererLifecycle g_resource_lifecycle;
+static bool g_resource_frame_ready = false;
 static bool g_postfx_enabled = false;
 static bool g_postfx_applied_this_frame = false;
 static bool g_screenshot_taken = false;
@@ -173,6 +176,8 @@ static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_cou
 static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int max_w, int max_h);
 static void stasis_sync_display_metrics(void);
 static void stasis_reset_text_cache(void);
+static void stasis_invalidate_renderer_resources(int discard_gpu_handles);
+static int stasis_restore_renderer_resources(void);
 
 /* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -208,6 +213,8 @@ typedef struct SpriteEntry {
     int needs_reraster;  /* flag for window resize */
     int reload_pending;  /* set when the asset watcher reloads this sprite */
     uint32_t generation;
+    uint32_t surface_generation;
+    uint32_t renderer_generation;
     int retired;         /* generation wrapped; never reuse this slot */
 } SpriteEntry;
 
@@ -243,9 +250,46 @@ typedef struct {
     int atlas_size;
     float pixel_scale;
     int needs_reraster;
+    uint32_t surface_generation;
+    uint32_t renderer_generation;
 } StasisFont;
 
 static StasisFont g_fonts[MAX_FONTS];
+
+static const char* stasis_renderer_reason_name(StasisRendererResourceReason reason) {
+    switch (reason) {
+        case STASIS_RENDERER_REASON_SURFACE_CHANGED: return "surface_changed";
+        case STASIS_RENDERER_REASON_TARGETS_RESET: return "targets_reset";
+        case STASIS_RENDERER_REASON_DEVICE_RESET: return "device_reset";
+        case STASIS_RENDERER_REASON_BACKGROUND: return "background";
+        case STASIS_RENDERER_REASON_FOREGROUND: return "foreground";
+        default: return "none";
+    }
+}
+
+static void stasis_invalidate_renderer_resources(int discard_gpu_handles) {
+    if (!g_use_sdl_renderer) return;
+    for (int i = 0; i < g_sprite_capacity; i++) {
+        SpriteEntry* entry = &g_sprites[i];
+        if (!entry->used) continue;
+        if (entry->sdl_tex && !discard_gpu_handles) SDL_DestroyTexture(entry->sdl_tex);
+        entry->sdl_tex = NULL;
+        entry->needs_reraster = 1;
+    }
+    if (g_sprite_fallback.sdl_tex && !discard_gpu_handles) {
+        SDL_DestroyTexture(g_sprite_fallback.sdl_tex);
+    }
+    memset(&g_sprite_fallback, 0, sizeof(g_sprite_fallback));
+    g_sprite_fallback.page_index = -1;
+    for (int i = 0; i < MAX_FONTS; i++) {
+        StasisFont* font = &g_fonts[i];
+        if (!font->active) continue;
+        if (font->sdl_texture && !discard_gpu_handles) SDL_DestroyTexture(font->sdl_texture);
+        font->sdl_texture = NULL;
+        font->needs_reraster = 1;
+    }
+    g_resource_frame_ready = false;
+}
 
 static int stasis_input_valid_index(int idx) {
     return idx >= 0 && idx < STASIS_MAX_POINTERS;
@@ -311,6 +355,11 @@ static void stasis_sync_display_metrics(void) {
     if (g_display_generation == 0 || dimensions_changed) {
         g_display_generation++;
         g_window_resized = true;
+    }
+    if (dimensions_changed && g_use_sdl_renderer &&
+        g_resource_lifecycle.state != STASIS_RENDERER_UNAVAILABLE) {
+        stasis_renderer_lifecycle_surface_changed(&g_resource_lifecycle);
+        stasis_invalidate_renderer_resources(0);
     }
     g_display_metrics = next;
     g_drawable_width = drawable_w;
@@ -516,6 +565,34 @@ static void stasis_pump_events(void) {
                     g_input_frame.viewport_w_px = g_window_width;
                     g_input_frame.viewport_h_px = g_window_height;
                     stasis_update_safe_viewport();
+                }
+                break;
+#if SDL_VERSION_ATLEAST(2,0,2)
+            case SDL_RENDER_TARGETS_RESET:
+                stasis_renderer_lifecycle_renderer_reset(
+                    &g_resource_lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
+                stasis_invalidate_renderer_resources(0);
+                SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=targets_reset surface_generation=%u renderer_generation=%u",
+                    g_resource_lifecycle.surface_generation,
+                    g_resource_lifecycle.renderer_generation);
+                break;
+            case SDL_RENDER_DEVICE_RESET:
+                stasis_renderer_lifecycle_renderer_reset(
+                    &g_resource_lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
+                stasis_invalidate_renderer_resources(0);
+                SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=device_reset surface_generation=%u renderer_generation=%u",
+                    g_resource_lifecycle.surface_generation,
+                    g_resource_lifecycle.renderer_generation);
+                break;
+#endif
+            case SDL_APP_WILLENTERBACKGROUND:
+                stasis_renderer_lifecycle_pause(&g_resource_lifecycle);
+                g_resource_frame_ready = false;
+                break;
+            case SDL_APP_DIDENTERFOREGROUND:
+                if (g_resource_lifecycle.state == STASIS_RENDERER_PAUSED) {
+                    stasis_renderer_lifecycle_resume(&g_resource_lifecycle);
+                    stasis_invalidate_renderer_resources(0);
                 }
                 break;
             case SDL_MOUSEBUTTONDOWN:
@@ -3613,6 +3690,8 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     }
 
     stasis_sync_display_metrics();
+    stasis_renderer_lifecycle_initialize(&g_resource_lifecycle);
+    g_resource_frame_ready = true;
     SDL_Log("Stasis display metrics: logical=%dx%d native=%dx%d drawable=%dx%d scale=%.2f",
         g_window_width, g_window_height,
         g_native_window_width, g_native_window_height,
@@ -3860,6 +3939,7 @@ STASIS_EXPORT void stasis_begin_frame(void) {
         stasis_pump_events();
         g_events_pumped_this_frame = 1;
     }
+    g_resource_frame_ready = stasis_restore_renderer_resources() != 0;
     g_line_count = 0;
     if (g_use_sdl_renderer) {
         SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
@@ -3877,6 +3957,11 @@ STASIS_EXPORT void stasis_begin_frame(void) {
  * End frame: flush lines, swap buffers, poll events
  */
 STASIS_EXPORT void stasis_end_frame(void) {
+    if (!g_resource_frame_ready) {
+        g_line_count = 0;
+        g_events_pumped_this_frame = 0;
+        return;
+    }
     if (g_use_sdl_renderer) {
         SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
         SDL_Color color;
@@ -4339,6 +4424,8 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
         e->sdl_tex = tex;
         e->mtime = get_file_mtime(path);
         e->needs_reraster = 0;
+        e->surface_generation = g_resource_lifecycle.surface_generation;
+        e->renderer_generation = g_resource_lifecycle.renderer_generation;
         if (previous) SDL_DestroyTexture(previous);
         return 1;
     }
@@ -4388,6 +4475,8 @@ static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int m
     sprite_set_gl_region(e, page_index, sprite_x, sprite_y, alloc_x, alloc_y, alloc_w, alloc_h, w, h);
     e->mtime = get_file_mtime(path);
     e->needs_reraster = 0;
+    e->surface_generation = g_resource_lifecycle.surface_generation;
+    e->renderer_generation = g_resource_lifecycle.renderer_generation;
     return 1;
 #else
     free(pixels);
@@ -4565,6 +4654,8 @@ static SpriteEntry* sprite_fallback_get(void) {
 #endif
     }
     next.used = 1;
+    next.surface_generation = g_resource_lifecycle.surface_generation;
+    next.renderer_generation = g_resource_lifecycle.renderer_generation;
     g_sprite_fallback = next;
     return &g_sprite_fallback;
 }
@@ -4634,6 +4725,15 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
      */
     if (e->needs_reraster) {
         if (e->path) sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h);
+    }
+    if (e->surface_generation != g_resource_lifecycle.surface_generation ||
+        e->renderer_generation != g_resource_lifecycle.renderer_generation) {
+        SDL_Log("Stasis renderer rejected stale sprite: handle=%d path=%s logical=%dx%d raster=%dx%d backend=%s surface_generation=%u resource_surface_generation=%u renderer_generation=%u resource_renderer_generation=%u",
+            handle, e->path ? e->path : "<fallback>", e->max_w, e->max_h, e->w, e->h,
+            g_use_sdl_renderer ? "sdl" : "gl",
+            g_resource_lifecycle.surface_generation, e->surface_generation,
+            g_resource_lifecycle.renderer_generation, e->renderer_generation);
+        return;
     }
 
     /* Convert degrees to radians */
@@ -4929,6 +5029,24 @@ STASIS_EXPORT void stasis_mobile_set_paused(int paused) {
     if (g_audio_device != 0) {
         SDL_PauseAudioDevice(g_audio_device, paused ? 1 : 0);
     }
+    if (paused) {
+        stasis_renderer_lifecycle_pause(&g_resource_lifecycle);
+        g_resource_frame_ready = false;
+    } else if (g_resource_lifecycle.state == STASIS_RENDERER_PAUSED) {
+        stasis_renderer_lifecycle_resume(&g_resource_lifecycle);
+        stasis_invalidate_renderer_resources(0);
+    }
+}
+
+STASIS_EXPORT int stasis_gfx_get_resource_lifecycle(int32_t* out_i32, int count) {
+    if (!out_i32 || count < 6) return 0;
+    out_i32[0] = (int32_t)g_resource_lifecycle.state;
+    out_i32[1] = (int32_t)g_resource_lifecycle.surface_generation;
+    out_i32[2] = (int32_t)g_resource_lifecycle.renderer_generation;
+    out_i32[3] = (int32_t)g_resource_lifecycle.restore_attempts;
+    out_i32[4] = (int32_t)g_resource_lifecycle.restore_failures;
+    out_i32[5] = (int32_t)g_resource_lifecycle.reason;
+    return 1;
 }
 
 /*
@@ -5054,6 +5172,8 @@ STASIS_EXPORT void stasis_shutdown(void) {
         g_window = NULL;
     }
     SDL_Quit();
+    memset(&g_resource_lifecycle, 0, sizeof(g_resource_lifecycle));
+    g_resource_frame_ready = false;
     SDL_Log("Stasis graphics shutdown");
 }
 
@@ -5364,6 +5484,8 @@ static int stasis_build_font_atlas(StasisFont* font) {
     font->pixel_scale = pixel_scale;
     font->scale = stbtt_ScaleForPixelHeight(&font->font_info, (float)raster_size);
     font->needs_reraster = 0;
+    font->surface_generation = g_resource_lifecycle.surface_generation;
+    font->renderer_generation = g_resource_lifecycle.renderer_generation;
     return 1;
 }
 
@@ -5442,6 +5564,71 @@ static int stasis_ensure_font_ready(int font_handle) {
         rebuilt_density_fonts = 1;
     }
     return !rebuilt_density_fonts || stasis_rebuild_text_runs();
+}
+
+static int stasis_restore_renderer_resources(void) {
+    if (g_resource_lifecycle.state == STASIS_RENDERER_PAUSED ||
+        g_resource_lifecycle.state == STASIS_RENDERER_UNAVAILABLE) {
+        return 0;
+    }
+    if (!stasis_renderer_lifecycle_begin_restore(&g_resource_lifecycle)) {
+        return stasis_renderer_lifecycle_can_present(&g_resource_lifecycle);
+    }
+
+    int restored = g_use_sdl_renderer ? g_renderer != NULL : g_gl_context != NULL;
+    for (int i = 0; i < g_sprite_capacity; i++) {
+        SpriteEntry* entry = &g_sprites[i];
+        if (!entry->used || !entry->path) continue;
+        if (!sprite_build_into_entry_sized(entry, entry->path, entry->max_w, entry->max_h)) {
+            SDL_Log("Stasis renderer restore failed: stage=sprite handle=%d path=%s logical=%dx%d raster=%dx%d backend=%s surface_generation=%u renderer_generation=%u reason=%s failure=texture_rebuild_failed",
+                sprite_handle_for_slot(i), entry->path, entry->max_w, entry->max_h,
+                entry->w, entry->h, g_use_sdl_renderer ? "sdl" : "gl",
+                g_resource_lifecycle.surface_generation,
+                g_resource_lifecycle.renderer_generation,
+                stasis_renderer_reason_name(g_resource_lifecycle.reason));
+            restored = 0;
+        }
+    }
+    if (!sprite_fallback_get()) {
+        SDL_Log("Stasis renderer restore failed: stage=fallback handle=0 path=<procedural> logical=2x2 raster=2x2 backend=%s surface_generation=%u renderer_generation=%u reason=%s failure=texture_rebuild_failed",
+            g_use_sdl_renderer ? "sdl" : "gl",
+            g_resource_lifecycle.surface_generation,
+            g_resource_lifecycle.renderer_generation,
+            stasis_renderer_reason_name(g_resource_lifecycle.reason));
+        restored = 0;
+    }
+    for (int i = 0; i < MAX_FONTS; i++) {
+        StasisFont* font = &g_fonts[i];
+        if (!font->active) continue;
+        if (!stasis_build_font_atlas(font)) {
+            SDL_Log("Stasis renderer restore failed: stage=font handle=%d path=<retained-font-bytes> logical=%dx%d raster=%dx%d backend=%s surface_generation=%u renderer_generation=%u reason=%s failure=atlas_rebuild_failed",
+                i + 1, font->font_size, font->font_size, font->raster_size,
+                font->raster_size, g_use_sdl_renderer ? "sdl" : "gl",
+                g_resource_lifecycle.surface_generation,
+                g_resource_lifecycle.renderer_generation,
+                stasis_renderer_reason_name(g_resource_lifecycle.reason));
+            restored = 0;
+        }
+    }
+    if (restored && !stasis_rebuild_text_runs()) {
+        SDL_Log("Stasis renderer restore failed: stage=cached_text handle=0 path=<retained-text-runs> logical=0x0 raster=0x0 backend=%s surface_generation=%u renderer_generation=%u reason=%s failure=quad_rebuild_failed",
+            g_use_sdl_renderer ? "sdl" : "gl",
+            g_resource_lifecycle.surface_generation,
+            g_resource_lifecycle.renderer_generation,
+            stasis_renderer_reason_name(g_resource_lifecycle.reason));
+        restored = 0;
+    }
+
+    stasis_renderer_lifecycle_finish_restore(&g_resource_lifecycle, restored);
+    if (restored) {
+        SDL_Log("Stasis renderer resources restored: backend=%s surface_generation=%u renderer_generation=%u reason=%s sprites=%d",
+            g_use_sdl_renderer ? "sdl" : "gl",
+            g_resource_lifecycle.surface_generation,
+            g_resource_lifecycle.renderer_generation,
+            stasis_renderer_reason_name(g_resource_lifecycle.reason),
+            g_sprite_count);
+    }
+    return stasis_renderer_lifecycle_can_present(&g_resource_lifecycle);
 }
 
 static int stasis_find_or_alloc_text_run_slot(int font_handle, uint32_t hash, const char* text, int len) {

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -66,6 +66,7 @@ EXPORTS
     stasis_gfx_cache_text
     stasis_gfx_draw_text_cached
     stasis_gfx_measure_text_cached
+    stasis_gfx_get_resource_lifecycle
     stasis_list_directory
     stasis_list_directory_struct
     stasis_copy_dir_entry_name

--- a/runtime/stasis_renderer_lifecycle.h
+++ b/runtime/stasis_renderer_lifecycle.h
@@ -1,0 +1,113 @@
+#ifndef STASIS_RENDERER_LIFECYCLE_H
+#define STASIS_RENDERER_LIFECYCLE_H
+
+#include <stdint.h>
+
+typedef enum {
+    STASIS_RENDERER_UNAVAILABLE = 0,
+    STASIS_RENDERER_READY = 1,
+    STASIS_RENDERER_PAUSED = 2,
+    STASIS_RENDERER_RESTORE_PENDING = 3,
+    STASIS_RENDERER_RESTORING = 4,
+    STASIS_RENDERER_RESTORE_FAILED = 5
+} StasisRendererResourceState;
+
+typedef enum {
+    STASIS_RENDERER_REASON_NONE = 0,
+    STASIS_RENDERER_REASON_SURFACE_CHANGED = 1,
+    STASIS_RENDERER_REASON_TARGETS_RESET = 2,
+    STASIS_RENDERER_REASON_DEVICE_RESET = 3,
+    STASIS_RENDERER_REASON_BACKGROUND = 4,
+    STASIS_RENDERER_REASON_FOREGROUND = 5
+} StasisRendererResourceReason;
+
+typedef struct {
+    uint32_t surface_generation;
+    uint32_t renderer_generation;
+    uint32_t restore_attempts;
+    uint32_t restore_failures;
+    StasisRendererResourceState state;
+    StasisRendererResourceReason reason;
+} StasisRendererLifecycle;
+
+static uint32_t stasis_renderer_next_generation(uint32_t generation) {
+    generation += 1u;
+    return generation == 0u ? 1u : generation;
+}
+
+static void stasis_renderer_lifecycle_initialize(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle) return;
+    lifecycle->surface_generation = 1u;
+    lifecycle->renderer_generation = 1u;
+    lifecycle->restore_attempts = 0u;
+    lifecycle->restore_failures = 0u;
+    lifecycle->state = STASIS_RENDERER_READY;
+    lifecycle->reason = STASIS_RENDERER_REASON_NONE;
+}
+
+static void stasis_renderer_lifecycle_surface_changed(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
+    lifecycle->surface_generation =
+        stasis_renderer_next_generation(lifecycle->surface_generation);
+    lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
+    lifecycle->reason = STASIS_RENDERER_REASON_SURFACE_CHANGED;
+}
+
+static void stasis_renderer_lifecycle_renderer_reset(
+    StasisRendererLifecycle* lifecycle,
+    StasisRendererResourceReason reason
+) {
+    if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
+    lifecycle->surface_generation =
+        stasis_renderer_next_generation(lifecycle->surface_generation);
+    lifecycle->renderer_generation =
+        stasis_renderer_next_generation(lifecycle->renderer_generation);
+    lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
+    lifecycle->reason = reason;
+}
+
+static void stasis_renderer_lifecycle_pause(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
+    lifecycle->state = STASIS_RENDERER_PAUSED;
+    lifecycle->reason = STASIS_RENDERER_REASON_BACKGROUND;
+}
+
+static void stasis_renderer_lifecycle_resume(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle || lifecycle->state != STASIS_RENDERER_PAUSED) return;
+    lifecycle->surface_generation =
+        stasis_renderer_next_generation(lifecycle->surface_generation);
+    lifecycle->renderer_generation =
+        stasis_renderer_next_generation(lifecycle->renderer_generation);
+    lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
+    lifecycle->reason = STASIS_RENDERER_REASON_FOREGROUND;
+}
+
+static int stasis_renderer_lifecycle_begin_restore(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle) return 0;
+    if (lifecycle->state != STASIS_RENDERER_RESTORE_PENDING &&
+        lifecycle->state != STASIS_RENDERER_RESTORE_FAILED) {
+        return 0;
+    }
+    lifecycle->restore_attempts += 1u;
+    lifecycle->state = STASIS_RENDERER_RESTORING;
+    return 1;
+}
+
+static void stasis_renderer_lifecycle_finish_restore(
+    StasisRendererLifecycle* lifecycle,
+    int succeeded
+) {
+    if (!lifecycle || lifecycle->state != STASIS_RENDERER_RESTORING) return;
+    if (succeeded) {
+        lifecycle->state = STASIS_RENDERER_READY;
+    } else {
+        lifecycle->restore_failures += 1u;
+        lifecycle->state = STASIS_RENDERER_RESTORE_FAILED;
+    }
+}
+
+static int stasis_renderer_lifecycle_can_present(const StasisRendererLifecycle* lifecycle) {
+    return lifecycle && lifecycle->state == STASIS_RENDERER_READY;
+}
+
+#endif

--- a/runtime/tests/stasis_renderer_lifecycle_test.c
+++ b/runtime/tests/stasis_renderer_lifecycle_test.c
@@ -1,0 +1,65 @@
+#include "stasis_renderer_lifecycle.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+static void test_restore_retry_and_generations(void) {
+    StasisRendererLifecycle lifecycle = {0};
+    stasis_renderer_lifecycle_initialize(&lifecycle);
+    CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
+    CHECK(lifecycle.surface_generation == 1u);
+    CHECK(lifecycle.renderer_generation == 1u);
+
+    stasis_renderer_lifecycle_surface_changed(&lifecycle);
+    CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
+    CHECK(lifecycle.surface_generation == 2u);
+    CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
+    stasis_renderer_lifecycle_finish_restore(&lifecycle, 0);
+    CHECK(lifecycle.restore_attempts == 1u);
+    CHECK(lifecycle.restore_failures == 1u);
+    CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
+    stasis_renderer_lifecycle_finish_restore(&lifecycle, 1);
+    CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
+    CHECK(lifecycle.restore_attempts == 2u);
+}
+
+static void test_pause_reset_and_wrap(void) {
+    StasisRendererLifecycle lifecycle = {0};
+    stasis_renderer_lifecycle_initialize(&lifecycle);
+    stasis_renderer_lifecycle_pause(&lifecycle);
+    CHECK(lifecycle.state == STASIS_RENDERER_PAUSED);
+    stasis_renderer_lifecycle_resume(&lifecycle);
+    CHECK(lifecycle.reason == STASIS_RENDERER_REASON_FOREGROUND);
+    CHECK(lifecycle.surface_generation == 2u);
+    CHECK(lifecycle.renderer_generation == 2u);
+    CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
+    stasis_renderer_lifecycle_finish_restore(&lifecycle, 1);
+
+    stasis_renderer_lifecycle_renderer_reset(
+        &lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
+    CHECK(lifecycle.surface_generation == 3u);
+    CHECK(lifecycle.renderer_generation == 3u);
+    CHECK(lifecycle.reason == STASIS_RENDERER_REASON_DEVICE_RESET);
+
+    lifecycle.surface_generation = UINT32_MAX;
+    lifecycle.renderer_generation = UINT32_MAX;
+    stasis_renderer_lifecycle_renderer_reset(
+        &lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
+    CHECK(lifecycle.surface_generation == 1u);
+    CHECK(lifecycle.renderer_generation == 1u);
+}
+
+int main(void) {
+    test_restore_retry_and_generations();
+    test_pause_reset_and_wrap();
+    puts("stasis_renderer_lifecycle_test: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add explicit renderer-resource lifecycle and generation tracking for SDL, legacy GL, and Android GLES
- retain CPU metadata, reject stale GPU objects, and withhold presentation until complete restoration succeeds
- add deterministic native/Android tests, full lifecycle diagnostics, and emulator rotate/background/recreate acceptance

## Validation
- cargo test --workspace --all-targets -- --test-threads=1
- python tools/ci/check_stasis_src_layout.py
- cargo fmt --all -- --check
- SDL-only CMake build + CTest (6/6)
- legacy-GL CMake build + CTest (6/6)
- Gradle Workshop unit tests (122/122) + Published Java compilation
- Gradle assembleWorkshopDebug
- validate_device.ps1 -Install -Lifecycle -RequireDevice -Serial emulator-5554 (passed; 4 restoration markers)

Maddox task #167.