### PR TITLE
Add entry-aware live TUI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Run Brickout Revenge v1 (Windows in-process dev runner):
 cargo run -p stasis --release -- play samples\brickout_revenge\brickout_revenge_v1.stasis
 ```
 
+Open the same entry-relative graphical workflow with the persistent live-workspace TUI:
+
+```powershell
+cargo run -p stasis --release -- tui samples\brickout_revenge\brickout_revenge_v1.stasis
+```
+
 Edit and save any `.stasis` file in the current import/dependency graph. You should see output like:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ Run Brickout Revenge v1 (Windows in-process dev runner):
 cargo run -p stasis --release -- play samples\brickout_revenge\brickout_revenge_v1.stasis
 ```
 
-Open the same entry-relative graphical workflow with the persistent live-workspace TUI:
+Open the workspace-backed state-inspection sample with the persistent live-workspace TUI:
 
 ```powershell
-cargo run -p stasis --release -- tui samples\brickout_revenge\brickout_revenge_v1.stasis
+cargo run -p stasis --release -- tui samples\state_inspection\src\main.stasis
 ```
 
 Edit and save any `.stasis` file in the current import/dependency graph. You should see output like:

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1614,11 +1614,34 @@ pub fn run_live_in_process(
     server: stasis_runner::live::LiveSessionServer,
     config: LiveRunConfig,
 ) -> Result<(), String> {
-    run_play_in_process_inner(
+    run_live_in_process_with_data(
         watch_file,
         watch_dir,
         None,
         None,
+        tick_sleep_micros,
+        max_ticks,
+        server,
+        config,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_live_in_process_with_data(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    server: stasis_runner::live::LiveSessionServer,
+    config: LiveRunConfig,
+) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
         None,
         tick_sleep_micros,
         max_ticks,

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -381,13 +381,14 @@ impl LiveWorkspace {
     }
 
     pub(crate) fn consumes_self_write(&mut self, path: &Path) -> bool {
-        let Some(expected_hash) = self.self_write_hashes.get(path) else {
+        let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let Some(expected_hash) = self.self_write_hashes.get(&path) else {
             return false;
         };
-        let matches = std::fs::read_to_string(path)
+        let matches = std::fs::read_to_string(&path)
             .is_ok_and(|source| workshop_source_hash(&source) == *expected_hash);
         if !matches {
-            self.self_write_hashes.remove(path);
+            self.self_write_hashes.remove(&path);
         }
         matches
     }
@@ -1277,10 +1278,10 @@ impl LiveWorkspace {
             } else {
                 &change.after_source
             };
-            self.self_write_hashes.insert(
-                self.config.project_root.join(&change.file),
-                workshop_source_hash(source),
-            );
+            let path = self.config.project_root.join(&change.file);
+            let path = path.canonicalize().unwrap_or(path);
+            self.self_write_hashes
+                .insert(path, workshop_source_hash(source));
         }
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -175,15 +175,6 @@ enum ToolchainCommand {
         /// Explicitly select the headless runtime (currently the default).
         #[arg(long)]
         headless: bool,
-        /// Keep the graphical game running while accepting live workspace commands.
-        #[arg(long, conflicts_with_all = ["watch", "headless"])]
-        interactive: bool,
-        /// Read interactive commands from a deterministic script instead of stdin.
-        #[arg(long, value_name = "PATH", requires = "interactive")]
-        live_script: Option<PathBuf>,
-        /// Emit versioned live response envelopes as JSON lines.
-        #[arg(long, requires = "interactive")]
-        live_json: bool,
     },
     /// Run one graphical entry with hot swap and the live-workspace TUI.
     Tui {
@@ -645,7 +636,11 @@ fn execute(
                 .to_string(),
         ),
         other => {
-            let workspace = load_workspace(workspace_arg.as_deref())?;
+            let workspace_path = workspace_arg.as_deref().or(match &other {
+                ToolchainCommand::Tui { entry, .. } => Some(entry.as_path()),
+                _ => None,
+            });
+            let workspace = load_workspace(workspace_path)?;
             match other {
                 ToolchainCommand::Fmt { check } => format_workspace(&workspace, check),
                 ToolchainCommand::Check => check_workspace(&workspace),
@@ -679,23 +674,8 @@ fn execute(
                     &tick,
                     &render,
                 ),
-                ToolchainCommand::Run {
-                    watch,
-                    headless,
-                    interactive,
-                    live_script,
-                    live_json,
-                } => {
-                    if interactive && json_output {
-                        Err("--json cannot be combined with --interactive; use --live-json for the response stream".to_string())
-                    } else if interactive {
-                        validate_optional_workspace_path(
-                            &workspace,
-                            "live script",
-                            live_script.as_deref(),
-                        )?;
-                        run_workspace_live(&workspace, live_script.as_deref(), live_json)
-                    } else if watch && json_output {
+                ToolchainCommand::Run { watch, headless } => {
+                    if watch && json_output {
                         Err("--json cannot be combined with --watch; watch mode is an unbounded event stream".to_string())
                     } else if watch && headless {
                         Err("--headless cannot be combined with --watch; watch mode uses the graphical hot-swap runner".to_string())
@@ -1219,23 +1199,6 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
     ))
 }
 
-fn run_workspace_live(
-    workspace: &Workspace,
-    script: Option<&Path>,
-    json_lines: bool,
-) -> Result<CommandResult, String> {
-    run_workspace_tui(
-        workspace,
-        Path::new(&workspace.manifest.entry),
-        None,
-        &[],
-        script,
-        json_lines,
-        16_000,
-        None,
-    )
-}
-
 #[allow(clippy::too_many_arguments)]
 fn run_workspace_tui(
     workspace: &Workspace,
@@ -1250,12 +1213,7 @@ fn run_workspace_tui(
     if !data_bind.is_empty() && data_bind.len() != 2 {
         return Err("--data-bind requires DATA_PATH and STRUCT_META_PATH".to_string());
     }
-    validate_relative_path("TUI entry", entry)?;
-    let entry_path = workspace.root.join(entry);
-    validate_workspace_destination(workspace, "TUI entry", &entry_path)?;
-    if !entry_path.is_file() {
-        return Err(format!("TUI entry is not a file: {}", entry_path.display()));
-    }
+    let (entry_path, entry_relative) = resolve_tui_entry(workspace, entry)?;
     validate_optional_workspace_path(workspace, "watch directory", watch_dir)?;
     validate_optional_workspace_path(workspace, "live script", script)?;
     for path in data_bind {
@@ -1273,7 +1231,7 @@ fn run_workspace_tui(
     });
     let config = LiveRunConfig::new(
         workspace.root.clone(),
-        entry.to_path_buf(),
+        entry_relative,
         PathBuf::from(&workspace.manifest.output),
     );
     let run_result = run_live_in_process_with_data(
@@ -1301,6 +1259,39 @@ fn run_workspace_tui(
         "interactive live session ended",
         json!({"backend": "jit", "headless": false, "interactive": true}),
     ))
+}
+
+fn resolve_tui_entry(workspace: &Workspace, entry: &Path) -> Result<(PathBuf, PathBuf), String> {
+    if entry.as_os_str().is_empty() {
+        return Err("TUI entry must not be empty".to_string());
+    }
+    let workspace_candidate = if entry.is_absolute() {
+        entry.to_path_buf()
+    } else {
+        workspace.root.join(entry)
+    };
+    let launch_candidate = absolute_path(entry)?;
+    let entry_path = if workspace_candidate.is_file() {
+        workspace_candidate
+    } else {
+        launch_candidate
+    };
+    validate_workspace_destination(workspace, "TUI entry", &entry_path)?;
+    if !entry_path.is_file() {
+        return Err(format!("TUI entry is not a file: {}", entry_path.display()));
+    }
+    let root = workspace
+        .root
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve workspace root: {error}"))?;
+    let entry_path = entry_path
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve TUI entry: {error}"))?;
+    let entry_relative = entry_path
+        .strip_prefix(&root)
+        .map_err(|_| "TUI entry resolves outside the workspace".to_string())?
+        .to_path_buf();
+    Ok((entry_path, entry_relative))
 }
 
 fn run_live_terminal(

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use stasis::{
-    run_jit_tests_in_directory_with_session, run_live_in_process, run_play_in_process,
-    run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
+    run_jit_tests_in_directory_with_session, run_live_in_process, run_live_in_process_with_data,
+    run_play_in_process, run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
@@ -67,6 +67,7 @@ const COMMANDS: &[&str] = &[
     "ai",
     "validate",
     "run",
+    "tui",
     "build",
     "package",
     "package-mobile",
@@ -85,7 +86,7 @@ const COMMANDS: &[&str] = &[
     name = "stasis",
     version,
     about = "The batteries-included Stasis toolchain",
-    long_about = "Create, format, check, test, run, build, inspect, and package Stasis projects without invoking Cargo."
+    long_about = "Create, format, check, test, run, live-edit, build, inspect, and package Stasis projects without invoking Cargo."
 )]
 struct ToolchainCli {
     #[arg(
@@ -183,6 +184,27 @@ enum ToolchainCommand {
         /// Emit versioned live response envelopes as JSON lines.
         #[arg(long, requires = "interactive")]
         live_json: bool,
+    },
+    /// Run one graphical entry with hot swap and the live-workspace TUI.
+    Tui {
+        #[arg(value_name = "ENTRY")]
+        entry: PathBuf,
+        /// Override the watched directory; defaults to the entry file's parent.
+        #[arg(long, value_name = "PATH")]
+        watch_dir: Option<PathBuf>,
+        /// Override the project data and struct-metadata files.
+        #[arg(long, num_args = 2, value_names = ["DATA_PATH", "STRUCT_META_PATH"])]
+        data_bind: Vec<PathBuf>,
+        /// Read live commands from a deterministic script instead of opening the TUI.
+        #[arg(long, value_name = "PATH")]
+        live_script: Option<PathBuf>,
+        /// Emit versioned live response envelopes as JSON lines.
+        #[arg(long)]
+        live_json: bool,
+        #[arg(long, default_value_t = 16_000)]
+        tick_sleep_us: u64,
+        #[arg(long)]
+        ticks: Option<u64>,
     },
     /// Build the project for development or as a release executable.
     Build {
@@ -583,6 +605,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Validate { .. } => "validate",
         ToolchainCommand::ValidateRuntime { .. } => "__validate-runtime",
         ToolchainCommand::Run { .. } => "run",
+        ToolchainCommand::Tui { .. } => "tui",
         ToolchainCommand::Build { .. } => "build",
         ToolchainCommand::Package { .. } => "package",
         ToolchainCommand::PackageMobile { .. } => "package-mobile",
@@ -680,6 +703,30 @@ fn execute(
                         run_workspace_watch(&workspace)
                     } else {
                         run_workspace(&workspace, headless)
+                    }
+                }
+                ToolchainCommand::Tui {
+                    entry,
+                    watch_dir,
+                    data_bind,
+                    live_script,
+                    live_json,
+                    tick_sleep_us,
+                    ticks,
+                } => {
+                    if json_output {
+                        Err("--json cannot be combined with tui; use --live-json for the response stream".to_string())
+                    } else {
+                        run_workspace_tui(
+                            &workspace,
+                            &entry,
+                            watch_dir.as_deref(),
+                            &data_bind,
+                            live_script.as_deref(),
+                            live_json,
+                            tick_sleep_us,
+                            ticks,
+                        )
                     }
                 }
                 ToolchainCommand::Build { mode, out } => {
@@ -1177,7 +1224,47 @@ fn run_workspace_live(
     script: Option<&Path>,
     json_lines: bool,
 ) -> Result<CommandResult, String> {
-    let entry = workspace.root.join(&workspace.manifest.entry);
+    run_workspace_tui(
+        workspace,
+        Path::new(&workspace.manifest.entry),
+        None,
+        &[],
+        script,
+        json_lines,
+        16_000,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_workspace_tui(
+    workspace: &Workspace,
+    entry: &Path,
+    watch_dir: Option<&Path>,
+    data_bind: &[PathBuf],
+    script: Option<&Path>,
+    json_lines: bool,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+) -> Result<CommandResult, String> {
+    if !data_bind.is_empty() && data_bind.len() != 2 {
+        return Err("--data-bind requires DATA_PATH and STRUCT_META_PATH".to_string());
+    }
+    validate_relative_path("TUI entry", entry)?;
+    let entry_path = workspace.root.join(entry);
+    validate_workspace_destination(workspace, "TUI entry", &entry_path)?;
+    if !entry_path.is_file() {
+        return Err(format!("TUI entry is not a file: {}", entry_path.display()));
+    }
+    validate_optional_workspace_path(workspace, "watch directory", watch_dir)?;
+    validate_optional_workspace_path(workspace, "live script", script)?;
+    for path in data_bind {
+        validate_relative_path("data binding", path)?;
+        validate_workspace_destination(workspace, "data binding", &workspace.root.join(path))?;
+    }
+    let data_json = data_bind.first().map(|path| workspace.root.join(path));
+    let data_meta = data_bind.get(1).map(|path| workspace.root.join(path));
+    let watch_dir = watch_dir.map(|path| workspace.root.join(path));
     let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
     let script = script.map(|path| workspace.root.join(path));
     let terminal_root = workspace.root.clone();
@@ -1186,11 +1273,19 @@ fn run_workspace_live(
     });
     let config = LiveRunConfig::new(
         workspace.root.clone(),
-        PathBuf::from(&workspace.manifest.entry),
+        entry.to_path_buf(),
         PathBuf::from(&workspace.manifest.output),
     );
-    let run_result =
-        run_live_in_process(&entry, Some(&workspace.root), 16_000, None, server, config);
+    let run_result = run_live_in_process_with_data(
+        &entry_path,
+        watch_dir.as_deref(),
+        data_json.as_deref(),
+        data_meta.as_deref(),
+        tick_sleep_micros,
+        max_ticks,
+        server,
+        config,
+    );
     if !terminal.is_finished() {
         return match run_result {
             Ok(()) => Err("live runner ended before the terminal session completed".to_string()),

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1226,7 +1226,7 @@ fn semantic_symbol_cli_reapplies_edit_when_revert_tests_fail() {
 
 #[cfg(windows)]
 #[test]
-fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
+fn tui_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     let parent = temp_dir("interactive_live");
     fs::create_dir_all(&parent).expect("create temp parent");
     let project = parent.join("demo");
@@ -1254,8 +1254,8 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
 
     let output = stasis(
         &[
-            "run",
-            "--interactive",
+            "tui",
+            "src/main.stasis",
             "--live-script",
             "live.commands",
             "--live-json",
@@ -1312,8 +1312,8 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write failing live script");
     let failed = stasis(
         &[
-            "run",
-            "--interactive",
+            "tui",
+            "src/main.stasis",
             "--live-script",
             "failed-live.commands",
             "--live-json",
@@ -1340,8 +1340,8 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write human live script");
     let human = stasis(
         &[
-            "run",
-            "--interactive",
+            "tui",
+            "src/main.stasis",
             "--live-script",
             "human-live.commands",
         ],
@@ -1371,8 +1371,8 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     .expect("write unfinished live script");
     let unfinished = stasis(
         &[
-            "run",
-            "--interactive",
+            "tui",
+            "src/main.stasis",
             "--live-script",
             "unfinished-live.commands",
         ],
@@ -1392,7 +1392,7 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
 
 #[cfg(windows)]
 #[test]
-fn tui_entry_parent_anchors_source_relative_graphical_assets() {
+fn tui_discovers_entry_workspace_and_anchors_source_relative_assets() {
     let parent = temp_dir("tui_asset_root");
     let project = parent.join("demo");
     fs::create_dir_all(project.join("src")).expect("create source directory");
@@ -1430,12 +1430,12 @@ fn tui_entry_parent_anchors_source_relative_graphical_assets() {
     let output = stasis(
         &[
             "tui",
-            "src/main.stasis",
+            "demo/src/main.stasis",
             "--live-script",
             "live.commands",
             "--live-json",
         ],
-        &project,
+        &parent,
     );
     assert_eq!(
         output.status.code(),
@@ -1447,17 +1447,26 @@ fn tui_entry_parent_anchors_source_relative_graphical_assets() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("\"kind\":\"quitting\""));
     assert!(!String::from_utf8_lossy(&output.stderr).contains("failed to open"));
 
+    let removed_alias = stasis(&["run", "--interactive"], &project);
+    assert_eq!(removed_alias.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&removed_alias.stderr).contains("unexpected argument"));
+
     fs::remove_dir_all(parent).ok();
 }
 
 #[test]
 #[cfg(windows)]
 fn state_inspection_sample_browses_state_and_watches_live_runtime() {
-    let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/state_inspection");
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
 
     let output = stasis(
-        &["run", "--interactive", "--live-script", "live.commands"],
-        &sample,
+        &[
+            "tui",
+            "samples/state_inspection/src/main.stasis",
+            "--live-script",
+            "live.commands",
+        ],
+        &repository,
     );
 
     assert_eq!(

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1390,6 +1390,66 @@ fn interactive_live_cli_updates_mutates_and_undoes_while_process_stays_alive() {
     fs::remove_dir_all(parent).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn tui_entry_parent_anchors_source_relative_graphical_assets() {
+    let parent = temp_dir("tui_asset_root");
+    let project = parent.join("demo");
+    fs::create_dir_all(project.join("src")).expect("create source directory");
+    fs::create_dir_all(project.join("assets")).expect("create asset directory");
+
+    let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/render_parity");
+    let main_source = fs::read_to_string(sample.join("main.stasis"))
+        .expect("read render parity entry")
+        .replace("\"assets/", "\"../assets/");
+    fs::write(project.join("src/main.stasis"), main_source).expect("write nested entry");
+    fs::copy(
+        sample.join("frame.stasis"),
+        project.join("src/frame.stasis"),
+    )
+    .expect("copy frame module");
+    for asset in [
+        "opaque.svg",
+        "translucent.svg",
+        "full_canvas.svg",
+        "parity.ttf",
+    ] {
+        fs::copy(
+            sample.join("assets").join(asset),
+            project.join("assets").join(asset),
+        )
+        .expect("copy render asset");
+    }
+    fs::write(
+        project.join("stasis.json"),
+        "{\n  \"manifest_version\": 1,\n  \"name\": \"tui_asset_root\",\n  \"entry\": \"src/main.stasis\",\n  \"tests\": \"tests\",\n  \"output\": \"build\"\n}\n",
+    )
+    .expect("write manifest");
+    fs::write(project.join("live.commands"), ":quit\n").expect("write live script");
+
+    let output = stasis(
+        &[
+            "tui",
+            "src/main.stasis",
+            "--live-script",
+            "live.commands",
+            "--live-json",
+        ],
+        &project,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("\"kind\":\"quitting\""));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("failed to open"));
+
+    fs::remove_dir_all(parent).ok();
+}
+
 #[test]
 #[cfg(windows)]
 fn state_inspection_sample_browses_state_and_watches_live_runtime() {

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -1,10 +1,15 @@
 # Interactive live workspace
 
-`stasis run --interactive` starts the manifest entry in the normal in-process graphical runner
+`stasis tui ENTRY` starts an explicit entry in the normal in-process graphical runner
 and opens a desktop-focused local terminal prompt. Rendering remains on the main thread. Terminal
 input enters the bounded `stasis_runner::live` protocol queue and every request is observed or
 committed at a normalized between-tick boundary. Android Workshop shares compiler-owned semantic
 edit and receipt contracts, but intentionally keeps its own mobile interaction model.
+
+Like `play ENTRY`, `tui ENTRY` watches the entry file's parent directory by default and uses that
+directory as the source-relative graphical asset root. The project root remains independently
+owned by semantic edits, tests, receipts, and build output. `run --interactive` remains a
+compatibility alias for the manifest entry.
 
 The default terminal is a human workspace view, not a protocol dump. It prints concise scalar,
 symbol, edit, scratch, status, and diagnostic lines; large semantic plans are summarized by changed
@@ -16,7 +21,7 @@ The project must provide the graphical lifecycle entry points `main`, `tick`, an
 
 ## Persistent TUI
 
-Status: the first desktop feel slice is implemented. Run `stasis run --interactive` in a Stasis
+Status: the first desktop feel slice is implemented. Run `stasis tui src/main.stasis` in a Stasis
 project to open it. The deterministic `--live-script` and `--live-json` clients remain available
 without the TUI.
 
@@ -374,5 +379,5 @@ request queue, compiler indexes, edit plans, tick boundaries, and response objec
 Run a repeatable session without Cargo or repository-only tools:
 
 ```text
-stasis run --interactive --live-script live.commands --live-json
+stasis tui src/main.stasis --live-script live.commands --live-json
 ```

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -8,8 +8,7 @@ edit and receipt contracts, but intentionally keeps its own mobile interaction m
 
 Like `play ENTRY`, `tui ENTRY` watches the entry file's parent directory by default and uses that
 directory as the source-relative graphical asset root. The project root remains independently
-owned by semantic edits, tests, receipts, and build output. `run --interactive` remains a
-compatibility alias for the manifest entry.
+owned by semantic edits, tests, receipts, and build output.
 
 The default terminal is a human workspace view, not a protocol dump. It prints concise scalar,
 symbol, edit, scratch, status, and diagnostic lines; large semantic plans are summarized by changed

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -30,7 +30,7 @@ stasis check
 stasis test
 stasis run --headless
 stasis run --watch
-stasis run --interactive
+stasis tui src/main.stasis
 stasis build --mode dev
 stasis build --mode release
 stasis package --target desktop
@@ -75,7 +75,7 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
   `i32` result is the process exit code. Headless execution is the default.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
-- `run --interactive`: keep the graphical runner and tick loop alive while a desktop terminal uses
+- `tui ENTRY`: launch the same entry-relative graphical hot-swap workflow as `play` while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
   typed between-tick inspection or mutation. The terminal includes history, a Ctrl-P command
   palette with live fuzzy compiler-backed symbol/member completion, keyboard navigation and
@@ -83,6 +83,9 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
   `--live-json` for complete schema-v1 response envelopes or `--live-script PATH` for a
   deterministic command script. See
   [Interactive live workspace](live_cli_workspace.md).
+- `run --interactive`: compatibility spelling that opens the manifest entry through the same TUI
+  session contract. New game-development instructions should use `tui ENTRY` so the graphical
+  entry and its source-relative asset root are explicit.
 - `build --mode dev`: compile through JIT and write `build/dev-build.json` as a deterministic
   receipt.
 - `build --mode release`: use the shared Cranelift AOT pipeline and write the native executable to

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -83,9 +83,6 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
   `--live-json` for complete schema-v1 response envelopes or `--live-script PATH` for a
   deterministic command script. See
   [Interactive live workspace](live_cli_workspace.md).
-- `run --interactive`: compatibility spelling that opens the manifest entry through the same TUI
-  session contract. New game-development instructions should use `tui ENTRY` so the graphical
-  entry and its source-relative asset root are explicit.
 - `build --mode dev`: compile through JIT and write `build/dev-build.json` as a deterministic
   receipt.
 - `build --mode release`: use the shared Cranelift AOT pipeline and write the native executable to


### PR DESCRIPTION
Adds stasis tui ENTRY as the sole live-workspace counterpart to play ENTRY. tui derives workspace discovery from ENTRY, defaults graphical watching and source-relative assets to the entry parent, and keeps the project root for edits, tests, receipts, and output. The former run --interactive spelling is removed. Windows self-write paths are canonicalized so a semantic TUI edit produces exactly one hot swap instead of being replayed by the file watcher. Verification: focused real-graphics workspace/asset regression passed; CLI integration 12/12 passed; live-workspace unit tests 44/44 passed serially; actual Chess TD TUI smoke loaded all four fonts through src/../assets; package Clippy passed with existing baseline warnings.