### PR TITLE
fix: preserve Android AI context for stale imports

### DIFF
--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
@@ -1,5 +1,10 @@
 package com.stasislang.workshop;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeSet;
+
+import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -26,5 +31,22 @@ public final class WorkshopAiSymbolDiscoveryTest {
         assertEquals(1, WorkshopAiSymbolDiscovery.boundedLimit(0));
         assertEquals(32, WorkshopAiSymbolDiscovery.boundedLimit(32));
         assertEquals(200, WorkshopAiSymbolDiscovery.boundedLimit(500));
+    }
+
+    @Test
+    public void preservesMissingDirectImportsAsRepairableContext() throws Exception {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("src/main.stasis",
+                "import \"missing.stasis\";\nfunction main(): void {}\n");
+
+        TreeSet<String> scope = WorkshopAiSymbolDiscovery.defaultScope(sources);
+        assertEquals(2, scope.size());
+        assertTrue(scope.contains("src/main.stasis"));
+        assertTrue(scope.contains("src/missing.stasis"));
+        JSONObject imports = WorkshopAiSymbolDiscovery.importsForFiles(sources, scope);
+        assertEquals(
+                "[\"src/missing.stasis\"]",
+                imports.getJSONArray("src/main.stasis").toString());
+        assertEquals(0, imports.getJSONArray("src/missing.stasis").length());
     }
 }

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -5378,34 +5378,22 @@ public final class MainActivity extends Activity {
     }
 
     private static TreeSet<String> aiDefaultSymbolScope(ProjectSnapshot project) throws Exception {
-        TreeSet<String> files = new TreeSet<>();
-        files.add(WorkshopAiSymbolDiscovery.DEFAULT_ENTRY_FILE);
-        if (project != null) {
-            JSONArray imports = aiDirectImportFiles(project,
-                    WorkshopAiSymbolDiscovery.DEFAULT_ENTRY_FILE);
-            for (int index = 0; index < imports.length(); index += 1) {
-                files.add(imports.getString(index));
-            }
-        }
-        return files;
+        return WorkshopAiSymbolDiscovery.defaultScope(aiProjectSources(project));
     }
 
     private static JSONObject aiImportsForFiles(ProjectSnapshot project, Iterable<String> files)
             throws Exception {
-        JSONObject imports = new JSONObject();
-        for (String file : files) imports.put(file, aiDirectImportFiles(project, file));
-        return imports;
+        return WorkshopAiSymbolDiscovery.importsForFiles(aiProjectSources(project), files);
     }
 
-    private static JSONArray aiDirectImportFiles(ProjectSnapshot project, String file)
-            throws Exception {
-        SourceFile sourceFile = findProjectFile(project, file);
-        JSONArray paths = parseImportPaths(sourceFile.source);
-        TreeSet<String> resolved = new TreeSet<>();
-        for (int index = 0; index < paths.length(); index += 1) {
-            resolved.add(WorkshopAiSymbolDiscovery.resolveImport(file, paths.getString(index)));
+    private static Map<String, String> aiProjectSources(ProjectSnapshot project) {
+        LinkedHashMap<String, String> sources = new LinkedHashMap<>();
+        if (project != null) {
+            for (SourceFile sourceFile : project.files) {
+                sources.put(sourceFile.path, sourceFile.source);
+            }
         }
-        return new JSONArray(resolved);
+        return sources;
     }
 
     private static JSONObject aiStasisBasics() throws Exception {
@@ -6976,41 +6964,11 @@ public final class MainActivity extends Activity {
     }
 
     private static JSONArray parseImportPaths(String source) throws Exception {
-        JSONArray imports = new JSONArray();
-        String[] lines = source.split("\\r?\\n");
-        for (String line : lines) {
-            String trimmed = line.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            if (!trimmed.startsWith("import ")) {
-                break;
-            }
-            String path = normalizeImportPath(trimmed);
-            if (!path.isEmpty()) {
-                imports.put(path);
-            }
-        }
-        return imports;
+        return WorkshopAiSymbolDiscovery.parseImportPaths(source);
     }
 
     private static String normalizeImportPath(String value) throws IOException {
-        String trimmed = value == null ? "" : value.trim();
-        if (trimmed.isEmpty()) {
-            return "";
-        }
-        if (trimmed.startsWith("import ")) {
-            int firstQuote = trimmed.indexOf('"');
-            int secondQuote = firstQuote < 0 ? -1 : trimmed.indexOf('"', firstQuote + 1);
-            if (firstQuote < 0 || secondQuote <= firstQuote + 1) {
-                throw new IOException("Invalid import line: " + trimmed);
-            }
-            return trimmed.substring(firstQuote + 1, secondQuote);
-        }
-        if (trimmed.indexOf('"') >= 0 || trimmed.indexOf(';') >= 0) {
-            throw new IOException("Import paths should not include quotes or semicolons: " + trimmed);
-        }
-        return trimmed;
+        return WorkshopAiSymbolDiscovery.normalizeImportPath(value);
     }
 
     private static String importBlockSource(JSONArray imports) throws Exception {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiSymbolDiscovery.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiSymbolDiscovery.java
@@ -1,7 +1,13 @@
 package com.stasislang.workshop;
 
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Locale;
+import java.util.Map;
+import java.util.TreeSet;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 final class WorkshopAiSymbolDiscovery {
     static final String DEFAULT_ENTRY_FILE = "src/main.stasis";
@@ -20,6 +26,66 @@ final class WorkshopAiSymbolDiscovery {
         int slash = normalizedSource.lastIndexOf('/');
         String parent = slash < 0 ? "" : normalizedSource.substring(0, slash + 1);
         return normalize(parent + importPath);
+    }
+
+    static TreeSet<String> defaultScope(Map<String, String> sources) throws Exception {
+        TreeSet<String> files = new TreeSet<>();
+        files.add(DEFAULT_ENTRY_FILE);
+        JSONArray imports = directImportFiles(sources, DEFAULT_ENTRY_FILE);
+        for (int index = 0; index < imports.length(); index += 1) {
+            files.add(imports.getString(index));
+        }
+        return files;
+    }
+
+    static JSONObject importsForFiles(Map<String, String> sources, Iterable<String> files)
+            throws Exception {
+        JSONObject imports = new JSONObject();
+        for (String file : files) imports.put(file, directImportFiles(sources, file));
+        return imports;
+    }
+
+    static JSONArray directImportFiles(Map<String, String> sources, String file)
+            throws Exception {
+        String source = sources.get(file);
+        if (source == null) return new JSONArray();
+        JSONArray paths = parseImportPaths(source);
+        TreeSet<String> resolved = new TreeSet<>();
+        for (int index = 0; index < paths.length(); index += 1) {
+            resolved.add(resolveImport(file, paths.getString(index)));
+        }
+        return new JSONArray(resolved);
+    }
+
+    static JSONArray parseImportPaths(String source) throws Exception {
+        JSONArray imports = new JSONArray();
+        String[] lines = source.split("\\r?\\n");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) continue;
+            if (!trimmed.startsWith("import ")) break;
+            String path = normalizeImportPath(trimmed);
+            if (!path.isEmpty()) imports.put(path);
+        }
+        return imports;
+    }
+
+    static String normalizeImportPath(String value) throws IOException {
+        String trimmed = value == null ? "" : value.trim();
+        if (trimmed.isEmpty()) return "";
+        if (trimmed.startsWith("import ")) {
+            int firstQuote = trimmed.indexOf('"');
+            int secondQuote = firstQuote < 0 ? -1 : trimmed.indexOf('"', firstQuote + 1);
+            if (firstQuote < 0 || secondQuote <= firstQuote + 1) {
+                throw new IOException("Invalid import line: " + trimmed);
+            }
+            return trimmed.substring(firstQuote + 1, secondQuote);
+        }
+        if (trimmed.indexOf('"') >= 0 || trimmed.indexOf(';') >= 0) {
+            throw new IOException(
+                    "Import paths should not include quotes or semicolons: " + trimmed);
+        }
+        return trimmed;
     }
 
     static boolean matches(String name, String signature, String kind, String owner,


### PR DESCRIPTION
## Summary
- preserve Android AI startup when `src/main.stasis` imports a missing file
- keep the stale path in the initial file/import graph as a repairable leaf instead of throwing and collapsing the request to `{}`
- share import parsing and targeted-scope construction through the pure Java discovery helper
- add regression coverage for the missing-direct-import scope and import map

## Review feedback
Addresses the unresolved P2 thread from #317: [Preserve AI startup when imports are broken](https://github.com/benwmaddox/StasisLang/pull/317#discussion_r3632528054).

## Validation
- `gradle :app:testWorkshopDebugUnitTest --tests com.stasislang.workshop.WorkshopAiSymbolDiscoveryTest --no-daemon`
- `gradle :app:testWorkshopDebugUnitTest :app:assembleWorkshopDebug --no-daemon`
- `git diff --check`

## Behavior
For `src/main.stasis` importing absent `src/missing.stasis`, the initial context now retains:

- `files`: `src/main.stasis`, `src/missing.stasis`
- `imports["src/main.stasis"]`: `src/missing.stasis`
- `imports["src/missing.stasis"]`: an empty leaf list

The normal request builder can therefore continue sending the user prompt, tools, globals, and symbol context so the AI can inspect diagnostics and repair the import block.
