### PR TITLE
fix: finish Android graphics restoration flow

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4008,6 +4008,22 @@ mod tests {
                     .contains("SDL_PauseAudioDevice(g_audio_device, paused ? 1 : 0)"),
             "mobile pause should continue polling events and pause the audio device"
         );
+        for required in [
+            "static void stasis_present_restore_loading(void)",
+            "Stasis renderer loading screen presented",
+            "stasis_renderer_lifecycle_resume(&g_resource_lifecycle);",
+        ] {
+            assert!(
+                STASIS_GRAPHICS_SOURCE.contains(required),
+                "mobile renderer lifecycle should contain {required}"
+            );
+        }
+        assert!(
+            !STASIS_GRAPHICS_SOURCE.contains(
+                "stasis_renderer_lifecycle_resume(&g_resource_lifecycle);\n                    stasis_invalidate_renderer_resources(0);"
+            ),
+            "ordinary foreground resume must not invalidate a surviving SDL renderer"
+        );
     }
 
     #[test]

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3945,6 +3945,28 @@ mod tests {
     }
 
     #[test]
+    fn graphics_runtime_presents_asset_free_loading_on_sdl_and_opengl() {
+        for required in [
+            "static void stasis_present_gpu_loading(void)",
+            "SDL_RenderPresent(g_renderer);",
+            "SDL_GL_SwapWindow(g_window);",
+            "g_use_sdl_renderer ? \"sdl\" : \"gl\"",
+        ] {
+            assert!(
+                STASIS_GRAPHICS_SOURCE.contains(required),
+                "shared graphics loading screen should contain {required}"
+            );
+        }
+        assert_eq!(
+            STASIS_GRAPHICS_SOURCE
+                .matches("stasis_present_gpu_loading();")
+                .count(),
+            3,
+            "loading should be presented at startup and both real SDL reset events"
+        );
+    }
+
+    #[test]
     fn mobile_runtime_uses_fixed_entries_and_sdl_only_static_target() {
         for required in [
             "typedef void (*StasisMobileBindEntry)(void)",
@@ -4009,7 +4031,7 @@ mod tests {
             "mobile pause should continue polling events and pause the audio device"
         );
         for required in [
-            "static void stasis_present_restore_loading(void)",
+            "static void stasis_present_gpu_loading(void)",
             "Stasis renderer loading screen presented",
             "stasis_renderer_lifecycle_resume(&g_resource_lifecycle);",
         ] {

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1010,7 +1010,12 @@ fn compile_function_to_object_bytes(
         |mut module, function_id, mut context| {
             module
                 .define_function(function_id, &mut context)
-                .map_err(|error| format!("failed to define AOT function {symbol}: {error}"))?;
+                .map_err(|error| {
+                    format!(
+                        "failed to define AOT function {symbol} ({name}): {error:?}",
+                        name = meta.name
+                    )
+                })?;
             module.clear_context(&mut context);
             module
                 .finish()
@@ -1652,6 +1657,23 @@ mod tests {
                 "core AOT global storage emitted a runtime call in {name}:\n{clif}"
             );
         }
+    }
+
+    #[test]
+    fn aot_dynamic_global_array_fallback_uses_runtime_helper_signature() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "dynamic_global_array.stasis",
+            "global values: i32[2];\nfunction read(index: i32, a: i32, b: i32, c: i32): i32 { return values[index]; }\nfunction main(): i32 { values[1] = 9; return read(1, 0, 0, 0); }\n",
+        );
+
+        process
+            .compile()
+            .expect("compile dynamic global array AOT fixture");
+        assert!(
+            undefined_runtime_symbols(&process).contains("stasis_jit_global_i32_array_load"),
+            "dynamic bounds fallback should reference the array-load runtime helper"
+        );
     }
 
     fn undefined_runtime_symbols(process: &AotProcess) -> BTreeSet<String> {

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1743,15 +1743,8 @@ where
         .declare_function(symbol, Linkage::Export, &context.func.signature)
         .map_err(|error| format!("failed to declare function {symbol}: {error}"))?;
     let referenced_call_targets = collect_call_targets_from_hir(hir);
-    let uses_collection_runtime = meta.params.iter().any(|type_id| {
-        named_struct_field_types.contains_key(type_id)
-            || type_table.type_info(*type_id).is_some_and(|info| {
-                matches!(
-                    info.category,
-                    TypeCategory::ArrayFixed | TypeCategory::ArrayView
-                )
-            })
-    });
+    let uses_runtime_storage = !global_path_types.is_empty();
+    let uses_collection_runtime = !collection_infos.is_empty();
     let runtime_call_imports = match backend_mode {
         SharedCompileBackendMode::Jit => build_runtime_call_import_ids(
             &mut module,
@@ -1763,6 +1756,7 @@ where
         SharedCompileBackendMode::AotDirect => build_aot_runtime_call_import_ids(
             &mut module,
             function_id,
+            uses_runtime_storage,
             uses_collection_runtime,
             &referenced_call_targets,
             call_signatures,
@@ -10533,6 +10527,7 @@ pub(crate) fn emit_bool_constant(builder: &mut FunctionBuilder<'_>, value: bool)
 fn build_aot_runtime_call_import_ids(
     module: &mut impl Module,
     fallback: FuncId,
+    uses_runtime_storage: bool,
     uses_collection_runtime: bool,
     referenced_call_targets: &BTreeSet<String>,
     call_signatures: &CallSignatureMap,
@@ -10568,16 +10563,15 @@ fn build_aot_runtime_call_import_ids(
         .filter(|(target, _)| referenced_call_targets.contains(*target))
         .map(|(target, signatures)| (target.clone(), signatures.clone()))
         .collect();
-    macro_rules! collection_import {
-        ($declaration:expr) => {
-            if uses_collection_runtime {
+    macro_rules! storage_import {
+        ($used:expr, $declaration:expr) => {
+            if $used {
                 $declaration?
             } else {
                 fallback
             }
         };
     }
-
     Ok(RuntimeCallImportIds {
         call_i32_0: fallback,
         call_i32_1: fallback,
@@ -10611,69 +10605,77 @@ fn build_aot_runtime_call_import_ids(
         lookup_code_ptr: fallback,
         sin_fast,
         cos_fast,
-        global_i32_load: fallback,
-        global_i32_store: fallback,
-        global_f32_load: fallback,
-        global_f32_store: fallback,
-        global_f64_load: fallback,
-        global_f64_store: fallback,
-        global_i32_array_load: collection_import!(declare_i32_array_load_import(
-            module,
-            "stasis_jit_global_i32_array_load",
-            linkage,
-        )),
-        global_i32_array_store: collection_import!(declare_i32_array_store_import(
-            module,
-            "stasis_jit_global_i32_array_store",
-            linkage,
-        )),
-        global_i32_array_ptr: collection_import!(declare_i32_array_ptr_import(
-            module,
-            "stasis_jit_global_i32_array_ptr",
-            linkage,
-        )),
-        global_f32_array_load: collection_import!(declare_f32_array_load_import(
-            module,
-            "stasis_jit_global_f32_array_load",
-            linkage,
-        )),
-        global_f32_array_store: collection_import!(declare_f32_array_store_import(
-            module,
-            "stasis_jit_global_f32_array_store",
-            linkage,
-        )),
-        global_f32_array_ptr: collection_import!(declare_f32_array_ptr_import(
-            module,
-            "stasis_jit_global_f32_array_ptr",
-            linkage,
-        )),
-        global_f64_array_load: collection_import!(declare_f64_array_load_import(
-            module,
-            "stasis_jit_global_f64_array_load",
-            linkage,
-        )),
-        global_f64_array_store: collection_import!(declare_f64_array_store_import(
-            module,
-            "stasis_jit_global_f64_array_store",
-            linkage,
-        )),
-        global_f64_array_ptr: collection_import!(declare_f64_array_ptr_import(
-            module,
-            "stasis_jit_global_f64_array_ptr",
-            linkage,
-        )),
-        collection_i32_load: collection_import!(declare_i32_call_import(
-            module,
-            "stasis_jit_collection_i32_load",
-            linkage,
-            2,
-        )),
-        collection_i32_store: collection_import!(declare_void_call_import(
-            module,
-            "stasis_jit_collection_i32_store",
-            linkage,
-            3,
-        )),
+        // Direct storage handles known standalone globals, but dynamic paths and
+        // bounds fallbacks still use the runtime registry. Never alias a runtime
+        // helper to the current function: their ABIs are unrelated.
+        global_i32_load: storage_import!(
+            uses_runtime_storage,
+            declare_i32_call_import(module, "stasis_jit_global_i32_load", linkage, 1)
+        ),
+        global_i32_store: storage_import!(
+            uses_runtime_storage,
+            declare_void_call_import(module, "stasis_jit_global_i32_store", linkage, 2,)
+        ),
+        global_f32_load: storage_import!(
+            uses_runtime_storage,
+            declare_f32_global_load_import(module, "stasis_jit_global_f32_load", linkage,)
+        ),
+        global_f32_store: storage_import!(
+            uses_runtime_storage,
+            declare_f32_global_store_import(module, "stasis_jit_global_f32_store", linkage,)
+        ),
+        global_f64_load: storage_import!(
+            uses_runtime_storage,
+            declare_f64_global_load_import(module, "stasis_jit_global_f64_load", linkage,)
+        ),
+        global_f64_store: storage_import!(
+            uses_runtime_storage,
+            declare_f64_global_store_import(module, "stasis_jit_global_f64_store", linkage,)
+        ),
+        global_i32_array_load: storage_import!(
+            uses_collection_runtime,
+            declare_i32_array_load_import(module, "stasis_jit_global_i32_array_load", linkage,)
+        ),
+        global_i32_array_store: storage_import!(
+            uses_collection_runtime,
+            declare_i32_array_store_import(module, "stasis_jit_global_i32_array_store", linkage,)
+        ),
+        global_i32_array_ptr: storage_import!(
+            uses_collection_runtime,
+            declare_i32_array_ptr_import(module, "stasis_jit_global_i32_array_ptr", linkage,)
+        ),
+        global_f32_array_load: storage_import!(
+            uses_collection_runtime,
+            declare_f32_array_load_import(module, "stasis_jit_global_f32_array_load", linkage,)
+        ),
+        global_f32_array_store: storage_import!(
+            uses_collection_runtime,
+            declare_f32_array_store_import(module, "stasis_jit_global_f32_array_store", linkage,)
+        ),
+        global_f32_array_ptr: storage_import!(
+            uses_collection_runtime,
+            declare_f32_array_ptr_import(module, "stasis_jit_global_f32_array_ptr", linkage,)
+        ),
+        global_f64_array_load: storage_import!(
+            uses_collection_runtime,
+            declare_f64_array_load_import(module, "stasis_jit_global_f64_array_load", linkage,)
+        ),
+        global_f64_array_store: storage_import!(
+            uses_collection_runtime,
+            declare_f64_array_store_import(module, "stasis_jit_global_f64_array_store", linkage,)
+        ),
+        global_f64_array_ptr: storage_import!(
+            uses_collection_runtime,
+            declare_f64_array_ptr_import(module, "stasis_jit_global_f64_array_ptr", linkage,)
+        ),
+        collection_i32_load: storage_import!(
+            uses_collection_runtime,
+            declare_i32_call_import(module, "stasis_jit_collection_i32_load", linkage, 2,)
+        ),
+        collection_i32_store: storage_import!(
+            uses_collection_runtime,
+            declare_void_call_import(module, "stasis_jit_collection_i32_store", linkage, 3,)
+        ),
         extern_calls: declare_extern_call_imports(
             module,
             &referenced_extern_signatures,

--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -63,6 +63,12 @@ errors expose the same fields in the visible resource error and under the
 Android also emits `resource_restore_timing` with wall time, sprite resolution,
 decode, upload, text rasterization, restored counts, and the number of budget
 deferrals. This makes asset-heavy games such as Chess TD diagnosable from logcat.
+Generated SDL mobile packages present the same asset-free `STASIS LOADING` pixel
+marker immediately after renderer creation and again on SDL target/device reset.
+The marker remains in the presented framebuffer while the synchronous SDL resource
+transaction rebuilds every sprite, fallback, font atlas, and cached text run. A
+normal game frame is presented only after that transaction succeeds. Ordinary
+Android foreground resume preserves resources unless SDL reports an actual reset.
 
 ## Verification
 

--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -38,7 +38,9 @@ rebuilds all active sprites, the procedural fallback, every active font atlas, a
 cached text geometry. A failure keeps the lifecycle retryable and withholds that
 game frame. The Android GLES adapter first presents a context-local `STASIS LOADING`
 marker drawn only with clears and scissor rectangles, before shaders, fonts,
-textures, or game assets. It then restores resources referenced by the production command frame in bounded
+textures, or game assets. Surface setup redraws rather than erases the marker, and
+the marker remains visible for at least 250 ms before restoration starts. It then
+restores resources referenced by the production command frame in bounded
 8 ms batches. Resources not reached in a batch use the procedural fallback (or
 temporarily omit text), so subsequent requested frames progressively replace them
 without blocking the UI for the entire asset set. A provider or GL failure marks

--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -40,11 +40,11 @@ game frame. The Android GLES adapter first presents a context-local `STASIS LOAD
 marker drawn only with clears and scissor rectangles, before shaders, fonts,
 textures, or game assets. Surface setup redraws rather than erases the marker, and
 the marker remains visible for at least 250 ms before restoration starts. It then
-restores resources referenced by the production command frame in bounded
-8 ms batches. Resources not reached in a batch use the procedural fallback (or
-temporarily omit text), so subsequent requested frames progressively replace them
-without blocking the UI for the entire asset set. A provider or GL failure marks
-the restore failed and retries it on the next requested frame.
+restores resources referenced by the production command frame in bounded 8 ms
+batches. Every incomplete batch keeps the loading marker presented; no partial game
+frame is published. The normal game frame replaces the marker only after every
+referenced sprite and text texture is ready and the GL checks succeed. A provider
+or GL failure marks the restore failed and retries it on the next requested frame.
 
 This path covers Android context loss and Activity recreation, plus SDL target and
 device resets. Resize, orientation, and Android background/resume retain resources

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
@@ -54,6 +54,11 @@ final class RendererResourceLifecycle {
         }
     }
 
+    void deferRestore() {
+        if (state != State.RESTORING) return;
+        state = State.RESTORE_PENDING;
+    }
+
     void resourceFailed() {
         if (state == State.UNAVAILABLE || state == State.PAUSED) return;
         restoreFailures = nextCounter(restoreFailures);

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -87,6 +87,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
 
         default String consumeFailure() { return null; }
 
+        default boolean isRestoreComplete() { return true; }
+
         default void onFrameStart() {}
 
         default void onDisplayMetricsChanged(float rasterScale, int densityGeneration) {}
@@ -316,11 +318,20 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             if (hasFrame) prepareFrameResources();
             String resourceFailure = textures.consumeFailure();
             int glError = GLES20.glGetError();
-            boolean restored = resourceFailure == null && glError == GLES20.GL_NO_ERROR;
+            boolean restoreComplete = textures.isRestoreComplete();
+            boolean restored = resourceFailure == null && glError == GLES20.GL_NO_ERROR
+                    && restoreComplete;
             if (restoring) {
-                resourceLifecycle.finishRestore(restored);
+                if (resourceFailure == null && glError == GLES20.GL_NO_ERROR
+                        && !restoreComplete) {
+                    resourceLifecycle.deferRestore();
+                } else {
+                    resourceLifecycle.finishRestore(restored);
+                }
             } else if (!restored) {
-                resourceLifecycle.resourceFailed();
+                if (resourceFailure != null || glError != GLES20.GL_NO_ERROR) {
+                    resourceLifecycle.resourceFailed();
+                }
             }
             if (restoring) {
                 if (restored) {
@@ -328,7 +339,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                             + resourceLifecycle.surfaceGeneration() + " renderer_generation="
                             + resourceLifecycle.rendererGeneration() + " reason="
                             + resourceLifecycle.reason());
-                } else {
+                } else if (resourceFailure != null || glError != GLES20.GL_NO_ERROR) {
                     Log.e(LOG_TAG, "resource restore failed backend=gles surface_generation="
                             + resourceLifecycle.surfaceGeneration() + " renderer_generation="
                             + resourceLifecycle.rendererGeneration() + " reason="
@@ -336,6 +347,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                             + (resourceFailure == null ? "gl_error_" + glError : resourceFailure));
                 }
             }
+            if (!restoreComplete && resourceFailure == null
+                    && glError == GLES20.GL_NO_ERROR) drawRestorePlaceholder();
             if (hasFrame && restored && resourceLifecycle.canPresent()) drawFrame();
             capture = pendingCapture;
             pendingCapture = null;

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -60,6 +60,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final int COLOR_VERTEX_BYTES = COLOR_VERTEX_FLOATS * 4;
     private static final int TEXTURE_VERTEX_BYTES = TEXTURE_VERTEX_FLOATS * 4;
     private static final int MAX_CAPTURE_PIXELS = 8_000_000;
+    private static final long MIN_RESTORE_LABEL_NANOS = 250_000_000L;
     private static final String[] RESTORE_LABEL = {
             "   01110 11111 01110 01110 11111 01110   ",
             "   10001 00100 10001 10001 00100 10001   ",
@@ -210,6 +211,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private int densityGeneration = -1;
     private CaptureCallback pendingCapture;
     private boolean restorePlaceholderPending;
+    private long restorePlaceholderUntilNanos;
 
     StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
         this.textures = textures;
@@ -261,6 +263,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             javax.microedition.khronos.egl.EGLConfig config) {
         resourceLifecycle.onRendererCreated();
         restorePlaceholderPending = true;
+        restorePlaceholderUntilNanos = System.nanoTime() + MIN_RESTORE_LABEL_NANOS;
         drawRestorePlaceholder();
         colorProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
         colorPosition = GLES20.glGetAttribLocation(colorProgram, "aPosition");
@@ -288,8 +291,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         surfaceWidth = Math.max(1, width);
         surfaceHeight = Math.max(1, height);
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
-        GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+        if (restorePlaceholderPending) drawRestorePlaceholder();
         displayGeneration = -1;
         Log.i(LOG_TAG, "drawable=" + surfaceWidth + "x" + surfaceHeight);
     }
@@ -300,12 +302,13 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         CaptureCallback capture;
         LogicalFrameSnapshot capturedFrame;
         synchronized (this) {
-            if (restorePlaceholderPending) {
-                restorePlaceholderPending = false;
+            if (restorePlaceholderPending
+                    && System.nanoTime() < restorePlaceholderUntilNanos) {
                 drawRestorePlaceholder();
                 timing.onRendered(System.nanoTime() - started);
                 return;
             }
+            restorePlaceholderPending = false;
             boolean restoring = resourceLifecycle.beginRestore();
             textures.beginRestoreAttempt();
             while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
@@ -73,4 +73,18 @@ public final class RendererResourceLifecycleTest {
         assertFalse(lifecycle.canPresent());
         assertTrue(lifecycle.beginRestore());
     }
+
+    @Test
+    public void deferredRestoreKeepsWithholdingGameFramesWithoutCountingFailure() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+        assertTrue(lifecycle.beginRestore());
+
+        lifecycle.deferRestore();
+
+        assertEquals(RendererResourceLifecycle.State.RESTORE_PENDING, lifecycle.state());
+        assertFalse(lifecycle.canPresent());
+        assertEquals(0, lifecycle.restoreFailures());
+        assertTrue(lifecycle.beginRestore());
+    }
 }

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -113,6 +113,11 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
     }
 
     @Override
+    public boolean isRestoreComplete() {
+        return !reportRestoreTiming;
+    }
+
+    @Override
     public void onFrameStart() {
         ensureCurrentProject();
         long now = System.nanoTime();

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -161,6 +161,23 @@ static uint64_t g_perf_pending_tick_us = 0;
 static uint64_t g_perf_pending_guest_render_us = 0;
 static uint64_t g_perf_render_started_counter = 0;
 static int g_perf_font_handle = -1;
+static const char* g_restore_label[] = {
+    "   01110 11111 01110 01110 11111 01110   ",
+    "   10001 00100 10001 10001 00100 10001   ",
+    "   10000 00100 10001 10000 00100 10000   ",
+    "   01110 00100 11111 01110 00100 01110   ",
+    "   00001 00100 10001 00001 00100 00001   ",
+    "   10001 00100 10001 10001 00100 10001   ",
+    "   01110 00100 10001 01110 11111 01110   ",
+    "                                         ",
+    "10000 01110 01110 11110 11111 10001 01110",
+    "10000 10001 10001 10001 00100 11001 10001",
+    "10000 10001 10001 10001 00100 10101 10000",
+    "10000 10001 11111 10001 00100 10011 10111",
+    "10000 10001 10001 10001 00100 10001 10001",
+    "10000 10001 10001 10001 00100 10001 10001",
+    "11111 01110 10001 11110 11111 10001 01110"
+};
 
 /* ============================================================
  * Input snapshot (mouse + touch) - per-frame deterministic view
@@ -217,6 +234,7 @@ static void stasis_sync_display_metrics(void);
 static void stasis_reset_text_cache(void);
 static void stasis_invalidate_renderer_resources(int discard_gpu_handles);
 static int stasis_restore_renderer_resources(void);
+static void stasis_present_restore_loading(void);
 
 /* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -332,6 +350,44 @@ static void stasis_invalidate_renderer_resources(int discard_gpu_handles) {
     g_resource_frame_ready = false;
 }
 
+static void stasis_present_restore_loading(void) {
+    if (!g_use_sdl_renderer || !g_renderer) return;
+    const int rows = (int)(sizeof(g_restore_label) / sizeof(g_restore_label[0]));
+    const int columns = (int)strlen(g_restore_label[0]);
+    int cell_w = g_window_width / (columns + 8);
+    int cell_h = g_window_height / 60;
+    int cell = cell_w < cell_h ? cell_w : cell_h;
+    if (cell < 2) cell = 2;
+    const int origin_x = (g_window_width - columns * cell) / 2;
+    const int origin_y = (g_window_height - rows * cell) / 2;
+
+    SDL_SetRenderTarget(g_renderer, NULL);
+    SDL_RenderSetLogicalSize(g_renderer, g_window_width, g_window_height);
+    SDL_RenderSetClipRect(g_renderer, NULL);
+    SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_NONE);
+    SDL_SetRenderDrawColor(g_renderer, 15, 20, 28, 255);
+    SDL_RenderClear(g_renderer);
+    SDL_SetRenderDrawColor(g_renderer, 66, 153, 225, 255);
+    for (int row = 0; row < rows; row++) {
+        const char* pixels = g_restore_label[row];
+        for (int column = 0; column < columns; column++) {
+            if (pixels[column] != '1') continue;
+            SDL_Rect pixel = {
+                origin_x + column * cell,
+                origin_y + row * cell,
+                cell,
+                cell
+            };
+            SDL_RenderFillRect(g_renderer, &pixel);
+        }
+    }
+    SDL_RenderPresent(g_renderer);
+    SDL_Log("Stasis renderer loading screen presented: backend=sdl reason=%s surface_generation=%u renderer_generation=%u",
+        stasis_renderer_reason_name(g_resource_lifecycle.reason),
+        g_resource_lifecycle.surface_generation,
+        g_resource_lifecycle.renderer_generation);
+}
+
 static int stasis_input_valid_index(int idx) {
     return idx >= 0 && idx < STASIS_MAX_POINTERS;
 }
@@ -400,7 +456,6 @@ static void stasis_sync_display_metrics(void) {
     if (dimensions_changed && g_use_sdl_renderer &&
         g_resource_lifecycle.state != STASIS_RENDERER_UNAVAILABLE) {
         stasis_renderer_lifecycle_surface_changed(&g_resource_lifecycle);
-        stasis_invalidate_renderer_resources(0);
     }
     g_display_metrics = next;
     g_drawable_width = drawable_w;
@@ -618,6 +673,7 @@ static void stasis_pump_events(void) {
                 stasis_renderer_lifecycle_renderer_reset(
                     &g_resource_lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
                 stasis_invalidate_renderer_resources(0);
+                stasis_present_restore_loading();
                 SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=targets_reset surface_generation=%u renderer_generation=%u",
                     g_resource_lifecycle.surface_generation,
                     g_resource_lifecycle.renderer_generation);
@@ -626,6 +682,7 @@ static void stasis_pump_events(void) {
                 stasis_renderer_lifecycle_renderer_reset(
                     &g_resource_lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
                 stasis_invalidate_renderer_resources(0);
+                stasis_present_restore_loading();
                 SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=device_reset surface_generation=%u renderer_generation=%u",
                     g_resource_lifecycle.surface_generation,
                     g_resource_lifecycle.renderer_generation);
@@ -638,7 +695,6 @@ static void stasis_pump_events(void) {
             case SDL_APP_DIDENTERFOREGROUND:
                 if (g_resource_lifecycle.state == STASIS_RENDERER_PAUSED) {
                     stasis_renderer_lifecycle_resume(&g_resource_lifecycle);
-                    stasis_invalidate_renderer_resources(0);
                 }
                 break;
             case SDL_MOUSEBUTTONDOWN:
@@ -3644,6 +3700,7 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     stasis_sync_display_metrics();
     stasis_renderer_lifecycle_initialize(&g_resource_lifecycle);
     g_resource_frame_ready = true;
+    stasis_present_restore_loading();
     SDL_Log("Stasis display metrics: logical=%dx%d native=%dx%d drawable=%dx%d scale=%.2f",
         g_window_width, g_window_height,
         g_native_window_width, g_native_window_height,
@@ -5225,7 +5282,6 @@ STASIS_EXPORT void stasis_mobile_set_paused(int paused) {
         g_resource_frame_ready = false;
     } else if (g_resource_lifecycle.state == STASIS_RENDERER_PAUSED) {
         stasis_renderer_lifecycle_resume(&g_resource_lifecycle);
-        stasis_invalidate_renderer_resources(0);
     }
 }
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -234,7 +234,7 @@ static void stasis_sync_display_metrics(void);
 static void stasis_reset_text_cache(void);
 static void stasis_invalidate_renderer_resources(int discard_gpu_handles);
 static int stasis_restore_renderer_resources(void);
-static void stasis_present_restore_loading(void);
+static void stasis_present_gpu_loading(void);
 
 /* Forward decls for helpers referenced early in the file (MSVC C mode does not allow implicit declarations). */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -350,8 +350,8 @@ static void stasis_invalidate_renderer_resources(int discard_gpu_handles) {
     g_resource_frame_ready = false;
 }
 
-static void stasis_present_restore_loading(void) {
-    if (!g_use_sdl_renderer || !g_renderer) return;
+static void stasis_present_gpu_loading(void) {
+    if (!g_window) return;
     const int rows = (int)(sizeof(g_restore_label) / sizeof(g_restore_label[0]));
     const int columns = (int)strlen(g_restore_label[0]);
     int cell_w = g_window_width / (columns + 8);
@@ -361,28 +361,74 @@ static void stasis_present_restore_loading(void) {
     const int origin_x = (g_window_width - columns * cell) / 2;
     const int origin_y = (g_window_height - rows * cell) / 2;
 
-    SDL_SetRenderTarget(g_renderer, NULL);
-    SDL_RenderSetLogicalSize(g_renderer, g_window_width, g_window_height);
-    SDL_RenderSetClipRect(g_renderer, NULL);
-    SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_NONE);
-    SDL_SetRenderDrawColor(g_renderer, 15, 20, 28, 255);
-    SDL_RenderClear(g_renderer);
-    SDL_SetRenderDrawColor(g_renderer, 66, 153, 225, 255);
-    for (int row = 0; row < rows; row++) {
-        const char* pixels = g_restore_label[row];
-        for (int column = 0; column < columns; column++) {
-            if (pixels[column] != '1') continue;
-            SDL_Rect pixel = {
-                origin_x + column * cell,
-                origin_y + row * cell,
-                cell,
-                cell
-            };
-            SDL_RenderFillRect(g_renderer, &pixel);
+    if (g_use_sdl_renderer && g_renderer) {
+        SDL_SetRenderTarget(g_renderer, NULL);
+        SDL_RenderSetLogicalSize(g_renderer, g_window_width, g_window_height);
+        SDL_RenderSetClipRect(g_renderer, NULL);
+        SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_NONE);
+        SDL_SetRenderDrawColor(g_renderer, 15, 20, 28, 255);
+        SDL_RenderClear(g_renderer);
+        SDL_SetRenderDrawColor(g_renderer, 66, 153, 225, 255);
+        for (int row = 0; row < rows; row++) {
+            const char* pixels = g_restore_label[row];
+            for (int column = 0; column < columns; column++) {
+                if (pixels[column] != '1') continue;
+                SDL_Rect pixel = {
+                    origin_x + column * cell,
+                    origin_y + row * cell,
+                    cell,
+                    cell
+                };
+                SDL_RenderFillRect(g_renderer, &pixel);
+            }
         }
+        SDL_RenderPresent(g_renderer);
     }
-    SDL_RenderPresent(g_renderer);
-    SDL_Log("Stasis renderer loading screen presented: backend=sdl reason=%s surface_generation=%u renderer_generation=%u",
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+    else if (g_gl_context) {
+        glPushAttrib(GL_ALL_ATTRIB_BITS);
+        glViewport(0, 0, g_drawable_width, g_drawable_height);
+        glDisable(GL_TEXTURE_2D);
+        glDisable(GL_BLEND);
+        glDisable(GL_DEPTH_TEST);
+        glDisable(GL_SCISSOR_TEST);
+        glMatrixMode(GL_PROJECTION);
+        glPushMatrix();
+        glLoadIdentity();
+        glOrtho(0.0, (double)g_window_width, (double)g_window_height, 0.0, -1.0, 1.0);
+        glMatrixMode(GL_MODELVIEW);
+        glPushMatrix();
+        glLoadIdentity();
+        glClearColor(15.0f / 255.0f, 20.0f / 255.0f, 28.0f / 255.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glColor4ub(66, 153, 225, 255);
+        glBegin(GL_QUADS);
+        for (int row = 0; row < rows; row++) {
+            const char* pixels = g_restore_label[row];
+            for (int column = 0; column < columns; column++) {
+                if (pixels[column] != '1') continue;
+                const int x = origin_x + column * cell;
+                const int y = origin_y + row * cell;
+                glVertex2i(x, y);
+                glVertex2i(x + cell, y);
+                glVertex2i(x + cell, y + cell);
+                glVertex2i(x, y + cell);
+            }
+        }
+        glEnd();
+        SDL_GL_SwapWindow(g_window);
+        glMatrixMode(GL_MODELVIEW);
+        glPopMatrix();
+        glMatrixMode(GL_PROJECTION);
+        glPopMatrix();
+        glPopAttrib();
+    }
+#endif
+    else {
+        return;
+    }
+    SDL_Log("Stasis renderer loading screen presented: backend=%s reason=%s surface_generation=%u renderer_generation=%u",
+        g_use_sdl_renderer ? "sdl" : "gl",
         stasis_renderer_reason_name(g_resource_lifecycle.reason),
         g_resource_lifecycle.surface_generation,
         g_resource_lifecycle.renderer_generation);
@@ -673,7 +719,7 @@ static void stasis_pump_events(void) {
                 stasis_renderer_lifecycle_renderer_reset(
                     &g_resource_lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
                 stasis_invalidate_renderer_resources(0);
-                stasis_present_restore_loading();
+                stasis_present_gpu_loading();
                 SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=targets_reset surface_generation=%u renderer_generation=%u",
                     g_resource_lifecycle.surface_generation,
                     g_resource_lifecycle.renderer_generation);
@@ -682,7 +728,7 @@ static void stasis_pump_events(void) {
                 stasis_renderer_lifecycle_renderer_reset(
                     &g_resource_lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
                 stasis_invalidate_renderer_resources(0);
-                stasis_present_restore_loading();
+                stasis_present_gpu_loading();
                 SDL_Log("Stasis renderer resources invalidated: backend=sdl reason=device_reset surface_generation=%u renderer_generation=%u",
                     g_resource_lifecycle.surface_generation,
                     g_resource_lifecycle.renderer_generation);
@@ -3700,7 +3746,7 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     stasis_sync_display_metrics();
     stasis_renderer_lifecycle_initialize(&g_resource_lifecycle);
     g_resource_frame_ready = true;
-    stasis_present_restore_loading();
+    stasis_present_gpu_loading();
     SDL_Log("Stasis display metrics: logical=%dx%d native=%dx%d drawable=%dx%d scale=%.2f",
         g_window_width, g_window_height,
         g_native_window_width, g_native_window_height,

--- a/runtime/stasis_renderer_lifecycle.h
+++ b/runtime/stasis_renderer_lifecycle.h
@@ -27,6 +27,7 @@ typedef struct {
     uint32_t restore_attempts;
     uint32_t restore_failures;
     StasisRendererResourceState state;
+    StasisRendererResourceState state_before_pause;
     StasisRendererResourceReason reason;
 } StasisRendererLifecycle;
 
@@ -42,6 +43,7 @@ static void stasis_renderer_lifecycle_initialize(StasisRendererLifecycle* lifecy
     lifecycle->restore_attempts = 0u;
     lifecycle->restore_failures = 0u;
     lifecycle->state = STASIS_RENDERER_READY;
+    lifecycle->state_before_pause = STASIS_RENDERER_READY;
     lifecycle->reason = STASIS_RENDERER_REASON_NONE;
 }
 
@@ -49,7 +51,6 @@ static void stasis_renderer_lifecycle_surface_changed(StasisRendererLifecycle* l
     if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
     lifecycle->surface_generation =
         stasis_renderer_next_generation(lifecycle->surface_generation);
-    lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
     lifecycle->reason = STASIS_RENDERER_REASON_SURFACE_CHANGED;
 }
 
@@ -68,17 +69,16 @@ static void stasis_renderer_lifecycle_renderer_reset(
 
 static void stasis_renderer_lifecycle_pause(StasisRendererLifecycle* lifecycle) {
     if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
+    lifecycle->state_before_pause = lifecycle->state;
     lifecycle->state = STASIS_RENDERER_PAUSED;
     lifecycle->reason = STASIS_RENDERER_REASON_BACKGROUND;
 }
 
 static void stasis_renderer_lifecycle_resume(StasisRendererLifecycle* lifecycle) {
     if (!lifecycle || lifecycle->state != STASIS_RENDERER_PAUSED) return;
-    lifecycle->surface_generation =
-        stasis_renderer_next_generation(lifecycle->surface_generation);
-    lifecycle->renderer_generation =
-        stasis_renderer_next_generation(lifecycle->renderer_generation);
-    lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
+    lifecycle->state = lifecycle->state_before_pause == STASIS_RENDERER_READY
+        ? STASIS_RENDERER_READY
+        : STASIS_RENDERER_RESTORE_PENDING;
     lifecycle->reason = STASIS_RENDERER_REASON_FOREGROUND;
 }
 

--- a/runtime/tests/stasis_renderer_lifecycle_test.c
+++ b/runtime/tests/stasis_renderer_lifecycle_test.c
@@ -18,9 +18,12 @@ static void test_restore_retry_and_generations(void) {
     CHECK(lifecycle.renderer_generation == 1u);
 
     stasis_renderer_lifecycle_surface_changed(&lifecycle);
-    CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
+    CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(lifecycle.surface_generation == 2u);
     CHECK(lifecycle.renderer_generation == 1u);
+    stasis_renderer_lifecycle_renderer_reset(
+        &lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
+    CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
     stasis_renderer_lifecycle_finish_restore(&lifecycle, 0);
     CHECK(lifecycle.restore_attempts == 1u);
@@ -38,15 +41,14 @@ static void test_pause_reset_and_wrap(void) {
     CHECK(lifecycle.state == STASIS_RENDERER_PAUSED);
     stasis_renderer_lifecycle_resume(&lifecycle);
     CHECK(lifecycle.reason == STASIS_RENDERER_REASON_FOREGROUND);
-    CHECK(lifecycle.surface_generation == 2u);
-    CHECK(lifecycle.renderer_generation == 2u);
-    CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
-    stasis_renderer_lifecycle_finish_restore(&lifecycle, 1);
+    CHECK(lifecycle.surface_generation == 1u);
+    CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
 
     stasis_renderer_lifecycle_renderer_reset(
         &lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
-    CHECK(lifecycle.surface_generation == 3u);
-    CHECK(lifecycle.renderer_generation == 3u);
+    CHECK(lifecycle.surface_generation == 2u);
+    CHECK(lifecycle.renderer_generation == 2u);
     CHECK(lifecycle.reason == STASIS_RENDERER_REASON_DEVICE_RESET);
 
     lifecycle.surface_generation = UINT32_MAX;
@@ -57,9 +59,21 @@ static void test_pause_reset_and_wrap(void) {
     CHECK(lifecycle.renderer_generation == 1u);
 }
 
+static void test_pause_before_restore_preserves_pending_state(void) {
+    StasisRendererLifecycle lifecycle = {0};
+    stasis_renderer_lifecycle_initialize(&lifecycle);
+    stasis_renderer_lifecycle_renderer_reset(
+        &lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
+    stasis_renderer_lifecycle_pause(&lifecycle);
+    stasis_renderer_lifecycle_resume(&lifecycle);
+    CHECK(lifecycle.state == STASIS_RENDERER_RESTORE_PENDING);
+    CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
+}
+
 int main(void) {
     test_restore_retry_and_generations();
     test_pause_reset_and_wrap();
+    test_pause_before_restore_preserves_pending_state();
     puts("stasis_renderer_lifecycle_test: ok");
     return 0;
 }


### PR DESCRIPTION
## Summary

- keep `STASIS` / `LOADING` visible through the complete Workshop graphics restoration transaction
- avoid surface-setup black clears and require all referenced resources plus clean GL state before publishing a game frame
- preserve SDL renderer resources across ordinary mobile foreground resume
- show the asset-free loading screen at startup and genuine GPU restoration on SDL across Android, iOS, Windows, macOS, and Linux
- render the same screen through the legacy desktop OpenGL backend without texture, shader, or font dependencies
- keep reset restoration all-or-nothing so the loading framebuffer remains presented until the first complete game frame
- preserve real AOT runtime-helper signatures for dynamic global and collection fallbacks exposed by ChessTD packaging

## Why this is a follow-up

PR #354 merged before the later restoration commits were pushed. This PR contains the remaining loading visibility, completion boundary, generated SDL runtime, and the AOT correction required to build ChessTD with that runtime.

## Validation

- complete Workshop Android unit suite
- Workshop debug APK assembly
- `cargo test -p stasis mobile_runtime_uses_fixed_entries_and_sdl_only_static_target`
- focused AOT dynamic-global fallback, direct-storage, and pure-symbol tests
- focused shared-runtime SDL/OpenGL loading presentation and mobile lifecycle tests
- ChessTD Android `package-mobile --development-build`
- ChessTD arm64 Gradle/NDK/SDL compile and APK assembly
- LAN-hosted APK byte/hash and HTTP length verification
- `git diff --check`

## LAN test artifact

ChessTD development APK published as `ChessTD-debug.apk`; SHA-256 `8D79D228E87BE258D420BF753C693A7F0C10EA13BB12EE82FF367E8BFAC6EABF`. An official ChessTD release still requires this PR to merge, a normal Stasis nightly, and repinning the game repository.

Theory gained: direct AOT storage is the fast path, but dynamic indices and bounds branches retain runtime fallbacks; every reachable fallback must keep its own helper ABI even when most accesses lower directly.