### PR TITLE
Report bounded simulation costs

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -898,10 +898,11 @@ impl IncrementalCompilerBackend {
     }
 
     fn source_cache_has_function(&self, function_name: &str) -> bool {
-        let needle = format!("function {function_name}(");
         self.source_by_path
             .values()
-            .any(|source| source.contains(&needle))
+            .filter_map(|source| parse_top_level_functions(source).ok())
+            .flatten()
+            .any(|function| function.name == function_name)
     }
 
     fn collect_cached_function_entries(&self) -> Result<Vec<EngineFunctionEntry>, String> {
@@ -8302,6 +8303,107 @@ mod tests {
             351
         );
         // Runtime bindings intentionally remain valid until the test process exits.
+        std::mem::forget(library);
+        fs::remove_dir_all(&temp_root).ok();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn bounded_performance_sample_links_and_executes_aot_if_real_link_available() {
+        let Some(linker_path) = find_lld_link() else {
+            return;
+        };
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root =
+            std::env::temp_dir().join(format!("stasis_bounded_performance_aot_{stamp}"));
+        let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../samples/bounded_performance/src/main.stasis");
+        let mut backend = IncrementalCompilerBackend::with_aot_config(
+            AotCompileConfig::default(),
+            temp_root.join("artifacts"),
+        );
+        let result = backend.compile(CompileRequest::new(
+            RequestId(17_201),
+            vec![source],
+            TargetMode::AotProd,
+        ));
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "{:?}",
+            result.diagnostics
+        );
+        let bundle = backend
+            .last_aot_engine_bundle()
+            .expect("AOT engine bundle")
+            .clone();
+        let manifest = backend
+            .read_engine_bundle_manifest(&bundle.manifest_path)
+            .expect("read manifest");
+        let runtime_fields = merge_runtime_fields(
+            backend.last_state_layout.as_ref().expect("state layout"),
+            &[],
+        )
+        .expect("derive AOT storage fields");
+        let aliases = ["main", "tick", "render"]
+            .into_iter()
+            .map(|name| PackagedFunctionAlias {
+                alias: name,
+                target_symbol: resolve_engine_bundle_symbol(&manifest, name)
+                    .expect("resolve entrypoint"),
+                returns_i32: true,
+            })
+            .collect::<Vec<_>>();
+        let function_symbols = manifest
+            .functions
+            .iter()
+            .map(|row| row.symbol.clone())
+            .collect::<Vec<_>>();
+        let bridge = emit_engine_bundle_runtime_bridge_object(
+            &backend,
+            &runtime_fields,
+            &function_symbols,
+            &aliases,
+            &[],
+        )
+        .expect("compile runtime bridge");
+        let mut objects = bundle
+            .object_paths_by_function
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        objects.push(bridge);
+        let linked = temp_root.join("bounded_performance.dll");
+        let dynload = ensure_stasis_dynload_link_library().expect("stasis dynload link library");
+        stasis_jit::link_objects_to_dynamic_library(
+            &objects,
+            &linked,
+            &[
+                "main".to_string(),
+                "tick".to_string(),
+                "stasis_aot_bind_runtime_globals".to_string(),
+            ],
+            &AotLinkConfig {
+                linker_path: Some(linker_path),
+                runtime_lib_paths: vec![dynload.clone()],
+                target: stasis_jit::AotTarget::default(),
+            },
+        )
+        .expect("link bounded-performance AOT bundle");
+        stage_stasis_dynload_runtime(&dynload, &linked).expect("stage runtime");
+
+        let library = DynamicLibrary::load(&linked).expect("load AOT bundle");
+        let bind = library
+            .symbol_address("stasis_aot_bind_runtime_globals")
+            .expect("resolve runtime binding");
+        stasis_dynload::invoke_noarg_void(bind).expect("bind runtime globals");
+        let main = library.symbol_address("main").expect("resolve main");
+        let tick = library.symbol_address("tick").expect("resolve tick");
+        assert_eq!(stasis_dynload::invoke_noarg_i32(main).expect("run main"), 0);
+        assert_eq!(stasis_dynload::invoke_noarg_i32(tick).expect("run tick"), 0);
         std::mem::forget(library);
         fs::remove_dir_all(&temp_root).ok();
     }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -40,7 +40,7 @@ use stasis_runner::swap::contracts::{
     TextSource,
 };
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -50,6 +50,87 @@ use std::time::Instant;
 use watch::WatchService;
 
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
+const TICK_BUDGET_SAMPLE_LIMIT: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TickBudgetDiagnostics {
+    generation: u64,
+    budget_us: u64,
+    sample_count: u64,
+    total_us: u128,
+    overruns: u64,
+    recent_us: VecDeque<u64>,
+}
+
+impl TickBudgetDiagnostics {
+    fn new(budget_us: u64, generation: u64) -> Self {
+        Self {
+            generation,
+            budget_us,
+            sample_count: 0,
+            total_us: 0,
+            overruns: 0,
+            recent_us: VecDeque::with_capacity(TICK_BUDGET_SAMPLE_LIMIT),
+        }
+    }
+
+    fn record(&mut self, elapsed_us: u64) {
+        self.sample_count = self.sample_count.saturating_add(1);
+        self.total_us = self.total_us.saturating_add(u128::from(elapsed_us));
+        if elapsed_us > self.budget_us {
+            self.overruns = self.overruns.saturating_add(1);
+        }
+        if self.recent_us.len() == TICK_BUDGET_SAMPLE_LIMIT {
+            self.recent_us.pop_front();
+        }
+        self.recent_us.push_back(elapsed_us);
+    }
+
+    fn average_us(&self) -> u64 {
+        if self.sample_count == 0 {
+            return 0;
+        }
+        u64::try_from(self.total_us / u128::from(self.sample_count)).unwrap_or(u64::MAX)
+    }
+
+    fn p99_us(&self) -> u64 {
+        let mut samples = self.recent_us.iter().copied().collect::<Vec<_>>();
+        if samples.is_empty() {
+            return 0;
+        }
+        samples.sort_unstable();
+        let rank = samples.len().saturating_mul(99).div_ceil(100);
+        samples[rank.saturating_sub(1)]
+    }
+
+    fn report(&self) -> String {
+        format!(
+            "[tick-budget] generation={} budget_us={} samples={} average_us={} p99_us={} overruns={}",
+            self.generation,
+            self.budget_us,
+            self.sample_count,
+            self.average_us(),
+            self.p99_us(),
+            self.overruns
+        )
+    }
+}
+
+fn update_tick_budget_after_swap(
+    current: &mut Option<TickBudgetDiagnostics>,
+    generation: &mut u64,
+    candidate_budget_us: Option<u64>,
+    committed: bool,
+) -> Option<String> {
+    if !committed {
+        return None;
+    }
+    let completed = current.take().map(|diagnostics| diagnostics.report());
+    *generation = generation.saturating_add(1);
+    *current =
+        candidate_budget_us.map(|budget_us| TickBudgetDiagnostics::new(budget_us, *generation));
+    completed
+}
 
 #[derive(Debug, Clone, Default)]
 struct PendingAotCompileMetadata {
@@ -1842,6 +1923,10 @@ fn run_play_in_process_inner(
     let _ = jit
         .compile()
         .map_err(|error| format!("initial JIT compile failed: {error:?}"))?;
+    let mut tick_budget_generation = 0u64;
+    let mut tick_budget = jit
+        .tick_budget_us()?
+        .map(|budget| TickBudgetDiagnostics::new(budget, tick_budget_generation));
     load_and_apply_play_data_bindings(&data_binding_paths, Some(&jit))?;
     let package = jit
         .build_engine_package(&EngineEntrypoints::runtime_default())
@@ -1957,6 +2042,13 @@ fn run_play_in_process_inner(
             match candidate.compile_staged() {
                 Ok(_) => {
                     let compile_ms = t_compile.elapsed().as_millis();
+                    let candidate_tick_budget = match candidate.tick_budget_us() {
+                        Ok(value) => value,
+                        Err(error) => {
+                            println!("[swap] compile rejected: {error}");
+                            continue;
+                        }
+                    };
 
                     let t_pkg = Instant::now();
                     match candidate.build_engine_package(&EngineEntrypoints::runtime_default()) {
@@ -1993,6 +2085,14 @@ fn run_play_in_process_inner(
                                 Ok(entrypoints) => {
                                     tick_code_ptr = entrypoints.tick_code_ptr;
                                     render_code_ptr = entrypoints.render_code_ptr;
+                                    if let Some(report) = update_tick_budget_after_swap(
+                                        &mut tick_budget,
+                                        &mut tick_budget_generation,
+                                        candidate_tick_budget,
+                                        true,
+                                    ) {
+                                        println!("{report}");
+                                    }
                                     if let Some(live) = live.as_mut() {
                                         live.refresh_after_external_edit(&jit);
                                     }
@@ -2046,6 +2146,9 @@ fn run_play_in_process_inner(
             let tick_started = Instant::now();
             let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
             tick_micros = tick_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
+            if let Some(budget) = tick_budget.as_mut() {
+                budget.record(tick_micros);
+            }
             if tick_rc != 0 {
                 break;
             }
@@ -2080,6 +2183,10 @@ fn run_play_in_process_inner(
                 break;
             }
         }
+    }
+
+    if let Some(budget) = tick_budget {
+        println!("{}", budget.report());
     }
 
     Ok(())
@@ -3408,6 +3515,52 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn tick_budget_diagnostics_report_bounded_average_p99_and_overruns() {
+        let mut diagnostics = TickBudgetDiagnostics::new(100, 7);
+        for sample in [25, 50, 75, 100, 125] {
+            diagnostics.record(sample);
+        }
+        assert_eq!(diagnostics.average_us(), 75);
+        assert_eq!(diagnostics.p99_us(), 125);
+        assert_eq!(diagnostics.overruns, 1);
+        assert_eq!(
+            diagnostics.report(),
+            "[tick-budget] generation=7 budget_us=100 samples=5 average_us=75 p99_us=125 overruns=1"
+        );
+
+        for sample in 0..(TICK_BUDGET_SAMPLE_LIMIT + 10) {
+            diagnostics.record(sample as u64);
+        }
+        assert_eq!(diagnostics.recent_us.len(), TICK_BUDGET_SAMPLE_LIMIT);
+    }
+
+    #[test]
+    fn tick_budget_generations_advance_only_after_committed_swaps() {
+        let mut generation = 0;
+        let mut current = Some(TickBudgetDiagnostics::new(100, generation));
+        current.as_mut().expect("generation zero").record(75);
+
+        assert_eq!(
+            update_tick_budget_after_swap(&mut current, &mut generation, Some(80), false),
+            None
+        );
+        assert_eq!(generation, 0);
+        assert_eq!(
+            current.as_ref().expect("preserved generation").sample_count,
+            1
+        );
+
+        let completed =
+            update_tick_budget_after_swap(&mut current, &mut generation, Some(80), true)
+                .expect("generation zero report");
+        assert!(completed.contains("generation=0 budget_us=100 samples=1"));
+        let next = current.as_ref().expect("generation one");
+        assert_eq!(generation, 1);
+        assert_eq!(next.generation, 1);
+        assert_eq!(next.sample_count, 0);
+    }
 
     const STASIS_GRAPHICS_SOURCE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7,6 +7,7 @@ use stasis::{
     run_play_in_process_with_window_title, run_self_host_aot_cli_with_options, LiveRunConfig,
     StasisTestRunSession,
 };
+use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
 use stasis_compiler::frontend::workshop::{
@@ -17,6 +18,7 @@ use stasis_compiler::frontend::workshop::{
     WorkshopSemanticEditOperation, WorkshopSemanticEditPlan, WorkshopSourceFile,
     WorkshopSourceItemKind, WorkshopSymbolSelector,
 };
+use stasis_jit::AotTarget;
 pub(super) use stasis_runner::live::LiveValidationRequirement as RuntimeValidationRequirement;
 use stasis_runner::live::{
     compare_live_validation_values, live_session, LiveCommand, LiveRequest, LiveResponse,
@@ -932,7 +934,7 @@ fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
         load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
     let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
     let mut jit = JitProcess::new();
-    jit.set_required_emit_roots(&["main".to_string()]);
+    jit.set_required_emit_roots(&runtime_analysis_roots());
     let mut sources = BTreeMap::new();
     for file in files {
         let path = workspace.root.join(&file.path);
@@ -957,6 +959,43 @@ fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
         }
     })?;
     Ok(jit)
+}
+
+fn compile_workspace_mobile_costs(workspace: &Workspace) -> Result<(u64, u64), String> {
+    let files =
+        load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
+    let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
+    let mut aot = AotProcess::new();
+    aot.set_target(AotTarget::android_arm64_default());
+    aot.set_required_emit_roots(&runtime_analysis_roots());
+    for file in files {
+        let path = workspace.root.join(&file.path);
+        let path = path.canonicalize().unwrap_or(path);
+        aot.upsert_file(path.to_string_lossy().to_string(), file.source);
+    }
+    aot.compile().map_err(|error| format!("{error:?}"))?;
+    let code_bytes = aot
+        .artifacts()
+        .iter()
+        .try_fold(0u64, |total, artifact| {
+            total.checked_add(artifact.object_bytes_len as u64)
+        })
+        .ok_or_else(|| "AOT object byte estimate overflow".to_string())?;
+    let literal_bytes = aot
+        .string_literals()
+        .values()
+        .try_fold(0u64, |total, literal| {
+            total.checked_add(literal.len() as u64)
+        })
+        .ok_or_else(|| "literal data byte estimate overflow".to_string())?;
+    Ok((code_bytes, literal_bytes))
+}
+
+fn runtime_analysis_roots() -> Vec<String> {
+    ["main", "tick", "render", "on_code_swap"]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
 }
 
 fn validate_fresh_runtime(
@@ -3306,6 +3345,9 @@ fn inspect_workspace(
     let capacity_overrides = parse_capacity_overrides(capacities)?;
     let jit = compile_workspace_jit(workspace)?;
     let memory = jit.state_memory_report(&capacity_overrides, mobile_budget_bytes)?;
+    let (aot_object_code_bytes, literal_data_bytes) = compile_workspace_mobile_costs(workspace)?;
+    let performance =
+        jit.performance_cost_report(&memory, aot_object_code_bytes, literal_data_bytes)?;
     let mut data_flow = jit.function_data_flow_summaries().to_vec();
     let canonical_root = workspace
         .root
@@ -3354,6 +3396,65 @@ fn inspect_workspace(
             )
         }));
     }
+    if let Some(budget_us) = performance.tick_budget_us {
+        human.push(format!(
+            "tick budget: {budget_us} us (runtime average/p99 reported by play)"
+        ));
+    }
+    if !performance.functions.is_empty() {
+        human.push("bounded performance costs:".to_string());
+        human.extend(performance.functions.iter().map(|function| {
+            format!(
+                "  {}: nested_product={} fields={} bytes_scanned={} pools={} host_calls=[{}]{}",
+                function.function,
+                function
+                    .worst_nested_iteration_product
+                    .map_or_else(|| "unknown".to_string(), |value| value.to_string()),
+                function.fields_scanned.len(),
+                function.conservative_max_bytes_scanned,
+                function.pools_iterated.len(),
+                function
+                    .host_calls
+                    .iter()
+                    .map(|call| format!(
+                        "{}:{}",
+                        call.function,
+                        call.max_invocations
+                            .map_or_else(|| "unknown".to_string(), |count| count.to_string())
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                if function.structural_bound_complete {
+                    ""
+                } else {
+                    " (incomplete bound)"
+                }
+            )
+        }));
+    }
+    if !performance.layout_choices.is_empty() {
+        human.push("layout choices (active lowering remains explicit SoA):".to_string());
+        human.extend(performance.layout_choices.iter().map(|layout| {
+            format!(
+                "  {}: SoA={} bytes; AoS={} bytes (stride {}, padding {}/element); recommendation={}",
+                layout.path,
+                layout.soa_bytes,
+                layout.aos_bytes,
+                layout.aos_stride_bytes,
+                layout.aos_padding_bytes_per_element,
+                layout.recommendation
+            )
+        }));
+    }
+    human.push(format!(
+        "mobile estimate: code={} data={} state={} buffers={} package={} peak_state_recommendation={}",
+        performance.mobile.aot_object_code_bytes,
+        performance.mobile.literal_data_bytes,
+        performance.mobile.state_capacity_bytes,
+        performance.mobile.command_buffer_bytes,
+        performance.mobile.package_estimate_bytes,
+        performance.mobile.peak_state_recommendation_bytes
+    ));
     Ok(CommandResult::success(
         human.join("\n"),
         json!({
@@ -3368,6 +3469,7 @@ fn inspect_workspace(
                 "schema_version": stasis_compiler::data_flow::FUNCTION_DATA_FLOW_SCHEMA_VERSION,
                 "functions": data_flow,
             },
+            "performance": performance,
         }),
     ))
 }
@@ -3690,7 +3792,10 @@ mod tests {
             .find(|summary| summary["function"] == "tick")
             .expect("tick summary");
 
-        assert_eq!(tick["schema_version"], 1);
+        assert_eq!(
+            tick["schema_version"],
+            stasis_compiler::data_flow::FUNCTION_DATA_FLOW_SCHEMA_VERSION
+        );
         assert_eq!(tick["file"], "src/main.stasis");
         assert_eq!(
             tick["signature_hash"]

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -153,6 +153,113 @@ fn inspect_reports_compiler_state_memory_and_capacity_projection() {
 }
 
 #[test]
+fn inspect_reports_nested_costs_tick_budget_layout_and_mobile_estimates() {
+    let project = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/bounded_performance");
+    let inspected = stasis(&["--json", "inspect"], &project);
+    assert_eq!(
+        inspected.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&inspected.stdout),
+        String::from_utf8_lossy(&inspected.stderr)
+    );
+    let result = json_stdout(&inspected);
+    let performance = &result["result"]["performance"];
+    assert_eq!(performance["schema_version"], 1);
+    assert_eq!(performance["tick_budget_us"], 1);
+    let expensive = performance["functions"]
+        .as_array()
+        .and_then(|functions| {
+            functions
+                .iter()
+                .find(|function| function["function"] == "expensive_scan")
+        })
+        .expect("expensive scan report");
+    assert_eq!(expensive["worst_nested_iteration_product"], 512);
+    assert_eq!(expensive["structural_bound_complete"], true);
+    assert!(expensive["fields_scanned"]
+        .as_array()
+        .is_some_and(|fields| fields.iter().any(|field| {
+            field["path"] == "particles[*].score"
+                && field["conservative_max_visits"] == 512
+                && field["conservative_max_bytes"] == 2048
+        })));
+    assert!(expensive["fields_scanned"]
+        .as_array()
+        .is_some_and(|fields| fields.iter().any(|field| {
+            field["path"] == "values[*]"
+                && field["element_bytes"] == 4
+                && field["conservative_max_visits"] == 5
+        })));
+    assert!(expensive["pools_iterated"]
+        .as_array()
+        .is_some_and(|pools| pools
+            .iter()
+            .any(|pool| { pool["path"] == "values" && pool["bytes_per_element"] == 4 })));
+    assert!(expensive["pools_iterated"]
+        .as_array()
+        .is_some_and(|pools| pools.iter().any(|pool| pool["path"] == "particles")));
+
+    let layout = performance["layout_choices"]
+        .as_array()
+        .and_then(|layouts| layouts.iter().find(|layout| layout["path"] == "particles"))
+        .expect("particle layout choice");
+    assert_eq!(layout["active_layout"], "soa");
+    assert!(layout["aos_padding_bytes_per_element"]
+        .as_u64()
+        .is_some_and(|padding| padding > 0));
+    assert!(performance["mobile"]["aot_object_code_bytes"]
+        .as_u64()
+        .is_some_and(|bytes| bytes > 0));
+    assert!(performance["mobile"]["package_estimate_bytes"]
+        .as_u64()
+        .is_some_and(|bytes| bytes > 512 * 1024));
+}
+
+#[cfg(windows)]
+#[test]
+fn play_reports_real_tick_budget_average_p99_and_overruns() {
+    let project = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/bounded_performance");
+    let entry = project.join("src/main.stasis");
+    let output = stasis(
+        &[
+            "play",
+            entry.to_str().expect("entry path"),
+            "--watch-dir",
+            project.to_str().expect("project path"),
+            "--ticks",
+            "3",
+        ],
+        &project,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report_line = stdout
+        .lines()
+        .find(|line| line.contains("[tick-budget]"))
+        .expect("tick budget report");
+    let report = &report_line[report_line.find("[tick-budget]").expect("report marker")..];
+    assert!(report.contains("generation=0 budget_us=1 samples=3"));
+    assert!(report.contains("average_us="));
+    assert!(report.contains("p99_us="));
+    let overruns = report
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("overruns="))
+        .and_then(|value| value.parse::<u64>().ok())
+        .expect("overrun count");
+    assert!(
+        overruns > 0,
+        "expected real tick work to exceed 1 us: {report}"
+    );
+}
+
+#[test]
 fn fresh_runtime_validation_runs_in_a_separate_cli_process() {
     let parent = temp_dir("fresh_validation");
     fs::create_dir_all(&parent).expect("create temp parent");

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -181,6 +181,10 @@ impl JitProcess {
         self.compiler.function_data_flow_summaries()
     }
 
+    pub fn tick_budget_us(&self) -> Result<Option<u64>, String> {
+        crate::performance::tick_budget_us(self.compiler.files())
+    }
+
     pub fn set_required_emit_roots(&mut self, roots: &[String]) {
         self.required_emit_roots.clear();
         self.required_emit_roots.extend_from_slice(roots);
@@ -611,6 +615,22 @@ impl JitProcess {
             &active_counts,
             capacity_overrides,
             mobile_budget_bytes,
+        )
+    }
+
+    pub fn performance_cost_report(
+        &self,
+        memory: &JitStateMemoryReport,
+        aot_object_code_bytes: u64,
+        literal_data_bytes: u64,
+    ) -> Result<crate::performance::PerformanceCostReport, String> {
+        crate::performance::build_performance_cost_report(
+            self.compiler.files(),
+            self.compiler.function_data_flow_summaries(),
+            &self.state_layout(),
+            memory,
+            aot_object_code_bytes,
+            literal_data_bytes,
         )
     }
 

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -237,6 +237,7 @@ impl Compiler {
 
     pub fn index_pass(&mut self) -> CompileResult<IndexPassResult> {
         self.last_source_diagnostic = None;
+        crate::performance::tick_budget_us(&self.files).map_err(CompileError::Frontend)?;
         let previous_hashes = self.capture_previous_hashes();
         self.functions.clear();
         self.parsed_statements.clear();
@@ -986,7 +987,10 @@ function tick(): i32 {
             .find(|summary| summary.function == "tick")
             .expect("tick summary");
 
-        assert_eq!(tick.schema_version, 1);
+        assert_eq!(
+            tick.schema_version,
+            crate::data_flow::FUNCTION_DATA_FLOW_SCHEMA_VERSION
+        );
         assert_eq!(
             tick.direct.calls,
             vec!["damage_all", "damage_all_function_form", "damage_view"]

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -12,7 +12,7 @@ use crate::frontend::types::{
     TypeCategory, TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
 };
 
-pub const FUNCTION_DATA_FLOW_SCHEMA_VERSION: u32 = 1;
+pub const FUNCTION_DATA_FLOW_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FunctionDataFlowEffects {
@@ -22,7 +22,16 @@ pub struct FunctionDataFlowEffects {
     pub parameter_writes: Vec<String>,
     pub calls: Vec<String>,
     pub host_calls: Vec<String>,
+    #[serde(default)]
+    pub host_call_costs: Vec<FunctionHostCallCost>,
     pub bounded_iterations: Vec<FunctionBoundedIteration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct FunctionHostCallCost {
+    pub function: String,
+    pub max_invocations: Option<u64>,
+    pub scope: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
@@ -31,7 +40,15 @@ pub struct FunctionBoundedIteration {
     pub kind: String,
     pub bound: String,
     pub max_iterations: Option<u64>,
+    #[serde(default)]
+    pub nesting_depth: u32,
+    #[serde(default)]
+    pub max_iteration_product: Option<u64>,
+    #[serde(default)]
+    pub source_order: u32,
     pub reads: Vec<String>,
+    #[serde(default)]
+    pub scanned_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -62,14 +79,20 @@ struct EffectSets {
     parameter_writes: BTreeSet<String>,
     calls: BTreeSet<String>,
     host_calls: BTreeSet<String>,
+    host_call_costs: BTreeMap<String, Option<u64>>,
     bounded_iterations: BTreeSet<FunctionBoundedIteration>,
     call_sites: Vec<CallSite>,
+    iteration_scans: BTreeMap<u32, Vec<String>>,
+    iteration_products: BTreeMap<u32, Option<u64>>,
+    active_iterations: Vec<u32>,
+    next_iteration_id: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CallSite {
     target_id: u32,
     arguments: Vec<Option<String>>,
+    max_invocations: Option<u64>,
 }
 
 impl EffectSets {
@@ -82,12 +105,14 @@ impl EffectSets {
             .extend(other.parameter_writes.iter().cloned());
         self.calls.extend(other.calls.iter().cloned());
         self.host_calls.extend(other.host_calls.iter().cloned());
+        merge_host_call_costs(&mut self.host_call_costs, &other.host_call_costs, Some(1));
         self.bounded_iterations
             .extend(other.bounded_iterations.iter().cloned());
         self.call_sites.extend(other.call_sites.iter().cloned());
     }
 
     fn insert_read(&mut self, path: String) {
+        self.record_scanned_path(&path);
         if path.starts_with('$') {
             self.parameter_reads.insert(path);
         } else {
@@ -96,6 +121,7 @@ impl EffectSets {
     }
 
     fn insert_write(&mut self, path: String) {
+        self.record_scanned_path(&path);
         if path.starts_with('$') {
             self.parameter_writes.insert(path);
         } else {
@@ -111,6 +137,15 @@ impl EffectSets {
             parameter_writes: public_parameter_paths(&self.parameter_writes, parameter_names),
             calls: self.calls.iter().cloned().collect(),
             host_calls: self.host_calls.iter().cloned().collect(),
+            host_call_costs: self
+                .host_call_costs
+                .iter()
+                .map(|(function, max_invocations)| FunctionHostCallCost {
+                    function: function.clone(),
+                    max_invocations: *max_invocations,
+                    scope: "direct".to_string(),
+                })
+                .collect(),
             bounded_iterations: self
                 .bounded_iterations
                 .iter()
@@ -118,6 +153,51 @@ impl EffectSets {
                 .collect(),
         }
     }
+
+    fn record_scanned_path(&mut self, path: &str) {
+        if !path.contains("[*]") || path.ends_with(".length") {
+            return;
+        }
+        if let Some(iteration_id) = self.active_iterations.last().copied() {
+            self.iteration_scans
+                .entry(iteration_id)
+                .or_default()
+                .push(path.to_string());
+        }
+    }
+
+    fn record_host_call(&mut self, function: &str) {
+        let multiplier = self
+            .active_iterations
+            .last()
+            .and_then(|id| self.iteration_products.get(id).copied())
+            .unwrap_or(Some(1));
+        merge_host_call_cost(
+            self.host_call_costs
+                .entry(function.to_string())
+                .or_insert(Some(0)),
+            multiplier,
+        );
+    }
+}
+
+fn merge_host_call_costs(
+    target: &mut BTreeMap<String, Option<u64>>,
+    source: &BTreeMap<String, Option<u64>>,
+    multiplier: Option<u64>,
+) {
+    for (function, count) in source {
+        let scaled = multiplier
+            .zip(*count)
+            .and_then(|(multiplier, count)| multiplier.checked_mul(count));
+        merge_host_call_cost(target.entry(function.clone()).or_insert(Some(0)), scaled);
+    }
+}
+
+fn merge_host_call_cost(target: &mut Option<u64>, value: Option<u64>) {
+    *target = target
+        .zip(value)
+        .and_then(|(target, value)| target.checked_add(value));
 }
 
 struct AnalysisContext<'a> {
@@ -372,7 +452,21 @@ fn analyze_function_effects(
         &mut local_types,
         &aliases,
         &mut effects,
+        0,
+        Some(1),
     );
+    effects.bounded_iterations = effects
+        .bounded_iterations
+        .iter()
+        .cloned()
+        .map(|mut iteration| {
+            iteration.scanned_paths = effects
+                .iteration_scans
+                .get(&iteration.source_order)
+                .map_or_else(Vec::new, |paths| paths.iter().cloned().collect());
+            iteration
+        })
+        .collect();
     Ok(effects)
 }
 
@@ -747,6 +841,8 @@ fn analyze_statements(
     local_types: &mut BTreeMap<String, TypeId>,
     aliases: &BTreeMap<String, String>,
     effects: &mut EffectSets,
+    nesting_depth: u32,
+    parent_iteration_product: Option<u64>,
 ) {
     for statement in statements {
         match statement {
@@ -807,6 +903,8 @@ fn analyze_statements(
                     local_types,
                     aliases,
                     effects,
+                    nesting_depth,
+                    parent_iteration_product,
                 );
                 if let Some(else_statements) = else_statements {
                     analyze_nested_statements(
@@ -818,6 +916,8 @@ fn analyze_statements(
                         local_types,
                         aliases,
                         effects,
+                        nesting_depth,
+                        parent_iteration_product,
                     );
                 }
             }
@@ -838,6 +938,8 @@ fn analyze_statements(
                     &mut loop_local_types,
                     aliases,
                     effects,
+                    nesting_depth,
+                    parent_iteration_product,
                 );
                 let mut bound_reads = EffectSets::default();
                 analyze_condition(
@@ -849,19 +951,33 @@ fn analyze_statements(
                     &mut bound_reads,
                 );
                 effects.merge(&bound_reads);
+                let max_iterations = static_for_max_iterations(
+                    init,
+                    condition,
+                    step,
+                    body_statements,
+                    &context.constants,
+                );
+                let max_iteration_product = parent_iteration_product
+                    .zip(max_iterations)
+                    .and_then(|(parent, current)| parent.checked_mul(current));
+                let iteration_id = effects.next_iteration_id;
+                effects.next_iteration_id = effects.next_iteration_id.saturating_add(1);
+                effects
+                    .iteration_products
+                    .insert(iteration_id, max_iteration_product);
                 effects.bounded_iterations.insert(FunctionBoundedIteration {
                     function: function.to_string(),
                     kind: "for".to_string(),
                     bound: display_condition(condition),
-                    max_iterations: static_for_max_iterations(
-                        init,
-                        condition,
-                        step,
-                        body_statements,
-                        &context.constants,
-                    ),
+                    max_iterations,
+                    nesting_depth,
+                    max_iteration_product,
+                    source_order: iteration_id,
                     reads: bound_reads.reads.into_iter().collect(),
+                    scanned_paths: Vec::new(),
                 });
+                effects.active_iterations.push(iteration_id);
                 analyze_nested_statements(
                     body_statements,
                     function_id,
@@ -871,7 +987,10 @@ fn analyze_statements(
                     &loop_local_types,
                     aliases,
                     effects,
+                    nesting_depth.saturating_add(1),
+                    max_iteration_product,
                 );
+                effects.active_iterations.pop();
                 analyze_statements(
                     std::slice::from_ref(step.as_ref()),
                     function_id,
@@ -881,6 +1000,8 @@ fn analyze_statements(
                     &mut loop_local_types,
                     aliases,
                     effects,
+                    nesting_depth,
+                    parent_iteration_product,
                 );
             }
             SimpleStmt::Foreach {
@@ -900,27 +1021,40 @@ fn analyze_statements(
                 } else if normalized.starts_with('$') {
                     effects.insert_read(bound_path.clone());
                 }
+                let max_iterations = context
+                    .collection_capacities
+                    .get(&normalized)
+                    .copied()
+                    .or_else(|| {
+                        symbolic_parameter_index(&normalized).and_then(|index| {
+                            context
+                                .fixed_parameter_capacities
+                                .get(&function_id)?
+                                .get(&index)
+                                .copied()
+                        })
+                    });
+                let max_iteration_product = parent_iteration_product
+                    .zip(max_iterations)
+                    .and_then(|(parent, current)| parent.checked_mul(current));
+                let iteration_id = effects.next_iteration_id;
+                effects.next_iteration_id = effects.next_iteration_id.saturating_add(1);
+                effects
+                    .iteration_products
+                    .insert(iteration_id, max_iteration_product);
                 effects.bounded_iterations.insert(FunctionBoundedIteration {
                     function: function.to_string(),
                     kind: "foreach".to_string(),
                     bound: normalized.clone(),
-                    max_iterations: context
-                        .collection_capacities
-                        .get(&normalized)
-                        .copied()
-                        .or_else(|| {
-                            symbolic_parameter_index(&normalized).and_then(|index| {
-                                context
-                                    .fixed_parameter_capacities
-                                    .get(&function_id)?
-                                    .get(&index)
-                                    .copied()
-                            })
-                        }),
+                    max_iterations,
+                    nesting_depth,
+                    max_iteration_product,
+                    source_order: iteration_id,
                     reads: (context.globals.contains(root_name(&normalized))
                         || normalized.starts_with('$'))
                     .then_some(vec![bound_path])
                     .unwrap_or_default(),
+                    scanned_paths: Vec::new(),
                 });
                 let mut loop_locals = locals.clone();
                 let mut loop_local_types = local_types.clone();
@@ -941,6 +1075,7 @@ fn analyze_statements(
                         loop_local_types.insert(item_name.clone(), element_type);
                     }
                 }
+                effects.active_iterations.push(iteration_id);
                 analyze_nested_statements(
                     body_statements,
                     function_id,
@@ -950,7 +1085,10 @@ fn analyze_statements(
                     &loop_local_types,
                     &loop_aliases,
                     effects,
+                    nesting_depth.saturating_add(1),
+                    max_iteration_product,
                 );
+                effects.active_iterations.pop();
             }
             SimpleStmt::Expr(expression) | SimpleStmt::Return(expression) => {
                 analyze_expression(expression, context, locals, local_types, aliases, effects);
@@ -968,6 +1106,8 @@ fn analyze_nested_statements(
     local_types: &BTreeMap<String, TypeId>,
     aliases: &BTreeMap<String, String>,
     effects: &mut EffectSets,
+    nesting_depth: u32,
+    parent_iteration_product: Option<u64>,
 ) {
     analyze_statements(
         statements,
@@ -978,6 +1118,8 @@ fn analyze_nested_statements(
         &mut local_types.clone(),
         aliases,
         effects,
+        nesting_depth,
+        parent_iteration_product,
     );
 }
 
@@ -1053,9 +1195,15 @@ fn analyze_expression(
                         .iter()
                         .map(|argument| expression_effect_path(argument, context, locals, aliases))
                         .collect(),
+                    max_invocations: effects
+                        .active_iterations
+                        .last()
+                        .and_then(|id| effects.iteration_products.get(id).copied())
+                        .unwrap_or(Some(1)),
                 });
             } else if context.extern_functions.contains(target) {
                 effects.host_calls.insert(target.clone());
+                effects.record_host_call(target);
             }
             for (index, argument) in args.iter().enumerate() {
                 let is_view = target_id
@@ -1335,7 +1483,7 @@ fn build_aggregate_effects(direct_by_id: &[EffectSets]) -> Result<Vec<EffectSets
             for function_id in component {
                 let direct = &direct_by_id[*function_id];
                 let mut aggregate = EffectSets::default();
-                merge_substituted_effects(direct, &BTreeMap::new(), true, &mut aggregate);
+                merge_substituted_effects(direct, &BTreeMap::new(), true, Some(1), &mut aggregate);
                 for call_site in &direct.call_sites {
                     let Some(child) = aggregate_by_id.get(call_site.target_id as usize) else {
                         continue;
@@ -1346,7 +1494,19 @@ fn build_aggregate_effects(direct_by_id: &[EffectSets]) -> Result<Vec<EffectSets
                         .enumerate()
                         .filter_map(|(index, path)| path.clone().map(|path| (index, path)))
                         .collect();
-                    merge_substituted_effects(child, &child_substitutions, false, &mut aggregate);
+                    let multiplier =
+                        if cyclic && component.contains(&(call_site.target_id as usize)) {
+                            None
+                        } else {
+                            call_site.max_invocations
+                        };
+                    merge_substituted_effects(
+                        child,
+                        &child_substitutions,
+                        false,
+                        multiplier,
+                        &mut aggregate,
+                    );
                 }
                 next.push(aggregate);
             }
@@ -1435,6 +1595,7 @@ fn merge_substituted_effects(
     direct: &EffectSets,
     substitutions: &BTreeMap<usize, String>,
     retain_unmapped_parameters: bool,
+    host_call_multiplier: Option<u64>,
     aggregate: &mut EffectSets,
 ) {
     aggregate.reads.extend(direct.reads.iter().cloned());
@@ -1443,6 +1604,11 @@ fn merge_substituted_effects(
     aggregate
         .host_calls
         .extend(direct.host_calls.iter().cloned());
+    merge_host_call_costs(
+        &mut aggregate.host_call_costs,
+        &direct.host_call_costs,
+        host_call_multiplier,
+    );
     for path in &direct.parameter_reads {
         if let Some(path) = substitute_path(path, substitutions, retain_unmapped_parameters) {
             aggregate.insert_read(path);
@@ -1462,6 +1628,11 @@ fn merge_substituted_effects(
         }
         iteration.reads = iteration
             .reads
+            .iter()
+            .filter_map(|path| substitute_path(path, substitutions, retain_unmapped_parameters))
+            .collect();
+        iteration.scanned_paths = iteration
+            .scanned_paths
             .iter()
             .filter_map(|path| substitute_path(path, substitutions, retain_unmapped_parameters))
             .collect();
@@ -1503,8 +1674,18 @@ fn public_iteration(
         bound: public_parameter_path(&iteration.bound, parameter_names)
             .unwrap_or_else(|| iteration.bound.clone()),
         max_iterations: iteration.max_iterations,
+        nesting_depth: iteration.nesting_depth,
+        max_iteration_product: iteration.max_iteration_product,
+        source_order: iteration.source_order,
         reads: iteration
             .reads
+            .iter()
+            .map(|path| {
+                public_parameter_path(path, parameter_names).unwrap_or_else(|| path.clone())
+            })
+            .collect(),
+        scanned_paths: iteration
+            .scanned_paths
             .iter()
             .map(|path| {
                 public_parameter_path(path, parameter_names).unwrap_or_else(|| path.clone())
@@ -1720,5 +1901,61 @@ mod tests {
         assert_eq!(tick.direct.host_calls, vec!["print_i32"]);
         assert_eq!(tick.direct.bounded_iterations[0].max_iterations, Some(3));
         assert!(tick.aggregate.writes.contains(&"state.score".to_string()));
+    }
+
+    #[test]
+    fn nested_loop_products_and_deepest_field_scans_are_bounded() {
+        let sample = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../samples/bounded_performance/src/main.stasis");
+        let source = std::fs::read_to_string(&sample).expect("read bounded-cost sample");
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&["main".to_string(), "tick".to_string()]);
+        jit.upsert_file(sample.to_string_lossy(), source);
+        jit.compile().expect("compile bounded-cost sample");
+        assert_eq!(jit.execute_i32_noarg_by_name("main").expect("run main"), 0);
+
+        let scan = jit
+            .function_data_flow_summaries()
+            .iter()
+            .find(|summary| summary.function == "expensive_scan")
+            .expect("expensive scan summary");
+        let inner = scan
+            .direct
+            .bounded_iterations
+            .iter()
+            .find(|iteration| iteration.nesting_depth == 1)
+            .expect("nested loop");
+        assert_eq!(inner.max_iterations, Some(16));
+        assert_eq!(inner.max_iteration_product, Some(512));
+        assert!(inner
+            .scanned_paths
+            .contains(&"particles[*].score".to_string()));
+        let outer = scan
+            .direct
+            .bounded_iterations
+            .iter()
+            .find(|iteration| iteration.nesting_depth == 0)
+            .expect("outer loop");
+        assert_eq!(outer.max_iteration_product, Some(32));
+        assert!(outer.scanned_paths.is_empty());
+    }
+
+    #[test]
+    fn host_call_cost_uses_lexical_nested_iteration_product() {
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&["tick".to_string()]);
+        jit.upsert_file(
+            "host_cost.stasis",
+            "extern function print_i32(value: i32): void;\nfunction tick(): i32 { for (let x: i32 = 0; x < 2; x += 1) { for (let y: i32 = 0; y < 3; y += 1) { print_i32(x + y); } } return 0; }\n",
+        );
+        jit.compile().expect("compile host-call cost fixture");
+        let tick = jit
+            .function_data_flow_summaries()
+            .iter()
+            .find(|summary| summary.function == "tick")
+            .expect("tick summary");
+        assert_eq!(tick.direct.host_call_costs.len(), 1);
+        assert_eq!(tick.direct.host_call_costs[0].function, "print_i32");
+        assert_eq!(tick.direct.host_call_costs[0].max_invocations, Some(6));
     }
 }

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -93,24 +93,10 @@ struct CallSite {
     target_id: u32,
     arguments: Vec<Option<String>>,
     max_invocations: Option<u64>,
+    outer_nesting_depth: u32,
 }
 
 impl EffectSets {
-    fn merge(&mut self, other: &Self) {
-        self.reads.extend(other.reads.iter().cloned());
-        self.writes.extend(other.writes.iter().cloned());
-        self.parameter_reads
-            .extend(other.parameter_reads.iter().cloned());
-        self.parameter_writes
-            .extend(other.parameter_writes.iter().cloned());
-        self.calls.extend(other.calls.iter().cloned());
-        self.host_calls.extend(other.host_calls.iter().cloned());
-        merge_host_call_costs(&mut self.host_call_costs, &other.host_call_costs, Some(1));
-        self.bounded_iterations
-            .extend(other.bounded_iterations.iter().cloned());
-        self.call_sites.extend(other.call_sites.iter().cloned());
-    }
-
     fn insert_read(&mut self, path: String) {
         self.record_scanned_path(&path);
         if path.starts_with('$') {
@@ -178,6 +164,29 @@ impl EffectSets {
                 .or_insert(Some(0)),
             multiplier,
         );
+    }
+
+    fn record_call_site(&mut self, target_id: u32, arguments: Vec<Option<String>>) {
+        let max_invocations = self
+            .active_iterations
+            .last()
+            .and_then(|id| self.iteration_products.get(id).copied())
+            .unwrap_or(Some(1));
+        let outer_nesting_depth = u32::try_from(self.active_iterations.len()).unwrap_or(u32::MAX);
+        if let Some(existing) = self.call_sites.iter_mut().find(|call_site| {
+            call_site.target_id == target_id
+                && call_site.arguments == arguments
+                && call_site.outer_nesting_depth == outer_nesting_depth
+        }) {
+            merge_host_call_cost(&mut existing.max_invocations, max_invocations);
+            return;
+        }
+        self.call_sites.push(CallSite {
+            target_id,
+            arguments,
+            max_invocations,
+            outer_nesting_depth,
+        });
     }
 }
 
@@ -950,7 +959,6 @@ fn analyze_statements(
                     aliases,
                     &mut bound_reads,
                 );
-                effects.merge(&bound_reads);
                 let max_iterations = static_for_max_iterations(
                     init,
                     condition,
@@ -978,6 +986,14 @@ fn analyze_statements(
                     scanned_paths: Vec::new(),
                 });
                 effects.active_iterations.push(iteration_id);
+                analyze_condition(
+                    condition,
+                    context,
+                    &loop_locals,
+                    &loop_local_types,
+                    aliases,
+                    effects,
+                );
                 analyze_nested_statements(
                     body_statements,
                     function_id,
@@ -990,7 +1006,6 @@ fn analyze_statements(
                     nesting_depth.saturating_add(1),
                     max_iteration_product,
                 );
-                effects.active_iterations.pop();
                 analyze_statements(
                     std::slice::from_ref(step.as_ref()),
                     function_id,
@@ -1000,9 +1015,10 @@ fn analyze_statements(
                     &mut loop_local_types,
                     aliases,
                     effects,
-                    nesting_depth,
-                    parent_iteration_product,
+                    nesting_depth.saturating_add(1),
+                    max_iteration_product,
                 );
+                effects.active_iterations.pop();
             }
             SimpleStmt::Foreach {
                 item_name,
@@ -1189,18 +1205,12 @@ fn analyze_expression(
             let target_id = resolve_internal_call(target, args, context, local_types, aliases);
             if let Some(target_id) = target_id {
                 effects.calls.insert(target.clone());
-                effects.call_sites.push(CallSite {
+                effects.record_call_site(
                     target_id,
-                    arguments: args
-                        .iter()
+                    args.iter()
                         .map(|argument| expression_effect_path(argument, context, locals, aliases))
                         .collect(),
-                    max_invocations: effects
-                        .active_iterations
-                        .last()
-                        .and_then(|id| effects.iteration_products.get(id).copied())
-                        .unwrap_or(Some(1)),
-                });
+                );
             } else if context.extern_functions.contains(target) {
                 effects.host_calls.insert(target.clone());
                 effects.record_host_call(target);
@@ -1478,12 +1488,19 @@ fn build_aggregate_effects(direct_by_id: &[EffectSets]) -> Result<Vec<EffectSets
                 .iter()
                 .any(|call_site| call_site.target_id as usize == component[0]);
         let mut converged = false;
-        for _ in 0..component.len().saturating_add(1) {
+        for _ in 0..component.len().saturating_add(2) {
             let mut next = Vec::with_capacity(component.len());
             for function_id in component {
                 let direct = &direct_by_id[*function_id];
                 let mut aggregate = EffectSets::default();
-                merge_substituted_effects(direct, &BTreeMap::new(), true, Some(1), &mut aggregate);
+                merge_substituted_effects(
+                    direct,
+                    &BTreeMap::new(),
+                    true,
+                    Some(1),
+                    0,
+                    &mut aggregate,
+                );
                 for call_site in &direct.call_sites {
                     let Some(child) = aggregate_by_id.get(call_site.target_id as usize) else {
                         continue;
@@ -1494,17 +1511,23 @@ fn build_aggregate_effects(direct_by_id: &[EffectSets]) -> Result<Vec<EffectSets
                         .enumerate()
                         .filter_map(|(index, path)| path.clone().map(|path| (index, path)))
                         .collect();
-                    let multiplier =
-                        if cyclic && component.contains(&(call_site.target_id as usize)) {
-                            None
-                        } else {
-                            call_site.max_invocations
-                        };
+                    let recursive_edge =
+                        cyclic && component.contains(&(call_site.target_id as usize));
+                    let multiplier = if recursive_edge {
+                        None
+                    } else {
+                        call_site.max_invocations
+                    };
                     merge_substituted_effects(
                         child,
                         &child_substitutions,
                         false,
                         multiplier,
+                        if recursive_edge {
+                            0
+                        } else {
+                            call_site.outer_nesting_depth
+                        },
                         &mut aggregate,
                     );
                 }
@@ -1596,6 +1619,7 @@ fn merge_substituted_effects(
     substitutions: &BTreeMap<usize, String>,
     retain_unmapped_parameters: bool,
     host_call_multiplier: Option<u64>,
+    outer_nesting_depth: u32,
     aggregate: &mut EffectSets,
 ) {
     aggregate.reads.extend(direct.reads.iter().cloned());
@@ -1621,6 +1645,10 @@ fn merge_substituted_effects(
     }
     for iteration in &direct.bounded_iterations {
         let mut iteration = iteration.clone();
+        iteration.max_iteration_product = host_call_multiplier
+            .zip(iteration.max_iteration_product)
+            .and_then(|(multiplier, product)| multiplier.checked_mul(product));
+        iteration.nesting_depth = iteration.nesting_depth.saturating_add(outer_nesting_depth);
         if let Some(bound) =
             substitute_path(&iteration.bound, substitutions, retain_unmapped_parameters)
         {

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -19,10 +19,32 @@ pub struct ParsedLocalBinding {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedFunctionSignature {
     pub name: String,
+    pub annotations: Vec<ParsedFunctionAnnotation>,
     pub params: Vec<ParsedParam>,
     pub return_type_name: String,
     pub signature_range: Range<usize>,
     pub body_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedFunctionAnnotation {
+    pub name: String,
+    pub has_parentheses: bool,
+    pub arguments: Vec<ParsedFunctionAnnotationArgument>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedFunctionAnnotationArgument {
+    pub kind: ParsedFunctionAnnotationArgumentKind,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParsedFunctionAnnotationArgumentKind {
+    Integer,
+    String,
+    Identifier,
+    Other,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -401,7 +423,8 @@ pub fn parse_top_level_functions(source: &str) -> Result<Vec<ParsedFunctionSigna
         }
         let signature_start = tokens[cursor].start;
         cursor += 1;
-        cursor = skip_function_annotations(source, &tokens, cursor)?;
+        let (next_cursor, _, annotations) = parse_function_annotations(source, &tokens, cursor)?;
+        cursor = next_cursor;
         let name = token_text(source, expect(&tokens, cursor, TokenKind::Identifier)?).to_string();
         cursor += 1;
         expect(&tokens, cursor, TokenKind::LParen)?;
@@ -462,6 +485,7 @@ pub fn parse_top_level_functions(source: &str) -> Result<Vec<ParsedFunctionSigna
         let body_range = body_start_token.start..body_end_token.end;
         out.push(ParsedFunctionSignature {
             name,
+            annotations,
             params,
             return_type_name,
             signature_range: signature_start..signature_end,
@@ -535,7 +559,7 @@ pub fn parse_top_level_extern_functions(
         }
 
         cursor += 1;
-        let (after_annotations, annotation_symbol) =
+        let (after_annotations, annotation_symbol, _) =
             parse_function_annotations(source, &tokens, cursor)?;
         cursor = after_annotations;
         let name = token_text(source, expect(&tokens, cursor, TokenKind::Identifier)?).to_string();
@@ -924,21 +948,13 @@ fn parse_braced_fields(
     Ok((fields, cursor))
 }
 
-fn skip_function_annotations(
-    source: &str,
-    tokens: &[Token],
-    cursor: usize,
-) -> Result<usize, String> {
-    let (next_cursor, _) = parse_function_annotations(source, tokens, cursor)?;
-    Ok(next_cursor)
-}
-
 fn parse_function_annotations(
     source: &str,
     tokens: &[Token],
     mut cursor: usize,
-) -> Result<(usize, Option<String>), String> {
+) -> Result<(usize, Option<String>, Vec<ParsedFunctionAnnotation>), String> {
     let mut extern_symbol: Option<String> = None;
+    let mut annotations = Vec::new();
     while tokens
         .get(cursor)
         .copied()
@@ -948,20 +964,59 @@ fn parse_function_annotations(
         let name = expect(tokens, cursor, TokenKind::Identifier)?;
         let annotation_name = token_text(source, name);
         cursor += 1;
-        if tokens
+        let has_parentheses = tokens
             .get(cursor)
-            .is_some_and(|token| token.kind == TokenKind::LParen)
-        {
+            .is_some_and(|token| token.kind == TokenKind::LParen);
+        let mut arguments = Vec::new();
+        if has_parentheses {
             if annotation_name == "extern" {
                 let parsed = parse_extern_symbol_annotation(source, tokens, cursor)?;
                 if parsed.is_some() {
                     extern_symbol = parsed;
                 }
             }
-            cursor = skip_parenthesized_tokens(tokens, cursor)?;
+            let next_cursor = skip_parenthesized_tokens(tokens, cursor)?;
+            let mut expects_argument = true;
+            for token in &tokens[cursor + 1..next_cursor - 1] {
+                if token.kind == TokenKind::Comma {
+                    if expects_argument {
+                        return Err(format!(
+                            "annotation '@{annotation_name}' has an empty argument"
+                        ));
+                    }
+                    expects_argument = true;
+                    continue;
+                }
+                if !expects_argument {
+                    return Err(format!(
+                        "annotation '@{annotation_name}' expects ',' between arguments"
+                    ));
+                }
+                arguments.push(ParsedFunctionAnnotationArgument {
+                    kind: match token.kind {
+                        TokenKind::Integer => ParsedFunctionAnnotationArgumentKind::Integer,
+                        TokenKind::StringLiteral => ParsedFunctionAnnotationArgumentKind::String,
+                        TokenKind::Identifier => ParsedFunctionAnnotationArgumentKind::Identifier,
+                        _ => ParsedFunctionAnnotationArgumentKind::Other,
+                    },
+                    text: token_text(source, *token).to_string(),
+                });
+                expects_argument = false;
+            }
+            if expects_argument && !arguments.is_empty() {
+                return Err(format!(
+                    "annotation '@{annotation_name}' has a trailing comma"
+                ));
+            }
+            cursor = next_cursor;
         }
+        annotations.push(ParsedFunctionAnnotation {
+            name: annotation_name.to_string(),
+            has_parentheses,
+            arguments,
+        });
     }
-    Ok((cursor, extern_symbol))
+    Ok((cursor, extern_symbol, annotations))
 }
 
 fn parse_extern_symbol_annotation(

--- a/crates/stasis_compiler/src/lib.rs
+++ b/crates/stasis_compiler/src/lib.rs
@@ -6,6 +6,7 @@ pub mod compiler;
 pub mod data_flow;
 pub mod frontend;
 pub mod ir;
+pub mod performance;
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;

--- a/crates/stasis_compiler/src/performance.rs
+++ b/crates/stasis_compiler/src/performance.rs
@@ -1,0 +1,487 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::state_layout::{StateLayout, StateMemoryEntry, StateMemoryReport};
+use crate::compiler::SourceFile;
+use crate::data_flow::{FunctionBoundedIteration, FunctionDataFlowSummary, FunctionHostCallCost};
+use crate::frontend::parser::{parse_top_level_functions, ParsedFunctionAnnotationArgumentKind};
+
+pub const PERFORMANCE_COST_SCHEMA_VERSION: u32 = 1;
+const MOBILE_RUNTIME_SHELL_ESTIMATE_BYTES: u64 = 512 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PerformanceCostReport {
+    pub schema_version: u32,
+    pub tick_budget_us: Option<u64>,
+    pub functions: Vec<FunctionCostReport>,
+    pub layout_choices: Vec<CollectionLayoutChoice>,
+    pub mobile: MobileCostEstimate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FunctionCostReport {
+    pub function: String,
+    pub structural_bound_complete: bool,
+    pub worst_nested_iteration_product: Option<u64>,
+    pub fields_scanned: Vec<FieldScanCost>,
+    pub conservative_max_bytes_scanned: u64,
+    pub pools_iterated: Vec<PoolIterationCost>,
+    pub host_calls: Vec<FunctionHostCallCost>,
+    pub bounded_iterations: Vec<FunctionBoundedIteration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldScanCost {
+    pub path: String,
+    pub element_bytes: u64,
+    pub conservative_max_visits: u64,
+    pub conservative_max_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoolIterationCost {
+    pub path: String,
+    pub capacity: u64,
+    pub bytes_per_element: u64,
+    pub max_iteration_product: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionLayoutChoice {
+    pub path: String,
+    pub active_layout: String,
+    pub active_field_groups: Vec<Vec<String>>,
+    pub aos_field_group: Vec<String>,
+    pub soa_bytes: u64,
+    pub aos_stride_bytes: u64,
+    pub aos_padding_bytes_per_element: u64,
+    pub aos_bytes: u64,
+    pub recommendation: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MobileCostEstimate {
+    pub aot_object_code_bytes: u64,
+    pub literal_data_bytes: u64,
+    pub state_capacity_bytes: u64,
+    pub command_buffer_bytes: u64,
+    pub package_estimate_bytes: u64,
+    pub peak_state_recommendation_bytes: u64,
+    pub package_estimate_basis: String,
+}
+
+pub fn tick_budget_us(files: &[SourceFile]) -> Result<Option<u64>, String> {
+    let mut budget = None;
+    for file in files {
+        for function in parse_top_level_functions(&file.content)? {
+            let annotations = function
+                .annotations
+                .iter()
+                .filter(|annotation| annotation.name == "tick_budget_us")
+                .collect::<Vec<_>>();
+            if annotations.is_empty() {
+                continue;
+            }
+            if annotations.len() != 1 {
+                return Err("duplicate @tick_budget_us annotation".to_string());
+            }
+            if function.name != "tick" {
+                return Err(format!(
+                    "@tick_budget_us may only annotate tick(), not '{}'",
+                    function.name
+                ));
+            }
+            let annotation = annotations[0];
+            if !annotation.has_parentheses
+                || annotation.arguments.len() != 1
+                || annotation.arguments[0].kind != ParsedFunctionAnnotationArgumentKind::Integer
+            {
+                return Err(
+                    "@tick_budget_us expects exactly one unsigned integer argument".to_string(),
+                );
+            }
+            let value = annotation.arguments[0]
+                .text
+                .parse::<u64>()
+                .map_err(|error| format!("invalid @tick_budget_us value: {error}"))?;
+            if value == 0 {
+                return Err("@tick_budget_us must be greater than zero".to_string());
+            }
+            if budget.replace(value).is_some() {
+                return Err("multiple @tick_budget_us annotations were found".to_string());
+            }
+        }
+    }
+    Ok(budget)
+}
+
+pub fn build_performance_cost_report(
+    files: &[SourceFile],
+    summaries: &[FunctionDataFlowSummary],
+    layout: &StateLayout,
+    memory: &StateMemoryReport,
+    aot_object_code_bytes: u64,
+    literal_data_bytes: u64,
+) -> Result<PerformanceCostReport, String> {
+    let tick_budget_us = tick_budget_us(files)?;
+    let functions = summaries
+        .iter()
+        .map(|summary| function_cost(summary, layout, memory))
+        .collect::<Result<Vec<_>, _>>()?;
+    let layout_choices = collection_layout_choices(layout, memory)?;
+    let command_buffer_bytes = memory
+        .command_buffers
+        .iter()
+        .try_fold(0u64, |total, buffer| {
+            total.checked_add(buffer.capacity_bytes)
+        })
+        .ok_or_else(|| "command-buffer byte estimate overflow".to_string())?;
+    let package_estimate_bytes = aot_object_code_bytes
+        .checked_add(literal_data_bytes)
+        .and_then(|total| total.checked_add(memory.projected_capacity_bytes))
+        .and_then(|total| total.checked_add(MOBILE_RUNTIME_SHELL_ESTIMATE_BYTES))
+        .ok_or_else(|| "mobile package estimate overflow".to_string())?;
+    let peak_state_recommendation_bytes = memory
+        .projected_capacity_bytes
+        .checked_add(memory.projected_capacity_bytes / 4)
+        .and_then(|value| value.checked_next_power_of_two())
+        .ok_or_else(|| "peak state recommendation overflow".to_string())?;
+    Ok(PerformanceCostReport {
+        schema_version: PERFORMANCE_COST_SCHEMA_VERSION,
+        tick_budget_us,
+        functions,
+        layout_choices,
+        mobile: MobileCostEstimate {
+            aot_object_code_bytes,
+            literal_data_bytes,
+            state_capacity_bytes: memory.projected_capacity_bytes,
+            command_buffer_bytes,
+            package_estimate_bytes,
+            peak_state_recommendation_bytes,
+            package_estimate_basis: "arm64 AOT object bytes + literal bytes + projected state + 512 KiB SDL runtime-shell allowance".to_string(),
+        },
+    })
+}
+
+fn function_cost(
+    summary: &FunctionDataFlowSummary,
+    layout: &StateLayout,
+    memory: &StateMemoryReport,
+) -> Result<FunctionCostReport, String> {
+    let iterations = &summary.direct.bounded_iterations;
+    let worst_nested_iteration_product = iterations
+        .iter()
+        .filter_map(|iteration| iteration.max_iteration_product)
+        .max();
+    let mut field_visits = BTreeMap::<String, (u64, u64)>::new();
+    for iteration in iterations {
+        let Some(visits) = iteration.max_iteration_product else {
+            continue;
+        };
+        for path in &iteration.scanned_paths {
+            if let Some(entry) = memory_entry_for_scan(memory, path) {
+                let item = field_visits
+                    .entry(path.clone())
+                    .or_insert((entry.element_bytes, 0));
+                item.1 = item
+                    .1
+                    .checked_add(visits)
+                    .ok_or_else(|| format!("field scan visit overflow for '{path}'"))?;
+            }
+        }
+    }
+    let fields_scanned = field_visits
+        .into_iter()
+        .map(|(path, (element_bytes, conservative_max_visits))| {
+            let conservative_max_bytes = element_bytes
+                .checked_mul(conservative_max_visits)
+                .ok_or_else(|| format!("field scan byte overflow for '{path}'"))?;
+            Ok(FieldScanCost {
+                path,
+                element_bytes,
+                conservative_max_visits,
+                conservative_max_bytes,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let conservative_max_bytes_scanned = fields_scanned
+        .iter()
+        .try_fold(0u64, |total, field| {
+            total.checked_add(field.conservative_max_bytes)
+        })
+        .ok_or_else(|| format!("function '{}' field scan byte overflow", summary.function))?;
+    let mut pools_iterated = Vec::new();
+    for iteration in iterations {
+        if iteration.kind != "foreach" {
+            continue;
+        }
+        let Some(collection) = layout
+            .collections
+            .iter()
+            .find(|collection| collection.path == iteration.bound)
+        else {
+            continue;
+        };
+        let capacity = u64::try_from(collection.capacity)
+            .map_err(|_| format!("collection '{}' has negative capacity", collection.path))?;
+        let bytes_per_element = memory
+            .entries
+            .iter()
+            .filter(|entry| entry.path == collection.path && entry.kind == "collection_field")
+            .try_fold(0u64, |total, entry| total.checked_add(entry.element_bytes))
+            .ok_or_else(|| format!("pool byte cost overflow for '{}'", collection.path))?;
+        pools_iterated.push(PoolIterationCost {
+            path: iteration.bound.clone(),
+            capacity,
+            bytes_per_element,
+            max_iteration_product: iteration.max_iteration_product,
+        });
+    }
+    let direct_host_calls = summary
+        .direct
+        .host_call_costs
+        .iter()
+        .map(|cost| cost.function.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut host_calls = summary.aggregate.host_call_costs.clone();
+    for cost in &mut host_calls {
+        cost.scope = if direct_host_calls.contains(cost.function.as_str()) {
+            "direct_and_transitive".to_string()
+        } else {
+            "transitive".to_string()
+        };
+    }
+    host_calls.sort_by(|left, right| left.function.cmp(&right.function));
+    Ok(FunctionCostReport {
+        function: summary.function.clone(),
+        structural_bound_complete: iterations
+            .iter()
+            .all(|iteration| iteration.max_iteration_product.is_some()),
+        worst_nested_iteration_product,
+        fields_scanned,
+        conservative_max_bytes_scanned,
+        pools_iterated,
+        host_calls,
+        bounded_iterations: iterations.clone(),
+    })
+}
+
+fn memory_entry_for_scan<'a>(
+    memory: &'a StateMemoryReport,
+    scan_path: &str,
+) -> Option<&'a StateMemoryEntry> {
+    memory.entries.iter().find(|entry| {
+        let path = if entry.kind == "collection_field" && entry.field.is_empty() {
+            format!("{}[*]", entry.path)
+        } else if entry.field.is_empty() {
+            entry.path.clone()
+        } else {
+            format!("{}[*].{}", entry.path, entry.field)
+        };
+        path == scan_path
+    })
+}
+
+fn collection_layout_choices(
+    layout: &StateLayout,
+    memory: &StateMemoryReport,
+) -> Result<Vec<CollectionLayoutChoice>, String> {
+    layout
+        .collections
+        .iter()
+        .map(|collection| {
+            let capacity = u64::try_from(collection.capacity)
+                .map_err(|_| format!("collection '{}' has negative capacity", collection.path))?;
+            let capacity = memory
+                .capacity_changes
+                .iter()
+                .find(|change| change.path == collection.path)
+                .map_or(capacity, |change| change.new_capacity);
+            let entries = collection
+                .fields
+                .iter()
+                .filter_map(|field| {
+                    memory.entries.iter().find(|entry| {
+                        entry.path == collection.path && entry.field == field.field
+                    })
+                })
+                .collect::<Vec<_>>();
+            let soa_stride = entries.iter().map(|entry| entry.element_bytes).sum::<u64>();
+            let mut offset = 0u64;
+            let mut max_alignment = 1u64;
+            for entry in &entries {
+                let alignment = entry.alignment_bytes.max(1);
+                max_alignment = max_alignment.max(alignment);
+                offset = align_up(offset, alignment)?;
+                offset = offset
+                    .checked_add(entry.element_bytes)
+                    .ok_or_else(|| "AoS stride overflow".to_string())?;
+            }
+            let aos_stride = align_up(offset, max_alignment)?;
+            let aos_padding = aos_stride.saturating_sub(soa_stride);
+            let soa_bytes = soa_stride
+                .checked_mul(capacity)
+                .ok_or_else(|| "SoA byte estimate overflow".to_string())?;
+            let aos_bytes = aos_stride
+                .checked_mul(capacity)
+                .ok_or_else(|| "AoS byte estimate overflow".to_string())?;
+            let (recommendation, reason) = if aos_padding == 0 && entries.len() <= 2 {
+                (
+                    "aos_candidate",
+                    "all fields fit without padding; profile whole-record access before changing the active SoA lowering",
+                )
+            } else {
+                (
+                    "soa",
+                    "active SoA avoids AoS padding and supports field-selective bounded scans",
+                )
+            };
+            Ok(CollectionLayoutChoice {
+                path: collection.path.clone(),
+                active_layout: "soa".to_string(),
+                active_field_groups: collection
+                    .fields
+                    .iter()
+                    .map(|field| vec![field.field.clone()])
+                    .collect(),
+                aos_field_group: collection
+                    .fields
+                    .iter()
+                    .map(|field| field.field.clone())
+                    .collect(),
+                soa_bytes,
+                aos_stride_bytes: aos_stride,
+                aos_padding_bytes_per_element: aos_padding,
+                aos_bytes,
+                recommendation: recommendation.to_string(),
+                reason: reason.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn align_up(value: u64, alignment: u64) -> Result<u64, String> {
+    let mask = alignment.saturating_sub(1);
+    value
+        .checked_add(mask)
+        .map(|value| value & !mask)
+        .ok_or_else(|| "layout alignment overflow".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::jit::JitProcess;
+
+    #[test]
+    fn tick_budget_annotation_is_explicit_and_tick_only() {
+        let files = vec![SourceFile {
+            path: "game.stasis".to_string(),
+            content: "function @tick_budget_us(250) tick(): i32 { return 0; }".to_string(),
+            hash: 0,
+            functions: Vec::new(),
+        }];
+        assert_eq!(tick_budget_us(&files), Ok(Some(250)));
+
+        let invalid = vec![SourceFile {
+            path: "game.stasis".to_string(),
+            content: "function @tick_budget_us(250) helper(): i32 { return 0; }".to_string(),
+            hash: 0,
+            functions: Vec::new(),
+        }];
+        assert!(tick_budget_us(&invalid)
+            .expect_err("non-tick annotation must fail")
+            .contains("only annotate tick"));
+
+        let mut jit = JitProcess::new();
+        jit.upsert_file("game.stasis", invalid[0].content.clone());
+        assert!(format!(
+            "{:?}",
+            jit.compile().expect_err("compiler must validate budget")
+        )
+        .contains("only annotate tick"));
+
+        let parse = |source: &str| {
+            tick_budget_us(&[SourceFile {
+                path: "budget.stasis".to_string(),
+                content: source.to_string(),
+                hash: 0,
+                functions: Vec::new(),
+            }])
+        };
+        assert_eq!(
+            parse("// @tick_budget_us(9)\nfunction tick(): i32 { return 0; }"),
+            Ok(None)
+        );
+        assert_eq!(
+            parse("function @tick_budget_us ( 300 ) tick(): i32 { return 0; }"),
+            Ok(Some(300))
+        );
+        for source in [
+            "function @tick_budget_us tick(): i32 { return 0; }",
+            "function @tick_budget_us(1) @tick_budget_us(2) tick(): i32 { return 0; }",
+            "function @tick_budget_us(0) tick(): i32 { return 0; }",
+            "function @tick_budget_us(18446744073709551616) tick(): i32 { return 0; }",
+            "function @tick_budget_us(1,) tick(): i32 { return 0; }",
+            "function @tick_budget_us(,1) tick(): i32 { return 0; }",
+            "function @tick_budget_us(1,,2) tick(): i32 { return 0; }",
+        ] {
+            assert!(parse(source).is_err(), "must reject {source}");
+        }
+    }
+
+    #[test]
+    fn report_counts_repeated_pool_scans_and_transitive_host_calls() {
+        let source = r#"
+global values: i32[4];
+extern function print_i32(value: i32): void;
+
+function helper(value: i32): void {
+    print_i32(value);
+}
+
+function tick(): i32 {
+    let total: i32 = 0;
+    foreach (let value in values) {
+        total += value;
+        total += value;
+        helper(value);
+    }
+    foreach (let value in values) {
+        total += value;
+        total += value;
+        helper(value);
+    }
+    return total;
+}
+"#;
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&["tick".to_string()]);
+        jit.upsert_file("costs.stasis", source);
+        jit.compile().expect("compile bounded repeated scans");
+        let memory = jit
+            .state_memory_report(&BTreeMap::new(), 1024 * 1024)
+            .expect("state memory report");
+        let report = jit
+            .performance_cost_report(&memory, 0, 0)
+            .expect("performance report");
+        let tick = report
+            .functions
+            .iter()
+            .find(|function| function.function == "tick")
+            .expect("tick costs");
+        assert_eq!(tick.pools_iterated.len(), 2);
+        assert_eq!(tick.fields_scanned[0].path, "values[*]");
+        assert_eq!(tick.fields_scanned[0].conservative_max_visits, 24);
+        assert_eq!(
+            tick.host_calls
+                .iter()
+                .find(|cost| cost.function == "print_i32")
+                .expect("transitive host call")
+                .max_invocations,
+            Some(8)
+        );
+    }
+}

--- a/crates/stasis_compiler/src/performance.rs
+++ b/crates/stasis_compiler/src/performance.rs
@@ -170,7 +170,7 @@ fn function_cost(
     layout: &StateLayout,
     memory: &StateMemoryReport,
 ) -> Result<FunctionCostReport, String> {
-    let iterations = &summary.direct.bounded_iterations;
+    let iterations = &summary.aggregate.bounded_iterations;
     let worst_nested_iteration_product = iterations
         .iter()
         .filter_map(|iteration| iteration.max_iteration_product)
@@ -442,7 +442,7 @@ function helper(value: i32): void {
     print_i32(value);
 }
 
-function tick(): i32 {
+function scan(): i32 {
     let total: i32 = 0;
     foreach (let value in values) {
         total += value;
@@ -456,9 +456,33 @@ function tick(): i32 {
     }
     return total;
 }
+
+function tick(): i32 {
+    scan();
+    scan();
+    return 0;
+}
+
+function stepped(): i32 {
+    for (let i: i32 = 0; i < 4; print_i32(i)) {
+        i += 1;
+    }
+    return 0;
+}
+
+function recursive(): void {
+    foreach (let value in values) {
+        print_i32(value);
+    }
+    recursive();
+}
 "#;
         let mut jit = JitProcess::new();
-        jit.set_required_emit_roots(&["tick".to_string()]);
+        jit.set_required_emit_roots(&[
+            "tick".to_string(),
+            "stepped".to_string(),
+            "recursive".to_string(),
+        ]);
         jit.upsert_file("costs.stasis", source);
         jit.compile().expect("compile bounded repeated scans");
         let memory = jit
@@ -474,14 +498,35 @@ function tick(): i32 {
             .expect("tick costs");
         assert_eq!(tick.pools_iterated.len(), 2);
         assert_eq!(tick.fields_scanned[0].path, "values[*]");
-        assert_eq!(tick.fields_scanned[0].conservative_max_visits, 24);
+        assert_eq!(tick.fields_scanned[0].conservative_max_visits, 48);
         assert_eq!(
             tick.host_calls
                 .iter()
                 .find(|cost| cost.function == "print_i32")
                 .expect("transitive host call")
                 .max_invocations,
-            Some(8)
+            Some(16)
         );
+        assert!(tick
+            .bounded_iterations
+            .iter()
+            .all(|iteration| iteration.max_iteration_product == Some(8)));
+
+        let stepped = report
+            .functions
+            .iter()
+            .find(|function| function.function == "stepped")
+            .expect("for-step costs");
+        assert_eq!(stepped.host_calls[0].function, "print_i32");
+        assert_eq!(stepped.host_calls[0].max_invocations, None);
+
+        let recursive = report
+            .functions
+            .iter()
+            .find(|function| function.function == "recursive")
+            .expect("recursive costs");
+        assert!(!recursive.structural_bound_complete);
+        assert_eq!(recursive.host_calls[0].function, "print_i32");
+        assert_eq!(recursive.host_calls[0].max_invocations, None);
     }
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -772,6 +772,37 @@ query contract between ticks.
 `samples/state_inspection/` is the representative executable fixture for static reporting, state
 tree browsing, indexed/predicate expressions, and change-only watches.
 
+### 14.3.2 Bounded cost, tick budget, and layout reporting
+
+`stasis inspect` exposes schema-versioned structural cost evidence from the same reachable
+statement artifacts and state layout used by lowering. Each function reports bounded loops,
+zero-based nesting depth, the maximum nested iteration product, conservative field visits and bytes
+scanned across enclosing loop boundaries, pools iterated, and reachable host-call names. An unknown loop bound remains explicit and makes the
+function's structural bound incomplete; the compiler must not replace it with a guessed value.
+
+`function @tick_budget_us(N) tick(): i32` declares a positive runtime budget in microseconds.
+The annotation is valid only on `tick`, and duplicates or malformed values fail deterministically.
+The development play loop keeps at most 4096 recent samples, reports whole-run average and overrun
+count, and calculates p99 from the bounded recent window. Measured wall-clock time is diagnostic
+evidence only and is kept separate from compile-time iteration and byte bounds.
+
+Collection layout reports make the compiler's active `soa` choice explicit. They also calculate an
+`aos` choice with stride, per-element padding, total bytes, the active singleton field groups, and
+the corresponding whole-record AoS group. The recommendation and reason fields expose the
+compiler-visible choice without silently changing lowering. `aos_candidate` means the cost model
+found a plausible alternative that still requires an explicit future lowering slice; it never
+claims the current runtime is AoS. This avoids treating SoA as universally optimal while preserving
+the current truthful runtime storage contract.
+
+Mobile estimates report exact Android-arm64 AOT object bytes, exact literal bytes, projected state
+and command-buffer capacity, a peak-state recommendation, and a visibly labeled package estimate.
+The package estimate is game payload plus a 512 KiB SDL runtime-shell allowance; it is not a claim
+about final signed APK/IPA compression or store metadata.
+
+`samples/bounded_performance/` is the representative executable fixture. Its 32 by 16 nested scan,
+mixed-width particle fields, capacity, host call, and tick budget provide deterministic acceptance
+evidence for the report.
+
 ### 14.4 Development File-Change Boundary Contracts
 
 During development, file-change handling uses explicit role ownership and message boundaries.

--- a/samples/bounded_performance/src/main.stasis
+++ b/samples/bounded_performance/src/main.stasis
@@ -1,0 +1,47 @@
+struct Particle {
+    active: u8;
+    score: i32;
+    weight: f64;
+}
+
+global particles: Particle[32];
+global values: i32[5];
+global checksum: i32;
+
+extern function print_i32(value: i32): void;
+
+function expensive_scan(): i32 {
+    let total: i32 = 0;
+    foreach (let value in values) {
+        total += value;
+    }
+    foreach (let particle in particles) {
+        for (let pass: i32 = 0; pass < 16; pass += 1) {
+            if (particle.active != 0) {
+                total += particle.score;
+            }
+        }
+    }
+    return total;
+}
+
+function @tick_budget_us(1) tick(): i32 {
+    checksum = expensive_scan();
+    print_i32(checksum);
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}
+
+function main(): i32 {
+    particles[0].active = 1;
+    particles[0].score = 3;
+    checksum = expensive_scan();
+    return checksum - 48;
+}

--- a/samples/bounded_performance/stasis.json
+++ b/samples/bounded_performance/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "bounded_performance",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}


### PR DESCRIPTION
## Summary
- report parser-owned tick budgets, bounded nested iteration/scan/host-call costs, and active SoA versus AoS layout choices
- add rolling runtime average/p99/overrun diagnostics isolated by successful hot-swap generation
- estimate Android arm64 AOT/mobile memory costs and add a representative JIT/AOT executable sample

## Validation
- repository Python validation gates
- cargo test --workspace --all-targets -- --test-threads=1
- cargo fmt --all -- --check
- git diff --check

Maddox task #154