### PR TITLE
feat: add Windows performance HUD

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2041,17 +2041,23 @@ fn run_play_in_process_inner(
         )?;
 
         let run_tick = live.as_ref().is_none_or(LiveWorkspace::should_run_tick);
+        let mut tick_micros = 0;
         if run_tick {
+            let tick_started = Instant::now();
             let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
+            tick_micros = tick_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
             if tick_rc != 0 {
                 break;
             }
         }
+        let render_started = Instant::now();
         let render_rc = stasis_dynload::invoke_noarg_i32(render_code_ptr as usize)?;
+        let render_micros = render_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
         if render_rc != 0 {
             break;
         }
 
+        gfx.host_set_performance_metrics(tick_micros, render_micros)?;
         gfx.gfx_submit_u8(&gfx_cmd_i32, &gfx_cmd_f32, &gfx_cmd_u8)?;
         if tick_sleep_micros > 0 {
             let ms = (tick_sleep_micros / 1000) as i32;
@@ -3407,6 +3413,10 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/stasis_graphics.c"
     ));
+    const STASIS_RUNNER_SOURCE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_runner.c"
+    ));
     const STASIS_MOBILE_RUNTIME_SOURCE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/stasis_mobile_runtime.c"
@@ -3465,6 +3475,27 @@ mod tests {
     fn process_env_lock() -> &'static std::sync::Mutex<()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn windows_performance_hud_uses_frame_work_and_60_fps_budget() {
+        for required in [
+            "event.key.keysym.sym == SDLK_F3",
+            "stasis_host_set_performance_metrics",
+            "g_perf_pending_guest_render_us",
+            "stasis_perf_elapsed_us(g_perf_render_started_counter, now)",
+            "budget@60fps=%d%%",
+            "const double total_ms = tick_ms + render_ms",
+        ] {
+            assert!(
+                STASIS_GRAPHICS_SOURCE.contains(required),
+                "Windows performance HUD contract should contain {required}"
+            );
+        }
+        assert!(
+            STASIS_RUNNER_SOURCE.contains("host_set_performance_metrics(tick_us, render_us)"),
+            "Windows AOT runner should feed tick and render timing into the shared HUD"
+        );
     }
 
     fn with_env_var_set(key: &str, value: &str, f: impl FnOnce()) {

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -273,6 +273,8 @@ pub struct StasisGraphicsApi {
     #[cfg(windows)]
     stasis_host_bulk_apply_requests: usize,
     #[cfg(windows)]
+    stasis_host_set_performance_metrics: usize,
+    #[cfg(windows)]
     stasis_gfx_submit_u8: usize,
     #[cfg(windows)]
     stasis_sleep_ms: usize,
@@ -311,6 +313,8 @@ impl StasisGraphicsApi {
             let stasis_host_bulk_init = lib.symbol_address("stasis_host_bulk_init")?;
             let stasis_host_bulk_apply_requests =
                 lib.symbol_address("stasis_host_bulk_apply_requests")?;
+            let stasis_host_set_performance_metrics =
+                lib.symbol_address("stasis_host_set_performance_metrics")?;
             let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
             let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
             Ok(Self {
@@ -319,6 +323,7 @@ impl StasisGraphicsApi {
                 stasis_host_get_frame,
                 stasis_host_bulk_init,
                 stasis_host_bulk_apply_requests,
+                stasis_host_set_performance_metrics,
                 stasis_gfx_submit_u8,
                 stasis_sleep_ms,
             })
@@ -419,6 +424,26 @@ impl StasisGraphicsApi {
             let _ = host_req_window_w_px;
             let _ = host_req_window_h_px;
             Err("stasis_graphics host_bulk_apply_requests is only supported on windows in stasis_dynload".to_string())
+        }
+    }
+
+    pub fn host_set_performance_metrics(
+        &self,
+        tick_micros: u64,
+        render_micros: u64,
+    ) -> Result<(), String> {
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn(u64, u64) =
+                unsafe { std::mem::transmute(self.stasis_host_set_performance_metrics) };
+            callback(tick_micros, render_micros);
+            return Ok(());
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = tick_micros;
+            let _ = render_micros;
+            Err("stasis_graphics performance metrics are only supported on windows in stasis_dynload".to_string())
         }
     }
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -65,6 +65,10 @@ captures use the drawable resolution.
    cargo run -p stasis --release -- play samples\asteroids.stasis
    ```
 
+Press `F3` in a Windows play window to toggle the performance HUD. It reports
+five-second average tick, render, and total times plus total use of the 60 fps
+frame budget.
+
 ## Android (NDK)
 
 Android uses the canonical SDL renderer process. `STASIS_GRAPHICS_SDL_ONLY`

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -100,6 +100,7 @@ static void log_package_provenance(void) {
 
 STASIS_EXPORT void stasis_set_window_size(int width, int height);
 STASIS_EXPORT int stasis_get_time_us(void);
+STASIS_EXPORT int stasis_load_font(const char* path, int font_size);
 STASIS_EXPORT int stasis_gfx_cache_text(int font_handle, const char* text);
 STASIS_EXPORT void stasis_gfx_draw_text_cached(int run_handle, float x, float y, float r, float g, float b, float a);
 STASIS_EXPORT float stasis_gfx_measure_text_cached(int run_handle);
@@ -126,6 +127,7 @@ static int g_density_generation = 0;
 static bool g_window_resized = false;
 static StasisRendererLifecycle g_resource_lifecycle;
 static bool g_resource_frame_ready = false;
+static bool g_force_debug_overlay = false;
 static bool g_postfx_enabled = false;
 static bool g_postfx_applied_this_frame = false;
 static bool g_screenshot_taken = false;
@@ -145,6 +147,20 @@ static float g_postfx_phase = 0.0f;
 static float g_postfx_speed = 0.0f;
 static float g_postfx_color[3] = {0.05f, 0.85f, 0.78f};
 static bool g_postfx_force_disable = false;
+
+#define STASIS_PERF_SAMPLE_CAPACITY 360
+typedef struct {
+    uint64_t captured_counter;
+    uint64_t tick_us;
+    uint64_t render_us;
+} StasisPerfSample;
+static StasisPerfSample g_perf_samples[STASIS_PERF_SAMPLE_CAPACITY];
+static int g_perf_sample_count = 0;
+static int g_perf_sample_next = 0;
+static uint64_t g_perf_pending_tick_us = 0;
+static uint64_t g_perf_pending_guest_render_us = 0;
+static uint64_t g_perf_render_started_counter = 0;
+static int g_perf_font_handle = -1;
 
 /* ============================================================
  * Input snapshot (mouse + touch) - per-frame deterministic view
@@ -209,6 +225,8 @@ static void setup_ortho(void);
 static void reset_line_program(void);
 static void reset_sprite_program(void);
 #endif
+static int stasis_perf_font(void);
+static uint64_t stasis_perf_elapsed_us(uint64_t started_counter, uint64_t finished_counter);
 
 /* Sprite atlas bookkeeping (paths + rasterized sprites). */
 #define SPRITE_TABLE_INITIAL_CAPACITY 256
@@ -576,6 +594,11 @@ static void stasis_pump_events(void) {
                 if (event.key.keysym.sym == SDLK_ESCAPE) {
                     g_should_quit = true;
                 }
+                if (event.key.keysym.sym == SDLK_F3 && event.key.repeat == 0) {
+                    g_force_debug_overlay = !g_force_debug_overlay;
+                    if (g_force_debug_overlay) (void)stasis_perf_font();
+                    SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
+                }
                 break;
             case SDL_WINDOWEVENT:
                 if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
@@ -849,6 +872,12 @@ STASIS_EXPORT void stasis_host_bulk_apply_requests(
     }
 }
 
+STASIS_EXPORT void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us)
+{
+    g_perf_pending_tick_us = tick_us;
+    g_perf_pending_guest_render_us = render_us;
+}
+
 typedef int (*stasis_tick_fn)(void);
 
 STASIS_EXPORT int stasis_host_bulk_step(
@@ -878,12 +907,17 @@ STASIS_EXPORT int stasis_host_bulk_step(
 
     stasis_host_bulk_apply_requests(host_req_seq, host_req_flags, host_req_window_w_px, host_req_window_h_px);
 
+    const uint64_t tick_started = SDL_GetPerformanceCounter();
     const int tick_result = tick_fn();
+    const uint64_t tick_finished = SDL_GetPerformanceCounter();
     if (tick_result != 0)
     {
         return tick_result;
     }
 
+    stasis_host_set_performance_metrics(
+        stasis_perf_elapsed_us(tick_started, tick_finished),
+        0);
     stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
     return 0;
 }
@@ -1168,7 +1202,6 @@ static struct {
 static LineVertex g_line_vertices[MAX_LINES * 2];
 static int g_line_count = 0;
 static int g_debug_frame_counter = 0;
-static bool g_force_debug_overlay = false;
 
 /* Simple shader + buffer for line rendering */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -3972,11 +4005,133 @@ STASIS_EXPORT void stasis_begin_frame(void) {
     }
 }
 
+static uint64_t stasis_perf_elapsed_us(uint64_t started_counter, uint64_t finished_counter) {
+    const uint64_t frequency = SDL_GetPerformanceFrequency();
+    if (started_counter == 0 || finished_counter < started_counter || frequency == 0) return 0;
+    return ((finished_counter - started_counter) * 1000000u) / frequency;
+}
+
+static void stasis_perf_finish_render_sample(void) {
+    const uint64_t now = SDL_GetPerformanceCounter();
+    StasisPerfSample* sample = &g_perf_samples[g_perf_sample_next];
+    sample->captured_counter = now;
+    sample->tick_us = g_perf_pending_tick_us;
+    sample->render_us = g_perf_pending_guest_render_us
+        + stasis_perf_elapsed_us(g_perf_render_started_counter, now);
+    g_perf_sample_next = (g_perf_sample_next + 1) % STASIS_PERF_SAMPLE_CAPACITY;
+    if (g_perf_sample_count < STASIS_PERF_SAMPLE_CAPACITY) {
+        g_perf_sample_count++;
+    }
+    g_perf_render_started_counter = 0;
+}
+
+static void stasis_perf_averages(double* tick_ms, double* render_ms) {
+    const uint64_t now = SDL_GetPerformanceCounter();
+    const uint64_t frequency = SDL_GetPerformanceFrequency();
+    const uint64_t window = frequency * 5u;
+    uint64_t tick_total = 0;
+    uint64_t render_total = 0;
+    int samples = 0;
+
+    for (int i = 0; i < g_perf_sample_count; i++) {
+        const StasisPerfSample* sample = &g_perf_samples[i];
+        if (sample->captured_counter == 0 || now < sample->captured_counter) continue;
+        if (now - sample->captured_counter > window) continue;
+        tick_total += sample->tick_us;
+        render_total += sample->render_us;
+        samples++;
+    }
+
+    if (samples == 0) {
+        *tick_ms = 0.0;
+        *render_ms = 0.0;
+        return;
+    }
+    *tick_ms = (double)tick_total / (double)samples / 1000.0;
+    *render_ms = (double)render_total / (double)samples / 1000.0;
+}
+
+static int stasis_perf_font(void) {
+    if (g_perf_font_handle >= 0) return g_perf_font_handle;
+#if defined(_WIN32)
+    const char* windows_dir = getenv("WINDIR");
+    char path[1024];
+    if (windows_dir && *windows_dir) {
+        snprintf(path, sizeof(path), "%s/Fonts/segoeui.ttf", windows_dir);
+    } else {
+        snprintf(path, sizeof(path), "C:/Windows/Fonts/segoeui.ttf");
+    }
+    g_perf_font_handle = stasis_load_font(path, 15);
+#else
+    g_perf_font_handle = 0;
+#endif
+    return g_perf_font_handle;
+}
+
+static void stasis_perf_draw_overlay(void) {
+    if (!g_force_debug_overlay) return;
+    const int font = stasis_perf_font();
+    if (font <= 0) return;
+
+    double tick_ms = 0.0;
+    double render_ms = 0.0;
+    stasis_perf_averages(&tick_ms, &render_ms);
+    const double total_ms = tick_ms + render_ms;
+    const int budget_percent = (int)(total_ms * 6.0 + 0.5);
+    char text[160];
+    snprintf(
+        text,
+        sizeof(text),
+        "tick=%.2f ms  render=%.2f ms  total=%.2f ms  budget@60fps=%d%%  [F3]",
+        tick_ms,
+        render_ms,
+        total_ms,
+        budget_percent);
+
+    float r = 1.0f;
+    float g = 1.0f;
+    float b = 1.0f;
+    if (budget_percent >= 100) {
+        r = 0.73f; g = 0.41f; b = 1.0f;
+    } else if (budget_percent >= 80) {
+        r = 1.0f; g = 0.36f; b = 0.36f;
+    } else if (budget_percent >= 50) {
+        r = 1.0f; g = 0.84f; b = 0.40f;
+    }
+
+    const int background_width = g_window_width > 690 ? 680 : g_window_width - 16;
+    if (g_use_sdl_renderer) {
+        SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
+        SDL_SetRenderDrawColor(g_renderer, 20, 28, 38, 170);
+        SDL_Rect background = { 8, 8, background_width, 28 };
+        if (background.w > 0) SDL_RenderFillRect(g_renderer, &background);
+    } else {
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+        flush_lines();
+        flush_sprites();
+        if (background_width > 0) {
+            glDisable(GL_TEXTURE_2D);
+            glColor4f(0.08f, 0.11f, 0.15f, 0.67f);
+            glBegin(GL_QUADS);
+            glVertex2f(8.0f, 8.0f);
+            glVertex2f(8.0f + (float)background_width, 8.0f);
+            glVertex2f(8.0f + (float)background_width, 36.0f);
+            glVertex2f(8.0f, 36.0f);
+            glEnd();
+        }
+#endif
+    }
+
+    stasis_draw_text(font, text, 13.0f, 12.0f, 0.0f, 0.0f, 0.0f, 0.9f);
+    stasis_draw_text(font, text, 12.0f, 11.0f, r, g, b, 1.0f);
+}
+
 /*
  * End frame: flush lines, swap buffers, poll events
  */
 STASIS_EXPORT void stasis_end_frame(void) {
     if (!g_resource_frame_ready) {
+        g_perf_render_started_counter = 0;
         g_line_count = 0;
         g_events_pumped_this_frame = 0;
         return;
@@ -3996,6 +4151,7 @@ STASIS_EXPORT void stasis_end_frame(void) {
 
         /* Capture before present so we read the current render target. */
         capture_scheduled_screenshot();
+        stasis_perf_finish_render_sample();
         SDL_RenderPresent(g_renderer);
         g_line_count = 0;
     } else {
@@ -4008,6 +4164,7 @@ STASIS_EXPORT void stasis_end_frame(void) {
         }
         /* Capture after all draws (including postfx) but before swap. */
         capture_scheduled_screenshot();
+        stasis_perf_finish_render_sample();
         SDL_GL_SwapWindow(g_window);
 #else
         /* STASIS_GRAPHICS_SDL_ONLY should never create a GL context. */
@@ -4181,6 +4338,7 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
         }
         return;
     }
+    g_perf_render_started_counter = SDL_GetPerformanceCounter();
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
     const int32_t gfx_cmd_max_lines = STASIS_RENDER_MAX_LINES;
@@ -4301,7 +4459,10 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
 
     /* Present only if requested (lets benchmarks exclude swap/vsync). */
     if ((flags & STASIS_RENDER_FLAG_PRESENT) != 0) {
+        stasis_perf_draw_overlay();
         stasis_end_frame();
+    } else {
+        g_perf_render_started_counter = 0;
     }
 }
 

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -50,6 +50,7 @@ typedef void (*stasis_host_bulk_apply_requests_fn)(
     const int32_t *host_req_flags,
     const int32_t *host_req_window_w_px,
     const int32_t *host_req_window_h_px);
+typedef void (*stasis_host_set_performance_metrics_fn)(uint64_t tick_us, uint64_t render_us);
 typedef int (*stasis_host_bulk_step_fn)(
     int32_t *host_i32,
     float *host_f32,
@@ -2044,6 +2045,7 @@ int main(int argc, char **argv)
         uint8_t *gfx_cmd_u8 = NULL;
 
         stasis_host_get_frame_fn host_get_frame = NULL;
+        stasis_host_set_performance_metrics_fn host_set_performance_metrics = NULL;
         stasis_gfx_submit_u8_fn gfx_submit_u8 = NULL;
         int32_t last_req_seq = host_req_seq ? *host_req_seq : 0;
 
@@ -2057,6 +2059,9 @@ int main(int argc, char **argv)
         if (gfx)
         {
             host_get_frame = (stasis_host_get_frame_fn)GetProcAddress(gfx, "stasis_host_get_frame");
+            host_set_performance_metrics = (stasis_host_set_performance_metrics_fn)GetProcAddress(
+                gfx,
+                "stasis_host_set_performance_metrics");
             gfx_submit_u8 = (stasis_gfx_submit_u8_fn)GetProcAddress(gfx, "stasis_gfx_submit_u8");
         }
 
@@ -2421,9 +2426,16 @@ int main(int argc, char **argv)
                 }
 
                 int step_result = 0;
+                uint64_t tick_us = 0;
+                uint64_t render_us = 0;
                 if (tick)
                 {
+                    LARGE_INTEGER phase_started;
+                    LARGE_INTEGER phase_finished;
+                    QueryPerformanceCounter(&phase_started);
                     step_result = tick();
+                    QueryPerformanceCounter(&phase_finished);
+                    tick_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
                     if (step_result != 0)
                     {
                         result = step_result == 1 ? 0 : step_result;
@@ -2433,7 +2445,12 @@ int main(int argc, char **argv)
 
                 if (render)
                 {
+                    LARGE_INTEGER phase_started;
+                    LARGE_INTEGER phase_finished;
+                    QueryPerformanceCounter(&phase_started);
                     step_result = render();
+                    QueryPerformanceCounter(&phase_finished);
+                    render_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
                     if (step_result != 0)
                     {
                         result = step_result == 1 ? 0 : step_result;
@@ -2450,6 +2467,10 @@ int main(int argc, char **argv)
 
                 if (gfx_submit_u8 && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
                 {
+                    if (host_set_performance_metrics)
+                    {
+                        host_set_performance_metrics(tick_us, render_us);
+                    }
                     gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
                 }
             }


### PR DESCRIPTION
## Summary

- add an `F3`-toggleable performance HUD to Windows play windows
- report five-second average tick, render, total frame-work time, and use of the 60 fps frame budget
- feed the same graphics-host HUD from both Rust JIT play and packaged Windows AOT runner paths
- color the budget readout using the Android Workshop thresholds

## Why

Android Workshop keeps frame performance visible, but Windows builds had no equivalent runtime view. The HUD now measures guest tick and render-command generation at their owning runners, adds graphics CPU work before presentation, and deliberately excludes pacing sleep and vsync wait.

## User impact

Press `F3` in a Windows play window to show or hide:

`tick=… ms  render=… ms  total=… ms  budget@60fps=…%`

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p stasis`
- `cargo test -p stasis --lib -- --test-threads=1` — 220 passed, 6 ignored
- CMake Release build of `stasis_graphics` and `stasis_runner`
- two-frame Brickout Windows play smoke test using the rebuilt graphics DLL

## Theory gained

Windows JIT and AOT own different frame loops, but both converge at graphics submission. Keeping sample aggregation and HUD rendering at that shared boundary provides one presentation path while the runners contribute phase timing from the boundaries they own.