### PR TITLE
feat: add bounded OpenRouter AI comparisons

### DIFF
--- a/docs/android_ai_grok_4_5_openrouter_2026-07-22.md
+++ b/docs/android_ai_grok_4_5_openrouter_2026-07-22.md
@@ -1,0 +1,52 @@
+# Android Workshop Grok 4.5 OpenRouter trial (2026-07-22)
+
+## Method
+
+- Model: `x-ai/grok-4.5` through OpenRouter.
+- Prompt: `make the ball 20 pixels square and keep it centered at its position and update collision behavior and tests`.
+- Fresh Android Workshop Pong project for the initial attempt.
+- Medium reasoning, JSON Schema responses, native tool calls, no provider
+  fallbacks, $2/M input and $6/M output ceilings, and a $5 cumulative guard.
+- Maximum 15 provider turns and 50 tool calls per response.
+- Model-authored Stasis tests ran before a four-test independent acceptance
+  fixture. The hidden fixture was removed before each repair request; Grok saw
+  only a short failure summary.
+
+## Outcome
+
+| Stage | Provider calls | Model seconds | Local tool seconds | Input | Cached | Output | Reasoning | Cost | Acceptance |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Initial | 2 | 40.70 | 0.02 before cold build | 13,223 | 5,376 | 3,923 | 1,151 | $0.04084 | 2/4 |
+| Repair 1 | 3 | 59.66 | 0.44 | 22,290 | 10,624 | 4,891 | 2,187 | $0.05587 | 3/4 |
+| Repair 2 | 3 | 28.33 | 0.43 | 19,348 | 10,624 | 2,275 | 436 | $0.03429 | 4/4 |
+| Total | 8 | 128.69 | 0.89 recorded warm tools | 54,861 | 26,624 | 11,089 | 3,774 | $0.13100 | 4/4 after feedback |
+
+The initial response batched eight inspection tools in 5.37 seconds. Its second
+response took 35.33 seconds and returned five actions: three source/test writes,
+one additional test write, and `run_tests`. Its generated suite passed, but the
+independent fixture found paddle-contact and full-exit scoring errors.
+
+The first repair used calls of 5.89, 13.97, and 39.81 seconds. It fixed rendered
+paddle centers and full-exit scoring, improving acceptance to 3/4. The remaining
+difference was inclusive versus exclusive exact-edge contact, a convention not
+stated explicitly in the original prompt.
+
+The clarified second repair used calls of 4.57, 5.34, and 18.42 seconds. It made
+the collision threshold inclusive, updated both sides of the boundary test, and
+reached 4/4 independent acceptance. Generated plus independent validation then
+reported 13 passing tests across three files.
+
+## Setup timing caveat
+
+The initial write batch triggered a cold release build in the new worktree. The
+outer command reached its five-minute bound before that build completed. A
+separate bounded continuation finished the one-time build in 146 seconds. Later
+warm compile/test batches took about 0.4 seconds, so the cold build is reported
+as setup cost and excluded from model back-and-forth time.
+
+The trial also exposed two harness regressions on current `main`: the test runner
+still used the removed `--dir` CLI form, and partial acceptance reporting could
+mislabel infrastructure failures. The OpenRouter PR updates the harness to use a
+temporary manifest with `stasis test --workspace`, removes that manifest after
+testing, and distinguishes infrastructure failure from partial assertion
+failure.

--- a/docs/android_workshop_codex_harness.md
+++ b/docs/android_workshop_codex_harness.md
@@ -184,6 +184,9 @@ native function-calling protocol and translates calls back into the shared local
 validation path. Native-tool runs allow ten sequential inspection batches by
 default because some models issue one tool per response; other runs retain the
 two-batch efficiency default. `--max-read-only-batches` overrides either value.
+`--openrouter-max-total-cost` adds a cumulative run ceiling using reported cost
+after each response and a conservative request-byte/output-token upper bound
+before the next request. It requires both per-million-token price ceilings.
 
 OpenRouter traces contain the exact JSON payload sent to the provider, excluding
 HTTP authorization headers. Each trace also writes a sibling `.usage.json`

--- a/docs/android_workshop_codex_harness.md
+++ b/docs/android_workshop_codex_harness.md
@@ -169,6 +169,27 @@ priority` opts into the API's separately billed Priority processing. This is a
 useful request/cache latency comparison, but it is not billed against ChatGPT
 subscription Fast-mode allowance and is reported separately.
 
+The host comparison runner can also use OpenRouter with `--provider
+openrouter`. It disables provider fallbacks and requires supported parameters.
+Use both `--openrouter-max-input-price` and
+`--openrouter-max-output-price` to enforce per-million-token price ceilings,
+and optionally pin a provider with `--openrouter-only-provider`. Providers
+without JSON Schema support can use `--openrouter-response-format none`; the
+same exact JSON contract remains in the system instruction and responses still
+pass local shape validation. OpenRouter 429 responses receive at most two
+bounded retries when the provider omits `Retry-After`.
+
+`--openrouter-native-tools` exposes the same Stasis tools through the provider's
+native function-calling protocol and translates calls back into the shared local
+validation path. Native-tool runs allow ten sequential inspection batches by
+default because some models issue one tool per response; other runs retain the
+two-batch efficiency default. `--max-read-only-batches` overrides either value.
+
+OpenRouter traces contain the exact JSON payload sent to the provider, excluding
+HTTP authorization headers. Each trace also writes a sibling `.usage.json`
+file containing only timing metadata and provider-reported token usage. API
+keys are loaded from `OPENROUTER_API_KEY` and are never written to either log.
+
 The host runner compiles the selected `--project-root` through the same
 `compile_android_workshop_project` bridge used by Android before accepting
 writes or final test success. Source and test writes are one atomic batch:

--- a/tools/android_ai_agent_host.py
+++ b/tools/android_ai_agent_host.py
@@ -24,6 +24,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PROJECT = ROOT / "mobile/android/app/src/main/assets/workshop_sample"
 DEFAULT_MODEL = "gpt-5.6-sol"
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_REASONING_EFFORT = "medium"
 DEFAULT_TRACE_DIR = ROOT / "artifacts/android_ai_runs"
 MAX_TURNS = 15
@@ -295,7 +296,7 @@ DEFAULT_MODEL_PRICING_PER_MILLION = {
     },
 }
 
-def response_usage_from_body(body: dict[str, Any]) -> dict[str, int]:
+def response_usage_from_body(body: dict[str, Any]) -> dict[str, Any]:
     usage = body.get("usage") if isinstance(body, dict) else {}
     if not isinstance(usage, dict):
         usage = {}
@@ -307,22 +308,27 @@ def response_usage_from_body(body: dict[str, Any]) -> dict[str, int]:
         input_details = {}
     cached_tokens = int(input_details.get("cached_tokens") or 0)
     cache_write_tokens = int(input_details.get("cache_write_tokens") or 0)
+    output_details = usage.get("output_tokens_details") or usage.get("completion_tokens_details") or {}
+    if not isinstance(output_details, dict):
+        output_details = {}
     return {
         "input_tokens": input_tokens,
         "cached_input_tokens": cached_tokens,
         "cache_write_input_tokens": cache_write_tokens,
         "uncached_input_tokens": max(input_tokens - cached_tokens - cache_write_tokens, 0),
         "output_tokens": output_tokens,
+        "reasoning_tokens": int(output_details.get("reasoning_tokens") or 0),
         "total_tokens": total_tokens,
+        "cost_usd": float(usage.get("cost") or 0.0),
     }
 
 
 def aggregate_trace_usage(trace_events: list[dict[str, Any]], model: str) -> dict[str, Any]:
-    totals = {"input_tokens": 0, "cached_input_tokens": 0, "cache_write_input_tokens": 0, "uncached_input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    totals = {"input_tokens": 0, "cached_input_tokens": 0, "cache_write_input_tokens": 0, "uncached_input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0, "total_tokens": 0, "cost_usd": 0.0}
     calls = 0
     per_call = []
     for event in trace_events:
-        if event.get("kind") == "openai_exchange":
+        if event.get("kind") in {"openai_exchange", "openrouter_exchange"}:
             usage = event.get("usage", {})
             if not isinstance(usage, dict):
                 usage = {}
@@ -331,6 +337,9 @@ def aggregate_trace_usage(trace_events: list[dict[str, Any]], model: str) -> dic
         calls += 1
         per_call.append({"turn": event.get("turn"), **usage})
         for key in totals:
+            if key == "cost_usd":
+                totals[key] += float(usage.get(key) or 0.0)
+                continue
             totals[key] += int(usage.get(key) or 0)
     pricing = DEFAULT_MODEL_PRICING_PER_MILLION.get(model, {})
     cost = None
@@ -346,6 +355,7 @@ def aggregate_trace_usage(trace_events: list[dict[str, Any]], model: str) -> dic
         "totals": totals,
         "per_call": per_call,
         "estimated_cost_usd": cost,
+        "provider_reported_cost_usd": totals["cost_usd"],
         "pricing_per_million_tokens": pricing or None,
         "pricing_note": pricing.get("source") if pricing else "No pricing estimate configured for this model.",
     }
@@ -361,6 +371,8 @@ def write_trace_file(path: Path, meta: dict[str, Any], trace_events: list[dict[s
         "exit_code": exit_code,
     }
     write_text(path, json.dumps(payload, indent=2))
+    usage_path = path.with_name(f"{path.stem}.usage.json")
+    write_text(usage_path, json.dumps({"meta": payload["meta"], "usage_summary": usage_summary}, indent=2))
 
 
 def default_trace_file() -> Path:
@@ -1020,6 +1032,229 @@ def call_openai(api_key: str, model: str, request: dict[str, Any], service_tier:
     return parsed
 
 
+def build_openrouter_payload(
+    model: str,
+    request: dict[str, Any],
+    only_provider: str = "",
+    max_input_price: float | None = None,
+    max_output_price: float | None = None,
+    response_format: str = "json_schema",
+    native_tools: bool = False,
+) -> dict[str, Any]:
+    """Translate the stable Workshop request into OpenRouter chat completions."""
+    source = build_openai_payload(model, request)
+    messages = [
+        {
+            "role": item["role"],
+            "content": "".join(str(block.get("text", "")) for block in item.get("content", [])),
+        }
+        for item in source["input"]
+    ]
+    provider: dict[str, Any] = {"allow_fallbacks": False, "require_parameters": True}
+    if only_provider:
+        provider["only"] = [only_provider]
+    if max_input_price is not None and max_output_price is not None:
+        provider["max_price"] = {"prompt": max_input_price, "completion": max_output_price}
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "reasoning": {"effort": DEFAULT_REASONING_EFFORT, "exclude": True},
+        "max_tokens": 16384,
+        "temperature": 0.2,
+        "provider": provider,
+    }
+    if response_format == "json_schema":
+        payload["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "stasis_host_ai_response",
+                "strict": False,
+                "schema": response_json_schema(),
+            },
+        }
+    if native_tools:
+        payload["messages"][0]["content"] += (
+            " Native tools are available and take precedence over the JSON tool-call envelope. "
+            "Call tools through the native API, never by emitting XML or textual tool syntax. "
+            "Batch every independent read_symbol, find_references, and test inspection needed for the current step in one response; up to 50 native calls are allowed. "
+            "Treat the initial project_symbol_index as the authoritative list of available symbols. Do not guess a main symbol or simulate a full-file read. "
+            "Prefer no more than two inspection responses before writing. Return the JSON done envelope only after local tests pass."
+        )
+        payload["tools"] = openrouter_native_tools()
+        payload["tool_choice"] = "auto"
+    return payload
+
+
+def openrouter_native_tools() -> list[dict[str, Any]]:
+    integer_args = {"page", "limit"}
+    array_args = {"files"}
+    tools = []
+    for spec in tool_specs():
+        argument_names = spec["required_args"] + spec["optional_args"]
+        properties: dict[str, Any] = {}
+        for name in argument_names:
+            if name in integer_args:
+                properties[name] = {"type": "integer"}
+            elif name in array_args:
+                properties[name] = {"type": "array", "items": {"type": "string"}}
+            else:
+                properties[name] = {"type": "string"}
+        tools.append({
+            "type": "function",
+            "function": {
+                "name": spec["tool"],
+                "description": spec["purpose"],
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": spec["required_args"],
+                    "additionalProperties": False,
+                },
+            },
+        })
+    return tools
+
+
+def validate_openrouter_payload(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    response_format = payload.get("response_format")
+    if response_format is not None and (
+        response_format.get("type") != "json_schema"
+        or not response_format.get("json_schema", {}).get("schema")
+    ):
+        errors.append("OpenRouter response_format must include the Workshop JSON schema")
+    if payload.get("reasoning") != {"effort": DEFAULT_REASONING_EFFORT, "exclude": True}:
+        errors.append(f"OpenRouter reasoning must use {DEFAULT_REASONING_EFFORT} effort and exclude private reasoning")
+    provider = payload.get("provider", {})
+    if provider.get("allow_fallbacks") is not False or provider.get("require_parameters") is not True:
+        errors.append("OpenRouter provider fallbacks must be disabled and parameters required")
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or len(messages) != 3:
+        errors.append("OpenRouter messages must preserve system, stable, and volatile turns")
+    return errors
+
+
+def call_openrouter(
+    api_key: str,
+    model: str,
+    request: dict[str, Any],
+    trace_events: list[dict[str, Any]] | None = None,
+    turn: int = 0,
+    timeout_seconds: float = 120.0,
+    only_provider: str = "",
+    max_input_price: float | None = None,
+    max_output_price: float | None = None,
+    response_format: str = "json_schema",
+    native_tools: bool = False,
+) -> dict[str, Any]:
+    started_at = time.perf_counter()
+    payload = build_openrouter_payload(
+        model, request, only_provider, max_input_price, max_output_price, response_format, native_tools)
+    errors = validate_openrouter_payload(payload)
+    if errors:
+        raise RuntimeError("OpenRouter payload preflight failed: " + "; ".join(errors))
+    if trace_events is not None:
+        # The payload contains exactly what is sent to the provider and no authorization header.
+        trace_events.append({"kind": "openrouter_request", "turn": turn, "payload": payload})
+    deadline = started_at + timeout_seconds
+    retry_count = 0
+    rate_limit_wait_seconds = 0.0
+    while True:
+        request_message = urllib.request.Request(
+            OPENROUTER_API_URL,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://github.com/stasislang/stasislang",
+                "X-Title": "Stasis Workshop model comparison",
+            },
+            method="POST",
+        )
+        try:
+            remaining = deadline - time.perf_counter()
+            with urllib.request.urlopen(request_message, timeout=max(1.0, min(120.0, remaining))) as response:
+                body = json.loads(response.read().decode("utf-8"))
+            break
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            retry_after = 0.0
+            if error.code == 429:
+                try:
+                    metadata = json.loads(detail).get("error", {}).get("metadata", {})
+                    retry_after = float(metadata.get("retry_after_seconds") or 0.0)
+                except (ValueError, TypeError, json.JSONDecodeError):
+                    retry_after = 0.0
+                if retry_after <= 0.0 and retry_count < 2:
+                    retry_after = 10.0 * (2 ** retry_count)
+            remaining = deadline - time.perf_counter()
+            if error.code == 429 and 0.0 < retry_after <= 60.0 and retry_after + 1.0 < remaining:
+                retry_count += 1
+                if trace_events is not None:
+                    trace_events.append({
+                        "kind": "openrouter_rate_limit_wait",
+                        "turn": turn,
+                        "retry": retry_count,
+                        "retry_after_seconds": retry_after,
+                    })
+                time.sleep(retry_after)
+                rate_limit_wait_seconds += retry_after
+                continue
+            raise RuntimeError(f"OpenRouter request failed with HTTP {error.code}: {detail}") from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"OpenRouter request failed: {error.reason}") from error
+    choices = body.get("choices", [])
+    message = choices[0].get("message", {}) if choices else {}
+    text = message.get("content") or ""
+    native_calls = message.get("tool_calls") or []
+    if trace_events is not None:
+        trace_events.append({
+            "kind": "openrouter_response",
+            "turn": turn,
+            "model": body.get("model", model),
+            "content": text,
+            "tool_calls": native_calls,
+            "finish_reason": choices[0].get("finish_reason") if choices else None,
+            "usage": body.get("usage", {}),
+        })
+    if native_calls:
+        tool_calls = []
+        for native_call in native_calls:
+            function = native_call.get("function", {})
+            arguments = function.get("arguments", {})
+            if isinstance(arguments, str):
+                arguments = json.loads(arguments or "{}")
+            tool_calls.append({"tool": function.get("name", ""), "args": arguments})
+        parsed = {
+            "mode": "tool_calls",
+            "working_notes": text.strip() or "Intent: continue. Observed: selected native tools. Next: inspect results. Blocker: none.",
+            "summary": text.strip(),
+            "tool_calls": tool_calls,
+        }
+    elif not text:
+        raise RuntimeError("OpenRouter response did not contain text content")
+    else:
+        parsed = parse_json_object(text)
+    if trace_events is not None:
+        trace_events.append({
+            "kind": "openrouter_exchange",
+            "turn": turn,
+            "elapsed_seconds": time.perf_counter() - started_at,
+            "rate_limit_wait_seconds": rate_limit_wait_seconds,
+            "request": summarize_request_for_trace(request),
+            "response": {
+                "response_model": body.get("model", model),
+                "mode": parsed.get("mode"),
+                "summary": parsed.get("summary", ""),
+                "working_notes": parsed.get("working_notes", ""),
+                "tool_call_count": len(parsed.get("tool_calls") or []),
+                "edit_count": len(parsed.get("edits") or []),
+            },
+            "usage": response_usage_from_body(body),
+        })
+    return parsed
+
+
 def validate_response_shape(response: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     errors: list[dict[str, Any]] = []
     contract = response_contract()
@@ -1111,6 +1346,17 @@ def can_auto_finalize_tested_writes(wrote_test: bool, final_test: dict[str, Any]
 
 def tool_call_batch_key(tool_calls: list[dict[str, Any]]) -> str:
     return json.dumps(tool_calls, sort_keys=True, separators=(",", ":"))
+
+
+def repeated_tool_call_correction() -> dict[str, Any]:
+    return {
+        "tool": "progress_policy",
+        "args": {},
+        "result": {
+            "status": "repeated_tool_call_not_executed",
+            "error": "This identical tool call already ran and its result is present in retained observations. Choose a different tool call, write the change, or return done.",
+        },
+    }
 
 
 def compact_observation_for_provider(observation: dict[str, Any]) -> dict[str, Any]:
@@ -1294,6 +1540,19 @@ def main() -> int:
     parser.add_argument("--prompt", required=True)
     parser.add_argument("--project-root", type=Path, default=DEFAULT_PROJECT)
     parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--provider", choices=("openai", "openrouter"), default="openai")
+    parser.add_argument("--openrouter-only-provider", default="",
+                        help="Allow only this OpenRouter provider slug; fallbacks remain disabled.")
+    parser.add_argument("--openrouter-max-input-price", type=float,
+                        help="Maximum accepted OpenRouter input price in USD per million tokens.")
+    parser.add_argument("--openrouter-max-output-price", type=float,
+                        help="Maximum accepted OpenRouter output price in USD per million tokens.")
+    parser.add_argument("--openrouter-response-format", choices=("json_schema", "none"), default="json_schema",
+                        help="Use provider-enforced JSON Schema or rely on the prompt contract for providers that do not support it.")
+    parser.add_argument("--openrouter-native-tools", action="store_true",
+                        help="Expose Workshop tools through the provider's native tool-calling API.")
+    parser.add_argument("--max-read-only-batches", type=int,
+                        help="Maximum sequential inspection batches before requiring a write or done response; defaults to 10 for native tools and 2 otherwise.")
     parser.add_argument("--service-tier", choices=("standard", "priority"), default="standard",
                         help="Use standard API processing or opt into separately billed Priority processing.")
     parser.add_argument("--reset-paddle-speed-feature", action="store_true", help="Reset the bundled Pong sample to the baseline before the requested paddle-speed feature.")
@@ -1301,31 +1560,47 @@ def main() -> int:
     parser.add_argument("--preflight", action="store_true", help="Validate the outgoing Responses payload locally without calling OpenAI or editing the project.")
     parser.add_argument("--max-seconds", type=float, default=DEFAULT_MAX_RUN_SECONDS, help="Stop the host comparison cleanly before the repository's five-minute command limit.")
     args = parser.parse_args()
+    if (args.openrouter_max_input_price is None) != (args.openrouter_max_output_price is None):
+        parser.error("OpenRouter max input and output prices must be supplied together")
+    max_read_only_batches = args.max_read_only_batches
+    if max_read_only_batches is None:
+        max_read_only_batches = 10 if args.provider == "openrouter" and args.openrouter_native_tools else MAX_READ_ONLY_BATCHES
+    if not 1 <= max_read_only_batches <= MAX_TURNS:
+        parser.error(f"max read-only batches must be between 1 and {MAX_TURNS}")
     load_env_file(ROOT / ".env")
     project = args.project_root.resolve()
     trace_file = args.trace_file or default_trace_file()
     request = build_agent_request(project, args.prompt, {"phase": "initial", "instruction": "Inspect the workspace with fine-grained tools, make the requested behavior change, add or update tests, run tests, then return done only after tests pass."})
     shared_context = request["shared_context"]
     trace_events: list[dict[str, Any]] = []
-    trace_meta = {"prompt": args.prompt, "provider": "openai_api", "model": args.model, "service_tier": args.service_tier, "project_root": str(project), "reset_paddle_speed_feature": bool(args.reset_paddle_speed_feature), "successful_write_count": 0, "rolled_back_write_count": 0}
+    trace_meta = {"prompt": args.prompt, "provider": f"{args.provider}_api", "model": args.model, "service_tier": args.service_tier, "project_root": str(project), "reset_paddle_speed_feature": bool(args.reset_paddle_speed_feature), "successful_write_count": 0, "rolled_back_write_count": 0}
     trace_events.append({"kind": "trace_meta", "meta": trace_meta})
     trace_events.append({"kind": "initial_request", "summary": summarize_request_for_trace(request)})
     print(f"Trace file: {trace_file}")
     started_at_iso = datetime.now(timezone.utc).isoformat()
     started_at_perf = time.perf_counter()
     if args.preflight:
-        payload = build_openai_payload(args.model, request, args.service_tier)
-        errors = validate_openai_payload(payload)
+        if args.provider == "openrouter":
+            payload = build_openrouter_payload(args.model, request, args.openrouter_only_provider,
+                                               args.openrouter_max_input_price, args.openrouter_max_output_price,
+                                               args.openrouter_response_format, args.openrouter_native_tools)
+            errors = validate_openrouter_payload(payload)
+            payload_summary = payload
+        else:
+            payload = build_openai_payload(args.model, request, args.service_tier)
+            errors = validate_openai_payload(payload)
+            payload_summary = summarize_openai_payload(payload)
         trace_events.append({"kind": "payload_preflight", "ok": not errors, "errors": errors,
-                             "payload": summarize_openai_payload(payload)})
+                             "payload": payload_summary})
         write_trace_file(trace_file, trace_meta, trace_events, 0 if not errors else 1, started_at_iso, time.perf_counter() - started_at_perf, 0)
         print(json.dumps({"preflight_ok": not errors, "errors": errors}, indent=2))
         return 0 if not errors else 1
-    api_key = os.environ.get("OPENAI_API_KEY")
+    key_name = "OPENROUTER_API_KEY" if args.provider == "openrouter" else "OPENAI_API_KEY"
+    api_key = os.environ.get(key_name)
     if not api_key:
-        trace_events.append({"kind": "api_error", "error": "OPENAI_API_KEY is required"})
+        trace_events.append({"kind": "api_error", "error": f"{key_name} is required"})
         write_trace_file(trace_file, trace_meta, trace_events, 2, started_at_iso, time.perf_counter() - started_at_perf, 0)
-        print("OPENAI_API_KEY is required", file=sys.stderr)
+        print(f"{key_name} is required", file=sys.stderr)
         return 2
     if args.reset_paddle_speed_feature:
         reset_paddle_speed_feature(project)
@@ -1336,6 +1611,7 @@ def main() -> int:
     total_actions = 0
     working_notes = ""
     previous_tool_call_batch = ""
+    repeated_tool_call_corrections = 0
     read_only_batches = 0
     observation_memory: dict[str, dict[str, Any]] = {}
     for turn in range(1, MAX_TURNS + 1):
@@ -1347,7 +1623,13 @@ def main() -> int:
             print(json.dumps({"error": "time_limit", "max_seconds": args.max_seconds, "actions": total_actions}, indent=2), file=sys.stderr)
             return 124
         try:
-            response = call_openai(api_key, args.model, request, args.service_tier, trace_events, turn, remaining_seconds)
+            if args.provider == "openrouter":
+                response = call_openrouter(
+                    api_key, args.model, request, trace_events, turn, remaining_seconds,
+                    args.openrouter_only_provider, args.openrouter_max_input_price, args.openrouter_max_output_price,
+                    args.openrouter_response_format, args.openrouter_native_tools)
+            else:
+                response = call_openai(api_key, args.model, request, args.service_tier, trace_events, turn, remaining_seconds)
         except Exception as error:
             trace_events.append({"kind": "api_error", "turn": turn, "error_type": type(error).__name__, "error": str(error)})
             write_trace_file(trace_file, trace_meta, trace_events, 1, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
@@ -1401,15 +1683,32 @@ def main() -> int:
             continue
         current_tool_call_batch = tool_call_batch_key(tool_calls)
         if current_tool_call_batch == previous_tool_call_batch:
+            if repeated_tool_call_corrections < 1 and turn < MAX_TURNS:
+                repeated_tool_call_corrections += 1
+                correction = repeated_tool_call_correction()
+                trace_events.append({
+                    "kind": "repeated_tool_call_correction",
+                    "turn": turn,
+                    "tool_calls": tool_calls,
+                })
+                request = build_followup_request(shared_context, retain_working_notes({
+                    "phase": "repeated_tool_call_correction",
+                    "tool_observations": retained_observations(observation_memory),
+                    "latest_tool_observations": [correction],
+                    "instruction": "The identical tool call was not rerun. Its prior result is already present. Use that result and take a different next action; do not repeat it again.",
+                }, working_notes))
+                trace_events.append({"kind": "next_request", "turn": turn, "summary": summarize_request_for_trace(request)})
+                continue
             repeated = {"kind": "repeated_tool_calls", "turn": turn, "tool_calls": tool_calls, "actions": total_actions}
             trace_events.append(repeated)
             passed_after_writes = trace_meta["successful_write_count"] > 0 and last_diagnostics.get("kind") == "behavior_tests" and last_diagnostics.get("ok")
             write_trace_file(trace_file, trace_meta, trace_events, 0 if passed_after_writes else 1, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
             print(json.dumps({"error": "repeated_tool_calls", "accepted_tested_writes": passed_after_writes, "actions": total_actions}, indent=2), file=sys.stderr)
             return 0 if passed_after_writes else 1
+        repeated_tool_call_corrections = 0
         previous_tool_call_batch = current_tool_call_batch
         batch_has_writes = any(call.get("tool") in {"write_symbol", "delete_symbol", "write_file", "write_test_file", "delete_test_file"} for call in tool_calls)
-        blocked_read_only_batch = not batch_has_writes and read_only_batches >= MAX_READ_ONLY_BATCHES
+        blocked_read_only_batch = not batch_has_writes and read_only_batches >= max_read_only_batches
         prior_observations = retained_observations(observation_memory)
         tool_started_at = time.perf_counter()
         if blocked_read_only_batch:
@@ -1440,7 +1739,7 @@ def main() -> int:
                 return 0
         write_trace_file(trace_file, trace_meta, trace_events, None, started_at_iso, time.perf_counter() - started_at_perf, total_actions)
         instruction = "Use retained tool_observations and working_notes as cumulative memory; update Intent, Observed, Next, and Blocker. Do not reread targets already present in retained observations. If tests fail, fix the exact required state/checks. Do not repeat identical tool calls."
-        if read_only_batches >= MAX_READ_ONLY_BATCHES:
+        if read_only_batches >= max_read_only_batches:
             instruction += " You have completed the maximum read-only inspection batches. Your next response must contain at least one write tool call or mode=done."
         request = build_followup_request(shared_context, retain_working_notes({"phase": "tool_observations", "tool_observations": prior_observations, "latest_tool_observations": [compact_observation_for_provider(observation) for observation in observations], "instruction": instruction}, working_notes))
         trace_events.append({"kind": "next_request", "turn": turn, "summary": summarize_request_for_trace(request)})

--- a/tools/android_ai_agent_host.py
+++ b/tools/android_ai_agent_host.py
@@ -400,8 +400,8 @@ def stasis_test_command(project: Path) -> list[str]:
     executable = stasis_test_executable()
     if os.name == "nt":
         runner = ROOT / ".cargo/stasis-sign-and-run.cmd"
-        return [str(runner), str(executable), "test", "--dir", str(project / "tests")]
-    return [str(executable), "test", "--dir", str(project / "tests")]
+        return [str(runner), str(executable), "test", "--workspace", str(project)]
+    return [str(executable), "test", "--workspace", str(project)]
 
 
 def stasis_test_runner_is_fresh() -> bool:
@@ -541,7 +541,21 @@ def run_behavior_tests(project: Path, compile_first: bool = True) -> dict[str, A
     runner = ensure_stasis_test_runner()
     if not runner.get("ok"):
         return {"kind": "behavior_tests", "ok": False, "status": "runner_build_failed", "runner_build": runner}
-    result = run_command(stasis_test_command(project))
+    manifest_path = project / "stasis.json"
+    created_manifest = not manifest_path.is_file()
+    if created_manifest:
+        write_text(manifest_path, json.dumps({
+            "manifest_version": 1,
+            "name": "workshop_ai_validation",
+            "entry": "src/main.stasis",
+            "tests": "tests",
+            "output": "build",
+        }, indent=2) + "\n")
+    try:
+        result = run_command(stasis_test_command(project))
+    finally:
+        if created_manifest:
+            manifest_path.unlink(missing_ok=True)
     result["kind"] = "behavior_tests"
     tests = list_test_files(project)
     stasis_tests = [test for test in tests if test.get("kind") == "stasis_test"]
@@ -1115,6 +1129,14 @@ def openrouter_native_tools() -> list[dict[str, Any]]:
     return tools
 
 
+def openrouter_request_cost_upper_bound(
+    payload: dict[str, Any], max_input_price: float, max_output_price: float
+) -> float:
+    input_bytes = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    max_output_tokens = int(payload.get("max_tokens") or 0)
+    return (input_bytes * max_input_price + max_output_tokens * max_output_price) / 1_000_000.0
+
+
 def validate_openrouter_payload(payload: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     response_format = payload.get("response_format")
@@ -1146,6 +1168,7 @@ def call_openrouter(
     max_output_price: float | None = None,
     response_format: str = "json_schema",
     native_tools: bool = False,
+    remaining_cost_usd: float | None = None,
 ) -> dict[str, Any]:
     started_at = time.perf_counter()
     payload = build_openrouter_payload(
@@ -1153,6 +1176,13 @@ def call_openrouter(
     errors = validate_openrouter_payload(payload)
     if errors:
         raise RuntimeError("OpenRouter payload preflight failed: " + "; ".join(errors))
+    if remaining_cost_usd is not None:
+        if max_input_price is None or max_output_price is None:
+            raise RuntimeError("OpenRouter total cost guard requires input and output price ceilings")
+        upper_bound = openrouter_request_cost_upper_bound(payload, max_input_price, max_output_price)
+        if upper_bound > remaining_cost_usd:
+            raise RuntimeError(
+                f"OpenRouter total cost guard stopped before request: ${upper_bound:.6f} upper bound exceeds ${remaining_cost_usd:.6f} remaining")
     if trace_events is not None:
         # The payload contains exactly what is sent to the provider and no authorization header.
         trace_events.append({"kind": "openrouter_request", "turn": turn, "payload": payload})
@@ -1547,6 +1577,8 @@ def main() -> int:
                         help="Maximum accepted OpenRouter input price in USD per million tokens.")
     parser.add_argument("--openrouter-max-output-price", type=float,
                         help="Maximum accepted OpenRouter output price in USD per million tokens.")
+    parser.add_argument("--openrouter-max-total-cost", type=float,
+                        help="Maximum cumulative provider-reported cost in USD for this run.")
     parser.add_argument("--openrouter-response-format", choices=("json_schema", "none"), default="json_schema",
                         help="Use provider-enforced JSON Schema or rely on the prompt contract for providers that do not support it.")
     parser.add_argument("--openrouter-native-tools", action="store_true",
@@ -1562,6 +1594,12 @@ def main() -> int:
     args = parser.parse_args()
     if (args.openrouter_max_input_price is None) != (args.openrouter_max_output_price is None):
         parser.error("OpenRouter max input and output prices must be supplied together")
+    if args.openrouter_max_total_cost is not None and (
+        args.openrouter_max_total_cost <= 0
+        or args.openrouter_max_input_price is None
+        or args.openrouter_max_output_price is None
+    ):
+        parser.error("OpenRouter total cost requires a positive value and both price ceilings")
     max_read_only_batches = args.max_read_only_batches
     if max_read_only_batches is None:
         max_read_only_batches = 10 if args.provider == "openrouter" and args.openrouter_native_tools else MAX_READ_ONLY_BATCHES
@@ -1624,10 +1662,16 @@ def main() -> int:
             return 124
         try:
             if args.provider == "openrouter":
+                spent_usd = sum(
+                    float(event.get("usage", {}).get("cost_usd") or 0.0)
+                    for event in trace_events if event.get("kind") == "openrouter_exchange")
+                remaining_cost_usd = (
+                    args.openrouter_max_total_cost - spent_usd
+                    if args.openrouter_max_total_cost is not None else None)
                 response = call_openrouter(
                     api_key, args.model, request, trace_events, turn, remaining_seconds,
                     args.openrouter_only_provider, args.openrouter_max_input_price, args.openrouter_max_output_price,
-                    args.openrouter_response_format, args.openrouter_native_tools)
+                    args.openrouter_response_format, args.openrouter_native_tools, remaining_cost_usd)
             else:
                 response = call_openai(api_key, args.model, request, args.service_tier, trace_events, turn, remaining_seconds)
         except Exception as error:

--- a/tools/ci/test_android_ai_agent_host.py
+++ b/tools/ci/test_android_ai_agent_host.py
@@ -114,6 +114,24 @@ class AndroidAiAgentHostTests(unittest.TestCase):
         self.assertIn("project_symbol_index as the authoritative list", instruction)
         self.assertIn("Do not guess a main symbol", instruction)
 
+    def test_openrouter_cost_upper_bound_uses_payload_bytes_and_max_output(self) -> None:
+        payload = {"messages": [{"content": "x" * 1000}], "max_tokens": 200}
+        bound = host.openrouter_request_cost_upper_bound(payload, 2.0, 6.0)
+        self.assertGreater(bound, 0.0012)
+        self.assertLess(bound, 0.004)
+
+    def test_openrouter_total_cost_guard_stops_before_network_call(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        with mock.patch.object(host.urllib.request, "urlopen") as urlopen, self.assertRaisesRegex(
+                RuntimeError, "total cost guard stopped before request"):
+            host.call_openrouter(
+                "secret", "x-ai/grok-4.5", request,
+                max_input_price=2.0, max_output_price=6.0,
+                remaining_cost_usd=0.000001)
+        urlopen.assert_not_called()
+
     def test_openrouter_usage_is_aggregated_and_written_separately(self) -> None:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -207,7 +225,54 @@ class AndroidAiAgentHostTests(unittest.TestCase):
         command = host.stasis_test_command(project)
         self.assertNotEqual("cargo", Path(command[0]).name.lower())
         self.assertNotIn("run", command[1:])
+        self.assertNotIn("--dir", command)
+        self.assertIn("--workspace", command)
+        self.assertEqual(str(project), command[-1])
         self.assertIn("stasis", " ".join(command).lower())
+
+    def test_behavior_runner_uses_and_removes_temporary_manifest(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        manifest_path = project / "stasis.json"
+
+        def observe_manifest(_args: list[str]) -> dict:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual("src/main.stasis", manifest["entry"])
+            self.assertEqual("tests", manifest["tests"])
+            return {"ok": True, "returncode": 0, "output_tail": ""}
+
+        with mock.patch.object(host, "ensure_stasis_test_runner", return_value={"ok": True}), \
+                mock.patch.object(host, "run_command", side_effect=observe_manifest):
+            result = host.run_behavior_tests(project, compile_first=False)
+        self.assertFalse(manifest_path.exists())
+        self.assertFalse(result["ok"], "a project without a test file must still fail validation")
+
+    def test_acceptance_does_not_report_passes_when_runner_fails(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        with mock.patch.object(host, "run_behavior_tests", return_value={
+            "ok": False,
+            "returncode": 2,
+            "output_tail": "runner argument error",
+        }):
+            result = comparison.run_acceptance(project, comparison.DEFAULT_ACCEPTANCE_TEST)
+        self.assertEqual(4, result["acceptance_tests_total"])
+        self.assertEqual(0, result["acceptance_tests_passed"])
+
+    def test_acceptance_reports_partial_assertion_failures(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        output = (
+            "comparison_acceptance.test.stasis :: first :: returned false | "
+            "comparison_acceptance.test.stasis :: second :: returned false"
+        )
+        with mock.patch.object(host, "run_behavior_tests", return_value={
+            "ok": False,
+            "returncode": 1,
+            "output_tail": output,
+        }):
+            result = comparison.run_acceptance(project, comparison.DEFAULT_ACCEPTANCE_TEST)
+        self.assertEqual(2, result["acceptance_tests_passed"])
 
     def make_project(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
         temporary = tempfile.TemporaryDirectory()

--- a/tools/ci/test_android_ai_agent_host.py
+++ b/tools/ci/test_android_ai_agent_host.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import io
 import sys
 import tempfile
 import unittest
@@ -58,6 +59,147 @@ class AndroidAiAgentHostTests(unittest.TestCase):
 
     def test_host_run_finishes_before_repository_command_limit(self) -> None:
         self.assertLess(host.DEFAULT_MAX_RUN_SECONDS, 300.0)
+
+    def test_openrouter_payload_preserves_exact_context_and_zero_price_route(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        openai_payload = host.build_openai_payload("poolside/laguna-xs-2.1:free", request)
+        payload = host.build_openrouter_payload(
+            "poolside/laguna-xs-2.1:free", request, "poolside", 0.0, 0.0)
+        self.assertEqual([], host.validate_openrouter_payload(payload))
+        self.assertEqual({"effort": "medium", "exclude": True}, payload["reasoning"])
+        self.assertEqual({
+            "allow_fallbacks": False,
+            "require_parameters": True,
+            "only": ["poolside"],
+            "max_price": {"prompt": 0.0, "completion": 0.0},
+        }, payload["provider"])
+        expected_messages = [
+            {
+                "role": item["role"],
+                "content": "".join(block["text"] for block in item["content"]),
+            }
+            for item in openai_payload["input"]
+        ]
+        self.assertEqual(expected_messages, payload["messages"])
+
+    def test_openrouter_can_omit_unsupported_structured_output(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        payload = host.build_openrouter_payload(
+            "poolside/laguna-xs-2.1:free", request, max_input_price=0.0,
+            max_output_price=0.0, response_format="none")
+        self.assertNotIn("response_format", payload)
+        self.assertEqual([], host.validate_openrouter_payload(payload))
+
+    def test_openrouter_native_tools_match_workshop_specs(self) -> None:
+        tools = host.openrouter_native_tools()
+        self.assertEqual([spec["tool"] for spec in host.tool_specs()], [
+            tool["function"]["name"] for tool in tools])
+        list_symbols = tools[0]["function"]["parameters"]
+        self.assertEqual({"type": "array", "items": {"type": "string"}},
+                         list_symbols["properties"]["files"])
+        self.assertEqual({"type": "integer"}, list_symbols["properties"]["limit"])
+
+    def test_openrouter_native_prompt_requires_batched_known_symbols(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        payload = host.build_openrouter_payload(
+            "poolside/laguna-xs-2.1", request, response_format="none", native_tools=True)
+        instruction = payload["messages"][0]["content"]
+        self.assertIn("Batch every independent read_symbol", instruction)
+        self.assertIn("project_symbol_index as the authoritative list", instruction)
+        self.assertIn("Do not guess a main symbol", instruction)
+
+    def test_openrouter_usage_is_aggregated_and_written_separately(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        trace_path = Path(temporary.name) / "laguna.json"
+        events = [{
+            "kind": "openrouter_exchange",
+            "turn": 1,
+            "usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 40,
+                "cache_write_input_tokens": 0,
+                "uncached_input_tokens": 60,
+                "output_tokens": 25,
+                "reasoning_tokens": 10,
+                "total_tokens": 125,
+                "cost_usd": 0.001,
+            },
+        }]
+        host.write_trace_file(trace_path, {"model": "poolside/laguna-xs-2.1:free"}, events, 0, "now", 1.0, 0)
+        usage = json.loads((Path(temporary.name) / "laguna.usage.json").read_text(encoding="utf-8"))
+        self.assertEqual(1, usage["usage_summary"]["calls"])
+        self.assertEqual(40, usage["usage_summary"]["totals"]["cached_input_tokens"])
+        self.assertEqual(10, usage["usage_summary"]["totals"]["reasoning_tokens"])
+        self.assertEqual(0.001, usage["usage_summary"]["provider_reported_cost_usd"])
+
+    def test_openrouter_usage_reads_reasoning_cache_and_cost(self) -> None:
+        usage = host.response_usage_from_body({"usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "cost": 0.002,
+            "prompt_tokens_details": {"cached_tokens": 60},
+            "completion_tokens_details": {"reasoning_tokens": 15},
+        }})
+        self.assertEqual(60, usage["cached_input_tokens"])
+        self.assertEqual(15, usage["reasoning_tokens"])
+        self.assertEqual(0.002, usage["cost_usd"])
+
+    def test_openrouter_retries_rate_limit_without_retry_after(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        error_body = io.BytesIO(b'{"error":{"metadata":{"provider_name":"Poolside"}}}')
+        rate_limit = host.urllib.error.HTTPError("url", 429, "limited", {}, error_body)
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps({
+            "model": "poolside/laguna-xs-2.1:free",
+            "choices": [{"message": {"content": json.dumps({
+                "mode": "done",
+                "working_notes": "Intent: done. Observed: done. Next: none. Blocker: none.",
+                "summary": "done",
+            })}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }).encode("utf-8")
+        events: list[dict] = []
+        with mock.patch.object(host.urllib.request, "urlopen", side_effect=[rate_limit, response]), \
+                mock.patch.object(host.time, "sleep") as sleep:
+            result = host.call_openrouter(
+                "secret", "poolside/laguna-xs-2.1:free", request, events,
+                response_format="none")
+        self.assertEqual("done", result["mode"])
+        sleep.assert_called_once_with(10.0)
+        self.assertEqual(10.0, events[-1]["rate_limit_wait_seconds"])
+
+    def test_openrouter_native_call_translates_to_internal_tool_call(self) -> None:
+        temporary, project = self.make_project()
+        self.addCleanup(temporary.cleanup)
+        request = host.build_agent_request(project, "change tick", {"phase": "initial"})
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps({
+            "model": "poolside/laguna-xs-2.1",
+            "choices": [{"message": {
+                "content": "Inspect tick.",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_symbol", "arguments": '{"name":"tick"}'},
+                }],
+            }}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }).encode("utf-8")
+        with mock.patch.object(host.urllib.request, "urlopen", return_value=response):
+            result = host.call_openrouter(
+                "secret", "poolside/laguna-xs-2.1", request,
+                response_format="none", native_tools=True)
+        self.assertEqual("tool_calls", result["mode"])
+        self.assertEqual([{"tool": "read_symbol", "args": {"name": "tick"}}], result["tool_calls"])
 
     def test_prebuilt_test_runner_command_avoids_cargo_run(self) -> None:
         temporary, project = self.make_project()
@@ -121,6 +263,11 @@ class AndroidAiAgentHostTests(unittest.TestCase):
         first = [{"tool": "read_symbol", "args": {"name": "tick", "file": "src/main.stasis"}}]
         second = [{"args": {"file": "src/main.stasis", "name": "tick"}, "tool": "read_symbol"}]
         self.assertEqual(host.tool_call_batch_key(first), host.tool_call_batch_key(second))
+
+    def test_repeat_correction_instruction_does_not_claim_execution(self) -> None:
+        correction = host.repeated_tool_call_correction()
+        self.assertEqual("repeated_tool_call_not_executed", correction["result"]["status"])
+        self.assertIn("already ran", correction["result"]["error"])
 
     def test_observation_memory_is_deduplicated_and_bounded(self) -> None:
         memory: dict[str, dict] = {}

--- a/tools/run_android_ai_model_comparison.py
+++ b/tools/run_android_ai_model_comparison.py
@@ -86,7 +86,7 @@ def run_acceptance(project: Path, acceptance_test: Path) -> dict[str, Any]:
     output = str(result.get("output_tail", ""))
     failed = len(re.findall(r"comparison_acceptance\.test\.stasis\s+::", output))
     result["acceptance_tests_total"] = total
-    result["acceptance_tests_passed"] = max(0, total - failed)
+    result["acceptance_tests_passed"] = max(0, total - failed) if result.get("ok") or failed else 0
     return result
 
 
@@ -96,7 +96,7 @@ def write_markdown(path: Path, prompt: str, rows: list[dict[str, Any]]) -> None:
         "",
         f"Prompt: `{prompt}`",
         "",
-        "All runs use fresh copies of the same baseline, medium reasoning, standard API service, and a 25-turn cap.",
+        f"All runs use fresh copies of the same baseline, medium reasoning, standard API service, and a {host.MAX_TURNS}-turn cap.",
         "",
         "| Model | Harness | Acceptance | Total s | Model s | Tool s | Calls | Tool batches | Actions | Schema retries | Failed write batches | Restored writes | Input | Cached | Cache % | Cache write | Output | Est. USD |",
         "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",


### PR DESCRIPTION
Adds a generic OpenRouter transport to the Android Workshop host comparison harness, including exact provider-payload traces without authorization headers, separate provider token/cost logs, hard routing and price controls, optional JSON Schema or prompt-enforced JSON, native tool translation, bounded 429 retries, and one non-executing repeated-call correction. This is needed because OpenRouter models vary in structured-output and tool-call support; the adapter keeps all responses on the existing Stasis validation and rollback path. It also makes sequential native-tool inspection configurable without changing the 15-turn or 50-tool-call limits. Validation: Python compilation, 31 focused unit tests, payload preflights for structured and native modes, and live OpenRouter compatibility trials against Laguna XS 2.1.