### PR TITLE
Add scoped integer preference storage

### DIFF
--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -2093,6 +2093,24 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v1(
 }
 
 #[no_mangle]
+pub extern "C" fn stasis_android_bridge_set_storage_root(storage_root: *const c_char) -> i32 {
+    let result = catch_unwind(AssertUnwindSafe(|| unsafe {
+        if storage_root.is_null() {
+            return Err("null storage root".to_string());
+        }
+        let root = CStr::from_ptr(storage_root)
+            .to_str()
+            .map_err(|error| format!("storage root was not UTF-8: {error}"))?;
+        if root.is_empty() {
+            return Err("empty storage root".to_string());
+        }
+        stasis_dynload::set_preference_storage_root(Some(PathBuf::from(root)));
+        Ok(())
+    }));
+    matches!(result, Ok(Ok(()))) as i32
+}
+
+#[no_mangle]
 pub extern "C" fn stasis_android_bridge_last_frame_error() -> *mut c_char {
     let message = LAST_FRAME_ERROR.with(|slot| {
         slot.borrow()

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2108,11 +2108,11 @@ mod tests {
     }
 
     #[test]
-    fn aot_process_prefers_runtime_string_shims_for_asset_externs() {
+    fn aot_process_prefers_runtime_string_shims_for_host_string_externs() {
         let mut process = AotProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;\nextern function gfx_release_sprite(handle: i32): void;\nextern function load_font(path: string, size: i32): i32;\nextern function measure_text(font: i32, text: string): f32;\nfunction @extern(\"stasis_gfx_cache_text\") gfx_cache_text(font: i32, text: string): i32;\nfunction main(): i32 { gfx_release_sprite(0); return 0; }\n",
+            "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;\nextern function gfx_release_sprite(handle: i32): void;\nextern function load_font(path: string, size: i32): i32;\nextern function measure_text(font: i32, text: string): f32;\nfunction @extern(\"stasis_gfx_cache_text\") gfx_cache_text(font: i32, text: string): i32;\nextern function storage_load_i32(scope: string, key: string, fallback: i32): i32;\nextern function storage_save_i32(scope: string, key: string, value: i32): bool;\nfunction main(): i32 { gfx_release_sprite(0); return 0; }\n",
         );
         process.compile().expect("compile");
 
@@ -2145,6 +2145,14 @@ mod tests {
         assert_eq!(
             resolved.get("gfx_cache_text").copied(),
             Some("stasis_jit_gfx_cache_text")
+        );
+        assert_eq!(
+            resolved.get("storage_load_i32").copied(),
+            Some("stasis_jit_storage_load_i32")
+        );
+        assert_eq!(
+            resolved.get("storage_save_i32").copied(),
+            Some("stasis_jit_storage_save_i32")
         );
     }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -1990,6 +1990,12 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "sleep_ms" | "stasis_sleep_ms" | "stasis_jit_sleep_ms" => {
             function_address(stasis_dynload::stasis_jit_sleep_ms as *const ())
         }
+        "storage_load_i32" | "stasis_storage_load_i32" | "stasis_jit_storage_load_i32" => {
+            function_address(stasis_dynload::stasis_jit_storage_load_i32 as *const ())
+        }
+        "storage_save_i32" | "stasis_storage_save_i32" | "stasis_jit_storage_save_i32" => {
+            function_address(stasis_dynload::stasis_jit_storage_save_i32 as *const ())
+        }
         "audio_init" | "stasis_audio_init" => {
             function_address(stasis_dynload::stasis_jit_audio_init as *const ())
         }

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -44,6 +44,8 @@ pub(crate) const AOT_RUNTIME_EXPORT_SYMBOLS: &[&str] = &[
     "stasis_jit_reject_code_swap",
     "stasis_jit_sin_fast",
     "stasis_jit_sleep_ms",
+    "stasis_jit_storage_load_i32",
+    "stasis_jit_storage_save_i32",
     "stasis_jit_sys_memcpy_f32",
     "stasis_jit_sys_memcpy_i32",
     "stasis_jit_sys_memcpy_u8",
@@ -63,6 +65,7 @@ mod tests {
     #[test]
     fn aot_runtime_export_contract_requires_exact_symbol_matches() {
         assert!(is_aot_runtime_export_symbol("stasis_jit_gfx_load_sprite"));
+        assert!(is_aot_runtime_export_symbol("stasis_jit_storage_load_i32"));
         assert!(is_aot_runtime_export_symbol(
             "stasis_jit_gfx_release_sprite"
         ));

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -2670,6 +2670,113 @@ pub extern "C" fn stasis_jit_gfx_release_sprite(handle: i32) {
     }
 }
 
+fn configured_preference_storage_root() -> &'static Mutex<Option<PathBuf>> {
+    static ROOT: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+    ROOT.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(not(windows))]
+fn preference_storage_root() -> Option<PathBuf> {
+    if let Some(root) = configured_preference_storage_root()
+        .lock()
+        .expect("preference storage root mutex poisoned")
+        .clone()
+    {
+        return Some(root);
+    }
+    if let Some(root) = std::env::var_os("STASIS_STORAGE_DIR").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(root));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return std::env::var_os("HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .map(|root| root.join("Library/Application Support/StasisLang"));
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(root) = std::env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
+            return Some(PathBuf::from(root).join("StasisLang"));
+        }
+        std::env::var_os("HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .map(|root| root.join(".local/share/StasisLang"))
+    }
+}
+
+pub fn set_preference_storage_root(root: Option<PathBuf>) {
+    *configured_preference_storage_root()
+        .lock()
+        .expect("preference storage root mutex poisoned") = root;
+}
+
+#[cfg(not(windows))]
+fn preference_component_valid(value: &[u8]) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+#[cfg(not(windows))]
+fn preference_i32_path(scope: &[u8], key: &[u8]) -> Option<PathBuf> {
+    if !preference_component_valid(scope) || !preference_component_valid(key) {
+        return None;
+    }
+    let scope = std::str::from_utf8(scope).ok()?;
+    let key = std::str::from_utf8(key).ok()?;
+    Some(
+        preference_storage_root()?
+            .join(scope)
+            .join(format!("{key}.i32")),
+    )
+}
+
+#[cfg(not(windows))]
+fn portable_storage_load_i32(scope: &[u8], key: &[u8], fallback: i32) -> i32 {
+    let Some(path) = preference_i32_path(scope, key) else {
+        return fallback;
+    };
+    let Ok(bytes) = std::fs::read(path) else {
+        return fallback;
+    };
+    if bytes.len() > 63 {
+        return fallback;
+    }
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return fallback;
+    };
+    text.trim().parse::<i32>().unwrap_or(fallback)
+}
+
+#[cfg(not(windows))]
+fn portable_storage_save_i32(scope: &[u8], key: &[u8], value: i32) -> bool {
+    let Some(path) = preference_i32_path(scope, key) else {
+        return false;
+    };
+    let Some(directory) = path.parent() else {
+        return false;
+    };
+    if std::fs::create_dir_all(directory).is_err() {
+        return false;
+    }
+    let temporary = path.with_extension("i32.tmp");
+    let result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&temporary)?;
+        writeln!(file, "{value}")?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, &path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(temporary);
+        return false;
+    }
+    true
+}
+
 #[no_mangle]
 pub extern "C" fn stasis_jit_storage_load_i32(scope_id: i32, key_id: i32, fallback: i32) -> i32 {
     #[cfg(windows)]
@@ -2692,9 +2799,11 @@ pub extern "C" fn stasis_jit_storage_load_i32(scope_id: i32, key_id: i32, fallba
     }
     #[cfg(not(windows))]
     {
-        let _ = scope_id;
-        let _ = key_id;
-        fallback
+        let (Some(scope), Some(key)) = (jit_text_arg_bytes(scope_id), jit_text_arg_bytes(key_id))
+        else {
+            return fallback;
+        };
+        portable_storage_load_i32(&scope, &key, fallback)
     }
 }
 
@@ -2720,10 +2829,11 @@ pub extern "C" fn stasis_jit_storage_save_i32(scope_id: i32, key_id: i32, value:
     }
     #[cfg(not(windows))]
     {
-        let _ = scope_id;
-        let _ = key_id;
-        let _ = value;
-        0
+        let (Some(scope), Some(key)) = (jit_text_arg_bytes(scope_id), jit_text_arg_bytes(key_id))
+        else {
+            return 0;
+        };
+        portable_storage_save_i32(&scope, &key, value) as i32
     }
 }
 
@@ -4353,6 +4463,35 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .expect("dynload test lock mutex poisoned")
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn portable_preferences_persist_and_fail_closed() {
+        let _guard = test_lock();
+        let root = std::env::temp_dir().join(format!(
+            "stasis_dynload_preferences_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        set_preference_storage_root(Some(root.clone()));
+
+        assert_eq!(portable_storage_load_i32(b"game", b"tier", 1), 1);
+        assert!(portable_storage_save_i32(b"game", b"tier", 4));
+        assert_eq!(portable_storage_load_i32(b"game", b"tier", 1), 4);
+        assert!(!portable_storage_save_i32(b"../game", b"tier", 5));
+        clear_jit_string_literal_table();
+        upsert_jit_string_literal(700, "game");
+        upsert_jit_string_literal(701, "tier");
+        assert_eq!(stasis_jit_storage_save_i32(700, 701, 6), 1);
+        assert_eq!(stasis_jit_storage_load_i32(700, 701, 1), 6);
+        std::fs::write(root.join("game/tier.i32"), "surprise\n").expect("write corrupt value");
+        assert_eq!(portable_storage_load_i32(b"game", b"tier", 2), 2);
+
+        clear_jit_string_literal_table();
+        set_preference_storage_root(None);
+        std::fs::remove_dir_all(root).expect("remove preference fixture");
     }
 
     #[cfg(windows)]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -482,6 +482,8 @@ struct StasisGraphicsAssetsApi {
     stasis_measure_text: usize,
     stasis_gfx_cache_text: usize,
     stasis_gfx_measure_text_cached: usize,
+    stasis_storage_load_i32: Option<usize>,
+    stasis_storage_save_i32: Option<usize>,
 }
 
 #[cfg(windows)]
@@ -512,6 +514,8 @@ impl StasisGraphicsAssetsApi {
             stasis_measure_text: lib.symbol_address("stasis_measure_text")?,
             stasis_gfx_cache_text: lib.symbol_address("stasis_gfx_cache_text")?,
             stasis_gfx_measure_text_cached: lib.symbol_address("stasis_gfx_measure_text_cached")?,
+            stasis_storage_load_i32: lib.symbol_address("stasis_storage_load_i32").ok(),
+            stasis_storage_save_i32: lib.symbol_address("stasis_storage_save_i32").ok(),
             _lib: lib,
         })
     }
@@ -2663,6 +2667,63 @@ pub extern "C" fn stasis_jit_gfx_release_sprite(handle: i32) {
     #[cfg(not(windows))]
     {
         let _ = handle;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_storage_load_i32(scope_id: i32, key_id: i32, fallback: i32) -> i32 {
+    #[cfg(windows)]
+    {
+        let (Ok(scope), Ok(key)) = (
+            jit_text_arg_to_cstring(scope_id),
+            jit_text_arg_to_cstring(key_id),
+        ) else {
+            return fallback;
+        };
+        let Ok(api) = stasis_graphics_assets_api() else {
+            return fallback;
+        };
+        let Some(address) = api.stasis_storage_load_i32 else {
+            return fallback;
+        };
+        let callback: extern "system" fn(*const c_char, *const c_char, i32) -> i32 =
+            unsafe { std::mem::transmute(address) };
+        return callback(scope.as_ptr(), key.as_ptr(), fallback);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = scope_id;
+        let _ = key_id;
+        fallback
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_storage_save_i32(scope_id: i32, key_id: i32, value: i32) -> i32 {
+    #[cfg(windows)]
+    {
+        let (Ok(scope), Ok(key)) = (
+            jit_text_arg_to_cstring(scope_id),
+            jit_text_arg_to_cstring(key_id),
+        ) else {
+            return 0;
+        };
+        let Ok(api) = stasis_graphics_assets_api() else {
+            return 0;
+        };
+        let Some(address) = api.stasis_storage_save_i32 else {
+            return 0;
+        };
+        let callback: extern "system" fn(*const c_char, *const c_char, i32) -> i32 =
+            unsafe { std::mem::transmute(address) };
+        return callback(scope.as_ptr(), key.as_ptr(), value);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = scope_id;
+        let _ = key_id;
+        let _ = value;
+        0
     }
 }
 

--- a/docs/runtime_storage.md
+++ b/docs/runtime_storage.md
@@ -1,0 +1,16 @@
+# Runtime integer storage
+
+Import `src/stdlib/storage.stasis` when a game needs a small durable integer such as an unlocked level, high score, or settings version.
+
+```stasis
+import "../src/stdlib/storage.stasis";
+
+let unlocked: i32 = storage_load_i32("my_game", "unlocked_level", 1);
+if (unlocked < 4) {
+    storage_save_i32("my_game", "unlocked_level", 4);
+}
+```
+
+The host stores values under SDL's app-private preference directory using the explicit game scope. Scope and key are restricted to 1-63 ASCII letters, digits, underscores, or hyphens; invalid names fail closed. A missing, invalid, or corrupt value returns the supplied fallback. Save returns `true` only after the complete integer value has been written and published.
+
+This API is intentionally narrow. It does not expose arbitrary filesystem paths, enumerate other games' values, serialize game memory, or provide a general document store. A future typed preference should extend the same scoped host boundary rather than exposing platform paths to Stasis code.

--- a/docs/runtime_storage.md
+++ b/docs/runtime_storage.md
@@ -11,6 +11,8 @@ if (unlocked < 4) {
 }
 ```
 
-The host stores values under SDL's app-private preference directory using the explicit game scope. Scope and key are restricted to 1-63 ASCII letters, digits, underscores, or hyphens; invalid names fail closed. A missing, invalid, or corrupt value returns the supplied fallback. Save returns `true` only after the complete integer value has been written and published.
+The graphical desktop host stores values under SDL's app-private preference directory. Android configures the same scoped storage contract under the application's private files directory. Headless Linux and macOS JIT hosts use the platform user-data directory; `STASIS_STORAGE_DIR` can override that root for controlled environments.
+
+Every host uses the explicit game scope. Scope and key are restricted to 1-63 ASCII letters, digits, underscores, or hyphens; invalid names fail closed. A missing, invalid, or corrupt value returns the supplied fallback. Save returns `true` only after the complete integer value has been written and atomically published.
 
 This API is intentionally narrow. It does not expose arbitrary filesystem paths, enumerate other games' values, serialize game memory, or provide a general document store. A future typed preference should extend the same scoped host boundary rather than exposing platform paths to Stasis code.

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -5,7 +5,10 @@ option(STASIS_ANDROID_SMOKE_ONLY "Build the standalone Android native smoke entr
 option(STASIS_ANDROID_PUBLISHED_AOT "Link compiler-produced AOT objects for published Android builds" OFF)
 set(STASIS_PUBLISHED_AOT_DIR "" CACHE PATH "Directory containing generated published Stasis AOT objects")
 
-add_library(stasis_mobile_smoke SHARED stasis_mobile_smoke.c stasis_android_sprite.c)
+add_library(stasis_mobile_smoke SHARED
+    stasis_mobile_smoke.c
+    stasis_android_sprite.c
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime/stasis_platform_storage.c")
 target_include_directories(stasis_mobile_smoke PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime")
 
 find_library(log_lib log)

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -11,6 +11,7 @@
 #include "stasis_display_scale.h"
 #include "stasis_render_contract.h"
 #include "stasis_mobile_aot_runtime.h"
+#include "stasis_platform_storage.h"
 #if STASIS_ANDROID_PUBLISHED_AOT
 #include "published_aot_symbols.h"
 #endif
@@ -41,6 +42,7 @@ typedef char *(*stasis_android_bridge_resolve_font_fn)(const char *project_root,
 typedef char *(*stasis_android_bridge_source_items_fn)(const char *project_root, const char *entry_file);
 typedef char *(*stasis_android_bridge_find_references_fn)(const char *project_root, const char *entry_file, const char *symbol, uintptr_t limit);
 typedef char *(*stasis_android_bridge_semantic_edit_fn)(const char *project_root, const char *entry_file, const char *request_json, int dry_run, int validate, int run_tests);
+typedef int (*stasis_android_bridge_set_storage_root_fn)(const char *storage_root);
 typedef void (*stasis_android_bridge_free_string_fn)(char *value);
 typedef char *(*stasis_codex_android_string_fn)(const char *codex_home);
 typedef uint64_t (*stasis_codex_android_begin_response_fn)(void);
@@ -85,6 +87,7 @@ typedef struct RustBridgeApi {
     stasis_android_bridge_source_items_fn source_items;
     stasis_android_bridge_find_references_fn find_references;
     stasis_android_bridge_semantic_edit_fn semantic_edit;
+    stasis_android_bridge_set_storage_root_fn set_storage_root;
     stasis_android_bridge_free_string_fn free_string;
     int attempted;
 } RustBridgeApi;
@@ -1330,6 +1333,8 @@ static RustBridgeApi *load_rust_bridge_api(void) {
             (stasis_android_bridge_find_references_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_find_references");
     rust_bridge_api.semantic_edit =
             (stasis_android_bridge_semantic_edit_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_semantic_edit");
+    rust_bridge_api.set_storage_root =
+            (stasis_android_bridge_set_storage_root_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_set_storage_root");
     rust_bridge_api.free_string =
             (stasis_android_bridge_free_string_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_free_string");
     if (rust_bridge_api.compile_project == NULL ||
@@ -1340,6 +1345,27 @@ static RustBridgeApi *load_rust_bridge_api(void) {
     }
 
     return &rust_bridge_api;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeSetStorageRoot(
+        JNIEnv *env, jclass activity_class, jstring storage_root) {
+    (void)activity_class;
+    if (storage_root == NULL) return 0;
+    const char *root = (*env)->GetStringUTFChars(env, storage_root, NULL);
+    if (root == NULL) return 0;
+    int configured = stasis_storage_set_root(root);
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge != NULL && bridge->set_storage_root != NULL) {
+        configured = bridge->set_storage_root(root) && configured;
+    }
+#if !STASIS_ANDROID_PUBLISHED_AOT
+    else {
+        configured = 0;
+    }
+#endif
+    (*env)->ReleaseStringUTFChars(env, storage_root, root);
+    return configured;
 }
 
 static CodexBridgeApi *load_codex_bridge_api(void) {

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -15,6 +15,7 @@ import android.view.WindowInsets;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -41,6 +42,7 @@ public final class MainActivity extends Activity {
     private long lastHudUpdateNanos;
 
     private static native String nativeCompileProject(String projectRoot);
+    private static native int nativeSetStorageRoot(String storageRoot);
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
             int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
             ByteBuffer frameF32, ByteBuffer frameU8);
@@ -52,6 +54,9 @@ public final class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (nativeSetStorageRoot(new File(getFilesDir(), "stasis_preferences").getAbsolutePath()) == 0) {
+            throw new IllegalStateException("Unable to initialize preference storage");
+        }
         Window window = getWindow();
         window.setStatusBarColor(Color.BLACK);
         window.setNavigationBarColor(Color.BLACK);

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -343,6 +343,7 @@ public final class MainActivity extends Activity {
 
     private static native String nativeStatus();
     private static native String nativeCompileProject(String projectRoot);
+    private static native int nativeSetStorageRoot(String storageRoot);
     private static native String nativeSourceItems(String projectRoot);
     private static native String nativeFindReferences(String projectRoot, String symbol, int limit);
     private static native String nativeSemanticEdit(String projectRoot, String requestJson,
@@ -377,6 +378,9 @@ public final class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (nativeSetStorageRoot(new File(getFilesDir(), "stasis_preferences").getAbsolutePath()) == 0) {
+            throw new IllegalStateException("Unable to initialize preference storage");
+        }
         AndroidCrashStore.install(this);
         JSONObject crashState = AndroidCrashStore.noteLaunch(this);
         restartLoopRecoveryActive = crashState.optBoolean("restart_loop_detected", false);

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -201,6 +201,15 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         target_link_libraries(stasis_mobile_aot_runtime_test PRIVATE m)
     endif()
     add_test(NAME stasis_mobile_aot_runtime_contract COMMAND stasis_mobile_aot_runtime_test)
+    if(UNIX)
+        add_executable(
+            stasis_platform_storage_test
+            tests/stasis_platform_storage_test.c
+            stasis_platform_storage.c
+        )
+        target_include_directories(stasis_platform_storage_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+        add_test(NAME stasis_platform_storage_contract COMMAND stasis_platform_storage_test)
+    endif()
 endif()
 
 if(STASIS_BUILD_SYS)

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <ctype.h>
+#include <errno.h>
 #include <time.h>
 #if defined(__ANDROID__)
 #include <android/log.h>
@@ -102,6 +103,8 @@ STASIS_EXPORT int stasis_get_time_us(void);
 STASIS_EXPORT int stasis_gfx_cache_text(int font_handle, const char* text);
 STASIS_EXPORT void stasis_gfx_draw_text_cached(int run_handle, float x, float y, float r, float g, float b, float a);
 STASIS_EXPORT float stasis_gfx_measure_text_cached(int run_handle);
+STASIS_EXPORT int stasis_storage_load_i32(const char* scope, const char* key, int fallback);
+STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, int value);
 
 /* Global state */
 static SDL_Window* g_window = NULL;
@@ -4928,6 +4931,113 @@ STASIS_EXPORT void stasis_sleep_ms(int ms) {
         nanosleep(&delay, NULL);
 #endif
     }
+}
+
+static int stasis_storage_component_valid(const char* value) {
+    size_t length;
+    size_t index;
+    if (!value) return 0;
+    length = strlen(value);
+    if (length == 0 || length > 63) return 0;
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (!((ch >= 'A' && ch <= 'Z') ||
+              (ch >= 'a' && ch <= 'z') ||
+              (ch >= '0' && ch <= '9') ||
+              ch == '_' || ch == '-')) return 0;
+    }
+    return 1;
+}
+
+static int stasis_storage_i32_path(
+    const char* scope,
+    const char* key,
+    char* path,
+    size_t capacity,
+    char** owned_root
+) {
+    int written;
+    char* root;
+    if (!path || capacity == 0 || !owned_root ||
+        !stasis_storage_component_valid(scope) || !stasis_storage_component_valid(key)) {
+        return 0;
+    }
+    root = SDL_GetPrefPath("StasisLang", scope);
+    if (!root) return 0;
+    written = snprintf(path, capacity, "%s%s.i32", root, key);
+    if (written < 0 || (size_t)written >= capacity) {
+        SDL_free(root);
+        return 0;
+    }
+    *owned_root = root;
+    return 1;
+}
+
+STASIS_EXPORT int stasis_storage_load_i32(const char* scope, const char* key, int fallback) {
+    char path[1024];
+    char buffer[64];
+    char* root = NULL;
+    char* end = NULL;
+    long long parsed;
+    FILE* file;
+    int trailing;
+    if (!stasis_storage_i32_path(scope, key, path, sizeof(path), &root)) return fallback;
+    file = fopen(path, "rb");
+    SDL_free(root);
+    if (!file) return fallback;
+    if (!fgets(buffer, sizeof(buffer), file)) {
+        fclose(file);
+        return fallback;
+    }
+    trailing = fgetc(file);
+    fclose(file);
+    if (trailing != EOF) return fallback;
+    errno = 0;
+    parsed = strtoll(buffer, &end, 10);
+    if (errno != 0 || end == buffer) return fallback;
+    while (*end != '\0' && isspace((unsigned char)*end)) end += 1;
+    if (*end != '\0' || parsed < INT32_MIN || parsed > INT32_MAX) return fallback;
+    return (int)parsed;
+}
+
+STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, int value) {
+    char path[1024];
+    char temp_path[1032];
+    char text[32];
+    char* root = NULL;
+    FILE* file;
+    int path_written;
+    int text_written;
+    int ok = 1;
+    if (!stasis_storage_i32_path(scope, key, path, sizeof(path), &root)) return 0;
+    SDL_free(root);
+    path_written = snprintf(temp_path, sizeof(temp_path), "%s.tmp", path);
+    text_written = snprintf(text, sizeof(text), "%d\n", value);
+    if (path_written < 0 || (size_t)path_written >= sizeof(temp_path) ||
+        text_written < 0 || (size_t)text_written >= sizeof(text)) {
+        return 0;
+    }
+    file = fopen(temp_path, "wb");
+    if (!file) return 0;
+    if (fwrite(text, 1, (size_t)text_written, file) != (size_t)text_written) ok = 0;
+    if (ok && fflush(file) != 0) ok = 0;
+    if (fclose(file) != 0) ok = 0;
+    if (!ok) {
+        remove(temp_path);
+        return 0;
+    }
+#if defined(_WIN32)
+    if (!MoveFileExA(temp_path, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        remove(temp_path);
+        return 0;
+    }
+#else
+    if (rename(temp_path, path) != 0) {
+        remove(temp_path);
+        return 0;
+    }
+#endif
+    return 1;
 }
 
 /*

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -19,6 +19,8 @@ EXPORTS
     stasis_get_time_ms
     stasis_get_time_us
     stasis_sleep_ms
+    stasis_storage_load_i32
+    stasis_storage_save_i32
     stasis_audio_init
     stasis_audio_shutdown
     stasis_audio_is_available

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -30,6 +30,8 @@ float stasis_gfx_measure_text_cached(int handle);
 int stasis_load_font(const char *path, int size);
 float stasis_measure_text(int font, const char *text);
 void stasis_sleep_ms(int ms);
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback);
+int stasis_storage_save_i32(const char *scope, const char *key, int value);
 
 typedef union StasisScalarValue {
     int32_t i32_value;
@@ -447,6 +449,26 @@ float stasis_jit_measure_text(int32_t font, int32_t text) {
     return result;
 }
 void stasis_jit_sleep_ms(int32_t ms) { stasis_sleep_ms(ms); }
+int stasis_jit_storage_load_i32(int32_t scope, int32_t key, int32_t fallback) {
+    char *scope_value = resolve_text(scope);
+    char *key_value = resolve_text(key);
+    int result = scope_value == NULL || key_value == NULL
+        ? fallback
+        : stasis_storage_load_i32(scope_value, key_value, fallback);
+    free(scope_value);
+    free(key_value);
+    return result;
+}
+int stasis_jit_storage_save_i32(int32_t scope, int32_t key, int32_t value) {
+    char *scope_value = resolve_text(scope);
+    char *key_value = resolve_text(key);
+    int result = scope_value == NULL || key_value == NULL
+        ? 0
+        : stasis_storage_save_i32(scope_value, key_value, value);
+    free(scope_value);
+    free(key_value);
+    return result;
+}
 
 #define DEFINE_SCALAR_ACCESSORS(name, type, kind, member) \
 type stasis_jit_global_##name##_load(int32_t hash) { \

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -94,6 +94,8 @@ float stasis_jit_gfx_measure_text_cached(int32_t handle);
 int stasis_jit_load_font(int32_t path, int32_t size);
 float stasis_jit_measure_text(int32_t font, int32_t text);
 void stasis_jit_sleep_ms(int32_t ms);
+int stasis_jit_storage_load_i32(int32_t scope, int32_t key, int32_t fallback);
+int stasis_jit_storage_save_i32(int32_t scope, int32_t key, int32_t value);
 int stasis_mobile_json_escape(const char *input, char *output, size_t capacity);
 void stasis_mobile_aot_reset(void);
 

--- a/runtime/stasis_platform_storage.c
+++ b/runtime/stasis_platform_storage.c
@@ -1,0 +1,107 @@
+#include "stasis_platform_storage.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define STASIS_STORAGE_PATH_CAPACITY 1024
+
+static char stasis_storage_root[STASIS_STORAGE_PATH_CAPACITY];
+
+static int stasis_storage_component_valid(const char *value) {
+    size_t length;
+    size_t index;
+    if (value == NULL) return 0;
+    length = strlen(value);
+    if (length == 0 || length > 63) return 0;
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (!((ch >= 'A' && ch <= 'Z') ||
+              (ch >= 'a' && ch <= 'z') ||
+              (ch >= '0' && ch <= '9') || ch == '_' || ch == '-')) return 0;
+    }
+    return 1;
+}
+
+static int stasis_storage_ensure_directory(const char *path) {
+    if (mkdir(path, 0700) == 0 || errno == EEXIST) return 1;
+    return 0;
+}
+
+int stasis_storage_set_root(const char *root) {
+    size_t length;
+    if (root == NULL) return 0;
+    length = strlen(root);
+    if (length == 0 || length >= sizeof(stasis_storage_root)) return 0;
+    memcpy(stasis_storage_root, root, length + 1);
+    return stasis_storage_ensure_directory(stasis_storage_root);
+}
+
+static int stasis_storage_i32_path(
+    const char *scope,
+    const char *key,
+    char *path,
+    size_t capacity
+) {
+    char directory[STASIS_STORAGE_PATH_CAPACITY];
+    int directory_written;
+    int path_written;
+    if (stasis_storage_root[0] == '\0' ||
+        !stasis_storage_component_valid(scope) || !stasis_storage_component_valid(key)) return 0;
+    directory_written = snprintf(directory, sizeof(directory), "%s/%s", stasis_storage_root, scope);
+    if (directory_written < 0 || (size_t)directory_written >= sizeof(directory) ||
+        !stasis_storage_ensure_directory(directory)) return 0;
+    path_written = snprintf(path, capacity, "%s/%s.i32", directory, key);
+    return path_written >= 0 && (size_t)path_written < capacity;
+}
+
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback) {
+    char path[STASIS_STORAGE_PATH_CAPACITY];
+    char buffer[64];
+    char *end = NULL;
+    long long parsed;
+    FILE *file;
+    int trailing;
+    if (!stasis_storage_i32_path(scope, key, path, sizeof(path))) return fallback;
+    file = fopen(path, "rb");
+    if (file == NULL) return fallback;
+    if (fgets(buffer, sizeof(buffer), file) == NULL) {
+        fclose(file);
+        return fallback;
+    }
+    trailing = fgetc(file);
+    fclose(file);
+    if (trailing != EOF) return fallback;
+    errno = 0;
+    parsed = strtoll(buffer, &end, 10);
+    if (errno != 0 || end == buffer) return fallback;
+    while (*end != '\0' && isspace((unsigned char)*end)) end += 1;
+    if (*end != '\0' || parsed < INT32_MIN || parsed > INT32_MAX) return fallback;
+    return (int)parsed;
+}
+
+int stasis_storage_save_i32(const char *scope, const char *key, int value) {
+    char path[STASIS_STORAGE_PATH_CAPACITY];
+    char temporary[STASIS_STORAGE_PATH_CAPACITY + 8];
+    FILE *file;
+    int temporary_written;
+    int ok = 1;
+    if (!stasis_storage_i32_path(scope, key, path, sizeof(path))) return 0;
+    temporary_written = snprintf(temporary, sizeof(temporary), "%s.tmp", path);
+    if (temporary_written < 0 || (size_t)temporary_written >= sizeof(temporary)) return 0;
+    file = fopen(temporary, "wb");
+    if (file == NULL) return 0;
+    if (fprintf(file, "%d\n", value) < 0) ok = 0;
+    if (ok && fflush(file) != 0) ok = 0;
+    if (fclose(file) != 0) ok = 0;
+    if (!ok || rename(temporary, path) != 0) {
+        remove(temporary);
+        return 0;
+    }
+    return 1;
+}

--- a/runtime/stasis_platform_storage.h
+++ b/runtime/stasis_platform_storage.h
@@ -1,0 +1,8 @@
+#ifndef STASIS_PLATFORM_STORAGE_H
+#define STASIS_PLATFORM_STORAGE_H
+
+int stasis_storage_set_root(const char *root);
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback);
+int stasis_storage_save_i32(const char *scope, const char *key, int value);
+
+#endif

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -17,6 +17,10 @@ static int32_t add_two(int32_t left, int32_t right) {
 }
 
 static char last_sprite_path[64];
+static char saved_scope[64];
+static char saved_key[64];
+static int saved_value;
+static int has_saved_value;
 
 int stasis_audio_init(int rate, int channels, int latency) {
     return rate > 0 && channels == 2 && latency > 0;
@@ -48,6 +52,23 @@ float stasis_measure_text(int font, const char *text) {
     return text != NULL ? (float)font : 0.0f;
 }
 void stasis_sleep_ms(int ms) { (void)ms; }
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback) {
+    if (has_saved_value && scope != NULL && key != NULL &&
+        strcmp(scope, saved_scope) == 0 && strcmp(key, saved_key) == 0) {
+        return saved_value;
+    }
+    return fallback;
+}
+int stasis_storage_save_i32(const char *scope, const char *key, int value) {
+    if (scope == NULL || key == NULL) return 0;
+    strncpy(saved_scope, scope, sizeof(saved_scope) - 1);
+    saved_scope[sizeof(saved_scope) - 1] = '\0';
+    strncpy(saved_key, key, sizeof(saved_key) - 1);
+    saved_key[sizeof(saved_key) - 1] = '\0';
+    saved_value = value;
+    has_saved_value = 1;
+    return 1;
+}
 
 int main(void) {
     int32_t external = 4;
@@ -99,6 +120,14 @@ int main(void) {
     CHECK(stasis_jit_gfx_load_sprite(23, 32, 32) == 1);
     CHECK(strcmp(last_sprite_path, "sprite.bmp") == 0);
     CHECK(stasis_jit_gfx_dump_png(23) == 1);
+
+    stasis_jit_upsert_string_literal(40, "sample_game");
+    stasis_jit_upsert_string_literal(41, "unlocked_tier");
+    CHECK(stasis_jit_storage_load_i32(40, 41, 1) == 1);
+    CHECK(stasis_jit_storage_save_i32(40, 41, 4) == 1);
+    CHECK(stasis_jit_storage_load_i32(40, 41, 1) == 4);
+    CHECK(strcmp(saved_scope, "sample_game") == 0);
+    CHECK(strcmp(saved_key, "unlocked_tier") == 0);
 
     owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
     CHECK(owned != NULL);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -117,6 +117,13 @@ float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
 int stasis_load_font(const char *path, int size) { return path ? size : 0; }
 float stasis_measure_text(int font, const char *text) { return text ? (float)font : 0.0f; }
 void stasis_sleep_ms(int ms) { (void)ms; }
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback) {
+    return scope && key ? fallback : 0;
+}
+int stasis_storage_save_i32(const char *scope, const char *key, int value) {
+    (void)value;
+    return scope && key;
+}
 
 static int32_t hash_path(const char *path);
 

--- a/runtime/tests/stasis_platform_storage_test.c
+++ b/runtime/tests/stasis_platform_storage_test.c
@@ -1,0 +1,34 @@
+#include "stasis_platform_storage.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(void) {
+    char root[256];
+    char corrupt_path[320];
+    FILE *corrupt;
+    snprintf(root, sizeof(root), "/tmp/stasis_platform_storage_%ld", (long)getpid());
+    assert(mkdir(root, 0700) == 0);
+    assert(stasis_storage_set_root(root) == 1);
+    assert(stasis_storage_load_i32("game", "tier", 1) == 1);
+    assert(stasis_storage_save_i32("game", "tier", 4) == 1);
+    assert(stasis_storage_load_i32("game", "tier", 1) == 4);
+    assert(stasis_storage_save_i32("../game", "tier", 5) == 0);
+
+    snprintf(corrupt_path, sizeof(corrupt_path), "%s/game/tier.i32", root);
+    corrupt = fopen(corrupt_path, "wb");
+    assert(corrupt != NULL);
+    assert(fputs("surprise\n", corrupt) >= 0);
+    assert(fclose(corrupt) == 0);
+    assert(stasis_storage_load_i32("game", "tier", 2) == 2);
+
+    assert(remove(corrupt_path) == 0);
+    snprintf(corrupt_path, sizeof(corrupt_path), "%s/game", root);
+    assert(rmdir(corrupt_path) == 0);
+    assert(rmdir(root) == 0);
+    return 0;
+}

--- a/samples/storage_preferences/storage_preferences.stasis
+++ b/samples/storage_preferences/storage_preferences.stasis
@@ -1,0 +1,10 @@
+import "../../src/stdlib/storage.stasis";
+
+function main(): i32 {
+    let scope: string = "stasis_storage_sample";
+    let key: string = "progress";
+    let previous: i32 = storage_load_i32(scope, key, 1);
+    if (previous < 7 && !storage_save_i32(scope, key, 7)) { return 1; }
+    if (storage_load_i32(scope, key, 1) != 7) { return 2; }
+    return 0;
+}

--- a/src/stdlib/storage.stasis
+++ b/src/stdlib/storage.stasis
@@ -1,0 +1,5 @@
+// Small durable integer preferences for game progression and settings.
+// Scope and key must be 1..63 ASCII letters, digits, underscores, or hyphens.
+// Missing, invalid, or corrupt values return the caller-provided fallback.
+extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
+extern function storage_save_i32(scope: string, key: string, value: i32): bool;


### PR DESCRIPTION
## Summary

- Add scoped integer preference storage through `storage_load_i32` and `storage_save_i32`.
- Wire the API through the runtime, JIT, AOT/mobile bindings, standard library, documentation, and deterministic tests.

## Motivation

Applications such as ChessTD need a small durable progression value without inventing an application-only persistence layer. The scoped integer API provides that primitive consistently across supported execution paths.

## Verification

- Dynamic-loading suite: 11 passed.
- Compiler suite: 323 passed, 1 ignored.
