### PR TITLE
Fix mobile AOT enum state storage

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3082,10 +3082,11 @@ fn state_layout_runtime_fields(
                 .get(parent)
                 .map(|capacity| serde_json::json!(capacity))
         });
+        let storage_type_name = scalar.storage_type_name();
         fields.push(PackagedRuntimeField {
             name: scalar.path.replace('.', "__"),
-            size: field_width(&scalar.type_name)?,
-            field_type: scalar.type_name.clone(),
+            size: field_width(storage_type_name)?,
+            field_type: storage_type_name.to_string(),
             array_count: 1,
             initial_value,
             collection_path: None,
@@ -3103,7 +3104,8 @@ fn state_layout_runtime_fields(
             )
         })?;
         for field in &collection.fields {
-            let width = field_width(&field.type_name)?;
+            let storage_type_name = field.storage_type_name();
+            let width = field_width(storage_type_name)?;
             let name = if field.field.is_empty() {
                 collection.path.replace('.', "__")
             } else {
@@ -3118,7 +3120,7 @@ fn state_layout_runtime_fields(
                 size: width.checked_mul(array_count).ok_or_else(|| {
                     format!("AOT state storage size overflow for '{}'", collection.path)
                 })?,
-                field_type: field.type_name.clone(),
+                field_type: storage_type_name.to_string(),
                 array_count,
                 initial_value: None,
                 collection_path: Some(collection.path.clone()),
@@ -4136,6 +4138,46 @@ mod tests {
     #[test]
     fn identifier_hash_matches_incremental_function() {
         assert_eq!(hash_identifier("on_code_swap"), -663_287_521);
+    }
+
+    #[test]
+    fn aot_direct_storage_source_uses_enum_i32_lanes() {
+        let layout = StateLayout {
+            scalars: vec![stasis_compiler::backend::state_layout::StateScalarLayout {
+                path: "game.phase".to_string(),
+                type_name: "GamePhase".to_string(),
+                storage_type_name: "i32".to_string(),
+            }],
+            collections: vec![
+                stasis_compiler::backend::state_layout::StateCollectionLayout {
+                    path: "game.samples".to_string(),
+                    capacity: 2,
+                    element_shape: "GamePhase".to_string(),
+                    fully_migratable: false,
+                    fields: vec![
+                        stasis_compiler::backend::state_layout::StateCollectionFieldLayout {
+                            field: String::new(),
+                            type_name: "GamePhase".to_string(),
+                            storage_type_name: "i32".to_string(),
+                        },
+                    ],
+                },
+            ],
+            structs: Vec::new(),
+            opaque: Vec::new(),
+        };
+
+        let (source, register_lines) =
+            build_aot_direct_storage_source(&layout).expect("build enum storage source");
+
+        assert!(source.contains("STASIS_EXPORT int32_t game__phase = 0;"));
+        assert!(source.contains("STASIS_EXPORT int32_t game__samples[2] = {0};"));
+        assert!(register_lines
+            .iter()
+            .any(|line| line.contains("stasis_jit_register_global_i32_ptr")));
+        assert!(register_lines
+            .iter()
+            .any(|line| line.contains("stasis_jit_register_global_i32_array")));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -481,7 +481,8 @@ impl AotProcess {
         let mut registrations = Vec::new();
 
         for scalar in &layout.scalars {
-            let width = storage_width(&scalar.type_name)?;
+            let storage_type_name = scalar.storage_type_name();
+            let width = storage_width(storage_type_name)?;
             let mut bytes = vec![0; width];
             if let Some(collection_path) = scalar.path.strip_suffix(".max_length") {
                 if let Some(collection) = layout
@@ -496,10 +497,10 @@ impl AotProcess {
             let data_id = define_standalone_storage_data(&mut module, &symbol, bytes)?;
             registrations.push((
                 data_id,
-                scalar.type_name.clone(),
+                storage_type_name.to_string(),
                 hash_global_path(&scalar.path),
                 0,
-                matches!(scalar.type_name.as_str(), "u8" | "u16").then_some(1),
+                matches!(storage_type_name, "u8" | "u16").then_some(1),
             ));
         }
         for collection in &layout.collections {
@@ -510,7 +511,8 @@ impl AotProcess {
                 )
             })?;
             for field in &collection.fields {
-                let width = storage_width(&field.type_name)?;
+                let storage_type_name = field.storage_type_name();
+                let width = storage_width(storage_type_name)?;
                 let size = len.checked_mul(width).ok_or_else(|| {
                     format!(
                         "standalone AOT storage size overflow for '{}.{}'",
@@ -521,7 +523,7 @@ impl AotProcess {
                 let data_id = define_standalone_storage_data(&mut module, &symbol, vec![0; size])?;
                 registrations.push((
                     data_id,
-                    field.type_name.clone(),
+                    storage_type_name.to_string(),
                     hash_global_path(&collection.path),
                     hash_foreach_field_suffix(&field.field),
                     Some(collection.capacity),

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1,5 +1,7 @@
 use crate::backend::emit::{DirectStorageBinding, DirectStorageBindings, RuntimeHelperLinkage};
-use crate::backend::state_layout::{build_state_layout, build_state_memory_report};
+use crate::backend::state_layout::{
+    build_state_layout, build_state_memory_report, is_named_scalar_state_path,
+};
 use crate::backend::state_query::{
     parse_state_query, BinaryOperator, ScalarExpression, StateQuery, StateValueReference,
 };
@@ -902,6 +904,9 @@ impl JitProcess {
             TYPE_ID_U32 => Ok(JitScalarValue::U32(
                 stasis_dynload::stasis_jit_global_i32_load(path_hash) as u32,
             )),
+            type_id if self.is_named_i32_state_scalar(path, type_id) => Ok(JitScalarValue::I32(
+                stasis_dynload::stasis_jit_global_i32_load(path_hash),
+            )),
             _ => Err(format!("global path '{path}' is not a supported scalar")),
         }
     }
@@ -930,6 +935,11 @@ impl JitProcess {
             }
             (TYPE_ID_U32, JitScalarValue::U32(value)) => {
                 stasis_dynload::stasis_jit_global_i32_store(path_hash, value as i32)
+            }
+            (type_id, JitScalarValue::I32(value))
+                if self.is_named_i32_state_scalar(path, type_id) =>
+            {
+                stasis_dynload::stasis_jit_global_i32_store(path_hash, value)
             }
             (_, value) => {
                 return Err(format!(
@@ -967,6 +977,19 @@ impl JitProcess {
             .as_ref()
             .and_then(|analysis| analysis.global_path_types.get(path).copied())
             .ok_or_else(|| format!("global path '{path}' was not found in compiler metadata"))
+    }
+
+    fn is_named_i32_state_scalar(&self, path: &str, type_id: u16) -> bool {
+        self.compile_analysis_cache
+            .as_ref()
+            .is_some_and(|analysis| {
+                is_named_scalar_state_path(
+                    path,
+                    type_id,
+                    &analysis.global_path_types,
+                    self.compiler.types(),
+                )
+            })
     }
 
     fn global_collection_value_type(&self, path: &str, field: &str) -> Result<(u16, i32), String> {
@@ -1776,7 +1799,11 @@ fn build_direct_storage_bindings(
         if collection_infos.contains_key(path) {
             continue;
         }
-        if let Some(kind) = scalar_storage_kind(type_table, *type_id) {
+        let kind = scalar_storage_kind(type_table, *type_id).or_else(|| {
+            is_named_scalar_state_path(path, *type_id, global_path_types, type_table)
+                .then_some(stasis_dynload::JitStorageKind::I32)
+        });
+        if let Some(kind) = kind {
             let path_hash = crate::backend::emit::hash_global_path(path);
             let address = stasis_dynload::direct_scalar_storage_slot_address(kind, path_hash)?;
             if provision {

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -19,6 +19,18 @@ pub struct StateLayout {
 pub struct StateScalarLayout {
     pub path: String,
     pub type_name: String,
+    #[serde(default)]
+    pub storage_type_name: String,
+}
+
+impl StateScalarLayout {
+    pub fn storage_type_name(&self) -> &str {
+        if self.storage_type_name.is_empty() {
+            &self.type_name
+        } else {
+            &self.storage_type_name
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -34,6 +46,18 @@ pub struct StateCollectionLayout {
 pub struct StateCollectionFieldLayout {
     pub field: String,
     pub type_name: String,
+    #[serde(default)]
+    pub storage_type_name: String,
+}
+
+impl StateCollectionFieldLayout {
+    pub fn storage_type_name(&self) -> &str {
+        if self.storage_type_name.is_empty() {
+            &self.type_name
+        } else {
+            &self.storage_type_name
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -161,11 +185,12 @@ pub fn build_state_memory_report(
         .scalars
         .iter()
         .map(|scalar| {
-            let element_bytes = storage_type_bytes(&scalar.type_name).unwrap_or(0);
+            let storage_type_name = scalar.storage_type_name();
+            let element_bytes = storage_type_bytes(storage_type_name).unwrap_or(0);
             if element_bytes == 0 {
                 warnings.push(format!(
-                    "state path '{}' has unsupported static type '{}'",
-                    scalar.path, scalar.type_name
+                    "state path '{}' has unsupported storage type '{}'",
+                    scalar.path, storage_type_name
                 ));
             }
             StateMemoryEntry {
@@ -173,7 +198,7 @@ pub fn build_state_memory_report(
                 field: String::new(),
                 kind: "scalar".to_string(),
                 type_name: scalar.type_name.clone(),
-                alignment_bytes: storage_type_alignment(&scalar.type_name).unwrap_or(1),
+                alignment_bytes: storage_type_alignment(storage_type_name).unwrap_or(1),
                 element_bytes,
                 padding_bytes: 0,
                 capacity: 1,
@@ -203,11 +228,12 @@ pub fn build_state_memory_report(
             .map(|count| count.min(old_capacity));
         let mut bytes_per_element = 0u64;
         for field in &collection.fields {
-            let element_bytes = storage_type_bytes(&field.type_name).unwrap_or(0);
+            let storage_type_name = field.storage_type_name();
+            let element_bytes = storage_type_bytes(storage_type_name).unwrap_or(0);
             if element_bytes == 0 {
                 warnings.push(format!(
-                    "collection path '{}' field '{}' has unsupported static type '{}'",
-                    collection.path, field.field, field.type_name
+                    "collection path '{}' field '{}' has unsupported storage type '{}'",
+                    collection.path, field.field, storage_type_name
                 ));
             }
             bytes_per_element = bytes_per_element
@@ -218,7 +244,7 @@ pub fn build_state_memory_report(
                 field: field.field.clone(),
                 kind: "collection_field".to_string(),
                 type_name: field.type_name.clone(),
-                alignment_bytes: storage_type_alignment(&field.type_name).unwrap_or(1),
+                alignment_bytes: storage_type_alignment(storage_type_name).unwrap_or(1),
                 element_bytes,
                 padding_bytes: 0,
                 capacity: old_capacity,
@@ -399,19 +425,17 @@ pub(crate) fn build_state_layout(
     let scalars = global_path_types
         .iter()
         .filter_map(|(path, type_id)| {
-            let type_name = scalar_type_name(type_table, *type_id)?;
             let info = type_table.type_info(*type_id)?;
-            let prefix = format!("{path}.");
+            let storage_type_name = scalar_storage_type_name(type_table, *type_id)?;
             if info.category == TypeCategory::Named
-                && global_path_types
-                    .keys()
-                    .any(|candidate| candidate.starts_with(&prefix))
+                && !is_named_scalar_state_path(path, *type_id, global_path_types, type_table)
             {
                 return None;
             }
             Some(StateScalarLayout {
                 path: path.clone(),
-                type_name: type_name.to_string(),
+                type_name: info.name.clone(),
+                storage_type_name: storage_type_name.to_string(),
             })
         })
         .collect();
@@ -419,22 +443,24 @@ pub(crate) fn build_state_layout(
         .iter()
         .map(|(path, info)| {
             let mut fields = Vec::new();
-            if let Some(type_name) = info
+            if let Some((type_name, storage_type_name)) = info
                 .element_type
-                .and_then(|type_id| collection_type_name(type_table, type_id))
+                .and_then(|type_id| state_value_type_names(type_table, type_id))
             {
                 fields.push(StateCollectionFieldLayout {
                     field: String::new(),
-                    type_name: type_name.to_string(),
+                    type_name,
+                    storage_type_name,
                 });
             }
             fields.extend(info.field_types.iter().filter_map(|(field, type_id)| {
-                collection_type_name(type_table, *type_id).map(|type_name| {
-                    StateCollectionFieldLayout {
+                state_value_type_names(type_table, *type_id).map(
+                    |(type_name, storage_type_name)| StateCollectionFieldLayout {
                         field: field.clone(),
-                        type_name: type_name.to_string(),
-                    }
-                })
+                        type_name,
+                        storage_type_name,
+                    },
+                )
             }));
             StateCollectionLayout {
                 path: path.clone(),
@@ -466,6 +492,7 @@ pub(crate) fn build_state_layout(
                 collection.fields.push(StateCollectionFieldLayout {
                     field: String::new(),
                     type_name: "u8".to_string(),
+                    storage_type_name: "u8".to_string(),
                 });
             }
             collection.fully_migratable = true;
@@ -479,6 +506,7 @@ pub(crate) fn build_state_layout(
             fields: vec![StateCollectionFieldLayout {
                 field: String::new(),
                 type_name: "u8".to_string(),
+                storage_type_name: "u8".to_string(),
             }],
         });
     }
@@ -490,7 +518,7 @@ pub(crate) fn build_state_layout(
     let opaque = global_path_types
         .iter()
         .filter_map(|(path, type_id)| {
-            if scalar_type_name(type_table, *type_id).is_some()
+            if scalar_storage_type_name(type_table, *type_id).is_some()
                 || collection_paths.contains(path.as_str())
             {
                 return None;
@@ -552,7 +580,21 @@ pub(crate) fn build_state_layout(
     }
 }
 
-fn scalar_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
+pub(crate) fn is_named_scalar_state_path(
+    path: &str,
+    type_id: u16,
+    global_path_types: &GlobalPathTypeMap,
+    type_table: &TypeTable,
+) -> bool {
+    type_table
+        .type_info(type_id)
+        .is_some_and(|info| info.category == TypeCategory::Named)
+        && !global_path_types
+            .keys()
+            .any(|candidate| candidate.starts_with(&format!("{path}.")))
+}
+
+fn scalar_storage_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
     match type_id {
         TYPE_ID_I32 => Some("i32"),
         TYPE_ID_F32 => Some("f32"),
@@ -571,8 +613,10 @@ fn scalar_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str
     }
 }
 
-fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
-    scalar_type_name(type_table, type_id)
+fn state_value_type_names(type_table: &TypeTable, type_id: u16) -> Option<(String, String)> {
+    let info = type_table.type_info(type_id)?;
+    let storage_type_name = scalar_storage_type_name(type_table, type_id)?;
+    Some((info.name.clone(), storage_type_name.to_string()))
 }
 
 #[cfg(test)]
@@ -731,19 +775,17 @@ mod tests {
 
         let layout = jit.state_layout();
         assert_eq!(layout, aot.state_layout());
-        assert!(layout
-            .scalars
-            .iter()
-            .any(|field| field.path == "game.phase" && field.type_name == "i32"));
+        assert!(layout.scalars.iter().any(|field| field.path == "game.phase"
+            && field.type_name == "Phase"
+            && field.storage_type_name() == "i32"));
         let enemies = layout
             .collections
             .iter()
             .find(|collection| collection.path == "game.enemies")
             .expect("enemy collection layout");
-        assert!(enemies
-            .fields
-            .iter()
-            .any(|field| field.field == "phase" && field.type_name == "i32"));
+        assert!(enemies.fields.iter().any(|field| field.field == "phase"
+            && field.type_name == "Phase"
+            && field.storage_type_name() == "i32"));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -399,7 +399,17 @@ pub(crate) fn build_state_layout(
     let scalars = global_path_types
         .iter()
         .filter_map(|(path, type_id)| {
-            scalar_type_name(*type_id).map(|type_name| StateScalarLayout {
+            let type_name = scalar_type_name(type_table, *type_id)?;
+            let info = type_table.type_info(*type_id)?;
+            let prefix = format!("{path}.");
+            if info.category == TypeCategory::Named
+                && global_path_types
+                    .keys()
+                    .any(|candidate| candidate.starts_with(&prefix))
+            {
+                return None;
+            }
+            Some(StateScalarLayout {
                 path: path.clone(),
                 type_name: type_name.to_string(),
             })
@@ -480,7 +490,9 @@ pub(crate) fn build_state_layout(
     let opaque = global_path_types
         .iter()
         .filter_map(|(path, type_id)| {
-            if scalar_type_name(*type_id).is_some() || collection_paths.contains(path.as_str()) {
+            if scalar_type_name(type_table, *type_id).is_some()
+                || collection_paths.contains(path.as_str())
+            {
                 return None;
             }
             let info = type_table.type_info(*type_id)?;
@@ -540,7 +552,7 @@ pub(crate) fn build_state_layout(
     }
 }
 
-fn scalar_type_name(type_id: u16) -> Option<&'static str> {
+fn scalar_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
     match type_id {
         TYPE_ID_I32 => Some("i32"),
         TYPE_ID_F32 => Some("f32"),
@@ -549,13 +561,18 @@ fn scalar_type_name(type_id: u16) -> Option<&'static str> {
         TYPE_ID_U8 => Some("u8"),
         TYPE_ID_U16 => Some("u16"),
         TYPE_ID_U32 => Some("u32"),
+        _ if type_table
+            .type_info(type_id)
+            .is_some_and(|info| info.category == TypeCategory::Named) =>
+        {
+            Some("i32")
+        }
         _ => None,
     }
 }
 
 fn collection_type_name(type_table: &TypeTable, type_id: u16) -> Option<&'static str> {
-    let _ = type_table;
-    scalar_type_name(type_id)
+    scalar_type_name(type_table, type_id)
 }
 
 #[cfg(test)]
@@ -695,6 +712,38 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing report entry for {path}"));
             assert_eq!(entry.element_bytes, expected_bytes, "{path}");
         }
+    }
+
+    #[test]
+    fn enum_state_uses_i32_storage_lanes() {
+        let source = "enum Phase { Waiting, Playing }\n\
+                      struct Enemy { phase: Phase; hp: i32; }\n\
+                      struct Game { phase: Phase; enemies: Enemy[2]; }\n\
+                      global game: Game;\n\
+                      function main(): i32 { game.phase = Phase.Playing; game.enemies[0].phase = game.phase; return 0; }\n";
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile_staged().expect("compile enum state fixture");
+
+        let mut aot = AotProcess::new();
+        aot.upsert_file("main.stasis", source);
+        aot.compile().expect("compile enum AOT fixture");
+
+        let layout = jit.state_layout();
+        assert_eq!(layout, aot.state_layout());
+        assert!(layout
+            .scalars
+            .iter()
+            .any(|field| field.path == "game.phase" && field.type_name == "i32"));
+        let enemies = layout
+            .collections
+            .iter()
+            .find(|collection| collection.path == "game.enemies")
+            .expect("enemy collection layout");
+        assert!(enemies
+            .fields
+            .iter()
+            .any(|field| field.field == "phase" && field.type_name == "i32"));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/state_migration.rs
+++ b/crates/stasis_compiler/src/backend/state_migration.rs
@@ -55,6 +55,7 @@ struct CapturedMigrationState {
 #[derive(Debug, Clone)]
 struct CollectionFieldLayout {
     type_name: String,
+    storage_type_name: String,
     capacity: u32,
 }
 
@@ -74,12 +75,28 @@ pub fn plan_state_migration(
     let active_scalars = active
         .scalars
         .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .map(|entry| {
+            (
+                entry.path.clone(),
+                (
+                    entry.type_name.clone(),
+                    entry.storage_type_name().to_string(),
+                ),
+            )
+        })
         .collect::<BTreeMap<_, _>>();
     let incoming_scalars = incoming
         .scalars
         .iter()
-        .map(|entry| (entry.path.clone(), entry.type_name.clone()))
+        .map(|entry| {
+            (
+                entry.path.clone(),
+                (
+                    entry.type_name.clone(),
+                    entry.storage_type_name().to_string(),
+                ),
+            )
+        })
         .collect::<BTreeMap<_, _>>();
     let active_collections = collection_field_layouts(active)?;
     let incoming_collections = collection_field_layouts(incoming)?;
@@ -151,17 +168,22 @@ pub fn plan_state_migration(
             ));
             affected_roots.insert(migration_root(path));
         }
-        for (path, incoming_type) in &incoming_scalars {
+        for (path, (incoming_type, incoming_storage_type)) in &incoming_scalars {
             if path.ends_with(".max_length") {
                 continue;
             }
             match active_scalars.get(path) {
-                Some(active_type) if active_type == incoming_type => steps.push(scalar_step(
-                    StateMigrationStepKind::Copy,
-                    path,
-                    incoming_type,
-                )),
-                Some(active_type) => {
+                Some((active_type, active_storage_type))
+                    if active_type == incoming_type
+                        && active_storage_type == incoming_storage_type =>
+                {
+                    steps.push(scalar_step(
+                        StateMigrationStepKind::Copy,
+                        path,
+                        incoming_storage_type,
+                    ));
+                }
+                Some((active_type, _)) => {
                     rejections.push(format!(
                         "state path '{path}' changed type '{active_type}' -> '{incoming_type}'"
                     ));
@@ -171,20 +193,20 @@ pub fn plan_state_migration(
                     steps.push(scalar_step(
                         StateMigrationStepKind::Initialize,
                         path,
-                        incoming_type,
+                        incoming_storage_type,
                     ));
                     affected_roots.insert(migration_root(path));
                 }
             }
         }
-        for (path, active_type) in &active_scalars {
+        for (path, (_, active_storage_type)) in &active_scalars {
             if path.ends_with(".max_length") || incoming_scalars.contains_key(path) {
                 continue;
             }
             steps.push(scalar_step(
                 StateMigrationStepKind::Remove,
                 path,
-                active_type,
+                active_storage_type,
             ));
             warnings.push(format!("removed state path '{path}' will be discarded"));
             affected_roots.insert(migration_root(path));
@@ -192,13 +214,16 @@ pub fn plan_state_migration(
 
         for ((path, field), incoming_field) in &incoming_collections {
             match active_collections.get(&(path.clone(), field.clone())) {
-                Some(active_field) if active_field.type_name == incoming_field.type_name => {
+                Some(active_field)
+                    if active_field.type_name == incoming_field.type_name
+                        && active_field.storage_type_name == incoming_field.storage_type_name =>
+                {
                     let elements = active_field.capacity.min(incoming_field.capacity);
                     steps.push(collection_step(
                         StateMigrationStepKind::Copy,
                         path,
                         field,
-                        &incoming_field.type_name,
+                        &incoming_field.storage_type_name,
                         0,
                         elements,
                         active_field.capacity,
@@ -219,7 +244,7 @@ pub fn plan_state_migration(
                             StateMigrationStepKind::Initialize,
                             path,
                             field,
-                            &incoming_field.type_name,
+                            &incoming_field.storage_type_name,
                             active_field.capacity,
                             incoming_field.capacity - active_field.capacity,
                             active_field.capacity,
@@ -242,7 +267,7 @@ pub fn plan_state_migration(
                         StateMigrationStepKind::Initialize,
                         path,
                         field,
-                        &incoming_field.type_name,
+                        &incoming_field.storage_type_name,
                         0,
                         incoming_field.capacity,
                         0,
@@ -260,7 +285,7 @@ pub fn plan_state_migration(
                 StateMigrationStepKind::Remove,
                 path,
                 field,
-                &active_field.type_name,
+                &active_field.storage_type_name,
                 0,
                 active_field.capacity,
                 active_field.capacity,
@@ -475,6 +500,7 @@ fn collection_field_layouts(
                 (collection.path.clone(), field.field.clone()),
                 CollectionFieldLayout {
                     type_name: field.type_name.clone(),
+                    storage_type_name: field.storage_type_name().to_string(),
                     capacity,
                 },
             );
@@ -828,6 +854,90 @@ mod tests {
     use super::*;
     use crate::backend::jit::{JitStateCollectionFieldLayout, JitStateCollectionLayout};
 
+    fn enum_state_layout(
+        type_name: &str,
+        include_score: bool,
+        include_enemies: bool,
+    ) -> JitStateLayout {
+        let enum_declaration = if type_name == "i32" {
+            String::new()
+        } else {
+            format!("enum {type_name} {{ Waiting, Playing }}\n")
+        };
+        let initializer = if type_name == "i32" {
+            "1".to_string()
+        } else {
+            format!("{type_name}.Playing")
+        };
+        let score_field = if include_score { "score: i32; " } else { "" };
+        let enemy_declaration = if include_enemies {
+            format!("struct Enemy {{ phase: {type_name}; hp: i32; }}\n")
+        } else {
+            String::new()
+        };
+        let enemies_field = if include_enemies {
+            "enemies: Enemy[2]; "
+        } else {
+            ""
+        };
+        let enemy_assignment = if include_enemies {
+            "game.enemies[0].phase = game.phase; "
+        } else {
+            ""
+        };
+        let source = format!(
+            "{enum_declaration}\
+             {enemy_declaration}\
+             struct Game {{ phase: {type_name}; {score_field}{enemies_field}}}\n\
+             global game: Game;\n\
+             function main(): i32 {{ game.phase = {initializer}; {enemy_assignment}return 0; }}\n"
+        );
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile_staged()
+            .expect("compile enum migration fixture");
+        jit.state_layout()
+    }
+
+    #[test]
+    fn enum_identity_changes_reject_state_migration() {
+        let active = enum_state_layout("Phase", false, true);
+        for incoming_type in ["Mode", "i32"] {
+            let incoming = enum_state_layout(incoming_type, false, true);
+            let preview = plan_state_migration(&active, &incoming, Vec::new(), false, None)
+                .expect("plan enum identity rejection");
+
+            assert!(!preview.state_layout_compatible);
+            let rejection = preview.rejection.as_deref().expect("enum type rejection");
+            assert!(rejection.contains(&format!(
+                "state path 'game.phase' changed type 'Phase' -> '{incoming_type}'"
+            )));
+            assert!(rejection.contains(&format!(
+                "collection state path 'game.enemies[].phase' changed type 'Phase' -> '{incoming_type}'"
+            )));
+        }
+    }
+
+    #[test]
+    fn unchanged_enum_identity_migrates_through_i32_storage() {
+        let active = enum_state_layout("Phase", false, false);
+        let incoming = enum_state_layout("Phase", true, false);
+        let preview = plan_state_migration(&active, &incoming, Vec::new(), false, None)
+            .expect("plan compatible enum migration");
+
+        assert!(
+            preview.state_layout_compatible,
+            "{}",
+            preview.rejection.as_deref().unwrap_or("missing rejection")
+        );
+        assert!(preview.migration_steps.iter().any(|step| {
+            step.kind == StateMigrationStepKind::Copy
+                && step.path == "game.phase"
+                && step.field.is_none()
+                && step.type_name == "i32"
+        }));
+    }
+
     #[test]
     fn non_migratable_collection_shape_rejects_before_activation() {
         let collection = |capacity| JitStateCollectionLayout {
@@ -838,6 +948,7 @@ mod tests {
             fields: vec![JitStateCollectionFieldLayout {
                 field: "value".to_string(),
                 type_name: "i32".to_string(),
+                storage_type_name: "i32".to_string(),
             }],
         };
         let active = JitStateLayout {

--- a/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
@@ -1,5 +1,14 @@
 import "preview_adapter.stasis";
 
+enum GamePhase {
+    Playing,
+    Finished
+}
+
+struct PhaseSample {
+    phase: GamePhase;
+}
+
 global Input {
     touch_x: i32;
     touch_y: i32;
@@ -9,6 +18,7 @@ global Input {
 }
 
 global GameState {
+    phase: GamePhase;
     tick_count: i32;
     screen_w: i32;
     screen_h: i32;
@@ -23,6 +33,8 @@ global GameState {
     player_score: i32;
     ai_score: i32;
 }
+
+global phase_samples: PhaseSample[2];
 
 global Render {
     command_schema_version: i32;
@@ -84,6 +96,9 @@ function pong_game_main(): void {
 }
 
 function init(): void {
+    GameState.phase = GamePhase.Playing;
+    phase_samples[0].phase = GamePhase.Playing;
+    phase_samples[1].phase = GamePhase.Finished;
     GameState.tick_count = 0;
     GameState.screen_w = 360;
     GameState.screen_h = 640;
@@ -100,6 +115,9 @@ function init(): void {
 }
 
 function pong_game_tick(): void {
+    if (GameState.phase == phase_samples[1].phase) {
+        GameState.phase = GamePhase.Playing;
+    }
     GameState.tick_count += 1;
 
     update_input();


### PR DESCRIPTION
## Summary

- Publish enum-valued named state through the canonical `i32` storage lanes used by generated mobile bindings.
- Cover both an enum scalar and an enum field inside a struct collection in the Android Workshop Pong fixture.

## Root cause

Direct mobile AOT lowering referenced enum state symbols that the state-layout publisher omitted. The generated native program therefore compiled but failed to link when application state contained enum values.

## Impact

This closes that layout/lowering mismatch and allows mobile apps with enum-valued state to link without adding app-specific runtime code.

## Verification

- Focused state-layout regression test passes.
- Android bundle native-symbol audit reproduces the missing symbol before the change and passes afterward.
- Compiler suite: 324 passed, 1 ignored.
- The full Stasis app suite had one unrelated transient access violation in `text_capacity_shrink_copies_bytes_and_clamps_lengths`; that exact test passed on immediate rerun.
