### PR TITLE
Allow spaces in project display names

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3565,13 +3565,17 @@ fn copy_file(source: &Path, destination: &Path) -> Result<(), String> {
 fn validate_project_name(name: &str) -> Result<(), String> {
     let valid = !name.is_empty()
         && name.len() <= 64
+        && name.trim_matches(' ') == name
         && name
             .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-');
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == ' ');
     if valid {
         Ok(())
     } else {
-        Err("project name must be 1-64 ASCII letters, digits, '-' or '_'".to_string())
+        Err(
+            "project name must be 1-64 ASCII letters, digits, spaces, '-' or '_', without leading or trailing spaces"
+                .to_string(),
+        )
     }
 }
 
@@ -4190,7 +4194,11 @@ mod tests {
             mobile_package_id("123-game"),
             "com.stasislang.game123x2dgame"
         );
-        for name in ["mobile_game", "123-game"] {
+        assert_eq!(
+            mobile_package_id("Chess TD"),
+            "com.stasislang.gamechessx20td"
+        );
+        for name in ["mobile_game", "123-game", "Chess TD"] {
             let package_id = mobile_package_id(name);
             let component = package_id.rsplit('.').next().expect("package component");
             assert!(component
@@ -4198,6 +4206,17 @@ mod tests {
                 .next()
                 .is_some_and(|value| value.is_ascii_alphabetic()));
             assert!(component.chars().all(|value| value.is_ascii_alphanumeric()));
+        }
+    }
+
+    #[test]
+    fn project_names_allow_internal_ascii_spaces() {
+        assert!(validate_project_name("Chess TD").is_ok());
+        for invalid in [" Chess TD", "Chess TD ", "Chess\tTD", "Chess/TD"] {
+            assert!(
+                validate_project_name(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
         }
     }
 

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1422,7 +1422,7 @@ fn tui_discovers_entry_workspace_and_anchors_source_relative_assets() {
     }
     fs::write(
         project.join("stasis.json"),
-        "{\n  \"manifest_version\": 1,\n  \"name\": \"tui_asset_root\",\n  \"entry\": \"src/main.stasis\",\n  \"tests\": \"tests\",\n  \"output\": \"build\"\n}\n",
+        "{\n  \"manifest_version\": 1,\n  \"name\": \"TUI Asset Root\",\n  \"entry\": \"src/main.stasis\",\n  \"tests\": \"tests\",\n  \"output\": \"build\"\n}\n",
     )
     .expect("write manifest");
     fs::write(project.join("live.commands"), ":quit\n").expect("write live script");

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -30,7 +30,7 @@ stasis check
 stasis test
 stasis run --headless
 stasis run --watch
-stasis tui src/main.stasis
+stasis tui
 stasis build --mode dev
 stasis build --mode release
 stasis package --target desktop
@@ -60,7 +60,9 @@ project root and nested directories. `--workspace PATH` selects a project explic
 }
 ```
 
-Manifest paths must be project-relative and cannot contain `..`. Generated projects include a
+The project `name` may contain internal ASCII spaces, so display names such as `Chess TD` are
+valid; leading or trailing spaces are rejected. Manifest paths must be project-relative and cannot
+contain `..`. Generated projects include a
 runnable `main()`, a real `.test.stasis` test, an `AGENTS.md` theory-building and semantic-edit
 guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
 
@@ -75,7 +77,8 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
   `i32` result is the process exit code. Headless execution is the default.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
-- `tui ENTRY`: launch the same entry-relative graphical hot-swap workflow as `play` while a desktop terminal uses
+- `tui [ENTRY]`: launch the same entry-relative graphical hot-swap workflow as `play`, using the
+  manifest `entry` when no override is supplied, while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
   typed between-tick inspection or mutation. The terminal includes history, a Ctrl-P command
   palette with live fuzzy compiler-backed symbol/member completion, keyboard navigation and


### PR DESCRIPTION
Allows internal ASCII spaces in stasis.json project names while rejecting leading/trailing spaces and other punctuation. Desktop paths remain valid and mobile package IDs continue deterministic byte encoding. Updates the CLI contract and verifies Chess TD through bare tui. Tests: 12 CLI integrations; 30 CLI units; Clippy baseline; fmt; diff check; real ChessTD Direct3D/font smoke.