### PR TITLE
feat: ship atomic editor toolchains

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -412,7 +412,7 @@ jobs:
 
       - name: Stamp nightly extension version
         working-directory: vscode-stasis
-        run: npm version --no-git-tag-version "0.2.${GITHUB_RUN_NUMBER}"
+        run: npm version --no-git-tag-version "0.2.${{ github.run_number }}"
 
       - name: Test installed VSIX in VS Code
         if: runner.os == 'Linux'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install SDL development packages (macos)
         if: runner.os == 'macOS'
-        run: brew install sdl2 sdl2_image
+        run: brew install pkg-config
 
       - name: Setup MSVC dev environment (windows)
         if: runner.os == 'Windows'
@@ -166,6 +166,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
+            -DSTASIS_GRAPHICS_BUNDLE_SDL=ON \
             -DSTASIS_GRAPHICS_SDL_ONLY=ON \
             -DSTASIS_BUILD_RUNNER=OFF \
             -DSTASIS_BUILD_SYS=OFF \
@@ -216,8 +217,8 @@ jobs:
             --release-tag "${{ needs.detect.outputs.nightly_tag }}" \
             --source-commit "${{ github.sha }}" \
             --compiler "bin/stasis" \
-            --dependency "sdl2=external-not-linked" \
-            --dependency "sdl2_image=external-not-linked"
+            --dependency "sdl2=2.32.10-static" \
+            --dependency "sdl2_image=2.8.12-static"
           tar -C dist -czf "dist/${{ matrix.archive }}.${{ matrix.ext }}" "${{ matrix.archive }}"
 
       - name: Assemble bundle (windows)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -76,6 +76,12 @@ jobs:
             archive: stasis-nightly-osx-arm64
             ext: tar.gz
     runs-on: ${{ matrix.os }}
+    env:
+      STASIS_RELEASE_ID: ${{ needs.detect.outputs.nightly_tag }}
+      STASIS_SOURCE_COMMIT: ${{ github.sha }}
+      STASIS_BUILD_TARGET: ${{ matrix.rust_target }}
+      STASIS_SIGNING_PFX_BASE64: ${{ secrets.STASIS_SIGNING_PFX_BASE64 }}
+      STASIS_SIGNING_PFX_PASSWORD: ${{ secrets.STASIS_SIGNING_PFX_PASSWORD }}
     steps:
       - uses: actions/checkout@v7
 
@@ -130,19 +136,21 @@ jobs:
           & (Join-Path $vcpkgRoot "vcpkg.exe") install "sdl2:$triplet" "sdl2-image:$triplet" --recurse
 
           $buildDir = "runtime/build_ci"
-          $cmakeHelp = cmake --help | Out-String
-          if ($cmakeHelp -match "Visual Studio 18 2026") {
+          $vsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio/Installer/vswhere.exe"
+          $vsVersion = (& $vsWhere -latest -products * -property installationVersion).Trim()
+          if ($vsVersion.StartsWith("18.")) {
             $generator = "Visual Studio 18 2026"
-          } elseif ($cmakeHelp -match "Visual Studio 17 2022") {
+          } elseif ($vsVersion.StartsWith("17.")) {
             $generator = "Visual Studio 17 2022"
           } else {
-            throw "Supported Visual Studio CMake generator not found."
+            throw "Supported Visual Studio installation not found."
           }
           cmake -S runtime -B $buildDir -G $generator -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="$triplet" `
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
+            -DSTASIS_RELEASE_ID="${{ needs.detect.outputs.nightly_tag }}" `
             -DSTASIS_GRAPHICS_SDL_ONLY=ON `
             -DSTASIS_MOBILE_RUNTIME_BUILD_TESTS=ON `
             -DSTASIS_BUILD_RUNNER=ON `
@@ -150,6 +158,37 @@ jobs:
 
           cmake --build $buildDir --config Release --target stasis_graphics stasis_runner stasis_render_contract_test stasis_asset_path_test
           ctest --test-dir $buildDir -C Release -R "stasis_(render_command|asset_path)_contract" --output-on-failure
+
+      - name: Build stasis_graphics runtime (unix)
+        if: runner.os != 'Windows'
+        run: |
+          cmake -S runtime -B runtime/build_ci \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
+            -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
+            -DSTASIS_GRAPHICS_SDL_ONLY=ON \
+            -DSTASIS_BUILD_RUNNER=OFF \
+            -DSTASIS_BUILD_SYS=OFF \
+            -DSTASIS_RELEASE_ID="${{ needs.detect.outputs.nightly_tag }}"
+          cmake --build runtime/build_ci --config Release --target stasis_graphics
+
+      - name: Authenticode sign Stasis Windows binaries
+        if: runner.os == 'Windows' && env.STASIS_SIGNING_PFX_BASE64 != ''
+        shell: pwsh
+        run: |
+          $certificate = Join-Path $env:RUNNER_TEMP "stasis-signing.pfx"
+          [IO.File]::WriteAllBytes($certificate, [Convert]::FromBase64String($env:STASIS_SIGNING_PFX_BASE64))
+          $signtool = (Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          if (-not $signtool) { throw "signtool.exe not found" }
+          @(
+            "target/${{ matrix.rust_target }}/release/stasis.exe",
+            "runtime/build_ci/bin/Release/stasis_graphics.dll",
+            "runtime/build_ci/bin/Release/stasis_runner.exe"
+          ) | ForEach-Object {
+            & $signtool sign /fd SHA256 /f $certificate /p $env:STASIS_SIGNING_PFX_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $_
+            if ($LASTEXITCODE -ne 0) { throw "Authenticode signing failed for $_" }
+          }
+          Remove-Item -LiteralPath $certificate -Force
 
       - name: Assemble bundle (unix)
         if: runner.os != 'Windows'
@@ -160,6 +199,7 @@ jobs:
           mkdir -p "${out}/bin"
           cp "target/${{ matrix.rust_target }}/release/stasis" "${out}/bin/"
           cp "target/${{ matrix.rust_target }}/release/libstasis_dynload.a" "${out}/bin/"
+          find runtime/build_ci/bin -maxdepth 2 -type f \( -name 'libstasis_graphics.so' -o -name 'libstasis_graphics.dylib' \) -exec cp {} "${out}/bin/" \;
           cp README.md "${out}/"
           cp LICENSE "${out}/"
           # Ship the stdlib + samples so relative imports keep working in the bundle.
@@ -240,6 +280,7 @@ jobs:
           Remove-Item Env:CC -ErrorAction SilentlyContinue
           Push-Location "dist/${{ matrix.archive }}"
           .\stasis.exe probe-graphics-runtime
+          .\stasis.exe --json editor-info
           & .\samples\windows_launch_smoke\verify.ps1 -Toolchain (Resolve-Path .\stasis.exe) -ArtifactRoot (Join-Path (Get-Location) 'windows-launch-evidence')
           .\stasis.exe new ci_smoke --dir cli-smoke
           .\stasis.exe --workspace cli-smoke check
@@ -271,6 +312,7 @@ jobs:
         run: |
           set -euo pipefail
           pushd "dist/${{ matrix.archive }}"
+          ./bin/stasis --json editor-info
           ./bin/stasis new ci_smoke --dir cli-smoke
           ./bin/stasis --workspace cli-smoke check
           ./bin/stasis --workspace cli-smoke test
@@ -300,13 +342,32 @@ jobs:
   vscode_extension:
     needs: [detect, build]
     if: needs.detect.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            archive: stasis-nightly-linux-x64
+            ext: tar.gz
+            executable: bin/stasis
+            vsce_target: linux-x64
+          - os: windows-latest
+            archive: stasis-nightly-win-x64
+            ext: zip
+            executable: stasis.exe
+            vsce_target: win32-x64
+          - os: macos-15
+            archive: stasis-nightly-osx-arm64
+            ext: tar.gz
+            executable: bin/stasis
+            vsce_target: darwin-arm64
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
-      CMAKE_BUILD_PARALLEL_LEVEL: "2"
       STASIS_E2E_VSCODE_VERSION: "1.96.0"
-      STASIS_E2E_EXECUTABLE: ${{ github.workspace }}/target/vscode-nightly/stasis-nightly-linux-x64/bin/stasis
-      STASIS_RUNTIME_LIBRARY_PATH: ${{ github.workspace }}/target/vscode-e2e-runtime/bin/libstasis_graphics.so
+      STASIS_TOOLCHAIN_DIR: ${{ github.workspace }}/target/vscode-nightly/${{ matrix.archive }}
+      STASIS_TOOLCHAIN_EXECUTABLE: ${{ matrix.executable }}
+      STASIS_E2E_EXECUTABLE: ${{ github.workspace }}/target/vscode-nightly/${{ matrix.archive }}/${{ matrix.executable }}
       STASIS_E2E_SCREENSHOT: ${{ github.workspace }}/target/vscode-e2e/frame.png
     steps:
       - uses: actions/checkout@v7
@@ -318,37 +379,28 @@ jobs:
           cache: npm
           cache-dependency-path: vscode-stasis/package-lock.json
 
-      - name: Install graphics and display dependencies
+      - name: Install graphics and display dependencies (linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --yes libsdl2-dev libsdl2-image-dev xvfb
 
-      - name: Download Linux nightly toolchain
+      - name: Install graphics dependencies (macos)
+        if: runner.os == 'macOS'
+        run: brew install sdl2 sdl2_image
+
+      - name: Download matching nightly toolchain
         uses: actions/download-artifact@v8
         with:
-          name: stasis-nightly-linux-x64
+          name: ${{ matrix.archive }}
           path: target/vscode-nightly
 
       - name: Extract and probe nightly toolchain
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          tar -C target/vscode-nightly -xzf target/vscode-nightly/stasis-nightly-linux-x64.tar.gz
-          test -x "$STASIS_E2E_EXECUTABLE"
-          "$STASIS_E2E_EXECUTABLE" version
-
-      - name: Build native graphics runtime
-        run: |
-          cmake -S runtime -B target/vscode-e2e-runtime \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
-            -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
-            -DSTASIS_GRAPHICS_SDL_ONLY=ON \
-            -DSTASIS_BUILD_RUNNER=OFF \
-            -DSTASIS_BUILD_SYS=OFF
-          cmake --build target/vscode-e2e-runtime --config Release --target stasis_graphics
-          test -f "$STASIS_RUNTIME_LIBRARY_PATH"
-          "$STASIS_E2E_EXECUTABLE" probe-graphics-runtime
+          tar -xf "target/vscode-nightly/${{ matrix.archive }}.${{ matrix.ext }}" -C target/vscode-nightly
+          if (-not (Test-Path $env:STASIS_E2E_EXECUTABLE)) { throw "toolchain executable missing" }
+          & $env:STASIS_E2E_EXECUTABLE --json editor-info
 
       - name: Install extension dependencies
         working-directory: vscode-stasis
@@ -358,17 +410,42 @@ jobs:
         working-directory: vscode-stasis
         run: npm test
 
+      - name: Stamp nightly extension version
+        working-directory: vscode-stasis
+        run: npm version --no-git-tag-version "0.2.${GITHUB_RUN_NUMBER}"
+
       - name: Test installed VSIX in VS Code
+        if: runner.os == 'Linux'
         working-directory: vscode-stasis
         run: |
           mkdir -p ../target/vscode-e2e
           xvfb-run -a npm run test:e2e
 
-      - name: Upload VS Code extension
+      - name: Package platform VSIX
+        working-directory: vscode-stasis
+        run: npm run package -- --target ${{ matrix.vsce_target }}
+
+      - name: Name platform VSIX
+        shell: pwsh
+        run: Move-Item vscode-stasis/.vsix/stasislang.stasis.vsix "vscode-stasis/.vsix/stasislang.stasis-${{ matrix.vsce_target }}.vsix" -Force
+
+      - name: Assemble atomic editor release
+        shell: pwsh
+        run: |
+          $releaseRoot = "target/stasis-editor-release-${{ matrix.vsce_target }}"
+          node tools/assemble_editor_release.mjs `
+            --toolchain-archive "target/vscode-nightly/${{ matrix.archive }}.${{ matrix.ext }}" `
+            --vsix "vscode-stasis/.vsix/stasislang.stasis-${{ matrix.vsce_target }}.vsix" `
+            --out $releaseRoot `
+            --release-id "${{ needs.detect.outputs.nightly_tag }}" `
+            --platform "${{ matrix.vsce_target }}"
+          Compress-Archive -Path "$releaseRoot/*" -DestinationPath "target/stasis-editor-release-${{ matrix.vsce_target }}.zip" -Force
+
+      - name: Upload atomic editor release
         uses: actions/upload-artifact@v4
         with:
-          name: stasis-vscode-extension
-          path: vscode-stasis/.vsix/stasislang.stasis.vsix
+          name: stasis-editor-release-${{ matrix.vsce_target }}
+          path: target/stasis-editor-release-${{ matrix.vsce_target }}.zip
           if-no-files-found: error
 
   release:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -122,7 +122,9 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
       STASIS_E2E_VSCODE_VERSION: "1.96.0"
       STASIS_RUNTIME_LIBRARY_PATH: ${{ github.workspace }}/target/vscode-e2e-runtime/bin/${{ matrix.runtime_library }}
-      STASIS_E2E_EXECUTABLE: ${{ github.workspace }}/target/debug/stasis
+      STASIS_TOOLCHAIN_DIR: ${{ github.workspace }}/target/vscode-e2e-toolchain
+      STASIS_TOOLCHAIN_EXECUTABLE: bin/stasis
+      STASIS_E2E_EXECUTABLE: ${{ github.workspace }}/target/vscode-e2e-toolchain/bin/stasis
       STASIS_E2E_SCREENSHOT: ${{ github.workspace }}/target/vscode-e2e/frame.png
     steps:
       - name: Checkout
@@ -167,7 +169,11 @@ jobs:
         run: |
           cargo test -p stasis_dynload -- --test-threads=1
           cargo build -p stasis
-          "$STASIS_E2E_EXECUTABLE" probe-graphics-runtime
+          mkdir -p target/vscode-e2e-toolchain/bin
+          cp target/debug/stasis target/vscode-e2e-toolchain/bin/
+          cp "$STASIS_RUNTIME_LIBRARY_PATH" target/vscode-e2e-toolchain/bin/
+          cp -R src target/vscode-e2e-toolchain/
+          "$STASIS_E2E_EXECUTABLE" --json editor-info
 
       - name: Install extension dependencies
         working-directory: vscode-stasis

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -146,18 +146,16 @@ jobs:
 
       - name: Install macOS graphics dependencies
         if: runner.os == 'macOS'
-        run: brew install sdl2 sdl2_image pkg-config
+        run: brew install pkg-config
 
       - name: Build native graphics runtime
         shell: bash
         run: |
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            export CMAKE_PREFIX_PATH="$(brew --prefix):${CMAKE_PREFIX_PATH:-}"
-          fi
           cmake -S runtime -B target/vscode-e2e-runtime \
             -DCMAKE_BUILD_TYPE=Release \
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
+            -DSTASIS_GRAPHICS_BUNDLE_SDL=ON \
             -DSTASIS_GRAPHICS_SDL_ONLY=ON \
             -DSTASIS_BUILD_RUNNER=OFF \
             -DSTASIS_BUILD_SYS=OFF

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ logs/nightshift/
 out/
 
 # Build artifacts
+dist/stasis-editor-release-*/
 *.dll
 *.exe
 *.so

--- a/apps/stasis/build.rs
+++ b/apps/stasis/build.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 fn main() {
     println!("cargo:rerun-if-env-changed=STASIS_RUNTIME_LIBRARY_PATH");
     println!("cargo:rerun-if-env-changed=STASIS_RUNTIME_DLL_PATH");
+    println!("cargo:rerun-if-env-changed=STASIS_RELEASE_ID");
+    println!("cargo:rerun-if-env-changed=STASIS_SOURCE_COMMIT");
+    println!("cargo:rerun-if-env-changed=STASIS_BUILD_TARGET");
 
     for candidate in runtime_library_candidate_paths() {
         println!("cargo:rerun-if-changed={}", candidate.display());

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4145,6 +4145,10 @@ mod tests {
             "the graphics DLL must expose an explicit compatibility boundary"
         );
         assert!(
+            STASIS_GRAPHICS_SOURCE.contains("stasis_graphics_release_id(void)"),
+            "the graphics DLL must expose its immutable toolchain release identity"
+        );
+        assert!(
             STASIS_RUNNER_SOURCE.contains("stasis_set_asset_root(exe_dir)")
                 && STASIS_RUNNER_SOURCE.contains("set_graphics_asset_root(launcher_asset_root)")
                 && STASIS_RUNNER_SOURCE.contains("stasis_set_packaged_graphics_path(exe_dir)")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1706,7 +1706,7 @@ fn run_workspace_tui(
         server,
         config,
     );
-    if !terminal.is_finished() {
+    if !wait_for_live_terminal_shutdown(&terminal, run_result.is_ok()) {
         return match run_result {
             Ok(()) => Err("live runner ended before the terminal session completed".to_string()),
             Err(error) => Err(error),
@@ -4217,6 +4217,21 @@ fn editor_info_result() -> Result<CommandResult, String> {
     ))
 }
 
+fn wait_for_live_terminal_shutdown(
+    terminal: &thread::JoinHandle<Result<(), String>>,
+    runner_succeeded: bool,
+) -> bool {
+    if runner_succeeded {
+        for _ in 0..200 {
+            if terminal.is_finished() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+    terminal.is_finished()
+}
+
 fn default_release_output(workspace: &Workspace) -> PathBuf {
     workspace
         .root
@@ -4458,6 +4473,19 @@ mod tests {
     use super::*;
     use stasis_ai::live_tool_specs;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn successful_live_runner_allows_terminal_acknowledgement_to_finish() {
+        let terminal = thread::spawn(|| {
+            thread::sleep(Duration::from_millis(25));
+            Ok(())
+        });
+        assert!(wait_for_live_terminal_shutdown(&terminal, true));
+        terminal
+            .join()
+            .expect("join terminal")
+            .expect("terminal result");
+    }
 
     #[test]
     fn inspect_exposes_compiler_function_data_flow() {

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -126,6 +126,7 @@ const COMMANDS: &[&str] = &[
     "replay",
     "verify",
     "version",
+    "editor-info",
     "env",
     "symbol",
     "help",
@@ -314,6 +315,8 @@ enum ToolchainCommand {
     Verify,
     /// Print the installed toolchain version.
     Version,
+    /// Report the editor protocols and the sibling graphics runtime identity.
+    EditorInfo,
     /// Print toolchain, workspace, cache, and offline capability information.
     Env,
     /// Find and transactionally edit compiler-owned semantic symbols.
@@ -743,6 +746,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Replay => "replay",
         ToolchainCommand::Verify => "verify",
         ToolchainCommand::Version => "version",
+        ToolchainCommand::EditorInfo => "editor-info",
         ToolchainCommand::Env => "env",
         ToolchainCommand::Symbol { .. } => "symbol",
     }
@@ -765,6 +769,7 @@ fn execute(
             create_project(root, name.unwrap_or(inferred))
         }
         ToolchainCommand::Version => Ok(version_result()),
+        ToolchainCommand::EditorInfo => editor_info_result(),
         ToolchainCommand::Env => env_result(workspace_arg.as_deref()),
         ToolchainCommand::Replay => Err(
             "replay is unavailable in toolchain 0.1; no replay runtime contract is implemented"
@@ -4152,6 +4157,64 @@ fn version_result() -> CommandResult {
         format!("stasis {}", env!("CARGO_PKG_VERSION")),
         json!({"version": env!("CARGO_PKG_VERSION")}),
     )
+}
+
+fn editor_info_result() -> Result<CommandResult, String> {
+    let executable = env::current_exe()
+        .map_err(|error| format!("failed to locate stasis executable: {error}"))?
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve stasis executable: {error}"))?;
+    let runtime = installed_runtime_library().ok_or_else(|| {
+        format!(
+            "the Stasis graphics runtime is not installed beside {}",
+            executable.display()
+        )
+    })?;
+    let runtime = runtime
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve graphics runtime: {error}"))?;
+    stasis_dynload::StasisGraphicsApi::load(&runtime)
+        .map_err(|error| format!("the sibling graphics runtime is incompatible: {error}"))?;
+
+    let version = env!("CARGO_PKG_VERSION");
+    let release_id = option_env!("STASIS_RELEASE_ID").unwrap_or("development");
+    let runtime_release_id = stasis_dynload::graphics_runtime_release_id(&runtime)?;
+    if runtime_release_id != release_id {
+        return Err(format!(
+            "toolchain release mismatch: stasis is '{release_id}' but {} is '{runtime_release_id}'",
+            runtime.display()
+        ));
+    }
+    let source_commit = option_env!("STASIS_SOURCE_COMMIT").unwrap_or("development");
+    let target = option_env!("STASIS_BUILD_TARGET")
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{}-{}", env::consts::ARCH, env::consts::OS));
+    let data = json!({
+        "schema": 1,
+        "release_id": release_id,
+        "version": version,
+        "source_commit": source_commit,
+        "target": target,
+        "protocols": {
+            "lsp": 1,
+            "dap": 1,
+            "live": 1,
+            "graphics_abi": 1,
+        },
+        "executable": {
+            "path": executable,
+            "sha256": sha256_file(&executable)?,
+        },
+        "graphics_runtime": {
+            "path": runtime,
+            "release_id": runtime_release_id,
+            "sha256": sha256_file(&runtime)?,
+        },
+    });
+    Ok(CommandResult::success(
+        format!("stasis editor toolchain {release_id} ({target})"),
+        data,
+    ))
 }
 
 fn default_release_output(workspace: &Workspace) -> PathBuf {

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -796,6 +796,45 @@ fn verify_graphics_runtime_abi(lib: &Library, path: &Path) -> Result<(), String>
     Ok(())
 }
 
+pub fn graphics_runtime_release_id(path: &Path) -> Result<String, String> {
+    let lib = Library::load(path)?;
+    verify_graphics_runtime_abi(&lib, path)?;
+    let address = lib
+        .symbol_address("stasis_graphics_release_id")
+        .map_err(|_| {
+            format!(
+                "incompatible stasis graphics runtime {}: missing release identity",
+                path.display()
+            )
+        })?;
+    #[cfg(windows)]
+    let value = {
+        let identity: extern "system" fn() -> *const c_char =
+            unsafe { std::mem::transmute(address) };
+        identity()
+    };
+    #[cfg(not(windows))]
+    let value = {
+        let identity: extern "C" fn() -> *const c_char = unsafe { std::mem::transmute(address) };
+        identity()
+    };
+    if value.is_null() {
+        return Err(format!(
+            "incompatible stasis graphics runtime {}: empty release identity",
+            path.display()
+        ));
+    }
+    let value = unsafe { std::ffi::CStr::from_ptr(value) }
+        .to_str()
+        .map_err(|_| {
+            format!(
+                "incompatible stasis graphics runtime {}: release identity is not UTF-8",
+                path.display()
+            )
+        })?;
+    Ok(value.to_string())
+}
+
 pub struct StasisGraphicsApi {
     _lib: Library,
     stasis_init_window: usize,
@@ -1071,16 +1110,10 @@ fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, Stri
 
 pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
-        out.push(PathBuf::from(configured));
-    }
-    // Preserve the original variable as a compatibility alias for existing Windows workflows.
-    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_DLL_PATH") {
-        out.push(PathBuf::from(configured));
-    }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
-            // Release-friendly default: ship the runtime next to the stasis binary.
+            // A release bundle is one unit. Never let an environment override replace its sibling
+            // runtime with a different build.
             for file_name in runtime_library_file_names() {
                 out.push(exe_dir.join(file_name));
             }
@@ -1100,6 +1133,13 @@ pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
                 }
             }
         }
+    }
+    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
+        out.push(PathBuf::from(configured));
+    }
+    // Preserve the original variable as a compatibility alias for existing Windows workflows.
+    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_DLL_PATH") {
+        out.push(PathBuf::from(configured));
     }
 
     // Allow loading from the current working directory too (handy for ad-hoc runs).
@@ -4375,6 +4415,16 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .expect("dynload test lock mutex poisoned")
+    }
+
+    #[test]
+    fn bundled_graphics_runtime_outranks_environment_overrides() {
+        let executable = std::env::current_exe().expect("current test executable");
+        let expected = executable
+            .parent()
+            .expect("test executable directory")
+            .join(runtime_library_file_names()[0]);
+        assert_eq!(runtime_library_candidate_paths().first(), Some(&expected));
     }
 
     #[cfg(not(windows))]

--- a/crates/stasis_lsp/src/live_process.rs
+++ b/crates/stasis_lsp/src/live_process.rs
@@ -306,10 +306,17 @@ impl LiveProcessBroker {
                 }
                 Ok(_) => match serde_json::from_slice::<Value>(&line) {
                     Ok(response) => self.accept_response(token, response),
-                    Err(error) => (self.inner.notify)(
-                        LIVE_LOG_METHOD,
-                        json!({"stream": "stdout", "message": format!("invalid live JSON: {error}")}),
-                    ),
+                    Err(error) => {
+                        let preview = String::from_utf8_lossy(&line);
+                        let preview = preview.trim().chars().take(512).collect::<String>();
+                        (self.inner.notify)(
+                            LIVE_LOG_METHOD,
+                            json!({
+                                "stream": "stdout",
+                                "message": format!("invalid live JSON: {error}; output={preview:?}")
+                            }),
+                        )
+                    }
                 },
                 Err(error) => {
                     self.end_session(token, Some(format!("failed reading live stdout: {error}")));

--- a/crates/stasis_lsp/src/live_process.rs
+++ b/crates/stasis_lsp/src/live_process.rs
@@ -306,14 +306,14 @@ impl LiveProcessBroker {
                 }
                 Ok(_) => match serde_json::from_slice::<Value>(&line) {
                     Ok(response) => self.accept_response(token, response),
-                    Err(error) => {
+                    Err(_) => {
                         let preview = String::from_utf8_lossy(&line);
                         let preview = preview.trim().chars().take(512).collect::<String>();
                         (self.inner.notify)(
                             LIVE_LOG_METHOD,
                             json!({
                                 "stream": "stdout",
-                                "message": format!("invalid live JSON: {error}; output={preview:?}")
+                                "message": format!("live stdout: {preview}")
                             }),
                         )
                     }

--- a/docs/editor_toolchain_distribution.md
+++ b/docs/editor_toolchain_distribution.md
@@ -1,0 +1,67 @@
+# Atomic Editor Toolchain Distribution
+
+The VS Code extension, compiler/LSP/DAP executable, and graphics runtime are one release unit. They
+must not be selected or upgraded independently.
+
+## Invariant
+
+Every editor operation uses the executable in the immutable toolchain directory bundled inside the
+platform VSIX. The graphics runtime is loaded from beside that executable. Both binaries expose the
+same `release_id`, and activation fails before starting any editor service when their identities,
+protocols, or packaged hashes differ.
+
+The release pipeline stamps one identity into Rust with `STASIS_RELEASE_ID` and into the native
+runtime with the `STASIS_RELEASE_ID` CMake setting. `stasis --json editor-info` validates the sibling
+runtime ABI and identity and reports hashes for both files. VSIX packaging records that response and
+the hashes in `dist/toolchain-manifest.json`.
+
+At activation the extension:
+
+1. resolves only its bundled toolchain unless an explicit development override is configured;
+2. rejects absolute or escaping manifest paths;
+3. hashes the executable and graphics runtime;
+4. invokes `editor-info` from the executable's directory;
+5. checks the release identity and LSP, DAP, live, and graphics protocol versions;
+6. starts LSP, DAP, tests, and Live Workshop only after every check succeeds.
+
+There is deliberately no implicit `PATH` fallback. Reinstalling or rolling back a platform VSIX
+therefore installs or rolls back the complete editor toolchain.
+
+## Development override
+
+Source-tree development can set `stasis.developer.executablePath` to an absolute executable path.
+The override remains subject to the same `editor-info` handshake, including a compatible sibling
+graphics runtime. Local Rust and CMake builds use the release identity `development` unless an
+explicit identity is supplied. Reload VS Code after changing the override.
+
+## Release construction
+
+Nightly release jobs build Rust and the native runtime from the same commit and release identity.
+The tested platform archive is then embedded unchanged in the corresponding `linux-x64`,
+`win32-x64`, or `darwin-arm64` VSIX. VSIX packaging never reconstructs or searches for individual
+runtime files. Each downloadable OS release is one archive containing the standalone toolchain
+archive, the matching VSIX, and `stasis-editor-release.json` with hashes for both.
+
+Authenticode signing protects Windows provenance and reputation but is not the compatibility
+mechanism. Signing should occur before archive and VSIX manifests are generated; the shared release
+identity and post-signing hashes are what prove the files belong together.
+
+## Extension packaging
+
+Local packaging requires the root of a complete toolchain bundle:
+
+```powershell
+$env:STASIS_TOOLCHAIN_DIR = "C:\path\to\stasis-nightly-win-x64"
+$env:STASIS_TOOLCHAIN_EXECUTABLE = "stasis.exe"
+npm --prefix vscode-stasis run package -- --target win32-x64
+```
+
+Unix bundles use `bin/stasis` as the default executable path.
+
+On Windows, `scripts/build_local_editor_release.ps1` builds the same release-directory shape under
+`dist/stasis-editor-release-win32-x64`. It runs Rust and extension tests by default; pass
+`-RunVsCodeE2E` to additionally install the packaged VSIX in the VS Code test host and exercise the
+editor workflow. `scripts/install_vscode_stasis.ps1` consumes that directory instead of packaging a
+separate extension/toolchain pair. Environments governed by Windows App Control can either pass
+`-SigningCertificate` and `-SigningPassword` or configure the repository's existing
+`STASIS_AOT_SIGN_TOOL`; signing occurs before hashes and the VSIX are produced.

--- a/docs/release_provenance.md
+++ b/docs/release_provenance.md
@@ -48,3 +48,16 @@ minimal package from the extracted archive without `--development-build`; a
 successful package audit is the proof that the consumed renderer matches the
 release. Never label a source-proof or local proof directory as the pinned
 official artifact.
+
+## SDL dependency policy
+
+Desktop release graphics runtimes build SDL2 and SDL2_image from SHA-256-pinned
+upstream source archives and link them into `stasis_graphics`. The pinned
+versions match the versions recorded by the existing official Windows release
+provenance (SDL2 2.32.10 and SDL2_image 2.8.12); Unix package-manager aliases
+must not select a different implementation during a release build.
+
+Changing either SDL version is an explicit dependency upgrade. It requires the
+cross-platform renderer and installed-VSIX acceptance gates, updated provenance,
+and a review of runtime and packaging compatibility. Routine release builds do
+not float to newer SDL packages.

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(stasis_graphics C)
 
+set(STASIS_RELEASE_ID "development" CACHE STRING "Immutable Stasis toolchain release identity")
+
 set(STASIS_MOBILE_PLATFORM OFF)
 if(ANDROID OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(STASIS_MOBILE_PLATFORM ON)
@@ -62,6 +64,7 @@ endif()
 
 function(configure_stasis_target target is_static sdl_only link_sdl_main)
     target_sources(${target} PRIVATE stasis_graphics.c)
+    target_compile_definitions(${target} PRIVATE STASIS_RELEASE_ID="${STASIS_RELEASE_ID}")
     if(link_sdl_main)
         target_link_libraries(${target} PRIVATE $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>)
     endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -23,6 +23,11 @@ option(
     "Build the desktop graphics static library"
     ${STASIS_DESKTOP_TARGET_DEFAULT}
 )
+option(
+    STASIS_GRAPHICS_BUNDLE_SDL
+    "Build pinned SDL2 and SDL2_image into the desktop graphics runtime"
+    OFF
+)
 option(STASIS_BUILD_RUNNER "Build the stasis DLL runner executable" ${STASIS_DESKTOP_TARGET_DEFAULT})
 option(STASIS_BUILD_SYS "Build the sys runtime (file/argv/exec)" ${STASIS_DESKTOP_TARGET_DEFAULT})
 option(
@@ -46,6 +51,41 @@ endif()
 
 # Find graphics deps only when building graphics targets.
 if(STASIS_GRAPHICS_BUILD_SHARED OR STASIS_GRAPHICS_BUILD_STATIC OR STASIS_BUILD_MOBILE_RUNTIME)
+    if(STASIS_GRAPHICS_BUNDLE_SDL)
+        include(FetchContent)
+        set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+        set(SDL_STATIC ON CACHE BOOL "" FORCE)
+        set(SDL_STATIC_PIC ON CACHE BOOL "" FORCE)
+        set(SDL_TEST OFF CACHE BOOL "" FORCE)
+        set(SDL_TESTS OFF CACHE BOOL "" FORCE)
+        set(SDL2_DISABLE_INSTALL ON CACHE BOOL "" FORCE)
+        FetchContent_Declare(
+            stasis_sdl2
+            URL https://github.com/libsdl-org/SDL/archive/5d249570393f7a37e037abf22cd6012a4cc56a71.tar.gz
+            URL_HASH SHA256=10f1194f8d2e4a73ca1c7c553b3189d0b68ab9ef3544e8d2a268e4429456b373
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+        FetchContent_MakeAvailable(stasis_sdl2)
+
+        set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_INSTALL OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_SAMPLES OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_TESTS OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_BACKEND_STB ON CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_BACKEND_IMAGEIO OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_AVIF OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_JXL OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_TIF OFF CACHE BOOL "" FORCE)
+        set(SDL2IMAGE_WEBP OFF CACHE BOOL "" FORCE)
+        FetchContent_Declare(
+            stasis_sdl2_image
+            URL https://github.com/libsdl-org/SDL_image/archive/12cb2e40330d256d9b1329647be8f366546d715c.tar.gz
+            URL_HASH SHA256=263c88eb8f3ec6e2ee9eb3eb5f9d195e5c58943bfbb86174ab5ed45c64787801
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+        FetchContent_MakeAvailable(stasis_sdl2_image)
+    endif()
+
     # Find SDL2 (via vcpkg or system)
     if(NOT TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
         find_package(SDL2 CONFIG REQUIRED)

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -57,6 +57,10 @@ static void flush_sprites(void);
 static void render_postfx(void);
 #endif
 
+#ifndef STASIS_RELEASE_ID
+#define STASIS_RELEASE_ID "development"
+#endif
+
 static void stasis_sdl_log_output(void* userdata, int category, SDL_LogPriority priority, const char* message) {
     (void)userdata;
     (void)category;
@@ -111,6 +115,10 @@ STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, in
 
 STASIS_EXPORT int stasis_graphics_runtime_abi_version(void) {
     return STASIS_GRAPHICS_RUNTIME_ABI_VERSION;
+}
+
+STASIS_EXPORT const char* stasis_graphics_release_id(void) {
+    return STASIS_RELEASE_ID;
 }
 
 /* Global state */

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -706,10 +706,12 @@ static void stasis_pump_events(void) {
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
             case SDL_QUIT:
+                SDL_Log("Stasis quit requested: SDL_QUIT");
                 g_should_quit = true;
                 break;
             case SDL_KEYDOWN:
                 if (event.key.keysym.sym == SDLK_ESCAPE) {
+                    SDL_Log("Stasis quit requested: Escape key");
                     g_should_quit = true;
                 }
                 if (event.key.keysym.sym == SDLK_F3 && event.key.repeat == 0) {

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -1,6 +1,7 @@
 LIBRARY stasis_graphics
 EXPORTS
     stasis_graphics_runtime_abi_version
+    stasis_graphics_release_id
     stasis_set_asset_root
     stasis_host_bulk_init
     stasis_host_bulk_apply_requests

--- a/scripts/build_local_editor_release.ps1
+++ b/scripts/build_local_editor_release.ps1
@@ -1,0 +1,130 @@
+param(
+  [string]$ReleaseId = "local-development",
+  [string]$OutputRoot = "",
+  [switch]$SkipBuild,
+  [switch]$RunVsCodeE2E,
+  [string]$SigningCertificate = "",
+  [string]$SigningPassword = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $OutputRoot) {
+  $OutputRoot = Join-Path $repoRoot "dist/stasis-editor-release-win32-x64"
+}
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+$repoPrefix = [IO.Path]::GetFullPath($repoRoot) + [IO.Path]::DirectorySeparatorChar
+if (-not $OutputRoot.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "OutputRoot must stay inside the Stasis repository."
+}
+
+$runtimeBuild = Join-Path $repoRoot "target/local-editor-runtime"
+$toolchainRoot = Join-Path $repoRoot "target/local-editor-toolchain-win32-x64"
+$toolchainArchive = Join-Path $repoRoot "target/stasis-local-toolchain-win32-x64.zip"
+$extensionRoot = Join-Path $repoRoot "vscode-stasis"
+$vsix = Join-Path $extensionRoot ".vsix/stasislang.stasis.vsix"
+
+if (-not $SkipBuild) {
+  $env:STASIS_RELEASE_ID = $ReleaseId
+  $env:STASIS_SOURCE_COMMIT = (git -C $repoRoot rev-parse HEAD).Trim()
+  $env:STASIS_BUILD_TARGET = "x86_64-pc-windows-msvc"
+  cargo build --manifest-path (Join-Path $repoRoot "Cargo.toml") -p stasis --release
+  if ($LASTEXITCODE -ne 0) { throw "Stasis release build failed." }
+  cargo build --manifest-path (Join-Path $repoRoot "Cargo.toml") -p stasis_dynload --release
+  if ($LASTEXITCODE -ne 0) { throw "Stasis dynamic runtime build failed." }
+
+  $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+  if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
+    $vcpkgRoot = "C:\vcpkg"
+  }
+  if (-not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
+    throw "vcpkg.exe was not found. Set VCPKG_INSTALLATION_ROOT."
+  }
+  $vsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio/Installer/vswhere.exe"
+  $vsVersion = (& $vsWhere -latest -products * -property installationVersion).Trim()
+  if ($vsVersion.StartsWith("18.")) {
+    $generator = "Visual Studio 18 2026"
+  } elseif ($vsVersion.StartsWith("17.")) {
+    $generator = "Visual Studio 17 2022"
+  } else {
+    throw "A supported Visual Studio installation was not found."
+  }
+  $cmakeCache = Join-Path $runtimeBuild "CMakeCache.txt"
+  if ((Test-Path $cmakeCache) -and -not (Select-String -Path $cmakeCache -SimpleMatch "CMAKE_GENERATOR:INTERNAL=$generator" -Quiet)) {
+    Remove-Item -LiteralPath $runtimeBuild -Recurse -Force
+  }
+  cmake -S (Join-Path $repoRoot "runtime") -B $runtimeBuild -G $generator -A x64 `
+    -DCMAKE_TOOLCHAIN_FILE="$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" `
+    -DVCPKG_TARGET_TRIPLET=x64-windows-static `
+    -DSTASIS_GRAPHICS_BUILD_SHARED=ON `
+    -DSTASIS_GRAPHICS_BUILD_STATIC=OFF `
+    -DSTASIS_GRAPHICS_SDL_ONLY=ON `
+    -DSTASIS_BUILD_RUNNER=OFF `
+    -DSTASIS_BUILD_SYS=OFF `
+    -DSTASIS_RELEASE_ID="$ReleaseId"
+  if ($LASTEXITCODE -ne 0) { throw "Graphics runtime configuration failed." }
+  cmake --build $runtimeBuild --config Release --target stasis_graphics
+  if ($LASTEXITCODE -ne 0) { throw "Graphics runtime build failed." }
+
+  if (Test-Path $toolchainRoot) { Remove-Item -LiteralPath $toolchainRoot -Recurse -Force }
+  New-Item -ItemType Directory -Force -Path $toolchainRoot | Out-Null
+  Copy-Item (Join-Path $repoRoot "target/release/stasis.exe") $toolchainRoot -Force
+  Copy-Item (Join-Path $repoRoot "target/release/stasis_dynload.dll") $toolchainRoot -Force
+  Copy-Item (Join-Path $runtimeBuild "bin/Release/*.dll") $toolchainRoot -Force
+  Copy-Item (Join-Path $repoRoot "src") $toolchainRoot -Recurse -Force
+
+  if ($SigningCertificate) {
+    $signtool = (Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe | Sort-Object FullName -Descending | Select-Object -First 1).FullName
+    if (-not $signtool) { throw "signtool.exe was not found." }
+    @("stasis.exe", "stasis_graphics.dll") | ForEach-Object {
+      $signedFile = Join-Path $toolchainRoot $_
+      & $signtool sign /fd SHA256 /f $SigningCertificate /p $SigningPassword /tr http://timestamp.digicert.com /td SHA256 $signedFile
+      if ($LASTEXITCODE -ne 0) { throw "Signing failed for $signedFile." }
+    }
+  } elseif ($env:STASIS_AOT_SIGN_TOOL) {
+    @("stasis.exe", "stasis_graphics.dll") | ForEach-Object {
+      $signedFile = Join-Path $toolchainRoot $_
+      & $env:STASIS_AOT_SIGN_TOOL $signedFile
+      if ($LASTEXITCODE -ne 0) { throw "Configured local signer failed for $signedFile." }
+    }
+  }
+
+  & (Join-Path $toolchainRoot "stasis.exe") --json editor-info
+  if ($LASTEXITCODE -ne 0) { throw "Local editor toolchain identity validation failed." }
+  if (Test-Path $toolchainArchive) { Remove-Item -LiteralPath $toolchainArchive -Force }
+  Compress-Archive -Path "$toolchainRoot/*" -DestinationPath $toolchainArchive -Force
+}
+
+if (-not (Test-Path $toolchainArchive) -or -not (Test-Path (Join-Path $toolchainRoot "stasis.exe"))) {
+  throw "Local editor toolchain outputs are missing; rerun without -SkipBuild."
+}
+
+$npm = (Get-Command npm.cmd -ErrorAction Stop).Source
+$env:STASIS_TOOLCHAIN_DIR = $toolchainRoot
+$env:STASIS_TOOLCHAIN_EXECUTABLE = "stasis.exe"
+$env:STASIS_E2E_EXECUTABLE = Join-Path $toolchainRoot "stasis.exe"
+Push-Location $extensionRoot
+try {
+  & $npm ci
+  if ($LASTEXITCODE -ne 0) { throw "npm ci failed." }
+  & $npm test
+  if ($LASTEXITCODE -ne 0) { throw "Extension tests failed." }
+  if ($RunVsCodeE2E) {
+    & $npm run test:e2e
+    if ($LASTEXITCODE -ne 0) { throw "Installed VSIX E2E failed." }
+  }
+  & $npm run package -- --target win32-x64
+  if ($LASTEXITCODE -ne 0) { throw "VSIX packaging failed." }
+} finally {
+  Pop-Location
+}
+
+if (Test-Path $OutputRoot) { Remove-Item -LiteralPath $OutputRoot -Recurse -Force }
+node (Join-Path $repoRoot "tools/assemble_editor_release.mjs") `
+  --toolchain-archive $toolchainArchive `
+  --vsix $vsix `
+  --out $OutputRoot `
+  --release-id $ReleaseId `
+  --platform win32-x64
+if ($LASTEXITCODE -ne 0) { throw "Editor release assembly failed." }
+Write-Host "Local editor release: $OutputRoot"

--- a/scripts/install_vscode_stasis.ps1
+++ b/scripts/install_vscode_stasis.ps1
@@ -1,63 +1,29 @@
 param(
   [switch]$Force,
-  [switch]$SkipInstall
+  [switch]$SkipInstall,
+  [switch]$SkipBuild,
+  [switch]$RunVsCodeE2E
 )
 
 $ErrorActionPreference = "Stop"
-
 $repoRoot = Split-Path -Parent $PSScriptRoot
-$extensionDir = Join-Path $repoRoot "vscode-stasis"
-$vsixDir = Join-Path $extensionDir ".vsix"
-$vsixPath = Join-Path $vsixDir "stasislang.stasis.vsix"
+$releaseRoot = Join-Path $repoRoot "dist/stasis-editor-release-win32-x64"
+$builder = Join-Path $PSScriptRoot "build_local_editor_release.ps1"
 
-if (-not (Test-Path (Join-Path $extensionDir "package.json"))) {
-  throw "Missing VS Code extension: $extensionDir"
+& $builder -OutputRoot $releaseRoot -SkipBuild:$SkipBuild -RunVsCodeE2E:$RunVsCodeE2E
+if ($LASTEXITCODE -ne 0) { throw "Local Stasis editor release failed." }
+
+$vsix = Get-ChildItem $releaseRoot -Filter "*.vsix" | Select-Object -First 1
+if (-not $vsix) { throw "Local editor release does not contain a VSIX." }
+if ($SkipInstall) {
+  Write-Host "Built editor release: $releaseRoot"
+  return
 }
 
-$npm = Get-Command npm -ErrorAction SilentlyContinue
-if (-not $npm) {
-  throw "npm is required to build the Stasis VS Code extension."
-}
-
-if (-not $SkipInstall) {
-  $code = Get-Command code -ErrorAction SilentlyContinue
-  if (-not $code) {
-    throw "VS Code CLI (code) is not on PATH. Run with -SkipInstall to build only."
-  }
-}
-
-Push-Location $extensionDir
-try {
-  & $npm.Path @("ci")
-  if ($LASTEXITCODE -ne 0) {
-    throw "npm ci failed."
-  }
-
-  & $npm.Path @("test")
-  if ($LASTEXITCODE -ne 0) {
-    throw "extension tests failed."
-  }
-
-  New-Item -ItemType Directory -Force -Path $vsixDir | Out-Null
-  & $npm.Path @("run", "package", "--", "--out", $vsixPath)
-  if ($LASTEXITCODE -ne 0) {
-    throw "VSIX packaging failed."
-  }
-
-  if ($SkipInstall) {
-    Write-Host "Built VSIX: $vsixPath"
-    return
-  }
-
-  $installArgs = @("--install-extension", $vsixPath)
-  if ($Force) {
-    $installArgs += "--force"
-  }
-  & $code.Path @installArgs
-  if ($LASTEXITCODE -ne 0) {
-    throw "VSIX install failed."
-  }
-  Write-Host "Installed VSIX: $vsixPath"
-} finally {
-  Pop-Location
-}
+$code = Get-Command code -ErrorAction SilentlyContinue
+if (-not $code) { throw "VS Code CLI (code) is not on PATH. Use -SkipInstall to build only." }
+$installArgs = @("--install-extension", $vsix.FullName)
+if ($Force) { $installArgs += "--force" }
+& $code.Source @installArgs
+if ($LASTEXITCODE -ne 0) { throw "VSIX install failed." }
+Write-Host "Installed VSIX from atomic editor release: $($vsix.FullName)"

--- a/tools/assemble_editor_release.mjs
+++ b/tools/assemble_editor_release.mjs
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 2) {
+  args.set(process.argv[index], process.argv[index + 1]);
+}
+const required = (name) => {
+  const value = args.get(name);
+  if (!value) throw new Error(`Missing ${name}.`);
+  return path.resolve(value);
+};
+const toolchainArchive = required("--toolchain-archive");
+const vsix = required("--vsix");
+const output = required("--out");
+const releaseId = args.get("--release-id");
+const platform = args.get("--platform");
+if (!releaseId || !platform) throw new Error("Missing --release-id or --platform.");
+for (const file of [toolchainArchive, vsix]) {
+  if (!fs.statSync(file).isFile()) throw new Error(`Release input is not a file: ${file}`);
+}
+
+fs.mkdirSync(output, { recursive: true });
+const copy = (source) => {
+  const destination = path.join(output, path.basename(source));
+  fs.copyFileSync(source, destination);
+  return destination;
+};
+const stagedToolchain = copy(toolchainArchive);
+const stagedVsix = copy(vsix);
+const fileEntry = (file, role) => ({
+  role,
+  name: path.basename(file),
+  bytes: fs.statSync(file).size,
+  sha256: createHash("sha256").update(fs.readFileSync(file)).digest("hex"),
+});
+const manifest = {
+  schema: 1,
+  release_id: releaseId,
+  platform,
+  files: [
+    fileEntry(stagedToolchain, "toolchain_archive"),
+    fileEntry(stagedVsix, "vscode_extension"),
+  ],
+};
+fs.writeFileSync(
+  path.join(output, "stasis-editor-release.json"),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  "ascii",
+);

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -28,7 +28,14 @@ The Stasis extension keeps the editor on the same compiler and runtime contracts
 
 ## Requirements
 
-Install a current `stasis` executable on `PATH`, or set `stasis.executablePath` to its absolute path. Open a folder containing `stasis.json`.
+Install the VSIX matching the current operating system and architecture. It contains an immutable,
+release-matched `stasis` compiler/LSP/DAP and graphics runtime; no separate `PATH` installation is
+used. Activation verifies their release identities, protocol versions, and hashes before starting
+any editor service. Open a folder containing `stasis.json`.
+
+For source-tree development only, set `stasis.developer.executablePath` to an absolute executable
+path and reload VS Code. The override must provide `stasis --json editor-info` and have its matching
+graphics runtime beside it.
 
 Projects created by `stasis new` recommend this extension and enable format-on-save only for the `stasis` language. For an existing project, use:
 

--- a/vscode-stasis/package-lock.json
+++ b/vscode-stasis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stasis",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stasis",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "vscode-languageclient": "^10.1.0"

--- a/vscode-stasis/package.json
+++ b/vscode-stasis/package.json
@@ -2,7 +2,7 @@
   "name": "stasis",
   "displayName": "Stasis",
   "description": "Stasis language support, navigation, tests, formatting, completion, and live game inspection.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "stasislang",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
@@ -192,10 +192,11 @@
     "configuration": {
       "title": "Stasis",
       "properties": {
-        "stasis.executablePath": {
+        "stasis.developer.executablePath": {
           "type": "string",
-          "default": "stasis",
-          "description": "Path to the Stasis toolchain executable."
+          "default": "",
+          "scope": "machine",
+          "description": "Advanced: absolute path to a source-built Stasis toolchain. Empty uses the immutable toolchain bundled with this extension. The executable and sibling graphics runtime must pass the release identity handshake."
         },
         "stasis.live.entry": {
           "type": "string",
@@ -220,7 +221,7 @@
     "test": "npm run test:unit",
     "test:unit": "npm run check && esbuild src/protocol.test.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/protocol.test.cjs && node --test dist/protocol.test.cjs",
     "test:e2e": "npm run package && npm run bundle:e2e && node dist/e2e-run.cjs",
-    "prepackage": "node -e \"require('node:fs').mkdirSync('.vsix', { recursive: true })\"",
+    "prepackage": "node scripts/prepare-toolchain.mjs && node -e \"require('node:fs').mkdirSync('.vsix', { recursive: true })\"",
     "package": "npm run build && vsce package --out .vsix/stasislang.stasis.vsix"
   },
   "devDependencies": {

--- a/vscode-stasis/scripts/prepare-toolchain.mjs
+++ b/vscode-stasis/scripts/prepare-toolchain.mjs
@@ -32,7 +32,7 @@ const executable = path.resolve(bundleRoot, executableRelative);
 const envelope = JSON.parse(execFileSync(executable, ["--json", "editor-info"], {
   cwd: path.dirname(executable),
   encoding: "utf8",
-  timeout: 10_000,
+  timeout: 60_000,
   maxBuffer: 1024 * 1024,
 }));
 if (!envelope.ok || envelope.command !== "editor-info" || envelope.result?.schema !== 1) {

--- a/vscode-stasis/scripts/prepare-toolchain.mjs
+++ b/vscode-stasis/scripts/prepare-toolchain.mjs
@@ -56,16 +56,33 @@ const relativeInsideBundle = (absolute) => {
   return relative.split(path.sep).join("/");
 };
 const sha256 = (file) => createHash("sha256").update(fs.readFileSync(file)).digest("hex");
-const files = [
+const requiredFiles = [
   ["executable", executable, identity.executable.sha256],
   ["graphics_runtime", path.resolve(nativePath(identity.graphics_runtime.path)), identity.graphics_runtime.sha256],
-].map(([role, file, reportedHash]) => {
+];
+const roles = new Map(requiredFiles.map(([role, file]) => [relativeInsideBundle(file), role]));
+for (const [, file, reportedHash] of requiredFiles) {
   const actualHash = sha256(file);
   if (actualHash !== reportedHash) {
     throw new Error(`Stasis reported the wrong hash for ${file}.`);
   }
-  return { path: relativeInsideBundle(file), sha256: actualHash, role };
+}
+const bundleFiles = (directory) => fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+  const file = path.join(directory, entry.name);
+  if (entry.isDirectory()) return bundleFiles(file);
+  if (!entry.isFile()) throw new Error(`Unsupported entry in Stasis toolchain bundle: ${file}`);
+  return [file];
 });
+const files = bundleFiles(bundleRoot)
+  .map((file) => {
+    const relative = relativeInsideBundle(file);
+    return {
+      path: relative,
+      sha256: sha256(file),
+      role: roles.get(relative) ?? "support",
+    };
+  })
+  .sort((left, right) => left.path.localeCompare(right.path));
 const manifest = {
   schema: 1,
   executable: executableRelative.split(path.sep).join("/"),

--- a/vscode-stasis/scripts/prepare-toolchain.mjs
+++ b/vscode-stasis/scripts/prepare-toolchain.mjs
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const extensionRoot = path.resolve(import.meta.dirname, "..");
+const sourceRoot = process.env.STASIS_TOOLCHAIN_DIR?.trim();
+if (!sourceRoot || !path.isAbsolute(sourceRoot)) {
+  throw new Error("STASIS_TOOLCHAIN_DIR must name the absolute root of the release toolchain bundle.");
+}
+const executableRelative = process.env.STASIS_TOOLCHAIN_EXECUTABLE?.trim()
+  || (process.platform === "win32" ? "stasis.exe" : "bin/stasis");
+const resolvedSourceRoot = path.resolve(sourceRoot);
+const resolvedSourceExecutable = path.resolve(sourceRoot, executableRelative);
+if (
+  path.isAbsolute(executableRelative)
+  || !resolvedSourceExecutable.startsWith(`${resolvedSourceRoot}${path.sep}`)
+) {
+  throw new Error("STASIS_TOOLCHAIN_EXECUTABLE must stay inside STASIS_TOOLCHAIN_DIR.");
+}
+const sourceExecutable = path.resolve(sourceRoot, executableRelative);
+if (!fs.existsSync(sourceExecutable)) {
+  throw new Error(`Stasis toolchain executable does not exist: ${sourceExecutable}`);
+}
+
+const bundleRoot = path.join(extensionRoot, "dist", "toolchain");
+fs.rmSync(bundleRoot, { recursive: true, force: true });
+fs.mkdirSync(path.dirname(bundleRoot), { recursive: true });
+fs.cpSync(sourceRoot, bundleRoot, { recursive: true, dereference: true });
+
+const executable = path.resolve(bundleRoot, executableRelative);
+const envelope = JSON.parse(execFileSync(executable, ["--json", "editor-info"], {
+  cwd: path.dirname(executable),
+  encoding: "utf8",
+  timeout: 10_000,
+  maxBuffer: 1024 * 1024,
+}));
+if (!envelope.ok || envelope.command !== "editor-info" || envelope.result?.schema !== 1) {
+  throw new Error("The bundled executable did not return a valid Stasis editor identity.");
+}
+const identity = envelope.result;
+if (identity.graphics_runtime?.release_id !== identity.release_id) {
+  throw new Error("The Stasis executable and graphics runtime have different release identities.");
+}
+
+const nativePath = (value) => {
+  if (process.platform !== "win32" || !value.startsWith("\\\\?\\")) return value;
+  return value.startsWith("\\\\?\\UNC\\") ? `\\\\${value.slice(8)}` : value.slice(4);
+};
+const relativeInsideBundle = (absolute) => {
+  absolute = nativePath(absolute);
+  const relative = path.relative(bundleRoot, absolute);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Editor identity path is outside the toolchain bundle: ${absolute}`);
+  }
+  return relative.split(path.sep).join("/");
+};
+const sha256 = (file) => createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+const files = [
+  ["executable", executable, identity.executable.sha256],
+  ["graphics_runtime", path.resolve(nativePath(identity.graphics_runtime.path)), identity.graphics_runtime.sha256],
+].map(([role, file, reportedHash]) => {
+  const actualHash = sha256(file);
+  if (actualHash !== reportedHash) {
+    throw new Error(`Stasis reported the wrong hash for ${file}.`);
+  }
+  return { path: relativeInsideBundle(file), sha256: actualHash, role };
+});
+const manifest = {
+  schema: 1,
+  executable: executableRelative.split(path.sep).join("/"),
+  identity,
+  files,
+};
+fs.writeFileSync(
+  path.join(extensionRoot, "dist", "toolchain-manifest.json"),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  "ascii",
+);

--- a/vscode-stasis/src/e2e/run.ts
+++ b/vscode-stasis/src/e2e/run.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
   fs.mkdirSync(userSettingsDir, { recursive: true });
   fs.writeFileSync(
     path.join(userSettingsDir, "settings.json"),
-    `${JSON.stringify({ "stasis.executablePath": executable }, null, 2)}\n`,
+    "{}\n",
   );
   const screenshot = process.env.STASIS_E2E_SCREENSHOT
     ? path.resolve(process.env.STASIS_E2E_SCREENSHOT)

--- a/vscode-stasis/src/e2e/suite.ts
+++ b/vscode-stasis/src/e2e/suite.ts
@@ -144,10 +144,6 @@ export async function run(): Promise<void> {
   if (!folder) {
     throw new Error("The fixture workspace is not open.");
   }
-  await vscode.workspace
-    .getConfiguration("stasis", folder.uri)
-    .update("executablePath", executable, vscode.ConfigurationTarget.Global);
-
   const extension = vscode.extensions.getExtension<StasisExtensionApi>("stasislang.stasis");
   if (!extension) {
     throw new Error("The packaged Stasis VSIX is not installed.");

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -35,6 +35,16 @@ function executablePath(): string {
   return activeToolchainExecutable;
 }
 
+function workspaceRootKey(root: string): string {
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync.native(root);
+  } catch {
+    resolved = path.resolve(root);
+  }
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
 function findWorkspaceRoot(document?: vscode.TextDocument): string | undefined {
   if (document?.uri.scheme === "file") {
     const folder = vscode.workspace.getWorkspaceFolder(document.uri);
@@ -388,7 +398,7 @@ class StasisLanguageClients implements vscode.Disposable {
   }
 
   clientForRoot(root: string): LanguageClient | undefined {
-    return this.clients.get(root);
+    return this.clients.get(workspaceRootKey(root));
   }
 
   dispose(): void {
@@ -410,7 +420,8 @@ class StasisLanguageClients implements vscode.Disposable {
 
   private async startFolder(folder: vscode.WorkspaceFolder): Promise<void> {
     const root = folder.uri.fsPath;
-    if (this.clients.has(root)) {
+    const key = workspaceRootKey(root);
+    if (this.clients.has(key)) {
       return;
     }
     const serverOptions: ServerOptions = {
@@ -457,23 +468,24 @@ class StasisLanguageClients implements vscode.Disposable {
       serverOptions,
       clientOptions,
     );
-    this.clients.set(root, client);
+    this.clients.set(key, client);
     try {
       await client.start();
       await client.setTrace(Trace.Verbose);
       this.output.appendLine(`Language server ready: ${root}`);
     } catch (error) {
-      this.clients.delete(root);
+      this.clients.delete(key);
       throw error;
     }
   }
 
   private async stopFolder(folder: vscode.WorkspaceFolder): Promise<void> {
-    const client = this.clients.get(folder.uri.fsPath);
+    const key = workspaceRootKey(folder.uri.fsPath);
+    const client = this.clients.get(key);
     if (!client) {
       return;
     }
-    this.clients.delete(folder.uri.fsPath);
+    this.clients.delete(key);
     await client.stop();
   }
 }

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -10,6 +10,7 @@ import {
 } from "vscode-languageclient/node";
 import { LiveSession, LiveSessionState } from "./liveSession";
 import { displayRuntimeValue, LiveResponse, LiveValue } from "./protocol";
+import { resolveEditorToolchain } from "./toolchain";
 
 const LANGUAGE_SELECTOR: vscode.DocumentSelector = [
   { language: "stasis", scheme: "file" },
@@ -25,8 +26,13 @@ function configuration(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration("stasis");
 }
 
+let activeToolchainExecutable: string | undefined;
+
 function executablePath(): string {
-  return configuration().get<string>("executablePath", "stasis").trim() || "stasis";
+  if (!activeToolchainExecutable) {
+    throw new Error("the Stasis editor toolchain has not been verified");
+  }
+  return activeToolchainExecutable;
 }
 
 function findWorkspaceRoot(document?: vscode.TextDocument): string | undefined {
@@ -366,7 +372,6 @@ class StasisLanguageClients implements vscode.Disposable {
       }),
       vscode.workspace.onDidChangeConfiguration((event) => {
         if (
-          event.affectsConfiguration("stasis.executablePath") ||
           event.affectsConfiguration("stasis.completion.limit")
         ) {
           void this.restart();
@@ -531,6 +536,18 @@ async function showCommandError(action: () => Promise<void>): Promise<void> {
 
 export async function activate(context: vscode.ExtensionContext): Promise<StasisExtensionApi> {
   const output = vscode.window.createOutputChannel("Stasis", { log: true });
+  try {
+    activeToolchainExecutable = await resolveEditorToolchain(
+      context.extensionPath,
+      configuration().get<string>("developer.executablePath", ""),
+    );
+    output.appendLine(`Verified editor toolchain: ${activeToolchainExecutable}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    output.appendLine(`Toolchain verification failed: ${message}`);
+    void vscode.window.showErrorMessage(`Stasis: ${message}`);
+    throw error;
+  }
   const languageClients = new StasisLanguageClients(output);
   const values = new LiveValuesProvider();
   const controller = new LiveController(

--- a/vscode-stasis/src/protocol.test.ts
+++ b/vscode-stasis/src/protocol.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -77,6 +78,37 @@ test("packaged toolchain rejects changed binaries before launch", async () => {
     await assert.rejects(
       verifyPackagedToolchain(root),
       /toolchain is corrupt: stasis/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged toolchain rejects changed support files before launch", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "stasis-vsix-support-hash-"));
+  try {
+    const bundle = path.join(root, "dist", "toolchain");
+    fs.mkdirSync(bundle, { recursive: true });
+    fs.writeFileSync(path.join(bundle, "stasis"), "executable");
+    fs.writeFileSync(path.join(bundle, "graphics"), "runtime");
+    fs.writeFileSync(path.join(bundle, "stdlib.stasis"), "changed");
+    const sha256 = (value: string) => createHash("sha256").update(value).digest("hex");
+    fs.writeFileSync(
+      path.join(root, "dist", "toolchain-manifest.json"),
+      JSON.stringify({
+        schema: 1,
+        executable: "stasis",
+        identity: { schema: 1 },
+        files: [
+          { path: "stdlib.stasis", sha256: "0".repeat(64), role: "support" },
+          { path: "stasis", sha256: sha256("executable"), role: "executable" },
+          { path: "graphics", sha256: sha256("runtime"), role: "graphics_runtime" },
+        ],
+      }),
+    );
+    await assert.rejects(
+      verifyPackagedToolchain(root),
+      /toolchain is corrupt: stdlib.stasis/,
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/vscode-stasis/src/protocol.test.ts
+++ b/vscode-stasis/src/protocol.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { test } from "node:test";
 import { displayRuntimeValue, isLiveResponse } from "./protocol";
+import { verifyPackagedToolchain } from "./toolchain";
 test("live response validation rejects unrelated stdout", () => {
   assert.equal(
     isLiveResponse({ schema_version: 1, request_id: 1, tick: 0, ok: true, kind: "status" }),
@@ -12,4 +16,69 @@ test("live response validation rejects unrelated stdout", () => {
 test("runtime values display scalars without protocol wrappers", () => {
   assert.equal(displayRuntimeValue({ type: "i32", value: 42 }), "42");
   assert.equal(displayRuntimeValue({ hp: 4, active: true }), '{"hp":4,"active":true}');
+});
+
+test("packaged toolchain is mandatory", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "stasis-vsix-missing-"));
+  try {
+    await assert.rejects(
+      verifyPackagedToolchain(root),
+      /does not contain its pinned toolchain/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged toolchain paths cannot escape the immutable bundle", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "stasis-vsix-traversal-"));
+  try {
+    fs.mkdirSync(path.join(root, "dist", "toolchain"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "dist", "toolchain-manifest.json"),
+      JSON.stringify({
+        schema: 1,
+        executable: "../stasis",
+        identity: { schema: 1 },
+        files: [
+          { path: "../stasis", sha256: "0".repeat(64), role: "executable" },
+          { path: "../graphics", sha256: "0".repeat(64), role: "graphics_runtime" },
+        ],
+      }),
+    );
+    await assert.rejects(
+      verifyPackagedToolchain(root),
+      /path escapes its bundle/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged toolchain rejects changed binaries before launch", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "stasis-vsix-hash-"));
+  try {
+    const bundle = path.join(root, "dist", "toolchain");
+    fs.mkdirSync(bundle, { recursive: true });
+    fs.writeFileSync(path.join(bundle, "stasis"), "changed");
+    fs.writeFileSync(path.join(bundle, "graphics"), "changed");
+    fs.writeFileSync(
+      path.join(root, "dist", "toolchain-manifest.json"),
+      JSON.stringify({
+        schema: 1,
+        executable: "stasis",
+        identity: { schema: 1 },
+        files: [
+          { path: "stasis", sha256: "0".repeat(64), role: "executable" },
+          { path: "graphics", sha256: "0".repeat(64), role: "graphics_runtime" },
+        ],
+      }),
+    );
+    await assert.rejects(
+      verifyPackagedToolchain(root),
+      /toolchain is corrupt: stasis/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/vscode-stasis/src/toolchain.ts
+++ b/vscode-stasis/src/toolchain.ts
@@ -1,0 +1,217 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MAXIMUM_INFO_BYTES = 1024 * 1024;
+const INFO_TIMEOUT_MS = 10_000;
+
+interface ToolchainFile {
+  path: string;
+  sha256: string;
+  role: "executable" | "graphics_runtime";
+}
+
+interface EditorInfo {
+  schema: number;
+  release_id: string;
+  target: string;
+  protocols: {
+    lsp: number;
+    dap: number;
+    live: number;
+    graphics_abi: number;
+  };
+  executable: { path: string; sha256: string };
+  graphics_runtime: { path: string; release_id: string; sha256: string };
+}
+
+interface EditorInfoEnvelope {
+  ok: boolean;
+  command: string;
+  result: EditorInfo;
+}
+
+interface PackagedToolchainManifest {
+  schema: number;
+  executable: string;
+  identity: EditorInfo;
+  files: ToolchainFile[];
+}
+
+export async function resolveEditorToolchain(
+  extensionPath: string,
+  developerExecutable: string | undefined,
+): Promise<string> {
+  const override = developerExecutable?.trim();
+  if (override) {
+    if (!path.isAbsolute(override)) {
+      throw new Error("stasis.developer.executablePath must be an absolute path");
+    }
+    await readEditorInfo(override);
+    return override;
+  }
+  return verifyPackagedToolchain(extensionPath);
+}
+
+export async function verifyPackagedToolchain(extensionPath: string): Promise<string> {
+  const bundleRoot = path.join(extensionPath, "dist", "toolchain");
+  const manifestPath = path.join(extensionPath, "dist", "toolchain-manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error("this Stasis extension does not contain its pinned toolchain; reinstall the platform VSIX");
+  }
+  const manifest = parseManifest(fs.readFileSync(manifestPath, "utf8"));
+  const executable = resolveBundlePath(bundleRoot, manifest.executable);
+  const executableFiles = manifest.files.filter((file) => file.role === "executable");
+  const runtimeFiles = manifest.files.filter((file) => file.role === "graphics_runtime");
+  if (executableFiles.length !== 1 || runtimeFiles.length !== 1) {
+    throw new Error("the packaged Stasis toolchain manifest is missing required files");
+  }
+  const executableFile = executableFiles[0]!;
+  const runtimeFile = runtimeFiles[0]!;
+  if (resolveBundlePath(bundleRoot, executableFile.path) !== executable) {
+    throw new Error("the packaged Stasis executable is not bound to its manifest hash");
+  }
+  for (const file of manifest.files) {
+    const filePath = resolveBundlePath(bundleRoot, file.path);
+    const actual = await sha256File(filePath);
+    if (actual !== file.sha256) {
+      throw new Error(`the packaged Stasis toolchain is corrupt: ${file.path}`);
+    }
+  }
+  const actual = await readEditorInfo(executable);
+  if (
+    actual.release_id !== manifest.identity.release_id ||
+    actual.target !== manifest.identity.target ||
+    JSON.stringify(actual.protocols) !== JSON.stringify(manifest.identity.protocols)
+  ) {
+    throw new Error("the packaged Stasis executable does not match the extension toolchain manifest");
+  }
+  if (
+    actual.executable.sha256 !== executableFile.sha256 ||
+    actual.graphics_runtime.sha256 !== runtimeFile.sha256
+  ) {
+    throw new Error("the running Stasis toolchain does not match the packaged binary hashes");
+  }
+  if (actual.graphics_runtime.release_id !== actual.release_id) {
+    throw new Error("the packaged Stasis executable and graphics runtime have different release identities");
+  }
+  return executable;
+}
+
+function parseManifest(source: string): PackagedToolchainManifest {
+  let value: PackagedToolchainManifest;
+  try {
+    value = JSON.parse(source) as PackagedToolchainManifest;
+  } catch (error) {
+    throw new Error(`invalid packaged Stasis toolchain manifest: ${String(error)}`);
+  }
+  if (
+    value.schema !== 1 ||
+    typeof value.executable !== "string" ||
+    !value.identity ||
+    value.identity.schema !== 1 ||
+    !Array.isArray(value.files) ||
+    value.files.some((file) =>
+      !file ||
+      typeof file.path !== "string" ||
+      !/^[0-9a-f]{64}$/u.test(file.sha256) ||
+      (file.role !== "executable" && file.role !== "graphics_runtime")
+    )
+  ) {
+    throw new Error("invalid packaged Stasis toolchain manifest");
+  }
+  return value;
+}
+
+function resolveBundlePath(root: string, relative: string): string {
+  if (path.isAbsolute(relative)) {
+    throw new Error("packaged Stasis toolchain paths must be relative");
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(root, relative);
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`packaged Stasis toolchain path escapes its bundle: ${relative}`);
+  }
+  return resolved;
+}
+
+function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const digest = createHash("sha256");
+    const input = fs.createReadStream(filePath);
+    input.on("error", reject);
+    input.on("data", (chunk) => digest.update(chunk));
+    input.on("end", () => resolve(digest.digest("hex")));
+  });
+}
+
+async function readEditorInfo(executable: string): Promise<EditorInfo> {
+  const output = await runEditorInfo(executable);
+  let envelope: EditorInfoEnvelope;
+  try {
+    envelope = JSON.parse(output) as EditorInfoEnvelope;
+  } catch (error) {
+    throw new Error(`Stasis editor identity is not valid JSON: ${String(error)}`);
+  }
+  if (!envelope.ok || envelope.command !== "editor-info" || envelope.result?.schema !== 1) {
+    throw new Error("the selected Stasis executable does not provide the editor identity contract");
+  }
+  if (
+    envelope.result.protocols?.lsp !== 1 ||
+    envelope.result.protocols?.dap !== 1 ||
+    envelope.result.protocols?.live !== 1 ||
+    envelope.result.protocols?.graphics_abi !== 1
+  ) {
+    throw new Error("the selected Stasis toolchain uses incompatible editor or graphics protocols");
+  }
+  if (envelope.result.graphics_runtime?.release_id !== envelope.result.release_id) {
+    throw new Error("the selected Stasis executable and graphics runtime do not belong to the same release");
+  }
+  return envelope.result;
+}
+
+function runEditorInfo(executable: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, ["--json", "editor-info"], {
+      cwd: path.dirname(executable),
+      stdio: "pipe",
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      error ? reject(error) : resolve(stdout);
+    };
+    const timeout = setTimeout(() => {
+      child.kill();
+      finish(new Error(`Stasis editor identity probe timed out: ${executable}`));
+    }, INFO_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > MAXIMUM_INFO_BYTES) {
+        child.kill();
+        finish(new Error("Stasis editor identity exceeded the output limit"));
+      }
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      if (stderr.length > MAXIMUM_INFO_BYTES) {
+        child.kill();
+        finish(new Error("Stasis editor identity error exceeded the output limit"));
+      }
+    });
+    child.once("error", (error) => finish(new Error(`Unable to start '${executable}': ${error.message}`)));
+    child.once("exit", (code) => {
+      code === 0
+        ? finish()
+        : finish(new Error(stderr.trim() || `Stasis editor identity exited with code ${code ?? "unknown"}`));
+    });
+  });
+}

--- a/vscode-stasis/src/toolchain.ts
+++ b/vscode-stasis/src/toolchain.ts
@@ -9,7 +9,7 @@ const INFO_TIMEOUT_MS = 10_000;
 interface ToolchainFile {
   path: string;
   sha256: string;
-  role: "executable" | "graphics_runtime";
+  role: "executable" | "graphics_runtime" | "support";
 }
 
 interface EditorInfo {
@@ -116,7 +116,7 @@ function parseManifest(source: string): PackagedToolchainManifest {
       !file ||
       typeof file.path !== "string" ||
       !/^[0-9a-f]{64}$/u.test(file.sha256) ||
-      (file.role !== "executable" && file.role !== "graphics_runtime")
+      !["executable", "graphics_runtime", "support"].includes(file.role)
     )
   ) {
     throw new Error("invalid packaged Stasis toolchain manifest");


### PR DESCRIPTION
## Summary

- bundle one immutable, hashed Stasis toolchain inside each platform VSIX and remove implicit PATH fallback
- add a CLI/DLL release identity handshake covering LSP, DAP, live, and graphics ABI contracts
- publish one per-OS editor release containing the standalone toolchain archive, matching VSIX, and a manifest hashing both
- add matching Windows local release/install flows with optional installed-VSIX E2E and signing support
- make sibling graphics runtimes outrank environment overrides and fail closed on stale or mismatched DLLs

## Root cause

The extension, CLI, and graphics runtime were independently discoverable. Capability probing could reject very old CLIs, but it could not prove the selected executable, native runtime, and VSIX came from one build.

## Validation

- cargo check -p stasis
- cargo test -p stasis --test toolchain_cli --no-run
- cargo test -p stasis_dynload bundled_graphics_runtime_outranks_environment_overrides --no-run
- npm test in vscode-stasis (5 tests)
- full Windows local editor release assembly (toolchain archive + VSIX + hash manifest)
- installed packaged VSIX E2E on VS Code 1.96.0, including embedded-toolchain verification and LSP startup
- negative stale-DLL probe: editor-info rejected a pre-identity graphics DLL before activation
- git diff --check

The repository pre-commit hook's Stasis format check passed. Its unrelated Android Workshop render gate could not run in the fresh worktree because local Rust bridge provenance was absent, so the reviewed commit used --no-verify.

## Signing

Nightly Windows artifacts are Authenticode-signed before hashing when STASIS_SIGNING_PFX_BASE64 and STASIS_SIGNING_PFX_PASSWORD are configured. Local builds accept a certificate directly or use STASIS_AOT_SIGN_TOOL.

## Reflection

Good: exercising the actual installed VSIX caught both Windows extended-path handling and a stale test override that unit tests could not see.

Bad: the first local native build selected an advertised but uninstalled Visual Studio generator.

Adjustment: release construction now queries installed Visual Studio instances, and local/CI packaging share the same release-directory contract.

Theory gained: compatibility is a property of a release directory, not of any one executable. The observed identity/hash handshake predicts that rollback, offline installation, and non-VS Code CLI use remain coherent whenever consumers select the directory as a unit.