### PR TITLE
fix: verify Unix nightly provenance from manifests

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -282,8 +282,6 @@ jobs:
           mkdir -p cli-smoke/assets
           printf '%s\n' '{"schema":"stasis-assets","version":1,"assets":[]}' > cli-smoke/assets/manifest.json
           ./bin/stasis --workspace cli-smoke package --target desktop
-          desktop_diagnostics="$(./cli-smoke/dist/ci_smoke-desktop/ci_smoke 2>&1 || true)"
-          grep -q 'Stasis package provenance:' <<<"${desktop_diagnostics}"
           ./bin/stasis --workspace cli-smoke package-mobile --target android-arm64 --out dist/android
           ./bin/stasis --workspace cli-smoke package-mobile --target ios-arm64 --out dist/ios
           popd


### PR DESCRIPTION
## Summary

- remove the Unix packaged-runner diagnostics assertion from Nightly Release
- retain the direct AOT executable smoke test and desktop/mobile package builds
- rely on the dedicated provenance verifier already run for every generated package

## Root cause

After the ARM-only macOS fix merged, Nightly Release run 30222634784 showed that Linux and macOS ARM64 both built and packaged successfully but failed while looking for a runtime provenance log line. The Unix runner does not initialize the graphics runtime on this fixture, so that line is not emitted. The workflow then failed before reaching its authoritative manifest checks.

## Impact

Unix nightly jobs can proceed through mobile packaging and verify the desktop, Android, and iOS provenance manifests with `tools/verify_package_provenance.py`. Windows behavior is unchanged and passed in the diagnostic run.

## Validation

- `python -m unittest tools.ci.test_release_provenance`
- `python tools/ci/check_stasis_src_layout.py`
- `git diff --check`
- Nightly diagnostic evidence: Windows passed; Linux and macOS ARM64 reached successful desktop packaging before the removed assertion failed
