### PR TITLE
docs: lock direct-call generation contract

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -4117,8 +4117,6 @@ mod tests {
     #[cfg(windows)]
     use object::{Object, ObjectSection};
     #[cfg(windows)]
-    use stasis_compiler::IncrementalCompilerHost;
-    #[cfg(windows)]
     use stasis_dynload::{invoke_noarg_u64, Library as DynamicLibrary};
     use stasis_runner::swap::contracts::{CompileRequest, CompileStatus, RequestId, TargetMode};
     use std::fs;
@@ -8200,23 +8198,6 @@ mod tests {
         )
         .expect("write source");
 
-        let mut host = IncrementalCompilerHost::new();
-        let parsed = host
-            .compile_changed_files(std::slice::from_ref(&source))
-            .expect("host parse");
-        let main_metric = parsed
-            .functions
-            .iter()
-            .find(|metric| metric.id_hash == hash_identifier("main"))
-            .expect("main metric");
-        let callee_metric = parsed
-            .functions
-            .iter()
-            .find(|metric| metric.id_hash == hash_identifier("callee"))
-            .expect("callee metric");
-        let expected_main_symbol = aot_symbol_name(main_metric);
-        let expected_callee_symbol = aot_symbol_name(callee_metric);
-
         let mut backend = IncrementalCompilerBackend::with_aot_compile_and_link_config(
             AotCompileConfig::default(),
             AotLinkConfig {
@@ -8240,6 +8221,25 @@ mod tests {
             fs::remove_dir_all(&temp_root).ok();
             return;
         };
+        let function_symbols = compiled
+            .aot_function_symbols
+            .as_ref()
+            .expect("successful AOT link should include function symbols");
+        let compiled_symbol_for = |name: &str| {
+            let key = format!("rust_native::{}::{name}", source.to_string_lossy());
+            let fn_id = backend
+                .fn_id_by_signature
+                .get(&key)
+                .unwrap_or_else(|| panic!("missing function id for {name}"));
+            function_symbols
+                .iter()
+                .find(|entry| entry.fn_id == *fn_id)
+                .unwrap_or_else(|| panic!("missing AOT symbol for {name}"))
+                .symbol
+                .clone()
+        };
+        let expected_main_symbol = compiled_symbol_for("main");
+        let expected_callee_symbol = compiled_symbol_for("callee");
 
         let library = DynamicLibrary::load(linked_path).expect("load linked image");
         let main_ptr = library

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -10,11 +10,14 @@ Status note:
 
 Locked decisions:
 - Entrypoint is `function main(): i32`.
-- Reachability-DCE roots are `main`, `tick`, and `on_code_swap` (when present), plus host-exported required entry symbols.
+- Reachability-DCE roots are lifecycle entries present in the program (`main`, `tick`, `render`,
+  `on_code_swap`) plus host-exported required entry symbols.
 - Initial host externs are `print_i32` and `print_string`.
 - Function-form calls remain supported indefinitely (receiver-form still preferred).
 - Runtime boundary is host-set-based and deny-by-default: Stasis can only access extern symbols exported by the selected host set.
-- Call dispatch policy: debug/hot-swap mode keeps indirect dispatch (`FnId -> code_ptr`); release/AOT mode can lower direct call edges where compatibility gates allow.
+- Call dispatch policy: JIT and AOT lower every reachable internal Stasis call directly inside one
+  complete generation. Only lifecycle/host-required exports cross the host boundary, and the host
+  publishes them through one owning `ActiveGeneration` reference.
 - Backend modes are:
 - Cranelift JIT for development/watch/hot-swap runtime
 - Cranelift AOT for production builds
@@ -56,6 +59,105 @@ Release AOT optimization:
 Historical bootstrap/self-host notes below are archival only and do not describe an active compiler track.
 
 ## Slice Plan
+
+### Direct-Call Generation Migration Track
+
+The canonical ABI, state machine, failure table, platform matrix, budgets, and ownership rules are
+in `docs/jit_generation_contract.md`. These slices replace the historical S7-S10 pointer-table and
+patch-set end state; they do not add a second compatibility mode.
+
+#### G0 - Lock Generation Architecture, ABI, and Lifecycle
+
+- Maddox task: #174.
+- Language: `docs`.
+- Scope: Replace product/spec/checklist requirements for internal `FnId -> code_ptr` dispatch with
+  complete reachable direct-call generations and one-reference publication.
+- Deliverable: Unambiguous ownership model, state machine, failure table, thread messages,
+  `on_code_swap` transaction, retirement rule, target matrix, performance budgets, and child gates.
+- Tests: Documentation consistency check, bounded repository validation, and touched-file cruft
+  review.
+- Done gate: No canonical current requirement permits mixed generations, independent pointer
+  publication, runtime-thread compiler work, or stale/superseded candidate visibility.
+- Status: `completed`
+
+#### G1 - Emit Complete Direct-Call Generation Modules
+
+- Maddox task: #175.
+- Language: `Rust + .stasis`.
+- Scope: Predeclare and define the complete reachable call graph in one JIT module through the
+  shared JIT/AOT direct-call lowering path.
+- Deliverable: One finalized pending generation with a compiler-derived immutable host-export map;
+  semantic caches stop before live machine-code ownership.
+- Tests: Direct-call/no-dispatch CLIF assertions for leaf, caller, shared utility, recursive/SCC,
+  lifecycle/export, added/deleted/renamed, and unreachable cases; representative executable JIT and
+  AOT sample.
+- Done gate: No internal arity wrapper, dispatch lookup, mutex, cross-generation relocation, or
+  per-function live machine-code patch remains.
+- Status: `pending`
+
+#### G2 - Publish and Retire One Generation Atomically
+
+- Maddox task: #176.
+- Language: `Rust + .stasis`.
+- Scope: Implement owned pending/active generations, versioned build messages, safe-point execution
+  windows, isolated migration/hook state, latest-request supersession, single-reference publication,
+  and owner-based retirement.
+- Deliverable: `tick` + `render` capture one generation; all fallible work precedes the atomic
+  exchange; old executable memory drops after the last window owner.
+- Tests: Delayed compile runs old code for multiple windows then purely new code; A -> B publishes
+  only B; compile/migration/hook rejection preserves exact active reference/state; 100 swaps reach
+  zero quiescent retired owners.
+- Done gate: Independent export stores, pointer-table commits, staged pointer previews, and fixed
+  tick-delay retirement are deleted.
+- Status: `pending`
+
+#### G3 - Verify the Function-Edit Transition Matrix
+
+- Maddox task: #177.
+- Language: `Rust + .stasis`.
+- Scope: Exercise every functional edit and rejection category against observable behavior and
+  generation/state identity.
+- Tests: Host roots, leaf/mid-level/shared/recursive calls, render, `on_code_swap`, multiple edits,
+  add/delete/rename, unreachable edits, host-ABI/layout incompatibility, syntax/lowering failure,
+  and recovery across JIT/AOT.
+- Done gate: Every failure preserves the previous complete generation and no test depends on an
+  implementation-only per-function pointer.
+- Status: `pending`
+
+#### G4 - Enforce Platform, Performance, and Memory Gates
+
+- Maddox task: #178.
+- Language: `Rust + CI + Android`.
+- Scope: Enforce the Windows x86_64, Linux x86_64, macOS x86_64/arm64, and Android arm64 JIT/AOT
+  matrix plus explicit exclusions.
+- Tests: Bounded target CI, Android Workshop JIT and published AOT acceptance on a named physical
+  arm64 device, optional x86_64 AVD smoke that does not satisfy the arm64 row, 100/1,000/5,000 and
+  Brickout-scale cold/edit benchmarks, publication latency, old-generation ticks, and retirement
+  memory stress.
+- Done gate: The budgets in `docs/jit_generation_contract.md` pass or are revised with recorded
+  evidence; unsupported combinations fail explicitly.
+- Status: `pending`
+
+#### Superseded checklist requirements
+
+The following completed slices remain history of the current implementation, but their listed end
+states are removal work for G1-G2 and are not compatibility requirements:
+
+- S7's "unchanged function bodies skip backend regeneration" may apply only to semantic/HIR or
+  target-independent lowering caches. It cannot reuse live machine code across generations.
+- S8's `FnId -> code_ptr` runtime dispatch, per-function publication, and safe-window retirement are
+  replaced by one owned complete generation and owner-based retirement.
+- S8b's per-function AOT patch manifests, symbol overrides, and per-function loader publication are
+  replaced wherever they participate in watch/live publication. Production AOT still emits one
+  complete direct-call program artifact.
+- S9's `CompileResult`/`SwapCommitRequest` patch sets and `swapped_fn_ids` publication truth are
+  replaced by the G0 versioned generation messages.
+- S10's hook `FnId`, staged pointer-table preview, and independent native hook address are replaced
+  by the validated `on_code_swap` export inside `PendingGeneration`.
+
+No new work may extend these obsolete paths. Each migration child deletes the paths it replaces and
+ends with a cruft review.
+
 ### Android Workshop Track
 
 #### AW0 - Product and Syntax Decisions
@@ -788,6 +890,8 @@ Archived priority override (2026-02-13, historical):
 - Status: `completed`
 
 ### S7 - Incremental Compiler V1
+- Contract status: historical implementation record. G0 supersedes machine-code reuse; only
+  semantic/HIR and target-independent lowering caches may survive into complete generations.
 - Language:
 - `Rust + .stasis`
 - Rust: in-memory file DB, cache storage, and invalidation substrate.
@@ -807,6 +911,8 @@ Archived priority override (2026-02-13, historical):
 - Status: `completed`
 
 ### S8 - Function Pointer Table ABI
+- Contract status: historical implementation record scheduled for deletion by G1-G2. The pointer
+  table is not a supported target ABI or compatibility path.
 - Language:
 - `Rust`
 - Scope:
@@ -823,6 +929,8 @@ Archived priority override (2026-02-13, historical):
 - Status: `completed`
 
 ### S8b - Cranelift AOT Production Path
+- Contract status: historical implementation record. Complete production AOT artifacts remain;
+  per-function patch/override publication does not and is superseded by G0-G2.
 - Language:
 - `Rust`
 - Scope:
@@ -946,6 +1054,8 @@ Archived priority override (2026-02-13, historical):
 - Slice R12 (optional): Perform long-session watch-mode stability/perf pass and memory-growth checks after R1-R11.
 
 ### S9 - Two-Phase Swap Commit
+- Contract status: historical implementation record. Transactional safe-point behavior remains,
+  but patch-set messages and independent pointer publication are superseded by G0-G2.
 - Language:
 - `Rust + .stasis`
 - Rust: commit transaction mechanism and thread-safe pointer swap.
@@ -967,6 +1077,8 @@ Archived priority override (2026-02-13, historical):
 - Status: `completed`
 
 ### S10 - `on_code_swap` Hook
+- Contract status: historical implementation record. Hook semantics remain, but hook `FnId`, staged
+  pointer preview, and independent entry publication are superseded by G0-G2.
 - Language:
 - `Rust + .stasis`
 - Rust: hook invocation boundary and rollback/error propagation.

--- a/docs/cranelift_backend_guardrails.md
+++ b/docs/cranelift_backend_guardrails.md
@@ -2,12 +2,22 @@
 
 The intended backend split is:
 
-- `crates/stasis_compiler/src/backend/emit.rs` owns compile analysis, shared per-function compilation, runtime import setup, and statement/expression lowering.
-- `crates/stasis_compiler/src/backend/jit.rs` is a thin JIT wrapper for host symbol registration, module finalize/commit, and runtime pointer publication.
+- `crates/stasis_compiler/src/backend/emit.rs` owns compile analysis, shared per-function lowering
+  inside a complete reachable module, direct internal-call declarations, runtime import setup, and
+  statement/expression lowering.
+- `crates/stasis_compiler/src/backend/jit.rs` is a thin JIT wrapper for host symbol registration,
+  complete module finalization, generation-owned executable memory, and immutable host-export map
+  extraction. It does not publish runtime pointers.
 - `crates/stasis_compiler/src/backend/aot.rs` is a thin AOT wrapper for extern binding policy, object emission, and link/bundle finalization.
+
+JIT and AOT share direct Stasis-to-Stasis call lowering. Per-function JIT dispatch is obsolete; the
+generation ABI, publication boundary, and lifetime rules are canonical in
+`docs/jit_generation_contract.md`.
 
 Review rule:
 
 - If a normal language feature requires touching both `jit.rs` and `aot.rs`, stop and check whether the work belongs in `emit.rs` instead.
 - `jit.rs` and `aot.rs` should not directly own statement parsing or expression/statement lowering.
+- Neither backend may introduce an internal-call dispatch policy or reuse live machine code from a
+  different generation.
 - Regressions for this contract live in backend tests that fail if wrapper files start calling shared parse/emit hooks directly again.

--- a/docs/jit_generation_contract.md
+++ b/docs/jit_generation_contract.md
@@ -122,19 +122,22 @@ compiler and runtime threads.
 The versioned message boundary is:
 
 ```text
-SourceChange(revision, changed_files, source_snapshot_id)
-BuildGeneration(request_id, revision, target, host_set, active_contract)
-BuildFinished(request_id, revision, diagnostics, pending_generation?)
+FileChangeEvent(path, revision, text_source, change_kind)
+BuildGeneration(request_id, revision, source_snapshot_id, target, host_set, active_contract)
+BuildFinished(request_id, revision, status, diagnostics[], pending_generation?)
 CommitGeneration(request_id, pending_generation)
 CommitFinished(request_id, status, active_generation_number?, diagnostic?)
 CancelBuild(request_id, superseded_by_request_id)
 ```
 
-`active_contract` contains immutable host-export ABI and state-layout metadata, not runtime values
-or pointers. `BuildFinished` transfers ownership of a finalized `PendingGeneration`; it never
-installs code or storage. Cancellation is a message/control flag only and does not expose mutable
-compiler state. The coordinator records the newest requested revision. Results for older revisions
-are discarded even if cancellation arrived too late to stop code generation.
+The watcher sends `FileChangeEvent` to the coordinator. The coordinator coalesces events, creates an
+immutable source snapshot, and sends its ID in `BuildGeneration`; the compiler never reconstructs a
+snapshot from mutable watcher state. `active_contract` contains immutable host-export ABI and
+state-layout metadata, not runtime values or pointers. `BuildFinished` transfers ownership of a
+finalized `PendingGeneration`; it never installs code or storage. Cancellation is a message/control
+flag only and does not expose mutable compiler state. The coordinator records the newest requested
+revision. Results for older revisions are discarded even if cancellation arrived too late to stop
+code generation.
 
 The runtime thread may validate metadata, prepare bounded candidate state, run the swap hook, and
 replace the active reference. It must not parse, check, lower, generate, link, or finalize code.

--- a/docs/jit_generation_contract.md
+++ b/docs/jit_generation_contract.md
@@ -1,0 +1,408 @@
+# Direct-Call JIT Generation Contract
+
+Status: architecture contract for the JIT generation migration
+
+This document is the canonical implementation contract for replacing per-function JIT dispatch
+with complete, immutable, direct-call generations. `docs/live-compilation-prd.md` owns product
+requirements, `docs/spec.md` owns observable language behavior, and this document owns the
+compiler/runtime ABI, lifecycle, and verification details.
+
+## Mapping, rationale, and extension point
+
+- Mapping: one source revision becomes one complete reachable program, one state layout, one host
+  export set, and one executable-memory owner. A tick and its render observe that package through
+  one `ActiveGeneration` reference.
+- Rationale: direct internal calls are safe only while the caller, callee, state bindings, and
+  executable memory have the same lifetime. Publishing individual function pointers would allow a
+  mixed generation and is therefore forbidden.
+- Extension point: a future debugger may retain immutable metadata or state snapshots by
+  generation number. It must not retain executable entry pointers or keep code memory alive after
+  the execution window ends.
+
+The nearest tempting alternative is to keep `FnId -> code_ptr` for unchanged functions and use
+direct calls only for changed code. That creates cross-generation edges, preserves the hot-path
+lookup mechanism, and makes retirement depend on an unbounded graph of code ownership. It is not a
+compatibility mode.
+
+## Non-negotiable invariants
+
+1. A development build finalizes the complete reachable Stasis program as one generation.
+2. Calls between Stasis functions are direct Cranelift calls within that generation.
+3. Only explicit host exports cross the generation boundary.
+4. The host publishes all exports, state bindings, and executable-memory ownership by replacing
+   one `ActiveGeneration` reference. Independent pointer stores are forbidden.
+5. An execution window snapshots one `ActiveGeneration`; `tick`, its following `render`, and every
+   synchronous internal call use only that snapshot.
+6. No Stasis frame or raw compiled pointer may outlive its execution window.
+7. Parse, index, semantic analysis, lowering, code generation, and finalization never run on the
+   runtime thread.
+8. A failed or superseded build never becomes visible and never mutates active state.
+9. Publication occurs only between complete execution windows.
+10. JIT and AOT use the same internal direct-call lowering and host-export ABI.
+
+`FnId` may remain as a compiler identity for diagnostics, call graphs, semantic caches, and edit
+summaries. It is not a runtime dispatch key and does not authorize retaining a body pointer.
+
+## Program and generation contents
+
+Reachability starts from:
+
+- lifecycle entries present in the program: `main`, `tick`, `render`, and `on_code_swap`;
+- entries required by the selected versioned host-set manifest; and
+- any other source declaration explicitly exported through that manifest.
+
+The compiler resolves this complete root set before lowering. A generation contains every
+reachable function body and reachable struct/type metadata, and excludes unreachable definitions.
+The host export manifest records each exported symbol's stable name, signature hash, phase policy,
+and code address inside the generation.
+
+Conceptual ownership is:
+
+```text
+ActiveGeneration
+  generation_number       successful-publication sequence
+  source_revision         immutable input revision
+  program_hash            complete reachable semantic identity
+  target                  host target and feature profile
+  host_exports            complete immutable name -> typed entry map
+  state_layout            canonical compiler-owned layout
+  state_bindings          storage used by this generation
+  executable_owner        keeps all generated code alive
+  diagnostics_metadata    symbols, source spans, and cost/data-flow summaries
+```
+
+`PendingGeneration` has the same code, metadata, and ownership fields plus a build request ID,
+compatibility report, and candidate state plan. It is not callable by ordinary runtime work. The
+commit transaction may invoke only its validated `on_code_swap` export against isolated candidate
+state.
+
+The active reference is immutable after publication. Mutable gameplay data lives behind the state
+bindings owned by that generation, but the identity and addresses of those bindings cannot change
+inside an execution window.
+
+## Call and host-export ABI
+
+### Internal calls
+
+- The compiler declares all reachable functions in one Cranelift module before defining bodies.
+- Each resolved Stasis-to-Stasis call lowers to the module-local callee `FuncRef`.
+- Recursive calls and strongly connected components use the same declarations and direct calls.
+- No internal call imports an arity wrapper, `FnId` lookup, dispatch mutex, or body pointer from a
+  previous generation.
+- Shared lowering selects the same direct-call ABI for JIT and AOT. Backend policy differs only in
+  target symbol binding, finalization, and artifact ownership.
+
+Semantic hashes still avoid unnecessary frontend analysis and may cache target-independent HIR,
+call-graph facts, or pre-finalization lowering inputs. They must not reuse a live machine-code body
+or relocation whose lifetime belongs to another generation.
+
+### Host exports
+
+The compiler, not the runtime, discovers exports from lifecycle rules and the selected host-set
+manifest. Before finalization it rejects duplicate names, missing required entries, unsupported
+signatures, and exports not reachable from the declared root set.
+
+The host resolves an export only through its execution-window generation snapshot. It may cache a
+typed entry address on the stack for that window; it may not store the address in a process-global,
+callback, component, or per-function table. A missing optional export is represented in the
+generation metadata, never by consulting another generation.
+
+Host-export signatures are compatibility boundaries. An update that changes a required export's
+ABI is rejected unless the host-set version changes through an explicit restart or negotiated
+upgrade path. Ordinary internal functions may be added, removed, renamed, or have signatures
+changed because all reachable callers are rebuilt together.
+
+## Thread ownership and messages
+
+The file watcher and editor produce immutable source revisions. The coordinator may coalesce them,
+but the compiler service owns its own source snapshot and compiler caches. Runtime state, compiler
+AST/HIR, Cranelift module state, and executable allocators are never shared mutably across the
+compiler and runtime threads.
+
+The versioned message boundary is:
+
+```text
+SourceChange(revision, changed_files, source_snapshot_id)
+BuildGeneration(request_id, revision, target, host_set, active_contract)
+BuildFinished(request_id, revision, diagnostics, pending_generation?)
+CommitGeneration(request_id, pending_generation)
+CommitFinished(request_id, status, active_generation_number?, diagnostic?)
+CancelBuild(request_id, superseded_by_request_id)
+```
+
+`active_contract` contains immutable host-export ABI and state-layout metadata, not runtime values
+or pointers. `BuildFinished` transfers ownership of a finalized `PendingGeneration`; it never
+installs code or storage. Cancellation is a message/control flag only and does not expose mutable
+compiler state. The coordinator records the newest requested revision. Results for older revisions
+are discarded even if cancellation arrived too late to stop code generation.
+
+The runtime thread may validate metadata, prepare bounded candidate state, run the swap hook, and
+replace the active reference. It must not parse, check, lower, generate, link, or finalize code.
+
+## One generation state machine
+
+There is one state machine per game process. `N` is the active successful generation number and
+`R` is a build request ID.
+
+| State | Accepted event | Guard and action | Next state |
+| --- | --- | --- | --- |
+| `Running(N)` | source revision queued | Allocate monotonically increasing `R`; keep running `N`. | `Building(N,R)` |
+| `Building(N,R)` | newer revision queued | Send cancellation for `R`, allocate newer request `R2`; `N` remains active. | `Building(N,R2)` |
+| `Building(N,R)` | build fails | Publish diagnostics only; release all request-owned artifacts. | `Running(N)` |
+| `Building(N,R)` | stale or cancelled build finishes | Release the result without commit or hook execution. | Current state for the newest request |
+| `Building(N,R)` | current build finishes successfully | Transfer one finalized `PendingGeneration`; keep running `N`. | `Ready(N,R)` |
+| `Ready(N,R)` | newer revision queued | Discard the candidate, allocate `R2`; `N` remains active. | `Building(N,R2)` |
+| `Ready(N,R)` | execution window is active | Defer; do not block or interrupt the window. | `Ready(N,R)` |
+| `Ready(N,R)` | between-window safe point | Revalidate request freshness, export ABI, target, layout plan, and resource bounds; create isolated candidate state. | `Preparing(N,R)` |
+| `Preparing(N,R)` | newer revision queued or supersession observed | Mark `R` stale, destroy any candidate state, and start the newest request `R2`; no hook runs. | `Building(N,R2)` |
+| `Preparing(N,R)` | validation or migration fails | Destroy candidate state and generation; active code/state are unchanged. | `Running(N)` |
+| `Preparing(N,R)` | no hook is present | Preflight the infallible publication record. | `Publishing(N,R)` |
+| `Preparing(N,R)` | valid hook is present | Invoke the candidate hook once against isolated candidate state. | `Hook(N,R)` |
+| `Hook(N,R)` | newer revision queued while the hook is running | Let the synchronous hook return, mark `R` stale, destroy its isolated effects, and start newest `R2`; never publish `R`. | `Building(N,R2)` |
+| `Hook(N,R)` | hook rejects or traps | Destroy candidate state and generation; active code/state are unchanged. | `Running(N)` |
+| `Hook(N,R)` | hook succeeds | Preflight the infallible publication record. | `Publishing(N,R)` |
+| `Publishing(N,R)` | current-request compare-and-exchange fails | `R` was superseded after preflight; destroy it and start the newest request without visibility. | `Building(N,R2)` |
+| `Publishing(N,R)` | current-request compare-and-exchange succeeds | Linearize request freshness and the owning-reference exchange, assign `N+1`, then report success. | `Running(N+1)` |
+
+`Publishing` has no fallible candidate work. Allocation, migration, hook execution, export lookup,
+and diagnostic construction finish before it. Its one compare-and-exchange verifies both that `R`
+is still the coordinator's current request and that `N` is still active while replacing the owning
+generation reference. A revision ordered before that linearization makes the exchange fail and can
+never publish `R`; a revision ordered after it is a new request based on `N+1`. If the platform
+cannot provide this atomic current-request + owning-reference publication boundary, that target
+must reject development hot swap at startup.
+
+Generation numbers start at one for the first successfully published program and increase only on
+successful publication. Failed, cancelled, and superseded request IDs do not consume generation
+numbers. Request IDs and source revisions are separate monotonic domains.
+
+## Safe point and execution window
+
+An execution window begins when the runtime acquires the active owning reference and ends after
+all synchronous Stasis calls for that frame return. For the graphical loop it contains `tick` and
+the following `render`; headless and tool entrypoints define the same acquire/call/release shape.
+
+A safe point exists only when:
+
+- the previous window has released its generation reference;
+- no Stasis stack frame is active;
+- no swap transaction is active;
+- no host callback can re-enter using a pointer captured from the previous window; and
+- state bindings are not being replaced by another host operation.
+
+Compilation may span any number of ticks. The runtime continues complete windows on `N` while
+`R` builds. Once a current candidate is ready, publication waits for the next safe point. It never
+interrupts a frame and never publishes between `tick` and `render`.
+
+## State migration and `on_code_swap`
+
+The compiler emits the canonical candidate layout and a deterministic migration plan. At the safe
+point the runtime creates candidate storage without rebinding active storage, copies compatible
+values, initializes new values, applies bounded collection rules, and verifies the result.
+
+The optional candidate `on_code_swap(): void` runs exactly once after migration and before
+publication. Its calls are direct calls inside the pending generation and use candidate state
+bindings. It may mutate candidate Stasis state or call `reject_code_swap()`. It cannot call
+`main`, `tick`, `render`, non-transactional host effects, or an extern that can retain a callback or
+pointer. Phase-policy validation rejects those call paths before execution.
+
+Because candidate state is isolated, a hook rejection or trap requires destruction, not restoration
+of already-mutated active state. The active generation continues with the exact code and values it
+held before the attempt.
+
+## Long-lived execution and callbacks
+
+- Host calls from Stasis are synchronous unless their ABI explicitly copies bounded value data and
+  returns before the Stasis frame exits.
+- An asynchronous service may later request a new host-export invocation by symbolic export name;
+  the runtime resolves that name from the generation captured by the future execution window.
+- Host code may not cache a Stasis body pointer, export pointer, state-binding address, or borrowed
+  reference after the call returns.
+- Fibers, suspended Stasis frames, coroutines, guest-created threads, and callbacks that re-enter a
+  captured generation are unsupported. The compiler or host-set validator emits
+  `GENERATION_LONG_LIVED_EXECUTION_UNSUPPORTED` rather than silently extending code lifetime.
+- Foreign libraries that require stable callbacks must use a host-owned trampoline that carries no
+  guest code pointer and schedules symbolic re-entry at a future safe execution window.
+
+## Retirement and executable memory
+
+The execution window holds an owning reference to `ActiveGeneration`. After publication the old
+generation becomes retiring. Its code, export map, state bindings, and loader/module handle are
+released together when the last owning window reference is dropped. A fixed tick delay is not a
+proof of safety and is removed with the pointer-table retirement window.
+
+Under the no-long-lived-frame rule, at most these complete code owners exist in steady operation:
+the active generation, one current pending generation, and one transient retiring generation. A
+new build supersedes and releases any older pending generation. Runtime diagnostics report active,
+pending, and retiring generation numbers and executable bytes separately. At a quiescent safe point
+after publication, retiring generation count must be zero.
+
+## Failure table
+
+| Failure | Detection owner | Active visibility | Required result |
+| --- | --- | --- | --- |
+| Parse, semantic, lowering, or finalization error | Compiler service | No change | Discard request artifacts; report source diagnostics. |
+| Missing/duplicate host export or invalid export ABI | Compiler service | No change | Reject build with symbol and expected ABI. |
+| Internal unresolved call or cross-generation import | Compiler service | No change | Reject build; never emit a fallback dispatch call. |
+| Target/feature mismatch | Compiler service/runtime preflight | No change | Reject with required and actual target profile. |
+| Cancelled or superseded request finishes before preparation | Coordinator | No change | Release it without migration or hook execution. |
+| Request is superseded during migration or hook execution | Coordinator/runtime pre-publication check | No change | Finish only the synchronous isolated work needed to unwind, destroy its effects, and start the newest request. |
+| Current-request compare-and-exchange fails | Runtime publication boundary | No change | Destroy the stale candidate; never retry it. |
+| No safe point yet | Runtime | No change | Continue complete old-generation windows and retry. |
+| Resource or executable-memory preflight fails | Runtime | No change | Release candidate; report requested and allowed bytes. |
+| Host-export signature incompatibility | Runtime preflight | No change | Reject with export name and old/new signatures. |
+| State-layout migration incompatibility | Runtime preflight | No change | Reject with exact state path and reason. |
+| Candidate allocation or migration fails | Runtime transaction | No change | Destroy candidate state and generation. |
+| `on_code_swap` phase violation, trap, or explicit rejection | Runtime transaction | No change | Destroy candidate state and generation; report hook diagnostic. |
+| Atomic owning-reference publication unavailable | Runtime startup/preflight | No change | Disable JIT hot swap with deterministic target diagnostic. |
+| Attempted retained pointer, callback, fiber, or guest thread | Compiler/host-set validation | No change | Reject as unsupported before execution. |
+
+There is no partial-publication recovery row: all fallible work precedes the one owning-reference
+exchange.
+
+## Target and platform matrix
+
+`Required` means the implementation children must provide the named deterministic CI or device
+evidence. A supported macOS development host is an unsigned/local developer process that can obtain
+Cranelift executable memory; a hardened process without the required entitlement is explicitly
+unsupported for JIT and must use AOT.
+
+| Target | Development JIT | Production AOT | Required G4 evidence |
+| --- | --- | --- | --- |
+| Windows x86_64 | Required, native host JIT | Required, native PE/COFF | Windows x86_64 PR CI plus the pinned performance runner; complete generation publication test. |
+| Linux x86_64 | Required, native host JIT | Required, native ELF | Linux x86_64 PR CI; complete generation publication test. |
+| macOS x86_64 | Required for unsigned/local developer processes | Required, native Mach-O | Native x86_64 macOS CI runner; explicit hardened-process exclusion diagnostic test. |
+| macOS arm64 | Required for unsigned/local developer processes | Required, native Mach-O | Native arm64 macOS CI runner; no translated JIT; explicit hardened-process exclusion diagnostic test. |
+| Android arm64 | Required in Workshop | Required in published package | Named physical arm64 device for Workshop JIT, plus published AOT package/link/launch evidence on arm64. |
+
+JIT is native-host-only. A requested JIT triple different from the running process fails with
+`JIT_TARGET_MUST_MATCH_HOST`; it never falls back to AOT or an interpreter. Production AOT packages
+do not perform source compilation or live JIT swaps. If an AOT watch/loader tool replaces code, it
+must load and publish a complete module through this same owning-reference contract.
+
+iOS arm64 remains AOT-only because the product does not ship a JIT/executable-memory entitlement
+path there. Android x86/x86_64, Windows arm64, Linux arm64, and WebAssembly are outside this task's
+required matrix and must be excluded by target selection rather than silently counted as covered.
+The repository's standard `Stasis_API_35` AVD is x86_64 and may provide a separate Workshop smoke
+check, but it cannot satisfy any Android arm64 G4 gate.
+
+## Performance and memory budgets
+
+These are initial gates, not claims about real games. Every report separates frontend, codegen,
+finalization/link, safe-point wait, publication, old-generation ticks, and executable bytes.
+
+Existing cold trivial-function observations are 11.275 ms for 100 functions, 110.160 ms for 1,000,
+and a historical 1,738.212 ms for 5,000. Their original machine profile was not recorded, so they
+are planning baselines rather than independently reproducible proof. G4 must check in a versioned
+`tests/perf/generation_reference_profile.json` before enforcing the gates. It records runner name,
+CPU model/core count, RAM, OS/build, power profile, target triple, Rust/Cranelift versions, tick
+rate, fixture hashes, parent commit, and benchmark command. A runner profile change requires a
+recorded parent-baseline rerun and contract review; results from another profile are not compared to
+these absolute gates.
+
+The complete-generation implementation must meet these bounded p95 gates on that pinned Windows
+x86_64 performance runner:
+
+| Fixture | Background complete-generation p95 | Edit-to-visible p95 |
+| --- | ---: | ---: |
+| 100 trivial reachable functions | 25 ms | compile time plus at most 2 tick intervals |
+| 1,000 trivial reachable functions | 150 ms | compile time plus at most 2 tick intervals |
+| 5,000 trivial reachable functions | 2,500 ms | compile time plus at most 2 tick intervals |
+| Brickout-scale representative game | Baseline and gate recorded by child G4 | compile time plus at most 2 tick intervals |
+
+Measurement protocol:
+
+1. Build release benchmark binaries before timing; compilation of the benchmark harness is excluded.
+2. Run with the pinned power profile and no concurrent repository compiler/test process.
+3. For cold-generation timing, start from an empty compiler cache and fresh process for each sample.
+4. Run five unmeasured warmups, then 30 measured samples for 100/1,000 functions and 10 measured
+   samples for 5,000 functions and Brickout-scale.
+5. Compute p50 and nearest-rank p95 from raw monotonic-clock nanoseconds. Store every raw sample,
+   phase breakdown, command, profile, and commit in the CI artifact.
+6. Measure edit-to-visible in a persistent runtime after one accepted baseline generation, using 30
+   deterministic one-function edits. Count old-generation ticks from source-revision enqueue through
+   successful publication.
+7. Run the parent commit and candidate commit on the same profile in the same job. The absolute gate
+   controls acceptance; the paired parent result explains environmental drift and is not a waiver.
+
+Publication itself has a p95 budget of 0.25 ms on the pinned Windows performance runner and 1.0 ms
+on the named Android arm64 target, excluding bounded state migration and hook time, and a hard
+requirement below one 60 Hz tick. Other desktop matrix rows record p50/p95 and must remain below one
+tick until a platform-specific tighter gate is established. Old-generation
+tick count must agree with `ceil(background_compile_ms / tick_period_ms)` within two ticks; a long
+compile is update latency, never a frame stall.
+
+At a safe point the runtime may own no more than active + current pending + one transient retiring
+generation. After the next quiescent safe point, retired executable bytes must be zero aside from
+allocator pages explicitly reported as reusable slack. A 100-swap stress test must show no upward
+trend in quiescent executable bytes after normalizing for the active generation size.
+
+Real-game desktop and Android p50/p95 are mandatory before the migration is declared complete. A
+budget miss blocks the relevant child or requires an evidence-backed contract revision; it does not
+authorize partial dispatch, mixed generations, or runtime-thread code generation.
+
+## Implementation sequence and bounded verification gates
+
+### G0 - Contract lock (Maddox #174)
+
+- Replace pointer-table and patch-set requirements in the PRD, specification, checklist, and shared
+  backend architecture notes.
+- Record this state machine, failure table, matrix, budgets, and obsolete-path deletion list.
+- Gate: documentation consistency checks plus repository validation; no runtime behavior claim.
+
+### G1 - Complete direct-call modules (Maddox #175)
+
+- Predeclare and define every reachable function in one JIT module using the shared JIT/AOT
+  direct-call lowering path.
+- Retain semantic caches only before final machine-code ownership.
+- Delete internal arity dispatch imports and per-function machine-code patch assembly.
+- Gates, each under 300 seconds: compiler unit tests; CLIF assertions for leaf, mid-level, shared,
+  recursive/SCC, host-root, added/deleted/renamed, and unreachable functions; representative
+  executable JIT and AOT sample with no internal dispatch imports.
+
+### G2 - Atomic publication and retirement (Maddox #176)
+
+- Add owning `PendingGeneration`/`ActiveGeneration`, versioned messages, single-reference
+  publication, safe-point snapshots, isolated migration/hook execution, supersession, and
+  reference-counted retirement.
+- Delete independent host-entry stores, pointer-table generation commits, and tick-delay retirement.
+- Gates: delayed build runs old code for multiple complete windows; the next window is purely new;
+  A -> B supersession publishes only B; compile/migration/hook failures preserve the exact active
+  reference and state; 100-swap lifetime test reaches zero retired owners.
+
+### G3 - Transition fixture matrix (Maddox #177)
+
+- Cover host roots, ordinary leaf and mid-level callers, shared utilities, recursive/SCC calls,
+  render, `on_code_swap`, multiple edits, add/delete/rename, unreachable changes, compatible body
+  edits, incompatible host ABI/layout edits, syntax/lowering failures, and recovery.
+- Gate: deterministic observable generation/state assertions across JIT and AOT; no fixture may
+  inspect an implementation-only per-function pointer.
+
+### G4 - Platform and performance matrix (Maddox #178)
+
+- Run every required target row and record explicit exclusions.
+- Measure cold generation, edit-to-visible p50/p95, affected function count, frontend/codegen/link/
+  publication time, ticks on old code, and executable-memory retirement for 100/1,000/5,000 and
+  Brickout-scale fixtures.
+- Gates: bounded repository validation, Android Workshop JIT and published AOT acceptance on the
+  named physical arm64 device, separate optional x86_64 AVD smoke, native JIT/AOT CI for supported
+  desktop rows, and all budgets above.
+
+Every child ends with a touched-file cruft pass, a representative compiled Stasis executable, and
+the AGENTS.md Good/Bad/Adjustment and Theory gained summary.
+
+## Obsolete paths to remove
+
+The migration is incomplete while any production path retains:
+
+- internal `FnId -> code_ptr` lookup or per-arity dispatch wrappers;
+- per-function live machine-code reuse, patches, staged pointer overrides, or independent export
+  stores;
+- patch-set-based compile/commit messages or `swapped_fn_ids` as publication truth;
+- hook lookup through a staged per-function pointer preview;
+- fixed tick-count retirement of executable regions;
+- separate JIT indirect-call and AOT direct-call lowering implementations; or
+- fallback behavior that emits placeholder code when complete generation compilation fails.
+
+Compatibility shims may exist only in tests during the child that deletes them and must be removed
+before that child is complete.

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -435,18 +435,19 @@ When a source file changes during development, ownership is:
 
 Interfaces are message-based and versioned. No cross-thread shared mutable compiler/runtime objects.
 
-- `FileChangeEvent`: producer file watcher/input bridge; consumer compiler service; fields `path`, `revision`, `text_source`, `change_kind`.
-- `BuildGeneration`: producer swap coordinator; consumer compiler service; fields `request_id`,
-  `revision`, immutable `source_snapshot_id`, `target`, `host_set`, and immutable active ABI/layout
-  contract.
-- `BuildFinished`: producer compiler service; consumer swap coordinator; fields `request_id`,
-  `revision`, `status`, `diagnostics[]`, and optional owning `pending_generation`.
-- `CommitGeneration`: producer swap coordinator; consumer runtime/main thread safe-point gate; fields
-  `request_id` and owning `pending_generation`.
-- `CommitFinished`: producer runtime/main thread; consumer swap coordinator + UI/status bridge;
-  fields `request_id`, `status`, optional `active_generation_number`, and optional diagnostic.
-- `CancelBuild`: producer swap coordinator; consumer compiler service; fields `request_id` and
-  `superseded_by_request_id`.
+- `FileChangeEvent(path, revision, text_source, change_kind)`: producer file watcher/input bridge;
+  consumer swap coordinator.
+- `BuildGeneration(request_id, revision, source_snapshot_id, target, host_set, active_contract)`:
+  producer swap coordinator; consumer compiler service; the snapshot and active contract are
+  immutable.
+- `BuildFinished(request_id, revision, status, diagnostics[], pending_generation?)`: producer
+  compiler service; consumer swap coordinator; the optional generation transfers ownership.
+- `CommitGeneration(request_id, pending_generation)`: producer swap coordinator; consumer
+  runtime/main thread safe-point gate; the generation transfers ownership.
+- `CommitFinished(request_id, status, active_generation_number?, diagnostic?)`: producer
+  runtime/main thread; consumer swap coordinator + UI/status bridge.
+- `CancelBuild(request_id, superseded_by_request_id)`: producer swap coordinator; consumer compiler
+  service.
 
 ### 12.3 Development Change Sequence (Single File Save)
 

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Stasis Live Compilation & Hot Swap System (File-Level, In-Process, Tick-Based)
+Stasis Live Compilation & Atomic Generation Swap System (File-Level, In-Process, Tick-Based)
 
 ## 1. Purpose & Goals
 
@@ -31,9 +31,10 @@ Android workshop requirements are tracked in `docs/android_workshop_prd.md`. Tha
 
 This system does not aim to:
 
-- support arbitrary runtime schema/layout changes (future possibility)
+- support unbounded or semantically ambiguous runtime schema/layout migration
 - implement full symbol-level dependency invalidation
-- automatically infer state migrations
+- infer semantic transformations beyond the compiler's deterministic path/type/capacity migration
+  rules
 - replace a full debugger
 - optimize production builds beyond baseline Cranelift AOT
 
@@ -60,18 +61,18 @@ Game Process
  |  |- Game loop (tick-based)
  |  |- Global Data
  |  |- Debug UI
- |  \- Function Pointer Table
+ |  \- Atomic ActiveGeneration reference
  |
  |- Compiler Service
  |  |- In-memory file database
  |  |- File-level incremental pipeline
- |  |- Semantic hashing
- |  \- Swap decision logic
+ |  |- Semantic/HIR caches
+ |  \- Complete-generation build decisions
  |
  \- Codegen Service (Cranelift JIT/AOT)
-    |- Code generation
-    |- Executable memory management
-    \- Code versioning
+    |- Shared direct-call JIT/AOT lowering
+    |- Complete module finalization
+    \- Generation-owned executable memory
 ```
 
 Disk I/O is not part of the hot path.
@@ -82,11 +83,13 @@ Disk I/O is not part of the hot path.
 
 - Invalidation unit: file
 - Correctness unit: file
-- Emission unit: function
+- Lowering/cache unit: function
+- Publication unit: complete reachable generation
 - Dead-code pruning unit: function + struct metadata (reachability-based)
 
 Semantic analysis always runs for the entire file.
-Code generation is gated per function.
+Semantic and target-independent lowering work may be gated per function. Every accepted development
+build still finalizes one complete reachable machine-code generation.
 Pruning is symbol-level and happens before Cranelift emission.
 
 ### 4.2 File-Level Pipeline
@@ -100,12 +103,14 @@ Raw Text
  -> Reachability Mark (functions + structs)
  -> Prune Unreachable Symbols
  -> Per-function semantic hashing
- -> Per-function codegen (gated)
+ -> Per-function lowering/cache lookup
+ -> Complete direct-call module finalization
 ```
 
 Reachability roots:
 - `main`
 - `tick` (when present)
+- `render` (when present)
 - `on_code_swap` (when present)
 - host-required exported entry symbols
 
@@ -120,16 +125,20 @@ Each function produces:
 
 Rules:
 
-- If `fnBodyHash` unchanged -> reuse machine code
+- If `fnBodyHash` is unchanged -> reuse target-independent analysis/lowering inputs when safe
 - If layout-affecting semantic fact changes -> full file re-codegen
-- Semantic hash comparison gates backend work only
+- Semantic hashes never reuse live machine code, relocations, or pointers from another generation
 
-### 4.4 Layout Stability Rule
+### 4.4 Generation Compatibility Rule
 
 Hot swap is permitted only if:
 
-- global struct layouts are unchanged
-- function signatures are unchanged (initial implementation constraint)
+- every required host export keeps its declared ABI and phase policy
+- the target and host-set versions remain compatible
+- global state layout is unchanged or the compiler-owned bounded migration plan is compatible
+
+Ordinary internal functions are not compatibility boundaries. They may be added, removed, renamed,
+or change signature because the complete reachable generation and all callers are rebuilt together.
 
 If violated:
 
@@ -175,21 +184,24 @@ alpha /= 180.0;
 Dev/runtime hot-swap mode uses Cranelift JIT.
 Production build mode uses Cranelift AOT outputs.
 
-### 5.1 Function Pointer Table ABI
+### 5.1 Complete Generation ABI
 
-All runtime calls use:
-
-```text
-FnId -> code_ptr
-```
+Every reachable Stasis-to-Stasis call uses a direct call inside one finalized JIT/AOT module. Only
+explicit lifecycle and host-required exports cross the runtime boundary. The runtime snapshots one
+immutable `ActiveGeneration` owning the complete export map, state bindings, and executable memory
+for an execution window.
 
 Rules:
 
-- `FnId` stable across recompiles
-- Call sites use indirect calls
-- No direct calls to raw compiled addresses
+- The compiler discovers host exports from lifecycle roots and the selected host-set manifest.
+- All host exports are published by one atomic owning-reference exchange; independent pointer swaps
+  are forbidden.
+- Internal body pointers never leave the generation and cannot be cached by the host.
+- `FnId` may identify symbols in diagnostics and caches, but is not a runtime dispatch key.
+- A `tick()` and its following `render()` use the same captured generation.
+- JIT and AOT share one direct-call lowering contract.
 
-This enables atomic swaps without patching call sites.
+The detailed ABI and lifetime contract is `docs/jit_generation_contract.md`.
 
 ### 5.2 Runtime API
 
@@ -236,13 +248,13 @@ The runtime API:
 
 ### 6.1 Two-Phase Commit
 
-Phase 1 - Background Compilation
+Phase 1 - Background Generation Build
 
 - File changes ingested
 - Semantics computed
-- Changed functions identified
-- Cranelift compiles changed functions
-- Results stored as a pending patch
+- Reachable functions and host exports resolved
+- Cranelift compiles and finalizes the complete direct-call module
+- Results transferred as one immutable `PendingGeneration`
 
 Phase 2 - Commit (Main Thread, Between Ticks)
 
@@ -250,20 +262,21 @@ Occurs strictly between ticks.
 
 Order:
 
-1. Finish the active generation's `tick()` and `render()`.
-2. Snapshot active bounded state when layout migration or the swap hook can mutate it.
-3. Activate candidate storage and migrate compatible struct/global fields.
-4. Run the candidate `on_code_swap()` when present.
-5. Atomically publish candidate storage bindings and function pointers.
-6. Retire the old code generation and signal runtime feedback.
+1. Finish the active generation's complete `tick()` + `render()` execution window.
+2. Revalidate that the candidate is current and compatible.
+3. Allocate isolated candidate storage and migrate compatible struct/global fields.
+4. Run the candidate `on_code_swap()` against isolated candidate state when present.
+5. Preflight all fallible work.
+6. Atomically replace the one owning `ActiveGeneration` reference.
+7. Release the old generation when its last execution-window reference ends.
 
 If any step fails, swap is aborted.
 
 This commit exists only for a pending code generation. It is not part of ordinary gameplay tick
 semantics: the host does not infer gameplay changes, and Stasis programs expose no
 `commit_tick`, `normalize_tick`, or `validate_tick` lifecycle functions. The first candidate
-`tick()` runs only after migration and publication succeed; rejection restores the old code and
-state before another tick begins.
+`tick()` runs only after migration and publication succeed; rejection destroys isolated candidate
+code/state while the old active generation remains unchanged.
 
 ## 7. Swap Hook (User-Defined)
 
@@ -288,10 +301,12 @@ function on_code_swap(): void {
 Properties:
 
 - Optional
-- Runs once per successful swap attempt
+- Runs at most once after a candidate enters hook execution; an attempt may later reject, trap, or
+  become superseded
+- A successfully published candidate with a hook runs it exactly once
 - Runs between ticks
 - Executes as candidate code before publication and before the next `tick()`
-- May mutate global data
+- May mutate only isolated candidate global data
 - Must not invoke gameplay entrypoints
 
 ### 7.3 Enforcement Rules
@@ -405,32 +420,50 @@ Rules:
 
 When a source file changes during development, ownership is:
 
-- Runtime/Main Thread: owns tick loop, safe-point detection, and final swap commit; never performs parsing/semantic/codegen work inline with tick execution.
-- Compiler Service Thread: owns lex/parse/index/semantic/hash analysis for changed files and produces either diagnostics or a staged swap candidate; it never activates candidate runtime state.
-- Codegen Service (Cranelift): owns JIT code emission for dev mode and AOT emission for prod mode; never mutates runtime state directly.
-- Swap Coordinator: owns two-phase commit transaction boundaries, all-or-nothing swap rules, and generation retirement scheduling after successful commit.
+- Runtime/Main Thread: owns the tick loop, execution-window generation snapshot, safe-point detection,
+  isolated state migration/hook transaction, and one-reference publication. It never parses, checks,
+  lowers, generates, links, or finalizes code.
+- Compiler Service Thread: owns an immutable source snapshot, lex/parse/index/semantic/hash analysis,
+  reachability, and complete `PendingGeneration` construction. It never reads or mutates runtime
+  values.
+- Codegen Service (Cranelift): owns shared direct-call JIT/AOT emission and complete module
+  finalization. It transfers an owning artifact rather than per-function pointers.
+- Swap Coordinator: owns request ordering, cancellation/supersession, message transport, and
+  all-or-nothing commit orchestration.
 
 ### 12.2 High-Level Interface Contracts (Development Mode)
 
 Interfaces are message-based and versioned. No cross-thread shared mutable compiler/runtime objects.
 
 - `FileChangeEvent`: producer file watcher/input bridge; consumer compiler service; fields `path`, `revision`, `text_source`, `change_kind`.
-- `CompileRequest`: producer swap coordinator; consumer compiler service; fields `request_id`, `changed_files[]`, `target_mode=jit-dev`.
-- `CompileResult`: producer compiler service; consumer swap coordinator; fields `request_id`, `status`, `diagnostics[]`, `layout_hash`, `fn_patch_set`, optional `hook_symbol`.
-- `SwapCommitRequest`: producer swap coordinator; consumer runtime/main thread safe-point gate; fields `request_id`, `layout_hash`, `fn_patch_set`, `hook_symbol`.
-- `SwapCommitResult`: producer runtime/main thread; consumer swap coordinator + UI/status bridge; fields `request_id`, `status`, `swapped_fn_ids[]`, `new_generation`, `error`.
+- `BuildGeneration`: producer swap coordinator; consumer compiler service; fields `request_id`,
+  `revision`, immutable `source_snapshot_id`, `target`, `host_set`, and immutable active ABI/layout
+  contract.
+- `BuildFinished`: producer compiler service; consumer swap coordinator; fields `request_id`,
+  `revision`, `status`, `diagnostics[]`, and optional owning `pending_generation`.
+- `CommitGeneration`: producer swap coordinator; consumer runtime/main thread safe-point gate; fields
+  `request_id` and owning `pending_generation`.
+- `CommitFinished`: producer runtime/main thread; consumer swap coordinator + UI/status bridge;
+  fields `request_id`, `status`, optional `active_generation_number`, and optional diagnostic.
+- `CancelBuild`: producer swap coordinator; consumer compiler service; fields `request_id` and
+  `superseded_by_request_id`.
 
 ### 12.3 Development Change Sequence (Single File Save)
 
 1. Watcher emits `FileChangeEvent`.
-2. Swap coordinator coalesces pending events and emits `CompileRequest`.
+2. Swap coordinator coalesces pending events, supersedes older requests, and emits
+   `BuildGeneration`.
 3. Compiler service runs full-file semantic pass.
-4. Compiler/codegen returns `CompileResult` with diagnostics or a patch plus its staged JIT candidate.
-5. If diagnostics exist, patch is discarded and old code remains active.
+4. Compiler/codegen returns `BuildFinished` with diagnostics or one finalized
+   `PendingGeneration`.
+5. If diagnostics exist or the result is stale, the candidate is discarded and old code remains
+   active.
 6. If eligible, coordinator waits for between-ticks safe point.
-7. Main thread runs the shared bounded state-migration transaction and `on_code_swap()` (if present).
-8. Main thread atomically activates the candidate runtime and pointer-table update, then records the new generation.
-9. Runtime publishes `SwapCommitResult`; debug UI updates swap indicator only on success.
+7. Main thread creates isolated candidate state, runs bounded migration and candidate
+   `on_code_swap()` (if present), and preflights publication.
+8. Main thread atomically replaces the complete `ActiveGeneration` reference and assigns the next
+   successful generation number.
+9. Runtime publishes `CommitFinished`; debug UI updates swap indicator only on success.
 
 Failure at any sequence step aborts commit and preserves old code/data.
 
@@ -447,59 +480,71 @@ Constraints:
 
 ## 13. Code Memory Management
 
-- Executable memory allocated per generation
-- Each successful swap increments generation
-- Old generations retired after safe window
-- Memory freed in bulk
+- Executable memory, exports, metadata, and state bindings share one generation owner.
+- Each successful one-reference publication increments the generation number.
+- Execution windows hold an owning reference; old code is freed in bulk after the last reference
+  ends, not after a fixed tick delay.
+- Fibers, suspended Stasis frames, cached code pointers, and callbacks retaining guest pointers are
+  unsupported and rejected deterministically.
+- Steady operation owns at most active + current pending + one transient retiring generation; a
+  superseded pending generation is released immediately.
 
 ## 14. Performance Targets
 
-| Scenario               | Target   |
-| ---------------------- | -------- |
-| Single function edit   | 10-25 ms |
-| Multiple function edit | 15-40 ms |
-| Comment-only change    | <15 ms   |
-| Swap commit            | <1 tick  |
+| Scenario | Initial p95 gate |
+| --- | ---: |
+| Complete 100-function trivial generation | 25 ms background |
+| Complete 1,000-function trivial generation | 150 ms background |
+| Complete 5,000-function trivial generation | 2,500 ms background |
+| Desktop owning-reference publication | 0.25 ms |
+| Android arm64 owning-reference publication | 1.0 ms |
 
-Disk I/O must not be on hot path.
+Edit-to-visible latency is background build time plus at most two tick intervals. Compilation may
+take many ticks while the old generation keeps running; it may not stall the runtime thread. The
+full measurement and executable-memory budgets are in `docs/jit_generation_contract.md`. Disk I/O
+must not be on the hot path.
 
 ## 15. Development Phases
 
-Phase 0:
-- Pointer table only
+Phase G0:
+- Lock the complete-generation ABI, lifecycle, matrix, budgets, and deletion list.
 
-Phase 1:
-- In-process compiler, file-level semantics
+Phase G1:
+- Emit one complete direct-call JIT module through shared JIT/AOT lowering.
 
-Phase 2:
-- Per-function codegen gating
+Phase G2:
+- Publish one owning generation reference between windows and retire by ownership.
 
-Phase 3:
-- Cranelift JIT (dev), swap hook, swap indicator
+Phase G3:
+- Prove the complete edit/failure transition matrix with deterministic executable fixtures.
 
-Phase 4:
-- Cranelift AOT (prod) artifact path
-Phase 5 (Optional):
-- LSP integration, live data inspection
+Phase G4:
+- Enforce the desktop/Android JIT/AOT platform and performance matrix.
+
+The prior pointer-table/patch-set phases describe migration substrate only. They are not retained as
+a compatibility path and are deleted by G1-G2.
 
 ## 16. Key Risks & Mitigations
 
-| Risk                   | Mitigation                                        |
-| ---------------------- | ------------------------------------------------- |
-| Stale code execution   | Atomic pointer swaps                              |
-| Partial state mutation | Swap hook transactional                           |
-| Developer confusion    | Swap indicator                                    |
-| Complexity creep       | File-level only                                   |
-| Inlining side effects  | Inline supported but inline change forces rebuild |
+| Risk | Mitigation |
+| --- | --- |
+| Mixed-generation execution | One immutable generation snapshot per execution window |
+| Stale build publication | Monotonic request IDs plus current-revision check at commit |
+| Partial state mutation | Isolated candidate state and fallible work before publication |
+| Use-after-free code | Owning execution-window references and no retained guest pointers |
+| Runtime frame stalls | Complete build/finalization restricted to compiler thread |
+| Complexity creep | Complete reachable module; no partial-dispatch compatibility path |
 
 ## 17. Success Criteria
 
 System is successful when:
 
-- Save -> new logic runs next tick
+- Save -> the latest complete successful generation runs after a safe-point publication
 - Game state persists
 - Swap confirmation is visible
 - Errors are safe and clear
+- A tick/render window never mixes generations
+- Internal calls contain no runtime dispatch lookup
 - Architecture remains understandable
 
 ## 18. Summary
@@ -513,4 +558,6 @@ This system is intentionally:
 - fast
 - developer-trust-focused
 
-It provides a robust, file-level hot reload pipeline with per-function efficiency, an explicit swap hook, and a deterministic tick-based UI confirmation mechanism.
+It provides a robust, file-correct hot reload pipeline with reusable semantic work, complete
+direct-call generations, an explicit transactional swap hook, and deterministic tick-based UI
+confirmation.

--- a/docs/shared_cranelift_backend_contract.md
+++ b/docs/shared_cranelift_backend_contract.md
@@ -32,9 +32,8 @@ When this work is complete:
   lowering and compile-analysis logic.
 - `jit.rs` mostly owns:
   - host/runtime symbol addresses
-  - JIT module finalization into executable memory
-  - code pointer / dispatch-table publication
-  - JIT-only runtime table refresh
+  - complete JIT module finalization into generation-owned executable memory
+  - construction of the immutable host-export map
 - `aot.rs` mostly owns:
   - extern binding policy for the linked runtime
   - direct-call/import policy where needed
@@ -90,16 +89,16 @@ It should answer:
    - `ObjectModule`
 
 2. How do internal calls lower?
-   - JIT runtime dispatch helper path
-   - AOT direct/imported call path
+   - Both JIT and AOT use module-local direct calls.
+   - Backend policy declares/finalizes symbols but cannot select a runtime dispatch path.
 
 3. How are externs resolved?
    - JIT: resolve to concrete host addresses
    - AOT: resolve to the symbol names exported by the linked runtime
 
-4. How is the compiled function finalized?
-   - JIT: define, finalize, publish code pointer
-   - AOT: define, finish module, emit object bytes
+4. How is the complete module finalized?
+   - JIT: define all reachable bodies, finalize, and return one owned pending generation
+   - AOT: define all reachable bodies, finish the module, and emit one linked artifact set
 
 Everything else should stay in shared code.
 
@@ -121,8 +120,8 @@ Everything else should stay in shared code.
 
 - lookup of host symbol addresses
 - registration of concrete symbol pointers in `JITBuilder`
-- final code pointer extraction
-- dispatch-table publication and runtime refresh
+- complete module finalization
+- host-export address extraction into generation-owned metadata
 
 ### AOT-only code may own
 
@@ -147,7 +146,7 @@ families.
 
 3. Calls
    - shared signature matching and argument lowering
-   - backend policy decides only internal-call execution mode
+   - shared module-local direct-call declarations and emission
 
 4. Control flow
    - `if`, `for`, `foreach`, `return`, `continue`
@@ -166,8 +165,8 @@ The shared compile path should converge on something conceptually like this:
 
 ```rust
 struct SharedCompileInputs<'a> {
-    meta: &'a FunctionMeta,
-    hir: &'a FunctionHIR,
+    reachable_functions: &'a [FunctionHIR],
+    host_exports: &'a HostExportManifest,
     analysis: &'a CompileAnalysisCache,
     type_table: &'a mut TypeTable,
 }
@@ -177,24 +176,19 @@ trait BackendCompilePolicy {
     type Artifact;
 
     fn module(&mut self) -> &mut Self::ModuleT;
-    fn internal_call_mode(&mut self, self_function_id: FunctionId, self_func_id: FuncId)
-        -> InternalCallMode<'_>;
-    fn finalize(
-        &mut self,
-        function_id: FuncId,
-        context: &mut cranelift_codegen::Context,
-    ) -> Result<Self::Artifact, String>;
+    fn finalize_module(self, exports: &[DeclaredHostExport]) -> Result<Self::Artifact, String>;
 }
 
-fn compile_function_with_policy<P: BackendCompilePolicy>(
+fn compile_generation_with_policy<P: BackendCompilePolicy>(
     inputs: SharedCompileInputs<'_>,
-    policy: &mut P,
+    policy: P,
 ) -> Result<P::Artifact, String>;
 ```
 
 The exact types can differ, but the seam should look like this:
 
-- shared compile function owns compile mechanics
+- shared compile function predeclares all reachable functions, owns per-function compile mechanics,
+  and emits direct internal references in one module
 - backend policy owns only the narrow behavior that truly differs
 
 ## Current Remaining Divergences To Eliminate
@@ -210,7 +204,9 @@ The exact types can differ, but the seam should look like this:
    - AOT still needs a stricter shared resolution policy for link targets
 
 3. Internal-call mode differences
-   - these should remain, but only as an explicit policy seam
+   - the historical JIT dispatch-helper mode is obsolete
+   - both backends must use the shared direct-call path described in
+     `docs/jit_generation_contract.md`
 
 4. Separate AOT helper tool path
    - if retained, it should not become a second lowering implementation
@@ -232,7 +228,7 @@ Recommended implementation order:
 
 1. Share compile-analysis and extern/import policy.
 2. Extract one shared per-function compile pipeline.
-3. Reduce internal-call divergence to an explicit policy switch only.
+3. Remove the JIT internal-dispatch policy switch and finalize complete direct-call generations.
 4. Add parity and architecture regressions to keep the split stable.
 
 This order improves correctness first, then performs the larger mechanical

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,7 +19,8 @@ Core direction:
 - Cranelift AOT for production builds.
 - File-level incremental compilation.
 - Symbol-level reachability pruning before lowering (functions + struct metadata).
-- Reachability roots: `main`, `tick`, `on_code_swap` (when present), and host-required exported entries.
+- Reachability roots: lifecycle entries present in the program (`main`, `tick`, `render`,
+  `on_code_swap`) and host-required exported entries.
 - Hot swap only between ticks.
 - Rust host/runtime with a Rust-implemented compiler pipeline.
 
@@ -525,6 +526,17 @@ Stasis treats these as strongly typed references/views, not implicit by-value co
 - Struct/array returns must reference global-backed storage (for example a global struct field/element path).
 - Struct-typed temporaries are not materialized as standalone local value objects in Stasis.
 
+### 7.6 Compiled Call Generations
+
+Within one compiled JIT or AOT generation, every resolved Stasis-to-Stasis call is a direct call to
+the callee in that generation. This includes recursion and mutually recursive functions. Runtime
+lookup by function ID is not part of Stasis call semantics.
+
+Only lifecycle and host-required exports cross the host boundary. Their signatures are stable ABI
+contracts. Ordinary internal functions may be added, removed, renamed, or change signature during
+a live edit because the compiler rebuilds every reachable caller in the same candidate generation.
+The host must not retain any compiled entry address after the execution window that resolved it.
+
 ## 8. Enums
 
 Enums are named types that lower to integer values.
@@ -685,11 +697,15 @@ function draw_debug_ui(): void {
 
 ## 14. Incremental Compilation and Hot Swap
 
+The compiler/runtime ownership, generation state machine, platform matrix, and performance gates are
+defined in `docs/jit_generation_contract.md`.
+
 ### 14.1 Granularity
 
 - Invalidation unit: file
 - Correctness unit: file
-- Emission unit: function
+- Analysis/cache unit: function
+- Publication unit: complete reachable generation
 
 ### 14.2 Hashes
 
@@ -697,7 +713,8 @@ function draw_debug_ui(): void {
 - `fnBodyHash`: behavior
 
 Rules:
-- Unchanged `fnBodyHash` can reuse generated machine code.
+- Unchanged `fnBodyHash` can reuse target-independent analysis or lowering inputs.
+- Live machine code, relocations, and code pointers cannot be reused across generations.
 - Layout-affecting changes force conservative rebuild for changed file.
 
 ### 14.3 Two-Phase Swap
@@ -705,29 +722,37 @@ Rules:
 1. Background compile:
 - Re-lex, parse, index, and semantic-check changed file.
 - Compute per-function semantic hashes.
-- Compile changed functions.
+- Resolve the complete lifecycle/host-export root set and reachable call/type graph.
+- Finalize every reachable function into one direct-call `PendingGeneration` off the runtime thread.
 2. Commit between ticks:
-- Snapshot active bounded state when migration or `on_code_swap()` may mutate it.
-- Activate candidate storage and migrate compatible struct/global fields.
-- Run the candidate `on_code_swap()` if present.
-- Atomically publish candidate storage bindings and function pointers.
-- Retire the previous code generation.
+- Wait until the current generation's `tick()` and following `render()` have both returned.
+- Revalidate that the candidate is the newest requested revision and its host-export ABI is
+  compatible.
+- Create isolated candidate storage and migrate compatible struct/global fields.
+- Run the candidate `on_code_swap()` against candidate storage if present.
+- Complete every fallible preflight, then atomically replace one owning `ActiveGeneration`
+  reference containing all exports, bindings, metadata, and executable memory.
+- Release the previous generation when its last execution-window owner ends.
 
 Swap is rejected if:
 - Global layout changes and state-map migration is missing or incompatible.
-- Signature compatibility changes.
+- A required host-export signature changes.
 - `on_code_swap()` fails.
+- The candidate is cancelled or superseded.
+- The target cannot provide atomic owning-reference publication.
 
 Current policy (pre-1.0):
 - Layout-affecting semantic edits produce a versioned preview and require explicit apply.
-- The preview reports candidate dispatch-patch functions, state-layout compatibility, struct or whole-state scope, migration steps, capacity-shrink warnings, and estimated commit cost.
+- The preview reports the complete candidate generation, state-layout compatibility, struct or
+  whole-state scope, migration steps, capacity-shrink warnings, and estimated commit cost.
 - Apply regenerates the preview; any preview/commit mismatch rejects the swap.
 
 On rejection, old code and old data remain active.
 
 Current migration policy (pre-1.0):
 - JIT and AOT derive layout identity from the same canonical compiler-owned state-layout model; source text and function bodies are not layout identity inputs.
-- Development JIT compilation produces a staged runtime candidate and never activates dispatch, literals, collection headers, or state from the compiler thread.
+- Development JIT compilation produces a complete staged runtime generation and never activates
+  code, literals, collection headers, or state from the compiler thread.
 - Every JIT entry point uses the same migration planner and bounded transactional activation at the runtime safe point. There is no scalar-only runner migration path.
 - Layout-changing commits without a staged JIT candidate, including current AOT runtime swaps, reject with a restart-required diagnostic.
 - Migration compatibility is path-based: overlapping paths must keep compatible scalar or collection-element type shape.
@@ -735,19 +760,21 @@ Current migration policy (pre-1.0):
 - Fixed-collection growth is storage-ownership preflighted and bounded before allocation, preserves the old prefix, and initializes the expanded tail.
 - Shrink copies the retained prefix, warns about the discarded range, and clamps logical lengths; UTF-8 shrink retains the largest valid code-point prefix and recomputes byte and character counts.
 - Incompatible or missing state metadata fails deterministically with an actionable diagnostic.
-- Migration, `on_code_swap`, or pointer commit failure restores the old code and complete bounded runtime snapshot; partial migration is forbidden.
+- Migration or `on_code_swap` failure destroys isolated candidate state; the old active generation
+  was never mutated. Partial publication is forbidden.
 
 The migration transaction is a code-swap operation, not a gameplay transaction. Ordinary calls to
 `tick()` do not commit pools, normalize gameplay state, or invoke migration lifecycle functions.
 When a compiled candidate changes a struct or global layout, the host waits until the current
 `tick()` and `render()` have both returned. At that between-ticks safe point it snapshots the active
-state, activates candidate storage, copies compatible fields, initializes new fields, runs
-`on_code_swap()` if present, and atomically publishes the candidate code and migrated state. The
+state into isolated candidate storage, copies compatible fields, initializes new fields, runs
+`on_code_swap()` if present, and atomically publishes the one complete candidate generation. The
 next `tick()` is the first gameplay call allowed to observe the new generation.
 
 There is one visibility rule: a tick and its following render use one code/layout generation. A
-failed migration or swap hook restores the complete old generation before gameplay resumes; no
-candidate field, storage binding, function pointer, or partial value may be visible to the next
+failed migration or swap hook destroys the isolated candidate while the old active generation
+remains unchanged; no
+candidate field, storage binding, export, or partial value may be visible to the next
 tick. The executable fixtures under `samples/between_tick_layout_migration/` cover accepted and
 rejected struct growth across this boundary.
 
@@ -809,22 +836,33 @@ During development, file-change handling uses explicit role ownership and messag
 
 Role ownership:
 - Runtime/main thread owns tick loop, safe-point gating, and final commit.
-- Compiler service thread owns lex/parse/index/semantic/hash and patch assembly.
-- Codegen service owns backend emission (JIT for dev, AOT for prod artifacts).
-- Swap coordinator owns transactional all-or-nothing commit orchestration.
+- Compiler service thread owns an immutable source snapshot, lex/parse/index/semantic/hash,
+  reachability, and complete candidate assembly.
+- Codegen service owns shared direct-call backend emission and complete module finalization (JIT for
+  dev, AOT for prod artifacts).
+- Swap coordinator owns request ordering, supersession, and transactional all-or-nothing commit
+  orchestration.
 
 Required high-level message contracts:
 - `FileChangeEvent(path, revision, text_source, change_kind)`
-- `CompileRequest(request_id, changed_files[], target_mode)`
-- `CompileResult(request_id, status, diagnostics[], layout_hash, fn_patch_set, hook_symbol?, staged_candidate?)`
-- `SwapCommitRequest(request_id, layout_hash, fn_patch_set, hook_symbol)`
-- `SwapCommitResult(request_id, status, swapped_fn_ids[], new_generation, error)`
+- `BuildGeneration(request_id, revision, source_snapshot_id, target, host_set, active_contract)`
+- `BuildFinished(request_id, revision, status, diagnostics[], pending_generation?)`
+- `CommitGeneration(request_id, pending_generation)`
+- `CommitFinished(request_id, status, active_generation_number?, diagnostic?)`
+- `CancelBuild(request_id, superseded_by_request_id)`
 
 Rules:
 - Compiler/codegen services must not mutate runtime game state directly.
 - Runtime must not execute parser/semantic/codegen work on tick path.
 - Commit may occur only between ticks and must be all-or-nothing.
 - Any failure at compile or commit stage preserves old code and old data.
+- An execution window owns one immutable generation reference from before `tick()` until after its
+  following `render()` returns.
+- Candidates superseded before hook entry never run `on_code_swap()`. If supersession arrives while
+  a synchronous hook is already running, the hook may finish only to unwind; all isolated effects
+  are discarded and that candidate never publishes.
+- Guest fibers, suspended frames, threads, or retained host callback/code pointers are unsupported
+  and must fail deterministically.
 
 ## 15. Swap Hook
 
@@ -837,11 +875,14 @@ function on_code_swap(): void {
 ```
 
 Rules:
-- Runs once per successful swap attempt.
+- Runs at most once after a candidate enters hook execution; the attempt may later reject, trap, or
+  become superseded.
+- Runs exactly once for every successfully published candidate that defines the hook.
 - Runs between ticks.
 - Runs before new code executes.
-- May mutate global data.
-- May call `reject_code_swap()` to abort; the runtime restores the old code and complete bounded state snapshot.
+- May mutate only isolated candidate global data.
+- May call `reject_code_swap()` to abort; the runtime destroys the candidate, and the old active
+  code/state remain unchanged.
 - Must not invoke gameplay entrypoints.
 
 ## 16. Diagnostics

--- a/tools/ci/check_jit_generation_contract.py
+++ b/tools/ci/check_jit_generation_contract.py
@@ -68,6 +68,17 @@ def validate_documents(documents: Mapping[str, str]) -> None:
     ):
         require(contract, invariant, contract_path)
 
+    message_shapes = (
+        "FileChangeEvent(path, revision, text_source, change_kind)",
+        "BuildGeneration(request_id, revision, source_snapshot_id, target, host_set, active_contract)",
+        "BuildFinished(request_id, revision, status, diagnostics[], pending_generation?)",
+        "CommitGeneration(request_id, pending_generation)",
+        "CommitFinished(request_id, status, active_generation_number?, diagnostic?)",
+        "CancelBuild(request_id, superseded_by_request_id)",
+    )
+    for message_shape in message_shapes:
+        require(contract, message_shape, contract_path)
+
     for state_rule in (
         "`Preparing(N,R)` | newer revision queued or supersession observed",
         "`Hook(N,R)` | newer revision queued while the hook is running",
@@ -115,6 +126,8 @@ def validate_documents(documents: Mapping[str, str]) -> None:
     require(prd, "Ordinary internal functions are not compatibility boundaries", prd_path)
     require(prd, "global state layout is unchanged or the compiler-owned bounded migration plan is compatible", prd_path)
     require(prd, "May mutate only isolated candidate global data", prd_path)
+    for message_shape in message_shapes:
+        require(prd, message_shape, prd_path)
     require(
         prd,
         "- `main` - `tick` (when present) - `render` (when present) "
@@ -126,6 +139,8 @@ def validate_documents(documents: Mapping[str, str]) -> None:
     spec = documents[spec_path]
     require(spec, "(`main`, `tick`, `render`, `on_code_swap`)", spec_path)
     require(spec, "May mutate only isolated candidate global data", spec_path)
+    for message_shape in message_shapes:
+        require(spec, message_shape, spec_path)
     require(
         spec,
         "If supersession arrives while a synchronous hook is already running, the hook may finish "

--- a/tools/ci/check_jit_generation_contract.py
+++ b/tools/ci/check_jit_generation_contract.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Reject contradictory direct-call generation documentation."""
+
+from pathlib import Path
+from typing import Mapping
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCUMENTS = (
+    "docs/jit_generation_contract.md",
+    "docs/live-compilation-prd.md",
+    "docs/spec.md",
+    "docs/build_checklist.md",
+    "docs/shared_cranelift_backend_contract.md",
+    "docs/cranelift_backend_guardrails.md",
+)
+
+
+class ContractError(ValueError):
+    """A canonical document is missing or contradicts the generation contract."""
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.split())
+
+
+def require(text: str, needle: str, relative: str) -> None:
+    if normalized(needle) not in normalized(text):
+        raise ContractError(
+            f"{relative}: missing required generation contract text: {needle!r}"
+        )
+
+
+def forbid(text: str, needle: str, relative: str) -> None:
+    if normalized(needle) in normalized(text):
+        raise ContractError(
+            f"{relative}: obsolete generation contract text remains: {needle!r}"
+        )
+
+
+def load_documents(root: Path = ROOT) -> dict[str, str]:
+    return {
+        relative: (root / relative).read_text(encoding="utf-8")
+        for relative in DOCUMENTS
+    }
+
+
+def validate_documents(documents: Mapping[str, str]) -> None:
+    contract_path = "docs/jit_generation_contract.md"
+    contract = documents[contract_path]
+    for heading in (
+        "## Non-negotiable invariants",
+        "## One generation state machine",
+        "## Failure table",
+        "## Target and platform matrix",
+        "## Performance and memory budgets",
+        "## Implementation sequence and bounded verification gates",
+        "## Obsolete paths to remove",
+    ):
+        require(contract, heading, contract_path)
+
+    for invariant in (
+        "one `ActiveGeneration` reference",
+        "Calls between Stasis functions are direct Cranelift calls",
+        "No Stasis frame or raw compiled pointer may outlive its execution window",
+        "A failed or superseded build never becomes visible",
+        "never run on the runtime thread",
+    ):
+        require(contract, invariant, contract_path)
+
+    for state_rule in (
+        "`Preparing(N,R)` | newer revision queued or supersession observed",
+        "`Hook(N,R)` | newer revision queued while the hook is running",
+        "`Publishing(N,R)` | current-request compare-and-exchange fails",
+        "`Publishing(N,R)` | current-request compare-and-exchange succeeds",
+        "a revision ordered after it is a new request based on `N+1`",
+    ):
+        require(contract, state_rule, contract_path)
+
+    for failure_rule in (
+        "Request is superseded during migration or hook execution",
+        "Current-request compare-and-exchange fails",
+        "Internal unresolved call or cross-generation import",
+        "Attempted retained pointer, callback, fiber, or guest thread",
+    ):
+        require(contract, failure_rule, contract_path)
+
+    for target_rule in (
+        "Windows x86_64 PR CI plus the pinned performance runner",
+        "Linux x86_64 PR CI",
+        "Native x86_64 macOS CI runner",
+        "Native arm64 macOS CI runner",
+        "Named physical arm64 device for Workshop JIT",
+        "standard `Stasis_API_35` AVD is x86_64",
+        "JIT_TARGET_MUST_MATCH_HOST",
+    ):
+        require(contract, target_rule, contract_path)
+
+    for performance_rule in (
+        "tests/perf/generation_reference_profile.json",
+        "five unmeasured warmups",
+        "30 measured samples for 100/1,000 functions",
+        "10 measured samples for 5,000 functions and Brickout-scale",
+        "nearest-rank p95",
+        "Run the parent commit and candidate commit on the same profile",
+        "100-swap stress test",
+    ):
+        require(contract, performance_rule, contract_path)
+
+    for relative in DOCUMENTS[1:]:
+        require(documents[relative], contract_path, relative)
+
+    prd_path = "docs/live-compilation-prd.md"
+    prd = documents[prd_path]
+    require(prd, "Ordinary internal functions are not compatibility boundaries", prd_path)
+    require(prd, "global state layout is unchanged or the compiler-owned bounded migration plan is compatible", prd_path)
+    require(prd, "May mutate only isolated candidate global data", prd_path)
+    require(
+        prd,
+        "- `main` - `tick` (when present) - `render` (when present) "
+        "- `on_code_swap` (when present) - host-required exported entry symbols",
+        prd_path,
+    )
+
+    spec_path = "docs/spec.md"
+    spec = documents[spec_path]
+    require(spec, "(`main`, `tick`, `render`, `on_code_swap`)", spec_path)
+    require(spec, "May mutate only isolated candidate global data", spec_path)
+    require(
+        spec,
+        "If supersession arrives while a synchronous hook is already running, the hook may finish "
+        "only to unwind; all isolated effects are discarded and that candidate never publishes",
+        spec_path,
+    )
+
+    checklist_path = "docs/build_checklist.md"
+    checklist = documents[checklist_path]
+    require(
+        checklist,
+        "Reachability-DCE roots are lifecycle entries present in the program "
+        "(`main`, `tick`, `render`, `on_code_swap`) plus host-exported required entry symbols",
+        checklist_path,
+    )
+    for child in ("#174", "#175", "#176", "#177", "#178"):
+        require(checklist, f"Maddox task: {child}.", checklist_path)
+    require(checklist, "#### Superseded checklist requirements", checklist_path)
+
+    forbidden_by_file = {
+        prd_path: (
+            "FnId -> code_ptr",
+            "fn_patch_set",
+            "swapped_fn_ids",
+            "global struct layouts are unchanged",
+            "function signatures are unchanged",
+            "rejection restores the old code and state",
+            "Runs once per successful swap attempt",
+        ),
+        spec_path: (
+            "FnId -> code_ptr",
+            "fn_patch_set",
+            "swapped_fn_ids",
+            "Unchanged `fnBodyHash` can reuse generated machine code",
+            "failed migration or swap hook restores the complete old generation",
+            "runtime restores the old code and complete bounded state snapshot",
+            "Superseded candidates never run `on_code_swap()`",
+            "Runs once per successful swap attempt",
+        ),
+    }
+    for relative, obsolete_phrases in forbidden_by_file.items():
+        for obsolete in obsolete_phrases:
+            forbid(documents[relative], obsolete, relative)
+
+
+def main() -> None:
+    try:
+        validate_documents(load_documents())
+    except ContractError as error:
+        raise SystemExit(str(error)) from error
+    print("JIT generation documentation contract is consistent")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/test_jit_generation_contract.py
+++ b/tools/ci/test_jit_generation_contract.py
@@ -1,0 +1,86 @@
+import copy
+import unittest
+
+from tools.ci import check_jit_generation_contract as contract_check
+
+
+class JitGenerationContractCheckTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.documents = contract_check.load_documents()
+
+    def assert_mutation_fails(self, relative: str, old: str, new: str = "") -> None:
+        mutated = copy.deepcopy(self.documents)
+        self.assertIn(old, mutated[relative])
+        mutated[relative] = mutated[relative].replace(old, new, 1)
+        with self.assertRaises(contract_check.ContractError):
+            contract_check.validate_documents(mutated)
+
+    def test_current_documents_pass(self) -> None:
+        contract_check.validate_documents(self.documents)
+
+    def test_missing_preparing_supersession_transition_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "`Preparing(N,R)` | newer revision queued or supersession observed",
+            "`Preparing(N,R)` | source event",
+        )
+
+    def test_missing_hook_supersession_transition_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "`Hook(N,R)` | newer revision queued while the hook is running",
+            "`Hook(N,R)` | source event",
+        )
+
+    def test_old_prd_signature_rule_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/live-compilation-prd.md",
+            "Ordinary internal functions are not compatibility boundaries.",
+            "function signatures are unchanged",
+        )
+
+    def test_missing_render_root_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/build_checklist.md",
+            "Reachability-DCE roots are lifecycle entries present in the program (`main`, `tick`, `render`,\n  `on_code_swap`) plus host-exported required entry symbols",
+            "Reachability-DCE roots are lifecycle entries present in the program (`main`, `tick`,\n  `on_code_swap`) plus host-exported required entry symbols",
+        )
+
+    def test_missing_prd_render_root_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/live-compilation-prd.md",
+            "- `render` (when present)\n",
+        )
+
+    def test_old_spec_restore_rule_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/spec.md",
+            "the runtime destroys the candidate, and the old active\n  code/state remain unchanged",
+            "the runtime restores the old code and complete bounded state snapshot",
+        )
+
+    def test_missing_benchmark_protocol_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "five unmeasured warmups",
+            "some warmups",
+        )
+
+    def test_missing_mid_hook_supersession_rule_fails(self) -> None:
+        self.assert_mutation_fails(
+            "docs/spec.md",
+            "If supersession arrives while\n  a synchronous hook is already running, the hook may finish only to unwind; all isolated effects\n  are discarded and that candidate never publishes",
+            "A superseded hook does not publish",
+        )
+
+    def test_android_arm64_gate_cannot_use_x86_avd(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "The repository's standard `Stasis_API_35` AVD is x86_64",
+            "The repository's standard `Stasis_API_35` AVD satisfies Android arm64",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_jit_generation_contract.py
+++ b/tools/ci/test_jit_generation_contract.py
@@ -26,6 +26,27 @@ class JitGenerationContractCheckTests(unittest.TestCase):
             "`Preparing(N,R)` | source event",
         )
 
+    def test_build_finished_status_is_required(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "BuildFinished(request_id, revision, status, diagnostics[], pending_generation?)",
+            "BuildFinished(request_id, revision, diagnostics[], pending_generation?)",
+        )
+
+    def test_build_generation_snapshot_is_required(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "BuildGeneration(request_id, revision, source_snapshot_id, target, host_set, active_contract)",
+            "BuildGeneration(request_id, revision, target, host_set, active_contract)",
+        )
+
+    def test_file_change_event_shape_is_required(self) -> None:
+        self.assert_mutation_fails(
+            "docs/jit_generation_contract.md",
+            "FileChangeEvent(path, revision, text_source, change_kind)",
+            "SourceChange(revision, changed_files, source_snapshot_id)",
+        )
+
     def test_missing_hook_supersession_transition_fails(self) -> None:
         self.assert_mutation_fails(
             "docs/jit_generation_contract.md",

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -9,6 +9,8 @@ if [[ -f "$HOME/.cargo/env" ]]; then
 fi
 
 python3 tools/ci/check_stasis_src_layout.py
+python3 tools/ci/check_jit_generation_contract.py
+python3 -m unittest tools.ci.test_jit_generation_contract
 python3 -m unittest tools.ci.test_stasis_ai_efficiency_matrix
 python3 -m unittest tools.ci.test_release_provenance
 python3 -m unittest tools.ci.test_verify_render_parity


### PR DESCRIPTION
## Summary
- lock the complete direct-call `ActiveGeneration`/`PendingGeneration` ABI and lifecycle
- replace canonical pointer-table/patch-set requirements across PRD, spec, checklist, and backend notes
- define supersession linearization, isolated migration/hook behavior, ownership retirement, target matrix, reproducible budgets, and #175-#178 gates
- add a repository validation check plus 10 mutation tests for cross-document regressions

## Verification
- `python tools/ci/check_stasis_src_layout.py` (pass)
- `python tools/ci/check_jit_generation_contract.py` (pass)
- `python -m unittest tools.ci.test_jit_generation_contract` (13 pass)
- `python -m unittest tools.ci.test_stasis_ai_efficiency_matrix` (5 pass)
- `python -m unittest tools.ci.test_release_provenance` (2 pass)
- `python -m unittest tools.ci.test_verify_render_parity` (6 pass)
- `python tools/ci/verify_render_parity.py` (pass)
- `git diff --check` (pass)
- `cargo test --workspace --all-targets -- --test-threads=1` completed in 124.9s with 224 pass, 1 fail, 6 ignored; the sole opportunistic real-link AOT export-resolution failure reproduces in isolation on unchanged current `origin/main` code, and this PR changes no production Rust/Cargo/runtime files
- independent sub-agent review: CLEAN after initial corrections and hosted message-ABI follow-up

## Scope
Documentation and deterministic contract validation only. No compiler/runtime implementation behavior is claimed by this slice.

Theory gained: direct internal calls are safe only when callers, callees, host exports, state bindings, and executable memory share one owning generation lifetime. The current pointer-table path obscures that ownership; a current-request plus active-generation compare-and-exchange makes freshness and visibility one linearization decision. An adjacent prediction is that #175 can delete internal arity dispatch only after predeclaring the complete reachable module, while #176 must make tick plus render hold one generation owner.

Reflection:
- Good: tracing tick -> render -> dispatch -> retirement before writing the contract exposed the exact ownership boundary, and mutation tests turned review findings into durable checks.
- Bad: the first draft missed supersession after hook entry, retained stale rollback/layout wording, and mislabeled the standard x86_64 Android AVD as arm64 evidence.
- Adjustment: future architecture slices will test every asynchronous event at every state-machine phase and verify target claims against checked-in platform tooling before calling the contract locked.