### PR TITLE
fix: unblock release-mode nightly builds

### DIFF
--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -174,6 +174,7 @@ struct AiAuditLog {
     file: fs::File,
     usage_path: PathBuf,
     usage_file: fs::File,
+    #[cfg(test)]
     timing_path: PathBuf,
     timing_file: fs::File,
     started_at: Instant,
@@ -213,6 +214,7 @@ impl AiAuditLog {
             file,
             usage_path,
             usage_file,
+            #[cfg(test)]
             timing_path,
             timing_file,
             started_at: now,


### PR DESCRIPTION
## Summary
- keep the AI timing-log path only in test builds, where it is asserted
- eliminate the release-only dead-code error that has failed nightly packaging since July 22

## Verification
- cargo fmt --check
- cargo check -p stasis --release
- cargo test -p stasis ai_audit_records_the_exact_tool_payload_seen_by_the_agent

Theory gained: release-mode deny(warnings) means fields used exclusively by unit tests must carry the same cfg(test) boundary as the tests; the focused audit test confirms the timing sidecar contract is preserved.