### PR TITLE
Use project name for dev window titles

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1582,6 +1582,42 @@ pub fn run_play_in_process(
         tick_sleep_micros,
         max_ticks,
         None,
+        None,
+    )
+}
+
+fn resolve_play_window_title(watch_file: &Path, configured_title: Option<&str>) -> String {
+    configured_title
+        .filter(|title| !title.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            watch_file
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "stasis".to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_play_in_process_with_window_title(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    window_title: &str,
+) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
+        None,
+        tick_sleep_micros,
+        max_ticks,
+        Some(window_title),
+        None,
     )
 }
 
@@ -1602,6 +1638,7 @@ pub fn run_play_in_process_with_input_script(
         input_script,
         tick_sleep_micros,
         max_ticks,
+        None,
         None,
     )
 }
@@ -1645,6 +1682,7 @@ pub fn run_live_in_process_with_data(
         None,
         tick_sleep_micros,
         max_ticks,
+        None,
         Some((server, config)),
     )
 }
@@ -1658,6 +1696,7 @@ fn run_play_in_process_inner(
     input_script: Option<&Path>,
     tick_sleep_micros: u64,
     max_ticks: Option<u64>,
+    window_title: Option<&str>,
     live: Option<(stasis_runner::live::LiveSessionServer, LiveRunConfig)>,
 ) -> Result<(), String> {
     if !cfg!(windows) {
@@ -1787,10 +1826,11 @@ fn run_play_in_process_inner(
     );
 
     let gfx = stasis_dynload::StasisGraphicsApi::load_default()?;
-    let title = watch_file
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .unwrap_or_else(|| "stasis".to_string());
+    let configured_title = window_title.or_else(|| {
+        live.as_ref()
+            .and_then(|(_, config)| config.window_title.as_deref())
+    });
+    let title = resolve_play_window_title(watch_file, configured_title);
     // Create a small default window up-front so runtime calls (fonts/sprites) succeed during guest main().
     // Guest `init_window(...)` requests will be applied immediately after main returns.
     let _ = gfx.init_window(800, 600, &title)?;
@@ -5275,6 +5315,17 @@ mod tests {
     fn resolve_play_watch_dir_defaults_to_dot_for_basename_entry() {
         let resolved = resolve_play_watch_dir(Path::new("flappy.stasis"), None);
         assert_eq!(resolved, PathBuf::from("."));
+    }
+
+    #[test]
+    fn resolve_play_window_title_prefers_project_name_and_falls_back_to_entry() {
+        let entry = Path::new("src/main.stasis");
+        assert_eq!(
+            resolve_play_window_title(entry, Some("Chess TD")),
+            "Chess TD"
+        );
+        assert_eq!(resolve_play_window_title(entry, None), "main.stasis");
+        assert_eq!(resolve_play_window_title(entry, Some("")), "main.stasis");
     }
 
     #[test]

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -44,6 +44,7 @@ pub struct LiveRunConfig {
     pub project_root: PathBuf,
     pub entry: PathBuf,
     pub output: PathBuf,
+    pub window_title: Option<String>,
 }
 
 impl LiveRunConfig {
@@ -52,7 +53,13 @@ impl LiveRunConfig {
             project_root,
             entry,
             output,
+            window_title: None,
         }
+    }
+
+    pub fn with_window_title(mut self, window_title: impl Into<String>) -> Self {
+        self.window_title = Some(window_title.into());
+        self
     }
 }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -4,7 +4,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use stasis::{
     run_jit_tests_in_directory_with_session, run_live_in_process, run_live_in_process_with_data,
-    run_play_in_process, run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
+    run_play_in_process_with_window_title, run_self_host_aot_cli_with_options, LiveRunConfig,
+    StasisTestRunSession,
 };
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
@@ -1149,7 +1150,15 @@ fn run_workspace(workspace: &Workspace, _headless: bool) -> Result<CommandResult
 
 fn run_workspace_watch(workspace: &Workspace) -> Result<CommandResult, String> {
     let entry = workspace.root.join(&workspace.manifest.entry);
-    run_play_in_process(&entry, Some(&workspace.root), None, None, 16_000, None)?;
+    run_play_in_process_with_window_title(
+        &entry,
+        Some(&workspace.root),
+        None,
+        None,
+        16_000,
+        None,
+        &workspace.manifest.name,
+    )?;
     Ok(CommandResult::success(
         "graphical watch session ended",
         json!({"backend": "jit", "headless": false, "watch": true}),
@@ -1176,7 +1185,8 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
         workspace.root.clone(),
         PathBuf::from(&workspace.manifest.entry),
         PathBuf::from(&workspace.manifest.output),
-    );
+    )
+    .with_window_title(&workspace.manifest.name);
     let run_result =
         run_live_in_process(&entry, Some(&workspace.root), 16_000, None, server, config);
     if let Err(error) = run_result {
@@ -1237,7 +1247,8 @@ fn run_workspace_tui(
         workspace.root.clone(),
         entry_relative,
         PathBuf::from(&workspace.manifest.output),
-    );
+    )
+    .with_window_title(&workspace.manifest.name);
     let run_result = run_live_in_process_with_data(
         &entry_path,
         watch_dir.as_deref(),

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -76,9 +76,11 @@ guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
 - `run [--headless]`: JIT-compile and execute no-argument `main(): i32` or `main(): void`; an
   `i32` result is the process exit code. Headless execution is the default.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
-  Because it is an unbounded graphical session, watch mode rejects `--json` and `--headless`.
+  The window title uses the manifest project name. Because it is an unbounded graphical session,
+  watch mode rejects `--json` and `--headless`.
 - `tui [ENTRY]`: launch the same entry-relative graphical hot-swap workflow as `play`, using the
-  manifest `entry` when no override is supplied, while a desktop terminal uses
+  manifest `entry` when no override is supplied and the manifest project name as the window title,
+  while a desktop terminal uses
   the runner's versioned LiveSession protocol for background-prepared code-aware symbol edits and
   typed between-tick inspection or mutation. The terminal includes history, a Ctrl-P command
   palette with live fuzzy compiler-backed symbol/member completion, keyboard navigation and


### PR DESCRIPTION
Manifest-backed graphical launches now use the validated stasis.json project name as the SDL window title. This covers bare or explicit tui, run --watch, and live AI; standalone play keeps the entry filename fallback. Verified actual Windows MainWindowTitle equals Chess TD, all fonts load, CLI integrations pass 12/12, CLI units pass 30/30, and the relevant title test passes. Clippy, fmt, and diff checks pass at the existing warning baseline.