### PR TITLE
perf: lower globals to direct storage

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -141,7 +141,6 @@ struct StructMetaExportFile {
 struct PackagedAotSupportFiles {
     data_bind_json_rel: Option<String>,
     data_bind_meta_rel: Option<String>,
-    export_symbols: Vec<String>,
     runtime_fields: Vec<PackagedRuntimeField>,
 }
 
@@ -3022,10 +3021,6 @@ fn stage_entry_support_files(
     }
     let runtime_fields: Vec<_> = fields_by_name.into_values().collect();
     let mut support = PackagedAotSupportFiles {
-        export_symbols: runtime_fields
-            .iter()
-            .map(|field| field.name.clone())
-            .collect(),
         runtime_fields,
         ..PackagedAotSupportFiles::default()
     };
@@ -3041,6 +3036,129 @@ fn stage_entry_support_files(
     }
 
     Ok(support)
+}
+
+fn state_layout_runtime_fields(
+    layout: &StateLayout,
+    include_bridge_owned: bool,
+) -> Result<Vec<PackagedRuntimeField>, String> {
+    fn field_width(type_name: &str) -> Result<usize, String> {
+        match type_name {
+            "bool" | "u16" | "u32" | "i32" | "f32" => Ok(4),
+            "u8" => Ok(1),
+            "f64" => Ok(8),
+            other => Err(format!("unsupported AOT state storage type '{other}'")),
+        }
+    }
+
+    fn is_bridge_owned(path: &str) -> bool {
+        matches!(
+            path,
+            "host_i32"
+                | "host_f32"
+                | "gfx_cmd_i32"
+                | "gfx_cmd_f32"
+                | "gfx_cmd_u8"
+                | "host_req_seq"
+                | "host_req_flags"
+                | "host_req_window_w_px"
+                | "host_req_window_h_px"
+        )
+    }
+
+    let collection_capacities = layout
+        .collections
+        .iter()
+        .map(|collection| (collection.path.as_str(), collection.capacity))
+        .collect::<BTreeMap<_, _>>();
+    let mut fields = Vec::new();
+    for scalar in &layout.scalars {
+        if !include_bridge_owned && is_bridge_owned(&scalar.path) {
+            continue;
+        }
+        let initial_value = scalar.path.strip_suffix(".max_length").and_then(|parent| {
+            collection_capacities
+                .get(parent)
+                .map(|capacity| serde_json::json!(capacity))
+        });
+        fields.push(PackagedRuntimeField {
+            name: scalar.path.replace('.', "__"),
+            size: field_width(&scalar.type_name)?,
+            field_type: scalar.type_name.clone(),
+            array_count: 1,
+            initial_value,
+            collection_path: None,
+            collection_field: None,
+        });
+    }
+    for collection in &layout.collections {
+        if !include_bridge_owned && is_bridge_owned(&collection.path) {
+            continue;
+        }
+        let array_count = usize::try_from(collection.capacity).map_err(|_| {
+            format!(
+                "negative AOT state collection capacity {} for '{}'",
+                collection.capacity, collection.path
+            )
+        })?;
+        for field in &collection.fields {
+            let width = field_width(&field.type_name)?;
+            let name = if field.field.is_empty() {
+                collection.path.replace('.', "__")
+            } else {
+                format!(
+                    "{}__{}",
+                    collection.path.replace('.', "__"),
+                    field.field.replace('.', "__")
+                )
+            };
+            fields.push(PackagedRuntimeField {
+                name,
+                size: width.checked_mul(array_count).ok_or_else(|| {
+                    format!("AOT state storage size overflow for '{}'", collection.path)
+                })?,
+                field_type: field.type_name.clone(),
+                array_count,
+                initial_value: None,
+                collection_path: Some(collection.path.clone()),
+                collection_field: (!field.field.is_empty()).then(|| field.field.clone()),
+            });
+        }
+    }
+    Ok(fields)
+}
+
+fn merge_runtime_fields(
+    layout: &StateLayout,
+    support_fields: &[PackagedRuntimeField],
+) -> Result<Vec<PackagedRuntimeField>, String> {
+    let mut fields = state_layout_runtime_fields(layout, false)?
+        .into_iter()
+        .map(|field| (field.name.clone(), field))
+        .collect::<BTreeMap<_, _>>();
+    for field in support_fields {
+        fields.insert(field.name.clone(), field.clone());
+    }
+    Ok(fields.into_values().collect())
+}
+
+pub fn build_aot_direct_storage_source(
+    layout: &StateLayout,
+) -> Result<(String, Vec<String>), String> {
+    let mut source = String::from(
+        "#ifndef STASIS_EXPORT\n\
+#if defined(_WIN32)\n\
+#define STASIS_EXPORT __declspec(dllexport)\n\
+#else\n\
+#define STASIS_EXPORT __attribute__((visibility(\"default\")))\n\
+#endif\n\
+#endif\n",
+    );
+    let mut register_lines = Vec::new();
+    for field in state_layout_runtime_fields(layout, true)? {
+        append_runtime_bridge_field_source(&mut source, &mut register_lines, &field)?;
+    }
+    Ok((source, register_lines))
 }
 
 fn append_runtime_bridge_field_source(
@@ -3110,10 +3228,40 @@ fn append_runtime_bridge_field_source(
         .as_deref()
         .map(crate::hash_global_path)
         .unwrap_or(0);
+    let is_array = field.collection_path.is_some() || field.array_count > 1;
     match field.field_type.as_str() {
+        "u8" if is_array => {
+            let values = values_for_field(field)?;
+            let initializer = if values.is_empty() {
+                "0".to_string()
+            } else {
+                values
+                    .iter()
+                    .map(|value| {
+                        let value = i32_literal(value, &field.name)?;
+                        let parsed = value.parse::<i32>().map_err(|error| error.to_string())?;
+                        u8::try_from(parsed)
+                            .map(|value| value.to_string())
+                            .map_err(|_| {
+                                format!("packaged data field {} is outside u8 range", field.name)
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .join(", ")
+            };
+            source.push_str(&format!(
+                "STASIS_EXPORT uint8_t {}[{}] = {{{initializer}}};\n",
+                field.name, field.array_count,
+            ));
+            register_lines.push(format!(
+                "stasis_jit_register_global_u8_array({collection_hash}, {field_hash}, {name}, {len});",
+                name = field.name,
+                len = field.array_count
+            ));
+        }
         "bool" | "u8" | "u16" | "u32" | "i32" => {
             let values = values_for_field(field)?;
-            if field.array_count > 1 {
+            if is_array {
                 let initializer = if values.is_empty() {
                     "0".to_string()
                 } else {
@@ -3150,7 +3298,7 @@ fn append_runtime_bridge_field_source(
         }
         "f32" => {
             let values = values_for_field(field)?;
-            if field.array_count > 1 {
+            if is_array {
                 let initializer = if values.is_empty() {
                     "0.0f".to_string()
                 } else {
@@ -3187,7 +3335,7 @@ fn append_runtime_bridge_field_source(
         }
         "f64" => {
             let values = values_for_field(field)?;
-            if field.array_count > 1 {
+            if is_array {
                 let initializer = if values.is_empty() {
                     "0.0".to_string()
                 } else {
@@ -3349,7 +3497,8 @@ typedef unsigned char uint8_t;\n\
 typedef unsigned long long uintptr_t;\n\
 #else\n\
 #include <stdint.h>\n\
-#endif\n",
+#endif\n\
+",
     );
     source.push_str(
         "#if defined(_WIN32)\n\
@@ -3665,6 +3814,11 @@ fn package_engine_bundle_release(
 
     let entry_file = resolve_self_host_aot_entry_file(project_dir, entry_file_override)?;
     let support = stage_entry_support_files(project_dir, entry_file.as_deref(), output_root)?;
+    let state_layout = backend
+        .last_state_layout
+        .as_ref()
+        .ok_or_else(|| "AOT state layout missing during packaging".to_string())?;
+    let runtime_fields = merge_runtime_fields(state_layout, &support.runtime_fields)?;
     let mut function_aliases = vec![PackagedFunctionAlias {
         alias: "main",
         target_symbol: entry_symbol.clone(),
@@ -3721,8 +3875,8 @@ fn package_engine_bundle_release(
     ] {
         export_symbols.insert(format!("{symbol},DATA"));
     }
-    for symbol in &support.export_symbols {
-        export_symbols.insert(format!("{symbol},DATA"));
+    for field in &runtime_fields {
+        export_symbols.insert(format!("{},DATA", field.name));
     }
 
     let mut link_config = backend.aot_link_config.clone();
@@ -3754,7 +3908,7 @@ fn package_engine_bundle_release(
     let string_literals = manifest.string_literals.clone().unwrap_or_default();
     let bridge_object = emit_engine_bundle_runtime_bridge_object(
         backend,
-        &support.runtime_fields,
+        &runtime_fields,
         &function_symbols,
         &function_aliases,
         &string_literals,
@@ -4045,6 +4199,7 @@ mod tests {
         )
         .expect("build android bridge source");
 
+        assert!(!source.contains("StasisDirectStorageSlot"));
         assert!(source.contains("STASIS_EXPORT void stasis_init(int width, int height)"));
         assert!(source.contains("host_i32[1] = width;"));
         assert!(source.contains("STASIS_EXPORT void stasis_tick(float dt)"));
@@ -7882,6 +8037,113 @@ mod tests {
         let callee_value = invoke_noarg_u64(callee_ptr).expect("invoke callee");
         assert_eq!(main_value, callee_value);
 
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn aot_bundle_executes_direct_global_storage_if_real_link_available() {
+        let Some(linker_path) = find_lld_link() else {
+            return;
+        };
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_direct_storage_{stamp}"));
+        let project_dir = temp_root.join("project");
+        fs::create_dir_all(&project_dir).expect("create project root");
+        let source = project_dir.join("main.stasis");
+        fs::write(
+            &source,
+            "struct Enemy { hp: i32; speed: f32; precise: f64; }\nglobal count: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal values: i32[2];\nglobal float_values: f32[2];\nglobal double_values: f64[2];\nglobal bytes: u8[3];\nglobal enemies: Enemy[1];\nglobal label: ascii[4];\nfunction main(): i32 { count = 7; ratio = 1.5; precise = 2.5; values[1] = 11; float_values[0] = 3.5; double_values[1] = 4.5; bytes[2] = 250; foreach (let byte in bytes) { byte += 1; } enemies[0].hp = 13; enemies[0].speed = 6.5; enemies[0].precise = 7.5; label[0] = 65; if (ratio < 1.4 || precise < 2.4 || float_values[0] < 3.4 || double_values[1] < 4.4 || enemies[0].speed < 6.4 || enemies[0].precise < 7.4) { return -1; } return count + values[1] + bytes[2] + enemies[0].hp + label[0] + label.max_length; }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
+        )
+        .expect("write source");
+
+        let artifact_root = temp_root.join("artifacts");
+        let mut backend =
+            IncrementalCompilerBackend::with_aot_config(AotCompileConfig::default(), artifact_root);
+        let result = backend.compile(CompileRequest::new(
+            RequestId(17_200),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "AOT direct storage compile failed: {:?}",
+            result.diagnostics
+        );
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle")
+            .clone();
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read manifest");
+        let runtime_fields = merge_runtime_fields(
+            backend.last_state_layout.as_ref().expect("state layout"),
+            &[],
+        )
+        .expect("derive AOT storage fields");
+        let aliases = ["main", "tick", "render"]
+            .into_iter()
+            .map(|name| PackagedFunctionAlias {
+                alias: name,
+                target_symbol: resolve_engine_bundle_symbol(&manifest, name)
+                    .expect("resolve entrypoint"),
+                returns_i32: true,
+            })
+            .collect::<Vec<_>>();
+        let function_symbols = manifest
+            .functions
+            .iter()
+            .map(|row| row.symbol.clone())
+            .collect::<Vec<_>>();
+        let bridge = emit_engine_bundle_runtime_bridge_object(
+            &backend,
+            &runtime_fields,
+            &function_symbols,
+            &aliases,
+            &[],
+        )
+        .expect("compile direct storage bridge");
+        let mut objects = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        objects.push(bridge);
+        let linked = temp_root.join("direct_storage.dll");
+        let dynload = ensure_stasis_dynload_link_library().expect("stasis dynload link library");
+        stasis_jit::link_objects_to_dynamic_library(
+            &objects,
+            &linked,
+            &[
+                "main".to_string(),
+                "stasis_aot_bind_runtime_globals".to_string(),
+            ],
+            &AotLinkConfig {
+                linker_path: Some(linker_path),
+                runtime_lib_paths: vec![dynload.clone()],
+                target: stasis_jit::AotTarget::default(),
+            },
+        )
+        .expect("link direct storage AOT bundle");
+        stage_stasis_dynload_runtime(&dynload, &linked).expect("stage stasis dynload runtime");
+
+        let library = DynamicLibrary::load(&linked).expect("load direct storage AOT bundle");
+        let bind = library
+            .symbol_address("stasis_aot_bind_runtime_globals")
+            .expect("resolve runtime binding");
+        stasis_dynload::invoke_noarg_void(bind).expect("bind runtime globals");
+        let main = library.symbol_address("main").expect("resolve main");
+        assert_eq!(
+            stasis_dynload::invoke_noarg_i32(main).expect("execute AOT main"),
+            351
+        );
+        // Runtime bindings intentionally remain valid until the test process exits.
+        std::mem::forget(library);
         fs::remove_dir_all(&temp_root).ok();
     }
     fn write_fake_linker(temp_root: &Path) -> PathBuf {

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -10,6 +10,7 @@ mod stasis_test_runner;
 mod watch;
 mod window_config;
 
+pub use compiler_backend::build_aot_direct_storage_source;
 pub use compiler_backend::run_self_host_aot_cli;
 pub use compiler_backend::run_self_host_aot_cli_with_options;
 pub use events::RunnerEvent;

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -14,9 +14,9 @@ use std::time::{Duration, Instant};
 
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use stasis::{
-    run_jit_tests_in_directory_with_session, run_play_in_process_with_input_script,
-    run_self_host_aot_cli_with_options, run_with_default_backend, run_with_real_backend,
-    RunnerConfig, StasisTestRunSession,
+    build_aot_direct_storage_source, run_jit_tests_in_directory_with_session,
+    run_play_in_process_with_input_script, run_self_host_aot_cli_with_options,
+    run_with_default_backend, run_with_real_backend, RunnerConfig, StasisTestRunSession,
 };
 use stasis_assets::{
     load_project_asset_manifest, AssetFormat, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
@@ -1623,7 +1623,12 @@ fn write_mobile_aot_engine_bundle(
     let symbols_header = output_dir.join("published_aot_symbols.h");
     write_mobile_aot_symbols_header(&manifest_json, &symbols_header)?;
     let bindings_source = output_dir.join("published_aot_bindings.c");
-    write_mobile_aot_bindings_source(&manifest_json, project_dir, &bindings_source)?;
+    write_mobile_aot_bindings_source(
+        &manifest_json,
+        &process.state_layout(),
+        project_dir,
+        &bindings_source,
+    )?;
     let cmake_file = if target == MobileAotTarget::AndroidArm64 {
         let path = output_dir.join("published_aot_objects.cmake");
         write_android_aot_cmake_file(&bundle.object_paths_by_function, &path)?;
@@ -1970,6 +1975,7 @@ fn write_mobile_aot_symbols_header(
 
 fn write_mobile_aot_bindings_source(
     manifest: &serde_json::Value,
+    state_layout: &stasis_compiler::backend::state_layout::StateLayout,
     project_dir: &Path,
     output_path: &Path,
 ) -> Result<(), String> {
@@ -1984,6 +1990,9 @@ fn write_mobile_aot_bindings_source(
     let mut out = String::from(
         "#include <stdint.h>\n#include <string.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n",
     );
+    let (direct_storage_source, direct_storage_register_lines) =
+        build_aot_direct_storage_source(state_layout)?;
+    out.push_str(&direct_storage_source);
     for function in functions {
         let symbol = function
             .get("symbol")
@@ -2055,6 +2064,9 @@ fn write_mobile_aot_bindings_source(
          }\n",
     );
     out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
+    for line in direct_storage_register_lines {
+        out.push_str(&format!("    {line}\n"));
+    }
     for function in functions {
         let symbol = function
             .get("symbol")
@@ -2884,18 +2896,22 @@ mod tests {
                 .expect("read shared mobile AOT runtime header");
         let graphics_runtime = fs::read_to_string(repo_root.join("runtime/stasis_graphics.c"))
             .expect("read graphics runtime");
+        let generated_bindings =
+            fs::read_to_string(summary.bundle_dir.join("published_aot_bindings.c"))
+                .expect("read generated AOT bindings");
         let missing: Vec<_> = undefined
             .difference(&defined)
             .filter(|symbol| {
                 !mobile_aot_runtime.contains(&format!("{symbol}("))
                     && !mobile_aot_header.contains(&format!("{symbol}("))
                     && !graphics_runtime.contains(&format!("{symbol}("))
+                    && !generated_bindings.contains(symbol.as_str())
             })
             .cloned()
             .collect();
         assert!(
             missing.is_empty(),
-            "shared mobile core must provide AOT imports: {missing:?}"
+            "mobile runtime or generated bindings must provide AOT imports: {missing:?}"
         );
         let runtime_exports = fs::read_to_string(
             repo_root.join("crates/stasis_compiler/src/backend/runtime_exports.rs"),

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2,7 +2,9 @@ use crate::backend::emit::*;
 use crate::backend::state_layout::{build_state_layout, StateLayout};
 use crate::backend::{AotOptimizationProfile, EngineEntrypoints};
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
-use crate::frontend::types::{TypeCategory, TypeTable, TYPE_ID_I32};
+use crate::frontend::types::{
+    TypeCategory, TypeId, TypeTable, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
+};
 use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
@@ -137,6 +139,12 @@ impl AotProcess {
         self.collection_max_lengths =
             collect_fixed_collection_max_lengths(&analysis.global_path_types, &analysis_type_table)
                 .map_err(crate::compiler::CompileError::Backend)?;
+        let direct_storage = build_aot_direct_storage_bindings(
+            &analysis.global_path_types,
+            &analysis.collection_infos,
+            &analysis_type_table,
+        )
+        .map_err(crate::compiler::CompileError::Backend)?;
         let compiled_body_hashes: HashMap<FunctionId, u64> = self
             .artifacts
             .iter()
@@ -188,6 +196,7 @@ impl AotProcess {
                     &target,
                     &analysis.collection_infos,
                     &analysis.named_struct_field_types,
+                    &direct_storage,
                 )?;
                 let object_index = *next_object_index;
                 *next_object_index = next_object_index.saturating_add(1);
@@ -570,6 +579,103 @@ fn object_file_extension(target: &stasis_jit::AotTarget) -> &'static str {
     }
 }
 
+fn aot_scalar_lane(type_id: TypeId, type_table: &TypeTable) -> Option<&'static str> {
+    if is_i32_abi_compatible_type(type_id, type_table) {
+        Some("i32")
+    } else if type_id == TYPE_ID_F32 {
+        Some("f32")
+    } else if type_id == TYPE_ID_F64 {
+        Some("f64")
+    } else {
+        None
+    }
+}
+
+fn aot_array_lane(
+    path: &str,
+    type_id: TypeId,
+    global_path_types: &GlobalPathTypeMap,
+    type_table: &TypeTable,
+) -> Option<&'static str> {
+    let text_storage = global_path_types
+        .get(path)
+        .and_then(|global_type| type_table.type_info(*global_type))
+        .is_some_and(|info| {
+            matches!(
+                info.category,
+                TypeCategory::AsciiFixed | TypeCategory::Utf8Fixed
+            )
+        });
+    let u8_storage = type_table
+        .type_info(type_id)
+        .is_some_and(|info| info.name == "u8");
+    if text_storage || u8_storage || path == "gfx_cmd_u8" {
+        Some("u8")
+    } else {
+        aot_scalar_lane(type_id, type_table)
+    }
+}
+
+fn build_aot_direct_storage_bindings(
+    global_path_types: &GlobalPathTypeMap,
+    collection_infos: &CollectionInfoMap,
+    type_table: &TypeTable,
+) -> Result<DirectStorageBindings, String> {
+    fn storage_symbol(path: &str, field: &str) -> String {
+        if field.is_empty() {
+            path.replace('.', "__")
+        } else {
+            format!("{}__{}", path.replace('.', "__"), field.replace('.', "__"))
+        }
+    }
+
+    let mut bindings = DirectStorageBindings::default();
+    for (path, type_id) in global_path_types {
+        if collection_infos.contains_key(path) {
+            continue;
+        }
+        if aot_scalar_lane(*type_id, type_table).is_some() {
+            bindings.scalars.insert(
+                path.clone(),
+                DirectStorageBinding::Symbol(storage_symbol(path, "")),
+            );
+        }
+    }
+    for (path, info) in collection_infos {
+        if let Some(type_id) = info.element_type {
+            let lane =
+                aot_array_lane(path, type_id, global_path_types, type_table).ok_or_else(|| {
+                    format!("unsupported AOT direct storage element type {type_id} for '{path}'")
+                })?;
+            bindings.arrays.insert(
+                (path.clone(), String::new()),
+                crate::backend::emit::DirectArrayStorageBinding {
+                    slot: DirectStorageBinding::Symbol(storage_symbol(path, "")),
+                    byte_lane: lane == "u8",
+                    static_len: Some(info.len as usize),
+                },
+            );
+        }
+        for (field, type_id) in &info.field_types {
+            let lane =
+                aot_array_lane(path, *type_id, global_path_types, type_table).ok_or_else(|| {
+                    format!(
+                        "unsupported AOT direct storage field type {type_id} for '{path}.{field}'"
+                    )
+                })?;
+            bindings.arrays.insert(
+                (path.clone(), field.clone()),
+                crate::backend::emit::DirectArrayStorageBinding {
+                    slot: DirectStorageBinding::Symbol(storage_symbol(path, field)),
+                    byte_lane: lane == "u8",
+                    static_len: Some(info.len as usize),
+                },
+            );
+        }
+    }
+    Ok(bindings)
+}
+
 fn compile_function_to_object_bytes(
     meta: &FunctionMeta,
     hir: &FunctionHIR,
@@ -583,6 +689,7 @@ fn compile_function_to_object_bytes(
     target: &stasis_jit::AotTarget,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    direct_storage: &DirectStorageBindings,
 ) -> Result<Vec<u8>, String> {
     let mut flag_builder = settings::builder();
     flag_builder
@@ -630,6 +737,7 @@ fn compile_function_to_object_bytes(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        Some(direct_storage),
         |statement| record_string_literals_in_stmt(statement, string_literals),
         |_meta, _func| {
             #[cfg(test)]
@@ -961,6 +1069,8 @@ mod tests {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    static CLIF_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
     struct ParityCorpusCase {
         label: &'static str,
         source: &'static str,
@@ -1065,6 +1175,7 @@ mod tests {
     }
 
     fn capture_aot_clif_by_function(process: &mut AotProcess) -> BTreeMap<String, String> {
+        let _capture_lock = CLIF_CAPTURE_LOCK.lock().expect("lock CLIF capture");
         let captured: Arc<Mutex<BTreeMap<String, String>>> = Arc::new(Mutex::new(BTreeMap::new()));
         let captured_hook = Arc::clone(&captured);
         set_clif_dump_hook(Some(Box::new(move |meta, func| {
@@ -1098,7 +1209,7 @@ mod tests {
                 expected_extern_symbols: &[],
                 expected_string_literals: &[],
                 expected_collection_max_lengths: &[("nums", 3)],
-                expected_clif_markers: &[("main", &["call", "iadd"])],
+                expected_clif_markers: &[("main", &["load.i32", "store", "iadd"])],
             },
             ParityCorpusCase {
                 label: "renderer_command_trace",
@@ -1228,6 +1339,35 @@ mod tests {
                 case.label
             );
         }
+    }
+
+    #[test]
+    fn aot_lowers_core_global_storage_without_runtime_calls() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "direct_storage.stasis",
+            "struct Enemy { hp: i32; speed: f32; }\nglobal count: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal ints: i32[2];\nglobal floats: f32[2];\nglobal doubles: f64[2];\nglobal bytes: u8[3];\nglobal enemies: Enemy[1];\nglobal label: ascii[4];\nfunction main(): i32 {\n    count = 7;\n    ratio = 1.5;\n    precise = 2.5;\n    ints[0] = 11;\n    floats[1] = 3.5;\n    doubles[0] = 4.5;\n    bytes[2] = 250;\n    foreach (let byte in bytes) { byte += 1; }\n    enemies[0].hp = 13;\n    enemies[0].speed = 6.5;\n    label[0] = 65;\n    ints[8] = 88;\n    if (ints[8] != 0) { return 1; }\n    if (enemies[0].speed < 6.4) { return 2; }\n    return count + ints[0] + bytes[2] + enemies[0].hp + label[0] + label.max_length;\n}\n",
+        );
+        let captured = capture_aot_clif_by_function(&mut process);
+        let clif = captured.get("main").expect("main CLIF");
+        assert!(clif.contains("load.i32"), "expected direct loads:\n{clif}");
+        assert!(
+            clif.contains("load.i8"),
+            "expected direct byte loads:\n{clif}"
+        );
+        assert!(clif.contains("store"), "expected direct stores:\n{clif}");
+        assert!(
+            clif.contains("ireduce.i8"),
+            "expected byte-width direct stores:\n{clif}"
+        );
+        let has_call_instruction = clif.lines().any(|line| {
+            let line = line.trim_start();
+            line.starts_with("call ") || line.contains(" = call ")
+        });
+        assert!(
+            !has_call_instruction,
+            "core AOT global storage emitted a runtime call:\n{clif}"
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -6,9 +6,11 @@ use crate::frontend::types::{
     TypeCategory, TypeId, TypeTable, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
 };
 use crate::ir::hir::FunctionHIR;
+use cranelift_codegen::ir::{types, AbiParam, InstBuilder};
 use cranelift_codegen::settings;
 use cranelift_codegen::settings::Configurable;
-use cranelift_module::{default_libcall_names, Module};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
+use cranelift_module::{default_libcall_names, DataDescription, DataId, Linkage, Module};
 use cranelift_object::{ObjectBuilder, ObjectModule};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
@@ -378,12 +380,11 @@ impl AotProcess {
                         artifact_function.name, artifact.object_index
                     )
                 })?;
-            let object_file_name = format!(
+            let object_path = object_dir.join(format!(
                 "{}_{}.obj",
                 sanitize_file_token(&artifact_function.name),
                 artifact.object_index
-            );
-            let object_path = object_dir.join(object_file_name);
+            ));
             fs::write(&object_path, object_bytes).map_err(|error| {
                 format!(
                     "failed to write object file {}: {error}",
@@ -398,13 +399,242 @@ impl AotProcess {
         let entry_object_path = entry_object_path
             .ok_or_else(|| format!("entry object path missing for function '{name}'"))?;
 
+        let mut link_entry = entry_artifact.symbol_name.clone();
+        if let Some((storage_bytes, wrapper_symbol)) =
+            self.compile_standalone_storage_object(&entry_artifact.symbol_name)?
+        {
+            let storage_path = object_dir.join("direct_storage.obj");
+            fs::write(&storage_path, storage_bytes).map_err(|error| {
+                format!(
+                    "failed to write direct storage object {}: {error}",
+                    storage_path.display()
+                )
+            })?;
+            object_paths.push(storage_path);
+            link_entry = wrapper_symbol;
+        }
+
         stasis_jit::link_objects_to_executable(
             &object_paths,
             output_executable,
-            &entry_artifact.symbol_name,
+            &link_entry,
             link_config,
         )?;
         Ok(entry_object_path)
+    }
+
+    fn compile_standalone_storage_object(
+        &self,
+        entry_symbol: &str,
+    ) -> Result<Option<(Vec<u8>, String)>, String> {
+        fn storage_width(type_name: &str) -> Result<usize, String> {
+            match type_name {
+                "u8" => Ok(1),
+                "bool" | "u16" | "u32" | "i32" | "f32" => Ok(4),
+                "f64" => Ok(8),
+                other => Err(format!("unsupported standalone AOT storage type '{other}'")),
+            }
+        }
+
+        let layout = self.state_layout();
+        if layout.scalars.is_empty() && layout.collections.is_empty() {
+            return Ok(None);
+        }
+        let mut flag_builder = settings::builder();
+        flag_builder
+            .set(
+                "opt_level",
+                self.optimization_profile.as_cranelift_opt_level(),
+            )
+            .map_err(|error| format!("failed to configure Cranelift opt level: {error}"))?;
+        if self.target.requires_position_independent_code() {
+            flag_builder.set("is_pic", "true").map_err(|error| {
+                format!("failed to configure position-independent AOT: {error}")
+            })?;
+        }
+        let flags = settings::Flags::new(flag_builder);
+        let isa_builder = match self.target.object_triple() {
+            Some(triple_text) => {
+                let triple = Triple::from_str(triple_text).map_err(|error| {
+                    format!("failed to parse AOT target triple {triple_text}: {error}")
+                })?;
+                let triple_display = triple.to_string();
+                cranelift_codegen::isa::lookup(triple).map_err(|error| {
+                    format!("failed to construct ISA builder for {triple_display}: {error}")
+                })?
+            }
+            None => cranelift_native::builder()
+                .map_err(|error| format!("failed to construct native ISA builder: {error}"))?,
+        };
+        let isa = isa_builder
+            .finish(flags)
+            .map_err(|error| format!("failed to finalize native ISA: {error}"))?;
+        let builder = ObjectBuilder::new(
+            isa,
+            "stasis_aot_standalone_storage".to_string(),
+            default_libcall_names(),
+        )
+        .map_err(|error| format!("failed to construct storage object builder: {error}"))?;
+        let mut module = ObjectModule::new(builder);
+        let pointer_type = module.target_config().pointer_type();
+        let mut registrations = Vec::new();
+
+        for scalar in &layout.scalars {
+            let width = storage_width(&scalar.type_name)?;
+            let mut bytes = vec![0; width];
+            if let Some(collection_path) = scalar.path.strip_suffix(".max_length") {
+                if let Some(collection) = layout
+                    .collections
+                    .iter()
+                    .find(|collection| collection.path == collection_path)
+                {
+                    bytes[..4].copy_from_slice(&collection.capacity.to_ne_bytes());
+                }
+            }
+            let symbol = aot_storage_symbol(&scalar.path, "");
+            let data_id = define_standalone_storage_data(&mut module, &symbol, bytes)?;
+            registrations.push((
+                data_id,
+                scalar.type_name.clone(),
+                hash_global_path(&scalar.path),
+                0,
+                None,
+            ));
+        }
+        for collection in &layout.collections {
+            let len = usize::try_from(collection.capacity).map_err(|_| {
+                format!(
+                    "negative standalone AOT collection capacity for '{}'",
+                    collection.path
+                )
+            })?;
+            for field in &collection.fields {
+                let width = storage_width(&field.type_name)?;
+                let size = len.checked_mul(width).ok_or_else(|| {
+                    format!(
+                        "standalone AOT storage size overflow for '{}.{}'",
+                        collection.path, field.field
+                    )
+                })?;
+                let symbol = aot_storage_symbol(&collection.path, &field.field);
+                let data_id = define_standalone_storage_data(&mut module, &symbol, vec![0; size])?;
+                registrations.push((
+                    data_id,
+                    field.type_name.clone(),
+                    hash_global_path(&collection.path),
+                    hash_foreach_field_suffix(&field.field),
+                    Some(collection.capacity),
+                ));
+            }
+        }
+
+        let mut entry_signature = module.make_signature();
+        entry_signature.returns.push(AbiParam::new(types::I32));
+        let entry_id = module
+            .declare_function(entry_symbol, Linkage::Import, &entry_signature)
+            .map_err(|error| format!("failed to declare standalone entry: {error}"))?;
+        let wrapper_symbol = "stasis_aot_standalone_entry".to_string();
+        let wrapper_id = module
+            .declare_function(&wrapper_symbol, Linkage::Export, &entry_signature)
+            .map_err(|error| format!("failed to declare standalone wrapper: {error}"))?;
+
+        let mut register_functions = BTreeMap::new();
+        for (_, type_name, _, _, len) in &registrations {
+            let lane = if type_name == "f32" {
+                "f32"
+            } else if type_name == "f64" {
+                "f64"
+            } else if type_name == "u8" && len.is_some() {
+                "u8"
+            } else {
+                "i32"
+            };
+            let key = (lane, len.is_some());
+            if register_functions.contains_key(&key) {
+                continue;
+            }
+            let symbol = if len.is_some() {
+                format!("stasis_jit_register_global_{lane}_array")
+            } else {
+                format!("stasis_jit_register_global_{lane}_ptr")
+            };
+            let mut signature = module.make_signature();
+            signature.params.push(AbiParam::new(types::I32));
+            if len.is_some() {
+                signature.params.push(AbiParam::new(types::I32));
+            }
+            signature.params.push(AbiParam::new(pointer_type));
+            if len.is_some() {
+                signature.params.push(AbiParam::new(types::I32));
+            }
+            let function_id = module
+                .declare_function(&symbol, Linkage::Import, &signature)
+                .map_err(|error| format!("failed to declare '{symbol}': {error}"))?;
+            register_functions.insert(key, function_id);
+        }
+
+        let mut context = module.make_context();
+        context.func.signature = entry_signature;
+        let entry_ref = module.declare_func_in_func(entry_id, &mut context.func);
+        let register_refs: BTreeMap<_, _> = register_functions
+            .into_iter()
+            .map(|(key, id)| (key, module.declare_func_in_func(id, &mut context.func)))
+            .collect();
+        let registration_refs: Vec<_> = registrations
+            .into_iter()
+            .map(|(data_id, type_name, path_hash, field_hash, len)| {
+                (
+                    module.declare_data_in_func(data_id, &mut context.func),
+                    type_name,
+                    path_hash,
+                    field_hash,
+                    len,
+                )
+            })
+            .collect();
+        let mut builder_context = FunctionBuilderContext::new();
+        {
+            let mut builder = FunctionBuilder::new(&mut context.func, &mut builder_context);
+            let block = builder.create_block();
+            builder.switch_to_block(block);
+            builder.seal_block(block);
+            for (data, type_name, path_hash, field_hash, len) in registration_refs {
+                let lane = if type_name == "f32" {
+                    "f32"
+                } else if type_name == "f64" {
+                    "f64"
+                } else if type_name == "u8" && len.is_some() {
+                    "u8"
+                } else {
+                    "i32"
+                };
+                let function_ref = register_refs[&(lane, len.is_some())];
+                let path = builder.ins().iconst(types::I32, i64::from(path_hash));
+                let pointer = builder.ins().global_value(pointer_type, data);
+                if let Some(len) = len {
+                    let field = builder.ins().iconst(types::I32, i64::from(field_hash));
+                    let length = builder.ins().iconst(types::I32, i64::from(len));
+                    builder
+                        .ins()
+                        .call(function_ref, &[path, field, pointer, length]);
+                } else {
+                    builder.ins().call(function_ref, &[path, pointer]);
+                }
+            }
+            let call = builder.ins().call(entry_ref, &[]);
+            let result = builder.inst_results(call)[0];
+            builder.ins().return_(&[result]);
+            builder.finalize();
+        }
+        module
+            .define_function(wrapper_id, &mut context)
+            .map_err(|error| format!("failed to define standalone wrapper: {error}"))?;
+        module.clear_context(&mut context);
+        let bytes = module
+            .finish()
+            .emit()
+            .map_err(|error| format!("failed to emit standalone AOT storage object: {error}"))?;
+        Ok(Some((bytes, wrapper_symbol)))
     }
 
     pub fn write_engine_bundle(
@@ -616,19 +846,35 @@ fn aot_array_lane(
     }
 }
 
+fn aot_storage_symbol(path: &str, field: &str) -> String {
+    if field.is_empty() {
+        path.replace('.', "__")
+    } else {
+        format!("{}__{}", path.replace('.', "__"), field.replace('.', "__"))
+    }
+}
+
+fn define_standalone_storage_data(
+    module: &mut ObjectModule,
+    symbol: &str,
+    bytes: Vec<u8>,
+) -> Result<DataId, String> {
+    let data_id = module
+        .declare_data(symbol, Linkage::Export, true, false)
+        .map_err(|error| format!("failed to declare standalone storage '{symbol}': {error}"))?;
+    let mut description = DataDescription::new();
+    description.define(bytes.into_boxed_slice());
+    module
+        .define_data(data_id, &description)
+        .map_err(|error| format!("failed to define standalone storage '{symbol}': {error}"))?;
+    Ok(data_id)
+}
+
 fn build_aot_direct_storage_bindings(
     global_path_types: &GlobalPathTypeMap,
     collection_infos: &CollectionInfoMap,
     type_table: &TypeTable,
 ) -> Result<DirectStorageBindings, String> {
-    fn storage_symbol(path: &str, field: &str) -> String {
-        if field.is_empty() {
-            path.replace('.', "__")
-        } else {
-            format!("{}__{}", path.replace('.', "__"), field.replace('.', "__"))
-        }
-    }
-
     let mut bindings = DirectStorageBindings::default();
     for (path, type_id) in global_path_types {
         if collection_infos.contains_key(path) {
@@ -637,7 +883,7 @@ fn build_aot_direct_storage_bindings(
         if aot_scalar_lane(*type_id, type_table).is_some() {
             bindings.scalars.insert(
                 path.clone(),
-                DirectStorageBinding::Symbol(storage_symbol(path, "")),
+                DirectStorageBinding::Symbol(aot_storage_symbol(path, "")),
             );
         }
     }
@@ -650,7 +896,7 @@ fn build_aot_direct_storage_bindings(
             bindings.arrays.insert(
                 (path.clone(), String::new()),
                 crate::backend::emit::DirectArrayStorageBinding {
-                    slot: DirectStorageBinding::Symbol(storage_symbol(path, "")),
+                    slot: DirectStorageBinding::Symbol(aot_storage_symbol(path, "")),
                     byte_lane: lane == "u8",
                     static_len: Some(info.len as usize),
                 },
@@ -666,7 +912,7 @@ fn build_aot_direct_storage_bindings(
             bindings.arrays.insert(
                 (path.clone(), field.clone()),
                 crate::backend::emit::DirectArrayStorageBinding {
-                    slot: DirectStorageBinding::Symbol(storage_symbol(path, field)),
+                    slot: DirectStorageBinding::Symbol(aot_storage_symbol(path, field)),
                     byte_lane: lane == "u8",
                     static_len: Some(info.len as usize),
                 },
@@ -1063,7 +1309,9 @@ mod tests {
     use super::*;
     use crate::backend::jit::JitProcess;
     use crate::backend::EngineEntrypoints;
-    use object::{Architecture, BinaryFormat, File, Object, ObjectSection, RelocationKind};
+    use object::{
+        Architecture, BinaryFormat, File, Object, ObjectSection, ObjectSymbol, RelocationKind,
+    };
     #[cfg(windows)]
     use std::process::Command;
     use std::sync::Arc;
@@ -1368,6 +1616,42 @@ mod tests {
             !has_call_instruction,
             "core AOT global storage emitted a runtime call:\n{clif}"
         );
+    }
+
+    #[test]
+    fn standalone_aot_storage_defines_and_registers_direct_symbols() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "storage.stasis",
+            "global count: i32;\nglobal ints: i32[2];\nglobal bytes: u8[3];\nfunction main(): i32 { count = 1; ints[0] = 2; bytes[0] = 3; return 0; }\n",
+        );
+        process.compile().expect("compile");
+        let (bytes, wrapper) = process
+            .compile_standalone_storage_object("aot_fn_0")
+            .expect("storage object")
+            .expect("storage required");
+        let object = File::parse(bytes.as_slice()).expect("parse storage object");
+        let symbols: BTreeSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+
+        assert_eq!(wrapper, "stasis_aot_standalone_entry");
+        for expected in [
+            "count",
+            "ints",
+            "bytes",
+            "stasis_aot_standalone_entry",
+            "stasis_jit_register_global_i32_ptr",
+            "stasis_jit_register_global_i32_array",
+            "stasis_jit_register_global_u8_array",
+            "aot_fn_0",
+        ] {
+            assert!(
+                symbols.contains(expected),
+                "standalone storage object missing symbol '{expected}': {symbols:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1594,28 +1594,37 @@ mod tests {
         let mut process = AotProcess::new();
         process.upsert_file(
             "direct_storage.stasis",
-            "struct Enemy { hp: i32; speed: f32; }\nglobal count: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal ints: i32[2];\nglobal floats: f32[2];\nglobal doubles: f64[2];\nglobal bytes: u8[3];\nglobal enemies: Enemy[1];\nglobal label: ascii[4];\nfunction main(): i32 {\n    count = 7;\n    ratio = 1.5;\n    precise = 2.5;\n    ints[0] = 11;\n    floats[1] = 3.5;\n    doubles[0] = 4.5;\n    bytes[2] = 250;\n    foreach (let byte in bytes) { byte += 1; }\n    enemies[0].hp = 13;\n    enemies[0].speed = 6.5;\n    label[0] = 65;\n    ints[8] = 88;\n    if (ints[8] != 0) { return 1; }\n    if (enemies[0].speed < 6.4) { return 2; }\n    return count + ints[0] + bytes[2] + enemies[0].hp + label[0] + label.max_length;\n}\n",
+            "struct Enemy { hp: i32; speed: f32; }\nglobal count: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal ints: i32[2];\nglobal floats: f32[2];\nglobal doubles: f64[2];\nglobal bytes: u8[3];\nglobal enemies: Enemy[1];\nglobal label: ascii[4];\nfunction write_globals(): void {\n    count = 7;\n    ratio = 1.5;\n    precise = 2.5;\n    ints[0] = 11;\n    floats[1] = 3.5;\n    doubles[0] = 4.5;\n    bytes[2] = 250;\n    foreach (let byte in bytes) { byte += 1; }\n    enemies[0].hp = 13;\n    enemies[0].speed = 6.5;\n    label[0] = 65;\n    ints[8] = 88;\n}\nfunction read_globals(): i32 {\n    if (ints[8] != 0) { return 1; }\n    if (enemies[0].speed < 6.4) { return 2; }\n    return count + ints[0] + bytes[2] + enemies[0].hp + label[0] + label.max_length;\n}\nfunction main(): i32 { write_globals(); return read_globals(); }\n",
         );
         let captured = capture_aot_clif_by_function(&mut process);
-        let clif = captured.get("main").expect("main CLIF");
-        assert!(clif.contains("load.i32"), "expected direct loads:\n{clif}");
+        let writer = captured.get("write_globals").expect("writer CLIF");
+        let reader = captured.get("read_globals").expect("reader CLIF");
         assert!(
-            clif.contains("load.i8"),
-            "expected direct byte loads:\n{clif}"
+            reader.contains("load.i32"),
+            "expected direct loads:\n{reader}"
         );
-        assert!(clif.contains("store"), "expected direct stores:\n{clif}");
         assert!(
-            clif.contains("ireduce.i8"),
-            "expected byte-width direct stores:\n{clif}"
+            reader.contains("load.i8"),
+            "expected direct byte loads:\n{reader}"
         );
-        let has_call_instruction = clif.lines().any(|line| {
-            let line = line.trim_start();
-            line.starts_with("call ") || line.contains(" = call ")
-        });
         assert!(
-            !has_call_instruction,
-            "core AOT global storage emitted a runtime call:\n{clif}"
+            writer.contains("store"),
+            "expected direct stores:\n{writer}"
         );
+        assert!(
+            writer.contains("ireduce.i8"),
+            "expected byte-width direct stores:\n{writer}"
+        );
+        for (name, clif) in [("writer", writer), ("reader", reader)] {
+            let has_call_instruction = clif.lines().any(|line| {
+                let line = line.trim_start();
+                line.starts_with("call ") || line.contains(" = call ")
+            });
+            assert!(
+                !has_call_instruction,
+                "core AOT global storage emitted a runtime call in {name}:\n{clif}"
+            );
+        }
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -10454,7 +10454,7 @@ fn resolve_direct_storage_refs(
             DirectStorageBinding::Absolute(address) => Ok(DirectStorageRef::Absolute(*address)),
             DirectStorageBinding::Symbol(symbol) => {
                 let data_id = module
-                    .declare_data(symbol, Linkage::Import, false, false)
+                    .declare_data(symbol, Linkage::Import, true, false)
                     .map_err(|error| {
                         format!("failed to declare direct storage symbol '{symbol}': {error}")
                     })?;

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -111,6 +111,7 @@ pub(crate) struct ForeachBinding {
     pub(crate) element_type: Option<TypeId>,
     pub(crate) struct_type_id: Option<TypeId>,
     pub(crate) field_types: BTreeMap<String, TypeId>,
+    pub(crate) u8_array_base_ptrs: BTreeMap<String, Value>,
     pub(crate) i32_array_base_ptrs: BTreeMap<String, Value>,
     pub(crate) f32_array_base_ptrs: BTreeMap<String, Value>,
     pub(crate) f64_array_base_ptrs: BTreeMap<String, Value>,
@@ -1412,6 +1413,45 @@ pub(crate) struct RuntimeCallRefs {
     pub(crate) collection_i32_load: FuncRef,
     pub(crate) collection_i32_store: FuncRef,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncRef>,
+    pub(crate) direct_storage: Option<DirectStorageRefs>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum DirectStorageBinding {
+    Absolute(usize),
+    Symbol(String),
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DirectStorageBindings {
+    pub(crate) scalars: BTreeMap<String, DirectStorageBinding>,
+    pub(crate) arrays: BTreeMap<(String, String), DirectArrayStorageBinding>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DirectArrayStorageBinding {
+    pub(crate) slot: DirectStorageBinding,
+    pub(crate) byte_lane: bool,
+    pub(crate) static_len: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DirectStorageRef {
+    Absolute(usize),
+    Symbol(cranelift_codegen::ir::GlobalValue),
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DirectStorageRefs {
+    pub(crate) scalars: BTreeMap<String, DirectStorageRef>,
+    pub(crate) arrays: BTreeMap<(String, String), DirectArrayStorageRef>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DirectArrayStorageRef {
+    pub(crate) slot: DirectStorageRef,
+    pub(crate) byte_lane: bool,
+    pub(crate) static_len: Option<usize>,
 }
 
 pub(crate) struct AotDirectCallMode<'a> {
@@ -1544,6 +1584,7 @@ pub(crate) fn compile_function_with_module<M, T, BeforeStatement, OnFunctionBuil
     constant_values: &ConstantValueMap,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    direct_storage: Option<&DirectStorageBindings>,
     mut before_statement: BeforeStatement,
     on_function_built: OnFunctionBuilt,
     finalize: Finalize,
@@ -1593,8 +1634,12 @@ where
     let mut function_builder_context = FunctionBuilderContext::new();
     {
         let mut builder = FunctionBuilder::new(&mut context.func, &mut function_builder_context);
-        let runtime_call_refs =
-            build_runtime_call_refs(&mut module, &runtime_call_imports, builder.func);
+        let runtime_call_refs = build_runtime_call_refs(
+            &mut module,
+            &runtime_call_imports,
+            builder.func,
+            direct_storage,
+        )?;
         let entry = builder.create_block();
         for param_type in &meta.params {
             if is_struct_view_type(*param_type, named_struct_field_types) {
@@ -6097,59 +6142,171 @@ pub(crate) fn emit_simple_statements(
                 let len_value = builder
                     .ins()
                     .iconst(types::I32, i64::from(collection_info.len));
+                let mut loop_len_value = len_value;
                 let mut i32_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
+                let mut u8_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
                 let mut f32_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
                 let mut f64_array_base_ptrs: BTreeMap<String, Value> = BTreeMap::new();
-                if collection_info
-                    .element_type
-                    .is_some_and(|type_id| is_i32_abi_compatible_type(type_id, type_table))
-                {
-                    let field_hash_value = builder.ins().iconst(types::I32, 0);
-                    let call = builder.ins().call(
-                        runtime_call_refs.global_i32_array_ptr,
-                        &[collection_hash_value, field_hash_value, len_value],
-                    );
-                    i32_array_base_ptrs.insert(String::new(), builder.inst_results(call)[0]);
-                }
-                if collection_info.element_type == Some(TYPE_ID_F32) {
-                    let field_hash_value = builder.ins().iconst(types::I32, 0);
-                    let call = builder.ins().call(
-                        runtime_call_refs.global_f32_array_ptr,
-                        &[collection_hash_value, field_hash_value, len_value],
-                    );
-                    f32_array_base_ptrs.insert(String::new(), builder.inst_results(call)[0]);
-                }
-                if collection_info.element_type == Some(TYPE_ID_F64) {
-                    let field_hash_value = builder.ins().iconst(types::I32, 0);
-                    let call = builder.ins().call(
-                        runtime_call_refs.global_f64_array_ptr,
-                        &[collection_hash_value, field_hash_value, len_value],
-                    );
-                    f64_array_base_ptrs.insert(String::new(), builder.inst_results(call)[0]);
-                }
-                for (suffix, type_id) in &collection_info.field_types {
-                    let field_hash = hash_foreach_field_suffix(suffix);
-                    let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
-                    if is_i32_abi_compatible_type(*type_id, type_table) {
+                if collection_info.element_type.is_some_and(|type_id| {
+                    is_i32_abi_compatible_type(type_id, type_table)
+                        && !is_u8_lane(type_table, type_id)
+                }) {
+                    let direct = matches!(collection_handle, ForeachCollectionHandle::PathHash(_))
+                        .then(|| runtime_call_refs.direct_storage.as_ref())
+                        .flatten()
+                        .and_then(|bindings| {
+                            bindings
+                                .arrays
+                                .get(&(collection_path.clone(), String::new()))
+                        })
+                        .copied();
+                    let base = if let Some(direct) = direct {
+                        loop_len_value =
+                            emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                        emit_direct_slot_data_ptr(builder, direct.slot)
+                    } else {
+                        let field_hash_value = builder.ins().iconst(types::I32, 0);
                         let call = builder.ins().call(
                             runtime_call_refs.global_i32_array_ptr,
                             &[collection_hash_value, field_hash_value, len_value],
                         );
-                        i32_array_base_ptrs.insert(suffix.clone(), builder.inst_results(call)[0]);
+                        builder.inst_results(call)[0]
+                    };
+                    i32_array_base_ptrs.insert(String::new(), base);
+                }
+                if collection_info
+                    .element_type
+                    .is_some_and(|type_id| is_u8_lane(type_table, type_id))
+                {
+                    if let Some(direct) =
+                        matches!(collection_handle, ForeachCollectionHandle::PathHash(_))
+                            .then(|| runtime_call_refs.direct_storage.as_ref())
+                            .flatten()
+                            .and_then(|bindings| {
+                                bindings
+                                    .arrays
+                                    .get(&(collection_path.clone(), String::new()))
+                            })
+                            .copied()
+                    {
+                        loop_len_value =
+                            emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                        u8_array_base_ptrs.insert(
+                            String::new(),
+                            emit_direct_slot_data_ptr(builder, direct.slot),
+                        );
                     }
-                    if *type_id == TYPE_ID_F32 {
+                }
+                if collection_info.element_type == Some(TYPE_ID_F32) {
+                    let direct = matches!(collection_handle, ForeachCollectionHandle::PathHash(_))
+                        .then(|| runtime_call_refs.direct_storage.as_ref())
+                        .flatten()
+                        .and_then(|bindings| {
+                            bindings
+                                .arrays
+                                .get(&(collection_path.clone(), String::new()))
+                        })
+                        .copied();
+                    let base = if let Some(direct) = direct {
+                        loop_len_value =
+                            emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                        emit_direct_slot_data_ptr(builder, direct.slot)
+                    } else {
+                        let field_hash_value = builder.ins().iconst(types::I32, 0);
                         let call = builder.ins().call(
                             runtime_call_refs.global_f32_array_ptr,
                             &[collection_hash_value, field_hash_value, len_value],
                         );
-                        f32_array_base_ptrs.insert(suffix.clone(), builder.inst_results(call)[0]);
-                    }
-                    if *type_id == TYPE_ID_F64 {
+                        builder.inst_results(call)[0]
+                    };
+                    f32_array_base_ptrs.insert(String::new(), base);
+                }
+                if collection_info.element_type == Some(TYPE_ID_F64) {
+                    let direct = matches!(collection_handle, ForeachCollectionHandle::PathHash(_))
+                        .then(|| runtime_call_refs.direct_storage.as_ref())
+                        .flatten()
+                        .and_then(|bindings| {
+                            bindings
+                                .arrays
+                                .get(&(collection_path.clone(), String::new()))
+                        })
+                        .copied();
+                    let base = if let Some(direct) = direct {
+                        loop_len_value =
+                            emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                        emit_direct_slot_data_ptr(builder, direct.slot)
+                    } else {
+                        let field_hash_value = builder.ins().iconst(types::I32, 0);
                         let call = builder.ins().call(
                             runtime_call_refs.global_f64_array_ptr,
                             &[collection_hash_value, field_hash_value, len_value],
                         );
-                        f64_array_base_ptrs.insert(suffix.clone(), builder.inst_results(call)[0]);
+                        builder.inst_results(call)[0]
+                    };
+                    f64_array_base_ptrs.insert(String::new(), base);
+                }
+                for (suffix, type_id) in &collection_info.field_types {
+                    let field_hash = hash_foreach_field_suffix(suffix);
+                    let field_hash_value = builder.ins().iconst(types::I32, i64::from(field_hash));
+                    let direct = matches!(collection_handle, ForeachCollectionHandle::PathHash(_))
+                        .then(|| runtime_call_refs.direct_storage.as_ref())
+                        .flatten()
+                        .and_then(|bindings| {
+                            bindings
+                                .arrays
+                                .get(&(collection_path.clone(), suffix.clone()))
+                        })
+                        .copied();
+                    if is_i32_abi_compatible_type(*type_id, type_table)
+                        && !is_u8_lane(type_table, *type_id)
+                    {
+                        let base = if let Some(direct) = direct {
+                            loop_len_value =
+                                emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                            emit_direct_slot_data_ptr(builder, direct.slot)
+                        } else {
+                            let call = builder.ins().call(
+                                runtime_call_refs.global_i32_array_ptr,
+                                &[collection_hash_value, field_hash_value, len_value],
+                            );
+                            builder.inst_results(call)[0]
+                        };
+                        i32_array_base_ptrs.insert(suffix.clone(), base);
+                    } else if is_u8_lane(type_table, *type_id) {
+                        if let Some(direct) = direct {
+                            loop_len_value =
+                                emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                            u8_array_base_ptrs.insert(
+                                suffix.clone(),
+                                emit_direct_slot_data_ptr(builder, direct.slot),
+                            );
+                        }
+                    } else if *type_id == TYPE_ID_F32 {
+                        let base = if let Some(direct) = direct {
+                            loop_len_value =
+                                emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                            emit_direct_slot_data_ptr(builder, direct.slot)
+                        } else {
+                            let call = builder.ins().call(
+                                runtime_call_refs.global_f32_array_ptr,
+                                &[collection_hash_value, field_hash_value, len_value],
+                            );
+                            builder.inst_results(call)[0]
+                        };
+                        f32_array_base_ptrs.insert(suffix.clone(), base);
+                    } else if *type_id == TYPE_ID_F64 {
+                        let base = if let Some(direct) = direct {
+                            loop_len_value =
+                                emit_bounded_direct_array_len(builder, direct, loop_len_value);
+                            emit_direct_slot_data_ptr(builder, direct.slot)
+                        } else {
+                            let call = builder.ins().call(
+                                runtime_call_refs.global_f64_array_ptr,
+                                &[collection_hash_value, field_hash_value, len_value],
+                            );
+                            builder.inst_results(call)[0]
+                        };
+                        f64_array_base_ptrs.insert(suffix.clone(), base);
                     }
                 }
 
@@ -6174,6 +6331,7 @@ pub(crate) fn emit_simple_statements(
                         element_type: collection_info.element_type,
                         struct_type_id: collection_struct_type_id,
                         field_types: collection_info.field_types.clone(),
+                        u8_array_base_ptrs,
                         i32_array_base_ptrs,
                         f32_array_base_ptrs,
                         f64_array_base_ptrs,
@@ -6192,13 +6350,10 @@ pub(crate) fn emit_simple_statements(
                 builder.switch_to_block(condition_block);
 
                 let index_value = builder.use_var(index_var);
-                let len_value = builder
-                    .ins()
-                    .iconst(types::I32, i64::from(collection_info.len));
                 let condition_value =
                     builder
                         .ins()
-                        .icmp(IntCC::SignedLessThan, index_value, len_value);
+                        .icmp(IntCC::SignedLessThan, index_value, loop_len_value);
                 builder
                     .ins()
                     .brif(condition_value, body_block, &[], exit_block, &[]);
@@ -7749,6 +7904,17 @@ pub(crate) fn emit_foreach_binding_load(
 ) -> Result<ValueBinding, String> {
     let resolved = resolve_foreach_binding_value_type(binding, suffix)?;
     let index_value = builder.use_var(binding.index_var);
+    if is_u8_lane(type_table, resolved) {
+        if let Some(base_ptr) = binding.u8_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let address = builder.ins().iadd(base_ptr, index_i64);
+            let byte = builder.ins().load(types::I8, MemFlags::new(), address, 0);
+            return Ok(ValueBinding {
+                value: builder.ins().uextend(types::I32, byte),
+                type_id: resolved,
+            });
+        }
+    }
     if is_i32_abi_compatible_type(resolved, type_table) {
         if let Some(base_ptr) = binding.i32_array_base_ptrs.get(suffix).copied() {
             let index_i64 = builder.ins().uextend(types::I64, index_value);
@@ -7910,7 +8076,12 @@ pub(crate) fn emit_foreach_binding_assignment(
                 builder.ins().srem(lhs, rhs.value)
             }
         };
-        if let Some(base_ptr) = binding.i32_array_base_ptrs.get(suffix).copied() {
+        if let Some(base_ptr) = binding.u8_array_base_ptrs.get(suffix).copied() {
+            let index_i64 = builder.ins().uextend(types::I64, index_value);
+            let addr = builder.ins().iadd(base_ptr, index_i64);
+            let byte = builder.ins().ireduce(types::I8, value);
+            builder.ins().store(MemFlags::new(), byte, addr, 0);
+        } else if let Some(base_ptr) = binding.i32_array_base_ptrs.get(suffix).copied() {
             let index_i64 = builder.ins().uextend(types::I64, index_value);
             let byte_offset = builder.ins().ishl_imm(index_i64, 2);
             let addr = builder.ins().iadd(base_ptr, byte_offset);
@@ -8878,6 +9049,151 @@ pub(crate) fn emit_local_indexed_collection_assignment(
     ))
 }
 
+fn is_u8_lane(type_table: &TypeTable, type_id: TypeId) -> bool {
+    type_table
+        .type_info(type_id)
+        .is_some_and(|info| info.name == "u8")
+}
+
+fn emit_direct_array_load(
+    builder: &mut FunctionBuilder<'_>,
+    slot_ref: DirectStorageRef,
+    index: Value,
+    type_id: TypeId,
+    type_table: &TypeTable,
+    byte_lane: bool,
+    static_len: Option<usize>,
+) -> Result<Value, String> {
+    let data = emit_direct_slot_data_ptr(builder, slot_ref);
+    let len = if let Some(len) = static_len {
+        builder.ins().iconst(types::I64, len as i64)
+    } else {
+        let slot = emit_direct_slot_address(builder, slot_ref);
+        builder.ins().load(
+            types::I64,
+            MemFlags::new(),
+            slot,
+            stasis_dynload::JitStorageSlot::LEN_OFFSET,
+        )
+    };
+    let non_negative = builder
+        .ins()
+        .icmp_imm(IntCC::SignedGreaterThanOrEqual, index, 0);
+    let index_i64 = builder.ins().sextend(types::I64, index);
+    let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index_i64, len);
+    let valid = builder.ins().band(non_negative, below_len);
+    let valid_block = builder.create_block();
+    let invalid_block = builder.create_block();
+    let merge_block = builder.create_block();
+    let result_type = if is_i32_abi_compatible_type(type_id, type_table) {
+        types::I32
+    } else if type_id == TYPE_ID_F32 {
+        types::F32
+    } else if type_id == TYPE_ID_F64 {
+        types::F64
+    } else {
+        return Err(format!("unsupported direct array load type {type_id}"));
+    };
+    builder.append_block_param(merge_block, result_type);
+    builder
+        .ins()
+        .brif(valid, valid_block, &[], invalid_block, &[]);
+    builder.switch_to_block(valid_block);
+    let shift = if type_id == TYPE_ID_F64 {
+        3
+    } else if byte_lane {
+        0
+    } else {
+        2
+    };
+    let byte_offset = if shift == 0 {
+        index_i64
+    } else {
+        builder.ins().ishl_imm(index_i64, shift)
+    };
+    let address = builder.ins().iadd(data, byte_offset);
+    let value = if byte_lane {
+        let byte = builder.ins().load(types::I8, MemFlags::new(), address, 0);
+        builder.ins().uextend(types::I32, byte)
+    } else {
+        builder.ins().load(result_type, MemFlags::new(), address, 0)
+    };
+    builder.ins().jump(merge_block, &[value]);
+    builder.seal_block(valid_block);
+    builder.switch_to_block(invalid_block);
+    let zero = if result_type == types::F32 {
+        builder.ins().f32const(Ieee32::with_float(0.0))
+    } else if result_type == types::F64 {
+        builder.ins().f64const(Ieee64::with_float(0.0))
+    } else {
+        builder.ins().iconst(types::I32, 0)
+    };
+    builder.ins().jump(merge_block, &[zero]);
+    builder.seal_block(invalid_block);
+    builder.seal_block(merge_block);
+    builder.switch_to_block(merge_block);
+    Ok(builder.block_params(merge_block)[0])
+}
+
+fn emit_direct_array_store(
+    builder: &mut FunctionBuilder<'_>,
+    slot_ref: DirectStorageRef,
+    index: Value,
+    value: Value,
+    type_id: TypeId,
+    byte_lane: bool,
+    static_len: Option<usize>,
+) -> Result<(), String> {
+    let data = emit_direct_slot_data_ptr(builder, slot_ref);
+    let len = if let Some(len) = static_len {
+        builder.ins().iconst(types::I64, len as i64)
+    } else {
+        let slot = emit_direct_slot_address(builder, slot_ref);
+        builder.ins().load(
+            types::I64,
+            MemFlags::new(),
+            slot,
+            stasis_dynload::JitStorageSlot::LEN_OFFSET,
+        )
+    };
+    let non_negative = builder
+        .ins()
+        .icmp_imm(IntCC::SignedGreaterThanOrEqual, index, 0);
+    let index_i64 = builder.ins().sextend(types::I64, index);
+    let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index_i64, len);
+    let valid = builder.ins().band(non_negative, below_len);
+    let store_block = builder.create_block();
+    let merge_block = builder.create_block();
+    builder
+        .ins()
+        .brif(valid, store_block, &[], merge_block, &[]);
+    builder.switch_to_block(store_block);
+    let shift = if type_id == TYPE_ID_F64 {
+        3
+    } else if byte_lane {
+        0
+    } else {
+        2
+    };
+    let byte_offset = if shift == 0 {
+        index_i64
+    } else {
+        builder.ins().ishl_imm(index_i64, shift)
+    };
+    let address = builder.ins().iadd(data, byte_offset);
+    let stored = if byte_lane {
+        builder.ins().ireduce(types::I8, value)
+    } else {
+        value
+    };
+    builder.ins().store(MemFlags::new(), stored, address, 0);
+    builder.ins().jump(merge_block, &[]);
+    builder.seal_block(store_block);
+    builder.seal_block(merge_block);
+    builder.switch_to_block(merge_block);
+    Ok(())
+}
+
 pub(crate) fn emit_indexed_collection_load(
     builder: &mut FunctionBuilder<'_>,
     runtime_call_refs: &RuntimeCallRefs,
@@ -8889,6 +9205,29 @@ pub(crate) fn emit_indexed_collection_load(
 ) -> Result<ValueBinding, String> {
     let resolved = resolve_collection_value_type(collection_info, suffix)?;
     let index_binding = normalize_index_binding(index_binding, type_table)?;
+    if let Some(direct) = runtime_call_refs
+        .direct_storage
+        .as_ref()
+        .and_then(|bindings| {
+            bindings
+                .arrays
+                .get(&(collection_path.to_string(), suffix.to_string()))
+        })
+        .copied()
+    {
+        return Ok(ValueBinding {
+            value: emit_direct_array_load(
+                builder,
+                direct.slot,
+                index_binding.value,
+                resolved,
+                type_table,
+                direct.byte_lane,
+                direct.static_len,
+            )?,
+            type_id: resolved,
+        });
+    }
     let collection_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_global_path(collection_path)));
@@ -8950,6 +9289,15 @@ pub(crate) fn emit_indexed_collection_assignment(
             collection_path, suffix, path_type, rhs.type_id
         ));
     }
+    let direct_slot = runtime_call_refs
+        .direct_storage
+        .as_ref()
+        .and_then(|bindings| {
+            bindings
+                .arrays
+                .get(&(collection_path.to_string(), suffix.to_string()))
+        })
+        .copied();
     let collection_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_global_path(collection_path)));
@@ -9026,10 +9374,22 @@ pub(crate) fn emit_indexed_collection_assignment(
                 builder.ins().srem(lhs, rhs.value)
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
-        );
+        if let Some(direct) = direct_slot {
+            emit_direct_array_store(
+                builder,
+                direct.slot,
+                index_binding.value,
+                value,
+                path_type,
+                direct.byte_lane,
+                direct.static_len,
+            )?;
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_i32_array_store,
+                &[collection_hash, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_BOOL {
@@ -9039,10 +9399,22 @@ pub(crate) fn emit_indexed_collection_assignment(
                 collection_path, suffix
             ));
         }
-        builder.ins().call(
-            runtime_call_refs.global_i32_array_store,
-            &[collection_hash, field_hash, index_binding.value, rhs.value],
-        );
+        if let Some(direct) = direct_slot {
+            emit_direct_array_store(
+                builder,
+                direct.slot,
+                index_binding.value,
+                rhs.value,
+                path_type,
+                direct.byte_lane,
+                direct.static_len,
+            )?;
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_i32_array_store,
+                &[collection_hash, field_hash, index_binding.value, rhs.value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_F32 {
@@ -9107,10 +9479,22 @@ pub(crate) fn emit_indexed_collection_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f32_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
-        );
+        if let Some(direct) = direct_slot {
+            emit_direct_array_store(
+                builder,
+                direct.slot,
+                index_binding.value,
+                value,
+                path_type,
+                direct.byte_lane,
+                direct.static_len,
+            )?;
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f32_array_store,
+                &[collection_hash, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -9175,10 +9559,22 @@ pub(crate) fn emit_indexed_collection_assignment(
                 ))
             }
         };
-        builder.ins().call(
-            runtime_call_refs.global_f64_array_store,
-            &[collection_hash, field_hash, index_binding.value, value],
-        );
+        if let Some(direct) = direct_slot {
+            emit_direct_array_store(
+                builder,
+                direct.slot,
+                index_binding.value,
+                value,
+                path_type,
+                direct.byte_lane,
+                direct.static_len,
+            )?;
+        } else {
+            builder.ins().call(
+                runtime_call_refs.global_f64_array_store,
+                &[collection_hash, field_hash, index_binding.value, value],
+            );
+        }
         return Ok(());
     }
     Err(format!(
@@ -9194,6 +9590,17 @@ pub(crate) fn emit_global_load(
     path: &str,
     path_type: TypeId,
 ) -> Result<ValueBinding, String> {
+    if let Some(slot_address) = runtime_call_refs
+        .direct_storage
+        .as_ref()
+        .and_then(|bindings| bindings.scalars.get(path))
+        .copied()
+    {
+        return Ok(ValueBinding {
+            value: emit_direct_scalar_load(builder, slot_address, path_type, type_table)?,
+            type_id: path_type,
+        });
+    }
     let path_hash = builder
         .ins()
         .iconst(types::I32, i64::from(hash_global_path(path)));
@@ -9291,12 +9698,14 @@ pub(crate) fn emit_global_assignment(
                 builder.ins().srem(lhs, rhs.value)
             }
         };
-        let path_hash = builder
-            .ins()
-            .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
-            .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, value]);
+        emit_global_scalar_store(
+            builder,
+            runtime_call_refs,
+            type_table,
+            path,
+            path_type,
+            value,
+        )?;
         return Ok(());
     }
     if path_type == TYPE_ID_BOOL {
@@ -9306,12 +9715,14 @@ pub(crate) fn emit_global_assignment(
                 path
             ));
         }
-        let path_hash = builder
-            .ins()
-            .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
-            .ins()
-            .call(runtime_call_refs.global_i32_store, &[path_hash, rhs.value]);
+        emit_global_scalar_store(
+            builder,
+            runtime_call_refs,
+            type_table,
+            path,
+            path_type,
+            rhs.value,
+        )?;
         return Ok(());
     }
     if path_type == TYPE_ID_F32 {
@@ -9348,12 +9759,14 @@ pub(crate) fn emit_global_assignment(
                 ))
             }
         };
-        let path_hash = builder
-            .ins()
-            .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
-            .ins()
-            .call(runtime_call_refs.global_f32_store, &[path_hash, value]);
+        emit_global_scalar_store(
+            builder,
+            runtime_call_refs,
+            type_table,
+            path,
+            path_type,
+            value,
+        )?;
         return Ok(());
     }
     if path_type == TYPE_ID_F64 {
@@ -9390,18 +9803,127 @@ pub(crate) fn emit_global_assignment(
                 ))
             }
         };
-        let path_hash = builder
-            .ins()
-            .iconst(types::I32, i64::from(hash_global_path(path)));
-        builder
-            .ins()
-            .call(runtime_call_refs.global_f64_store, &[path_hash, value]);
+        emit_global_scalar_store(
+            builder,
+            runtime_call_refs,
+            type_table,
+            path,
+            path_type,
+            value,
+        )?;
         return Ok(());
     }
     Err(format!(
         "unsupported global path type {} for '{}'",
         path_type, path
     ))
+}
+
+fn emit_direct_slot_address(
+    builder: &mut FunctionBuilder<'_>,
+    slot_ref: DirectStorageRef,
+) -> Value {
+    match slot_ref {
+        DirectStorageRef::Absolute(address) => builder.ins().iconst(types::I64, address as i64),
+        DirectStorageRef::Symbol(symbol) => builder.ins().global_value(types::I64, symbol),
+    }
+}
+
+fn emit_direct_slot_data_ptr(
+    builder: &mut FunctionBuilder<'_>,
+    slot_ref: DirectStorageRef,
+) -> Value {
+    match slot_ref {
+        DirectStorageRef::Absolute(_) => {
+            let slot = emit_direct_slot_address(builder, slot_ref);
+            builder.ins().load(
+                types::I64,
+                MemFlags::new(),
+                slot,
+                stasis_dynload::JitStorageSlot::DATA_OFFSET,
+            )
+        }
+        DirectStorageRef::Symbol(symbol) => builder.ins().global_value(types::I64, symbol),
+    }
+}
+
+fn emit_bounded_direct_array_len(
+    builder: &mut FunctionBuilder<'_>,
+    direct: DirectArrayStorageRef,
+    current_len: Value,
+) -> Value {
+    if direct.static_len.is_some() {
+        return current_len;
+    }
+    let slot = emit_direct_slot_address(builder, direct.slot);
+    let direct_len = builder.ins().load(
+        types::I64,
+        MemFlags::new(),
+        slot,
+        stasis_dynload::JitStorageSlot::LEN_OFFSET,
+    );
+    let current_len_i64 = builder.ins().uextend(types::I64, current_len);
+    let direct_is_shorter =
+        builder
+            .ins()
+            .icmp(IntCC::UnsignedLessThan, direct_len, current_len_i64);
+    let bounded_len = builder
+        .ins()
+        .select(direct_is_shorter, direct_len, current_len_i64);
+    builder.ins().ireduce(types::I32, bounded_len)
+}
+
+fn emit_direct_scalar_load(
+    builder: &mut FunctionBuilder<'_>,
+    slot_ref: DirectStorageRef,
+    type_id: TypeId,
+    type_table: &TypeTable,
+) -> Result<Value, String> {
+    let data = emit_direct_slot_data_ptr(builder, slot_ref);
+    let clif_type = if is_i32_abi_compatible_type(type_id, type_table) {
+        types::I32
+    } else if type_id == TYPE_ID_F32 {
+        types::F32
+    } else if type_id == TYPE_ID_F64 {
+        types::F64
+    } else {
+        return Err(format!("unsupported direct scalar load type {type_id}"));
+    };
+    Ok(builder.ins().load(clif_type, MemFlags::new(), data, 0))
+}
+
+fn emit_global_scalar_store(
+    builder: &mut FunctionBuilder<'_>,
+    runtime_call_refs: &RuntimeCallRefs,
+    type_table: &TypeTable,
+    path: &str,
+    type_id: TypeId,
+    value: Value,
+) -> Result<(), String> {
+    if let Some(slot_ref) = runtime_call_refs
+        .direct_storage
+        .as_ref()
+        .and_then(|bindings| bindings.scalars.get(path))
+        .copied()
+    {
+        let data = emit_direct_slot_data_ptr(builder, slot_ref);
+        builder.ins().store(MemFlags::new(), value, data, 0);
+        return Ok(());
+    }
+    let path_hash = builder
+        .ins()
+        .iconst(types::I32, i64::from(hash_global_path(path)));
+    let helper = if is_i32_abi_compatible_type(type_id, type_table) {
+        runtime_call_refs.global_i32_store
+    } else if type_id == TYPE_ID_F32 {
+        runtime_call_refs.global_f32_store
+    } else if type_id == TYPE_ID_F64 {
+        runtime_call_refs.global_f64_store
+    } else {
+        return Err(format!("unsupported global scalar store type {type_id}"));
+    };
+    builder.ins().call(helper, &[path_hash, value]);
+    Ok(())
 }
 
 pub(crate) fn hash_global_path(path: &str) -> i32 {
@@ -9854,8 +10376,12 @@ pub(crate) fn build_runtime_call_refs(
     module: &mut impl Module,
     imports: &RuntimeCallImportIds,
     func: &mut cranelift_codegen::ir::Function,
-) -> RuntimeCallRefs {
-    RuntimeCallRefs {
+    direct_storage: Option<&DirectStorageBindings>,
+) -> Result<RuntimeCallRefs, String> {
+    let direct_storage = direct_storage
+        .map(|bindings| resolve_direct_storage_refs(module, func, bindings))
+        .transpose()?;
+    Ok(RuntimeCallRefs {
         call_i32_0: module.declare_func_in_func(imports.call_i32_0, func),
         call_i32_1: module.declare_func_in_func(imports.call_i32_1, func),
         call_i32_2: module.declare_func_in_func(imports.call_i32_2, func),
@@ -9910,5 +10436,54 @@ pub(crate) fn build_runtime_call_refs(
             .iter()
             .map(|(key, id)| (key.clone(), module.declare_func_in_func(*id, func)))
             .collect(),
+        direct_storage,
+    })
+}
+
+fn resolve_direct_storage_refs(
+    module: &mut impl Module,
+    func: &mut cranelift_codegen::ir::Function,
+    bindings: &DirectStorageBindings,
+) -> Result<DirectStorageRefs, String> {
+    fn resolve(
+        module: &mut impl Module,
+        func: &mut cranelift_codegen::ir::Function,
+        binding: &DirectStorageBinding,
+    ) -> Result<DirectStorageRef, String> {
+        match binding {
+            DirectStorageBinding::Absolute(address) => Ok(DirectStorageRef::Absolute(*address)),
+            DirectStorageBinding::Symbol(symbol) => {
+                let data_id = module
+                    .declare_data(symbol, Linkage::Import, false, false)
+                    .map_err(|error| {
+                        format!("failed to declare direct storage symbol '{symbol}': {error}")
+                    })?;
+                Ok(DirectStorageRef::Symbol(
+                    module.declare_data_in_func(data_id, func),
+                ))
+            }
+        }
     }
+
+    Ok(DirectStorageRefs {
+        scalars: bindings
+            .scalars
+            .iter()
+            .map(|(path, binding)| Ok((path.clone(), resolve(module, func, binding)?)))
+            .collect::<Result<_, String>>()?,
+        arrays: bindings
+            .arrays
+            .iter()
+            .map(|(key, binding)| {
+                Ok((
+                    key.clone(),
+                    DirectArrayStorageRef {
+                        slot: resolve(module, func, &binding.slot)?,
+                        byte_lane: binding.byte_lane,
+                        static_len: binding.static_len,
+                    },
+                ))
+            })
+            .collect::<Result<_, String>>()?,
+    })
 }

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1,4 +1,4 @@
-use crate::backend::emit::RuntimeHelperLinkage;
+use crate::backend::emit::{DirectStorageBinding, DirectStorageBindings, RuntimeHelperLinkage};
 use crate::backend::state_layout::build_state_layout;
 use crate::backend::EngineEntrypoints;
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
@@ -12,9 +12,11 @@ use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{default_libcall_names, Module};
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
+use std::rc::Rc;
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::SystemTime;
@@ -53,6 +55,7 @@ pub struct JitArtifact {
     pub slot: u32,
     pub body_hash: u64,
     pub code_ptr: u64,
+    pub clif: String,
 }
 
 pub struct JitProcess {
@@ -272,6 +275,13 @@ impl JitProcess {
                 "jit compile analysis cache missing after refresh".to_string(),
             )
         })?;
+        let direct_storage = build_direct_storage_bindings(
+            &analysis.global_path_types,
+            &analysis.collection_infos,
+            self.compiler.types(),
+            false,
+        )
+        .map_err(crate::compiler::CompileError::Backend)?;
         let emit_function_ids = select_emit_function_ids(
             self.compiler.functions(),
             self.artifacts(),
@@ -303,10 +313,11 @@ impl JitProcess {
                         &analysis.collection_infos,
                         &analysis.named_struct_field_types,
                         &analysis.extern_symbol_addresses,
+                        &direct_storage,
                         local_runtime_helper_trampolines,
                     )
                 }));
-                let (module, code_ptr) = match compiled {
+                let (module, code_ptr, clif) = match compiled {
                     Ok(result) => result?,
                     Err(payload) => {
                         let message = payload
@@ -329,6 +340,7 @@ impl JitProcess {
                     slot,
                     body_hash: meta.body_hash,
                     code_ptr,
+                    clif,
                 });
                 Ok(())
             },
@@ -352,6 +364,16 @@ impl JitProcess {
         &self.artifacts
     }
 
+    pub fn clif_for_function_name(&self, name: &str) -> Option<&str> {
+        let function = self
+            .compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == name)?;
+        self.artifact_for_function_id(function.id)
+            .map(|artifact| artifact.clif.as_str())
+    }
+
     pub fn last_source_diagnostic(&self) -> Option<&crate::SourceDiagnostic> {
         self.compiler.last_source_diagnostic()
     }
@@ -366,6 +388,12 @@ impl JitProcess {
             .compile_analysis_cache
             .as_ref()
             .ok_or_else(|| "cannot activate an uncompiled JIT process".to_string())?;
+        build_direct_storage_bindings(
+            &analysis.global_path_types,
+            &analysis.collection_infos,
+            self.compiler.types(),
+            true,
+        )?;
         seed_fixed_collection_max_length_headers(
             &analysis.global_path_types,
             self.compiler.types(),
@@ -1231,6 +1259,120 @@ fn is_u8_type(type_table: &TypeTable, type_id: u16) -> bool {
         .is_some_and(|info| info.name == "u8")
 }
 
+fn scalar_storage_kind(
+    type_table: &TypeTable,
+    type_id: u16,
+) -> Option<stasis_dynload::JitStorageKind> {
+    match type_id {
+        TYPE_ID_I32 | TYPE_ID_BOOL => Some(stasis_dynload::JitStorageKind::I32),
+        TYPE_ID_F32 => Some(stasis_dynload::JitStorageKind::F32),
+        TYPE_ID_F64 => Some(stasis_dynload::JitStorageKind::F64),
+        type_id if is_u8_type(type_table, type_id) => Some(stasis_dynload::JitStorageKind::I32),
+        _ => None,
+    }
+}
+
+fn array_storage_kind(
+    type_table: &TypeTable,
+    type_id: u16,
+) -> Option<stasis_dynload::JitStorageKind> {
+    if is_u8_type(type_table, type_id) {
+        return Some(stasis_dynload::JitStorageKind::U8);
+    }
+    if crate::backend::emit::is_i32_abi_compatible_type(type_id, type_table) {
+        return Some(stasis_dynload::JitStorageKind::I32);
+    }
+    scalar_storage_kind(type_table, type_id)
+}
+
+fn build_direct_storage_bindings(
+    global_path_types: &crate::backend::emit::GlobalPathTypeMap,
+    collection_infos: &crate::backend::emit::CollectionInfoMap,
+    type_table: &TypeTable,
+    provision: bool,
+) -> Result<DirectStorageBindings, String> {
+    let mut bindings = DirectStorageBindings::default();
+    for (path, type_id) in global_path_types {
+        if collection_infos.contains_key(path) {
+            continue;
+        }
+        if let Some(kind) = scalar_storage_kind(type_table, *type_id) {
+            let path_hash = crate::backend::emit::hash_global_path(path);
+            let address = stasis_dynload::direct_scalar_storage_slot_address(kind, path_hash)?;
+            if provision {
+                stasis_dynload::provision_direct_scalar_storage(kind, path_hash)?;
+            }
+            bindings
+                .scalars
+                .insert(path.clone(), DirectStorageBinding::Absolute(address));
+        }
+    }
+    for (path, info) in collection_infos {
+        let path_hash = crate::backend::emit::hash_global_path(path);
+        if let Some(type_id) = info.element_type {
+            let text_storage = global_path_types
+                .get(path)
+                .and_then(|global_type| type_table.type_info(*global_type))
+                .is_some_and(|type_info| {
+                    matches!(
+                        type_info.category,
+                        TypeCategory::AsciiFixed | TypeCategory::Utf8Fixed
+                    )
+                });
+            let kind = if text_storage {
+                Some(stasis_dynload::JitStorageKind::U8)
+            } else {
+                array_storage_kind(type_table, type_id)
+            }
+            .ok_or_else(|| {
+                format!("unsupported direct storage element type {type_id} for '{path}'")
+            })?;
+            let address = stasis_dynload::direct_array_storage_slot_address(kind, path_hash, 0)?;
+            if provision {
+                stasis_dynload::provision_direct_array_storage(
+                    kind,
+                    path_hash,
+                    0,
+                    info.len as usize,
+                )?;
+            }
+            bindings.arrays.insert(
+                (path.clone(), String::new()),
+                crate::backend::emit::DirectArrayStorageBinding {
+                    slot: DirectStorageBinding::Absolute(address),
+                    byte_lane: kind == stasis_dynload::JitStorageKind::U8,
+                    static_len: None,
+                },
+            );
+        }
+        for (field, type_id) in &info.field_types {
+            let kind = array_storage_kind(type_table, *type_id).ok_or_else(|| {
+                format!("unsupported direct storage field type {type_id} for '{path}.{field}'")
+            })?;
+            let field_hash = crate::backend::emit::hash_foreach_field_suffix(field);
+            let address =
+                stasis_dynload::direct_array_storage_slot_address(kind, path_hash, field_hash)?;
+            if provision {
+                stasis_dynload::provision_direct_array_storage(
+                    kind,
+                    path_hash,
+                    field_hash,
+                    info.len as usize,
+                )?;
+            }
+            bindings.arrays.insert(
+                (path.clone(), field.clone()),
+                crate::backend::emit::DirectArrayStorageBinding {
+                    slot: DirectStorageBinding::Absolute(address),
+                    byte_lane: kind == stasis_dynload::JitStorageKind::U8,
+                    static_len: None,
+                },
+            );
+        }
+    }
+    Ok(bindings)
+}
+
 fn collect_current_string_literals(compiler: &Compiler) -> Result<HashMap<i32, String>, String> {
     let mut literals = HashMap::new();
     for file in compiler.files() {
@@ -1585,8 +1727,9 @@ fn compile_function_to_jit_module(
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
     extern_symbol_addresses: &ExternSymbolAddressMap,
+    direct_storage: &DirectStorageBindings,
     local_runtime_helper_trampolines: bool,
-) -> Result<(JITModule, u64), String> {
+) -> Result<(JITModule, u64, String), String> {
     let mut jit_builder = new_stasis_jit_builder()?;
     jit_builder.symbol(
         "stasis_jit_call_i32_0",
@@ -1804,7 +1947,9 @@ fn compile_function_to_jit_module(
         .map_or(RuntimeHelperLinkage::Imported, |addresses| {
             RuntimeHelperLinkage::LocalTrampolines(addresses)
         });
-    compile_function_with_module(
+    let clif = Rc::new(RefCell::new(String::new()));
+    let clif_capture = Rc::clone(&clif);
+    let (module, code_ptr) = compile_function_with_module(
         JITModule::new(jit_builder),
         meta,
         hir,
@@ -1817,8 +1962,11 @@ fn compile_function_to_jit_module(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        Some(direct_storage),
         |_| Ok(()),
-        |_, _| {},
+        move |_, function| {
+            *clif_capture.borrow_mut() = function.display().to_string();
+        },
         |mut module, function_id, mut context| {
             module
                 .define_function(function_id, &mut context)
@@ -1830,7 +1978,9 @@ fn compile_function_to_jit_module(
             let code_ptr = module.get_finalized_function(function_id) as usize as u64;
             Ok((module, code_ptr))
         },
-    )
+    )?;
+    let clif = clif.borrow().clone();
+    Ok((module, code_ptr, clif))
 }
 
 #[cfg(test)]
@@ -1868,20 +2018,61 @@ mod tests {
     }
 
     #[test]
-    fn local_runtime_helper_trampolines_emit_only_referenced_helpers() {
+    fn direct_global_storage_emits_no_local_runtime_helper_trampolines() {
         crate::backend::emit::reset_runtime_helper_trampoline_count_for_test();
         let mut process = JitProcess::new();
         process.set_local_runtime_helper_trampolines(true);
         process.upsert_file(
             "sample.stasis",
-            "global State { value: i32; }\nfunction main(): i32 { State.value = 7; return State.value; }\n",
+            "global State { value: i32; }\nglobal bytes: u8[3];\nfunction main(): i32 { State.value = 7; bytes[0] = 1; bytes[1] = 2; bytes[2] = 3; let total: i32 = 0; foreach (let byte in bytes) { total += byte; byte += 1; } return State.value + total + bytes[0]; }\n",
         );
         process.compile().expect("jit compile");
-        assert_eq!(process.execute_i32_noarg_by_name("main").unwrap(), 7);
+        assert_eq!(process.execute_i32_noarg_by_name("main").unwrap(), 15);
         assert_eq!(
             crate::backend::emit::runtime_helper_trampoline_count_for_test(),
-            2
+            0
         );
+    }
+
+    #[test]
+    fn direct_foreach_caps_iteration_at_rebound_storage_length() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "rebound_foreach.stasis",
+            "struct ReboundItem172 { score: i32; weight: f32; }\nglobal rebound_nums_172: i32[4];\nglobal rebound_bytes_172: u8[4];\nglobal rebound_items_172: ReboundItem172[4];\nfunction main(): i32 { let total: i32 = 0; foreach (let value in rebound_nums_172) { total += value; } foreach (let byte in rebound_bytes_172) { total += byte; } foreach (let item in rebound_items_172) { total += item.score; if (item.weight > 0.0) { total += 1; } } return total; }\n",
+        );
+        process.compile().expect("jit compile");
+
+        let nums = Box::leak(Box::new([2, 3]));
+        let bytes = Box::leak(Box::new([4]));
+        let scores = Box::leak(Box::new([5, 6]));
+        let weights = Box::leak(Box::new([1.0]));
+        stasis_dynload::register_global_i32_array(
+            hash_global_path("rebound_nums_172"),
+            0,
+            nums.as_mut_ptr(),
+            nums.len(),
+        );
+        stasis_dynload::register_global_u8_array(
+            hash_global_path("rebound_bytes_172"),
+            0,
+            bytes.as_mut_ptr(),
+            bytes.len(),
+        );
+        stasis_dynload::register_global_i32_array(
+            hash_global_path("rebound_items_172"),
+            crate::backend::emit::hash_foreach_field_suffix("score"),
+            scores.as_mut_ptr(),
+            scores.len(),
+        );
+        stasis_dynload::register_global_f32_array(
+            hash_global_path("rebound_items_172"),
+            crate::backend::emit::hash_foreach_field_suffix("weight"),
+            weights.as_mut_ptr(),
+            weights.len(),
+        );
+
+        assert_eq!(process.execute_i32_noarg_by_name("main").unwrap(), 15);
     }
 
     #[test]
@@ -3463,6 +3654,114 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 7);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_lowers_core_global_storage_without_runtime_calls() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "direct_storage.stasis",
+            "struct Enemy { hp: i32; speed: f32; }\nglobal count: i32;\nglobal ratio: f32;\nglobal precise: f64;\nglobal ints: i32[2];\nglobal floats: f32[2];\nglobal doubles: f64[2];\nglobal bytes: u8[3];\nglobal enemies: Enemy[1];\nglobal label: ascii[4];\nfunction main(): i32 {\n    count = 7;\n    ratio = 1.5;\n    precise = 2.5;\n    ints[0] = 11;\n    floats[1] = 3.5;\n    doubles[0] = 4.5;\n    bytes[2] = 250;\n    enemies[0].hp = 13;\n    enemies[0].speed = 6.5;\n    label[0] = 65;\n    let negative: i32 = 0 - 1;\n    ints[negative] = 99;\n    ints[8] = 88;\n    let result: i32 = count + ints[0] + bytes[2] + enemies[0].hp + label[0] + label.max_length;\n    if (ints[negative] != 0) { return 1; }\n    if (ints[8] != 0) { return 2; }\n    if (ratio < 1.4) { return 3; }\n    if (precise < 2.4) { return 4; }\n    if (floats[1] < 3.4) { return 5; }\n    if (doubles[0] < 4.4) { return 6; }\n    if (enemies[0].speed < 6.4) { return 7; }\n    return result;\n}\n",
+        );
+        process.compile().expect("compile direct storage fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute direct storage fixture"),
+            350
+        );
+        let clif = process.clif_for_function_name("main").expect("main CLIF");
+        assert!(clif.contains("load.i32"), "expected direct loads:\n{clif}");
+        assert!(clif.contains("store"), "expected direct stores:\n{clif}");
+        let has_call_instruction = clif.lines().any(|line| {
+            let line = line.trim_start();
+            line.starts_with("call ") || line.contains(" = call ")
+        });
+        assert!(
+            !has_call_instruction,
+            "core global storage emitted a runtime call:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_storage_rebinding_is_rejected_during_execution_windows() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "rebind.stasis",
+            "global value: i32;\nfunction main(): i32 { value += 1; return value; }\n",
+        );
+        process.compile().expect("compile rebind fixture");
+        let path_hash = hash_global_path("value");
+        let first = Box::leak(Box::new(40));
+        let second = Box::leak(Box::new(90));
+        stasis_dynload::register_global_i32_ptr(path_hash, first);
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("first run"),
+            41
+        );
+        {
+            let _execution = stasis_dynload::JitExecutionGuard::enter();
+            stasis_dynload::register_global_i32_ptr(path_hash, second);
+        }
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("run after rejected in-window rebind"),
+            42
+        );
+        assert_eq!(*second, 90);
+        stasis_dynload::register_global_i32_ptr(path_hash, second);
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("run after boundary rebind"),
+            91
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_direct_array_bounds_follow_between_tick_rebinding() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "resize.stasis",
+            "global values: i32[2];\nfunction main(): i32 { return values[3]; }\n",
+        );
+        process.compile().expect("compile resize fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("initial run"),
+            0
+        );
+
+        let hash = hash_global_path("values");
+        let expanded = Box::leak(Box::new([1, 2, 3, 44]));
+        stasis_dynload::register_global_i32_array(hash, 0, expanded.as_mut_ptr(), expanded.len());
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("expanded run"),
+            44
+        );
+
+        let contracted = Box::leak(Box::new([9]));
+        stasis_dynload::register_global_i32_array(
+            hash,
+            0,
+            contracted.as_mut_ptr(),
+            contracted.len(),
+        );
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("contracted run"),
+            0
+        );
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -6,7 +6,8 @@ use std::ffi::c_char;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 #[cfg(windows)]
 use std::ffi::{c_void, CString, OsStr};
@@ -31,7 +32,11 @@ impl Library {
             wide.push(0);
             let handle = unsafe { LoadLibraryW(wide.as_ptr()) };
             if handle.is_null() {
-                return Err(format!("failed to load dynamic library {}", path.display()));
+                return Err(format!(
+                    "failed to load dynamic library {}: {}",
+                    path.display(),
+                    std::io::Error::last_os_error()
+                ));
             }
             return Ok(Self { handle });
         }
@@ -84,6 +89,7 @@ pub fn invoke_noarg_u64(address: usize) -> Result<u64, String> {
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn() -> u64 = unsafe { std::mem::transmute(address) };
@@ -103,6 +109,7 @@ pub fn invoke_noarg_i32(address: usize) -> Result<i32, String> {
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn() -> i32 = unsafe { std::mem::transmute(address) };
@@ -122,6 +129,7 @@ pub fn invoke_noarg_void(address: usize) -> Result<(), String> {
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn() = unsafe { std::mem::transmute(address) };
@@ -160,6 +168,7 @@ pub fn invoke_i32_to_void(address: usize, arg0: i32) -> Result<(), String> {
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn(i32) = unsafe { std::mem::transmute(address) };
@@ -181,6 +190,7 @@ pub fn invoke_i32_i32_to_i32(address: usize, left: i32, right: i32) -> Result<i3
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn(i32, i32) -> i32 = unsafe { std::mem::transmute(address) };
@@ -205,6 +215,7 @@ pub fn invoke_i32_i32_i32_to_i32(
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn(i32, i32, i32) -> i32 =
@@ -231,6 +242,7 @@ pub fn invoke_i32_i32_i32_i32_to_void(
     let _dispatch_lock = jit_dispatch_lock()
         .lock()
         .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
     #[cfg(windows)]
     {
         let callback: extern "system" fn(i32, i32, i32, i32) =
@@ -726,6 +738,160 @@ pub fn jit_string_literal_value(id: i32) -> Option<String> {
 
 type ArrayKey = (i32, i32); // (collection_hash, field_hash)
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JitStorageKind {
+    I32,
+    F32,
+    F64,
+    U8,
+}
+
+#[repr(C)]
+pub struct JitStorageSlot {
+    data: usize,
+    len: usize,
+}
+
+impl JitStorageSlot {
+    pub const DATA_OFFSET: i32 = 0;
+    pub const LEN_OFFSET: i32 = std::mem::size_of::<usize>() as i32;
+}
+
+// Slot fields are only rebound while no guest execution window is active. Generated code reads
+// them directly, so the registry mutex is deliberately absent from the load/store hot path.
+unsafe impl Send for JitStorageSlot {}
+unsafe impl Sync for JitStorageSlot {}
+
+type StorageKey = (JitStorageKind, i32, i32);
+
+fn direct_storage_slots() -> &'static Mutex<HashMap<StorageKey, Box<JitStorageSlot>>> {
+    static TABLE: OnceLock<Mutex<HashMap<StorageKey, Box<JitStorageSlot>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn guest_execution_count() -> &'static AtomicUsize {
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+    &COUNT
+}
+
+pub struct JitExecutionGuard;
+
+impl JitExecutionGuard {
+    pub fn enter() -> Self {
+        guest_execution_count().fetch_add(1, Ordering::AcqRel);
+        Self
+    }
+}
+
+impl Drop for JitExecutionGuard {
+    fn drop(&mut self) {
+        guest_execution_count().fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn ensure_rebind_allowed() -> Result<(), String> {
+    (guest_execution_count().load(Ordering::Acquire) == 0)
+        .then_some(())
+        .ok_or_else(|| {
+            "storage rebinding is only allowed between guest execution windows".to_string()
+        })
+}
+
+fn acquire_rebind_guard() -> Result<MutexGuard<'static, ()>, String> {
+    ensure_rebind_allowed()?;
+    let guard = jit_dispatch_lock()
+        .lock()
+        .expect("jit dispatch lock mutex poisoned");
+    ensure_rebind_allowed()?;
+    Ok(guard)
+}
+
+fn update_direct_storage_slot(key: StorageKey, data: usize, len: usize) {
+    if let Some(slot) = direct_storage_slots()
+        .lock()
+        .expect("direct storage slot table mutex poisoned")
+        .get_mut(&key)
+    {
+        slot.data = data;
+        slot.len = len;
+    }
+}
+
+pub fn direct_scalar_storage_slot_address(
+    kind: JitStorageKind,
+    path_hash: i32,
+) -> Result<usize, String> {
+    direct_storage_slot_address(kind, path_hash, 0)
+}
+
+pub fn direct_array_storage_slot_address(
+    kind: JitStorageKind,
+    collection_hash: i32,
+    field_hash: i32,
+) -> Result<usize, String> {
+    direct_storage_slot_address(kind, collection_hash, field_hash)
+}
+
+fn direct_storage_slot_address(
+    kind: JitStorageKind,
+    collection_hash: i32,
+    field_hash: i32,
+) -> Result<usize, String> {
+    let key = (kind, collection_hash, field_hash);
+    let current = registered_storage(kind, collection_hash, field_hash);
+    let (data, actual_len) = current.unwrap_or((0, 0));
+    let mut slots = direct_storage_slots()
+        .lock()
+        .expect("direct storage slot table mutex poisoned");
+    let slot = slots.entry(key).or_insert_with(|| {
+        Box::new(JitStorageSlot {
+            data,
+            len: actual_len,
+        })
+    });
+    Ok(slot.as_ref() as *const JitStorageSlot as usize)
+}
+
+pub fn provision_direct_scalar_storage(kind: JitStorageKind, path_hash: i32) -> Result<(), String> {
+    let _rebind = acquire_rebind_guard()?;
+    match kind {
+        JitStorageKind::I32 => ensure_owned_i32_scalar(path_hash)?,
+        JitStorageKind::F32 => ensure_owned_f32_scalar(path_hash)?,
+        JitStorageKind::F64 => ensure_owned_f64_scalar(path_hash)?,
+        JitStorageKind::U8 => return Err("u8 scalar storage uses the i32 ABI lane".to_string()),
+    }
+    let (data, len) = registered_storage(kind, path_hash, 0)?;
+    update_direct_storage_slot((kind, path_hash, 0), data, len);
+    Ok(())
+}
+
+pub fn provision_direct_array_storage(
+    kind: JitStorageKind,
+    collection_hash: i32,
+    field_hash: i32,
+    len: usize,
+) -> Result<(), String> {
+    let _rebind = acquire_rebind_guard()?;
+    let key = (kind, collection_hash, field_hash);
+    match kind {
+        JitStorageKind::I32 => {
+            ensure_jit_i32_array_capacity_unlocked(collection_hash, field_hash, len)?
+        }
+        JitStorageKind::F32 => {
+            ensure_jit_f32_array_capacity_unlocked(collection_hash, field_hash, len)?
+        }
+        JitStorageKind::F64 => {
+            ensure_jit_f64_array_capacity_unlocked(collection_hash, field_hash, len)?
+        }
+        JitStorageKind::U8 => {
+            ensure_jit_u8_array_capacity_unlocked(collection_hash, field_hash, len)?
+        }
+    }
+    let (data, actual_len) = registered_storage(kind, collection_hash, field_hash)?;
+    update_direct_storage_slot(key, data, actual_len);
+    Ok(())
+}
+
 fn registered_i32_ptrs() -> &'static Mutex<HashMap<i32, usize>> {
     static TABLE: OnceLock<Mutex<HashMap<i32, usize>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
@@ -779,6 +945,146 @@ fn owned_u8_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<u8>>> {
 fn owned_f64_arrays() -> &'static Mutex<HashMap<ArrayKey, Vec<f64>>> {
     static TABLE: OnceLock<Mutex<HashMap<ArrayKey, Vec<f64>>>> = OnceLock::new();
     TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_i32_scalars() -> &'static Mutex<HashMap<i32, Box<i32>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<i32>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_f32_scalars() -> &'static Mutex<HashMap<i32, Box<f32>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<f32>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn owned_f64_scalars() -> &'static Mutex<HashMap<i32, Box<f64>>> {
+    static TABLE: OnceLock<Mutex<HashMap<i32, Box<f64>>>> = OnceLock::new();
+    TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn ensure_owned_scalar<T: Copy + Default>(
+    path_hash: i32,
+    owned: &Mutex<HashMap<i32, Box<T>>>,
+    registered: &Mutex<HashMap<i32, usize>>,
+    fallback: &Mutex<HashMap<i32, T>>,
+) -> Result<(), String> {
+    if registered
+        .lock()
+        .expect("registered scalar table mutex poisoned")
+        .contains_key(&path_hash)
+    {
+        return Ok(());
+    }
+    ensure_rebind_allowed()?;
+    let initial = fallback
+        .lock()
+        .expect("fallback scalar table mutex poisoned")
+        .remove(&path_hash)
+        .unwrap_or_default();
+    let mut owned = owned.lock().expect("owned scalar table mutex poisoned");
+    let value = owned.entry(path_hash).or_insert_with(|| Box::new(initial));
+    let address = value.as_mut() as *mut T as usize;
+    registered
+        .lock()
+        .expect("registered scalar table mutex poisoned")
+        .insert(path_hash, address);
+    Ok(())
+}
+
+fn ensure_owned_i32_scalar(path_hash: i32) -> Result<(), String> {
+    ensure_owned_scalar(
+        path_hash,
+        owned_i32_scalars(),
+        registered_i32_ptrs(),
+        jit_i32_global_table(),
+    )
+}
+
+fn ensure_owned_f32_scalar(path_hash: i32) -> Result<(), String> {
+    ensure_owned_scalar(
+        path_hash,
+        owned_f32_scalars(),
+        registered_f32_ptrs(),
+        jit_f32_global_table(),
+    )
+}
+
+fn ensure_owned_f64_scalar(path_hash: i32) -> Result<(), String> {
+    ensure_owned_scalar(
+        path_hash,
+        owned_f64_scalars(),
+        registered_f64_ptrs(),
+        jit_f64_global_table(),
+    )
+}
+
+fn registered_storage(
+    kind: JitStorageKind,
+    collection_hash: i32,
+    field_hash: i32,
+) -> Result<(usize, usize), String> {
+    let value = match kind {
+        JitStorageKind::I32 if field_hash == 0 => registered_i32_ptrs()
+            .lock()
+            .expect("registered i32 ptr table mutex poisoned")
+            .get(&collection_hash)
+            .copied()
+            .map(|ptr| (ptr, 1))
+            .or_else(|| {
+                registered_i32_arrays()
+                    .lock()
+                    .expect("registered i32 array table mutex poisoned")
+                    .get(&(collection_hash, field_hash))
+                    .copied()
+            }),
+        JitStorageKind::I32 => registered_i32_arrays()
+            .lock()
+            .expect("registered i32 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .copied(),
+        JitStorageKind::F32 if field_hash == 0 => registered_f32_ptrs()
+            .lock()
+            .expect("registered f32 ptr table mutex poisoned")
+            .get(&collection_hash)
+            .copied()
+            .map(|ptr| (ptr, 1))
+            .or_else(|| {
+                registered_f32_arrays()
+                    .lock()
+                    .expect("registered f32 array table mutex poisoned")
+                    .get(&(collection_hash, field_hash))
+                    .copied()
+            }),
+        JitStorageKind::F32 => registered_f32_arrays()
+            .lock()
+            .expect("registered f32 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .copied(),
+        JitStorageKind::F64 if field_hash == 0 => registered_f64_ptrs()
+            .lock()
+            .expect("registered f64 ptr table mutex poisoned")
+            .get(&collection_hash)
+            .copied()
+            .map(|ptr| (ptr, 1))
+            .or_else(|| {
+                registered_f64_arrays()
+                    .lock()
+                    .expect("registered f64 array table mutex poisoned")
+                    .get(&(collection_hash, field_hash))
+                    .copied()
+            }),
+        JitStorageKind::F64 => registered_f64_arrays()
+            .lock()
+            .expect("registered f64 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .copied(),
+        JitStorageKind::U8 => registered_u8_arrays()
+            .lock()
+            .expect("registered u8 array table mutex poisoned")
+            .get(&(collection_hash, field_hash))
+            .copied(),
+    };
+    value.ok_or_else(|| "direct storage backing was not provisioned".to_string())
 }
 
 fn ensure_owned_array_capacity<T: Copy>(
@@ -926,12 +1232,34 @@ fn migrate_fallback_array<T: Copy>(
     }
 }
 
+fn direct_array_rebind_guard(
+    kind: JitStorageKind,
+    collection_hash: i32,
+    field_hash: i32,
+) -> Result<Option<MutexGuard<'static, ()>>, String> {
+    let has_direct_slot = direct_storage_slots()
+        .lock()
+        .expect("direct storage slot table mutex poisoned")
+        .contains_key(&(kind, collection_hash, field_hash));
+    has_direct_slot.then(acquire_rebind_guard).transpose()
+}
+
 pub fn ensure_jit_i32_array_capacity(
     collection_hash: i32,
     field_hash: i32,
     requested_len: usize,
 ) -> Result<(), String> {
+    let _rebind = direct_array_rebind_guard(JitStorageKind::I32, collection_hash, field_hash)?;
+    ensure_jit_i32_array_capacity_unlocked(collection_hash, field_hash, requested_len)
+}
+
+fn ensure_jit_i32_array_capacity_unlocked(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
     let key = (collection_hash, field_hash);
+    discard_integer_array_lane(key, JitStorageKind::I32);
     ensure_owned_array_capacity(
         key,
         requested_len,
@@ -940,10 +1268,27 @@ pub fn ensure_jit_i32_array_capacity(
         registered_i32_arrays(),
     )?;
     migrate_fallback_array(key, owned_i32_arrays(), jit_i32_array_global_table());
+    if let Some((data, len)) = registered_i32_arrays()
+        .lock()
+        .expect("registered i32 array table mutex poisoned")
+        .get(&key)
+        .copied()
+    {
+        update_direct_storage_slot((JitStorageKind::I32, key.0, key.1), data, len);
+    }
     Ok(())
 }
 
 pub fn ensure_jit_f32_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let _rebind = direct_array_rebind_guard(JitStorageKind::F32, collection_hash, field_hash)?;
+    ensure_jit_f32_array_capacity_unlocked(collection_hash, field_hash, requested_len)
+}
+
+fn ensure_jit_f32_array_capacity_unlocked(
     collection_hash: i32,
     field_hash: i32,
     requested_len: usize,
@@ -957,10 +1302,27 @@ pub fn ensure_jit_f32_array_capacity(
         registered_f32_arrays(),
     )?;
     migrate_fallback_array(key, owned_f32_arrays(), jit_f32_array_global_table());
+    if let Some((data, len)) = registered_f32_arrays()
+        .lock()
+        .expect("registered f32 array table mutex poisoned")
+        .get(&key)
+        .copied()
+    {
+        update_direct_storage_slot((JitStorageKind::F32, key.0, key.1), data, len);
+    }
     Ok(())
 }
 
 pub fn ensure_jit_f64_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let _rebind = direct_array_rebind_guard(JitStorageKind::F64, collection_hash, field_hash)?;
+    ensure_jit_f64_array_capacity_unlocked(collection_hash, field_hash, requested_len)
+}
+
+fn ensure_jit_f64_array_capacity_unlocked(
     collection_hash: i32,
     field_hash: i32,
     requested_len: usize,
@@ -974,10 +1336,54 @@ pub fn ensure_jit_f64_array_capacity(
         registered_f64_arrays(),
     )?;
     migrate_fallback_array(key, owned_f64_arrays(), jit_f64_array_global_table());
+    if let Some((data, len)) = registered_f64_arrays()
+        .lock()
+        .expect("registered f64 array table mutex poisoned")
+        .get(&key)
+        .copied()
+    {
+        update_direct_storage_slot((JitStorageKind::F64, key.0, key.1), data, len);
+    }
+    Ok(())
+}
+
+pub fn ensure_jit_u8_array_capacity(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let _rebind = direct_array_rebind_guard(JitStorageKind::U8, collection_hash, field_hash)?;
+    ensure_jit_u8_array_capacity_unlocked(collection_hash, field_hash, requested_len)
+}
+
+fn ensure_jit_u8_array_capacity_unlocked(
+    collection_hash: i32,
+    field_hash: i32,
+    requested_len: usize,
+) -> Result<(), String> {
+    let key = (collection_hash, field_hash);
+    discard_integer_array_lane(key, JitStorageKind::U8);
+    ensure_owned_array_capacity(
+        key,
+        requested_len,
+        0,
+        owned_u8_arrays(),
+        registered_u8_arrays(),
+    )?;
+    let (data, len) = registered_u8_arrays()
+        .lock()
+        .expect("registered u8 array table mutex poisoned")
+        .get(&key)
+        .copied()
+        .ok_or_else(|| "u8 storage was not provisioned".to_string())?;
+    update_direct_storage_slot((JitStorageKind::U8, key.0, key.1), data, len);
     Ok(())
 }
 
 pub fn clear_registered_global_memory() {
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     registered_i32_ptrs()
         .lock()
         .expect("registered i32 ptr table mutex poisoned")
@@ -1023,6 +1429,22 @@ pub fn clear_registered_global_memory() {
         .lock()
         .expect("owned u8 array table mutex poisoned")
         .clear();
+    owned_i32_scalars()
+        .lock()
+        .expect("owned i32 scalar table mutex poisoned")
+        .clear();
+    owned_f32_scalars()
+        .lock()
+        .expect("owned f32 scalar table mutex poisoned")
+        .clear();
+    owned_f64_scalars()
+        .lock()
+        .expect("owned f64 scalar table mutex poisoned")
+        .clear();
+    direct_storage_slots()
+        .lock()
+        .expect("direct storage slot table mutex poisoned")
+        .clear();
 }
 
 #[derive(Debug, Clone)]
@@ -1033,13 +1455,21 @@ pub struct JitRuntimeStateSnapshot {
     i32_array_globals: JitI32ArrayGlobalMap,
     f32_array_globals: JitF32ArrayGlobalMap,
     f64_array_globals: JitF64ArrayGlobalMap,
-    i32_ptrs: Vec<(usize, i32)>,
-    f32_ptrs: Vec<(usize, f32)>,
-    f64_ptrs: Vec<(usize, f64)>,
+    i32_ptrs: Vec<RegisteredScalarSnapshot<i32>>,
+    f32_ptrs: Vec<RegisteredScalarSnapshot<f32>>,
+    f64_ptrs: Vec<RegisteredScalarSnapshot<f64>>,
     i32_arrays: Vec<RegisteredArraySnapshot<i32>>,
     f32_arrays: Vec<RegisteredArraySnapshot<f32>>,
     f64_arrays: Vec<RegisteredArraySnapshot<f64>>,
     u8_arrays: Vec<RegisteredArraySnapshot<u8>>,
+}
+
+#[derive(Debug, Clone)]
+struct RegisteredScalarSnapshot<T> {
+    key: i32,
+    address: usize,
+    value: T,
+    owned: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1089,9 +1519,9 @@ pub fn snapshot_jit_runtime_state_bounded(
             .lock()
             .expect("jit f64 array global table mutex poisoned")
             .clone(),
-        i32_ptrs: snapshot_registered_ptrs(registered_i32_ptrs()),
-        f32_ptrs: snapshot_registered_ptrs(registered_f32_ptrs()),
-        f64_ptrs: snapshot_registered_ptrs(registered_f64_ptrs()),
+        i32_ptrs: snapshot_registered_ptrs(registered_i32_ptrs(), owned_i32_scalars()),
+        f32_ptrs: snapshot_registered_ptrs(registered_f32_ptrs(), owned_f32_scalars()),
+        f64_ptrs: snapshot_registered_ptrs(registered_f64_ptrs(), owned_f64_scalars()),
         i32_arrays: snapshot_registered_arrays(registered_i32_arrays(), Some(owned_i32_arrays())),
         f32_arrays: snapshot_registered_arrays(registered_f32_arrays(), Some(owned_f32_arrays())),
         f64_arrays: snapshot_registered_arrays(registered_f64_arrays(), Some(owned_f64_arrays())),
@@ -1207,6 +1637,9 @@ fn add_registered_array_bytes(
 }
 
 pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     *jit_i32_global_table()
         .lock()
         .expect("jit i32 global table mutex poisoned") = snapshot.i32_globals.clone();
@@ -1225,9 +1658,21 @@ pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
     *jit_f64_array_global_table()
         .lock()
         .expect("jit f64 array global table mutex poisoned") = snapshot.f64_array_globals.clone();
-    restore_registered_ptrs(&snapshot.i32_ptrs);
-    restore_registered_ptrs(&snapshot.f32_ptrs);
-    restore_registered_ptrs(&snapshot.f64_ptrs);
+    restore_registered_ptrs(
+        &snapshot.i32_ptrs,
+        registered_i32_ptrs(),
+        owned_i32_scalars(),
+    );
+    restore_registered_ptrs(
+        &snapshot.f32_ptrs,
+        registered_f32_ptrs(),
+        owned_f32_scalars(),
+    );
+    restore_registered_ptrs(
+        &snapshot.f64_ptrs,
+        registered_f64_ptrs(),
+        owned_f64_scalars(),
+    );
     restore_registered_arrays(
         &snapshot.i32_arrays,
         registered_i32_arrays(),
@@ -1248,27 +1693,74 @@ pub fn restore_jit_runtime_state(snapshot: &JitRuntimeStateSnapshot) {
         registered_u8_arrays(),
         Some(owned_u8_arrays()),
     );
+    refresh_direct_storage_slots();
 }
 
-fn snapshot_registered_ptrs<T: Copy>(table: &Mutex<HashMap<i32, usize>>) -> Vec<(usize, T)> {
+fn refresh_direct_storage_slots() {
+    let keys = direct_storage_slots()
+        .lock()
+        .expect("direct storage slot table mutex poisoned")
+        .keys()
+        .copied()
+        .collect::<Vec<_>>();
+    for (kind, collection_hash, field_hash) in keys {
+        let (data, len) = registered_storage(kind, collection_hash, field_hash).unwrap_or((0, 0));
+        update_direct_storage_slot((kind, collection_hash, field_hash), data, len);
+    }
+}
+
+fn snapshot_registered_ptrs<T: Copy>(
+    table: &Mutex<HashMap<i32, usize>>,
+    owned: &Mutex<HashMap<i32, Box<T>>>,
+) -> Vec<RegisteredScalarSnapshot<T>> {
+    let owned_addresses = owned
+        .lock()
+        .expect("owned scalar table mutex poisoned")
+        .iter()
+        .map(|(key, value)| (*key, value.as_ref() as *const T as usize))
+        .collect::<HashMap<_, _>>();
     table
         .lock()
         .expect("registered global pointer table mutex poisoned")
-        .values()
-        .copied()
-        .map(|address| {
+        .iter()
+        .map(|(key, address)| {
             // Registered pointers remain host-owned and stable for the in-process runtime.
-            let value = unsafe { *(address as *const T) };
-            (address, value)
+            let value = unsafe { *(*address as *const T) };
+            RegisteredScalarSnapshot {
+                key: *key,
+                address: *address,
+                value,
+                owned: owned_addresses.get(key) == Some(address),
+            }
         })
         .collect()
 }
 
-fn restore_registered_ptrs<T: Copy>(values: &[(usize, T)]) {
-    for (address, value) in values {
-        // Restoration runs at a main-thread tick boundary while the registered owner is alive.
-        unsafe { *(*address as *mut T) = *value };
+fn restore_registered_ptrs<T: Copy>(
+    values: &[RegisteredScalarSnapshot<T>],
+    registered: &Mutex<HashMap<i32, usize>>,
+    owned: &Mutex<HashMap<i32, Box<T>>>,
+) {
+    let mut restored = HashMap::new();
+    let mut owned = owned.lock().expect("owned scalar table mutex poisoned");
+    owned.retain(|key, _| values.iter().any(|value| value.owned && value.key == *key));
+    for snapshot in values {
+        let address = if snapshot.owned {
+            let value = owned
+                .entry(snapshot.key)
+                .or_insert_with(|| Box::new(snapshot.value));
+            **value = snapshot.value;
+            value.as_mut() as *mut T as usize
+        } else {
+            // Restoration runs at a main-thread tick boundary while the registered owner is alive.
+            unsafe { *(snapshot.address as *mut T) = snapshot.value };
+            snapshot.address
+        };
+        restored.insert(snapshot.key, address);
     }
+    *registered
+        .lock()
+        .expect("registered scalar table mutex poisoned") = restored;
 }
 
 fn snapshot_registered_arrays<T: Copy>(
@@ -1342,52 +1834,76 @@ pub fn register_global_i32_ptr(path_hash: i32, ptr: *mut i32) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let table = registered_i32_ptrs();
     let mut guard = table
         .lock()
         .expect("registered i32 ptr table mutex poisoned");
     guard.insert(path_hash, ptr as usize);
+    update_direct_storage_slot((JitStorageKind::I32, path_hash, 0), ptr as usize, 1);
 }
 
 pub fn register_global_f32_ptr(path_hash: i32, ptr: *mut f32) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let table = registered_f32_ptrs();
     let mut guard = table
         .lock()
         .expect("registered f32 ptr table mutex poisoned");
     guard.insert(path_hash, ptr as usize);
+    update_direct_storage_slot((JitStorageKind::F32, path_hash, 0), ptr as usize, 1);
 }
 
 pub fn register_global_f64_ptr(path_hash: i32, ptr: *mut f64) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let table = registered_f64_ptrs();
     let mut guard = table
         .lock()
         .expect("registered f64 ptr table mutex poisoned");
     guard.insert(path_hash, ptr as usize);
+    update_direct_storage_slot((JitStorageKind::F64, path_hash, 0), ptr as usize, 1);
 }
 
 pub fn register_global_i32_array(collection_hash: i32, field_hash: i32, ptr: *mut i32, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let key = (collection_hash, field_hash);
+    discard_integer_array_lane(key, JitStorageKind::I32);
     remove_replaced_owned_array(key, ptr as usize, owned_i32_arrays());
     let table = registered_i32_arrays();
     let mut guard = table
         .lock()
         .expect("registered i32 array table mutex poisoned");
     guard.insert(key, (ptr as usize, len));
+    update_direct_storage_slot(
+        (JitStorageKind::I32, collection_hash, field_hash),
+        ptr as usize,
+        len,
+    );
 }
 
 pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mut f32, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let key = (collection_hash, field_hash);
     remove_replaced_owned_array(key, ptr as usize, owned_f32_arrays());
     let table = registered_f32_arrays();
@@ -1395,12 +1911,20 @@ pub fn register_global_f32_array(collection_hash: i32, field_hash: i32, ptr: *mu
         .lock()
         .expect("registered f32 array table mutex poisoned");
     guard.insert(key, (ptr as usize, len));
+    update_direct_storage_slot(
+        (JitStorageKind::F32, collection_hash, field_hash),
+        ptr as usize,
+        len,
+    );
 }
 
 pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mut f64, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
     let key = (collection_hash, field_hash);
     remove_replaced_owned_array(key, ptr as usize, owned_f64_arrays());
     let table = registered_f64_arrays();
@@ -1408,6 +1932,11 @@ pub fn register_global_f64_array(collection_hash: i32, field_hash: i32, ptr: *mu
         .lock()
         .expect("registered f64 array table mutex poisoned");
     guard.insert(key, (ptr as usize, len));
+    update_direct_storage_slot(
+        (JitStorageKind::F64, collection_hash, field_hash),
+        ptr as usize,
+        len,
+    );
 }
 
 fn remove_replaced_owned_array<T>(
@@ -1424,15 +1953,52 @@ fn remove_replaced_owned_array<T>(
     }
 }
 
+fn discard_integer_array_lane(key: ArrayKey, retained: JitStorageKind) {
+    match retained {
+        JitStorageKind::I32 => {
+            registered_u8_arrays()
+                .lock()
+                .expect("registered u8 array table mutex poisoned")
+                .remove(&key);
+            owned_u8_arrays()
+                .lock()
+                .expect("owned u8 array table mutex poisoned")
+                .remove(&key);
+        }
+        JitStorageKind::U8 => {
+            registered_i32_arrays()
+                .lock()
+                .expect("registered i32 array table mutex poisoned")
+                .remove(&key);
+            owned_i32_arrays()
+                .lock()
+                .expect("owned i32 array table mutex poisoned")
+                .remove(&key);
+        }
+        JitStorageKind::F32 | JitStorageKind::F64 => {}
+    }
+}
+
 pub fn register_global_u8_array(collection_hash: i32, field_hash: i32, ptr: *mut u8, len: usize) {
     if ptr.is_null() {
         return;
     }
+    let Ok(_rebind) = acquire_rebind_guard() else {
+        return;
+    };
+    let key = (collection_hash, field_hash);
+    discard_integer_array_lane(key, JitStorageKind::U8);
+    remove_replaced_owned_array(key, ptr as usize, owned_u8_arrays());
     let table = registered_u8_arrays();
     let mut guard = table
         .lock()
         .expect("registered u8 array table mutex poisoned");
-    guard.insert((collection_hash, field_hash), (ptr as usize, len));
+    guard.insert(key, (ptr as usize, len));
+    update_direct_storage_slot(
+        (JitStorageKind::U8, collection_hash, field_hash),
+        ptr as usize,
+        len,
+    );
 }
 
 #[no_mangle]
@@ -1512,71 +2078,26 @@ pub extern "C" fn stasis_jit_global_i32_array_ptr(
         return std::ptr::null_mut();
     }
 
-    // Fast path: already registered (host-owned or previously allocated).
-    let registered_len = {
-        let table = registered_i32_arrays();
-        let guard = table
-            .lock()
-            .expect("registered i32 array table mutex poisoned");
-        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
-            if registered_len >= len as usize {
-                return ptr as *mut i32;
-            }
-            Some(registered_len)
-        } else {
-            None
-        }
-    };
-
-    if registered_len.is_some() {
-        if ensure_jit_i32_array_capacity(collection_hash, field_hash, len as usize).is_err() {
-            return std::ptr::null_mut();
-        }
-        return registered_i32_arrays()
-            .lock()
-            .expect("registered i32 array table mutex poisoned")
-            .get(&(collection_hash, field_hash))
-            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut i32);
-    }
-
     let requested_len = len as usize;
     let key = (collection_hash, field_hash);
-
-    let ptr = {
-        let mut owned_guard = owned_i32_arrays()
-            .lock()
-            .expect("owned i32 array table mutex poisoned");
-        let array = owned_guard
-            .entry(key)
-            .or_insert_with(|| vec![0; requested_len]);
-        if array.len() < requested_len {
-            array.resize(requested_len, 0);
-        }
-
-        // Migrate any previously-stored values from the fallback hash map.
-        {
-            let table = jit_i32_array_global_table();
-            let mut guard = table.lock().expect("jit global table mutex poisoned");
-            for idx in 0..requested_len {
-                let idx_i32 = idx as i32;
-                if let Some(value) = guard.remove(&(collection_hash, field_hash, idx_i32)) {
-                    array[idx] = value;
-                }
-            }
-        }
-
-        array.as_mut_ptr()
-    };
-
+    if let Some((ptr, registered_len)) = registered_i32_arrays()
+        .lock()
+        .expect("registered i32 array table mutex poisoned")
+        .get(&key)
+        .copied()
     {
-        let table = registered_i32_arrays();
-        let mut guard = table
-            .lock()
-            .expect("registered i32 array table mutex poisoned");
-        guard.insert(key, (ptr as usize, requested_len));
+        if registered_len >= requested_len {
+            return ptr as *mut i32;
+        }
     }
-
-    ptr
+    if ensure_jit_i32_array_capacity(collection_hash, field_hash, requested_len).is_err() {
+        return std::ptr::null_mut();
+    }
+    registered_i32_arrays()
+        .lock()
+        .expect("registered i32 array table mutex poisoned")
+        .get(&key)
+        .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut i32)
 }
 
 #[no_mangle]
@@ -1589,74 +2110,26 @@ pub extern "C" fn stasis_jit_global_f32_array_ptr(
         return std::ptr::null_mut();
     }
 
-    // Fast path: already registered (host-owned or previously allocated).
-    let registered_len = {
-        let table = registered_f32_arrays();
-        let guard = table
-            .lock()
-            .expect("registered f32 array table mutex poisoned");
-        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
-            if registered_len >= len as usize {
-                return ptr as *mut f32;
-            }
-            Some(registered_len)
-        } else {
-            None
-        }
-    };
-
-    if registered_len.is_some() {
-        if ensure_jit_f32_array_capacity(collection_hash, field_hash, len as usize).is_err() {
-            return std::ptr::null_mut();
-        }
-        return registered_f32_arrays()
-            .lock()
-            .expect("registered f32 array table mutex poisoned")
-            .get(&(collection_hash, field_hash))
-            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f32);
-    }
-
     let requested_len = len as usize;
     let key = (collection_hash, field_hash);
-
-    // Allocate (or reuse) an owned backing array, then register it so subsequent helper calls
-    // can skip the fallback hash map path.
-    let ptr = {
-        let mut owned_guard = owned_f32_arrays()
-            .lock()
-            .expect("owned f32 array table mutex poisoned");
-        let array = owned_guard
-            .entry(key)
-            .or_insert_with(|| vec![0.0; requested_len]);
-        if array.len() < requested_len {
-            array.resize(requested_len, 0.0);
-        }
-
-        // Migrate any previously-stored values from the fallback hash map.
-        {
-            let table = jit_f32_array_global_table();
-            let mut guard = table.lock().expect("jit global table mutex poisoned");
-            for idx in 0..requested_len {
-                let idx_i32 = idx as i32;
-                if let Some(value) = guard.remove(&(collection_hash, field_hash, idx_i32)) {
-                    array[idx] = value;
-                }
-            }
-        }
-
-        array.as_mut_ptr()
-    };
-
+    if let Some((ptr, registered_len)) = registered_f32_arrays()
+        .lock()
+        .expect("registered f32 array table mutex poisoned")
+        .get(&key)
+        .copied()
     {
-        let table = registered_f32_arrays();
-        let mut guard = table
-            .lock()
-            .expect("registered f32 array table mutex poisoned");
-        // Register with the requested len so helper loads/stores use the same bounds as foreach.
-        guard.insert(key, (ptr as usize, requested_len));
+        if registered_len >= requested_len {
+            return ptr as *mut f32;
+        }
     }
-
-    ptr
+    if ensure_jit_f32_array_capacity(collection_hash, field_hash, requested_len).is_err() {
+        return std::ptr::null_mut();
+    }
+    registered_f32_arrays()
+        .lock()
+        .expect("registered f32 array table mutex poisoned")
+        .get(&key)
+        .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f32)
 }
 
 fn global_u8_array_ptr(collection_hash: i32, field_hash: i32, len: i32) -> *mut u8 {
@@ -1672,38 +2145,18 @@ fn global_u8_array_ptr(collection_hash: i32, field_hash: i32, len: i32) -> *mut 
         .get(&key)
         .copied()
     {
-        return if registered_len >= requested_len {
-            ptr as *mut u8
-        } else {
-            std::ptr::null_mut()
-        };
+        if registered_len >= requested_len {
+            return ptr as *mut u8;
+        }
     }
-
-    let ptr = {
-        let mut owned_guard = owned_u8_arrays()
-            .lock()
-            .expect("owned u8 array table mutex poisoned");
-        let array = owned_guard
-            .entry(key)
-            .or_insert_with(|| vec![0; requested_len]);
-        if array.len() < requested_len {
-            array.resize(requested_len, 0);
-        }
-        let mut fallback = jit_i32_array_global_table()
-            .lock()
-            .expect("jit global table mutex poisoned");
-        for (index, value) in array.iter_mut().enumerate() {
-            if let Some(stored) = fallback.remove(&(collection_hash, field_hash, index as i32)) {
-                *value = stored as u8;
-            }
-        }
-        array.as_mut_ptr()
-    };
+    if ensure_jit_u8_array_capacity(collection_hash, field_hash, requested_len).is_err() {
+        return std::ptr::null_mut();
+    }
     registered_u8_arrays()
         .lock()
         .expect("registered u8 array table mutex poisoned")
-        .insert(key, (ptr as usize, requested_len));
-    ptr
+        .get(&key)
+        .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut u8)
 }
 
 #[no_mangle]
@@ -1716,71 +2169,26 @@ pub extern "C" fn stasis_jit_global_f64_array_ptr(
         return std::ptr::null_mut();
     }
 
-    // Fast path: already registered (host-owned or previously allocated).
-    let registered_len = {
-        let table = registered_f64_arrays();
-        let guard = table
-            .lock()
-            .expect("registered f64 array table mutex poisoned");
-        if let Some((ptr, registered_len)) = guard.get(&(collection_hash, field_hash)).copied() {
-            if registered_len >= len as usize {
-                return ptr as *mut f64;
-            }
-            Some(registered_len)
-        } else {
-            None
-        }
-    };
-
-    if registered_len.is_some() {
-        if ensure_jit_f64_array_capacity(collection_hash, field_hash, len as usize).is_err() {
-            return std::ptr::null_mut();
-        }
-        return registered_f64_arrays()
-            .lock()
-            .expect("registered f64 array table mutex poisoned")
-            .get(&(collection_hash, field_hash))
-            .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f64);
-    }
-
     let requested_len = len as usize;
     let key = (collection_hash, field_hash);
-
-    let ptr = {
-        let mut owned_guard = owned_f64_arrays()
-            .lock()
-            .expect("owned f64 array table mutex poisoned");
-        let array = owned_guard
-            .entry(key)
-            .or_insert_with(|| vec![0.0; requested_len]);
-        if array.len() < requested_len {
-            array.resize(requested_len, 0.0);
-        }
-
-        // Migrate any previously-stored values from the fallback hash map.
-        {
-            let table = jit_f64_array_global_table();
-            let mut guard = table.lock().expect("jit global table mutex poisoned");
-            for idx in 0..requested_len {
-                let idx_i32 = idx as i32;
-                if let Some(value) = guard.remove(&(collection_hash, field_hash, idx_i32)) {
-                    array[idx] = value;
-                }
-            }
-        }
-
-        array.as_mut_ptr()
-    };
-
+    if let Some((ptr, registered_len)) = registered_f64_arrays()
+        .lock()
+        .expect("registered f64 array table mutex poisoned")
+        .get(&key)
+        .copied()
     {
-        let table = registered_f64_arrays();
-        let mut guard = table
-            .lock()
-            .expect("registered f64 array table mutex poisoned");
-        guard.insert(key, (ptr as usize, requested_len));
+        if registered_len >= requested_len {
+            return ptr as *mut f64;
+        }
     }
-
-    ptr
+    if ensure_jit_f64_array_capacity(collection_hash, field_hash, requested_len).is_err() {
+        return std::ptr::null_mut();
+    }
+    registered_f64_arrays()
+        .lock()
+        .expect("registered f64 array table mutex poisoned")
+        .get(&key)
+        .map_or(std::ptr::null_mut(), |(ptr, _)| *ptr as *mut f64)
 }
 
 #[no_mangle]
@@ -2978,36 +3386,78 @@ pub fn clear_jit_i32_global_table() {
     let table = jit_i32_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for value in owned_i32_scalars()
+        .lock()
+        .expect("owned i32 scalar table mutex poisoned")
+        .values_mut()
+    {
+        **value = 0;
+    }
 }
 
 pub fn clear_jit_f32_global_table() {
     let table = jit_f32_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for value in owned_f32_scalars()
+        .lock()
+        .expect("owned f32 scalar table mutex poisoned")
+        .values_mut()
+    {
+        **value = 0.0;
+    }
 }
 
 pub fn clear_jit_f64_global_table() {
     let table = jit_f64_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for value in owned_f64_scalars()
+        .lock()
+        .expect("owned f64 scalar table mutex poisoned")
+        .values_mut()
+    {
+        **value = 0.0;
+    }
 }
 
 pub fn clear_jit_i32_array_global_table() {
     let table = jit_i32_array_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for values in owned_i32_arrays()
+        .lock()
+        .expect("owned i32 array table mutex poisoned")
+        .values_mut()
+    {
+        values.fill(0);
+    }
 }
 
 pub fn clear_jit_f32_array_global_table() {
     let table = jit_f32_array_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for values in owned_f32_arrays()
+        .lock()
+        .expect("owned f32 array table mutex poisoned")
+        .values_mut()
+    {
+        values.fill(0.0);
+    }
 }
 
 pub fn clear_jit_f64_array_global_table() {
     let table = jit_f64_array_global_table();
     let mut guard = table.lock().expect("jit global table mutex poisoned");
     guard.clear();
+    for values in owned_f64_arrays()
+        .lock()
+        .expect("owned f64 array table mutex poisoned")
+        .values_mut()
+    {
+        values.fill(0.0);
+    }
 }
 
 #[no_mangle]
@@ -3674,9 +4124,10 @@ mod tests {
     use std::sync::MutexGuard;
 
     fn test_lock() -> MutexGuard<'static, ()> {
-        jit_dispatch_lock()
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
             .lock()
-            .expect("jit dispatch lock mutex poisoned")
+            .expect("dynload test lock mutex poisoned")
     }
 
     #[cfg(windows)]
@@ -3809,6 +4260,56 @@ mod tests {
         assert_eq!(stasis_jit_global_i32_load(30), 9);
         assert_eq!(stasis_jit_global_i32_load(31), 0);
         assert_eq!(stasis_jit_global_f32_array_load(40, 2, 0), 1.5);
+    }
+
+    #[test]
+    fn runtime_state_rollback_rebinds_direct_storage_descriptor_atomically() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        let key = 77;
+        let mut original = [3, 5];
+        register_global_i32_array(key, 0, original.as_mut_ptr(), original.len());
+        let slot_address = direct_array_storage_slot_address(JitStorageKind::I32, key, 0)
+            .expect("reserve direct slot");
+        let snapshot = snapshot_jit_runtime_state();
+
+        let mut replacement = [9, 8, 7, 6];
+        register_global_i32_array(key, 0, replacement.as_mut_ptr(), replacement.len());
+        let slot = unsafe { &*(slot_address as *const JitStorageSlot) };
+        assert_eq!(slot.data, replacement.as_ptr() as usize);
+        assert_eq!(slot.len, replacement.len());
+
+        restore_jit_runtime_state(&snapshot);
+        let slot = unsafe { &*(slot_address as *const JitStorageSlot) };
+        assert_eq!(slot.data, original.as_ptr() as usize);
+        assert_eq!(slot.len, original.len());
+        assert_eq!(unsafe { *(slot.data as *const i32).add(1) }, 5);
+        clear_registered_global_memory();
+    }
+
+    #[test]
+    fn direct_array_growth_is_rejected_during_guest_execution() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        let key = 78;
+        let mut values = [3, 5];
+        register_global_i32_array(key, 0, values.as_mut_ptr(), values.len());
+        let slot_address = direct_array_storage_slot_address(JitStorageKind::I32, key, 0)
+            .expect("reserve direct slot");
+
+        {
+            let _execution = JitExecutionGuard::enter();
+            let error = ensure_jit_i32_array_capacity(key, 0, 4)
+                .expect_err("growth must not rebind direct storage during guest execution");
+            assert!(error.contains("between guest execution windows"));
+            assert!(stasis_jit_global_i32_array_ptr(key, 0, 4).is_null());
+        }
+
+        let slot = unsafe { &*(slot_address as *const JitStorageSlot) };
+        assert_eq!(slot.data, values.as_ptr() as usize);
+        assert_eq!(slot.len, values.len());
+        assert_eq!(values, [3, 5]);
+        clear_registered_global_memory();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- lower core scalar, fixed-array, fixed-text, and struct-field storage to direct Cranelift memory operations
- keep JIT storage behind stable execution-window descriptors while binding AOT directly to final data symbols and compile-time lengths
- hoist foreach base pointers and live JIT bounds outside iteration, including byte-width and contracted struct-lane handling
- reject storage rebinding/growth during guest execution

## Why
Android Workshop profiling showed helper-mediated global access added significant tick latency and severe tail spikes. Core load/store helpers performed hash-table and synchronization work on every access.

## Impact
The same-emulator Pong benchmark improved confirmed tick avg/p50/p95 from 0.75/0.10/9.81 ms to 0.19/0.08/0.26 ms. AOT retains direct symbol access with no descriptor indirection.

## Validation
- `cargo test --workspace --all-targets -- --test-threads=1` (pass, 120.4s)
- linked AOT direct-storage executable covers i32/f32/f64/u8/fixed text/struct and byte foreach
- targeted JIT contraction tests cover i32/u8 and mismatched i32/f32 struct lanes
- exact Python stages from `tools/validate_repo.sh` pass
- `cargo fmt --all -- --check`
- `git diff --check`
- independent code review: no actionable findings

Maddox task #172.