### PR TITLE
feat: add typed immediate axis placement

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2253,6 +2253,33 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn aot_process_links_and_executes_immediate_axis_layout_sample() {
+        let Some(link_config) = resolve_link_config_for_smoke() else {
+            return;
+        };
+
+        let mut process = AotProcess::new();
+        process.set_import_base_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."));
+        process.upsert_file(
+            "src/stdlib/ui_axis_layout.stasis",
+            include_str!("../../../../src/stdlib/ui_axis_layout.stasis"),
+        );
+        process.upsert_file(
+            "samples/immediate_axis_layout/main.stasis",
+            include_str!("../../../../samples/immediate_axis_layout/main.stasis"),
+        );
+        process
+            .compile()
+            .expect("compile immediate axis layout sample");
+        assert_eq!(
+            run_linked_i32_noarg_fixture(&process, "main", "immediate_axis_layout", &link_config,),
+            Some(0),
+            "axis layout sample assertions failed"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn aot_process_links_and_executes_internal_i32_call() {
         let Some(link_config) = resolve_link_config_for_smoke() else {
             return;

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -832,7 +832,7 @@ pub(crate) fn collect_top_level_constant_values(
             )
         })?;
         for parsed_enum in parsed.enums {
-            let enum_type_id = type_table.resolve(&parsed_enum.name).unwrap_or(TYPE_ID_I32);
+            let enum_type_id = type_table.resolve_or_intern(&parsed_enum.name)?;
             let mut next_value: i32 = 0;
             for variant in parsed_enum.variants {
                 let value = if let Some(explicit) = variant.value {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3980,6 +3980,32 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_process_rejects_swapped_ui_axis_enum_argument() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "enum UiHorizontal { Left, Center, Right }\nenum UiVertical { Top, Center, Bottom }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, UiVertical.Top); return 0; }\n",
+        );
+        process
+            .compile()
+            .expect_err("swapped UI axis enum argument must fail");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_rejects_i32_ui_axis_argument() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "enum UiHorizontal { Left, Center, Right }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, 1); return 0; }\n",
+        );
+        process
+            .compile()
+            .expect_err("i32 UI axis argument must fail");
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_process_allows_i32_return_from_named_i32_abi_expression() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/frontend/types.rs
+++ b/crates/stasis_compiler/src/frontend/types.rs
@@ -469,10 +469,7 @@ fn are_i32_scalar_abi_compatible(argument: &TypeKey, parameter: &TypeKey) -> boo
         ) | (
             TypeKey::Builtin(BuiltinType::Bool),
             TypeKey::Builtin(BuiltinType::I32)
-        ) | (TypeKey::Builtin(BuiltinType::I32), TypeKey::Named(_))
-            | (TypeKey::Builtin(BuiltinType::Bool), TypeKey::Named(_))
-            | (TypeKey::Named(_), TypeKey::Builtin(BuiltinType::I32))
-            | (TypeKey::Named(_), TypeKey::Builtin(BuiltinType::Bool))
+        )
     )
 }
 

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1520,6 +1520,39 @@ Archived priority override (2026-02-13, historical):
 - Host-set misuse cannot produce partial state mutation or silent nondeterminism.
 - Status: `planned (post-S10b)`
 
+### S17 - Immediate Axis Placement and Float Presentation Geometry
+
+- Source requirements: `docs/immediate_layout_prd.md`.
+- Selection: explicitly selected by the user after PR #349 merged.
+- Language ownership: `.stasis` for placement helpers, tests, and representative UI composition; Rust/C host code for coordinated HostFrame and graphics-command ABI migration.
+- AP1 - Typed scalar axis placement:
+  - Add distinct `UiHorizontal` and `UiVertical` enums.
+  - Add allocation-free `ui_place_x` and `ui_place_y` scalar-return helpers.
+  - Verify all axis choices, fractional and oversized bounds, and compile-time rejection of swapped enum types.
+  - Add a representative sample that reaches Cranelift IR, builds as an executable, runs, and asserts behavior.
+  - Status: `complete`.
+- AP1.5 - Reachable AOT runtime surface:
+  - Declare runtime helpers in AOT objects only when emitted operations reference them; do not make pure arithmetic/layout objects advertise the full JIT helper surface.
+  - Keep JIT runtime registration independent from the narrower AOT object dependency set.
+  - Verify object symbol tables for a pure function and representative helper-using functions, then link and run without unrelated runtime imports.
+  - Status: `planned after AP1` (explicitly selected during AP1 executable verification).
+- AP2 - Float presentation boundary:
+  - Migrate canonical logical/safe/pointer/sprite geometry to `f32`.
+  - Remove pre-1.0 compatibility display/input APIs and active HostFrame alias fields.
+  - Bump HostFrame and graphics command versions and migrate every host, decoder, fixture, and parity path atomically.
+  - Status: `planned after AP1.5`.
+- AP3 - Representative menu adoption:
+  - Cache text run widths during initialization.
+  - Center a menu title, anchor a button within an adjusted region, center its label, and reuse scalar bounds for hit testing.
+  - Status: `planned after AP2`.
+- Done gate:
+  - All PRD acceptance criteria pass through JIT/AOT and the real renderer boundary as applicable.
+- AP1 work summary:
+  - Theory gained: enum variants must be interned with their declared nominal type before call checking; the swapped-axis fixture exposed the old `i32` fallback, and distinct enum calls now predictably fail before lowering.
+  - Good: the realistic menu/button sample exposed both enum typing and AOT linkage behavior while the slice was still narrow.
+  - Bad: the original AOT smoke path could report success by skipping when no linker or runtime symbols were available.
+  - Adjustment: executable slice tests must use an explicit discovered linker and the runtime fixture helper until AP1.5 removes unrelated AOT imports.
+
 ## PR Sequence
 
 1. PR-A: S0-S2

--- a/samples/immediate_axis_layout/main.stasis
+++ b/samples/immediate_axis_layout/main.stasis
@@ -1,0 +1,24 @@
+import "../../src/stdlib/ui_axis_layout.stasis";
+
+function main(): i32 {
+    let safe_x: f32 = 0.0;
+    let safe_y: f32 = 0.0;
+    let safe_w: f32 = 360.0;
+    let safe_h: f32 = 720.0;
+
+    let title_x: f32 = ui_place_x(safe_x, safe_w, 180.0, UiHorizontal.Center);
+
+    let button_area_x: f32 = safe_x + 20.0;
+    let button_area_y: f32 = safe_y + 140.0;
+    let button_area_w: f32 = safe_w - 40.0;
+    let button_area_h: f32 = safe_h - 160.0;
+    let button_x: f32 = ui_place_x(button_area_x, button_area_w, 180.0, UiHorizontal.Left);
+    let button_y: f32 = ui_place_y(button_area_y, button_area_h, 56.0, UiVertical.Top);
+    let label_x: f32 = ui_place_x(button_x, 180.0, 64.0, UiHorizontal.Center);
+    let label_y: f32 = ui_place_y(button_y, 56.0, 28.0, UiVertical.Center);
+
+    if (title_x != 90.0) { return 1; }
+    if (button_x != 20.0 || button_y != 140.0) { return 2; }
+    if (label_x != 78.0 || label_y != 154.0) { return 3; }
+    return 0;
+}

--- a/src/stdlib/ui_axis_layout.stasis
+++ b/src/stdlib/ui_axis_layout.stasis
@@ -1,0 +1,43 @@
+// Immediate one-axis placement for scalar UI geometry.
+
+enum UiHorizontal {
+    Left,
+    Center,
+    Right
+}
+
+enum UiVertical {
+    Top,
+    Center,
+    Bottom
+}
+
+function @inline ui_place_x(
+    parent_x: f32,
+    parent_width: f32,
+    child_width: f32,
+    horizontal: UiHorizontal
+): f32 {
+    if (horizontal == UiHorizontal.Center) {
+        return parent_x + (parent_width - child_width) * 0.5;
+    }
+    if (horizontal == UiHorizontal.Right) {
+        return parent_x + parent_width - child_width;
+    }
+    return parent_x;
+}
+
+function @inline ui_place_y(
+    parent_y: f32,
+    parent_height: f32,
+    child_height: f32,
+    vertical: UiVertical
+): f32 {
+    if (vertical == UiVertical.Center) {
+        return parent_y + (parent_height - child_height) * 0.5;
+    }
+    if (vertical == UiVertical.Bottom) {
+        return parent_y + parent_height - child_height;
+    }
+    return parent_y;
+}

--- a/tests/stasis/ui_axis_layout.test.stasis
+++ b/tests/stasis/ui_axis_layout.test.stasis
@@ -1,0 +1,29 @@
+import "../../src/stdlib/ui_axis_layout.stasis";
+
+test `ui place x aligns left center and right`(): bool {
+    if (ui_place_x(10.0, 101.0, 40.0, UiHorizontal.Left) != 10.0) { return false; }
+    if (ui_place_x(10.0, 101.0, 40.0, UiHorizontal.Center) != 40.5) { return false; }
+    if (ui_place_x(10.0, 101.0, 40.0, UiHorizontal.Right) != 71.0) { return false; }
+    return true;
+}
+
+test `ui place y aligns top center and bottom`(): bool {
+    if (ui_place_y(20.0, 81.0, 30.0, UiVertical.Top) != 20.0) { return false; }
+    if (ui_place_y(20.0, 81.0, 30.0, UiVertical.Center) != 45.5) { return false; }
+    if (ui_place_y(20.0, 81.0, 30.0, UiVertical.Bottom) != 71.0) { return false; }
+    return true;
+}
+
+test `ui axis placement preserves selected edge for oversized child`(): bool {
+    if (ui_place_x(10.0, 20.0, 40.0, UiHorizontal.Left) != 10.0) { return false; }
+    if (ui_place_x(10.0, 20.0, 40.0, UiHorizontal.Center) != 0.0) { return false; }
+    if (ui_place_x(10.0, 20.0, 40.0, UiHorizontal.Right) != -10.0) { return false; }
+    if (ui_place_y(10.0, 20.0, 40.0, UiVertical.Bottom) != -10.0) { return false; }
+    return true;
+}
+
+test `ui axis placement accepts fractional regions`(): bool {
+    if (ui_place_x(0.25, 10.5, 2.0, UiHorizontal.Center) != 4.5) { return false; }
+    if (ui_place_y(1.25, 8.5, 2.0, UiVertical.Bottom) != 7.75) { return false; }
+    return true;
+}


### PR DESCRIPTION
## Summary

- add distinct `UiHorizontal` and `UiVertical` enums
- add allocation-free scalar `f32` placement helpers for horizontal and vertical axes
- add realistic menu title, button, and centered-label composition
- enforce nominal enum arguments so swapped axes and raw integers fail compilation
- add an AOT executable fixture covering the representative layout sample

## Why

This is the first implementation slice from `docs/immediate_layout_prd.md`. It provides the small immediate-mode placement primitive needed before migrating the presentation boundary and adopting it in a rendered menu.

## Impact

Stasis UI code can calculate one axis at a time with a single scalar return and explicit axis-specific enum. Fractional and oversized bounds retain direct arithmetic behavior without allocation or hidden state.

The broader AOT helper import surface discovered during executable verification is documented as AP1.5 follow-up; this PR uses the existing runtime fixture to validate the executable without claiming that narrowing is already complete.

## Validation

- `cargo test -p stasis_compiler --lib` (345 passed, 1 ignored)
- representative sample compiled through AOT, linked as a Windows executable, ran, and returned 0
- `cargo fmt --all`