### PR TITLE
feat: ship agent workflow guidance

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -100,7 +100,7 @@ jobs:
           mkdir -p "${out}/runtime"
           cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
-          cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
+          cp docs/agent_workflow.md docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/stasis-release-${{ runner.os }}.tar.gz" "stasis-release-${{ runner.os }}"
 
       - name: Assemble bundle (windows)
@@ -136,7 +136,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
           @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
-          Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
+          Copy-Item docs/agent_workflow.md,docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/stasis-release-${{ runner.os }}.zip" -Force
 
       - name: Smoke test bundled graphics runtime (windows)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -164,7 +164,7 @@ jobs:
           mkdir -p "${out}/runtime"
           cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
-          cp docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
+          cp docs/agent_workflow.md docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md "${out}/docs/"
           tar -C dist -czf "dist/${{ matrix.archive }}.${{ matrix.ext }}" "${{ matrix.archive }}"
 
       - name: Assemble bundle (windows)
@@ -201,7 +201,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
           @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
-          Copy-Item docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
+          Copy-Item docs/agent_workflow.md,docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md "$out/docs/" -Force
           Compress-Archive -Path "$out/*" -DestinationPath "dist/${{ matrix.archive }}.${{ matrix.ext }}" -Force
 
       - name: Smoke test bundled graphics runtime (windows)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Most users will:
 The integrated CLI, `stasis.json` workspace contract, JSON output, offline behavior, and
 installation layout are documented in `docs/toolchain_cli.md`.
 
+`stasis new` and `stasis init` also create a concise `AGENTS.md` that teaches coding agents to use
+the compiler-backed symbol, reference, semantic-edit, test, and fresh-runtime validation commands
+instead of scanning and rewriting whole files. The same guide ships as `docs/agent_workflow.md` in
+release archives so it can be copied into an existing project.
+
 Lean Android/iOS app packaging is documented in `docs/mobile_packaging.md`;
 the lower-level AOT artifact contract is in `docs/mobile_aot_artifacts.md`.
 
@@ -54,7 +59,7 @@ Windows release zip layout:
 - `stasis_graphics.dll` at the archive root
 - `lld-link.exe`, `clang-cl.exe`, `stasis_dynload.dll`, and `stasis_dynload.dll.lib` for offline AOT builds
 - `stasis_runner.exe` and `stasis_graphics.dll` for packaged desktop games
-- `src/`, `samples/`, `mobile/shells/`, and `runtime/` at the archive root
+- `src/`, `samples/`, `mobile/shells/`, `runtime/`, and `docs/agent_workflow.md` at the archive root
 
 That keeps the common Windows command simple:
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -35,6 +35,7 @@ mod live_tui;
 
 const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
+const PROJECT_AGENT_GUIDE: &str = include_str!("../../../docs/agent_workflow.md");
 const COMMANDS: &[&str] = &[
     "new",
     "init",
@@ -687,6 +688,7 @@ fn create_project(path: PathBuf, name: String) -> Result<CommandResult, String> 
     let manifest_path = root.join(MANIFEST_NAME);
     let reserved_paths = [
         manifest_path.clone(),
+        root.join("AGENTS.md"),
         root.join("src/main.stasis"),
         root.join("tests/main.test.stasis"),
         root.join("stdlib"),
@@ -703,6 +705,7 @@ fn create_project(path: PathBuf, name: String) -> Result<CommandResult, String> 
     let manifest = ProjectManifest::new(name.clone());
     write_manifest(&manifest_path, &manifest)?;
     copy_dir_if_exists(&bundled_stdlib, &root.join("stdlib"))?;
+    write_new_file(&root.join("AGENTS.md"), PROJECT_AGENT_GUIDE)?;
     write_new_file(
         &root.join("src/main.stasis"),
         "import \"../stdlib/stdlib.stasis\";\n\nfunction main(): i32 {\n    return 0;\n}\n",
@@ -3579,6 +3582,22 @@ mod tests {
         assert_eq!(
             fs::read_to_string(root.join("src/main.stasis")).expect("read user source"),
             "user source\n"
+        );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn init_preserves_existing_agent_instructions_without_partial_writes() {
+        let root = temp_dir("agent_guide_preflight");
+        fs::create_dir_all(&root).expect("create project directory");
+        fs::write(root.join("AGENTS.md"), "user guidance\n").expect("write user guide");
+
+        let error = create_project(root.clone(), "demo".to_string()).expect_err("reject conflict");
+        assert!(error.contains("AGENTS.md"));
+        assert!(!root.join(MANIFEST_NAME).exists());
+        assert_eq!(
+            fs::read_to_string(root.join("AGENTS.md")).expect("read user guide"),
+            "user guidance\n"
         );
         remove_temp(&root);
     }

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -51,6 +51,10 @@ fn project_commands_emit_stable_json_from_nested_directories() {
     let created_json = json_stdout(&created);
     assert_eq!(created_json["ok"], true);
     assert_eq!(created_json["command"], "new");
+    let agent_guide = fs::read_to_string(project.join("AGENTS.md")).expect("read agent guide");
+    assert!(agent_guide.contains("stasis --json symbol list"));
+    assert!(agent_guide.contains("stasis --json symbol references SYMBOL"));
+    assert!(agent_guide.contains("stasis validate PATH OP VALUE --frames N"));
 
     let version = stasis(&["--json", "--version"], &parent);
     assert_eq!(version.status.code(), Some(0));

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -1,0 +1,55 @@
+# Stasis agent workflow
+
+Use the installed `stasis` CLI from the directory containing `stasis.json`. Do not invoke Cargo
+for normal project work.
+
+## Inspect narrowly
+
+1. Start a code task with `stasis --json symbol list`. Without `--file`, this returns a compact,
+   source-free index for the manifest entry file and its direct imports, plus their import map.
+2. Narrow follow-up discovery with `--query`, `--kind`, `--owner`, and repeated `--file` options.
+   Do not enumerate every project symbol or read whole source files by default.
+3. Read only likely targets with `stasis --json symbol read NAME` and disambiguate with `--file`,
+   `--kind`, `--owner`, or `--signature`. Batch independent reads when the agent environment
+   supports parallel tool calls; up to 50 deliberate reads in one turn is reasonable.
+4. Before changing behavior, run `stasis --json symbol references SYMBOL` for the relevant
+   function, global, or qualified field such as `GameState.paddle_y`. Inspect related callers,
+   reads, and writes before editing.
+
+## Edit semantically
+
+Prefer `stasis symbol add`, `update`, `delete`, or `apply` over text-range edits. `symbol read`
+returns `source_hash`; echo it as `--expected-source-hash` so a concurrent change fails instead of
+being overwritten. Use the complete declaration as the replacement source.
+
+For related changes, submit one atomic batch with `stasis symbol apply --request REQUEST.json`:
+
+```json
+{
+  "schema_version": 1,
+  "edits": [
+    {
+      "operation": "update",
+      "target": {"kind": "function", "file": "src/main.stasis", "name": "tick"},
+      "expected_source_hash": "HASH_FROM_SYMBOL_READ",
+      "new_source": "function tick(): i32 { return 0; }"
+    }
+  ]
+}
+```
+
+The compiler plans the entire batch, reconciles imports, compiles it, runs project tests, and
+rolls every touched file back on failure. Do not use `--no-tests` unless the user explicitly asks.
+
+## Prove behavior
+
+- For deterministic logic, add or update a real `.test.stasis` regression test. When practical,
+  run `stasis test` before the implementation to observe the requested test fail, then run it again
+  after the edit.
+- For observable runtime state, use `stasis validate PATH OP VALUE --frames N`. It starts a fresh,
+  isolated runtime, so it is suitable for an integration-style red/green check without depending
+  on a currently running game's state.
+- Finish with `stasis fmt`, `stasis check`, and `stasis test`.
+
+Use `stasis ai "PROMPT"` only when the user explicitly wants Stasis's subscription-backed nested
+AI turn. An agent already performing the task should use the commands above directly.


### PR DESCRIPTION
## Summary
- generate a concise AGENTS.md in every new or initialized Stasis project
- guide agents through targeted symbol discovery, reference checks, stale-safe semantic edits, atomic batches, and red/green validation
- include the same guide in nightly and bootstrap release archives
- preserve existing user-authored AGENTS.md files during initialization

## Validation
- cargo fmt --all -- --check
- python tools/ci/check_stasis_src_layout.py
- cargo test --workspace --all-targets -- --test-threads=1
- cargo test -p stasis --test toolchain_cli project_commands_emit_stable_json_from_nested_directories -- --exact
- cargo test -p stasis --bin stasis toolchain_cli::tests::init_preserves_existing_agent_instructions_without_partial_writes -- --exact

The repository validation shell wrapper could not launch because bash is unavailable on this Windows host; its two commands were run directly and passed.