### PR TITLE
Add cross-platform VS Code extension E2E

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -102,6 +102,100 @@ jobs:
       - name: Bootstrap Compile Smoke (compiler .stasis)
         run: cargo test -p stasis_compiler -- --nocapture
 
+  vscode-extension-e2e:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    name: VS Code E2E (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            os: ubuntu-latest
+            runtime_library: libstasis_graphics.so
+          - name: macOS arm64
+            os: macos-15
+            runtime_library: libstasis_graphics.dylib
+    env:
+      CARGO_INCREMENTAL: "0"
+      CMAKE_BUILD_PARALLEL_LEVEL: "2"
+      STASIS_E2E_VSCODE_VERSION: "1.96.0"
+      STASIS_RUNTIME_LIBRARY_PATH: ${{ github.workspace }}/target/vscode-e2e-runtime/bin/${{ matrix.runtime_library }}
+      STASIS_E2E_EXECUTABLE: ${{ github.workspace }}/target/debug/stasis
+      STASIS_E2E_SCREENSHOT: ${{ github.workspace }}/target/vscode-e2e/frame.png
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: vscode-stasis/package-lock.json
+
+      - name: Install Linux graphics and display dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev libsdl2-image-dev xvfb
+
+      - name: Install macOS graphics dependencies
+        if: runner.os == 'macOS'
+        run: brew install sdl2 sdl2_image pkg-config
+
+      - name: Build native graphics runtime
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            export CMAKE_PREFIX_PATH="$(brew --prefix):${CMAKE_PREFIX_PATH:-}"
+          fi
+          cmake -S runtime -B target/vscode-e2e-runtime \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
+            -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
+            -DSTASIS_GRAPHICS_SDL_ONLY=ON \
+            -DSTASIS_BUILD_RUNNER=OFF \
+            -DSTASIS_BUILD_SYS=OFF
+          cmake --build target/vscode-e2e-runtime --config Release --target stasis_graphics
+          test -f "$STASIS_RUNTIME_LIBRARY_PATH"
+
+      - name: Build and probe Stasis runtime loading
+        shell: bash
+        run: |
+          cargo test -p stasis_dynload -- --test-threads=1
+          cargo build -p stasis
+          "$STASIS_E2E_EXECUTABLE" probe-graphics-runtime
+
+      - name: Install extension dependencies
+        working-directory: vscode-stasis
+        run: npm ci
+
+      - name: Test installed VSIX in VS Code
+        working-directory: vscode-stasis
+        shell: bash
+        run: |
+          mkdir -p ../target/vscode-e2e
+          set -o pipefail
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            xvfb-run -a npm run test:e2e 2>&1 | tee ../target/vscode-e2e/extension-host.log
+          else
+            npm run test:e2e 2>&1 | tee ../target/vscode-e2e/extension-host.log
+          fi
+
+      - name: Upload VS Code E2E evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-e2e-${{ runner.os }}-${{ runner.arch }}
+          if-no-files-found: warn
+          path: |
+            target/vscode-e2e/frame.png
+            target/vscode-e2e/extension-host.log
+            vscode-stasis/.vsix/stasislang.stasis.vsix
+
   android-package-link:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest

--- a/apps/stasis/build.rs
+++ b/apps/stasis/build.rs
@@ -4,20 +4,17 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=STASIS_RUNTIME_LIBRARY_PATH");
     println!("cargo:rerun-if-env-changed=STASIS_RUNTIME_DLL_PATH");
 
-    if env::var_os("CARGO_CFG_WINDOWS").is_none() {
-        return;
-    }
-
-    for candidate in runtime_dll_candidate_paths() {
+    for candidate in runtime_library_candidate_paths() {
         println!("cargo:rerun-if-changed={}", candidate.display());
         if let Some(parent) = candidate.parent() {
             println!("cargo:rerun-if-changed={}", parent.display());
         }
     }
 
-    let Some(source) = runtime_dll_candidate_paths()
+    let Some(source) = runtime_library_candidate_paths()
         .into_iter()
         .find(|candidate| candidate.exists())
     else {
@@ -26,12 +23,19 @@ fn main() {
 
     let Some(output_dir) = cargo_profile_output_dir() else {
         println!(
-            "cargo:warning=stasis build could not determine the cargo profile output dir; skipping runtime DLL staging"
+            "cargo:warning=stasis build could not determine the cargo profile output dir; skipping runtime library staging"
         );
         return;
     };
 
-    let destination = output_dir.join("stasis_graphics.dll");
+    let Some(file_name) = source.file_name() else {
+        println!(
+            "cargo:warning=stasis build could not determine the runtime library name for {}",
+            source.display()
+        );
+        return;
+    };
+    let destination = output_dir.join(file_name);
     if let Err(error) = fs::create_dir_all(&output_dir) {
         println!(
             "cargo:warning=stasis build failed to create output dir {}: {error}",
@@ -59,7 +63,7 @@ fn cargo_profile_output_dir() -> Option<PathBuf> {
         .map(Path::to_path_buf)
 }
 
-fn runtime_dll_candidate_paths() -> Vec<PathBuf> {
+fn runtime_library_candidate_paths() -> Vec<PathBuf> {
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
@@ -67,34 +71,35 @@ fn runtime_dll_candidate_paths() -> Vec<PathBuf> {
         .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join(".."));
 
     let mut candidates = Vec::new();
+    if let Some(configured) = env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
+        candidates.push(PathBuf::from(configured));
+    }
     if let Some(configured) = env::var_os("STASIS_RUNTIME_DLL_PATH") {
         candidates.push(PathBuf::from(configured));
     }
-    candidates.push(repo_root.join("stasis_graphics.dll"));
-    candidates.push(repo_root.join("build").join("stasis_graphics.dll"));
-    candidates.push(
-        repo_root
-            .join("runtime")
-            .join("build")
-            .join("bin")
-            .join("Release")
-            .join("stasis_graphics.dll"),
-    );
-    candidates.push(
-        repo_root
-            .join("runtime")
-            .join("build")
-            .join("bin")
-            .join("Debug")
-            .join("stasis_graphics.dll"),
-    );
-    candidates.push(
-        repo_root
-            .join("runtime")
-            .join("build_ci")
-            .join("bin")
-            .join("Release")
-            .join("stasis_graphics.dll"),
-    );
+    for file_name in runtime_library_file_names() {
+        candidates.push(repo_root.join(file_name));
+        candidates.push(repo_root.join("build").join(file_name));
+        for build_dir in ["build", "build_ci"] {
+            for configuration in [None, Some("Release"), Some("Debug")] {
+                let mut candidate = repo_root.join("runtime").join(build_dir).join("bin");
+                if let Some(configuration) = configuration {
+                    candidate.push(configuration);
+                }
+                candidate.push(file_name);
+                candidates.push(candidate);
+            }
+        }
+    }
     candidates
+}
+
+fn runtime_library_file_names() -> &'static [&'static str] {
+    if env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        &["stasis_graphics.dll"]
+    } else if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        &["libstasis_graphics.dylib", "stasis_graphics.dylib"]
+    } else {
+        &["libstasis_graphics.so", "stasis_graphics.so"]
+    }
 }

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -2370,6 +2370,12 @@ fn resolve_runtime_runner_path(repo_root: &Path) -> Option<PathBuf> {
 }
 
 fn resolve_runtime_graphics_path(repo_root: &Path) -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
+        let configured = PathBuf::from(configured);
+        if configured.is_file() {
+            return Some(configured);
+        }
+    }
     if let Some(configured) = std::env::var_os("STASIS_RUNTIME_DLL_PATH") {
         let configured = PathBuf::from(configured);
         if configured.is_file() {

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1813,10 +1813,6 @@ fn run_play_in_process_inner(
     window_title: Option<&str>,
     live: Option<(stasis_runner::live::LiveSessionServer, LiveRunConfig)>,
 ) -> Result<(), String> {
-    if !cfg!(windows) {
-        return Err("in-process play runner currently supports Windows only".to_string());
-    }
-
     let watch_dir = resolve_play_watch_dir(watch_file, watch_dir);
     let launch_dir = std::env::current_dir()
         .map_err(|error| format!("failed to read current directory before play launch: {error}"))?;
@@ -3585,22 +3581,14 @@ fn probe_aot_loadability(path: &Path) -> Result<(), String> {
             path.display()
         ));
     }
-    #[cfg(windows)]
-    {
-        stasis_dynload::Library::load(path)
-            .map(|_| ())
-            .map_err(|error| {
-                format!(
-                    "AOT loadability probe failed for {}: {error}",
-                    path.display()
-                )
-            })
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = path;
-        Err("AOT loadability probe is currently supported on Windows only".to_string())
-    }
+    stasis_dynload::Library::load(path)
+        .map(|_| ())
+        .map_err(|error| {
+            format!(
+                "AOT loadability probe failed for {}: {error}",
+                path.display()
+            )
+        })
 }
 
 fn sleep_for_tick(tick_sleep_micros: u64) {

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -808,11 +808,6 @@ fn try_run_probe_graphics_runtime_subcommand() -> Option<i32> {
         return None;
     }
 
-    if !cfg!(windows) {
-        eprintln!("probe-graphics-runtime is only supported on Windows today");
-        return Some(2);
-    }
-
     let candidates = stasis_dynload::runtime_library_candidate_paths();
     for candidate in &candidates {
         if !candidate.exists() {

--- a/apps/stasis/src/runtime_exec.rs
+++ b/apps/stasis/src/runtime_exec.rs
@@ -84,14 +84,15 @@ impl RuntimeLauncher {
     }
 
     fn spawn_runtime_process(&self) -> Result<Child, String> {
-        if !cfg!(windows) {
-            return Err("runtime execution path currently supports Windows only".to_string());
-        }
         let stasis_exe = self
             .repo_root
             .join("target")
             .join("debug")
-            .join("stasis.exe");
+            .join(if cfg!(windows) {
+                "stasis.exe"
+            } else {
+                "stasis"
+            });
         if !stasis_exe.exists() {
             return Err(format!(
                 "runtime launcher requires in-process runner binary at {}",

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -2,20 +2,26 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::c_char;
+use std::ffi::{c_char, c_void, CString};
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+#[cfg(unix)]
+use std::ffi::CStr;
 #[cfg(windows)]
-use std::ffi::{c_void, CString, OsStr};
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 
 pub struct Library {
     #[cfg(windows)]
+    handle: *mut c_void,
+    #[cfg(unix)]
     handle: *mut c_void,
 }
 
@@ -135,7 +141,8 @@ fn call_jit_host_void_target(address: usize) {
 
 // Library handles are process-wide OS resources and can be moved between threads.
 unsafe impl Send for Library {}
-// Loading a module and calling exports is thread-safe on Windows; the handle is immutable after load.
+// Loading a module and calling exports is thread-safe on supported desktop platforms; the handle
+// is immutable after load.
 unsafe impl Sync for Library {}
 
 impl Library {
@@ -155,10 +162,30 @@ impl Library {
             return Ok(Self { handle });
         }
 
-        #[cfg(not(windows))]
+        #[cfg(unix)]
+        {
+            let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+                format!(
+                    "dynamic library path contains interior NUL byte: {}",
+                    path.display()
+                )
+            })?;
+            clear_dynamic_loading_error();
+            let handle = unsafe { dlopen(path.as_ptr(), RTLD_NOW | RTLD_LOCAL) };
+            if handle.is_null() {
+                return Err(format!(
+                    "failed to load dynamic library {}: {}",
+                    path.to_string_lossy(),
+                    dynamic_loading_error()
+                ));
+            }
+            Ok(Self { handle })
+        }
+
+        #[cfg(not(any(windows, unix)))]
         {
             let _ = path;
-            Err("dynamic loading is only supported on windows in stasis_dynload".to_string())
+            Err("dynamic loading is unsupported on this platform in stasis_dynload".to_string())
         }
     }
 
@@ -174,11 +201,27 @@ impl Library {
             return Ok(address as usize);
         }
 
-        #[cfg(not(windows))]
+        #[cfg(unix)]
+        {
+            let name = CString::new(symbol)
+                .map_err(|_| format!("symbol name contains interior NUL byte: {symbol}"))?;
+            clear_dynamic_loading_error();
+            let address = unsafe { dlsym(self.handle, name.as_ptr()) };
+            let error = dynamic_loading_error_if_present();
+            if let Some(error) = error {
+                return Err(format!("failed to resolve symbol {symbol}: {error}"));
+            }
+            if address.is_null() {
+                return Err(format!("failed to resolve symbol {symbol}: null address"));
+            }
+            Ok(address as usize)
+        }
+
+        #[cfg(not(any(windows, unix)))]
         {
             let _ = symbol;
             Err(
-                "dynamic symbol resolution is only supported on windows in stasis_dynload"
+                "dynamic symbol resolution is unsupported on this platform in stasis_dynload"
                     .to_string(),
             )
         }
@@ -191,6 +234,12 @@ impl Drop for Library {
         {
             if !self.handle.is_null() {
                 let _ = unsafe { FreeLibrary(self.handle) };
+            }
+        }
+        #[cfg(unix)]
+        {
+            if !self.handle.is_null() {
+                let _ = unsafe { dlclose(self.handle) };
             }
         }
     }
@@ -405,10 +454,8 @@ pub fn invoke_i32_i32_i32_f32_to_void(
 // stasis_graphics host API (dev in-process runner)
 // ============================================================
 
-#[cfg(windows)]
 const STASIS_GRAPHICS_RUNTIME_ABI_VERSION: i32 = 1;
 
-#[cfg(windows)]
 fn verify_graphics_runtime_abi(lib: &Library, path: &Path) -> Result<(), String> {
     let address = lib
         .symbol_address("stasis_graphics_runtime_abi_version")
@@ -418,8 +465,16 @@ fn verify_graphics_runtime_abi(lib: &Library, path: &Path) -> Result<(), String>
                 path.display()
             )
         })?;
-    let version: extern "system" fn() -> i32 = unsafe { std::mem::transmute(address) };
-    let actual = version();
+    #[cfg(windows)]
+    let actual = {
+        let version: extern "system" fn() -> i32 = unsafe { std::mem::transmute(address) };
+        version()
+    };
+    #[cfg(not(windows))]
+    let actual = {
+        let version: extern "C" fn() -> i32 = unsafe { std::mem::transmute(address) };
+        version()
+    };
     if actual != STASIS_GRAPHICS_RUNTIME_ABI_VERSION {
         return Err(format!(
             "incompatible stasis graphics runtime {}: expected ABI {}, found {}",
@@ -433,82 +488,55 @@ fn verify_graphics_runtime_abi(lib: &Library, path: &Path) -> Result<(), String>
 
 pub struct StasisGraphicsApi {
     _lib: Library,
-    #[cfg(windows)]
     stasis_init_window: usize,
-    #[cfg(windows)]
     stasis_host_get_frame: usize,
-    #[cfg(windows)]
     stasis_host_bulk_init: usize,
-    #[cfg(windows)]
     stasis_host_bulk_apply_requests: usize,
-    #[cfg(windows)]
     stasis_host_set_performance_metrics: usize,
-    #[cfg(windows)]
     stasis_gfx_submit_u8: usize,
-    #[cfg(windows)]
     stasis_sleep_ms: usize,
 }
 
 impl StasisGraphicsApi {
     pub fn load_default() -> Result<Self, String> {
-        #[cfg(windows)]
-        {
-            let mut last_error = None;
-            for candidate in runtime_library_candidate_paths() {
-                if !candidate.exists() {
-                    continue;
-                }
-                match Self::load(&candidate) {
-                    Ok(api) => return Ok(api),
-                    Err(error) => last_error = Some(error),
-                }
+        let mut last_error = None;
+        for candidate in runtime_library_candidate_paths() {
+            if !candidate.exists() {
+                continue;
             }
-            Err(last_error.unwrap_or_else(|| "failed to load stasis_graphics runtime library (set STASIS_RUNTIME_DLL_PATH or build runtime)".to_string()))
+            match Self::load(&candidate) {
+                Ok(api) => return Ok(api),
+                Err(error) => last_error = Some(error),
+            }
         }
-
-        #[cfg(not(windows))]
-        {
-            Err(
-                "stasis_graphics runtime loading is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
-        }
+        Err(last_error.unwrap_or_else(|| {
+            "failed to load stasis_graphics runtime library (set STASIS_RUNTIME_LIBRARY_PATH or build runtime)"
+                .to_string()
+        }))
     }
 
     pub fn load(path: &Path) -> Result<Self, String> {
-        #[cfg(windows)]
-        {
-            let lib = Library::load(path)?;
-            verify_graphics_runtime_abi(&lib, path)?;
-            let stasis_init_window = lib.symbol_address("stasis_init_window")?;
-            let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
-            let stasis_host_bulk_init = lib.symbol_address("stasis_host_bulk_init")?;
-            let stasis_host_bulk_apply_requests =
-                lib.symbol_address("stasis_host_bulk_apply_requests")?;
-            let stasis_host_set_performance_metrics =
-                lib.symbol_address("stasis_host_set_performance_metrics")?;
-            let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
-            let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
-            Ok(Self {
-                _lib: lib,
-                stasis_init_window,
-                stasis_host_get_frame,
-                stasis_host_bulk_init,
-                stasis_host_bulk_apply_requests,
-                stasis_host_set_performance_metrics,
-                stasis_gfx_submit_u8,
-                stasis_sleep_ms,
-            })
-        }
-
-        #[cfg(not(windows))]
-        {
-            let _ = path;
-            Err(
-                "stasis_graphics runtime loading is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
-        }
+        let lib = Library::load(path)?;
+        verify_graphics_runtime_abi(&lib, path)?;
+        let stasis_init_window = lib.symbol_address("stasis_init_window")?;
+        let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
+        let stasis_host_bulk_init = lib.symbol_address("stasis_host_bulk_init")?;
+        let stasis_host_bulk_apply_requests =
+            lib.symbol_address("stasis_host_bulk_apply_requests")?;
+        let stasis_host_set_performance_metrics =
+            lib.symbol_address("stasis_host_set_performance_metrics")?;
+        let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
+        let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
+        Ok(Self {
+            _lib: lib,
+            stasis_init_window,
+            stasis_host_get_frame,
+            stasis_host_bulk_init,
+            stasis_host_bulk_apply_requests,
+            stasis_host_set_performance_metrics,
+            stasis_gfx_submit_u8,
+            stasis_sleep_ms,
+        })
     }
 
     pub fn init_window(&self, width: i32, height: i32, title: &str) -> Result<bool, String> {
@@ -523,13 +551,11 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = width;
-            let _ = height;
-            let _ = title;
-            Err(
-                "stasis_graphics init_window is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
+            let title = CString::new(title)
+                .map_err(|_| "window title contains interior NUL byte".to_string())?;
+            let callback: extern "C" fn(i32, i32, *const c_char) -> i32 =
+                unsafe { std::mem::transmute(self.stasis_init_window) };
+            Ok(callback(width, height, title.as_ptr()) != 0)
         }
     }
 
@@ -543,12 +569,10 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = out_i32;
-            let _ = out_f32;
-            Err(
-                "stasis_graphics host_get_frame is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
+            let callback: extern "C" fn(*mut i32, *mut f32) =
+                unsafe { std::mem::transmute(self.stasis_host_get_frame) };
+            callback(out_i32.as_mut_ptr(), out_f32.as_mut_ptr());
+            Ok(())
         }
     }
 
@@ -562,11 +586,10 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = host_req_seq;
-            Err(
-                "stasis_graphics host_bulk_init is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
+            let callback: extern "C" fn(*const i32) =
+                unsafe { std::mem::transmute(self.stasis_host_bulk_init) };
+            callback(host_req_seq as *const i32);
+            Ok(())
         }
     }
 
@@ -591,11 +614,15 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = host_req_seq;
-            let _ = host_req_flags;
-            let _ = host_req_window_w_px;
-            let _ = host_req_window_h_px;
-            Err("stasis_graphics host_bulk_apply_requests is only supported on windows in stasis_dynload".to_string())
+            let callback: extern "C" fn(*const i32, *const i32, *const i32, *const i32) =
+                unsafe { std::mem::transmute(self.stasis_host_bulk_apply_requests) };
+            callback(
+                host_req_seq as *const i32,
+                host_req_flags as *const i32,
+                host_req_window_w_px as *const i32,
+                host_req_window_h_px as *const i32,
+            );
+            Ok(())
         }
     }
 
@@ -613,9 +640,10 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = tick_micros;
-            let _ = render_micros;
-            Err("stasis_graphics performance metrics are only supported on windows in stasis_dynload".to_string())
+            let callback: extern "C" fn(u64, u64) =
+                unsafe { std::mem::transmute(self.stasis_host_set_performance_metrics) };
+            callback(tick_micros, render_micros);
+            Ok(())
         }
     }
 
@@ -634,13 +662,10 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = cmd_i32;
-            let _ = cmd_f32;
-            let _ = cmd_u8;
-            Err(
-                "stasis_graphics gfx_submit_u8 is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
+            let callback: extern "C" fn(*const i32, *const f32, *const u8) =
+                unsafe { std::mem::transmute(self.stasis_gfx_submit_u8) };
+            callback(cmd_i32.as_ptr(), cmd_f32.as_ptr(), cmd_u8.as_ptr());
+            Ok(())
         }
     }
 
@@ -654,11 +679,9 @@ impl StasisGraphicsApi {
         }
         #[cfg(not(windows))]
         {
-            let _ = ms;
-            Err(
-                "stasis_graphics sleep_ms is only supported on windows in stasis_dynload"
-                    .to_string(),
-            )
+            let callback: extern "C" fn(i32) = unsafe { std::mem::transmute(self.stasis_sleep_ms) };
+            callback(ms);
+            Ok(())
         }
     }
 }
@@ -667,7 +690,6 @@ impl StasisGraphicsApi {
 // stasis_graphics asset API (JIT extern call bridge)
 // ============================================================
 
-#[cfg(windows)]
 struct StasisGraphicsAssetsApi {
     _lib: Library,
     stasis_gfx_load_sprite: usize,
@@ -680,11 +702,12 @@ struct StasisGraphicsAssetsApi {
     stasis_gfx_cache_text: usize,
     stasis_gfx_measure_text_cached: usize,
     stasis_gfx_measure_text_cached_height: usize,
+    #[cfg(windows)]
     stasis_storage_load_i32: Option<usize>,
+    #[cfg(windows)]
     stasis_storage_save_i32: Option<usize>,
 }
 
-#[cfg(windows)]
 impl StasisGraphicsAssetsApi {
     fn load_default() -> Result<Self, String> {
         let mut last_error = None;
@@ -709,8 +732,8 @@ impl StasisGraphicsAssetsApi {
             stasis_gfx_load_sprite: lib.symbol_address("stasis_gfx_load_sprite")?,
             stasis_gfx_release_sprite: lib.symbol_address("stasis_gfx_release_sprite")?,
             stasis_gfx_dump_bmp: lib.symbol_address("stasis_gfx_dump_bmp")?,
-            // PNG capture was added after the original asset ABI. Keep older runtime
-            // DLLs usable for all pre-existing calls and report PNG as unsupported.
+            // PNG capture was added after the original asset ABI. Keep older runtimes usable for
+            // all pre-existing calls and report PNG as unsupported.
             stasis_gfx_dump_png: lib.symbol_address("stasis_gfx_dump_png").ok(),
             stasis_gfx_poll_reload: lib.symbol_address("stasis_gfx_poll_reload")?,
             stasis_load_font: lib.symbol_address("stasis_load_font")?,
@@ -719,14 +742,15 @@ impl StasisGraphicsAssetsApi {
             stasis_gfx_measure_text_cached: lib.symbol_address("stasis_gfx_measure_text_cached")?,
             stasis_gfx_measure_text_cached_height: lib
                 .symbol_address("stasis_gfx_measure_text_cached_height")?,
+            #[cfg(windows)]
             stasis_storage_load_i32: lib.symbol_address("stasis_storage_load_i32").ok(),
+            #[cfg(windows)]
             stasis_storage_save_i32: lib.symbol_address("stasis_storage_save_i32").ok(),
             _lib: lib,
         })
     }
 }
 
-#[cfg(windows)]
 fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, String> {
     static API: OnceLock<Result<StasisGraphicsAssetsApi, String>> = OnceLock::new();
     match API.get_or_init(StasisGraphicsAssetsApi::load_default) {
@@ -737,63 +761,74 @@ fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, Stri
 
 pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
     let mut out = Vec::new();
+    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
+        out.push(PathBuf::from(configured));
+    }
+    // Preserve the original variable as a compatibility alias for existing Windows workflows.
     if let Some(configured) = std::env::var_os("STASIS_RUNTIME_DLL_PATH") {
         out.push(PathBuf::from(configured));
     }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
-            // Release-friendly default: ship the DLL next to the stasis binary.
-            out.push(exe_dir.join("stasis_graphics.dll"));
+            // Release-friendly default: ship the runtime next to the stasis binary.
+            for file_name in runtime_library_file_names() {
+                out.push(exe_dir.join(file_name));
+            }
 
-            // Dev-friendly default: locate the runtime DLL built under the repo tree by
+            // Dev-friendly default: locate the runtime built under the repo tree by
             // walking a few parents from the executable location.
             for ancestor in exe_dir.ancestors().take(6) {
-                out.push(
-                    ancestor
-                        .join("runtime")
-                        .join("build")
-                        .join("bin")
-                        .join("Release")
-                        .join("stasis_graphics.dll"),
-                );
-                out.push(
-                    ancestor
-                        .join("runtime")
-                        .join("build")
-                        .join("bin")
-                        .join("Debug")
-                        .join("stasis_graphics.dll"),
-                );
+                for file_name in runtime_library_file_names() {
+                    for configuration in [None, Some("Release"), Some("Debug")] {
+                        let mut candidate = ancestor.join("runtime").join("build").join("bin");
+                        if let Some(configuration) = configuration {
+                            candidate.push(configuration);
+                        }
+                        candidate.push(file_name);
+                        out.push(candidate);
+                    }
+                }
             }
         }
     }
 
     // Allow loading from the current working directory too (handy for ad-hoc runs).
-    out.push(PathBuf::from("stasis_graphics.dll"));
+    for file_name in runtime_library_file_names() {
+        out.push(PathBuf::from(file_name));
+    }
 
-    // Dev-friendly fallback: if the runtime DLL exists under this repo checkout, include it.
+    // Dev-friendly fallback: if the runtime exists under this repo checkout, include it.
     // This helps when `CARGO_TARGET_DIR` points outside the workspace (so `current_exe()` ancestry
     // won't include the repo root).
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
-    let repo_release = repo_root
-        .join("runtime")
-        .join("build")
-        .join("bin")
-        .join("Release")
-        .join("stasis_graphics.dll");
-    if repo_release.exists() {
-        out.push(repo_release);
-    }
-    let repo_debug = repo_root
-        .join("runtime")
-        .join("build")
-        .join("bin")
-        .join("Debug")
-        .join("stasis_graphics.dll");
-    if repo_debug.exists() {
-        out.push(repo_debug);
+    for file_name in runtime_library_file_names() {
+        for configuration in [None, Some("Release"), Some("Debug")] {
+            let mut candidate = repo_root.join("runtime").join("build").join("bin");
+            if let Some(configuration) = configuration {
+                candidate.push(configuration);
+            }
+            candidate.push(file_name);
+            if candidate.exists() {
+                out.push(candidate);
+            }
+        }
     }
     out
+}
+
+#[cfg(windows)]
+fn runtime_library_file_names() -> &'static [&'static str] {
+    &["stasis_graphics.dll"]
+}
+
+#[cfg(target_os = "macos")]
+fn runtime_library_file_names() -> &'static [&'static str] {
+    &["libstasis_graphics.dylib", "stasis_graphics.dylib"]
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn runtime_library_file_names() -> &'static [&'static str] {
+    &["libstasis_graphics.so", "stasis_graphics.so"]
 }
 
 pub fn clear_jit_string_literal_table() {
@@ -2771,7 +2806,6 @@ fn embedded_graphics_host() -> Option<EmbeddedGraphicsHost> {
     EMBEDDED_GRAPHICS_HOST.with(|slot| slot.get())
 }
 
-#[cfg(windows)]
 fn jit_text_arg_to_cstring(value_id: i32) -> Result<CString, String> {
     let bytes = jit_text_arg_bytes(value_id).ok_or_else(|| {
         format!("missing jit text handle for id={value_id} (neither literal nor utf8 buffer)")
@@ -2788,34 +2822,28 @@ pub extern "C" fn stasis_jit_gfx_load_sprite(path_id: i32, max_w: i32, max_h: i3
     if let (Some(host), Some(path)) = (embedded_graphics_host(), jit_text_arg_bytes(path_id)) {
         return (host.load_sprite)(&path, max_w, max_h);
     }
-    #[cfg(windows)]
-    {
-        let Ok(path) = jit_text_arg_to_cstring(path_id) else {
-            eprintln!("gfx_load_sprite failed: unknown string handle {path_id}");
+    let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+        eprintln!("gfx_load_sprite failed: unknown string handle {path_id}");
+        return 0;
+    };
+    let api = match stasis_graphics_assets_api() {
+        Ok(api) => api,
+        Err(error) => {
+            eprintln!("gfx_load_sprite failed: {error}");
             return 0;
-        };
-        let api = match stasis_graphics_assets_api() {
-            Ok(api) => api,
-            Err(error) => {
-                eprintln!("gfx_load_sprite failed: {error}");
-                return 0;
-            }
-        };
-        let callback: extern "system" fn(*const c_char, i32, i32) -> i32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_load_sprite) };
-        let handle = callback(path.as_ptr(), max_w, max_h);
-        if handle == 0 {
-            eprintln!("gfx_load_sprite failed for {}", path.to_string_lossy());
         }
-        return handle;
-    }
+    };
+    #[cfg(windows)]
+    let callback: extern "system" fn(*const c_char, i32, i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_load_sprite) };
     #[cfg(not(windows))]
-    {
-        let _ = path_id;
-        let _ = max_w;
-        let _ = max_h;
-        0
+    let callback: extern "C" fn(*const c_char, i32, i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_load_sprite) };
+    let handle = callback(path.as_ptr(), max_w, max_h);
+    if handle == 0 {
+        eprintln!("gfx_load_sprite failed for {}", path.to_string_lossy());
     }
+    handle
 }
 
 #[no_mangle]
@@ -2824,19 +2852,16 @@ pub extern "C" fn stasis_jit_gfx_release_sprite(handle: i32) {
         (host.release_sprite)(handle);
         return;
     }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return;
+    };
     #[cfg(windows)]
-    {
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return;
-        };
-        let callback: extern "system" fn(i32) =
-            unsafe { std::mem::transmute(api.stasis_gfx_release_sprite) };
-        callback(handle);
-    }
+    let callback: extern "system" fn(i32) =
+        unsafe { std::mem::transmute(api.stasis_gfx_release_sprite) };
     #[cfg(not(windows))]
-    {
-        let _ = handle;
-    }
+    let callback: extern "C" fn(i32) =
+        unsafe { std::mem::transmute(api.stasis_gfx_release_sprite) };
+    callback(handle);
 }
 
 fn configured_preference_storage_root() -> &'static Mutex<Option<PathBuf>> {
@@ -3008,47 +3033,38 @@ pub extern "C" fn stasis_jit_storage_save_i32(scope_id: i32, key_id: i32, value:
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_dump_bmp(path_id: i32) -> i32 {
+    let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+        return 0;
+    };
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(path) = jit_text_arg_to_cstring(path_id) else {
-            return 0;
-        };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
-        };
-        let callback: extern "system" fn(*const c_char) -> i32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_dump_bmp) };
-        return callback(path.as_ptr());
-    }
+    let callback: extern "system" fn(*const c_char) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_dump_bmp) };
     #[cfg(not(windows))]
-    {
-        let _ = path_id;
-        0
-    }
+    let callback: extern "C" fn(*const c_char) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_dump_bmp) };
+    callback(path.as_ptr())
 }
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_dump_png(path_id: i32) -> i32 {
+    let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+        return 0;
+    };
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
+    let Some(address) = api.stasis_gfx_dump_png else {
+        return 0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(path) = jit_text_arg_to_cstring(path_id) else {
-            return 0;
-        };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
-        };
-        let Some(address) = api.stasis_gfx_dump_png else {
-            return 0;
-        };
-        let callback: extern "system" fn(*const c_char) -> i32 =
-            unsafe { std::mem::transmute(address) };
-        return callback(path.as_ptr());
-    }
+    let callback: extern "system" fn(*const c_char) -> i32 =
+        unsafe { std::mem::transmute(address) };
     #[cfg(not(windows))]
-    {
-        let _ = path_id;
-        0
-    }
+    let callback: extern "C" fn(*const c_char) -> i32 = unsafe { std::mem::transmute(address) };
+    callback(path.as_ptr())
 }
 
 #[no_mangle]
@@ -3056,24 +3072,19 @@ pub extern "C" fn stasis_jit_load_font(path_id: i32, size: i32) -> i32 {
     if let (Some(host), Some(path)) = (embedded_graphics_host(), jit_text_arg_bytes(path_id)) {
         return (host.load_font)(&path, size);
     }
+    let Ok(path) = jit_text_arg_to_cstring(path_id) else {
+        return 0;
+    };
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(path) = jit_text_arg_to_cstring(path_id) else {
-            return 0;
-        };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
-        };
-        let callback: extern "system" fn(*const c_char, i32) -> i32 =
-            unsafe { std::mem::transmute(api.stasis_load_font) };
-        return callback(path.as_ptr(), size);
-    }
+    let callback: extern "system" fn(*const c_char, i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_load_font) };
     #[cfg(not(windows))]
-    {
-        let _ = path_id;
-        let _ = size;
-        0
-    }
+    let callback: extern "C" fn(*const c_char, i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_load_font) };
+    callback(path.as_ptr(), size)
 }
 
 #[no_mangle]
@@ -3085,24 +3096,19 @@ pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
             return width;
         }
     }
+    let Ok(text) = jit_text_arg_to_cstring(text_id) else {
+        return 0.0;
+    };
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0.0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(text) = jit_text_arg_to_cstring(text_id) else {
-            return 0.0;
-        };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0.0;
-        };
-        let callback: extern "system" fn(i32, *const c_char) -> f32 =
-            unsafe { std::mem::transmute(api.stasis_measure_text) };
-        return callback(font, text.as_ptr());
-    }
+    let callback: extern "system" fn(i32, *const c_char) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_measure_text) };
     #[cfg(not(windows))]
-    {
-        let _ = font;
-        let _ = text_id;
-        0.0
-    }
+    let callback: extern "C" fn(i32, *const c_char) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_measure_text) };
+    callback(font, text.as_ptr())
 }
 
 #[no_mangle]
@@ -3110,24 +3116,19 @@ pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
     if let (Some(host), Some(text)) = (embedded_graphics_host(), jit_text_arg_bytes(text_id)) {
         return (host.cache_text)(font, &text);
     }
+    let Ok(text) = jit_text_arg_to_cstring(text_id) else {
+        return 0;
+    };
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(text) = jit_text_arg_to_cstring(text_id) else {
-            return 0;
-        };
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
-        };
-        let callback: extern "system" fn(i32, *const c_char) -> i32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_cache_text) };
-        return callback(font, text.as_ptr());
-    }
+    let callback: extern "system" fn(i32, *const c_char) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_cache_text) };
     #[cfg(not(windows))]
-    {
-        let _ = font;
-        let _ = text_id;
-        0
-    }
+    let callback: extern "C" fn(i32, *const c_char) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_cache_text) };
+    callback(font, text.as_ptr())
 }
 
 #[no_mangle]
@@ -3135,20 +3136,16 @@ pub extern "C" fn stasis_jit_gfx_poll_reload(handle: i32) -> i32 {
     if let Some(host) = embedded_graphics_host() {
         return (host.poll_reload)(handle);
     }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0;
-        };
-        let callback: extern "system" fn(i32) -> i32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_poll_reload) };
-        return callback(handle);
-    }
+    let callback: extern "system" fn(i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_poll_reload) };
     #[cfg(not(windows))]
-    {
-        let _ = handle;
-        0
-    }
+    let callback: extern "C" fn(i32) -> i32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_poll_reload) };
+    callback(handle)
 }
 
 #[no_mangle]
@@ -3156,20 +3153,16 @@ pub extern "C" fn stasis_jit_gfx_measure_text_cached(run_handle: i32) -> f32 {
     if let Some(host) = embedded_graphics_host() {
         return (host.measure_text_cached)(run_handle);
     }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0.0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0.0;
-        };
-        let callback: extern "system" fn(i32) -> f32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached) };
-        return callback(run_handle);
-    }
+    let callback: extern "system" fn(i32) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached) };
     #[cfg(not(windows))]
-    {
-        let _ = run_handle;
-        0.0
-    }
+    let callback: extern "C" fn(i32) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached) };
+    callback(run_handle)
 }
 
 #[no_mangle]
@@ -3177,20 +3170,16 @@ pub extern "C" fn stasis_jit_gfx_measure_text_cached_height(run_handle: i32) -> 
     if let Some(host) = embedded_graphics_host() {
         return (host.measure_text_cached_height)(run_handle);
     }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0.0;
+    };
     #[cfg(windows)]
-    {
-        let Ok(api) = stasis_graphics_assets_api() else {
-            return 0.0;
-        };
-        let callback: extern "system" fn(i32) -> f32 =
-            unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached_height) };
-        return callback(run_handle);
-    }
+    let callback: extern "system" fn(i32) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached_height) };
     #[cfg(not(windows))]
-    {
-        let _ = run_handle;
-        0.0
-    }
+    let callback: extern "C" fn(i32) -> f32 =
+        unsafe { std::mem::transmute(api.stasis_gfx_measure_text_cached_height) };
+    callback(run_handle)
 }
 
 fn struct_field_path_hash(base_hash: i32, suffix: &str) -> i32 {
@@ -4025,6 +4014,50 @@ extern "system" {
     fn GetProcAddress(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
 }
 
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+const RTLD_LOCAL: i32 = 0;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+const RTLD_LOCAL: i32 = 4;
+#[cfg(unix)]
+const RTLD_NOW: i32 = 2;
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+#[link(name = "dl")]
+unsafe extern "C" {
+    fn dlopen(path: *const c_char, flags: i32) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dlclose(handle: *mut c_void) -> i32;
+    fn dlerror() -> *const c_char;
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+unsafe extern "C" {
+    fn dlopen(path: *const c_char, flags: i32) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dlclose(handle: *mut c_void) -> i32;
+    fn dlerror() -> *const c_char;
+}
+
+#[cfg(unix)]
+fn clear_dynamic_loading_error() {
+    let _ = unsafe { dlerror() };
+}
+
+#[cfg(unix)]
+fn dynamic_loading_error_if_present() -> Option<String> {
+    let error = unsafe { dlerror() };
+    (!error.is_null()).then(|| {
+        unsafe { CStr::from_ptr(error) }
+            .to_string_lossy()
+            .into_owned()
+    })
+}
+
+#[cfg(unix)]
+fn dynamic_loading_error() -> String {
+    dynamic_loading_error_if_present().unwrap_or_else(|| "unknown dynamic loader error".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4073,6 +4106,23 @@ mod tests {
         let address = library
             .symbol_address("GetTickCount")
             .expect("resolve GetTickCount");
+        assert_ne!(address, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn can_load_linux_libc_and_resolve_export() {
+        let library = Library::load(Path::new("libc.so.6")).expect("load libc");
+        let address = library.symbol_address("malloc").expect("resolve malloc");
+        assert_ne!(address, 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn can_load_macos_libsystem_and_resolve_export() {
+        let library =
+            Library::load(Path::new("/usr/lib/libSystem.B.dylib")).expect("load libSystem");
+        let address = library.symbol_address("malloc").expect("resolve malloc");
         assert_ne!(address, 0);
     }
 

--- a/vscode-stasis/.gitignore
+++ b/vscode-stasis/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+.vscode-test/
 *.vsix

--- a/vscode-stasis/.vscodeignore
+++ b/vscode-stasis/.vscodeignore
@@ -2,7 +2,9 @@
 .vscode/**
 node_modules/**
 src/**
+test/**
 dist/*.test.cjs
+dist/e2e-*.cjs
 dist/*.map
 tsconfig.json
 *.vsix

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -61,7 +61,9 @@ npm run package
 
 `npm run test:e2e` packages the extension, installs that VSIX into a clean VS Code profile, and
 drives formatting, completion, graphical play, pause/step/resume, live values, and framebuffer
-capture. It requires a built `stasis` executable and graphics runtime. Set
+capture. The test decodes the captured PNG and verifies its physical dimensions, clear color, and
+a command-buffer line, so a platform only passes after it produces the expected rendered pixels.
+It requires a built `stasis` executable and graphics runtime. Set
 `STASIS_E2E_EXECUTABLE` and `STASIS_RUNTIME_LIBRARY_PATH` when they are not in their standard
 development locations. Linux runs need a display such as `xvfb-run`; GitHub CI supplies one.
 

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -59,4 +59,10 @@ npm run build
 npm run package
 ```
 
+`npm run test:e2e` packages the extension, installs that VSIX into a clean VS Code profile, and
+drives formatting, completion, graphical play, pause/step/resume, live values, and framebuffer
+capture. It requires a built `stasis` executable and graphics runtime. Set
+`STASIS_E2E_EXECUTABLE` and `STASIS_RUNTIME_LIBRARY_PATH` when they are not in their standard
+development locations. Linux runs need a display such as `xvfb-run`; GitHub CI supplies one.
+
 The extension is intentionally a thin CLI client. Language or runtime semantics belong in Stasis, where the terminal UI, editor, tests, and packaged games can share them.

--- a/vscode-stasis/package-lock.json
+++ b/vscode-stasis/package-lock.json
@@ -10,10 +10,12 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/node": "^22.10.2",
+        "@types/pngjs": "^6.0.5",
         "@types/vscode": "^1.96.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.2.1",
         "esbuild": "^0.28.1",
+        "pngjs": "^7.0.0",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -999,6 +1001,16 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
@@ -3616,6 +3628,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/prebuild-install": {

--- a/vscode-stasis/package-lock.json
+++ b/vscode-stasis/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/node": "^22.10.2",
         "@types/vscode": "^1.96.0",
+        "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.2.1",
         "esbuild": "^0.28.1",
         "typescript": "^5.7.2"
@@ -1028,6 +1029,23 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@vscode/vsce": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.2.tgz",
@@ -1587,6 +1605,35 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cockatiel": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
@@ -1639,6 +1686,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -2155,6 +2209,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2445,6 +2512,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/index-to-position": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
@@ -2463,8 +2537,7 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -2542,6 +2615,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2550,6 +2636,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -2567,6 +2666,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/istextorbinary": {
       "version": "9.5.0",
@@ -2679,6 +2785,52 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -2723,6 +2875,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/linkify-it": {
@@ -2807,6 +2969,49 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2924,6 +3129,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -3115,6 +3333,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -3126,6 +3360,68 @@
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
         "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3146,6 +3442,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -3344,6 +3647,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -3506,6 +3816,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -3627,6 +3954,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
@@ -3701,6 +4035,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-concat": {
@@ -3818,6 +4165,19 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4206,8 +4566,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/vscode-stasis/package.json
+++ b/vscode-stasis/package.json
@@ -188,6 +188,7 @@
     "test": "npm run test:unit",
     "test:unit": "npm run check && esbuild src/protocol.test.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/protocol.test.cjs && node --test dist/protocol.test.cjs",
     "test:e2e": "npm run package && npm run bundle:e2e && node dist/e2e-run.cjs",
+    "prepackage": "node -e \"require('node:fs').mkdirSync('.vsix', { recursive: true })\"",
     "package": "npm run build && vsce package --out .vsix/stasislang.stasis.vsix"
   },
   "devDependencies": {

--- a/vscode-stasis/package.json
+++ b/vscode-stasis/package.json
@@ -27,8 +27,13 @@
     "languages": [
       {
         "id": "stasis",
-        "aliases": ["Stasis", "stasis"],
-        "extensions": [".stasis"],
+        "aliases": [
+          "Stasis",
+          "stasis"
+        ],
+        "extensions": [
+          ".stasis"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -40,39 +45,116 @@
       }
     ],
     "commands": [
-      { "command": "stasis.startPlaySession", "title": "Stasis: Start Play Session", "icon": "$(play)" },
-      { "command": "stasis.stopPlaySession", "title": "Stasis: Stop Play Session", "icon": "$(debug-stop)" },
-      { "command": "stasis.pausePlaySession", "title": "Stasis: Pause Play Session", "icon": "$(debug-pause)" },
-      { "command": "stasis.resumePlaySession", "title": "Stasis: Resume Play Session", "icon": "$(debug-continue)" },
-      { "command": "stasis.stepPlaySession", "title": "Stasis: Step One Tick", "icon": "$(debug-step-over)" },
-      { "command": "stasis.inspectValue", "title": "Stasis: Inspect Live Value" },
-      { "command": "stasis.addWatch", "title": "Stasis: Add Live Watch", "icon": "$(add)" },
-      { "command": "stasis.removeWatch", "title": "Stasis: Remove Live Watch", "icon": "$(trash)" },
-      { "command": "stasis.refreshLiveValues", "title": "Stasis: Refresh Live Values", "icon": "$(refresh)" },
-      { "command": "stasis.showOutput", "title": "Stasis: Show Output" }
+      {
+        "command": "stasis.startPlaySession",
+        "title": "Stasis: Start Play Session",
+        "icon": "$(play)"
+      },
+      {
+        "command": "stasis.stopPlaySession",
+        "title": "Stasis: Stop Play Session",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "stasis.pausePlaySession",
+        "title": "Stasis: Pause Play Session",
+        "icon": "$(debug-pause)"
+      },
+      {
+        "command": "stasis.resumePlaySession",
+        "title": "Stasis: Resume Play Session",
+        "icon": "$(debug-continue)"
+      },
+      {
+        "command": "stasis.stepPlaySession",
+        "title": "Stasis: Step One Tick",
+        "icon": "$(debug-step-over)"
+      },
+      {
+        "command": "stasis.inspectValue",
+        "title": "Stasis: Inspect Live Value"
+      },
+      {
+        "command": "stasis.addWatch",
+        "title": "Stasis: Add Live Watch",
+        "icon": "$(add)"
+      },
+      {
+        "command": "stasis.removeWatch",
+        "title": "Stasis: Remove Live Watch",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "stasis.refreshLiveValues",
+        "title": "Stasis: Refresh Live Values",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "stasis.showOutput",
+        "title": "Stasis: Show Output"
+      }
     ],
     "viewsContainers": {
       "activitybar": [
-        { "id": "stasis", "title": "Stasis", "icon": "media/stasis.svg" }
+        {
+          "id": "stasis",
+          "title": "Stasis",
+          "icon": "media/stasis.svg"
+        }
       ]
     },
     "views": {
       "stasis": [
-        { "id": "stasis.liveValues", "name": "Live Values" }
+        {
+          "id": "stasis.liveValues",
+          "name": "Live Values"
+        }
       ]
     },
     "menus": {
       "view/title": [
-        { "command": "stasis.startPlaySession", "when": "view == stasis.liveValues && !stasis.liveSessionActive", "group": "navigation@1" },
-        { "command": "stasis.stopPlaySession", "when": "view == stasis.liveValues && stasis.liveSessionActive", "group": "navigation@1" },
-        { "command": "stasis.pausePlaySession", "when": "view == stasis.liveValues && stasis.liveSessionRunning", "group": "navigation@2" },
-        { "command": "stasis.resumePlaySession", "when": "view == stasis.liveValues && stasis.liveSessionPaused", "group": "navigation@2" },
-        { "command": "stasis.stepPlaySession", "when": "view == stasis.liveValues && stasis.liveSessionPaused", "group": "navigation@3" },
-        { "command": "stasis.addWatch", "when": "view == stasis.liveValues && stasis.liveSessionActive", "group": "navigation@4" },
-        { "command": "stasis.refreshLiveValues", "when": "view == stasis.liveValues && stasis.liveSessionActive", "group": "navigation@5" }
+        {
+          "command": "stasis.startPlaySession",
+          "when": "view == stasis.liveValues && !stasis.liveSessionActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "stasis.stopPlaySession",
+          "when": "view == stasis.liveValues && stasis.liveSessionActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "stasis.pausePlaySession",
+          "when": "view == stasis.liveValues && stasis.liveSessionRunning",
+          "group": "navigation@2"
+        },
+        {
+          "command": "stasis.resumePlaySession",
+          "when": "view == stasis.liveValues && stasis.liveSessionPaused",
+          "group": "navigation@2"
+        },
+        {
+          "command": "stasis.stepPlaySession",
+          "when": "view == stasis.liveValues && stasis.liveSessionPaused",
+          "group": "navigation@3"
+        },
+        {
+          "command": "stasis.addWatch",
+          "when": "view == stasis.liveValues && stasis.liveSessionActive",
+          "group": "navigation@4"
+        },
+        {
+          "command": "stasis.refreshLiveValues",
+          "when": "view == stasis.liveValues && stasis.liveSessionActive",
+          "group": "navigation@5"
+        }
       ],
       "view/item/context": [
-        { "command": "stasis.removeWatch", "when": "view == stasis.liveValues && viewItem == stasisLiveWatch", "group": "inline" }
+        {
+          "command": "stasis.removeWatch",
+          "when": "view == stasis.liveValues && viewItem == stasisLiveWatch",
+          "group": "inline"
+        }
       ]
     },
     "configuration": {
@@ -101,13 +183,17 @@
   "scripts": {
     "build": "npm run check && npm run bundle",
     "bundle": "esbuild src/extension.ts --bundle --platform=node --target=node20 --format=cjs --external:vscode --sourcemap --outfile=dist/extension.js",
+    "bundle:e2e": "esbuild src/e2e/run.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/e2e-run.cjs && esbuild src/e2e/suite.ts --bundle --platform=node --target=node20 --format=cjs --external:vscode --outfile=dist/e2e-suite.cjs",
     "check": "tsc --noEmit",
-    "test": "npm run check && esbuild src/protocol.test.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/protocol.test.cjs && node --test dist/protocol.test.cjs",
-    "package": "npm run build && vsce package"
+    "test": "npm run test:unit",
+    "test:unit": "npm run check && esbuild src/protocol.test.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/protocol.test.cjs && node --test dist/protocol.test.cjs",
+    "test:e2e": "npm run package && npm run bundle:e2e && node dist/e2e-run.cjs",
+    "package": "npm run build && vsce package --out .vsix/stasislang.stasis.vsix"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "@types/vscode": "^1.96.0",
+    "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.2.1",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2"

--- a/vscode-stasis/package.json
+++ b/vscode-stasis/package.json
@@ -193,10 +193,12 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@types/pngjs": "^6.0.5",
     "@types/vscode": "^1.96.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.2.1",
     "esbuild": "^0.28.1",
+    "pngjs": "^7.0.0",
     "typescript": "^5.7.2"
   }
 }

--- a/vscode-stasis/src/e2e/run.ts
+++ b/vscode-stasis/src/e2e/run.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+  runTests,
+} from "@vscode/test-electron";
+
+async function main(): Promise<void> {
+  const extensionRoot = path.resolve(__dirname, "..");
+  const repositoryRoot = path.resolve(extensionRoot, "..");
+  const vscodeVersion = process.env.STASIS_E2E_VSCODE_VERSION ?? "1.96.0";
+  const vsix = path.join(extensionRoot, ".vsix", "stasislang.stasis.vsix");
+  const executable = process.env.STASIS_E2E_EXECUTABLE
+    ? path.resolve(process.env.STASIS_E2E_EXECUTABLE)
+    : path.join(repositoryRoot, "target", "debug", process.platform === "win32" ? "stasis.exe" : "stasis");
+  if (!fs.existsSync(vsix)) {
+    throw new Error(`Packaged extension not found: ${vsix}`);
+  }
+  if (!fs.existsSync(executable)) {
+    throw new Error(`Stasis executable not found: ${executable}`);
+  }
+
+  const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stasis-vscode-e2e-"));
+  const extensionsDir = path.join(profileRoot, "extensions");
+  const userDataDir = path.join(profileRoot, "user-data");
+  const fixtureWorkspace = path.join(profileRoot, "workspace");
+  fs.cpSync(path.join(extensionRoot, "test", "fixture"), fixtureWorkspace, { recursive: true });
+  const screenshot = process.env.STASIS_E2E_SCREENSHOT
+    ? path.resolve(process.env.STASIS_E2E_SCREENSHOT)
+    : path.join(profileRoot, "live-frame.png");
+  fs.mkdirSync(path.dirname(screenshot), { recursive: true });
+  fs.rmSync(screenshot, { force: true });
+
+  try {
+    const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
+    const [cli, ...defaultCliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+    if (!cli) {
+      throw new Error("VS Code test download did not provide a command-line launcher.");
+    }
+    const cliArgs = defaultCliArgs.filter(
+      (arg) => !arg.startsWith("--extensions-dir=") && !arg.startsWith("--user-data-dir="),
+    );
+    const install = spawnSync(
+      cli,
+      [
+        ...cliArgs,
+        "--extensions-dir",
+        extensionsDir,
+        "--user-data-dir",
+        userDataDir,
+        "--install-extension",
+        vsix,
+        "--force",
+      ],
+      {
+        encoding: "utf8",
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      },
+    );
+    if (install.error) {
+      throw install.error;
+    }
+    if (install.status !== 0) {
+      throw new Error(`VSIX installation failed with exit code ${install.status ?? "unknown"}.`);
+    }
+    // The Windows CLI wrapper can return just before its Electron helper releases the profile
+    // mutex. Give that helper a short bounded drain window before starting the Extension Host.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath: path.join(extensionRoot, "test", "harness"),
+      extensionTestsPath: path.join(extensionRoot, "dist", "e2e-suite.cjs"),
+      extensionTestsEnv: {
+        ...process.env,
+        STASIS_E2E_EXECUTABLE: executable,
+        STASIS_E2E_SCREENSHOT: screenshot,
+        STASIS_SCREENSHOT_ONCE: screenshot,
+        STASIS_SCREENSHOT_FRAME: "2",
+      },
+      launchArgs: [
+        fixtureWorkspace,
+        `--extensions-dir=${extensionsDir}`,
+        `--user-data-dir=${userDataDir}`,
+        "--disable-workspace-trust",
+        "--skip-welcome",
+        "--skip-release-notes",
+      ],
+    });
+  } finally {
+    fs.rmSync(profileRoot, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/vscode-stasis/src/e2e/suite.ts
+++ b/vscode-stasis/src/e2e/suite.ts
@@ -1,6 +1,7 @@
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { PNG } from "pngjs";
 import * as vscode from "vscode";
 import type { LiveResponse, LiveValue } from "../protocol";
 import type { LiveSessionState } from "../liveSession";
@@ -11,6 +12,63 @@ interface StasisExtensionApi {
   start(): Promise<void>;
   stop(): Promise<void>;
   request(type: string, fields?: Record<string, unknown>): Promise<LiveResponse>;
+}
+
+type Rgba = readonly [number, number, number, number];
+
+function pixelAt(png: PNG, x: number, y: number): Rgba {
+  assert.ok(x >= 0 && x < png.width, `pixel x ${x} is inside the ${png.width}-pixel framebuffer`);
+  assert.ok(y >= 0 && y < png.height, `pixel y ${y} is inside the ${png.height}-pixel framebuffer`);
+  const offset = (y * png.width + x) * 4;
+  return [png.data[offset]!, png.data[offset + 1]!, png.data[offset + 2]!, png.data[offset + 3]!];
+}
+
+function isNear(actual: Rgba, expected: Rgba, tolerance: number): boolean {
+  return actual.every((channel, index) => Math.abs(channel - expected[index]!) <= tolerance);
+}
+
+function assertRenderedFrame(framePath: string): void {
+  const png = PNG.sync.read(fs.readFileSync(framePath));
+  const logicalWidth = 800;
+  const logicalHeight = 600;
+  const scaleX = png.width / logicalWidth;
+  const scaleY = png.height / logicalHeight;
+
+  assert.ok(scaleX >= 1 && scaleY >= 1, `framebuffer is at least ${logicalWidth}x${logicalHeight}`);
+  assert.ok(Math.abs(scaleX - scaleY) < 0.001, "framebuffer preserves the 4:3 logical render size");
+
+  const background: Rgba = [10, 20, 40, 255];
+  for (const [logicalX, logicalY] of [
+    [40, 40],
+    [400, 100],
+    [40, 560],
+    [760, 560],
+  ] as const) {
+    const actual = pixelAt(png, Math.floor(logicalX * scaleX), Math.floor(logicalY * scaleY));
+    assert.ok(
+      isNear(actual, background, 2),
+      `rendered background at (${logicalX}, ${logicalY}) is ${background.join(",")}, received ${actual.join(",")}`,
+    );
+  }
+
+  const line: Rgba = [229, 51, 25, 255];
+  const minX = Math.floor(120 * scaleX);
+  const maxX = Math.ceil(680 * scaleX);
+  const centerY = 300 * scaleY;
+  const minY = Math.max(0, Math.floor(centerY - 2 * scaleY));
+  const maxY = Math.min(png.height - 1, Math.ceil(centerY + 2 * scaleY));
+  let linePixels = 0;
+  for (let y = minY; y <= maxY; y += 1) {
+    for (let x = minX; x <= maxX; x += 1) {
+      if (isNear(pixelAt(png, x, y), line, 3)) {
+        linePixels += 1;
+      }
+    }
+  }
+  assert.ok(
+    linePixels >= 400 * scaleX,
+    `rendered command-buffer line contains enough expected pixels, found ${linePixels}`,
+  );
 }
 
 async function waitFor(description: string, predicate: () => boolean, timeoutMs = 30_000): Promise<void> {
@@ -171,8 +229,11 @@ export async function run(): Promise<void> {
 
     await api.request("resume");
     await waitFor("resumed live session", () => api.state() === "running");
-    await waitFor("runtime framebuffer capture", () => fs.existsSync(screenshot));
-    assert.ok(fs.statSync(screenshot).size > 100, "the graphical play process produced a PNG framebuffer");
+    await waitFor(
+      "runtime framebuffer capture",
+      () => fs.existsSync(screenshot) && fs.statSync(screenshot).size > 100,
+    );
+    assertRenderedFrame(screenshot);
   } finally {
     await api.stop();
     await waitFor("stopped live session", () => api.state() === "stopped");

--- a/vscode-stasis/src/e2e/suite.ts
+++ b/vscode-stasis/src/e2e/suite.ts
@@ -1,0 +1,180 @@
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { LiveResponse, LiveValue } from "../protocol";
+import type { LiveSessionState } from "../liveSession";
+
+interface StasisExtensionApi {
+  state(): LiveSessionState;
+  values(): readonly LiveValue[];
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  request(type: string, fields?: Record<string, unknown>): Promise<LiveResponse>;
+}
+
+async function waitFor(description: string, predicate: () => boolean, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${description}.`);
+}
+
+function inspectedI32(response: LiveResponse): number {
+  const data = response.data as Record<string, unknown> | undefined;
+  const value = data?.value as Record<string, unknown> | undefined;
+  if (!value) {
+    throw new Error(`Inspection response did not contain a typed value: ${JSON.stringify(response)}`);
+  }
+  assert.equal(value?.type, "i32");
+  assert.equal(typeof value.value, "number");
+  return value.value as number;
+}
+
+function applyTextEdits(document: vscode.TextDocument, edits: readonly vscode.TextEdit[]): string {
+  let text = document.getText();
+  const replacements = edits
+    .map((edit) => ({
+      start: document.offsetAt(edit.range.start),
+      end: document.offsetAt(edit.range.end),
+      newText: edit.newText,
+    }))
+    .sort((left, right) => right.start - left.start || right.end - left.end);
+  for (const replacement of replacements) {
+    text = `${text.slice(0, replacement.start)}${replacement.newText}${text.slice(replacement.end)}`;
+  }
+  return text;
+}
+
+export async function run(): Promise<void> {
+  const executable = process.env.STASIS_E2E_EXECUTABLE;
+  const screenshot = process.env.STASIS_E2E_SCREENSHOT;
+  if (!executable || !fs.existsSync(executable)) {
+    throw new Error("The built Stasis executable is not available.");
+  }
+  if (!screenshot) {
+    throw new Error("The screenshot output path is not configured.");
+  }
+
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) {
+    throw new Error("The fixture workspace is not open.");
+  }
+  await vscode.workspace
+    .getConfiguration("stasis", folder.uri)
+    .update("executablePath", executable, vscode.ConfigurationTarget.Global);
+
+  const extension = vscode.extensions.getExtension<StasisExtensionApi>("stasislang.stasis");
+  if (!extension) {
+    throw new Error("The packaged Stasis VSIX is not installed.");
+  }
+  const api = await extension.activate();
+
+  const formatUri = vscode.Uri.file(path.join(folder.uri.fsPath, "format-input.stasis"));
+  fs.writeFileSync(
+    formatUri.fsPath,
+    "global value:i32;\nfunction sample():i32 {\nvalue += 1;\nreturn value;\n}\n",
+  );
+  const formatDocument = await vscode.workspace.openTextDocument(formatUri);
+
+  const formatEdits = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+    "vscode.executeFormatDocumentProvider",
+    formatUri,
+    { tabSize: 4, insertSpaces: true },
+  );
+  assert.ok(formatEdits && formatEdits.length > 0, "the packaged formatter returns canonical edits");
+  const formatted = applyTextEdits(formatDocument, formatEdits);
+  assert.match(
+    formatted,
+    /global value: i32;/,
+    "formatter output applies canonical type spacing",
+  );
+  assert.match(
+    formatted,
+    /function sample\(\): i32 \{\r?\n    value \+= 1;/,
+    "formatter output applies canonical block newlines and indentation",
+  );
+
+  const sourceUri = vscode.Uri.file(path.join(folder.uri.fsPath, "src", "main.stasis"));
+  const document = await vscode.workspace.openTextDocument(sourceUri);
+  await vscode.window.showTextDocument(document);
+
+  const tickLineNumber = document
+    .getText()
+    .split(/\r?\n/)
+    .findIndex((line) => line.includes("function tick"));
+  assert.notEqual(tickLineNumber, -1, "the fixture contains the tick function");
+  const tickLine = document.lineAt(tickLineNumber);
+  const completionPosition = new vscode.Position(
+    tickLineNumber,
+    tickLine.text.indexOf("tick") + "tick".length,
+  );
+  const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+    "vscode.executeCompletionItemProvider",
+    sourceUri,
+    completionPosition,
+  );
+  assert.ok(
+    completions?.items.some((item) => item.label === "tick"),
+    "compiler-backed completion returns the fixture function",
+  );
+
+  try {
+    await api.start();
+    await waitFor("running live session", () => api.state() === "running");
+    await api.request("pause");
+    await waitFor("paused live session", () => api.state() === "paused");
+
+    const before = inspectedI32(await api.request("inspect", { path: "score" }));
+    await api.request("watch", { path: "score" });
+    await api.request("step", { ticks: 1 });
+    const after = inspectedI32(await api.request("inspect", { path: "score" }));
+    assert.equal(after, before + 1, "single-step executes exactly one game tick");
+    assert.ok(api.values().some((value) => value.path === "score"), "the Live Values model receives runtime state");
+
+    const source = document.getText();
+    const oldTick = "score += 1";
+    const oldTickOffset = source.indexOf(oldTick);
+    assert.notEqual(oldTickOffset, -1, "the fixture contains its original tick operation");
+    const hotEdit = new vscode.WorkspaceEdit();
+    hotEdit.replace(
+      sourceUri,
+      new vscode.Range(
+        document.positionAt(oldTickOffset),
+        document.positionAt(oldTickOffset + oldTick.length),
+      ),
+      "score += 3",
+    );
+    assert.equal(await vscode.workspace.applyEdit(hotEdit), true, "VS Code applies the live source edit");
+    assert.equal(await document.save(), true, "VS Code saves the live source edit");
+
+    let current = after;
+    let hotSwapObserved = false;
+    const hotSwapDeadline = Date.now() + 30_000;
+    while (Date.now() < hotSwapDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await api.request("step", { ticks: 1 });
+      const next = inspectedI32(await api.request("inspect", { path: "score" }));
+      const delta = next - current;
+      assert.ok(delta === 1 || delta === 3, `tick delta remains old or newly swapped logic, received ${delta}`);
+      current = next;
+      if (delta === 3) {
+        hotSwapObserved = true;
+        break;
+      }
+    }
+    assert.equal(hotSwapObserved, true, "saving in VS Code hot-swaps the running tick function");
+
+    await api.request("resume");
+    await waitFor("resumed live session", () => api.state() === "running");
+    await waitFor("runtime framebuffer capture", () => fs.existsSync(screenshot));
+    assert.ok(fs.statSync(screenshot).size > 100, "the graphical play process produced a PNG framebuffer");
+  } finally {
+    await api.stop();
+    await waitFor("stopped live session", () => api.state() === "stopped");
+  }
+}

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -321,6 +321,14 @@ class LiveController implements vscode.Disposable {
     return this.current?.root === root ? this.current : undefined;
   }
 
+  get state(): LiveSessionState {
+    return this.current?.state ?? "stopped";
+  }
+
+  get liveValues(): readonly LiveValue[] {
+    return this.current?.values ?? [];
+  }
+
   requireSession(): LiveSession {
     if (!this.current || this.current.state === "stopped") {
       throw new Error("Start a Stasis play session first.");
@@ -413,7 +421,7 @@ async function showCommandError(action: () => Promise<void>): Promise<void> {
   }
 }
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): StasisExtensionApi {
   const output = vscode.window.createOutputChannel("Stasis");
   const values = new LiveValuesProvider();
   const controller = new LiveController(values, output);
@@ -463,6 +471,22 @@ export function activate(context: vscode.ExtensionContext): void {
     command("stasis.refreshLiveValues", async () => controller.requireSession().refresh()),
     command("stasis.showOutput", async () => output.show(true)),
   );
+
+  return {
+    state: () => controller.state,
+    values: () => controller.liveValues,
+    start: () => controller.start(),
+    stop: () => controller.stop(),
+    request: (type, fields = {}) => controller.requireSession().request(type, fields),
+  } satisfies StasisExtensionApi;
+}
+
+export interface StasisExtensionApi {
+  state(): LiveSessionState;
+  values(): readonly LiveValue[];
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  request(type: string, fields?: Record<string, unknown>): Promise<LiveResponse>;
 }
 
 export function deactivate(): void {}

--- a/vscode-stasis/test/fixture/src/main.stasis
+++ b/vscode-stasis/test/fixture/src/main.stasis
@@ -20,10 +20,22 @@ function render(): i32 {
     gfx_cmd_i32[0] = 1196967473;
     gfx_cmd_i32[1] = 2;
     gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 1;
+    gfx_cmd_i32[4] = 0;
+    gfx_cmd_i32[7] = 0;
+    gfx_cmd_i32[9] = 0;
     gfx_cmd_f32[0] = 0.04;
     gfx_cmd_f32[1] = 0.08;
     gfx_cmd_f32[2] = 0.16;
     gfx_cmd_f32[3] = 1.0;
+    gfx_cmd_f32[4] = 120.0;
+    gfx_cmd_f32[5] = 300.0;
+    gfx_cmd_f32[6] = 680.0;
+    gfx_cmd_f32[7] = 300.0;
+    gfx_cmd_f32[8] = 0.9;
+    gfx_cmd_f32[9] = 0.2;
+    gfx_cmd_f32[10] = 0.1;
+    gfx_cmd_f32[11] = 1.0;
     return 0;
 }
 

--- a/vscode-stasis/test/fixture/src/main.stasis
+++ b/vscode-stasis/test/fixture/src/main.stasis
@@ -1,0 +1,32 @@
+global gfx_cmd_i32: i32[18464];
+
+global gfx_cmd_f32: f32[108676];
+
+global gfx_cmd_u8: u8[65536];
+
+global score: i32;
+
+function main(): i32 {
+    score = 1;
+    return 0;
+}
+
+function tick(): i32 {
+    score += 1;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 2;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_f32[0] = 0.04;
+    gfx_cmd_f32[1] = 0.08;
+    gfx_cmd_f32[2] = 0.16;
+    gfx_cmd_f32[3] = 1.0;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/vscode-stasis/test/fixture/stasis.json
+++ b/vscode-stasis/test/fixture/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "vscode_e2e",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}

--- a/vscode-stasis/test/harness/extension.js
+++ b/vscode-stasis/test/harness/extension.js
@@ -1,0 +1,1 @@
+exports.activate = function activate() {};

--- a/vscode-stasis/test/harness/package.json
+++ b/vscode-stasis/test/harness/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "stasis-vscode-e2e-harness",
+  "displayName": "Stasis VS Code E2E Harness",
+  "version": "0.0.0",
+  "private": true,
+  "engines": {
+    "vscode": "^1.96.0"
+  },
+  "main": "./extension.js"
+}


### PR DESCRIPTION
## What changed

- make the in-process graphics/play loader portable across Windows, Linux, and macOS using native dynamic-loading APIs and platform library names
- remove Windows-only guards from play, runtime probing, loadability checks, runtime staging, and the helper launcher
- enable sprite, font, text-cache, reload, and framebuffer asset calls through the native Unix ABI
- add an installed-VSIX Extension Host test that covers formatting, compiler completion, graphical play launch, pause/step/resume, live inspection/watch values, saved-source hot swap, and a fresh PNG framebuffer
- add Linux x64 and macOS arm64 GitHub Actions jobs that build the SDL runtime, probe native loading, run the VSIX test, and upload the VSIX/log/frame evidence

## Why

The C graphics runtime and compiler already had substantial Unix support, but the Rust in-process runner and dynamic loader imposed an explicit Windows-only boundary. That prevented meaningful end-to-end verification of the VS Code play workflow on Linux and macOS.

## Impact

Stasis play and the VS Code live workflow can now execute through native shared libraries on all three desktop platforms. PR CI will provide actual Linux/macOS evidence instead of relying on compilation alone.

## Validation

- `cargo check -p stasis`
- `cargo check --release -p stasis`
- `cargo check --release -p stasis_dynload`
- `cargo test -p stasis_dynload -- --test-threads=1`
- focused `tui_live_stdio_keeps_a_jsonl_editor_session_open` integration test
- `npm test` in `vscode-stasis`
- installed packaged VSIX E2E on Windows against VS Code 1.96 and 1.131, including hot swap and a fresh 1.9 MB framebuffer
- repository pre-commit Android Workshop JIT / Published AOT parity gate (matching framebuffer hash)
- `git diff --check`
