### PR TITLE
ci: install SDL for Unix nightly smoke tests

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -88,6 +88,16 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      - name: Install SDL development packages (linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libsdl2-dev libsdl2-image-dev
+
+      - name: Install SDL development packages (macos)
+        if: runner.os == 'macOS'
+        run: brew install sdl2 sdl2_image
+
       - name: Setup MSVC dev environment (windows)
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Summary
- install SDL2 and SDL2_image development packages on Linux and macOS nightly runners
- allow the bundled desktop package smoke test to configure its native graphics runtime

## Evidence
Nightly run 30219292790 passed Windows but failed the Linux and both macOS jobs at the bundled CLI smoke step because CMake could not find SDL2Config.cmake. The release-mode compiler blocker from #332 is resolved.

## Validation
- git diff --check
- workflow diff reviewed against all four matrix targets

Theory gained: Unix release archives intentionally treat SDL as an external dependency, but the release workflow's desktop packaging smoke test still compiles the runtime and therefore must provision the development package.