### PR TITLE
docs: consolidate scaled agent discovery

### DIFF
--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -7,12 +7,17 @@ for normal project work.
 
 1. Start a code task with `stasis --json symbol list`. Without `--file`, this returns a compact,
    source-free index for the manifest entry file and its direct imports, plus their import map.
-2. Narrow follow-up discovery with `--query`, `--kind`, `--owner`, and repeated `--file` options.
-   Do not enumerate every project symbol or read whole source files by default.
-3. Read only likely targets with `stasis --json symbol read NAME` and disambiguate with `--file`,
+2. If that page is truncated or dominated by unrelated imports, use the import map to select the
+   likely implementation file. Prefer one file-scoped function inventory, for example
+   `stasis --json symbol list --file src/main.stasis --kind function`, over a series of one-word
+   queries. Request globals separately with the exact kind `--kind globals` only when state fields
+   matter. The accepted kinds are `imports`, `globals`, `struct`, `function`, and `test`.
+3. Otherwise, narrow follow-up discovery with `--query`, `--kind`, `--owner`, and repeated `--file`
+   options. Do not enumerate every project symbol or read whole source files by default.
+4. Read only likely targets with `stasis --json symbol read NAME` and disambiguate with `--file`,
    `--kind`, `--owner`, or `--signature`. Batch independent reads when the agent environment
    supports parallel tool calls; up to 50 deliberate reads in one turn is reasonable.
-4. Before changing behavior, run `stasis --json symbol references SYMBOL` for the relevant
+5. Before changing behavior, run `stasis --json symbol references SYMBOL` for the relevant
    function, global, or qualified field such as `GameState.paddle_y`. Inspect related callers,
    reads, and writes before editing.
 

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -57,6 +57,11 @@ A single refinement that discouraged repeated validation and generated-output in
 passed 4/4, but regressed to 329.7 seconds, 48 actions, and an estimated $1.298, so the instruction
 was not retained.
 
+A final generalist attempt added a narrow stop condition after atomic edit validation and the final
+diff audit. It still passed 4/4 and improved slightly to 288.4 seconds and 46 actions, but input
+rose to 1,336,968 tokens and estimated weighted cost regressed to $1.333. The stop instruction was
+therefore not retained; the existing guide remains the better overall-cost configuration.
+
 ## Next provider target
 
 Built-in Stasis AI remains faster and consumes far fewer raw input tokens, but its medium result

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -48,6 +48,15 @@ inventory preserved 4/4 acceptance while reducing agent time by 57.0 seconds, ac
 34, input tokens by 29.2%, and estimated weighted cost by 18.4%. The trace also eliminated an
 invalid `--kind global` attempt by documenting the exact `globals` spelling.
 
+## Fair-contract rerun
+
+The revised prompt explicitly states every hidden acceptance behavior, including inclusive paddle
+contact and strict full-exit scoring. With that contract, the retained generalist workflow passed
+4/4 on medium in 293.1 seconds using 47 actions, 1,097,919 input tokens, and an estimated $1.292.
+A single refinement that discouraged repeated validation and generated-output inspection also
+passed 4/4, but regressed to 329.7 seconds, 48 actions, and an estimated $1.298, so the instruction
+was not retained.
+
 ## Next provider target
 
 Built-in Stasis AI remains faster and consumes far fewer raw input tokens, but its medium result

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -26,6 +26,8 @@ estimates.
 | Generalist | non-mutating format + geometry checks | small | 3/4 | 211.6 | 0.1 | 211.7 | 633,800 | 579,328 | 8,188 | 0.808 |
 | Generalist | explicit equality and adjacent threshold checks | small | 4/4 | 278.0 | 0.1 | 278.1 | 782,492 | 727,040 | 10,493 | 0.956 |
 | Generalist | explicit equality and adjacent threshold checks | medium | 4/4 | 201.0 | 0.1 | 201.1 | 652,734 | 596,480 | 8,670 | 0.840 |
+| Generalist | equality checks, one-word discovery | large | 4/4 | 261.1 | 0.1 | 261.2 | 969,217 | 907,008 | 10,163 | 1.069 |
+| Generalist | consolidated file-scoped discovery | large | 4/4 | 204.1 | 0.1 | 204.2 | 685,771 | 623,872 | 8,368 | 0.872 |
 | Built-in Stasis AI | current | small | 4/4 | 182.1 | 0.1 | 182.2 | 139,196 | 0 | 8,757 | 0.959 |
 | Built-in Stasis AI | current | medium | 2/4 | 127.2 | 0.1 | 127.3 | 140,125 | 12,032 | 5,726 | 0.818 |
 
@@ -40,6 +42,11 @@ gate.
 The guide now also uses `stasis fmt --check` instead of mutating whole-project formatting. In the
 original run, `stasis fmt` rewrote comment-only placeholder files unrelated to the request. The
 refined runs left those files unchanged and required a final changed-file audit.
+
+On the large fixture, replacing a series of one-word queries with one file-scoped function
+inventory preserved 4/4 acceptance while reducing agent time by 57.0 seconds, actions from 52 to
+34, input tokens by 29.2%, and estimated weighted cost by 18.4%. The trace also eliminated an
+invalid `--kind global` attempt by documenting the exact `globals` spelling.
 
 ## Next provider target
 


### PR DESCRIPTION
## Summary
- retain consolidated file-scoped discovery for large projects
- merge the fair prompt/acceptance contract from #320
- record one additional generalist refinement attempt

## Fair generalist rerun
- retained workflow: 4/4, 293.1s, 47 actions, estimated $1.292
- one repeat-validation refinement: 4/4, 329.7s, 48 actions, estimated $1.298
- the new instruction was worse and was discarded

## Existing retained improvement
On the large fixture, consolidated discovery previously preserved 4/4 while reducing 261.1s to 204.1s and 52 actions to 34.

## Tests
- fair hidden Pong suite on a fresh medium project
- `python -m unittest tools.ci.test_stasis_ai_efficiency_matrix`

Stacked on #320.