### PR TITLE
feat: migrate presentation geometry to f32

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3604,8 +3604,8 @@ void stasis_jit_upsert_string_literal(int32_t id, const char* value);\n",
     source.push_str(
         "STASIS_EXPORT int32_t host_i32[768] = {0};\n\
 STASIS_EXPORT float host_f32[64] = {0};\n\
-STASIS_EXPORT int32_t gfx_cmd_i32[34848] = {0};\n\
-STASIS_EXPORT float gfx_cmd_f32[92292] = {0};\n\
+STASIS_EXPORT int32_t gfx_cmd_i32[18464] = {0};\n\
+STASIS_EXPORT float gfx_cmd_f32[108676] = {0};\n\
 STASIS_EXPORT uint8_t gfx_cmd_u8[65536] = {0};\n\
 STASIS_EXPORT int32_t host_req_seq = 0;\n\
 STASIS_EXPORT int32_t host_req_flags = 0;\n\
@@ -3621,10 +3621,10 @@ STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
             "stasis_jit_register_global_f32_array({host_f32_hash}, 0, host_f32, 64);"
         ),
         format!(
-            "stasis_jit_register_global_i32_array({gfx_cmd_i32_hash}, 0, gfx_cmd_i32, 34848);"
+            "stasis_jit_register_global_i32_array({gfx_cmd_i32_hash}, 0, gfx_cmd_i32, 18464);"
         ),
         format!(
-            "stasis_jit_register_global_f32_array({gfx_cmd_f32_hash}, 0, gfx_cmd_f32, 92292);"
+            "stasis_jit_register_global_f32_array({gfx_cmd_f32_hash}, 0, gfx_cmd_f32, 108676);"
         ),
         format!(
             "stasis_jit_register_global_u8_array({gfx_cmd_u8_hash}, 0, gfx_cmd_u8, 65536);"
@@ -3682,25 +3682,23 @@ STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
     if matches!(target, stasis_jit::AotTarget::AndroidArm64 { .. }) {
         source.push_str(
             "STASIS_EXPORT void stasis_init(int width, int height) {\n\
-    host_i32[1] = width;\n\
-    host_i32[2] = height;\n\
-    host_i32[5] = width;\n\
-    host_i32[6] = height;\n\
     host_i32[12] = width;\n\
     host_i32[13] = height;\n\
-    host_i32[14] = 2;\n\
-    host_i32[20] = width;\n\
-    host_i32[21] = height;\n\
+    host_i32[14] = 3;\n\
     host_i32[22] = width;\n\
     host_i32[23] = height;\n\
     host_i32[24] = width;\n\
     host_i32[25] = height;\n\
-    host_i32[28] = width;\n\
-    host_i32[29] = height;\n\
     host_i32[30] = 1;\n\
     host_i32[31] = 1;\n\
     host_f32[48] = 1.0f;\n\
     host_f32[49] = 1.0f;\n\
+    host_f32[50] = (float)width;\n\
+    host_f32[51] = (float)height;\n\
+    host_f32[52] = 0.0f;\n\
+    host_f32[53] = 0.0f;\n\
+    host_f32[54] = (float)width;\n\
+    host_f32[55] = (float)height;\n\
     host_req_window_w_px = width;\n\
     host_req_window_h_px = height;\n\
     main();\n\
@@ -4361,7 +4359,8 @@ mod tests {
 
         assert!(!source.contains("StasisDirectStorageSlot"));
         assert!(source.contains("STASIS_EXPORT void stasis_init(int width, int height)"));
-        assert!(source.contains("host_i32[1] = width;"));
+        assert!(source.contains("host_i32[14] = 3;"));
+        assert!(source.contains("host_f32[50] = (float)width;"));
         assert!(source.contains("STASIS_EXPORT void stasis_tick(float dt)"));
         assert!(source.contains("host_i32[10] = host_i32[10] + 1;"));
         assert!(source.contains("STASIS_EXPORT void stasis_render(void)"));
@@ -5618,7 +5617,12 @@ mod tests {
             vec![source],
             TargetMode::JitDev,
         ));
-        assert_eq!(result.status, CompileStatus::Success);
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "brickout diagnostics: {:?}",
+            result.diagnostics
+        );
         let jit_overrides = result
             .jit_code_ptr_overrides
             .as_ref()
@@ -5725,7 +5729,12 @@ mod tests {
             vec![source],
             TargetMode::JitDev,
         ));
-        assert_eq!(result.status, CompileStatus::Success);
+        assert_eq!(
+            result.status,
+            CompileStatus::Success,
+            "brickout diagnostics: {:?}",
+            result.diagnostics
+        );
         let package = backend
             .last_jit_engine_package()
             .expect("jit engine package should be present");
@@ -6056,8 +6065,12 @@ mod tests {
         let store_ptr = library
             .symbol_address("stasis_jit_global_i32_array_store")
             .expect("resolve host_i32 store");
+        let store_f32_ptr = library
+            .symbol_address("stasis_jit_global_f32_array_store")
+            .expect("resolve host_f32 store");
 
         let host_i32 = hash_global_path("host_i32");
+        let host_f32 = hash_global_path("host_f32");
         let field = 0;
         let store = |index: i32, value: i32| {
             stasis_dynload::invoke_i32_i32_i32_i32_to_void(
@@ -6065,17 +6078,27 @@ mod tests {
             )
             .expect("invoke host_i32 store");
         };
+        let store_f32 = |index: i32, value: f32| {
+            stasis_dynload::invoke_i32_i32_i32_f32_to_void(
+                store_f32_ptr,
+                host_f32,
+                field,
+                index,
+                value,
+            )
+            .expect("invoke host_f32 store");
+        };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
         // Indices from src/runtime/host_frame.stasis.
         let t0_ms: i32 = 12345;
         store(0, t0_ms); // HOST_I_TIME_MS
-        store(1, 360); // HOST_I_WINDOW_W_PX
-        store(2, 720); // HOST_I_WINDOW_H_PX
-        store(3, 0); // HOST_I_VIEWPORT_X_PX
-        store(4, 0); // HOST_I_VIEWPORT_Y_PX
-        store(5, 360); // HOST_I_VIEWPORT_W_PX
-        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store_f32(50, 360.0); // HOST_F_LOGICAL_W
+        store_f32(51, 720.0); // HOST_F_LOGICAL_H
+        store_f32(52, 0.0); // HOST_F_SAFE_X
+        store_f32(53, 0.0); // HOST_F_SAFE_Y
+        store_f32(54, 360.0); // HOST_F_SAFE_W
+        store_f32(55, 720.0); // HOST_F_SAFE_H
         store(7, 0); // HOST_I_POINTER_COUNT
         store(8, 0); // HOST_I_DROPPED_POINTERS
         store(9, 0); // HOST_I_QUIT_REQUESTED
@@ -6174,21 +6197,25 @@ mod tests {
         assert_ne!(tick_ptr, 0);
 
         let host_i32 = hash_global_path("host_i32");
+        let host_f32 = hash_global_path("host_f32");
         let field = 0;
         let store = |index: i32, value: i32| {
             stasis_dynload::stasis_jit_global_i32_array_store(host_i32, field, index, value);
+        };
+        let store_f32 = |index: i32, value: f32| {
+            stasis_dynload::stasis_jit_global_f32_array_store(host_f32, field, index, value);
         };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
         // Indices from src/host_frame.stasis.
         let t0_ms: i32 = 12345;
         store(0, t0_ms); // HOST_I_TIME_MS
-        store(1, 360); // HOST_I_WINDOW_W_PX
-        store(2, 720); // HOST_I_WINDOW_H_PX
-        store(3, 0); // HOST_I_VIEWPORT_X_PX
-        store(4, 0); // HOST_I_VIEWPORT_Y_PX
-        store(5, 360); // HOST_I_VIEWPORT_W_PX
-        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store_f32(50, 360.0); // HOST_F_LOGICAL_W
+        store_f32(51, 720.0); // HOST_F_LOGICAL_H
+        store_f32(52, 0.0); // HOST_F_SAFE_X
+        store_f32(53, 0.0); // HOST_F_SAFE_Y
+        store_f32(54, 360.0); // HOST_F_SAFE_W
+        store_f32(55, 720.0); // HOST_F_SAFE_H
         store(7, 0); // HOST_I_POINTER_COUNT
         store(8, 0); // HOST_I_DROPPED_POINTERS
         store(9, 0); // HOST_I_QUIT_REQUESTED
@@ -6520,8 +6547,12 @@ mod tests {
         let store_ptr = library
             .symbol_address("stasis_jit_global_i32_array_store")
             .expect("resolve host_i32 store");
+        let store_f32_ptr = library
+            .symbol_address("stasis_jit_global_f32_array_store")
+            .expect("resolve host_f32 store");
 
         let host_i32 = hash_global_path("host_i32");
+        let host_f32 = hash_global_path("host_f32");
         let field = 0;
         let store = |index: i32, value: i32| {
             stasis_dynload::invoke_i32_i32_i32_i32_to_void(
@@ -6529,17 +6560,27 @@ mod tests {
             )
             .expect("invoke host_i32 store");
         };
+        let store_f32 = |index: i32, value: f32| {
+            stasis_dynload::invoke_i32_i32_i32_f32_to_void(
+                store_f32_ptr,
+                host_f32,
+                field,
+                index,
+                value,
+            )
+            .expect("invoke host_f32 store");
+        };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
         // Indices from src/host_frame.stasis.
         let t0_ms: i32 = 12345;
         store(0, t0_ms); // HOST_I_TIME_MS
-        store(1, 360); // HOST_I_WINDOW_W_PX
-        store(2, 720); // HOST_I_WINDOW_H_PX
-        store(3, 0); // HOST_I_VIEWPORT_X_PX
-        store(4, 0); // HOST_I_VIEWPORT_Y_PX
-        store(5, 360); // HOST_I_VIEWPORT_W_PX
-        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store_f32(50, 360.0); // HOST_F_LOGICAL_W
+        store_f32(51, 720.0); // HOST_F_LOGICAL_H
+        store_f32(52, 0.0); // HOST_F_SAFE_X
+        store_f32(53, 0.0); // HOST_F_SAFE_Y
+        store_f32(54, 360.0); // HOST_F_SAFE_W
+        store_f32(55, 720.0); // HOST_F_SAFE_H
         store(7, 0); // HOST_I_POINTER_COUNT
         store(8, 0); // HOST_I_DROPPED_POINTERS
         store(9, 0); // HOST_I_QUIT_REQUESTED
@@ -6872,8 +6913,12 @@ mod tests {
         let store_ptr = library
             .symbol_address("stasis_jit_global_i32_array_store")
             .expect("resolve host_i32 store");
+        let store_f32_ptr = library
+            .symbol_address("stasis_jit_global_f32_array_store")
+            .expect("resolve host_f32 store");
 
         let host_i32 = hash_global_path("host_i32");
+        let host_f32 = hash_global_path("host_f32");
         let field = 0;
         let store = |index: i32, value: i32| {
             stasis_dynload::invoke_i32_i32_i32_i32_to_void(
@@ -6881,17 +6926,27 @@ mod tests {
             )
             .expect("invoke host_i32 store");
         };
+        let store_f32 = |index: i32, value: f32| {
+            stasis_dynload::invoke_i32_i32_i32_f32_to_void(
+                store_f32_ptr,
+                host_f32,
+                field,
+                index,
+                value,
+            )
+            .expect("invoke host_f32 store");
+        };
 
         // Seed enough HostFrame state for Brickout to initialize and tick headlessly.
         // Indices from src/host_frame.stasis.
         let t0_ms: i32 = 12345;
         store(0, t0_ms); // HOST_I_TIME_MS
-        store(1, 360); // HOST_I_WINDOW_W_PX
-        store(2, 720); // HOST_I_WINDOW_H_PX
-        store(3, 0); // HOST_I_VIEWPORT_X_PX
-        store(4, 0); // HOST_I_VIEWPORT_Y_PX
-        store(5, 360); // HOST_I_VIEWPORT_W_PX
-        store(6, 720); // HOST_I_VIEWPORT_H_PX
+        store_f32(50, 360.0); // HOST_F_LOGICAL_W
+        store_f32(51, 720.0); // HOST_F_LOGICAL_H
+        store_f32(52, 0.0); // HOST_F_SAFE_X
+        store_f32(53, 0.0); // HOST_F_SAFE_Y
+        store_f32(54, 360.0); // HOST_F_SAFE_W
+        store_f32(55, 720.0); // HOST_F_SAFE_H
         store(7, 0); // HOST_I_POINTER_COUNT
         store(8, 0); // HOST_I_DROPPED_POINTERS
         store(9, 0); // HOST_I_QUIT_REQUESTED

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1375,13 +1375,11 @@ const PLAY_INPUT_MAX_POINTERS: usize = 8;
 const PLAY_INPUT_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
 const HOST_I_POINTER_COUNT: usize = 7;
 const HOST_I_DROPPED_POINTERS: usize = 8;
-const HOST_I_WINDOW_W_PX: usize = 1;
-const HOST_I_WINDOW_H_PX: usize = 2;
-const HOST_I_VIEWPORT_W_PX: usize = 5;
-const HOST_I_VIEWPORT_H_PX: usize = 6;
 const HOST_I_POINTER_BASE: usize = 544;
 const HOST_I_POINTER_STRIDE: usize = 4;
 const HOST_F_POINTER_STRIDE: usize = 6;
+const HOST_F_LOGICAL_W: usize = 50;
+const HOST_F_LOGICAL_H: usize = 51;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1561,22 +1559,13 @@ fn apply_play_input_frame(
     host_f32: &mut [f32],
 ) -> Result<(), String> {
     if host_i32.len() < HOST_I_POINTER_BASE + PLAY_INPUT_MAX_POINTERS * HOST_I_POINTER_STRIDE
-        || host_f32.len() < PLAY_INPUT_MAX_POINTERS * HOST_F_POINTER_STRIDE
+        || host_f32.len() <= HOST_F_LOGICAL_H
     {
         return Err("host frame buffers are too small for input-script pointers".to_string());
     }
-    // The graphics runtime pumps its first event snapshot while servicing the
-    // first host frame, after the viewport fields have already been copied.
-    // On that one Windows frame, the window dimensions are the exact viewport.
-    let mut viewport_w = host_i32[HOST_I_VIEWPORT_W_PX];
-    let mut viewport_h = host_i32[HOST_I_VIEWPORT_H_PX];
-    if viewport_w <= 0 {
-        viewport_w = host_i32[HOST_I_WINDOW_W_PX];
-    }
-    if viewport_h <= 0 {
-        viewport_h = host_i32[HOST_I_WINDOW_H_PX];
-    }
-    if viewport_w <= 0 || viewport_h <= 0 {
+    let viewport_w = host_f32[HOST_F_LOGICAL_W];
+    let viewport_h = host_f32[HOST_F_LOGICAL_H];
+    if viewport_w <= 0.0 || viewport_h <= 0.0 {
         return Err("input-script requires positive host viewport dimensions".to_string());
     }
 
@@ -1608,7 +1597,7 @@ fn apply_play_input_frame(
         }
     }
     for (slot, pointer) in timeline.pointers.iter().enumerate() {
-        if pointer.x > viewport_w as f32 || pointer.y > viewport_h as f32 {
+        if pointer.x > viewport_w || pointer.y > viewport_h {
             return Err(format!(
                 "input-script frame {frame} pointer {} is outside the {}x{} viewport",
                 pointer.id, viewport_w, viewport_h
@@ -1627,8 +1616,8 @@ fn apply_play_input_frame(
         host_f32[f32_base + 1] = pointer.y;
         host_f32[f32_base + 2] = dx;
         host_f32[f32_base + 3] = dy;
-        host_f32[f32_base + 4] = (pointer.x / viewport_w as f32).clamp(0.0, 1.0);
-        host_f32[f32_base + 5] = (pointer.y / viewport_h as f32).clamp(0.0, 1.0);
+        host_f32[f32_base + 4] = (pointer.x / viewport_w).clamp(0.0, 1.0);
+        host_f32[f32_base + 5] = (pointer.y / viewport_h).clamp(0.0, 1.0);
     }
     Ok(())
 }
@@ -1852,8 +1841,8 @@ fn run_play_in_process_inner(
     // Allocate and register all global buffers used by HostFrame / gfx_cmd + window requests.
     let mut host_i32: Vec<i32> = vec![0; 768];
     let mut host_f32: Vec<f32> = vec![0.0; 64];
-    let mut gfx_cmd_i32: Vec<i32> = vec![0; 34848];
-    let mut gfx_cmd_f32: Vec<f32> = vec![0.0; 92292];
+    let mut gfx_cmd_i32: Vec<i32> = vec![0; 18464];
+    let mut gfx_cmd_f32: Vec<f32> = vec![0.0; 108676];
     let mut gfx_cmd_u8: Vec<u8> = vec![0; 65536];
 
     let mut host_req_seq: i32 = 0;
@@ -3882,8 +3871,8 @@ mod tests {
         let mut timeline = validate_play_input_script(document).expect("valid static bounds");
         let mut host_i32 = vec![0; 768];
         let mut host_f32 = vec![0.0; 64];
-        host_i32[HOST_I_VIEWPORT_W_PX] = 180;
-        host_i32[HOST_I_VIEWPORT_H_PX] = 120;
+        host_f32[HOST_F_LOGICAL_W] = 180.0;
+        host_f32[HOST_F_LOGICAL_H] = 120.0;
         assert!(
             apply_play_input_frame(&mut timeline, 1, &mut host_i32, &mut host_f32)
                 .expect_err("viewport bound should fail")
@@ -3892,7 +3881,7 @@ mod tests {
     }
 
     #[test]
-    fn input_script_uses_window_dimensions_before_first_viewport_snapshot() {
+    fn input_script_uses_logical_dimensions_from_first_snapshot() {
         let document = PlayInputScriptDocument {
             version: 1,
             frames: vec![PlayInputFrame {
@@ -3903,11 +3892,11 @@ mod tests {
         let mut timeline = validate_play_input_script(document).expect("valid script");
         let mut host_i32 = vec![0; 768];
         let mut host_f32 = vec![0.0; 64];
-        host_i32[HOST_I_WINDOW_W_PX] = 360;
-        host_i32[HOST_I_WINDOW_H_PX] = 720;
+        host_f32[HOST_F_LOGICAL_W] = 360.0;
+        host_f32[HOST_F_LOGICAL_H] = 720.0;
 
         apply_play_input_frame(&mut timeline, 1, &mut host_i32, &mut host_f32)
-            .expect("window fallback should accept first-frame input");
+            .expect("logical dimensions should accept first-frame input");
         assert_eq!(host_f32[4], 0.5);
         assert_eq!(host_f32[5], 0.5);
     }
@@ -3924,8 +3913,8 @@ mod tests {
         let mut timeline = validate_play_input_script(document).expect("valid script");
         let mut host_i32 = vec![99; 768];
         let mut host_f32 = vec![99.0; 64];
-        host_i32[HOST_I_VIEWPORT_W_PX] = 180;
-        host_i32[HOST_I_VIEWPORT_H_PX] = 120;
+        host_f32[HOST_F_LOGICAL_W] = 180.0;
+        host_f32[HOST_F_LOGICAL_H] = 120.0;
 
         apply_play_input_frame(&mut timeline, 1, &mut host_i32, &mut host_f32).expect("frame one");
         assert_eq!(host_i32[HOST_I_POINTER_COUNT], 1);
@@ -4040,15 +4029,16 @@ mod tests {
     fn shipping_renderers_share_one_versioned_sdl_command_process() {
         let runtime_cmake = STASIS_RUNTIME_CMAKE.replace("\r\n", "\n");
         for required in [
-            "STASIS_RENDER_V1_MAGIC 0x47584631",
-            "STASIS_RENDER_V1_VERSION 1",
-            "STASIS_RENDER_V1_TRACE_VERSION 1",
+            "STASIS_RENDER_V2_MAGIC 0x47584631",
+            "STASIS_RENDER_V2_VERSION 2",
+            "STASIS_RENDER_V2_TRACE_VERSION 2",
+            "STASIS_RENDER_SPRITE_F32_STRIDE 4",
             "STASIS_RENDER_I32_COUNT",
             "STASIS_RENDER_F32_COUNT",
-            "stasis_render_v1_validate",
-            "stasis_render_v1_validation_name",
-            "stasis_render_v1_is_valid",
-            "stasis_render_v1_trace",
+            "stasis_render_v2_validate",
+            "stasis_render_v2_validation_name",
+            "stasis_render_v2_is_valid",
+            "stasis_render_v2_trace",
         ] {
             assert!(
                 STASIS_RENDER_CONTRACT_HEADER.contains(required),
@@ -4062,7 +4052,7 @@ mod tests {
             "shipping runtime should default to the canonical SDL backend"
         );
         assert!(
-            STASIS_GRAPHICS_SOURCE.contains("stasis_render_v1_validate(cmd_i32, cmd_f32)")
+            STASIS_GRAPHICS_SOURCE.contains("stasis_render_v2_validate(cmd_i32, cmd_f32)")
                 && STASIS_GRAPHICS_SOURCE.contains("STASIS_RENDER_FLAG_PRESENT")
                 && STASIS_GRAPHICS_SOURCE
                     .contains("SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, \"linear\")")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -2604,9 +2604,9 @@ fn verify_release_provenance(path: &Path) -> Result<Value, String> {
     if value["schema"] != "stasis.release_provenance.v1"
         || value["development_build"] != false
         || value["dirty_state"] != false
-        || value["command_buffer"]["version"] != 1
+        || value["command_buffer"]["version"] != 2
     {
-        return Err("release provenance is not a clean official gfx_cmd v1 build".to_string());
+        return Err("release provenance is not a clean official gfx_cmd v2 build".to_string());
     }
     let release_tag = provenance_string_field(&value, "release_tag")?;
     let source_commit = provenance_string_field(&value, "source_commit")?;
@@ -2720,7 +2720,7 @@ fn development_provenance() -> Result<Value, String> {
         },
         "runtime_sources": sources,
         "mobile_shell_sources": content_hashes(&mobile_shells, "mobile/shells")?,
-        "command_buffer": {"name": "gfx_cmd", "version": 1},
+        "command_buffer": {"name": "gfx_cmd", "version": 2},
         "backends": ["sdl2"],
         "features": ["aot", "jit", "mobile-aot", "shared-renderer"],
         "dependencies": {"stasis": env!("CARGO_PKG_VERSION"), "toolchain": "development"},
@@ -4264,7 +4264,7 @@ mod tests {
             },
             "runtime_sources": runtime_sources,
             "mobile_shell_sources": mobile_shell_sources,
-            "command_buffer": {"name": "gfx_cmd", "version": 1},
+            "command_buffer": {"name": "gfx_cmd", "version": 2},
             "backends": ["sdl2"],
             "features": ["aot", "jit", "mobile-aot", "shared-renderer"],
             "dependencies": {

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -34,9 +34,9 @@ pub const ANDROID_RENDER_FRAME_HEADER_SIZE: usize = 6;
 pub const ANDROID_RENDER_COMMAND_STRIDE: usize = 13;
 pub const ANDROID_RENDER_FRAME_I32_CAPACITY: usize = ANDROID_RENDER_FRAME_HEADER_SIZE
     + ANDROID_RENDER_COMMAND_CAPACITY * ANDROID_RENDER_COMMAND_STRIDE;
-pub const ANDROID_RENDER_V1_I32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_I32_COUNT;
-pub const ANDROID_RENDER_V1_F32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_F32_COUNT;
-pub const ANDROID_RENDER_V1_U8_CAPACITY: usize = stasis_dynload::STASIS_RENDER_U8_COUNT;
+pub const ANDROID_RENDER_V2_I32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_I32_COUNT;
+pub const ANDROID_RENDER_V2_F32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_F32_COUNT;
+pub const ANDROID_RENDER_V2_U8_CAPACITY: usize = stasis_dynload::STASIS_RENDER_U8_COUNT;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndroidBridgeTickInput {
@@ -1112,12 +1112,6 @@ fn write_production_host_frame(
         metrics.native_to_logical(value.touch_x, value.touch_y)
     });
     host_i32[0] = stasis_dynload::stasis_get_time_ms();
-    host_i32[1] = metrics.logical_w;
-    host_i32[2] = metrics.logical_h;
-    host_i32[3] = 0;
-    host_i32[4] = 0;
-    host_i32[5] = metrics.logical_w;
-    host_i32[6] = metrics.logical_h;
     host_i32[7] = 1;
     host_i32[8] = 0;
     host_i32[9] = 0;
@@ -1125,22 +1119,16 @@ fn write_production_host_frame(
     host_i32[11] = i32::from(resized);
     host_i32[12] = metrics.native_w;
     host_i32[13] = metrics.native_h;
-    host_i32[14] = 2;
+    host_i32[14] = 3;
     host_i32[15] = 0;
     host_i32[16] = 60;
     host_i32[17] = 1;
     host_i32[18] = 0;
     host_i32[19] = stasis_dynload::stasis_get_time_us();
-    host_i32[20] = metrics.logical_w;
-    host_i32[21] = metrics.logical_h;
     host_i32[22] = metrics.native_w;
     host_i32[23] = metrics.native_h;
     host_i32[24] = metrics.drawable_w;
     host_i32[25] = metrics.drawable_h;
-    host_i32[26] = 0;
-    host_i32[27] = 0;
-    host_i32[28] = metrics.logical_w;
-    host_i32[29] = metrics.logical_h;
     host_i32[30] = session.display_generation;
     host_i32[31] = session.density_generation;
     host_i32[POINTER_I32_BASE] = 0;
@@ -1155,6 +1143,12 @@ fn write_production_host_frame(
     host_f32[5] = touch_y / metrics.logical_h as f32;
     host_f32[48] = metrics.content_scale;
     host_f32[49] = metrics.raster_scale;
+    host_f32[50] = metrics.logical_w as f32;
+    host_f32[51] = metrics.logical_h as f32;
+    host_f32[52] = 0.0;
+    host_f32[53] = 0.0;
+    host_f32[54] = metrics.logical_w as f32;
+    host_f32[55] = metrics.logical_h as f32;
     session.previous_input = Some(input);
     Ok(metrics)
 }
@@ -2016,7 +2010,7 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame(
 }
 
 #[no_mangle]
-pub extern "C" fn stasis_android_bridge_run_tick_frame_v1(
+pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
     project_root: *const c_char,
     entry_file: *const c_char,
     touch_x: i32,
@@ -2034,9 +2028,9 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v1(
     if out_i32.is_null()
         || out_f32.is_null()
         || out_u8.is_null()
-        || out_i32_len < ANDROID_RENDER_V1_I32_CAPACITY
-        || out_f32_len < ANDROID_RENDER_V1_F32_CAPACITY
-        || out_u8_len < ANDROID_RENDER_V1_U8_CAPACITY
+        || out_i32_len < ANDROID_RENDER_V2_I32_CAPACITY
+        || out_f32_len < ANDROID_RENDER_V2_F32_CAPACITY
+        || out_u8_len < ANDROID_RENDER_V2_U8_CAPACITY
     {
         return -1;
     }
@@ -2065,7 +2059,7 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v1(
         let i32_values = std::slice::from_raw_parts_mut(out_i32, out_i32_len);
         let f32_values = std::slice::from_raw_parts_mut(out_f32, out_f32_len);
         let u8_values = std::slice::from_raw_parts_mut(out_u8, out_u8_len);
-        stasis_dynload::copy_jit_render_v1_active(i32_values, f32_values, u8_values)?;
+        stasis_dynload::copy_jit_render_v2_active(i32_values, f32_values, u8_values)?;
         write_android_display_metadata(i32_values)
     }));
     match result {
@@ -3304,7 +3298,7 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
     }
 
     #[test]
-    fn c_bridge_run_tick_frame_v1_copies_only_production_active_spans() {
+    fn c_bridge_run_tick_frame_v2_copies_only_production_active_spans() {
         let _guard = bridge_runtime_test_guard();
         clear_runtime_session_for_test();
         let root = temp_project("ffi_production_frame_tick");
@@ -3314,14 +3308,14 @@ function render(): void { Render.command_count = 1; Render.command0_kind = 1; Re
 global host_f32: f32[64];
 global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 function main(): void { host_req_window_w_px = 360; host_req_window_h_px = 720; }
 function tick(): void {}
 function render(): void {
   gfx_cmd_i32[0] = 1196967473;
-  gfx_cmd_i32[1] = 1;
+  gfx_cmd_i32[1] = 2;
   gfx_cmd_i32[2] = 3;
   gfx_cmd_i32[3] = 1;
   gfx_cmd_i32[4] = 1;
@@ -3335,10 +3329,15 @@ function render(): void {
   gfx_cmd_f32[8] = 1.0;
   gfx_cmd_i32[32] = 77;
   gfx_cmd_i32[33] = 11;
-  gfx_cmd_i32[28704] = 5;
-  gfx_cmd_i32[28705] = 0;
-  gfx_cmd_i32[28706] = 1;
-  gfx_cmd_f32[80004] = 12.0;
+  gfx_cmd_i32[34] = 255;
+  gfx_cmd_i32[12320] = 5;
+  gfx_cmd_i32[12321] = 0;
+  gfx_cmd_i32[12322] = 1;
+  gfx_cmd_f32[80004] = 10.25;
+  gfx_cmd_f32[80005] = 20.5;
+  gfx_cmd_f32[80006] = 30.75;
+  gfx_cmd_f32[80007] = 40.125;
+  gfx_cmd_f32[96388] = 12.0;
   gfx_cmd_u8[0] = 65;
   gfx_cmd_u8[1] = 0;
 }
@@ -3347,10 +3346,10 @@ function render(): void {
         .expect("write production source");
         let root_c = CString::new(root.to_string_lossy().as_bytes()).expect("root cstr");
         let entry_c = CString::new("src/main.stasis").expect("entry cstr");
-        let mut frame_i32 = vec![0i32; ANDROID_RENDER_V1_I32_CAPACITY];
-        let mut frame_f32 = vec![0.0f32; ANDROID_RENDER_V1_F32_CAPACITY];
-        let mut frame_u8 = vec![0u8; ANDROID_RENDER_V1_U8_CAPACITY];
-        let status = stasis_android_bridge_run_tick_frame_v1(
+        let mut frame_i32 = vec![0i32; ANDROID_RENDER_V2_I32_CAPACITY];
+        let mut frame_f32 = vec![0.0f32; ANDROID_RENDER_V2_F32_CAPACITY];
+        let mut frame_u8 = vec![0u8; ANDROID_RENDER_V2_U8_CAPACITY];
+        let status = stasis_android_bridge_run_tick_frame_v2(
             root_c.as_ptr(),
             entry_c.as_ptr(),
             540,
@@ -3366,16 +3365,17 @@ function render(): void {
             frame_u8.len(),
         );
         assert_eq!(status, 0);
-        assert_eq!(&frame_i32[..5], &[1196967473, 1, 3, 1, 1]);
+        assert_eq!(&frame_i32[..5], &[1196967473, 2, 3, 1, 1]);
         assert_eq!(&frame_i32[10..16], &[360, 720, 1080, 2400, 1080, 2400]);
         assert_eq!(&frame_i32[16..20], &[0, 0, 360, 720]);
         assert_eq!(&frame_i32[20..22], &[1, 1]);
         assert_eq!(frame_i32[32], 77);
         assert_eq!(frame_i32[33], 11);
-        assert_eq!(&frame_i32[28704..28707], &[5, 0, 1]);
+        assert_eq!(&frame_i32[12320..12323], &[5, 0, 1]);
         assert_eq!(frame_f32[4], 180.0);
         assert_eq!(frame_f32[5], 360.0);
-        assert_eq!(frame_f32[80004], 12.0);
+        assert_eq!(&frame_f32[80004..80008], &[10.25, 20.5, 30.75, 40.125]);
+        assert_eq!(frame_f32[96388], 12.0);
         assert_eq!(&frame_u8[..2], &[65, 0]);
         fs::remove_dir_all(&root).ok();
     }
@@ -3390,8 +3390,8 @@ function render(): void {
             "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 global host_i32: i32[768];
 global host_f32: f32[64];
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 function main(): void { gfx_load_sprite(\"../assets/missing.svg\", 32, 32); }
 function tick(): void {}
@@ -3401,10 +3401,10 @@ function render(): void {}
         .expect("write source");
         let root_c = CString::new(root.to_string_lossy().as_bytes()).expect("root cstr");
         let entry_c = CString::new("src/main.stasis").expect("entry cstr");
-        let mut i32_values = vec![0; ANDROID_RENDER_V1_I32_CAPACITY];
-        let mut f32_values = vec![0.0; ANDROID_RENDER_V1_F32_CAPACITY];
-        let mut u8_values = vec![0; ANDROID_RENDER_V1_U8_CAPACITY];
-        let status = stasis_android_bridge_run_tick_frame_v1(
+        let mut i32_values = vec![0; ANDROID_RENDER_V2_I32_CAPACITY];
+        let mut f32_values = vec![0.0; ANDROID_RENDER_V2_F32_CAPACITY];
+        let mut u8_values = vec![0; ANDROID_RENDER_V2_U8_CAPACITY];
+        let status = stasis_android_bridge_run_tick_frame_v2(
             root_c.as_ptr(),
             entry_c.as_ptr(),
             0,

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1480,15 +1480,15 @@ mod tests {
             ParityCorpusCase {
                 label: "renderer_command_trace",
                 source: RENDER_TRACE_FIXTURE,
-                expected_exit: 829_981_937,
+                expected_exit: -403_440_835,
                 expected_extern_symbols: &[(
                     "native_render_trace",
-                    "stasis_jit_render_v1_trace",
+                    "stasis_jit_render_v2_trace",
                 )],
                 expected_string_literals: &[],
                 expected_collection_max_lengths: &[
-                    ("cmd_i32", 34_848),
-                    ("cmd_f32", 92_292),
+                    ("cmd_i32", 18_464),
+                    ("cmd_f32", 108_676),
                     ("cmd_u8", 65_536),
                 ],
                 expected_clif_markers: &[("main", &["call"])],

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2123,8 +2123,8 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "reject_code_swap" | "stasis_jit_reject_code_swap" => {
             function_address(stasis_dynload::stasis_jit_reject_code_swap as *const ())
         }
-        "stasis_jit_render_v1_trace" => {
-            function_address(stasis_dynload::stasis_jit_render_v1_trace as *const ())
+        "stasis_jit_render_v2_trace" => {
+            function_address(stasis_dynload::stasis_jit_render_v2_trace as *const ())
         }
         _ => return None,
     };

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3482,8 +3482,7 @@ mod tests {
             stasis_dynload::stasis_jit_global_i32_load(hash_global_path("model_escape_down"));
         let first_went_down =
             stasis_dynload::stasis_jit_global_i32_load(hash_global_path("model_first_went_down"));
-        let first_x =
-            stasis_dynload::stasis_jit_global_f32_load(hash_global_path("model_first_x_px"));
+        let first_x = stasis_dynload::stasis_jit_global_f32_load(hash_global_path("model_first_x"));
         let latched =
             stasis_dynload::stasis_jit_global_i32_load(hash_global_path("last_tick_code"));
         assert_eq!(pointer_count, 1);

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -258,6 +258,35 @@ pub fn invoke_i32_i32_i32_i32_to_void(
     }
 }
 
+pub fn invoke_i32_i32_i32_f32_to_void(
+    address: usize,
+    arg0: i32,
+    arg1: i32,
+    arg2: i32,
+    arg3: f32,
+) -> Result<(), String> {
+    if address == 0 {
+        return Err("cannot invoke null function pointer".to_string());
+    }
+    let _dispatch_lock = jit_dispatch_lock()
+        .lock()
+        .expect("jit dispatch lock mutex poisoned");
+    let _execution = JitExecutionGuard::enter();
+    #[cfg(windows)]
+    {
+        let callback: extern "system" fn(i32, i32, i32, f32) =
+            unsafe { std::mem::transmute(address) };
+        callback(arg0, arg1, arg2, arg3);
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    {
+        let callback: extern "C" fn(i32, i32, i32, f32) = unsafe { std::mem::transmute(address) };
+        callback(arg0, arg1, arg2, arg3);
+        Ok(())
+    }
+}
+
 // ============================================================
 // stasis_graphics host API (dev in-process runner)
 // ============================================================
@@ -2384,25 +2413,27 @@ pub extern "C" fn stasis_jit_print_string(value_id: i32) {
     }
 }
 
-pub const STASIS_RENDER_I32_COUNT: usize = 34_848;
-pub const STASIS_RENDER_F32_COUNT: usize = 92_292;
+pub const STASIS_RENDER_I32_COUNT: usize = 18_464;
+pub const STASIS_RENDER_F32_COUNT: usize = 108_676;
 pub const STASIS_RENDER_U8_COUNT: usize = 65_536;
 const STASIS_RENDER_MAGIC: i32 = 0x4758_4631;
-const STASIS_RENDER_VERSION: i32 = 1;
+const STASIS_RENDER_VERSION: i32 = 2;
 const STASIS_RENDER_HEADER_I32_COUNT: usize = 10;
 const STASIS_RENDER_SPRITE_BASE: usize = 32;
 const STASIS_RENDER_MAX_LINES: usize = 10_000;
 const STASIS_RENDER_LINE_STRIDE: usize = 8;
 const STASIS_RENDER_MAX_SPRITES: usize = 4_096;
-const STASIS_RENDER_SPRITE_STRIDE: usize = 7;
-const STASIS_RENDER_TEXT_BASE_I32: usize = 28_704;
-const STASIS_RENDER_TEXT_BASE_F32: usize = 80_004;
+const STASIS_RENDER_SPRITE_STRIDE_I32: usize = 3;
+const STASIS_RENDER_SPRITE_BASE_F32: usize = 80_004;
+const STASIS_RENDER_SPRITE_STRIDE_F32: usize = 4;
+const STASIS_RENDER_TEXT_BASE_I32: usize = 12_320;
+const STASIS_RENDER_TEXT_BASE_F32: usize = 96_388;
 const STASIS_RENDER_MAX_TEXT: usize = 2_048;
 const STASIS_RENDER_TEXT_STRIDE_I32: usize = 3;
 const STASIS_RENDER_TEXT_STRIDE_F32: usize = 6;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RenderV1ActiveCounts {
+pub struct RenderV2ActiveCounts {
     pub lines: usize,
     pub sprites: usize,
     pub text: usize,
@@ -2422,11 +2453,11 @@ fn global_path_hash(path: &str) -> i32 {
 ///
 /// The destination retains production offsets so the Android GLES adapter consumes the exact
 /// same ABI as the SDL renderer without copying unused command capacity.
-pub fn copy_jit_render_v1_active(
+pub fn copy_jit_render_v2_active(
     out_i32: &mut [i32],
     out_f32: &mut [f32],
     out_u8: &mut [u8],
-) -> Result<RenderV1ActiveCounts, String> {
+) -> Result<RenderV2ActiveCounts, String> {
     if out_i32.len() < STASIS_RENDER_I32_COUNT
         || out_f32.len() < STASIS_RENDER_F32_COUNT
         || out_u8.len() < STASIS_RENDER_U8_COUNT
@@ -2455,10 +2486,10 @@ pub fn copy_jit_render_v1_active(
     let source_f32 = unsafe { std::slice::from_raw_parts(f32_ptr, STASIS_RENDER_F32_COUNT) };
     let source_u8 = unsafe { std::slice::from_raw_parts(u8_ptr, STASIS_RENDER_U8_COUNT) };
     if source_i32[0] != STASIS_RENDER_MAGIC || source_i32[1] != STASIS_RENDER_VERSION {
-        return Err("JIT frame is not production gfx_cmd v1".to_string());
+        return Err("JIT frame is not production gfx_cmd v2".to_string());
     }
 
-    let counts = RenderV1ActiveCounts {
+    let counts = RenderV2ActiveCounts {
         lines: source_i32[3].clamp(0, STASIS_RENDER_MAX_LINES as i32) as usize,
         sprites: source_i32[4].clamp(0, STASIS_RENDER_MAX_SPRITES as i32) as usize,
         text: source_i32[7].clamp(0, STASIS_RENDER_MAX_TEXT as i32) as usize,
@@ -2466,7 +2497,7 @@ pub fn copy_jit_render_v1_active(
     };
     out_i32[..STASIS_RENDER_HEADER_I32_COUNT]
         .copy_from_slice(&source_i32[..STASIS_RENDER_HEADER_I32_COUNT]);
-    let sprite_end = STASIS_RENDER_SPRITE_BASE + counts.sprites * STASIS_RENDER_SPRITE_STRIDE;
+    let sprite_end = STASIS_RENDER_SPRITE_BASE + counts.sprites * STASIS_RENDER_SPRITE_STRIDE_I32;
     out_i32[STASIS_RENDER_SPRITE_BASE..sprite_end]
         .copy_from_slice(&source_i32[STASIS_RENDER_SPRITE_BASE..sprite_end]);
     let text_i32_end = STASIS_RENDER_TEXT_BASE_I32 + counts.text * STASIS_RENDER_TEXT_STRIDE_I32;
@@ -2476,6 +2507,10 @@ pub fn copy_jit_render_v1_active(
     out_f32[..4].copy_from_slice(&source_f32[..4]);
     let line_end = 4 + counts.lines * STASIS_RENDER_LINE_STRIDE;
     out_f32[4..line_end].copy_from_slice(&source_f32[4..line_end]);
+    let sprite_f32_end =
+        STASIS_RENDER_SPRITE_BASE_F32 + counts.sprites * STASIS_RENDER_SPRITE_STRIDE_F32;
+    out_f32[STASIS_RENDER_SPRITE_BASE_F32..sprite_f32_end]
+        .copy_from_slice(&source_f32[STASIS_RENDER_SPRITE_BASE_F32..sprite_f32_end]);
     let text_f32_end = STASIS_RENDER_TEXT_BASE_F32 + counts.text * STASIS_RENDER_TEXT_STRIDE_F32;
     out_f32[STASIS_RENDER_TEXT_BASE_F32..text_f32_end]
         .copy_from_slice(&source_f32[STASIS_RENDER_TEXT_BASE_F32..text_f32_end]);
@@ -2484,7 +2519,7 @@ pub fn copy_jit_render_v1_active(
 }
 
 unsafe extern "C" {
-    fn stasis_render_v1_trace_native(
+    fn stasis_render_v2_trace_native(
         cmd_i32: *const i32,
         cmd_f32: *const f32,
         cmd_u8: *const u8,
@@ -2492,7 +2527,7 @@ unsafe extern "C" {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn stasis_jit_render_v1_trace(
+pub unsafe extern "C" fn stasis_jit_render_v2_trace(
     cmd_i32_id: i32,
     cmd_i32_len: i32,
     cmd_f32_id: i32,
@@ -2512,7 +2547,7 @@ pub unsafe extern "C" fn stasis_jit_render_v1_trace(
     if cmd_i32.is_null() || cmd_f32.is_null() || cmd_u8.is_null() {
         return 0;
     }
-    stasis_render_v1_trace_native(cmd_i32, cmd_f32, cmd_u8) as i32
+    stasis_render_v2_trace_native(cmd_i32, cmd_f32, cmd_u8) as i32
 }
 
 fn jit_text_buffer_is_registered(value_id: i32) -> bool {
@@ -4588,7 +4623,7 @@ mod tests {
 
         // Safety: invalid lengths must be rejected before any pointer is resolved.
         let trace = unsafe {
-            stasis_jit_render_v1_trace(
+            stasis_jit_render_v2_trace(
                 101,
                 i32::MAX,
                 102,

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1540,7 +1540,7 @@ Archived priority override (2026-02-13, historical):
   - Migrate canonical logical/safe/pointer/sprite geometry to `f32`.
   - Remove pre-1.0 compatibility display/input APIs and active HostFrame alias fields.
   - Bump HostFrame and graphics command versions and migrate every host, decoder, fixture, and parity path atomically.
-  - Status: `planned after AP1.5`.
+  - Status: `complete`.
 - AP3 - Representative menu adoption:
   - Cache text run widths during initialization.
   - Center a menu title, anchor a button within an adjusted region, center its label, and reuse scalar bounds for hit testing.
@@ -1557,6 +1557,11 @@ Archived priority override (2026-02-13, historical):
   - Good: symbol-table tests turned the 49-helper linker failure into a precise dependency contract, and the layout sample now links and runs without the runtime library.
   - Bad: the first narrowing treated collection views like direct AOT globals and exposed the distinction only in the parity corpus.
   - Adjustment: retain collection helper families for functions whose ABI accepts collection/view handles, and keep direct-storage globals independent from that rule.
+- AP2 work summary:
+  - Theory gained: logical geometry is one typed path from HostFrame through layout and command submission; splitting sprite identity/state into the integer lane and geometry into the float lane preserves that invariant while physical raster dimensions remain explicit integer metadata.
+  - Good: versioning HostFrame and the render command together made stale producers and decoders mechanically discoverable across desktop, Android, fixtures, and samples.
+  - Bad: the first mechanical capacity migration missed the Android Java renderer and briefly assigned the sprite float base to the text base in one duplicated runtime module.
+  - Adjustment: future command-ABI changes must audit every language implementation by semantic field names and assert all derived bases/capacities in each platform test, not rely on numeric replacement alone.
 
 ## PR Sequence
 

--- a/docs/display_metrics.md
+++ b/docs/display_metrics.md
@@ -62,7 +62,7 @@ the logical draw size remains unchanged.
 
 Desktop and packaged mobile builds perform this policy in
 `runtime/stasis_graphics.c`. Workshop and bundled Published previews receive
-the same logical/native/drawable metadata in reserved gfx_cmd v1 header slots,
+the same logical/native/drawable metadata in reserved gfx_cmd v2 header slots,
 use the same aspect-fit viewport, and replace SVG/font/text textures when the
 density generation changes. Those metadata slots are host-populated and are
 not part of the command trace, so JIT/AOT command parity is unchanged.

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -613,7 +613,7 @@ let safe_w: f32 = gfx_safe_viewport_width();
 let safe_h: f32 = gfx_safe_viewport_height();
 ```
 
-These public layout-facing functions return `f32`. A raw host snapshot may still store safe viewport values as `i32`; the wrapper owns that one boundary conversion. No `f32[4]` wrapper is required.
+These public layout-facing functions return `f32`. HostFrame v3 stores logical and safe viewport geometry directly in its `f32` lane; physical native and drawable pixel counts remain `i32` metadata. No `f32[4]` wrapper is required.
 
 Logical presentation dimensions use one canonical public API:
 

--- a/docs/render_parity_gate.md
+++ b/docs/render_parity_gate.md
@@ -1,6 +1,6 @@
 # Render parity gate
 
-`samples/render_parity` is the framework-owned gfx_cmd v1 conformance scene. It
+`samples/render_parity` is the framework-owned gfx_cmd v2 conformance scene. It
 does not depend on a game. One frame contains a clear, two overlapping lines,
 the procedural fallback sprite, opaque and translucent SVGs, a full-canvas SVG,
 a rotated/scaled sprite, direct UTF-8 text, cached text, and present.
@@ -25,8 +25,8 @@ cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --n
 ```
 
 The `renderer_command_trace` case compiles
-`samples/render_parity/trace.stasis`. It asserts the exact gfx_cmd v1 trace
-`829981937` in JIT, links and executes the AOT object where the host linker is
+`samples/render_parity/trace.stasis`. It asserts the exact gfx_cmd v2 trace
+`3891526461` as an unsigned trace (`-403440835` as the Stasis `i32` result) in JIT, links and executes the AOT object where the host linker is
 available, and requires both results to match. Display and density metadata are
 present in the fixture but intentionally excluded from the backend-independent
 trace.

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -32,7 +32,7 @@ cache keys, and resource replacement live in `stasis_graphics.c`, so platform
 shells cannot redefine them.
 
 Logical, native, drawable, safe-viewport, input-transform, and resource-density
-semantics are defined in `display_metrics.md`. Reserved gfx_cmd v1 header slots
+semantics are defined in `display_metrics.md`. Reserved gfx_cmd v2 header slots
 carry host display metadata to embedded previews but do not participate in the
 backend-independent command trace.
 

--- a/mobile/android/app/src/main/assets/exploration_sample/src/host_runtime.stasis
+++ b/mobile/android/app/src/main/assets/exploration_sample/src/host_runtime.stasis
@@ -1,9 +1,7 @@
 @link("stasis_graphics");
 
-const HOST_I_WINDOW_W: i32 = 1;
-const HOST_I_WINDOW_H: i32 = 2;
-const HOST_I_VIEWPORT_W: i32 = 5;
-const HOST_I_VIEWPORT_H: i32 = 6;
+const HOST_F_LOGICAL_W: i32 = 50;
+const HOST_F_LOGICAL_H: i32 = 51;
 const HOST_I_POINTER_COUNT: i32 = 7;
 const HOST_I_POINTER_BASE: i32 = 544;
 const HOST_I_POINTER_STRIDE: i32 = 4;
@@ -19,7 +17,7 @@ global host_i32: i32[768];
 global host_f32: f32[64];
 
 const GFX_MAGIC: i32 = 1196967473;
-const GFX_VERSION: i32 = 1;
+const GFX_VERSION: i32 = 2;
 const GFX_FLAG_CLEAR: i32 = 1;
 const GFX_FLAG_PRESENT: i32 = 2;
 const GFX_I_FLAGS: i32 = 2;
@@ -27,8 +25,9 @@ const GFX_I_LINE_COUNT: i32 = 3;
 const GFX_I_SPRITE_COUNT: i32 = 4;
 const GFX_I_SPRITE_BASE: i32 = 32;
 const GFX_F_LINE_BASE: i32 = 4;
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+const GFX_F_SPRITE_BASE: i32 = 80004;
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 
 extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
@@ -40,9 +39,7 @@ function exploration_host_request_window(): void {
 }
 
 function exploration_host_sync_input(): void {
-    Input.screen_w = host_i32[HOST_I_VIEWPORT_W]; Input.screen_h = host_i32[HOST_I_VIEWPORT_H];
-    if (Input.screen_w <= 0) { Input.screen_w = host_i32[HOST_I_WINDOW_W]; }
-    if (Input.screen_h <= 0) { Input.screen_h = host_i32[HOST_I_WINDOW_H]; }
+    Input.screen_w.from_f32(host_f32[HOST_F_LOGICAL_W]); Input.screen_h.from_f32(host_f32[HOST_F_LOGICAL_H]);
     if (Input.screen_w <= 0) { Input.screen_w = 360; }
     if (Input.screen_h <= 0) { Input.screen_h = 640; }
     Input.touch_active = 0;
@@ -66,10 +63,11 @@ function exploration_host_begin_frame(): void {
 function exploration_host_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rotation: i32, alpha: i32): void {
     let index: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
     if (index >= 4096) { return; }
-    let base: i32 = GFX_I_SPRITE_BASE + index * 7;
-    gfx_cmd_i32[base] = handle; gfx_cmd_i32[base + 1] = x; gfx_cmd_i32[base + 2] = y;
-    gfx_cmd_i32[base + 3] = w; gfx_cmd_i32[base + 4] = h;
-    gfx_cmd_i32[base + 5] = rotation; gfx_cmd_i32[base + 6] = alpha;
+    let i_base: i32 = GFX_I_SPRITE_BASE + index * 3;
+    let f_base: i32 = GFX_F_SPRITE_BASE + index * 4;
+    gfx_cmd_i32[i_base] = handle; gfx_cmd_i32[i_base + 1] = rotation; gfx_cmd_i32[i_base + 2] = alpha;
+    gfx_cmd_f32[f_base].from_i32(x); gfx_cmd_f32[f_base + 1].from_i32(y);
+    gfx_cmd_f32[f_base + 2].from_i32(w); gfx_cmd_f32[f_base + 3].from_i32(h);
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = index + 1;
 }
 

--- a/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
@@ -1,22 +1,23 @@
 @link("stasis_graphics");
 global host_i32: i32[768];
 global host_f32: f32[64];
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 global PongHost { ball_sprite: i32; paddle_sprite: i32; center_sprite: i32; }
 extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 
 function pong_host_sprite(index: i32, handle: i32, x: i32, y: i32, w: i32, h: i32): void {
-    let base: i32 = 32 + index * 7;
-    gfx_cmd_i32[base] = handle; gfx_cmd_i32[base + 1] = x; gfx_cmd_i32[base + 2] = y;
-    gfx_cmd_i32[base + 3] = w; gfx_cmd_i32[base + 4] = h;
-    gfx_cmd_i32[base + 5] = 0; gfx_cmd_i32[base + 6] = 255;
+    let i_base: i32 = 32 + index * 3;
+    let f_base: i32 = 80004 + index * 4;
+    gfx_cmd_i32[i_base] = handle; gfx_cmd_i32[i_base + 1] = 0; gfx_cmd_i32[i_base + 2] = 255;
+    gfx_cmd_f32[f_base].from_i32(x); gfx_cmd_f32[f_base + 1].from_i32(y);
+    gfx_cmd_f32[f_base + 2].from_i32(w); gfx_cmd_f32[f_base + 3].from_i32(h);
 }
 
 function pong_host_render(): void {
     pong_game_render();
-    gfx_cmd_i32[0] = 1196967473; gfx_cmd_i32[1] = 1; gfx_cmd_i32[2] = 1;
+    gfx_cmd_i32[0] = 1196967473; gfx_cmd_i32[1] = 2; gfx_cmd_i32[2] = 1;
     gfx_cmd_i32[3] = 0; gfx_cmd_i32[4] = 0; gfx_cmd_i32[7] = 0; gfx_cmd_i32[9] = 0;
     gfx_cmd_f32[0] = 0.0588; gfx_cmd_f32[1] = 0.0667;
     gfx_cmd_f32[2] = 0.1098; gfx_cmd_f32[3] = 1.0;
@@ -24,8 +25,8 @@ function pong_host_render(): void {
     pong_host_sprite(1, PongHost.paddle_sprite, Render.command2_x, Render.command2_y, Render.command2_w, Render.command2_h);
     pong_host_sprite(2, PongHost.center_sprite, Render.command4_x, Render.command4_y, Render.command4_w, Render.command4_h);
     pong_host_sprite(3, PongHost.ball_sprite, Render.command3_x, Render.command3_y, Render.command3_w, Render.command3_h);
-    let ball_base: i32 = 53;
-    gfx_cmd_i32[ball_base + 5] = (GameState.tick_count * 3) % 360;
+    let ball_base: i32 = 41;
+    gfx_cmd_i32[ball_base + 1] = (GameState.tick_count * 3) % 360;
     gfx_cmd_i32[4] = 4;
     gfx_cmd_i32[2] = 3;
 }
@@ -40,7 +41,7 @@ function main(): i32 {
 }
 
 function tick(): i32 {
-    Input.screen_w = host_i32[5]; Input.screen_h = host_i32[6];
+    Input.screen_w.from_f32(host_f32[50]); Input.screen_h.from_f32(host_f32[51]);
     Input.touch_active = host_i32[545];
     let touch_x: i32; touch_x.from_f32(host_f32[0]); Input.touch_x = touch_x;
     let touch_y: i32; touch_y.from_f32(host_f32[1]); Input.touch_y = touch_y;

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -27,5 +27,5 @@ if(STASIS_ANDROID_PUBLISHED_AOT)
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime/stasis_mobile_aot_runtime.c")
     target_include_directories(stasis_mobile_smoke PRIVATE "${STASIS_PUBLISHED_AOT_DIR}")
     target_compile_definitions(stasis_mobile_smoke PRIVATE
-        STASIS_ANDROID_PUBLISHED_AOT=1 STASIS_RENDER_V1_DIRECT=1)
+        STASIS_ANDROID_PUBLISHED_AOT=1 STASIS_RENDER_V2_DIRECT=1)
 endif()

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -108,7 +108,7 @@ typedef struct CodexBridgeApi {
 } CodexBridgeApi;
 
 static CodexBridgeApi codex_bridge_api = {0};
-#if STASIS_ANDROID_PUBLISHED_AOT && !STASIS_RENDER_V1_DIRECT
+#if STASIS_ANDROID_PUBLISHED_AOT && !STASIS_RENDER_V2_DIRECT
 typedef struct PublishedRenderCommand {
     int32_t kind;
     int32_t x;
@@ -314,7 +314,7 @@ static int stasis_published_run_tick_frame(int touch_x, int touch_y, int touch_a
     return 0;
 }
 
-static int stasis_published_run_tick_frame_v1(
+static int stasis_published_run_tick_frame_v2(
         int touch_x, int touch_y, int touch_active, int screen_w, int screen_h,
         int32_t *out_i32, float *out_f32, uint8_t *out_u8) {
     int32_t legacy[STASIS_RENDER_FRAME_I32_CAPACITY] = {0};
@@ -323,8 +323,8 @@ static int stasis_published_run_tick_frame_v1(
             legacy, STASIS_RENDER_FRAME_I32_CAPACITY);
     if (status != 0) return status;
     (void)out_u8;
-    out_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
-    out_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
+    out_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
+    out_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V2_VERSION;
     out_i32[STASIS_RENDER_I_FLAGS] = STASIS_RENDER_FLAG_CLEAR | STASIS_RENDER_FLAG_PRESENT;
     out_i32[STASIS_RENDER_I_LINE_COUNT] = 0;
     out_i32[STASIS_RENDER_I_SPRITE_COUNT] = 0;
@@ -369,15 +369,17 @@ static int stasis_published_run_tick_frame_v1(
         } else if (legacy[base] == 2) {
             int32_t sprite = out_i32[STASIS_RENDER_I_SPRITE_COUNT];
             if (sprite >= STASIS_RENDER_MAX_SPRITES) continue;
-            int32_t sprite_base = STASIS_RENDER_I_SPRITE_BASE +
+            int32_t sprite_i32_base = STASIS_RENDER_I_SPRITE_BASE +
                     sprite * STASIS_RENDER_SPRITE_I32_STRIDE;
-            out_i32[sprite_base + 0] = legacy[base + 6];
-            out_i32[sprite_base + 1] = legacy[base + 1];
-            out_i32[sprite_base + 2] = legacy[base + 2];
-            out_i32[sprite_base + 3] = legacy[base + 3];
-            out_i32[sprite_base + 4] = legacy[base + 4];
-            out_i32[sprite_base + 5] = legacy[base + 7];
-            out_i32[sprite_base + 6] = legacy[base + 8];
+            int32_t sprite_f32_base = STASIS_RENDER_F_SPRITE_BASE +
+                    sprite * STASIS_RENDER_SPRITE_F32_STRIDE;
+            out_i32[sprite_i32_base + 0] = legacy[base + 6];
+            out_i32[sprite_i32_base + 1] = legacy[base + 7];
+            out_i32[sprite_i32_base + 2] = legacy[base + 8];
+            out_f32[sprite_f32_base + 0] = (float)legacy[base + 1];
+            out_f32[sprite_f32_base + 1] = (float)legacy[base + 2];
+            out_f32[sprite_f32_base + 2] = (float)legacy[base + 3];
+            out_f32[sprite_f32_base + 3] = (float)legacy[base + 4];
             out_i32[STASIS_RENDER_I_SPRITE_COUNT] = sprite + 1;
         }
     }
@@ -385,7 +387,7 @@ static int stasis_published_run_tick_frame_v1(
 }
 #endif
 
-#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V2_DIRECT
 #define STASIS_PUBLISHED_MAX_FONTS 64
 #define STASIS_PUBLISHED_MAX_TEXT_RUNS 4096
 typedef struct PublishedFontResource { char path[256]; int32_t size; } PublishedFontResource;
@@ -497,10 +499,10 @@ int stasis_get_time_us(void) {
             ? (int)(now.tv_sec * 1000000 + now.tv_nsec / 1000) : 0;
 }
 
-static int published_v1_initialized;
-static int32_t *published_v1_i32;
-static float *published_v1_f32;
-static uint8_t *published_v1_u8;
+static int published_v2_initialized;
+static int32_t *published_v2_i32;
+static float *published_v2_f32;
+static uint8_t *published_v2_u8;
 static int32_t published_host_i32[768];
 static float published_host_f32[64];
 static int32_t published_previous_touch_x;
@@ -568,28 +570,18 @@ static void stasis_published_write_host_frame(
     int32_t was_down = published_has_previous_input && published_previous_touch_active != 0;
     int32_t is_down = touch_active != 0;
     published_host_i32[0] = stasis_get_time_ms();
-    published_host_i32[1] = logical_w;
-    published_host_i32[2] = logical_h;
-    published_host_i32[5] = logical_w;
-    published_host_i32[6] = logical_h;
     published_host_i32[7] = 1;
     published_host_i32[11] = display_changed;
     published_host_i32[12] = screen_w;
     published_host_i32[13] = screen_h;
-    published_host_i32[14] = 2;
+    published_host_i32[14] = 3;
     published_host_i32[16] = 60;
     published_host_i32[17] = 1;
     published_host_i32[19] = stasis_get_time_us();
-    published_host_i32[20] = logical_w;
-    published_host_i32[21] = logical_h;
     published_host_i32[22] = screen_w;
     published_host_i32[23] = screen_h;
     published_host_i32[24] = screen_w;
     published_host_i32[25] = screen_h;
-    published_host_i32[26] = 0;
-    published_host_i32[27] = 0;
-    published_host_i32[28] = logical_w;
-    published_host_i32[29] = logical_h;
     published_host_i32[30] = published_display_generation;
     published_host_i32[31] = published_density_generation;
     published_host_i32[544] = 0;
@@ -604,28 +596,34 @@ static void stasis_published_write_host_frame(
     published_host_f32[5] = logical_h > 0 ? logical_touch_y / (float)logical_h : 0.0f;
     published_host_f32[48] = published_display_metrics.content_scale;
     published_host_f32[49] = published_display_metrics.raster_scale;
+    published_host_f32[50] = (float)logical_w;
+    published_host_f32[51] = (float)logical_h;
+    published_host_f32[52] = 0.0f;
+    published_host_f32[53] = 0.0f;
+    published_host_f32[54] = (float)logical_w;
+    published_host_f32[55] = (float)logical_h;
     published_previous_touch_x = touch_x;
     published_previous_touch_y = touch_y;
     published_previous_touch_active = touch_active;
     published_has_previous_input = 1;
 }
 
-static int stasis_published_run_tick_frame_v1(
+static int stasis_published_run_tick_frame_v2(
         int touch_x, int touch_y, int touch_active, int screen_w, int screen_h,
         int32_t *out_i32, float *out_f32, uint8_t *out_u8) {
-    if (published_v1_initialized &&
-            (out_i32 != published_v1_i32 || out_f32 != published_v1_f32 || out_u8 != published_v1_u8)) {
-        published_v1_initialized = 0;
-        published_v1_i32 = NULL;
-        published_v1_f32 = NULL;
-        published_v1_u8 = NULL;
+    if (published_v2_initialized &&
+            (out_i32 != published_v2_i32 || out_f32 != published_v2_f32 || out_u8 != published_v2_u8)) {
+        published_v2_initialized = 0;
+        published_v2_i32 = NULL;
+        published_v2_f32 = NULL;
+        published_v2_u8 = NULL;
         published_font_count = 0;
         published_text_run_count = 0;
         published_has_previous_input = 0;
         memset(published_host_i32, 0, sizeof(published_host_i32));
         memset(published_host_f32, 0, sizeof(published_host_f32));
     }
-    if (!published_v1_initialized) {
+    if (!published_v2_initialized) {
         published_resource_error[0] = '\0';
         stasis_mobile_aot_reset();
         STASIS_AOT_BIND_RUNTIME_GLOBALS();
@@ -639,19 +637,19 @@ static int stasis_published_run_tick_frame_v1(
                 stasis_published_hash_path("gfx_cmd_f32"), 0, out_f32, STASIS_RENDER_F32_COUNT);
         stasis_jit_register_global_u8_array(
                 stasis_published_hash_path("gfx_cmd_u8"), 0, out_u8, STASIS_RENDER_U8_COUNT);
-        published_v1_i32 = out_i32;
-        published_v1_f32 = out_f32;
-        published_v1_u8 = out_u8;
+        published_v2_i32 = out_i32;
+        published_v2_f32 = out_f32;
+        published_v2_u8 = out_u8;
         stasis_published_write_host_frame(touch_x, touch_y, touch_active, screen_w, screen_h);
         if (STASIS_AOT_MAIN() != 0) return -1;
         if (published_resource_error[0] != '\0') return -1;
-        published_v1_initialized = 1;
+        published_v2_initialized = 1;
     }
     stasis_published_write_host_frame(touch_x, touch_y, touch_active, screen_w, screen_h);
     if (STASIS_AOT_TICK() != 0 || STASIS_AOT_RENDER() != 0) return -1;
     if (published_resource_error[0] != '\0') return -1;
     published_host_i32[10] += 1;
-    if (!stasis_render_v1_is_valid(out_i32)) return -1;
+    if (!stasis_render_v2_is_valid(out_i32)) return -1;
     out_i32[STASIS_RENDER_I_LOGICAL_W] = published_display_metrics.logical_w;
     out_i32[STASIS_RENDER_I_LOGICAL_H] = published_display_metrics.logical_h;
     out_i32[STASIS_RENDER_I_NATIVE_W] = published_display_metrics.native_w;
@@ -1312,7 +1310,7 @@ static RustBridgeApi *load_rust_bridge_api(void) {
     rust_bridge_api.run_tick =
             (stasis_android_bridge_run_tick_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick");
     rust_bridge_api.run_tick_frame =
-            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v1");
+            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v2");
     rust_bridge_api.last_frame_error =
             (stasis_android_bridge_last_frame_error_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_last_frame_error");
     rust_bridge_api.inspect_runtime_state =
@@ -1672,7 +1670,7 @@ JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeResolveCachedText(
         JNIEnv *env, jclass activity_class, jstring project_root, jint handle) {
     (void)activity_class;
-#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V2_DIRECT
     (void)project_root;
     if (handle <= 0 || handle > published_text_run_count) {
         return (*env)->NewStringUTF(env,
@@ -1721,7 +1719,7 @@ JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeResolveFont(
         JNIEnv *env, jclass activity_class, jstring project_root, jint handle) {
     (void)activity_class;
-#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V2_DIRECT
     (void)project_root;
     if (handle <= 0 || handle > published_font_count) {
         return (*env)->NewStringUTF(env,
@@ -1838,7 +1836,7 @@ Java_com_stasislang_workshop_MainActivity_nativeCompileProject(JNIEnv *env, jcla
     (void)activity_class;
 #if STASIS_ANDROID_PUBLISHED_AOT
     (void)project_root;
-#if !STASIS_RENDER_V1_DIRECT
+#if !STASIS_RENDER_V2_DIRECT
     stasis_published_init_globals();
 #endif
     return (*env)->NewStringUTF(env, "CompilePlanned: reload=PublishedAot files=0 functions=0 hash=0000000000000000 manifest=published_aot state=compiled status=0");
@@ -1986,7 +1984,7 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
 
 #if STASIS_ANDROID_PUBLISHED_AOT
     (void)project_root;
-    int status = stasis_published_run_tick_frame_v1(
+    int status = stasis_published_run_tick_frame_v2(
             (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h,
             values_i32, values_f32, values_u8);
 #else
@@ -2011,9 +2009,9 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
         if (last_traced_frame != values_i32 ||
                 last_display_generation != values_i32[STASIS_RENDER_I_DISPLAY_GENERATION] ||
                 last_density_generation != values_i32[STASIS_RENDER_I_DENSITY_GENERATION]) {
-            uint32_t trace = stasis_render_v1_trace(values_i32, values_f32, values_u8);
+            uint32_t trace = stasis_render_v2_trace(values_i32, values_f32, values_u8);
             __android_log_print(ANDROID_LOG_INFO, STASIS_ANDROID_LOG_TAG,
-                    "Stasis preview gfx_cmd v1 trace=%u flags=%d lines=%d sprites=%d text=%d "
+                    "Stasis preview gfx_cmd v2 trace=%u flags=%d lines=%d sprites=%d text=%d "
                     "logical=%dx%d native=%dx%d drawable=%dx%d display_gen=%d density_gen=%d",
                     trace, values_i32[STASIS_RENDER_I_FLAGS],
                     values_i32[STASIS_RENDER_I_LINE_COUNT],
@@ -2039,7 +2037,7 @@ JNIEXPORT jstring JNICALL
 Java_com_stasislang_workshop_MainActivity_nativeLastFrameError(
         JNIEnv *env, jclass activity_class) {
     (void)activity_class;
-#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V1_DIRECT
+#if STASIS_ANDROID_PUBLISHED_AOT && STASIS_RENDER_V2_DIRECT
     const char *message = published_resource_error[0] == '\0'
             ? "native preview frame failed" : published_resource_error;
     return (*env)->NewStringUTF(env, message);

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -13,7 +13,7 @@ import java.nio.IntBuffer;
 final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final String LOG_TAG = "StasisRenderer";
     static final int RENDER_MAGIC = 0x47584631;
-    static final int RENDER_VERSION = 1;
+    static final int RENDER_VERSION = 2;
     static final int FLAG_CLEAR = 1;
     static final int FLAG_PRESENT = 2;
 
@@ -39,13 +39,15 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     static final int MAX_LINES = 10_000;
     static final int LINE_F32_STRIDE = 8;
     static final int MAX_SPRITES = 4_096;
-    static final int SPRITE_I32_STRIDE = 7;
+    static final int SPRITE_I32_STRIDE = 3;
+    static final int SPRITE_F32_STRIDE = 4;
     static final int MAX_TEXT = 2_048;
     static final int TEXT_I32_STRIDE = 3;
     static final int TEXT_F32_STRIDE = 6;
     static final int TEXT_U8_CAPACITY = 65_536;
     static final int I_TEXT_BASE = I_SPRITE_BASE + MAX_SPRITES * SPRITE_I32_STRIDE;
-    static final int F_TEXT_BASE = F_LINE_BASE + MAX_LINES * LINE_F32_STRIDE;
+    static final int F_SPRITE_BASE = F_LINE_BASE + MAX_LINES * LINE_F32_STRIDE;
+    static final int F_TEXT_BASE = F_SPRITE_BASE + MAX_SPRITES * SPRITE_F32_STRIDE;
     static final int FRAME_I32_CAPACITY = I_TEXT_BASE + MAX_TEXT * TEXT_I32_STRIDE;
     static final int FRAME_F32_CAPACITY = F_TEXT_BASE + MAX_TEXT * TEXT_F32_STRIDE;
 
@@ -103,15 +105,17 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         final int[] header;
         final float[] lines;
         final int[] sprites;
+        final float[] spriteValues;
         final int[] textMetadata;
         final float[] textValues;
         final byte[] textBytes;
 
-        LogicalFrameSnapshot(int[] header, float[] lines, int[] sprites,
+        LogicalFrameSnapshot(int[] header, float[] lines, int[] sprites, float[] spriteValues,
                 int[] textMetadata, float[] textValues, byte[] textBytes) {
             this.header = header;
             this.lines = lines;
             this.sprites = sprites;
+            this.spriteValues = spriteValues;
             this.textMetadata = textMetadata;
             this.textValues = textValues;
             this.textBytes = textBytes;
@@ -563,16 +567,18 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void appendSprite(int base) {
-        float left = frameI32.get(base + 1);
-        float top = frameI32.get(base + 2);
-        float right = left + frameI32.get(base + 3);
-        float bottom = top + frameI32.get(base + 4);
+        int index = (base - I_SPRITE_BASE) / SPRITE_I32_STRIDE;
+        int values = F_SPRITE_BASE + index * SPRITE_F32_STRIDE;
+        float left = frameF32.get(values);
+        float top = frameF32.get(values + 1);
+        float right = left + frameF32.get(values + 2);
+        float bottom = top + frameF32.get(values + 3);
         float centerX = (left + right) * 0.5f;
         float centerY = (top + bottom) * 0.5f;
-        double radians = Math.toRadians(frameI32.get(base + 5) % 360);
+        double radians = Math.toRadians(frameI32.get(base + 1) % 360);
         float cosine = (float)Math.cos(radians);
         float sine = (float)Math.sin(radians);
-        float alpha = clampUnit(frameI32.get(base + 6) / 255.0f);
+        float alpha = clampUnit(frameI32.get(base + 2) / 255.0f);
         putTextureVertex(spriteVertices, left, top, centerX, centerY, cosine, sine, 0, 0, 1, 1, 1, alpha);
         putTextureVertex(spriteVertices, right, top, centerX, centerY, cosine, sine, 1, 0, 1, 1, 1, alpha);
         putTextureVertex(spriteVertices, left, bottom, centerX, centerY, cosine, sine, 0, 1, 1, 1, 1, alpha);
@@ -706,6 +712,10 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         return clampCount(spriteCount, MAX_SPRITES) * SPRITE_I32_STRIDE;
     }
 
+    static int activeSpriteF32Count(int spriteCount) {
+        return clampCount(spriteCount, MAX_SPRITES) * SPRITE_F32_STRIDE;
+    }
+
     static int activeTextI32Count(int textCount) {
         return clampCount(textCount, MAX_TEXT) * TEXT_I32_STRIDE;
     }
@@ -746,6 +756,10 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         for (int index = 0; index < sprites.length; index += 1) {
             sprites[index] = frameI32.get(I_SPRITE_BASE + index);
         }
+        float[] spriteValues = new float[activeSpriteF32Count(spriteCount)];
+        for (int index = 0; index < spriteValues.length; index += 1) {
+            spriteValues[index] = frameF32.get(F_SPRITE_BASE + index);
+        }
         int[] textMetadata = new int[activeTextI32Count(textCount)];
         for (int index = 0; index < textMetadata.length; index += 1) {
             textMetadata[index] = frameI32.get(I_TEXT_BASE + index);
@@ -759,7 +773,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             textBytes[index] = frameU8Bytes.get(index);
         }
         return new LogicalFrameSnapshot(
-                header, lines, sprites, textMetadata, textValues, textBytes);
+                header, lines, sprites, spriteValues, textMetadata, textValues, textBytes);
     }
 
     private static ByteBuffer directBytes(int capacity) {

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -225,7 +225,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         if (pendingCapture != null) {
             pendingCapture.onCaptured(null, "a newer preview capture replaced this request",
                     new LogicalFrameSnapshot(new int[0], new float[0], new int[0],
-                            new int[0], new float[0], new byte[0]));
+                            new float[0], new int[0], new float[0], new byte[0]));
         }
         pendingCapture = callback;
     }

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -13,6 +13,23 @@ import org.junit.Test;
 
 public final class StasisPreviewRendererSchemaTest {
     @Test
+    public void replacedCaptureIncludesEmptyTypedSpriteLanes() {
+        StasisPreviewRenderer renderer = new StasisPreviewRenderer(
+                new StasisPreviewRenderer.TextureProvider() {
+                    @Override public void onResourceGenerationChanged(
+                            int surfaceGeneration, int rendererGeneration,
+                            boolean discardGpuHandles, String transitionReason) {}
+                    @Override public int textureFor(int handle) { return 0; }
+                }, ignored -> {});
+        StasisPreviewRenderer.LogicalFrameSnapshot[] replaced = {null};
+        renderer.requestCapture((bitmap, error, snapshot) -> replaced[0] = snapshot);
+        renderer.requestCapture((bitmap, error, snapshot) -> {});
+
+        assertEquals(0, replaced[0].sprites.length);
+        assertEquals(0, replaced[0].spriteValues.length);
+    }
+
+    @Test
     public void productionSchemaMatchesNativeContract() {
         assertEquals(12_320, StasisPreviewRenderer.I_TEXT_BASE);
         assertEquals(80_004, StasisPreviewRenderer.F_SPRITE_BASE);

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -14,10 +14,11 @@ import org.junit.Test;
 public final class StasisPreviewRendererSchemaTest {
     @Test
     public void productionSchemaMatchesNativeContract() {
-        assertEquals(28_704, StasisPreviewRenderer.I_TEXT_BASE);
-        assertEquals(80_004, StasisPreviewRenderer.F_TEXT_BASE);
-        assertEquals(34_848, StasisPreviewRenderer.FRAME_I32_CAPACITY);
-        assertEquals(92_292, StasisPreviewRenderer.FRAME_F32_CAPACITY);
+        assertEquals(12_320, StasisPreviewRenderer.I_TEXT_BASE);
+        assertEquals(80_004, StasisPreviewRenderer.F_SPRITE_BASE);
+        assertEquals(96_388, StasisPreviewRenderer.F_TEXT_BASE);
+        assertEquals(18_464, StasisPreviewRenderer.FRAME_I32_CAPACITY);
+        assertEquals(108_676, StasisPreviewRenderer.FRAME_F32_CAPACITY);
         assertEquals(65_536, StasisPreviewRenderer.TEXT_U8_CAPACITY);
     }
 
@@ -73,7 +74,7 @@ public final class StasisPreviewRendererSchemaTest {
         assertFalse(StasisPreviewRenderer.shouldPresent(frame));
         frame.put(StasisPreviewRenderer.I_FLAGS, StasisPreviewRenderer.FLAG_PRESENT);
         assertTrue(StasisPreviewRenderer.shouldPresent(frame));
-        frame.put(1, 2);
+        frame.put(1, 1);
         assertFalse(StasisPreviewRenderer.isValidFrame(frame));
         assertFalse(StasisPreviewRenderer.shouldPresent(frame));
         assertFalse(StasisPreviewRenderer.isValidFrame(IntBuffer.allocate(10)));
@@ -86,6 +87,8 @@ public final class StasisPreviewRendererSchemaTest {
         assertEquals(8, StasisPreviewRenderer.clampCount(20, 8));
         assertEquals(StasisPreviewRenderer.MAX_SPRITES * StasisPreviewRenderer.SPRITE_I32_STRIDE,
                 StasisPreviewRenderer.activeSpriteI32Count(Integer.MAX_VALUE));
+        assertEquals(StasisPreviewRenderer.MAX_SPRITES * StasisPreviewRenderer.SPRITE_F32_STRIDE,
+                StasisPreviewRenderer.activeSpriteF32Count(Integer.MAX_VALUE));
         assertEquals(StasisPreviewRenderer.MAX_TEXT * StasisPreviewRenderer.TEXT_I32_STRIDE,
                 StasisPreviewRenderer.activeTextI32Count(Integer.MAX_VALUE));
         assertEquals(StasisPreviewRenderer.MAX_LINES * StasisPreviewRenderer.LINE_F32_STRIDE,
@@ -159,6 +162,7 @@ public final class StasisPreviewRendererSchemaTest {
         renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_DENSITY_GENERATION, 7);
         renderer.frameF32Bytes().asFloatBuffer().put(StasisPreviewRenderer.F_LINE_BASE, 12.5f);
         renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_SPRITE_BASE, 77);
+        renderer.frameF32Bytes().asFloatBuffer().put(StasisPreviewRenderer.F_SPRITE_BASE, 19.25f);
         renderer.frameI32Bytes().asIntBuffer().put(StasisPreviewRenderer.I_TEXT_BASE, 5);
         renderer.frameF32Bytes().asFloatBuffer().put(StasisPreviewRenderer.F_TEXT_BASE, 42.0f);
         renderer.frameU8Bytes().put(0, (byte)'A');
@@ -176,6 +180,8 @@ public final class StasisPreviewRendererSchemaTest {
         assertEquals(12.5f, snapshot.lines[0], 0.0f);
         assertEquals(StasisPreviewRenderer.SPRITE_I32_STRIDE, snapshot.sprites.length);
         assertEquals(77, snapshot.sprites[0]);
+        assertEquals(StasisPreviewRenderer.SPRITE_F32_STRIDE, snapshot.spriteValues.length);
+        assertEquals(19.25f, snapshot.spriteValues[0], 0.0f);
         assertEquals(StasisPreviewRenderer.TEXT_I32_STRIDE, snapshot.textMetadata.length);
         assertEquals(5, snapshot.textMetadata[0]);
         assertEquals(StasisPreviewRenderer.TEXT_F32_STRIDE, snapshot.textValues.length);

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -130,7 +130,7 @@ The library exports these functions for Stasis programs:
 | `stasis_draw_lines_f32(lines, count)` | Batch: queue `count` lines from an `f32` array (8 floats per line) |
 | `stasis_gfx_load_sprite(path, max_w, max_h)` | Load and bake an image into the sprite atlas system; returns handle |
 | `stasis_gfx_draw_sprite(handle, x, y, sx, sy, rot, r, g, b, a)` | Draw baked sprite (centered) with scale/rotation/tint |
-| `stasis_gfx_draw_sprites_i32(cmds, count)` | Batch: draw `count` sprites from an `i32` array (7 ints per sprite) |
+| `stasis_gfx_draw_sprites(cmd_i32, cmd_f32, count)` | Batch: draw sprites from typed state and logical-geometry arrays |
 | `stasis_gfx_debug_bake_hash(path)` | Debug: bake SVG on CPU and return a pixel hash |
 | `stasis_gfx_debug_enable_hash(enabled)` | Debug: enable per-frame draw-call hash (for verifying batch equivalence) |
 | `stasis_gfx_debug_get_frame_hash()` | Debug: get current frame hash (0 if disabled) |
@@ -141,7 +141,6 @@ The library exports these functions for Stasis programs:
 | `stasis_should_quit()` | Pump input/events (once per frame) and report quit state |
 | `stasis_input_pointer_count()` | Number of pointers tracked this frame (mouse + active touches) |
 | `stasis_input_pointer_*` | Pointer snapshot queries (pos, deltas, edge flags) |
-| `stasis_input_viewport_*_px` | Viewport rectangle (currently full window) |
 | `stasis_audio_is_available()` | Initialize audio if needed; returns 1 on success |
 | `stasis_audio_get_sample_rate()` | Current audio sample rate (Hz) |
 | `stasis_audio_get_channels()` | Current audio channels (v1: 2) |

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -203,7 +203,7 @@ STASIS_EXPORT int stasis_get_time_ms(void);
 STASIS_EXPORT int stasis_should_quit(void);
 STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32);
 STASIS_EXPORT int stasis_set_fullscreen(int fullscreen);
-STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, int x, int y, int w, int h, int rot_degrees, int a);
+STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, float x, float y, float w, float h, int rot_degrees, int a);
 STASIS_EXPORT void stasis_gfx_submit_u8(const int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8);
 STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, float y, float r, float g, float b, float a);
 
@@ -211,8 +211,7 @@ STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, 
 typedef struct SpriteEntry SpriteEntry;
 static SpriteEntry* sprite_get(int handle);
 static SpriteEntry* sprite_fallback_get(void);
-static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int h, int rot_degrees, int a, int do_hash);
-static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_count);
+static void stasis_gfx_draw_sprite_internal(int handle, float x, float y, float w, float h, int rot_degrees, int a, int do_hash);
 static int sprite_build_into_entry_sized(SpriteEntry* e, const char* path, int max_w, int max_h);
 static void stasis_sync_display_metrics(void);
 static void stasis_reset_text_cache(void);
@@ -757,22 +756,22 @@ STASIS_EXPORT int stasis_input_pointer_went_up(int idx) {
     return g_input_frame.pointers[idx].went_up ? 1 : 0;
 }
 
-STASIS_EXPORT float stasis_input_pointer_x_px(int idx) {
+STASIS_EXPORT float stasis_input_pointer_x_logical(int idx) {
     if (!g_window || !stasis_input_valid_index(idx)) return 0.0f;
     return g_input_frame.pointers[idx].x_px;
 }
 
-STASIS_EXPORT float stasis_input_pointer_y_px(int idx) {
+STASIS_EXPORT float stasis_input_pointer_y_logical(int idx) {
     if (!g_window || !stasis_input_valid_index(idx)) return 0.0f;
     return g_input_frame.pointers[idx].y_px;
 }
 
-STASIS_EXPORT float stasis_input_pointer_dx_px(int idx) {
+STASIS_EXPORT float stasis_input_pointer_dx_logical(int idx) {
     if (!g_window || !stasis_input_valid_index(idx)) return 0.0f;
     return g_input_frame.pointers[idx].dx_px;
 }
 
-STASIS_EXPORT float stasis_input_pointer_dy_px(int idx) {
+STASIS_EXPORT float stasis_input_pointer_dy_logical(int idx) {
     if (!g_window || !stasis_input_valid_index(idx)) return 0.0f;
     return g_input_frame.pointers[idx].dy_px;
 }
@@ -789,22 +788,6 @@ STASIS_EXPORT float stasis_input_pointer_y_n(int idx) {
 
 STASIS_EXPORT int stasis_input_dropped_pointers(void) {
     return g_window ? g_input_frame.dropped_pointers : 0;
-}
-
-STASIS_EXPORT int stasis_input_viewport_x_px(void) {
-    return g_window ? g_input_frame.viewport_x_px : 0;
-}
-
-STASIS_EXPORT int stasis_input_viewport_y_px(void) {
-    return g_window ? g_input_frame.viewport_y_px : 0;
-}
-
-STASIS_EXPORT int stasis_input_viewport_w_px(void) {
-    return g_window ? g_input_frame.viewport_w_px : 0;
-}
-
-STASIS_EXPORT int stasis_input_viewport_h_px(void) {
-    return g_window ? g_input_frame.viewport_h_px : 0;
 }
 
 STASIS_EXPORT void stasis_get_desktop_size(int* width, int* height);
@@ -932,18 +915,13 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     if (!out_i32 || !out_f32) return;
 
     static int32_t g_host_tick_index = 0;
-    const int32_t host_version = 2;
+    const int32_t host_version = 3;
     const int i32_key_base = 32;
     const int i32_key_count = 512;
 
     /* i32 header */
     out_i32[0] = stasis_get_time_ms();
-    out_i32[1] = g_window_width;
-    out_i32[2] = g_window_height;
-    out_i32[3] = g_input_frame.viewport_x_px;
-    out_i32[4] = g_input_frame.viewport_y_px;
-    out_i32[5] = g_input_frame.viewport_w_px;
-    out_i32[6] = g_input_frame.viewport_h_px;
+    for (int index = 1; index <= 6; index++) out_i32[index] = 0;
     out_i32[7] = g_input_frame.pointer_count;
     out_i32[8] = g_input_frame.dropped_pointers;
     out_i32[9] = stasis_should_quit();
@@ -982,16 +960,13 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     out_i32[18] = minimized;
     out_i32[19] = stasis_get_time_us();
 
-    out_i32[20] = g_display_metrics.logical_w;
-    out_i32[21] = g_display_metrics.logical_h;
+    out_i32[20] = 0;
+    out_i32[21] = 0;
     out_i32[22] = g_display_metrics.native_w;
     out_i32[23] = g_display_metrics.native_h;
     out_i32[24] = g_display_metrics.drawable_w;
     out_i32[25] = g_display_metrics.drawable_h;
-    out_i32[26] = (int32_t)floorf(g_display_metrics.safe_logical_viewport.x);
-    out_i32[27] = (int32_t)floorf(g_display_metrics.safe_logical_viewport.y);
-    out_i32[28] = (int32_t)ceilf(g_display_metrics.safe_logical_viewport.w);
-    out_i32[29] = (int32_t)ceilf(g_display_metrics.safe_logical_viewport.h);
+    for (int index = 26; index <= 29; index++) out_i32[index] = 0;
     out_i32[30] = g_display_generation;
     out_i32[31] = g_density_generation;
 
@@ -1025,6 +1000,12 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     for (int i = f32_base + STASIS_MAX_POINTERS * f32_stride; i < 64; i++) out_f32[i] = 0.0f;
     out_f32[48] = g_display_metrics.content_scale;
     out_f32[49] = g_display_metrics.raster_scale;
+    out_f32[50] = (float)g_display_metrics.logical_w;
+    out_f32[51] = (float)g_display_metrics.logical_h;
+    out_f32[52] = g_display_metrics.safe_logical_viewport.x;
+    out_f32[53] = g_display_metrics.safe_logical_viewport.y;
+    out_f32[54] = g_display_metrics.safe_logical_viewport.w;
+    out_f32[55] = g_display_metrics.safe_logical_viewport.h;
 }
 
 /* ============================================================
@@ -3097,87 +3078,6 @@ static void flush_sprites(void) {
 }
 #endif
 
-/* Fast path for command-buffer sprite submission.
- *
- * When debug hashing is disabled and most sprites are unrotated, we avoid per-sprite trig
- * and reduce function-call overhead by writing vertices directly from the stream.
- *
- * NOTE: rotation != 0 falls back to the general path.
- */
-static void stasis_gfx_draw_sprites_i32_fast(const int32_t* cmds, int sprite_count) {
-    if (!cmds || sprite_count <= 0) return;
-
-    if (g_use_sdl_renderer) {
-        for (int i = 0; i < sprite_count; i++) {
-            const int base = i * 7;
-            stasis_gfx_draw_sprite_internal(
-                cmds[base + 0],
-                cmds[base + 1],
-                cmds[base + 2],
-                cmds[base + 3],
-                cmds[base + 4],
-                cmds[base + 5],
-                cmds[base + 6],
-                0);
-        }
-        return;
-    }
-
-#if !defined(STASIS_GRAPHICS_SDL_ONLY)
-    for (int i = 0; i < sprite_count; i++) {
-        const int base = i * 7;
-        const int handle = cmds[base + 0];
-        const int x = cmds[base + 1];
-        const int y = cmds[base + 2];
-        const int w = cmds[base + 3];
-        const int h = cmds[base + 4];
-        const int rot_degrees = cmds[base + 5];
-        const int a = cmds[base + 6];
-
-        if (w <= 0 || h <= 0) continue;
-        SpriteEntry* e = sprite_get(handle);
-        if (!e) e = sprite_fallback_get();
-        if (!e) continue;
-
-        if (e->needs_reraster) {
-            if (e->path) sprite_build_into_entry_sized(e, e->path, e->max_w, e->max_h);
-        }
-
-        if (rot_degrees != 0) {
-            stasis_gfx_draw_sprite_internal(handle, x, y, w, h, rot_degrees, a, 0);
-            continue;
-        }
-
-        if (g_sprite_vert_count + 6 > MAX_SPRITE_VERTS) {
-            flush_sprites();
-        }
-        if (g_sprite_vert_count > 0 && g_sprite_batch_page != e->page_index) {
-            flush_sprites();
-        }
-        g_sprite_batch_page = e->page_index;
-
-        const float af = (float)a / 255.0f;
-        const float u0 = e->u0, v0 = e->v0, u1 = e->u1, v1 = e->v1;
-        const float x0 = (float)x;
-        const float y0 = (float)y;
-        const float x1p = (float)(x + w);
-        const float y1p = (float)(y + h);
-
-        SpriteVertex* v = &g_sprite_vertices[g_sprite_vert_count];
-        v[0] = (SpriteVertex){ x0,  y0,  u0, v0, af, af, af, af };
-        v[1] = (SpriteVertex){ x1p, y0,  u1, v0, af, af, af, af };
-        v[2] = (SpriteVertex){ x1p, y1p, u1, v1, af, af, af, af };
-        v[3] = (SpriteVertex){ x1p, y1p, u1, v1, af, af, af, af };
-        v[4] = (SpriteVertex){ x0,  y1p, u0, v1, af, af, af, af };
-        v[5] = (SpriteVertex){ x0,  y0,  u0, v0, af, af, af, af };
-        g_sprite_vert_count += 6;
-    }
-#else
-    (void)cmds;
-    (void)sprite_count;
-#endif
-}
-
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
 static const char* kFallbackPostfxVert =
 "#version 120\n"
@@ -4284,7 +4184,7 @@ STASIS_EXPORT void stasis_draw_lines_f32(const float* lines, int line_count) {
 }
 
 /*
- * Command-buffer submission (v1 prototype).
+ * Command-buffer submission (v2).
  *
  * Command coordinates are host pixels. Ordering is fixed by the buffer layout:
  * clear -> lines -> sprites -> text -> present.
@@ -4321,14 +4221,14 @@ static void flush_sprites_before_text(void) {
 #endif
 }
 
-static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
+static void stasis_gfx_submit_v2(const int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
     static int contract_logged = 0;
-    StasisRenderV1Validation validation = stasis_render_v1_validate(cmd_i32, cmd_f32);
-    if (validation != STASIS_RENDER_V1_VALID) {
+    StasisRenderV2Validation validation = stasis_render_v2_validate(cmd_i32, cmd_f32);
+    if (validation != STASIS_RENDER_V2_VALID) {
         if (!contract_logged) {
             SDL_Log(
                 "Stasis renderer rejected frame: stage=command_header failure=%s magic=%d version=%d backend=%s surface_generation=%u renderer_generation=%u",
-                stasis_render_v1_validation_name(validation),
+                stasis_render_v2_validation_name(validation),
                 cmd_i32 ? cmd_i32[STASIS_RENDER_I_MAGIC] : 0,
                 cmd_i32 ? cmd_i32[STASIS_RENDER_I_VERSION] : 0,
                 g_use_sdl_renderer ? "sdl" : "gl",
@@ -4364,8 +4264,8 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
     if (!contract_logged) {
         SDL_Log(
             "Stasis render contract v%d trace=%u flags=%d lines=%d sprites=%d text=%d",
-            STASIS_RENDER_V1_VERSION,
-            (unsigned int)stasis_render_v1_trace(cmd_i32, cmd_f32, cmd_u8),
+            STASIS_RENDER_V2_VERSION,
+            (unsigned int)stasis_render_v2_trace(cmd_i32, cmd_f32, cmd_u8),
             flags,
             line_count,
             sprite_count,
@@ -4388,24 +4288,22 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
      * cannot cover text after text has already been drawn. */
     flush_lines_before_later_layers();
 
-    /* sprites: i32 header is 32, then sprite payload */
+    /* sprites: identity/state in i32, logical geometry in f32 */
     if (sprite_count > 0) {
-        const int32_t* sprites = cmd_i32 + STASIS_RENDER_I_SPRITE_BASE;
-        if (!g_debug_hash_enabled && !g_use_sdl_renderer) {
-            stasis_gfx_draw_sprites_i32_fast(sprites, sprite_count);
-        } else {
-            for (int i = 0; i < sprite_count; i++) {
-                const int base = i * 7;
-                stasis_gfx_draw_sprite_internal(
-                    sprites[base + 0],
-                    sprites[base + 1],
-                    sprites[base + 2],
-                    sprites[base + 3],
-                    sprites[base + 4],
-                    sprites[base + 5],
-                    sprites[base + 6],
-                    g_debug_hash_enabled);
-            }
+        const int32_t* sprite_i32 = cmd_i32 + STASIS_RENDER_I_SPRITE_BASE;
+        const float* sprite_f32 = cmd_f32 + STASIS_RENDER_F_SPRITE_BASE;
+        for (int i = 0; i < sprite_count; i++) {
+            const int base_i = i * STASIS_RENDER_SPRITE_I32_STRIDE;
+            const int base_f = i * STASIS_RENDER_SPRITE_F32_STRIDE;
+            stasis_gfx_draw_sprite_internal(
+                sprite_i32[base_i + 0],
+                sprite_f32[base_f + 0],
+                sprite_f32[base_f + 1],
+                sprite_f32[base_f + 2],
+                sprite_f32[base_f + 3],
+                sprite_i32[base_i + 1],
+                sprite_i32[base_i + 2],
+                g_debug_hash_enabled);
         }
     }
 
@@ -4440,7 +4338,7 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
                 continue;
             }
             if (!cmd_u8 || text_bytes_used <= 0) continue;
-            if (!stasis_render_v1_text_span_is_valid(
+            if (!stasis_render_v2_text_span_is_valid(
                     byte_off, byte_len, text_bytes_used)) continue;
 
             const char* text = (const char*)(cmd_u8 + byte_off);
@@ -4467,11 +4365,11 @@ static void stasis_gfx_submit_v1(const int32_t* cmd_i32, const float* cmd_f32, c
 }
 
 STASIS_EXPORT void stasis_gfx_submit(const int32_t* cmd_i32, const float* cmd_f32) {
-    stasis_gfx_submit_v1(cmd_i32, cmd_f32, NULL);
+    stasis_gfx_submit_v2(cmd_i32, cmd_f32, NULL);
 }
 
 STASIS_EXPORT void stasis_gfx_submit_u8(const int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
-    stasis_gfx_submit_v1(cmd_i32, cmd_f32, cmd_u8);
+    stasis_gfx_submit_v2(cmd_i32, cmd_f32, cmd_u8);
 }
 
 static SpriteEntry* sprite_get(int handle) {
@@ -4876,20 +4774,18 @@ STASIS_EXPORT void stasis_gfx_release_sprite(int handle) {
 
 /*
  * Draw a sprite at a specific size (top-left anchored) with rotation and tint.
- * All parameters are integers for simpler Stasis integration.
- * x, y: top-left position in pixels
- * w, h: desired size in pixels
+ * Geometry remains logical f32 through submission and rasterizes here.
  * rot_degrees: rotation in degrees (0-359), around the sprite center
  * a: alpha 0-255
  */
-static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int h,
+static void stasis_gfx_draw_sprite_internal(int handle, float x, float y, float w, float h,
                                            int rot_degrees, int a, int do_hash) {
     if (do_hash) {
         gfx_debug_hash_i32(handle);
-        gfx_debug_hash_i32(x);
-        gfx_debug_hash_i32(y);
-        gfx_debug_hash_i32(w);
-        gfx_debug_hash_i32(h);
+        gfx_debug_hash_f32(x);
+        gfx_debug_hash_f32(y);
+        gfx_debug_hash_f32(w);
+        gfx_debug_hash_f32(h);
         gfx_debug_hash_i32(rot_degrees);
         gfx_debug_hash_i32(a);
     }
@@ -4929,21 +4825,25 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
         if (!g_renderer || !e->sdl_tex) return;
 #if SDL_VERSION_ATLEAST(2,0,10)
         SDL_FRect dst;
-        dst.w = (float)w;
-        dst.h = (float)h;
-        dst.x = (float)x;
-        dst.y = (float)y;
+        dst.w = w;
+        dst.h = h;
+        dst.x = x;
+        dst.y = y;
         SDL_FPoint center = { dst.w * 0.5f, dst.h * 0.5f };
         SDL_SetTextureColorMod(e->sdl_tex, 255, 255, 255);
         SDL_SetTextureAlphaMod(e->sdl_tex, (Uint8)a);
         SDL_RenderCopyExF(g_renderer, e->sdl_tex, NULL, &dst, (double)rot_degrees, &center, SDL_FLIP_NONE);
 #else
         SDL_Rect dst;
-        dst.w = w;
-        dst.h = h;
-        dst.x = x;
-        dst.y = y;
-        SDL_Point center = { w / 2, h / 2 };
+        const int left = (int)floorf(x);
+        const int top = (int)floorf(y);
+        const int right = (int)ceilf(x + w);
+        const int bottom = (int)ceilf(y + h);
+        dst.w = right - left;
+        dst.h = bottom - top;
+        dst.x = left;
+        dst.y = top;
+        SDL_Point center = { dst.w / 2, dst.h / 2 };
         SDL_SetTextureColorMod(e->sdl_tex, 255, 255, 255);
         SDL_SetTextureAlphaMod(e->sdl_tex, (Uint8)a);
         SDL_RenderCopyEx(g_renderer, e->sdl_tex, NULL, &dst, (double)rot_degrees, &center, SDL_FLIP_NONE);
@@ -4961,8 +4861,8 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
     g_sprite_batch_page = e->page_index;
 #endif
 
-    float hw = (float)w * 0.5f;
-    float hh = (float)h * 0.5f;
+    float hw = w * 0.5f;
+    float hh = h * 0.5f;
     float c = cosf(rot);
     float s = sinf(rot);
 
@@ -4994,27 +4894,28 @@ static void stasis_gfx_draw_sprite_internal(int handle, int x, int y, int w, int
     g_sprite_vert_count += 6;
 }
 
-STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, int x, int y, int w, int h,
+STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, float x, float y, float w, float h,
                                           int rot_degrees, int a) {
     stasis_gfx_draw_sprite_internal(handle, x, y, w, h, rot_degrees, a, 1);
 }
 
 /*
  * Batched sprite submission.
- * cmds: array of 7*i32 per sprite: handle,x,y,w,h,rot_degrees,a
+ * Identity/state and logical geometry use separate typed lanes.
  */
-STASIS_EXPORT void stasis_gfx_draw_sprites_i32(const int32_t* cmds, int sprite_count) {
-    if (!cmds || sprite_count <= 0) return;
+STASIS_EXPORT void stasis_gfx_draw_sprites(const int32_t* cmd_i32, const float* cmd_f32, int sprite_count) {
+    if (!cmd_i32 || !cmd_f32 || sprite_count <= 0) return;
     for (int i = 0; i < sprite_count; i++) {
-        const int base = i * 7;
+        const int base_i = i * STASIS_RENDER_SPRITE_I32_STRIDE;
+        const int base_f = i * STASIS_RENDER_SPRITE_F32_STRIDE;
         stasis_gfx_draw_sprite_internal(
-            cmds[base + 0],
-            cmds[base + 1],
-            cmds[base + 2],
-            cmds[base + 3],
-            cmds[base + 4],
-            cmds[base + 5],
-            cmds[base + 6],
+            cmd_i32[base_i + 0],
+            cmd_f32[base_f + 0],
+            cmd_f32[base_f + 1],
+            cmd_f32[base_f + 2],
+            cmd_f32[base_f + 3],
+            cmd_i32[base_i + 1],
+            cmd_i32[base_i + 2],
             g_debug_hash_enabled);
     }
 }
@@ -5337,20 +5238,6 @@ STASIS_EXPORT int stasis_gfx_get_resource_lifecycle(int32_t* out_i32, int count)
     out_i32[4] = (int32_t)g_resource_lifecycle.restore_failures;
     out_i32[5] = (int32_t)g_resource_lifecycle.reason;
     return 1;
-}
-
-/*
- * Get current window width in pixels
- */
-STASIS_EXPORT int stasis_gfx_window_width(void) {
-    return g_window_width;
-}
-
-/*
- * Get current window height in pixels
- */
-STASIS_EXPORT int stasis_gfx_window_height(void) {
-    return g_window_height;
 }
 
 /*

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -37,17 +37,13 @@ EXPORTS
     stasis_input_pointer_is_down
     stasis_input_pointer_went_down
     stasis_input_pointer_went_up
-    stasis_input_pointer_x_px
-    stasis_input_pointer_y_px
-    stasis_input_pointer_dx_px
-    stasis_input_pointer_dy_px
+    stasis_input_pointer_x_logical
+    stasis_input_pointer_y_logical
+    stasis_input_pointer_dx_logical
+    stasis_input_pointer_dy_logical
     stasis_input_pointer_x_n
     stasis_input_pointer_y_n
     stasis_input_dropped_pointers
-    stasis_input_viewport_x_px
-    stasis_input_viewport_y_px
-    stasis_input_viewport_w_px
-    stasis_input_viewport_h_px
     stasis_host_get_frame
     stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite
@@ -56,7 +52,7 @@ EXPORTS
     stasis_gfx_submit
     stasis_gfx_submit_u8
     stasis_gfx_poll_reload
-    stasis_gfx_draw_sprites_i32
+    stasis_gfx_draw_sprites
     stasis_gfx_debug_bake_hash
     stasis_gfx_debug_enable_hash
     stasis_gfx_debug_get_frame_hash

--- a/runtime/stasis_render_contract.h
+++ b/runtime/stasis_render_contract.h
@@ -6,9 +6,9 @@
 #include <string.h>
 
 /* Canonical guest-to-renderer command ABI used by JIT and AOT runtimes. */
-#define STASIS_RENDER_V1_MAGIC 0x47584631
-#define STASIS_RENDER_V1_VERSION 1
-#define STASIS_RENDER_V1_TRACE_VERSION 1
+#define STASIS_RENDER_V2_MAGIC 0x47584631
+#define STASIS_RENDER_V2_VERSION 2
+#define STASIS_RENDER_V2_TRACE_VERSION 2
 
 #define STASIS_RENDER_FLAG_CLEAR 1
 #define STASIS_RENDER_FLAG_PRESENT 2
@@ -40,7 +40,8 @@
 #define STASIS_RENDER_MAX_LINES 10000
 #define STASIS_RENDER_LINE_F32_STRIDE 8
 #define STASIS_RENDER_MAX_SPRITES 4096
-#define STASIS_RENDER_SPRITE_I32_STRIDE 7
+#define STASIS_RENDER_SPRITE_I32_STRIDE 3
+#define STASIS_RENDER_SPRITE_F32_STRIDE 4
 #define STASIS_RENDER_MAX_TEXT 2048
 #define STASIS_RENDER_TEXT_I32_STRIDE 3
 #define STASIS_RENDER_TEXT_F32_STRIDE 6
@@ -51,6 +52,10 @@
      STASIS_RENDER_MAX_SPRITES * STASIS_RENDER_SPRITE_I32_STRIDE)
 #define STASIS_RENDER_F_TEXT_BASE \
     (STASIS_RENDER_F_LINE_BASE + \
+     STASIS_RENDER_MAX_LINES * STASIS_RENDER_LINE_F32_STRIDE + \
+     STASIS_RENDER_MAX_SPRITES * STASIS_RENDER_SPRITE_F32_STRIDE)
+#define STASIS_RENDER_F_SPRITE_BASE \
+    (STASIS_RENDER_F_LINE_BASE + \
      STASIS_RENDER_MAX_LINES * STASIS_RENDER_LINE_F32_STRIDE)
 #define STASIS_RENDER_I32_COUNT \
     (STASIS_RENDER_I_TEXT_BASE + \
@@ -60,38 +65,38 @@
      STASIS_RENDER_MAX_TEXT * STASIS_RENDER_TEXT_F32_STRIDE)
 #define STASIS_RENDER_U8_COUNT STASIS_RENDER_TEXT_MAX_BYTES
 
-typedef enum StasisRenderV1Validation {
-    STASIS_RENDER_V1_VALID = 0,
-    STASIS_RENDER_V1_NULL_I32 = 1,
-    STASIS_RENDER_V1_NULL_F32 = 2,
-    STASIS_RENDER_V1_BAD_MAGIC = 3,
-    STASIS_RENDER_V1_BAD_VERSION = 4
-} StasisRenderV1Validation;
+typedef enum StasisRenderV2Validation {
+    STASIS_RENDER_V2_VALID = 0,
+    STASIS_RENDER_V2_NULL_I32 = 1,
+    STASIS_RENDER_V2_NULL_F32 = 2,
+    STASIS_RENDER_V2_BAD_MAGIC = 3,
+    STASIS_RENDER_V2_BAD_VERSION = 4
+} StasisRenderV2Validation;
 
-static inline StasisRenderV1Validation stasis_render_v1_validate(
+static inline StasisRenderV2Validation stasis_render_v2_validate(
     const int32_t *cmd_i32,
     const float *cmd_f32
 ) {
-    if (cmd_i32 == NULL) return STASIS_RENDER_V1_NULL_I32;
-    if (cmd_f32 == NULL) return STASIS_RENDER_V1_NULL_F32;
-    if (cmd_i32[STASIS_RENDER_I_MAGIC] != STASIS_RENDER_V1_MAGIC) {
-        return STASIS_RENDER_V1_BAD_MAGIC;
+    if (cmd_i32 == NULL) return STASIS_RENDER_V2_NULL_I32;
+    if (cmd_f32 == NULL) return STASIS_RENDER_V2_NULL_F32;
+    if (cmd_i32[STASIS_RENDER_I_MAGIC] != STASIS_RENDER_V2_MAGIC) {
+        return STASIS_RENDER_V2_BAD_MAGIC;
     }
-    if (cmd_i32[STASIS_RENDER_I_VERSION] != STASIS_RENDER_V1_VERSION) {
-        return STASIS_RENDER_V1_BAD_VERSION;
+    if (cmd_i32[STASIS_RENDER_I_VERSION] != STASIS_RENDER_V2_VERSION) {
+        return STASIS_RENDER_V2_BAD_VERSION;
     }
-    return STASIS_RENDER_V1_VALID;
+    return STASIS_RENDER_V2_VALID;
 }
 
-static inline const char *stasis_render_v1_validation_name(
-    StasisRenderV1Validation validation
+static inline const char *stasis_render_v2_validation_name(
+    StasisRenderV2Validation validation
 ) {
     switch (validation) {
-        case STASIS_RENDER_V1_VALID: return "ok";
-        case STASIS_RENDER_V1_NULL_I32: return "missing_i32_buffer";
-        case STASIS_RENDER_V1_NULL_F32: return "missing_f32_buffer";
-        case STASIS_RENDER_V1_BAD_MAGIC: return "invalid_magic";
-        case STASIS_RENDER_V1_BAD_VERSION: return "unsupported_version";
+        case STASIS_RENDER_V2_VALID: return "ok";
+        case STASIS_RENDER_V2_NULL_I32: return "missing_i32_buffer";
+        case STASIS_RENDER_V2_NULL_F32: return "missing_f32_buffer";
+        case STASIS_RENDER_V2_BAD_MAGIC: return "invalid_magic";
+        case STASIS_RENDER_V2_BAD_VERSION: return "unsupported_version";
         default: return "unknown_validation_failure";
     }
 }
@@ -101,13 +106,13 @@ static inline int32_t stasis_render_clamp_count(int32_t value, int32_t maximum) 
     return value > maximum ? maximum : value;
 }
 
-static inline int stasis_render_v1_is_valid(const int32_t *cmd_i32) {
+static inline int stasis_render_v2_is_valid(const int32_t *cmd_i32) {
     return cmd_i32 != NULL &&
-        cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V1_MAGIC &&
-        cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V1_VERSION;
+        cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V2_MAGIC &&
+        cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V2_VERSION;
 }
 
-static inline int stasis_render_v1_text_span_is_valid(
+static inline int stasis_render_v2_text_span_is_valid(
     int32_t byte_offset,
     int32_t byte_length,
     int32_t text_bytes_used
@@ -145,16 +150,16 @@ static inline uint32_t stasis_render_trace_mix_bytes(
 }
 
 /*
- * Returns a backend-independent trace of the interpreted v1 frame. The trace
+ * Returns a backend-independent trace of the interpreted v2 frame. The trace
  * includes command kind markers, normalized counts, every consumed value, and
  * the fixed clear -> line -> sprite -> cached/text -> present order.
  */
-static inline uint32_t stasis_render_v1_trace(
+static inline uint32_t stasis_render_v2_trace(
     const int32_t *cmd_i32,
     const float *cmd_f32,
     const uint8_t *cmd_u8
 ) {
-    if (!stasis_render_v1_is_valid(cmd_i32) || cmd_f32 == NULL) return 0;
+    if (!stasis_render_v2_is_valid(cmd_i32) || cmd_f32 == NULL) return 0;
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
     const int32_t line_count = stasis_render_clamp_count(
@@ -167,7 +172,7 @@ static inline uint32_t stasis_render_v1_trace(
         cmd_i32[STASIS_RENDER_I_TEXT_BYTES_USED], STASIS_RENDER_TEXT_MAX_BYTES);
 
     uint32_t hash = 2166136261u;
-    hash = stasis_render_trace_mix_u32(hash, STASIS_RENDER_V1_TRACE_VERSION);
+    hash = stasis_render_trace_mix_u32(hash, STASIS_RENDER_V2_TRACE_VERSION);
     if ((flags & STASIS_RENDER_FLAG_CLEAR) != 0) {
         hash = stasis_render_trace_mix_u32(hash, 1u);
         for (int index = 0; index < 4; index++) {
@@ -187,10 +192,15 @@ static inline uint32_t stasis_render_v1_trace(
 
     for (int32_t index = 0; index < sprite_count; index++) {
         hash = stasis_render_trace_mix_u32(hash, 3u);
-        const int32_t base = STASIS_RENDER_I_SPRITE_BASE +
+        const int32_t base_i = STASIS_RENDER_I_SPRITE_BASE +
             index * STASIS_RENDER_SPRITE_I32_STRIDE;
+        const int32_t base_f = STASIS_RENDER_F_SPRITE_BASE +
+            index * STASIS_RENDER_SPRITE_F32_STRIDE;
         for (int field = 0; field < STASIS_RENDER_SPRITE_I32_STRIDE; field++) {
-            hash = stasis_render_trace_mix_u32(hash, (uint32_t)cmd_i32[base + field]);
+            hash = stasis_render_trace_mix_u32(hash, (uint32_t)cmd_i32[base_i + field]);
+        }
+        for (int field = 0; field < STASIS_RENDER_SPRITE_F32_STRIDE; field++) {
+            hash = stasis_render_trace_mix_f32(hash, cmd_f32[base_f + field]);
         }
     }
 
@@ -208,7 +218,7 @@ static inline uint32_t stasis_render_v1_trace(
         for (int field = 0; field < STASIS_RENDER_TEXT_F32_STRIDE; field++) {
             hash = stasis_render_trace_mix_f32(hash, cmd_f32[float_base + field]);
         }
-        if (byte_length > 0 && stasis_render_v1_text_span_is_valid(
+        if (byte_length > 0 && stasis_render_v2_text_span_is_valid(
                 byte_offset, byte_length, text_bytes_used)) {
             hash = stasis_render_trace_mix_bytes(
                 hash, cmd_u8 == NULL ? NULL : cmd_u8 + byte_offset, byte_length);

--- a/runtime/stasis_render_trace.c
+++ b/runtime/stasis_render_trace.c
@@ -1,9 +1,9 @@
 #include "stasis_render_contract.h"
 
-uint32_t stasis_render_v1_trace_native(
+uint32_t stasis_render_v2_trace_native(
     const int32_t *cmd_i32,
     const float *cmd_f32,
     const uint8_t *cmd_u8
 ) {
-    return stasis_render_v1_trace(cmd_i32, cmd_f32, cmd_u8);
+    return stasis_render_v2_trace(cmd_i32, cmd_f32, cmd_u8);
 }

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -105,8 +105,8 @@ void stasis_gfx_submit_u8(
     assert(cmd_i32 == game_gfx_cmd_i32);
     assert(cmd_f32 == game_gfx_cmd_f32);
     assert(cmd_u8 == game_gfx_cmd_u8);
-    assert(cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V1_MAGIC);
-    assert(cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V1_VERSION);
+    assert(cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V2_MAGIC);
+    assert(cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V2_VERSION);
     gfx_submit_calls += 1;
     stasis_begin_frame();
     stasis_end_frame();
@@ -178,8 +178,8 @@ static int32_t game_tick(void) {
 
 static int32_t game_render(void) {
     render_calls += 1;
-    game_gfx_cmd_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
-    game_gfx_cmd_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
+    game_gfx_cmd_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
+    game_gfx_cmd_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V2_VERSION;
     return render_result;
 }
 

--- a/runtime/tests/stasis_render_contract_test.c
+++ b/runtime/tests/stasis_render_contract_test.c
@@ -9,8 +9,8 @@ static void build_representative_frame(
     float *f32s,
     uint8_t *u8s
 ) {
-    i32s[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V1_MAGIC;
-    i32s[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V1_VERSION;
+    i32s[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
+    i32s[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V2_VERSION;
     i32s[STASIS_RENDER_I_FLAGS] =
         STASIS_RENDER_FLAG_CLEAR | STASIS_RENDER_FLAG_PRESENT;
     i32s[STASIS_RENDER_I_LINE_COUNT] = 1;
@@ -28,8 +28,10 @@ static void build_representative_frame(
     const float line[] = {1.0f, 2.0f, 3.0f, 4.0f, 0.5f, 0.6f, 0.7f, 0.8f};
     memcpy(f32s + STASIS_RENDER_F_LINE_BASE, line, sizeof(line));
 
-    const int32_t sprite[] = {17, 10, 20, 30, 40, 45, 192};
-    memcpy(i32s + STASIS_RENDER_I_SPRITE_BASE, sprite, sizeof(sprite));
+    const int32_t sprite_i32[] = {17, 45, 192};
+    const float sprite_f32[] = {10.25f, 20.5f, 30.75f, 40.125f};
+    memcpy(i32s + STASIS_RENDER_I_SPRITE_BASE, sprite_i32, sizeof(sprite_i32));
+    memcpy(f32s + STASIS_RENDER_F_SPRITE_BASE, sprite_f32, sizeof(sprite_f32));
 
     int32_t *text = i32s + STASIS_RENDER_I_TEXT_BASE;
     text[0] = 3; text[1] = 0; text[2] = 4;
@@ -59,13 +61,13 @@ int main(void) {
 
     build_representative_frame(first_i32, first_f32, first_u8);
     build_representative_frame(second_i32, second_f32, second_u8);
-    CHECK(stasis_render_v1_validate(first_i32, first_f32) == STASIS_RENDER_V1_VALID);
-    CHECK(strcmp(stasis_render_v1_validation_name(STASIS_RENDER_V1_VALID), "ok") == 0);
-    CHECK(stasis_render_v1_validate(NULL, first_f32) == STASIS_RENDER_V1_NULL_I32);
-    CHECK(stasis_render_v1_validate(first_i32, NULL) == STASIS_RENDER_V1_NULL_F32);
-    CHECK(stasis_render_v1_is_valid(first_i32));
-    uint32_t first_trace = stasis_render_v1_trace(first_i32, first_f32, first_u8);
-    uint32_t second_trace = stasis_render_v1_trace(second_i32, second_f32, second_u8);
+    CHECK(stasis_render_v2_validate(first_i32, first_f32) == STASIS_RENDER_V2_VALID);
+    CHECK(strcmp(stasis_render_v2_validation_name(STASIS_RENDER_V2_VALID), "ok") == 0);
+    CHECK(stasis_render_v2_validate(NULL, first_f32) == STASIS_RENDER_V2_NULL_I32);
+    CHECK(stasis_render_v2_validate(first_i32, NULL) == STASIS_RENDER_V2_NULL_F32);
+    CHECK(stasis_render_v2_is_valid(first_i32));
+    uint32_t first_trace = stasis_render_v2_trace(first_i32, first_f32, first_u8);
+    uint32_t second_trace = stasis_render_v2_trace(second_i32, second_f32, second_u8);
     CHECK(first_trace != 0);
     CHECK(first_trace == second_trace);
 
@@ -73,31 +75,31 @@ int main(void) {
     second_i32[STASIS_RENDER_I_DRAWABLE_H] = 1080;
     second_i32[STASIS_RENDER_I_DISPLAY_GENERATION]++;
     second_i32[STASIS_RENDER_I_DENSITY_GENERATION]++;
-    CHECK(first_trace == stasis_render_v1_trace(second_i32, second_f32, second_u8));
+    CHECK(first_trace == stasis_render_v2_trace(second_i32, second_f32, second_u8));
 
-    second_i32[STASIS_RENDER_I_SPRITE_BASE + 1] += 1;
-    CHECK(first_trace != stasis_render_v1_trace(second_i32, second_f32, second_u8));
+    second_f32[STASIS_RENDER_F_SPRITE_BASE + 1] += 0.5f;
+    CHECK(first_trace != stasis_render_v2_trace(second_i32, second_f32, second_u8));
     second_i32[STASIS_RENDER_I_VERSION] = 99;
-    CHECK(stasis_render_v1_validate(second_i32, second_f32) == STASIS_RENDER_V1_BAD_VERSION);
+    CHECK(stasis_render_v2_validate(second_i32, second_f32) == STASIS_RENDER_V2_BAD_VERSION);
     CHECK(strcmp(
-        stasis_render_v1_validation_name(STASIS_RENDER_V1_BAD_VERSION),
+        stasis_render_v2_validation_name(STASIS_RENDER_V2_BAD_VERSION),
         "unsupported_version") == 0);
-    CHECK(!stasis_render_v1_is_valid(second_i32));
-    CHECK(stasis_render_v1_trace(second_i32, second_f32, second_u8) == 0);
+    CHECK(!stasis_render_v2_is_valid(second_i32));
+    CHECK(stasis_render_v2_trace(second_i32, second_f32, second_u8) == 0);
 
     second_i32[STASIS_RENDER_I_MAGIC] = 0;
-    CHECK(stasis_render_v1_validate(second_i32, second_f32) == STASIS_RENDER_V1_BAD_MAGIC);
+    CHECK(stasis_render_v2_validate(second_i32, second_f32) == STASIS_RENDER_V2_BAD_MAGIC);
     CHECK(strcmp(
-        stasis_render_v1_validation_name(STASIS_RENDER_V1_BAD_MAGIC),
+        stasis_render_v2_validation_name(STASIS_RENDER_V2_BAD_MAGIC),
         "invalid_magic") == 0);
 
     build_representative_frame(second_i32, second_f32, second_u8);
     second_i32[STASIS_RENDER_I_TEXT_BASE + 1] = 1;
     second_i32[STASIS_RENDER_I_TEXT_BASE + 2] = INT32_MAX;
-    CHECK(!stasis_render_v1_text_span_is_valid(1, INT32_MAX, 5));
-    CHECK(stasis_render_v1_text_span_is_valid(0, 4, 5));
-    CHECK(!stasis_render_v1_text_span_is_valid(0, 5, 5));
-    CHECK(stasis_render_v1_trace(second_i32, second_f32, second_u8) != 0);
+    CHECK(!stasis_render_v2_text_span_is_valid(1, INT32_MAX, 5));
+    CHECK(stasis_render_v2_text_span_is_valid(0, 4, 5));
+    CHECK(!stasis_render_v2_text_span_is_valid(0, 5, 5));
+    CHECK(stasis_render_v2_trace(second_i32, second_f32, second_u8) != 0);
 
     free(first_i32); free(first_f32); free(first_u8);
     free(second_i32); free(second_f32); free(second_u8);

--- a/samples/brickout_revenge/brickout_revenge.stasis
+++ b/samples/brickout_revenge/brickout_revenge.stasis
@@ -33,8 +33,9 @@ struct Sprites {
 // Build render lists as pure data, then submit in bulk once per tick.
 // This is the preferred hot-path model: no per-draw host calls.
 struct GfxState {
-    // Packed sprite stream: [handle,x,y,w,h,rot_deg,a] * 256
-    sprites_i32: i32[1792];
+    // Split sprite stream: [handle,rot_deg,a] and [x,y,w,h] * 256
+    sprites_i32: i32[768];
+    sprites_f32: f32[1024];
     sprite_count: i32;
 
     // Packed line stream: [x1,y1,x2,y2,r,g,b,a] * 512
@@ -63,14 +64,15 @@ function render_begin(): void {
 function render_push_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
     let i: i32 = state.gfx.sprite_count;
     if (i >= 256) { return; }
-    let base: i32 = i * 7;
-    state.gfx.sprites_i32[base + 0] = handle;
-    state.gfx.sprites_i32[base + 1] = x;
-    state.gfx.sprites_i32[base + 2] = y;
-    state.gfx.sprites_i32[base + 3] = w;
-    state.gfx.sprites_i32[base + 4] = h;
-    state.gfx.sprites_i32[base + 5] = rot_deg;
-    state.gfx.sprites_i32[base + 6] = a;
+    let base_i: i32 = i * 3;
+    let base_f: i32 = i * 4;
+    state.gfx.sprites_i32[base_i + 0] = handle;
+    state.gfx.sprites_i32[base_i + 1] = rot_deg;
+    state.gfx.sprites_i32[base_i + 2] = a;
+    state.gfx.sprites_f32[base_f + 0].from_i32(x);
+    state.gfx.sprites_f32[base_f + 1].from_i32(y);
+    state.gfx.sprites_f32[base_f + 2].from_i32(w);
+    state.gfx.sprites_f32[base_f + 3].from_i32(h);
     state.gfx.sprite_count = i + 1;
 }
 
@@ -172,7 +174,7 @@ function tick(): i32 {
     clear(0.05, 0.05, 0.15, 1.0);
     
     //update_game(dt, delta_ms);
-    gfx_draw_sprites(state.gfx.sprites_i32, state.gfx.sprite_count);
+    gfx_draw_sprites(state.gfx.sprites_i32, state.gfx.sprites_f32, state.gfx.sprite_count);
     draw_lines(state.gfx.lines_f32, state.gfx.line_count);
     draw_frame();
 

--- a/samples/brickout_revenge/brickout_revenge_v1.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1.stasis
@@ -30,9 +30,9 @@ const UI_FONT_SIZE_PX: i32 = 24;
 // - clear(r: f32, g: f32, b: f32, a: f32): clears frame buffer
 // - draw_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32)
 // - gfx_load_sprite(path: string, max_w: i32, max_h: i32) -> i32
-// - gfx_draw_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): top-left
-// - gfx_window_width() -> i32
-// - gfx_window_height() -> i32
+// - gfx_draw_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): top-left
+// - gfx_logical_width() -> f32
+// - gfx_logical_height() -> f32
 // - gfx_window_resized() -> bool
 // - input_viewport_x_px() -> i32
 // - input_viewport_y_px() -> i32
@@ -609,8 +609,8 @@ function sync_screen_size(): void {
         return;
     }
 
-    let w: i32 = gfx_window_width();
-    let h: i32 = gfx_window_height();
+    let w: i32 = f32_to_i32(gfx_logical_width());
+    let h: i32 = f32_to_i32(gfx_logical_height());
     if (w < 1 || h < 1) {
         return;
     }
@@ -620,14 +620,10 @@ function sync_screen_size(): void {
 }
 
 function update_layout(): void {
-    let vx: f32;
-    vx.from_i32(input_viewport_x_px());
-    let vy: f32;
-    vy.from_i32(input_viewport_y_px());
-    let vw: f32;
-    vw.from_i32(input_viewport_w_px());
-    let vh: f32;
-    vh.from_i32(input_viewport_h_px());
+    let vx: f32 = gfx_safe_viewport_x();
+    let vy: f32 = gfx_safe_viewport_y();
+    let vw: f32 = gfx_safe_viewport_width();
+    let vh: f32 = gfx_safe_viewport_height();
     if (vw < 1.0 || vh < 1.0) {
         return;
     }
@@ -1713,7 +1709,7 @@ function play_draw_sprite(handle: i32, x: f32, y: f32, width: f32, height: f32, 
     screen_y_i.from_f32(screen_y);
     let top_left_x: i32 = screen_x_i - (screen_w / 2);
     let top_left_y: i32 = screen_y_i - (screen_h / 2);
-    gfx_draw_sprite(handle, top_left_x, top_left_y, screen_w, screen_h, rot_deg, alpha);
+    gfx_draw_sprite(handle, i32_to_f32(top_left_x), i32_to_f32(top_left_y), i32_to_f32(screen_w), i32_to_f32(screen_h), rot_deg, alpha);
 }
 
 function draw_bricks(): void {
@@ -2303,7 +2299,7 @@ function draw_menu_panel(x: f32, y: f32, w: f32, h: f32): void {
                         icon_w_i.from_f32(icon_size);
                         let icon_h_i: i32;
                         icon_h_i.from_f32(icon_size);
-                        gfx_draw_sprite(icon_handle, icon_x_i, icon_y_i, icon_w_i, icon_h_i, 0, 255);
+                        gfx_draw_sprite(icon_handle, i32_to_f32(icon_x_i), i32_to_f32(icon_y_i), i32_to_f32(icon_w_i), i32_to_f32(icon_h_i), 0, 255);
                     }
                 }
                 let selected: bool = false;
@@ -2501,7 +2497,7 @@ function compute_delta_ms(): i32 {
 
 function refresh_input_model(): void {
     input_model.quit_requested = should_quit();
-    input_model.escape_down = is_key_down(Scancode.Escape);
+    input_model.escape_down = is_key_down(41);
 
     let count: i32 = input_pointer_count();
     if (count < 0) { count = 0; }
@@ -2515,8 +2511,8 @@ function refresh_input_model(): void {
             input_model.pointers[i].is_down = input_pointer_is_down(i);
             input_model.pointers[i].went_down = input_pointer_went_down(i);
             input_model.pointers[i].went_up = input_pointer_went_up(i);
-            input_model.pointers[i].x_px = input_pointer_x_px(i);
-            input_model.pointers[i].y_px = input_pointer_y_px(i);
+            input_model.pointers[i].x_px = input_pointer_x_logical(i);
+            input_model.pointers[i].y_px = input_pointer_y_logical(i);
         } else {
             input_model.pointers[i].id = -1;
             input_model.pointers[i].is_down = false;
@@ -2639,8 +2635,8 @@ function main(): i32 {
         audio_sr = 0;
     }
 
-    state.runtime_screen.w = gfx_window_width();
-    state.runtime_screen.h = gfx_window_height();
+    state.runtime_screen.w = f32_to_i32(gfx_logical_width());
+    state.runtime_screen.h = f32_to_i32(gfx_logical_height());
     state.layout.viewport_x = 0.0;
     state.layout.viewport_y = 0.0;
     state.layout.viewport_w.from_i32(state.runtime_screen.w);

--- a/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
@@ -22,10 +22,10 @@ import "../../src/stdlib/audio.stasis";
 // - gfx_cmd_clear(r: f32, g: f32, b: f32, a: f32): clears frame buffer
 // - gfx_cmd_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32)
 // - gfx_load_sprite(path: string, max_w: i32, max_h: i32) -> i32
-// - gfx_cmd_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): top-left
+// - gfx_cmd_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): top-left
 // - gfx_poll_reload(handle: i32) -> bool
-// - gfx_window_width() -> i32
-// - gfx_window_height() -> i32
+// - gfx_logical_width() -> f32
+// - gfx_logical_height() -> f32
 // - gfx_window_resized() -> bool
 // - input_viewport_x_px() -> i32
 // - input_viewport_y_px() -> i32
@@ -564,8 +564,8 @@ function audio_update(): void {
 }
 
 function sync_screen_size(): void {
-    let w: i32 = host_window_w_px();
-    let h: i32 = host_window_h_px();
+    let w: i32 = f32_to_i32(host_logical_width());
+    let h: i32 = f32_to_i32(host_logical_height());
     if (w < 1 || h < 1) {
         return;
     }
@@ -575,14 +575,10 @@ function sync_screen_size(): void {
 }
 
 function update_layout(): void {
-    let vx: f32;
-    vx.from_i32(host_viewport_x_px());
-    let vy: f32;
-    vy.from_i32(host_viewport_y_px());
-    let vw: f32;
-    vw.from_i32(host_viewport_w_px());
-    let vh: f32;
-    vh.from_i32(host_viewport_h_px());
+    let vx: f32 = host_safe_x();
+    let vy: f32 = host_safe_y();
+    let vw: f32 = host_safe_width();
+    let vh: f32 = host_safe_height();
     if (vw < 1.0 || vh < 1.0) {
         return;
     }
@@ -2291,8 +2287,8 @@ function handle_pointer_input(): void {
         let went_down: bool = host_pointer_went_down(i);
         let went_up: bool = host_pointer_went_up(i);
         let is_down: bool = host_pointer_is_down(i);
-        let sx: f32 = host_pointer_x_px(i) + state.layout.viewport_x;
-        let sy: f32 = host_pointer_y_px(i) + state.layout.viewport_y;
+        let sx: f32 = host_pointer_x_logical(i) + state.layout.viewport_x;
+        let sy: f32 = host_pointer_y_logical(i) + state.layout.viewport_y;
 
         if (state.drag_active != 0) {
             if (pid == state.drag_pointer_id) {
@@ -2368,8 +2364,8 @@ function record_tap_pulses(): void {
     for (i = 0; i < count; i = i + 1) {
         let went_down: bool = host_pointer_went_down(i);
         if (went_down) {
-            let x: f32 = host_pointer_x_px(i);
-            let y: f32 = host_pointer_y_px(i);
+            let x: f32 = host_pointer_x_logical(i);
+            let y: f32 = host_pointer_y_logical(i);
             let vx: f32 = state.layout.viewport_x;
             let vy: f32 = state.layout.viewport_y;
             let j: i32 = 0;

--- a/samples/brickout_revenge/window_size_probe.stasis
+++ b/samples/brickout_revenge/window_size_probe.stasis
@@ -92,9 +92,13 @@ function main(): i32 {
     maximize_window_for_desktop();
 
     print_string("WINDOW_SIZE ");
-    print_int(gfx_window_width());
+    let logical_w: i32;
+    logical_w.from_f32(gfx_logical_width());
+    print_int(logical_w);
     print_string(" ");
-    print_int(gfx_window_height());
+    let logical_h: i32;
+    logical_h.from_f32(gfx_logical_height());
+    print_int(logical_h);
     print_string("\n");
     return 0;
 }

--- a/samples/bucket_catcher.stasis
+++ b/samples/bucket_catcher.stasis
@@ -215,7 +215,7 @@ function update_input(): void {
     // This is not passive hover tracking. Keyboard input also requires window focus.
     let count: i32 = input_pointer_count();
     if (count > 0 && input_pointer_is_down(0)) {
-        state.bucket_target_x = f32_to_i32(input_pointer_x_px(0));
+        state.bucket_target_x = f32_to_i32(input_pointer_x_logical(0));
     }
 
     // Keyboard input: steer left/right with arrow keys.
@@ -280,10 +280,10 @@ function draw_bucket(): void {
 
     gfx_draw_sprite(
         state.bucket_sprite,
-        x0,
-        y0,
-        state.config.bucket_width,
-        state.config.bucket_height,
+        i32_to_f32(x0),
+        i32_to_f32(y0),
+        i32_to_f32(state.config.bucket_width),
+        i32_to_f32(state.config.bucket_height),
         0,
         255
     );
@@ -294,10 +294,10 @@ function draw_balls(): void {
         if (ball.active) {
             gfx_draw_sprite(
                 state.ball_sprite,
-                ball.x - state.config.ball_radius,
-                ball.y - state.config.ball_radius,
-                state.config.ball_radius * 2,
-                state.config.ball_radius * 2,
+                i32_to_f32(ball.x - state.config.ball_radius),
+                i32_to_f32(ball.y - state.config.ball_radius),
+                i32_to_f32(state.config.ball_radius * 2),
+                i32_to_f32(state.config.ball_radius * 2),
                 0,
                 255
             );

--- a/samples/render_parity/capture_manifest.json
+++ b/samples/render_parity/capture_manifest.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "fixture": "samples/render_parity/main.stasis",
   "trace_fixture": "samples/render_parity/trace.stasis",
-  "command_trace": 829981937,
+  "command_trace": 3891526461,
   "font_sha256": "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47",
   "logical_size": [640, 360],
   "required_commands": {

--- a/samples/render_parity/frame.stasis
+++ b/samples/render_parity/frame.stasis
@@ -1,20 +1,25 @@
 const PARITY_WINDOW_W: i32 = 640;
 const PARITY_WINDOW_H: i32 = 360;
 const PARITY_GFX_MAGIC: i32 = 1196967473;
-const PARITY_GFX_VERSION: i32 = 1;
+const PARITY_GFX_VERSION: i32 = 2;
 const PARITY_GFX_FLAG_CLEAR: i32 = 1;
 const PARITY_GFX_FLAG_PRESENT: i32 = 2;
 const PARITY_GFX_I_SPRITE_BASE: i32 = 32;
-const PARITY_GFX_I_TEXT_BASE: i32 = 28704;
-const PARITY_GFX_F_TEXT_BASE: i32 = 80004;
+const PARITY_GFX_I_TEXT_BASE: i32 = 12320;
+const PARITY_GFX_F_SPRITE_BASE: i32 = 80004;
+const PARITY_GFX_F_TEXT_BASE: i32 = 96388;
 
-function parity_add_sprite(cmd_i32: i32[], handle: i32, x: i32, y: i32, w: i32, h: i32, rotation: i32, alpha: i32): void {
+function parity_add_sprite(cmd_i32: i32[], handle: i32, rotation: i32, alpha: i32): void {
     let index: i32 = cmd_i32[4];
-    let base: i32 = PARITY_GFX_I_SPRITE_BASE + index * 7;
-    cmd_i32[base] = handle; cmd_i32[base + 1] = x; cmd_i32[base + 2] = y;
-    cmd_i32[base + 3] = w; cmd_i32[base + 4] = h;
-    cmd_i32[base + 5] = rotation; cmd_i32[base + 6] = alpha;
+    let base_i: i32 = PARITY_GFX_I_SPRITE_BASE + index * 3;
+    cmd_i32[base_i] = handle; cmd_i32[base_i + 1] = rotation; cmd_i32[base_i + 2] = alpha;
     cmd_i32[4] = index + 1;
+}
+
+function parity_add_sprite_geometry(cmd_f32: f32[], index: i32, x: f32, y: f32, w: f32, h: f32): void {
+    let base_f: i32 = PARITY_GFX_F_SPRITE_BASE + index * 4;
+    cmd_f32[base_f] = x; cmd_f32[base_f + 1] = y;
+    cmd_f32[base_f + 2] = w; cmd_f32[base_f + 3] = h;
 }
 
 function parity_add_direct_label(cmd_i32: i32[], cmd_f32: f32[], cmd_u8: u8[], font: i32): void {
@@ -65,11 +70,16 @@ function build_parity_frame(
     cmd_f32[16] = 0.10; cmd_f32[17] = 0.85;
     cmd_f32[18] = 1.0; cmd_f32[19] = 0.85;
 
-    parity_add_sprite(cmd_i32, canvas_sprite, 0, 0, PARITY_WINDOW_W, PARITY_WINDOW_H, 0, 96);
-    parity_add_sprite(cmd_i32, 0, 32, 48, 64, 64, 0, 255);
-    parity_add_sprite(cmd_i32, opaque_sprite, 136, 44, 96, 72, 0, 255);
-    parity_add_sprite(cmd_i32, translucent_sprite, 272, 44, 96, 72, 0, 180);
-    parity_add_sprite(cmd_i32, opaque_sprite, 440, 36, 112, 84, 27, 180);
+    parity_add_sprite(cmd_i32, canvas_sprite, 0, 96);
+    parity_add_sprite_geometry(cmd_f32, 0, 0.0, 0.0, 640.0, 360.0);
+    parity_add_sprite(cmd_i32, 0, 0, 255);
+    parity_add_sprite_geometry(cmd_f32, 1, 32.0, 48.0, 64.0, 64.0);
+    parity_add_sprite(cmd_i32, opaque_sprite, 0, 255);
+    parity_add_sprite_geometry(cmd_f32, 2, 136.0, 44.0, 96.0, 72.0);
+    parity_add_sprite(cmd_i32, translucent_sprite, 0, 180);
+    parity_add_sprite_geometry(cmd_f32, 3, 272.0, 44.0, 96.0, 72.0);
+    parity_add_sprite(cmd_i32, opaque_sprite, 27, 180);
+    parity_add_sprite_geometry(cmd_f32, 4, 440.0, 36.0, 112.0, 84.0);
     parity_add_direct_label(cmd_i32, cmd_f32, cmd_u8, font);
     parity_add_cached_label(cmd_i32, cmd_f32, font, cached_label);
 }

--- a/samples/render_parity/main.stasis
+++ b/samples/render_parity/main.stasis
@@ -5,8 +5,8 @@ extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 extern function load_font(path: string, size: i32): i32;
 function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
 
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 
 // The host consumes this request between ticks; mobile shells already own the

--- a/samples/render_parity/trace.stasis
+++ b/samples/render_parity/trace.stasis
@@ -1,11 +1,11 @@
-function @extern("stasis_jit_render_v1_trace") native_render_trace(
+function @extern("stasis_jit_render_v2_trace") native_render_trace(
     cmd_i32: i32[], cmd_i32_len: i32,
     cmd_f32: f32[], cmd_f32_len: i32,
     cmd_u8: u8[], cmd_u8_len: i32
 ): i32;
 
-global cmd_i32: i32[34848];
-global cmd_f32: f32[92292];
+global cmd_i32: i32[18464];
+global cmd_f32: f32[108676];
 global cmd_u8: u8[65536];
 
 function main(): i32 {
@@ -19,5 +19,5 @@ function main(): i32 {
 
     build_parity_frame(cmd_i32, cmd_f32, cmd_u8, 3, 1, 2, 1, 1);
 
-    return native_render_trace(cmd_i32, 34848, cmd_f32, 92292, cmd_u8, 65536);
+    return native_render_trace(cmd_i32, 18464, cmd_f32, 108676, cmd_u8, 65536);
 }

--- a/src/runtime/gfx_cmd.stasis
+++ b/src/runtime/gfx_cmd.stasis
@@ -1,14 +1,14 @@
 import "../stdlib/graphics.stasis";
 import "../stdlib/stdlib.stasis";
 
-// Graphics command buffer (v1 prototype)
+// Graphics command buffer (v2)
 //
 // Policy:
 // - Ordering: fixed by field order in this layout: clear -> lines -> sprites -> present.
 // - Coordinates: logical top-left pixels from the HostFrame display contract.
 
 const GFX_CMD_MAGIC: i32 = 1196967473; // 0x47584631 ('GXF1')
-const GFX_CMD_VERSION: i32 = 1;
+const GFX_CMD_VERSION: i32 = 2;
 
 // i32 header indices
 const GFX_I_MAGIC: i32 = 0;
@@ -45,7 +45,8 @@ const GFX_FLAG_PRESENT: i32 = 2;
 const GFX_MAX_LINES: i32 = 10000;
 const GFX_LINE_STRIDE_F32: i32 = 8;
 const GFX_MAX_SPRITES: i32 = 4096;
-const GFX_SPRITE_STRIDE_I32: i32 = 7; // handle,x,y,w,h,rot_deg,a
+const GFX_SPRITE_STRIDE_I32: i32 = 3; // handle,rot_deg,a
+const GFX_SPRITE_STRIDE_F32: i32 = 4; // x,y,w,h
 
 const GFX_MAX_TEXT: i32 = 2048;
 const GFX_TEXT_STRIDE_I32: i32 = 3; // font, byte_offset, byte_len
@@ -58,16 +59,17 @@ const GFX_F_CLEAR_G: i32 = 1;
 const GFX_F_CLEAR_B: i32 = 2;
 const GFX_F_CLEAR_A: i32 = 3;
 const GFX_F_LINE_BASE: i32 = 4;
-const GFX_F_TEXT_BASE: i32 = 80004;
+const GFX_F_SPRITE_BASE: i32 = 80004;
+const GFX_F_TEXT_BASE: i32 = 96388;
 
 // NOTE: Array sizes must be integer literals in Stasis today.
 // Keep these in sync with the constants above:
-// - i32 count = 32 + (4096*7) + (2048*3) = 34848
-// - f32 count = 4 + (10000*8) + (2048*6) = 92292
-const GFX_I_TEXT_BASE: i32 = 28704;
+// - i32 count = 32 + (4096*3) + (2048*3) = 18464
+// - f32 count = 4 + (10000*8) + (4096*4) + (2048*6) = 108676
+const GFX_I_TEXT_BASE: i32 = 12320;
 
-global gfx_cmd_i32: i32[34848];
-global gfx_cmd_f32: f32[92292];
+global gfx_cmd_i32: i32[18464];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 
 // Begin a new frame, resetting all counts (typical immediate-mode usage).
@@ -126,37 +128,39 @@ function gfx_cmd_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32
     gfx_cmd_i32[GFX_I_LINE_COUNT] = i + 1;
 }
 
-function gfx_cmd_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
+function gfx_cmd_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
     let i: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
     if (i >= GFX_MAX_SPRITES) {
         gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = gfx_cmd_i32[GFX_I_DROPPED_SPRITES] + 1;
         return;
     }
 
-    let base: i32 = GFX_I_SPRITE_BASE + i * GFX_SPRITE_STRIDE_I32;
-    gfx_cmd_i32[base + 0] = handle;
-    gfx_cmd_i32[base + 1] = x;
-    gfx_cmd_i32[base + 2] = y;
-    gfx_cmd_i32[base + 3] = w;
-    gfx_cmd_i32[base + 4] = h;
-    gfx_cmd_i32[base + 5] = rot_deg;
-    gfx_cmd_i32[base + 6] = a;
+    let base_i: i32 = GFX_I_SPRITE_BASE + i * GFX_SPRITE_STRIDE_I32;
+    let base_f: i32 = GFX_F_SPRITE_BASE + i * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_i32[base_i + 0] = handle;
+    gfx_cmd_i32[base_i + 1] = rot_deg;
+    gfx_cmd_i32[base_i + 2] = a;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = w;
+    gfx_cmd_f32[base_f + 3] = h;
 
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = i + 1;
 }
 
-function gfx_cmd_set_sprite_at(index: i32, handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
+function gfx_cmd_set_sprite_at(index: i32, handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
     if (index < 0 || index >= GFX_MAX_SPRITES) {
         return;
     }
-    let base: i32 = GFX_I_SPRITE_BASE + index * GFX_SPRITE_STRIDE_I32;
-    gfx_cmd_i32[base + 0] = handle;
-    gfx_cmd_i32[base + 1] = x;
-    gfx_cmd_i32[base + 2] = y;
-    gfx_cmd_i32[base + 3] = w;
-    gfx_cmd_i32[base + 4] = h;
-    gfx_cmd_i32[base + 5] = rot_deg;
-    gfx_cmd_i32[base + 6] = a;
+    let base_i: i32 = GFX_I_SPRITE_BASE + index * GFX_SPRITE_STRIDE_I32;
+    let base_f: i32 = GFX_F_SPRITE_BASE + index * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_i32[base_i + 0] = handle;
+    gfx_cmd_i32[base_i + 1] = rot_deg;
+    gfx_cmd_i32[base_i + 2] = a;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = w;
+    gfx_cmd_f32[base_f + 3] = h;
 }
 
 function gfx_cmd_lines_from(lines: f32[], count: i32): void {
@@ -181,7 +185,7 @@ function gfx_cmd_lines_from(lines: f32[], count: i32): void {
     gfx_cmd_i32[GFX_I_LINE_COUNT] = start + n;
 }
 
-function gfx_cmd_sprites_from(cmds: i32[], count: i32): void {
+function gfx_cmd_sprites_from(cmd_i32: i32[], cmd_f32: f32[], count: i32): void {
     if (count <= 0) {
         return;
     }
@@ -197,9 +201,12 @@ function gfx_cmd_sprites_from(cmds: i32[], count: i32): void {
         return;
     }
 
-    let dst: i32 = GFX_I_SPRITE_BASE + start * GFX_SPRITE_STRIDE_I32;
-    let total: i32 = n * GFX_SPRITE_STRIDE_I32;
-    sys_memcpy_i32(gfx_cmd_i32, dst, cmds, 0, total);
+    let dst_i: i32 = GFX_I_SPRITE_BASE + start * GFX_SPRITE_STRIDE_I32;
+    let total_i: i32 = n * GFX_SPRITE_STRIDE_I32;
+    sys_memcpy_i32(gfx_cmd_i32, dst_i, cmd_i32, 0, total_i);
+    let dst_f: i32 = GFX_F_SPRITE_BASE + start * GFX_SPRITE_STRIDE_F32;
+    let total_f: i32 = n * GFX_SPRITE_STRIDE_F32;
+    sys_memcpy_f32(gfx_cmd_f32, dst_f, cmd_f32, 0, total_f);
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = start + n;
 }
 

--- a/src/runtime/host_frame.stasis
+++ b/src/runtime/host_frame.stasis
@@ -12,12 +12,7 @@ const HOST_MAX_POINTERS: i32 = 8;
 
 // i32 layout
 const HOST_I_TIME_MS: i32 = 0;
-const HOST_I_WINDOW_W_PX: i32 = 1;
-const HOST_I_WINDOW_H_PX: i32 = 2;
-const HOST_I_VIEWPORT_X_PX: i32 = 3;
-const HOST_I_VIEWPORT_Y_PX: i32 = 4;
-const HOST_I_VIEWPORT_W_PX: i32 = 5;
-const HOST_I_VIEWPORT_H_PX: i32 = 6;
+// 1..6 removed with pre-1.0 window/viewport compatibility aliases.
 const HOST_I_POINTER_COUNT: i32 = 7;
 const HOST_I_DROPPED_POINTERS: i32 = 8;
 const HOST_I_QUIT_REQUESTED: i32 = 9;
@@ -36,18 +31,12 @@ const HOST_I_WINDOW_FOCUSED: i32 = 17;
 const HOST_I_WINDOW_MINIMIZED: i32 = 18;
 const HOST_I_TIME_US: i32 = 19;
 
-// Display metrics. Window width/height remain compatibility aliases for the
-// logical canvas; native and drawable extents may change independently.
-const HOST_I_LOGICAL_W_PX: i32 = 20;
-const HOST_I_LOGICAL_H_PX: i32 = 21;
+// Physical display metrics. Logical and safe geometry live in the f32 lane.
 const HOST_I_NATIVE_W_PX: i32 = 22;
 const HOST_I_NATIVE_H_PX: i32 = 23;
 const HOST_I_DRAWABLE_W_PX: i32 = 24;
 const HOST_I_DRAWABLE_H_PX: i32 = 25;
-const HOST_I_SAFE_X_PX: i32 = 26;
-const HOST_I_SAFE_Y_PX: i32 = 27;
-const HOST_I_SAFE_W_PX: i32 = 28;
-const HOST_I_SAFE_H_PX: i32 = 29;
+// 20,21 and 26..29 removed with integer presentation geometry.
 const HOST_I_DISPLAY_GENERATION: i32 = 30;
 const HOST_I_DENSITY_GENERATION: i32 = 31;
 
@@ -65,6 +54,12 @@ const HOST_F_POINTER_BASE: i32 = 0;
 const HOST_F_POINTER_STRIDE: i32 = 6; // x_px, y_px, dx_px, dy_px, x_n, y_n
 const HOST_F_CONTENT_SCALE: i32 = 48;
 const HOST_F_RASTER_SCALE: i32 = 49;
+const HOST_F_LOGICAL_W: i32 = 50;
+const HOST_F_LOGICAL_H: i32 = 51;
+const HOST_F_SAFE_X: i32 = 52;
+const HOST_F_SAFE_Y: i32 = 53;
+const HOST_F_SAFE_W: i32 = 54;
+const HOST_F_SAFE_H: i32 = 55;
 const HOST_F32_COUNT: i32 = 64;
 
 global host_i32: i32[768];
@@ -72,16 +67,6 @@ global host_f32: f32[64];
 
 function host_tick_index(): i32 { return host_i32[HOST_I_TICK_INDEX]; }
 function host_time_ms(): i32 { return host_i32[HOST_I_TIME_MS]; }
-function host_window_w_px(): i32 { return host_i32[HOST_I_WINDOW_W_PX]; }
-function host_window_h_px(): i32 { return host_i32[HOST_I_WINDOW_H_PX]; }
-function host_viewport_x_px(): i32 { return host_i32[HOST_I_VIEWPORT_X_PX]; }
-function host_viewport_y_px(): i32 { return host_i32[HOST_I_VIEWPORT_Y_PX]; }
-function host_viewport_w_px(): i32 { return host_i32[HOST_I_VIEWPORT_W_PX]; }
-function host_viewport_h_px(): i32 { return host_i32[HOST_I_VIEWPORT_H_PX]; }
-function host_viewport_x_px_f32(): f32 { return i32_to_f32(host_i32[HOST_I_VIEWPORT_X_PX]); }
-function host_viewport_y_px_f32(): f32 { return i32_to_f32(host_i32[HOST_I_VIEWPORT_Y_PX]); }
-function host_viewport_w_px_f32(): f32 { return i32_to_f32(host_i32[HOST_I_VIEWPORT_W_PX]); }
-function host_viewport_h_px_f32(): f32 { return i32_to_f32(host_i32[HOST_I_VIEWPORT_H_PX]); }
 function host_pointer_count(): i32 { return host_i32[HOST_I_POINTER_COUNT]; }
 function host_dropped_pointers(): i32 { return host_i32[HOST_I_DROPPED_POINTERS]; }
 function host_quit_requested(): bool { return host_i32[HOST_I_QUIT_REQUESTED] != 0; }
@@ -94,16 +79,16 @@ function host_tick_hz(): i32 { return host_i32[HOST_I_TICK_HZ]; }
 function host_window_focused(): bool { return host_i32[HOST_I_WINDOW_FOCUSED] != 0; }
 function host_window_minimized(): bool { return host_i32[HOST_I_WINDOW_MINIMIZED] != 0; }
 function host_time_us(): i32 { return host_i32[HOST_I_TIME_US]; }
-function host_logical_w_px(): i32 { return host_i32[HOST_I_LOGICAL_W_PX]; }
-function host_logical_h_px(): i32 { return host_i32[HOST_I_LOGICAL_H_PX]; }
+function host_logical_width(): f32 { return host_f32[HOST_F_LOGICAL_W]; }
+function host_logical_height(): f32 { return host_f32[HOST_F_LOGICAL_H]; }
 function host_native_w_px(): i32 { return host_i32[HOST_I_NATIVE_W_PX]; }
 function host_native_h_px(): i32 { return host_i32[HOST_I_NATIVE_H_PX]; }
 function host_drawable_w_px(): i32 { return host_i32[HOST_I_DRAWABLE_W_PX]; }
 function host_drawable_h_px(): i32 { return host_i32[HOST_I_DRAWABLE_H_PX]; }
-function host_safe_x_px(): i32 { return host_i32[HOST_I_SAFE_X_PX]; }
-function host_safe_y_px(): i32 { return host_i32[HOST_I_SAFE_Y_PX]; }
-function host_safe_w_px(): i32 { return host_i32[HOST_I_SAFE_W_PX]; }
-function host_safe_h_px(): i32 { return host_i32[HOST_I_SAFE_H_PX]; }
+function host_safe_x(): f32 { return host_f32[HOST_F_SAFE_X]; }
+function host_safe_y(): f32 { return host_f32[HOST_F_SAFE_Y]; }
+function host_safe_width(): f32 { return host_f32[HOST_F_SAFE_W]; }
+function host_safe_height(): f32 { return host_f32[HOST_F_SAFE_H]; }
 function host_display_generation(): i32 { return host_i32[HOST_I_DISPLAY_GENERATION]; }
 function host_density_generation(): i32 { return host_i32[HOST_I_DENSITY_GENERATION]; }
 function host_content_scale(): f32 { return host_f32[HOST_F_CONTENT_SCALE]; }
@@ -130,19 +115,19 @@ function host_pointer_went_up(index: i32): bool {
     return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3] != 0;
 }
 
-function host_pointer_x_px(index: i32): f32 {
+function host_pointer_x_logical(index: i32): f32 {
     return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0];
 }
 
-function host_pointer_y_px(index: i32): f32 {
+function host_pointer_y_logical(index: i32): f32 {
     return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1];
 }
 
-function host_pointer_dx_px(index: i32): f32 {
+function host_pointer_dx_logical(index: i32): f32 {
     return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 2];
 }
 
-function host_pointer_dy_px(index: i32): f32 {
+function host_pointer_dy_logical(index: i32): f32 {
     return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 3];
 }
 

--- a/src/stdlib/gfx_cmd.stasis
+++ b/src/stdlib/gfx_cmd.stasis
@@ -1,14 +1,14 @@
 import "graphics.stasis";
 import "stdlib.stasis";
 
-// Graphics command buffer (v1 prototype)
+// Graphics command buffer (v2)
 //
 // Policy:
 // - Ordering: fixed by field order in this layout: clear -> lines -> sprites -> present.
-// - Coordinates: host pixels.
+// - Coordinates: logical presentation units.
 
 const GFX_CMD_MAGIC: i32 = 0x47584631; // 'GXF1'
-const GFX_CMD_VERSION: i32 = 1;
+const GFX_CMD_VERSION: i32 = 2;
 
 // i32 header indices
 const GFX_I_MAGIC: i32 = 0;
@@ -31,7 +31,8 @@ const GFX_FLAG_PRESENT: i32 = 2;
 const GFX_MAX_LINES: i32 = 10000;
 const GFX_LINE_STRIDE_F32: i32 = 8;
 const GFX_MAX_SPRITES: i32 = 4096;
-const GFX_SPRITE_STRIDE_I32: i32 = 7; // handle,x,y,w,h,rot_deg,a
+const GFX_SPRITE_STRIDE_I32: i32 = 3; // handle,rot_deg,a
+const GFX_SPRITE_STRIDE_F32: i32 = 4; // x,y,w,h
 
 const GFX_MAX_TEXT: i32 = 2048;
 const GFX_TEXT_STRIDE_I32: i32 = 3; // font, byte_offset, byte_len
@@ -44,7 +45,8 @@ const GFX_F_CLEAR_G: i32 = 1;
 const GFX_F_CLEAR_B: i32 = 2;
 const GFX_F_CLEAR_A: i32 = 3;
 const GFX_F_LINE_BASE: i32 = 4;
-const GFX_F_TEXT_BASE: i32 = GFX_F_LINE_BASE + GFX_MAX_LINES * GFX_LINE_STRIDE_F32;
+const GFX_F_SPRITE_BASE: i32 = GFX_F_LINE_BASE + GFX_MAX_LINES * GFX_LINE_STRIDE_F32;
+const GFX_F_TEXT_BASE: i32 = GFX_F_SPRITE_BASE + GFX_MAX_SPRITES * GFX_SPRITE_STRIDE_F32;
 
 const GFX_I_TEXT_BASE: i32 = GFX_I_SPRITE_BASE + GFX_MAX_SPRITES * GFX_SPRITE_STRIDE_I32;
 
@@ -96,21 +98,22 @@ function gfx_cmd_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32
     gfx_cmd_i32[GFX_I_LINE_COUNT] = i + 1;
 }
 
-function gfx_cmd_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
+function gfx_cmd_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
     let i: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
     if (i >= GFX_MAX_SPRITES) {
         gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = gfx_cmd_i32[GFX_I_DROPPED_SPRITES] + 1;
         return;
     }
 
-    let base: i32 = GFX_I_SPRITE_BASE + i * GFX_SPRITE_STRIDE_I32;
-    gfx_cmd_i32[base + 0] = handle;
-    gfx_cmd_i32[base + 1] = x;
-    gfx_cmd_i32[base + 2] = y;
-    gfx_cmd_i32[base + 3] = w;
-    gfx_cmd_i32[base + 4] = h;
-    gfx_cmd_i32[base + 5] = rot_deg;
-    gfx_cmd_i32[base + 6] = a;
+    let base_i: i32 = GFX_I_SPRITE_BASE + i * GFX_SPRITE_STRIDE_I32;
+    let base_f: i32 = GFX_F_SPRITE_BASE + i * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_i32[base_i + 0] = handle;
+    gfx_cmd_i32[base_i + 1] = rot_deg;
+    gfx_cmd_i32[base_i + 2] = a;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = w;
+    gfx_cmd_f32[base_f + 3] = h;
 
     gfx_cmd_i32[GFX_I_SPRITE_COUNT] = i + 1;
 }

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -90,12 +90,12 @@ function draw_lines(lines: f32[], count: i32): void {
     gfx_cmd_lines_from(lines, count);
 }
 
-function gfx_draw_sprite(handle: i32, x: i32, y: i32, w: i32, h: i32, rot_deg: i32, a: i32): void {
+function gfx_draw_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
     gfx_cmd_sprite(handle, x, y, w, h, rot_deg, a);
 }
 
-function gfx_draw_sprites(cmds: i32[], count: i32): void {
-    gfx_cmd_sprites_from(cmds, count);
+function gfx_draw_sprites(cmd_i32: i32[], cmd_f32: f32[], count: i32): void {
+    gfx_cmd_sprites_from(cmd_i32, cmd_f32, count);
 }
 
 /* Text positioning uses a top-left origin, matching sprite placement. */
@@ -107,19 +107,17 @@ function draw_text_cached(font: i32, run_handle: i32, x: f32, y: f32, r: f32, g:
     gfx_cmd_text_cached(font, run_handle, x, y, r, g, b, a);
 }
 
-function gfx_window_width(): i32 { return host_window_w_px(); }
-function gfx_window_height(): i32 { return host_window_h_px(); }
 function gfx_window_resized(): bool { return host_resized(); }
-function gfx_logical_width(): i32 { return host_logical_w_px(); }
-function gfx_logical_height(): i32 { return host_logical_h_px(); }
-function gfx_native_width(): i32 { return host_native_w_px(); }
-function gfx_native_height(): i32 { return host_native_h_px(); }
-function gfx_drawable_width(): i32 { return host_drawable_w_px(); }
-function gfx_drawable_height(): i32 { return host_drawable_h_px(); }
-function gfx_safe_viewport_x(): i32 { return host_safe_x_px(); }
-function gfx_safe_viewport_y(): i32 { return host_safe_y_px(); }
-function gfx_safe_viewport_width(): i32 { return host_safe_w_px(); }
-function gfx_safe_viewport_height(): i32 { return host_safe_h_px(); }
+function gfx_logical_width(): f32 { return host_logical_width(); }
+function gfx_logical_height(): f32 { return host_logical_height(); }
+function gfx_native_width_px(): i32 { return host_native_w_px(); }
+function gfx_native_height_px(): i32 { return host_native_h_px(); }
+function gfx_drawable_width_px(): i32 { return host_drawable_w_px(); }
+function gfx_drawable_height_px(): i32 { return host_drawable_h_px(); }
+function gfx_safe_viewport_x(): f32 { return host_safe_x(); }
+function gfx_safe_viewport_y(): f32 { return host_safe_y(); }
+function gfx_safe_viewport_width(): f32 { return host_safe_width(); }
+function gfx_safe_viewport_height(): f32 { return host_safe_height(); }
 function gfx_content_scale(): f32 { return host_content_scale(); }
 function gfx_raster_scale(): f32 { return host_raster_scale(); }
 function gfx_display_generation(): i32 { return host_display_generation(); }
@@ -143,14 +141,10 @@ function input_pointer_id(index: i32): i32 { return host_pointer_id(index); }
 function input_pointer_is_down(index: i32): bool { return host_pointer_is_down(index); }
 function input_pointer_went_down(index: i32): bool { return host_pointer_went_down(index); }
 function input_pointer_went_up(index: i32): bool { return host_pointer_went_up(index); }
-function input_pointer_x_px(index: i32): f32 { return host_pointer_x_px(index); }
-function input_pointer_y_px(index: i32): f32 { return host_pointer_y_px(index); }
-function input_pointer_dx_px(index: i32): f32 { return host_pointer_dx_px(index); }
-function input_pointer_dy_px(index: i32): f32 { return host_pointer_dy_px(index); }
+function input_pointer_x_logical(index: i32): f32 { return host_pointer_x_logical(index); }
+function input_pointer_y_logical(index: i32): f32 { return host_pointer_y_logical(index); }
+function input_pointer_dx_logical(index: i32): f32 { return host_pointer_dx_logical(index); }
+function input_pointer_dy_logical(index: i32): f32 { return host_pointer_dy_logical(index); }
 function input_pointer_x_n(index: i32): f32 { return host_pointer_x_n(index); }
 function input_pointer_y_n(index: i32): f32 { return host_pointer_y_n(index); }
 function input_dropped_pointers(): i32 { return host_dropped_pointers(); }
-function input_viewport_x_px(): i32 { return host_viewport_x_px(); }
-function input_viewport_y_px(): i32 { return host_viewport_y_px(); }
-function input_viewport_w_px(): i32 { return host_viewport_w_px(); }
-function input_viewport_h_px(): i32 { return host_viewport_h_px(); }

--- a/src/stdlib/ui_button_9slice.stasis
+++ b/src/stdlib/ui_button_9slice.stasis
@@ -3,7 +3,7 @@ import "graphics.stasis";
 // Background uses 9 sprites (3x3 grid). Icons are sprites; text uses draw_text.
 
 function ui_draw_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, a: i32): void {
-    gfx_draw_sprite(handle, f32_to_i32(x), f32_to_i32(y), f32_to_i32(w), f32_to_i32(h), 0, a);
+    gfx_draw_sprite(handle, x, y, w, h, 0, a);
 }
 
 function ui_row_button_width(available_w: f32, count: i32, gap: f32): f32 {

--- a/tests/stasis/rust_native_tick_input_snapshot.stasis
+++ b/tests/stasis/rust_native_tick_input_snapshot.stasis
@@ -5,7 +5,7 @@ global snapshot_mode: i32;
 global model_pointer_count: i32;
 global model_escape_down: bool;
 global model_first_went_down: bool;
-global model_first_x_px: f32;
+global model_first_x: f32;
 
 function apply_test_snapshot(): void {
     if (snapshot_mode == 1) {
@@ -28,10 +28,10 @@ function refresh_input_model_for_test(): void {
     model_pointer_count = host_pointer_count();
     model_escape_down = host_key_down(41);
     model_first_went_down = false;
-    model_first_x_px = 0.0;
+    model_first_x = 0.0;
     if (model_pointer_count > 0) {
         model_first_went_down = host_pointer_went_down(0);
-        model_first_x_px = host_pointer_x_px(0);
+        model_first_x = host_pointer_x_logical(0);
     }
     return;
 }
@@ -43,7 +43,7 @@ function tick(): i32 {
         last_tick_code = -1;
         return last_tick_code;
     }
-    if (model_escape_down && model_first_went_down && model_first_x_px > 9.5) {
+    if (model_escape_down && model_first_went_down && model_first_x > 9.5) {
         last_tick_code = 1;
         return last_tick_code;
     }

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -1284,7 +1284,8 @@ def main() -> int:
     assert "gamePreview.touchActive()" in activity
     assert "MotionEvent" in activity
     assert "LINE_F32_STRIDE = 8" in preview_renderer
-    assert "SPRITE_I32_STRIDE = 7" in preview_renderer
+    assert "SPRITE_I32_STRIDE = 3" in preview_renderer
+    assert "SPRITE_F32_STRIDE = 4" in preview_renderer
     assert "TEXT_I32_STRIDE = 3" in preview_renderer
     assert "drawColorBatch" in preview_renderer
     assert "drawPreparedTextureBatch" in preview_renderer
@@ -1409,7 +1410,7 @@ def main() -> int:
     assert "Java_com_stasislang_workshop_MainActivity_nativeRunTick" in native
     assert "Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto" in native
     assert "bytes_i32 < (jlong)(STASIS_RENDER_I32_COUNT * sizeof(int32_t))" in native
-    assert 'dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v1")' in native
+    assert 'dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v2")' in native
     assert "#define STASIS_RENDER_COMMAND_STRIDE 13" in native
     assert '"Render.command_schema_version"' in native
     assert '"Render.command" #index "_rotation_degrees"' in native

--- a/tools/ci/test_verify_render_parity.py
+++ b/tools/ci/test_verify_render_parity.py
@@ -109,13 +109,13 @@ class RenderParityGateTest(unittest.TestCase):
                 validate_fixture(temporary)
 
     def test_runtime_evidence_requires_generation_advance_and_foreground_restore(self):
-        manifest = {"command_trace": 829981937}
+        manifest = {"command_trace": 3891526461}
         log = """Stasis display metrics: logical=1280x720 native=2400x1080 drawable=2400x1080 scale=1.50
 gfx_load_sprite: /fixture/assets/opaque.svg (96x72) -> handle=1 raster=144x108 backend=sdl
 gfx_load_sprite: /fixture/assets/translucent.svg (96x72) -> handle=2 raster=144x108 backend=sdl
 gfx_load_sprite: /fixture/assets/full_canvas.svg (640x360) -> handle=3 raster=960x540 backend=sdl
 stasis_load_font: loaded /fixture/assets/parity.ttf logical_size=24 raster_size=36 scale=1.50 handle=1
-Stasis render contract v1 trace=829981937 flags=3 lines=2 sprites=5 text=2
+Stasis render contract v2 trace=3891526461 flags=3 lines=2 sprites=5 text=2
 Stasis renderer resources restored: backend=sdl surface_generation=3 renderer_generation=1 reason=surface_changed sprites=3
 Stasis renderer resources restored: backend=sdl surface_generation=4 renderer_generation=1 reason=surface_changed sprites=3
 Stasis renderer resources restored: backend=sdl surface_generation=5 renderer_generation=2 reason=foreground sprites=3

--- a/tools/ci/verify_render_parity.py
+++ b/tools/ci/verify_render_parity.py
@@ -358,7 +358,7 @@ def verify_runtime_evidence(
 ) -> None:
     log = _read_runtime_log(log_path)
     trace_match = re.search(
-        r"Stasis render contract v1 trace=(\d+)\s+flags=3\s+lines=2\s+sprites=5\s+text=2",
+        r"Stasis render contract v2 trace=(\d+)\s+flags=3\s+lines=2\s+sprites=5\s+text=2",
         log,
     )
     if trace_match is None or int(trace_match.group(1)) != int(manifest["command_trace"]):

--- a/tools/generate_release_provenance.py
+++ b/tools/generate_release_provenance.py
@@ -120,7 +120,7 @@ def main() -> int:
         },
         "runtime_sources": runtime_sources,
         "mobile_shell_sources": mobile_shell_sources,
-        "command_buffer": {"name": "gfx_cmd", "version": 1},
+        "command_buffer": {"name": "gfx_cmd", "version": 2},
         "backends": ["sdl2"],
         "features": ["aot", "jit", "mobile-aot", "shared-renderer"],
         "dependencies": dependencies,


### PR DESCRIPTION
## Summary

- publish HostFrame v3 with logical/safe presentation geometry in the f32 lane and explicit physical pixel metadata in i32
- publish gfx_cmd v2 with sprite identity/state in i32 and fractional x/y/width/height in f32
- remove pre-1.0 display/input compatibility APIs and migrate desktop, Android, samples, parity fixtures, provenance, and tests atomically

## Impact

Layout, pointer hit testing, text measurement, flex output, and sprite submission now share one logical f32 coordinate path. Rounding is deferred to the platform renderer.

## Validation

- `cargo test -p stasis compiler_backend::tests::jit_dev_brickout_v1_builds_engine_package_with_render_pointer -- --nocapture`
- `cargo test -p stasis input_script_uses_logical_dimensions_from_first_snapshot -- --nocapture`
- `cargo test -p stasis shipping_renderers_share_one_versioned_sdl_command_process -- --nocapture`
- `cargo test -p stasis_android_bridge c_bridge_run_tick_frame_v2_copies_only_production_active_spans -- --nocapture`
- `cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture --test-threads=1`
- native MSVC compile/run of `runtime/tests/stasis_render_contract_test.c`
- portable repository validation Python suites and render parity fixture
- `cargo test -p stasis_dynload -p stasis_android_bridge -p stasis --no-run`

## Environment notes

- full Android Gradle unit test exceeded the repository's five-minute bound without output and was stopped
- some broad Rust test executions are intermittently blocked before test code by local Windows Device Guard; targeted signed executions above passed
- `tools/ci/check_android_shell.py` reaches an unrelated pre-existing `MAX_TOOL_CALLS_PER_BATCH = 12` assertion