### PR TITLE
Prepare manifest assets for desktop play

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -26,6 +26,9 @@ use live_workspace::LiveWorkspace;
 use runtime_exec::RuntimeLauncher;
 use serde::Deserialize;
 use serde_json::Value;
+use stasis_assets::{
+    load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
+};
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::{
     activate_candidate_transactionally, finalize_runtime_preview, plan_state_migration,
@@ -1370,6 +1373,47 @@ fn resolve_play_watch_dir(watch_file: &Path, watch_dir: Option<&Path>) -> PathBu
     PathBuf::from(".")
 }
 
+fn prepare_play_asset_working_dir(watch_dir: &Path) -> Result<PathBuf, String> {
+    let Some(project_root) = watch_dir
+        .ancestors()
+        .find(|ancestor| ancestor.join(DEFAULT_ASSET_MANIFEST_PATH).is_file())
+    else {
+        return Ok(watch_dir.to_path_buf());
+    };
+    let relative_watch_dir = watch_dir.strip_prefix(project_root).map_err(|error| {
+        format!(
+            "failed to map play directory {} into asset project {}: {error}",
+            watch_dir.display(),
+            project_root.display()
+        )
+    })?;
+    let prepared_root = project_root.join(".stasis_cache/play-assets");
+    if prepared_root.exists() {
+        fs::remove_dir_all(&prepared_root).map_err(|error| {
+            format!(
+                "failed to clear prepared play assets {}: {error}",
+                prepared_root.display()
+            )
+        })?;
+    }
+    let resolved = load_project_asset_manifest(project_root, AssetLimits::default())
+        .map_err(|error| format!("failed to resolve play assets: {error}"))?;
+    prepare_asset_bundle(
+        &resolved,
+        &prepared_root,
+        project_root.join(".stasis_cache/assets"),
+    )
+    .map_err(|error| format!("failed to prepare play assets: {error}"))?;
+    let prepared_watch_dir = prepared_root.join(relative_watch_dir);
+    fs::create_dir_all(&prepared_watch_dir).map_err(|error| {
+        format!(
+            "failed to create prepared play directory {}: {error}",
+            prepared_watch_dir.display()
+        )
+    })?;
+    Ok(prepared_watch_dir)
+}
+
 const PLAY_INPUT_MAX_FRAMES: usize = 10_000;
 const PLAY_INPUT_MAX_POINTERS: usize = 8;
 const PLAY_INPUT_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
@@ -1829,10 +1873,11 @@ fn run_play_in_process_inner(
         .unwrap_or_else(|_| watch_file.to_path_buf());
     let root_path_str = root_path.to_string_lossy().to_string();
 
-    std::env::set_current_dir(&watch_dir_abs).map_err(|error| {
+    let asset_working_dir = prepare_play_asset_working_dir(&watch_dir_abs)?;
+    std::env::set_current_dir(&asset_working_dir).map_err(|error| {
         format!(
             "failed to set current directory to {}: {error}",
-            watch_dir_abs.display()
+            asset_working_dir.display()
         )
     })?;
 
@@ -5580,6 +5625,47 @@ mod tests {
             Some(Path::new("override")),
         );
         assert_eq!(resolved, PathBuf::from("override"));
+    }
+
+    #[test]
+    fn play_prepares_manifest_assets_in_a_source_relative_cache_mirror() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_play_assets_{stamp}"));
+        let source_dir = root.join("src");
+        let asset_dir = root.join("assets/fonts");
+        fs::create_dir_all(&source_dir).expect("create source directory");
+        fs::create_dir_all(&asset_dir).expect("create asset directory");
+        let font = b"font fixture";
+        fs::write(asset_dir.join("ui.ttf"), font).expect("write font");
+        let manifest = serde_json::json!({
+            "schema": "stasis-assets",
+            "version": 2,
+            "assets": [{
+                "id": "ui",
+                "path": "assets/fonts/ui.ttf",
+                "content_sha256": stasis_assets::sha256_bytes(font),
+                "format": { "kind": "font", "encoding": "ttf" },
+                "dependencies": []
+            }]
+        });
+        fs::write(
+            root.join(DEFAULT_ASSET_MANIFEST_PATH),
+            serde_json::to_vec_pretty(&manifest).expect("encode manifest"),
+        )
+        .expect("write manifest");
+
+        let working_dir = prepare_play_asset_working_dir(&source_dir).expect("prepare play assets");
+
+        assert_eq!(working_dir, root.join(".stasis_cache/play-assets/src"));
+        assert_eq!(
+            fs::read(working_dir.join("../assets/fonts/ui.ttf")).expect("read prepared font"),
+            font
+        );
+        assert!(root.join(".stasis_cache/assets").is_dir());
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -2135,6 +2135,15 @@ fn build_workspace(
             contents.push('\n');
             fs::write(&receipt, contents)
                 .map_err(|error| format!("failed to write {}: {error}", receipt.display()))?;
+            stage_workspace_assets(
+                workspace,
+                receipt.parent().ok_or_else(|| {
+                    format!(
+                        "development build receipt has no parent: {}",
+                        receipt.display()
+                    )
+                })?,
+            )?;
             Ok(CommandResult::success(
                 format!("built JIT development image: {}", receipt.display()),
                 json!({"backend": "jit", "receipt": display_path(&receipt)}),

--- a/crates/stasis_assets/src/lib.rs
+++ b/crates/stasis_assets/src/lib.rs
@@ -399,30 +399,19 @@ pub fn prepare_asset_bundle(
             prepared_axis(prepare.max_logical_width, scale, prepare.max_render_scale);
         let target_height =
             prepared_axis(prepare.max_logical_height, scale, prepare.max_render_scale);
-        let image = image::ImageReader::open(&source.absolute_path)
-            .map_err(|error| format!("failed to open PNG asset {}: {error}", entry.id))?
-            .with_guessed_format()
-            .map_err(|error| format!("failed to inspect PNG asset {}: {error}", entry.id))?
-            .decode()
-            .map_err(|error| format!("failed to decode PNG asset {}: {error}", entry.id))?;
-        if let AssetFormat::Sprite { width, height, .. } = entry.format {
-            if image.width() != width || image.height() != height {
-                return Err(format!(
-                    "PNG asset {} dimensions are {}x{}, manifest declares {width}x{height}",
-                    entry.id,
-                    image.width(),
-                    image.height()
-                ));
-            }
-        }
+        let (declared_width, declared_height) = match entry.format {
+            AssetFormat::Sprite { width, height, .. } => (width, height),
+            _ => unreachable!("PNG preparation requires a sprite entry"),
+        };
         let ratio = f64::min(
-            target_width as f64 / image.width() as f64,
-            target_height as f64 / image.height() as f64,
+            target_width as f64 / declared_width as f64,
+            target_height as f64 / declared_height as f64,
         )
         .min(1.0);
-        let output_width = ((image.width() as f64 * ratio).round() as u32).max(1);
-        let output_height = ((image.height() as f64 * ratio).round() as u32).max(1);
-        if output_width == image.width() && output_height == image.height() {
+        let output_width = ((declared_width as f64 * ratio).round() as u32).max(1);
+        let output_height = ((declared_height as f64 * ratio).round() as u32).max(1);
+        if output_width == declared_width && output_height == declared_height {
+            validate_png_dimensions(source, declared_width, declared_height)?;
             fs::copy(&source.absolute_path, &destination)
                 .map_err(|error| format!("failed to copy asset {}: {error}", entry.id))?;
             summary.copied_assets += 1;
@@ -442,6 +431,15 @@ pub fn prepare_asset_bundle(
                 .map_err(|error| format!("failed to copy cached asset {}: {error}", entry.id))?;
             summary.cache_hits += 1;
         } else {
+            let image = decode_png(source)?;
+            if image.width() != declared_width || image.height() != declared_height {
+                return Err(format!(
+                    "PNG asset {} dimensions are {}x{}, manifest declares {declared_width}x{declared_height}",
+                    entry.id,
+                    image.width(),
+                    image.height()
+                ));
+            }
             let resized = image.resize_exact(
                 output_width,
                 output_height,
@@ -497,6 +495,33 @@ pub fn prepare_asset_bundle(
     )
     .map_err(|error| format!("failed to write prepared asset manifest: {error}"))?;
     Ok(summary)
+}
+
+fn decode_png(source: &ResolvedAsset) -> Result<image::DynamicImage, String> {
+    image::ImageReader::open(&source.absolute_path)
+        .map_err(|error| format!("failed to open PNG asset {}: {error}", source.entry.id))?
+        .with_guessed_format()
+        .map_err(|error| format!("failed to inspect PNG asset {}: {error}", source.entry.id))?
+        .decode()
+        .map_err(|error| format!("failed to decode PNG asset {}: {error}", source.entry.id))
+}
+
+fn validate_png_dimensions(
+    source: &ResolvedAsset,
+    declared_width: u32,
+    declared_height: u32,
+) -> Result<(), String> {
+    let image = decode_png(source)?;
+    if image.width() == declared_width && image.height() == declared_height {
+        Ok(())
+    } else {
+        Err(format!(
+            "PNG asset {} dimensions are {}x{}, manifest declares {declared_width}x{declared_height}",
+            source.entry.id,
+            image.width(),
+            image.height()
+        ))
+    }
 }
 
 fn display_scale(display: &AssetDisplay) -> f64 {

--- a/docs/asset_manifest.md
+++ b/docs/asset_manifest.md
@@ -58,6 +58,10 @@ preparation metadata is not valid for fonts.
 
 Preparation writes only beneath the build output; project masters and the source manifest are never changed. The packaged manifest records the prepared dimensions and content hash. A resized entry also records `prepared_from_sha256`, which is the master hash. Preparation cache identity includes the master hash, algorithm version, and output dimensions, so unchanged assets can be reused deterministically.
 
+`stasis play` prepares the same bundle beneath `.stasis_cache/play-assets` before guest startup and mirrors the source directory's position relative to the project root. Existing source-relative paths such as `../assets/images/hero.png` therefore resolve to prepared output without source rewriting. Resized cache hits do not decode the master again. Both development and release `stasis build` commands stage the same prepared bundle beside their build output.
+
+Once a project has an asset manifest, every runtime-loaded asset must be declared. Source-only provenance files may remain elsewhere in the project, but undeclared files are not copied into prepared play or build output.
+
 The package contains only the selected display envelope's output, not multiple resolution variants. A future target-profile extension can select different display envelopes without changing the per-sprite sizing contract.
 
 ## Identity and validation

--- a/samples/render_parity/assets/manifest.json
+++ b/samples/render_parity/assets/manifest.json
@@ -17,6 +17,13 @@
       "dependencies": []
     },
     {
+      "id": "parity_font",
+      "path": "assets/parity.ttf",
+      "content_sha256": "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47",
+      "format": {"kind": "font", "encoding": "ttf"},
+      "dependencies": []
+    },
+    {
       "id": "translucent",
       "path": "assets/translucent.svg",
       "content_sha256": "8319b2879d03d06a2a4bb947ad0c5c9a37ef08be8888666b06086252770c526c",


### PR DESCRIPTION
## Summary
- prepare manifest assets into a source-relative cache mirror before desktop/JIT play
- stage the same prepared bundle for development builds
- skip master PNG decode on resized cache hits
- document declared-only runtime asset behavior

## Tests
- cargo test -p stasis_assets
- cargo test -p stasis play_prepares_manifest_assets_in_a_source_relative_cache_mirror
- cargo test -p stasis -- --test-threads=1 (232 library + 99 CLI unit tests pass; 4 integration tests require a locally built graphics runtime and fail when it is absent)
- git diff --check