### PR TITLE
Refactor built-in AI completion validation

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3158,9 +3158,7 @@ mod tests {
             ("write_symbol", "stasis symbol update / :update"),
             ("delete_symbol", "stasis symbol delete / :delete"),
             ("inspect_runtime_state", ":inspect"),
-            ("validate_runtime_state", "stasis validate / :validate"),
             ("run_frame", ":step / stasis validate --frames"),
-            ("run_tests", "stasis test / tested TUI apply"),
         ]);
 
         for tool in live_tool_specs() {

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -174,6 +174,10 @@ struct AiAuditLog {
     file: fs::File,
     usage_path: PathBuf,
     usage_file: fs::File,
+    timing_path: PathBuf,
+    timing_file: fs::File,
+    started_at: Instant,
+    last_event_at: Instant,
 }
 
 impl AiAuditLog {
@@ -187,6 +191,7 @@ impl AiAuditLog {
             .as_millis();
         let path = directory.join(format!("tui-ai-{stamp}.jsonl"));
         let usage_path = directory.join(format!("tui-ai-{stamp}.usage.jsonl"));
+        let timing_path = directory.join(format!("tui-ai-{stamp}.timing.jsonl"));
         let file = OpenOptions::new()
             .create_new(true)
             .write(true)
@@ -197,11 +202,21 @@ impl AiAuditLog {
             .write(true)
             .open(&usage_path)
             .map_err(|error| format!("failed creating AI usage trace: {error}"))?;
+        let timing_file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&timing_path)
+            .map_err(|error| format!("failed creating AI timing trace: {error}"))?;
+        let now = Instant::now();
         let mut log = Self {
             path,
             file,
             usage_path,
             usage_file,
+            timing_path,
+            timing_file,
+            started_at: now,
+            last_event_at: now,
         };
         log.write(serde_json::json!({
             "event": "request",
@@ -217,6 +232,13 @@ impl AiAuditLog {
     }
 
     fn write(&mut self, value: Value) -> Result<(), String> {
+        let now = Instant::now();
+        let timing = serde_json::json!({
+            "event": value.get("event").cloned().unwrap_or(Value::Null),
+            "elapsed_ms": duration_millis(now.duration_since(self.started_at)),
+            "since_previous_ms": duration_millis(now.duration_since(self.last_event_at)),
+        });
+        self.last_event_at = now;
         serde_json::to_writer(&mut self.file, &value)
             .map_err(|error| format!("failed encoding AI trace: {error}"))?;
         self.file
@@ -224,7 +246,15 @@ impl AiAuditLog {
             .map_err(|error| format!("failed writing AI trace: {error}"))?;
         self.file
             .flush()
-            .map_err(|error| format!("failed flushing AI trace: {error}"))
+            .map_err(|error| format!("failed flushing AI trace: {error}"))?;
+        serde_json::to_writer(&mut self.timing_file, &timing)
+            .map_err(|error| format!("failed encoding AI timing trace: {error}"))?;
+        self.timing_file
+            .write_all(b"\n")
+            .map_err(|error| format!("failed writing AI timing trace: {error}"))?;
+        self.timing_file
+            .flush()
+            .map_err(|error| format!("failed flushing AI timing trace: {error}"))
     }
 
     fn write_usage(&mut self, usage: &Value) -> Result<(), String> {
@@ -237,6 +267,10 @@ impl AiAuditLog {
             .flush()
             .map_err(|error| format!("failed flushing AI usage trace: {error}"))
     }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 impl Drop for AiRun {
@@ -2944,9 +2978,31 @@ mod tests {
             "output_tokens": 20,
         });
         let mut log = AiAuditLog::create(&root, "test prompt").expect("audit log");
+        let trace_path = log.path.clone();
         let usage_path = log.usage_path.clone();
+        let timing_path = log.timing_path.clone();
+        log.write(serde_json::json!({"event": "test"}))
+            .expect("timed trace");
         log.write_usage(&usage).expect("usage log");
         drop(log);
+        let trace = fs::read_to_string(trace_path).expect("trace contents");
+        let records = trace
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("trace record"))
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 2);
+        assert!(records
+            .iter()
+            .all(|record| record.get("elapsed_ms").is_none()));
+        let timings = fs::read_to_string(timing_path).expect("timing contents");
+        let timings = timings
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("timing record"))
+            .collect::<Vec<_>>();
+        assert_eq!(timings.len(), 2);
+        assert!(timings
+            .iter()
+            .all(|record| record["elapsed_ms"].is_u64() && record["since_previous_ms"].is_u64()));
         assert_eq!(
             fs::read_to_string(&usage_path).expect("usage contents"),
             format!("{}\n", serde_json::to_string(&usage).unwrap())

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1,4 +1,4 @@
-use super::{format_live_response, scalar_text, RuntimeValidationRequirement};
+use super::{format_live_response, scalar_text};
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use crossterm::execute;
@@ -18,15 +18,13 @@ use stasis_compiler::frontend::workshop::{
     workshop_source_hash, WorkshopSourceItem, WorkshopSourceItemKind,
 };
 use stasis_runner::live::{
-    compare_live_validation_values, CompletionContext, CompletionItem, CompletionQuery,
-    LiveCommand, LiveEdit, LiveEditOperation, LiveRequest, LiveResponse, LiveSessionClient,
-    LiveSymbolTarget, TerminalBuffer, TerminalInput,
+    CompletionContext, CompletionItem, CompletionQuery, LiveCommand, LiveEdit, LiveEditOperation,
+    LiveRequest, LiveResponse, LiveSessionClient, LiveSymbolTarget, TerminalBuffer, TerminalInput,
 };
 use std::collections::{BTreeMap, VecDeque};
 use std::fs::{self, OpenOptions};
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -34,7 +32,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const MAX_TRANSCRIPT_LINES: usize = 500;
 const MAX_UNDO_STATES: usize = 100;
-const MAX_AI_DIAGNOSTIC_CHARS: usize = 4096;
 const COMPLETION_LIMIT: usize = 64;
 const TUI_REQUEST_START: u64 = 1u64 << 61;
 const AI_REQUEST_START: u64 = 1u64 << 62;
@@ -63,7 +60,7 @@ pub(super) fn run_scripted_ai_with_cancel(
     let trace_path = audit.path.clone();
     let usage_path = audit.usage_path.clone();
     let mut provider = CodexExecProvider::default();
-    let mut tools = LiveAiTools::new(client.clone(), project_root.to_path_buf());
+    let mut tools = LiveAiTools::new(client.clone());
     let initial_context = load_ai_initial_context(&mut tools, canceled)?;
     audit.write(serde_json::json!({
         "event": "initial_context",
@@ -1233,13 +1230,12 @@ impl LiveTui {
             }
         }
         let client = self.client.clone();
-        let project_root = self.project_root.clone();
         let canceled = Arc::new(AtomicBool::new(false));
         let worker_canceled = canceled.clone();
         let (events_tx, events_rx) = mpsc::channel();
         let worker = thread::spawn(move || {
             let mut provider = CodexExecProvider::default();
-            let mut tools = LiveAiTools::new(client, project_root);
+            let mut tools = LiveAiTools::new(client);
             let progress = events_tx.clone();
             let result =
                 load_ai_initial_context(&mut tools, &worker_canceled).and_then(|initial_context| {
@@ -1910,39 +1906,19 @@ fn completion_key(item: &CompletionItem) -> (String, String, String) {
     (item.text.clone(), item.kind.clone(), item.detail.clone())
 }
 
-#[derive(Clone, PartialEq)]
-struct AiValidationContract {
-    requirements: Value,
-    frames: usize,
-    baseline: String,
-    setup: String,
-    tick: String,
-    render: String,
-}
-
 struct LiveAiTools {
     client: LiveSessionClient,
-    project_root: PathBuf,
     next_request_id: u64,
     last_write: Option<LiveResponse>,
-    validation_baseline_active: bool,
-    validation_was_paused: bool,
-    red_validation_contract: Option<AiValidationContract>,
-    write_needs_green_validation: bool,
     reference_search_ready: bool,
 }
 
 impl LiveAiTools {
-    fn new(client: LiveSessionClient, project_root: PathBuf) -> Self {
+    fn new(client: LiveSessionClient) -> Self {
         Self {
             client,
-            project_root,
             next_request_id: AI_REQUEST_START,
             last_write: None,
-            validation_baseline_active: false,
-            validation_was_paused: false,
-            red_validation_contract: None,
-            write_needs_green_validation: false,
             reference_search_ready: false,
         }
     }
@@ -2012,22 +1988,6 @@ impl LiveAiTools {
                 concise: true,
             },
             "run_frame" => LiveCommand::Step { ticks: 1 },
-            "run_tests" => {
-                return match &self.last_write {
-                    Some(response) if response.ok => ToolObservation::result(
-                        "run_tests",
-                        serde_json::json!({
-                            "status": "passed_with_latest_atomic_write",
-                            "write": compact_write_transaction(response.data.as_ref()),
-                        }),
-                    ),
-                    _ => ToolObservation::error(
-                        "run_tests",
-                        "live AI tests run as part of each atomic write batch; no successful write batch is available",
-                    ),
-                };
-            }
-            "validate_runtime_state" => return self.execute_validation(call, canceled),
             _ => return ToolObservation::error(&call.tool, "tool is not a read operation"),
         };
         match self.request(command, canceled) {
@@ -2042,341 +2002,11 @@ impl LiveAiTools {
         }
     }
 
-    fn execute_validation(&mut self, call: &ToolCall, canceled: &AtomicBool) -> ToolObservation {
-        let args = call.args.as_object().expect("validated tool args");
-        let expected_outcome = string_arg(args, "expected_outcome").unwrap_or_default();
-        if !matches!(expected_outcome.as_str(), "pass" | "fail") {
-            return ToolObservation::error(&call.tool, "expected_outcome must be 'pass' or 'fail'");
-        }
-        let Some(requirements) = args.get("requirements").and_then(Value::as_array) else {
-            return ToolObservation::error(&call.tool, "requirements must be an array");
-        };
-        if requirements.is_empty() || requirements.len() > 16 {
-            return ToolObservation::error(&call.tool, "requirements must contain 1..=16 checks");
-        }
-        let frames = usize_arg(args, "frames").unwrap_or(0);
-        if frames > 600 {
-            return ToolObservation::error(&call.tool, "frames exceeds the 600-frame limit");
-        }
-        let baseline = string_arg(args, "baseline").unwrap_or_else(|| "live".to_string());
-        if !matches!(baseline.as_str(), "live" | "fresh") {
-            return ToolObservation::error(&call.tool, "baseline must be 'live' or 'fresh'");
-        }
-        let setup = string_arg(args, "setup").unwrap_or_else(|| "main".to_string());
-        let tick = string_arg(args, "tick").unwrap_or_else(|| "tick".to_string());
-        let render = string_arg(args, "render").unwrap_or_else(|| "render".to_string());
-        let validation_contract = AiValidationContract {
-            requirements: Value::Array(requirements.clone()),
-            frames,
-            baseline: baseline.clone(),
-            setup,
-            tick,
-            render,
-        };
-        if expected_outcome == "pass"
-            && self.write_needs_green_validation
-            && self.red_validation_contract.as_ref() != Some(&validation_contract)
-        {
-            return ToolObservation::error(
-                &call.tool,
-                "green validation must use the same baseline, requirements, and frame count as the accepted red validation",
-            );
-        }
-        if baseline == "fresh" {
-            let result = self.execute_fresh_validation(&validation_contract, canceled);
-            return self.finish_validation_observation(
-                &call.tool,
-                expected_outcome,
-                validation_contract,
-                result,
-            );
-        }
-        if !self.validation_baseline_active {
-            self.validation_was_paused = match self.request(LiveCommand::Status, canceled) {
-                Ok(response) if response.ok => response
-                    .data
-                    .as_ref()
-                    .and_then(|data| data.get("paused"))
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-                Ok(response) => {
-                    return ToolObservation::error(&call.tool, format_live_response(&response))
-                }
-                Err(error) => return ToolObservation::error(&call.tool, error),
-            };
-        }
-        let mut validation_pause_acquired = false;
-        let result = (|| -> Result<Value, String> {
-            let response = self.request(LiveCommand::Pause, canceled)?;
-            if !response.ok {
-                return Err(format_live_response(&response));
-            }
-            validation_pause_acquired = true;
-            let baseline_command = if self.validation_baseline_active {
-                LiveCommand::ValidationRestore
-            } else {
-                LiveCommand::ValidationSnapshot
-            };
-            let response = self.request(baseline_command, canceled)?;
-            if !response.ok {
-                return Err(format_live_response(&response));
-            }
-            self.validation_baseline_active = true;
-            for _ in 0..frames {
-                let response = self.request(LiveCommand::Step { ticks: 1 }, canceled)?;
-                if !response.ok {
-                    return Err(format_live_response(&response));
-                }
-            }
-            let mut checks = Vec::new();
-            let mut requirements_met = true;
-            for requirement in requirements {
-                let object = requirement
-                    .as_object()
-                    .ok_or_else(|| "each requirement must be an object".to_string())?;
-                let path = string_arg(object, "path")
-                    .ok_or_else(|| "each requirement needs a path".to_string())?;
-                let operator = string_arg(object, "op").unwrap_or_else(|| "eq".to_string());
-                let expected = object
-                    .get("value")
-                    .cloned()
-                    .ok_or_else(|| format!("requirement for {path} needs a value"))?;
-                let response =
-                    self.request(LiveCommand::Inspect { path: path.clone() }, canceled)?;
-                if !response.ok {
-                    return Err(format_live_response(&response));
-                }
-                let actual = response
-                    .data
-                    .as_ref()
-                    .and_then(|data| data.get("value"))
-                    .and_then(|value| value.get("value"))
-                    .cloned()
-                    .ok_or_else(|| format!("inspection for {path} returned no scalar value"))?;
-                let passed = compare_live_validation_values(&actual, &operator, &expected)?;
-                requirements_met &= passed;
-                checks.push(serde_json::json!({
-                    "path": path,
-                    "op": operator,
-                    "expected": expected,
-                    "actual": actual,
-                    "passed": passed,
-                }));
-            }
-            let expected_met = expected_outcome == "pass";
-            Ok(serde_json::json!({
-                "status": if requirements_met == expected_met { "accepted" } else { "unexpected" },
-                "expected_outcome": expected_outcome,
-                "requirements_met": requirements_met,
-                "validation_passed": requirements_met == expected_met,
-                "frames": frames,
-                "checks": checks,
-            }))
-        })();
-        let requirements_met = result
-            .as_ref()
-            .ok()
-            .and_then(|value| value.get("requirements_met"))
-            .and_then(Value::as_bool);
-        let should_finish = result.is_err()
-            || expected_outcome == "pass"
-            || (expected_outcome == "fail" && requirements_met == Some(true));
-        if should_finish {
-            if self.validation_baseline_active {
-                self.finish_validation();
-            } else if validation_pause_acquired && !self.validation_was_paused {
-                let _ = self.request(LiveCommand::Resume, &AtomicBool::new(false));
-            }
-        } else if self.validation_baseline_active {
-            let _ = self.request(LiveCommand::ValidationRestore, canceled);
-        }
-        self.finish_validation_observation(
-            &call.tool,
-            expected_outcome,
-            validation_contract,
-            result,
-        )
-    }
-
-    fn execute_fresh_validation(
-        &self,
-        contract: &AiValidationContract,
-        canceled: &AtomicBool,
-    ) -> Result<Value, String> {
-        let requirements = contract
-            .requirements
-            .as_array()
-            .expect("validated requirements array")
-            .iter()
-            .cloned()
-            .map(serde_json::from_value::<RuntimeValidationRequirement>)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| format!("invalid fresh validation requirement: {error}"))?;
-        let executable = std::env::current_exe()
-            .map_err(|error| format!("failed locating stasis executable: {error}"))?;
-        let mut child = Command::new(executable)
-            .arg("--json")
-            .arg("--workspace")
-            .arg(&self.project_root)
-            .arg("__validate-runtime")
-            .arg("--frames")
-            .arg(contract.frames.to_string())
-            .arg("--requirements-json")
-            .arg(
-                serde_json::to_string(&requirements)
-                    .map_err(|error| format!("failed encoding validation requirements: {error}"))?,
-            )
-            .arg("--setup")
-            .arg(&contract.setup)
-            .arg("--tick")
-            .arg(&contract.tick)
-            .arg("--render")
-            .arg(&contract.render)
-            .current_dir(&self.project_root)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|error| format!("failed starting fresh validation process: {error}"))?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "fresh validation stdout was unavailable".to_string())?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| "fresh validation stderr was unavailable".to_string())?;
-        let stdout_worker = thread::spawn(move || read_bounded_process_output(stdout));
-        let stderr_worker = thread::spawn(move || read_bounded_process_output(stderr));
-        let started = Instant::now();
-        let status = loop {
-            if canceled.load(Ordering::Acquire) {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stdout_worker.join();
-                let _ = stderr_worker.join();
-                return Err("AI request canceled".to_string());
-            }
-            if let Some(status) = child
-                .try_wait()
-                .map_err(|error| format!("fresh validation process failed: {error}"))?
-            {
-                break status;
-            }
-            if started.elapsed() >= Duration::from_secs(60) {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stdout_worker.join();
-                let _ = stderr_worker.join();
-                return Err("fresh validation exceeded 60 seconds".to_string());
-            }
-            thread::sleep(Duration::from_millis(20));
-        };
-        let stdout = stdout_worker
-            .join()
-            .map_err(|_| "fresh validation stdout reader panicked".to_string())??;
-        let stderr = stderr_worker
-            .join()
-            .map_err(|_| "fresh validation stderr reader panicked".to_string())??;
-        if !status.success() {
-            return Err(format!(
-                "fresh validation failed: {}",
-                stderr.lines().last().unwrap_or("child process failed")
-            ));
-        }
-        let envelope = stdout
-            .lines()
-            .rev()
-            .find_map(|line| serde_json::from_str::<Value>(line).ok())
-            .ok_or_else(|| "fresh validation returned no JSON result".to_string())?;
-        let mut result = envelope
-            .get("result")
-            .cloned()
-            .ok_or_else(|| "fresh validation JSON omitted result".to_string())?;
-        if !stderr.trim().is_empty() {
-            result["diagnostics"] = Value::String(
-                stderr
-                    .chars()
-                    .take(MAX_AI_DIAGNOSTIC_CHARS)
-                    .collect::<String>(),
-            );
-        }
-        Ok(result)
-    }
-
-    fn finish_validation_observation(
-        &mut self,
-        tool: &str,
-        expected_outcome: String,
-        validation_contract: AiValidationContract,
-        result: Result<Value, String>,
-    ) -> ToolObservation {
-        match result {
-            Ok(mut result) => {
-                let requirements_met = result
-                    .get("requirements_met")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false);
-                let validation_passed = requirements_met == (expected_outcome == "pass");
-                let object = result.as_object_mut().expect("validation result object");
-                object.insert(
-                    "expected_outcome".into(),
-                    Value::String(expected_outcome.clone()),
-                );
-                object.insert("validation_passed".into(), Value::Bool(validation_passed));
-                object.insert(
-                    "status".into(),
-                    Value::String(
-                        if validation_passed {
-                            "accepted"
-                        } else {
-                            "unexpected"
-                        }
-                        .into(),
-                    ),
-                );
-                if validation_passed && expected_outcome == "fail" {
-                    self.red_validation_contract = Some(validation_contract);
-                }
-                if validation_passed && expected_outcome == "pass" && self.last_write.is_some() {
-                    self.write_needs_green_validation = false;
-                    self.red_validation_contract = None;
-                }
-                ToolObservation::result(tool, result)
-            }
-            Err(error) => ToolObservation::error(tool, error),
-        }
-    }
-
-    fn finish_validation(&mut self) {
-        if !self.validation_baseline_active {
-            return;
-        }
-        let cleanup_canceled = AtomicBool::new(false);
-        let _ = self.request(LiveCommand::ValidationRestore, &cleanup_canceled);
-        let _ = self.request(LiveCommand::ValidationClear, &cleanup_canceled);
-        if !self.validation_was_paused {
-            let _ = self.request(LiveCommand::Resume, &cleanup_canceled);
-        }
-        self.validation_baseline_active = false;
-    }
-
     fn execute_writes(
         &mut self,
         calls: &[&ToolCall],
         canceled: &AtomicBool,
     ) -> Vec<ToolObservation> {
-        if self.red_validation_contract.is_none() {
-            return calls
-                .iter()
-                .map(|call| {
-                    ToolObservation::error(
-                        &call.tool,
-                        "run validate_runtime_state with expected_outcome=fail before a live AI write",
-                    )
-                })
-                .collect();
-        }
         if !self.reference_search_ready {
             return calls
                 .iter()
@@ -2425,38 +2055,46 @@ impl LiveAiTools {
                 let applied = response.ok && response.kind == "edit_applied";
                 if applied {
                     self.last_write = Some(response.clone());
-                    self.write_needs_green_validation = true;
                     self.reference_search_ready = false;
                 }
-                calls
-                    .iter()
-                    .enumerate()
-                    .map(|(index, call)| {
-                        if applied {
-                            applied_write_observation(
-                                call,
-                                index,
-                                calls.len(),
-                                &response.data,
-                            )
-                        } else {
-                            let error = if response.ok && response.kind == "edit_preview" {
-                                "layout-changing AI edit was validated but requires explicit user :apply approval"
-                                    .to_string()
-                            } else {
-                                format_live_response(&response)
-                            };
-                            ToolObservation::error(&call.tool, error)
-                        }
-                    })
-                    .collect()
+                if applied {
+                    calls
+                        .iter()
+                        .enumerate()
+                        .map(|(index, call)| {
+                            applied_write_observation(call, index, calls.len(), &response.data)
+                        })
+                        .collect()
+                } else {
+                    let error = if response.ok && response.kind == "edit_preview" {
+                        "layout-changing AI edit was validated but requires explicit user :apply approval"
+                            .to_string()
+                    } else {
+                        format_live_response(&response)
+                    };
+                    failed_write_observations(calls, error)
+                }
             }
-            Err(error) => calls
-                .iter()
-                .map(|call| ToolObservation::error(&call.tool, error.clone()))
-                .collect(),
+            Err(error) => failed_write_observations(calls, error),
         }
     }
+}
+
+fn failed_write_observations(calls: &[&ToolCall], error: String) -> Vec<ToolObservation> {
+    calls
+        .iter()
+        .enumerate()
+        .map(|(index, call)| {
+            ToolObservation::error(
+                &call.tool,
+                if index == 0 {
+                    error.clone()
+                } else {
+                    "atomic write batch failed; see the first write observation".to_string()
+                },
+            )
+        })
+        .collect()
 }
 
 fn applied_write_observation(
@@ -2518,14 +2156,6 @@ fn contiguous_write_range(calls: &[ToolCall]) -> Result<Option<std::ops::Range<u
     Ok(Some(first..last + 1))
 }
 
-impl Drop for LiveAiTools {
-    fn drop(&mut self) {
-        if self.validation_baseline_active {
-            self.finish_validation();
-        }
-    }
-}
-
 impl ToolExecutor for LiveAiTools {
     fn execute(&mut self, calls: &[ToolCall], canceled: &AtomicBool) -> Vec<ToolObservation> {
         let write_range = match contiguous_write_range(calls) {
@@ -2537,7 +2167,7 @@ impl ToolExecutor for LiveAiTools {
                     .collect()
             }
         };
-        let mut observations = Vec::with_capacity(calls.len() + 1);
+        let mut observations = Vec::with_capacity(calls.len());
         let mut index = 0;
         while index < calls.len() {
             if write_range
@@ -2546,31 +2176,7 @@ impl ToolExecutor for LiveAiTools {
             {
                 let range = write_range.as_ref().expect("write range");
                 let writes = calls[range.clone()].iter().collect::<Vec<_>>();
-                let write_observations = self.execute_writes(&writes, canceled);
-                let applied = write_observations
-                    .iter()
-                    .all(|observation| observation.error.is_none())
-                    && self.write_needs_green_validation;
-                observations.extend(write_observations);
-                if applied {
-                    let contract = self
-                        .red_validation_contract
-                        .clone()
-                        .expect("applied AI write has red validation contract");
-                    let green_call = ToolCall {
-                        tool: "validate_runtime_state".to_string(),
-                        args: serde_json::json!({
-                            "requirements": contract.requirements,
-                            "expected_outcome": "pass",
-                            "frames": contract.frames,
-                            "baseline": contract.baseline,
-                            "setup": contract.setup,
-                            "tick": contract.tick,
-                            "render": contract.render,
-                        }),
-                    };
-                    observations.push(self.execute_validation(&green_call, canceled));
-                }
+                observations.extend(self.execute_writes(&writes, canceled));
                 index = range.end;
             } else {
                 observations.push(self.execute_read(&calls[index], canceled));
@@ -2581,10 +2187,23 @@ impl ToolExecutor for LiveAiTools {
     }
 
     fn validate_completion(&self) -> Result<(), String> {
-        if self.write_needs_green_validation {
-            Err("the applied live edit still requires validate_runtime_state with expected_outcome=pass".to_string())
-        } else {
-            Ok(())
+        match &self.last_write {
+            Some(response)
+                if response.ok
+                    && response.kind == "edit_applied"
+                    && response
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("tests"))
+                        .and_then(Value::as_str)
+                        == Some("passed") =>
+            {
+                Ok(())
+            }
+            _ => Err(
+                "complete the requested change with one atomic write that compiles and passes project tests"
+                    .to_string(),
+            ),
         }
     }
 }
@@ -2623,23 +2242,6 @@ fn string_array_arg(
                 .ok_or_else(|| format!("{name} must contain non-empty strings"))
         })
         .collect()
-}
-
-fn read_bounded_process_output(mut reader: impl Read) -> Result<String, String> {
-    const CAPTURE_LIMIT: usize = 65_536;
-    let mut captured = Vec::with_capacity(CAPTURE_LIMIT);
-    let mut buffer = [0u8; 8_192];
-    loop {
-        let count = reader
-            .read(&mut buffer)
-            .map_err(|error| format!("failed reading validation process output: {error}"))?;
-        if count == 0 {
-            break;
-        }
-        let remaining = CAPTURE_LIMIT.saturating_sub(captured.len());
-        captured.extend_from_slice(&buffer[..count.min(remaining)]);
-    }
-    Ok(String::from_utf8_lossy(&captured).into_owned())
 }
 
 fn audit_tool_call(call: &ToolCall) -> Value {
@@ -3155,125 +2757,9 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn runtime_validation_comparisons_cover_scalar_requirements() {
-        assert!(compare_live_validation_values(&json!(144), "eq", &json!(144)).expect("eq"));
-        assert!(compare_live_validation_values(&json!(72), "ne", &json!(144)).expect("ne"));
-        assert!(compare_live_validation_values(&json!(2.5), "lt", &json!(15)).expect("lt"));
-        assert!(compare_live_validation_values(&json!(true), "eq", &json!(true)).expect("bool"));
-        assert!(compare_live_validation_values(&json!(7), "gte", &json!(7)).expect("gte"));
-        assert!(compare_live_validation_values(&json!(9), "gt", &json!(7)).expect("gt"));
-        assert!(compare_live_validation_values(&json!(7), "lte", &json!(7)).expect("lte"));
-    }
-
-    #[test]
-    fn runtime_validation_runs_bounded_red_green_requirements() {
-        let (client, server) = stasis_runner::live::live_session(8);
-        let worker = thread::spawn(move || {
-            let mut handled = 0;
-            let mut inspections = 0;
-            while handled < 11 {
-                for request in server.drain(8) {
-                    let (kind, data) = match request.command {
-                        LiveCommand::Status => ("status", json!({"paused": false})),
-                        LiveCommand::Pause => ("paused", json!({"paused": true})),
-                        LiveCommand::ValidationSnapshot => {
-                            ("validation_snapshot", json!({"captured": true}))
-                        }
-                        LiveCommand::ValidationRestore => {
-                            ("validation_restored", json!({"restored": true}))
-                        }
-                        LiveCommand::ValidationClear => {
-                            ("validation_cleared", json!({"cleared": true}))
-                        }
-                        LiveCommand::Inspect { path } => {
-                            inspections += 1;
-                            let value = if inspections == 1 { 72 } else { 144 };
-                            (
-                                "inspection",
-                                json!({"path": path, "value": {"type": "i32", "value": value}}),
-                            )
-                        }
-                        LiveCommand::Resume => ("resumed", json!({"paused": false})),
-                        command => panic!("unexpected validation command: {command:?}"),
-                    };
-                    server
-                        .respond(LiveResponse::success(request.request_id, 0, kind, data))
-                        .expect("respond");
-                    handled += 1;
-                }
-                thread::sleep(Duration::from_millis(1));
-            }
-        });
-        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
-        let red = tools.execute(
-            &[ToolCall {
-                tool: "validate_runtime_state".into(),
-                args: json!({
-                    "expected_outcome": "fail",
-                    "requirements": [{"path": "Render.command1_h", "op": "eq", "value": 144}]
-                }),
-            }],
-            &AtomicBool::new(false),
-        );
-        let green = tools.execute(
-            &[ToolCall {
-                tool: "validate_runtime_state".into(),
-                args: json!({
-                    "expected_outcome": "pass",
-                    "requirements": [{"path": "Render.command1_h", "op": "eq", "value": 144}]
-                }),
-            }],
-            &AtomicBool::new(false),
-        );
-
-        worker.join().expect("validation server");
-        assert_eq!(red.len(), 1);
-        assert_eq!(
-            red[0].result.as_ref().expect("red")["validation_passed"],
-            true
-        );
-        assert!(tools.red_validation_contract.is_some());
-        assert_eq!(
-            green[0].result.as_ref().expect("green")["validation_passed"],
-            true
-        );
-    }
-
-    #[test]
-    fn live_ai_write_is_rejected_until_red_validation_exists() {
-        let (client, _server) = stasis_runner::live::live_session(1);
-        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
-
-        let observations = tools.execute(
-            &[ToolCall {
-                tool: "write_symbol".into(),
-                args: json!({
-                    "file": "src/main.stasis",
-                    "name": "tick",
-                    "new_source": "function tick(): void { return; }"
-                }),
-            }],
-            &AtomicBool::new(false),
-        );
-
-        assert!(observations[0]
-            .error
-            .as_deref()
-            .is_some_and(|error| error.contains("expected_outcome=fail")));
-    }
-
-    #[test]
     fn live_ai_write_is_rejected_until_references_were_checked() {
         let (client, _server) = stasis_runner::live::live_session(1);
-        let mut tools = LiveAiTools::new(client, PathBuf::from("."));
-        tools.red_validation_contract = Some(AiValidationContract {
-            requirements: json!([{"path": "State.value", "op": "eq", "value": 2}]),
-            frames: 0,
-            baseline: "live".into(),
-            setup: "main".into(),
-            tick: "tick".into(),
-            render: "render".into(),
-        });
+        let mut tools = LiveAiTools::new(client);
 
         let observations = tools.execute(
             &[ToolCall {
@@ -3334,6 +2820,58 @@ mod tests {
             second.result.as_ref().unwrap()["write_receipt"],
             "build/live-edits/receipt.json"
         );
+    }
+
+    #[test]
+    fn failed_atomic_batch_reports_details_once() {
+        let calls = [
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({"name": "tick"}),
+            },
+            ToolCall {
+                tool: "write_symbol".into(),
+                args: json!({"name": "render"}),
+            },
+        ];
+        let call_refs = calls.iter().collect::<Vec<_>>();
+
+        let observations = failed_write_observations(&call_refs, "compile failed at line 4".into());
+
+        assert_eq!(
+            observations[0].error.as_deref(),
+            Some("compile failed at line 4")
+        );
+        assert_eq!(
+            observations[1].error.as_deref(),
+            Some("atomic write batch failed; see the first write observation")
+        );
+    }
+
+    #[test]
+    fn live_ai_completion_requires_a_tested_atomic_write() {
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let mut tools = LiveAiTools::new(client);
+        assert!(tools
+            .validate_completion()
+            .expect_err("write required")
+            .contains("compiles and passes project tests"));
+
+        tools.last_write = Some(LiveResponse::success(
+            1,
+            0,
+            "edit_applied",
+            json!({"tests": "skipped"}),
+        ));
+        assert!(tools.validate_completion().is_err());
+
+        tools.last_write = Some(LiveResponse::success(
+            2,
+            0,
+            "edit_applied",
+            json!({"tests": "passed"}),
+        ));
+        tools.validate_completion().expect("tested write completes");
     }
 
     #[test]

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -14,7 +14,7 @@ pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 pub const DEFAULT_REASONING_EFFORT: &str = "medium";
 pub const MAX_OBSERVATION_BYTES: usize = 1024 * 1024;
-const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection or validation. Start with initial_context.initial_symbols, which is the completed compact default list_symbols result for the entry file and its direct imports. Treat every listed function whose name directly contains the requested behavior noun as a candidate: batch read_symbol and find_references for all of them before editing. Do not skip update, movement, collision, or render candidates merely because one function exposes the visible value. If relevant symbols are missing, batch multiple narrow list_symbols searches directly suggested by the request, such as the behavior noun plus render or update terms; never enumerate the whole project. A reference lookup does not require a prior source read. Call find_references for behavior-bearing symbols before writing. For an observable requested behavior, call validate_runtime_state with the target requirements and expected_outcome=fail before writing. Never guess setup, tick, or render names: omit optional entrypoints unless a tool observation established the exact function. When source edits are ready, place red validation immediately before one contiguous atomic write batch in the same turn; writes run only when the red contract is accepted. The runtime automatically applies the identical green validation after a successful write, so do not request it again. Use baseline=fresh for startup/reset or integration-style behavior and baseline=live when the current running state matters. If the before check already passes, report that the request is already satisfied without rewriting it. Do not claim an affected behavior is consistent unless you inspected its source or validated it. Return done after the edit reports compilation/tests passed and automatic green validation passes. Return exactly one JSON object matching the response contract.";
+const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection. Start with initial_context.initial_symbols, which is the completed compact default list_symbols result for the entry file and its direct imports. Treat every listed function whose name directly contains the requested behavior noun as a candidate: batch read_symbol and find_references for all of them before editing. Do not skip update, movement, collision, or render candidates merely because one function exposes the visible value. If relevant symbols are missing, batch multiple narrow list_symbols searches directly suggested by the request, such as the behavior noun plus render or update terms; never enumerate the whole project. A reference lookup does not require a prior source read. Call find_references for behavior-bearing symbols before writing. For collision or geometry changes, use rendered rectangle bounds as the coordinate source of truth and derive contact test inputs after the update function's movement order instead of copying old collision constants. Put all related source and requested durable-test changes in one contiguous atomic write batch. The write compiles the batch and runs project tests; if it succeeds, return done immediately without a separate test call. If it fails, correct only the reported defect and retry atomically. Return exactly one JSON object matching the response contract.";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -340,7 +340,6 @@ pub fn workshop_tool_specs() -> Vec<ToolSpec> {
         spec("get_diagnostics", "Read the latest compiler diagnostics.", &[], &[]),
         spec("set_input_state", "Set simulated input state.", &[], &["x", "y", "active", "screen_w", "screen_h"]),
         spec("inspect_runtime_state", "Read bounded live scalar state.", &[], &[]),
-        spec("validate_runtime_state", "Evaluate 1..=16 scalar requirements shaped as {path, op, value}, where op is eq, ne, lt, lte, gt, or gte. baseline=live pauses and restores the running game; baseline=fresh boots an isolated child process for an integration-style check. Fresh defaults to main/tick/render. Omit setup, tick, or render unless an earlier tool result established the exact game-level function; never infer an entrypoint name. Use expected_outcome=fail immediately before a contiguous write batch; the runtime automatically repeats the identical contract as green validation after a successful write.", &["requirements", "expected_outcome"], &["frames", "baseline", "setup", "tick", "render"]),
         spec("run_frame", "Advance the live runtime by one deterministic tick.", &[], &[]),
         spec("take_screenshot", "Capture a logical render snapshot and runtime state.", &[], &[]),
         spec("list_tests", "List Stasis test files.", &[], &[]),
@@ -359,9 +358,7 @@ pub fn live_tool_specs() -> Vec<ToolSpec> {
         "write_symbol",
         "delete_symbol",
         "inspect_runtime_state",
-        "validate_runtime_state",
         "run_frame",
-        "run_tests",
     ];
     workshop_tool_specs()
         .into_iter()
@@ -870,7 +867,7 @@ mod tests {
             fn validate_completion(&self) -> Result<(), String> {
                 self.ready
                     .then_some(())
-                    .ok_or_else(|| "green validation required".to_string())
+                    .ok_or_else(|| "successful tool execution required".to_string())
             }
         }
 
@@ -891,7 +888,7 @@ mod tests {
                     }],
                 },
                 ModelResponse::Done {
-                    working_notes: "Intent: finish. Observed: green. Next: none. Blocker: none."
+                    working_notes: "Intent: finish. Observed: success. Next: none. Blocker: none."
                         .to_string(),
                     summary: "verified".to_string(),
                 },
@@ -967,7 +964,8 @@ mod tests {
             .all(|tool| workshop.iter().any(|candidate| candidate.tool == tool.tool)));
         assert!(live.iter().any(|tool| tool.tool == "write_symbol"));
         assert!(live.iter().any(|tool| tool.tool == "find_references"));
-        assert!(live
+        assert!(!live.iter().any(|tool| tool.tool == "run_tests"));
+        assert!(!workshop
             .iter()
             .any(|tool| tool.tool == "validate_runtime_state"));
         assert!(!live.iter().any(|tool| tool.tool == "capture_screenshot"));

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -122,3 +122,30 @@ These single-run timings vary enough that the change is not claimed as a univers
 retained because it removes an ineffective validation loop, keeps all acceptance checks green,
 and makes the mandatory completion path one tested atomic edit rather than an edit plus a second
 synthetic runtime protocol.
+
+## Medium phase timing sample
+
+A subsequent single medium-project run added out-of-band event timing without changing the model
+payload. It passed 4/4 in 274.1 seconds with 43 tool calls. Provider waits consumed 271.6 seconds
+(99.2% of the traced AI action); initial context and every local tool batch together consumed 2.3
+seconds. The independent acceptance run took another 0.1 seconds.
+
+| Phase | Time |
+|---|---:|
+| Initial symbol context | 0.4s |
+| Turn 1: choose narrow discovery queries | 13.1s |
+| Five local symbol searches | 0.2s |
+| Turn 2: choose source/reference batch | 16.4s |
+| Sixteen local reads and reference lookups | 0.8s |
+| Turn 3: identify remaining test/state context | 13.8s |
+| Seven local context reads | 0.3s |
+| Turn 4: design the source and boundary-test batch | 124.7s |
+| Atomic compile/tests, failed pre-existing test | 0.3s |
+| Turn 5: diagnose failure and prepare retry | 96.7s |
+| Atomic compile/tests, successful retry | 0.3s |
+| Turn 6: final summary | 6.9s |
+| Independent four-test acceptance | 0.1s |
+
+This sample shows that making local validation faster cannot materially approach a one-minute
+task by itself. The largest opportunity is reducing or bounding the two long edit/repair provider
+turns while preserving first-pass accuracy.

--- a/docs/ai_efficiency_matrix_2026-07-22.md
+++ b/docs/ai_efficiency_matrix_2026-07-22.md
@@ -92,3 +92,33 @@ red/green replay tests passed, but the model used the capability only for render
 task still scored 3/4 with the same paddle-center failure, while rising to 342.4 seconds, 50 tool
 calls, 308,626 input tokens, and an estimated $1.849. The capability and its prompt instruction
 were therefore reverted rather than adding unproven surface area.
+
+## Tested-write completion
+
+The next refinement removed runtime-state validation from the built-in AI contract. Human
+`stasis validate` and TUI `:validate` remain available, but AI writes now compile and run project
+tests atomically, and the agent cannot report completion without a successful write batch. A
+separate live `run_tests` tool was also removed because it only repeated the result already
+returned by the write. Repeated failures from the same atomic batch now include full diagnostics
+once instead of duplicating them for every write observation.
+
+The first lean run passed medium 4/4 in 201.9 seconds with 38 tool calls, 160,967 input tokens,
+25,344 cached input tokens, 9,540 output tokens, and an estimated $0.977. Its first small run was
+faster and cheaper but failed one paddle-contact case, so that configuration was rejected. The
+trace showed that the model copied an old collision constant instead of deriving contact from the
+rendered rectangle after movement.
+
+A generic game-geometry instruction corrected that reasoning: collision and geometry changes use
+rendered rectangle bounds as the coordinate source of truth and derive test inputs after the
+update function's movement order. The retained configuration passed 4/4 at every scale:
+
+| Size | Total s | Tool calls | Input | Cached | Output | Est. USD |
+|---|---:|---:|---:|---:|---:|---:|
+| small | 255.6 | 31 | 131,859 | 22,016 | 12,972 | 0.949 |
+| medium | 262.6 | 41 | 183,149 | 30,208 | 12,620 | 1.158 |
+| large | 204.7 | 40 | 224,678 | 32,000 | 9,551 | 1.266 |
+
+These single-run timings vary enough that the change is not claimed as a universal speedup. It is
+retained because it removes an ineffective validation loop, keeps all acceptance checks green,
+and makes the mandatory completion path one tested atomic edit rather than an edit plus a second
+synthetic runtime protocol.

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -78,6 +78,12 @@ with the agent. Tool source arguments and results therefore appear verbatim when
 or received from the agent. The trace does not store the complete Codex transport request, response
 schema, tool catalog, repeated conversation envelope, or CLI transport output.
 
+Event timing is written separately to `tui-ai-<timestamp>.timing.jsonl`, preserving the exact
+payload trace without adding fields the AI did not receive. Timing records contain only the event
+name, milliseconds since the request began, and milliseconds since the previous event. The gap
+from `turn` to `working_notes` measures provider time; `tool_calls` to `tool_observations` measures
+the local tool batch, including compilation and tests for writes.
+
 Provider-reported token usage is written separately to
 `build/ai-traces/tui-ai-<timestamp>.usage.jsonl`. Each line is the exact `usage` object from a
 Codex `turn.completed` event; Stasis does not estimate or add missing token categories. The Codex

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -50,21 +50,12 @@ in `initial_context`, avoiding a provider round trip while retaining filtered an
 searches. Explicit file arguments remain an exact scope.
 
 Before changing a behavior-bearing symbol, the AI must use compiler-backed `find_references` to
-locate its definition, reads, writes, and calls without receiving unrelated source bodies. For an
-observable game change it uses AI-only `validate_runtime_state` acceptance checks: the requested
-condition must fail before the edit (red), the atomic edit must compile and pass project tests, and
-the runtime automatically evaluates the same condition afterward (green). Red validation may be
-immediately followed by one contiguous write batch in the same model turn, reducing provider turns
-without allowing writes when the red contract is not accepted. The default `live` baseline pauses
-and restores the same bounded runtime snapshot, so normal game progression cannot manufacture a
-pass. The optional `fresh` baseline boots `main`, advances bounded `tick` frames, renders, and
-inspects state in a separate Stasis child process for integration-style red/green checks without
-changing the running game. Successful fresh checks retain bounded stderr diagnostics as evidence
-instead of discarding otherwise valid results. Projects with host adapters can select game-level
-`setup`, `tick`, and `render` entrypoints so the isolated check exercises logical gameplay without
-opening a second window or duplicating host resource side effects. These acceptance checks are
-ephemeral and do not create or replace project `.test.stasis` files; durable regression tests remain
-the appropriate place for behavior that should be protected after the AI turn.
+locate its definition, reads, writes, and calls without receiving unrelated source bodies. Related
+source edits and requested durable tests are submitted as one atomic batch. The normal preparation
+worker compiles that batch and runs project tests before applying it; failure rolls back the whole
+batch. A built-in AI change cannot report completion until one such tested batch is applied. The
+successful write receipt is the completion evidence, so the live AI does not run a second test or
+model-authored runtime-validation loop afterward.
 
 Human commands intentionally cover every useful live AI capability:
 
@@ -75,9 +66,7 @@ Human commands intentionally cover every useful live AI capability:
 | `read_symbol` | `stasis symbol read SYMBOL` / `:read SYMBOL` |
 | `write_symbol`, `delete_symbol` | `stasis symbol add|update|delete` / `:add`, `:update`, `:delete` |
 | `inspect_runtime_state` | `:inspect`; `stasis validate` exposes fresh-run scalar evidence |
-| `validate_runtime_state` | `stasis validate PATH OP VALUE` / `:validate PATH OP VALUE` |
 | `run_frame` | `:step`; `stasis validate --frames N` in an isolated CLI run |
-| `run_tests` | `stasis test`; live `:apply`, `:undo`, `:redo`, and definition apply run tests automatically |
 
 `stasis validate` uses the isolated `fresh` baseline and accepts `--frames`, `--setup`, `--tick`,
 and `--render`. TUI `:validate` uses a snapshot of the live game, runs the requested frames, reports


### PR DESCRIPTION
## Summary
- remove the AI-only runtime red/green validation protocol while preserving human stasis validate and TUI :validate
- require a successful atomic edit whose project tests explicitly passed before built-in AI may report completion
- remove the redundant live-AI un_tests echo and compact duplicate atomic-batch failures
- add generic game-geometry reasoning guidance derived from a failed acceptance trace
- document retained and rejected benchmark results across small, medium, and large projects

## Accuracy and efficiency
- small: 4/4, 255.6s, 31 tool calls
- medium: 4/4, 262.6s, 41 tool calls
- large: 4/4, 204.7s, 40 tool calls

The first lean variant failed one small-project contact case and was rejected. The retained variant passed all acceptance checks at every scale.

## Validation
- python tools/ci/check_stasis_src_layout.py
- python -m unittest tools.ci.test_stasis_ai_efficiency_matrix
- cargo test --workspace --all-targets -- --test-threads=1
- targeted live AI completion-gate and stasis_ai tests
- cargo fmt --all -- --check
- git diff --check

## Reflection
- Good: replacing a model-authored runtime protocol with the tested atomic write receipt removed substantial orchestration while maintaining cross-size correctness.
- Bad: the first lean prompt copied a stale collision constant and failed one hidden boundary check.
- Adjustment: for game geometry, derive collision inputs from rendered bounds after movement order; require explicit test-passed evidence at completion.