### PR TITLE
Add project architecture scaffolding and canonical formatter

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
 mod toolchain_cli;
+mod toolchain_formatter;
 
 use std::collections::BTreeSet;
 use std::env;

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -64,10 +64,13 @@ const MOBILE_RUNTIME_FILES: &[&str] = &[
 ];
 const PROJECT_AGENT_GUIDE: &str = include_str!("../../../docs/agent_workflow.md");
 const PROJECT_CLAUDE_GUIDE: &str = "# CLAUDE.md\n\n@AGENTS.md\n";
+const PROJECT_ARCHITECTURE_GUIDE: &str = include_str!("../../../docs/project_architecture.md");
+const PROJECT_ARCHITECTURE_NAME: &str = "PROJECT_ARCHITECTURE.md";
 const COMMANDS: &[&str] = &[
     "new",
     "init",
     "fmt",
+    "format",
     "check",
     "test",
     "ai",
@@ -130,6 +133,7 @@ enum ToolchainCommand {
         name: Option<String>,
     },
     /// Format project source files deterministically.
+    #[command(visible_alias = "format")]
     Fmt {
         #[arg(long)]
         check: bool,
@@ -775,6 +779,7 @@ fn create_project(path: PathBuf, name: String) -> Result<CommandResult, String> 
         manifest_path.clone(),
         root.join("AGENTS.md"),
         root.join("CLAUDE.md"),
+        root.join(PROJECT_ARCHITECTURE_NAME),
         root.join("src/main.stasis"),
         root.join("tests/main.test.stasis"),
         root.join("stdlib"),
@@ -793,6 +798,10 @@ fn create_project(path: PathBuf, name: String) -> Result<CommandResult, String> 
     copy_dir_if_exists(&bundled_stdlib, &root.join("stdlib"))?;
     write_new_file(&root.join("AGENTS.md"), PROJECT_AGENT_GUIDE)?;
     write_new_file(&root.join("CLAUDE.md"), PROJECT_CLAUDE_GUIDE)?;
+    write_new_file(
+        &root.join(PROJECT_ARCHITECTURE_NAME),
+        PROJECT_ARCHITECTURE_GUIDE,
+    )?;
     write_new_file(
         &root.join("src/main.stasis"),
         "import \"../stdlib/stdlib.stasis\";\n\nfunction main(): i32 {\n    return 0;\n}\n",
@@ -4539,6 +4548,24 @@ mod tests {
         assert!(!root.join(MANIFEST_NAME).exists());
         assert_eq!(
             fs::read_to_string(root.join("CLAUDE.md")).expect("read user guide"),
+            "user guidance\n"
+        );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn init_preserves_existing_project_architecture_without_partial_writes() {
+        let root = temp_dir("architecture_guide_preflight");
+        fs::create_dir_all(&root).expect("create project directory");
+        fs::write(root.join(PROJECT_ARCHITECTURE_NAME), "user guidance\n")
+            .expect("write project architecture guide");
+
+        let error = create_project(root.clone(), "demo".to_string()).expect_err("reject conflict");
+        assert!(error.contains(PROJECT_ARCHITECTURE_NAME));
+        assert!(!root.join(MANIFEST_NAME).exists());
+        assert_eq!(
+            fs::read_to_string(root.join(PROJECT_ARCHITECTURE_NAME))
+                .expect("read project architecture guide"),
             "user guidance\n"
         );
         remove_temp(&root);

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -39,6 +39,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use crate::toolchain_formatter::format_source;
+
 mod live_tui;
 
 const MANIFEST_NAME: &str = "stasis.json";
@@ -132,7 +134,7 @@ enum ToolchainCommand {
         #[arg(long)]
         name: Option<String>,
     },
-    /// Format project source files deterministically.
+    /// Apply the canonical Stasis source layout.
     #[command(visible_alias = "format")]
     Fmt {
         #[arg(long)]
@@ -886,21 +888,64 @@ fn format_workspace(workspace: &Workspace, check: bool) -> Result<CommandResult,
     collect_stasis_files(&test_root, &mut files)?;
     files.sort();
     files.dedup();
-    let mut changed = Vec::new();
+    struct FormatChange {
+        path: PathBuf,
+        relative: String,
+        original: String,
+        formatted: String,
+    }
+
+    let mut changes = Vec::new();
     for file in files {
         let original = fs::read_to_string(&file)
             .map_err(|error| format!("failed to read {}: {error}", file.display()))?;
-        let formatted = format_source(&original);
+        let formatted = format_source(&original)
+            .map_err(|error| format!("failed to format {}: {error}", file.display()))?;
+        let reformatted = format_source(&formatted)
+            .map_err(|error| format!("failed to verify {}: {error}", file.display()))?;
+        if formatted != reformatted {
+            return Err(format!(
+                "formatter is not idempotent for {}",
+                file.display()
+            ));
+        }
         if original != formatted {
-            changed.push(relative_display(&workspace.root, &file));
-            if !check {
-                fs::write(&file, formatted)
-                    .map_err(|error| format!("failed to write {}: {error}", file.display()))?;
-            }
+            changes.push(FormatChange {
+                relative: relative_display(&workspace.root, &file),
+                path: file,
+                original,
+                formatted,
+            });
         }
     }
+    let changed = changes
+        .iter()
+        .map(|change| change.relative.clone())
+        .collect::<Vec<_>>();
     if check && !changed.is_empty() {
         return Err(format!("formatting required: {}", changed.join(", ")));
+    }
+    if !check {
+        for (index, change) in changes.iter().enumerate() {
+            if let Err(error) = fs::write(&change.path, &change.formatted) {
+                let mut rollback_errors = Vec::new();
+                for applied in changes[..=index].iter().rev() {
+                    if let Err(rollback_error) = fs::write(&applied.path, &applied.original) {
+                        rollback_errors
+                            .push(format!("{}: {rollback_error}", applied.path.display()));
+                    }
+                }
+                let rollback = if rollback_errors.is_empty() {
+                    "previous writes were rolled back".to_string()
+                } else {
+                    format!("rollback also failed for {}", rollback_errors.join(", "))
+                };
+                return Err(format!(
+                    "failed to write {}: {error}; {rollback}",
+                    change.path.display()
+                ));
+            }
+        }
     }
     Ok(CommandResult::success(
         if changed.is_empty() {
@@ -910,21 +955,6 @@ fn format_workspace(workspace: &Workspace, check: bool) -> Result<CommandResult,
         },
         json!({"changed": changed, "check": check}),
     ))
-}
-
-fn format_source(source: &str) -> String {
-    let normalized = source.replace("\r\n", "\n").replace('\r', "\n");
-    let mut lines: Vec<&str> = normalized.lines().collect();
-    while lines.last().is_some_and(|line| line.trim().is_empty()) {
-        lines.pop();
-    }
-    let mut output = lines
-        .iter()
-        .map(|line| line.trim_end_matches([' ', '\t']))
-        .collect::<Vec<_>>()
-        .join("\n");
-    output.push('\n');
-    output
 }
 
 fn check_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
@@ -4164,8 +4194,8 @@ mod tests {
     fn source_formatter_is_deterministic() {
         let source = "function main(): i32 {  \r\n    return 0;\t\r\n}\r\n\r\n";
         let expected = "function main(): i32 {\n    return 0;\n}\n";
-        assert_eq!(format_source(source), expected);
-        assert_eq!(format_source(expected), expected);
+        assert_eq!(format_source(source).expect("format"), expected);
+        assert_eq!(format_source(expected).expect("format"), expected);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_formatter.rs
+++ b/apps/stasis/src/toolchain_formatter.rs
@@ -1,0 +1,926 @@
+const INDENT_WIDTH: usize = 4;
+pub(crate) const LINE_WIDTH: usize = 160;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenKind {
+    Word,
+    Number,
+    String,
+    Backtick,
+    LineComment,
+    BlockComment,
+    Symbol,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    kind: TokenKind,
+    text: String,
+    newline_before: bool,
+    blank_before: bool,
+}
+
+impl Token {
+    fn is_symbol(&self, expected: &str) -> bool {
+        self.kind == TokenKind::Symbol && self.text == expected
+    }
+
+    fn is_word(&self, expected: &str) -> bool {
+        self.kind == TokenKind::Word && self.text == expected
+    }
+
+    fn is_comment(&self) -> bool {
+        matches!(self.kind, TokenKind::LineComment | TokenKind::BlockComment)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BraceKind {
+    Block,
+    Enum,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParenContext {
+    wrapped: bool,
+    for_header: bool,
+}
+
+#[derive(Debug, Default)]
+struct Writer {
+    output: String,
+    line: String,
+    indent: usize,
+    extra_indent_once: usize,
+}
+
+impl Writer {
+    fn column(&self) -> usize {
+        if self.line.is_empty() {
+            (self.indent + self.extra_indent_once) * INDENT_WIDTH
+        } else {
+            self.line.chars().count()
+        }
+    }
+
+    fn line_is_empty(&self) -> bool {
+        self.line.is_empty()
+    }
+
+    fn ensure_indent(&mut self) {
+        if self.line.is_empty() {
+            let count = (self.indent + self.extra_indent_once) * INDENT_WIDTH;
+            self.line.push_str(&" ".repeat(count));
+            self.extra_indent_once = 0;
+        }
+    }
+
+    fn write(&mut self, text: &str) {
+        self.ensure_indent();
+        self.line.push_str(text);
+    }
+
+    fn space(&mut self) {
+        if !self.line.is_empty() && !self.line.ends_with(' ') {
+            self.line.push(' ');
+        }
+    }
+
+    fn trim_line_end(&mut self) {
+        let trimmed = self.line.trim_end_matches([' ', '\t']).len();
+        self.line.truncate(trimmed);
+    }
+
+    fn newline(&mut self) {
+        self.trim_line_end();
+        if !self.line.is_empty() {
+            self.output.push_str(&self.line);
+        }
+        self.output.push('\n');
+        self.line.clear();
+        self.extra_indent_once = 0;
+    }
+
+    fn blank_line(&mut self) {
+        if !self.line.is_empty() {
+            self.newline();
+        }
+        while self.output.ends_with("\n\n\n") {
+            self.output.pop();
+        }
+        if !self.output.is_empty() && !self.output.ends_with("\n\n") {
+            self.output.push('\n');
+        }
+    }
+
+    fn newline_if_needed(&mut self) {
+        if !self.line.is_empty() {
+            self.newline();
+        }
+    }
+
+    fn write_multiline_comment(&mut self, text: &str) {
+        let mut lines = text.split('\n');
+        if let Some(first) = lines.next() {
+            self.write(first.trim_end_matches('\r'));
+        }
+        for line in lines {
+            self.newline();
+            self.line.push_str(line.trim_end_matches('\r'));
+        }
+    }
+
+    fn finish(mut self) -> String {
+        self.newline_if_needed();
+        self.output
+            .truncate(self.output.trim_end_matches('\n').len());
+        self.output.push('\n');
+        self.output
+    }
+}
+
+pub(crate) fn format_source(source: &str) -> Result<String, String> {
+    let tokens = scan(source)?;
+    let formatted = render(&tokens)?;
+    let formatted_tokens = scan(&formatted)?;
+    let original_significant = significant_tokens(&tokens);
+    let formatted_significant = significant_tokens(&formatted_tokens);
+    if original_significant != formatted_significant {
+        return Err("formatter changed the Stasis token stream".to_string());
+    }
+    if compiler_tokens(source)? != compiler_tokens(&formatted)? {
+        return Err("formatter changed the compiler token stream".to_string());
+    }
+    Ok(formatted)
+}
+
+fn compiler_tokens(
+    source: &str,
+) -> Result<Vec<(stasis_compiler::frontend::lexer::TokenKind, &str)>, String> {
+    stasis_compiler::frontend::lexer::lex(source).map(|tokens| {
+        tokens
+            .into_iter()
+            .map(|token| (token.kind, &source[token.start..token.end]))
+            .collect()
+    })
+}
+
+fn significant_tokens(tokens: &[Token]) -> Vec<(TokenKind, &str)> {
+    tokens
+        .iter()
+        .map(|token| (token.kind, token.text.as_str()))
+        .collect()
+}
+
+fn scan(source: &str) -> Result<Vec<Token>, String> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0usize;
+    let mut newline_count = 0usize;
+
+    while cursor < bytes.len() {
+        if bytes[cursor].is_ascii_whitespace() {
+            if bytes[cursor] == b'\n' {
+                newline_count += 1;
+                cursor += 1;
+            } else if bytes[cursor] == b'\r' {
+                newline_count += 1;
+                cursor += 1;
+                if cursor < bytes.len() && bytes[cursor] == b'\n' {
+                    cursor += 1;
+                }
+            } else {
+                cursor += 1;
+            }
+            continue;
+        }
+
+        let start = cursor;
+        let kind;
+        if bytes[cursor] == b'/' && cursor + 1 < bytes.len() && bytes[cursor + 1] == b'/' {
+            cursor += 2;
+            while cursor < bytes.len() && !matches!(bytes[cursor], b'\r' | b'\n') {
+                cursor += 1;
+            }
+            kind = TokenKind::LineComment;
+        } else if bytes[cursor] == b'/' && cursor + 1 < bytes.len() && bytes[cursor + 1] == b'*' {
+            cursor += 2;
+            let mut closed = false;
+            while cursor + 1 < bytes.len() {
+                if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+                    cursor += 2;
+                    closed = true;
+                    break;
+                }
+                cursor += utf8_width(bytes[cursor]);
+            }
+            if !closed {
+                return Err("unterminated block comment".to_string());
+            }
+            kind = TokenKind::BlockComment;
+        } else if bytes[cursor] == b'"' {
+            cursor += 1;
+            let mut closed = false;
+            while cursor < bytes.len() {
+                if bytes[cursor] == b'\\' {
+                    cursor += 1;
+                    if cursor < bytes.len() {
+                        cursor += utf8_width(bytes[cursor]);
+                    }
+                    continue;
+                }
+                if bytes[cursor] == b'"' {
+                    cursor += 1;
+                    closed = true;
+                    break;
+                }
+                cursor += utf8_width(bytes[cursor]);
+            }
+            if !closed {
+                return Err("unterminated string literal".to_string());
+            }
+            kind = TokenKind::String;
+        } else if bytes[cursor] == b'`' {
+            cursor += 1;
+            let mut closed = false;
+            while cursor < bytes.len() {
+                if bytes[cursor] == b'`' {
+                    cursor += 1;
+                    closed = true;
+                    break;
+                }
+                cursor += utf8_width(bytes[cursor]);
+            }
+            if !closed {
+                return Err("unterminated backtick literal".to_string());
+            }
+            kind = TokenKind::Backtick;
+        } else if is_word_start(bytes[cursor]) {
+            cursor += 1;
+            while cursor < bytes.len() && is_word_continue(bytes[cursor]) {
+                cursor += 1;
+            }
+            kind = TokenKind::Word;
+        } else if bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+            while cursor < bytes.len() {
+                if bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_' {
+                    cursor += 1;
+                } else if bytes[cursor] == b'.'
+                    && cursor + 1 < bytes.len()
+                    && bytes[cursor + 1].is_ascii_digit()
+                {
+                    cursor += 1;
+                } else if matches!(bytes[cursor], b'+' | b'-')
+                    && matches!(bytes[cursor - 1], b'e' | b'E')
+                    && cursor + 1 < bytes.len()
+                    && bytes[cursor + 1].is_ascii_digit()
+                {
+                    cursor += 1;
+                } else {
+                    break;
+                }
+            }
+            kind = TokenKind::Number;
+        } else {
+            let width = matched_operator_width(&bytes[cursor..]);
+            cursor += width;
+            kind = TokenKind::Symbol;
+        }
+
+        let text = source
+            .get(start..cursor)
+            .ok_or_else(|| "formatter encountered an invalid UTF-8 boundary".to_string())?
+            .to_string();
+        tokens.push(Token {
+            kind,
+            text,
+            newline_before: newline_count > 0,
+            blank_before: newline_count > 1,
+        });
+        newline_count = 0;
+    }
+
+    Ok(tokens)
+}
+
+fn utf8_width(byte: u8) -> usize {
+    if byte < 0x80 {
+        1
+    } else if byte < 0xE0 {
+        2
+    } else if byte < 0xF0 {
+        3
+    } else {
+        4
+    }
+}
+
+fn is_word_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+fn is_word_continue(byte: u8) -> bool {
+    is_word_start(byte) || byte.is_ascii_digit()
+}
+
+fn matched_operator_width(bytes: &[u8]) -> usize {
+    if bytes.len() >= 2 {
+        let pair = &bytes[..2];
+        if matches!(
+            pair,
+            b"+="
+                | b"-="
+                | b"*="
+                | b"/="
+                | b"%="
+                | b"=="
+                | b"!="
+                | b"<="
+                | b">="
+                | b"&&"
+                | b"||"
+                | b"->"
+                | b"::"
+        ) {
+            return 2;
+        }
+    }
+    utf8_width(bytes[0])
+}
+
+fn render(tokens: &[Token]) -> Result<String, String> {
+    let mut writer = Writer::default();
+    let mut braces = Vec::<BraceKind>::new();
+    let mut parens = Vec::<ParenContext>::new();
+    let mut bracket_depth = 0usize;
+    let mut last_significant: Option<&Token> = None;
+    let mut last_was_unary = false;
+    let mut force_space_after_comment = false;
+    let mut enum_member_started = false;
+    let mut top_level_kind: Option<String> = None;
+    let mut top_level_has_enum = false;
+
+    let mut index = 0usize;
+    while index < tokens.len() {
+        let token = &tokens[index];
+
+        if token.blank_before && !writer.line_is_empty() && token.is_comment() {
+            writer.blank_line();
+        } else if token.blank_before
+            && !token.is_symbol("}")
+            && writer.line_is_empty()
+            && !writer.output.ends_with("\n\n")
+            && !writer.output.is_empty()
+        {
+            writer.blank_line();
+        }
+
+        if token.kind == TokenKind::LineComment {
+            let attached = !token.newline_before && !writer.line_is_empty();
+            if !writer.line_is_empty() {
+                writer.space();
+            }
+            writer.write(&token.text);
+            writer.newline();
+            if attached
+                && braces.is_empty()
+                && last_significant
+                    .is_some_and(|previous| previous.is_symbol(";") || previous.is_symbol("}"))
+            {
+                if !keeps_import_group(tokens, index + 1, top_level_kind.as_deref()) {
+                    writer.blank_line();
+                    top_level_kind = None;
+                    top_level_has_enum = false;
+                }
+            } else if last_significant.is_some_and(is_operator) {
+                writer.extra_indent_once = 1;
+            }
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.kind == TokenKind::BlockComment {
+            let starts_line = writer.line_is_empty();
+            let closes_line = last_significant.is_some_and(|previous| {
+                (previous.is_symbol(";")
+                    && !parens.last().is_some_and(|context| context.for_header))
+                    || previous.is_symbol("{")
+                    || previous.is_symbol("}")
+            });
+            if !writer.line_is_empty() {
+                writer.space();
+            }
+            if token.text.contains(['\r', '\n']) {
+                writer.write_multiline_comment(&token.text);
+            } else {
+                writer.write(&token.text);
+            }
+            if starts_line || closes_line || token.text.contains(['\r', '\n']) {
+                writer.newline();
+                if closes_line
+                    && braces.is_empty()
+                    && last_significant
+                        .is_some_and(|previous| previous.is_symbol(";") || previous.is_symbol("}"))
+                {
+                    if !keeps_import_group(tokens, index + 1, top_level_kind.as_deref()) {
+                        writer.blank_line();
+                        top_level_kind = None;
+                        top_level_has_enum = false;
+                    }
+                }
+            } else {
+                force_space_after_comment = true;
+            }
+            index += 1;
+            continue;
+        }
+
+        if braces.last() == Some(&BraceKind::Enum)
+            && parens.is_empty()
+            && bracket_depth == 0
+            && token.kind == TokenKind::Word
+            && enum_member_started
+            && !last_significant.is_some_and(|previous| previous.is_symbol("="))
+        {
+            writer.newline_if_needed();
+        }
+
+        if braces.is_empty() && parens.is_empty() && bracket_depth == 0 && top_level_kind.is_none()
+        {
+            if token.kind == TokenKind::Word {
+                top_level_kind = Some(token.text.clone());
+            }
+        }
+        if braces.is_empty() && parens.is_empty() && bracket_depth == 0 && token.is_word("enum") {
+            top_level_has_enum = true;
+        }
+
+        if token.is_symbol("{") {
+            if !writer.line_is_empty() {
+                writer.space();
+            }
+            writer.write("{");
+            writer.indent += 1;
+            let kind = if top_level_has_enum && braces.is_empty() {
+                enum_member_started = false;
+                BraceKind::Enum
+            } else {
+                BraceKind::Block
+            };
+            braces.push(kind);
+            if !has_attached_line_comment(tokens, index + 1) {
+                writer.newline();
+            }
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol("}") {
+            writer.newline_if_needed();
+            writer.indent = writer.indent.saturating_sub(1);
+            let closed = braces
+                .pop()
+                .ok_or_else(|| "unmatched closing brace".to_string())?;
+            writer.write("}");
+            if closed == BraceKind::Enum {
+                enum_member_started = false;
+            }
+            let next = next_significant(tokens, index + 1);
+            if !has_attached_comment(tokens, index + 1) {
+                if next.is_some_and(|next| next.is_word("else")) {
+                    writer.space();
+                } else if !next.is_some_and(|next| next.is_symbol(";") || next.is_symbol(",")) {
+                    if braces.is_empty() {
+                        writer.blank_line();
+                        top_level_kind = None;
+                        top_level_has_enum = false;
+                    } else {
+                        writer.newline();
+                    }
+                }
+            }
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol("(") {
+            if needs_space_before(last_significant, token, false, last_was_unary)
+                || force_space_after_comment
+            {
+                writer.space();
+            }
+            writer.write("(");
+            let for_header = last_significant.is_some_and(|previous| previous.is_word("for"));
+            let wrapped = !for_header && should_wrap_parens(tokens, index, writer.column());
+            parens.push(ParenContext {
+                wrapped,
+                for_header,
+            });
+            if wrapped {
+                writer.indent += 1;
+                writer.newline();
+            }
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol(")") {
+            let context = parens
+                .pop()
+                .ok_or_else(|| "unmatched closing parenthesis".to_string())?;
+            if context.wrapped {
+                writer.newline_if_needed();
+                writer.indent = writer.indent.saturating_sub(1);
+            }
+            writer.write(")");
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol("[") {
+            writer.write("[");
+            bracket_depth += 1;
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol("]") {
+            if bracket_depth == 0 {
+                return Err("unmatched closing bracket".to_string());
+            }
+            bracket_depth -= 1;
+            writer.write("]");
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol(";") {
+            writer.write(";");
+            if parens.last().is_some_and(|context| context.for_header) {
+                writer.space();
+            } else if !has_attached_comment(tokens, index + 1) {
+                writer.newline();
+                if braces.is_empty() {
+                    let next_kind = next_top_level_word(tokens, index + 1);
+                    let keep_grouped = matches!(top_level_kind.as_deref(), Some("import"))
+                        && next_kind.as_deref() == Some("import");
+                    if !keep_grouped {
+                        writer.blank_line();
+                    }
+                    top_level_kind = None;
+                    top_level_has_enum = false;
+                }
+            }
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if token.is_symbol(",") {
+            writer.write(",");
+            if parens.last().is_some_and(|context| context.wrapped) {
+                writer.newline();
+            } else {
+                writer.space();
+            }
+            last_significant = Some(token);
+            last_was_unary = false;
+            force_space_after_comment = false;
+            index += 1;
+            continue;
+        }
+
+        if matches!(token.text.as_str(), "&&" | "||")
+            && parens.last().is_some_and(|context| context.wrapped)
+            && !writer.line_is_empty()
+        {
+            writer.newline();
+        }
+
+        let unary = is_unary_operator(token, last_significant);
+        if needs_space_before(last_significant, token, unary, last_was_unary)
+            || force_space_after_comment
+        {
+            writer.space();
+        }
+        writer.write(&token.text);
+
+        if braces.last() == Some(&BraceKind::Enum)
+            && parens.is_empty()
+            && bracket_depth == 0
+            && token.kind == TokenKind::Word
+        {
+            enum_member_started = true;
+        }
+
+        last_significant = Some(token);
+        last_was_unary = unary;
+        force_space_after_comment = false;
+        index += 1;
+    }
+
+    if !braces.is_empty() {
+        return Err("unmatched opening brace".to_string());
+    }
+    if !parens.is_empty() {
+        return Err("unmatched opening parenthesis".to_string());
+    }
+    if bracket_depth != 0 {
+        return Err("unmatched opening bracket".to_string());
+    }
+    Ok(writer.finish())
+}
+
+fn next_significant(tokens: &[Token], start: usize) -> Option<&Token> {
+    tokens
+        .get(start..)?
+        .iter()
+        .find(|token| !token.is_comment())
+}
+
+fn has_attached_comment(tokens: &[Token], index: usize) -> bool {
+    tokens
+        .get(index)
+        .is_some_and(|token| token.is_comment() && !token.newline_before)
+}
+
+fn has_attached_line_comment(tokens: &[Token], index: usize) -> bool {
+    tokens
+        .get(index)
+        .is_some_and(|token| token.kind == TokenKind::LineComment && !token.newline_before)
+}
+
+fn next_top_level_word(tokens: &[Token], start: usize) -> Option<String> {
+    next_significant(tokens, start)
+        .filter(|token| token.kind == TokenKind::Word)
+        .map(|token| token.text.clone())
+}
+
+fn keeps_import_group(tokens: &[Token], start: usize, top_level_kind: Option<&str>) -> bool {
+    top_level_kind == Some("import")
+        && next_top_level_word(tokens, start).as_deref() == Some("import")
+}
+
+fn is_unary_operator(token: &Token, previous: Option<&Token>) -> bool {
+    if token.kind != TokenKind::Symbol || !matches!(token.text.as_str(), "!" | "-" | "+") {
+        return false;
+    }
+    previous.is_none_or(|previous| {
+        previous.is_symbol("(")
+            || previous.is_symbol("[")
+            || previous.is_symbol("{")
+            || previous.is_symbol(",")
+            || previous.is_symbol(";")
+            || is_operator(previous)
+            || previous.is_word("return")
+    })
+}
+
+fn is_operator(token: &Token) -> bool {
+    token.kind == TokenKind::Symbol
+        && matches!(
+            token.text.as_str(),
+            "=" | "+="
+                | "-="
+                | "*="
+                | "/="
+                | "%="
+                | "=="
+                | "!="
+                | "<"
+                | "<="
+                | ">"
+                | ">="
+                | "+"
+                | "-"
+                | "*"
+                | "/"
+                | "%"
+                | "&&"
+                | "||"
+                | "|"
+                | "&"
+                | "->"
+        )
+}
+
+fn needs_space_before(
+    previous: Option<&Token>,
+    current: &Token,
+    current_is_unary: bool,
+    previous_was_unary: bool,
+) -> bool {
+    let Some(previous) = previous else {
+        return false;
+    };
+    if current.is_symbol("(") {
+        return previous.is_word("if") || previous.is_word("for") || previous.is_word("foreach");
+    }
+    if matches!(current.text.as_str(), ")" | "]" | "," | ";" | ":" | ".") {
+        return false;
+    }
+    if matches!(previous.text.as_str(), "(" | "[" | "." | "@") {
+        return false;
+    }
+    if current.is_symbol("[") || current.is_symbol("@") {
+        return current.is_symbol("@") && previous.kind == TokenKind::Word;
+    }
+    if current_is_unary {
+        return previous.kind == TokenKind::Word
+            || previous.kind == TokenKind::Number
+            || is_operator(previous);
+    }
+    if previous_was_unary {
+        return false;
+    }
+    if is_operator(current) || is_operator(previous) {
+        return true;
+    }
+    if previous.is_symbol(":") || previous.is_symbol(",") {
+        return true;
+    }
+    if previous.is_symbol("}") && current.is_word("else") {
+        return true;
+    }
+    if previous.is_symbol(")") && current.kind == TokenKind::Word {
+        return true;
+    }
+    matches!(
+        (previous.kind, current.kind),
+        (
+            TokenKind::Word | TokenKind::Number | TokenKind::String | TokenKind::Backtick,
+            TokenKind::Word | TokenKind::Number | TokenKind::String | TokenKind::Backtick
+        )
+    )
+}
+
+fn should_wrap_parens(tokens: &[Token], open_index: usize, current_column: usize) -> bool {
+    let Some(close_index) = matching_close(tokens, open_index, "(", ")") else {
+        return false;
+    };
+    if tokens[open_index + 1..close_index]
+        .iter()
+        .any(|token| token.kind == TokenKind::LineComment || token.text.contains(['\r', '\n']))
+    {
+        return true;
+    }
+    let estimated = tokens[open_index + 1..=close_index]
+        .iter()
+        .map(|token| token.text.chars().count() + 1)
+        .sum::<usize>();
+    current_column + estimated > LINE_WIDTH
+}
+
+fn matching_close(tokens: &[Token], open_index: usize, open: &str, close: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, token) in tokens.iter().enumerate().skip(open_index) {
+        if token.is_symbol(open) {
+            depth += 1;
+        } else if token.is_symbol(close) {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_source, LINE_WIDTH};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn formats_declarations_blocks_and_spacing() {
+        let source = "struct Player{health :i32;position:Vec2;} enum Screen{Menu Playing} global state :Player; function damage (self:Player,amount:i32):void {if(amount<=0){return;}else{self.health-=amount;}}";
+        let expected = "struct Player {\n    health: i32;\n    position: Vec2;\n}\n\nenum Screen {\n    Menu\n    Playing\n}\n\nglobal state: Player;\n\nfunction damage(self: Player, amount: i32): void {\n    if (amount <= 0) {\n        return;\n    } else {\n        self.health -= amount;\n    }\n}\n";
+        assert_eq!(format_source(source).expect("format"), expected);
+    }
+
+    #[test]
+    fn preserves_comments_strings_and_for_header_semicolons() {
+        let source = "// header\nfunction main():i32{/* before */let value:i32=1/* plus */+2;for/* header */(let i:i32=0/* ; */;i<2;i+=1){value+=i;}print_string(\"{;}//\");return value;// tail\n}\n";
+        let formatted = format_source(source).expect("format");
+        assert!(formatted.contains("// header"));
+        assert!(formatted.contains("/* before */"));
+        assert!(formatted.contains("/* ; */"));
+        assert!(formatted.contains("for /* header */ (let i: i32 = 0 /* ; */; i < 2; i += 1) {"));
+        assert!(formatted.contains("print_string(\"{;}//\");"));
+        assert!(formatted.contains("return value; // tail"));
+        assert_eq!(format_source(&formatted).expect("reformat"), formatted);
+    }
+
+    #[test]
+    fn wraps_long_parameter_lists_at_the_soft_limit() {
+        let names = (0..18)
+            .map(|index| format!("parameter_{index}: i32"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let source = format!("function calculate({names}):i32{{return parameter_0;}}");
+        let formatted = format_source(&source).expect("format");
+        assert!(formatted.starts_with("function calculate(\n"));
+        assert!(formatted.contains("    parameter_0: i32,\n"));
+        assert!(formatted.contains("    parameter_17: i32\n): i32 {"));
+        assert!(formatted
+            .lines()
+            .all(|line| line.chars().count() <= LINE_WIDTH));
+        assert_eq!(format_source(&formatted).expect("reformat"), formatted);
+    }
+
+    #[test]
+    fn normalizes_tabs_blank_lines_and_line_endings() {
+        let source = "function main(): i32 {\r\n\treturn 0;   \r\n\r\n\r\n}\r\n\r\n";
+        let expected = "function main(): i32 {\n    return 0;\n}\n";
+        assert_eq!(format_source(source).expect("format"), expected);
+    }
+
+    #[test]
+    fn formats_annotations_unary_values_and_attached_comments() {
+        let source = "function @extern(\"native_tick\")tick(value:i32):i32; enum Phase{Menu// initial\nPlaying} function main():i32{/* first\n * second\n */let value:i32=2*-3;return value;} // entry\n";
+        let expected = "function @extern(\"native_tick\") tick(value: i32): i32;\n\nenum Phase {\n    Menu // initial\n    Playing\n}\n\nfunction main(): i32 {\n    /* first\n * second\n */\n    let value: i32 = 2 * -3;\n    return value;\n} // entry\n";
+        assert_eq!(format_source(source).expect("format"), expected);
+        assert_eq!(format_source(expected).expect("reformat"), expected);
+    }
+
+    #[test]
+    fn keeps_commented_imports_in_one_group() {
+        let source = "import\"a.stasis\";// first\nimport \"b.stasis\";/* second */\nfunction main():i32{return 0;}";
+        let expected = "import \"a.stasis\"; // first\nimport \"b.stasis\"; /* second */\n\nfunction main(): i32 {\n    return 0;\n}\n";
+        assert_eq!(format_source(source).expect("format"), expected);
+        assert_eq!(format_source(expected).expect("reformat"), expected);
+    }
+
+    #[test]
+    fn formats_repository_stasis_corpus_idempotently() {
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut files = Vec::new();
+        for relative in [
+            "src",
+            "samples",
+            "tests/stasis",
+            "tools/fixtures",
+            "mobile/android/app/src/main/assets",
+        ] {
+            collect_stasis_files(&repository.join(relative), &mut files);
+        }
+        assert!(!files.is_empty(), "expected repository Stasis fixtures");
+        for path in files {
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            let formatted = format_source(&source)
+                .unwrap_or_else(|error| panic!("failed to format {}: {error}", path.display()));
+            assert_eq!(
+                format_source(&formatted).expect("reformat corpus file"),
+                formatted,
+                "formatter was not idempotent for {}",
+                path.display()
+            );
+        }
+    }
+
+    fn collect_stasis_files(root: &Path, files: &mut Vec<PathBuf>) {
+        if !root.is_dir() {
+            return;
+        }
+        for entry in fs::read_dir(root).expect("read corpus directory") {
+            let entry = entry.expect("read corpus entry");
+            let file_type = entry.file_type().expect("read corpus file type");
+            if file_type.is_symlink() {
+                continue;
+            }
+            let path = entry.path();
+            if file_type.is_dir() {
+                collect_stasis_files(&path, files);
+            } else if path
+                .extension()
+                .is_some_and(|extension| extension == "stasis")
+            {
+                files.push(path);
+            }
+        }
+    }
+}

--- a/apps/stasis/src/toolchain_formatter.rs
+++ b/apps/stasis/src/toolchain_formatter.rs
@@ -140,7 +140,7 @@ impl Writer {
 }
 
 pub(crate) fn format_source(source: &str) -> Result<String, String> {
-    let tokens = scan(source)?;
+    let tokens = canonicalize_enum_commas(&scan(source)?)?;
     let formatted = render(&tokens)?;
     let formatted_tokens = scan(&formatted)?;
     let original_significant = significant_tokens(&tokens);
@@ -148,21 +148,49 @@ pub(crate) fn format_source(source: &str) -> Result<String, String> {
     if original_significant != formatted_significant {
         return Err("formatter changed the Stasis token stream".to_string());
     }
-    if compiler_tokens(source)? != compiler_tokens(&formatted)? {
+    if compiler_tokens_without_enum_commas(source)?
+        != compiler_tokens_without_enum_commas(&formatted)?
+    {
         return Err("formatter changed the compiler token stream".to_string());
     }
     Ok(formatted)
 }
 
-fn compiler_tokens(
+fn compiler_tokens_without_enum_commas(
     source: &str,
 ) -> Result<Vec<(stasis_compiler::frontend::lexer::TokenKind, &str)>, String> {
-    stasis_compiler::frontend::lexer::lex(source).map(|tokens| {
-        tokens
-            .into_iter()
-            .map(|token| (token.kind, &source[token.start..token.end]))
-            .collect()
-    })
+    use stasis_compiler::frontend::lexer::TokenKind as CompilerTokenKind;
+
+    let tokens = stasis_compiler::frontend::lexer::lex(source)?;
+    let mut normalized = Vec::new();
+    let mut brace_depth = 0usize;
+    let mut pending_enum = false;
+    let mut enum_depth = None;
+    for token in tokens {
+        let text = &source[token.start..token.end];
+        if brace_depth == 0 && token.kind == CompilerTokenKind::Identifier && text == "enum" {
+            pending_enum = true;
+        }
+        if token.kind == CompilerTokenKind::LBrace {
+            brace_depth += 1;
+            if pending_enum {
+                enum_depth = Some(brace_depth);
+                pending_enum = false;
+            }
+        }
+        let enum_comma = token.kind == CompilerTokenKind::Comma
+            && enum_depth.is_some_and(|depth| depth == brace_depth);
+        if !enum_comma {
+            normalized.push((token.kind, text));
+        }
+        if token.kind == CompilerTokenKind::RBrace {
+            if enum_depth == Some(brace_depth) {
+                enum_depth = None;
+            }
+            brace_depth = brace_depth.saturating_sub(1);
+        }
+    }
+    Ok(normalized)
 }
 
 fn significant_tokens(tokens: &[Token]) -> Vec<(TokenKind, &str)> {
@@ -170,6 +198,110 @@ fn significant_tokens(tokens: &[Token]) -> Vec<(TokenKind, &str)> {
         .iter()
         .map(|token| (token.kind, token.text.as_str()))
         .collect()
+}
+
+fn canonicalize_enum_commas(tokens: &[Token]) -> Result<Vec<Token>, String> {
+    let mut insert_after = vec![false; tokens.len()];
+    let mut remove = vec![false; tokens.len()];
+    let mut brace_depth = 0usize;
+    let mut index = 0usize;
+
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if brace_depth == 0 && token.is_word("enum") {
+            let name = next_non_comment_index(tokens, index + 1)
+                .ok_or_else(|| "incomplete enum declaration".to_string())?;
+            if tokens[name].kind != TokenKind::Word {
+                return Err("expected enum name".to_string());
+            }
+            let open = next_non_comment_index(tokens, name + 1)
+                .ok_or_else(|| "enum declaration is missing its body".to_string())?;
+            if !tokens[open].is_symbol("{") {
+                return Err("enum declaration is missing its opening brace".to_string());
+            }
+
+            let mut cursor = next_non_comment_index(tokens, open + 1)
+                .ok_or_else(|| "enum declaration is missing its closing brace".to_string())?;
+            while !tokens[cursor].is_symbol("}") {
+                if tokens[cursor].kind != TokenKind::Word {
+                    return Err("expected enum variant name".to_string());
+                }
+                let mut last_core = cursor;
+                let mut delimiter = next_non_comment_index(tokens, cursor + 1)
+                    .ok_or_else(|| "enum declaration is missing its closing brace".to_string())?;
+                if tokens[delimiter].is_symbol("=") {
+                    delimiter = next_non_comment_index(tokens, delimiter + 1)
+                        .ok_or_else(|| "enum variant is missing its value".to_string())?;
+                    if tokens[delimiter].is_symbol("-") {
+                        delimiter = next_non_comment_index(tokens, delimiter + 1)
+                            .ok_or_else(|| "enum variant is missing its value".to_string())?;
+                    }
+                    if tokens[delimiter].kind != TokenKind::Number {
+                        return Err("enum variant value must be an integer".to_string());
+                    }
+                    last_core = delimiter;
+                    delimiter = next_non_comment_index(tokens, delimiter + 1).ok_or_else(|| {
+                        "enum declaration is missing its closing brace".to_string()
+                    })?;
+                }
+
+                if tokens[delimiter].is_symbol(",") {
+                    if delimiter != last_core + 1 {
+                        remove[delimiter] = true;
+                        insert_after[last_core] = true;
+                    }
+                    cursor = next_non_comment_index(tokens, delimiter + 1).ok_or_else(|| {
+                        "enum declaration is missing its closing brace".to_string()
+                    })?;
+                } else if tokens[delimiter].kind == TokenKind::Word
+                    || tokens[delimiter].is_symbol("}")
+                {
+                    insert_after[last_core] = true;
+                    cursor = delimiter;
+                } else {
+                    return Err(format!(
+                        "unexpected token '{}' after enum variant",
+                        tokens[delimiter].text
+                    ));
+                }
+            }
+            index = cursor + 1;
+            continue;
+        }
+
+        if token.is_symbol("{") {
+            brace_depth += 1;
+        } else if token.is_symbol("}") {
+            brace_depth = brace_depth.saturating_sub(1);
+        }
+        index += 1;
+    }
+
+    let mut canonical =
+        Vec::with_capacity(tokens.len() + insert_after.iter().filter(|add| **add).count());
+    for (index, token) in tokens.iter().enumerate() {
+        if !remove[index] {
+            canonical.push(token.clone());
+        }
+        if insert_after[index] {
+            canonical.push(Token {
+                kind: TokenKind::Symbol,
+                text: ",".to_string(),
+                newline_before: false,
+                blank_before: false,
+            });
+        }
+    }
+    Ok(canonical)
+}
+
+fn next_non_comment_index(tokens: &[Token], start: usize) -> Option<usize> {
+    tokens
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find(|(_, token)| !token.is_comment())
+        .map(|(index, _)| index)
 }
 
 fn scan(source: &str) -> Result<Vec<Token>, String> {
@@ -600,7 +732,15 @@ fn render(tokens: &[Token]) -> Result<String, String> {
 
         if token.is_symbol(",") {
             writer.write(",");
-            if parens.last().is_some_and(|context| context.wrapped) {
+            if braces.last() == Some(&BraceKind::Enum) && parens.is_empty() && bracket_depth == 0 {
+                enum_member_started = false;
+                if !tokens
+                    .get(index + 1)
+                    .is_some_and(|next| next.is_comment() && !next.newline_before)
+                {
+                    writer.newline();
+                }
+            } else if parens.last().is_some_and(|context| context.wrapped) {
                 writer.newline();
             } else {
                 writer.space();
@@ -817,7 +957,7 @@ mod tests {
     #[test]
     fn formats_declarations_blocks_and_spacing() {
         let source = "struct Player{health :i32;position:Vec2;} enum Screen{Menu Playing} global state :Player; function damage (self:Player,amount:i32):void {if(amount<=0){return;}else{self.health-=amount;}}";
-        let expected = "struct Player {\n    health: i32;\n    position: Vec2;\n}\n\nenum Screen {\n    Menu\n    Playing\n}\n\nglobal state: Player;\n\nfunction damage(self: Player, amount: i32): void {\n    if (amount <= 0) {\n        return;\n    } else {\n        self.health -= amount;\n    }\n}\n";
+        let expected = "struct Player {\n    health: i32;\n    position: Vec2;\n}\n\nenum Screen {\n    Menu,\n    Playing,\n}\n\nglobal state: Player;\n\nfunction damage(self: Player, amount: i32): void {\n    if (amount <= 0) {\n        return;\n    } else {\n        self.health -= amount;\n    }\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
     }
 
@@ -861,7 +1001,7 @@ mod tests {
     #[test]
     fn formats_annotations_unary_values_and_attached_comments() {
         let source = "function @extern(\"native_tick\")tick(value:i32):i32; enum Phase{Menu// initial\nPlaying} function main():i32{/* first\n * second\n */let value:i32=2*-3;return value;} // entry\n";
-        let expected = "function @extern(\"native_tick\") tick(value: i32): i32;\n\nenum Phase {\n    Menu // initial\n    Playing\n}\n\nfunction main(): i32 {\n    /* first\n * second\n */\n    let value: i32 = 2 * -3;\n    return value;\n} // entry\n";
+        let expected = "function @extern(\"native_tick\") tick(value: i32): i32;\n\nenum Phase {\n    Menu, // initial\n    Playing,\n}\n\nfunction main(): i32 {\n    /* first\n * second\n */\n    let value: i32 = 2 * -3;\n    return value;\n} // entry\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(expected).expect("reformat"), expected);
     }
@@ -870,6 +1010,15 @@ mod tests {
     fn keeps_commented_imports_in_one_group() {
         let source = "import\"a.stasis\";// first\nimport \"b.stasis\";/* second */\nfunction main():i32{return 0;}";
         let expected = "import \"a.stasis\"; // first\nimport \"b.stasis\"; /* second */\n\nfunction main(): i32 {\n    return 0;\n}\n";
+        assert_eq!(format_source(source).expect("format"), expected);
+        assert_eq!(format_source(expected).expect("reformat"), expected);
+    }
+
+    #[test]
+    fn adds_trailing_enum_commas_before_attached_comments() {
+        let source = "enum Phase{Ready Running=4// active\n,Finished/* done */}";
+        let expected =
+            "enum Phase {\n    Ready,\n    Running = 4, // active\n    Finished, /* done */\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(expected).expect("reformat"), expected);
     }

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -149,7 +149,7 @@ fn format_alias_applies_canonical_layout_and_fmt_check_enforces_it() {
     assert_eq!(json_stdout(&formatted)["command"], "fmt");
     assert_eq!(
         fs::read_to_string(&entry).expect("read formatted fixture"),
-        "struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu\n    Playing\n}\n\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n"
+        "struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu,\n    Playing,\n}\n\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n"
     );
 
     let fixed_modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
 
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 
@@ -150,6 +151,32 @@ fn format_alias_applies_canonical_layout_and_fmt_check_enforces_it() {
         fs::read_to_string(&entry).expect("read formatted fixture"),
         "struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu\n    Playing\n}\n\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n"
     );
+
+    let fixed_modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    fs::File::options()
+        .write(true)
+        .open(&entry)
+        .expect("open formatted fixture without truncating")
+        .set_times(fs::FileTimes::new().set_modified(fixed_modified))
+        .expect("set fixture modification time");
+    let baseline_modified = fs::metadata(&entry)
+        .expect("read fixture metadata")
+        .modified()
+        .expect("read fixture modification time");
+
+    for command in ["fmt", "format"] {
+        let unchanged = stasis(&["--json", command], &project);
+        assert_eq!(unchanged.status.code(), Some(0));
+        assert_eq!(json_stdout(&unchanged)["result"]["changed"], json!([]));
+        assert_eq!(
+            fs::metadata(&entry)
+                .expect("read unchanged fixture metadata")
+                .modified()
+                .expect("read unchanged fixture modification time"),
+            baseline_modified,
+            "{command} rewrote an unchanged source file"
+        );
+    }
 
     assert_eq!(stasis(&["fmt", "--check"], &project).status.code(), Some(0));
     let checked = stasis(&["check"], &project);

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -119,6 +119,51 @@ fn init_includes_the_project_architecture_guide() {
 }
 
 #[test]
+fn format_alias_applies_canonical_layout_and_fmt_check_enforces_it() {
+    let parent = temp_dir("opinionated_format");
+    fs::create_dir_all(&parent).expect("create temp parent");
+    let project = parent.join("demo");
+    assert_eq!(
+        stasis(&["new", "demo", "--dir", "demo"], &parent)
+            .status
+            .code(),
+        Some(0)
+    );
+    let entry = project.join("src/main.stasis");
+    fs::write(
+        &entry,
+        "struct Player{health:i32;active:bool;}enum Mode{Menu Playing}global player:Player;function update(amount:i32):void{if(amount>0){player.health+=amount;}else{player.health=0;}}function main():i32{update(1);return player.health;}\n",
+    )
+    .expect("write unformatted fixture");
+
+    let before = stasis(&["--json", "fmt", "--check"], &project);
+    assert_eq!(before.status.code(), Some(1));
+    assert!(json_stderr(&before)["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("src/main.stasis"));
+
+    let formatted = stasis(&["--json", "format"], &project);
+    assert_eq!(formatted.status.code(), Some(0));
+    assert_eq!(json_stdout(&formatted)["command"], "fmt");
+    assert_eq!(
+        fs::read_to_string(&entry).expect("read formatted fixture"),
+        "struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu\n    Playing\n}\n\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n"
+    );
+
+    assert_eq!(stasis(&["fmt", "--check"], &project).status.code(), Some(0));
+    let checked = stasis(&["check"], &project);
+    assert_eq!(
+        checked.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&checked.stdout),
+        String::from_utf8_lossy(&checked.stderr)
+    );
+    fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
 fn inspect_reports_compiler_state_memory_and_capacity_projection() {
     let parent = temp_dir("memory_report");
     fs::create_dir_all(&parent).expect("create temp parent");

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -59,8 +59,26 @@ fn project_commands_emit_stable_json_from_nested_directories() {
     assert!(agent_guide.contains("Mapping:"));
     assert!(agent_guide.contains("Rationale:"));
     assert!(agent_guide.contains("Extension:"));
+    assert!(agent_guide.contains("Read `PROJECT_ARCHITECTURE.md`"));
     let claude_guide = fs::read_to_string(project.join("CLAUDE.md")).expect("read Claude guide");
     assert_eq!(claude_guide, "# CLAUDE.md\n\n@AGENTS.md\n");
+    let architecture_guide = fs::read_to_string(project.join("PROJECT_ARCHITECTURE.md"))
+        .expect("read project architecture guide");
+    assert_eq!(
+        architecture_guide,
+        include_str!("../../../docs/project_architecture.md")
+    );
+
+    let formatted = stasis(&["--json", "fmt", "--check"], &project);
+    assert_eq!(formatted.status.code(), Some(0));
+    let formatted_json = json_stdout(&formatted);
+    assert_eq!(formatted_json["command"], "fmt");
+
+    let format_alias = stasis(&["--json", "format", "--check"], &project);
+    assert_eq!(format_alias.status.code(), Some(0));
+    let format_alias_json = json_stdout(&format_alias);
+    assert_eq!(format_alias_json["command"], "fmt");
+    assert_eq!(format_alias_json["result"], formatted_json["result"]);
 
     let version = stasis(&["--json", "--version"], &parent);
     assert_eq!(version.status.code(), Some(0));
@@ -78,6 +96,24 @@ fn project_commands_emit_stable_json_from_nested_directories() {
         .as_str()
         .unwrap_or_default()
         .contains("does not exist"));
+
+    fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+fn init_includes_the_project_architecture_guide() {
+    let parent = temp_dir("init_architecture");
+    let project = parent.join("existing");
+    fs::create_dir_all(&project).expect("create existing project directory");
+
+    let initialized = stasis(&["--json", "init", "--name", "existing", "."], &project);
+    assert_eq!(initialized.status.code(), Some(0));
+    assert_eq!(json_stdout(&initialized)["command"], "init");
+    assert_eq!(
+        fs::read_to_string(project.join("PROJECT_ARCHITECTURE.md"))
+            .expect("read project architecture guide"),
+        include_str!("../../../docs/project_architecture.md")
+    );
 
     fs::remove_dir_all(&parent).ok();
 }

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -4746,7 +4746,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "enum BrickType { Basic, Armored, Reflector }\nconst COUNT: i32 = 2;\nstruct Brick { brick_type: BrickType; hp: i32; }\nglobal bricks: Brick[COUNT];\nfunction place(kind: BrickType): i32 { bricks[0].brick_type = kind; return 0; }\nfunction main(): i32 {\n    let ignored: i32 = place(BrickType.Reflector);\n    if (bricks[0].brick_type == BrickType.Reflector) { return 1; }\n    return ignored;\n}\n",
+            "enum BrickType { Basic, Armored, Reflector, }\nconst COUNT: i32 = 2;\nstruct Brick { brick_type: BrickType; hp: i32; }\nglobal bricks: Brick[COUNT];\nfunction place(kind: BrickType): i32 { bricks[0].brick_type = kind; return 0; }\nfunction main(): i32 {\n    let ignored: i32 = place(BrickType.Reflector);\n    if (bricks[0].brick_type == BrickType.Reflector) { return 1; }\n    return ignored;\n}\n",
         );
         process.compile().expect("compile");
         let value = process
@@ -4761,7 +4761,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "enum BrickType { Basic, Armored }\nfunction cost(kind: BrickType): i32 { if (kind == BrickType.Armored) { return 2; } return 1; }\nfunction main(): i32 { let t: BrickType = BrickType.Armored; return cost(t); }\n",
+            "enum BrickType { Basic, Armored, }\nfunction cost(kind: BrickType): i32 { if (kind == BrickType.Armored) { return 2; } return 1; }\nfunction main(): i32 { let t: BrickType = BrickType.Armored; return cost(t); }\n",
         );
         process.compile().expect("compile");
         let value = process
@@ -4776,7 +4776,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "enum UiHorizontal { Left, Center, Right }\nenum UiVertical { Top, Center, Bottom }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, UiVertical.Top); return 0; }\n",
+            "enum UiHorizontal { Left, Center, Right, }\nenum UiVertical { Top, Center, Bottom, }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, UiVertical.Top); return 0; }\n",
         );
         process
             .compile()
@@ -4789,7 +4789,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "enum UiHorizontal { Left, Center, Right }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, 1); return 0; }\n",
+            "enum UiHorizontal { Left, Center, Right, }\nfunction ui_place_x(parent_x: f32, horizontal: UiHorizontal): f32 { return parent_x; }\nfunction main(): i32 { let x: f32 = ui_place_x(0.0, 1); return 0; }\n",
         );
         process
             .compile()

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -760,7 +760,7 @@ mod tests {
 
     #[test]
     fn enum_state_uses_i32_storage_lanes() {
-        let source = "enum Phase { Waiting, Playing }\n\
+        let source = "enum Phase { Waiting, Playing, }\n\
                       struct Enemy { phase: Phase; hp: i32; }\n\
                       struct Game { phase: Phase; enemies: Enemy[2]; }\n\
                       global game: Game;\n\

--- a/crates/stasis_compiler/src/backend/state_migration.rs
+++ b/crates/stasis_compiler/src/backend/state_migration.rs
@@ -862,7 +862,7 @@ mod tests {
         let enum_declaration = if type_name == "i32" {
             String::new()
         } else {
-            format!("enum {type_name} {{ Waiting, Playing }}\n")
+            format!("enum {type_name} {{ Waiting, Playing, }}\n")
         };
         let initializer = if type_name == "i32" {
             "1".to_string()

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -793,17 +793,23 @@ fn parse_enum_definition(
             explicit_value = Some(value.saturating_mul(sign));
             next_cursor += 1;
         }
+        if tokens
+            .get(next_cursor)
+            .is_some_and(|token| token.kind == TokenKind::Comma)
+        {
+            next_cursor += 1;
+        } else if !tokens
+            .get(next_cursor)
+            .is_some_and(|token| token.kind == TokenKind::RBrace)
+        {
+            return Err(format!(
+                "enum variant '{variant_name}' must be followed by a comma"
+            ));
+        }
         variants.push(ParsedEnumVariant {
             name: variant_name,
             value: explicit_value,
         });
-        if tokens
-            .get(next_cursor)
-            .copied()
-            .is_some_and(|token| token.kind == TokenKind::Comma)
-        {
-            next_cursor += 1;
-        }
     }
     expect(tokens, next_cursor, TokenKind::RBrace)?;
     next_cursor += 1;
@@ -1522,7 +1528,7 @@ function tick(): i32 {
 
     #[test]
     fn parses_top_level_enums_with_variants() {
-        let source = "enum BrickType { Basic, Armored, Reflector }\n";
+        let source = "enum BrickType { Basic, Armored, Reflector, }\n";
         let parsed = parse_top_level_type_layout(source).expect("parse");
         assert_eq!(parsed.enums.len(), 1);
         assert_eq!(parsed.enums[0].name, "BrickType");
@@ -1542,7 +1548,7 @@ function tick(): i32 {
 
     #[test]
     fn parses_top_level_enum_variant_explicit_values() {
-        let source = "enum Scancode { A = 4, Return = 40, Escape = 41 }\n";
+        let source = "enum Scancode { A = 4, Return = 40, Escape = 41, }\n";
         let parsed = parse_top_level_type_layout(source).expect("parse");
         assert_eq!(parsed.enums.len(), 1);
         assert_eq!(parsed.enums[0].name, "Scancode");
@@ -1553,6 +1559,27 @@ function tick(): i32 {
         assert_eq!(parsed.enums[0].variants[1].value, Some(40));
         assert_eq!(parsed.enums[0].variants[2].name, "Escape");
         assert_eq!(parsed.enums[0].variants[2].value, Some(41));
+    }
+
+    #[test]
+    fn accepts_an_optional_final_enum_comma() {
+        for source in [
+            "enum Phase { Ready, Running }\n",
+            "enum Phase { Ready, Running, }\n",
+        ] {
+            let parsed = parse_top_level_type_layout(source).expect("parse enum");
+            assert_eq!(parsed.enums[0].variants.len(), 2);
+        }
+    }
+
+    #[test]
+    fn rejects_missing_commas_between_enum_variants() {
+        let source = "enum Phase { Ready Running, }\n";
+        let error = parse_top_level_type_layout(source).expect_err("missing enum comma must fail");
+        assert!(
+            error.contains("must be followed by a comma"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -4033,7 +4033,7 @@ mod workshop_contract_tests {
             path: "src/main.stasis".to_string(),
             source: r#"
 struct Player { hp: i32; speed: f32; }
-enum Mode { Playing, Paused }
+enum Mode { Playing, Paused, }
 global state { player: Player; }
 function damage(player: Player, amount: i32): i32 { return player.hp - amount; }
 function tick(): i32 {
@@ -4203,7 +4203,7 @@ function tick(): i32 {
         let files = vec![
             WorkshopSourceFile {
                 path: "src/main.stasis".to_string(),
-                source: "import \"unused.stasis\";\nimport \"mixed.stasis\";\nimport \"combat.stasis\";\nenum Phase { Ready = 1 }\nstruct Player { value: i32; }\nglobal State { player: Player; }\nfunction main(): i32 { let value: i32 = 1; State.player.damage(1); return value; }\nfunction parameter(amount: i32): i32 { return amount; }\nfunction shadow(): i32 { let helper: i32 = 3; return helper; }\nfunction imported_call(): i32 { return helper(); }\n"
+                source: "import \"unused.stasis\";\nimport \"mixed.stasis\";\nimport \"combat.stasis\";\nenum Phase { Ready = 1, }\nstruct Player { value: i32; }\nglobal State { player: Player; }\nfunction main(): i32 { let value: i32 = 1; State.player.damage(1); return value; }\nfunction parameter(amount: i32): i32 { return amount; }\nfunction shadow(): i32 { let helper: i32 = 3; return helper; }\nfunction imported_call(): i32 { return helper(); }\n"
                     .to_string(),
             },
             WorkshopSourceFile {

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -3,6 +3,9 @@
 Use the installed `stasis` CLI from the directory containing `stasis.json`. Do not invoke Cargo
 for normal project work.
 
+Read `PROJECT_ARCHITECTURE.md` before structuring game code. Use its input, tick, state, and
+rendering boundaries as the default unless the project documents a concrete reason to differ.
+
 ## Theory-building practice
 
 - Treat programming as building and maintaining an explainable theory of how real-world behavior maps through Stasis source, explicit state, deterministic tick systems, rendering, tests, and the packaged user experience. Code, tests, and documentation are evidence and memory cues; they are not substitutes for understanding.

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -91,13 +91,13 @@ Horizontal and vertical choices use different enums so the compiler rejects swap
 enum UiHorizontal {
     Left,
     Center,
-    Right
+    Right,
 }
 
 enum UiVertical {
     Top,
     Center,
-    Bottom
+    Bottom,
 }
 ```
 

--- a/docs/project_architecture.md
+++ b/docs/project_architecture.md
@@ -62,8 +62,21 @@ and gives live code replacement one clear layout to preserve.
 const MAX_ACTORS: i32 = 128;
 const MAX_INTENTS: i32 = 8;
 
-enum Screen { Menu, Playing, Paused, Result }
-enum IntentKind { None, Start, Move, UseAction, Pause, Resume }
+enum Screen {
+    Menu,
+    Playing,
+    Paused,
+    Result,
+}
+
+enum IntentKind {
+    None,
+    Start,
+    Move,
+    UseAction,
+    Pause,
+    Resume,
+}
 
 struct Actor {
     active: bool;
@@ -306,8 +319,19 @@ game state, not from a rounded draw position.
 If only one state can be active, use an enum:
 
 ```stasis
-enum Screen { Menu, Playing, Paused, Result }
-enum MatchPhase { Preparing, Active, Won, Lost }
+enum Screen {
+    Menu,
+    Playing,
+    Paused,
+    Result,
+}
+
+enum MatchPhase {
+    Preparing,
+    Active,
+    Won,
+    Lost,
+}
 ```
 
 A collection of `show_menu`, `paused`, `show_result`, and `modal_open` booleans

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -558,12 +558,13 @@ Enums are named types that lower to integer values.
 enum State {
     Idle,
     Jump,
-    Run
+    Run,
 }
 ```
 
 Rules:
 - Members default to sequential values from `0`.
+- Members are separated by commas. The final comma is optional.
 - Enum members can be explicitly assigned integer constants.
 - Enum comparisons and assignments must be type-correct.
 - Enum underlying type is `i32`.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -70,9 +70,9 @@ guide, a minimal `CLAUDE.md` that points to `AGENTS.md`, and a version-matched
 ## Commands and outputs
 
 - `new` / `init`: create the manifest and built-in starter template without network access.
-- `fmt [--check]` / `format [--check]`: normalize line endings, trailing whitespace, blank EOF
-  lines, and the final newline. `format` is an alias for `fmt`; both emit `fmt` as the canonical
-  JSON command name. The operation is idempotent and never follows symlinks.
+- `fmt [--check]` / `format [--check]`: apply the canonical Stasis source layout described below.
+  `format` is an alias for `fmt`; both emit `fmt` as the canonical JSON command name. The operation
+  is idempotent and never follows symlinks.
 - `check`: run the shared frontend and Cranelift JIT compilation path without executing `main`.
 - `test [PATH]`: run Stasis tests in one isolated JIT session.
 - `run [--headless]`: JIT-compile and execute no-argument `main(): i32` or `main(): void`; an
@@ -120,6 +120,53 @@ manifest. When working from a source checkout, pass `--development-build` to `pa
 Add `--json` to receive one stable JSON result object. Usage errors exit 2, command/compile/test
 failures exit 1, and successful commands exit 0 except `run`, which preserves the guest's `i32`
 exit code. Guest program output may precede the final JSON object for `run`.
+
+## Source formatting
+
+`stasis fmt` is intentionally opinionated about layout while preserving program structure. It
+keeps token and comment text, explicit parentheses, declaration order, and import order unchanged.
+Before writing, it verifies that both its lossless token stream and the compiler token stream are
+unchanged. It plans every source and test-file rewrite first; a formatting or verification error
+therefore leaves the workspace untouched. If a later file write fails, it attempts to restore all
+files already written.
+
+The canonical rules are:
+
+- Indent with four spaces. Tabs are never emitted.
+- Put an opening brace on the declaration or control-flow line. Every braced body is multiline,
+  including short functions and one-statement branches.
+- Put each struct or block-global field, enum member, and semicolon-terminated statement on its own
+  line. Put `else` on the same line as the preceding closing brace.
+- Use one space around assignment, comparison, arithmetic, and boolean operators. Do not put spaces
+  before `:`, `,`, `;`, member access, indexing, or calls; put one space after `:` and `,`.
+- Keep adjacent imports together and separate other top-level declarations with one blank line.
+  Preserve at most one intentional blank line inside a body, but omit a blank line immediately
+  before a closing brace.
+- Use LF line endings, remove trailing whitespace and blank lines at end of file, and emit exactly
+  one final newline.
+- Treat 160 columns as a soft limit. When a parenthesized signature, call, or condition would exceed
+  it, put its comma-separated items on indented lines without adding trailing commas. Wrapped
+  boolean conditions may also break before `&&` and `||`. A comment, string, or other indivisible
+  token may exceed 160 columns rather than having its contents changed.
+
+For example:
+
+```stasis
+struct Player {
+    health: i32;
+    active: bool;
+}
+
+function update_player(player: Player, damage: i32): void {
+    if (damage > 0) {
+        player.health -= damage;
+    } else {
+        player.active = false;
+    }
+}
+```
+
+Use `stasis fmt --check` in CI when formatting differences should fail without modifying files.
 
 ## Cache and offline behavior
 

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -127,8 +127,8 @@ exit code. Guest program output may precede the final JSON object for `run`.
 keeps token and comment text, explicit parentheses, declaration order, and import order unchanged.
 Before writing, it verifies that both its lossless token stream and the compiler token stream are
 unchanged. It plans every source and test-file rewrite first; a formatting or verification error
-therefore leaves the workspace untouched. If a later file write fails, it attempts to restore all
-files already written.
+therefore leaves the workspace untouched. Files whose formatted bytes already match are never
+opened for writing. If a later file write fails, it attempts to restore all files already written.
 
 The canonical rules are:
 

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -64,13 +64,15 @@ The project `name` may contain internal ASCII spaces, so display names such as `
 valid; leading or trailing spaces are rejected. Manifest paths must be project-relative and cannot
 contain `..`. Generated projects include a
 runnable `main()`, a real `.test.stasis` test, an `AGENTS.md` theory-building and semantic-edit
-guide, and a minimal `CLAUDE.md` that points to `AGENTS.md`.
+guide, a minimal `CLAUDE.md` that points to `AGENTS.md`, and a version-matched
+`PROJECT_ARCHITECTURE.md` with practical input, tick, state, and rendering guidance.
 
 ## Commands and outputs
 
 - `new` / `init`: create the manifest and built-in starter template without network access.
-- `fmt [--check]`: normalize line endings, trailing whitespace, blank EOF lines, and the final
-  newline. The operation is idempotent and never follows symlinks.
+- `fmt [--check]` / `format [--check]`: normalize line endings, trailing whitespace, blank EOF
+  lines, and the final newline. `format` is an alias for `fmt`; both emit `fmt` as the canonical
+  JSON command name. The operation is idempotent and never follows symlinks.
 - `check`: run the shared frontend and Cranelift JIT compilation path without executing `main`.
 - `test [PATH]`: run Stasis tests in one isolated JIT session.
 - `run [--headless]`: JIT-compile and execute no-argument `main(): i32` or `main(): void`; an

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -136,7 +136,8 @@ The canonical rules are:
 - Put an opening brace on the declaration or control-flow line. Every braced body is multiline,
   including short functions and one-statement branches.
 - Put each struct or block-global field, enum member, and semicolon-terminated statement on its own
-  line. Put `else` on the same line as the preceding closing brace.
+  line. End every enum member with a comma, including the compiler-optional final comma. Put `else`
+  on the same line as the preceding closing brace.
 - Use one space around assignment, comparison, arithmetic, and boolean operators. Do not put spaces
   before `:`, `,`, `;`, member access, indexing, or calls; put one space after `:` and `,`.
 - Keep adjacent imports together and separate other top-level declarations with one blank line.

--- a/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/main.stasis
@@ -2,7 +2,7 @@ import "preview_adapter.stasis";
 
 enum GamePhase {
     Playing,
-    Finished
+    Finished,
 }
 
 struct PhaseSample {

--- a/samples/brickout_revenge/brickout_revenge_v1.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1.stasis
@@ -92,14 +92,14 @@ const GAME_H: f32 = 624.0;
 enum BrickType {
     Basic,
     Armored,
-    Reflector
+    Reflector,
 }
 
 enum Phase {
     Setup,
     Battle,
     Win,
-    Lose
+    Lose,
 }
 
 // Math

--- a/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_cmd.stasis
@@ -82,14 +82,14 @@ const GAME_H: f32 = 624.0;
 enum BrickType {
     Basic,
     Armored,
-    Reflector
+    Reflector,
 }
 
 enum Phase {
     Setup,
     Battle,
     Win,
-    Lose
+    Lose,
 }
 
 // Math

--- a/samples/brickout_revenge/brickout_revenge_v1_core.stasis
+++ b/samples/brickout_revenge/brickout_revenge_v1_core.stasis
@@ -9,13 +9,13 @@ const BRICKOUT_LEVEL_COUNT: i32 = 3;
 
 enum BrickoutScreen {
     Menu,
-    Game
+    Game,
 }
 
 enum BrickoutBallPreset {
     Normal,
     Heavy,
-    Splitter
+    Splitter,
 }
 
 const BRICKOUT_LEVEL_EVENT_CAP: i32 = 192; // BRICKOUT_LEVEL_COUNT * BRICKOUT_LEVEL_MAX_EVENTS

--- a/src/stdlib/sdl_scancodes.stasis
+++ b/src/stdlib/sdl_scancodes.stasis
@@ -13,5 +13,5 @@ enum Scancode {
     Right = 79,
     Left = 80,
     Down = 81,
-    Up = 82
+    Up = 82,
 }

--- a/src/stdlib/ui_axis_layout.stasis
+++ b/src/stdlib/ui_axis_layout.stasis
@@ -3,13 +3,13 @@
 enum UiHorizontal {
     Left,
     Center,
-    Right
+    Right,
 }
 
 enum UiVertical {
     Top,
     Center,
-    Bottom
+    Bottom,
 }
 
 function @inline ui_place_x(

--- a/tests/stasis/run_enum_to_i32_conversion.stasis
+++ b/tests/stasis/run_enum_to_i32_conversion.stasis
@@ -1,6 +1,6 @@
 enum Phase {
     Idle = 10,
-    Play = 11
+    Play = 11,
 }
 
 function main(): i32 {


### PR DESCRIPTION
## Summary

- embed the practical game architecture guide in the Stasis executable and generate `PROJECT_ARCHITECTURE.md` from both `stasis new` and `stasis init`
- direct generated agent guidance to the version-matched architecture guide without overwriting an existing project-owned copy
- make `stasis format` a visible alias for `stasis fmt`, while keeping `fmt` as the canonical JSON command name
- replace whitespace-only formatting with a canonical, comment-preserving Stasis layout
- use four-space indentation, multiline braces and statements, consistent operator/punctuation spacing, grouped imports, deterministic blank lines, and canonical enum commas
- apply a 160-column soft limit to parenthesized signatures, calls, and conditions
- require commas between enum members in the compiler, accept an optional final comma, and have the formatter emit the final comma consistently
- verify lossless and compiler token equivalence, formatter idempotence, and all files before writing; write only byte-different files and roll back prior writes if a later write fails

## Why

New Stasis projects should receive practical input, tick, state, and render guidance alongside their source. The formatter should also settle routine layout choices so game code stays readable and diffs remain focused, while refusing to rewrite program structure or comment contents.

## User impact

Both project creation commands place `PROJECT_ARCHITECTURE.md` at the project root. Users may run either `stasis fmt` or `stasis format`, including `--check`. Formatting is now intentionally opinionated, with 160 columns as a soft rather than destructive limit. Enum members require separators; source may omit the last comma, while formatting always adds it.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets -- --test-threads=1`
- parser coverage for required enum separators and optional final enum commas
- formatter unit coverage for declarations, blocks, canonical enum commas, explicit enum values, attached comments, annotations, unary expressions, strings, `for` headers, import groups, LF normalization, and 160-column wrapping
- repository-wide Stasis source corpus formats idempotently with identical lossless and compiler token streams apart from canonical enum comma insertion
- end-to-end generated project test proves `fmt --check` fails before formatting, `format` applies the golden layout (including enum commas), a second `fmt --check` passes, and the formatted project compiles
- no-op regression proves both `fmt` and `format` report no changes and preserve the source modification timestamp
- rebuilt the release Android Rust bridge for arm64-v8a and x86_64
- normal pre-commit Android gate passed:
  - Workshop JIT: 3/3 render-parity captures
  - Published Android x86_64 AOT: 3/3 render-parity captures

## Scope

Generated bridge artifacts and render captures remain ignored and are not part of this PR.