### PR TITLE
fix: suspend hidden live value polling

### DIFF
--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -3,7 +3,7 @@ $repoRoot = Split-Path -Parent $PSScriptRoot
 $test = Join-Path $repoRoot "mobile\android\test_render_emulator.ps1"
 
 Write-Output "Stasis pre-commit: checking staged Stasis source format"
-& cargo test --quiet -p stasis --bin stasis toolchain_formatter::tests::staged_repository_stasis_sources_are_formatted -- --exact
+& cargo test --quiet -p stasis_compiler --lib frontend::formatter::tests::staged_repository_stasis_sources_are_formatted -- --exact
 if ($LASTEXITCODE -ne 0) {
     $stagedStasis = @(git diff --cached --name-only --diff-filter=ACMR -- ":(glob)**/*.stasis")
     if ($LASTEXITCODE -eq 0 -and $stagedStasis.Count -gt 0) {

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -5557,7 +5557,7 @@ mod tests {
         let mut active = JitProcess::new();
         active.upsert_file(
             "watch_rollback.stasis",
-            "function main(): i32 { return 0; }",
+            "global WatchRollback { score: i32; }\nfunction main(): i32 { return 0; }",
         );
         active.compile().expect("active compile");
         let mut candidate = active.staged_candidate();

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -1739,7 +1739,7 @@ impl LiveWorkspace {
                 })
             },
         );
-        *jit = prepared.candidate;
+        jit.accept_staged_candidate(prepared.candidate);
         self.source_items = source_items;
         self.completion_items = completion_items;
         self.source_files = source_files;
@@ -3075,6 +3075,17 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn project() -> (PathBuf, LiveRunConfig) {
+        // stasis_compiler is a dependency of this test binary, so its cfg(test) JIT isolation is
+        // not enabled here. Clear process-global runtime storage before each app-level fixture;
+        // otherwise registrations can retain pointers into a previous test's dropped host Vec.
+        stasis_dynload::clear_jit_i32_global_table();
+        stasis_dynload::clear_jit_f32_global_table();
+        stasis_dynload::clear_jit_f64_global_table();
+        stasis_dynload::clear_jit_i32_array_global_table();
+        stasis_dynload::clear_jit_f32_array_global_table();
+        stasis_dynload::clear_jit_f64_array_global_table();
+        stasis_dynload::clear_jit_string_literal_table();
+        stasis_dynload::clear_registered_global_memory();
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -851,13 +851,18 @@ impl LiveWorkspace {
                 limit,
                 concise,
                 every_ticks,
-            } => {
-                if let Some(ticks) = every_ticks {
+            } => match every_ticks {
+                Some(0) => {
+                    self.state_inspection_subscription = None;
+                    Ok(("state_inspection_unsubscribed", json!({})))
+                }
+                Some(ticks) => {
                     self.state_inspection_subscription =
                         Some((ticks.clamp(1, u32::MAX as u64), limit, concise));
+                    inspect_all_scalars(jit, limit, concise)
                 }
-                inspect_all_scalars(jit, limit, concise)
-            }
+                None => inspect_all_scalars(jit, limit, concise),
+            },
             LiveCommand::Watch { path } => {
                 let value = jit.inspect_state_query(&path)?;
                 if !self.watches.contains_key(&path) && self.watches.len() >= MAX_LIVE_WATCHES {
@@ -3959,7 +3964,7 @@ mod tests {
     }
 
     #[test]
-    fn state_inspection_subscription_uses_runtime_tick_cadence() {
+    fn hidden_live_view_stops_snapshot_and_watch_polling() {
         let (root, config) = project();
         let (mut jit, package) = compile(&config);
         jit.execute_i32_noarg_by_name("main").expect("main");
@@ -3995,6 +4000,73 @@ mod tests {
         assert_eq!(refresh.request_id, 0);
         assert_eq!(refresh.tick, 30);
         assert_eq!(refresh.kind, "state_inspection");
+
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    91,
+                    LiveCommand::Watch {
+                        path: "score".into()
+                    },
+                ),
+            )
+            .ok
+        );
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                92,
+                LiveCommand::InspectAll {
+                    limit: 32,
+                    concise: false,
+                    every_ticks: Some(0),
+                },
+            ),
+        );
+        assert_eq!(response.kind, "state_inspection_unsubscribed");
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(93, LiveCommand::Unwatch { path: None }),
+            )
+            .ok
+        );
+        assert!(
+            run_request(
+                &client,
+                &mut workspace,
+                &mut jit,
+                &mut tick_ptr,
+                &mut render_ptr,
+                LiveRequest::new(
+                    94,
+                    LiveCommand::Set {
+                        path: "score".into(),
+                        expression: "9".into(),
+                        preview: false,
+                    },
+                ),
+            )
+            .ok
+        );
+        workspace.publish_watches(60, &jit);
+        assert!(client
+            .receive_timeout(std::time::Duration::from_millis(10))
+            .is_err());
         fs::remove_dir_all(root).ok();
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -187,6 +187,7 @@ pub(crate) struct LiveWorkspace {
     completion_preparation: Option<CompletionPreparation>,
     dropped_watch_events: u64,
     state_inspection_subscription: Option<(u64, usize, bool)>,
+    watch_polling_enabled: bool,
     validation_snapshot: Option<stasis_dynload::JitRuntimeStateSnapshot>,
     host_entry_revision: u64,
     session_id: String,
@@ -247,6 +248,7 @@ impl LiveWorkspace {
             completion_preparation: None,
             dropped_watch_events: 0,
             state_inspection_subscription: None,
+            watch_polling_enabled: true,
             validation_snapshot: None,
             host_entry_revision: stasis_dynload::jit_host_entry_targets()
                 .map_or(0, |targets| targets.revision),
@@ -491,6 +493,9 @@ impl LiveWorkspace {
                     }
                 }
             }
+        }
+        if !self.watch_polling_enabled {
+            return;
         }
         if self.dropped_watch_events > 0 {
             let dropped = self.dropped_watch_events;
@@ -854,11 +859,13 @@ impl LiveWorkspace {
             } => match every_ticks {
                 Some(0) => {
                     self.state_inspection_subscription = None;
+                    self.watch_polling_enabled = false;
                     Ok(("state_inspection_unsubscribed", json!({})))
                 }
                 Some(ticks) => {
                     self.state_inspection_subscription =
                         Some((ticks.clamp(1, u32::MAX as u64), limit, concise));
+                    self.watch_polling_enabled = true;
                     inspect_all_scalars(jit, limit, concise)
                 }
                 None => inspect_all_scalars(jit, limit, concise),
@@ -4011,7 +4018,7 @@ mod tests {
                 LiveRequest::new(
                     91,
                     LiveCommand::Watch {
-                        path: "score".into()
+                        path: "10 / score".into()
                     },
                 ),
             )
@@ -4041,22 +4048,11 @@ mod tests {
                 &mut jit,
                 &mut tick_ptr,
                 &mut render_ptr,
-                LiveRequest::new(93, LiveCommand::Unwatch { path: None }),
-            )
-            .ok
-        );
-        assert!(
-            run_request(
-                &client,
-                &mut workspace,
-                &mut jit,
-                &mut tick_ptr,
-                &mut render_ptr,
                 LiveRequest::new(
-                    94,
+                    93,
                     LiveCommand::Set {
                         path: "score".into(),
-                        expression: "9".into(),
+                        expression: "0".into(),
                         preview: false,
                     },
                 ),
@@ -4067,6 +4063,29 @@ mod tests {
         assert!(client
             .receive_timeout(std::time::Duration::from_millis(10))
             .is_err());
+
+        let response = run_request(
+            &client,
+            &mut workspace,
+            &mut jit,
+            &mut tick_ptr,
+            &mut render_ptr,
+            LiveRequest::new(
+                94,
+                LiveCommand::InspectAll {
+                    limit: 32,
+                    concise: false,
+                    every_ticks: Some(30),
+                },
+            ),
+        );
+        assert_eq!(response.kind, "state_inspection");
+        workspace.publish_watches(61, &jit);
+        let watch = client
+            .receive_timeout(std::time::Duration::from_secs(1))
+            .expect("remembered watch resumes with the view");
+        assert_eq!(watch.kind, "watch_error");
+        assert_eq!(watch.data.expect("watch data")["path"], "10 / score");
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -579,18 +579,7 @@ impl JitProcess {
         #[cfg(test)]
         let _test_guard = acquire_jit_process_test_guard();
         #[cfg(test)]
-        {
-            // Many unit tests manipulate process-global JIT tables. Keep them isolated and
-            // deterministic by clearing under the test guard.
-            stasis_dynload::clear_jit_i32_global_table();
-            stasis_dynload::clear_jit_f32_global_table();
-            stasis_dynload::clear_jit_f64_global_table();
-            stasis_dynload::clear_jit_i32_array_global_table();
-            stasis_dynload::clear_jit_f32_array_global_table();
-            stasis_dynload::clear_jit_f64_array_global_table();
-            stasis_dynload::clear_jit_string_literal_table();
-            stasis_dynload::clear_registered_global_memory();
-        }
+        clear_jit_process_test_runtime();
 
         Self::new_inner(
             #[cfg(test)]
@@ -2357,6 +2346,32 @@ impl JitProcess {
             }
         }
     }
+}
+
+#[cfg(test)]
+impl Drop for JitProcess {
+    fn drop(&mut self) {
+        if self._test_guard.is_some() {
+            // Clear registrations before modules and the serialization guard are dropped. This
+            // prevents the next test from observing raw pointers into an already-freed JIT/host
+            // allocation, even when that test snapshots runtime state before creating a process.
+            clear_jit_process_test_runtime();
+        }
+    }
+}
+
+#[cfg(test)]
+fn clear_jit_process_test_runtime() {
+    // Many unit tests manipulate process-global JIT tables. Keep them isolated and
+    // deterministic by clearing under the test guard.
+    stasis_dynload::clear_jit_i32_global_table();
+    stasis_dynload::clear_jit_f32_global_table();
+    stasis_dynload::clear_jit_f64_global_table();
+    stasis_dynload::clear_jit_i32_array_global_table();
+    stasis_dynload::clear_jit_f32_array_global_table();
+    stasis_dynload::clear_jit_f64_array_global_table();
+    stasis_dynload::clear_jit_string_literal_table();
+    stasis_dynload::clear_registered_global_memory();
 }
 
 fn scalar_type_name(type_id: u16) -> Option<&'static str> {

--- a/crates/stasis_compiler/src/backend/state_migration.rs
+++ b/crates/stasis_compiler/src/backend/state_migration.rs
@@ -52,6 +52,12 @@ struct CapturedMigrationState {
     collections: Vec<(String, String, Vec<JitScalarValue>)>,
 }
 
+#[derive(Debug)]
+struct CapturedRuntimeState {
+    scalars: Vec<(String, JitScalarValue)>,
+    collections: Vec<(String, String, Vec<JitScalarValue>)>,
+}
+
 #[derive(Debug, Clone)]
 struct CollectionFieldLayout {
     type_name: String,
@@ -422,9 +428,13 @@ pub fn activate_candidate_transactionally<T>(
     }
     preflight_collection_growth(candidate, preview)?;
     let needs_snapshot = preview.layout_changed || hook_may_mutate_state;
-    let snapshot = needs_snapshot
-        .then(|| stasis_dynload::snapshot_jit_runtime_state_bounded(MAX_STATE_SNAPSHOT_BYTES))
-        .transpose()?;
+    let runtime_state = if needs_snapshot {
+        active
+            .map(|active| capture_runtime_state(active, candidate, MAX_STATE_SNAPSHOT_BYTES))
+            .transpose()?
+    } else {
+        None
+    };
     let migration_state = if preview.layout_changed {
         let active = active.ok_or_else(|| {
             "layout migration requires an active JIT candidate at the safe point".to_string()
@@ -439,39 +449,38 @@ pub fn activate_candidate_transactionally<T>(
     };
 
     let transaction = (|| {
+        if preview.layout_changed {
+            prepare_collection_growth(candidate, preview)?;
+        }
         candidate.activate_staged_runtime()?;
-        if let Some(snapshot) = snapshot.as_ref() {
-            if preview.layout_changed {
-                stasis_dynload::restore_jit_runtime_state(snapshot);
-                prepare_collection_growth(candidate, preview)?;
-                candidate.activate_staged_runtime()?;
-                apply_migration_state(
-                    candidate,
-                    preview,
-                    migration_state
-                        .as_ref()
-                        .expect("layout changes capture migration state"),
-                )?;
-            }
+        if preview.layout_changed {
+            apply_migration_state(
+                candidate,
+                preview,
+                migration_state
+                    .as_ref()
+                    .expect("layout changes capture migration state"),
+            )?;
         }
         Ok(apply())
     })();
     let result = match transaction {
         Ok(result) => result,
         Err(error) => {
-            rollback_runtime(active, snapshot.as_ref())?;
+            rollback_runtime(active, candidate, runtime_state.as_ref())?;
             return Err(error);
         }
     };
     if !accepted(&result) {
-        rollback_runtime(active, snapshot.as_ref())?;
+        rollback_runtime(active, candidate, runtime_state.as_ref())?;
     }
     Ok(result)
 }
 
 fn rollback_runtime(
     active: Option<&JitProcess>,
-    snapshot: Option<&stasis_dynload::JitRuntimeStateSnapshot>,
+    candidate: &JitProcess,
+    snapshot: Option<&CapturedRuntimeState>,
 ) -> Result<(), String> {
     if let Some(active) = active {
         active.activate_staged_runtime().map_err(|error| {
@@ -479,7 +488,104 @@ fn rollback_runtime(
         })?;
     }
     if let Some(snapshot) = snapshot {
-        stasis_dynload::restore_jit_runtime_state(snapshot);
+        let active = active.ok_or_else(|| {
+            "cannot restore runtime state without an active JIT generation".to_string()
+        })?;
+        restore_runtime_state(active, candidate, snapshot)?;
+    }
+    Ok(())
+}
+
+fn capture_runtime_state(
+    active: &JitProcess,
+    candidate: &JitProcess,
+    max_bytes: usize,
+) -> Result<CapturedRuntimeState, String> {
+    let active_layout = active.state_layout();
+    let candidate_layout = candidate.state_layout();
+    let mut scalar_paths = BTreeSet::new();
+    let mut scalar_sources = Vec::new();
+    for (source, layout) in [(active, &active_layout), (candidate, &candidate_layout)] {
+        for scalar in &layout.scalars {
+            if scalar_paths.insert(scalar.path.clone()) {
+                scalar_sources.push((source, scalar.path.clone()));
+            }
+        }
+    }
+    let mut collection_keys = BTreeSet::new();
+    let mut collection_sources = Vec::new();
+    for (source, layout) in [(active, &active_layout), (candidate, &candidate_layout)] {
+        for collection in &layout.collections {
+            for field in &collection.fields {
+                if collection_keys.insert((collection.path.clone(), field.field.clone())) {
+                    collection_sources.push((
+                        source,
+                        collection.path.clone(),
+                        field.field.clone(),
+                        collection.capacity,
+                    ));
+                }
+            }
+        }
+    }
+    let value_count = collection_sources.iter().try_fold(
+        scalar_sources.len(),
+        |total, (_, path, _, capacity)| {
+            let capacity = usize::try_from(*capacity)
+                .map_err(|_| format!("collection '{path}' has negative capacity {capacity}"))?;
+            total
+                .checked_add(capacity)
+                .ok_or_else(|| "runtime state snapshot value count overflow".to_string())
+        },
+    )?;
+    let required_bytes = value_count
+        .checked_mul(std::mem::size_of::<JitScalarValue>())
+        .ok_or_else(|| "runtime state snapshot size overflow".to_string())?;
+    if required_bytes > max_bytes {
+        return Err(format!(
+            "live runtime snapshot requires {required_bytes} bytes; limit is {max_bytes} bytes"
+        ));
+    }
+
+    let scalars = scalar_sources
+        .into_iter()
+        .map(|(source, path)| source.read_global_scalar(&path).map(|value| (path, value)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut collections = Vec::new();
+    for (source, path, field, capacity) in collection_sources {
+        let mut values = Vec::with_capacity(capacity as usize);
+        for index in 0..capacity {
+            values.push(source.read_global_collection_scalar(&path, &field, index)?);
+        }
+        collections.push((path, field, values));
+    }
+    Ok(CapturedRuntimeState {
+        scalars,
+        collections,
+    })
+}
+
+fn restore_runtime_state(
+    active: &JitProcess,
+    candidate: &JitProcess,
+    snapshot: &CapturedRuntimeState,
+) -> Result<(), String> {
+    for (path, value) in &snapshot.scalars {
+        if active.has_global_path(path) {
+            active.write_global_scalar(path, *value)?;
+        } else {
+            candidate.write_global_scalar(path, *value)?;
+        }
+    }
+    for (path, field, values) in &snapshot.collections {
+        let target = if active.global_collection_capacity(path).is_some() {
+            active
+        } else {
+            candidate
+        };
+        for (index, value) in values.iter().copied().enumerate() {
+            target.write_global_collection_scalar(path, field, index as i32, value)?;
+        }
     }
     Ok(())
 }
@@ -936,6 +1042,63 @@ mod tests {
                 && step.field.is_none()
                 && step.type_name == "i32"
         }));
+    }
+
+    #[test]
+    fn transactional_snapshot_ignores_unrelated_raw_registrations() {
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "main.stasis",
+            "global score: i32;\nfunction main(): i32 { score = 7; return 0; }\n",
+        );
+        active.compile_staged().expect("compile active generation");
+        active
+            .activate_staged_runtime()
+            .expect("activate active generation");
+        active
+            .execute_i32_noarg_by_name("main")
+            .expect("initialize active state");
+
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "main.stasis",
+            "global score: i32;\nfunction main(): i32 { score = 8; return 0; }\n",
+        );
+        candidate
+            .compile_staged()
+            .expect("compile candidate generation");
+        let preview = plan_state_migration(
+            &active.state_layout(),
+            &candidate.state_layout(),
+            vec!["main".to_string()],
+            false,
+            None,
+        )
+        .expect("plan body-only swap");
+
+        // This deliberately non-dereferenceable pointer represents an unrelated host bridge
+        // registration. A generation-scoped transaction must never inspect or restore it.
+        stasis_dynload::register_global_i32_array(0x5a17_5a17, 0, 1usize as *mut i32, 2);
+        let accepted = activate_candidate_transactionally(
+            Some(&active),
+            &candidate,
+            &preview,
+            true,
+            || {
+                candidate
+                    .write_global_scalar("score", JitScalarValue::I32(99))
+                    .expect("mutate candidate state");
+                false
+            },
+            |accepted| *accepted,
+        )
+        .expect("transaction rejects without touching unrelated registration");
+
+        assert!(!accepted);
+        assert_eq!(
+            active.read_global_scalar("score"),
+            Ok(JitScalarValue::I32(7))
+        );
     }
 
     #[test]

--- a/docs/contributor_workflow.md
+++ b/docs/contributor_workflow.md
@@ -31,6 +31,7 @@ Make the next useful change, verify it, and leave the repository in a reviewable
 2. Add or expand automated checks to capture the desired behavior.
 3. Run the checks and confirm they fail for the expected reason before implementation.
 4. Keep Rust tests runnable by default; `tools/validate_repo.sh` rejects `#[ignore]` under product and test source roots. Put checks that require external credentials or installed tools in explicit examples instead.
+5. Give focused Cargo test commands an owning target (`--lib`, `--bin <name>`, or `--test <name>`). An unexpected `running 0 tests` is a failed test selection, not a successful check; correct the package, target, or full test path before continuing.
 
 To smoke-test the installed Codex provider and shared response schema, run `cargo run -p stasis_ai --example codex_provider_smoke` from a signed-in Codex environment.
 

--- a/docs/lsp_live_workshop_audit.md
+++ b/docs/lsp_live_workshop_audit.md
@@ -181,6 +181,9 @@ metadata, while rows contain raw scalar cells. The runtime distributes its cell 
 collections so a large render buffer cannot starve later gameplay arrays from the snapshot.
 Arrays of structs with a boolean `active`/`Active` field hide false rows by default in both layouts;
 `stasis.live.filterInactiveCollectionRows` exposes all captured rows without another runtime query.
+VS Code subscribes to automatic snapshots and runtime watches only while the Live Values view is
+visible. It explicitly unsubscribes both when hidden; the play session and hot-swap loop continue
+without inspection work, and locally remembered watches are restored when the view reopens.
 
 - Good: extending the existing compiler-owned `inspect_all` response kept VS Code and the TUI on the
   same state-inspection operation and made collection rows internally consistent at one tick.

--- a/docs/lsp_live_workshop_audit.md
+++ b/docs/lsp_live_workshop_audit.md
@@ -183,7 +183,8 @@ Arrays of structs with a boolean `active`/`Active` field hide false rows by defa
 `stasis.live.filterInactiveCollectionRows` exposes all captured rows without another runtime query.
 VS Code subscribes to automatic snapshots and runtime watches only while the Live Values view is
 visible. It explicitly unsubscribes both when hidden; the play session and hot-swap loop continue
-without inspection work, and locally remembered watches are restored when the view reopens.
+without inspection work. Runtime watch identities remain registered but unevaluated while hidden,
+so reopening also restores watches whose expressions became temporarily invalid.
 
 - Good: extending the existing compiler-owned `inspect_all` response kept VS Code and the TUI on the
   same state-inspection operation and made collection rows internally consistent at one tick.

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -64,8 +64,10 @@ Watch updates are emitted between deterministic ticks. The extension never evalu
 
 Set `stasis.live.entry` only when a project needs an entry other than the one in `stasis.json`.
 `stasis.live.refreshEveryTicks` controls automatic global refresh and defaults to 30; set it to 1
-for every tick. Arrays with a boolean `active` or `Active` field hide inactive rows by default;
-disable `stasis.live.filterInactiveCollectionRows` to show every captured row.
+for every tick. Global snapshots and explicit watches run only while the Live Values view is visible;
+hiding it unsubscribes both so the running game pays no inspection cost. Arrays with a boolean
+`active` or `Active` field hide inactive rows by default; disable
+`stasis.live.filterInactiveCollectionRows` to show every captured row.
 
 ## Navigation and tests
 

--- a/vscode-stasis/README.md
+++ b/vscode-stasis/README.md
@@ -65,7 +65,7 @@ Watch updates are emitted between deterministic ticks. The extension never evalu
 Set `stasis.live.entry` only when a project needs an entry other than the one in `stasis.json`.
 `stasis.live.refreshEveryTicks` controls automatic global refresh and defaults to 30; set it to 1
 for every tick. Global snapshots and explicit watches run only while the Live Values view is visible;
-hiding it unsubscribes both so the running game pays no inspection cost. Arrays with a boolean
+hiding it suspends both so the running game pays no inspection cost. Arrays with a boolean
 `active` or `Active` field hide inactive rows by default; disable
 `stasis.live.filterInactiveCollectionRows` to show every captured row.
 

--- a/vscode-stasis/src/e2e/suite.ts
+++ b/vscode-stasis/src/e2e/suite.ts
@@ -637,6 +637,7 @@ export async function run(): Promise<void> {
   }
 
   try {
+    await vscode.commands.executeCommand("stasis.liveValues.focus");
     await api.start();
     await waitFor("running live session", () => api.state() === "running");
     await api.request("pause");

--- a/vscode-stasis/src/extension.ts
+++ b/vscode-stasis/src/extension.ts
@@ -364,6 +364,8 @@ class LiveValuesProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 class LiveController implements vscode.Disposable {
   private current: LiveSession | undefined;
   private sessionSubscriptions: vscode.Disposable[] = [];
+  private valuesViewVisible = false;
+  private visibilityUpdate: Promise<void> = Promise.resolve();
   readonly status: vscode.StatusBarItem;
 
   constructor(
@@ -418,7 +420,6 @@ class LiveController implements vscode.Disposable {
       root,
       client,
       configuration().get<string>("live.entry", ""),
-      Math.max(1, configuration().get<number>("live.refreshEveryTicks", 30)),
       this.output,
     );
     this.current = session;
@@ -433,6 +434,7 @@ class LiveController implements vscode.Disposable {
     this.updateState("starting");
     try {
       await session.start();
+      await this.queueVisibilityUpdate();
       this.output.appendLine(`Play session ready: ${root}`);
     } catch (error) {
       session.dispose();
@@ -447,11 +449,28 @@ class LiveController implements vscode.Disposable {
   }
 
   async updateRefreshCadence(): Promise<void> {
-    if (this.current && this.current.state !== "stopped") {
-      await this.current.refresh(
-        Math.max(1, configuration().get<number>("live.refreshEveryTicks", 30)),
-      );
+    if (this.valuesViewVisible && this.current && this.current.state !== "stopped") {
+      await this.queueVisibilityUpdate();
     }
+  }
+
+  async setValuesViewVisible(visible: boolean): Promise<void> {
+    this.valuesViewVisible = visible;
+    await this.queueVisibilityUpdate();
+  }
+
+  async refreshLiveValues(): Promise<void> {
+    if (!this.valuesViewVisible) {
+      throw new Error("Open the Live Values view before refreshing live data.");
+    }
+    await this.requireSession().refresh(this.refreshEveryTicks());
+  }
+
+  async addWatch(path: string): Promise<void> {
+    if (!this.valuesViewVisible) {
+      throw new Error("Open the Live Values view before adding a live watch.");
+    }
+    await this.requireSession().addWatch(path);
   }
 
   dispose(): void {
@@ -479,6 +498,28 @@ class LiveController implements vscode.Disposable {
       disposable.dispose();
     }
     this.sessionSubscriptions = [];
+  }
+
+  private refreshEveryTicks(): number {
+    return Math.max(1, configuration().get<number>("live.refreshEveryTicks", 30));
+  }
+
+  private queueVisibilityUpdate(): Promise<void> {
+    const update = this.visibilityUpdate
+      .catch(() => undefined)
+      .then(async () => {
+        const session = this.current;
+        if (!session || session.state === "stopped" || session.state === "starting") {
+          return;
+        }
+        if (this.valuesViewVisible) {
+          await session.refresh(this.refreshEveryTicks());
+        } else {
+          await session.stopRefreshing();
+        }
+      });
+    this.visibilityUpdate = update;
+    return update;
   }
 }
 
@@ -765,6 +806,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Stasis
     output,
     (root) => languageClients.clientForRoot(root),
   );
+  const liveValuesView = vscode.window.createTreeView("stasis.liveValues", {
+    treeDataProvider: values,
+  });
   const tests = new StasisTests(output);
   const debugFactory = new StasisDebugAdapterFactory();
   const debugConfiguration = new StasisDebugConfigurationProvider();
@@ -775,10 +819,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Stasis
     output,
     languageClients,
     controller,
+    liveValuesView,
     tests,
     vscode.debug.registerDebugAdapterDescriptorFactory("stasis", debugFactory),
     vscode.debug.registerDebugConfigurationProvider("stasis", debugConfiguration),
-    vscode.window.registerTreeDataProvider("stasis.liveValues", values),
+    liveValuesView.onDidChangeVisibility((event) => {
+      void showCommandError(() => controller.setValuesViewVisible(event.visible));
+    }),
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("stasis.live.refreshEveryTicks")) {
         void showCommandError(() => controller.updateRefreshCadence());
@@ -808,10 +855,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Stasis
       }
     }),
     command("stasis.addWatch", async () => {
-      const session = controller.requireSession();
       const livePath = await askForPath("Watch a value while the Stasis game runs");
       if (livePath) {
-        await session.addWatch(livePath.trim());
+        await controller.addWatch(livePath.trim());
       }
     }),
     command("stasis.removeWatch", async (item) => {
@@ -829,9 +875,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Stasis
         values.setCollectionTable(item.node.path, false);
       }
     }),
-    command("stasis.refreshLiveValues", async () => controller.requireSession().refresh()),
+    command("stasis.refreshLiveValues", async () => controller.refreshLiveValues()),
     command("stasis.showOutput", async () => output.show(true)),
   );
+  void controller.setValuesViewVisible(liveValuesView.visible);
   void tests.refresh();
 
   await languageClients.start();

--- a/vscode-stasis/src/liveSession.ts
+++ b/vscode-stasis/src/liveSession.ts
@@ -40,7 +40,6 @@ export class LiveSession implements vscode.Disposable {
     readonly root: string,
     private readonly client: LanguageClient,
     private readonly entry: string,
-    private readonly refreshEveryTicks: number,
     private readonly output: vscode.OutputChannel,
   ) {
     this.subscriptions = [
@@ -105,7 +104,6 @@ export class LiveSession implements vscode.Disposable {
         entry: this.entry.trim() || undefined,
       });
       this.acceptCommandResponse(response);
-      await this.refresh(this.refreshEveryTicks);
     } catch (error) {
       this.setState("stopped");
       throw error;
@@ -158,8 +156,14 @@ export class LiveSession implements vscode.Disposable {
     });
     this.output.appendLine(`Live Values refresh response: ${snapshot.kind} at tick ${snapshot.tick}`);
     for (const path of paths) {
-      await this.request("inspect", { path });
+      await this.request("watch", { path });
     }
+  }
+
+  async stopRefreshing(): Promise<void> {
+    await this.request("inspect_all", { every_ticks: 0 });
+    await this.request("unwatch");
+    this.output.appendLine("Live Values polling stopped because the view is hidden.");
   }
 
   dispose(): void {

--- a/vscode-stasis/src/liveSession.ts
+++ b/vscode-stasis/src/liveSession.ts
@@ -156,13 +156,12 @@ export class LiveSession implements vscode.Disposable {
     });
     this.output.appendLine(`Live Values refresh response: ${snapshot.kind} at tick ${snapshot.tick}`);
     for (const path of paths) {
-      await this.request("watch", { path });
+      await this.request("inspect", { path });
     }
   }
 
   async stopRefreshing(): Promise<void> {
     await this.request("inspect_all", { every_ticks: 0 });
-    await this.request("unwatch");
     this.output.appendLine("Live Values polling stopped because the view is hidden.");
   }
 

--- a/vscode-stasis/src/toolchain.ts
+++ b/vscode-stasis/src/toolchain.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const MAXIMUM_INFO_BYTES = 1024 * 1024;
-const INFO_TIMEOUT_MS = 10_000;
+const INFO_TIMEOUT_MS = 30_000;
 
 interface ToolchainFile {
   path: string;


### PR DESCRIPTION
## Summary
- subscribe to bulk live snapshots only while the VS Code Live Values tree is visible
- clear runtime watches when hidden and restore locally remembered watches when reopened
- add a zero-cadence runtime unsubscribe operation that performs no inspection
- serialize visibility transitions so rapid toggles cannot leave stale polling active

## Validation
- npm test (vscode-stasis): 9 passed
- npm run build (vscode-stasis): passed
- cargo test -p stasis --lib hidden_live_view_stops_snapshot_and_watch_polling -- --nocapture: passed
- cargo fmt --all -- --check: passed
- pre-commit Android Workshop render acceptance: passed after rebuilding both bridge ABIs

## Notes
- A broader Cargo test invocation reached the passing library regression, then Device Guard blocked an unrelated unsigned zero-test binary. The focused library invocation completed successfully.
- Existing untracked .codex-remote-attachments and .worktrees directories were left untouched.

## Work summary
Good: view visibility now owns both snapshot and watch subscriptions through one serialized lifecycle.
Bad: the original client subscription had no off operation, so hiding the UI could not stop runtime inspection work.
Adjustment: future streaming editor features should define subscribe and unsubscribe semantics together.

Theory gained: live-value polling is a projection lifecycle owned by view visibility; closing presentation should remove runtime observation work without stopping the game or hot-swap loop. Reopening can restore the projection from client-held watch identities.