### PR TITLE
Fix mobile AOT buffers and link generated APKs in CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -100,3 +100,48 @@ jobs:
 
       - name: Bootstrap Compile Smoke (compiler .stasis)
         run: cargo test -p stasis_compiler -- --nocapture
+
+  android-package-link:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Stasis
+        uses: actions/checkout@v4
+
+      - name: Checkout SDL2
+        uses: actions/checkout@v4
+        with:
+          repository: libsdl-org/SDL
+          ref: 5d249570393f7a37e037abf22cd6012a4cc56a71
+          path: target/android-link-deps/SDL
+
+      - name: Checkout SDL2_image
+        uses: actions/checkout@v4
+        with:
+          repository: libsdl-org/SDL_image
+          ref: 12cb2e40330d256d9b1329647be8f366546d715c
+          path: target/android-link-deps/SDL_image
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android native toolchain
+        run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;27.0.12077973" "cmake;3.22.1"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.9"
+
+      - name: Package and link generated Android game
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: "2"
+          STASIS_SDL2_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL
+          STASIS_SDL2_IMAGE_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL_image
+        run: |
+          cargo run -p stasis -- --workspace samples/mobile_storage_link package-mobile --target android-arm64 --out dist/android --development-build
+          gradle -p samples/mobile_storage_link/dist/android/android :app:assembleDebug --no-daemon --max-workers=2 --console=plain
+          test -f samples/mobile_storage_link/dist/android/android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Checkout Stasis
         uses: actions/checkout@v4
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.9"
+
       - name: Checkout SDL2
         uses: actions/checkout@v4
         with:
@@ -130,11 +135,6 @@ jobs:
 
       - name: Install Android native toolchain
         run: sdkmanager "platforms;android-35" "build-tools;35.0.0" "ndk;27.0.12077973" "cmake;3.22.1"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: "8.9"
 
       - name: Package and link generated Android game
         env:

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -553,6 +553,13 @@ int32_t *stasis_jit_global_i32_array_ptr(int32_t c, int32_t f, int32_t len) {
     return (int32_t *)ensure_array(entry, (size_t)len);
 }
 
+uint8_t *stasis_jit_global_u8_array_ptr(int32_t c, int32_t f, int32_t len) {
+    StasisArray *entry;
+    if (len <= 0) return NULL;
+    entry = find_array(c, f, STASIS_VALUE_U8, 1);
+    return (uint8_t *)ensure_array(entry, (size_t)len);
+}
+
 static int32_t collection_meta_hash(int32_t hash, int32_t kind) {
     const char *suffix = kind == 1 ? ".length" : kind == 2 ? ".max_length" :
         kind == 3 ? ".char_length" : NULL;

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -34,6 +34,7 @@ void stasis_jit_global_f64_store(int32_t hash, double value);
 int32_t stasis_jit_global_i32_array_load(int32_t c, int32_t f, int32_t i);
 void stasis_jit_global_i32_array_store(int32_t c, int32_t f, int32_t i, int32_t value);
 int32_t *stasis_jit_global_i32_array_ptr(int32_t c, int32_t f, int32_t len);
+uint8_t *stasis_jit_global_u8_array_ptr(int32_t c, int32_t f, int32_t len);
 float stasis_jit_global_f32_array_load(int32_t c, int32_t f, int32_t i);
 void stasis_jit_global_f32_array_store(int32_t c, int32_t f, int32_t i, float value);
 float *stasis_jit_global_f32_array_ptr(int32_t c, int32_t f, int32_t len);

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -24,15 +24,11 @@ void stasis_gfx_submit_u8(
 );
 void stasis_shutdown(void);
 
-static int32_t host_i32[768];
-static float host_f32[64];
-static int32_t gfx_cmd_i32[STASIS_RENDER_I32_COUNT];
-static float gfx_cmd_f32[STASIS_RENDER_F32_COUNT];
-static uint8_t gfx_cmd_u8[STASIS_RENDER_U8_COUNT];
-static int32_t host_req_seq;
-static int32_t host_req_flags;
-static int32_t host_req_window_w_px;
-static int32_t host_req_window_h_px;
+static int32_t *host_i32;
+static float *host_f32;
+static int32_t *gfx_cmd_i32;
+static float *gfx_cmd_f32;
+static uint8_t *gfx_cmd_u8;
 
 typedef struct StasisMobileRuntimeState {
     StasisMobileGameEntries entries;
@@ -52,30 +48,33 @@ static int32_t hash_global_path(const char *path) {
     return (int32_t)hash;
 }
 
-static void bind_host_globals(void) {
-    memset(host_i32, 0, sizeof(host_i32));
-    memset(host_f32, 0, sizeof(host_f32));
-    memset(gfx_cmd_i32, 0, sizeof(gfx_cmd_i32));
-    memset(gfx_cmd_f32, 0, sizeof(gfx_cmd_f32));
-    memset(gfx_cmd_u8, 0, sizeof(gfx_cmd_u8));
-    host_req_seq = 0;
-    host_req_flags = 0;
-    host_req_window_w_px = 0;
-    host_req_window_h_px = 0;
-    stasis_jit_register_global_i32_array(hash_global_path("host_i32"), 0, host_i32, 768);
-    stasis_jit_register_global_f32_array(hash_global_path("host_f32"), 0, host_f32, 64);
-    stasis_jit_register_global_i32_array(
-        hash_global_path("gfx_cmd_i32"), 0, gfx_cmd_i32, STASIS_RENDER_I32_COUNT);
-    stasis_jit_register_global_f32_array(
-        hash_global_path("gfx_cmd_f32"), 0, gfx_cmd_f32, STASIS_RENDER_F32_COUNT);
-    stasis_jit_register_global_u8_array(
-        hash_global_path("gfx_cmd_u8"), 0, gfx_cmd_u8, STASIS_RENDER_U8_COUNT);
-    stasis_jit_register_global_i32_ptr(hash_global_path("host_req_seq"), &host_req_seq);
-    stasis_jit_register_global_i32_ptr(hash_global_path("host_req_flags"), &host_req_flags);
-    stasis_jit_register_global_i32_ptr(
-        hash_global_path("host_req_window_w_px"), &host_req_window_w_px);
-    stasis_jit_register_global_i32_ptr(
-        hash_global_path("host_req_window_h_px"), &host_req_window_h_px);
+static int bind_guest_globals(void) {
+    host_i32 = stasis_jit_global_i32_array_ptr(hash_global_path("host_i32"), 0, 768);
+    host_f32 = stasis_jit_global_f32_array_ptr(hash_global_path("host_f32"), 0, 64);
+    gfx_cmd_i32 = stasis_jit_global_i32_array_ptr(
+        hash_global_path("gfx_cmd_i32"), 0, STASIS_RENDER_I32_COUNT);
+    gfx_cmd_f32 = stasis_jit_global_f32_array_ptr(
+        hash_global_path("gfx_cmd_f32"), 0, STASIS_RENDER_F32_COUNT);
+    gfx_cmd_u8 = stasis_jit_global_u8_array_ptr(
+        hash_global_path("gfx_cmd_u8"), 0, STASIS_RENDER_U8_COUNT);
+    if (host_i32 == NULL || host_f32 == NULL || gfx_cmd_i32 == NULL ||
+        gfx_cmd_f32 == NULL || gfx_cmd_u8 == NULL) {
+        return 0;
+    }
+    memset(host_i32, 0, 768 * sizeof(*host_i32));
+    memset(host_f32, 0, 64 * sizeof(*host_f32));
+    memset(gfx_cmd_i32, 0, STASIS_RENDER_I32_COUNT * sizeof(*gfx_cmd_i32));
+    memset(gfx_cmd_f32, 0, STASIS_RENDER_F32_COUNT * sizeof(*gfx_cmd_f32));
+    memset(gfx_cmd_u8, 0, STASIS_RENDER_U8_COUNT * sizeof(*gfx_cmd_u8));
+    return 1;
+}
+
+static void apply_guest_host_requests(void) {
+    int32_t seq = stasis_jit_global_i32_load(hash_global_path("host_req_seq"));
+    int32_t flags = stasis_jit_global_i32_load(hash_global_path("host_req_flags"));
+    int32_t width = stasis_jit_global_i32_load(hash_global_path("host_req_window_w_px"));
+    int32_t height = stasis_jit_global_i32_load(hash_global_path("host_req_window_h_px"));
+    stasis_host_bulk_apply_requests(&seq, &flags, &width, &height);
 }
 
 static int entries_are_valid(const StasisMobileGameEntries *entries) {
@@ -106,20 +105,15 @@ int32_t stasis_mobile_runtime_initialize(
     runtime_state.initialized = 1;
     runtime_state.paused = 0;
     runtime_state.entries.bind_runtime_entry();
-    bind_host_globals();
-    stasis_host_bulk_apply_requests(
-        &host_req_seq,
-        &host_req_flags,
-        &host_req_window_w_px,
-        &host_req_window_h_px
-    );
+    if (!bind_guest_globals()) {
+        stasis_shutdown();
+        stasis_mobile_aot_reset();
+        runtime_state = (StasisMobileRuntimeState){0};
+        return STASIS_MOBILE_RUNTIME_INVALID_ARGUMENT;
+    }
+    apply_guest_host_requests();
     runtime_state.last_entry_result = runtime_state.entries.main_entry();
-    stasis_host_bulk_apply_requests(
-        &host_req_seq,
-        &host_req_flags,
-        &host_req_window_w_px,
-        &host_req_window_h_px
-    );
+    apply_guest_host_requests();
     if (runtime_state.last_entry_result != 0) {
         return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
     }
@@ -140,12 +134,7 @@ int32_t stasis_mobile_runtime_step(void) {
     }
 
     stasis_host_get_frame(host_i32, host_f32);
-    stasis_host_bulk_apply_requests(
-        &host_req_seq,
-        &host_req_flags,
-        &host_req_window_w_px,
-        &host_req_window_h_px
-    );
+    apply_guest_host_requests();
     runtime_state.last_entry_result = runtime_state.entries.tick_entry();
     if (runtime_state.last_entry_result != 0) {
         return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -100,6 +100,7 @@ int main(void) {
     CHECK(external_array[2] == 12);
 
     stasis_jit_register_global_u8_array(22, 0, external_u8, 4);
+    CHECK(stasis_jit_global_u8_array_ptr(22, 0, 4) == external_u8);
     stasis_jit_global_i32_array_store(22, 0, 1, 258);
     CHECK(external_u8[1] == 2);
     CHECK(stasis_jit_global_i32_array_load(22, 0, 1) == 2);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -1,4 +1,5 @@
 #include "stasis_mobile_runtime.h"
+#include "stasis_render_contract.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -35,6 +36,15 @@ static int host_request_calls;
 static int32_t host_request_sequences[8];
 static int gfx_submit_calls;
 static int shutdown_calls;
+static int32_t game_host_i32[768];
+static float game_host_f32[64];
+static int32_t game_gfx_cmd_i32[STASIS_RENDER_I32_COUNT];
+static float game_gfx_cmd_f32[STASIS_RENDER_F32_COUNT];
+static uint8_t game_gfx_cmd_u8[STASIS_RENDER_U8_COUNT];
+static int32_t game_host_req_seq;
+static int32_t game_host_req_flags;
+static int32_t game_host_req_window_w_px;
+static int32_t game_host_req_window_h_px;
 
 int stasis_init_window(int width, int height, const char *title) {
     assert(width == 1280);
@@ -70,6 +80,8 @@ void stasis_end_frame(void) {
 void stasis_host_get_frame(int32_t *out_i32, float *out_f32) {
     assert(out_i32 != NULL);
     assert(out_f32 != NULL);
+    assert(out_i32 == game_host_i32);
+    assert(out_f32 == game_host_f32);
     host_frame_calls += 1;
 }
 
@@ -90,6 +102,11 @@ void stasis_gfx_submit_u8(
     const uint8_t *cmd_u8
 ) {
     assert(cmd_i32 != NULL && cmd_f32 != NULL && cmd_u8 != NULL);
+    assert(cmd_i32 == game_gfx_cmd_i32);
+    assert(cmd_f32 == game_gfx_cmd_f32);
+    assert(cmd_u8 == game_gfx_cmd_u8);
+    assert(cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V1_MAGIC);
+    assert(cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V1_VERSION);
     gfx_submit_calls += 1;
     stasis_begin_frame();
     stasis_end_frame();
@@ -129,15 +146,29 @@ static int32_t hash_path(const char *path);
 
 static int32_t game_main(void) {
     main_calls += 1;
-    stasis_jit_global_i32_store(hash_path("host_req_seq"), 1);
-    stasis_jit_global_i32_store(hash_path("host_req_flags"), 1);
-    stasis_jit_global_i32_store(hash_path("host_req_window_w_px"), 960);
-    stasis_jit_global_i32_store(hash_path("host_req_window_h_px"), 540);
+    game_host_req_seq = 1;
+    game_host_req_flags = 1;
+    game_host_req_window_w_px = 960;
+    game_host_req_window_h_px = 540;
     return main_result;
 }
 
 static void bind_runtime(void) {
     bind_runtime_calls += 1;
+    stasis_jit_register_global_i32_array(hash_path("host_i32"), 0, game_host_i32, 768);
+    stasis_jit_register_global_f32_array(hash_path("host_f32"), 0, game_host_f32, 64);
+    stasis_jit_register_global_i32_array(
+        hash_path("gfx_cmd_i32"), 0, game_gfx_cmd_i32, STASIS_RENDER_I32_COUNT);
+    stasis_jit_register_global_f32_array(
+        hash_path("gfx_cmd_f32"), 0, game_gfx_cmd_f32, STASIS_RENDER_F32_COUNT);
+    stasis_jit_register_global_u8_array(
+        hash_path("gfx_cmd_u8"), 0, game_gfx_cmd_u8, STASIS_RENDER_U8_COUNT);
+    stasis_jit_register_global_i32_ptr(hash_path("host_req_seq"), &game_host_req_seq);
+    stasis_jit_register_global_i32_ptr(hash_path("host_req_flags"), &game_host_req_flags);
+    stasis_jit_register_global_i32_ptr(
+        hash_path("host_req_window_w_px"), &game_host_req_window_w_px);
+    stasis_jit_register_global_i32_ptr(
+        hash_path("host_req_window_h_px"), &game_host_req_window_h_px);
 }
 
 static int32_t game_tick(void) {
@@ -147,6 +178,8 @@ static int32_t game_tick(void) {
 
 static int32_t game_render(void) {
     render_calls += 1;
+    game_gfx_cmd_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
+    game_gfx_cmd_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
     return render_result;
 }
 
@@ -191,6 +224,15 @@ static void reset_fakes(void) {
     memset(host_request_sequences, 0, sizeof(host_request_sequences));
     gfx_submit_calls = 0;
     shutdown_calls = 0;
+    memset(game_host_i32, 0, sizeof(game_host_i32));
+    memset(game_host_f32, 0, sizeof(game_host_f32));
+    memset(game_gfx_cmd_i32, 0, sizeof(game_gfx_cmd_i32));
+    memset(game_gfx_cmd_f32, 0, sizeof(game_gfx_cmd_f32));
+    memset(game_gfx_cmd_u8, 0, sizeof(game_gfx_cmd_u8));
+    game_host_req_seq = 0;
+    game_host_req_flags = 0;
+    game_host_req_window_w_px = 0;
+    game_host_req_window_h_px = 0;
 }
 
 static void test_rejects_invalid_configuration(void) {

--- a/samples/mobile_storage_link/assets/manifest.json
+++ b/samples/mobile_storage_link/assets/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stasis-assets",
+  "version": 1,
+  "assets": []
+}

--- a/samples/mobile_storage_link/main.stasis
+++ b/samples/mobile_storage_link/main.stasis
@@ -1,0 +1,12 @@
+extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
+extern function storage_save_i32(scope: string, key: string, value: i32): bool;
+
+function main(): i32 {
+    let unlocked: i32 = storage_load_i32("mobile_link_ci", "unlocked", 1);
+    if (unlocked < 2 && !storage_save_i32("mobile_link_ci", "unlocked", 2)) { return 1; }
+    return 0;
+}
+
+function tick(): i32 { return 0; }
+
+function render(): i32 { return 0; }

--- a/samples/mobile_storage_link/stasis.json
+++ b/samples/mobile_storage_link/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "mobile_storage_link",
+  "entry": "main.stasis",
+  "tests": "tests",
+  "output": "build"
+}


### PR DESCRIPTION
## What changed

- Make the mobile host use the exact AOT-registered host-frame, render-command, and request globals written by generated game code.
- Add lifecycle regressions that assert identity and valid render headers across the guest/host boundary.
- Add a minimal mobile storage fixture and PR CI job that packages and links a real arm64 Android APK with pinned SDL dependencies and two-worker limits.

## Why

Generated AOT code accesses its globals directly. The mobile runtime previously rebound the same names to separate host-owned buffers, so input and window requests were disconnected and the renderer submitted a zeroed command header. Existing package-only checks also missed final native-link failures.

## Validation

- Focused mobile lifecycle and AOT runtime C tests pass.
- The generated Android sample packages and completes Gradle/NDK arm64 assembleDebug in 48 seconds with the fixed runtime.
- cargo fmt --all -- --check.
- git diff --check.
