### PR TITLE
Fix duplicate mobile preference host

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3747,9 +3747,12 @@ mod tests {
             "mobile target should be static, SDL-only, and exclude the SDL desktop main shim"
         );
         assert!(
-            STASIS_RUNTIME_CMAKE.contains("stasis_platform_storage.c")
-                && STASIS_MOBILE_MAIN_SOURCE.contains("stasis_storage_set_root(root)"),
-            "mobile packages must link and configure the app-private preference host"
+            STASIS_GRAPHICS_SOURCE.contains("stasis_storage_load_i32")
+                && STASIS_GRAPHICS_SOURCE.contains("stasis_storage_save_i32")
+                && !STASIS_RUNTIME_CMAKE
+                    .contains("stasis_mobile_aot_runtime.c\n        stasis_platform_storage.c")
+                && !STASIS_MOBILE_MAIN_SOURCE.contains("stasis_storage_set_root"),
+            "graphical mobile packages must use the single SDL preference host"
         );
         assert!(
             !STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_dynload")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -4128,7 +4128,7 @@ mod tests {
         let config =
             fs::read_to_string(ios.join("ios/StasisMobile.xcconfig")).expect("read Xcode config");
         assert!(project.contains("stasis_mobile_runtime.c in Sources"));
-        assert!(project.contains("stasis_platform_storage.c in Sources"));
+        assert!(!project.contains("stasis_platform_storage.c in Sources"));
         assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
         assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
         assert!(ios.join("runtime/stasis_display_scale.h").is_file());

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -7,7 +7,6 @@
 #include "published_aot_symbols.h"
 #include "stasis_package_provenance.h"
 #include "stasis_mobile_runtime.h"
-#include "stasis_platform_storage.h"
 
 static int configure_asset_root(void) {
 #if defined(__APPLE__) && !defined(__ANDROID__)
@@ -32,25 +31,11 @@ static int configure_asset_root(void) {
 #endif
 }
 
-static int configure_storage_root(void) {
-    char *root = SDL_GetPrefPath("StasisLang", "@STASIS_APP_NAME@");
-    if (root == NULL) {
-        return -1;
-    }
-    int configured = stasis_storage_set_root(root);
-    SDL_free(root);
-    return configured ? 0 : -1;
-}
-
 int SDL_main(int argc, char **argv) {
     (void)argc;
     (void)argv;
     if (configure_asset_root() != 0) {
         SDL_Log("Stasis could not configure the bundled asset root");
-        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
-    }
-    if (configure_storage_root() != 0) {
-        SDL_Log("Stasis could not configure app-private preference storage");
         return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
     }
     SDL_Log(

--- a/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
+++ b/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		100000000000000000000005 /* stasis_graphics.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000005 /* stasis_graphics.c */; };
 		100000000000000000000006 /* published_aot_bindings.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000006 /* published_aot_bindings.c */; };
 		100000000000000000000007 /* stasis_game in Resources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000007 /* stasis_game */; };
-		100000000000000000000008 /* stasis_platform_storage.c in Sources */ = {isa = PBXBuildFile; fileRef = 20000000000000000000000A /* stasis_platform_storage.c */; };
 
 		300000000000000000000001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -24,7 +23,6 @@
 				100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */,
 				100000000000000000000005 /* stasis_graphics.c in Sources */,
 				100000000000000000000006 /* published_aot_bindings.c in Sources */,
-				100000000000000000000008 /* stasis_platform_storage.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,8 +53,6 @@
 		200000000000000000000007 /* stasis_game */ = {isa = PBXFileReference; lastKnownFileType = folder; path = StasisMobile/stasis_game; sourceTree = "<group>"; };
 		200000000000000000000008 /* StasisMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StasisMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		200000000000000000000009 /* StasisMobile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StasisMobile.xcconfig; sourceTree = "<group>"; };
-		20000000000000000000000A /* stasis_platform_storage.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_platform_storage.c; sourceTree = "<group>"; };
-		20000000000000000000000B /* stasis_platform_storage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../runtime/stasis_platform_storage.h; sourceTree = "<group>"; };
 
 		400000000000000000000001 = {
 			isa = PBXGroup;
@@ -67,8 +63,6 @@
 				200000000000000000000004 /* stasis_mobile_aot_runtime.c */,
 				200000000000000000000005 /* stasis_graphics.c */,
 				200000000000000000000006 /* published_aot_bindings.c */,
-				20000000000000000000000A /* stasis_platform_storage.c */,
-				20000000000000000000000B /* stasis_platform_storage.h */,
 				200000000000000000000007 /* stasis_game */,
 				200000000000000000000009 /* StasisMobile.xcconfig */,
 				400000000000000000000002 /* Products */,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -139,7 +139,6 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
         stasis_mobile_runtime STATIC
         stasis_mobile_runtime.c
         stasis_mobile_aot_runtime.c
-        stasis_platform_storage.c
     )
     configure_stasis_target(stasis_mobile_runtime ON TRUE OFF)
     target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -149,7 +148,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
     )
     install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
     install(
-        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h stasis_platform_storage.h
+        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
         DESTINATION include
     )
 endif()


### PR DESCRIPTION
## What changed

- Keep the standalone platform preference host out of graphical mobile targets.
- Use the existing SDL-backed implementation in `stasis_graphics.c` as the single mobile host.
- Preserve the standalone host in release bundles for headless and non-graphics consumers.
- Add source-ownership and package-project regression assertions.

## Root cause

PR #338 added `stasis_platform_storage.c` to the same mobile static library that already compiled the preference exports from `stasis_graphics.c`. Android then failed to link `libmain.so` because both objects defined `stasis_storage_load_i32` and `stasis_storage_save_i32`.

## Validation

- Built and linked a real ChessTD Android APK after applying this source arrangement.
- `cargo fmt --all -- --check`
- `cargo test -p stasis mobile_runtime_uses_fixed_entries_and_sdl_only_static_target`
- `cargo test -p stasis mobile_shells_are_platform_projects_over_one_shared_runtime`
- `python -m unittest tools.ci.test_release_provenance`
- `git diff --check`
