### PR TITLE
Fix mobile preference host release packaging

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -98,7 +98,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_renderer_lifecycle.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_renderer_lifecycle.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stasis_platform_storage.c runtime/stasis_platform_storage.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/agent_workflow.md docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md docs/release_provenance.md "${out}/docs/"
           release_tag="${{ github.event.release.tag_name }}"
@@ -148,7 +148,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
           Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
-          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_render_contract.h', 'stasis_renderer_lifecycle.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_render_contract.h', 'stasis_renderer_lifecycle.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stasis_platform_storage.c', 'stasis_platform_storage.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
           Copy-Item docs/agent_workflow.md,docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md,docs/release_provenance.md "$out/docs/" -Force
           $releaseTag = "${{ github.event.release.tag_name }}"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -168,7 +168,7 @@ jobs:
           mkdir -p "${out}/mobile"
           cp -R mobile/shells "${out}/mobile/"
           mkdir -p "${out}/runtime"
-          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_renderer_lifecycle.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stb_truetype.h "${out}/runtime/"
+          cp runtime/CMakeLists.txt runtime/nanosvg.h runtime/nanosvgrast.h runtime/stasis_asset_path.h runtime/stasis_display_scale.h runtime/stasis_render_contract.h runtime/stasis_renderer_lifecycle.h runtime/stasis_graphics.c runtime/stasis_mobile_aot_runtime.c runtime/stasis_mobile_aot_runtime.h runtime/stasis_mobile_runtime.c runtime/stasis_mobile_runtime.h runtime/stasis_platform_storage.c runtime/stasis_platform_storage.h runtime/stb_truetype.h "${out}/runtime/"
           mkdir -p "${out}/docs"
           cp docs/agent_workflow.md docs/mobile_packaging.md docs/mobile_packaging_abi.md docs/mobile_aot_artifacts.md docs/release_provenance.md "${out}/docs/"
           python3 tools/generate_release_provenance.py \
@@ -212,7 +212,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "$out/mobile" | Out-Null
           Copy-Item mobile/shells "$out/mobile/" -Recurse -Force
           New-Item -ItemType Directory -Force -Path "$out/runtime" | Out-Null
-          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_render_contract.h', 'stasis_renderer_lifecycle.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
+          @('CMakeLists.txt', 'nanosvg.h', 'nanosvgrast.h', 'stasis_asset_path.h', 'stasis_display_scale.h', 'stasis_render_contract.h', 'stasis_renderer_lifecycle.h', 'stasis_graphics.c', 'stasis_mobile_aot_runtime.c', 'stasis_mobile_aot_runtime.h', 'stasis_mobile_runtime.c', 'stasis_mobile_runtime.h', 'stasis_platform_storage.c', 'stasis_platform_storage.h', 'stb_truetype.h') | ForEach-Object { Copy-Item "runtime/$_" "$out/runtime/" -Force }
           New-Item -ItemType Directory -Force -Path "$out/docs" | Out-Null
           Copy-Item docs/agent_workflow.md,docs/mobile_packaging.md,docs/mobile_packaging_abi.md,docs/mobile_aot_artifacts.md,docs/release_provenance.md "$out/docs/" -Force
           $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3352,6 +3352,10 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/stasis_mobile_runtime.h"
     ));
+    const STASIS_MOBILE_MAIN_SOURCE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../mobile/shells/common/stasis_mobile_main.c"
+    ));
     const STASIS_MOBILE_AOT_RUNTIME_SOURCE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/stasis_mobile_aot_runtime.c"
@@ -3741,6 +3745,11 @@ mod tests {
             STASIS_RUNTIME_CMAKE
                 .contains("configure_stasis_target(stasis_mobile_runtime ON TRUE OFF)"),
             "mobile target should be static, SDL-only, and exclude the SDL desktop main shim"
+        );
+        assert!(
+            STASIS_RUNTIME_CMAKE.contains("stasis_platform_storage.c")
+                && STASIS_MOBILE_MAIN_SOURCE.contains("stasis_storage_set_root(root)"),
+            "mobile packages must link and configure the app-private preference host"
         );
         assert!(
             !STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_dynload")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -4128,12 +4128,15 @@ mod tests {
         let config =
             fs::read_to_string(ios.join("ios/StasisMobile.xcconfig")).expect("read Xcode config");
         assert!(project.contains("stasis_mobile_runtime.c in Sources"));
+        assert!(project.contains("stasis_platform_storage.c in Sources"));
         assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
         assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
         assert!(ios.join("runtime/stasis_display_scale.h").is_file());
         assert!(ios.join("runtime/stasis_asset_path.h").is_file());
         assert!(ios.join("runtime/stasis_render_contract.h").is_file());
         assert!(ios.join("runtime/stasis_renderer_lifecycle.h").is_file());
+        assert!(ios.join("runtime/stasis_platform_storage.c").is_file());
+        assert!(ios.join("runtime/stasis_platform_storage.h").is_file());
         assert!(config.contains("@executable_path/Frameworks"));
         assert!(project.contains("Embed SDL frameworks"));
         assert!(ios

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -52,6 +52,8 @@ const MOBILE_RUNTIME_FILES: &[&str] = &[
     "stasis_mobile_aot_runtime.h",
     "stasis_mobile_runtime.c",
     "stasis_mobile_runtime.h",
+    "stasis_platform_storage.c",
+    "stasis_platform_storage.h",
     "stb_truetype.h",
 ];
 const PROJECT_AGENT_GUIDE: &str = include_str!("../../../docs/agent_workflow.md");
@@ -4084,6 +4086,8 @@ mod tests {
         assert!(runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));
         assert!(android.join("runtime/stasis_display_scale.h").is_file());
         assert!(android.join("runtime/stasis_asset_path.h").is_file());
+        assert!(android.join("runtime/stasis_platform_storage.c").is_file());
+        assert!(android.join("runtime/stasis_platform_storage.h").is_file());
         assert!(android.join("runtime/stasis_render_contract.h").is_file());
         assert!(android
             .join("runtime/stasis_renderer_lifecycle.h")

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -7,6 +7,7 @@
 #include "published_aot_symbols.h"
 #include "stasis_package_provenance.h"
 #include "stasis_mobile_runtime.h"
+#include "stasis_platform_storage.h"
 
 static int configure_asset_root(void) {
 #if defined(__APPLE__) && !defined(__ANDROID__)
@@ -31,11 +32,25 @@ static int configure_asset_root(void) {
 #endif
 }
 
+static int configure_storage_root(void) {
+    char *root = SDL_GetPrefPath("StasisLang", "@STASIS_APP_NAME@");
+    if (root == NULL) {
+        return -1;
+    }
+    int configured = stasis_storage_set_root(root);
+    SDL_free(root);
+    return configured ? 0 : -1;
+}
+
 int SDL_main(int argc, char **argv) {
     (void)argc;
     (void)argv;
     if (configure_asset_root() != 0) {
         SDL_Log("Stasis could not configure the bundled asset root");
+        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
+    }
+    if (configure_storage_root() != 0) {
+        SDL_Log("Stasis could not configure app-private preference storage");
         return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
     }
     SDL_Log(

--- a/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
+++ b/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		100000000000000000000005 /* stasis_graphics.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000005 /* stasis_graphics.c */; };
 		100000000000000000000006 /* published_aot_bindings.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000006 /* published_aot_bindings.c */; };
 		100000000000000000000007 /* stasis_game in Resources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000007 /* stasis_game */; };
+		100000000000000000000008 /* stasis_platform_storage.c in Sources */ = {isa = PBXBuildFile; fileRef = 20000000000000000000000A /* stasis_platform_storage.c */; };
 
 		300000000000000000000001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -23,6 +24,7 @@
 				100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */,
 				100000000000000000000005 /* stasis_graphics.c in Sources */,
 				100000000000000000000006 /* published_aot_bindings.c in Sources */,
+				100000000000000000000008 /* stasis_platform_storage.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,6 +55,8 @@
 		200000000000000000000007 /* stasis_game */ = {isa = PBXFileReference; lastKnownFileType = folder; path = StasisMobile/stasis_game; sourceTree = "<group>"; };
 		200000000000000000000008 /* StasisMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StasisMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		200000000000000000000009 /* StasisMobile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StasisMobile.xcconfig; sourceTree = "<group>"; };
+		20000000000000000000000A /* stasis_platform_storage.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_platform_storage.c; sourceTree = "<group>"; };
+		20000000000000000000000B /* stasis_platform_storage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../runtime/stasis_platform_storage.h; sourceTree = "<group>"; };
 
 		400000000000000000000001 = {
 			isa = PBXGroup;
@@ -63,6 +67,8 @@
 				200000000000000000000004 /* stasis_mobile_aot_runtime.c */,
 				200000000000000000000005 /* stasis_graphics.c */,
 				200000000000000000000006 /* published_aot_bindings.c */,
+				20000000000000000000000A /* stasis_platform_storage.c */,
+				20000000000000000000000B /* stasis_platform_storage.h */,
 				200000000000000000000007 /* stasis_game */,
 				200000000000000000000009 /* StasisMobile.xcconfig */,
 				400000000000000000000002 /* Products */,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -139,6 +139,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
         stasis_mobile_runtime STATIC
         stasis_mobile_runtime.c
         stasis_mobile_aot_runtime.c
+        stasis_platform_storage.c
     )
     configure_stasis_target(stasis_mobile_runtime ON TRUE OFF)
     target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -148,7 +149,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
     )
     install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
     install(
-        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
+        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h stasis_platform_storage.h
         DESTINATION include
     )
 endif()

--- a/tools/ci/test_release_provenance.py
+++ b/tools/ci/test_release_provenance.py
@@ -6,12 +6,18 @@ import sys
 import tempfile
 import unittest
 
+from tools.generate_release_provenance import RUNTIME_FILES
+
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 VERIFY = ROOT / "tools" / "verify_package_provenance.py"
 
 
 class ReleaseProvenanceTests(unittest.TestCase):
+    def test_mobile_preference_host_is_part_of_release_provenance(self):
+        self.assertIn("stasis_platform_storage.c", RUNTIME_FILES)
+        self.assertIn("stasis_platform_storage.h", RUNTIME_FILES)
+
     def test_package_verifier_detects_runtime_substitution(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)

--- a/tools/generate_release_provenance.py
+++ b/tools/generate_release_provenance.py
@@ -24,6 +24,8 @@ RUNTIME_FILES = (
     "stasis_mobile_aot_runtime.h",
     "stasis_mobile_runtime.c",
     "stasis_mobile_runtime.h",
+    "stasis_platform_storage.c",
+    "stasis_platform_storage.h",
     "stb_truetype.h",
 )
 


### PR DESCRIPTION
## Summary
- link the scoped preference host into generic Android/iOS mobile runtime packages
- configure its app-private root before guest startup
- include and hash the host sources in nightly/bootstrap release archives
- add lifecycle, package-assembly, and release-provenance regressions

## Validation
- cargo test -p stasis mobile_runtime_uses_fixed_entries_and_sdl_only_static_target
- cargo test -p stasis mobile_shells_are_platform_projects_over_one_shared_runtime
- python -m unittest tools.ci.test_release_provenance
- git diff --check