### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -20,7 +20,7 @@ jobs:
       nightly_tag: ${{ steps.meta.outputs.nightly_tag }}
       last_tag: ${{ steps.meta.outputs.last_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
             ext: tar.gz
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -302,11 +302,11 @@ jobs:
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -98,7 +98,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -174,7 +174,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check Stasis src layout
         run: python tools/ci/check_stasis_src_layout.py
@@ -58,7 +58,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check Stasis src layout
         run: python tools/ci/check_stasis_src_layout.py
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Stasis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -115,14 +115,14 @@ jobs:
           gradle-version: "8.9"
 
       - name: Checkout SDL2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: libsdl-org/SDL
           ref: 5d249570393f7a37e037abf22cd6012a4cc56a71
           path: target/android-link-deps/SDL
 
       - name: Checkout SDL2_image
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: libsdl-org/SDL_image
           ref: 12cb2e40330d256d9b1329647be8f366546d715c


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v7 across all workflows
- upgrade actions/download-artifact from v4 to v8 in the nightly release

## Why
The successful post-merge nightly run emitted Node 20 deprecation annotations for these actions. The current official majors target the supported Node 24 action runtime.

## Validation
- audited all checkout and download-artifact references under .github/workflows
- git diff --check
- full Nightly Release passed before this dependency-only follow-up