### PR TITLE
Evaluate bare expressions in the live TUI

### DIFF
--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1303,7 +1303,12 @@ impl LiveWorkspace {
 
     fn rebuild_completion(&mut self, jit: &JitProcess) {
         let mut items = live_command_completions();
-        items.extend(self.completion_items.iter().map(live_completion_item));
+        items.extend(
+            self.completion_items
+                .iter()
+                .filter(|item| !is_static_type_field(item))
+                .map(live_completion_item),
+        );
         items.extend(
             jit.global_scalar_paths()
                 .into_iter()
@@ -1352,6 +1357,16 @@ impl LiveWorkspace {
             context,
         )
     }
+}
+
+fn is_static_type_field(item: &WorkshopCompletionItem) -> bool {
+    item.kind == "field"
+        && item.scope.is_none()
+        && item.owner.as_deref().is_some_and(|owner| {
+            item.text
+                .strip_prefix(owner)
+                .is_some_and(|suffix| suffix.starts_with('.'))
+        })
 }
 
 fn completion_query_from_snapshot(
@@ -4118,6 +4133,48 @@ mod tests {
                 .count(),
             1
         );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn static_type_fields_are_hidden_at_root_and_available_while_editing() {
+        let (root, config) = project();
+        fs::write(
+            root.join("src/main.stasis"),
+            "struct Player { hp: i32; }\nstruct Enemy { hp: i32; }\nstruct Game { enemies: Enemy[2]; }\nglobal player: Player;\nglobal game: Game;\nfunction main(): i32 { player.hp = 7; game.enemies[0].hp = 37; return 0; }\nfunction tick(): i32 { return player.hp; }\nfunction render(): i32 { return 0; }\nfunction on_code_swap(): void { return; }\n",
+        )
+        .expect("source");
+        let (jit, _) = compile(&config);
+        jit.execute_i32_noarg_by_name("main").expect("run main");
+        let (kind, printed) = print_scalar(&jit, "game.enemies[0].hp").expect("print hp");
+        assert_eq!(kind, "print");
+        assert_eq!(printed["static_type"], "i32");
+        assert_eq!(printed["value"]["value"], 37);
+        let (_, server) = stasis_runner::live::live_session(8);
+        let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
+
+        let root_query = workspace.completion.query("Player.h", 8, 10);
+        assert!(root_query.items.iter().all(|item| item.text != "Player.hp"));
+        assert_eq!(
+            workspace.completion.query("player.h", 8, 10).items[0].text,
+            "player.hp"
+        );
+
+        let tick = workspace
+            .source_items
+            .iter()
+            .find(|item| item.name == "tick")
+            .expect("tick item");
+        let buffer = "function tick(): i32 { return Player.h";
+        let context = CompletionContext {
+            owner: Some("tick".into()),
+            file: Some(tick.file.clone()),
+            owner_signature: Some(tick.signature.clone()),
+            source_offset: Some(tick.source_spans[0].start as usize + buffer.len()),
+            expected_type: None,
+        };
+        let edit_query = workspace.completion_query(buffer, buffer.len(), 10, &context);
+        assert!(edit_query.items.iter().any(|item| item.text == "Player.hp"));
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -761,6 +761,7 @@ impl LiveWorkspace {
                 preview,
             } => set_scalar(jit, &path, &expression, preview),
             LiveCommand::Print { expression } => print_scalar(jit, &expression),
+            LiveCommand::Evaluate { expression } => evaluate_expression(jit, &expression),
             LiveCommand::Do { code, preview } => apply_scalar_transaction(jit, &code, preview),
             LiveCommand::CellPut { name, code } => {
                 self.scratch.put(&name, code)?;
@@ -2332,6 +2333,13 @@ fn concise_state_path_is_visible(path: &str, all_paths: &HashSet<String>) -> boo
 
 fn print_scalar(jit: &JitProcess, expression: &str) -> Result<(&'static str, Value), String> {
     Ok(("print", jit.inspect_state_query(expression)?))
+}
+
+fn evaluate_expression(
+    jit: &JitProcess,
+    expression: &str,
+) -> Result<(&'static str, Value), String> {
+    Ok(("evaluation", jit.inspect_state_query(expression)?))
 }
 
 fn set_scalar(
@@ -4146,10 +4154,11 @@ mod tests {
         .expect("source");
         let (jit, _) = compile(&config);
         jit.execute_i32_noarg_by_name("main").expect("run main");
-        let (kind, printed) = print_scalar(&jit, "game.enemies[0].hp").expect("print hp");
-        assert_eq!(kind, "print");
-        assert_eq!(printed["static_type"], "i32");
-        assert_eq!(printed["value"]["value"], 37);
+        let (kind, evaluation) =
+            evaluate_expression(&jit, "game.enemies[0].hp").expect("evaluate hp");
+        assert_eq!(kind, "evaluation");
+        assert_eq!(evaluation["static_type"], "i32");
+        assert_eq!(evaluation["value"]["value"], 37);
         let (_, server) = stasis_runner::live::live_session(8);
         let workspace = LiveWorkspace::new(server, config, &jit).expect("workspace");
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1475,7 +1475,7 @@ fn format_live_response(response: &LiveResponse) -> String {
         "inspection" => format_live_inspection(data),
         "state_inspection" => format_live_state_inspection(data),
         "runtime_validation" => format_live_runtime_validation(data),
-        "print" => format!(
+        "print" | "evaluation" => format!(
             "{} = {}",
             string_field(data, "static_type", "value"),
             scalar_text(data.get("value").unwrap_or(&Value::Null))

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1003,13 +1003,18 @@ impl LiveTui {
         if line.trim_start().starts_with(":edit") {
             return self.open_definition(&line);
         }
-        let evaluated_line = (!self.terminal.has_pending_input()
-            && !line.trim_start().starts_with([':', '{']))
-        .then(|| format!(":print {line}"));
-        match self
-            .terminal
-            .feed_line(evaluated_line.as_deref().unwrap_or(&line))
-        {
+        if !self.terminal.has_pending_input() && !line.trim_start().starts_with([':', '{']) {
+            let request_id = self.next_request();
+            if let Err(error) = self.client.submit(LiveRequest::new(
+                request_id,
+                LiveCommand::Evaluate { expression: line },
+            )) {
+                self.status = format!("live expression queued failed: {error}");
+                self.push_transcript(format!("error: {error}"));
+            }
+            return Ok(());
+        }
+        match self.terminal.feed_line(&line) {
             Ok(TerminalInput::Continue { prompt }) => {
                 self.prompt = prompt;
                 self.status = "multiline compatibility input; finish with :end".to_string();
@@ -2860,7 +2865,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn root_prompt_submits_a_bare_expression_for_printing() {
+    fn root_prompt_submits_a_bare_expression_for_evaluation() {
         let (client, server) = stasis_runner::live::live_session(8);
         let mut app = LiveTui::new(client, std::env::temp_dir());
 
@@ -2871,7 +2876,7 @@ mod tests {
         assert_eq!(requests.len(), 1);
         assert!(matches!(
             &requests[0].command,
-            LiveCommand::Print { expression } if expression == "game.enemies[0].hp"
+            LiveCommand::Evaluate { expression } if expression == "game.enemies[0].hp"
         ));
         assert_eq!(
             app.transcript.back().map(String::as_str),

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -1003,7 +1003,13 @@ impl LiveTui {
         if line.trim_start().starts_with(":edit") {
             return self.open_definition(&line);
         }
-        match self.terminal.feed_line(&line) {
+        let evaluated_line = (!self.terminal.has_pending_input()
+            && !line.trim_start().starts_with([':', '{']))
+        .then(|| format!(":print {line}"));
+        match self
+            .terminal
+            .feed_line(evaluated_line.as_deref().unwrap_or(&line))
+        {
             Ok(TerminalInput::Continue { prompt }) => {
                 self.prompt = prompt;
                 self.status = "multiline compatibility input; finish with :end".to_string();
@@ -2852,6 +2858,44 @@ fn write_at(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn root_prompt_submits_a_bare_expression_for_printing() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
+
+        app.submit_line("game.enemies[0].hp".to_string())
+            .expect("submit expression");
+
+        let requests = server.drain(8);
+        assert_eq!(requests.len(), 1);
+        assert!(matches!(
+            &requests[0].command,
+            LiveCommand::Print { expression } if expression == "game.enemies[0].hp"
+        ));
+        assert_eq!(
+            app.transcript.back().map(String::as_str),
+            Some("stasis> game.enemies[0].hp")
+        );
+    }
+
+    #[test]
+    fn bare_lines_inside_a_multiline_command_remain_source() {
+        let (client, server) = stasis_runner::live::live_session(8);
+        let mut app = LiveTui::new(client, std::env::temp_dir());
+
+        app.submit_line(":do".to_string()).expect("start block");
+        app.submit_line("game.score = 7;".to_string())
+            .expect("add source line");
+        app.submit_line(":end".to_string()).expect("finish block");
+
+        let requests = server.drain(8);
+        assert_eq!(requests.len(), 1);
+        assert!(matches!(
+            &requests[0].command,
+            LiveCommand::Do { code, preview: false } if code == "game.score = 7;"
+        ));
+    }
 
     #[test]
     fn live_ai_write_is_rejected_until_references_were_checked() {

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -1064,6 +1064,10 @@ impl TerminalBuffer {
         self.pending.take().is_some()
     }
 
+    pub fn has_pending_input(&self) -> bool {
+        self.pending.is_some()
+    }
+
     pub fn completion_context(&self) -> CompletionContext {
         let Some(PendingMultiline {
             command: PendingCommand::Edit { target, .. },

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -185,6 +185,9 @@ pub enum LiveCommand {
     Print {
         expression: String,
     },
+    Evaluate {
+        expression: String,
+    },
     Do {
         code: String,
         #[serde(default)]
@@ -1371,6 +1374,23 @@ fn split_terminal_args(line: &str) -> Result<Vec<String>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn evaluate_has_a_stable_json_contract() {
+        let request = LiveRequest::new(
+            9,
+            LiveCommand::Evaluate {
+                expression: "game.enemies[0].hp".into(),
+            },
+        );
+        let json = serde_json::to_value(&request).expect("serialize");
+        assert_eq!(json["type"], "evaluate");
+        assert_eq!(json["expression"], "game.enemies[0].hp");
+        assert_eq!(
+            serde_json::from_value::<LiveRequest>(json).expect("round trip"),
+            request
+        );
+    }
 
     #[test]
     fn edit_batch_has_a_stable_json_contract() {

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -25,9 +25,19 @@ project to open it. The deterministic `--live-script` and `--live-json` clients 
 without the TUI.
 
 At the root prompt, a bare scalar expression is evaluated against the current live state and its
-typed value is returned in the transcript. For example, entering `game.enemies[0].hp` is equivalent
-to `:print game.enemies[0].hp`. Explicit commands, JSON requests, and lines inside `:do ... :end`
+typed value is returned in the transcript. For example, entering `game.enemies[0].hp` returns that
+enemy's current HP. Bare input uses a dedicated live `evaluate` request; `:print` remains an explicit
+one-time observation command. Explicit commands, JSON requests, and lines inside `:do ... :end`
 keep their existing behavior.
+
+This first evaluation slice is intentionally side-effect-free and limited to the compiler-backed
+live scalar-expression surface. The prompt is designed to grow into a live-runtime REPL: later
+slices may compile a transient evaluation entry point that can call Stasis functions and return a
+typed or structured result, followed by explicit command execution that may mutate runtime state
+and then return data. Evaluation results stay separate from guest stdout. Transient evaluation must
+run at a between-tick boundary and must not overload `on_code_swap`, whose only responsibility is
+restoring application invariants after a durable code swap. Source edits continue through the
+existing compile, test, atomic apply, and rollback transaction.
 
 ### Subscription-backed AI
 

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -24,6 +24,11 @@ Status: the first desktop feel slice is implemented. Run `stasis tui src/main.st
 project to open it. The deterministic `--live-script` and `--live-json` clients remain available
 without the TUI.
 
+At the root prompt, a bare scalar expression is evaluated against the current live state and its
+typed value is returned in the transcript. For example, entering `game.enemies[0].hp` is equivalent
+to `:print game.enemies[0].hp`. Explicit commands, JSON requests, and lines inside `:do ... :end`
+keep their existing behavior.
+
 ### Subscription-backed AI
 
 `stasis ai "PROMPT"` starts the live runtime, executes one AI change, and exits after the atomic
@@ -268,9 +273,11 @@ itself.
 
 The palette includes functions, structs, enum variants, globals, state paths, parameters,
 explicitly typed locals, fields, and receiver-qualified members such as `hero.hp` or
-`hero.damage`. Scoped candidates carry compiler-owned file, semantic-owner, visibility-span, and
-type metadata, so locals from another function or an out-of-scope block are excluded. Each row
-stays concise with kind and type/signature/source context. `:palette QUERY [--page N --limit N]
+`hero.damage`. Root search omits static `Type.field` catalog entries that cannot be evaluated
+without an instance; definition editing retains them as useful type context. Scoped candidates
+carry compiler-owned file, semantic-owner, visibility-span, and type metadata, so locals from
+another function or an out-of-scope block are excluded. Each row stays concise with kind and
+type/signature/source context. `:palette QUERY [--page N --limit N]
 [--owner OWNER --file FILE --signature SIGNATURE --offset N --expected-type TYPE]` exposes the same deterministic,
 bounded ranking to scripts and future desktop clients. Press Ctrl-C or enter `:abort` to discard a
 multiline buffer without submitting it. Symbol results are paged; selectors accept `--file`,


### PR DESCRIPTION
## Summary

- evaluate bare root-prompt input against the current live runtime state
- add a dedicated schema-v1 `evaluate` request so prompt evaluation can later grow beyond `:print`
- return typed scalar expression values in the TUI transcript
- hide static `Type.field` catalog entries from root completion while retaining them during definition editing
- preserve explicit commands, JSON requests, and multiline `:do ... :end` input

## Why

The TUI root prompt previously parsed bare expressions as unknown commands even though the live state-query engine could already evaluate paths such as `game.enemies[0].hp`. Root completion also surfaced static `Type.field` entries that are not directly evaluable without an instance.

This change makes current-state expression evaluation immediate while reserving a separate protocol boundary for future transient function calls, structured return values, and explicit command execution. Evaluation remains separate from guest stdout and does not overload `on_code_swap`.

## Developer impact

Entering a supported side-effect-free scalar expression now returns its current typed value. Instance paths remain available in root completion, and static type-field context remains available where it is useful: inside definition editing.

## Verification

- `cargo test -p stasis_runner` — 39 passed
- `cargo test -p stasis --bin stasis toolchain_cli::live_tui::tests` — 32 passed
- focused indexed-expression and completion-context regression tests passed
- `cargo fmt --all -- --check`
- `git diff --check`

The broader `cargo test -p stasis` run was not clean in this Windows workspace: unrelated JIT/layout tests failed concurrently and the library harness ended with `STATUS_ACCESS_VIOLATION`. The affected runner, TUI, evaluation, and completion test groups pass independently.
