### PR TITLE
feat: prepare raster assets for target displays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +121,18 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
@@ -449,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +570,19 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
 
 [[package]]
 name = "indexmap"
@@ -694,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +772,15 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -768,6 +827,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +856,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quote"
@@ -1066,6 +1144,7 @@ dependencies = [
 name = "stasis_assets"
 version = "0.1.0"
 dependencies = [
+ "image",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 atomic-write-file = "0.3"
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 cranelift-codegen = { version = "0.117", features = ["arm64"] }
 cranelift-frontend = "0.117"

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -19,7 +19,8 @@ use stasis::{
     run_with_default_backend, run_with_real_backend, RunnerConfig, StasisTestRunSession,
 };
 use stasis_assets::{
-    load_project_asset_manifest, AssetFormat, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
+    load_project_asset_manifest, prepare_asset_bundle, AssetFormat, AssetLimits,
+    DEFAULT_ASSET_MANIFEST_PATH,
 };
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
@@ -1677,24 +1678,17 @@ fn write_mobile_asset_bundle(
         })?;
     }
     let game_root = asset_root.join("stasis_game");
-    let manifest_destination = game_root.join(DEFAULT_ASSET_MANIFEST_PATH);
-    fs::create_dir_all(manifest_destination.parent().expect("manifest parent"))
-        .map_err(|error| format!("failed to create mobile AOT manifest directory: {error}"))?;
-    fs::copy(&resolved.manifest_path, &manifest_destination)
-        .map_err(|error| format!("failed to package mobile AOT asset manifest: {error}"))?;
-    let mut packaged_paths = BTreeSet::new();
-    for asset in resolved.assets {
-        packaged_paths.insert(PathBuf::from(&asset.entry.path));
-        let destination = game_root.join(&asset.entry.path);
-        fs::create_dir_all(destination.parent().expect("asset parent"))
-            .map_err(|error| format!("failed to create mobile AOT asset directory: {error}"))?;
-        fs::copy(&asset.absolute_path, &destination).map_err(|error| {
-            format!(
-                "failed to package mobile AOT asset {}: {error}",
-                asset.entry.id
-            )
-        })?;
-    }
+    let mut packaged_paths = resolved
+        .assets
+        .iter()
+        .map(|asset| PathBuf::from(&asset.entry.path))
+        .collect::<BTreeSet<_>>();
+    prepare_asset_bundle(
+        &resolved,
+        &game_root,
+        output_dir.join("asset-preparation-cache"),
+    )
+    .map_err(|error| format!("failed to prepare mobile AOT assets: {error}"))?;
     for (relative_path, source_path) in collect_mobile_source_font_assets(project_dir, sources)? {
         if !packaged_paths.insert(relative_path.clone()) {
             continue;

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7,6 +7,9 @@ use stasis::{
     run_play_in_process_with_window_title, run_self_host_aot_cli_with_options, LiveRunConfig,
     StasisTestRunSession,
 };
+use stasis_assets::{
+    load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
+};
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
@@ -2234,7 +2237,18 @@ fn package_workspace(
         )?;
         let assets = workspace.root.join("assets");
         validate_workspace_destination(workspace, "assets directory", &assets)?;
-        copy_dir_if_exists(&assets, &staging_root.join("assets"))?;
+        if workspace.root.join(DEFAULT_ASSET_MANIFEST_PATH).is_file() {
+            let resolved = load_project_asset_manifest(&workspace.root, AssetLimits::default())
+                .map_err(|error| format!("failed to resolve desktop package assets: {error}"))?;
+            prepare_asset_bundle(
+                &resolved,
+                &staging_root,
+                workspace.root.join(".stasis_cache/assets"),
+            )
+            .map_err(|error| format!("failed to prepare desktop package assets: {error}"))?;
+        } else {
+            copy_dir_if_exists(&assets, &staging_root.join("assets"))?;
+        }
         if let Some(runtime) = installed_runtime_library() {
             copy_file(
                 &runtime,

--- a/crates/stasis_assets/Cargo.toml
+++ b/crates/stasis_assets/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+image.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/stasis_assets/src/lib.rs
+++ b/crates/stasis_assets/src/lib.rs
@@ -2,12 +2,12 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 pub const ASSET_MANIFEST_SCHEMA: &str = "stasis-assets";
-pub const ASSET_MANIFEST_VERSION: u32 = 1;
+pub const ASSET_MANIFEST_VERSION: u32 = 2;
 pub const DEFAULT_ASSET_MANIFEST_PATH: &str = "assets/manifest.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,23 +27,60 @@ impl Default for AssetLimits {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AssetManifest {
     pub schema: String,
     pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display: Option<AssetDisplay>,
     pub assets: Vec<AssetEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssetDisplay {
+    pub logical_width: u32,
+    pub logical_height: u32,
+    pub max_physical_width: u32,
+    pub max_physical_height: u32,
+    #[serde(default)]
+    pub scale_mode: AssetScaleMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetScaleMode {
+    #[default]
+    Fit,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AssetEntry {
     pub id: String,
     pub path: String,
     pub content_sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prepared_from_sha256: Option<String>,
     pub format: AssetFormat,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prepare: Option<SpritePreparation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpritePreparation {
+    pub max_logical_width: u32,
+    pub max_logical_height: u32,
+    #[serde(default = "default_render_scale")]
+    pub max_render_scale: f64,
+}
+
+fn default_render_scale() -> f64 {
+    1.0
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,7 +138,7 @@ impl AssetHandle {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedAsset {
     pub handle: AssetHandle,
     pub entry: AssetEntry,
@@ -109,7 +146,7 @@ pub struct ResolvedAsset {
     pub byte_length: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedAssetManifest {
     pub manifest_path: PathBuf,
     pub assets: Vec<ResolvedAsset>,
@@ -209,6 +246,7 @@ pub fn load_project_asset_manifest(
         )
     })?;
     validate_manifest_header(&manifest)?;
+    validate_display(&manifest)?;
     if manifest.assets.len() > limits.max_assets {
         return Err(manifest_error(
             "asset_manifest_too_many_entries",
@@ -286,6 +324,191 @@ pub fn sha256_bytes(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
+pub fn prepare_asset_bundle(
+    resolved: &ResolvedAssetManifest,
+    destination_root: impl AsRef<Path>,
+    cache_root: impl AsRef<Path>,
+) -> Result<PreparedAssetSummary, String> {
+    let manifest_bytes = fs::read(&resolved.manifest_path)
+        .map_err(|error| format!("failed to read source asset manifest: {error}"))?;
+    let mut manifest: AssetManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|error| format!("failed to decode source asset manifest: {error}"))?;
+    let destination_root = destination_root.as_ref();
+    let cache_root = cache_root.as_ref();
+    fs::create_dir_all(destination_root.join("assets"))
+        .map_err(|error| format!("failed to create asset output: {error}"))?;
+    fs::create_dir_all(cache_root)
+        .map_err(|error| format!("failed to create asset cache: {error}"))?;
+
+    let display_scale = manifest.display.as_ref().map(display_scale);
+    let by_id = resolved
+        .assets
+        .iter()
+        .map(|asset| (asset.entry.id.as_str(), asset))
+        .collect::<BTreeMap<_, _>>();
+    let mut summary = PreparedAssetSummary {
+        copied_assets: 0,
+        resized_assets: 0,
+        cache_hits: 0,
+    };
+
+    for entry in &mut manifest.assets {
+        let source = by_id
+            .get(entry.id.as_str())
+            .ok_or_else(|| format!("resolved asset missing from manifest: {}", entry.id))?;
+        let destination = destination_root.join(&entry.path);
+        fs::create_dir_all(destination.parent().expect("asset destination parent"))
+            .map_err(|error| format!("failed to create asset directory: {error}"))?;
+        let Some(prepare) = &entry.prepare else {
+            fs::copy(&source.absolute_path, &destination)
+                .map_err(|error| format!("failed to copy asset {}: {error}", entry.id))?;
+            summary.copied_assets += 1;
+            continue;
+        };
+        let Some(scale) = display_scale else {
+            return Err(format!(
+                "asset {} has prepare metadata without display metadata",
+                entry.id
+            ));
+        };
+        if !matches!(
+            entry.format,
+            AssetFormat::Sprite {
+                encoding: SpriteEncoding::Png,
+                ..
+            }
+        ) {
+            fs::copy(&source.absolute_path, &destination)
+                .map_err(|error| format!("failed to copy asset {}: {error}", entry.id))?;
+            summary.copied_assets += 1;
+            continue;
+        }
+
+        let target_width =
+            prepared_axis(prepare.max_logical_width, scale, prepare.max_render_scale);
+        let target_height =
+            prepared_axis(prepare.max_logical_height, scale, prepare.max_render_scale);
+        let image = image::ImageReader::open(&source.absolute_path)
+            .map_err(|error| format!("failed to open PNG asset {}: {error}", entry.id))?
+            .with_guessed_format()
+            .map_err(|error| format!("failed to inspect PNG asset {}: {error}", entry.id))?
+            .decode()
+            .map_err(|error| format!("failed to decode PNG asset {}: {error}", entry.id))?;
+        if let AssetFormat::Sprite { width, height, .. } = entry.format {
+            if image.width() != width || image.height() != height {
+                return Err(format!(
+                    "PNG asset {} dimensions are {}x{}, manifest declares {width}x{height}",
+                    entry.id,
+                    image.width(),
+                    image.height()
+                ));
+            }
+        }
+        let ratio = f64::min(
+            target_width as f64 / image.width() as f64,
+            target_height as f64 / image.height() as f64,
+        )
+        .min(1.0);
+        let output_width = ((image.width() as f64 * ratio).round() as u32).max(1);
+        let output_height = ((image.height() as f64 * ratio).round() as u32).max(1);
+        if output_width == image.width() && output_height == image.height() {
+            fs::copy(&source.absolute_path, &destination)
+                .map_err(|error| format!("failed to copy asset {}: {error}", entry.id))?;
+            summary.copied_assets += 1;
+            continue;
+        }
+
+        let cache_key = sha256_bytes(
+            format!(
+                "stasis-png-v1:{}:{output_width}:{output_height}",
+                source.entry.content_sha256
+            )
+            .as_bytes(),
+        );
+        let cached = cache_root.join(format!("{cache_key}.png"));
+        if cached.is_file() {
+            fs::copy(&cached, &destination)
+                .map_err(|error| format!("failed to copy cached asset {}: {error}", entry.id))?;
+            summary.cache_hits += 1;
+        } else {
+            let resized = image.resize_exact(
+                output_width,
+                output_height,
+                image::imageops::FilterType::Lanczos3,
+            );
+            let temporary = cache_root.join(format!("{cache_key}.{}.tmp", std::process::id()));
+            strip_opaque_alpha(resized)
+                .save_with_format(&temporary, image::ImageFormat::Png)
+                .map_err(|error| format!("failed to encode PNG asset {}: {error}", entry.id))?;
+            if cached.is_file() {
+                fs::remove_file(&temporary).map_err(|error| {
+                    format!(
+                        "failed to remove duplicate cache file for {}: {error}",
+                        entry.id
+                    )
+                })?;
+            } else {
+                if let Err(error) = fs::rename(&temporary, &cached) {
+                    if cached.is_file() {
+                        fs::remove_file(&temporary).map_err(|remove_error| {
+                            format!(
+                                "failed to resolve cache race for {} after {error}: {remove_error}",
+                                entry.id
+                            )
+                        })?;
+                    } else {
+                        return Err(format!(
+                            "failed to publish cached asset {}: {error}",
+                            entry.id
+                        ));
+                    }
+                }
+            }
+            fs::copy(&cached, &destination)
+                .map_err(|error| format!("failed to stage asset {}: {error}", entry.id))?;
+        }
+        let (output_hash, _) = sha256_file(&destination, u64::MAX)
+            .map_err(|error| format!("failed to hash prepared asset {}: {}", entry.id, error.1))?;
+        entry.prepared_from_sha256 = Some(entry.content_sha256.clone());
+        entry.content_sha256 = output_hash;
+        if let AssetFormat::Sprite { width, height, .. } = &mut entry.format {
+            *width = output_width;
+            *height = output_height;
+        }
+        summary.resized_assets += 1;
+    }
+
+    let generated = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| format!("failed to encode prepared asset manifest: {error}"))?;
+    fs::write(
+        destination_root.join(DEFAULT_ASSET_MANIFEST_PATH),
+        generated,
+    )
+    .map_err(|error| format!("failed to write prepared asset manifest: {error}"))?;
+    Ok(summary)
+}
+
+fn display_scale(display: &AssetDisplay) -> f64 {
+    f64::min(
+        display.max_physical_width as f64 / display.logical_width as f64,
+        display.max_physical_height as f64 / display.logical_height as f64,
+    )
+}
+
+fn prepared_axis(logical: u32, display_scale: f64, render_scale: f64) -> u32 {
+    (logical as f64 * display_scale * render_scale)
+        .ceil()
+        .clamp(1.0, 16_384.0) as u32
+}
+
+fn strip_opaque_alpha(image: image::DynamicImage) -> image::DynamicImage {
+    if image.color().has_alpha() && image.to_rgba8().pixels().all(|pixel| pixel[3] == 255) {
+        image::DynamicImage::ImageRgb8(image.to_rgb8())
+    } else {
+        image
+    }
+}
+
 fn validate_manifest_header(manifest: &AssetManifest) -> Result<(), AssetManifestError> {
     if manifest.schema != ASSET_MANIFEST_SCHEMA {
         return Err(manifest_error(
@@ -298,16 +521,63 @@ fn validate_manifest_header(manifest: &AssetManifest) -> Result<(), AssetManifes
             ),
         ));
     }
-    if manifest.version != ASSET_MANIFEST_VERSION {
+    if !(1..=ASSET_MANIFEST_VERSION).contains(&manifest.version) {
         return Err(manifest_error(
             "asset_manifest_version_unsupported",
             None,
             None,
             format!(
-                "expected version {ASSET_MANIFEST_VERSION}, found {}",
+                "expected version 1..={ASSET_MANIFEST_VERSION}, found {}",
                 manifest.version
             ),
         ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreparedAssetSummary {
+    pub copied_assets: usize,
+    pub resized_assets: usize,
+    pub cache_hits: usize,
+}
+
+fn validate_display(manifest: &AssetManifest) -> Result<(), AssetManifestError> {
+    if manifest.version == 1
+        && (manifest.display.is_some()
+            || manifest.assets.iter().any(|entry| entry.prepare.is_some()))
+    {
+        return Err(manifest_error(
+            "asset_display_requires_v2",
+            None,
+            None,
+            "display preparation metadata requires manifest version 2",
+        ));
+    }
+    if manifest.display.is_none() {
+        if let Some(entry) = manifest.assets.iter().find(|entry| entry.prepare.is_some()) {
+            return Err(entry_error(
+                "asset_prepare_display_missing",
+                entry,
+                "sprite preparation requires top-level display metadata",
+            ));
+        }
+    }
+    if let Some(display) = &manifest.display {
+        if display.logical_width == 0
+            || display.logical_height == 0
+            || display.max_physical_width == 0
+            || display.max_physical_height == 0
+            || display.max_physical_width > 16_384
+            || display.max_physical_height > 16_384
+        {
+            return Err(manifest_error(
+                "asset_display_dimensions_invalid",
+                None,
+                None,
+                "display dimensions must be within 1..=16384",
+            ));
+        }
     }
     Ok(())
 }
@@ -338,6 +608,19 @@ fn validate_entry(entry: &AssetEntry) -> Result<(), AssetManifestError> {
             "content_sha256 must be 64 lowercase hexadecimal characters",
         ));
     }
+    if let Some(hash) = &entry.prepared_from_sha256 {
+        if hash.len() != 64
+            || !hash
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(entry_error(
+                "asset_prepared_source_hash_invalid",
+                entry,
+                "prepared_from_sha256 must be 64 lowercase hexadecimal characters",
+            ));
+        }
+    }
     match entry.format {
         AssetFormat::Sprite {
             encoding,
@@ -366,6 +649,26 @@ fn validate_entry(entry: &AssetEntry) -> Result<(), AssetManifestError> {
                 return Err(entry_error("asset_audio_metadata_invalid", entry, "audio requires sample rate 8000..=384000, channels 1..=8, and nonzero duration"));
             }
             validate_extension(entry, audio_extension(encoding))?;
+        }
+    }
+    if let Some(prepare) = &entry.prepare {
+        if !matches!(entry.format, AssetFormat::Sprite { .. }) {
+            return Err(entry_error(
+                "asset_prepare_non_sprite",
+                entry,
+                "prepare metadata is only valid for sprites",
+            ));
+        }
+        if prepare.max_logical_width == 0
+            || prepare.max_logical_height == 0
+            || !prepare.max_render_scale.is_finite()
+            || !(1.0..=8.0).contains(&prepare.max_render_scale)
+        {
+            return Err(entry_error(
+                "asset_prepare_invalid",
+                entry,
+                "logical dimensions must be nonzero and max_render_scale must be within 1.0..=8.0",
+            ));
         }
     }
     Ok(())
@@ -588,11 +891,13 @@ mod tests {
             id: id.to_string(),
             path: path.to_string(),
             content_sha256: sha256_bytes(bytes),
+            prepared_from_sha256: None,
             format: AssetFormat::Sprite {
                 encoding: SpriteEncoding::Png,
                 width: 2,
                 height: 3,
             },
+            prepare: None,
             dependencies: vec![],
         }
     }
@@ -601,6 +906,7 @@ mod tests {
         let manifest = AssetManifest {
             schema: ASSET_MANIFEST_SCHEMA.to_string(),
             version: ASSET_MANIFEST_VERSION,
+            display: None,
             assets: entries,
         };
         fs::write(
@@ -720,7 +1026,7 @@ mod tests {
         let mut json: serde_json::Value =
             serde_json::from_slice(&fs::read(root.join(DEFAULT_ASSET_MANIFEST_PATH)).unwrap())
                 .unwrap();
-        json["version"] = serde_json::json!(2);
+        json["version"] = serde_json::json!(ASSET_MANIFEST_VERSION + 1);
         fs::write(
             root.join(DEFAULT_ASSET_MANIFEST_PATH),
             serde_json::to_vec(&json).unwrap(),
@@ -732,6 +1038,74 @@ mod tests {
                 .code,
             "asset_manifest_version_unsupported"
         );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn prepares_png_for_logical_display_size_and_reuses_cache() {
+        let root = project("prepare_png");
+        let source_path = root.join("assets/images/hero.png");
+        image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            800,
+            800,
+            image::Rgba([20, 40, 60, 255]),
+        ))
+        .save_with_format(&source_path, image::ImageFormat::Png)
+        .unwrap();
+        let source_bytes = fs::read(&source_path).unwrap();
+        let mut hero = sprite("hero", "assets/images/hero.png", &source_bytes);
+        hero.format = AssetFormat::Sprite {
+            encoding: SpriteEncoding::Png,
+            width: 800,
+            height: 800,
+        };
+        hero.prepare = Some(SpritePreparation {
+            max_logical_width: 50,
+            max_logical_height: 50,
+            max_render_scale: 1.0,
+        });
+        let manifest = AssetManifest {
+            schema: ASSET_MANIFEST_SCHEMA.to_string(),
+            version: ASSET_MANIFEST_VERSION,
+            display: Some(AssetDisplay {
+                logical_width: 100,
+                logical_height: 200,
+                max_physical_width: 400,
+                max_physical_height: 1000,
+                scale_mode: AssetScaleMode::Fit,
+            }),
+            assets: vec![hero],
+        };
+        fs::write(
+            root.join(DEFAULT_ASSET_MANIFEST_PATH),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let resolved = load_project_asset_manifest(&root, AssetLimits::default()).unwrap();
+        let output = root.join("output");
+        let cache = root.join("cache");
+
+        let first = prepare_asset_bundle(&resolved, &output, &cache).unwrap();
+        assert_eq!(first.resized_assets, 1);
+        assert_eq!(first.cache_hits, 0);
+        let prepared = image::open(output.join("assets/images/hero.png")).unwrap();
+        assert_eq!((prepared.width(), prepared.height()), (200, 200));
+        assert_eq!(prepared.color(), image::ColorType::Rgb8);
+        let generated: AssetManifest =
+            serde_json::from_slice(&fs::read(output.join(DEFAULT_ASSET_MANIFEST_PATH)).unwrap())
+                .unwrap();
+        assert_eq!(
+            generated.assets[0].prepared_from_sha256,
+            Some(sha256_bytes(&source_bytes))
+        );
+        assert_ne!(
+            generated.assets[0].content_sha256,
+            sha256_bytes(&source_bytes)
+        );
+
+        let second = prepare_asset_bundle(&resolved, &output, &cache).unwrap();
+        assert_eq!(second.resized_assets, 1);
+        assert_eq!(second.cache_hits, 1);
         fs::remove_dir_all(root).ok();
     }
 }

--- a/docs/asset_manifest.md
+++ b/docs/asset_manifest.md
@@ -1,36 +1,37 @@
-# Stasis Asset Manifest v1
+# Stasis Asset Manifest v2
 
-`assets/manifest.json` is the shared project contract for sprite and audio identity. Desktop, JIT, AOT, Android Workshop, and published runtimes must consume this contract rather than inventing platform-specific asset IDs or accepting arbitrary filesystem paths.
+`assets/manifest.json` is the shared project contract for asset identity, integrity, and optional build-time raster preparation. Desktop, JIT, AOT, Android Workshop, and published runtimes consume this contract rather than inventing platform-specific asset IDs or accepting arbitrary filesystem paths.
 
-## Shape
+Version 1 manifests remain valid and package their files unchanged. Version 2 adds optional display and sprite preparation metadata.
+
+## Prepared sprite example
 
 ```json
 {
   "schema": "stasis-assets",
-  "version": 1,
+  "version": 2,
+  "display": {
+    "logical_width": 360,
+    "logical_height": 720,
+    "max_physical_width": 1440,
+    "max_physical_height": 3200,
+    "scale_mode": "fit"
+  },
   "assets": [
     {
-      "id": "player",
-      "path": "assets/images/player.png",
-      "content_sha256": "<64 lowercase hexadecimal characters>",
+      "id": "white_queen",
+      "path": "assets/images/white_queen.png",
+      "content_sha256": "<master file SHA-256>",
       "format": {
         "kind": "sprite",
         "encoding": "png",
-        "width": 64,
-        "height": 64
+        "width": 2048,
+        "height": 2048
       },
-      "dependencies": []
-    },
-    {
-      "id": "jump",
-      "path": "assets/audio/jump.ogg",
-      "content_sha256": "<64 lowercase hexadecimal characters>",
-      "format": {
-        "kind": "audio",
-        "encoding": "ogg",
-        "sample_rate": 48000,
-        "channels": 2,
-        "duration_frames": 24000
+      "prepare": {
+        "max_logical_width": 42,
+        "max_logical_height": 42,
+        "max_render_scale": 1.15
       },
       "dependencies": []
     }
@@ -38,22 +39,37 @@
 }
 ```
 
+For `fit`, Stasis computes one display scale:
+
+```text
+min(max_physical_width / logical_width,
+    max_physical_height / logical_height)
+```
+
+Each prepared axis is the ceiling of `maximum logical axis * display scale * max_render_scale`. The source aspect ratio is retained, the result never exceeds either bound, and Stasis never enlarges a master. `max_render_scale` defaults to `1.0` and accepts `1.0..=8.0`; use it for the greatest zoom, bounce, or other enlargement that can actually be painted.
+
+Only PNG resizing is implemented initially. Other sprite encodings and assets without `prepare` are copied unchanged. SVG remains resolution-independent. Opaque prepared PNGs are encoded as RGB; images with any transparency retain alpha.
+
+## Generated package contract
+
+Preparation writes only beneath the build output; project masters and the source manifest are never changed. The packaged manifest records the prepared dimensions and content hash. A resized entry also records `prepared_from_sha256`, which is the master hash. Preparation cache identity includes the master hash, algorithm version, and output dimensions, so unchanged assets can be reused deterministically.
+
+The package contains only the selected display envelope's output, not multiple resolution variants. A future target-profile extension can select different display envelopes without changing the per-sprite sizing contract.
+
 ## Identity and validation
 
 - IDs are 1-128 ASCII letters, digits, `.`, `_`, or `-` and are unique within a project.
 - Runtime handles are the nonzero FNV-1a 32-bit hash of `<kind>:<id>`. Load fails if two entries collide; platforms must not repair or renumber collisions independently.
 - Paths use forward slashes, start with `assets/`, contain only normal path components, and must resolve to a regular file under the canonical project root.
 - SHA-256 is checked against the complete bounded file before the asset is accepted.
-- Declared encodings must match file extensions. Sprite dimensions, audio channel/sample-rate metadata, manifest size, entry count, and individual file size are bounded by the shared resolver.
+- Declared encodings must match file extensions. Sprite dimensions, audio metadata, display dimensions, manifest size, entry count, and individual file size are bounded by the shared resolver.
+- Sprite preparation requires a version 2 manifest and top-level `display` metadata.
 - Dependencies must name manifest entries, cannot repeat or reference themselves, and must be acyclic.
-- Unknown fields, schemas, and versions fail with stable diagnostic codes. New formats require a manifest version change or an explicitly backward-compatible enum addition.
+- Unknown fields, schemas, and future versions fail with stable diagnostic codes.
 
-The manifest establishes identity, confinement, and integrity. Decode, upload, playback, packaging, and hot-reload behavior are subsequent runtime slices.
+## Mobile packaging
 
-## Android sprite policy
-
-- The AOT bundle command resolves and verifies the manifest with `stasis_assets`, then packages its entries under `assets/stasis_game/`; published APK builds do not copy project source or arbitrary project files.
-- As a narrow supplement for the path-based `load_font` API, mobile packaging scans compiled `.stasis` source string literals for `.ttf` and `.otf` paths. It copies only referenced regular font files that resolve beneath the canonical project `assets/` directory, preserving their project-relative path. Missing, unreferenced, and out-of-project fonts are not packaged.
-- Android uses one GL texture per resolved sprite and batches only consecutive commands that share texture and clip state. Atlas layout remains a backend-private desktop optimization, so atlas coordinates never enter the manifest or render-command ABI.
-- Render command schema v3 carries rotation, alpha, and an optional top-left clip rectangle. A non-positive clip width or height disables clipping for backward compatibility; otherwise Android intersects the rectangle with the surface and uses a scissor test without reordering commands.
+- The AOT bundle command resolves and verifies the source manifest, then invokes the shared `stasis_assets` preparation path and packages the generated manifest and files under `assets/stasis_game/`.
+- As a narrow supplement for the path-based `load_font` API, mobile packaging scans compiled `.stasis` source string literals for `.ttf` and `.otf` paths. It copies only referenced regular font files beneath the canonical project `assets/` directory.
+- Android uses one GL texture per resolved sprite and batches only consecutive commands that share texture and clip state. Atlas layout remains backend-private, so atlas coordinates never enter the manifest or render-command ABI.
 - Missing, corrupt, oversized, hash-mismatched, or unsupported packaged sprites render the deterministic magenta checker fallback.


### PR DESCRIPTION
## Summary

- add optional Stasis asset manifest v2 display and per-sprite preparation metadata
- resize packaged PNGs from logical painted size and the supported physical display envelope
- preserve project masters, alpha when needed, and resolution-independent SVGs
- cache deterministic prepared outputs and emit generated dimensions plus source/output hashes
- use the shared preparation path for Android, iOS, and desktop packages while retaining manifest v1 compatibility

## Why

Raster masters were previously copied directly into every published package, forcing projects to choose between oversized APK/executable output and manually maintained reduced copies. Stasis can now derive the required packaged resolution from the game’s logical coordinate system and its supported physical display ceiling.

## Validation

- `cargo check --workspace`
- `cargo test -p stasis_assets`
- `cargo test -p stasis mobile_asset_bundle_copies_only_source_referenced_project_fonts`
- `cargo fmt --all -- --check`
- `git diff --check`

The canonical `tools/validate_repo.sh` could not run because Bash is unavailable in the Windows environment.

## Compatibility

Manifest v1 projects continue to package unchanged. Version 2 preparation is optional, PNG-only initially, never enlarges masters, and leaves unsupported or unconfigured assets untouched.
