### PR TITLE
feat: add state memory inspection

### DIFF
--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -38,6 +38,7 @@ const MAX_LIVE_EDIT_BATCH: usize = 64;
 const MAX_LIVE_TRANSACTION_ASSIGNMENTS: usize = 64;
 const MAX_STAGED_TEST_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_STAGED_TEST_DIAGNOSTIC_BYTES: usize = 4096;
+const MAX_WATCH_PREDICATE_SCAN_PER_TICK: usize = 4096;
 #[derive(Debug, Clone)]
 pub struct LiveRunConfig {
     pub project_root: PathBuf,
@@ -409,9 +410,49 @@ impl LiveWorkspace {
             }
         }
         let paths = self.watches.keys().cloned().collect::<Vec<_>>();
-        for path in paths {
-            let Ok(value) = jit.inspect_state_query(&path) else {
-                continue;
+        let mut remaining_scan = MAX_WATCH_PREDICATE_SCAN_PER_TICK;
+        let path_count = paths.len();
+        for (index, path) in paths.into_iter().enumerate() {
+            let paths_left = path_count - index;
+            let scan_limit = if remaining_scan == 0 {
+                0
+            } else {
+                (remaining_scan / paths_left).max(1)
+            };
+            let value = match jit.inspect_state_query_with_scan_limit(&path, scan_limit) {
+                Ok(value) => {
+                    let scanned = value
+                        .get("scanned")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .unwrap_or(0);
+                    remaining_scan = remaining_scan.saturating_sub(scanned);
+                    value
+                }
+                Err(error) => {
+                    let value = json!({"kind": "error", "error": error.clone()});
+                    let prior = self.watches.get(&path).and_then(Option::as_ref);
+                    if prior == Some(&value) {
+                        continue;
+                    }
+                    self.watches.insert(path.clone(), Some(value));
+                    match self.server.respond(LiveResponse::success(
+                        0,
+                        tick,
+                        "watch_error",
+                        json!({"path": path, "error": error}),
+                    )) {
+                        Ok(()) => {}
+                        Err(LiveResponseSendError::Full(_)) => {
+                            self.dropped_watch_events = self.dropped_watch_events.saturating_add(1);
+                        }
+                        Err(LiveResponseSendError::Disconnected) => {
+                            self.quit = true;
+                            return;
+                        }
+                    }
+                    continue;
+                }
             };
             let prior = self.watches.get(&path).and_then(Option::as_ref);
             if prior == Some(&value) {
@@ -2977,6 +3018,103 @@ mod tests {
         assert!(workspace.should_run_tick());
         workspace.after_tick();
         assert!(!workspace.should_run_tick());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn expression_watch_reports_and_deduplicates_evaluation_errors() {
+        let (root, config) = project();
+        let (mut jit, package) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("main");
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        let mut tick_ptr = package.tick_code_ptr;
+        let mut render_ptr = package.render_code_ptr;
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    43,
+                    LiveCommand::Watch {
+                        path: "10 / score".into(),
+                    },
+                ),
+            )
+            .ok
+        );
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    44,
+                    LiveCommand::Set {
+                        path: "score".into(),
+                        expression: "0".into(),
+                        preview: false,
+                    },
+                ),
+            )
+            .ok
+        );
+
+        workspace.publish_watches(2, &jit);
+        let error = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("watch error");
+        assert_eq!(error.kind, "watch_error");
+        assert!(error.data.expect("watch error data")["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("division by zero"));
+        workspace.publish_watches(3, &jit);
+        assert!(client
+            .receive_timeout(std::time::Duration::from_millis(10))
+            .is_err());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn predicate_watches_share_one_per_tick_scan_budget() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "struct Enemy { hp: i32; }\n\
+             global alpha: Enemy[4096];\n\
+             global beta: Enemy[4096];\n\
+             function main(): i32 { return alpha[0].hp + beta[0].hp; }\n\
+             function tick(): i32 { return 0; }\n\
+             function render(): i32 { return 0; }\n\
+             function on_code_swap(): void { return; }\n",
+        )
+        .expect("predicate watch source");
+        let (jit, _) = compile(&config);
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+        workspace.watches.insert("alpha[?hp >= 0]".into(), None);
+        workspace.watches.insert("beta[?hp >= 0]".into(), None);
+
+        workspace.publish_watches(1, &jit);
+
+        let scanned = (0..2)
+            .map(|_| {
+                client
+                    .receive_timeout(std::time::Duration::from_secs(1))
+                    .expect("predicate watch event")
+                    .data
+                    .expect("predicate watch data")["inspection"]["scanned"]
+                    .as_u64()
+                    .unwrap_or(0)
+            })
+            .sum::<u64>();
+        assert_eq!(scanned, MAX_WATCH_PREDICATE_SCAN_PER_TICK as u64);
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -157,7 +157,7 @@ pub(crate) struct LiveWorkspace {
     source_files: Vec<WorkshopSourceFile>,
     completion_snapshot: Arc<CompletionSnapshot>,
     scratch: ScratchWorkspace,
-    watches: BTreeMap<String, Option<JitScalarValue>>,
+    watches: BTreeMap<String, Option<Value>>,
     pending_plan: Option<PendingEdit>,
     pending_requests: VecDeque<LiveRequest>,
     pending_responses: VecDeque<LiveResponse>,
@@ -410,19 +410,20 @@ impl LiveWorkspace {
         }
         let paths = self.watches.keys().cloned().collect::<Vec<_>>();
         for path in paths {
-            let Ok(value) = jit.read_global_scalar(&path) else {
+            let Ok(value) = jit.inspect_state_query(&path) else {
                 continue;
             };
-            let prior = self.watches.get(&path).copied().flatten();
-            if prior == Some(value) {
+            let prior = self.watches.get(&path).and_then(Option::as_ref);
+            if prior == Some(&value) {
                 continue;
             }
-            self.watches.insert(path.clone(), Some(value));
+            self.watches.insert(path.clone(), Some(value.clone()));
+            let observed = inspection_observed_value(&value);
             match self.server.respond(LiveResponse::success(
                 0,
                 tick,
                 "watch",
-                json!({"path": path, "value": value}),
+                json!({"path": path, "value": observed, "inspection": value}),
             )) {
                 Ok(()) => {}
                 Err(LiveResponseSendError::Full(_)) => {
@@ -681,16 +682,17 @@ impl LiveWorkspace {
             LiveCommand::Inspect { path } => inspect_scalar(jit, &path),
             LiveCommand::InspectAll { limit, concise } => inspect_all_scalars(jit, limit, concise),
             LiveCommand::Watch { path } => {
-                let value = jit.read_global_scalar(&path)?;
+                let value = jit.inspect_state_query(&path)?;
                 if !self.watches.contains_key(&path) && self.watches.len() >= MAX_LIVE_WATCHES {
                     return Err(format!(
                         "live watching is limited to {MAX_LIVE_WATCHES} paths"
                     ));
                 }
+                let observed = inspection_observed_value(&value);
                 self.watches.insert(path.clone(), Some(value));
                 Ok((
                     "watch_added",
-                    json!({"path": path, "value": value, "tick": tick}),
+                    json!({"path": path, "value": observed, "tick": tick}),
                 ))
             }
             LiveCommand::Unwatch { path } => {
@@ -1982,9 +1984,9 @@ fn help_data() -> Value {
             ":complete BUFFER", ":palette [QUERY]",
             ":add KIND NAME FILE ... :end", ":update KIND NAME [FILE] ... :end",
             ":delete KIND NAME [FILE]", ":preview", ":apply", ":changes", ":undo", ":redo",
-            ":inspect [PATH]", ":watch PATH", ":unwatch [PATH]",
+            ":inspect [QUERY]", ":watch QUERY", ":unwatch [QUERY]",
             ":set PATH VALUE",
-            ":print VALUE_OR_PATH", ":do ... :end", ":cell put|run|list|clear"
+            ":print SCALAR_EXPRESSION", ":do ... :end", ":cell put|run|list|clear"
         ],
         "multiline_terminator": ":end",
         "multiline_cancel": ":abort or Ctrl-C",
@@ -2112,11 +2114,14 @@ fn candidate_diagnostic(candidate: &JitProcess, error: CompileError) -> String {
 }
 
 fn inspect_scalar(jit: &JitProcess, path: &str) -> Result<(&'static str, Value), String> {
-    let value = jit.read_global_scalar(path)?;
-    Ok((
-        "inspection",
-        json!({"path": path, "static_type": value.type_name(), "value": value}),
-    ))
+    Ok(("inspection", jit.inspect_state_query(path)?))
+}
+
+fn inspection_observed_value(inspection: &Value) -> Value {
+    inspection
+        .get("value")
+        .cloned()
+        .unwrap_or_else(|| inspection.clone())
 }
 
 fn validate_live_runtime(
@@ -2196,9 +2201,47 @@ fn inspect_all_scalars(
             Ok(json!({"path": path, "static_type": static_type, "value": value}))
         })
         .collect::<Result<Vec<_>, String>>()?;
+    let memory = jit.state_memory_report(&BTreeMap::new(), MAX_STATE_SNAPSHOT_BYTES as u64)?;
+    let layout = jit.state_layout();
+    let collections = layout
+        .collections
+        .iter()
+        .take(limit)
+        .map(|collection| {
+            let active_count = memory
+                .entries
+                .iter()
+                .find(|entry| entry.path == collection.path && entry.kind == "collection_field")
+                .and_then(|entry| entry.active_count);
+            json!({
+                "path": collection.path,
+                "kind": "collection",
+                "element_shape": collection.element_shape,
+                "capacity": collection.capacity,
+                "active_count": active_count,
+                "fields": collection.fields,
+            })
+        })
+        .collect::<Vec<_>>();
+    let structs = layout.structs.iter().take(limit).collect::<Vec<_>>();
     Ok((
         "state_inspection",
-        json!({"total": total, "limit": limit, "truncated": total > limit, "concise": concise, "items": items}),
+        json!({
+            "total": total,
+            "limit": limit,
+            "truncated": total > limit || layout.collections.len() > limit || layout.structs.len() > limit,
+            "concise": concise,
+            "items": items,
+            "collections": collections,
+            "structs": structs,
+            "memory": {
+                "storage_model": memory.storage_model,
+                "total_capacity_bytes": memory.total_capacity_bytes,
+                "snapshot_bytes": memory.snapshot_bytes,
+                "mobile_budget_bytes": memory.mobile_budget_bytes,
+                "warnings": memory.warnings,
+            },
+        }),
     ))
 }
 
@@ -2224,19 +2267,7 @@ fn concise_state_path_is_visible(path: &str, all_paths: &HashSet<String>) -> boo
 }
 
 fn print_scalar(jit: &JitProcess, expression: &str) -> Result<(&'static str, Value), String> {
-    if jit.has_global_path(expression) {
-        return inspect_scalar(jit, expression);
-    }
-    if let Ok(value) = expression.parse::<i32>() {
-        return Ok(("print", json!({"static_type": "i32", "value": value})));
-    }
-    if matches!(expression, "true" | "false") {
-        return Ok((
-            "print",
-            json!({"static_type": "bool", "value": expression == "true"}),
-        ));
-    }
-    Err("live print currently accepts a compiler-indexed scalar path, i32 literal, or bool literal; unsupported expressions fail instead of using a second evaluator".to_string())
+    Ok(("print", jit.inspect_state_query(expression)?))
 }
 
 fn set_scalar(
@@ -2859,7 +2890,7 @@ mod tests {
     }
 
     #[test]
-    fn pause_step_and_watch_events_are_boundary_exact() {
+    fn pause_step_and_expression_watch_events_are_boundary_exact() {
         let (root, config) = project();
         let (mut jit, package) = compile(&config);
         jit.execute_i32_noarg_by_name("main").expect("main");
@@ -2877,7 +2908,7 @@ mod tests {
                 LiveRequest::new(
                     40,
                     LiveCommand::Watch {
-                        path: "score".into()
+                        path: "score + 1".into()
                     }
                 ),
             )
@@ -2912,7 +2943,7 @@ mod tests {
             .expect("watch event");
         assert_eq!(watch.request_id, 0);
         assert_eq!(watch.tick, 1);
-        assert_eq!(watch.data.expect("watch data")["value"]["value"], 9);
+        assert_eq!(watch.data.expect("watch data")["value"]["value"], 10);
         workspace.publish_watches(1, &jit);
         assert!(client
             .receive_timeout(std::time::Duration::from_millis(10))

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -894,14 +894,26 @@ fn check_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
 fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
     let entry = workspace.root.join(&workspace.manifest.entry);
     validate_workspace_destination(workspace, "entry", &entry)?;
-    let source = fs::read_to_string(&entry)
-        .map_err(|error| format!("failed to read entry {}: {error}", entry.display()))?;
+    let files =
+        load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
+    let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
     let mut jit = JitProcess::new();
     jit.set_required_emit_roots(&["main".to_string()]);
-    jit.upsert_file(display_path(&entry), source.clone());
+    let mut sources = BTreeMap::new();
+    for file in files {
+        let path = workspace.root.join(&file.path);
+        let path = path.canonicalize().unwrap_or(path);
+        let path = path.to_string_lossy().to_string();
+        sources.insert(path.clone(), file.source.clone());
+        jit.upsert_file(path, file.source);
+    }
     jit.compile().map_err(|error| {
         if let Some(diagnostic) = jit.last_source_diagnostic() {
-            let (line, column) = line_column(&source, diagnostic.start);
+            let source = sources
+                .get(&diagnostic.path)
+                .map(String::as_str)
+                .unwrap_or("");
+            let (line, column) = line_column(source, diagnostic.start);
             format!(
                 "{}:{}:{}: {}",
                 diagnostic.path, line, column, diagnostic.message
@@ -1374,6 +1386,11 @@ fn format_live_response(response: &LiveResponse) -> String {
             "{} -> {}",
             string_field(data, "path", "value"),
             scalar_text(data.get("value").unwrap_or(&Value::Null))
+        ),
+        "watch_error" => format!(
+            "{} watch error: {}",
+            string_field(data, "path", "value"),
+            string_field(data, "error", "unknown watch error")
         ),
         "watch_removed" => format_live_watch_removed(data),
         "watch_backpressure" => format!(

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7,6 +7,7 @@ use stasis::{
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
+use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
     plan_workshop_semantic_edits, workshop_direct_import_files, workshop_reachable_files,
@@ -210,8 +211,15 @@ enum ToolchainCommand {
         #[arg(long)]
         development_build: bool,
     },
-    /// Report deterministic workspace and output layout information.
-    Inspect,
+    /// Report compiler-owned state memory, layout, and mobile budget information.
+    Inspect {
+        /// Project the byte impact of a collection capacity change (PATH=COUNT).
+        #[arg(long = "capacity", value_name = "PATH=COUNT")]
+        capacities: Vec<String>,
+        /// Mobile snapshot budget used for deterministic warnings.
+        #[arg(long, default_value_t = MAX_STATE_SNAPSHOT_BYTES as u64)]
+        mobile_budget_bytes: u64,
+    },
     /// Replay support is reserved until the replay runtime lands.
     Replay,
     /// Replay verification is reserved until the replay runtime lands.
@@ -576,7 +584,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Build { .. } => "build",
         ToolchainCommand::Package { .. } => "package",
         ToolchainCommand::PackageMobile { .. } => "package-mobile",
-        ToolchainCommand::Inspect => "inspect",
+        ToolchainCommand::Inspect { .. } => "inspect",
         ToolchainCommand::Replay => "replay",
         ToolchainCommand::Verify => "verify",
         ToolchainCommand::Version => "version",
@@ -708,7 +716,10 @@ fn execute(
                         development_build,
                     )
                 }
-                ToolchainCommand::Inspect => inspect_workspace(&workspace),
+                ToolchainCommand::Inspect {
+                    capacities,
+                    mobile_budget_bytes,
+                } => inspect_workspace(&workspace, &capacities, mobile_budget_bytes),
                 ToolchainCommand::Symbol { command } => symbol_workspace(&workspace, command),
                 _ => Err("unsupported command routing".to_string()),
             }
@@ -1346,25 +1357,8 @@ fn format_live_response(response: &LiveResponse) -> String {
             "completion response exceeded the output bound; narrow the query".to_string()
         }
         "completion" | "palette" => format_live_completion(data),
-        "inspection" => format!(
-            "{}: {} = {}",
-            string_field(data, "path", "value"),
-            string_field(data, "static_type", "unknown"),
-            scalar_text(data.get("value").unwrap_or(&Value::Null))
-        ),
-        "state_inspection" => format!(
-            "{} live state value(s){}",
-            data.get("total").and_then(Value::as_u64).unwrap_or(0),
-            if data
-                .get("truncated")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-            {
-                " (view bounded)"
-            } else {
-                ""
-            }
-        ),
+        "inspection" => format_live_inspection(data),
+        "state_inspection" => format_live_state_inspection(data),
         "runtime_validation" => format_live_runtime_validation(data),
         "print" => format!(
             "{} = {}",
@@ -1437,6 +1431,125 @@ fn scalar_text(value: &Value) -> String {
         Value::String(value) => value.clone(),
         _ => "<structured value>".to_string(),
     }
+}
+
+fn format_live_inspection(data: &Value) -> String {
+    if data.get("kind").and_then(Value::as_str) == Some("predicate") {
+        let matches = data
+            .get("total_matches")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let suffix = if data
+            .get("scan_truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || data
+                .get("matches_truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        {
+            " (bounded)"
+        } else {
+            ""
+        };
+        return format!(
+            "{}: {matches} match(es){suffix}",
+            string_field(data, "query", "predicate")
+        );
+    }
+    format!(
+        "{}: {} = {}",
+        string_field(data, "path", "value"),
+        string_field(data, "static_type", "unknown"),
+        scalar_text(data.get("value").unwrap_or(&Value::Null))
+    )
+}
+
+fn format_live_state_inspection(data: &Value) -> String {
+    let mut lines = vec![format!(
+        "{} live state value(s){}",
+        data.get("total").and_then(Value::as_u64).unwrap_or(0),
+        if data
+            .get("truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            " (view bounded)"
+        } else {
+            ""
+        }
+    )];
+    for item in data
+        .get("items")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+    {
+        lines.push(format!(
+            "  {}: {} = {}",
+            string_field(item, "path", "value"),
+            string_field(item, "static_type", "unknown"),
+            scalar_text(item.get("value").unwrap_or(&Value::Null))
+        ));
+    }
+    for collection in data
+        .get("collections")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+    {
+        lines.push(format!(
+            "  {} [{}/{}]",
+            string_field(collection, "path", "collection"),
+            collection
+                .get("active_count")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            collection
+                .get("capacity")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        ));
+        for field in collection
+            .get("fields")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+        {
+            let name = string_field(field, "field", "element");
+            lines.push(format!(
+                "    {}: {}",
+                if name.is_empty() { "element" } else { name },
+                string_field(field, "type_name", "unknown")
+            ));
+        }
+    }
+    for state_struct in data
+        .get("structs")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+    {
+        lines.push(format!(
+            "  {}: {}",
+            string_field(state_struct, "path", "state"),
+            string_field(state_struct, "type_name", "struct")
+        ));
+    }
+    if let Some(memory) = data.get("memory") {
+        lines.push(format!(
+            "  memory: {} bytes; snapshot: {} bytes",
+            memory
+                .get("total_capacity_bytes")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            memory
+                .get("snapshot_bytes")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        ));
+    }
+    lines.join("\n")
 }
 
 fn format_live_help(data: &Value) -> String {
@@ -3062,18 +3175,45 @@ fn is_editable_workshop_path(path: &str) -> bool {
     normalized.starts_with("src/") || normalized.starts_with("tests/")
 }
 
-fn inspect_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
+fn inspect_workspace(
+    workspace: &Workspace,
+    capacities: &[String],
+    mobile_budget_bytes: u64,
+) -> Result<CommandResult, String> {
     let entry = workspace.root.join(&workspace.manifest.entry);
     let tests = workspace.root.join(&workspace.manifest.tests);
     let output = workspace.root.join(&workspace.manifest.output);
+    let capacity_overrides = parse_capacity_overrides(capacities)?;
+    let jit = compile_workspace_jit(workspace)?;
+    let memory = jit.state_memory_report(&capacity_overrides, mobile_budget_bytes)?;
+    let mut human = vec![format!(
+        "state memory: {} capacity bytes; {} snapshot bytes; {} mobile budget bytes",
+        memory.total_capacity_bytes, memory.snapshot_bytes, memory.mobile_budget_bytes
+    )];
+    if memory.projected_capacity_bytes != memory.total_capacity_bytes {
+        human.push(format!(
+            "projected capacity: {} bytes ({:+} bytes)",
+            memory.projected_capacity_bytes,
+            i128::from(memory.projected_capacity_bytes) - i128::from(memory.total_capacity_bytes)
+        ));
+    }
+    if !memory.largest_pools.is_empty() {
+        human.push("largest pools:".to_string());
+        human.extend(memory.largest_pools.iter().map(|pool| {
+            format!(
+                "  {}: {} bytes ({} x {})",
+                pool.path, pool.capacity_bytes, pool.capacity, pool.bytes_per_element
+            )
+        }));
+    }
+    human.extend(
+        memory
+            .warnings
+            .iter()
+            .map(|warning| format!("warning: {warning}")),
+    );
     Ok(CommandResult::success(
-        format!(
-            "workspace={} entry={} tests={} output={}",
-            workspace.root.display(),
-            entry.display(),
-            tests.display(),
-            output.display()
-        ),
+        human.join("\n"),
         json!({
             "name": workspace.manifest.name,
             "root": display_path(&workspace.root),
@@ -3081,8 +3221,30 @@ fn inspect_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
             "tests": display_path(&tests),
             "output": display_path(&output),
             "manifest_version": workspace.manifest.manifest_version,
+            "memory": memory,
         }),
     ))
+}
+
+fn parse_capacity_overrides(values: &[String]) -> Result<BTreeMap<String, u64>, String> {
+    let mut overrides = BTreeMap::new();
+    for value in values {
+        let (path, count) = value
+            .split_once('=')
+            .ok_or_else(|| format!("invalid capacity override '{value}'; expected PATH=COUNT"))?;
+        if path.is_empty() {
+            return Err(format!(
+                "invalid capacity override '{value}'; path cannot be empty"
+            ));
+        }
+        let count = count
+            .parse::<u64>()
+            .map_err(|error| format!("invalid capacity override '{value}': {error}"))?;
+        if overrides.insert(path.to_string(), count).is_some() {
+            return Err(format!("duplicate capacity override for '{path}'"));
+        }
+    }
+    Ok(overrides)
 }
 
 fn env_result(explicit: Option<&Path>) -> Result<CommandResult, String> {

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1671,6 +1671,9 @@ impl LiveTui {
         };
         self.inspector.title = "Live state (default)".to_string();
         self.inspector.lines = items.iter().map(format_state_item).collect();
+        if let Some(data) = response.data.as_ref() {
+            append_state_tree_lines(data, &mut self.inspector.lines);
+        }
         if self.inspector.lines.is_empty() {
             self.inspector.lines = vec!["No concise state values; use :inspect PATH.".to_string()];
         }
@@ -2331,6 +2334,64 @@ fn format_state_item(item: &Value) -> String {
         name,
         scalar_text(item.get("value").unwrap_or(&Value::Null))
     )
+}
+
+fn append_state_tree_lines(data: &Value, lines: &mut Vec<String>) {
+    if let Some(collections) = data.get("collections").and_then(Value::as_array) {
+        for collection in collections {
+            let path = collection
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or("collection");
+            let active = collection
+                .get("active_count")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let capacity = collection
+                .get("capacity")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            lines.push(format!("{path} [{active}/{capacity}]"));
+            if let Some(fields) = collection.get("fields").and_then(Value::as_array) {
+                for field in fields {
+                    let name = field
+                        .get("field")
+                        .and_then(Value::as_str)
+                        .filter(|name| !name.is_empty())
+                        .unwrap_or("element");
+                    let static_type = field
+                        .get("type_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown");
+                    lines.push(format!("  {name}: {static_type}"));
+                }
+            }
+        }
+    }
+    if let Some(structs) = data.get("structs").and_then(Value::as_array) {
+        for state_struct in structs {
+            let path = state_struct
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or("struct");
+            let name = state_struct
+                .get("type_name")
+                .and_then(Value::as_str)
+                .unwrap_or("struct");
+            lines.push(format!("{path}: {name}"));
+        }
+    }
+    if let Some(memory) = data.get("memory") {
+        let bytes = memory
+            .get("total_capacity_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let snapshot = memory
+            .get("snapshot_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        lines.push(format!("memory: {bytes} bytes; snapshot: {snapshot} bytes"));
+    }
 }
 
 fn current_token(buffer: &EditBuffer) -> &str {
@@ -3127,6 +3188,33 @@ mod tests {
             "value": {"type": "f32", "value": 12.5}
         });
         assert_eq!(format_state_item(&item), "    score = 12.5");
+    }
+
+    #[test]
+    fn default_state_tree_includes_collections_structs_and_memory() {
+        let data = serde_json::json!({
+            "collections": [{
+                "path": "state.enemies",
+                "active_count": 2,
+                "capacity": 8,
+                "fields": [{"field": "hp", "type_name": "i32"}]
+            }],
+            "structs": [{"path": "state.player", "type_name": "Player"}],
+            "memory": {"total_capacity_bytes": 96, "snapshot_bytes": 96}
+        });
+        let mut lines = Vec::new();
+
+        append_state_tree_lines(&data, &mut lines);
+
+        assert_eq!(
+            lines,
+            vec![
+                "state.enemies [2/8]",
+                "  hp: i32",
+                "state.player: Player",
+                "memory: 96 bytes; snapshot: 96 bytes",
+            ]
+        );
     }
 
     #[test]

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1387,6 +1387,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
 }
 
 #[test]
+#[cfg(windows)]
 fn state_inspection_sample_browses_state_and_watches_live_runtime() {
     let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/state_inspection");
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -83,6 +83,72 @@ fn project_commands_emit_stable_json_from_nested_directories() {
 }
 
 #[test]
+fn inspect_reports_compiler_state_memory_and_capacity_projection() {
+    let parent = temp_dir("memory_report");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    fs::write(
+        project.join("src/main.stasis"),
+        "struct Enemy { hp: i32; speed: f64; }\n\
+         struct GameState { score: i32; enemies: Enemy[4]; }\n\
+         global state: GameState;\n\
+         global gfx_cmd_i32: i32[8];\n\
+         function main(): i32 { return state.score; }\n",
+    )
+    .expect("write memory fixture");
+
+    let inspected = stasis(
+        &[
+            "--json",
+            "inspect",
+            "--capacity",
+            "state.enemies=8",
+            "--mobile-budget-bytes",
+            "64",
+        ],
+        &project,
+    );
+    assert_eq!(
+        inspected.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&inspected.stdout),
+        String::from_utf8_lossy(&inspected.stderr)
+    );
+    let result = json_stdout(&inspected);
+    let memory = &result["result"]["memory"];
+    assert_eq!(memory["storage_model"], "soa_direct_bindings");
+    assert_eq!(memory["capacity_changes"][0]["path"], "state.enemies");
+    assert_eq!(memory["capacity_changes"][0]["delta_bytes"], 48);
+    assert!(memory["structs"]
+        .as_array()
+        .is_some_and(|items| items.iter().any(|item| item["path"] == "state")));
+    assert!(memory["command_buffers"]
+        .as_array()
+        .is_some_and(|items| items.iter().any(|item| item["path"] == "gfx_cmd_i32")));
+    assert!(memory["warnings"]
+        .as_array()
+        .is_some_and(|items| items.iter().any(|item| item
+            .as_str()
+            .unwrap_or_default()
+            .contains("mobile snapshot budget"))));
+
+    let invalid = stasis(&["--json", "inspect", "--capacity", "missing=4"], &project);
+    assert_eq!(invalid.status.code(), Some(1));
+    assert!(json_stderr(&invalid)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("not found in compiler collection metadata"));
+    fs::remove_dir_all(parent).ok();
+}
+
+#[test]
 fn fresh_runtime_validation_runs_in_a_separate_cli_process() {
     let parent = temp_dir("fresh_validation");
     fs::create_dir_all(&parent).expect("create temp parent");
@@ -1318,6 +1384,41 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     assert!(String::from_utf8_lossy(&unfinished.stderr)
         .contains("live script ended with unfinished multiline input"));
     fs::remove_dir_all(parent).ok();
+}
+
+#[test]
+fn state_inspection_sample_browses_state_and_watches_live_runtime() {
+    let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/state_inspection");
+
+    let output = stasis(
+        &["run", "--interactive", "--live-script", "live.commands"],
+        &sample,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("state.enemies [4/4]"), "{stdout}");
+    assert!(stdout.contains("state: SimulationState"), "{stdout}");
+    assert!(
+        stdout.contains("memory: 132 bytes; snapshot: 132 bytes"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("state.enemies[1].hp: i32 = 8"), "{stdout}");
+    assert!(
+        stdout.contains("state.enemies[?hp >= 8]: 2 match(es)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("watching state.score + state.enemies[1].hp = 18"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("session closed"), "{stdout}");
 }
 
 fn walk_files(root: &Path) -> Vec<PathBuf> {

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -95,13 +95,17 @@ fn inspect_reports_compiler_state_memory_and_capacity_projection() {
     );
     fs::write(
         project.join("src/main.stasis"),
+        "import \"state.stasis\";\nfunction main(): i32 { return state.score; }\n",
+    )
+    .expect("write memory entry fixture");
+    fs::write(
+        project.join("src/state.stasis"),
         "struct Enemy { hp: i32; speed: f64; }\n\
          struct GameState { score: i32; enemies: Enemy[4]; }\n\
          global state: GameState;\n\
-         global gfx_cmd_i32: i32[8];\n\
-         function main(): i32 { return state.score; }\n",
+         global gfx_cmd_i32: i32[8];\n",
     )
-    .expect("write memory fixture");
+    .expect("write imported memory fixture");
 
     let inspected = stasis(
         &[

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -603,6 +603,14 @@ impl JitProcess {
     }
 
     pub fn inspect_state_query(&self, query: &str) -> Result<JsonValue, String> {
+        self.inspect_state_query_with_scan_limit(query, MAX_STATE_QUERY_SCAN)
+    }
+
+    pub fn inspect_state_query_with_scan_limit(
+        &self,
+        query: &str,
+        max_predicate_scan: usize,
+    ) -> Result<JsonValue, String> {
         match parse_state_query(query)? {
             StateQuery::Scalar(expression) => {
                 let value = self.evaluate_state_expression(&expression)?;
@@ -615,6 +623,9 @@ impl JitProcess {
                 }))
             }
             StateQuery::Predicate(predicate) => {
+                if max_predicate_scan == 0 {
+                    return Err("state predicate query scan budget is exhausted".to_string());
+                }
                 let (_, capacity) =
                     self.global_collection_value_type(&predicate.path, &predicate.field)?;
                 let capacity = usize::try_from(capacity).map_err(|_| {
@@ -623,7 +634,7 @@ impl JitProcess {
                         predicate.path
                     )
                 })?;
-                let scan_count = capacity.min(MAX_STATE_QUERY_SCAN);
+                let scan_count = capacity.min(MAX_STATE_QUERY_SCAN).min(max_predicate_scan);
                 let right = self.evaluate_state_expression(&predicate.right)?;
                 let mut total_matches = 0usize;
                 let mut matches = Vec::new();
@@ -5292,6 +5303,12 @@ mod tests {
         assert_eq!(predicate["total_matches"], 2);
         assert_eq!(predicate["matches"][0]["index"], 1);
         assert_eq!(predicate["matches"][1]["index"], 2);
+        let bounded = process
+            .inspect_state_query_with_scan_limit("enemies[?hp >= score]", 2)
+            .expect("bounded predicate query");
+        assert_eq!(bounded["scanned"], 2);
+        assert_eq!(bounded["total_matches"], 1);
+        assert!(bounded["scan_truncated"].as_bool().unwrap_or(false));
 
         assert!(process
             .inspect_state_query("enemies[9].hp")

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1,5 +1,8 @@
 use crate::backend::emit::{DirectStorageBinding, DirectStorageBindings, RuntimeHelperLinkage};
-use crate::backend::state_layout::build_state_layout;
+use crate::backend::state_layout::{build_state_layout, build_state_memory_report};
+use crate::backend::state_query::{
+    parse_state_query, BinaryOperator, ScalarExpression, StateQuery, StateValueReference,
+};
 use crate::backend::EngineEntrypoints;
 use crate::compiler::{CompileReport, CompileResult, Compiler, FunctionId, FunctionMeta};
 use crate::frontend::indexer::hash_text;
@@ -12,6 +15,7 @@ use crate::ir::hir::FunctionHIR;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{default_libcall_names, Module};
+use serde_json::{json, Value as JsonValue};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -22,10 +26,19 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::SystemTime;
 
 pub use crate::backend::state_layout::{
+    StateCapacityChangeReport as JitStateCapacityChangeReport,
     StateCollectionFieldLayout as JitStateCollectionFieldLayout,
     StateCollectionLayout as JitStateCollectionLayout, StateLayout as JitStateLayout,
+    StateMemoryEntry as JitStateMemoryEntry, StateMemoryPoolReport as JitStateMemoryPoolReport,
+    StateMemoryReport as JitStateMemoryReport,
+    StateMemoryStructFieldReport as JitStateMemoryStructFieldReport,
+    StateMemoryStructReport as JitStateMemoryStructReport,
     StateOpaqueLayout as JitStateOpaqueLayout, StateScalarLayout as JitStateScalarLayout,
+    StateStructFieldLayout as JitStateStructFieldLayout, StateStructLayout as JitStateStructLayout,
 };
+
+const MAX_STATE_QUERY_SCAN: usize = 4096;
+const MAX_STATE_QUERY_MATCHES: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
@@ -556,6 +569,132 @@ impl JitProcess {
                     self.compiler.types(),
                 )
             })
+    }
+
+    pub fn state_memory_report(
+        &self,
+        capacity_overrides: &BTreeMap<String, u64>,
+        mobile_budget_bytes: u64,
+    ) -> Result<JitStateMemoryReport, String> {
+        let layout = self.state_layout();
+        let active_counts = layout
+            .collections
+            .iter()
+            .map(|collection| {
+                let capacity = u64::try_from(collection.capacity).unwrap_or(0);
+                let active = if self.global_fixed_text_encoding(&collection.path).is_some() {
+                    self.read_global_scalar(&format!("{}.byte_length", collection.path))
+                        .ok()
+                        .and_then(jit_value_as_nonnegative_u64)
+                        .unwrap_or(0)
+                        .min(capacity)
+                } else {
+                    capacity
+                };
+                (collection.path.clone(), active)
+            })
+            .collect::<BTreeMap<_, _>>();
+        build_state_memory_report(
+            &layout,
+            &active_counts,
+            capacity_overrides,
+            mobile_budget_bytes,
+        )
+    }
+
+    pub fn inspect_state_query(&self, query: &str) -> Result<JsonValue, String> {
+        match parse_state_query(query)? {
+            StateQuery::Scalar(expression) => {
+                let value = self.evaluate_state_expression(&expression)?;
+                Ok(json!({
+                    "query": query,
+                    "path": query,
+                    "kind": "scalar",
+                    "static_type": value.type_name(),
+                    "value": value,
+                }))
+            }
+            StateQuery::Predicate(predicate) => {
+                let (_, capacity) =
+                    self.global_collection_value_type(&predicate.path, &predicate.field)?;
+                let capacity = usize::try_from(capacity).map_err(|_| {
+                    format!(
+                        "collection '{}' has invalid capacity {capacity}",
+                        predicate.path
+                    )
+                })?;
+                let scan_count = capacity.min(MAX_STATE_QUERY_SCAN);
+                let right = self.evaluate_state_expression(&predicate.right)?;
+                let mut total_matches = 0usize;
+                let mut matches = Vec::new();
+                for index in 0..scan_count {
+                    let value = self.read_global_collection_scalar(
+                        &predicate.path,
+                        &predicate.field,
+                        i32::try_from(index)
+                            .map_err(|_| "state query index overflow".to_string())?,
+                    )?;
+                    let matched = apply_state_binary(value, predicate.operator, right)?;
+                    if matched != JitScalarValue::Bool(true) {
+                        continue;
+                    }
+                    total_matches += 1;
+                    if matches.len() < MAX_STATE_QUERY_MATCHES {
+                        matches.push(json!({"index": index, "value": value}));
+                    }
+                }
+                Ok(json!({
+                    "query": query,
+                    "path": query,
+                    "kind": "predicate",
+                    "path": predicate.path,
+                    "field": predicate.field,
+                    "operator": predicate.operator.text(),
+                    "capacity": capacity,
+                    "scanned": scan_count,
+                    "scan_truncated": scan_count < capacity,
+                    "total_matches": total_matches,
+                    "matches_truncated": total_matches > matches.len(),
+                    "matches": matches,
+                }))
+            }
+        }
+    }
+
+    fn evaluate_state_expression(
+        &self,
+        expression: &ScalarExpression,
+    ) -> Result<JitScalarValue, String> {
+        match expression {
+            ScalarExpression::Value(reference) => self.evaluate_state_reference(reference),
+            ScalarExpression::Negate(expression) => {
+                negate_state_value(self.evaluate_state_expression(expression)?)
+            }
+            ScalarExpression::Binary {
+                left,
+                operator,
+                right,
+            } => apply_state_binary(
+                self.evaluate_state_expression(left)?,
+                *operator,
+                self.evaluate_state_expression(right)?,
+            ),
+        }
+    }
+
+    fn evaluate_state_reference(
+        &self,
+        reference: &StateValueReference,
+    ) -> Result<JitScalarValue, String> {
+        match reference {
+            StateValueReference::Path(path) => self.read_global_scalar(path),
+            StateValueReference::CollectionItem { path, index, field } => {
+                self.read_global_collection_scalar(path, field, *index)
+            }
+            StateValueReference::I32(value) => Ok(JitScalarValue::I32(*value)),
+            StateValueReference::F64(value) => Ok(JitScalarValue::F64(*value)),
+            StateValueReference::Bool(value) => Ok(JitScalarValue::Bool(*value)),
+        }
     }
 
     pub fn read_global_collection_scalar(
@@ -1250,6 +1389,167 @@ fn scalar_type_name(type_id: u16) -> Option<&'static str> {
         TYPE_ID_F64 => Some("f64"),
         TYPE_ID_BOOL => Some("bool"),
         _ => None,
+    }
+}
+
+fn jit_value_as_nonnegative_u64(value: JitScalarValue) -> Option<u64> {
+    match value {
+        JitScalarValue::I32(value) if value >= 0 => Some(value as u64),
+        JitScalarValue::U8(value) => Some(u64::from(value)),
+        _ => None,
+    }
+}
+
+fn negate_state_value(value: JitScalarValue) -> Result<JitScalarValue, String> {
+    match value {
+        JitScalarValue::I32(value) => value
+            .checked_neg()
+            .map(JitScalarValue::I32)
+            .ok_or_else(|| "state expression i32 negation overflow".to_string()),
+        JitScalarValue::U8(value) => Ok(JitScalarValue::I32(-i32::from(value))),
+        JitScalarValue::F32(value) => Ok(JitScalarValue::F32(-value)),
+        JitScalarValue::F64(value) => Ok(JitScalarValue::F64(-value)),
+        JitScalarValue::Bool(_) => Err("state expression cannot negate a bool value".to_string()),
+    }
+}
+
+fn apply_state_binary(
+    left: JitScalarValue,
+    operator: BinaryOperator,
+    right: JitScalarValue,
+) -> Result<JitScalarValue, String> {
+    if matches!(operator, BinaryOperator::Equal | BinaryOperator::NotEqual) {
+        let equal = match (left, right) {
+            (JitScalarValue::Bool(left), JitScalarValue::Bool(right)) => left == right,
+            (left, right) => {
+                let (left, right) = state_numeric_pair(left, right).ok_or_else(|| {
+                    format!(
+                        "state expression operator '{}' requires two numeric operands or two bool operands",
+                        operator.text()
+                    )
+                })?;
+                left == right
+            }
+        };
+        return Ok(JitScalarValue::Bool(if operator == BinaryOperator::Equal {
+            equal
+        } else {
+            !equal
+        }));
+    }
+    if matches!(
+        operator,
+        BinaryOperator::Less
+            | BinaryOperator::LessEqual
+            | BinaryOperator::Greater
+            | BinaryOperator::GreaterEqual
+    ) {
+        let (left, right) = state_numeric_pair(left, right).ok_or_else(|| {
+            format!(
+                "state expression operator '{}' requires numeric operands",
+                operator.text()
+            )
+        })?;
+        let result = match operator {
+            BinaryOperator::Less => left < right,
+            BinaryOperator::LessEqual => left <= right,
+            BinaryOperator::Greater => left > right,
+            BinaryOperator::GreaterEqual => left >= right,
+            _ => unreachable!("comparison operators are matched above"),
+        };
+        return Ok(JitScalarValue::Bool(result));
+    }
+    if matches!(left, JitScalarValue::Bool(_)) || matches!(right, JitScalarValue::Bool(_)) {
+        return Err(format!(
+            "state expression operator '{}' does not accept bool operands",
+            operator.text()
+        ));
+    }
+    if matches!(left, JitScalarValue::F64(_)) || matches!(right, JitScalarValue::F64(_)) {
+        let (left, right) = state_numeric_pair(left, right).expect("numeric operands checked");
+        return apply_state_f64(left, operator, right).map(JitScalarValue::F64);
+    }
+    if matches!(left, JitScalarValue::F32(_)) || matches!(right, JitScalarValue::F32(_)) {
+        let left = state_value_as_f32(left).expect("numeric operands checked");
+        let right = state_value_as_f32(right).expect("numeric operands checked");
+        return apply_state_f32(left, operator, right).map(JitScalarValue::F32);
+    }
+    let left = state_value_as_i32(left).expect("integer operands checked");
+    let right = state_value_as_i32(right).expect("integer operands checked");
+    apply_state_i32(left, operator, right).map(JitScalarValue::I32)
+}
+
+fn state_numeric_pair(left: JitScalarValue, right: JitScalarValue) -> Option<(f64, f64)> {
+    Some((state_value_as_f64(left)?, state_value_as_f64(right)?))
+}
+
+fn state_value_as_f64(value: JitScalarValue) -> Option<f64> {
+    match value {
+        JitScalarValue::I32(value) => Some(f64::from(value)),
+        JitScalarValue::U8(value) => Some(f64::from(value)),
+        JitScalarValue::F32(value) => Some(f64::from(value)),
+        JitScalarValue::F64(value) => Some(value),
+        JitScalarValue::Bool(_) => None,
+    }
+}
+
+fn state_value_as_f32(value: JitScalarValue) -> Option<f32> {
+    match value {
+        JitScalarValue::I32(value) => Some(value as f32),
+        JitScalarValue::U8(value) => Some(f32::from(value)),
+        JitScalarValue::F32(value) => Some(value),
+        JitScalarValue::F64(_) | JitScalarValue::Bool(_) => None,
+    }
+}
+
+fn state_value_as_i32(value: JitScalarValue) -> Option<i32> {
+    match value {
+        JitScalarValue::I32(value) => Some(value),
+        JitScalarValue::U8(value) => Some(i32::from(value)),
+        JitScalarValue::F32(_) | JitScalarValue::F64(_) | JitScalarValue::Bool(_) => None,
+    }
+}
+
+fn apply_state_i32(left: i32, operator: BinaryOperator, right: i32) -> Result<i32, String> {
+    match operator {
+        BinaryOperator::Add => left.checked_add(right),
+        BinaryOperator::Subtract => left.checked_sub(right),
+        BinaryOperator::Multiply => left.checked_mul(right),
+        BinaryOperator::Divide if right != 0 => left.checked_div(right),
+        BinaryOperator::Remainder if right != 0 => left.checked_rem(right),
+        BinaryOperator::Divide | BinaryOperator::Remainder => {
+            return Err("state expression division by zero".to_string())
+        }
+        _ => return Err(format!("unsupported i32 operator '{}'", operator.text())),
+    }
+    .ok_or_else(|| format!("state expression i32 '{}' overflow", operator.text()))
+}
+
+fn apply_state_f32(left: f32, operator: BinaryOperator, right: f32) -> Result<f32, String> {
+    if matches!(operator, BinaryOperator::Divide | BinaryOperator::Remainder) && right == 0.0 {
+        return Err("state expression division by zero".to_string());
+    }
+    match operator {
+        BinaryOperator::Add => Ok(left + right),
+        BinaryOperator::Subtract => Ok(left - right),
+        BinaryOperator::Multiply => Ok(left * right),
+        BinaryOperator::Divide => Ok(left / right),
+        BinaryOperator::Remainder => Ok(left % right),
+        _ => Err(format!("unsupported f32 operator '{}'", operator.text())),
+    }
+}
+
+fn apply_state_f64(left: f64, operator: BinaryOperator, right: f64) -> Result<f64, String> {
+    if matches!(operator, BinaryOperator::Divide | BinaryOperator::Remainder) && right == 0.0 {
+        return Err("state expression division by zero".to_string());
+    }
+    match operator {
+        BinaryOperator::Add => Ok(left + right),
+        BinaryOperator::Subtract => Ok(left - right),
+        BinaryOperator::Multiply => Ok(left * right),
+        BinaryOperator::Divide => Ok(left / right),
+        BinaryOperator::Remainder => Ok(left % right),
+        _ => Err(format!("unsupported f64 operator '{}'", operator.text())),
     }
 }
 
@@ -4951,5 +5251,67 @@ mod tests {
             .expect_err("void tick should fail");
         assert!(error.contains("expected `function tick(): i32`"));
         assert!(error.contains("actual return type id"));
+    }
+
+    #[test]
+    fn compiler_indexed_state_queries_cover_indexes_predicates_and_expressions() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "state_queries.stasis",
+            "struct Enemy { hp: i32; alive: bool; }\n\
+             global enemies: Enemy[4];\n\
+             global score: i32;\n\
+             function main(): i32 {\n\
+                 score = 5;\n\
+                 enemies[0].hp = 2; enemies[0].alive = true;\n\
+                 enemies[1].hp = 7; enemies[1].alive = true;\n\
+                 enemies[2].hp = 9; enemies[2].alive = false;\n\
+                 return 0;\n\
+             }\n",
+        );
+        process.compile().expect("compile query fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("initialize query fixture"),
+            0
+        );
+
+        let indexed = process
+            .inspect_state_query("enemies[1].hp + score * 2")
+            .expect("indexed expression");
+        assert_eq!(indexed["kind"], "scalar");
+        assert_eq!(indexed["static_type"], "i32");
+        assert_eq!(indexed["value"]["value"], 17);
+
+        let predicate = process
+            .inspect_state_query("enemies[?hp >= score]")
+            .expect("predicate query");
+        assert_eq!(predicate["kind"], "predicate");
+        assert_eq!(predicate["capacity"], 4);
+        assert_eq!(predicate["total_matches"], 2);
+        assert_eq!(predicate["matches"][0]["index"], 1);
+        assert_eq!(predicate["matches"][1]["index"], 2);
+
+        assert!(process
+            .inspect_state_query("enemies[9].hp")
+            .expect_err("out-of-range index")
+            .contains("outside capacity 4"));
+        assert!(process
+            .inspect_state_query("enemies[?missing > 0]")
+            .expect_err("unknown field")
+            .contains("field 'missing' was not found"));
+        assert!(process
+            .inspect_state_query("score / 0")
+            .expect_err("division by zero")
+            .contains("division by zero"));
+        assert!(process
+            .inspect_state_query("enemies[0].alive == score")
+            .expect_err("mixed equality operands")
+            .contains("two numeric operands or two bool operands"));
+        assert!(process
+            .inspect_state_query("enemies[?alive == score]")
+            .expect_err("mixed predicate operands")
+            .contains("two numeric operands or two bool operands"));
     }
 }

--- a/crates/stasis_compiler/src/backend/mod.rs
+++ b/crates/stasis_compiler/src/backend/mod.rs
@@ -5,6 +5,7 @@ mod reachability;
 mod runtime_exports;
 pub mod state_layout;
 pub mod state_migration;
+mod state_query;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EngineEntrypoints {

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -3,12 +3,14 @@ use crate::frontend::types::{
     TypeCategory, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
 };
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StateLayout {
     pub scalars: Vec<StateScalarLayout>,
     pub collections: Vec<StateCollectionLayout>,
+    #[serde(default)]
+    pub structs: Vec<StateStructLayout>,
     pub opaque: Vec<StateOpaqueLayout>,
 }
 
@@ -34,9 +36,89 @@ pub struct StateCollectionFieldLayout {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateStructLayout {
+    pub path: String,
+    pub type_name: String,
+    pub fields: Vec<StateStructFieldLayout>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateStructFieldLayout {
+    pub field: String,
+    pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StateOpaqueLayout {
     pub path: String,
     pub type_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateMemoryReport {
+    pub storage_model: String,
+    pub total_capacity_bytes: u64,
+    pub projected_capacity_bytes: u64,
+    pub snapshot_bytes: u64,
+    pub mobile_budget_bytes: u64,
+    pub entries: Vec<StateMemoryEntry>,
+    pub structs: Vec<StateMemoryStructReport>,
+    pub largest_pools: Vec<StateMemoryPoolReport>,
+    pub command_buffers: Vec<StateMemoryPoolReport>,
+    pub capacity_changes: Vec<StateCapacityChangeReport>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateMemoryEntry {
+    pub path: String,
+    pub field: String,
+    pub kind: String,
+    pub type_name: String,
+    pub alignment_bytes: u64,
+    pub element_bytes: u64,
+    pub padding_bytes: u64,
+    pub capacity: u64,
+    pub active_count: Option<u64>,
+    pub capacity_bytes: u64,
+    pub active_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateMemoryStructReport {
+    pub path: String,
+    pub type_name: String,
+    pub capacity_bytes: u64,
+    pub fields: Vec<StateMemoryStructFieldReport>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateMemoryStructFieldReport {
+    pub field: String,
+    pub type_name: String,
+    pub alignment_bytes: u64,
+    pub padding_bytes: u64,
+    pub capacity_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateMemoryPoolReport {
+    pub path: String,
+    pub element_shape: String,
+    pub capacity: u64,
+    pub active_count: Option<u64>,
+    pub bytes_per_element: u64,
+    pub capacity_bytes: u64,
+    pub active_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct StateCapacityChangeReport {
+    pub path: String,
+    pub old_capacity: u64,
+    pub new_capacity: u64,
+    pub bytes_per_element: u64,
+    pub delta_bytes: i64,
 }
 
 pub fn state_layout_digest(layout: &StateLayout) -> Result<[u8; 32], String> {
@@ -53,6 +135,258 @@ pub fn state_layout_version(layout: &StateLayout) -> Result<String, String> {
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect())
+}
+
+pub fn build_state_memory_report(
+    layout: &StateLayout,
+    active_counts: &BTreeMap<String, u64>,
+    capacity_overrides: &BTreeMap<String, u64>,
+    mobile_budget_bytes: u64,
+) -> Result<StateMemoryReport, String> {
+    for path in capacity_overrides.keys() {
+        if !layout
+            .collections
+            .iter()
+            .any(|collection| &collection.path == path)
+        {
+            return Err(format!(
+                "capacity override path '{path}' was not found in compiler collection metadata"
+            ));
+        }
+    }
+
+    let mut warnings = Vec::new();
+    let mut entries = layout
+        .scalars
+        .iter()
+        .map(|scalar| {
+            let element_bytes = storage_type_bytes(&scalar.type_name).unwrap_or(0);
+            if element_bytes == 0 {
+                warnings.push(format!(
+                    "state path '{}' has unsupported static type '{}'",
+                    scalar.path, scalar.type_name
+                ));
+            }
+            StateMemoryEntry {
+                path: scalar.path.clone(),
+                field: String::new(),
+                kind: "scalar".to_string(),
+                type_name: scalar.type_name.clone(),
+                alignment_bytes: storage_type_alignment(&scalar.type_name).unwrap_or(1),
+                element_bytes,
+                padding_bytes: 0,
+                capacity: 1,
+                active_count: Some(1),
+                capacity_bytes: element_bytes,
+                active_bytes: Some(element_bytes),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut pools = Vec::new();
+    let mut capacity_changes = Vec::new();
+    for collection in &layout.collections {
+        let old_capacity = u64::try_from(collection.capacity).map_err(|_| {
+            format!(
+                "collection '{}' has negative capacity {}",
+                collection.path, collection.capacity
+            )
+        })?;
+        let new_capacity = capacity_overrides
+            .get(&collection.path)
+            .copied()
+            .unwrap_or(old_capacity);
+        let active_count = active_counts
+            .get(&collection.path)
+            .copied()
+            .map(|count| count.min(old_capacity));
+        let mut bytes_per_element = 0u64;
+        for field in &collection.fields {
+            let element_bytes = storage_type_bytes(&field.type_name).unwrap_or(0);
+            if element_bytes == 0 {
+                warnings.push(format!(
+                    "collection path '{}' field '{}' has unsupported static type '{}'",
+                    collection.path, field.field, field.type_name
+                ));
+            }
+            bytes_per_element = bytes_per_element
+                .checked_add(element_bytes)
+                .ok_or_else(|| "state memory report byte count overflow".to_string())?;
+            entries.push(StateMemoryEntry {
+                path: collection.path.clone(),
+                field: field.field.clone(),
+                kind: "collection_field".to_string(),
+                type_name: field.type_name.clone(),
+                alignment_bytes: storage_type_alignment(&field.type_name).unwrap_or(1),
+                element_bytes,
+                padding_bytes: 0,
+                capacity: old_capacity,
+                active_count,
+                capacity_bytes: checked_memory_bytes(old_capacity, element_bytes)?,
+                active_bytes: active_count
+                    .map(|count| checked_memory_bytes(count, element_bytes))
+                    .transpose()?,
+            });
+        }
+        let capacity_bytes = checked_memory_bytes(old_capacity, bytes_per_element)?;
+        let projected_bytes = checked_memory_bytes(new_capacity, bytes_per_element)?;
+        pools.push(StateMemoryPoolReport {
+            path: collection.path.clone(),
+            element_shape: collection.element_shape.clone(),
+            capacity: old_capacity,
+            active_count,
+            bytes_per_element,
+            capacity_bytes,
+            active_bytes: active_count
+                .map(|count| checked_memory_bytes(count, bytes_per_element))
+                .transpose()?,
+        });
+        if new_capacity != old_capacity {
+            let delta = i128::from(projected_bytes) - i128::from(capacity_bytes);
+            let delta_bytes = i64::try_from(delta)
+                .map_err(|_| "capacity change byte delta overflow".to_string())?;
+            capacity_changes.push(StateCapacityChangeReport {
+                path: collection.path.clone(),
+                old_capacity,
+                new_capacity,
+                bytes_per_element,
+                delta_bytes,
+            });
+        }
+    }
+    entries.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.field.cmp(&right.field))
+    });
+
+    let total_capacity_bytes = entries.iter().try_fold(0u64, |total, entry| {
+        total
+            .checked_add(entry.capacity_bytes)
+            .ok_or_else(|| "state memory report byte count overflow".to_string())
+    })?;
+    let projected_delta = capacity_changes
+        .iter()
+        .map(|change| i128::from(change.delta_bytes))
+        .sum::<i128>();
+    let projected_capacity_bytes =
+        u64::try_from(i128::from(total_capacity_bytes) + projected_delta)
+            .map_err(|_| "projected state memory byte count overflow".to_string())?;
+
+    let structs = layout
+        .structs
+        .iter()
+        .map(|structure| build_struct_memory_report(structure, &entries))
+        .collect();
+    pools.sort_by(|left, right| {
+        right
+            .capacity_bytes
+            .cmp(&left.capacity_bytes)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    let largest_pools = pools.iter().take(8).cloned().collect();
+    let command_buffers = pools
+        .iter()
+        .filter(|pool| is_command_buffer_path(&pool.path))
+        .cloned()
+        .collect();
+
+    if projected_capacity_bytes > mobile_budget_bytes {
+        warnings.push(format!(
+            "projected state requires {projected_capacity_bytes} bytes, exceeding the {mobile_budget_bytes}-byte mobile snapshot budget"
+        ));
+    } else if mobile_budget_bytes > 0
+        && projected_capacity_bytes.saturating_mul(4) >= mobile_budget_bytes.saturating_mul(3)
+    {
+        warnings.push(format!(
+            "projected state uses at least 75% of the {mobile_budget_bytes}-byte mobile snapshot budget"
+        ));
+    }
+    for opaque in &layout.opaque {
+        warnings.push(format!(
+            "opaque state path '{}' of type '{}' is excluded from the byte total",
+            opaque.path, opaque.type_name
+        ));
+    }
+
+    Ok(StateMemoryReport {
+        storage_model: "soa_direct_bindings".to_string(),
+        total_capacity_bytes,
+        projected_capacity_bytes,
+        snapshot_bytes: total_capacity_bytes,
+        mobile_budget_bytes,
+        entries,
+        structs,
+        largest_pools,
+        command_buffers,
+        capacity_changes,
+        warnings,
+    })
+}
+
+fn build_struct_memory_report(
+    structure: &StateStructLayout,
+    entries: &[StateMemoryEntry],
+) -> StateMemoryStructReport {
+    let fields = structure
+        .fields
+        .iter()
+        .map(|field| {
+            let path = format!("{}.{}", structure.path, field.field);
+            let matching = entries
+                .iter()
+                .filter(|entry| entry.path == path || entry.path.starts_with(&format!("{path}.")));
+            let (alignment_bytes, capacity_bytes) = matching.fold((1u64, 0u64), |sum, entry| {
+                (
+                    sum.0.max(entry.alignment_bytes),
+                    sum.1.saturating_add(entry.capacity_bytes),
+                )
+            });
+            StateMemoryStructFieldReport {
+                field: field.field.clone(),
+                type_name: field.type_name.clone(),
+                alignment_bytes,
+                padding_bytes: 0,
+                capacity_bytes,
+            }
+        })
+        .collect::<Vec<_>>();
+    StateMemoryStructReport {
+        path: structure.path.clone(),
+        type_name: structure.type_name.clone(),
+        capacity_bytes: fields.iter().map(|field| field.capacity_bytes).sum(),
+        fields,
+    }
+}
+
+fn storage_type_bytes(type_name: &str) -> Option<u64> {
+    match type_name {
+        "u8" => Some(1),
+        "i32" | "f32" | "bool" => Some(4),
+        "f64" => Some(8),
+        _ => None,
+    }
+}
+
+fn storage_type_alignment(type_name: &str) -> Option<u64> {
+    storage_type_bytes(type_name)
+}
+
+fn checked_memory_bytes(count: u64, element_bytes: u64) -> Result<u64, String> {
+    count
+        .checked_mul(element_bytes)
+        .ok_or_else(|| "state memory report byte count overflow".to_string())
+}
+
+fn is_command_buffer_path(path: &str) -> bool {
+    path.starts_with("gfx_cmd_")
+        || path.starts_with("render_cmd_")
+        || path.starts_with("audio_cmd_")
+        || path.starts_with("cmd_")
+        || path.contains(".gfx_cmd_")
+        || path.contains(".render_cmd_")
+        || path.contains(".audio_cmd_")
+        || path.contains(".cmd_")
 }
 
 pub(crate) fn build_state_layout(
@@ -162,9 +496,44 @@ pub(crate) fn build_state_layout(
             })
         })
         .collect();
+    let structs = global_path_types
+        .iter()
+        .filter_map(|(path, type_id)| {
+            let info = type_table.type_info(*type_id)?;
+            if info.category != TypeCategory::Named {
+                return None;
+            }
+            let prefix = format!("{path}.");
+            let mut fields = BTreeMap::new();
+            for (candidate, child_type_id) in global_path_types {
+                let Some(rest) = candidate.strip_prefix(&prefix) else {
+                    continue;
+                };
+                let Some(field) = rest.split('.').next() else {
+                    continue;
+                };
+                let child_path = format!("{prefix}{field}");
+                let child_type_id = global_path_types
+                    .get(&child_path)
+                    .copied()
+                    .unwrap_or(*child_type_id);
+                let child_type = type_table.type_info(child_type_id)?.name.clone();
+                fields.entry(field.to_string()).or_insert(child_type);
+            }
+            Some(StateStructLayout {
+                path: path.clone(),
+                type_name: info.name.clone(),
+                fields: fields
+                    .into_iter()
+                    .map(|(field, type_name)| StateStructFieldLayout { field, type_name })
+                    .collect(),
+            })
+        })
+        .collect();
     StateLayout {
         scalars,
         collections,
+        structs,
         opaque,
     }
 }
@@ -192,8 +561,10 @@ fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static
 
 #[cfg(test)]
 mod tests {
+    use super::build_state_memory_report;
     use crate::backend::aot::AotProcess;
     use crate::backend::jit::JitProcess;
+    use std::collections::BTreeMap;
 
     #[test]
     fn jit_and_aot_share_canonical_state_layout() {
@@ -243,5 +614,105 @@ mod tests {
             .expect("changed rows collection layout");
         assert!(changed_rows.element_shape.contains("samples:f32[3]"));
         assert_ne!(original_shape, changed_rows.element_shape);
+    }
+
+    #[test]
+    fn compiler_layout_drives_bounded_memory_report_and_capacity_impact() {
+        let source = "struct Enemy { hp: i32; speed: f64; alive: bool; }\n\
+                      struct GameState { score: i32; enemies: Enemy[4]; }\n\
+                      global state: GameState;\n\
+                      global gfx_cmd_i32: i32[8];\n\
+                      function main(): i32 { return state.score; }\n";
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile_staged().expect("compile report fixture");
+
+        let active_counts = BTreeMap::from([("state.enemies".to_string(), 2)]);
+        let overrides = BTreeMap::from([("state.enemies".to_string(), 10)]);
+        let report =
+            build_state_memory_report(&jit.state_layout(), &active_counts, &overrides, 128)
+                .expect("build memory report");
+
+        let enemies = report
+            .largest_pools
+            .iter()
+            .find(|pool| pool.path == "state.enemies")
+            .expect("enemy pool");
+        assert_eq!(enemies.bytes_per_element, 16);
+        assert_eq!(enemies.capacity_bytes, 64);
+        assert_eq!(enemies.active_count, Some(2));
+        assert_eq!(enemies.active_bytes, Some(32));
+        assert!(report
+            .structs
+            .iter()
+            .any(|structure| structure.path == "state"
+                && structure.type_name == "GameState"
+                && structure
+                    .fields
+                    .iter()
+                    .any(|field| field.field == "enemies")));
+        assert!(report
+            .command_buffers
+            .iter()
+            .any(|pool| pool.path == "gfx_cmd_i32"));
+        assert_eq!(report.capacity_changes[0].delta_bytes, 96);
+        assert_eq!(
+            report.projected_capacity_bytes,
+            report.total_capacity_bytes + 96
+        );
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("mobile snapshot budget")));
+        assert!(report.entries.iter().all(|entry| entry.padding_bytes == 0));
+    }
+
+    #[test]
+    fn state_inspection_sample_runs_through_cranelift_and_exposes_live_queries() {
+        let sample = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../samples/state_inspection/src/main.stasis");
+        let source = std::fs::read_to_string(&sample).expect("read state inspection sample");
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&[
+            "main".to_string(),
+            "tick".to_string(),
+            "render".to_string(),
+        ]);
+        jit.upsert_file(sample.to_string_lossy(), source);
+        jit.compile().expect("compile state inspection sample");
+        assert!(jit
+            .artifacts()
+            .iter()
+            .all(|artifact| !artifact.clif.is_empty() && artifact.code_ptr != 0));
+        assert_eq!(
+            jit.execute_i32_noarg_by_name("main")
+                .expect("run sample main"),
+            0
+        );
+        assert_eq!(
+            jit.execute_i32_noarg_by_name("tick")
+                .expect("run sample tick"),
+            0
+        );
+        assert_eq!(
+            jit.execute_i32_noarg_by_name("render")
+                .expect("run sample render"),
+            0
+        );
+        assert_eq!(
+            jit.inspect_state_query("state.score + state.enemies[1].hp")
+                .expect("sample expression")["value"]["value"],
+            18
+        );
+        let predicate = jit
+            .inspect_state_query("state.enemies[?hp >= 8]")
+            .expect("sample predicate");
+        assert_eq!(predicate["total_matches"], 1);
+        assert_eq!(predicate["matches"][0]["index"], 2);
+        assert_eq!(
+            jit.read_global_collection_scalar("render_cmd_i32", "", 0)
+                .expect("sample rendered command"),
+            crate::backend::jit::JitScalarValue::I32(11)
+        );
     }
 }

--- a/crates/stasis_compiler/src/backend/state_migration.rs
+++ b/crates/stasis_compiler/src/backend/state_migration.rs
@@ -839,11 +839,13 @@ mod tests {
         let active = JitStateLayout {
             scalars: Vec::new(),
             collections: vec![collection(4)],
+            structs: Vec::new(),
             opaque: Vec::new(),
         };
         let incoming = JitStateLayout {
             scalars: Vec::new(),
             collections: vec![collection(8)],
+            structs: Vec::new(),
             opaque: Vec::new(),
         };
 

--- a/crates/stasis_compiler/src/backend/state_query.rs
+++ b/crates/stasis_compiler/src/backend/state_query.rs
@@ -1,0 +1,435 @@
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StateQuery {
+    Scalar(ScalarExpression),
+    Predicate(PredicateQuery),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PredicateQuery {
+    pub(crate) path: String,
+    pub(crate) field: String,
+    pub(crate) operator: BinaryOperator,
+    pub(crate) right: ScalarExpression,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ScalarExpression {
+    Value(StateValueReference),
+    Negate(Box<ScalarExpression>),
+    Binary {
+        left: Box<ScalarExpression>,
+        operator: BinaryOperator,
+        right: Box<ScalarExpression>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StateValueReference {
+    Path(String),
+    CollectionItem {
+        path: String,
+        index: i32,
+        field: String,
+    },
+    I32(i32),
+    F64(f64),
+    Bool(bool),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BinaryOperator {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Remainder,
+    Equal,
+    NotEqual,
+    Less,
+    LessEqual,
+    Greater,
+    GreaterEqual,
+}
+
+impl BinaryOperator {
+    pub(crate) fn text(self) -> &'static str {
+        match self {
+            Self::Add => "+",
+            Self::Subtract => "-",
+            Self::Multiply => "*",
+            Self::Divide => "/",
+            Self::Remainder => "%",
+            Self::Equal => "==",
+            Self::NotEqual => "!=",
+            Self::Less => "<",
+            Self::LessEqual => "<=",
+            Self::Greater => ">",
+            Self::GreaterEqual => ">=",
+        }
+    }
+
+    fn precedence(self) -> u8 {
+        match self {
+            Self::Equal
+            | Self::NotEqual
+            | Self::Less
+            | Self::LessEqual
+            | Self::Greater
+            | Self::GreaterEqual => 1,
+            Self::Add | Self::Subtract => 2,
+            Self::Multiply | Self::Divide | Self::Remainder => 3,
+        }
+    }
+}
+
+pub(crate) fn parse_state_query(source: &str) -> Result<StateQuery, String> {
+    let source = source.trim();
+    if source.is_empty() {
+        return Err("state query cannot be empty".to_string());
+    }
+    if let Some((path, predicate)) = source.split_once("[?") {
+        if !source.ends_with(']') {
+            return Err("state predicate query is missing closing ']'".to_string());
+        }
+        validate_path(path, "predicate collection path")?;
+        let predicate = &predicate[..predicate.len() - 1];
+        let (operator_offset, operator) = find_predicate_operator(predicate)
+            .ok_or_else(|| "state predicate requires ==, !=, <, <=, >, or >=".to_string())?;
+        let field = predicate[..operator_offset].trim();
+        validate_path(field, "predicate field")?;
+        let right_source = predicate[operator_offset + operator.text().len()..].trim();
+        if right_source.is_empty() {
+            return Err("state predicate is missing its right-hand expression".to_string());
+        }
+        let mut parser = ExpressionParser::new(right_source)?;
+        let right = parser.parse()?;
+        return Ok(StateQuery::Predicate(PredicateQuery {
+            path: path.trim().to_string(),
+            field: field.to_string(),
+            operator,
+            right,
+        }));
+    }
+    let mut parser = ExpressionParser::new(source)?;
+    Ok(StateQuery::Scalar(parser.parse()?))
+}
+
+fn find_predicate_operator(source: &str) -> Option<(usize, BinaryOperator)> {
+    let bytes = source.as_bytes();
+    let mut cursor = 0usize;
+    while cursor < bytes.len() {
+        let remaining = &source[cursor..];
+        for (text, operator) in [
+            ("==", BinaryOperator::Equal),
+            ("!=", BinaryOperator::NotEqual),
+            ("<=", BinaryOperator::LessEqual),
+            (">=", BinaryOperator::GreaterEqual),
+            ("<", BinaryOperator::Less),
+            (">", BinaryOperator::Greater),
+        ] {
+            if remaining.starts_with(text) {
+                return Some((cursor, operator));
+            }
+        }
+        cursor += source[cursor..].chars().next()?.len_utf8();
+    }
+    None
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum QueryToken {
+    Reference(String),
+    I32(i32),
+    F64(f64),
+    Bool(bool),
+    Operator(BinaryOperator),
+    Minus,
+    LeftParen,
+    RightParen,
+}
+
+struct ExpressionParser {
+    tokens: Vec<QueryToken>,
+    cursor: usize,
+}
+
+impl ExpressionParser {
+    fn new(source: &str) -> Result<Self, String> {
+        Ok(Self {
+            tokens: tokenize_expression(source)?,
+            cursor: 0,
+        })
+    }
+
+    fn parse(&mut self) -> Result<ScalarExpression, String> {
+        let expression = self.parse_precedence(1)?;
+        if self.cursor != self.tokens.len() {
+            return Err(format!(
+                "unexpected token in state expression: {:?}",
+                self.tokens[self.cursor]
+            ));
+        }
+        Ok(expression)
+    }
+
+    fn parse_precedence(&mut self, minimum: u8) -> Result<ScalarExpression, String> {
+        let mut left = self.parse_prefix()?;
+        loop {
+            let Some(operator) = self.peek_operator() else {
+                break;
+            };
+            let precedence = operator.precedence();
+            if precedence < minimum {
+                break;
+            }
+            self.cursor += 1;
+            let right = self.parse_precedence(precedence + 1)?;
+            left = ScalarExpression::Binary {
+                left: Box::new(left),
+                operator,
+                right: Box::new(right),
+            };
+        }
+        Ok(left)
+    }
+
+    fn parse_prefix(&mut self) -> Result<ScalarExpression, String> {
+        let token = self
+            .tokens
+            .get(self.cursor)
+            .cloned()
+            .ok_or_else(|| "state expression ended before a value".to_string())?;
+        self.cursor += 1;
+        match token {
+            QueryToken::Minus => Ok(ScalarExpression::Negate(Box::new(self.parse_prefix()?))),
+            QueryToken::LeftParen => {
+                let expression = self.parse_precedence(1)?;
+                if self.tokens.get(self.cursor) != Some(&QueryToken::RightParen) {
+                    return Err("state expression is missing closing ')'".to_string());
+                }
+                self.cursor += 1;
+                Ok(expression)
+            }
+            QueryToken::Reference(reference) => {
+                Ok(ScalarExpression::Value(parse_value_reference(&reference)?))
+            }
+            QueryToken::I32(value) => Ok(ScalarExpression::Value(StateValueReference::I32(value))),
+            QueryToken::F64(value) => Ok(ScalarExpression::Value(StateValueReference::F64(value))),
+            QueryToken::Bool(value) => {
+                Ok(ScalarExpression::Value(StateValueReference::Bool(value)))
+            }
+            QueryToken::Operator(_) | QueryToken::RightParen => {
+                Err("state expression expected a scalar value".to_string())
+            }
+        }
+    }
+
+    fn peek_operator(&self) -> Option<BinaryOperator> {
+        match self.tokens.get(self.cursor) {
+            Some(QueryToken::Operator(operator)) => Some(*operator),
+            Some(QueryToken::Minus) => Some(BinaryOperator::Subtract),
+            _ => None,
+        }
+    }
+}
+
+fn tokenize_expression(source: &str) -> Result<Vec<QueryToken>, String> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < bytes.len() {
+        if bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        let remaining = &source[cursor..];
+        let matched_operator = [
+            ("==", BinaryOperator::Equal),
+            ("!=", BinaryOperator::NotEqual),
+            ("<=", BinaryOperator::LessEqual),
+            (">=", BinaryOperator::GreaterEqual),
+            ("+", BinaryOperator::Add),
+            ("*", BinaryOperator::Multiply),
+            ("/", BinaryOperator::Divide),
+            ("%", BinaryOperator::Remainder),
+            ("<", BinaryOperator::Less),
+            (">", BinaryOperator::Greater),
+        ]
+        .into_iter()
+        .find(|(text, _)| remaining.starts_with(text));
+        if let Some((text, operator)) = matched_operator {
+            tokens.push(QueryToken::Operator(operator));
+            cursor += text.len();
+            continue;
+        }
+        match bytes[cursor] {
+            b'-' => {
+                tokens.push(QueryToken::Minus);
+                cursor += 1;
+            }
+            b'(' => {
+                tokens.push(QueryToken::LeftParen);
+                cursor += 1;
+            }
+            b')' => {
+                tokens.push(QueryToken::RightParen);
+                cursor += 1;
+            }
+            byte if byte.is_ascii_digit() => {
+                let start = cursor;
+                cursor += 1;
+                let mut decimal = false;
+                while cursor < bytes.len()
+                    && (bytes[cursor].is_ascii_digit() || (!decimal && bytes[cursor] == b'.'))
+                {
+                    decimal |= bytes[cursor] == b'.';
+                    cursor += 1;
+                }
+                let number = &source[start..cursor];
+                if decimal {
+                    tokens.push(QueryToken::F64(number.parse::<f64>().map_err(|error| {
+                        format!("invalid f64 literal '{number}' in state query: {error}")
+                    })?));
+                } else {
+                    tokens.push(QueryToken::I32(number.parse::<i32>().map_err(|error| {
+                        format!("invalid i32 literal '{number}' in state query: {error}")
+                    })?));
+                }
+            }
+            byte if byte == b'_' || byte.is_ascii_alphabetic() => {
+                let start = cursor;
+                cursor += 1;
+                let mut bracket_depth = 0u8;
+                while cursor < bytes.len() {
+                    let byte = bytes[cursor];
+                    if byte == b'[' {
+                        bracket_depth = bracket_depth.saturating_add(1);
+                    } else if byte == b']' {
+                        bracket_depth = bracket_depth.saturating_sub(1);
+                    } else if bracket_depth == 0
+                        && !(byte == b'_' || byte == b'.' || byte.is_ascii_alphanumeric())
+                    {
+                        break;
+                    }
+                    cursor += 1;
+                }
+                let reference = &source[start..cursor];
+                match reference {
+                    "true" => tokens.push(QueryToken::Bool(true)),
+                    "false" => tokens.push(QueryToken::Bool(false)),
+                    _ => tokens.push(QueryToken::Reference(reference.to_string())),
+                }
+            }
+            _ => {
+                return Err(format!(
+                    "unsupported character '{}' at byte {cursor} in state query",
+                    source[cursor..].chars().next().unwrap_or('?')
+                ))
+            }
+        }
+    }
+    if tokens.is_empty() {
+        return Err("state expression cannot be empty".to_string());
+    }
+    Ok(tokens)
+}
+
+fn parse_value_reference(reference: &str) -> Result<StateValueReference, String> {
+    let Some(open) = reference.find('[') else {
+        validate_path(reference, "state path")?;
+        return Ok(StateValueReference::Path(reference.to_string()));
+    };
+    let close = reference[open + 1..]
+        .find(']')
+        .map(|offset| open + 1 + offset)
+        .ok_or_else(|| format!("indexed state path '{reference}' is missing closing ']'"))?;
+    let path = &reference[..open];
+    validate_path(path, "collection path")?;
+    let index_text = &reference[open + 1..close];
+    let index = index_text
+        .parse::<i32>()
+        .map_err(|error| format!("invalid collection index '{index_text}': {error}"))?;
+    if index < 0 {
+        return Err(format!("collection index {index} cannot be negative"));
+    }
+    let field = reference[close + 1..]
+        .strip_prefix('.')
+        .unwrap_or(&reference[close + 1..]);
+    if close + 1 < reference.len() && field.is_empty() {
+        return Err(format!(
+            "indexed state path '{reference}' is missing its field"
+        ));
+    }
+    if !field.is_empty() {
+        validate_path(field, "collection field")?;
+    }
+    Ok(StateValueReference::CollectionItem {
+        path: path.to_string(),
+        index,
+        field: field.to_string(),
+    })
+}
+
+fn validate_path(path: &str, label: &str) -> Result<(), String> {
+    let path = path.trim();
+    if path.is_empty()
+        || path.split('.').any(|segment| {
+            segment.is_empty()
+                || !segment.bytes().enumerate().all(|(index, byte)| {
+                    byte == b'_'
+                        || byte.is_ascii_alphabetic()
+                        || (index > 0 && byte.is_ascii_digit())
+                })
+        })
+    {
+        return Err(format!("invalid {label} '{path}'"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_state_query, BinaryOperator, ScalarExpression, StateQuery, StateValueReference,
+    };
+
+    #[test]
+    fn parses_indexed_precedence_and_predicate_queries() {
+        let scalar =
+            parse_state_query("state.score + enemies[2].hp * 2").expect("parse scalar expression");
+        let StateQuery::Scalar(ScalarExpression::Binary {
+            operator, right, ..
+        }) = scalar
+        else {
+            panic!("expected binary scalar query");
+        };
+        assert_eq!(operator, BinaryOperator::Add);
+        assert!(matches!(
+            *right,
+            ScalarExpression::Binary {
+                operator: BinaryOperator::Multiply,
+                ..
+            }
+        ));
+
+        let predicate =
+            parse_state_query("enemies[?hp >= state.minimum_hp]").expect("parse predicate query");
+        let StateQuery::Predicate(predicate) = predicate else {
+            panic!("expected predicate query");
+        };
+        assert_eq!(predicate.path, "enemies");
+        assert_eq!(predicate.field, "hp");
+        assert_eq!(predicate.operator, BinaryOperator::GreaterEqual);
+        assert!(
+            matches!(predicate.right, ScalarExpression::Value(StateValueReference::Path(path)) if path == "state.minimum_hp")
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_unbounded_query_syntax() {
+        assert!(parse_state_query("").is_err());
+        assert!(parse_state_query("enemies[?hp]").is_err());
+        assert!(parse_state_query("enemies[-1].hp").is_err());
+        assert!(parse_state_query("score + system()").is_err());
+    }
+}

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -1198,10 +1198,10 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
             concise: false,
         }),
         ":inspect" => ready(LiveCommand::Inspect {
-            path: required_arg(&args, 1, "state path")?.to_string(),
+            path: remaining_args(&args, 1, "state query")?,
         }),
         ":watch" => ready(LiveCommand::Watch {
-            path: required_arg(&args, 1, "state path")?.to_string(),
+            path: remaining_args(&args, 1, "state query")?,
         }),
         ":unwatch" => ready(LiveCommand::Unwatch {
             path: args.get(1).cloned(),
@@ -1212,7 +1212,7 @@ fn parse_terminal_command(line: &str) -> Result<ParsedTerminalCommand, String> {
             preview: args.iter().any(|arg| arg == "--preview"),
         }),
         ":print" => ready(LiveCommand::Print {
-            expression: required_arg(&args, 1, "expression")?.to_string(),
+            expression: remaining_args(&args, 1, "expression")?,
         }),
         ":do" => Ok(ParsedTerminalCommand::Pending(PendingCommand::Do {
             preview: args.iter().any(|arg| arg == "--preview"),
@@ -1304,6 +1304,13 @@ fn required_arg<'a>(args: &'a [String], index: usize, name: &str) -> Result<&'a 
     args.get(index)
         .map(String::as_str)
         .ok_or_else(|| format!("missing {name}"))
+}
+
+fn remaining_args(args: &[String], index: usize, name: &str) -> Result<String, String> {
+    if args.len() <= index {
+        return Err(format!("missing {name}"));
+    }
+    Ok(args[index..].join(" "))
 }
 
 fn parse_u32(name: &str, value: &str) -> Result<u32, String> {
@@ -1841,6 +1848,35 @@ mod tests {
             LiveCommand::InspectAll {
                 limit: 32,
                 concise: false,
+            }
+        );
+    }
+
+    #[test]
+    fn terminal_preserves_spaced_state_queries() {
+        let mut terminal = TerminalBuffer::new();
+        let TerminalInput::Request(inspect) = terminal
+            .feed_line(":inspect enemies[?hp >= score + 1]")
+            .expect("inspect query")
+        else {
+            panic!("expected inspect request")
+        };
+        assert_eq!(
+            inspect.command,
+            LiveCommand::Inspect {
+                path: "enemies[?hp >= score + 1]".to_string(),
+            }
+        );
+        let TerminalInput::Request(watch) = terminal
+            .feed_line(":watch score + enemies[2].hp")
+            .expect("watch query")
+        else {
+            panic!("expected watch request")
+        };
+        assert_eq!(
+            watch.command,
+            LiveCommand::Watch {
+                path: "score + enemies[2].hp".to_string(),
             }
         );
     }

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -315,7 +315,9 @@ and `:watch` use compiler-indexed state queries. Queries support scalar paths, f
 indexes (`state.enemies[2].hp`), bounded predicates (`state.enemies[?hp >= 10]`), parentheses,
 and scalar arithmetic/comparison with normal precedence. Predicate scans stop after 4096 elements
 and return at most 64 matches with explicit truncation fields. Watches re-evaluate the same query
-between ticks and publish only changes.
+between ticks and publish only changes. Predicate watches share one 4096-element scan budget per
+tick, and a watch that becomes invalid publishes one `watch_error` until it recovers or its error
+changes.
 
 Queries do not expose arbitrary addresses, lexical stacks, calls, or runtime reflection. Missing
 paths/fields, invalid indexes/types/operators, divide-by-zero, and unsupported syntax return stable

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -234,9 +234,11 @@ fail-fast behavior. Invalid human commands remain nonfatal and return focus to t
 :edit tick
 :inspect
 :inspect score
-:watch score
+:inspect state.enemies[2].hp
+:inspect state.enemies[?hp >= 10]
+:watch score + state.enemies[2].hp
 :set score 10
-:print score
+:print score * 2
 :changes
 :undo
 :redo
@@ -307,8 +309,19 @@ validating or adjusting migrated state; the runtime then restores the prior disk
 
 ## Scratch and state transactions
 
-`:inspect`, `:set`, and `:do` accept compiler-indexed scalar paths (`i32`, `f32`, `f64`, or
-`bool`). `:do` is a semicolon-separated assignment transaction:
+Bare `:inspect` returns a bounded state tree containing scalar values, collection shapes,
+capacities/active counts, struct fields, and current memory totals. Explicit `:inspect`, `:print`,
+and `:watch` use compiler-indexed state queries. Queries support scalar paths, fixed collection
+indexes (`state.enemies[2].hp`), bounded predicates (`state.enemies[?hp >= 10]`), parentheses,
+and scalar arithmetic/comparison with normal precedence. Predicate scans stop after 4096 elements
+and return at most 64 matches with explicit truncation fields. Watches re-evaluate the same query
+between ticks and publish only changes.
+
+Queries do not expose arbitrary addresses, lexical stacks, calls, or runtime reflection. Missing
+paths/fields, invalid indexes/types/operators, divide-by-zero, and unsupported syntax return stable
+diagnostics from the compiler metadata path. `:set` and `:do` remain intentionally narrower:
+they accept compiler-indexed scalar paths (`i32`, `f32`, `f64`, or `bool`) and literal/path values.
+`:do` is a semicolon-separated assignment transaction:
 
 ```text
 :do --preview
@@ -318,8 +331,8 @@ ready = true;
 ```
 
 All paths and values are validated before any assignment is written. Preview performs no write.
-Calls, arbitrary addresses, and unsupported expressions fail clearly instead of using a second
-parser or lowering pipeline.
+Calls, arbitrary addresses, and unsupported mutation expressions fail clearly instead of using a
+second compiler or runtime-reflection path.
 
 Named cells retain code and results only for the current development session:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -722,6 +722,27 @@ candidate field, storage binding, function pointer, or partial value may be visi
 tick. The executable fixtures under `samples/between_tick_layout_migration/` cover accepted and
 rejected struct growth across this boundary.
 
+### 14.3.1 State memory and development inspection
+
+The canonical compiler state layout also owns development memory reporting and live inspection.
+JIT and AOT must describe the same scalar bindings, SoA collection lanes, struct paths, field
+types, capacities, and opaque exclusions. `stasis inspect` derives capacity bytes, scalar/lane
+alignment, zero intra-allocation padding, struct/field rollups, snapshot size, largest pools,
+recognized command buffers, capacity-change projections, and mobile snapshot warnings from that
+metadata. A report must label the direct-binding storage model and must not imply an AoS packed
+layout when runtime storage is SoA.
+
+The development runtime may read those compiler-indexed bindings at between-tick observation
+points. It supports scalar paths, fixed indexes, bounded collection predicates, and scalar
+arithmetic/comparisons. Predicate scans and returned matches are bounded and report truncation.
+Invalid paths, fields, indexes, types, operators, and expressions fail deterministically. This is
+metadata-guided inspection, not general reflection: it exposes no arbitrary memory, lexical stack,
+host object, call expression, or release-runtime evaluator. Change-only watches evaluate the same
+query contract between ticks.
+
+`samples/state_inspection/` is the representative executable fixture for static reporting, state
+tree browsing, indexed/predicate expressions, and change-only watches.
+
 ### 14.4 Development File-Change Boundary Contracts
 
 During development, file-change handling uses explicit role ownership and message boundaries.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -36,6 +36,8 @@ stasis build --mode release
 stasis package --target desktop
 stasis package-mobile --target android-arm64
 stasis package-mobile --target ios-arm64
+stasis inspect
+stasis inspect --capacity state.enemies=512
 ```
 
 `stasis init --name brick_game .` initializes an existing directory. The built-in template copies
@@ -91,7 +93,14 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
   shared AOT output, SDL-only runtime, bundled assets, verified provenance, and thin Gradle or
   Xcode app shell.
 - `package --target android-arm64|ios-arm64`: compatibility spelling that uses the manifest entry.
-- `inspect`, `version`, and `env`: report workspace, installation, cache, and output locations.
+- `inspect [--capacity PATH=COUNT] [--mobile-budget-bytes N]`: compile the manifest entry and
+  report the canonical direct-storage model: bytes and alignment by state path/field, struct
+  rollups, capacity versus active count, snapshot size, the eight largest pools, recognized
+  command buffers, projected capacity-change bytes, and mobile-budget warnings. Repeating
+  `--capacity` compares several proposed pool sizes without changing source or runtime state.
+  JSON output includes the complete deterministic report; human output emphasizes totals,
+  largest pools, projections, and warnings.
+- `version` and `env`: report installation, cache, and workspace locations.
 
 `replay` and `verify` intentionally return deterministic unsupported diagnostics until the replay
 runtime contract lands; they do not fake successful behavior.

--- a/samples/state_inspection/live.commands
+++ b/samples/state_inspection/live.commands
@@ -1,0 +1,9 @@
+:pause
+:inspect
+:inspect state.enemies[1].hp
+:print state.score + state.enemies[1].hp
+:inspect state.enemies[?hp >= 8]
+:watch state.score + state.enemies[1].hp
+:step 1
+:inspect state.score
+:quit

--- a/samples/state_inspection/src/main.stasis
+++ b/samples/state_inspection/src/main.stasis
@@ -1,0 +1,42 @@
+struct Enemy {
+    hp: i32;
+    speed: f32;
+    active: bool;
+}
+
+struct SimulationState {
+    score: i32;
+    enemies: Enemy[4];
+}
+
+global state: SimulationState;
+global render_cmd_i32: i32[16];
+
+function main(): i32 {
+    state.score = 10;
+    state.enemies[0].hp = 3;
+    state.enemies[0].speed = 1.0;
+    state.enemies[0].active = true;
+    state.enemies[1].hp = 8;
+    state.enemies[1].speed = 2.0;
+    state.enemies[1].active = true;
+    state.enemies[2].hp = 12;
+    state.enemies[2].speed = 1.5;
+    state.enemies[2].active = false;
+    return 0;
+}
+
+function tick(): i32 {
+    state.score += 1;
+    state.enemies[1].hp -= 1;
+    return 0;
+}
+
+function render(): i32 {
+    render_cmd_i32[0] = state.score;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/samples/state_inspection/stasis.json
+++ b/samples/state_inspection/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "state_inspection",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}


### PR DESCRIPTION
## Summary

- add compiler-derived state memory reports with per-path/field bytes, alignment, active/capacity totals, snapshot size, largest pools, command buffers, capacity projections, and mobile budget warnings
- add bounded live state queries for indexes, predicates, scalar expressions, and watches without runtime reflection
- expose reports through the CLI and live state tree, with deterministic diagnostics and a runnable `state_inspection` sample

## Why

Maddox task #149 requires the compiler's canonical state metadata to power both static memory planning and running state inspection. Keeping these features on `StateLayout` and the existing JIT direct-storage boundary avoids a duplicate reflection path and keeps JIT/AOT layout semantics aligned.

## Validation

- `cargo fmt --all -- --check`
- exact `tools/validate_repo.sh` steps run individually on Windows (the host has no `bash`): layout check, 12 Python/parity tests, render parity fixture, and `cargo test --workspace --all-targets -- --test-threads=1`
- focused compiler layout/query, live watch, terminal parsing, CLI report, TUI tree, sample Cranelift execution, and end-to-end live-script tests
- built `stasis.exe` ran `samples/state_inspection/live.commands` and exited cleanly

## Theory gained

Static memory planning and live inspection are two views of the same direct-storage metadata: declarations map to scalar allocations and SoA lanes, so new collection semantics should extend active-count metadata at that boundary rather than introduce reflection.

## Reflection

- Good: sharing `StateLayout` made static reporting and live inspection agree end to end.
- Bad: the first presentation pass used assumed JSON field names and hid tree metadata in human script output.
- Adjustment: test presentation against real serialized protocol responses and run the checked-in live script before declaring an inspection slice complete.
