### PR TITLE
docs: define immediate axis placement

### DIFF
--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -1,0 +1,890 @@
+# Product Requirements Document (PRD)
+
+## Project
+
+Stasis Immediate Box Layout
+
+## 1. Purpose
+
+Provide a small, shared layout foundation for Stasis games and tools using explicit bounding boxes and deterministic placement rules.
+
+The system computes a child rectangle from:
+
+- an available parent rectangle
+- the child's measured or fixed width and height
+- independent horizontal and vertical placement
+- explicit x and y offsets
+
+Rendering, hit testing, and debug visualization consume the same computed rectangles. Layout is recalculated from current state when needed and does not create or retain a host-side UI tree.
+
+This PRD defines the first reusable layer beneath buttons, menus, HUDs, cards, and other UI compositions. It builds on the existing `src/stdlib/flex_layout.stasis`, graphics command buffers, cached text measurement, host display snapshots, and plain-array conventions.
+
+## 2. Goals
+
+The first version must:
+
+1. Establish one canonical rectangle representation for shared layout code.
+2. Place fixed-size or measured content within a parent rectangle using start, center, or end placement on each axis.
+3. Support explicit offsets without adding specialized constraint types for common cases.
+4. Calculate top-left text draw coordinates from cached text width and an explicit line-box height.
+5. Keep layout computation independent from painting and interaction behavior.
+6. Allow paint bounds, content bounds, and hit bounds to be derived from the same allocated box.
+7. Compose with existing row, column, and grid layout helpers.
+8. Operate without heap allocation, callbacks, closures, or retained component trees.
+9. Produce deterministic results suitable for Stasis tests and Cranelift JIT/AOT execution.
+10. Make layout errors and computed bounds easy to inspect.
+
+## 3. Non-Goals
+
+Version 1 does not aim to provide:
+
+- a retained-mode component or widget tree
+- a CSS-compatible flexbox implementation
+- a general constraint solver
+- automatic text wrapping, ellipsis, or font scaling
+- scroll containers
+- clipping or scissor support
+- automatic overlap avoidance
+- automatic portrait/landscape screen redesign
+- animation ownership
+- keyboard, gamepad, or accessibility focus management
+- a complete button interaction lifecycle
+- percentage, intrinsic, min/max, or weighted size resolution
+- persistence of computed rectangles across frames
+
+These features may build on the box primitives later, but they are not prerequisites for a useful first version.
+
+## 4. Product Principles
+
+### 4.1 Explicit data over hidden layout state
+
+Layout functions receive ordinary values and arrays and write ordinary rectangle data. They do not create hidden nodes, register components, or depend on call history.
+
+### 4.2 Immediate computation
+
+The expected frame model is:
+
+```text
+current game and display state
+ -> compute available boxes
+ -> place child boxes
+ -> emit draw commands from those boxes
+ -> test input against those boxes
+ -> discard temporary box data
+```
+
+Persistent state is reserved for behavior that genuinely crosses frames, such as pointer capture, focus, selection, scrolling, or animation progress.
+
+### 4.3 One box, multiple consumers
+
+An allocated box is authoritative. Paint, content placement, hit-bound derivation, overflow checks, and debug drawing must not independently reconstruct its coordinates.
+
+### 4.4 Layout is not painting
+
+Core layout functions do not emit graphics commands. Text placement computes coordinates and bounds; a separate call draws the cached run.
+
+### 4.5 Independent, strongly typed axes
+
+Horizontal and vertical placement use separate enum types:
+
+- horizontal: `Left`, `Center`, or `Right`
+- vertical: `Top`, `Center`, or `Bottom`
+
+This creates nine common placements without special constants such as `TOP_RIGHT` or `CENTER_XY`. Separate types make call sites readable and let the compiler reject accidentally swapped horizontal and vertical arguments.
+
+### 4.6 Offsets use screen-coordinate signs
+
+Offsets are always added after placement:
+
+- positive x moves right
+- negative x moves left
+- positive y moves down
+- negative y moves up
+
+For example, content placed at `UiHorizontal.Right` with `offset_x = -16.0` is shifted 16 logical units left from the parent's right edge.
+
+### 4.7 Coordinate-space policy is explicit
+
+The box primitives operate in whichever coordinate space the caller supplies. They do not silently scale between logical, native, drawable, safe-viewport, or design-canvas coordinates.
+
+Screen-space safe layout and fixed-design canvas fitting are separate policies layered above the box primitives.
+
+## 5. User and Developer Scenarios
+
+### 5.1 Centered title
+
+A game measures a cached title run, supplies an explicit line height, and places its line box at horizontal `Center` and vertical `Top` within a header box.
+
+### 5.2 Button label
+
+A button painter derives a padded content box from the button's allocated box, centers a cached label within it, and draws at the returned top-left coordinate.
+
+### 5.3 Right-aligned HUD counter
+
+A HUD derives an inset safe-content box and places a measured counter at horizontal `Right`, vertical `Top` with no specialized right-edge API.
+
+### 5.4 Corner icon
+
+A fixed-size icon is placed at `UiHorizontal.Right` and `UiVertical.Bottom` within a card's content box. Its result is passed directly to sprite drawing.
+
+### 5.5 Flex-composed footer
+
+`flex_row` allocates button boxes across a footer. The Msplacement primitive centers each icon or text run within its allocated button box.
+
+### 5.6 Larger touch target
+
+A visual icon box is expanded into a separate hit box using explicit edge expansion. Hit testing uses the expanded box while debug mode can display both bounds.
+
+## 6. Canonical Data Model
+
+### 6.1 Rectangle representation
+
+Shared layout uses the existing plain-array representation:
+
+```stasis
+// [x, y, width, height]
+const UI_RECT_STRIDE: i32 = 4;
+const UI_RECT_X: i32 = 0;
+const UI_RECT_Y: i32 = 1;
+const UI_RECT_W: i32 = 2;
+const UI_RECT_H: i32 = 3;
+```
+
+The final prefix and module name may be selected during implementation, but the repository must converge on one shared set of rectangle constants and helpers. New duplicate `FLEX_RECT_*`, `HUD_RECT_*`, and `UI_RECT_*` vocabularies must not remain as independent public contracts.
+
+Rectangles use top-left coordinates, matching Stasis sprite and text placement.
+
+### 6.2 Rectangle invariants
+
+Public geometry and placement functions must:
+
+- preserve finite input values when valid
+- normalize computed negative width and height to zero where an operation can shrink a box
+- define edge inclusion consistently for hit testing
+- accept rectangles stored individually or at a fixed stride in a larger array where applicable
+- avoid writes outside the documented output rectangle
+
+The v1 hit-test edge policy is:
+
+```text
+x >= left and x < right
+y >= top  and y < bottom
+```
+
+Half-open bounds avoid two adjacent controls claiming a shared edge.
+
+### 6.3 Placement enums
+
+```stasis
+enum UiHorizontal {
+    Left,
+    Center,
+    Right
+}
+
+enum UiVertical {
+    Top,
+    Center,
+    Bottom
+}
+```
+
+Placement is a closed semantic choice, so the public API uses Stasis enums rather than unrelated integer constants. This lets the compiler reject invalid values and prevents callers from accidentally passing a flex justification, alignment value, sprite handle, or arbitrary integer as a placement.
+
+The axes intentionally use different enum types. A call that supplies `UiVertical.Top` in the horizontal argument is a compile-time type error.
+
+The implementation should compare enum members directly and should not convert them to `i32` unless an actual integer ABI boundary requires it. Any such boundary must use the explicit `enum_to_i32` conversion described by the language spec.
+
+## 7. Realistic Usage Examples
+
+These examples show the intended call style. Cached text handles and sprite handles are loaded during initialization; layout and drawing happen from current frame state.
+
+The examples use the proposed names from this PRD. Exact module imports may change during implementation.
+
+### 7.1 Initialization of reusable resources
+
+Text used every frame is cached once rather than rebuilt or measured from an uncached string in the render path.
+
+```stasis
+global ui_font: i32;
+global menu_title_run: i32;
+global play_label_run: i32;
+global button_sprite: i32;
+
+function menu_load_ui(): void {
+    ui_font = load_font("assets/ui.ttf", 28);
+    menu_title_run = gfx_cache_text(ui_font, "BRICKOUT REVENGE");
+    play_label_run = gfx_cache_text(ui_font, "PLAY");
+    button_sprite = gfx_load_sprite("assets/button.png", 256, 96);
+}
+```
+
+### 7.2 Menu title centered horizontally
+
+This places a title at the horizontal center of a header box while keeping its top edge 24 logical units below the header's top edge.
+
+```stasis
+function menu_draw_title(screen: f32[]): void {
+    let header: f32[4];
+    let title: f32[4];
+
+    // Reserve the top 96 units of the supplied screen or safe-area box.
+    ui_rect_set(
+        header,
+        screen[UI_RECT_X],
+        screen[UI_RECT_Y],
+        screen[UI_RECT_W],
+        96.0
+    );
+
+    let fits: bool = ui_place_text_run(
+        title,
+        header,
+        menu_title_run,
+        32.0,
+        UiHorizontal.Center,
+        UiVertical.Top,
+        0.0,
+        24.0
+    );
+
+    draw_text_cached(
+        ui_font,
+        menu_title_run,
+        title[UI_RECT_X],
+        title[UI_RECT_Y],
+        1.0,
+        0.9,
+        0.7,
+        1.0
+    );
+
+    if (!fits) {
+        ui_debug_draw_overflow(title);
+    }
+}
+```
+
+The important inputs are independent:
+
+- `UiHorizontal.Center` centers the measured text width horizontally.
+- `UiVertical.Top` starts from the header's top edge vertically.
+- `offset_y = 24.0` moves the title down from that edge.
+
+No caller needs to calculate the title's x coordinate.
+
+### 7.3 Button anchored to the top-left with an offset
+
+This places a fixed-size button 20 units from the left and 140 units from the top of the supplied screen box.
+
+```stasis
+function menu_place_play_button(
+    out_button: f32[],
+    screen: f32[]
+): void {
+    ui_place_in_rect(
+        out_button,
+        screen,
+        180.0,
+        56.0,
+        UiHorizontal.Left,
+        UiVertical.Top,
+        20.0,
+        140.0
+    );
+}
+```
+
+Because offsets always use screen-coordinate signs, positive x moves the button right and positive y moves it down. The same function can anchor a button to the top-right:
+
+```stasis
+ui_place_in_rect(
+    button,
+    screen,
+    180.0,
+    56.0,
+    UiHorizontal.Right,
+    UiVertical.Top,
+    -20.0,
+    140.0
+);
+```
+
+Here `offset_x = -20.0` moves the right-aligned button 20 units left from the screen's right edge.
+
+### 7.4 Text centered inside a button
+
+The button's allocated rectangle is authoritative. Its background consumes the button rectangle, while its label is centered in a derived content rectangle.
+
+```stasis
+function menu_draw_play_button(button: f32[]): void {
+    let content: f32[4];
+    let label: f32[4];
+
+    gfx_draw_sprite(
+        button_sprite,
+        f32_to_i32(button[UI_RECT_X]),
+        f32_to_i32(button[UI_RECT_Y]),
+        f32_to_i32(button[UI_RECT_W]),
+        f32_to_i32(button[UI_RECT_H]),
+        0,
+        255
+    );
+
+    ui_rect_inset_edges(
+        content,
+        button,
+        16.0,
+        8.0,
+        16.0,
+        8.0
+    );
+
+    let fits: bool = ui_place_text_run(
+        label,
+        content,
+        play_label_run,
+        28.0,
+        UiHorizontal.Center,
+        UiVertical.Center,
+        0.0,
+        1.0
+    );
+
+    draw_text_cached(
+        ui_font,
+        play_label_run,
+        label[UI_RECT_X],
+        label[UI_RECT_Y],
+        1.0,
+        1.0,
+        1.0,
+        1.0
+    );
+
+    if (!fits) {
+        ui_debug_draw_overflow(label);
+    }
+}
+```
+
+The one-unit y offset is an explicit optical adjustment. The actual line box remains centered before that adjustment; no button-specific `0.55 * height` heuristic is hidden in the painter.
+
+### 7.5 Drawing and hit testing the same button
+
+This complete menu fragment places the button once, draws from that rectangle, derives a larger touch target, and tests the current pointer snapshot against it.
+
+```stasis
+function menu_draw_and_hit_test(screen: f32[]): bool {
+    let button: f32[4];
+    let hit: f32[4];
+
+    menu_place_play_button(button, screen);
+    menu_draw_play_button(button);
+
+    // Increase the touch target without changing the painted button.
+    ui_rect_expand_edges(
+        hit,
+        button,
+        6.0,
+        6.0,
+        6.0,
+        6.0
+    );
+
+    if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
+        return ui_rect_contains(
+            hit,
+            input_pointer_x_px(0),
+            input_pointer_y_px(0)
+        );
+    }
+
+    return false;
+}
+```
+
+This example demonstrates geometric reuse, not the final click lifecycle. A later interaction layer must capture a stable button ID on pointer-down and define whether pointer-up outside the captured button cancels activation.
+
+### 7.6 Full menu rendering from the safe viewport
+
+An adaptive menu begins in safe screen-space coordinates. It does not automatically fit a fixed design canvas.
+
+```stasis
+function menu_render(): void {
+    let safe: f32[4];
+
+    ui_rect_set(
+        safe,
+        gfx_safe_viewport_x().to_f32(),
+        gfx_safe_viewport_y().to_f32(),
+        gfx_safe_viewport_width().to_f32(),
+        gfx_safe_viewport_height().to_f32()
+    );
+
+    menu_draw_title(safe);
+
+    if (menu_draw_and_hit_test(safe)) {
+        game_start();
+    }
+}
+```
+
+If the implementation provides `ui_safe_viewport_rect(out_rect)`, the four-value setup above becomes:
+
+```stasis
+let safe: f32[4];
+ui_safe_viewport_rect(safe);
+```
+
+The explicit version remains useful documentation of which coordinate space the menu uses.
+
+### 7.7 Centered labels in a flex button row
+
+Flex distributes sibling boxes; anchored placement positions each label within its assigned box.
+
+```stasis
+function menu_draw_footer(footer: f32[]): void {
+    let buttons: f32[8];
+    let widths: f32[2];
+    let heights: f32[2];
+
+    widths[0] = 140.0;
+    widths[1] = 140.0;
+    heights[0] = 52.0;
+    heights[1] = 52.0;
+
+    flex_row(
+        buttons,
+        footer,
+        widths,
+        heights,
+        2,
+        16.0,
+        FLEX_JUSTIFY_CENTER,
+        FLEX_ALIGN_CENTER
+    );
+
+    menu_draw_button_at(buttons, 0, back_label_run);
+    menu_draw_button_at(buttons, 1, play_label_run);
+}
+```
+
+`menu_draw_button_at` reads the rectangle at `index * UI_RECT_STRIDE`, derives its content box, and calls `ui_place_text_run` with center/center placement. Row distribution and content alignment therefore remain separate, composable operations.
+
+## 8. Required API Behavior
+
+Exact naming may change during implementation, but v1 must provide the following capabilities.
+
+### 8.1 Basic rectangle construction
+
+```stasis
+function ui_rect_set(
+    out_rect: f32[],
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32
+): void;
+```
+
+### 8.2 Edge inset
+
+```stasis
+function ui_rect_inset_edges(
+    out_rect: f32[],
+    rect: f32[],
+    left: f32,
+    top: f32,
+    right: f32,
+    bottom: f32
+): void;
+```
+
+Result:
+
+```text
+x = rect.x + left
+y = rect.y + top
+w = max(0, rect.w - left - right)
+h = max(0, rect.h - top - bottom)
+```
+
+In-place operation, where `out_rect` and `rect` refer to the same array, must either be supported and tested or rejected explicitly in documentation. Supporting it is preferred.
+
+### 8.3 Edge expansion
+
+```stasis
+function ui_rect_expand_edges(
+    out_rect: f32[],
+    rect: f32[],
+    left: f32,
+    top: f32,
+    right: f32,
+    bottom: f32
+): void;
+```
+
+This supports touch bounds larger than paint bounds without changing the visual layout.
+
+### 8.4 Point containment
+
+```stasis
+function ui_rect_contains(
+    rect: f32[],
+    x: f32,
+    y: f32
+): bool;
+```
+
+Containment follows the half-open edge policy in section 6.2.
+
+### 8.5 Child placement
+
+```stasis
+function ui_place_in_rect(
+    out_rect: f32[],
+    parent: f32[],
+    width: f32,
+    height: f32,
+    horizontal: UiHorizontal,
+    vertical: UiVertical,
+    offset_x: f32,
+    offset_y: f32
+): void;
+```
+
+Placement formula per axis:
+
+```text
+Left/Top:     parent_start
+Center:       parent_start + (parent_size - child_size) * 0.5
+Right/Bottom: parent_start + parent_size - child_size
+
+result = selected_position + offset
+```
+
+The function does not automatically clamp the child to the parent. A child larger than its parent remains aligned according to the selected rule and can be detected as overflow.
+
+### 8.6 Cached text placement
+
+```stasis
+function ui_place_text_run(
+    out_rect: f32[],
+    parent: f32[],
+    run_handle: i32,
+    line_height: f32,
+    horizontal: UiHorizontal,
+    vertical: UiVertical,
+    offset_x: f32,
+    offset_y: f32
+): bool;
+```
+
+Behavior:
+
+1. Read width with `gfx_measure_text_cached(run_handle)`.
+2. Use the explicit `line_height` as the text line-box height.
+3. Place that measured line box using `ui_place_in_rect`.
+4. Return whether the entire line box fits within the parent rectangle before offsets move it outside.
+
+The result rectangle's x and y are suitable for `draw_text_cached` because Stasis text drawing uses a top-left origin.
+
+The function does not draw, wrap, truncate, shrink, cache, or allocate text.
+
+### 8.7 Rectangle fit check
+
+The implementation must provide or internally use a deterministic whole-box containment check so non-text content can report overflow using the same policy as text.
+
+## 9. Composition with Existing Flex Layout
+
+The existing `flex_row`, `flex_column`, and `flex_grid` remain responsible for distributing sibling boxes.
+
+The placement primitive is responsible for positioning content inside each distributed box.
+
+```text
+parent box
+ -> flex row/column/grid
+ -> allocated child boxes
+ -> inset each child box
+ -> place measured content in each content box
+ -> draw and hit-test from the results
+```
+
+V1 must not add a competing row, column, or grid algorithm solely to obtain anchored content placement.
+
+As part of implementation, `flex_layout.stasis` should consume the canonical rectangle module or otherwise migrate toward its constants and helpers without breaking supported samples unnecessarily.
+
+## 10. Coordinate Spaces and Viewports
+
+### 10.1 Default screen-space layout
+
+Adaptive UI should normally begin with a rectangle derived from the host safe viewport:
+
+```stasis
+gfx_safe_viewport_x()
+gfx_safe_viewport_y()
+gfx_safe_viewport_width()
+gfx_safe_viewport_height()
+```
+
+The safe-viewport helper converts these snapshot values into an `f32[4]` rectangle. It performs no additional scale or letterbox policy.
+
+### 10.2 Fixed-design canvas
+
+Games may separately fit a fixed logical canvas into a safe or full viewport while preserving aspect ratio. This policy may expose scale and offset data similar to Brickout's existing play layout.
+
+Fixed-canvas fitting is not embedded into `ui_place_in_rect`. The caller must deliberately choose and consistently use a coordinate space for layout, drawing, and input conversion.
+
+### 10.3 Pixel snapping
+
+Core layout remains in floating-point coordinates. Pixel snapping belongs at the final coordinate transform or paint boundary so repeated composition does not accumulate rounding error.
+
+## 11. Text Model
+
+### 11.1 Measurement
+
+V1 uses cached text runs for per-frame UI placement. Text runs are created during initialization or resource updates, not during the rendering hot path.
+
+### 11.2 Height
+
+Until the runtime exposes font ascent, descent, baseline, and measured height, callers supply an explicit line-box height.
+
+This height represents layout space, not glyph ink bounds and not a baseline coordinate.
+
+### 11.3 Optical adjustment
+
+Art-directed vertical adjustment is represented by ordinary `offset_y`. The core layout layer does not contain font-specific optical correction tables.
+
+Reusable game-level text styles may hold line height, color, font handle, and optical offsets, but style storage is outside the v1 geometry contract.
+
+### 11.4 Overflow
+
+V1 detects fit and returns the result to the caller. It does not decide whether the caller should:
+
+- draw overflowing content
+- substitute shorter copy
+- choose a separately cached smaller-font run
+- skip drawing
+- render debug diagnostics
+
+## 12. Rendering and Interaction Boundaries
+
+### 12.1 Rendering
+
+Painting functions receive resolved rectangles. They must not independently recalculate layout from unrelated screen constants.
+
+A button painter may:
+
+1. draw a sprite or corrected nine-slice into the button box
+2. derive a padded content box
+3. place a cached text run within that box
+4. draw at the returned x and y
+
+### 12.2 Hit testing
+
+Hit testing receives the authoritative allocated or explicitly expanded hit rectangle.
+
+V1 geometry does not define click timing, pointer capture, multi-pointer arbitration, focus, or disabled-state transitions. Those behaviors require persistent interaction identity and belong in a later interaction slice.
+
+### 12.3 Stable identity
+
+Any later immediate-mode widget behavior must use explicit stable integer IDs. Rectangle equality or call order must not be the sole persistent identity of a control.
+
+## 13. Debuggability
+
+The first implementation must make pure layout results testable without a renderer.
+
+A debug paint helper should also be provided or demonstrated that can distinguish at least:
+
+- allocated bounds
+- inset content bounds
+- expanded hit bounds
+- overflowing content
+- safe viewport bounds
+
+Debug drawing must consume computed boxes and must not change layout results.
+
+## 14. Error and Edge Policies
+
+V1 must define and test:
+
+- zero-size parent rectangles
+- zero-size children
+- children larger than parents
+- excessive inset values
+- negative offsets
+- fractional coordinates and odd sizes
+- compile-time rejection when a caller supplies a non-placement value
+- compile-time rejection when a caller swaps `UiHorizontal` and `UiVertical` arguments
+- points exactly on every edge
+- invalid or zero cached-run handles according to existing graphics runtime behavior
+
+The core API does not silently reposition overflowing children to make them fit. Overflow is data that the caller may detect and handle.
+
+## 15. Performance Requirements
+
+- Core geometry and placement perform no heap allocation.
+- Placement is constant time.
+- No host call is introduced on the per-frame layout path beyond the existing cached text width behavior. If cached width currently crosses the host boundary, a follow-up should move the width into Stasis-owned cached metadata rather than growing additional hot-path calls.
+- Row, column, and grid behavior remains bounded by explicit item counts and fixed arrays.
+- The same functions and semantics are used in diagnostic and normal builds.
+- JIT and AOT produce equivalent placement results within documented floating-point tolerance.
+
+## 16. Testing Requirements
+
+### 16.1 Pure geometry tests
+
+Tests must cover all nine combinations of horizontal and vertical placement.
+
+For each axis, verify:
+
+- start placement
+- center placement with even and odd dimensions
+- end placement
+- positive and negative offsets
+- a child larger than its parent
+
+### 16.2 Rectangle operation tests
+
+Tests must cover:
+
+- symmetric and asymmetric inset
+- inset larger than available size
+- expansion
+- in-place inset if supported
+- half-open containment on all four edges
+- adjacent boxes sharing an edge
+
+### 16.3 Text tests
+
+Tests must cover:
+
+- short cached run that fits
+- exact-width fit
+- width overflow
+- line-height overflow
+- horizontal centering invariant
+- vertical line-box centering invariant
+- optical adjustment through offsets
+
+Representative invariants include:
+
+```text
+child_center_x == parent_center_x + offset_x
+child_center_y == parent_center_y + offset_y
+end_child_right == parent_right + offset_x
+```
+
+### 16.4 Composition tests
+
+At least one test must:
+
+1. allocate multiple boxes using the existing flex row or column path
+2. place content within each allocated box
+3. verify the computed content and hit bounds
+
+### 16.5 End-to-end compiler gate
+
+The slice must include at least one representative `.stasis` sample or test program that:
+
+1. imports the shared layout modules
+2. computes a safe or fixed parent box
+3. uses flex and anchored placement
+4. reaches Cranelift IR
+5. is built into an executable
+6. runs with asserted placement behavior
+
+All test commands must remain bounded to 300 seconds, with lingering test/compiler processes checked after each run.
+
+## 17. Recommended Delivery Slices
+
+### Slice 1: Canonical geometry
+
+- introduce the shared rectangle constants and helpers
+- add inset, expansion, containment, and fit behavior
+- add deterministic Stasis tests
+- migrate only the minimum existing code needed to validate reuse
+
+### Slice 2: Anchored placement
+
+- add independent-axis placement
+- cover all nine placement combinations
+- verify overflow and offset behavior
+- compose placement with an existing flex row or column
+
+### Slice 3: Cached text line boxes
+
+- add cached-run placement using explicit line height
+- return fit status
+- replace one real screen's hardcoded text-start calculation
+- visually verify debug bounds and text positioning
+
+### Slice 4: Paint integration
+
+- update one sprite-backed or nine-slice button path to consume resolved boxes
+- correct undersized nine-slice behavior before treating it as a shared primitive
+- derive paint, content, and hit bounds from one allocated button box
+
+Interaction identity and pointer capture should be proposed as a separate PRD or follow-up slice after the geometry proves useful on real screens.
+
+## 18. Acceptance Criteria
+
+V1 is complete when:
+
+1. One canonical rectangle representation is used by the new shared APIs.
+2. A caller can place a known-size child in any of nine parent positions with explicit offsets.
+3. A caller can obtain correct top-left coordinates for a cached text run using measured width and explicit line height.
+4. Layout functions emit no drawing commands and retain no component state.
+5. Existing flex output can be used directly as placement input.
+6. Insets and expansions allow content and hit bounds to derive from one allocated box.
+7. Overflow is detectable and does not silently change placement.
+8. Safe screen-space layout does not implicitly force fixed-design scaling.
+9. Tests establish half-open edge behavior and all placement invariants.
+10. One representative UI path compiles and runs end to end through Cranelift with asserted results.
+11. Debug output can display the authoritative allocated and derived boxes.
+12. Touched code passes a simplicity review and leaves no duplicate or obsolete rectangle helpers without an explicit migration reason.
+13. Placement parameters use distinct `UiHorizontal` and `UiVertical` enums end to end, with explicit conversion only at a demonstrated integer ABI boundary.
+
+## 19. Future Extensions
+
+Potential follow-up work includes:
+
+- parent-anchor to child-anchor attachment for tooltips, badges, and world labels
+- fixed/fill/weight size resolution before flex placement
+- multiline text metrics and wrapping
+- clipping and scroll containers
+- stable-ID interaction state with pointer capture
+- focus navigation and accessibility metadata
+- reusable style tables after multiple screens establish stable needs
+- richer overflow diagnostics
+- baseline-aware text placement when runtime font metrics are available
+
+Each extension should remain a deterministic transformation or explicit persistent behavior layer. It must not require a parallel retained rendering pipeline.
+
+## 20. Theory of Operation
+
+### Mapping
+
+Real UI composition is represented as nested available rectangles. Layout transforms a parent rectangle and explicit placement inputs into child rectangles. Rendering projects those rectangles into graphics commands, while input compares pointer snapshots against the same geometry.
+
+The model deliberately excludes semantic component trees, event dispatch ownership, and automatic reflow policy.
+
+### Rationale
+
+Stasis already renders immediately from current state into command buffers and uses fixed arrays across compiler backends. Plain rectangle transforms match that execution model, remain inspectable, and compose with the existing flex helpers.
+
+The nearest tempting alternative is a retained component hierarchy with automatic measurement and callbacks. That would introduce hidden lifecycle, identity, allocation, and compiler-surface requirements before the underlying placement needs are proven.
+
+### Extension point
+
+A future layout behavior should fit as either:
+
+- a pure transformation that produces rectangles from rectangles and explicit size rules, or
+- an explicit persistent interaction structure keyed by stable IDs
+
+For example, a tooltip can add parent-anchor to child-anchor attachment without changing rendering ownership or creating a UI tree.
+
+### Prediction
+
+If the model is sound, adding a new container such as an equal-cell toolbar will require only a deterministic box-allocation function. Existing text placement, painting, hit testing, and debug visualization will consume its output unchanged.

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -44,7 +44,7 @@ V1 must:
 3. Use different enum types for horizontal and vertical placement.
 4. Express margins and padding by adjusting the available region before placement.
 5. Work entirely with supported scalar parameters, locals, and returns.
-6. Support cached text placement using existing cached width measurement and explicit line height.
+6. Support cached text placement using width measured and stored during resource initialization plus an explicit line height.
 7. Support buttons, icons, HUD labels, menu titles, and similar immediate-mode drawing.
 8. Compose with existing flex rows, columns, and grids without replacing them.
 9. Perform no allocation and no host-side UI registration.
@@ -237,18 +237,22 @@ The enum-typed signatures prevent ordinary callers from supplying arbitrary inte
 ```stasis
 global ui_font: i32;
 global menu_title_run: i32;
+global menu_title_width: f32;
 global play_label_run: i32;
+global play_label_width: f32;
 global button_sprite: i32;
 
 function menu_load_ui(): void {
     ui_font = load_font("assets/ui.ttf", 28);
     menu_title_run = gfx_cache_text(ui_font, "BRICKOUT REVENGE");
+    menu_title_width = gfx_measure_text_cached(menu_title_run);
     play_label_run = gfx_cache_text(ui_font, "PLAY");
+    play_label_width = gfx_measure_text_cached(play_label_run);
     button_sprite = gfx_load_sprite("assets/button.png", 256, 96);
 }
 ```
 
-Caching is separate from placement. Per-frame code reads cached width and calculates coordinates using scalar values.
+The host call that measures a cached run occurs during initialization or an explicit resource update. Stasis-owned width scalars are stored alongside the run handles. Per-frame code reads those scalars and makes no text-measurement host call.
 
 ### 7.2 Menu title centered horizontally
 
@@ -260,7 +264,7 @@ function menu_draw_title(): void {
     let safe_y: f32 = gfx_safe_viewport_y();
     let safe_w: f32 = gfx_safe_viewport_width();
 
-    let title_w: f32 = gfx_measure_text_cached(menu_title_run);
+    let title_w: f32 = menu_title_width;
     let title_h: f32 = 32.0;
 
     let title_x: f32 = ui_place_x(
@@ -365,7 +369,7 @@ let content_y: f32 = button_y + pad_y;
 let content_w: f32 = button_w - pad_x * 2.0;
 let content_h: f32 = button_h - pad_y * 2.0;
 
-let label_w: f32 = gfx_measure_text_cached(play_label_run);
+let label_w: f32 = play_label_width;
 let label_h: f32 = 28.0;
 
 let label_x: f32 = ui_place_x(
@@ -514,7 +518,19 @@ The new API therefore composes with the existing array-based flex implementation
 
 ### 8.1 Width
 
-Per-frame UI should use cached runs and `gfx_measure_text_cached`. Text caching occurs during initialization or an explicit resource update, not during the rendering hot path.
+Text caching and width measurement occur together during initialization or an explicit resource update:
+
+```stasis
+title_run = gfx_cache_text(ui_font, "BRICKOUT REVENGE");
+title_width = gfx_measure_text_cached(title_run);
+```
+
+Per-frame UI uses the Stasis-owned `title_width` scalar. It must not call `gfx_measure_text_cached`, because that binding crosses the host boundary and the graphics stdlib excludes host calls from rendering hot paths.
+
+Each reusable text resource therefore has two distinct values:
+
+- cached run handle: `i32`, used for drawing
+- cached measured width: `f32`, used for layout
 
 ### 8.2 Height
 
@@ -655,7 +671,7 @@ bottom_child_edge == parent_bottom
 At least one test or sample must:
 
 1. read or define scalar parent bounds
-2. measure a cached text run or use an explicit test width
+2. use a width cached during initialization or an explicit test width
 3. center text horizontally
 4. derive an inset available region and place a button at its top-left
 5. center a label inside that button
@@ -670,17 +686,19 @@ Tests must verify that:
 - sprite command encoding and host decoding agree on the new geometry representation
 - fractional sprite positions and sizes survive command submission until renderer rasterization
 - odd and adjacent sprite bounds follow the documented backend snapping policy without gaps introduced by independent truncation
-- legacy callers receive a deterministic migration diagnostic or are updated in the same slice
+- legacy callers receive a deterministic migration diagnostic or are updated in the same checklist-selected migration group
 
 ### 12.6 End-to-end compiler gate
 
-The completed implementation slice must include a representative `.stasis` program that reaches Cranelift IR, builds into an executable, runs, and verifies behavior with assertions.
+Completed implementation work must include a representative `.stasis` program that reaches Cranelift IR, builds into an executable, runs, and verifies behavior with assertions.
 
 All test commands remain bounded to 300 seconds, with lingering processes checked after each run.
 
-## 13. Delivery Plan
+## 13. Implementation Areas
 
-### Slice 1: Float presentation boundary
+`docs/build_checklist.md` is the authoritative source for implementation selection, grouping, and ordering. This PRD defines required implementation areas only. When this work is selected, the checklist must sequence these areas according to repository priorities and migration constraints.
+
+### Float presentation boundary
 
 - expose safe and input viewport geometry as `f32` to Stasis layout callers
 - migrate sprite x/y/width/height parameters and command storage to `f32`
@@ -688,14 +706,14 @@ All test commands remain bounded to 300 seconds, with lingering processes checke
 - update existing sprite callers and parity fixtures
 - verify fractional geometry through a real renderer path
 
-### Slice 2: Typed scalar axis placement
+### Typed scalar axis placement
 
 - add `UiHorizontal` and `UiVertical`
 - add `ui_place_x` and `ui_place_y`
 - add deterministic axis and type-safety tests
 - run an end-to-end executable fixture
 
-### Slice 3: One real menu adoption
+### One real menu adoption
 
 - replace one menu title's manual centering calculation
 - anchor one button using the shared axis functions
@@ -703,7 +721,7 @@ All test commands remain bounded to 300 seconds, with lingering processes checke
 - use the same button bounds for drawing and hit testing
 - add visual or command-buffer verification where practical
 
-No further layout abstraction is required before these slices prove the API.
+No further layout abstraction is required before these implementation areas prove the API. Their order in this document is descriptive, not authoritative.
 
 ## 14. Acceptance Criteria
 

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -2,178 +2,83 @@
 
 ## Project
 
-Stasis Immediate Box Layout
+Stasis Immediate Axis Placement
 
 ## 1. Purpose
 
-Provide a small, shared layout foundation for Stasis games and tools using explicit bounding boxes and deterministic placement rules.
+Provide a small, shared way to calculate the starting x or y coordinate of fixed-size or measured UI content within an available region.
 
-The system computes a child rectangle from:
+The v1 system is deliberately scalar. Each placement function receives:
 
-- an available parent rectangle
-- the child's measured or fixed width and height
-- independent horizontal and vertical placement
-- explicit x and y offsets
+- the parent start coordinate
+- the parent size
+- the child size
+- a strongly typed placement choice
+- an explicit offset
 
-Rendering, hit testing, and debug visualization consume the same computed rectangles. Layout is recalculated from current state when needed and does not create or retain a host-side UI tree.
+It returns one `f32` coordinate. The caller uses those returned coordinates for text, sprites, buttons, hit testing, or as inputs to another layout calculation.
 
-This PRD defines the first reusable layer beneath buttons, menus, HUDs, cards, and other UI compositions. It builds on the existing `src/stdlib/flex_layout.stasis`, graphics command buffers, cached text measurement, host display snapshots, and plain-array conventions.
+This design matches the Stasis language surface implemented today. It uses ordinary scalar locals and scalar returns. It does not require function-local arrays, local struct materialization, array returns, hidden allocation, or a retained UI tree.
 
-## 2. Goals
+## 2. Problem
 
-The first version must:
-
-1. Establish one canonical rectangle representation for shared layout code.
-2. Place fixed-size or measured content within a parent rectangle using start, center, or end placement on each axis.
-3. Support explicit offsets without adding specialized constraint types for common cases.
-4. Calculate top-left text draw coordinates from cached text width and an explicit line-box height.
-5. Keep layout computation independent from painting and interaction behavior.
-6. Allow paint bounds, content bounds, and hit bounds to be derived from the same allocated box.
-7. Compose with existing row, column, and grid layout helpers.
-8. Operate without heap allocation, callbacks, closures, or retained component trees.
-9. Produce deterministic results suitable for Stasis tests and Cranelift JIT/AOT execution.
-10. Make layout errors and computed bounds easy to inspect.
-
-## 3. Non-Goals
-
-Version 1 does not aim to provide:
-
-- a retained-mode component or widget tree
-- a CSS-compatible flexbox implementation
-- a general constraint solver
-- automatic text wrapping, ellipsis, or font scaling
-- scroll containers
-- clipping or scissor support
-- automatic overlap avoidance
-- automatic portrait/landscape screen redesign
-- animation ownership
-- keyboard, gamepad, or accessibility focus management
-- a complete button interaction lifecycle
-- percentage, intrinsic, min/max, or weighted size resolution
-- persistence of computed rectangles across frames
-
-These features may build on the box primitives later, but they are not prerequisites for a useful first version.
-
-## 4. Product Principles
-
-### 4.1 Explicit data over hidden layout state
-
-Layout functions receive ordinary values and arrays and write ordinary rectangle data. They do not create hidden nodes, register components, or depend on call history.
-
-### 4.2 Immediate computation
-
-The expected frame model is:
-
-```text
-current game and display state
- -> compute available boxes
- -> place child boxes
- -> emit draw commands from those boxes
- -> test input against those boxes
- -> discard temporary box data
-```
-
-Persistent state is reserved for behavior that genuinely crosses frames, such as pointer capture, focus, selection, scrolling, or animation progress.
-
-### 4.3 One box, multiple consumers
-
-An allocated box is authoritative. Paint, content placement, hit-bound derivation, overflow checks, and debug drawing must not independently reconstruct its coordinates.
-
-### 4.4 Layout is not painting
-
-Core layout functions do not emit graphics commands. Text placement computes coordinates and bounds; a separate call draws the cached run.
-
-### 4.5 Independent, strongly typed axes
-
-Horizontal and vertical placement use separate enum types:
-
-- horizontal: `Left`, `Center`, or `Right`
-- vertical: `Top`, `Center`, or `Bottom`
-
-This creates nine common placements without special constants such as `TOP_RIGHT` or `CENTER_XY`. Separate types make call sites readable and let the compiler reject accidentally swapped horizontal and vertical arguments.
-
-### 4.6 Offsets use screen-coordinate signs
-
-Offsets are always added after placement:
-
-- positive x moves right
-- negative x moves left
-- positive y moves down
-- negative y moves up
-
-For example, content placed at `UiHorizontal.Right` with `offset_x = -16.0` is shifted 16 logical units left from the parent's right edge.
-
-### 4.7 Coordinate-space policy is explicit
-
-The box primitives operate in whichever coordinate space the caller supplies. They do not silently scale between logical, native, drawable, safe-viewport, or design-canvas coordinates.
-
-Screen-space safe layout and fixed-design canvas fitting are separate policies layered above the box primitives.
-
-## 5. User and Developer Scenarios
-
-### 5.1 Centered title
-
-A game measures a cached title run, supplies an explicit line height, and places its line box at horizontal `Center` and vertical `Top` within a header box.
-
-### 5.2 Button label
-
-A button painter derives a padded content box from the button's allocated box, centers a cached label within it, and draws at the returned top-left coordinate.
-
-### 5.3 Right-aligned HUD counter
-
-A HUD derives an inset safe-content box and places a measured counter at horizontal `Right`, vertical `Top` with no specialized right-edge API.
-
-### 5.4 Corner icon
-
-A fixed-size icon is placed at `UiHorizontal.Right` and `UiVertical.Bottom` within a card's content box. Its result is passed directly to sprite drawing.
-
-### 5.5 Flex-composed footer
-
-`flex_row` allocates button boxes across a footer. The Msplacement primitive centers each icon or text run within its allocated button box.
-
-### 5.6 Larger touch target
-
-A visual icon box is expanded into a separate hit box using explicit edge expansion. Hit testing uses the expanded box while debug mode can display both bounds.
-
-## 6. Canonical Data Model
-
-### 6.1 Rectangle representation
-
-Shared layout uses the existing plain-array representation:
+Stasis games currently repeat placement calculations such as:
 
 ```stasis
-// [x, y, width, height]
-const UI_RECT_STRIDE: i32 = 4;
-const UI_RECT_X: i32 = 0;
-const UI_RECT_Y: i32 = 1;
-const UI_RECT_W: i32 = 2;
-const UI_RECT_H: i32 = 3;
+let title_x: f32 = safe_x + (safe_w - title_w) * 0.5;
+let label_y: f32 = button_y + (button_h - line_h) * 0.5 + 1.0;
+let icon_x: f32 = panel_x + panel_w - icon_w - 12.0;
 ```
 
-The final prefix and module name may be selected during implementation, but the repository must converge on one shared set of rectangle constants and helpers. New duplicate `FLEX_RECT_*`, `HUD_RECT_*`, and `UI_RECT_*` vocabularies must not remain as independent public contracts.
+These calculations are individually simple, but repeated versions can diverge between screens, drawing, and hit testing. The existing `flex_layout.stasis` distributes multiple sibling rectangles but does not provide a small typed primitive for positioning one item along one axis.
 
-Rectangles use top-left coordinates, matching Stasis sprite and text placement.
+The shared system should capture that missing operation without introducing a larger UI framework.
 
-### 6.2 Rectangle invariants
+## 3. Goals
 
-Public geometry and placement functions must:
+V1 must:
 
-- preserve finite input values when valid
-- normalize computed negative width and height to zero where an operation can shrink a box
-- define edge inclusion consistently for hit testing
-- accept rectangles stored individually or at a fixed stride in a larger array where applicable
-- avoid writes outside the documented output rectangle
+1. Calculate a child x coordinate from horizontal placement inputs.
+2. Calculate a child y coordinate from vertical placement inputs.
+3. Use different enum types for horizontal and vertical placement.
+4. Use ordinary screen-coordinate offset signs.
+5. Work entirely with supported scalar parameters, locals, and returns.
+6. Support cached text placement using existing cached width measurement and explicit line height.
+7. Support buttons, icons, HUD labels, menu titles, and similar immediate-mode drawing.
+8. Compose with existing flex rows, columns, and grids without replacing them.
+9. Perform no allocation and no host-side UI registration.
+10. Produce deterministic JIT and AOT behavior.
 
-The v1 hit-test edge policy is:
+## 4. Non-Goals
 
-```text
-x >= left and x < right
-y >= top  and y < bottom
-```
+V1 does not provide:
 
-Half-open bounds avoid two adjacent controls claiming a shared edge.
+- a rectangle value type
+- local `f32[4]` rectangle storage
+- functions that write rectangles through `f32[]` output parameters
+- a retained component or widget tree
+- a general constraint solver
+- CSS-compatible flexbox
+- automatic text wrapping, ellipsis, or font scaling
+- clipping or scrolling
+- automatic sibling distribution beyond the existing flex helpers
+- pointer capture, focus, or click lifecycle ownership
+- automatic portrait/landscape redesign
+- automatic overflow resolution
+- style ownership
+- animation ownership
 
-### 6.3 Placement enums
+Flat arrays remain valid for existing global-backed bulk layout storage, such as the outputs consumed by `flex_row`. They are not required by the v1 single-item placement API.
+
+## 5. Product Principles
+
+### 5.1 One axis, one scalar result
+
+Horizontal placement returns x. Vertical placement returns y. The API does not manufacture a rectangle when the caller only needs a draw origin.
+
+### 5.2 Strongly typed axes
+
+Horizontal and vertical choices use different enums so the compiler rejects swapped arguments.
 
 ```stasis
 enum UiHorizontal {
@@ -189,21 +94,101 @@ enum UiVertical {
 }
 ```
 
-Placement is a closed semantic choice, so the public API uses Stasis enums rather than unrelated integer constants. This lets the compiler reject invalid values and prevents callers from accidentally passing a flex justification, alignment value, sprite handle, or arbitrary integer as a placement.
+The implementation compares enum members directly. It does not convert them to `i32` unless an actual integer ABI boundary requires it, in which case it uses explicit `enum_to_i32` conversion.
 
-The axes intentionally use different enum types. A call that supplies `UiVertical.Top` in the horizontal argument is a compile-time type error.
+### 5.3 Offsets have one meaning
 
-The implementation should compare enum members directly and should not convert them to `i32` unless an actual integer ABI boundary requires it. Any such boundary must use the explicit `enum_to_i32` conversion described by the language spec.
+Offsets are added after alignment:
+
+- positive x moves right
+- negative x moves left
+- positive y moves down
+- negative y moves up
+
+A button aligned to `UiHorizontal.Right` with `offset_x = -20.0` sits 20 units left of the parent's right edge.
+
+### 5.4 Layout is pure calculation
+
+Placement functions do not draw, measure text, inspect input, retain state, or change host state.
+
+### 5.5 Coordinate space belongs to the caller
+
+The functions operate in whatever coordinate space the caller supplies. They do not silently translate among safe viewport, window, native, drawable, fixed-design, or world coordinates.
+
+### 5.6 Current language behavior is the boundary
+
+V1 examples must compile using implemented Stasis features. In particular, examples must not declare function-local fixed arrays such as:
+
+```stasis
+// Not part of the currently supported v1 contract.
+let rect: f32[4];
+```
+
+`Type[]` parameters are supported Stasis views, but this placement API does not need them.
+
+## 6. Required API
+
+### 6.1 Horizontal placement
+
+```stasis
+function ui_place_x(
+    parent_x: f32,
+    parent_width: f32,
+    child_width: f32,
+    horizontal: UiHorizontal,
+    offset_x: f32
+): f32;
+```
+
+Behavior:
+
+```text
+Left:   parent_x
+Center: parent_x + (parent_width - child_width) * 0.5
+Right:  parent_x + parent_width - child_width
+
+result = aligned_x + offset_x
+```
+
+### 6.2 Vertical placement
+
+```stasis
+function ui_place_y(
+    parent_y: f32,
+    parent_height: f32,
+    child_height: f32,
+    vertical: UiVertical,
+    offset_y: f32
+): f32;
+```
+
+Behavior:
+
+```text
+Top:    parent_y
+Center: parent_y + (parent_height - child_height) * 0.5
+Bottom: parent_y + parent_height - child_height
+
+result = aligned_y + offset_y
+```
+
+### 6.3 Oversized children
+
+The functions do not clamp or resize children larger than their parents. They apply the selected formula consistently:
+
+- left/top alignment preserves the parent's starting edge
+- center alignment overflows equally on both sides
+- right/bottom alignment preserves the parent's ending edge
+
+The caller decides whether overflow is acceptable.
+
+### 6.4 Invalid placement values
+
+The enum-typed signatures prevent ordinary callers from supplying arbitrary integers or swapping horizontal and vertical values. No runtime fallback for an unknown placement integer is required.
 
 ## 7. Realistic Usage Examples
 
-These examples show the intended call style. Cached text handles and sprite handles are loaded during initialization; layout and drawing happen from current frame state.
-
-The examples use the proposed names from this PRD. Exact module imports may change during implementation.
-
-### 7.1 Initialization of reusable resources
-
-Text used every frame is cached once rather than rebuilt or measured from an uncached string in the render path.
+### 7.1 Cache reusable UI resources during initialization
 
 ```stasis
 global ui_font: i32;
@@ -219,672 +204,463 @@ function menu_load_ui(): void {
 }
 ```
 
+Caching is separate from placement. Per-frame code reads cached width and calculates coordinates using scalar values.
+
 ### 7.2 Menu title centered horizontally
 
-This places a title at the horizontal center of a header box while keeping its top edge 24 logical units below the header's top edge.
+The title is centered within the safe viewport and placed 24 units below its top edge.
 
 ```stasis
-function menu_draw_title(screen: f32[]): void {
-    let header: f32[4];
-    let title: f32[4];
+function menu_draw_title(): void {
+    let safe_x: f32 = gfx_safe_viewport_x().to_f32();
+    let safe_y: f32 = gfx_safe_viewport_y().to_f32();
+    let safe_w: f32 = gfx_safe_viewport_width().to_f32();
 
-    // Reserve the top 96 units of the supplied screen or safe-area box.
-    ui_rect_set(
-        header,
-        screen[UI_RECT_X],
-        screen[UI_RECT_Y],
-        screen[UI_RECT_W],
-        96.0
+    let title_w: f32 = gfx_measure_text_cached(menu_title_run);
+    let title_h: f32 = 32.0;
+
+    let title_x: f32 = ui_place_x(
+        safe_x,
+        safe_w,
+        title_w,
+        UiHorizontal.Center,
+        0.0
     );
 
-    let fits: bool = ui_place_text_run(
-        title,
-        header,
-        menu_title_run,
-        32.0,
-        UiHorizontal.Center,
+    let title_y: f32 = ui_place_y(
+        safe_y,
+        96.0,
+        title_h,
         UiVertical.Top,
-        0.0,
         24.0
     );
 
     draw_text_cached(
         ui_font,
         menu_title_run,
-        title[UI_RECT_X],
-        title[UI_RECT_Y],
+        title_x,
+        title_y,
         1.0,
         0.9,
         0.7,
         1.0
     );
-
-    if (!fits) {
-        ui_debug_draw_overflow(title);
-    }
 }
 ```
 
-The important inputs are independent:
+The caller never manually calculates the centered x coordinate.
 
-- `UiHorizontal.Center` centers the measured text width horizontally.
-- `UiVertical.Top` starts from the header's top edge vertically.
-- `offset_y = 24.0` moves the title down from that edge.
+### 7.3 Button anchored top-left with offsets
 
-No caller needs to calculate the title's x coordinate.
-
-### 7.3 Button anchored to the top-left with an offset
-
-This places a fixed-size button 20 units from the left and 140 units from the top of the supplied screen box.
+This creates scalar button bounds 20 units from the safe viewport's left edge and 140 units below its top edge.
 
 ```stasis
-function menu_place_play_button(
-    out_button: f32[],
-    screen: f32[]
-): void {
-    ui_place_in_rect(
-        out_button,
-        screen,
-        180.0,
-        56.0,
+function menu_draw_play_button(): void {
+    let safe_x: f32 = gfx_safe_viewport_x().to_f32();
+    let safe_y: f32 = gfx_safe_viewport_y().to_f32();
+    let safe_w: f32 = gfx_safe_viewport_width().to_f32();
+    let safe_h: f32 = gfx_safe_viewport_height().to_f32();
+
+    let button_w: f32 = 180.0;
+    let button_h: f32 = 56.0;
+
+    let button_x: f32 = ui_place_x(
+        safe_x,
+        safe_w,
+        button_w,
         UiHorizontal.Left,
+        20.0
+    );
+
+    let button_y: f32 = ui_place_y(
+        safe_y,
+        safe_h,
+        button_h,
         UiVertical.Top,
-        20.0,
         140.0
     );
-}
-```
-
-Because offsets always use screen-coordinate signs, positive x moves the button right and positive y moves it down. The same function can anchor a button to the top-right:
-
-```stasis
-ui_place_in_rect(
-    button,
-    screen,
-    180.0,
-    56.0,
-    UiHorizontal.Right,
-    UiVertical.Top,
-    -20.0,
-    140.0
-);
-```
-
-Here `offset_x = -20.0` moves the right-aligned button 20 units left from the screen's right edge.
-
-### 7.4 Text centered inside a button
-
-The button's allocated rectangle is authoritative. Its background consumes the button rectangle, while its label is centered in a derived content rectangle.
-
-```stasis
-function menu_draw_play_button(button: f32[]): void {
-    let content: f32[4];
-    let label: f32[4];
 
     gfx_draw_sprite(
         button_sprite,
-        f32_to_i32(button[UI_RECT_X]),
-        f32_to_i32(button[UI_RECT_Y]),
-        f32_to_i32(button[UI_RECT_W]),
-        f32_to_i32(button[UI_RECT_H]),
+        button_x.to_i32(),
+        button_y.to_i32(),
+        button_w.to_i32(),
+        button_h.to_i32(),
         0,
         255
     );
-
-    ui_rect_inset_edges(
-        content,
-        button,
-        16.0,
-        8.0,
-        16.0,
-        8.0
-    );
-
-    let fits: bool = ui_place_text_run(
-        label,
-        content,
-        play_label_run,
-        28.0,
-        UiHorizontal.Center,
-        UiVertical.Center,
-        0.0,
-        1.0
-    );
-
-    draw_text_cached(
-        ui_font,
-        play_label_run,
-        label[UI_RECT_X],
-        label[UI_RECT_Y],
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    );
-
-    if (!fits) {
-        ui_debug_draw_overflow(label);
-    }
 }
 ```
 
-The one-unit y offset is an explicit optical adjustment. The actual line box remains centered before that adjustment; no button-specific `0.55 * height` heuristic is hidden in the painter.
-
-### 7.5 Drawing and hit testing the same button
-
-This complete menu fragment places the button once, draws from that rectangle, derives a larger touch target, and tests the current pointer snapshot against it.
+The same button anchored top-right uses:
 
 ```stasis
-function menu_draw_and_hit_test(screen: f32[]): bool {
-    let button: f32[4];
-    let hit: f32[4];
+let button_x: f32 = ui_place_x(
+    safe_x,
+    safe_w,
+    button_w,
+    UiHorizontal.Right,
+    -20.0
+);
+```
 
-    menu_place_play_button(button, screen);
-    menu_draw_play_button(button);
+### 7.4 Text centered inside a button
 
-    // Increase the touch target without changing the painted button.
-    ui_rect_expand_edges(
-        hit,
-        button,
-        6.0,
-        6.0,
-        6.0,
-        6.0
-    );
+The button has scalar bounds. Padding derives a scalar content region, and the label is centered within it.
 
-    if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
-        return ui_rect_contains(
-            hit,
-            input_pointer_x_px(0),
-            input_pointer_y_px(0)
-        );
-    }
+```stasis
+let pad_x: f32 = 16.0;
+let pad_y: f32 = 8.0;
+let content_x: f32 = button_x + pad_x;
+let content_y: f32 = button_y + pad_y;
+let content_w: f32 = button_w - pad_x * 2.0;
+let content_h: f32 = button_h - pad_y * 2.0;
 
-    return false;
+let label_w: f32 = gfx_measure_text_cached(play_label_run);
+let label_h: f32 = 28.0;
+
+let label_x: f32 = ui_place_x(
+    content_x,
+    content_w,
+    label_w,
+    UiHorizontal.Center,
+    0.0
+);
+
+let label_y: f32 = ui_place_y(
+    content_y,
+    content_h,
+    label_h,
+    UiVertical.Center,
+    1.0
+);
+
+draw_text_cached(
+    ui_font,
+    play_label_run,
+    label_x,
+    label_y,
+    1.0,
+    1.0,
+    1.0,
+    1.0
+);
+```
+
+The one-unit y offset is an explicit optical correction. The shared placement function does not hide font- or button-specific heuristics.
+
+### 7.5 Fit detection with scalars
+
+V1 does not need a rectangle helper to detect whether the label fits:
+
+```stasis
+let label_fits: bool =
+    label_w <= content_w &&
+    label_h <= content_h;
+```
+
+The caller may draw normally, use alternate cached copy, or display a debug warning.
+
+### 7.6 Hit testing with the same scalar button bounds
+
+The button draw and input paths use the same `button_x`, `button_y`, `button_w`, and `button_h` values:
+
+```stasis
+function ui_point_in_box(
+    point_x: f32,
+    point_y: f32,
+    box_x: f32,
+    box_y: f32,
+    box_w: f32,
+    box_h: f32
+): bool {
+    return
+        point_x >= box_x &&
+        point_x < box_x + box_w &&
+        point_y >= box_y &&
+        point_y < box_y + box_h;
 }
 ```
 
-This example demonstrates geometric reuse, not the final click lifecycle. A later interaction layer must capture a stable button ID on pointer-down and define whether pointer-up outside the captured button cancels activation.
-
-### 7.6 Full menu rendering from the safe viewport
-
-An adaptive menu begins in safe screen-space coordinates. It does not automatically fit a fixed design canvas.
-
 ```stasis
-function menu_render(): void {
-    let safe: f32[4];
+let hit_pad: f32 = 6.0;
+let hit_x: f32 = button_x - hit_pad;
+let hit_y: f32 = button_y - hit_pad;
+let hit_w: f32 = button_w + hit_pad * 2.0;
+let hit_h: f32 = button_h + hit_pad * 2.0;
 
-    ui_rect_set(
-        safe,
-        gfx_safe_viewport_x().to_f32(),
-        gfx_safe_viewport_y().to_f32(),
-        gfx_safe_viewport_width().to_f32(),
-        gfx_safe_viewport_height().to_f32()
+if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
+    let clicked: bool = ui_point_in_box(
+        input_pointer_x_px(0),
+        input_pointer_y_px(0),
+        hit_x,
+        hit_y,
+        hit_w,
+        hit_h
     );
-
-    menu_draw_title(safe);
-
-    if (menu_draw_and_hit_test(safe)) {
-        game_start();
-    }
 }
 ```
 
-If the implementation provides `ui_safe_viewport_rect(out_rect)`, the four-value setup above becomes:
+This demonstrates geometric reuse, not a final click lifecycle. Pointer capture and stable control IDs remain separate future interaction work.
+
+### 7.7 Using placement with existing flex arrays
+
+Existing flex layout remains array-based because it writes multiple sibling boxes. Storage is global-backed, matching currently demonstrated Stasis behavior:
 
 ```stasis
-let safe: f32[4];
-ui_safe_viewport_rect(safe);
+global footer: f32[4];
+global footer_buttons: f32[8];
+global footer_widths: f32[2];
+global footer_heights: f32[2];
 ```
 
-The explicit version remains useful documentation of which coordinate space the menu uses.
-
-### 7.7 Centered labels in a flex button row
-
-Flex distributes sibling boxes; anchored placement positions each label within its assigned box.
-
 ```stasis
-function menu_draw_footer(footer: f32[]): void {
-    let buttons: f32[8];
-    let widths: f32[2];
-    let heights: f32[2];
+function menu_layout_footer(): void {
+    flex_rect_set(footer, 20.0, 620.0, 320.0, 56.0);
 
-    widths[0] = 140.0;
-    widths[1] = 140.0;
-    heights[0] = 52.0;
-    heights[1] = 52.0;
+    footer_widths[0] = 140.0;
+    footer_widths[1] = 140.0;
+    footer_heights[0] = 52.0;
+    footer_heights[1] = 52.0;
 
     flex_row(
-        buttons,
+        footer_buttons,
         footer,
-        widths,
-        heights,
+        footer_widths,
+        footer_heights,
         2,
         16.0,
         FLEX_JUSTIFY_CENTER,
         FLEX_ALIGN_CENTER
     );
-
-    menu_draw_button_at(buttons, 0, back_label_run);
-    menu_draw_button_at(buttons, 1, play_label_run);
 }
 ```
 
-`menu_draw_button_at` reads the rectangle at `index * UI_RECT_STRIDE`, derives its content box, and calls `ui_place_text_run` with center/center placement. Row distribution and content alignment therefore remain separate, composable operations.
-
-## 8. Required API Behavior
-
-Exact naming may change during implementation, but v1 must provide the following capabilities.
-
-### 8.1 Basic rectangle construction
+Content placement reads scalar values from the flex output and uses the same axis functions:
 
 ```stasis
-function ui_rect_set(
-    out_rect: f32[],
-    x: f32,
-    y: f32,
-    width: f32,
-    height: f32
-): void;
+let button_x: f32 = flex_rect_x(footer_buttons, 1);
+let button_y: f32 = flex_rect_y(footer_buttons, 1);
+let button_w: f32 = flex_rect_w(footer_buttons, 1);
+let button_h: f32 = flex_rect_h(footer_buttons, 1);
+
+let label_x: f32 = ui_place_x(
+    button_x,
+    button_w,
+    label_w,
+    UiHorizontal.Center,
+    0.0
+);
+
+let label_y: f32 = ui_place_y(
+    button_y,
+    button_h,
+    label_h,
+    UiVertical.Center,
+    1.0
+);
 ```
 
-### 8.2 Edge inset
+The new API therefore composes with the existing array-based flex implementation without requiring new rectangle arrays for individual placement.
+
+## 8. Text Model
+
+### 8.1 Width
+
+Per-frame UI should use cached runs and `gfx_measure_text_cached`. Text caching occurs during initialization or an explicit resource update, not during the rendering hot path.
+
+### 8.2 Height
+
+Until the runtime exposes ascent, descent, baseline, and measured text height, callers provide an explicit line-box height.
+
+The height represents layout space, not glyph ink bounds or a baseline coordinate.
+
+### 8.3 Optical adjustment
+
+Art-directed correction uses ordinary placement offsets. It is explicit at the call site or in a game-owned style value.
+
+### 8.4 Overflow
+
+V1 exposes enough scalar information for the caller to detect fit. It does not wrap, shrink, clip, reject, or otherwise resolve overflow.
+
+## 9. Coordinate Spaces
+
+### 9.1 Adaptive safe-area UI
+
+Adaptive menus and HUDs can read safe viewport scalars directly:
 
 ```stasis
-function ui_rect_inset_edges(
-    out_rect: f32[],
-    rect: f32[],
-    left: f32,
-    top: f32,
-    right: f32,
-    bottom: f32
-): void;
+let safe_x: f32 = gfx_safe_viewport_x().to_f32();
+let safe_y: f32 = gfx_safe_viewport_y().to_f32();
+let safe_w: f32 = gfx_safe_viewport_width().to_f32();
+let safe_h: f32 = gfx_safe_viewport_height().to_f32();
 ```
 
-Result:
+No `f32[4]` wrapper is required.
+
+### 9.2 Fixed-design canvas
+
+A game may separately calculate a fixed logical canvas scale and offset, similar to Brickout's existing play layout. The caller then passes coordinates from that chosen space into `ui_place_x` and `ui_place_y`.
+
+The axis functions do not silently choose letterboxing or convert input coordinates.
+
+### 9.3 Pixel snapping
+
+Placement remains in `f32`. Conversion or snapping occurs at the final paint boundary so nested calculations do not accumulate rounding error.
+
+## 10. Rendering and Interaction Boundaries
+
+### 10.1 Rendering
+
+Drawing consumes the calculated scalar coordinates. Placement functions emit no graphics commands.
+
+### 10.2 Hit testing
+
+Hit testing consumes the same scalar bounds used for drawing, or explicitly expanded scalar bounds for a larger touch target.
+
+V1 uses half-open bounds:
 
 ```text
-x = rect.x + left
-y = rect.y + top
-w = max(0, rect.w - left - right)
-h = max(0, rect.h - top - bottom)
+x >= left and x < left + width
+y >= top  and y < top + height
 ```
 
-In-place operation, where `out_rect` and `rect` refer to the same array, must either be supported and tested or rejected explicitly in documentation. Supporting it is preferred.
+This prevents adjacent controls from both claiming a shared edge.
 
-### 8.3 Edge expansion
+### 10.3 Interaction state
 
-```stasis
-function ui_rect_expand_edges(
-    out_rect: f32[],
-    rect: f32[],
-    left: f32,
-    top: f32,
-    right: f32,
-    bottom: f32
-): void;
-```
+V1 does not define click timing or pointer capture. A later interaction layer should use stable integer control IDs and explicitly define press, capture, release, cancellation, focus, and multi-pointer behavior.
 
-This supports touch bounds larger than paint bounds without changing the visual layout.
+## 11. Performance Requirements
 
-### 8.4 Point containment
+- Each axis function is constant time.
+- Placement performs no allocation.
+- Placement makes no host calls.
+- Cached width measurement remains the only text-width dependency.
+- Diagnostic behavior uses the same placement path.
+- JIT and AOT results are equivalent within documented floating-point tolerance.
 
-```stasis
-function ui_rect_contains(
-    rect: f32[],
-    x: f32,
-    y: f32
-): bool;
-```
+## 12. Testing Requirements
 
-Containment follows the half-open edge policy in section 6.2.
+### 12.1 Axis tests
 
-### 8.5 Child placement
+Horizontal tests cover:
 
-```stasis
-function ui_place_in_rect(
-    out_rect: f32[],
-    parent: f32[],
-    width: f32,
-    height: f32,
-    horizontal: UiHorizontal,
-    vertical: UiVertical,
-    offset_x: f32,
-    offset_y: f32
-): void;
-```
-
-Placement formula per axis:
-
-```text
-Left/Top:     parent_start
-Center:       parent_start + (parent_size - child_size) * 0.5
-Right/Bottom: parent_start + parent_size - child_size
-
-result = selected_position + offset
-```
-
-The function does not automatically clamp the child to the parent. A child larger than its parent remains aligned according to the selected rule and can be detected as overflow.
-
-### 8.6 Cached text placement
-
-```stasis
-function ui_place_text_run(
-    out_rect: f32[],
-    parent: f32[],
-    run_handle: i32,
-    line_height: f32,
-    horizontal: UiHorizontal,
-    vertical: UiVertical,
-    offset_x: f32,
-    offset_y: f32
-): bool;
-```
-
-Behavior:
-
-1. Read width with `gfx_measure_text_cached(run_handle)`.
-2. Use the explicit `line_height` as the text line-box height.
-3. Place that measured line box using `ui_place_in_rect`.
-4. Return whether the entire line box fits within the parent rectangle before offsets move it outside.
-
-The result rectangle's x and y are suitable for `draw_text_cached` because Stasis text drawing uses a top-left origin.
-
-The function does not draw, wrap, truncate, shrink, cache, or allocate text.
-
-### 8.7 Rectangle fit check
-
-The implementation must provide or internally use a deterministic whole-box containment check so non-text content can report overflow using the same policy as text.
-
-## 9. Composition with Existing Flex Layout
-
-The existing `flex_row`, `flex_column`, and `flex_grid` remain responsible for distributing sibling boxes.
-
-The placement primitive is responsible for positioning content inside each distributed box.
-
-```text
-parent box
- -> flex row/column/grid
- -> allocated child boxes
- -> inset each child box
- -> place measured content in each content box
- -> draw and hit-test from the results
-```
-
-V1 must not add a competing row, column, or grid algorithm solely to obtain anchored content placement.
-
-As part of implementation, `flex_layout.stasis` should consume the canonical rectangle module or otherwise migrate toward its constants and helpers without breaking supported samples unnecessarily.
-
-## 10. Coordinate Spaces and Viewports
-
-### 10.1 Default screen-space layout
-
-Adaptive UI should normally begin with a rectangle derived from the host safe viewport:
-
-```stasis
-gfx_safe_viewport_x()
-gfx_safe_viewport_y()
-gfx_safe_viewport_width()
-gfx_safe_viewport_height()
-```
-
-The safe-viewport helper converts these snapshot values into an `f32[4]` rectangle. It performs no additional scale or letterbox policy.
-
-### 10.2 Fixed-design canvas
-
-Games may separately fit a fixed logical canvas into a safe or full viewport while preserving aspect ratio. This policy may expose scale and offset data similar to Brickout's existing play layout.
-
-Fixed-canvas fitting is not embedded into `ui_place_in_rect`. The caller must deliberately choose and consistently use a coordinate space for layout, drawing, and input conversion.
-
-### 10.3 Pixel snapping
-
-Core layout remains in floating-point coordinates. Pixel snapping belongs at the final coordinate transform or paint boundary so repeated composition does not accumulate rounding error.
-
-## 11. Text Model
-
-### 11.1 Measurement
-
-V1 uses cached text runs for per-frame UI placement. Text runs are created during initialization or resource updates, not during the rendering hot path.
-
-### 11.2 Height
-
-Until the runtime exposes font ascent, descent, baseline, and measured height, callers supply an explicit line-box height.
-
-This height represents layout space, not glyph ink bounds and not a baseline coordinate.
-
-### 11.3 Optical adjustment
-
-Art-directed vertical adjustment is represented by ordinary `offset_y`. The core layout layer does not contain font-specific optical correction tables.
-
-Reusable game-level text styles may hold line height, color, font handle, and optical offsets, but style storage is outside the v1 geometry contract.
-
-### 11.4 Overflow
-
-V1 detects fit and returns the result to the caller. It does not decide whether the caller should:
-
-- draw overflowing content
-- substitute shorter copy
-- choose a separately cached smaller-font run
-- skip drawing
-- render debug diagnostics
-
-## 12. Rendering and Interaction Boundaries
-
-### 12.1 Rendering
-
-Painting functions receive resolved rectangles. They must not independently recalculate layout from unrelated screen constants.
-
-A button painter may:
-
-1. draw a sprite or corrected nine-slice into the button box
-2. derive a padded content box
-3. place a cached text run within that box
-4. draw at the returned x and y
-
-### 12.2 Hit testing
-
-Hit testing receives the authoritative allocated or explicitly expanded hit rectangle.
-
-V1 geometry does not define click timing, pointer capture, multi-pointer arbitration, focus, or disabled-state transitions. Those behaviors require persistent interaction identity and belong in a later interaction slice.
-
-### 12.3 Stable identity
-
-Any later immediate-mode widget behavior must use explicit stable integer IDs. Rectangle equality or call order must not be the sole persistent identity of a control.
-
-## 13. Debuggability
-
-The first implementation must make pure layout results testable without a renderer.
-
-A debug paint helper should also be provided or demonstrated that can distinguish at least:
-
-- allocated bounds
-- inset content bounds
-- expanded hit bounds
-- overflowing content
-- safe viewport bounds
-
-Debug drawing must consume computed boxes and must not change layout results.
-
-## 14. Error and Edge Policies
-
-V1 must define and test:
-
-- zero-size parent rectangles
-- zero-size children
-- children larger than parents
-- excessive inset values
-- negative offsets
-- fractional coordinates and odd sizes
-- compile-time rejection when a caller supplies a non-placement value
-- compile-time rejection when a caller swaps `UiHorizontal` and `UiVertical` arguments
-- points exactly on every edge
-- invalid or zero cached-run handles according to existing graphics runtime behavior
-
-The core API does not silently reposition overflowing children to make them fit. Overflow is data that the caller may detect and handle.
-
-## 15. Performance Requirements
-
-- Core geometry and placement perform no heap allocation.
-- Placement is constant time.
-- No host call is introduced on the per-frame layout path beyond the existing cached text width behavior. If cached width currently crosses the host boundary, a follow-up should move the width into Stasis-owned cached metadata rather than growing additional hot-path calls.
-- Row, column, and grid behavior remains bounded by explicit item counts and fixed arrays.
-- The same functions and semantics are used in diagnostic and normal builds.
-- JIT and AOT produce equivalent placement results within documented floating-point tolerance.
-
-## 16. Testing Requirements
-
-### 16.1 Pure geometry tests
-
-Tests must cover all nine combinations of horizontal and vertical placement.
-
-For each axis, verify:
-
-- start placement
-- center placement with even and odd dimensions
-- end placement
+- left, center, and right placement
 - positive and negative offsets
-- a child larger than its parent
+- zero-size parent and child
+- child larger than parent
+- fractional values and odd sizes
 
-### 16.2 Rectangle operation tests
+Vertical tests cover the equivalent top, center, and bottom behavior.
 
-Tests must cover:
+### 12.2 Type-safety tests
 
-- symmetric and asymmetric inset
-- inset larger than available size
-- expansion
-- in-place inset if supported
-- half-open containment on all four edges
-- adjacent boxes sharing an edge
+Compiler tests verify that:
 
-### 16.3 Text tests
+- `UiHorizontal` is accepted by `ui_place_x`
+- `UiVertical` is accepted by `ui_place_y`
+- arbitrary `i32` values are rejected
+- passing `UiVertical` to `ui_place_x` is rejected
+- passing `UiHorizontal` to `ui_place_y` is rejected
 
-Tests must cover:
+### 12.3 Placement invariants
 
-- short cached run that fits
-- exact-width fit
-- width overflow
-- line-height overflow
-- horizontal centering invariant
-- vertical line-box centering invariant
-- optical adjustment through offsets
-
-Representative invariants include:
+Representative assertions include:
 
 ```text
-child_center_x == parent_center_x + offset_x
-child_center_y == parent_center_y + offset_y
-end_child_right == parent_right + offset_x
+centered_child_center == parent_center + offset
+right_child_edge == parent_right + offset_x
+bottom_child_edge == parent_bottom + offset_y
 ```
 
-### 16.4 Composition tests
+### 12.4 Realistic composition
 
-At least one test must:
+At least one test or sample must:
 
-1. allocate multiple boxes using the existing flex row or column path
-2. place content within each allocated box
-3. verify the computed content and hit bounds
+1. read or define scalar parent bounds
+2. measure a cached text run or use an explicit test width
+3. center text horizontally
+4. place a button at top-left with offsets
+5. center a label inside that button
+6. verify the calculated values
 
-### 16.5 End-to-end compiler gate
+### 12.5 End-to-end compiler gate
 
-The slice must include at least one representative `.stasis` sample or test program that:
+The completed implementation slice must include a representative `.stasis` program that reaches Cranelift IR, builds into an executable, runs, and verifies behavior with assertions.
 
-1. imports the shared layout modules
-2. computes a safe or fixed parent box
-3. uses flex and anchored placement
-4. reaches Cranelift IR
-5. is built into an executable
-6. runs with asserted placement behavior
+All test commands remain bounded to 300 seconds, with lingering processes checked after each run.
 
-All test commands must remain bounded to 300 seconds, with lingering test/compiler processes checked after each run.
+## 13. Delivery Plan
 
-## 17. Recommended Delivery Slices
+### Slice 1: Typed scalar axis placement
 
-### Slice 1: Canonical geometry
+- add `UiHorizontal` and `UiVertical`
+- add `ui_place_x` and `ui_place_y`
+- add deterministic axis and type-safety tests
+- run an end-to-end executable fixture
 
-- introduce the shared rectangle constants and helpers
-- add inset, expansion, containment, and fit behavior
-- add deterministic Stasis tests
-- migrate only the minimum existing code needed to validate reuse
+### Slice 2: One real menu adoption
 
-### Slice 2: Anchored placement
+- replace one menu title's manual centering calculation
+- anchor one button using the shared axis functions
+- center one cached label inside that button
+- use the same button bounds for drawing and hit testing
+- add visual or command-buffer verification where practical
 
-- add independent-axis placement
-- cover all nine placement combinations
-- verify overflow and offset behavior
-- compose placement with an existing flex row or column
+No further abstraction is required before these two slices prove the API.
 
-### Slice 3: Cached text line boxes
-
-- add cached-run placement using explicit line height
-- return fit status
-- replace one real screen's hardcoded text-start calculation
-- visually verify debug bounds and text positioning
-
-### Slice 4: Paint integration
-
-- update one sprite-backed or nine-slice button path to consume resolved boxes
-- correct undersized nine-slice behavior before treating it as a shared primitive
-- derive paint, content, and hit bounds from one allocated button box
-
-Interaction identity and pointer capture should be proposed as a separate PRD or follow-up slice after the geometry proves useful on real screens.
-
-## 18. Acceptance Criteria
+## 14. Acceptance Criteria
 
 V1 is complete when:
 
-1. One canonical rectangle representation is used by the new shared APIs.
-2. A caller can place a known-size child in any of nine parent positions with explicit offsets.
-3. A caller can obtain correct top-left coordinates for a cached text run using measured width and explicit line height.
-4. Layout functions emit no drawing commands and retain no component state.
-5. Existing flex output can be used directly as placement input.
-6. Insets and expansions allow content and hit bounds to derive from one allocated box.
-7. Overflow is detectable and does not silently change placement.
-8. Safe screen-space layout does not implicitly force fixed-design scaling.
-9. Tests establish half-open edge behavior and all placement invariants.
-10. One representative UI path compiles and runs end to end through Cranelift with asserted results.
-11. Debug output can display the authoritative allocated and derived boxes.
-12. Touched code passes a simplicity review and leaves no duplicate or obsolete rectangle helpers without an explicit migration reason.
-13. Placement parameters use distinct `UiHorizontal` and `UiVertical` enums end to end, with explicit conversion only at a demonstrated integer ABI boundary.
+1. `ui_place_x` returns correct left, center, and right positions.
+2. `ui_place_y` returns correct top, center, and bottom positions.
+3. Horizontal and vertical choices use distinct enum types end to end.
+4. Offsets always use screen-coordinate signs.
+5. Oversized children follow the documented alignment formulas without implicit clamping.
+6. Realistic examples use supported scalar locals and returns.
+7. No v1 example or API requires function-local fixed arrays or local struct materialization.
+8. Cached text width and explicit line height are sufficient to calculate draw origins.
+9. Existing flex arrays can feed scalar placement without changing their storage model.
+10. One real menu title, button, and centered button label demonstrate the API.
+11. Drawing and hit testing reuse the same scalar button bounds.
+12. Tests execute the representative path through Cranelift and verify results.
 
-## 19. Future Extensions
+## 15. Deferred Extensions
 
-Potential follow-up work includes:
+Add later only when a demonstrated caller requires them:
 
-- parent-anchor to child-anchor attachment for tooltips, badges, and world labels
-- fixed/fill/weight size resolution before flex placement
+- a first-class `UiRect` value after local struct values and ergonomic struct returns are implemented
+- rectangle inset and expansion helpers over a supported value model
+- a combined nine-position anchor for stored configuration
+- parent-anchor to child-anchor attachment for tooltips and badges
+- fixed/fill/weight size resolution
 - multiline text metrics and wrapping
 - clipping and scroll containers
 - stable-ID interaction state with pointer capture
 - focus navigation and accessibility metadata
-- reusable style tables after multiple screens establish stable needs
-- richer overflow diagnostics
-- baseline-aware text placement when runtime font metrics are available
 
-Each extension should remain a deterministic transformation or explicit persistent behavior layer. It must not require a parallel retained rendering pipeline.
+The scalar axis functions remain useful beneath these extensions.
 
-## 20. Theory of Operation
+## 16. Theory of Operation
 
 ### Mapping
 
-Real UI composition is represented as nested available rectangles. Layout transforms a parent rectangle and explicit placement inputs into child rectangles. Rendering projects those rectangles into graphics commands, while input compares pointer snapshots against the same geometry.
+The real behavior being represented is one-dimensional placement: choose where a child of known size begins within an available span. Two independent applications of that rule produce a two-dimensional draw origin.
 
-The model deliberately excludes semantic component trees, event dispatch ownership, and automatic reflow policy.
+Text width comes from cached measurement, text height from an explicit line box, and button or sprite sizes from game-owned values. Drawing and input consume the resulting scalar bounds.
 
 ### Rationale
 
-Stasis already renders immediately from current state into command buffers and uses fixed arrays across compiler backends. Plain rectangle transforms match that execution model, remain inspectable, and compose with the existing flex helpers.
+Stasis currently supports scalar locals and returns cleanly, while `Type[]` is a view over existing fixed storage rather than local temporary array construction. A scalar-return API expresses the needed calculation without pretending that local rectangle values are available.
 
-The nearest tempting alternative is a retained component hierarchy with automatic measurement and callbacks. That would introduce hidden lifecycle, identity, allocation, and compiler-surface requirements before the underlying placement needs are proven.
+The nearest tempting alternative is an output `f32[]` rectangle API. Although array views are supported, that design requires pre-existing storage and makes a simple calculation appear to create a local rectangle. It also encourages unnecessary global scratch layout state.
 
 ### Extension point
 
-A future layout behavior should fit as either:
-
-- a pure transformation that produces rectangles from rectangles and explicit size rules, or
-- an explicit persistent interaction structure keyed by stable IDs
-
-For example, a tooltip can add parent-anchor to child-anchor attachment without changing rendering ownership or creating a UI tree.
+A future rectangle type can call the same axis functions internally. Existing flex output can already expose scalar x, y, width, and height through its accessors and feed them into the axis functions.
 
 ### Prediction
 
-If the model is sound, adding a new container such as an equal-cell toolbar will require only a deterministic box-allocation function. Existing text placement, painting, hit testing, and debug visualization will consume its output unchanged.
+If this model is sufficient, menu titles, button labels, corner icons, HUD counters, and content inside flex-generated boxes will share `ui_place_x` and `ui_place_y` without needing a general rectangle framework. A request for rectangle values should arise only when multiple downstream consumers genuinely need to pass or store the complete box as one value.

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -21,6 +21,8 @@ This design matches the Stasis language surface implemented today. It uses ordin
 
 `f32` is the canonical type for presentation geometry across the proposed public path. Positions, sizes, padding, pointer coordinates, text measurement, flex results, and sprite geometry remain `f32` until a platform renderer explicitly rasterizes them.
 
+Stasis is a pre-1.0 language. This work chooses a clear canonical API and removes superseded compatibility aliases in the same change. It does not preserve ambiguous names, duplicate wrappers, deprecated stubs, or old HostFrame fields solely for source or ABI compatibility.
+
 ## 2. Problem
 
 Stasis games currently repeat placement calculations such as:
@@ -51,6 +53,7 @@ V1 must:
 10. Produce deterministic JIT and AOT behavior.
 11. Remove avoidable `i32`/`f32` conversions from the public presentation path.
 12. Expose layout-facing viewport and sprite geometry as `f32`, updating host/runtime definitions where required.
+13. Remove ambiguous pre-1.0 display and input compatibility APIs in favor of explicit logical-coordinate and physical-pixel APIs.
 
 ## 4. Non-Goals
 
@@ -175,6 +178,57 @@ function gfx_draw_sprite(
 Sprite handles, rotation policy, and alpha remain unchanged. The graphics command-buffer version and host decoder must change together so sprite geometry is carried in the floating-point command stream or an equivalently typed representation.
 
 Rounding and rasterization then occur in one platform rendering layer. Stasis layout and widget code do not choose an integer rounding policy independently.
+
+### 5.9 Pre-1.0 API replacement policy
+
+This is an intentional breaking cleanup. The implementation must remove, not deprecate, compatibility APIs whose names obscure coordinate semantics.
+
+Remove:
+
+```stasis
+gfx_window_width()
+gfx_window_height()
+
+input_viewport_x_px()
+input_viewport_y_px()
+input_viewport_w_px()
+input_viewport_h_px()
+
+input_pointer_x_px(index)
+input_pointer_y_px(index)
+input_pointer_dx_px(index)
+input_pointer_dy_px(index)
+```
+
+The `gfx_window_*` functions are compatibility aliases for logical canvas size. The `input_viewport_*` family is an older ambiguous surface and is not needed by the new layout contract. Pointer values are logical coordinates, so names ending in `_px` incorrectly suggest native or drawable pixels.
+
+Use the canonical replacements:
+
+```stasis
+gfx_logical_width(): f32
+gfx_logical_height(): f32
+
+gfx_safe_viewport_x(): f32
+gfx_safe_viewport_y(): f32
+gfx_safe_viewport_width(): f32
+gfx_safe_viewport_height(): f32
+
+input_pointer_x_logical(index): f32
+input_pointer_y_logical(index): f32
+input_pointer_dx_logical(index): f32
+input_pointer_dy_logical(index): f32
+```
+
+Normalized pointer accessors may retain their explicit `_n` names. Native and drawable queries use names ending in `_px` and return integer physical pixel counts:
+
+```stasis
+gfx_native_width_px(): i32
+gfx_native_height_px(): i32
+gfx_drawable_width_px(): i32
+gfx_drawable_height_px(): i32
+```
+
+The HostFrame version must be bumped. Compatibility fields such as `HOST_I_WINDOW_*` and `HOST_I_VIEWPORT_*` must be removed from the active contract rather than populated indefinitely as aliases. All hosts, fixtures, generated bindings, and consumers migrate atomically. Removed source APIs fail with normal deterministic unknown-function diagnostics; no compatibility implementation remains.
 
 ## 6. Required API
 
@@ -443,8 +497,8 @@ let hit_h: f32 = button_h + hit_pad * 2.0;
 
 if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
     let clicked: bool = ui_point_in_box(
-        input_pointer_x_px(0),
-        input_pointer_y_px(0),
+        input_pointer_x_logical(0),
+        input_pointer_y_logical(0),
         hit_x,
         hit_y,
         hit_w,
@@ -561,11 +615,9 @@ let safe_h: f32 = gfx_safe_viewport_height();
 
 These public layout-facing functions return `f32`. A raw host snapshot may still store safe viewport values as `i32`; the wrapper owns that one boundary conversion. No `f32[4]` wrapper is required.
 
-Window and logical presentation dimensions follow the same public rule:
+Logical presentation dimensions use one canonical public API:
 
 ```stasis
-function gfx_window_width(): f32;
-function gfx_window_height(): f32;
 function gfx_logical_width(): f32;
 function gfx_logical_height(): f32;
 function gfx_safe_viewport_x(): f32;
@@ -574,18 +626,9 @@ function gfx_safe_viewport_width(): f32;
 function gfx_safe_viewport_height(): f32;
 ```
 
-Window creation and resize requests may continue accepting `i32` because they request discrete host pixels. Screen, native, and drawable queries may also retain explicitly named raw integer forms for platform integration. The public functions used as layout inputs return `f32`.
+Window creation and resize requests may continue accepting integer logical dimensions because they establish a discrete requested canvas configuration. Native and drawable pixel counts use the explicit `_px` integer APIs defined in section 5.9. They are not used directly as layout coordinates.
 
-Layout-facing input viewport accessors follow the same rule:
-
-```stasis
-function input_viewport_x_px(): f32;
-function input_viewport_y_px(): f32;
-function input_viewport_w_px(): f32;
-function input_viewport_h_px(): f32;
-```
-
-Native and drawable pixel counts may retain explicit integer APIs when callers genuinely need discrete device pixels. They are not used directly as layout coordinates without conversion through a layout-facing boundary.
+There is no new `input_viewport_*` layout API. Safe-area layout uses `gfx_safe_viewport_*`, full-canvas layout uses `gfx_logical_*`, and hit testing uses the logical pointer accessors. Each name identifies its coordinate space.
 
 ### 9.2 Fixed-design canvas
 
@@ -681,12 +724,15 @@ At least one test or sample must:
 
 Tests must verify that:
 
-- layout-facing safe and input viewport accessors return `f32`
+- logical canvas and safe viewport accessors return `f32`
+- removed compatibility display and input APIs are absent from the stdlib surface
+- canonical logical pointer accessors return `f32` in the same coordinate space as logical and safe layout bounds
 - pointer, text, line, flex, placement, and sprite geometry share the `f32` presentation path
 - sprite command encoding and host decoding agree on the new geometry representation
 - fractional sprite positions and sizes survive command submission until renderer rasterization
 - odd and adjacent sprite bounds follow the documented backend snapping policy without gaps introduced by independent truncation
-- legacy callers receive a deterministic migration diagnostic or are updated in the same checklist-selected migration group
+- all repository callers are migrated in the same checklist-selected group; removed external source calls receive deterministic unknown-function diagnostics
+- the HostFrame version is bumped and active hosts no longer populate compatibility window or viewport alias fields
 
 ### 12.6 End-to-end compiler gate
 
@@ -700,9 +746,12 @@ All test commands remain bounded to 300 seconds, with lingering processes checke
 
 ### Float presentation boundary
 
-- expose safe and input viewport geometry as `f32` to Stasis layout callers
+- expose logical canvas and safe viewport geometry as `f32` to Stasis layout callers
+- replace `_px` pointer compatibility names with explicit logical-coordinate accessors
+- remove `gfx_window_*`, `input_viewport_*`, and superseded HostFrame alias fields
+- rename native and drawable queries with explicit `_px` suffixes
+- bump HostFrame and command-buffer versions and migrate every host and fixture atomically
 - migrate sprite x/y/width/height parameters and command storage to `f32`
-- update the graphics command-buffer version and every host decoder together
 - update existing sprite callers and parity fixtures
 - verify fractional geometry through a real renderer path
 
@@ -739,10 +788,14 @@ V1 is complete when:
 10. One real menu title, button, and centered button label demonstrate the API.
 11. Drawing and hit testing reuse the same scalar button bounds.
 12. Tests execute the representative path through Cranelift and verify results.
-13. Layout-facing safe and input viewport accessors return `f32` without caller-side conversion.
+13. Canonical logical and safe viewport accessors return `f32` without caller-side conversion.
 14. Sprite x/y/width/height remain `f32` through Stasis command submission.
 15. The graphics command-buffer version and all host decoders agree on the migrated sprite representation.
 16. Raw physical pixel counts, handles, counts, and indices remain `i32` where integer semantics are intrinsic.
+17. `gfx_window_*`, `input_viewport_*`, and logical pointer APIs ending in `_px` are removed rather than deprecated.
+18. Canonical logical pointer accessors share the coordinate space used by `gfx_logical_*` and `gfx_safe_viewport_*`.
+19. Native and drawable integer queries use explicit `_px` names.
+20. The bumped HostFrame contract contains no active compatibility aliases for removed window or viewport fields.
 
 ## 15. Deferred Extensions
 

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -14,13 +14,12 @@ The v1 system is deliberately scalar. Each placement function receives:
 - the parent size
 - the child size
 - a strongly typed placement choice
-- an explicit offset
 
 It returns one `f32` coordinate. The caller uses those returned coordinates for text, sprites, buttons, hit testing, or as inputs to another layout calculation.
 
 This design matches the Stasis language surface implemented today. It uses ordinary scalar locals and scalar returns. It does not require function-local arrays, local struct materialization, array returns, hidden allocation, or a retained UI tree.
 
-`f32` is the canonical type for presentation geometry across the proposed public path. Positions, sizes, offsets, pointer coordinates, text measurement, flex results, and sprite geometry remain `f32` until a platform renderer explicitly rasterizes them.
+`f32` is the canonical type for presentation geometry across the proposed public path. Positions, sizes, padding, pointer coordinates, text measurement, flex results, and sprite geometry remain `f32` until a platform renderer explicitly rasterizes them.
 
 ## 2. Problem
 
@@ -43,7 +42,7 @@ V1 must:
 1. Calculate a child x coordinate from horizontal placement inputs.
 2. Calculate a child y coordinate from vertical placement inputs.
 3. Use different enum types for horizontal and vertical placement.
-4. Use ordinary screen-coordinate offset signs.
+4. Express margins and padding by adjusting the available region before placement.
 5. Work entirely with supported scalar parameters, locals, and returns.
 6. Support cached text placement using existing cached width measurement and explicit line height.
 7. Support buttons, icons, HUD labels, menu titles, and similar immediate-mode drawing.
@@ -101,16 +100,23 @@ enum UiVertical {
 
 The implementation compares enum members directly. It does not convert them to `i32` unless an actual integer ABI boundary requires it, in which case it uses explicit `enum_to_i32` conversion.
 
-### 5.3 Offsets have one meaning
+### 5.3 The available region owns margins and padding
 
-Offsets are added after alignment:
+Placement functions do not accept an offset. Callers express margins and padding by deriving the region in which content is allowed to appear:
 
-- positive x moves right
-- negative x moves left
-- positive y moves down
-- negative y moves up
+```stasis
+let content_x: f32 = parent_x + left_padding;
+let content_width: f32 = parent_width - left_padding - right_padding;
+```
 
-A button aligned to `UiHorizontal.Right` with `offset_x = -20.0` sits 20 units left of the parent's right edge.
+Alignment then has one stable meaning within that adjusted region. This avoids negative right/bottom offsets and avoids an ambiguous direction for center offsets.
+
+An art-directed visual nudge is a separate operation applied explicitly after placement:
+
+```stasis
+let label_y: f32 = ui_place_y(content_y, content_h, label_h, UiVertical.Center);
+label_y += label_optical_y;
+```
 
 ### 5.4 Layout is pure calculation
 
@@ -139,7 +145,7 @@ The canonical public presentation types are:
 |---|---|
 | Layout x/y | `f32` |
 | Layout width/height | `f32` |
-| Layout offsets and padding | `f32` |
+| Layout margins, padding, and optical nudges | `f32` |
 | Pointer x/y used for hit testing | `f32` |
 | Measured text width and line-box height | `f32` |
 | Line endpoints | `f32` |
@@ -179,8 +185,7 @@ function ui_place_x(
     parent_x: f32,
     parent_width: f32,
     child_width: f32,
-    horizontal: UiHorizontal,
-    offset_x: f32
+    horizontal: UiHorizontal
 ): f32;
 ```
 
@@ -190,8 +195,6 @@ Behavior:
 Left:   parent_x
 Center: parent_x + (parent_width - child_width) * 0.5
 Right:  parent_x + parent_width - child_width
-
-result = aligned_x + offset_x
 ```
 
 ### 6.2 Vertical placement
@@ -201,8 +204,7 @@ function ui_place_y(
     parent_y: f32,
     parent_height: f32,
     child_height: f32,
-    vertical: UiVertical,
-    offset_y: f32
+    vertical: UiVertical
 ): f32;
 ```
 
@@ -212,8 +214,6 @@ Behavior:
 Top:    parent_y
 Center: parent_y + (parent_height - child_height) * 0.5
 Bottom: parent_y + parent_height - child_height
-
-result = aligned_y + offset_y
 ```
 
 ### 6.3 Oversized children
@@ -267,16 +267,16 @@ function menu_draw_title(): void {
         safe_x,
         safe_w,
         title_w,
-        UiHorizontal.Center,
-        0.0
+        UiHorizontal.Center
     );
 
+    let title_area_y: f32 = safe_y + 24.0;
+    let title_area_h: f32 = 96.0 - 24.0;
     let title_y: f32 = ui_place_y(
-        safe_y,
-        96.0,
+        title_area_y,
+        title_area_h,
         title_h,
-        UiVertical.Top,
-        24.0
+        UiVertical.Top
     );
 
     draw_text_cached(
@@ -294,7 +294,7 @@ function menu_draw_title(): void {
 
 The caller never manually calculates the centered x coordinate.
 
-### 7.3 Button anchored top-left with offsets
+### 7.3 Button anchored top-left within an adjusted region
 
 This creates scalar button bounds 20 units from the safe viewport's left edge and 140 units below its top edge.
 
@@ -308,20 +308,23 @@ function menu_draw_play_button(): void {
     let button_w: f32 = 180.0;
     let button_h: f32 = 56.0;
 
+    let button_area_x: f32 = safe_x + 20.0;
+    let button_area_y: f32 = safe_y + 140.0;
+    let button_area_w: f32 = safe_w - 20.0;
+    let button_area_h: f32 = safe_h - 140.0;
+
     let button_x: f32 = ui_place_x(
-        safe_x,
-        safe_w,
+        button_area_x,
+        button_area_w,
         button_w,
-        UiHorizontal.Left,
-        20.0
+        UiHorizontal.Left
     );
 
     let button_y: f32 = ui_place_y(
-        safe_y,
-        safe_h,
+        button_area_y,
+        button_area_h,
         button_h,
-        UiVertical.Top,
-        140.0
+        UiVertical.Top
     );
 
     gfx_draw_sprite(
@@ -336,15 +339,17 @@ function menu_draw_play_button(): void {
 }
 ```
 
-The same button anchored top-right uses:
+For a 20-unit margin on both horizontal edges, define the available region once and select either edge:
 
 ```stasis
+let button_area_x: f32 = safe_x + 20.0;
+let button_area_w: f32 = safe_w - 40.0;
+
 let button_x: f32 = ui_place_x(
-    safe_x,
-    safe_w,
+    button_area_x,
+    button_area_w,
     button_w,
-    UiHorizontal.Right,
-    -20.0
+    UiHorizontal.Right
 );
 ```
 
@@ -367,17 +372,16 @@ let label_x: f32 = ui_place_x(
     content_x,
     content_w,
     label_w,
-    UiHorizontal.Center,
-    0.0
+    UiHorizontal.Center
 );
 
 let label_y: f32 = ui_place_y(
     content_y,
     content_h,
     label_h,
-    UiVertical.Center,
-    1.0
+    UiVertical.Center
 );
+label_y += 1.0;
 
 draw_text_cached(
     ui_font,
@@ -391,7 +395,7 @@ draw_text_cached(
 );
 ```
 
-The one-unit y offset is an explicit optical correction. The shared placement function does not hide font- or button-specific heuristics.
+The one-unit y change is an explicit optical nudge after placement. The available region still represents button padding, and the shared placement function does not hide font- or button-specific heuristics.
 
 ### 7.5 Fit detection with scalars
 
@@ -492,17 +496,16 @@ let label_x: f32 = ui_place_x(
     button_x,
     button_w,
     label_w,
-    UiHorizontal.Center,
-    0.0
+    UiHorizontal.Center
 );
 
 let label_y: f32 = ui_place_y(
     button_y,
     button_h,
     label_h,
-    UiVertical.Center,
-    1.0
+    UiVertical.Center
 );
+label_y += 1.0;
 ```
 
 The new API therefore composes with the existing array-based flex implementation without requiring new rectangle arrays for individual placement.
@@ -521,7 +524,7 @@ The height represents layout space, not glyph ink bounds or a baseline coordinat
 
 ### 8.3 Optical adjustment
 
-Art-directed correction uses ordinary placement offsets. It is explicit at the call site or in a game-owned style value.
+Art-directed correction is applied explicitly after placement as a signed nudge at the call site or from a game-owned style value. It is not part of the placement API.
 
 ### 8.4 Overflow
 
@@ -621,7 +624,6 @@ V1 does not define click timing or pointer capture. A later interaction layer sh
 Horizontal tests cover:
 
 - left, center, and right placement
-- positive and negative offsets
 - zero-size parent and child
 - child larger than parent
 - fractional values and odd sizes
@@ -643,9 +645,9 @@ Compiler tests verify that:
 Representative assertions include:
 
 ```text
-centered_child_center == parent_center + offset
-right_child_edge == parent_right + offset_x
-bottom_child_edge == parent_bottom + offset_y
+centered_child_center == parent_center
+right_child_edge == parent_right
+bottom_child_edge == parent_bottom
 ```
 
 ### 12.4 Realistic composition
@@ -655,7 +657,7 @@ At least one test or sample must:
 1. read or define scalar parent bounds
 2. measure a cached text run or use an explicit test width
 3. center text horizontally
-4. place a button at top-left with offsets
+4. derive an inset available region and place a button at its top-left
 5. center a label inside that button
 6. verify the calculated values
 
@@ -710,7 +712,7 @@ V1 is complete when:
 1. `ui_place_x` returns correct left, center, and right positions.
 2. `ui_place_y` returns correct top, center, and bottom positions.
 3. Horizontal and vertical choices use distinct enum types end to end.
-4. Offsets always use screen-coordinate signs.
+4. Margins and padding adjust the available region before placement; placement accepts no offset.
 5. Oversized children follow the documented alignment formulas without implicit clamping.
 6. Realistic examples use supported scalar locals and returns.
 7. No v1 example or API requires function-local fixed arrays or local struct materialization.

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -20,6 +20,8 @@ It returns one `f32` coordinate. The caller uses those returned coordinates for 
 
 This design matches the Stasis language surface implemented today. It uses ordinary scalar locals and scalar returns. It does not require function-local arrays, local struct materialization, array returns, hidden allocation, or a retained UI tree.
 
+`f32` is the canonical type for presentation geometry across the proposed public path. Positions, sizes, offsets, pointer coordinates, text measurement, flex results, and sprite geometry remain `f32` until a platform renderer explicitly rasterizes them.
+
 ## 2. Problem
 
 Stasis games currently repeat placement calculations such as:
@@ -48,6 +50,8 @@ V1 must:
 8. Compose with existing flex rows, columns, and grids without replacing them.
 9. Perform no allocation and no host-side UI registration.
 10. Produce deterministic JIT and AOT behavior.
+11. Remove avoidable `i32`/`f32` conversions from the public presentation path.
+12. Expose layout-facing viewport and sprite geometry as `f32`, updating host/runtime definitions where required.
 
 ## 4. Non-Goals
 
@@ -67,6 +71,7 @@ V1 does not provide:
 - automatic overflow resolution
 - style ownership
 - animation ownership
+- replacing integer handles, counts, indices, enum representations, or physical device metadata with floats
 
 Flat arrays remain valid for existing global-backed bulk layout storage, such as the outputs consumed by `flex_row`. They are not required by the v1 single-item placement API.
 
@@ -125,6 +130,45 @@ let rect: f32[4];
 ```
 
 `Type[]` parameters are supported Stasis views, but this placement API does not need them.
+
+### 5.7 Presentation geometry uses `f32`
+
+The canonical public presentation types are:
+
+| Value | Type |
+|---|---|
+| Layout x/y | `f32` |
+| Layout width/height | `f32` |
+| Layout offsets and padding | `f32` |
+| Pointer x/y used for hit testing | `f32` |
+| Measured text width and line-box height | `f32` |
+| Line endpoints | `f32` |
+| Sprite x/y/width/height | `f32` |
+| Resource handles | `i32` |
+| Counts and array indices | `i32` |
+| Physical pixel counts retained only as host metadata | `i32` |
+
+Raw platform dimensions may originate as integers because physical pixels are discrete. The host snapshot may continue storing those raw values as `i32`. The layout-facing Stasis API converts them once and exposes `f32`; callers must not repeat that conversion at every use.
+
+### 5.8 Sprite geometry remains floating point through submission
+
+The current sprite API and command stream use `i32` geometry. The implementation associated with this PRD should migrate sprite x, y, width, and height to `f32` rather than hiding four conversions inside a convenience wrapper:
+
+```stasis
+function gfx_draw_sprite(
+    handle: i32,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    rot_deg: i32,
+    alpha: i32
+): void;
+```
+
+Sprite handles, rotation policy, and alpha remain unchanged. The graphics command-buffer version and host decoder must change together so sprite geometry is carried in the floating-point command stream or an equivalently typed representation.
+
+Rounding and rasterization then occur in one platform rendering layer. Stasis layout and widget code do not choose an integer rounding policy independently.
 
 ## 6. Required API
 
@@ -212,9 +256,9 @@ The title is centered within the safe viewport and placed 24 units below its top
 
 ```stasis
 function menu_draw_title(): void {
-    let safe_x: f32 = gfx_safe_viewport_x().to_f32();
-    let safe_y: f32 = gfx_safe_viewport_y().to_f32();
-    let safe_w: f32 = gfx_safe_viewport_width().to_f32();
+    let safe_x: f32 = gfx_safe_viewport_x();
+    let safe_y: f32 = gfx_safe_viewport_y();
+    let safe_w: f32 = gfx_safe_viewport_width();
 
     let title_w: f32 = gfx_measure_text_cached(menu_title_run);
     let title_h: f32 = 32.0;
@@ -256,10 +300,10 @@ This creates scalar button bounds 20 units from the safe viewport's left edge an
 
 ```stasis
 function menu_draw_play_button(): void {
-    let safe_x: f32 = gfx_safe_viewport_x().to_f32();
-    let safe_y: f32 = gfx_safe_viewport_y().to_f32();
-    let safe_w: f32 = gfx_safe_viewport_width().to_f32();
-    let safe_h: f32 = gfx_safe_viewport_height().to_f32();
+    let safe_x: f32 = gfx_safe_viewport_x();
+    let safe_y: f32 = gfx_safe_viewport_y();
+    let safe_w: f32 = gfx_safe_viewport_width();
+    let safe_h: f32 = gfx_safe_viewport_height();
 
     let button_w: f32 = 180.0;
     let button_h: f32 = 56.0;
@@ -282,10 +326,10 @@ function menu_draw_play_button(): void {
 
     gfx_draw_sprite(
         button_sprite,
-        button_x.to_i32(),
-        button_y.to_i32(),
-        button_w.to_i32(),
-        button_h.to_i32(),
+        button_x,
+        button_y,
+        button_w,
+        button_h,
         0,
         255
     );
@@ -490,13 +534,39 @@ V1 exposes enough scalar information for the caller to detect fit. It does not w
 Adaptive menus and HUDs can read safe viewport scalars directly:
 
 ```stasis
-let safe_x: f32 = gfx_safe_viewport_x().to_f32();
-let safe_y: f32 = gfx_safe_viewport_y().to_f32();
-let safe_w: f32 = gfx_safe_viewport_width().to_f32();
-let safe_h: f32 = gfx_safe_viewport_height().to_f32();
+let safe_x: f32 = gfx_safe_viewport_x();
+let safe_y: f32 = gfx_safe_viewport_y();
+let safe_w: f32 = gfx_safe_viewport_width();
+let safe_h: f32 = gfx_safe_viewport_height();
 ```
 
-No `f32[4]` wrapper is required.
+These public layout-facing functions return `f32`. A raw host snapshot may still store safe viewport values as `i32`; the wrapper owns that one boundary conversion. No `f32[4]` wrapper is required.
+
+Window and logical presentation dimensions follow the same public rule:
+
+```stasis
+function gfx_window_width(): f32;
+function gfx_window_height(): f32;
+function gfx_logical_width(): f32;
+function gfx_logical_height(): f32;
+function gfx_safe_viewport_x(): f32;
+function gfx_safe_viewport_y(): f32;
+function gfx_safe_viewport_width(): f32;
+function gfx_safe_viewport_height(): f32;
+```
+
+Window creation and resize requests may continue accepting `i32` because they request discrete host pixels. Screen, native, and drawable queries may also retain explicitly named raw integer forms for platform integration. The public functions used as layout inputs return `f32`.
+
+Layout-facing input viewport accessors follow the same rule:
+
+```stasis
+function input_viewport_x_px(): f32;
+function input_viewport_y_px(): f32;
+function input_viewport_w_px(): f32;
+function input_viewport_h_px(): f32;
+```
+
+Native and drawable pixel counts may retain explicit integer APIs when callers genuinely need discrete device pixels. They are not used directly as layout coordinates without conversion through a layout-facing boundary.
 
 ### 9.2 Fixed-design canvas
 
@@ -506,7 +576,9 @@ The axis functions do not silently choose letterboxing or convert input coordina
 
 ### 9.3 Pixel snapping
 
-Placement remains in `f32`. Conversion or snapping occurs at the final paint boundary so nested calculations do not accumulate rounding error.
+Placement and graphics submission remain in `f32`. Conversion or snapping occurs inside the platform renderer at rasterization so nested calculations and Stasis command construction do not accumulate rounding error.
+
+If a backend requires integer raster bounds, it must use one documented edge-based policy. It should derive width from snapped right and left edges rather than independently truncating x and width, which can introduce seams.
 
 ## 10. Rendering and Interaction Boundaries
 
@@ -537,6 +609,8 @@ V1 does not define click timing or pointer capture. A later interaction layer sh
 - Placement performs no allocation.
 - Placement makes no host calls.
 - Cached width measurement remains the only text-width dependency.
+- Viewport integers are converted to `f32` once at the host/stdlib boundary, not once per caller.
+- Sprite submission does not convert x, y, width, or height back to `i32` in Stasis code.
 - Diagnostic behavior uses the same placement path.
 - JIT and AOT results are equivalent within documented floating-point tolerance.
 
@@ -585,7 +659,18 @@ At least one test or sample must:
 5. center a label inside that button
 6. verify the calculated values
 
-### 12.5 End-to-end compiler gate
+### 12.5 Graphics boundary tests
+
+Tests must verify that:
+
+- layout-facing safe and input viewport accessors return `f32`
+- pointer, text, line, flex, placement, and sprite geometry share the `f32` presentation path
+- sprite command encoding and host decoding agree on the new geometry representation
+- fractional sprite positions and sizes survive command submission until renderer rasterization
+- odd and adjacent sprite bounds follow the documented backend snapping policy without gaps introduced by independent truncation
+- legacy callers receive a deterministic migration diagnostic or are updated in the same slice
+
+### 12.6 End-to-end compiler gate
 
 The completed implementation slice must include a representative `.stasis` program that reaches Cranelift IR, builds into an executable, runs, and verifies behavior with assertions.
 
@@ -593,14 +678,22 @@ All test commands remain bounded to 300 seconds, with lingering processes checke
 
 ## 13. Delivery Plan
 
-### Slice 1: Typed scalar axis placement
+### Slice 1: Float presentation boundary
+
+- expose safe and input viewport geometry as `f32` to Stasis layout callers
+- migrate sprite x/y/width/height parameters and command storage to `f32`
+- update the graphics command-buffer version and every host decoder together
+- update existing sprite callers and parity fixtures
+- verify fractional geometry through a real renderer path
+
+### Slice 2: Typed scalar axis placement
 
 - add `UiHorizontal` and `UiVertical`
 - add `ui_place_x` and `ui_place_y`
 - add deterministic axis and type-safety tests
 - run an end-to-end executable fixture
 
-### Slice 2: One real menu adoption
+### Slice 3: One real menu adoption
 
 - replace one menu title's manual centering calculation
 - anchor one button using the shared axis functions
@@ -608,7 +701,7 @@ All test commands remain bounded to 300 seconds, with lingering processes checke
 - use the same button bounds for drawing and hit testing
 - add visual or command-buffer verification where practical
 
-No further abstraction is required before these two slices prove the API.
+No further layout abstraction is required before these slices prove the API.
 
 ## 14. Acceptance Criteria
 
@@ -626,6 +719,10 @@ V1 is complete when:
 10. One real menu title, button, and centered button label demonstrate the API.
 11. Drawing and hit testing reuse the same scalar button bounds.
 12. Tests execute the representative path through Cranelift and verify results.
+13. Layout-facing safe and input viewport accessors return `f32` without caller-side conversion.
+14. Sprite x/y/width/height remain `f32` through Stasis command submission.
+15. The graphics command-buffer version and all host decoders agree on the migrated sprite representation.
+16. Raw physical pixel counts, handles, counts, and indices remain `i32` where integer semantics are intrinsic.
 
 ## 15. Deferred Extensions
 
@@ -654,6 +751,8 @@ Text width comes from cached measurement, text height from an explicit line box,
 ### Rationale
 
 Stasis currently supports scalar locals and returns cleanly, while `Type[]` is a view over existing fixed storage rather than local temporary array construction. A scalar-return API expresses the needed calculation without pretending that local rectangle values are available.
+
+Using `f32` throughout presentation geometry also matches cached text measurement, pointer input, line commands, flex layout, and scaled canvases. Keeping sprite geometry or layout-facing viewport accessors as `i32` would insert conversion and rounding decisions into ordinary UI code without providing a meaningful performance benefit.
 
 The nearest tempting alternative is an output `f32[]` rectangle API. Although array views are supported, that design requires pre-existing storage and makes a simple calculation appear to create a local rectangle. It also encourages unnecessary global scratch layout state.
 


### PR DESCRIPTION
## Summary

- define scalar-return ui_place_x and ui_place_y primitives for immediate UI positioning
- use separate, strongly typed UiHorizontal and UiVertical enums
- document realistic centered menu title, anchored button, centered label, hit testing, and flex composition
- explicitly exclude unsupported function-local rectangle arrays from the v1 contract

## Why

Stasis games repeat simple axis-alignment calculations, while the earlier rectangle-oriented proposal implied local 32[4] storage that is not part of the currently demonstrated language surface. This PRD narrows v1 to supported scalar parameters, locals, and returns.

## Developer impact

Future implementation needs only two pure constant-time functions plus tests and one real menu adoption. Existing global-backed flex arrays remain unchanged and feed scalar values through their accessors.

## Validation

- git diff --check 
- documentation-only change; no runtime behavior changed