### PR TITLE
fix: improve Android graphics resume

### DIFF
--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -15,11 +15,14 @@ Every renderer moves through the same states:
 - `RestoreFailed`: the frame is withheld and the complete restore is retried on the
   next frame.
 
-Surface resize and orientation advance `surface_generation`. Renderer/context
-creation, foreground recovery, `SDL_RENDER_TARGETS_RESET`, and
+Surface resize and orientation advance `surface_generation` without invalidating
+device-local resources. Renderer/context creation, `SDL_RENDER_TARGETS_RESET`, and
 `SDL_RENDER_DEVICE_RESET` advance both `surface_generation` and
 `renderer_generation`. Generations skip zero. A sprite, fallback texture, font
-atlas, or text texture can be submitted only when both generations match.
+atlas, or text texture can be submitted only when its renderer generation matches.
+Android pause/resume is a visibility transition: the Workshop asks GLSurfaceView to
+preserve its EGL context and retains textures when that context survives. A later
+`onSurfaceCreated` callback is the authoritative signal that the context was lost.
 
 The native SDL runtime retains sprite paths, logical raster requests, decoded font
 bytes, font metrics, and cached text bytes/quads. Android Workshop and Published
@@ -30,16 +33,20 @@ handles before rebuilding them.
 
 ## Restore transaction
 
-Before the first post-transition frame is presented, the native renderer rebuilds
-all active sprites, the procedural fallback, every active font atlas, and cached
-text geometry. A failure keeps the lifecycle retryable and withholds presentation.
-The Android GLES adapter restores from the complete production command frame; every
-referenced sprite, fallback, cached-text, and direct-text texture is resolved during
-that frame. A provider or GL failure marks the restore failed and retries it on the
-next requested frame.
+Before the first post-context-loss game frame is presented, the native renderer
+rebuilds all active sprites, the procedural fallback, every active font atlas, and
+cached text geometry. A failure keeps the lifecycle retryable and withholds that
+game frame. The Android GLES adapter first presents a context-local `STASIS LOADING`
+marker drawn only with clears and scissor rectangles, before shaders, fonts,
+textures, or game assets. It then restores resources referenced by the production command frame in bounded
+8 ms batches. Resources not reached in a batch use the procedural fallback (or
+temporarily omit text), so subsequent requested frames progressively replace them
+without blocking the UI for the entire asset set. A provider or GL failure marks
+the restore failed and retries it on the next requested frame.
 
-This path covers desktop/mobile resize, orientation, Android background/resume,
-Activity recreation, SDL target reset, and SDL device reset. The legacy desktop GL
+This path covers Android context loss and Activity recreation, plus SDL target and
+device resets. Resize, orientation, and Android background/resume retain resources
+when the graphics context remains valid. The legacy desktop GL
 backend remains a conformance-only adapter; its supported resize path resets GL
 program state, while shipping desktop and mobile packages use SDL.
 
@@ -51,6 +58,9 @@ and failure. `stasis_gfx_get_resource_lifecycle` exposes state, both generations
 attempt/failure counters, and the last reason for build audits. Android preview
 errors expose the same fields in the visible resource error and under the
 `StasisRenderer` log tag.
+Android also emits `resource_restore_timing` with wall time, sprite resolution,
+decode, upload, text rasterization, restored counts, and the number of budget
+deferrals. This makes asset-heavy games such as Chess TD diagnosable from logcat.
 
 ## Verification
 

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
@@ -8,6 +8,7 @@ final class RendererResourceLifecycle {
     private int restoreAttempts;
     private int restoreFailures;
     private State state = State.UNAVAILABLE;
+    private State stateBeforePause = State.UNAVAILABLE;
     private String reason = "none";
 
     void onRendererCreated() {
@@ -20,21 +21,19 @@ final class RendererResourceLifecycle {
     void onSurfaceChanged() {
         if (state == State.UNAVAILABLE) return;
         surfaceGeneration = nextGeneration(surfaceGeneration);
-        state = State.RESTORE_PENDING;
         reason = "surface_changed";
     }
 
     void onPause() {
         if (state == State.UNAVAILABLE) return;
+        stateBeforePause = state;
         state = State.PAUSED;
         reason = "background";
     }
 
     void onResume() {
         if (state != State.PAUSED) return;
-        surfaceGeneration = nextGeneration(surfaceGeneration);
-        rendererGeneration = nextGeneration(rendererGeneration);
-        state = State.RESTORE_PENDING;
+        state = stateBeforePause == State.READY ? State.READY : State.RESTORE_PENDING;
         reason = "foreground";
     }
 

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -60,6 +60,23 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final int COLOR_VERTEX_BYTES = COLOR_VERTEX_FLOATS * 4;
     private static final int TEXTURE_VERTEX_BYTES = TEXTURE_VERTEX_FLOATS * 4;
     private static final int MAX_CAPTURE_PIXELS = 8_000_000;
+    private static final String[] RESTORE_LABEL = {
+            "   01110 11111 01110 01110 11111 01110   ",
+            "   10001 00100 10001 10001 00100 10001   ",
+            "   10000 00100 10001 10000 00100 10000   ",
+            "   01110 00100 11111 01110 00100 01110   ",
+            "   00001 00100 10001 00001 00100 00001   ",
+            "   10001 00100 10001 10001 00100 10001   ",
+            "   01110 00100 10001 01110 11111 01110   ",
+            "                                         ",
+            "10000 01110 01110 11110 11111 10001 01110",
+            "10000 10001 10001 10001 00100 11001 10001",
+            "10000 10001 10001 10001 00100 10101 10000",
+            "10000 10001 11111 10001 00100 10011 10111",
+            "10000 10001 10001 10001 00100 10001 10001",
+            "10000 10001 10001 10001 00100 10001 10001",
+            "11111 01110 10001 11110 11111 10001 01110"
+    };
 
     interface TextureProvider {
         void onResourceGenerationChanged(int surfaceGeneration, int rendererGeneration,
@@ -192,6 +209,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private int displayGeneration = -1;
     private int densityGeneration = -1;
     private CaptureCallback pendingCapture;
+    private boolean restorePlaceholderPending;
 
     StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
         this.textures = textures;
@@ -235,19 +253,15 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     synchronized void onHostResumed() {
-        RendererResourceLifecycle.State before = resourceLifecycle.state();
         resourceLifecycle.onResume();
-        if (before == RendererResourceLifecycle.State.PAUSED) {
-            textures.onResourceGenerationChanged(
-                    resourceLifecycle.surfaceGeneration(),
-                    resourceLifecycle.rendererGeneration(), false, resourceLifecycle.reason());
-        }
     }
 
     @Override
     public synchronized void onSurfaceCreated(javax.microedition.khronos.opengles.GL10 gl,
             javax.microedition.khronos.egl.EGLConfig config) {
         resourceLifecycle.onRendererCreated();
+        restorePlaceholderPending = true;
+        drawRestorePlaceholder();
         colorProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
         colorPosition = GLES20.glGetAttribLocation(colorProgram, "aPosition");
         colorValue = GLES20.glGetAttribLocation(colorProgram, "aColor");
@@ -273,9 +287,6 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         resourceLifecycle.onSurfaceChanged();
         surfaceWidth = Math.max(1, width);
         surfaceHeight = Math.max(1, height);
-        textures.onResourceGenerationChanged(
-                resourceLifecycle.surfaceGeneration(),
-                resourceLifecycle.rendererGeneration(), false, resourceLifecycle.reason());
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
         GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
@@ -289,6 +300,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         CaptureCallback capture;
         LogicalFrameSnapshot capturedFrame;
         synchronized (this) {
+            if (restorePlaceholderPending) {
+                restorePlaceholderPending = false;
+                drawRestorePlaceholder();
+                timing.onRendered(System.nanoTime() - started);
+                return;
+            }
             boolean restoring = resourceLifecycle.beginRestore();
             textures.beginRestoreAttempt();
             while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
@@ -323,6 +340,44 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         }
         captureIfRequested(capture, capturedFrame);
         timing.onRendered(System.nanoTime() - started);
+    }
+
+    private void drawRestorePlaceholder() {
+        GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+        GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
+        GLES20.glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+        int columns = RESTORE_LABEL[0].length();
+        int cell = Math.max(2, Math.min(surfaceWidth / (columns + 8), surfaceHeight / 60));
+        int labelWidth = columns * cell;
+        int labelHeight = RESTORE_LABEL.length * cell;
+        int originX = (surfaceWidth - labelWidth) / 2;
+        int originY = (surfaceHeight - labelHeight) / 2;
+        GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
+        GLES20.glClearColor(66.0f / 255.0f, 153.0f / 255.0f, 225.0f / 255.0f, 1.0f);
+        for (int row = 0; row < RESTORE_LABEL.length; row += 1) {
+            String pixels = RESTORE_LABEL[row];
+            for (int column = 0; column < pixels.length(); column += 1) {
+                if (pixels.charAt(column) != '1') continue;
+                GLES20.glScissor(originX + column * cell,
+                        originY + (RESTORE_LABEL.length - row - 1) * cell, cell, cell);
+                GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+            }
+        }
+        GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
+    }
+
+    static boolean isValidRestoreLabel() {
+        if (RESTORE_LABEL.length != 15 || RESTORE_LABEL[0].isEmpty()) return false;
+        int width = RESTORE_LABEL[0].length();
+        for (String row : RESTORE_LABEL) {
+            if (row.length() != width) return false;
+            for (int index = 0; index < width; index += 1) {
+                char pixel = row.charAt(index);
+                if (pixel != '0' && pixel != '1' && pixel != ' ') return false;
+            }
+        }
+        return true;
     }
 
     private void drawFrame() {

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -260,6 +260,7 @@ public final class MainActivity extends Activity {
             super(activity);
             this.activity = activity;
             setEGLContextClientVersion(2);
+            setPreserveEGLContextOnPause(true);
             renderer = new StasisPreviewRenderer(
                     new PublishedSpriteCatalog(activity, activity.getAssets()),
                     activity::recordRenderTimeNanos);

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
@@ -27,18 +27,50 @@ public final class RendererResourceLifecycleTest {
     }
 
     @Test
-    public void repeatedPauseResumeAndRecreationAdvanceGenerations() {
+    public void pauseResumePreservesResourcesAndRecreationAdvancesGenerations() {
         RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
         lifecycle.onRendererCreated();
+        assertTrue(lifecycle.beginRestore());
+        lifecycle.finishRestore(true);
         lifecycle.onPause();
         assertEquals(RendererResourceLifecycle.State.PAUSED, lifecycle.state());
         lifecycle.onResume();
-        assertEquals(2, lifecycle.surfaceGeneration());
-        assertEquals(2, lifecycle.rendererGeneration());
+        assertEquals(RendererResourceLifecycle.State.READY, lifecycle.state());
+        assertEquals(1, lifecycle.surfaceGeneration());
+        assertEquals(1, lifecycle.rendererGeneration());
         assertEquals("foreground", lifecycle.reason());
         lifecycle.onRendererCreated();
-        assertEquals(3, lifecycle.surfaceGeneration());
-        assertEquals(3, lifecycle.rendererGeneration());
+        assertEquals(2, lifecycle.surfaceGeneration());
+        assertEquals(2, lifecycle.rendererGeneration());
         assertFalse(lifecycle.canPresent());
+    }
+
+    @Test
+    public void surfaceResizeKeepsRendererReadyAndGpuResourcesValid() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+        assertTrue(lifecycle.beginRestore());
+        lifecycle.finishRestore(true);
+
+        lifecycle.onSurfaceChanged();
+
+        assertEquals(RendererResourceLifecycle.State.READY, lifecycle.state());
+        assertEquals(2, lifecycle.surfaceGeneration());
+        assertEquals(1, lifecycle.rendererGeneration());
+        assertTrue(lifecycle.canPresent());
+        assertEquals("surface_changed", lifecycle.reason());
+    }
+
+    @Test
+    public void pauseBeforeInitialRestoreStillRequiresRestoreAfterResume() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+
+        lifecycle.onPause();
+        lifecycle.onResume();
+
+        assertEquals(RendererResourceLifecycle.State.RESTORE_PENDING, lifecycle.state());
+        assertFalse(lifecycle.canPresent());
+        assertTrue(lifecycle.beginRestore());
     }
 }

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -13,6 +13,11 @@ import org.junit.Test;
 
 public final class StasisPreviewRendererSchemaTest {
     @Test
+    public void twoLineContextRestoreLabelNeedsNoTextureOrFontAsset() {
+        assertTrue(StasisPreviewRenderer.isValidRestoreLabel());
+    }
+
+    @Test
     public void replacedCaptureIncludesEmptyTypedSpriteLanes() {
         StasisPreviewRenderer renderer = new StasisPreviewRenderer(
                 new StasisPreviewRenderer.TextureProvider() {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -11673,6 +11673,7 @@ public final class MainActivity extends Activity {
             super(activity);
             this.activity = activity;
             setEGLContextClientVersion(2);
+            setPreserveEGLContextOnPause(true);
             renderer = new StasisPreviewRenderer(
                     new WorkshopTextureProvider(activity),
                     activity::recordRenderTimeNanos);

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -6,6 +6,7 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.opengl.GLES20;
 import android.util.SparseArray;
+import android.util.Log;
 
 import org.json.JSONObject;
 
@@ -14,11 +15,15 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProvider {
+    private static final String LOG_TAG = "StasisRenderer";
     private static final long MANIFEST_CHECK_INTERVAL_NANOS = 500_000_000L;
+    private static final long RESTORE_BUDGET_NANOS = 8_000_000L;
     private final MainActivity activity;
     private final SparseArray<SpriteTexture> textures = new SparseArray<>();
+    private final HashMap<String, SpriteTexture> spriteTexturesByHash = new HashMap<>();
     private final SparseArray<TextTexture> textTextures = new SparseArray<>();
     private final SparseArray<FontInfo> fonts = new SparseArray<>();
     private final ArrayList<DynamicTextTexture> dynamicTextTextures = new ArrayList<>();
@@ -36,6 +41,17 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     private int fallbackRendererGeneration;
     private String lastFailure;
     private String transitionReason = "none";
+    private boolean reportRestoreTiming;
+    private long restoreStartedNanos;
+    private long spriteResolveNanos;
+    private long spriteDecodeNanos;
+    private long spriteUploadNanos;
+    private long textRasterNanos;
+    private int restoredSprites;
+    private int restoredTextRuns;
+    private long restoreDeadlineNanos;
+    private boolean restoreDeferred;
+    private int deferredResources;
 
     WorkshopTextureProvider(MainActivity activity) {
         this.activity = activity;
@@ -49,6 +65,8 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         surfaceGeneration = nextSurfaceGeneration;
         rendererGeneration = nextRendererGeneration;
         transitionReason = nextTransitionReason;
+        reportRestoreTiming = true;
+        restoreStartedNanos = 0L;
         setProjectRoot(activity.projectRootPath());
         manifestStamp = Long.MIN_VALUE;
         nextManifestCheckNanos = 0L;
@@ -57,12 +75,40 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     @Override
     public void beginRestoreAttempt() {
         lastFailure = null;
+        if (reportRestoreTiming) {
+            long now = System.nanoTime();
+            restoreDeadlineNanos = now + RESTORE_BUDGET_NANOS;
+            restoreDeferred = false;
+            if (restoreStartedNanos == 0L) {
+                restoreStartedNanos = now;
+                spriteResolveNanos = 0L;
+                spriteDecodeNanos = 0L;
+                spriteUploadNanos = 0L;
+                textRasterNanos = 0L;
+                restoredSprites = 0;
+                restoredTextRuns = 0;
+                deferredResources = 0;
+            }
+        }
     }
 
     @Override
     public String consumeFailure() {
         String failure = lastFailure;
         lastFailure = null;
+        if (reportRestoreTiming && !restoreDeferred) {
+            long total = Math.max(0L, System.nanoTime() - restoreStartedNanos);
+            Log.i(LOG_TAG, "resource_restore_timing reason=" + transitionReason
+                    + " total_ms=" + millis(total)
+                    + " sprite_resolve_ms=" + millis(spriteResolveNanos)
+                    + " sprite_decode_ms=" + millis(spriteDecodeNanos)
+                    + " sprite_upload_ms=" + millis(spriteUploadNanos)
+                    + " text_raster_ms=" + millis(textRasterNanos)
+                    + " sprites=" + restoredSprites + " text_runs=" + restoredTextRuns
+                    + " deferred=" + deferredResources);
+            reportRestoreTiming = failure != null;
+            if (!reportRestoreTiming) restoreStartedNanos = 0L;
+        }
         return failure;
     }
 
@@ -95,12 +141,16 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         }
         if (cached != null && !cached.matches(surfaceGeneration, rendererGeneration)) {
             textures.remove(handle);
+            releaseSpriteIfUnreferenced(cached);
             cached = null;
         }
+        if (deferRestoreResource()) return fallbackTexture();
         JSONObject resolved = null;
         try {
+            long resolveStarted = System.nanoTime();
             resolved = new JSONObject(MainActivity.nativeResolveSpriteAsset(
                     projectRootPath, handle));
+            if (reportRestoreTiming) spriteResolveNanos += System.nanoTime() - resolveStarted;
             if (!"ok".equals(resolved.optString("status"))) {
                 throw new IOException(resolved.optString("error", "sprite resolution failed"));
             }
@@ -109,16 +159,30 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
                 cached.checkedManifestStamp = manifestStamp;
                 return cached.texture;
             }
+            SpriteTexture shared = spriteTexturesByHash.get(hash);
+            if (shared != null && shared.matches(surfaceGeneration, rendererGeneration)) {
+                shared.checkedManifestStamp = manifestStamp;
+                textures.put(handle, shared);
+                releaseSpriteIfUnreferenced(cached);
+                return shared.texture;
+            }
+            long decodeStarted = System.nanoTime();
             Bitmap bitmap = decode(resolved, rasterScale);
+            if (reportRestoreTiming) spriteDecodeNanos += System.nanoTime() - decodeStarted;
             int uploaded;
             try {
+                long uploadStarted = System.nanoTime();
                 uploaded = upload(bitmap);
+                if (reportRestoreTiming) spriteUploadNanos += System.nanoTime() - uploadStarted;
             } finally {
                 bitmap.recycle();
             }
-            textures.put(handle, new SpriteTexture(uploaded, hash, manifestStamp,
-                    surfaceGeneration, rendererGeneration));
-            if (cached != null) deleteTexture(cached.texture);
+            if (reportRestoreTiming) restoredSprites += 1;
+            SpriteTexture replacement = new SpriteTexture(uploaded, hash, manifestStamp,
+                    surfaceGeneration, rendererGeneration);
+            textures.put(handle, replacement);
+            spriteTexturesByHash.put(hash, replacement);
+            releaseSpriteIfUnreferenced(cached);
             return uploaded;
         } catch (Exception error) {
             recordFailure("sprite", handle,
@@ -159,7 +223,9 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
                 cached.texture, cached.width, cached.height);
         }
         if (cached != null) textTextures.remove(runHandle);
+        if (deferRestoreResource()) return 0L;
         try {
+            long rasterStarted = System.nanoTime();
             JSONObject resolved = new JSONObject(MainActivity.nativeResolveCachedText(
                     activity.projectRootPath(), runHandle));
             if (!"ok".equals(resolved.optString("status"))) {
@@ -186,6 +252,10 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
                     Math.max(1, Math.round(height / rasterScale)),
                     surfaceGeneration, rendererGeneration);
             textTextures.put(runHandle, cached);
+            if (reportRestoreTiming) {
+                textRasterNanos += System.nanoTime() - rasterStarted;
+                restoredTextRuns += 1;
+            }
             return StasisPreviewRenderer.packTexture(texture, cached.width, cached.height);
         } catch (Exception error) {
             recordFailure("cached_text", runHandle, "<resolved-cached-text>", 0, 0, error);
@@ -204,7 +274,9 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
                         cached.texture.texture, cached.texture.width, cached.texture.height);
             }
         }
+        if (deferRestoreResource()) return 0L;
         try {
+            long rasterStarted = System.nanoTime();
             if (dynamicTextTextures.size() >= 4096) throw new IOException("dynamic text cache is full");
             byte[] bytes = new byte[length];
             for (int index = 0; index < length; index += 1) bytes[index] = utf8.get(offset + index);
@@ -213,6 +285,10 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
                     fontInfo, new String(bytes, StandardCharsets.UTF_8), rasterScale,
                     surfaceGeneration, rendererGeneration);
             dynamicTextTextures.add(new DynamicTextTexture(font, bytes, texture));
+            if (reportRestoreTiming) {
+                textRasterNanos += System.nanoTime() - rasterStarted;
+                restoredTextRuns += 1;
+            }
             return StasisPreviewRenderer.packTexture(texture.texture, texture.width, texture.height);
         } catch (Exception error) {
             recordFailure("text", font, "<resolved-font>", 0, 0, error);
@@ -283,10 +359,13 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     }
 
     private void clearTextures(boolean deleteGpuHandles) {
-        for (int index = 0; index < textures.size(); index++) {
-            if (deleteGpuHandles) deleteTexture(textures.valueAt(index).texture);
+        if (deleteGpuHandles) {
+            for (SpriteTexture texture : spriteTexturesByHash.values()) {
+                deleteTexture(texture.texture);
+            }
         }
         textures.clear();
+        spriteTexturesByHash.clear();
         for (int index = 0; index < textTextures.size(); index++) {
             if (deleteGpuHandles) deleteTexture(textTextures.valueAt(index).texture);
         }
@@ -315,6 +394,27 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     private void deleteTexture(int texture) {
         deletedTexture[0] = texture;
         GLES20.glDeleteTextures(1, deletedTexture, 0);
+    }
+
+    private void releaseSpriteIfUnreferenced(SpriteTexture candidate) {
+        if (candidate == null) return;
+        for (int index = 0; index < textures.size(); index += 1) {
+            if (textures.valueAt(index) == candidate) return;
+        }
+        if (spriteTexturesByHash.remove(candidate.contentHash, candidate)) {
+            deleteTexture(candidate.texture);
+        }
+    }
+
+    private static String millis(long nanos) {
+        return String.format(java.util.Locale.US, "%.3f", nanos / 1_000_000.0);
+    }
+
+    private boolean deferRestoreResource() {
+        if (!reportRestoreTiming || System.nanoTime() < restoreDeadlineNanos) return false;
+        restoreDeferred = true;
+        deferredResources += 1;
+        return true;
     }
 
     private static Bitmap decode(JSONObject resolved, float rasterScale) throws Exception {


### PR DESCRIPTION
## Summary

- preserve valid EGL/SDL contexts and GPU textures across ordinary Android pause/resume
- reserve full resource invalidation for actual renderer/context reset events
- keep an asset-independent two-line `STASIS` / `LOADING` screen presented until complete graphics restoration succeeds
- restore Workshop context-loss resources within bounded frame budgets without publishing partial game frames
- present the same loading screen in generated SDL mobile packages at startup and on SDL target/device reset
- deduplicate Workshop sprite textures by content hash and emit detailed restoration timings
- document and test the revised lifecycle behavior

## Root cause

Activity visibility transitions were treated as graphics-context loss. Every resume advanced renderer generations, cleared the GPU cache, and rebuilt sprites and text before presentation. Asset-heavy games therefore displayed a blank surface for several seconds. Generated SDL packages had the same visibility/reset conflation.

## Impact

Normal app switching returns to the existing frame immediately when Android preserves the renderer. Genuine context loss now displays `STASIS` / `LOADING` until every required graphics resource is valid and the first complete game frame can be presented.

## Validation

- `gradle --no-daemon --console=plain --max-workers=1 :app:testWorkshopDebugUnitTest`
- `gradle --no-daemon --console=plain --max-workers=1 :app:assembleWorkshopDebug`
- `gradle --no-daemon --console=plain --max-workers=1 :app:assemblePublishedDebug '-Pstasis.publishedGame=pong'`
- `cargo test -p stasis mobile_runtime_uses_fixed_entries_and_sdl_only_static_target`
- representative `package-mobile --target android-arm64 --development-build`
- generated Android arm64 package compiled and linked with the real Gradle/NDK/SDL toolchain
- `git diff --check`

## Follow-up

A ChessTD development package from the current source branch reaches an existing Cranelift verifier failure at `aot_fn_22` before Android generation. The representative Android NDK gate passes, so that ChessTD AOT failure is separate from this renderer/runtime change and must be resolved before a new official nightly can be repinned by ChessTD.