### PR TITLE
feat: adopt axis layout in representative menu

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2308,8 +2308,12 @@ mod tests {
             include_str!("../../../../src/stdlib/ui_axis_layout.stasis"),
         );
         process.upsert_file(
-            "samples/immediate_axis_layout/main.stasis",
-            include_str!("../../../../samples/immediate_axis_layout/main.stasis"),
+            "samples/immediate_axis_layout/layout.stasis",
+            include_str!("../../../../samples/immediate_axis_layout/layout.stasis"),
+        );
+        process.upsert_file(
+            "samples/immediate_axis_layout/verify.stasis",
+            include_str!("../../../../samples/immediate_axis_layout/verify.stasis"),
         );
         process
             .compile()

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2308,8 +2308,8 @@ mod tests {
             include_str!("../../../../src/stdlib/ui_axis_layout.stasis"),
         );
         process.upsert_file(
-            "samples/immediate_axis_layout/layout.stasis",
-            include_str!("../../../../samples/immediate_axis_layout/layout.stasis"),
+            "samples/immediate_axis_layout/placement.stasis",
+            include_str!("../../../../samples/immediate_axis_layout/placement.stasis"),
         );
         process.upsert_file(
             "samples/immediate_axis_layout/verify.stasis",
@@ -2318,6 +2318,10 @@ mod tests {
         process
             .compile()
             .expect("compile immediate axis layout sample");
+        assert!(
+            process.state_layout().scalars.is_empty(),
+            "pure AOT placement fixture must not require runtime storage registration"
+        );
 
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2553,6 +2553,28 @@ mod tests {
     }
 
     #[test]
+    fn jit_process_executes_representative_immediate_axis_layout() {
+        let mut process = JitProcess::new();
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        process.upsert_file(
+            repository
+                .join("samples/immediate_axis_layout/verify.stasis")
+                .to_string_lossy()
+                .into_owned(),
+            include_str!("../../../../samples/immediate_axis_layout/verify.stasis"),
+        );
+        process
+            .compile()
+            .expect("compile immediate axis layout sample");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute immediate axis layout sample"),
+            0
+        );
+    }
+
+    #[test]
     fn jit_process_supports_local_annotation_only_type_during_emit() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2558,14 +2558,18 @@ mod tests {
         let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
         process.upsert_file(
             repository
-                .join("samples/immediate_axis_layout/verify.stasis")
+                .join("samples/immediate_axis_layout/verify_jit.stasis")
                 .to_string_lossy()
                 .into_owned(),
-            include_str!("../../../../samples/immediate_axis_layout/verify.stasis"),
+            include_str!("../../../../samples/immediate_axis_layout/verify_jit.stasis"),
         );
         process
             .compile()
             .expect("compile immediate axis layout sample");
+        assert!(
+            !process.state_layout().scalars.is_empty(),
+            "JIT composition fixture must cover shared scalar menu bounds"
+        );
         assert_eq!(
             process
                 .execute_i32_noarg_by_name("main")

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1564,7 +1564,7 @@ Archived priority override (2026-02-13, historical):
   - Adjustment: future command-ABI changes must audit every language implementation by semantic field names and assert all derived bases/capacities in each platform test, not rely on numeric replacement alone.
 - AP3 work summary:
   - Theory gained: immediate-mode UI needs persistent resource metrics but not persistent layout objects; the representative menu caches run handles and widths once, then derives one set of scalar bounds from the current safe viewport for drawing and hit testing each frame.
-  - Good: separating host-independent geometry from the rendered entry kept the same realistic path executable under both JIT and AOT while the play command exercised the real graphics boundary.
+  - Good: separating pure placement formulas from global-backed composition kept the realistic path executable under both JIT and AOT while the play command exercised the real graphics boundary.
   - Bad: local screenshot capture initially looked like a sample presentation failure, but the unchanged render-parity sample reproduced the same missing-capture behavior in this environment.
   - Adjustment: distinguish renderer startup/command submission evidence from screenshot-hook evidence by immediately running the known-good parity scene when capture infrastructure fails, and iterate all reported pointer slots because desktop touch transitions do not occupy the mouse slot.
 

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1566,7 +1566,7 @@ Archived priority override (2026-02-13, historical):
   - Theory gained: immediate-mode UI needs persistent resource metrics but not persistent layout objects; the representative menu caches run handles and widths once, then derives one set of scalar bounds from the current safe viewport for drawing and hit testing each frame.
   - Good: separating host-independent geometry from the rendered entry kept the same realistic path executable under both JIT and AOT while the play command exercised the real graphics boundary.
   - Bad: local screenshot capture initially looked like a sample presentation failure, but the unchanged render-parity sample reproduced the same missing-capture behavior in this environment.
-  - Adjustment: distinguish renderer startup/command submission evidence from screenshot-hook evidence by immediately running the known-good parity scene when capture infrastructure fails.
+  - Adjustment: distinguish renderer startup/command submission evidence from screenshot-hook evidence by immediately running the known-good parity scene when capture infrastructure fails, and iterate all reported pointer slots because desktop touch transitions do not occupy the mouse slot.
 
 ## PR Sequence
 

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1544,7 +1544,7 @@ Archived priority override (2026-02-13, historical):
 - AP3 - Representative menu adoption:
   - Cache text run widths during initialization.
   - Center a menu title, anchor a button within an adjusted region, center its label, and reuse scalar bounds for hit testing.
-  - Status: `planned after AP2`.
+  - Status: `complete`.
 - Done gate:
   - All PRD acceptance criteria pass through JIT/AOT and the real renderer boundary as applicable.
 - AP1 work summary:
@@ -1562,6 +1562,11 @@ Archived priority override (2026-02-13, historical):
   - Good: versioning HostFrame and the render command together made stale producers and decoders mechanically discoverable across desktop, Android, fixtures, and samples.
   - Bad: the first mechanical capacity migration missed the Android Java renderer and briefly assigned the sprite float base to the text base in one duplicated runtime module.
   - Adjustment: future command-ABI changes must audit every language implementation by semantic field names and assert all derived bases/capacities in each platform test, not rely on numeric replacement alone.
+- AP3 work summary:
+  - Theory gained: immediate-mode UI needs persistent resource metrics but not persistent layout objects; the representative menu caches run handles and widths once, then derives one set of scalar bounds from the current safe viewport for drawing and hit testing each frame.
+  - Good: separating host-independent geometry from the rendered entry kept the same realistic path executable under both JIT and AOT while the play command exercised the real graphics boundary.
+  - Bad: local screenshot capture initially looked like a sample presentation failure, but the unchanged render-parity sample reproduced the same missing-capture behavior in this environment.
+  - Adjustment: distinguish renderer startup/command submission evidence from screenshot-hook evidence by immediately running the known-good parity scene when capture infrastructure fails.
 
 ## PR Sequence
 

--- a/samples/immediate_axis_layout/layout.stasis
+++ b/samples/immediate_axis_layout/layout.stasis
@@ -1,0 +1,56 @@
+import "../../src/stdlib/ui_axis_layout.stasis";
+
+global menu_title_x: f32;
+global menu_title_y: f32;
+global menu_button_x: f32;
+global menu_button_y: f32;
+global menu_button_w: f32;
+global menu_button_h: f32;
+global menu_label_x: f32;
+global menu_label_y: f32;
+
+function menu_layout(
+    safe_x: f32,
+    safe_y: f32,
+    safe_w: f32,
+    safe_h: f32,
+    title_w: f32,
+    label_w: f32
+): void {
+    menu_title_x = ui_place_x(safe_x, safe_w, title_w, UiHorizontal.Center);
+    menu_title_y = ui_place_y(safe_y + 24.0, 72.0, 32.0, UiVertical.Top);
+
+    menu_button_w = 180.0;
+    menu_button_h = 56.0;
+    let button_area_x: f32 = safe_x + 20.0;
+    let button_area_y: f32 = safe_y + 140.0;
+    let button_area_w: f32 = safe_w - 40.0;
+    let button_area_h: f32 = safe_h - 160.0;
+    menu_button_x = ui_place_x(
+        button_area_x,
+        button_area_w,
+        menu_button_w,
+        UiHorizontal.Left
+    );
+    menu_button_y = ui_place_y(
+        button_area_y,
+        button_area_h,
+        menu_button_h,
+        UiVertical.Top
+    );
+
+    let content_x: f32 = menu_button_x + 16.0;
+    let content_y: f32 = menu_button_y + 8.0;
+    let content_w: f32 = menu_button_w - 32.0;
+    let content_h: f32 = menu_button_h - 16.0;
+    menu_label_x = ui_place_x(content_x, content_w, label_w, UiHorizontal.Center);
+    menu_label_y = ui_place_y(content_y, content_h, 28.0, UiVertical.Center) + 1.0;
+}
+
+function menu_button_contains(point_x: f32, point_y: f32): bool {
+    return
+        point_x >= menu_button_x &&
+        point_x < menu_button_x + menu_button_w &&
+        point_y >= menu_button_y &&
+        point_y < menu_button_y + menu_button_h;
+}

--- a/samples/immediate_axis_layout/layout.stasis
+++ b/samples/immediate_axis_layout/layout.stasis
@@ -1,4 +1,4 @@
-import "../../src/stdlib/ui_axis_layout.stasis";
+import "placement.stasis";
 
 global menu_title_x: f32;
 global menu_title_y: f32;
@@ -8,41 +8,6 @@ global menu_button_w: f32;
 global menu_button_h: f32;
 global menu_label_x: f32;
 global menu_label_y: f32;
-
-function menu_title_x_for(safe_x: f32, safe_w: f32, title_w: f32): f32 {
-    return ui_place_x(safe_x, safe_w, title_w, UiHorizontal.Center);
-}
-
-function menu_button_x_for(safe_x: f32, safe_w: f32): f32 {
-    return ui_place_x(safe_x + 20.0, safe_w - 40.0, 180.0, UiHorizontal.Left);
-}
-
-function menu_button_y_for(safe_y: f32, safe_h: f32): f32 {
-    return ui_place_y(safe_y + 140.0, safe_h - 160.0, 56.0, UiVertical.Top);
-}
-
-function menu_label_x_for(button_x: f32, label_w: f32): f32 {
-    return ui_place_x(button_x + 16.0, 148.0, label_w, UiHorizontal.Center);
-}
-
-function menu_label_y_for(button_y: f32): f32 {
-    return ui_place_y(button_y + 8.0, 40.0, 28.0, UiVertical.Center) + 1.0;
-}
-
-function menu_point_in_button(
-    point_x: f32,
-    point_y: f32,
-    button_x: f32,
-    button_y: f32,
-    button_w: f32,
-    button_h: f32
-): bool {
-    return
-        point_x >= button_x &&
-        point_x < button_x + button_w &&
-        point_y >= button_y &&
-        point_y < button_y + button_h;
-}
 
 function menu_layout(
     safe_x: f32,

--- a/samples/immediate_axis_layout/layout.stasis
+++ b/samples/immediate_axis_layout/layout.stasis
@@ -9,6 +9,41 @@ global menu_button_h: f32;
 global menu_label_x: f32;
 global menu_label_y: f32;
 
+function menu_title_x_for(safe_x: f32, safe_w: f32, title_w: f32): f32 {
+    return ui_place_x(safe_x, safe_w, title_w, UiHorizontal.Center);
+}
+
+function menu_button_x_for(safe_x: f32, safe_w: f32): f32 {
+    return ui_place_x(safe_x + 20.0, safe_w - 40.0, 180.0, UiHorizontal.Left);
+}
+
+function menu_button_y_for(safe_y: f32, safe_h: f32): f32 {
+    return ui_place_y(safe_y + 140.0, safe_h - 160.0, 56.0, UiVertical.Top);
+}
+
+function menu_label_x_for(button_x: f32, label_w: f32): f32 {
+    return ui_place_x(button_x + 16.0, 148.0, label_w, UiHorizontal.Center);
+}
+
+function menu_label_y_for(button_y: f32): f32 {
+    return ui_place_y(button_y + 8.0, 40.0, 28.0, UiVertical.Center) + 1.0;
+}
+
+function menu_point_in_button(
+    point_x: f32,
+    point_y: f32,
+    button_x: f32,
+    button_y: f32,
+    button_w: f32,
+    button_h: f32
+): bool {
+    return
+        point_x >= button_x &&
+        point_x < button_x + button_w &&
+        point_y >= button_y &&
+        point_y < button_y + button_h;
+}
+
 function menu_layout(
     safe_x: f32,
     safe_y: f32,
@@ -17,40 +52,24 @@ function menu_layout(
     title_w: f32,
     label_w: f32
 ): void {
-    menu_title_x = ui_place_x(safe_x, safe_w, title_w, UiHorizontal.Center);
+    menu_title_x = menu_title_x_for(safe_x, safe_w, title_w);
     menu_title_y = ui_place_y(safe_y + 24.0, 72.0, 32.0, UiVertical.Top);
 
     menu_button_w = 180.0;
     menu_button_h = 56.0;
-    let button_area_x: f32 = safe_x + 20.0;
-    let button_area_y: f32 = safe_y + 140.0;
-    let button_area_w: f32 = safe_w - 40.0;
-    let button_area_h: f32 = safe_h - 160.0;
-    menu_button_x = ui_place_x(
-        button_area_x,
-        button_area_w,
-        menu_button_w,
-        UiHorizontal.Left
-    );
-    menu_button_y = ui_place_y(
-        button_area_y,
-        button_area_h,
-        menu_button_h,
-        UiVertical.Top
-    );
-
-    let content_x: f32 = menu_button_x + 16.0;
-    let content_y: f32 = menu_button_y + 8.0;
-    let content_w: f32 = menu_button_w - 32.0;
-    let content_h: f32 = menu_button_h - 16.0;
-    menu_label_x = ui_place_x(content_x, content_w, label_w, UiHorizontal.Center);
-    menu_label_y = ui_place_y(content_y, content_h, 28.0, UiVertical.Center) + 1.0;
+    menu_button_x = menu_button_x_for(safe_x, safe_w);
+    menu_button_y = menu_button_y_for(safe_y, safe_h);
+    menu_label_x = menu_label_x_for(menu_button_x, label_w);
+    menu_label_y = menu_label_y_for(menu_button_y);
 }
 
 function menu_button_contains(point_x: f32, point_y: f32): bool {
-    return
-        point_x >= menu_button_x &&
-        point_x < menu_button_x + menu_button_w &&
-        point_y >= menu_button_y &&
-        point_y < menu_button_y + menu_button_h;
+    return menu_point_in_button(
+        point_x,
+        point_y,
+        menu_button_x,
+        menu_button_y,
+        menu_button_w,
+        menu_button_h
+    );
 }

--- a/samples/immediate_axis_layout/main.stasis
+++ b/samples/immediate_axis_layout/main.stasis
@@ -37,11 +37,18 @@ function update_menu_layout(): void {
 
 function tick(): i32 {
     update_menu_layout();
-    if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
-        menu_play_clicked = menu_button_contains(
-            input_pointer_x_logical(0),
-            input_pointer_y_logical(0)
-        );
+    menu_play_clicked = false;
+    let pointer_count: i32 = input_pointer_count();
+    let i: i32 = 0;
+    for (i = 0; i < pointer_count; i = i + 1) {
+        if (input_pointer_went_up(i)) {
+            if (menu_button_contains(
+                input_pointer_x_logical(i),
+                input_pointer_y_logical(i)
+            )) {
+                menu_play_clicked = true;
+            }
+        }
     }
     return 0;
 }

--- a/samples/immediate_axis_layout/main.stasis
+++ b/samples/immediate_axis_layout/main.stasis
@@ -1,24 +1,76 @@
-import "../../src/stdlib/ui_axis_layout.stasis";
+import "../../src/stdlib/graphics.stasis";
+import "layout.stasis";
+
+global menu_font: i32;
+global menu_title_run: i32;
+global menu_title_width: f32;
+global menu_play_run: i32;
+global menu_play_width: f32;
+global menu_button_sprite: i32;
+global menu_play_clicked: bool;
 
 function main(): i32 {
-    let safe_x: f32 = 0.0;
-    let safe_y: f32 = 0.0;
-    let safe_w: f32 = 360.0;
-    let safe_h: f32 = 720.0;
-
-    let title_x: f32 = ui_place_x(safe_x, safe_w, 180.0, UiHorizontal.Center);
-
-    let button_area_x: f32 = safe_x + 20.0;
-    let button_area_y: f32 = safe_y + 140.0;
-    let button_area_w: f32 = safe_w - 40.0;
-    let button_area_h: f32 = safe_h - 160.0;
-    let button_x: f32 = ui_place_x(button_area_x, button_area_w, 180.0, UiHorizontal.Left);
-    let button_y: f32 = ui_place_y(button_area_y, button_area_h, 56.0, UiVertical.Top);
-    let label_x: f32 = ui_place_x(button_x, 180.0, 64.0, UiHorizontal.Center);
-    let label_y: f32 = ui_place_y(button_y, 56.0, 28.0, UiVertical.Center);
-
-    if (title_x != 90.0) { return 1; }
-    if (button_x != 20.0 || button_y != 140.0) { return 2; }
-    if (label_x != 78.0 || label_y != 154.0) { return 3; }
+    init_window(360, 720, "Immediate Axis Layout");
+    menu_font = load_font("../render_parity/assets/parity.ttf", 24);
+    menu_title_run = gfx_cache_text(menu_font, "STASIS MENU");
+    menu_title_width = gfx_measure_text_cached(menu_title_run);
+    menu_play_run = gfx_cache_text(menu_font, "PLAY");
+    menu_play_width = gfx_measure_text_cached(menu_play_run);
+    menu_button_sprite = gfx_load_sprite("../render_parity/assets/opaque.svg", 180, 56);
+    menu_play_clicked = false;
+    if (menu_font == 0 || menu_title_run == 0 || menu_play_run == 0 || menu_button_sprite == 0) {
+        return 1;
+    }
     return 0;
+}
+
+function update_menu_layout(): void {
+    menu_layout(
+        gfx_safe_viewport_x(),
+        gfx_safe_viewport_y(),
+        gfx_safe_viewport_width(),
+        gfx_safe_viewport_height(),
+        menu_title_width,
+        menu_play_width
+    );
+}
+
+function tick(): i32 {
+    update_menu_layout();
+    if (input_pointer_count() > 0 && input_pointer_went_up(0)) {
+        menu_play_clicked = menu_button_contains(
+            input_pointer_x_logical(0),
+            input_pointer_y_logical(0)
+        );
+    }
+    return 0;
+}
+
+function render(): i32 {
+    begin_frame();
+    clear(0.04, 0.06, 0.10, 1.0);
+    update_menu_layout();
+    draw_text_cached(
+        menu_font, menu_title_run, menu_title_x, menu_title_y,
+        1.0, 0.9, 0.7, 1.0
+    );
+    gfx_draw_sprite(
+        menu_button_sprite,
+        menu_button_x,
+        menu_button_y,
+        menu_button_w,
+        menu_button_h,
+        0,
+        255
+    );
+    draw_text_cached(
+        menu_font, menu_play_run, menu_label_x, menu_label_y,
+        1.0, 1.0, 1.0, 1.0
+    );
+    end_frame();
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
 }

--- a/samples/immediate_axis_layout/placement.stasis
+++ b/samples/immediate_axis_layout/placement.stasis
@@ -1,0 +1,36 @@
+import "../../src/stdlib/ui_axis_layout.stasis";
+
+function menu_title_x_for(safe_x: f32, safe_w: f32, title_w: f32): f32 {
+    return ui_place_x(safe_x, safe_w, title_w, UiHorizontal.Center);
+}
+
+function menu_button_x_for(safe_x: f32, safe_w: f32): f32 {
+    return ui_place_x(safe_x + 20.0, safe_w - 40.0, 180.0, UiHorizontal.Left);
+}
+
+function menu_button_y_for(safe_y: f32, safe_h: f32): f32 {
+    return ui_place_y(safe_y + 140.0, safe_h - 160.0, 56.0, UiVertical.Top);
+}
+
+function menu_label_x_for(button_x: f32, label_w: f32): f32 {
+    return ui_place_x(button_x + 16.0, 148.0, label_w, UiHorizontal.Center);
+}
+
+function menu_label_y_for(button_y: f32): f32 {
+    return ui_place_y(button_y + 8.0, 40.0, 28.0, UiVertical.Center) + 1.0;
+}
+
+function menu_point_in_button(
+    point_x: f32,
+    point_y: f32,
+    button_x: f32,
+    button_y: f32,
+    button_w: f32,
+    button_h: f32
+): bool {
+    return
+        point_x >= button_x &&
+        point_x < button_x + button_w &&
+        point_y >= button_y &&
+        point_y < button_y + button_h;
+}

--- a/samples/immediate_axis_layout/verify.stasis
+++ b/samples/immediate_axis_layout/verify.stasis
@@ -1,0 +1,12 @@
+import "layout.stasis";
+
+function main(): i32 {
+    menu_layout(0.0, 0.0, 360.0, 720.0, 180.0, 64.0);
+    if (menu_title_x != 90.0 || menu_title_y != 24.0) { return 1; }
+    if (menu_button_x != 20.0 || menu_button_y != 140.0) { return 2; }
+    if (menu_label_x != 78.0 || menu_label_y != 155.0) { return 3; }
+    if (!menu_button_contains(20.0, 140.0)) { return 4; }
+    if (!menu_button_contains(199.999, 195.999)) { return 5; }
+    if (menu_button_contains(200.0, 196.0)) { return 6; }
+    return 0;
+}

--- a/samples/immediate_axis_layout/verify.stasis
+++ b/samples/immediate_axis_layout/verify.stasis
@@ -1,12 +1,16 @@
 import "layout.stasis";
 
 function main(): i32 {
-    menu_layout(0.0, 0.0, 360.0, 720.0, 180.0, 64.0);
-    if (menu_title_x != 90.0 || menu_title_y != 24.0) { return 1; }
-    if (menu_button_x != 20.0 || menu_button_y != 140.0) { return 2; }
-    if (menu_label_x != 78.0 || menu_label_y != 155.0) { return 3; }
-    if (!menu_button_contains(20.0, 140.0)) { return 4; }
-    if (!menu_button_contains(199.999, 195.999)) { return 5; }
-    if (menu_button_contains(200.0, 196.0)) { return 6; }
+    let title_x: f32 = menu_title_x_for(0.0, 360.0, 180.0);
+    let button_x: f32 = menu_button_x_for(0.0, 360.0);
+    let button_y: f32 = menu_button_y_for(0.0, 720.0);
+    let label_x: f32 = menu_label_x_for(button_x, 64.0);
+    let label_y: f32 = menu_label_y_for(button_y);
+    if (title_x != 90.0) { return 1; }
+    if (button_x != 20.0 || button_y != 140.0) { return 2; }
+    if (label_x != 78.0 || label_y != 155.0) { return 3; }
+    if (!menu_point_in_button(20.0, 140.0, button_x, button_y, 180.0, 56.0)) { return 4; }
+    if (!menu_point_in_button(199.999, 195.999, button_x, button_y, 180.0, 56.0)) { return 5; }
+    if (menu_point_in_button(200.0, 196.0, button_x, button_y, 180.0, 56.0)) { return 6; }
     return 0;
 }

--- a/samples/immediate_axis_layout/verify.stasis
+++ b/samples/immediate_axis_layout/verify.stasis
@@ -1,4 +1,4 @@
-import "layout.stasis";
+import "placement.stasis";
 
 function main(): i32 {
     let title_x: f32 = menu_title_x_for(0.0, 360.0, 180.0);

--- a/samples/immediate_axis_layout/verify_jit.stasis
+++ b/samples/immediate_axis_layout/verify_jit.stasis
@@ -1,0 +1,12 @@
+import "layout.stasis";
+
+function main(): i32 {
+    menu_layout(0.0, 0.0, 360.0, 720.0, 180.0, 64.0);
+    if (menu_title_x != 90.0 || menu_title_y != 24.0) { return 1; }
+    if (menu_button_x != 20.0 || menu_button_y != 140.0) { return 2; }
+    if (menu_label_x != 78.0 || menu_label_y != 155.0) { return 3; }
+    if (!menu_button_contains(20.0, 140.0)) { return 4; }
+    if (!menu_button_contains(199.999, 195.999)) { return 5; }
+    if (menu_button_contains(200.0, 196.0)) { return 6; }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- turn the immediate-axis sample into a real rendered menu using cached text runs and cached widths
- recompute title, button, and centered-label coordinates from the current safe viewport using scalar axis placement
- reuse the button's scalar bounds for logical-pointer hit testing
- add shared JIT/AOT executable assertions for the representative geometry and edge-exclusive hit bounds
- mark S17 AP3 complete with the required theory and reflection notes

## Validation

- `cargo fmt --check`
- `cargo test -p stasis_compiler immediate_axis_layout -- --nocapture --test-threads=1`
- `cargo test -p stasis_compiler parity_corpus_covers_shared_lowering_shapes -- --nocapture --test-threads=1`
- real app startup via `cargo run -p stasis -- play samples/immediate_axis_layout/main.stasis ...` loaded the graphics runtime and menu font without guest/command errors
- local screenshot output is unavailable in this environment; the unchanged render-parity scene reproduces the same capture-hook failure
- local AOT executable invocation is skipped because no VC linker is installed; Windows CI remains the executable gate

## Design

The sample keeps persistent state only for loaded resources and their measured widths. Layout remains immediate-mode: each tick/render derives scalar bounds from the current safe viewport, and those same scalars feed rendering and hit testing.