### PR TITLE
test: measure Stasis AI efficiency by project size

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Check Stasis src layout
         run: python tools/ci/check_stasis_src_layout.py
 
+      - name: Test AI efficiency matrix
+        run: python -m unittest tools.ci.test_stasis_ai_efficiency_matrix
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -16,6 +16,13 @@ for normal project work.
    function, global, or qualified field such as `GameState.paddle_y`. Inspect related callers,
    reads, and writes before editing.
 
+For geometry or collision work, treat the rendered rectangle as the observable contract. Read the
+render, movement, collision, scoring/reset, and existing test symbols together. Test the exact
+contact boundary plus one value inside and outside it; do not infer physics extents from a name or
+an old collision constant alone. For every changed inequality or threshold—including walls,
+collision, scoring, clamping, and reset conditions—test equality and the adjacent value on each
+side so `<` versus `<=` behavior is explicit.
+
 ## Edit semantically
 
 Prefer `stasis symbol add`, `update`, `delete`, or `apply` over text-range edits. `symbol read`
@@ -48,8 +55,12 @@ rolls every touched file back on failure. Do not use `--no-tests` unless the use
   after the edit.
 - For observable runtime state, use `stasis validate PATH OP VALUE --frames N`. It starts a fresh,
   isolated runtime, so it is suitable for an integration-style red/green check without depending
-  on a currently running game's state.
-- Finish with `stasis fmt`, `stasis check`, and `stasis test`.
+  on a currently running game's state. Do not report an observable change complete without a
+  passing fresh validation or an equivalent focused integration test.
+- Finish with `stasis fmt --check`, `stasis check`, and `stasis test`. Semantic symbol edits already
+  preserve untouched formatting; do not run mutating whole-project formatting as routine cleanup.
+- Inspect the final changed-file list. Restore only unrelated changes created during the task and
+  do not accept broad rewrites or empty placeholder files as incidental cleanup.
 
 Use `stasis ai "PROMPT"` only when the user explicitly wants Stasis's subscription-backed nested
 AI turn. An agent already performing the task should use the commands above directly.

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -13,7 +13,7 @@ for normal project work.
    `--kind`, `--owner`, or `--signature`. Batch independent reads when the agent environment
    supports parallel tool calls; up to 50 deliberate reads in one turn is reasonable.
 4. Before changing behavior, run `stasis --json symbol references SYMBOL` for the relevant
-   function, global, or qualified field such as `GameState.paddle_y`. Inspect related callers,
+   function, global, or qualified field such as `PlayerState.health`. Inspect related callers,
    reads, and writes before editing.
 
 For geometry or collision work, treat the rendered rectangle as the observable contract. Read the

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -1,0 +1,50 @@
+# Generalist and built-in AI efficiency matrix
+
+Date: 2026-07-22
+
+## Method
+
+Every run used `gpt-5.6-sol` with medium reasoning and a fresh Git-initialized copy of the same
+Pong project. The task was:
+
+> make the ball 20 pixels square and keep it centered at its position and update collision behavior and tests
+
+The small project contains the ten baseline Stasis files. The medium project adds eight directly
+imported files containing 200 unrelated functions. The large fixture adds 32 files and 1,600
+unrelated functions; it is retained in the harness for the next provider iteration. A hidden
+four-test acceptance file is copied in only after the agent exits. Each agent run is capped at 300
+seconds. Cached input is costed at 10% of uncached input.
+
+These are single controlled trials, so time and token totals are directional rather than variance
+estimates.
+
+## Results
+
+| Approach | Instructions | Size | Hidden acceptance | Agent s | Acceptance s | Total s | Input | Cached | Output | Est. USD |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Generalist | original #319 | small | 3/4 | 225.9 | 0.1 | 226.0 | 699,426 | 648,192 | 9,642 | 0.870 |
+| Generalist | non-mutating format + geometry checks | small | 3/4 | 211.6 | 0.1 | 211.7 | 633,800 | 579,328 | 8,188 | 0.808 |
+| Generalist | explicit equality and adjacent threshold checks | small | 4/4 | 278.0 | 0.1 | 278.1 | 782,492 | 727,040 | 10,493 | 0.956 |
+| Generalist | explicit equality and adjacent threshold checks | medium | 4/4 | 201.0 | 0.1 | 201.1 | 652,734 | 596,480 | 8,670 | 0.840 |
+| Built-in Stasis AI | current | small | 4/4 | 182.1 | 0.1 | 182.2 | 139,196 | 0 | 8,757 | 0.959 |
+| Built-in Stasis AI | current | medium | 2/4 | 127.2 | 0.1 | 127.3 | 140,125 | 12,032 | 5,726 | 0.818 |
+
+## Retained instruction changes
+
+The first generalist refinement reduced time, tokens, and unrelated file churn but remained
+incorrect, so it was not sufficient by itself. Explicit equality and adjacent-value tests for
+every changed inequality raised hidden acceptance from 3/4 to 4/4 on both small and medium
+projects. The extra small-project verification cost is retained because correctness is the primary
+gate.
+
+The guide now also uses `stasis fmt --check` instead of mutating whole-project formatting. In the
+original run, `stasis fmt` rewrote comment-only placeholder files unrelated to the request. The
+refined runs left those files unchanged and required a final changed-file audit.
+
+## Next provider target
+
+Built-in Stasis AI remains faster and consumes far fewer raw input tokens, but its medium result
+missed paddle-contact and scoring-boundary behavior. The next iteration will use the trace to
+improve test discovery and threshold coverage, then rerun small, medium, and large fixtures. No
+provider change is accepted unless it preserves the small pass and fixes the medium failure within
+the same five-minute bound.

--- a/tools/ci/test_stasis_ai_efficiency_matrix.py
+++ b/tools/ci/test_stasis_ai_efficiency_matrix.py
@@ -1,0 +1,66 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("matrix", ROOT / "tools/run_stasis_ai_efficiency_matrix.py")
+matrix = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = matrix
+SPEC.loader.exec_module(matrix)
+
+
+class StasisAiEfficiencyMatrixTests(unittest.TestCase):
+    def test_scaled_projects_are_deterministic_and_agent_ready(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = {"small": 0, "medium": 200, "large": 1600}
+            for scale, padding_functions in expected.items():
+                project = root / scale
+                stats = matrix.prepare_project(project, scale)
+                manifest = json.loads((project / "stasis.json").read_text(encoding="utf-8"))
+                self.assertEqual(padding_functions, stats["padding_functions"])
+                self.assertIn("stasis --json symbol list", (project / "AGENTS.md").read_text(encoding="utf-8"))
+                self.assertEqual("src/main.stasis" if scale == "small" else "src/eval_entry.stasis", manifest["entry"])
+                if scale != "small":
+                    entry = (project / manifest["entry"]).read_text(encoding="utf-8")
+                    self.assertIn('import "main.stasis";', entry)
+
+    def test_usage_parser_supports_codex_and_stasis_usage_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "usage.jsonl"
+            path.write_text(
+                '{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":4,"output_tokens":2}}\n'
+                '{"input_tokens":20,"cached_input_tokens":10,"cache_write_input_tokens":3,"output_tokens":5}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(30, matrix.usage_from_jsonl(path, last_only=False)["input_tokens"])
+            self.assertEqual(20, matrix.usage_from_jsonl(path, last_only=True)["input_tokens"])
+
+    def test_cost_uses_cached_input_at_ten_percent(self) -> None:
+        cost = matrix.estimated_cost({
+            "input_tokens": 1_000_000,
+            "cached_input_tokens": 1_000_000,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 0,
+        })
+        self.assertEqual(0.5, cost)
+
+    def test_event_counts_do_not_double_count_started_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "events.jsonl"
+            path.write_text(
+                '{"type":"item.started","item":{"type":"command_execution"}}\n'
+                '{"type":"item.completed","item":{"type":"command_execution"}}\n'
+                '{"event":"tool_calls","calls":[{"tool":"read_symbol"},{"tool":"find_references"}]}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(1, matrix.count_events(path, "item.completed", "command_execution"))
+            self.assertEqual(2, matrix.count_events(path, "tool_calls"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_stasis_ai_efficiency_matrix.py
+++ b/tools/ci/test_stasis_ai_efficiency_matrix.py
@@ -14,6 +14,31 @@ SPEC.loader.exec_module(matrix)
 
 
 class StasisAiEfficiencyMatrixTests(unittest.TestCase):
+    def test_default_prompt_states_every_hidden_acceptance_requirement(self) -> None:
+        prompt = matrix.DEFAULT_PROMPT.lower()
+        acceptance = matrix.ACCEPTANCE.read_text(encoding="utf-8").lower()
+        prompt_requirements = (
+            "exact 20 by 20 pixel square",
+            "centered on its existing logical position",
+            "top and bottom wall bounds",
+            "10-pixel half-size",
+            "exact rectangle edge contact with a paddle counts as a collision",
+            "score only after the entire square leaves the screen",
+            "touching a screen edge does not score",
+            "normal render and update paths",
+            "exact boundary and the adjacent values",
+        )
+        acceptance_cases = (
+            "comparison ball renders centered at twenty pixels",
+            "comparison ball uses ten pixel wall bounds",
+            "comparison paddle collision matches rendered center",
+            "comparison scoring waits for full ball exit",
+        )
+        for requirement in prompt_requirements:
+            self.assertIn(requirement, prompt)
+        for case in acceptance_cases:
+            self.assertIn(case, acceptance)
+
     def test_scaled_projects_are_deterministic_and_agent_ready(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tools/run_stasis_ai_efficiency_matrix.py
+++ b/tools/run_stasis_ai_efficiency_matrix.py
@@ -16,7 +16,14 @@ ROOT = Path(__file__).resolve().parents[1]
 BASELINE = ROOT / "mobile/android/app/src/main/assets/workshop_sample"
 GUIDE = ROOT / "docs/agent_workflow.md"
 ACCEPTANCE = ROOT / "tools/fixtures/ball_20_comparison_acceptance.test.stasis"
-DEFAULT_PROMPT = "make the ball 20 pixels square and keep it centered at its position and update collision behavior and tests"
+DEFAULT_PROMPT = (
+    "Make the Pong ball render as an exact 20 by 20 pixel square centered on its existing logical "
+    "position. Update top and bottom wall bounds and paddle collision bounds to use the square's "
+    "10-pixel half-size. Exact rectangle edge contact with a paddle counts as a collision. Preserve "
+    "scoring, but score only after the entire square leaves the screen: touching a screen edge does "
+    "not score, while crossing one pixel beyond full exit does. Add durable tests through the normal "
+    "render and update paths at each exact boundary and the adjacent values."
+)
 SCALE_LAYOUT = {"small": (0, 0), "medium": (8, 25), "large": (32, 50)}
 MODEL = "gpt-5.6-sol"
 REASONING = "medium"

--- a/tools/run_stasis_ai_efficiency_matrix.py
+++ b/tools/run_stasis_ai_efficiency_matrix.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Compare general coding agents with Stasis AI on scaled, resettable projects."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BASELINE = ROOT / "mobile/android/app/src/main/assets/workshop_sample"
+GUIDE = ROOT / "docs/agent_workflow.md"
+ACCEPTANCE = ROOT / "tools/fixtures/ball_20_comparison_acceptance.test.stasis"
+DEFAULT_PROMPT = "make the ball 20 pixels square and keep it centered at its position and update collision behavior and tests"
+SCALE_LAYOUT = {"small": (0, 0), "medium": (8, 25), "large": (32, 50)}
+MODEL = "gpt-5.6-sol"
+REASONING = "medium"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    returncode: int
+    elapsed_seconds: float
+    timed_out: bool
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def prepare_project(destination: Path, scale: str, guide: Path = GUIDE) -> dict[str, int]:
+    if scale not in SCALE_LAYOUT:
+        raise ValueError(f"unknown scale: {scale}")
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(BASELINE, destination)
+    _write(destination / "AGENTS.md", guide.read_text(encoding="utf-8"))
+
+    file_count, functions_per_file = SCALE_LAYOUT[scale]
+    imports = ['import "main.stasis";']
+    for file_index in range(file_count):
+        name = f"aaa_eval_padding_{file_index:02d}.stasis"
+        imports.insert(0, f'import "{name}";')
+        functions = []
+        for function_index in range(functions_per_file):
+            ordinal = file_index * functions_per_file + function_index
+            functions.append(
+                f"function eval_padding_{ordinal:04d}(value: i32): i32 {{\n"
+                f"    return value + {ordinal % 17};\n"
+                "}\n"
+            )
+        _write(destination / "src" / name, "\n".join(functions))
+
+    entry = "src/main.stasis"
+    if imports != ['import "main.stasis";']:
+        entry = "src/eval_entry.stasis"
+        _write(destination / entry, "\n".join(imports) + "\n")
+    manifest = {
+        "manifest_version": 1,
+        "name": f"ai_efficiency_{scale}",
+        "entry": entry,
+        "tests": "tests",
+        "output": "build",
+    }
+    _write(destination / "stasis.json", json.dumps(manifest, indent=2) + "\n")
+    return {
+        "padding_files": file_count,
+        "padding_functions": file_count * functions_per_file,
+        "stasis_files": len(list(destination.rglob("*.stasis"))),
+    }
+
+
+def run_process(command: list[str], cwd: Path, stdout_path: Path, stderr_path: Path,
+                env: dict[str, str], timeout_seconds: int) -> RunResult:
+    started = time.perf_counter()
+    timed_out = False
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as error:
+        timed_out = True
+        returncode = 124
+        stdout = error.stdout or ""
+        stderr = error.stderr or ""
+    _write(stdout_path, stdout)
+    _write(stderr_path, stderr)
+    return RunResult(returncode, time.perf_counter() - started, timed_out)
+
+
+def usage_from_jsonl(path: Path, last_only: bool) -> dict[str, int]:
+    usages: list[dict[str, Any]] = []
+    if not path.exists():
+        return {}
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = event.get("usage") if isinstance(event, dict) else None
+        if isinstance(usage, dict):
+            usages.append(usage)
+        elif isinstance(event, dict) and any(key.endswith("tokens") for key in event):
+            usages.append(event)
+    if last_only and usages:
+        usages = usages[-1:]
+    keys = {key for usage in usages for key in usage if key.endswith("tokens")}
+    return {key: sum(int(usage.get(key, 0) or 0) for usage in usages) for key in sorted(keys)}
+
+
+def count_events(path: Path, event_type: str, item_type: str | None = None) -> int:
+    count = 0
+    if not path.exists():
+        return count
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("event") == event_type:
+            count += len(event.get("calls", [])) if event_type == "tool_calls" else 1
+        if event.get("type") == event_type and (item_type is None or event.get("item", {}).get("type") == item_type):
+            count += 1
+    return count
+
+
+def estimated_cost(usage: dict[str, int]) -> float:
+    total = usage.get("input_tokens", 0)
+    cached = usage.get("cached_input_tokens", 0)
+    cache_write = usage.get("cache_write_input_tokens", 0)
+    uncached = max(0, total - cached - cache_write)
+    output = usage.get("output_tokens", 0)
+    return (uncached * 5.0 + cached * 0.5 + cache_write * 6.25 + output * 30.0) / 1_000_000
+
+
+def initialize_git(project: Path) -> None:
+    subprocess.run(["git", "init", "--quiet"], cwd=project, check=True)
+    subprocess.run(["git", "config", "user.email", "ai-eval@localhost"], cwd=project, check=True)
+    subprocess.run(["git", "config", "user.name", "Stasis AI Eval"], cwd=project, check=True)
+    subprocess.run(["git", "add", "."], cwd=project, check=True)
+    subprocess.run(["git", "commit", "--quiet", "-m", "baseline"], cwd=project, check=True)
+
+
+def run_acceptance(project: Path, stasis: Path, env: dict[str, str]) -> RunResult:
+    shutil.copyfile(ACCEPTANCE, project / "tests/comparison_acceptance.test.stasis")
+    return run_process(
+        [str(stasis), "test"], project,
+        project / "build/eval-acceptance.stdout.txt",
+        project / "build/eval-acceptance.stderr.txt", env, 300,
+    )
+
+
+def run_one(mode: str, scale: str, run_root: Path, stasis: Path, codex: Path,
+            prompt: str, timeout_seconds: int) -> dict[str, Any]:
+    project = run_root / "project"
+    stats = prepare_project(project, scale)
+    initialize_git(project)
+    env = os.environ.copy()
+    env["PATH"] = str(stasis.parent) + os.pathsep + env.get("PATH", "")
+    env["STASIS_CODEX_EXE"] = str(codex)
+    env["STASIS_AI_MODEL"] = MODEL
+    env["STASIS_AI_REASONING_EFFORT"] = REASONING
+    preflight = run_process(
+        [str(stasis), "check"], project,
+        run_root / "preflight.stdout.txt", run_root / "preflight.stderr.txt", env, 300,
+    )
+    if preflight.returncode != 0:
+        raise RuntimeError(f"{scale} project preflight failed; see {run_root / 'preflight.stderr.txt'}")
+    stdout = run_root / "agent.stdout.jsonl"
+    stderr = run_root / "agent.stderr.txt"
+
+    if mode == "generalist":
+        command = [
+            str(codex), "exec", "--cd", str(project), "--model", MODEL,
+            "-c", f'model_reasoning_effort="{REASONING}"',
+            "--sandbox", "workspace-write", "--ephemeral", "--json", prompt,
+        ]
+    elif mode == "stasis":
+        command = [str(stasis), "--json", "ai", prompt]
+    else:
+        raise ValueError(f"unknown mode: {mode}")
+    result = run_process(command, project, stdout, stderr, env, timeout_seconds)
+    acceptance = run_acceptance(project, stasis, env)
+
+    if mode == "generalist":
+        usage = usage_from_jsonl(stdout, last_only=True)
+        trace = stdout
+    else:
+        usage_files = sorted((project / "build/ai-traces").glob("*.usage.jsonl"))
+        usage = usage_from_jsonl(usage_files[-1], last_only=False) if usage_files else {}
+        traces = sorted(path for path in (project / "build/ai-traces").glob("*.jsonl") if ".usage." not in path.name)
+        trace = traces[-1] if traces else stdout
+    trace_text = trace.read_text(encoding="utf-8", errors="replace") if trace.exists() else ""
+    return {
+        "mode": mode,
+        "scale": scale,
+        **stats,
+        "returncode": result.returncode,
+        "timed_out": result.timed_out,
+        "elapsed_seconds": round(result.elapsed_seconds, 3),
+        "acceptance_seconds": round(acceptance.elapsed_seconds, 3),
+        "total_seconds": round(result.elapsed_seconds + acceptance.elapsed_seconds, 3),
+        "acceptance_passed": acceptance.returncode == 0,
+        "input_tokens": usage.get("input_tokens", 0),
+        "cached_input_tokens": usage.get("cached_input_tokens", 0),
+        "cache_write_input_tokens": usage.get("cache_write_input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "estimated_cost_usd": round(estimated_cost(usage), 6),
+        "command_actions": count_events(trace, "item.completed", "command_execution"),
+        "tool_calls": count_events(trace, "tool_calls"),
+        "run_root": str(run_root),
+    }
+
+
+def write_summary(output: Path, rows: list[dict[str, Any]], prompt: str) -> None:
+    _write(output / "summary.json", json.dumps({"prompt": prompt, "rows": rows}, indent=2) + "\n")
+    lines = [
+        "# Stasis AI efficiency matrix", "", f"Prompt: `{prompt}`", "",
+        "| Mode | Scale | Files | Padding symbols | Correct | Agent s | Acceptance s | Total s | Input | Cached | Cache write | Output | Est. USD |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row['mode']} | {row['scale']} | {row['stasis_files']} | {row['padding_functions']} | "
+            f"{'yes' if row['acceptance_passed'] else 'no'} | {row['elapsed_seconds']:.1f} | "
+            f"{row['acceptance_seconds']:.1f} | {row['total_seconds']:.1f} | "
+            f"{row['input_tokens']} | {row['cached_input_tokens']} | {row['cache_write_input_tokens']} | "
+            f"{row['output_tokens']} | {row['estimated_cost_usd']:.4f} |"
+        )
+    _write(output / "summary.md", "\n".join(lines) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stasis", type=Path, default=ROOT / "target/debug/stasis.exe")
+    parser.add_argument("--codex", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--modes", nargs="+", choices=("generalist", "stasis"), default=["generalist", "stasis"])
+    parser.add_argument("--scales", nargs="+", choices=tuple(SCALE_LAYOUT), default=list(SCALE_LAYOUT))
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--timeout-seconds", type=int, default=300)
+    args = parser.parse_args()
+    output = args.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for scale in args.scales:
+        for mode in args.modes:
+            run_root = output / f"{scale}-{mode}"
+            run_root.mkdir(parents=True, exist_ok=True)
+            row = run_one(mode, scale, run_root, args.stasis.resolve(), args.codex.resolve(), args.prompt, args.timeout_seconds)
+            rows.append(row)
+            write_summary(output, rows, args.prompt)
+            print(json.dumps(row), flush=True)
+    return 0 if all(row["acceptance_passed"] for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -9,4 +9,5 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 python3 tools/ci/check_stasis_src_layout.py
+python3 -m unittest tools.ci.test_stasis_ai_efficiency_matrix
 cargo test --workspace --all-targets -- --test-threads=1


### PR DESCRIPTION
## Summary
- add a reproducible small/medium/large Stasis AI efficiency harness
- make the default Pong prompt explicitly state every hidden acceptance behavior
- test that prompt clauses and hidden cases stay aligned
- record time, acceptance time, tokens, cache, cost, and actions/tools

## Fair contract
The prompt now explicitly requires centered 20x20 rendering, 10-pixel wall and paddle bounds, inclusive paddle edge contact, strict full-exit scoring, and public render/update boundary tests.

## Tests
- `python -m unittest tools.ci.test_stasis_ai_efficiency_matrix`
- PR CI

Follow-up results are stacked in #321 and #322.