### PR TITLE
test: gate Android JIT and AOT rendering

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+hook="$repo_root/.githooks/pre-commit.ps1"
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    exec powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$hook"
+fi
+if command -v pwsh >/dev/null 2>&1; then
+    exec pwsh -NoProfile -File "$hook"
+fi
+
+echo "Stasis pre-commit requires PowerShell to run Android render acceptance." >&2
+exit 1

--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$test = Join-Path $repoRoot "mobile\android\test_render_emulator.ps1"
+
+Write-Output "Stasis pre-commit: verifying Android Workshop JIT and Published AOT rendering"
+try {
+    & $test -Headless
+} catch {
+    Write-Error "Commit blocked: Android render E2E failed. Inspect artifacts/android_render_e2e. $($_.Exception.Message)"
+    exit 1
+}

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2160,7 +2160,7 @@ fn should_link_stasis_dynload(target: &stasis_jit::AotTarget) -> bool {
 }
 
 fn default_runtime_bridge_compiler(target: &stasis_jit::AotTarget) -> PathBuf {
-    if matches!(target, stasis_jit::AotTarget::AndroidArm64 { .. }) {
+    if target.is_android() {
         PathBuf::from("clang")
     } else if cfg!(windows) {
         std::env::current_exe()
@@ -3685,7 +3685,7 @@ STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
         }
     }
     // Keep the Android ABI surface fixed while the host shell/input event mapping lands separately.
-    if matches!(target, stasis_jit::AotTarget::AndroidArm64 { .. }) {
+    if target.is_android() {
         source.push_str(
             "STASIS_EXPORT void stasis_init(int width, int height) {\n\
     host_i32[12] = width;\n\
@@ -3798,12 +3798,7 @@ fn emit_engine_bundle_runtime_bridge_object(
             .arg("c")
             .arg("-o")
             .arg(&object_path);
-        if !cfg!(windows)
-            || matches!(
-                backend.aot_compile_config.target,
-                stasis_jit::AotTarget::AndroidArm64 { .. }
-            )
-        {
+        if !cfg!(windows) || backend.aot_compile_config.target.is_android() {
             command.arg("-fPIC");
         }
         if let Some(target) = backend.aot_compile_config.target.clang_target() {

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -63,6 +63,7 @@ struct AndroidAotBundleArgs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MobileAotTarget {
     AndroidArm64,
+    AndroidX86_64,
     IosArm64,
 }
 
@@ -70,9 +71,10 @@ impl MobileAotTarget {
     fn parse(value: &str) -> Result<Self, String> {
         match value.to_ascii_lowercase().as_str() {
             "android-arm64" | "android" => Ok(Self::AndroidArm64),
+            "android-x86_64" => Ok(Self::AndroidX86_64),
             "ios-arm64" | "ios" => Ok(Self::IosArm64),
             _ => Err(format!(
-                "invalid mobile AOT target '{value}'. Use android-arm64 or ios-arm64"
+                "invalid mobile AOT target '{value}'. Use android-arm64, android-x86_64, or ios-arm64"
             )),
         }
     }
@@ -80,6 +82,7 @@ impl MobileAotTarget {
     fn as_str(self) -> &'static str {
         match self {
             Self::AndroidArm64 => "android-arm64",
+            Self::AndroidX86_64 => "android-x86_64",
             Self::IosArm64 => "ios-arm64",
         }
     }
@@ -87,13 +90,14 @@ impl MobileAotTarget {
     fn aot_target(self) -> AotTarget {
         match self {
             Self::AndroidArm64 => AotTarget::android_arm64_default(),
+            Self::AndroidX86_64 => AotTarget::android_x86_64_default(),
             Self::IosArm64 => AotTarget::ios_arm64_default(),
         }
     }
 
     fn asset_root_dir(self) -> &'static str {
         match self {
-            Self::AndroidArm64 => "apk_assets",
+            Self::AndroidArm64 | Self::AndroidX86_64 => "apk_assets",
             Self::IosArm64 => "ios_assets",
         }
     }
@@ -1436,7 +1440,9 @@ fn parse_mobile_aot_bundle_args(args: &[String]) -> Result<MobileAotBundleArgs, 
         }
     }
     let Some(target) = target else {
-        return Err("missing required --target <android-arm64|ios-arm64>".to_string());
+        return Err(
+            "missing required --target <android-arm64|android-x86_64|ios-arm64>".to_string(),
+        );
     };
     let Some(project_dir) = project_dir else {
         return Err("missing required --project-dir <path>".to_string());
@@ -1630,7 +1636,10 @@ fn write_mobile_aot_engine_bundle(
         project_dir,
         &bindings_source,
     )?;
-    let cmake_file = if target == MobileAotTarget::AndroidArm64 {
+    let cmake_file = if matches!(
+        target,
+        MobileAotTarget::AndroidArm64 | MobileAotTarget::AndroidX86_64
+    ) {
         let path = output_dir.join("published_aot_objects.cmake");
         write_android_aot_cmake_file(&bundle.object_paths_by_function, &path)?;
         Some(path)
@@ -2753,6 +2762,28 @@ mod tests {
         );
         assert_eq!(parsed.entry_file, Some(PathBuf::from("src/main.stasis")));
         assert_eq!(parsed.output_dir, PathBuf::from("target/mobile-aot"));
+    }
+
+    #[test]
+    fn parse_mobile_aot_bundle_args_accepts_android_x86_64_target() {
+        let args = vec![
+            "--target".to_string(),
+            "android-x86_64".to_string(),
+            "--project-dir".to_string(),
+            "samples/render_parity".to_string(),
+            "--entry-file".to_string(),
+            "main.stasis".to_string(),
+            "--out-dir".to_string(),
+            "target/android-x86_64-aot".to_string(),
+        ];
+        let parsed = parse_mobile_aot_bundle_args(&args).expect("parse should succeed");
+        assert_eq!(parsed.target, MobileAotTarget::AndroidX86_64);
+        assert_eq!(parsed.target.as_str(), "android-x86_64");
+        assert_eq!(
+            parsed.target.aot_target(),
+            AotTarget::android_x86_64_default()
+        );
+        assert_eq!(parsed.target.asset_root_dir(), "apk_assets");
     }
 
     #[test]

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -3393,7 +3393,7 @@ mod tests {
             .canonicalize()
             .expect("bundled sample root");
         let result = run_android_workshop_stasis_tests(&root).expect("run bundled Stasis tests");
-        assert_eq!(result["passed"], 1, "{result}");
+        assert_eq!(result["passed"], 2, "{result}");
         assert_eq!(result["failed"], 0);
         assert_eq!(result["all_passed"], true);
         assert_eq!(

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -51,12 +51,17 @@ impl Default for AotCompileConfig {
 pub enum AotTarget {
     Native,
     AndroidArm64 { min_sdk: u32 },
+    AndroidX86_64 { min_sdk: u32 },
     IosArm64,
 }
 
 impl AotTarget {
     pub fn android_arm64_default() -> Self {
         Self::AndroidArm64 { min_sdk: 26 }
+    }
+
+    pub fn android_x86_64_default() -> Self {
+        Self::AndroidX86_64 { min_sdk: 26 }
     }
 
     pub fn ios_arm64_default() -> Self {
@@ -67,6 +72,7 @@ impl AotTarget {
         match self {
             Self::Native => None,
             Self::AndroidArm64 { .. } => Some("aarch64-linux-android"),
+            Self::AndroidX86_64 { .. } => Some("x86_64-linux-android"),
             Self::IosArm64 => Some("aarch64-apple-ios"),
         }
     }
@@ -75,8 +81,13 @@ impl AotTarget {
         match self {
             Self::Native => None,
             Self::AndroidArm64 { min_sdk } => Some(format!("aarch64-linux-android{min_sdk}")),
+            Self::AndroidX86_64 { min_sdk } => Some(format!("x86_64-linux-android{min_sdk}")),
             Self::IosArm64 => Some("aarch64-apple-ios".to_string()),
         }
+    }
+
+    pub fn is_android(&self) -> bool {
+        matches!(self, Self::AndroidArm64 { .. } | Self::AndroidX86_64 { .. })
     }
 
     pub fn requires_position_independent_code(&self) -> bool {
@@ -453,7 +464,7 @@ fn resolve_linker_path(config: &AotLinkConfig) -> PathBuf {
     if let Some(path) = config.linker_path.as_ref() {
         return path.clone();
     }
-    if matches!(config.target, AotTarget::AndroidArm64 { .. }) {
+    if config.target.is_android() {
         PathBuf::from("clang")
     } else if cfg!(windows) {
         PathBuf::from("lld-link.exe")
@@ -788,7 +799,19 @@ echo "fake-shared" > "$OUT"
     fn aot_target_reports_position_independent_code_requirement() {
         assert!(!AotTarget::Native.requires_position_independent_code());
         assert!(AotTarget::android_arm64_default().requires_position_independent_code());
+        assert!(AotTarget::android_x86_64_default().requires_position_independent_code());
         assert!(AotTarget::ios_arm64_default().requires_position_independent_code());
+    }
+
+    #[test]
+    fn android_x86_64_target_reports_emulator_triples() {
+        let target = AotTarget::android_x86_64_default();
+        assert_eq!(target.object_triple(), Some("x86_64-linux-android"));
+        assert_eq!(
+            target.clang_target().as_deref(),
+            Some("x86_64-linux-android26")
+        );
+        assert!(target.is_android());
     }
 
     #[test]

--- a/docs/contributor_workflow.md
+++ b/docs/contributor_workflow.md
@@ -10,6 +10,7 @@ Make the next useful change, verify it, and leave the repository in a reviewable
 2. If the tree is dirty because a cross-repo inbox synced tracked docs, either commit that sync first or stop if the state is unsafe to modify.
 3. Run the baseline validation command: `tools/validate_repo.sh`.
 4. If validation fails, fix it first or move the task to `NEEDS INPUT FROM USER` with evidence.
+5. Run `tools/install_git_hooks.ps1` once per clone. This repository's pre-commit hook blocks commits unless the Android Workshop JIT and Published AOT render-parity emulator gate passes.
 
 ## Choose work
 

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -65,7 +65,7 @@ From this directory:
 .\build_debug.ps1
 ```
 
-This builds the Stasis Rust bridge plus the optimized phone-native Codex login
+This builds the Stasis Rust bridge with the Cargo release profile plus the optimized phone-native Codex login
 library from its pinned official revision, packages the Android Rustls verifier,
 and assembles the Workshop APK. The first Codex build downloads upstream Rust
 dependencies and takes longer; subsequent builds reuse Cargo output.
@@ -76,6 +76,13 @@ Gradle directly:
 ```powershell
 gradle :app:assembleWorkshopDebug
 ```
+
+Direct Gradle assembly verifies the generated Rust bridge provenance manifest,
+including the release profile, current Rust/Cargo input fingerprint, and exact
+SHA-256 for both required Workshop ABIs. Rebuild with
+`build_rust_bridge.ps1 -Release` if verification fails. For an intentional
+native-debug session only, build with `build_rust_bridge.ps1 -Debug` and pass
+`-Pstasis.allowDebugRustBridge=true` to Gradle.
 
 Build the descriptor-selected Pong package directly with:
 

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -5,7 +5,7 @@ This is the first checked-in Android app shell for the `android` branch.
 Current scope:
 
 - Builds one Android app module with `workshop` and `published` product flavors.
-- Targets `arm64-v8a` devices and `x86_64` Android emulators for Workshop debug builds. Published builds remain arm64-only.
+- Targets `arm64-v8a` devices and `x86_64` Android emulators for Workshop debug builds. Production published builds remain arm64-only; the render acceptance suite can emit a real x86_64 Android AOT package for the local emulator.
 - Loads a tiny native C library through JNI.
 - Bundles the default Exploration Garden tutorial plus Pong as independently identified Workshop templates.
 - Opens the native Android symbol browser and source editor from a top-right hamburger overlay grouped by Main, Structs, Systems, and Root.
@@ -127,6 +127,22 @@ Then build, install, launch, and record the normal Workshop acceptance check wit
 ```
 
 Pass `-Headless` for unattended runs or `-SkipBuild` to relaunch and validate an APK that is already installed. The emulator gate rotates, backgrounds/resumes, and force-recreates Workshop, requires successful `StasisRenderer` resource restoration markers, and force-stops the app when finished. Pass `-Lifecycle` to `validate_device.ps1` for the same lifecycle matrix on an attached device. `start_emulator.ps1` can also be used independently. Workshop validation prefers an attached emulator when both an emulator and phone are connected; pass `-Serial` to `validate_device.ps1` to select explicitly.
+
+Run the blocking render end-to-end gate directly with:
+
+```powershell
+.\test_render_emulator.ps1 -Headless
+```
+
+This builds the canonical `samples/render_parity` fixture twice: Workshop uses the real x86_64 development JIT and Published uses real `android-x86_64` AOT objects linked into a runtime-only APK. It installs both packages into `Stasis_API_35`, captures their OpenGL surfaces, normalizes the letterboxed 640x360 viewport, and checks Android parity regions for the background, procedural fallback, opaque/translucent/rotated SVG sprites, crossing lines, direct text, and cached text. Each flavor must pass three spaced captures and log at least 30 rendered frames; Workshop must also log a successful non-empty JIT compile. Fatal renderer logs, blank/incorrect regions, process exits, build failures, stale release Rust bridge provenance, or a missing emulator block the command. Build subprocesses are limited to five minutes each and the full gate to fifteen minutes. The render-only build verifies and reuses the release Rust bridge and phone-native Codex artifacts instead of rebuilding unrelated native support. Captures, UI bounds, build output, process-scoped logs, and a success/failure JSON summary are retained under ignored `artifacts/android_render_e2e/` directories.
+
+Install the repository-owned blocking pre-commit hook once per clone:
+
+```powershell
+.\tools\install_git_hooks.ps1
+```
+
+The hook runs the same headless gate for every local commit and returns nonzero on any failure. `android-x86_64` exists only to execute Published AOT on the standard x86_64 AVD; normal `build_published.ps1` and production publishing continue to default to `android-arm64`.
 
 ## Host AI Run Review
 

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -5,6 +5,9 @@ plugins {
 def repoRootDir = rootProject.projectDir.parentFile.parentFile
 def publishedAotDir = layout.buildDirectory.dir('generated/stasisAot/publishedArm64')
 def workshopAssetsDir = layout.buildDirectory.dir('generated/stasisAssets/workshop')
+def workshopRustBridgeManifestFile = file('src/workshop/jniLibs/stasis-rust-bridge.json')
+def allowDebugWorkshopRustBridge = (project.findProperty('stasis.allowDebugRustBridge') ?: 'false')
+        .toString().toBoolean()
 def publishedGameName = (project.findProperty('stasis.publishedGame') ?: 'pong').toString()
 def publishedGameDescriptorFile = rootProject.file("games/${publishedGameName}.gradle")
 if (!publishedGameDescriptorFile.isFile()) {
@@ -112,6 +115,16 @@ tasks.register('prepareWorkshopAssets', Sync) {
     into(workshopAssetsDir)
 }
 
+tasks.register('verifyWorkshopRustBridge', Exec) {
+    inputs.file(workshopRustBridgeManifestFile)
+    inputs.files('src/workshop/jniLibs/arm64-v8a/libstasis_android_bridge.so',
+            'src/workshop/jniLibs/x86_64/libstasis_android_bridge.so')
+    def expectedProfile = allowDebugWorkshopRustBridge ? 'debug' : 'release'
+    commandLine 'powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
+            rootProject.file('rust_bridge_provenance.ps1').absolutePath,
+            '-Mode', 'Verify', '-Profile', expectedProfile
+}
+
 tasks.register('generatePublishedAotBundle', Exec) {
     def outputDir = publishedAotDir.get().asFile
     inputs.file(publishedGameDescriptorFile)
@@ -127,6 +140,7 @@ tasks.register('generatePublishedAotBundle', Exec) {
 tasks.configureEach { task ->
     if (task.name.startsWith('preWorkshop')) {
         task.dependsOn(tasks.named('prepareWorkshopAssets'))
+        task.dependsOn(tasks.named('verifyWorkshopRustBridge'))
     }
     if (task.name.startsWith('prePublished') || (task.name.startsWith('configureCMake') && task.name.contains('Published'))) {
         task.dependsOn(tasks.named('generatePublishedAotBundle'))

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -3,10 +3,21 @@ plugins {
 }
 
 def repoRootDir = rootProject.projectDir.parentFile.parentFile
-def publishedAotDir = layout.buildDirectory.dir('generated/stasisAot/publishedArm64')
+def publishedAotTarget = (project.findProperty('stasis.androidAotTarget') ?: 'android-arm64').toString()
+def publishedAotAbis = [
+        'android-arm64': 'arm64-v8a',
+        'android-x86_64': 'x86_64'
+]
+if (!publishedAotAbis.containsKey(publishedAotTarget)) {
+    throw new GradleException("Unsupported Android AOT target: ${publishedAotTarget}")
+}
+def publishedAotAbi = publishedAotAbis[publishedAotTarget]
+def publishedAotDir = layout.buildDirectory.dir("generated/stasisAot/${publishedAotTarget}")
 def workshopAssetsDir = layout.buildDirectory.dir('generated/stasisAssets/workshop')
 def workshopRustBridgeManifestFile = file('src/workshop/jniLibs/stasis-rust-bridge.json')
 def allowDebugWorkshopRustBridge = (project.findProperty('stasis.allowDebugRustBridge') ?: 'false')
+        .toString().toBoolean()
+def renderAcceptance = (project.findProperty('stasis.renderAcceptance') ?: 'false')
         .toString().toBoolean()
 def publishedGameName = (project.findProperty('stasis.publishedGame') ?: 'pong').toString()
 def publishedGameDescriptorFile = rootProject.file("games/${publishedGameName}.gradle")
@@ -37,6 +48,7 @@ android {
         targetSdk = (project.findProperty('stasis.targetSdk') ?: '35').toString().toInteger()
         versionCode 1
         versionName '0.1.0'
+        buildConfigField 'boolean', 'STASIS_RENDER_ACCEPTANCE', renderAcceptance.toString()
 
         externalNativeBuild {
             cmake {
@@ -71,7 +83,7 @@ android {
             dimension 'mode'
             applicationId publishedGame.applicationId
             ndk {
-                abiFilters 'arm64-v8a'
+                abiFilters publishedAotAbi
             }
             manifestPlaceholders = [appLabel: publishedGame.label]
             buildConfigField 'boolean', 'STASIS_PUBLISHED_BUILD', 'true'
@@ -79,7 +91,8 @@ android {
             buildConfigField 'String', 'STASIS_RUNTIME_ID', "\"${publishedGame.runtimeId}\""
             externalNativeBuild {
                 cmake {
-                    arguments '-DSTASIS_ANDROID_PUBLISHED_AOT=ON', "-DSTASIS_PUBLISHED_AOT_DIR=${projectDir}/build/generated/stasisAot/publishedArm64"
+                    arguments '-DSTASIS_ANDROID_PUBLISHED_AOT=ON',
+                            "-DSTASIS_PUBLISHED_AOT_DIR=${publishedAotDir.get().asFile.absolutePath}"
                 }
             }
         }
@@ -112,6 +125,16 @@ tasks.register('prepareWorkshopAssets', Sync) {
         exclude 'workshop_sample/build/**'
         exclude 'exploration_sample/build/**'
     }
+    if (renderAcceptance) {
+        from(new File(repoRootDir, 'samples/render_parity')) {
+            exclude '*.stasis'
+            into 'render_parity_sample'
+        }
+        from(new File(repoRootDir, 'samples/render_parity')) {
+            include '*.stasis'
+            into 'render_parity_sample/src'
+        }
+    }
     into(workshopAssetsDir)
 }
 
@@ -131,7 +154,8 @@ tasks.register('generatePublishedAotBundle', Exec) {
     inputs.dir(publishedGame.projectDirectory)
     outputs.dir(outputDir)
     workingDir repoRootDir
-    commandLine 'cargo', 'run', '-p', 'stasis', '--', 'android-aot-bundle',
+    commandLine 'cargo', 'run', '-p', 'stasis', '--', 'mobile-aot-bundle',
+            '--target', publishedAotTarget,
             '--project-dir', publishedGame.projectDirectory.absolutePath,
             '--entry-file', publishedGame.entrySource,
             '--out-dir', outputDir.absolutePath

--- a/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
@@ -166,11 +166,21 @@ function update_enemy_paddle(): void {
     let enemy_speed = GameState.enemy_paddle_speed_x100 / 100;
 
     if (GameState.ai_y < GameState.ball_y) {
-        GameState.ai_y += enemy_speed;
+        let remaining_distance = GameState.ball_y - GameState.ai_y;
+        if (enemy_speed >= remaining_distance) {
+            GameState.ai_y = GameState.ball_y;
+        } else {
+            GameState.ai_y += enemy_speed;
+        }
     }
 
     if (GameState.ai_y > GameState.ball_y) {
-        GameState.ai_y -= enemy_speed;
+        let remaining_distance = GameState.ai_y - GameState.ball_y;
+        if (enemy_speed >= remaining_distance) {
+            GameState.ai_y = GameState.ball_y;
+        } else {
+            GameState.ai_y -= enemy_speed;
+        }
     }
 
     if (GameState.ai_y < 36) {

--- a/mobile/android/app/src/main/assets/workshop_sample/tests/enemy_paddle_speed_schedule.test.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/tests/enemy_paddle_speed_schedule.test.stasis
@@ -23,3 +23,27 @@ test `enemy paddle speed schedule is linear`(): bool {
     if (GameState.enemy_paddle_speed_x100 != 1500) { return false; }
     return GameState.ball_age_ticks == 0;
 }
+
+test `enemy paddle clamps at target`(): bool {
+    init();
+    GameState.ball_age_ticks = 0;
+    GameState.ai_y = 40;
+    GameState.ball_y = 45;
+    update_enemy_paddle();
+    if (GameState.ai_y != 45) { return false; }
+
+    GameState.ai_y = 50;
+    GameState.ball_y = 45;
+    update_enemy_paddle();
+    if (GameState.ai_y != 45) { return false; }
+
+    GameState.ai_y = 40;
+    GameState.ball_y = 70;
+    update_enemy_paddle();
+    if (GameState.ai_y != 55) { return false; }
+
+    GameState.ai_y = 70;
+    GameState.ball_y = 55;
+    update_enemy_paddle();
+    return GameState.ai_y == 55;
+}

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -178,7 +178,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             "vColor=aColor;gl_Position=vec4(p.x,-p.y,0.0,1.0);}";
     private static final String TEXTURE_FRAGMENT_SHADER =
             "precision mediump float;uniform sampler2D uTexture;varying vec2 vTexCoord;" +
-            "varying vec4 vColor;void main(){gl_FragColor=texture2D(uTexture,vTexCoord)*vColor;}";
+            "varying vec4 vColor;void main(){vec4 texel=texture2D(uTexture,vTexCoord);" +
+            "gl_FragColor=texel*vec4(vColor.rgb*vColor.a,vColor.a);}";
 
     private final TextureProvider textures;
     private final TimingListener timing;
@@ -214,6 +215,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private CaptureCallback pendingCapture;
     private boolean restorePlaceholderPending;
     private long restorePlaceholderUntilNanos;
+    private int renderAcceptanceFrameCount;
 
     StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
         this.textures = textures;
@@ -349,7 +351,15 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             }
             if (!restoreComplete && resourceFailure == null
                     && glError == GLES20.GL_NO_ERROR) drawRestorePlaceholder();
-            if (hasFrame && restored && resourceLifecycle.canPresent()) drawFrame();
+            if (hasFrame && restored && resourceLifecycle.canPresent()) {
+                drawFrame();
+                if (BuildConfig.STASIS_RENDER_ACCEPTANCE) {
+                    renderAcceptanceFrameCount += 1;
+                    if (renderAcceptanceFrameCount == 1 || renderAcceptanceFrameCount % 30 == 0) {
+                        Log.i(LOG_TAG, "RenderAcceptanceFrame: count=" + renderAcceptanceFrameCount);
+                    }
+                }
+            }
             capture = pendingCapture;
             pendingCapture = null;
             capturedFrame = capture == null ? null : captureLogicalFrame();
@@ -718,6 +728,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void drawColorBatch(FloatBuffer vertices, int vertexCount, int mode) {
+        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
         GLES20.glUseProgram(colorProgram);
         GLES20.glUniform2f(colorResolution, logicalWidth, logicalHeight);
         GLES20.glEnableVertexAttribArray(colorPosition);
@@ -733,6 +744,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void beginTextureBatches(FloatBuffer vertices) {
+        GLES20.glBlendFunc(GLES20.GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA);
         GLES20.glUseProgram(textureProgram);
         GLES20.glUniform2f(textureResolution, logicalWidth, logicalHeight);
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);

--- a/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/published/java/com/stasislang/workshop/MainActivity.java
@@ -66,6 +66,7 @@ public final class MainActivity extends Activity {
         installSystemInsetGuard(root);
 
         gameSurface = new GameSurfaceView(this);
+        gameSurface.setContentDescription("Published Stasis game surface");
         root.addView(gameSurface, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.MATCH_PARENT));
@@ -76,7 +77,8 @@ public final class MainActivity extends Activity {
         hud.setSingleLine(false);
         hud.setPadding(dp(10), dp(6), dp(10), dp(6));
         hud.setBackgroundColor(Color.argb(135, 20, 28, 38));
-        hud.setVisibility(BuildConfig.DEBUG ? View.VISIBLE : View.GONE);
+        hud.setVisibility(BuildConfig.DEBUG && !BuildConfig.STASIS_RENDER_ACCEPTANCE
+                ? View.VISIBLE : View.GONE);
         FrameLayout.LayoutParams hudParams = new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT,

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -388,7 +388,9 @@ public final class MainActivity extends Activity {
 
         try {
             activeProject = WorkshopProjectRegistry.initialize(this,
-                    WorkshopTemplateCatalog.DEFAULT_TEMPLATE_ID);
+                    BuildConfig.STASIS_RENDER_ACCEPTANCE
+                            ? WorkshopTemplateCatalog.RENDER_ACCEPTANCE_TEMPLATE_ID
+                            : WorkshopTemplateCatalog.DEFAULT_TEMPLATE_ID);
             projectRootFile = activeProject.root;
         } catch (Exception error) {
             projectRegistryError = error.getMessage();
@@ -431,7 +433,7 @@ public final class MainActivity extends Activity {
                     ? "Restart loop detected; preview and queued AI are paused until the local crash record is cleared in Privacy & Data"
                     : "Previous crash detected; export a redacted support bundle or clear the local crash record in Privacy & Data");
         }
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && !BuildConfig.STASIS_RENDER_ACCEPTANCE) {
             gameLoopHandler.post(new Runnable() {
                 @Override public void run() {
                     WorkshopOnboardingPolicy.Progress progress = onboardingProgress();
@@ -10709,8 +10711,23 @@ public final class MainActivity extends Activity {
         if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
             throw new IOException("failed to create " + parent.getAbsolutePath());
         }
-
-        writeTextFile(diskFile, readAsset(assets, assetPath));
+        File temporary = new File(parent, diskFile.getName() + ".asset.tmp");
+        try (InputStream input = assets.open(assetPath);
+                FileOutputStream output = new FileOutputStream(temporary, false)) {
+            byte[] buffer = new byte[8192];
+            int count;
+            while ((count = input.read(buffer)) != -1) output.write(buffer, 0, count);
+            output.getFD().sync();
+        }
+        try {
+            try {
+                Files.move(temporary.toPath(), diskFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException unsupported) {
+                Files.move(temporary.toPath(), diskFile.toPath());
+            }
+        } finally {
+            if (temporary.exists()) temporary.delete();
+        }
     }
 
     private void deleteProjectDirectory(File file) {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTemplateCatalog.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTemplateCatalog.java
@@ -7,6 +7,7 @@ import java.util.List;
 final class WorkshopTemplateCatalog {
     static final String DEFAULT_TEMPLATE_ID = "exploration";
     static final String LEGACY_TEMPLATE_ID = "pong";
+    static final String RENDER_ACCEPTANCE_TEMPLATE_ID = "render-parity";
 
     private static final Template PONG = new Template(
             "pong",
@@ -71,16 +72,33 @@ final class WorkshopTemplateCatalog {
                     "qa/first_keepsake.json"
             });
 
+    private static final Template RENDER_ACCEPTANCE = new Template(
+            RENDER_ACCEPTANCE_TEMPLATE_ID,
+            "Render Parity Acceptance",
+            "render_parity_sample/",
+            new String[] { "src/main.stasis", "src/frame.stasis", "src/trace.stasis" },
+            new String[] {},
+            new String[] {
+                    "stasis.json",
+                    "capture_manifest.json",
+                    "assets/manifest.json",
+                    "assets/full_canvas.svg",
+                    "assets/opaque.svg",
+                    "assets/translucent.svg",
+                    "assets/parity.ttf"
+            });
+
     private WorkshopTemplateCatalog() {}
 
     static Template require(String id) {
         if (PONG.id.equals(id)) return PONG;
         if (EXPLORATION.id.equals(id)) return EXPLORATION;
+        if (RENDER_ACCEPTANCE.id.equals(id)) return RENDER_ACCEPTANCE;
         throw new IllegalArgumentException("unknown Workshop template: " + id);
     }
 
     static boolean isKnown(String id) {
-        return PONG.id.equals(id) || EXPLORATION.id.equals(id);
+        return PONG.id.equals(id) || EXPLORATION.id.equals(id) || RENDER_ACCEPTANCE.id.equals(id);
     }
 
     static List<Template> list() {

--- a/mobile/android/build_debug.ps1
+++ b/mobile/android/build_debug.ps1
@@ -1,5 +1,10 @@
 param(
     [switch]$Install,
+    [switch]$RenderAcceptance,
+    [switch]$SkipCodexNative,
+    [switch]$SkipRustBridgeBuild,
+    [switch]$NoGradleDaemon,
+    [string]$GradlePath = "",
     [string]$CompileSdk = "",
     [string]$TargetSdk = ""
 )
@@ -10,7 +15,10 @@ $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Push-Location $scriptRoot
 try {
     $gradle = Join-Path $scriptRoot "gradlew.bat"
-    if (Test-Path $gradle) {
+    if ($GradlePath) {
+        if (-not (Test-Path $GradlePath)) { throw "Gradle was not found: $GradlePath" }
+        $gradleCmd = $GradlePath
+    } elseif (Test-Path $gradle) {
         $gradleCmd = $gradle
     } elseif (Get-Command gradle -ErrorAction SilentlyContinue) {
         $gradleCmd = "gradle"
@@ -18,11 +26,19 @@ try {
         throw "Gradle was not found. Install Gradle or open mobile/android in Android Studio."
     }
 
-    & (Join-Path $scriptRoot "build_rust_bridge.ps1") -Release
-    & (Join-Path $scriptRoot "build_codex_native.ps1") -Release
+    if ($SkipRustBridgeBuild) {
+        & (Join-Path $scriptRoot "rust_bridge_provenance.ps1") -Mode Verify -Profile release
+    } else {
+        & (Join-Path $scriptRoot "build_rust_bridge.ps1") -Release
+    }
+    if (-not $SkipCodexNative) {
+        & (Join-Path $scriptRoot "build_codex_native.ps1") -Release
+    }
 
     $task = if ($Install) { ":app:installWorkshopDebug" } else { ":app:assembleWorkshopDebug" }
     $args = @($task)
+    if ($NoGradleDaemon) { $args += "--no-daemon" }
+    if ($RenderAcceptance) { $args += "-Pstasis.renderAcceptance=true" }
     if ($CompileSdk) { $args += "-Pstasis.compileSdk=$CompileSdk" }
     if ($TargetSdk) { $args += "-Pstasis.targetSdk=$TargetSdk" }
 

--- a/mobile/android/build_debug.ps1
+++ b/mobile/android/build_debug.ps1
@@ -18,7 +18,7 @@ try {
         throw "Gradle was not found. Install Gradle or open mobile/android in Android Studio."
     }
 
-    & (Join-Path $scriptRoot "build_rust_bridge.ps1")
+    & (Join-Path $scriptRoot "build_rust_bridge.ps1") -Release
     & (Join-Path $scriptRoot "build_codex_native.ps1") -Release
 
     $task = if ($Install) { ":app:installWorkshopDebug" } else { ":app:assembleWorkshopDebug" }

--- a/mobile/android/build_published.ps1
+++ b/mobile/android/build_published.ps1
@@ -1,6 +1,12 @@
 param(
     [switch]$Install,
     [switch]$ValidateAot,
+    [string]$Game = "pong",
+    [ValidateSet("android-arm64", "android-x86_64")]
+    [string]$AotTarget = "android-arm64",
+    [switch]$RenderAcceptance,
+    [switch]$NoGradleDaemon,
+    [string]$GradlePath = "",
     [string]$CompileSdk = "",
     [string]$TargetSdk = ""
 )
@@ -11,7 +17,10 @@ $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Push-Location $scriptRoot
 try {
     $gradle = Join-Path $scriptRoot "gradlew.bat"
-    if (Test-Path $gradle) {
+    if ($GradlePath) {
+        if (-not (Test-Path $GradlePath)) { throw "Gradle was not found: $GradlePath" }
+        $gradleCmd = $GradlePath
+    } elseif (Test-Path $gradle) {
         $gradleCmd = $gradle
     } elseif (Get-Command gradle -ErrorAction SilentlyContinue) {
         $gradleCmd = "gradle"
@@ -32,6 +41,10 @@ try {
 
     $task = if ($Install) { ":app:installPublishedDebug" } else { ":app:assemblePublishedRelease" }
     $args = @($task)
+    if ($NoGradleDaemon) { $args += "--no-daemon" }
+    $args += "-Pstasis.publishedGame=$Game"
+    $args += "-Pstasis.androidAotTarget=$AotTarget"
+    if ($RenderAcceptance) { $args += "-Pstasis.renderAcceptance=true" }
     if ($CompileSdk) { $args += "-Pstasis.compileSdk=$CompileSdk" }
     if ($TargetSdk) { $args += "-Pstasis.targetSdk=$TargetSdk" }
 
@@ -43,7 +56,10 @@ try {
     } else {
         Join-Path $scriptRoot "app\build\outputs\apk\published\release\app-published-release-unsigned.apk"
     }
-    & python (Join-Path $scriptRoot "..\..\tools\ci\check_android_published_apk.py") $apk
+    $expectedAbi = if ($AotTarget -eq "android-x86_64") { "x86_64" } else { "arm64-v8a" }
+    $requiredAsset = if ($Game -eq "render_parity") { "assets/opaque.svg" } else { "assets/ball.svg" }
+    & python (Join-Path $scriptRoot "..\..\tools\ci\check_android_published_apk.py") `
+        $apk --abi $expectedAbi --required-asset $requiredAsset
     if ($LASTEXITCODE -ne 0) { throw "Published APK validation failed with exit code $LASTEXITCODE" }
 }
 finally {

--- a/mobile/android/build_rust_bridge.ps1
+++ b/mobile/android/build_rust_bridge.ps1
@@ -3,7 +3,8 @@ param(
     [string]$NdkVersion = "",
     [int]$MinSdk = 26,
     [string[]]$Abis = @("arm64-v8a", "x86_64"),
-    [switch]$Release
+    [switch]$Release,
+    [switch]$Debug
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,9 +37,16 @@ $prebuilt = Join-Path $ndkRoot "toolchains\llvm\prebuilt\windows-x86_64"
 $installedTargets = & rustup target list --installed
 if ($LASTEXITCODE -ne 0) { throw "rustup target discovery failed with exit code $LASTEXITCODE" }
 $env:CARGO_INCREMENTAL = "0"
+$useRelease = -not $Debug
+if ($Release -and $Debug) {
+    throw "Choose either -Release or -Debug, not both."
+}
+if ($Release) {
+    $useRelease = $true
+}
 $profileArgs = @()
 $profileDir = "debug"
-if ($Release) {
+if ($useRelease) {
     $profileArgs += "--release"
     $profileDir = "release"
 }
@@ -46,6 +54,12 @@ if ($Release) {
 $targets = @{
     "arm64-v8a" = @{ Rust = "aarch64-linux-android"; Clang = "aarch64-linux-android" }
     "x86_64" = @{ Rust = "x86_64-linux-android"; Clang = "x86_64-linux-android" }
+}
+$requiredAbis = @("arm64-v8a", "x86_64")
+$requestedAbis = @($Abis | Sort-Object -Unique)
+if ($requestedAbis.Count -ne $requiredAbis.Count -or
+        (Compare-Object ($requiredAbis | Sort-Object) $requestedAbis)) {
+    throw "Workshop Rust bridge packaging requires both ABIs: $($requiredAbis -join ', ')."
 }
 
 foreach ($abi in $Abis) {
@@ -80,3 +94,6 @@ foreach ($abi in $Abis) {
     Copy-Item -Force $source $dest
     Write-Host "Packaged Rust Android bridge: $dest"
 }
+
+& (Join-Path $scriptRoot "rust_bridge_provenance.ps1") -Mode Write -Profile $profileDir
+if ($LASTEXITCODE -ne 0) { throw "Rust bridge provenance write failed with exit code $LASTEXITCODE" }

--- a/mobile/android/games/render_parity.gradle
+++ b/mobile/android/games/render_parity.gradle
@@ -1,0 +1,11 @@
+ext.stasisGameDescriptor = [
+        schemaVersion: 1,
+        id: 'render-parity',
+        runtimeId: 'render_parity_aot',
+        applicationId: 'com.stasislang.renderparity',
+        label: 'Stasis Render Parity',
+        projectDirectory: new File(rootProject.projectDir, '../../samples/render_parity'),
+        entrySource: 'main.stasis',
+        assetManifest: 'assets/manifest.json',
+        testPattern: 'tests/**/*.test.stasis'
+]

--- a/mobile/android/rust_bridge_provenance.ps1
+++ b/mobile/android/rust_bridge_provenance.ps1
@@ -1,0 +1,114 @@
+param(
+    [ValidateSet("Write", "Verify")]
+    [string]$Mode = "Verify",
+    [ValidateSet("release", "debug")]
+    [string]$Profile = "release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$jniRoot = Join-Path $scriptRoot "app\src\workshop\jniLibs"
+$manifestPath = Join-Path $jniRoot "stasis-rust-bridge.json"
+$requiredTargets = [ordered]@{
+    "arm64-v8a" = "aarch64-linux-android"
+    "x86_64" = "x86_64-linux-android"
+}
+
+function Get-BridgeInputFingerprint([string]$Root) {
+    $rootFiles = @(
+        Get-Item -LiteralPath (Join-Path $Root "Cargo.toml"), (Join-Path $Root "Cargo.lock")
+    )
+    $crateFiles = Get-ChildItem -LiteralPath (Join-Path $Root "crates") -Recurse -File |
+        Where-Object {
+            $_.Name -eq "Cargo.toml" -or
+            $_.Name -eq "build.rs" -or
+            $_.Extension -in @(".rs", ".stasis", ".json", ".c", ".h", ".txt")
+        }
+    $records = foreach ($file in @($rootFiles) + @($crateFiles) | Sort-Object FullName) {
+        $relative = $file.FullName.Substring($Root.Length).TrimStart("\", "/").Replace("\", "/")
+        $fileHash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        "$relative`t$fileHash`n"
+    }
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes(($records -join ""))
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return ([BitConverter]::ToString($sha.ComputeHash($bytes))).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-BridgeEntries([string]$ExpectedProfile) {
+    $entries = @()
+    foreach ($pair in $requiredTargets.GetEnumerator()) {
+        $abi = $pair.Key
+        $bridge = Join-Path $jniRoot "$abi\libstasis_android_bridge.so"
+        if (-not (Test-Path -LiteralPath $bridge)) {
+            throw "Workshop Rust bridge is missing ABI $abi."
+        }
+        $item = Get-Item -LiteralPath $bridge
+        $entries += [ordered]@{
+            abi = $abi
+            rustTarget = $pair.Value
+            profile = $ExpectedProfile
+            file = "$abi/libstasis_android_bridge.so"
+            bytes = [long]$item.Length
+            sha256 = (Get-FileHash -LiteralPath $bridge -Algorithm SHA256).Hash.ToLowerInvariant()
+        }
+    }
+    return $entries
+}
+
+if ($Mode -eq "Write") {
+    $manifest = [ordered]@{
+        schemaVersion = 1
+        crate = "stasis_android_bridge"
+        profile = $Profile
+        inputFingerprint = Get-BridgeInputFingerprint $repoRoot
+        entries = @(Get-BridgeEntries $Profile)
+    }
+    $manifest | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+    Write-Host "Recorded Rust Android bridge provenance: $manifestPath"
+    return
+}
+
+if (-not (Test-Path -LiteralPath $manifestPath)) {
+    throw "Workshop Rust bridge provenance is missing. Run build_rust_bridge.ps1 -Release."
+}
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+if ($manifest.schemaVersion -ne 1 -or $manifest.crate -ne "stasis_android_bridge") {
+    throw "Workshop Rust bridge provenance is invalid."
+}
+if ($manifest.profile -ne $Profile) {
+    throw "Workshop Rust bridge must use the $Profile profile. Use -Pstasis.allowDebugRustBridge=true only with a -Debug bridge build."
+}
+$entries = @($manifest.entries)
+if ($entries.Count -ne $requiredTargets.Count -or
+        (@($entries.abi | Sort-Object -Unique).Count -ne $requiredTargets.Count)) {
+    throw "Workshop Rust bridge provenance must contain exactly one entry for each required ABI."
+}
+$inputFingerprint = Get-BridgeInputFingerprint $repoRoot
+if ($manifest.inputFingerprint -ne $inputFingerprint) {
+    throw "Workshop Rust bridge is stale for the current Rust/Cargo inputs (manifest=$($manifest.inputFingerprint), current=$inputFingerprint). Rebuild the bridge before assembling the APK."
+}
+foreach ($pair in $requiredTargets.GetEnumerator()) {
+    $abi = $pair.Key
+    $entry = @($entries | Where-Object abi -eq $abi)
+    $expectedFile = "$abi/libstasis_android_bridge.so"
+    if ($entry.Count -ne 1 -or $entry[0].rustTarget -ne $pair.Value -or
+            $entry[0].file -ne $expectedFile -or $entry[0].profile -ne $Profile) {
+        throw "Workshop Rust bridge provenance is invalid for ABI $abi."
+    }
+    $bridge = Join-Path $jniRoot "$abi\libstasis_android_bridge.so"
+    if (-not (Test-Path -LiteralPath $bridge)) {
+        throw "Workshop Rust bridge is missing ABI $abi."
+    }
+    $item = Get-Item -LiteralPath $bridge
+    $hash = (Get-FileHash -LiteralPath $bridge -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ([long]$entry[0].bytes -ne $item.Length -or $entry[0].sha256 -ne $hash) {
+        throw "Workshop Rust bridge provenance mismatch for $abi. Rebuild the bridge before assembling the APK."
+    }
+}
+Write-Host "Verified $Profile Rust Android bridge provenance for both Workshop ABIs."

--- a/mobile/android/start_emulator.ps1
+++ b/mobile/android/start_emulator.ps1
@@ -19,6 +19,10 @@ $emulator = Join-Path $androidHome "emulator\emulator.exe"
 $adb = Join-Path $androidHome "platform-tools\adb.exe"
 if (-not (Test-Path $emulator)) { throw "Android Emulator was not found: $emulator" }
 if (-not (Test-Path $adb)) { throw "adb.exe was not found: $adb" }
+if (-not $env:ANDROID_AVD_HOME -and $env:USERPROFILE) {
+    $defaultAvdHome = Join-Path $env:USERPROFILE ".android\avd"
+    if (Test-Path $defaultAvdHome) { $env:ANDROID_AVD_HOME = $defaultAvdHome }
+}
 
 $serial = "emulator-$Port"
 $deviceLines = @(& $adb devices)

--- a/mobile/android/test_render_emulator.ps1
+++ b/mobile/android/test_render_emulator.ps1
@@ -1,0 +1,299 @@
+param(
+    [string]$AvdName = "Stasis_API_35",
+    [int]$Port = 5554,
+    [switch]$Headless,
+    [switch]$SkipBuild,
+    [int]$RenderTimeoutSeconds = 45,
+    [int]$TotalTimeoutSeconds = 900,
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$startedAt = [System.Diagnostics.Stopwatch]::StartNew()
+$serial = "emulator-$Port"
+$startedEmulator = $false
+$packages = @("com.stasislang.workshop", "com.stasislang.renderparity")
+
+$androidHome = if ($env:ANDROID_HOME) {
+    $env:ANDROID_HOME
+} elseif ($env:ANDROID_SDK_ROOT) {
+    $env:ANDROID_SDK_ROOT
+} else {
+    "C:\Android\Sdk"
+}
+$adb = Join-Path $androidHome "platform-tools\adb.exe"
+if (-not (Test-Path $adb)) { throw "adb.exe was not found: $adb" }
+
+$stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $repoRoot "artifacts\android_render_e2e\$stamp"
+}
+$artifactRoot = [System.IO.Path]::GetFullPath($OutputPath)
+New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+
+function Assert-In-Time([string]$Step) {
+    if ($startedAt.Elapsed.TotalSeconds -gt $TotalTimeoutSeconds) {
+        throw "Android render E2E exceeded ${TotalTimeoutSeconds}s after $Step"
+    }
+}
+
+function Invoke-BoundedScript([string]$Path, [string[]]$Arguments, [string]$Phase) {
+    $remainingSeconds = [math]::Floor($TotalTimeoutSeconds - $startedAt.Elapsed.TotalSeconds)
+    $stepSeconds = [math]::Min(300, $remainingSeconds)
+    if ($stepSeconds -le 0) { throw "Android render E2E exceeded ${TotalTimeoutSeconds}s before $Phase" }
+    $stdout = Join-Path $artifactRoot "$Phase-stdout.log"
+    $stderr = Join-Path $artifactRoot "$Phase-stderr.log"
+    $hostExecutable = (Get-Process -Id $PID).Path
+    $childArguments = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $Path) + $Arguments
+    $quotedArguments = $childArguments | ForEach-Object {
+        if ($_ -match '[\s"]') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
+    }
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $hostExecutable
+    $startInfo.Arguments = $quotedArguments -join ' '
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) { throw "$Phase could not start" }
+    $outputTask = $process.StandardOutput.ReadToEndAsync()
+    $errorTask = $process.StandardError.ReadToEndAsync()
+    $timedOut = -not $process.WaitForExit($stepSeconds * 1000)
+    if ($timedOut) {
+        & taskkill.exe /PID $process.Id /T /F 2>$null | Out-Null
+    }
+    $process.WaitForExit()
+    $outputTask.Result | Set-Content -LiteralPath $stdout -Encoding UTF8
+    $errorTask.Result | Set-Content -LiteralPath $stderr -Encoding UTF8
+    $output = @($outputTask.Result -split '\r?\n') | Where-Object { $_ }
+    $errors = @($errorTask.Result -split '\r?\n') | Where-Object { $_ }
+    if ($output) { $output | Write-Output }
+    if ($errors) { $errors | Write-Warning }
+    if ($timedOut) { throw "$Phase exceeded its ${stepSeconds}s limit; child processes were stopped" }
+    if ($process.ExitCode -ne 0) { throw "$Phase failed with exit code $($process.ExitCode)" }
+    return $output
+}
+
+function Invoke-Adb([string[]]$Arguments) {
+    $result = & $adb -s $serial @Arguments
+    if ($LASTEXITCODE -ne 0) { throw "adb command failed: $($Arguments -join ' ')" }
+    return $result
+}
+
+function Invoke-AdbQuiet([string[]]$Arguments) {
+    $previousPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $adb -s $serial @Arguments 2>$null | Out-Null
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+    if ($exitCode -ne 0) { throw "adb command failed: $($Arguments -join ' ')" }
+}
+
+function Resolve-Gradle {
+    $wrapper = Join-Path $scriptRoot "gradlew.bat"
+    if (Test-Path $wrapper) { return $wrapper }
+    if ($env:ChocolateyInstall) {
+        $installed = Get-ChildItem (Join-Path $env:ChocolateyInstall "lib\gradle\tools") `
+            -Recurse -Filter gradle.bat -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+        if ($installed) { return $installed.FullName }
+    }
+    $command = Get-Command gradle -ErrorAction SilentlyContinue
+    if ($command) { return $command.Source }
+    throw "Gradle was not found; install Gradle 8.9 or newer"
+}
+
+function Save-Screenshot([string]$Path) {
+    $process = Start-Process -FilePath $adb -ArgumentList @(
+        "-s", $serial, "exec-out", "screencap", "-p"
+    ) -RedirectStandardOutput $Path -RedirectStandardError "$Path.stderr" -NoNewWindow -PassThru -Wait
+    if ($process.ExitCode -ne 0 -or -not (Test-Path $Path)) {
+        throw "Android screenshot capture failed for $serial"
+    }
+}
+
+function Read-SurfaceBounds([string]$Description, [string]$XmlPath) {
+    $deviceXml = "/data/local/tmp/stasis-render-window.xml"
+    Invoke-AdbQuiet @("shell", "uiautomator", "dump", $deviceXml)
+    Invoke-AdbQuiet @("pull", $deviceXml, $XmlPath)
+    Invoke-Adb @("shell", "rm", "-f", $deviceXml) | Out-Null
+    [xml]$tree = Get-Content -Raw -LiteralPath $XmlPath
+    $node = @($tree.SelectNodes("//node")) |
+        Where-Object { $_.GetAttribute("content-desc") -eq $Description } |
+        Select-Object -First 1
+    if (-not $node) { throw "render surface '$Description' was absent from the Android UI tree" }
+    $match = [regex]::Match($node.GetAttribute("bounds"), '^\[(\d+),(\d+)\]\[(\d+),(\d+)\]$')
+    if (-not $match.Success) { throw "render surface has invalid bounds: $($node.GetAttribute('bounds'))" }
+    $left = [int]$match.Groups[1].Value
+    $top = [int]$match.Groups[2].Value
+    $right = [int]$match.Groups[3].Value
+    $bottom = [int]$match.Groups[4].Value
+    return @($left, $top, ($right - $left), ($bottom - $top))
+}
+
+function Fit-LogicalViewport([int[]]$Surface) {
+    $logicalWidth = 640
+    $logicalHeight = 360
+    $width = $Surface[2]
+    $height = $Surface[3]
+    if ($width * $logicalHeight -gt $height * $logicalWidth) {
+        $viewportWidth = [int][math]::Floor($height * $logicalWidth / $logicalHeight)
+        $viewportLeft = $Surface[0] + [int][math]::Floor(($width - $viewportWidth) / 2)
+        return @($viewportLeft, $Surface[1], $viewportWidth, $height)
+    }
+    $viewportHeight = [int][math]::Floor($width * $logicalHeight / $logicalWidth)
+    $viewportTop = $Surface[1] + [int][math]::Floor(($height - $viewportHeight) / 2)
+    return @($Surface[0], $viewportTop, $width, $viewportHeight)
+}
+
+function Assert-RenderedVariant(
+    [string]$Name,
+    [string]$Package,
+    [string]$Apk,
+    [string]$SurfaceDescription,
+    [bool]$RequireJit
+) {
+    if (-not (Test-Path $Apk)) { throw "$Name APK was not found: $Apk" }
+    Invoke-Adb @("install", "-r", $Apk) | Out-Null
+    Invoke-Adb @("shell", "pm", "clear", $Package) | Out-Null
+    Invoke-Adb @("logcat", "-c") | Out-Null
+    Invoke-Adb @("shell", "am", "start", "-W", "-n",
+        "$Package/com.stasislang.workshop.MainActivity") | Out-Null
+
+    $capture = Join-Path $artifactRoot "$Name.png"
+    $uiTree = Join-Path $artifactRoot "$Name-window.xml"
+    $deadline = (Get-Date).AddSeconds($RenderTimeoutSeconds)
+    $lastFailure = "render did not become ready"
+    $renderPassed = $false
+    $stableCaptures = 0
+    $processId = ""
+    $viewportArg = ""
+    $logFile = Join-Path $artifactRoot "$Name-logcat.txt"
+    $log = @()
+    try {
+        do {
+            Start-Sleep -Seconds 2
+            $processId = (Invoke-Adb @("shell", "pidof", $Package) | Select-Object -First 1).Trim()
+            if (-not $processId) { throw "$Name exited before rendering" }
+            try {
+                if (-not $viewportArg) {
+                    $surface = Read-SurfaceBounds $SurfaceDescription $uiTree
+                    $viewport = Fit-LogicalViewport $surface
+                    $viewportArg = ($viewport | ForEach-Object { $_.ToString() }) -join ","
+                }
+                Write-Host "$Name viewport=$viewportArg"
+                Save-Screenshot $capture
+                & python (Join-Path $repoRoot "tools\ci\verify_render_parity.py") `
+                    --capture $capture --capture-only --profile android_emulator `
+                    "--viewport=$viewportArg"
+                if ($LASTEXITCODE -eq 0) {
+                    $stableCaptures += 1
+                    if ($stableCaptures -ge 3) {
+                        $renderPassed = $true
+                        break
+                    }
+                } else {
+                    $stableCaptures = 0
+                    $lastFailure = "Android render-parity regions did not match"
+                }
+            } catch {
+                $stableCaptures = 0
+                $lastFailure = $_.Exception.Message
+            }
+        } while ((Get-Date) -lt $deadline)
+    } finally {
+        if ($processId) { $log = @(& $adb -s $serial logcat "--pid=$processId" -d 2>$null) }
+        if (-not $processId -or $LASTEXITCODE -ne 0) {
+            $log = @(& $adb -s $serial logcat -d 2>$null)
+        }
+        $log | Set-Content -LiteralPath $logFile -Encoding UTF8
+        & $adb -s $serial shell am force-stop $Package 2>$null | Out-Null
+    }
+    $fatalPatterns = @(
+        "native preview frame failed",
+        "Render resource error",
+        "resource restore failed",
+        "FATAL EXCEPTION"
+    )
+    $fatal = $log | Select-String -SimpleMatch $fatalPatterns
+    if ($fatal) { throw "$Name logged a rendering/runtime failure; see $logFile" }
+    $frameCounts = [regex]::Matches(($log -join "`n"), 'RenderAcceptanceFrame: count=(\d+)') |
+        ForEach-Object { [int]$_.Groups[1].Value }
+    if (-not $frameCounts -or ($frameCounts | Measure-Object -Maximum).Maximum -lt 30) {
+        throw "$Name did not prove 30 actively rendered acceptance frames; see $logFile"
+    }
+    if ($RequireJit -and -not ($log -match 'CompilePlanned: reload=InitialCompile status=0 functions=[1-9][0-9]*')) {
+        throw "$Name did not log a successful non-empty Workshop JIT compile; see $logFile"
+    }
+    if (-not $renderPassed) {
+        throw "$Name render acceptance timed out: $lastFailure; see $artifactRoot"
+    }
+    Write-Output "$Name render acceptance passed: $capture"
+}
+
+try {
+    $runningBefore = @(& $adb devices) | Where-Object {
+        $_ -match "^$([regex]::Escape($serial))\s+device(?:\s|$)"
+    }
+    $startedEmulator = -not [bool]$runningBefore
+    $emulatorArguments = @("-AvdName", $AvdName, "-Port", "$Port")
+    if ($Headless) { $emulatorArguments += "-Headless" }
+    $serial = Invoke-BoundedScript (Join-Path $scriptRoot "start_emulator.ps1") `
+        $emulatorArguments "start-emulator"
+    $serial = @($serial) | Select-Object -Last 1
+
+    if (-not $SkipBuild) {
+        $gradle = Resolve-Gradle
+        Invoke-BoundedScript (Join-Path $scriptRoot "build_debug.ps1") @(
+            "-RenderAcceptance", "-SkipCodexNative", "-SkipRustBridgeBuild",
+            "-NoGradleDaemon", "-GradlePath", $gradle
+        ) "build-workshop" | Out-Null
+        Assert-In-Time "Workshop build"
+        Invoke-BoundedScript (Join-Path $scriptRoot "build_published.ps1") @(
+            "-Install", "-Game", "render_parity", "-AotTarget", "android-x86_64",
+            "-RenderAcceptance", "-NoGradleDaemon", "-GradlePath", $gradle
+        ) "build-published-aot" | Out-Null
+        Assert-In-Time "Published AOT build"
+    }
+
+    Assert-RenderedVariant "workshop" "com.stasislang.workshop" `
+        (Join-Path $scriptRoot "app\build\outputs\apk\workshop\debug\app-workshop-debug.apk") `
+        "Interactive Stasis game preview. Touch the game to control it." $true
+    Assert-RenderedVariant "published-aot" "com.stasislang.renderparity" `
+        (Join-Path $scriptRoot "app\build\outputs\apk\published\debug\app-published-debug.apk") `
+        "Published Stasis game surface" $false
+    Assert-In-Time "render acceptance"
+
+    @{
+        status = "passed"
+        serial = $serial
+        avd = $AvdName
+        elapsed_seconds = [math]::Round($startedAt.Elapsed.TotalSeconds, 3)
+        workshop = "Workshop JIT"
+        published = "Published android-x86_64 AOT"
+    } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $artifactRoot "summary.json") -Encoding UTF8
+    Write-Output "Android Workshop JIT and Published AOT rendering passed in $([math]::Round($startedAt.Elapsed.TotalSeconds, 1))s"
+} catch {
+    @{
+        status = "failed"
+        serial = $serial
+        avd = $AvdName
+        elapsed_seconds = [math]::Round($startedAt.Elapsed.TotalSeconds, 3)
+        error = $_.Exception.Message
+    } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $artifactRoot "summary.json") -Encoding UTF8
+    throw
+} finally {
+    foreach ($package in $packages) {
+        & $adb -s $serial shell am force-stop $package 2>$null | Out-Null
+    }
+    if ($startedEmulator) {
+        & $adb -s $serial emu kill 2>$null | Out-Null
+    }
+}

--- a/samples/render_parity/capture_manifest.json
+++ b/samples/render_parity/capture_manifest.json
@@ -42,6 +42,19 @@
         {"name": "direct_text", "rect": [64, 252, 190, 34], "predicate": "neutral_bright", "min_coverage": 0.04},
         {"name": "cached_text", "rect": [344, 252, 190, 34], "predicate": "gold_text", "min_coverage": 0.04}
       ]
+    },
+    "android_emulator": {
+      "comparison": "regions",
+      "regions": [
+        {"name": "background", "rect": [12, 12, 12, 12], "rgba": [18, 30, 48, 255], "max_channel_delta": 28, "min_coverage": 0.80},
+        {"name": "fallback", "rect": [44, 60, 40, 40], "rgba": [255, 0, 255, 255], "max_channel_delta": 36, "min_coverage": 0.08},
+        {"name": "opaque_svg", "rect": [146, 54, 76, 52], "rgba": [49, 209, 124, 255], "max_channel_delta": 32, "min_coverage": 0.35},
+        {"name": "translucent_svg", "rect": [282, 54, 76, 52], "non_background_fraction": 0.50},
+        {"name": "rotated_scaled_sprite", "rect": [440, 36, 112, 84], "predicate": "green_sprite", "min_coverage": 0.20},
+        {"name": "overlapping_lines", "rect": [304, 168, 32, 24], "predicate": "crossing_lines", "min_red_coverage": 0.008, "min_cyan_coverage": 0.008},
+        {"name": "direct_text", "rect": [64, 252, 190, 34], "predicate": "neutral_bright", "min_coverage": 0.04},
+        {"name": "cached_text", "rect": [344, 252, 190, 34], "predicate": "gold_text", "min_coverage": 0.04}
+      ]
     }
   }
 }

--- a/samples/render_parity/main.stasis
+++ b/samples/render_parity/main.stasis
@@ -11,6 +11,8 @@ function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, 
 global gfx_cmd_i32: i32[18464];
 global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
+global host_i32: i32[768];
+global host_f32: f32[64];
 
 // The host consumes this request between ticks; mobile shells already own the
 // surface and simply ignore the desktop window size request.

--- a/tools/ci/check_android_published_apk.py
+++ b/tools/ci/check_android_published_apk.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python3
-"""Validate that an Android published APK is runtime-only and arm64 AOT-backed."""
+"""Validate that an Android published APK is runtime-only and AOT-backed."""
 
 from __future__ import annotations
 
+import argparse
 import json
-import sys
 import zipfile
 from pathlib import Path
 
 
 MAX_APK_BYTES = 50 * 1024 * 1024
-REQUIRED_ENTRIES = {
+BASE_REQUIRED_ENTRIES = {
     "AndroidManifest.xml",
     "classes.dex",
-    "lib/arm64-v8a/libstasis_mobile_smoke.so",
     "assets/stasis_game/assets/manifest.json",
-    "assets/stasis_game/assets/ball.svg",
 }
 FORBIDDEN_SUFFIXES = {
     "libstasis_android_bridge.so",
@@ -25,14 +23,18 @@ FORBIDDEN_SUFFIXES = {
 }
 
 
-def validate(apk: Path) -> dict[str, object]:
+def validate(apk: Path, abi: str = "arm64-v8a", required_asset: str = "assets/ball.svg") -> dict[str, object]:
     if not apk.is_file():
         raise ValueError(f"published APK was not found: {apk}")
     if apk.stat().st_size > MAX_APK_BYTES:
         raise ValueError(f"published APK exceeds {MAX_APK_BYTES} bytes: {apk.stat().st_size}")
     with zipfile.ZipFile(apk) as archive:
         entries = set(archive.namelist())
-        missing = sorted(REQUIRED_ENTRIES - entries)
+        required_entries = set(BASE_REQUIRED_ENTRIES)
+        required_entries.add(f"lib/{abi}/libstasis_mobile_smoke.so")
+        if required_asset:
+            required_entries.add(f"assets/stasis_game/{required_asset}")
+        missing = sorted(required_entries - entries)
         if missing:
             raise ValueError(f"published APK is missing required entries: {missing}")
         forbidden = sorted(
@@ -44,7 +46,7 @@ def validate(apk: Path) -> dict[str, object]:
         if forbidden:
             raise ValueError(f"published APK contains workshop-only files: {forbidden[:10]}")
         native_libraries = sorted(entry for entry in entries if entry.startswith("lib/"))
-        wrong_abis = [entry for entry in native_libraries if not entry.startswith("lib/arm64-v8a/")]
+        wrong_abis = [entry for entry in native_libraries if not entry.startswith(f"lib/{abi}/")]
         if wrong_abis:
             raise ValueError(f"published APK contains unsupported ABIs: {wrong_abis}")
     return {
@@ -52,16 +54,19 @@ def validate(apk: Path) -> dict[str, object]:
         "bytes": apk.stat().st_size,
         "entry_count": len(entries),
         "native_libraries": native_libraries,
+        "abi": abi,
         "runtime_only": True,
     }
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: check_android_published_apk.py <apk>", file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser()
+    parser.add_argument("apk", type=Path)
+    parser.add_argument("--abi", default="arm64-v8a")
+    parser.add_argument("--required-asset", default="assets/ball.svg")
+    args = parser.parse_args()
     try:
-        summary = validate(Path(sys.argv[1]))
+        summary = validate(args.apk, args.abi, args.required_asset)
     except (OSError, ValueError, zipfile.BadZipFile) as error:
         print(f"published APK validation failed: {error}", file=sys.stderr)
         return 1

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -6,6 +6,7 @@ REQUIRED_FILES = [
     "mobile/android/settings.gradle",
     "mobile/android/build.gradle",
     "mobile/android/build_rust_bridge.ps1",
+    "mobile/android/rust_bridge_provenance.ps1",
     "mobile/android/build_published.ps1",
     "mobile/android/validate_device.ps1",
     "mobile/android/app/build.gradle",
@@ -142,6 +143,7 @@ def main() -> int:
     assert "render_workshop_artifacts" in bridge
 
     rust_bridge_script = read("mobile/android/build_rust_bridge.ps1")
+    rust_bridge_provenance = read("mobile/android/rust_bridge_provenance.ps1")
     debug_script = read("mobile/android/build_debug.ps1")
     emulator_script = read("mobile/android/start_emulator.ps1")
     emulator_test_script = read("mobile/android/test_emulator.ps1")
@@ -152,11 +154,20 @@ def main() -> int:
     device_script = read("mobile/android/validate_device.ps1")
     android_gitignore = read("mobile/android/.gitignore")
     assert 'linkerVariable = "CARGO_TARGET_' in rust_bridge_script
+    assert "$useRelease = -not $Debug" in rust_bridge_script
+    assert "rust_bridge_provenance.ps1" in rust_bridge_script
+    assert "requires both ABIs" in rust_bridge_script
+    assert "Get-BridgeInputFingerprint" in rust_bridge_provenance
+    assert "stasis-rust-bridge.json" in rust_bridge_provenance
+    assert "inputFingerprint = Get-BridgeInputFingerprint" in rust_bridge_provenance
+    assert "Get-FileHash -LiteralPath $bridge -Algorithm SHA256" in rust_bridge_provenance
+    assert "must contain exactly one entry for each required ABI" in rust_bridge_provenance
+    assert "stale for the current Rust/Cargo inputs" in rust_bridge_provenance
     assert "aarch64-linux-android" in rust_bridge_script
     assert "x86_64-linux-android" in rust_bridge_script
     assert "libstasis_android_bridge.so" in rust_bridge_script
     assert '"app\\src\\workshop\\jniLibs\\$abi"' in rust_bridge_script
-    assert "build_rust_bridge.ps1" in debug_script
+    assert 'build_rust_bridge.ps1") -Release' in debug_script
     assert ":app:assembleWorkshopDebug" in debug_script
     assert ":app:assemblePublishedRelease" in published_script
     assert ":app:installPublishedDebug" in published_script
@@ -182,6 +193,9 @@ def main() -> int:
     app_gradle = read("mobile/android/app/build.gradle")
     pong_descriptor = read("mobile/android/games/pong.gradle")
     assert "flavorDimensions 'mode'" in app_gradle
+    assert "verifyWorkshopRustBridge" in app_gradle
+    assert "stasis.allowDebugRustBridge" in app_gradle
+    assert "rust_bridge_provenance.ps1" in app_gradle
     assert "workshop {" in app_gradle
     assert "published {" in app_gradle
     assert "applicationId 'com.stasislang.workshop'" in app_gradle

--- a/tools/ci/test_check_android_published_apk.py
+++ b/tools/ci/test_check_android_published_apk.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from tools.ci.check_android_published_apk import BASE_REQUIRED_ENTRIES, validate
+
+
+class AndroidPublishedApkTest(unittest.TestCase):
+    def write_apk(self, path: Path, abi: str, asset: str) -> None:
+        with zipfile.ZipFile(path, "w") as archive:
+            for entry in BASE_REQUIRED_ENTRIES:
+                archive.writestr(entry, b"fixture")
+            archive.writestr(f"lib/{abi}/libstasis_mobile_smoke.so", b"native")
+            archive.writestr(f"assets/stasis_game/{asset}", b"asset")
+
+    def test_accepts_emulator_aot_abi_and_fixture_asset(self):
+        with tempfile.TemporaryDirectory() as directory:
+            apk = Path(directory) / "render-parity.apk"
+            self.write_apk(apk, "x86_64", "assets/opaque.svg")
+            summary = validate(apk, "x86_64", "assets/opaque.svg")
+            self.assertEqual(summary["abi"], "x86_64")
+
+    def test_rejects_native_library_from_another_abi(self):
+        with tempfile.TemporaryDirectory() as directory:
+            apk = Path(directory) / "wrong-abi.apk"
+            self.write_apk(apk, "arm64-v8a", "assets/ball.svg")
+            with self.assertRaisesRegex(ValueError, "missing required entries"):
+                validate(apk, "x86_64", "assets/ball.svg")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_verify_render_parity.py
+++ b/tools/ci/test_verify_render_parity.py
@@ -36,6 +36,7 @@ class RenderParityGateTest(unittest.TestCase):
         manifest = validate_fixture(DEFAULT_MANIFEST)
         self.assertEqual(manifest["logical_size"], [640, 360])
         self.assertEqual(len(manifest["stages"]), 4)
+        self.assertIn("android_emulator", manifest["capture_profiles"])
 
     def test_bmp_reader_and_exact_capture_hash(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/ci/verify_render_parity.py
+++ b/tools/ci/verify_render_parity.py
@@ -491,6 +491,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--capture", type=Path)
+    parser.add_argument(
+        "--capture-only",
+        action="store_true",
+        help="verify capture regions without desktop runtime-log evidence",
+    )
     parser.add_argument("--profile", default="portable")
     parser.add_argument("--stage", choices=sorted(ALLOWED_STAGES))
     parser.add_argument(
@@ -506,6 +511,15 @@ def main() -> int:
     try:
         manifest = validate_fixture(args.manifest.resolve())
         if args.capture:
+            viewport = [int(value) for value in args.viewport.split(",")] if args.viewport else None
+            if viewport is not None and len(viewport) != 4:
+                raise ValueError("--viewport requires x,y,width,height")
+            if args.capture_only:
+                digest = verify_capture(
+                    manifest, args.capture.resolve(), args.profile, viewport
+                )
+                print(f"render parity capture passed: sha256_rgba={digest}")
+                return 0
             if not args.stage:
                 raise ValueError("--capture requires --stage")
             if not args.runtime_log:
@@ -527,9 +541,6 @@ def main() -> int:
                 args.stage,
                 args.require_load_details,
             )
-            viewport = [int(value) for value in args.viewport.split(",")] if args.viewport else None
-            if viewport is not None and len(viewport) != 4:
-                raise ValueError("--viewport requires x,y,width,height")
             digest = verify_capture(
                 manifest, args.capture.resolve(), args.profile, viewport
             )

--- a/tools/install_git_hooks.ps1
+++ b/tools/install_git_hooks.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    git config --local core.hooksPath .githooks
+    if ($LASTEXITCODE -ne 0) { throw "unable to configure core.hooksPath" }
+    $configured = git config --local --get core.hooksPath
+    if ($configured -ne ".githooks") {
+        throw "core.hooksPath verification failed: $configured"
+    }
+    Write-Output "Installed blocking Stasis hooks from .githooks"
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- clamp the bundled Pong enemy paddle so one tick cannot overshoot its ball target
- require both Workshop Rust bridge ABIs to be release-built, source-current, and hash-verified before packaging
- add a real Cranelift `android-x86_64` AOT target for the standard x86_64 emulator while keeping production publishing ARM64/full AOT by default
- run the canonical render-parity scene through Workshop JIT and Published AOT, with pixel-region checks for background, fallback, SVG sprites, rotation/translucency, crossing lines, and direct/cached text
- require three spaced valid captures, at least 30 active render frames, process-scoped fatal-log checks, and a successful non-empty Workshop JIT compile
- install a repository-owned blocking pre-commit hook with five-minute child-process and fifteen-minute total bounds, failure artifacts, and app/emulator cleanup
- correct Android premultiplied texture blending and preserve binary template assets byte-for-byte

This replacement branch starts from PR #366's merged commit and contains only post-merge follow-up work. It supersedes PR #367.

## Android render evidence
- full hook-equivalent build/install/render gate: passed in 130.9 s
- actual blocking commit hook: passed in 87.6 s
- focused installed-APK rerun: passed in 63.3 s
- Workshop JIT and Published x86_64 AOT produced the same normalized RGBA digest on every capture: `1b2f223da31f1c923ca72c56cee1b5fbc57743a5cd0a5ce67e4fe16cd2521edf`
- both apps were force-stopped and the headless emulator was shut down after testing

## Other validation
- `python -m unittest tools.ci.test_check_android_published_apk tools.ci.test_verify_render_parity`: 8 passed
- validation-entrypoint Python stages: 31 passed; layout/JIT/render fixture checks passed
- `cargo test -p stasis_jit android_x86_64_target_reports_emulator_triples -- --test-threads=1`: passed
- `cargo test -p stasis parse_mobile_aot_bundle_args_accepts_android_x86_64_target -- --test-threads=1`: passed
- `:app:testWorkshopDebugUnitTest --no-daemon`: passed
- full workspace suite: all relevant suites passed; one existing graphical TUI process test failed once, then its exact isolated rerun passed
- PowerShell parse, `cargo fmt --all -- --check`, and `git diff --check`: passed
- independent review findings for flicker coverage, real timeouts, failure artifacts, process-scoped logs, JIT proof, and PowerShell-host portability were fixed

## Bridge build and size evidence
- initial complete release cross-build: 273.4 s; clean-base cached rebuild: 123.8 s; unchanged release rebuild: about 1.7 s
- Workshop APK: 59,348,323 bytes before -> 25,734,467 bytes after (about 56.6% smaller)
- x86_64 bridge: 138,764,248 bytes debug -> 6,400,544 bytes release (about 95.4% smaller)
- ARM64 release bridge: 4,498,512 bytes

Existing optimized ARM64 device evidence remains JIT 0.71 ms/frame versus AOT 0.73 ms/frame. Production publish remains fully AOT; the x86_64 target exists to make the Published AOT renderer testable on the local emulator.

Maddox task: #158