### PR TITLE
Let tui use the stasis.json entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,15 @@ Run Brickout Revenge v1 (Windows in-process dev runner):
 cargo run -p stasis --release -- play samples\brickout_revenge\brickout_revenge_v1.stasis
 ```
 
-Open the workspace-backed state-inspection sample with the persistent live-workspace TUI:
+From a directory containing `stasis.json`, open its manifest `entry` with the persistent
+live-workspace TUI:
 
 ```powershell
-cargo run -p stasis --release -- tui samples\state_inspection\src\main.stasis
+stasis tui
 ```
+
+Pass an entry path to override the manifest for that invocation, for example
+`stasis tui samples\state_inspection\src\main.stasis`.
 
 Edit and save any `.stasis` file in the current import/dependency graph. You should see output like:
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -178,8 +178,9 @@ enum ToolchainCommand {
     },
     /// Run one graphical entry with hot swap and the live-workspace TUI.
     Tui {
+        /// Override the entry declared in stasis.json.
         #[arg(value_name = "ENTRY")]
-        entry: PathBuf,
+        entry: Option<PathBuf>,
         /// Override the watched directory; defaults to the entry file's parent.
         #[arg(long, value_name = "PATH")]
         watch_dir: Option<PathBuf>,
@@ -637,7 +638,7 @@ fn execute(
         ),
         other => {
             let workspace_path = workspace_arg.as_deref().or(match &other {
-                ToolchainCommand::Tui { entry, .. } => Some(entry.as_path()),
+                ToolchainCommand::Tui { entry, .. } => entry.as_deref(),
                 _ => None,
             });
             let workspace = load_workspace(workspace_path)?;
@@ -697,9 +698,12 @@ fn execute(
                     if json_output {
                         Err("--json cannot be combined with tui; use --live-json for the response stream".to_string())
                     } else {
+                        let entry = entry
+                            .as_deref()
+                            .unwrap_or_else(|| Path::new(&workspace.manifest.entry));
                         run_workspace_tui(
                             &workspace,
-                            &entry,
+                            entry,
                             watch_dir.as_deref(),
                             &data_bind,
                             live_script.as_deref(),
@@ -4032,6 +4036,30 @@ mod tests {
                 headless: true,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn tui_entry_is_optional_and_accepts_an_override() {
+        let manifest_entry =
+            ToolchainCli::try_parse_from(["stasis", "tui"]).expect("parse manifest TUI entry");
+        assert!(matches!(
+            manifest_entry.command,
+            ToolchainCommand::Tui { entry: None, .. }
+        ));
+
+        let explicit_entry = ToolchainCli::try_parse_from([
+            "stasis",
+            "tui",
+            "samples/state_inspection/src/main.stasis",
+        ])
+        .expect("parse explicit TUI entry");
+        assert!(matches!(
+            explicit_entry.command,
+            ToolchainCommand::Tui {
+                entry: Some(ref entry),
+                ..
+            } if entry == Path::new("samples/state_inspection/src/main.stasis")
         ));
     }
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1447,6 +1447,20 @@ fn tui_discovers_entry_workspace_and_anchors_source_relative_assets() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("\"kind\":\"quitting\""));
     assert!(!String::from_utf8_lossy(&output.stderr).contains("failed to open"));
 
+    let manifest_entry = stasis(
+        &["tui", "--live-script", "live.commands", "--live-json"],
+        &project,
+    );
+    assert_eq!(
+        manifest_entry.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&manifest_entry.stdout),
+        String::from_utf8_lossy(&manifest_entry.stderr)
+    );
+    assert!(String::from_utf8_lossy(&manifest_entry.stdout).contains("\"kind\":\"quitting\""));
+    assert!(!String::from_utf8_lossy(&manifest_entry.stderr).contains("failed to open"));
+
     let removed_alias = stasis(&["run", "--interactive"], &project);
     assert_eq!(removed_alias.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&removed_alias.stderr).contains("unexpected argument"));


### PR DESCRIPTION
## Summary

- make the TUI entry positional optional
- use the validated stasis.json entry when no override is supplied
- preserve explicit entry discovery and source-relative asset anchoring
- document the bare stasis tui workflow

## Entry precedence

1. An explicit TUI entry argument, when supplied.
2. The entry field from the discovered or --workspace-selected stasis.json.

Both paths continue through the existing workspace containment and file validation.

## Verification

- cargo test -p stasis --test toolchain_cli -- --nocapture --test-threads=1 (12 passed)
- cargo test -p stasis --bin stasis toolchain_cli::tests -- --test-threads=1 (29 passed)
- cargo clippy -p stasis --all-targets --no-deps (passed with existing baseline warnings)
- cargo fmt --all -- --check
- git diff --check
- real ChessTD bare TUI smoke: Direct3D initialized, all four source-relative Nunito fonts loaded, scripted status/quit exited 0
