### PR TITLE
feat: add autonomous game gauntlet

### DIFF
--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -19,10 +19,10 @@ crossterm = "0.28"
 stasis_dynload = { path = "../../crates/stasis_dynload" }
 stasis_assets = { path = "../../crates/stasis_assets" }
 stasis_ai = { path = "../../crates/stasis_ai" }
+image.workspace = true
 
 [dev-dependencies]
 object = "0.36"
-image.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2194,6 +2194,9 @@ fn run_play_in_process_inner(
                 &mut host_f32,
             )?;
         }
+        if let Some(live) = live.as_ref() {
+            live.apply_input_override(&mut host_i32, &mut host_f32)?;
+        }
         gfx.host_bulk_apply_requests(
             &host_req_seq,
             &host_req_flags,
@@ -4378,6 +4381,18 @@ mod tests {
             STASIS_MOBILE_RUNTIME_SOURCE.contains("STASIS_RENDER_I32_COUNT")
                 && STASIS_MOBILE_RUNTIME_SOURCE.contains("stasis_gfx_submit_u8("),
             "mobile AOT should bind and submit the same command representation"
+        );
+    }
+
+    #[test]
+    fn live_runtime_exposes_repeatable_pre_present_png_capture() {
+        assert!(
+            STASIS_GRAPHICS_SOURCE
+                .contains("STASIS_EXPORT int stasis_host_schedule_screenshot(const char* path)")
+                && STASIS_GRAPHICS_SOURCE
+                    .contains("g_screenshot_frame = (int)(g_debug_frame_counter + 1);")
+                && STASIS_GRAPHICS_SOURCE.contains("capture_scheduled_screenshot();"),
+            "Gauntlet captures must arm the existing pre-present screenshot path"
         );
     }
 

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -193,6 +193,7 @@ pub(crate) struct LiveWorkspace {
     session_id: String,
     language_service: LanguageService,
     language_paths: BTreeSet<String>,
+    input_override: Option<Vec<stasis_runner::live::LivePointerInput>>,
 }
 
 impl Drop for LiveWorkspace {
@@ -255,6 +256,7 @@ impl LiveWorkspace {
             session_id,
             language_service,
             language_paths: BTreeSet::new(),
+            input_override: None,
         };
         workspace.refresh_completion(jit)?;
         Ok(workspace)
@@ -443,6 +445,67 @@ impl LiveWorkspace {
         if self.paused && self.step_remaining > 0 {
             self.step_remaining -= 1;
         }
+        if let Some(pointers) = self.input_override.as_mut() {
+            for pointer in pointers {
+                pointer.went_down = false;
+                pointer.went_up = false;
+            }
+        }
+    }
+
+    pub(crate) fn apply_input_override(
+        &self,
+        host_i32: &mut [i32],
+        host_f32: &mut [f32],
+    ) -> Result<(), String> {
+        const I_COUNT: usize = 7;
+        const I_DROPPED: usize = 8;
+        const I_BASE: usize = 544;
+        const I_STRIDE: usize = 4;
+        const F_STRIDE: usize = 6;
+        const F_LOGICAL_W: usize = 50;
+        const F_LOGICAL_H: usize = 51;
+        let Some(pointers) = self.input_override.as_ref() else {
+            return Ok(());
+        };
+        if host_i32.len() < I_BASE + pointers.len() * I_STRIDE
+            || host_f32.len() < pointers.len() * F_STRIDE
+            || host_f32.len() <= F_LOGICAL_H
+        {
+            return Err("host frame buffers are too small for live input".to_string());
+        }
+        let width = host_f32[F_LOGICAL_W];
+        let height = host_f32[F_LOGICAL_H];
+        if width <= 0.0 || height <= 0.0 {
+            return Err("live input requires a positive logical viewport".to_string());
+        }
+        host_i32[I_COUNT] = pointers.len() as i32;
+        host_i32[I_DROPPED] = 0;
+        for (slot, pointer) in pointers.iter().enumerate() {
+            if pointer.x < 0
+                || pointer.y < 0
+                || pointer.x as f32 > width
+                || pointer.y as f32 > height
+            {
+                return Err(format!(
+                    "live pointer {} is outside the {}x{} viewport",
+                    pointer.id, width, height
+                ));
+            }
+            let ib = I_BASE + slot * I_STRIDE;
+            let fb = slot * F_STRIDE;
+            host_i32[ib] = pointer.id;
+            host_i32[ib + 1] = i32::from(pointer.is_down);
+            host_i32[ib + 2] = i32::from(pointer.went_down);
+            host_i32[ib + 3] = i32::from(pointer.went_up);
+            host_f32[fb] = pointer.x as f32;
+            host_f32[fb + 1] = pointer.y as f32;
+            host_f32[fb + 2] = 0.0;
+            host_f32[fb + 3] = 0.0;
+            host_f32[fb + 4] = (pointer.x as f32 / width).clamp(0.0, 1.0);
+            host_f32[fb + 5] = (pointer.y as f32 / height).clamp(0.0, 1.0);
+        }
+        Ok(())
     }
 
     pub(crate) fn should_quit(&self) -> bool {
@@ -633,6 +696,34 @@ impl LiveWorkspace {
                 Ok((
                     "step_scheduled",
                     json!({"ticks": ticks, "after_tick": tick}),
+                ))
+            }
+            LiveCommand::CaptureFrame { artifact } => {
+                let artifact = validate_capture_artifact(&artifact)?;
+                let directory = self
+                    .config
+                    .project_root
+                    .join(&self.config.output)
+                    .join("gauntlet-captures");
+                std::fs::create_dir_all(&directory)
+                    .map_err(|error| format!("failed creating live capture directory: {error}"))?;
+                let path = directory.join(format!("{artifact}.png"));
+                if path.exists() {
+                    std::fs::remove_file(&path)
+                        .map_err(|error| format!("failed replacing prior live capture: {error}"))?;
+                }
+                stasis_dynload::schedule_runtime_screenshot(&path)?;
+                Ok((
+                    "capture_scheduled",
+                    json!({"artifact": artifact, "path": path, "next_presented_frame": true}),
+                ))
+            }
+            LiveCommand::SetInputState { pointers } => {
+                validate_live_pointers(&pointers)?;
+                self.input_override = (!pointers.is_empty()).then_some(pointers);
+                Ok((
+                    "input_state_set",
+                    json!({"pointer_count": self.input_override.as_ref().map_or(0, Vec::len)}),
                 ))
             }
             LiveCommand::Cancel { .. } => unreachable!("cancellation handled before dispatch"),
@@ -1891,6 +1982,44 @@ impl LiveWorkspace {
     }
 }
 
+fn validate_capture_artifact(value: &str) -> Result<&str, String> {
+    if value.is_empty()
+        || value.len() > 80
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(
+            "capture artifact must contain 1..=80 ASCII letters, digits, '-' or '_'".to_string(),
+        );
+    }
+    Ok(value)
+}
+
+fn validate_live_pointers(
+    pointers: &[stasis_runner::live::LivePointerInput],
+) -> Result<(), String> {
+    if pointers.len() > 8 {
+        return Err("live input supports at most eight pointers".to_string());
+    }
+    let mut ids = BTreeSet::new();
+    for pointer in pointers {
+        if pointer.id < 0 || pointer.x < 0 || pointer.y < 0 {
+            return Err("live input ids and coordinates must be non-negative".to_string());
+        }
+        if !ids.insert(pointer.id) {
+            return Err(format!("duplicate live pointer id {}", pointer.id));
+        }
+        if pointer.went_down && (!pointer.is_down || pointer.went_up) {
+            return Err("went_down requires is_down and cannot coincide with went_up".to_string());
+        }
+        if pointer.went_up && pointer.is_down {
+            return Err("went_up requires is_down=false".to_string());
+        }
+    }
+    Ok(())
+}
+
 fn is_static_type_field(item: &WorkshopCompletionItem) -> bool {
     item.kind == "field"
         && item.scope.is_none()
@@ -3073,6 +3202,34 @@ mod tests {
     use super::*;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn gauntlet_capture_ids_and_input_edges_are_bounded() {
+        assert!(validate_capture_artifact("candidate-0001").is_ok());
+        assert!(validate_capture_artifact("../escape").is_err());
+        assert!(
+            validate_live_pointers(&[stasis_runner::live::LivePointerInput {
+                id: 0,
+                x: 480,
+                y: 270,
+                is_down: true,
+                went_down: true,
+                went_up: false,
+            }])
+            .is_ok()
+        );
+        assert!(
+            validate_live_pointers(&[stasis_runner::live::LivePointerInput {
+                id: 0,
+                x: 0,
+                y: 0,
+                is_down: false,
+                went_down: true,
+                went_up: false,
+            }])
+            .is_err()
+        );
+    }
 
     fn project() -> (PathBuf, LiveRunConfig) {
         // stasis_compiler is a dependency of this test binary, so its cfg(test) JIT isolation is

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -41,6 +41,7 @@ use std::thread;
 use std::time::Duration;
 
 mod dap;
+mod gauntlet;
 mod live_tui;
 
 const MANIFEST_NAME: &str = "stasis.json";
@@ -116,6 +117,7 @@ const COMMANDS: &[&str] = &[
     "check",
     "test",
     "ai",
+    "gauntlet",
     "validate",
     "run",
     "lsp",
@@ -199,6 +201,11 @@ enum ToolchainCommand {
     Ai {
         #[arg(value_name = "PROMPT")]
         prompt: String,
+    },
+    /// Create, run, observe, and recover an autonomous live-game Gauntlet.
+    Gauntlet {
+        #[command(subcommand)]
+        command: gauntlet::GauntletCommand,
     },
     /// Boot a fresh isolated runtime and validate one scalar requirement.
     Validate {
@@ -745,6 +752,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Check => "check",
         ToolchainCommand::Test { .. } => "test",
         ToolchainCommand::Ai { .. } => "ai",
+        ToolchainCommand::Gauntlet { .. } => "gauntlet",
         ToolchainCommand::Validate { .. } => "validate",
         ToolchainCommand::ValidateRuntime { .. } => "__validate-runtime",
         ToolchainCommand::Run { .. } => "run",
@@ -779,6 +787,9 @@ fn execute(
                 .unwrap_or("stasis_game")
                 .to_string();
             create_project(root, name.unwrap_or(inferred))
+        }
+        ToolchainCommand::Gauntlet { command } => {
+            gauntlet::execute(command, workspace_arg.as_deref(), json_output)
         }
         ToolchainCommand::Version => Ok(version_result()),
         ToolchainCommand::EditorInfo => editor_info_result(),
@@ -836,6 +847,9 @@ fn execute(
                     test_workspace(&workspace, path.as_deref())
                 }
                 ToolchainCommand::Ai { prompt } => run_workspace_ai(&workspace, &prompt),
+                ToolchainCommand::Gauntlet { .. } => {
+                    unreachable!("gauntlet commands route before workspace discovery")
+                }
                 ToolchainCommand::Validate {
                     path,
                     op,
@@ -1735,7 +1749,7 @@ fn run_workspace_ai(workspace: &Workspace, prompt: &str) -> Result<CommandResult
     let ai_canceled = Arc::clone(&canceled);
     let ai = thread::spawn(move || {
         let result =
-            live_tui::run_scripted_ai_with_cancel(&client, &ai_root, &prompt, &ai_canceled);
+            live_tui::run_scripted_project_ai_with_cancel(&client, &ai_root, &prompt, &ai_canceled);
         let _ = client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
         result
     });

--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -1,0 +1,834 @@
+use super::{
+    absolute_path, bundled_stdlib_dir, create_new_project, load_workspace, CommandResult, Workspace,
+};
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+pub(super) mod assets;
+mod controller;
+
+pub(super) const GAUNTLET_CONFIG_NAME: &str = "gauntlet.json";
+pub(super) const GAUNTLET_GOAL_NAME: &str = "GAUNTLET_GOAL.md";
+const GAUNTLET_SCHEMA_VERSION: u32 = 1;
+const DEFAULT_MODEL_CALLS: u32 = 100;
+const DEFAULT_STALLED_CANDIDATES: u32 = 5;
+const DEFAULT_BUILDER_MAX_TURNS: u32 = 30;
+const MAX_GOAL_BYTES: u64 = 256 * 1024;
+const MAX_REFERENCE_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Debug, Subcommand)]
+pub(super) enum GauntletCommand {
+    /// Create a graphical Stasis project and start its first Gauntlet run.
+    New {
+        name: String,
+        #[arg(long, value_name = "PATH")]
+        dir: PathBuf,
+        #[arg(long, value_name = "PATH")]
+        goal_file: PathBuf,
+        #[arg(long, value_name = "FILE")]
+        reference: Vec<PathBuf>,
+        #[arg(long)]
+        discover_references: bool,
+        #[arg(long, conflicts_with = "jsonl")]
+        tui: bool,
+        #[arg(long, conflicts_with = "tui")]
+        jsonl: bool,
+        #[arg(long, default_value_t = 8)]
+        max_hours: u32,
+        #[arg(long, default_value_t = DEFAULT_MODEL_CALLS)]
+        max_model_calls: u32,
+    },
+    /// Improve an existing Stasis project in an isolated run branch.
+    Run {
+        #[arg(long, value_name = "PATH", default_value = GAUNTLET_CONFIG_NAME)]
+        config: PathBuf,
+        #[arg(long, value_name = "FILE")]
+        reference: Vec<PathBuf>,
+        #[arg(long)]
+        discover_references: bool,
+        #[arg(long, conflicts_with = "jsonl")]
+        tui: bool,
+        #[arg(long, conflicts_with = "tui")]
+        jsonl: bool,
+        #[arg(long)]
+        max_hours: Option<u32>,
+        #[arg(long)]
+        max_model_calls: Option<u32>,
+    },
+    /// Resume a stopped or interrupted run from its last accepted checkpoint.
+    Resume {
+        run_id: String,
+        #[arg(long, conflicts_with = "jsonl")]
+        tui: bool,
+        #[arg(long, conflicts_with = "tui")]
+        jsonl: bool,
+    },
+    /// Read one persisted run without contacting a model.
+    Status { run_id: String },
+    /// Cooperatively stop one active run.
+    Stop { run_id: String },
+    /// Integrate an accepted run branch into the original clean checkout.
+    Promote { run_id: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletConfigV1 {
+    pub schema_version: u32,
+    pub goal_file: String,
+    pub quality_bar: GauntletQualityBarConfig,
+    pub budget: GauntletBudget,
+    pub execution: GauntletExecution,
+    #[serde(default)]
+    pub models: GauntletRoleModels,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletQualityBarConfig {
+    pub allow_web_discovery: bool,
+    #[serde(default)]
+    pub references: Vec<GauntletReference>,
+    #[serde(default)]
+    pub required_scenarios: Vec<GauntletScenarioRequirement>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletReference {
+    pub path: String,
+    pub sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletScenarioRequirement {
+    pub id: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletBudget {
+    pub wall_time_minutes: u32,
+    pub model_calls: u32,
+    pub stalled_candidates: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum GauntletAutonomy {
+    Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum GauntletObserver {
+    Auto,
+    Tui,
+    Jsonl,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletExecution {
+    pub autonomy: GauntletAutonomy,
+    pub observer: GauntletObserver,
+    #[serde(default = "default_builder_max_turns")]
+    pub builder_max_turns: u32,
+    #[serde(default)]
+    pub compaction: GauntletCompaction,
+}
+
+fn default_builder_max_turns() -> u32 {
+    DEFAULT_BUILDER_MAX_TURNS
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletCompaction {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_compaction_bytes")]
+    pub max_request_bytes: usize,
+    #[serde(default = "default_compaction_retained_turns")]
+    pub retain_recent_turns: usize,
+}
+
+impl Default for GauntletCompaction {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_request_bytes: default_compaction_bytes(),
+            retain_recent_turns: default_compaction_retained_turns(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_compaction_bytes() -> usize {
+    2 * 1024 * 1024
+}
+
+fn default_compaction_retained_turns() -> usize {
+    6
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletRoleModels {
+    #[serde(default)]
+    pub scout: GauntletRoleModel,
+    #[serde(default)]
+    pub lead: GauntletRoleModel,
+    #[serde(default)]
+    pub builder: GauntletRoleModel,
+    #[serde(default)]
+    pub visual_critic: GauntletRoleModel,
+    #[serde(default)]
+    pub gameplay_critic: GauntletRoleModel,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletRoleModel {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum GauntletRunPhase {
+    Created,
+    DiscoveringBar,
+    Planning,
+    Building,
+    Evaluating,
+    Checkpointing,
+    Converged,
+    BudgetExhausted,
+    Stalled,
+    Canceled,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletRunStateV1 {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub phase: GauntletRunPhase,
+    pub project_root: String,
+    pub original_root: String,
+    pub branch: String,
+    pub base_commit: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub best_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_workstream: Option<String>,
+    pub model_calls: u32,
+    pub accepted_candidates: u32,
+    pub rejected_candidates: u32,
+    pub consecutive_stalls: u32,
+    pub started_unix_ms: u64,
+    pub updated_unix_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
+}
+
+impl GauntletConfigV1 {
+    fn new(
+        allow_web_discovery: bool,
+        references: Vec<GauntletReference>,
+        max_hours: u32,
+        max_model_calls: u32,
+        observer: GauntletObserver,
+    ) -> Result<Self, String> {
+        let wall_time_minutes = max_hours
+            .checked_mul(60)
+            .ok_or_else(|| "Gauntlet max-hours is too large".to_string())?;
+        let config = Self {
+            schema_version: GAUNTLET_SCHEMA_VERSION,
+            goal_file: GAUNTLET_GOAL_NAME.to_string(),
+            quality_bar: GauntletQualityBarConfig {
+                allow_web_discovery,
+                references,
+                required_scenarios: Vec::new(),
+            },
+            budget: GauntletBudget {
+                wall_time_minutes,
+                model_calls: max_model_calls,
+                stalled_candidates: DEFAULT_STALLED_CANDIDATES,
+            },
+            execution: GauntletExecution {
+                autonomy: GauntletAutonomy::Full,
+                observer,
+                builder_max_turns: DEFAULT_BUILDER_MAX_TURNS,
+                compaction: GauntletCompaction::default(),
+            },
+            models: GauntletRoleModels::default(),
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub(super) fn validate(&self) -> Result<(), String> {
+        if self.schema_version != GAUNTLET_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported Gauntlet schema version {}; expected {GAUNTLET_SCHEMA_VERSION}",
+                self.schema_version
+            ));
+        }
+        validate_relative_path("goal_file", Path::new(&self.goal_file))?;
+        if self.budget.wall_time_minutes == 0
+            || self.budget.model_calls == 0
+            || self.budget.stalled_candidates == 0
+        {
+            return Err("Gauntlet budgets must be greater than zero".to_string());
+        }
+        if self.execution.builder_max_turns == 0
+            || self.execution.builder_max_turns as usize > stasis_ai::MAX_AGENT_TURNS
+        {
+            return Err(format!(
+                "Gauntlet builder_max_turns must be between 1 and {}",
+                stasis_ai::MAX_AGENT_TURNS
+            ));
+        }
+        if self.execution.compaction.enabled
+            && (!(stasis_ai::MIN_COMPACTION_BYTES..=stasis_ai::MAX_COMPACTION_BYTES)
+                .contains(&self.execution.compaction.max_request_bytes)
+                || self.execution.compaction.retain_recent_turns == 0
+                || self.execution.compaction.retain_recent_turns
+                    > stasis_ai::MAX_COMPACTION_RETAINED_TURNS)
+        {
+            return Err(format!(
+                "Gauntlet compaction requires max_request_bytes between {} and {} and retain_recent_turns between 1 and {}",
+                stasis_ai::MIN_COMPACTION_BYTES,
+                stasis_ai::MAX_COMPACTION_BYTES,
+                stasis_ai::MAX_COMPACTION_RETAINED_TURNS
+            ));
+        }
+        for (role, profile) in [
+            ("scout", &self.models.scout),
+            ("lead", &self.models.lead),
+            ("builder", &self.models.builder),
+            ("visual_critic", &self.models.visual_critic),
+            ("gameplay_critic", &self.models.gameplay_critic),
+        ] {
+            profile.validate(role)?;
+        }
+        for reference in &self.quality_bar.references {
+            validate_relative_path("reference path", Path::new(&reference.path))?;
+            validate_sha256(&reference.sha256)?;
+        }
+        for scenario in &self.quality_bar.required_scenarios {
+            if scenario.id.trim().is_empty() || scenario.description.trim().is_empty() {
+                return Err("Gauntlet scenarios require non-empty id and description".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl GauntletRoleModel {
+    fn validate(&self, role: &str) -> Result<(), String> {
+        for (field, value) in [
+            ("model", self.model.as_deref()),
+            ("reasoning_effort", self.reasoning_effort.as_deref()),
+        ] {
+            if let Some(value) = value {
+                if value.trim().is_empty()
+                    || value.len() > 128
+                    || !value.bytes().all(|byte| {
+                        byte.is_ascii_alphanumeric()
+                            || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+                    })
+                {
+                    return Err(format!(
+                        "Gauntlet models.{role}.{field} contains an invalid model setting"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn execute(
+    command: GauntletCommand,
+    workspace_arg: Option<&Path>,
+    json_output: bool,
+) -> Result<CommandResult, String> {
+    match command {
+        GauntletCommand::New {
+            name,
+            dir,
+            goal_file,
+            reference,
+            discover_references,
+            tui,
+            jsonl,
+            max_hours,
+            max_model_calls,
+        } => create_and_start(NewOptions {
+            name,
+            dir,
+            goal_file,
+            references: reference,
+            discover_references,
+            observer: selected_observer(tui, jsonl),
+            max_hours,
+            max_model_calls,
+        }),
+        GauntletCommand::Run {
+            config,
+            reference,
+            discover_references,
+            tui,
+            jsonl,
+            max_hours,
+            max_model_calls,
+        } => {
+            let workspace = load_workspace(workspace_arg)?;
+            start_existing(
+                &workspace,
+                &config,
+                &reference,
+                discover_references,
+                selected_observer(tui, jsonl),
+                max_hours,
+                max_model_calls,
+            )
+        }
+        GauntletCommand::Resume { run_id, tui, jsonl } => {
+            let workspace = load_workspace(workspace_arg)?;
+            resume(&workspace, &run_id, selected_observer(tui, jsonl))
+        }
+        GauntletCommand::Status { run_id } => {
+            let workspace = load_workspace(workspace_arg)?;
+            status(&workspace, &run_id)
+        }
+        GauntletCommand::Stop { run_id } => {
+            let workspace = load_workspace(workspace_arg)?;
+            stop(&workspace, &run_id)
+        }
+        GauntletCommand::Promote { run_id } => {
+            let workspace = load_workspace(workspace_arg)?;
+            promote(&workspace, &run_id, json_output)
+        }
+    }
+}
+
+struct NewOptions {
+    name: String,
+    dir: PathBuf,
+    goal_file: PathBuf,
+    references: Vec<PathBuf>,
+    discover_references: bool,
+    observer: GauntletObserver,
+    max_hours: u32,
+    max_model_calls: u32,
+}
+
+fn create_and_start(options: NewOptions) -> Result<CommandResult, String> {
+    if options.max_hours == 0 || options.max_model_calls == 0 {
+        return Err("Gauntlet budgets must be greater than zero".to_string());
+    }
+    let goal = read_bounded_utf8(&options.goal_file, MAX_GOAL_BYTES, "Gauntlet goal")?;
+    if goal.trim().is_empty() {
+        return Err("Gauntlet goal must not be empty".to_string());
+    }
+    let root = absolute_path(&options.dir)?;
+    create_new_project(root.clone(), options.name)?;
+    write_graphical_seed(&root)?;
+    fs::write(root.join(GAUNTLET_GOAL_NAME), normalized_text_file(&goal))
+        .map_err(|error| format!("failed writing Gauntlet goal: {error}"))?;
+    let references = import_references(&root, &options.references)?;
+    let config = GauntletConfigV1::new(
+        options.discover_references || references.is_empty(),
+        references,
+        options.max_hours,
+        options.max_model_calls,
+        options.observer,
+    )?;
+    write_json(&root.join(GAUNTLET_CONFIG_NAME), &config)?;
+    let workspace = load_workspace(Some(&root))?;
+    start_existing(
+        &workspace,
+        Path::new(GAUNTLET_CONFIG_NAME),
+        &[],
+        false,
+        config.execution.observer.clone(),
+        None,
+        None,
+    )
+}
+
+fn selected_observer(tui: bool, jsonl: bool) -> GauntletObserver {
+    if tui {
+        GauntletObserver::Tui
+    } else if jsonl {
+        GauntletObserver::Jsonl
+    } else {
+        GauntletObserver::Auto
+    }
+}
+
+fn write_graphical_seed(root: &Path) -> Result<(), String> {
+    fs::create_dir_all(root.join("assets"))
+        .map_err(|error| format!("failed creating Gauntlet assets: {error}"))?;
+    fs::create_dir_all(root.join("runtime"))
+        .map_err(|error| format!("failed creating Gauntlet runtime source directory: {error}"))?;
+    let stdlib = bundled_stdlib_dir()?;
+    let runtime_gfx = stdlib
+        .parent()
+        .ok_or_else(|| "bundled stdlib has no source parent".to_string())?
+        .join("runtime/gfx_cmd.stasis");
+    fs::copy(&runtime_gfx, root.join("runtime/gfx_cmd.stasis")).map_err(|error| {
+        format!(
+            "failed copying graphical command-buffer module {}: {error}",
+            runtime_gfx.display()
+        )
+    })?;
+    fs::write(root.join("src/main.stasis"), GAUNTLET_SEED_SOURCE)
+        .map_err(|error| format!("failed writing Gauntlet seed source: {error}"))?;
+    fs::write(root.join("tests/main.test.stasis"), GAUNTLET_SEED_TEST)
+        .map_err(|error| format!("failed writing Gauntlet seed test: {error}"))?;
+    fs::write(root.join("assets/manifest.json"), EMPTY_ASSET_MANIFEST)
+        .map_err(|error| format!("failed writing Gauntlet asset manifest: {error}"))?;
+    Ok(())
+}
+
+fn import_references(root: &Path, paths: &[PathBuf]) -> Result<Vec<GauntletReference>, String> {
+    let destination = root.join("build/gauntlet/bootstrap-references");
+    let mut imported = Vec::with_capacity(paths.len());
+    for (index, path) in paths.iter().enumerate() {
+        let absolute = absolute_path(path)?;
+        let bytes = read_bounded_bytes(&absolute, MAX_REFERENCE_BYTES, "Gauntlet reference")?;
+        let extension = image_extension(&absolute)?;
+        fs::create_dir_all(&destination)
+            .map_err(|error| format!("failed creating Gauntlet reference directory: {error}"))?;
+        let hash = hex_sha256(&bytes);
+        let relative = format!(
+            "build/gauntlet/bootstrap-references/reference-{index}-{}.{}",
+            &hash[..12],
+            extension
+        );
+        fs::write(root.join(&relative), bytes)
+            .map_err(|error| format!("failed copying Gauntlet reference: {error}"))?;
+        imported.push(GauntletReference {
+            path: relative,
+            sha256: hash,
+            source_url: None,
+        });
+    }
+    Ok(imported)
+}
+
+fn image_extension(path: &Path) -> Result<&'static str, String> {
+    match path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("png") => Ok("png"),
+        Some("jpg") | Some("jpeg") => Ok("jpg"),
+        Some("webp") => Ok("webp"),
+        _ => Err(format!(
+            "Gauntlet reference must be PNG, JPEG, or WebP: {}",
+            path.display()
+        )),
+    }
+}
+
+fn read_bounded_utf8(path: &Path, limit: u64, label: &str) -> Result<String, String> {
+    let bytes = read_bounded_bytes(path, limit, label)?;
+    String::from_utf8(bytes).map_err(|_| format!("{label} is not valid UTF-8"))
+}
+
+fn read_bounded_bytes(path: &Path, limit: u64, label: &str) -> Result<Vec<u8>, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|error| format!("failed reading {label} {}: {error}", path.display()))?;
+    if !metadata.is_file() || metadata.len() > limit {
+        return Err(format!(
+            "{label} must be a regular file no larger than {limit} bytes: {}",
+            path.display()
+        ));
+    }
+    let file = fs::File::open(path)
+        .map_err(|error| format!("failed opening {label} {}: {error}", path.display()))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(limit + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed reading {label} {}: {error}", path.display()))?;
+    if bytes.len() as u64 > limit {
+        return Err(format!("{label} exceeds {limit} bytes"));
+    }
+    Ok(bytes)
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("failed serializing {}: {error}", path.display()))?;
+    bytes.push(b'\n');
+    fs::write(path, bytes).map_err(|error| format!("failed writing {}: {error}", path.display()))
+}
+
+fn normalized_text_file(source: &str) -> String {
+    let normalized = source.replace("\r\n", "\n").replace('\r', "\n");
+    format!("{}\n", normalized.trim_end())
+}
+
+fn validate_relative_path(field: &str, path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(format!("{field} must be a non-empty project-relative path"));
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_) | Component::CurDir))
+    {
+        return Err(format!(
+            "{field} must not contain parent or rooted components"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str) -> Result<(), String> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("Gauntlet reference sha256 must contain 64 hexadecimal characters".to_string());
+    }
+    Ok(())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+const GAUNTLET_SEED_SOURCE: &str = r#"@link("stasis_graphics");
+import "../runtime/gfx_cmd.stasis";
+
+global host_req_flags: i32;
+global host_req_window_w_px: i32;
+global host_req_window_h_px: i32;
+global host_req_seq: i32;
+
+struct Game {
+    ticks: i32;
+    swaps: i32;
+}
+
+global game: Game;
+
+function main(): i32 {
+    host_req_flags = 1;
+    host_req_window_w_px = 960;
+    host_req_window_h_px = 540;
+    host_req_seq += 1;
+    game.ticks = 0;
+    game.swaps = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    game.ticks += 1;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_begin();
+    gfx_cmd_clear(0.025, 0.035, 0.06, 1.0);
+    gfx_cmd_line(320.0, 270.0, 640.0, 270.0, 0.18, 0.72, 0.92, 1.0);
+    gfx_cmd_line(480.0, 190.0, 480.0, 350.0, 0.18, 0.72, 0.92, 1.0);
+    gfx_cmd_mark_present();
+    return 0;
+}
+
+function on_code_swap(): void {
+    game.swaps += 1;
+    return;
+}
+"#;
+
+const GAUNTLET_SEED_TEST: &str = r#"import "../src/main.stasis";
+
+test `Gauntlet seed advances deterministically`(): bool {
+    game.ticks = 0;
+    tick();
+    tick();
+    return game.ticks == 2;
+}
+
+test `Gauntlet seed emits a visible frame`(): bool {
+    render();
+    if (gfx_cmd_i32[GFX_I_MAGIC] != GFX_CMD_MAGIC) { return false; }
+    if (gfx_cmd_i32[GFX_I_LINE_COUNT] != 2) { return false; }
+    return gfx_cmd_i32[GFX_I_FLAGS] == GFX_FLAG_CLEAR + GFX_FLAG_PRESENT;
+}
+"#;
+
+const EMPTY_ASSET_MANIFEST: &str = r#"{
+  "schema": "stasis-assets",
+  "version": 2,
+  "display": {
+    "logical_width": 960,
+    "logical_height": 540,
+    "max_physical_width": 1920,
+    "max_physical_height": 1080,
+    "scale_mode": "fit"
+  },
+  "assets": []
+}
+"#;
+
+fn start_existing(
+    workspace: &Workspace,
+    config_path: &Path,
+    references: &[PathBuf],
+    discover_references: bool,
+    observer: GauntletObserver,
+    max_hours: Option<u32>,
+    max_model_calls: Option<u32>,
+) -> Result<CommandResult, String> {
+    controller::start(
+        workspace,
+        config_path,
+        references,
+        discover_references,
+        observer,
+        max_hours,
+        max_model_calls,
+    )
+}
+
+fn resume(
+    workspace: &Workspace,
+    run_id: &str,
+    observer: GauntletObserver,
+) -> Result<CommandResult, String> {
+    controller::resume(workspace, run_id, observer)
+}
+
+fn status(workspace: &Workspace, run_id: &str) -> Result<CommandResult, String> {
+    controller::status(workspace, run_id)
+}
+
+fn stop(workspace: &Workspace, run_id: &str) -> Result<CommandResult, String> {
+    controller::stop(workspace, run_id)
+}
+
+fn promote(
+    workspace: &Workspace,
+    run_id: &str,
+    json_output: bool,
+) -> Result<CommandResult, String> {
+    controller::promote(workspace, run_id, json_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn config_defaults_match_the_product_contract() {
+        let config = GauntletConfigV1::new(
+            true,
+            Vec::new(),
+            8,
+            DEFAULT_MODEL_CALLS,
+            GauntletObserver::Auto,
+        )
+        .expect("config");
+        assert_eq!(config.budget.wall_time_minutes, 8 * 60);
+        assert_eq!(config.budget.model_calls, 100);
+        assert_eq!(config.budget.stalled_candidates, 5);
+        assert_eq!(config.execution.autonomy, GauntletAutonomy::Full);
+        assert_eq!(config.execution.builder_max_turns, 30);
+        assert!(config.execution.compaction.enabled);
+        assert_eq!(
+            config.execution.compaction.max_request_bytes,
+            2 * 1024 * 1024
+        );
+        assert_eq!(config.execution.compaction.retain_recent_turns, 6);
+        assert!(config.models.builder.model.is_none());
+    }
+
+    #[test]
+    fn config_rejects_unknown_fields_and_zero_budgets() {
+        let source = r#"{
+            "schema_version":1,
+            "goal_file":"GAUNTLET_GOAL.md",
+            "quality_bar":{"allow_web_discovery":true,"references":[],"required_scenarios":[]},
+            "budget":{"wall_time_minutes":0,"model_calls":1,"stalled_candidates":1},
+            "execution":{"autonomy":"full","observer":"auto"},
+            "surprise":true
+        }"#;
+        assert!(serde_json::from_str::<GauntletConfigV1>(source).is_err());
+
+        let mut config = GauntletConfigV1::new(true, Vec::new(), 8, 100, GauntletObserver::Auto)
+            .expect("config");
+        config.budget.model_calls = 0;
+        assert!(config.validate().is_err());
+        config.budget.model_calls = 100;
+        config.execution.builder_max_turns = 49;
+        assert!(config.validate().is_err());
+        config.execution.builder_max_turns = 30;
+        config.execution.compaction.max_request_bytes = 1;
+        assert!(config.validate().is_err());
+        config.execution.compaction = GauntletCompaction::default();
+        config.models.scout.model = Some("bad model with spaces".to_string());
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn seed_has_the_required_graphical_lifecycle() {
+        for required in [
+            "function main(): i32",
+            "function tick(): i32",
+            "function render(): i32",
+            "function on_code_swap(): void",
+            "gfx_cmd_mark_present()",
+        ] {
+            assert!(GAUNTLET_SEED_SOURCE.contains(required), "{required}");
+        }
+    }
+
+    #[test]
+    fn graphical_seed_compiles_and_its_tests_execute_through_jit() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_seed_{}_{}",
+            std::process::id(),
+            stamp
+        ));
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(root.clone());
+        create_new_project(root.clone(), "gauntlet_seed_test".to_string())
+            .expect("create seed project");
+        write_graphical_seed(&root).expect("write graphical seed");
+        let workspace = load_workspace(Some(&root)).expect("load seed workspace");
+        super::super::check_workspace(&workspace).expect("seed compiles through JIT");
+        super::super::test_workspace(&workspace, None).expect("seed tests execute through JIT");
+    }
+}

--- a/apps/stasis/src/toolchain_cli/gauntlet/assets.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet/assets.rs
@@ -1,0 +1,622 @@
+use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use stasis_ai::ToolCall;
+use stasis_assets::{
+    load_project_asset_manifest, AssetEntry, AssetFormat, AssetLimits, AssetManifest,
+    AudioEncoding, SpriteEncoding, DEFAULT_ASSET_MANIFEST_PATH,
+};
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::Cursor;
+use std::path::{Component, Path, PathBuf};
+
+const MAX_TEXT_ASSET_BYTES: usize = 256 * 1024;
+const MAX_PNG_ASSET_BYTES: u64 = 16 * 1024 * 1024;
+
+pub(crate) struct AppliedAssetTransaction {
+    backups: Vec<(PathBuf, Option<Vec<u8>>)>,
+}
+
+impl AppliedAssetTransaction {
+    pub(crate) fn rollback(self) -> Result<(), String> {
+        for (path, prior) in self.backups.into_iter().rev() {
+            match prior {
+                Some(bytes) => fs::write(&path, bytes)
+                    .map_err(|error| format!("failed restoring {}: {error}", path.display()))?,
+                None if path.exists() => fs::remove_file(&path)
+                    .map_err(|error| format!("failed removing {}: {error}", path.display()))?,
+                None => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn apply_asset_calls(
+    project_root: &Path,
+    calls: &[&ToolCall],
+) -> Result<AppliedAssetTransaction, String> {
+    let manifest_path = project_root.join(DEFAULT_ASSET_MANIFEST_PATH);
+    let manifest_source = fs::read(&manifest_path)
+        .map_err(|error| format!("failed reading asset manifest: {error}"))?;
+    let mut manifest: AssetManifest = serde_json::from_slice(&manifest_source)
+        .map_err(|error| format!("invalid asset manifest: {error}"))?;
+    let mut writes = Vec::<(PathBuf, Vec<u8>)>::new();
+    let mut touched = BTreeSet::new();
+    for call in calls {
+        let args = call
+            .args
+            .as_object()
+            .ok_or_else(|| "asset args must be an object".to_string())?;
+        let relative = required_string(args, "path")?;
+        let path = controlled_asset_path(project_root, &relative, call.tool.as_str())?;
+        if !touched.insert(path.clone()) {
+            return Err(format!("asset path appears more than once: {relative}"));
+        }
+        match call.tool.as_str() {
+            "write_svg_asset" => {
+                let id = controlled_id(&required_string(args, "id")?)?;
+                let source = required_string(args, "source")?;
+                let width = required_u32(args, "width", 1, 4096)?;
+                let height = required_u32(args, "height", 1, 4096)?;
+                validate_svg(&source)?;
+                let bytes = source.into_bytes();
+                upsert_entry(
+                    &mut manifest,
+                    AssetEntry {
+                        id,
+                        path: relative.replace('\\', "/"),
+                        content_sha256: sha256(&bytes),
+                        prepared_from_sha256: None,
+                        format: AssetFormat::Sprite {
+                            encoding: SpriteEncoding::Svg,
+                            width,
+                            height,
+                        },
+                        prepare: None,
+                        dependencies: Vec::new(),
+                    },
+                );
+                writes.push((path, bytes));
+            }
+            "write_png_asset" => {
+                let id = controlled_id(&required_string(args, "id")?)?;
+                let width = required_u32(args, "width", 1, 2048)?;
+                let height = required_u32(args, "height", 1, 2048)?;
+                if u64::from(width) * u64::from(height) > 4_194_304 {
+                    return Err("PNG asset exceeds the 4,194,304-pixel limit".to_string());
+                }
+                let background = parse_color(&required_string(args, "background")?)?;
+                let shapes = args
+                    .get("shapes")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| "PNG asset shapes must be an array".to_string())?;
+                if shapes.len() > 512 {
+                    return Err("PNG asset supports at most 512 shapes".to_string());
+                }
+                let bytes = render_png(width, height, background, shapes)?;
+                upsert_entry(
+                    &mut manifest,
+                    AssetEntry {
+                        id,
+                        path: relative.replace('\\', "/"),
+                        content_sha256: sha256(&bytes),
+                        prepared_from_sha256: None,
+                        format: AssetFormat::Sprite {
+                            encoding: SpriteEncoding::Png,
+                            width,
+                            height,
+                        },
+                        prepare: None,
+                        dependencies: Vec::new(),
+                    },
+                );
+                writes.push((path, bytes));
+            }
+            "import_png_asset" => {
+                let id = controlled_id(&required_string(args, "id")?)?;
+                let source = required_string(args, "source_path")?;
+                let (bytes, width, height) = load_imagegen_png(project_root, &source)?;
+                upsert_entry(
+                    &mut manifest,
+                    AssetEntry {
+                        id,
+                        path: relative.replace('\\', "/"),
+                        content_sha256: sha256(&bytes),
+                        prepared_from_sha256: None,
+                        format: AssetFormat::Sprite {
+                            encoding: SpriteEncoding::Png,
+                            width,
+                            height,
+                        },
+                        prepare: None,
+                        dependencies: Vec::new(),
+                    },
+                );
+                writes.push((path, bytes));
+            }
+            "write_data_asset" => {
+                let source = required_string(args, "source")?;
+                if source.len() > MAX_TEXT_ASSET_BYTES {
+                    return Err("data asset exceeds 256 KiB".to_string());
+                }
+                if path
+                    .extension()
+                    .is_some_and(|value| value.eq_ignore_ascii_case("json"))
+                {
+                    serde_json::from_str::<Value>(&source)
+                        .map_err(|error| format!("invalid JSON data asset: {error}"))?;
+                }
+                writes.push((path, source.into_bytes()));
+            }
+            "write_procedural_wav" => {
+                let id = controlled_id(&required_string(args, "id")?)?;
+                let frequency = required_u32(args, "frequency_hz", 20, 8_000)?;
+                let duration_ms = required_u32(args, "duration_ms", 20, 5_000)?;
+                let (bytes, frames) = procedural_wav(frequency, duration_ms);
+                upsert_entry(
+                    &mut manifest,
+                    AssetEntry {
+                        id,
+                        path: relative.replace('\\', "/"),
+                        content_sha256: sha256(&bytes),
+                        prepared_from_sha256: None,
+                        format: AssetFormat::Audio {
+                            encoding: AudioEncoding::Wav,
+                            sample_rate: 44_100,
+                            channels: 1,
+                            duration_frames: frames,
+                        },
+                        prepare: None,
+                        dependencies: Vec::new(),
+                    },
+                );
+                writes.push((path, bytes));
+            }
+            _ => return Err(format!("unsupported Gauntlet asset tool: {}", call.tool)),
+        }
+    }
+    let mut manifest_bytes = serde_json::to_vec_pretty(&manifest)
+        .map_err(|error| format!("failed encoding asset manifest: {error}"))?;
+    manifest_bytes.push(b'\n');
+    writes.push((manifest_path, manifest_bytes));
+    let mut backups = Vec::with_capacity(writes.len());
+    for (path, bytes) in &writes {
+        if path
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            restore(&backups)?;
+            return Err(format!(
+                "refusing to write through asset symlink: {}",
+                path.display()
+            ));
+        }
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("failed creating asset directory: {error}"))?;
+        }
+        let prior = fs::read(path).ok();
+        backups.push((path.clone(), prior));
+        if let Err(error) = fs::write(path, bytes) {
+            restore(&backups)?;
+            return Err(format!("failed staging asset {}: {error}", path.display()));
+        }
+    }
+    if let Err(error) = load_project_asset_manifest(project_root, AssetLimits::default()) {
+        restore(&backups)?;
+        return Err(format!("asset transaction validation failed: {error}"));
+    }
+    if let Err(error) = sync_prepared_assets(project_root, &writes, &mut backups) {
+        restore(&backups)?;
+        return Err(error);
+    }
+    Ok(AppliedAssetTransaction { backups })
+}
+
+fn sync_prepared_assets(
+    project_root: &Path,
+    writes: &[(PathBuf, Vec<u8>)],
+    backups: &mut Vec<(PathBuf, Option<Vec<u8>>)>,
+) -> Result<(), String> {
+    let prepared = project_root.join(".stasis_cache/play-assets");
+    if !prepared.is_dir() {
+        return Ok(());
+    }
+    for (source, bytes) in writes {
+        let relative = source
+            .strip_prefix(project_root)
+            .map_err(|_| "asset transaction escaped the project".to_string())?;
+        let destination = prepared.join(relative);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("failed creating prepared asset directory: {error}"))?;
+        }
+        backups.push((destination.clone(), fs::read(&destination).ok()));
+        fs::write(&destination, bytes)
+            .map_err(|error| format!("failed synchronizing prepared asset: {error}"))?;
+    }
+    Ok(())
+}
+
+fn restore(backups: &[(PathBuf, Option<Vec<u8>>)]) -> Result<(), String> {
+    for (path, prior) in backups.iter().rev() {
+        match prior {
+            Some(bytes) => fs::write(path, bytes)
+                .map_err(|error| format!("failed rolling back {}: {error}", path.display()))?,
+            None if path.exists() => fs::remove_file(path)
+                .map_err(|error| format!("failed rolling back {}: {error}", path.display()))?,
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+fn controlled_asset_path(root: &Path, relative: &str, tool: &str) -> Result<PathBuf, String> {
+    let relative = Path::new(relative);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        || !relative.starts_with("assets/generated")
+    {
+        return Err("Gauntlet assets must be normal paths under assets/generated".to_string());
+    }
+    let valid_extension = match tool {
+        "write_svg_asset" => relative
+            .extension()
+            .is_some_and(|value| value.eq_ignore_ascii_case("svg")),
+        "write_png_asset" | "import_png_asset" => relative
+            .extension()
+            .is_some_and(|value| value.eq_ignore_ascii_case("png")),
+        "write_data_asset" => relative.extension().is_some_and(|value| {
+            value.eq_ignore_ascii_case("json") || value.eq_ignore_ascii_case("csv")
+        }),
+        "write_procedural_wav" => relative
+            .extension()
+            .is_some_and(|value| value.eq_ignore_ascii_case("wav")),
+        _ => false,
+    };
+    if !valid_extension {
+        return Err(format!("invalid file extension for {tool}"));
+    }
+    Ok(root.join(relative))
+}
+
+fn load_imagegen_png(root: &Path, relative: &str) -> Result<(Vec<u8>, u32, u32), String> {
+    let relative = Path::new(relative);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+        || !(relative.starts_with("build/ai-assets/imagegen")
+            || relative.starts_with("build/gauntlet/imagegen"))
+        || !relative
+            .extension()
+            .is_some_and(|value| value.eq_ignore_ascii_case("png"))
+    {
+        return Err(
+            "ImageGen input must be a normal PNG path under build/ai-assets/imagegen or build/gauntlet/imagegen"
+                .to_string(),
+        );
+    }
+    let path = root.join(relative);
+    let metadata = path
+        .symlink_metadata()
+        .map_err(|error| format!("failed reading ImageGen PNG {}: {error}", path.display()))?;
+    if !metadata.is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.len() > MAX_PNG_ASSET_BYTES
+    {
+        return Err(
+            "ImageGen PNG must be a regular non-symlink file no larger than 16 MiB".to_string(),
+        );
+    }
+    let bytes = fs::read(&path)
+        .map_err(|error| format!("failed reading ImageGen PNG {}: {error}", path.display()))?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(2048);
+    limits.max_image_height = Some(2048);
+    limits.max_alloc = Some(32 * 1024 * 1024);
+    let mut reader = image::ImageReader::with_format(Cursor::new(&bytes), ImageFormat::Png);
+    reader.limits(limits);
+    let decoded = reader
+        .decode()
+        .map_err(|error| format!("invalid or oversized ImageGen PNG: {error}"))?;
+    let width = decoded.width();
+    let height = decoded.height();
+    if u64::from(width) * u64::from(height) > 4_194_304 {
+        return Err("ImageGen PNG exceeds the 4,194,304-pixel limit".to_string());
+    }
+    Ok((bytes, width, height))
+}
+
+fn render_png(
+    width: u32,
+    height: u32,
+    background: Rgba<u8>,
+    shapes: &[Value],
+) -> Result<Vec<u8>, String> {
+    let mut image = RgbaImage::from_pixel(width, height, background);
+    for (index, shape) in shapes.iter().enumerate() {
+        let shape = shape
+            .as_object()
+            .ok_or_else(|| format!("PNG shape {index} must be an object"))?;
+        let kind = shape
+            .get("kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("PNG shape {index} requires kind"))?;
+        let color = parse_color(
+            shape
+                .get("color")
+                .and_then(Value::as_str)
+                .ok_or_else(|| format!("PNG shape {index} requires color"))?,
+        )?;
+        match kind {
+            "rect" => draw_rect(
+                &mut image,
+                shape_i32(shape, "x", index)?,
+                shape_i32(shape, "y", index)?,
+                shape_u32(shape, "width", index, 1, 4096)?,
+                shape_u32(shape, "height", index, 1, 4096)?,
+                color,
+            ),
+            "circle" => draw_circle(
+                &mut image,
+                shape_i32(shape, "x", index)?,
+                shape_i32(shape, "y", index)?,
+                shape_u32(shape, "radius", index, 1, 2048)? as i32,
+                color,
+            ),
+            "line" => draw_line(
+                &mut image,
+                shape_i32(shape, "x1", index)?,
+                shape_i32(shape, "y1", index)?,
+                shape_i32(shape, "x2", index)?,
+                shape_i32(shape, "y2", index)?,
+                shape_u32(shape, "thickness", index, 1, 128)? as i32,
+                color,
+            ),
+            _ => return Err(format!("PNG shape {index} has unsupported kind {kind}")),
+        }
+    }
+    let mut output = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(image)
+        .write_to(&mut output, ImageFormat::Png)
+        .map_err(|error| format!("failed encoding PNG asset: {error}"))?;
+    Ok(output.into_inner())
+}
+
+fn draw_rect(image: &mut RgbaImage, x: i32, y: i32, width: u32, height: u32, color: Rgba<u8>) {
+    for py in y..y.saturating_add(height as i32) {
+        for px in x..x.saturating_add(width as i32) {
+            put_pixel_clipped(image, px, py, color);
+        }
+    }
+}
+
+fn draw_circle(image: &mut RgbaImage, x: i32, y: i32, radius: i32, color: Rgba<u8>) {
+    let radius_squared = i64::from(radius) * i64::from(radius);
+    for py in y.saturating_sub(radius)..=y.saturating_add(radius) {
+        for px in x.saturating_sub(radius)..=x.saturating_add(radius) {
+            let dx = i64::from(px) - i64::from(x);
+            let dy = i64::from(py) - i64::from(y);
+            if dx * dx + dy * dy <= radius_squared {
+                put_pixel_clipped(image, px, py, color);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_line(
+    image: &mut RgbaImage,
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    thickness: i32,
+    color: Rgba<u8>,
+) {
+    let dx = x2.saturating_sub(x1);
+    let dy = y2.saturating_sub(y1);
+    let steps = dx.unsigned_abs().max(dy.unsigned_abs()).max(1);
+    for step in 0..=steps {
+        let t = f64::from(step) / f64::from(steps);
+        let x = (f64::from(x1) + f64::from(dx) * t).round() as i32;
+        let y = (f64::from(y1) + f64::from(dy) * t).round() as i32;
+        draw_circle(image, x, y, (thickness / 2).max(1), color);
+    }
+}
+
+fn put_pixel_clipped(image: &mut RgbaImage, x: i32, y: i32, color: Rgba<u8>) {
+    if x >= 0 && y >= 0 && (x as u32) < image.width() && (y as u32) < image.height() {
+        image.put_pixel(x as u32, y as u32, color);
+    }
+}
+
+fn parse_color(value: &str) -> Result<Rgba<u8>, String> {
+    let hex = value.strip_prefix('#').unwrap_or(value);
+    if !matches!(hex.len(), 6 | 8) || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("PNG colors must be #RRGGBB or #RRGGBBAA".to_string());
+    }
+    let channel =
+        |start| u8::from_str_radix(&hex[start..start + 2], 16).map_err(|error| error.to_string());
+    Ok(Rgba([
+        channel(0)?,
+        channel(2)?,
+        channel(4)?,
+        if hex.len() == 8 { channel(6)? } else { 255 },
+    ]))
+}
+
+fn shape_i32(
+    shape: &serde_json::Map<String, Value>,
+    name: &str,
+    index: usize,
+) -> Result<i32, String> {
+    shape
+        .get(name)
+        .and_then(Value::as_i64)
+        .and_then(|value| i32::try_from(value).ok())
+        .filter(|value| (-4096..=4096).contains(value))
+        .ok_or_else(|| format!("PNG shape {index} arg {name} must be between -4096 and 4096"))
+}
+
+fn shape_u32(
+    shape: &serde_json::Map<String, Value>,
+    name: &str,
+    index: usize,
+    min: u32,
+    max: u32,
+) -> Result<u32, String> {
+    shape
+        .get(name)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| (*value >= min) && (*value <= max))
+        .ok_or_else(|| format!("PNG shape {index} arg {name} must be between {min} and {max}"))
+}
+
+fn controlled_id(value: &str) -> Result<String, String> {
+    if value.is_empty()
+        || value.len() > 80
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err("asset id must contain 1..=80 ASCII letters, digits, '_' or '-'".to_string());
+    }
+    Ok(value.to_string())
+}
+
+fn validate_svg(source: &str) -> Result<(), String> {
+    if source.len() > MAX_TEXT_ASSET_BYTES || !source.trim_start().starts_with("<svg") {
+        return Err("SVG must start with <svg and be no larger than 256 KiB".to_string());
+    }
+    let lower = source.to_ascii_lowercase();
+    for forbidden in ["<script", "<!doctype", "href=\"http", "href='http"] {
+        if lower.contains(forbidden) {
+            return Err(format!("SVG contains forbidden content: {forbidden}"));
+        }
+    }
+    Ok(())
+}
+
+fn upsert_entry(manifest: &mut AssetManifest, entry: AssetEntry) {
+    if let Some(existing) = manifest
+        .assets
+        .iter_mut()
+        .find(|existing| existing.id == entry.id)
+    {
+        *existing = entry;
+    } else {
+        manifest.assets.push(entry);
+    }
+    manifest.assets.sort_by(|a, b| a.id.cmp(&b.id));
+}
+
+fn required_string(args: &serde_json::Map<String, Value>, name: &str) -> Result<String, String> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("asset tool requires non-empty string arg: {name}"))
+}
+
+fn required_u32(
+    args: &serde_json::Map<String, Value>,
+    name: &str,
+    min: u32,
+    max: u32,
+) -> Result<u32, String> {
+    args.get(name)
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| (*value >= min) && (*value <= max))
+        .ok_or_else(|| format!("asset arg {name} must be between {min} and {max}"))
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn procedural_wav(frequency: u32, duration_ms: u32) -> (Vec<u8>, u64) {
+    const RATE: u32 = 44_100;
+    let frames = u64::from(RATE) * u64::from(duration_ms) / 1_000;
+    let data_bytes = u32::try_from(frames.saturating_mul(2)).unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(44 + data_bytes as usize);
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(36 + data_bytes).to_le_bytes());
+    out.extend_from_slice(b"WAVEfmt \x10\0\0\0\x01\0\x01\0");
+    out.extend_from_slice(&RATE.to_le_bytes());
+    out.extend_from_slice(&(RATE * 2).to_le_bytes());
+    out.extend_from_slice(&2_u16.to_le_bytes());
+    out.extend_from_slice(&16_u16.to_le_bytes());
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&data_bytes.to_le_bytes());
+    for frame in 0..frames {
+        let phase =
+            2.0 * std::f64::consts::PI * f64::from(frequency) * frame as f64 / f64::from(RATE);
+        let envelope = 1.0 - frame as f64 / frames.max(1) as f64;
+        let sample = (phase.sin() * envelope * 10_000.0) as i16;
+        out.extend_from_slice(&sample.to_le_bytes());
+    }
+    (out, frames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn svg_rejects_active_and_remote_content() {
+        assert!(validate_svg("<svg><path d='M0 0'/></svg>").is_ok());
+        assert!(validate_svg("<svg><script>alert(1)</script></svg>").is_err());
+        assert!(validate_svg("<svg><image href=\"https://example.com/a.png\"/></svg>").is_err());
+    }
+
+    #[test]
+    fn wav_is_bounded_and_has_a_real_header() {
+        let (wav, frames) = procedural_wav(440, 100);
+        assert_eq!(&wav[..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(frames, 4_410);
+        assert_eq!(wav.len(), 44 + frames as usize * 2);
+    }
+
+    #[test]
+    fn png_renderer_produces_a_decodable_source_asset() {
+        let shapes = vec![serde_json::json!({
+            "kind": "circle",
+            "x": 8,
+            "y": 8,
+            "radius": 4,
+            "color": "#ff8844ff"
+        })];
+        let png = render_png(16, 16, parse_color("#102030").unwrap(), &shapes).unwrap();
+        let decoded = image::load_from_memory_with_format(&png, ImageFormat::Png).unwrap();
+        assert_eq!((decoded.width(), decoded.height()), (16, 16));
+    }
+
+    #[test]
+    fn imagegen_png_import_is_bounded_and_decodable() {
+        let root =
+            std::env::temp_dir().join(format!("stasis_gauntlet_imagegen_{}", std::process::id()));
+        let source = root.join("build/gauntlet/imagegen/ship.png");
+        fs::create_dir_all(source.parent().expect("imagegen parent")).expect("imagegen dir");
+        let png = render_png(32, 24, parse_color("#102030").unwrap(), &[]).unwrap();
+        fs::write(&source, &png).expect("imagegen input");
+        let (imported, width, height) =
+            load_imagegen_png(&root, "build/gauntlet/imagegen/ship.png").expect("import");
+        assert_eq!((width, height), (32, 24));
+        assert_eq!(imported, png);
+        assert!(load_imagegen_png(&root, "../ship.png").is_err());
+        let assisted = root.join("build/ai-assets/imagegen/ship.png");
+        fs::create_dir_all(assisted.parent().expect("assisted parent")).expect("assisted dir");
+        fs::write(&assisted, &png).expect("assisted input");
+        assert!(load_imagegen_png(&root, "build/ai-assets/imagegen/ship.png").is_ok());
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
@@ -1,0 +1,2024 @@
+use super::{
+    hex_sha256, image_extension, import_references, read_bounded_bytes, read_bounded_utf8,
+    write_json, GauntletConfigV1, GauntletObserver, GauntletReference, GauntletRoleModel,
+    GauntletRunPhase, GauntletRunStateV1, GAUNTLET_SCHEMA_VERSION, MAX_GOAL_BYTES,
+    MAX_REFERENCE_BYTES,
+};
+use crate::toolchain_cli::live_tui;
+use crate::toolchain_cli::{CommandResult, Workspace};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use stasis::{run_live_in_process, LiveRunConfig};
+use stasis_ai::{AgentCompactionPolicy, AgentProfile, CodexExecProvider, ModelProvider};
+use stasis_runner::live::{
+    live_session, LiveCommand, LivePointerInput, LiveRequest, LiveResponse, LiveSessionClient,
+};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const RUNS_PATH: &str = "build/gauntlet";
+const RUN_STATE_NAME: &str = "run.json";
+const EFFECTIVE_CONFIG_NAME: &str = "effective-config.json";
+const EVENTS_NAME: &str = "events.jsonl";
+const USAGE_NAME: &str = "usage.jsonl";
+const DECISIONS_NAME: &str = "decisions.jsonl";
+const REPORT_NAME: &str = "index.html";
+const STOP_NAME: &str = "stop.request";
+const QUALITY_BAR_NAME: &str = "quality-bar.json";
+const MAX_CAPTURE_WAIT: Duration = Duration::from_secs(10);
+const FINAL_ACCEPTANCES: u32 = 2;
+const MAX_MEMORY_RECORDS: usize = 48;
+const MAX_MEMORY_CHARS: usize = 32 * 1024;
+const MAX_DECISION_FIELD_CHARS: usize = 2_000;
+
+struct StopWatcher {
+    done: Arc<AtomicBool>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl StopWatcher {
+    fn start(artifacts: &Path, canceled: Arc<AtomicBool>, wall_limit: Duration) -> Self {
+        let done = Arc::new(AtomicBool::new(false));
+        let worker_done = Arc::clone(&done);
+        let stop_path = artifacts.join(STOP_NAME);
+        let worker = thread::spawn(move || {
+            let started = Instant::now();
+            while !worker_done.load(Ordering::Acquire) {
+                if stop_path.is_file() || started.elapsed() >= wall_limit {
+                    canceled.store(true, Ordering::Release);
+                    break;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+        });
+        Self {
+            done,
+            worker: Some(worker),
+        }
+    }
+}
+
+impl Drop for StopWatcher {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FrozenBar {
+    schema_version: u32,
+    goal_sha256: String,
+    goal: String,
+    workstreams: Vec<String>,
+    hard_gates: Vec<String>,
+    required_scenarios: Vec<Value>,
+    references: Vec<GauntletReference>,
+    web_sources: Vec<ScoutSource>,
+    acceptance_score: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoutResult {
+    summary: String,
+    sources: Vec<ScoutSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ScoutSource {
+    url: String,
+    relevance: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LeadBootstrap {
+    workstreams: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LeadDecision {
+    done: bool,
+    workstream: String,
+    builder_prompt: String,
+    rationale: String,
+    next_step: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BlindCritique {
+    preferred: String,
+    score_a: u32,
+    score_b: u32,
+    largest_gap: String,
+    summary: String,
+}
+
+pub(super) fn start(
+    workspace: &Workspace,
+    config_path: &Path,
+    additional_references: &[PathBuf],
+    discover_references: bool,
+    observer: GauntletObserver,
+    max_hours: Option<u32>,
+    max_model_calls: Option<u32>,
+) -> Result<CommandResult, String> {
+    let config_path = if config_path.is_absolute() {
+        config_path.to_path_buf()
+    } else {
+        workspace.root.join(config_path)
+    };
+    let source = fs::read_to_string(&config_path)
+        .map_err(|error| format!("failed reading {}: {error}", config_path.display()))?;
+    let mut config: GauntletConfigV1 = serde_json::from_str(&source)
+        .map_err(|error| format!("invalid Gauntlet config {}: {error}", config_path.display()))?;
+    config.validate()?;
+    config.execution.observer = observer;
+    config.quality_bar.allow_web_discovery |= discover_references;
+    if let Some(hours) = max_hours {
+        config.budget.wall_time_minutes = hours
+            .checked_mul(60)
+            .filter(|value| *value > 0)
+            .ok_or_else(|| "Gauntlet max-hours must be greater than zero".to_string())?;
+    }
+    if let Some(calls) = max_model_calls {
+        if calls == 0 {
+            return Err("Gauntlet max-model-calls must be greater than zero".to_string());
+        }
+        config.budget.model_calls = calls;
+    }
+    config.validate()?;
+
+    ensure_initial_commit(&workspace.root)?;
+    require_clean_checkout(&workspace.root)?;
+    let base_commit = git_stdout(&workspace.root, &["rev-parse", "HEAD"])?;
+    let run_id = new_run_id(&base_commit);
+    let branch = format!("stasis/gauntlet/{run_id}");
+    let artifacts = run_artifacts(&workspace.root, &run_id);
+    let worktree = workspace
+        .root
+        .join(RUNS_PATH)
+        .join("worktrees")
+        .join(&run_id);
+    fs::create_dir_all(&artifacts)
+        .map_err(|error| format!("failed creating Gauntlet run directory: {error}"))?;
+    let mut references = config.quality_bar.references.clone();
+    references.extend(import_references(&workspace.root, additional_references)?);
+    config.quality_bar.references = freeze_references(&workspace.root, &run_id, references)?;
+    config.validate()?;
+    write_json(&artifacts.join(EFFECTIVE_CONFIG_NAME), &config)?;
+    git_ok(
+        &workspace.root,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &branch,
+            &worktree.to_string_lossy(),
+            &base_commit,
+        ],
+    )?;
+    let bootstrap_commit = ensure_worktree_ignores(&worktree)?;
+    let now = unix_ms();
+    let mut state = GauntletRunStateV1 {
+        schema_version: GAUNTLET_SCHEMA_VERSION,
+        run_id: run_id.clone(),
+        phase: GauntletRunPhase::Created,
+        project_root: worktree.to_string_lossy().to_string(),
+        original_root: workspace.root.to_string_lossy().to_string(),
+        branch,
+        base_commit: base_commit.clone(),
+        best_commit: Some(bootstrap_commit),
+        current_workstream: None,
+        model_calls: 0,
+        accepted_candidates: 0,
+        rejected_candidates: 0,
+        consecutive_stalls: 0,
+        started_unix_ms: now,
+        updated_unix_ms: now,
+        terminal_reason: None,
+    };
+    persist_state(&artifacts, &mut state)?;
+    emit_event(
+        &artifacts,
+        "run_created",
+        json!({"run_id": run_id, "branch": state.branch, "worktree": worktree}),
+    )?;
+    run_persistent(workspace, config, state, artifacts)
+}
+
+fn freeze_references(
+    original_root: &Path,
+    run_id: &str,
+    references: Vec<GauntletReference>,
+) -> Result<Vec<GauntletReference>, String> {
+    let mut frozen_references = Vec::with_capacity(references.len());
+    for (index, mut reference) in references.into_iter().enumerate() {
+        let source = original_root.join(&reference.path);
+        let bytes = read_bounded_bytes(&source, MAX_REFERENCE_BYTES, "Gauntlet reference")?;
+        let actual_hash = hex_sha256(&bytes);
+        if actual_hash != reference.sha256 {
+            return Err(format!(
+                "Gauntlet reference hash does not match {}",
+                source.display()
+            ));
+        }
+        let extension = image_extension(&source)?;
+        let relative = PathBuf::from(RUNS_PATH)
+            .join(&run_id)
+            .join("references")
+            .join(format!(
+                "reference-{index}-{}.{}",
+                &actual_hash[..12],
+                extension
+            ));
+        let destination = original_root.join(&relative);
+        let parent = destination
+            .parent()
+            .ok_or_else(|| "Gauntlet reference destination has no parent".to_string())?;
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed creating run reference directory: {error}"))?;
+        fs::write(&destination, bytes)
+            .map_err(|error| format!("failed freezing run reference: {error}"))?;
+        reference.path = relative.to_string_lossy().replace('\\', "/");
+        frozen_references.push(reference);
+    }
+    Ok(frozen_references)
+}
+
+pub(super) fn resume(
+    workspace: &Workspace,
+    run_id: &str,
+    observer: GauntletObserver,
+) -> Result<CommandResult, String> {
+    validate_run_id(run_id)?;
+    let artifacts = run_artifacts(&workspace.root, run_id);
+    let mut state = load_state(&artifacts)?;
+    if matches!(state.phase, GauntletRunPhase::Converged) {
+        return status(workspace, run_id);
+    }
+    let mut config: GauntletConfigV1 = read_json(&artifacts.join(EFFECTIVE_CONFIG_NAME))?;
+    config.execution.observer = observer;
+    config.validate()?;
+    write_json(&artifacts.join(EFFECTIVE_CONFIG_NAME), &config)?;
+    let worktree = PathBuf::from(&state.project_root);
+    if !worktree.join("stasis.json").is_file() {
+        return Err(format!(
+            "Gauntlet worktree is unavailable: {}",
+            worktree.display()
+        ));
+    }
+    rollback_candidate(
+        &worktree,
+        state.best_commit.as_deref().unwrap_or(&state.base_commit),
+    )?;
+    let stop = artifacts.join(STOP_NAME);
+    if stop.exists() {
+        fs::remove_file(&stop)
+            .map_err(|error| format!("failed clearing prior stop request: {error}"))?;
+    }
+    state.phase = GauntletRunPhase::Building;
+    state.terminal_reason = None;
+    persist_state(&artifacts, &mut state)?;
+    emit_event(&artifacts, "run_resumed", json!({}))?;
+    run_persistent(workspace, config, state, artifacts)
+}
+
+pub(super) fn status(workspace: &Workspace, run_id: &str) -> Result<CommandResult, String> {
+    validate_run_id(run_id)?;
+    let artifacts = run_artifacts(&workspace.root, run_id);
+    let state = load_state(&artifacts)?;
+    Ok(CommandResult::success(
+        format_status(&state, &artifacts),
+        serde_json::to_value(&state).map_err(|error| error.to_string())?,
+    ))
+}
+
+pub(super) fn stop(workspace: &Workspace, run_id: &str) -> Result<CommandResult, String> {
+    validate_run_id(run_id)?;
+    let artifacts = run_artifacts(&workspace.root, run_id);
+    let state = load_state(&artifacts)?;
+    fs::write(artifacts.join(STOP_NAME), format!("{}\n", unix_ms()))
+        .map_err(|error| format!("failed writing Gauntlet stop request: {error}"))?;
+    emit_event(&artifacts, "stop_requested", json!({"phase": state.phase}))?;
+    Ok(CommandResult::success(
+        format!("stop requested for Gauntlet {run_id}"),
+        json!({"run_id": run_id, "stop_requested": true}),
+    ))
+}
+
+pub(super) fn promote(
+    workspace: &Workspace,
+    run_id: &str,
+    _json_output: bool,
+) -> Result<CommandResult, String> {
+    validate_run_id(run_id)?;
+    require_clean_checkout_ignoring_runs(&workspace.root)?;
+    let artifacts = run_artifacts(&workspace.root, run_id);
+    let state = load_state(&artifacts)?;
+    if state.accepted_candidates == 0 {
+        return Err("Gauntlet has no accepted game candidate to promote".to_string());
+    }
+    let best = state
+        .best_commit
+        .as_deref()
+        .ok_or_else(|| "Gauntlet has no accepted checkpoint to promote".to_string())?;
+    let head = git_stdout(&workspace.root, &["rev-parse", "HEAD"])?;
+    if head != state.base_commit {
+        return Err(format!(
+            "promotion requires the original checkout to remain at {}; current HEAD is {head}",
+            state.base_commit
+        ));
+    }
+    git_ok(&workspace.root, &["merge", "--ff-only", best])?;
+    emit_event(&artifacts, "promoted", json!({"commit": best}))?;
+    Ok(CommandResult::success(
+        format!("promoted Gauntlet {run_id} checkpoint {best}"),
+        json!({"run_id": run_id, "commit": best, "branch": state.branch}),
+    ))
+}
+
+fn run_persistent(
+    original: &Workspace,
+    config: GauntletConfigV1,
+    state: GauntletRunStateV1,
+    artifacts: PathBuf,
+) -> Result<CommandResult, String> {
+    let project_root = PathBuf::from(&state.project_root);
+    let manifest_source = fs::read_to_string(project_root.join("stasis.json"))
+        .map_err(|error| format!("failed reading isolated project manifest: {error}"))?;
+    let manifest: Value = serde_json::from_str(&manifest_source)
+        .map_err(|error| format!("invalid isolated project manifest: {error}"))?;
+    let entry = manifest
+        .get("entry")
+        .and_then(Value::as_str)
+        .unwrap_or("src/main.stasis");
+    let output = manifest
+        .get("output")
+        .and_then(Value::as_str)
+        .unwrap_or("build");
+    let name = manifest
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("Stasis Gauntlet");
+    let entry_path = project_root.join(entry);
+    let (client, server) = live_session(stasis_runner::live::DEFAULT_LIVE_QUEUE_CAPACITY);
+    let controller_client = client.clone();
+    let controller_artifacts = artifacts.clone();
+    let controller = thread::spawn(move || {
+        let result = controller_loop(
+            controller_client.clone(),
+            config,
+            state,
+            &controller_artifacts,
+        );
+        let _ = controller_client.submit(LiveRequest::new(u64::MAX, LiveCommand::Quit));
+        result
+    });
+    let live_config = LiveRunConfig::new(
+        project_root.clone(),
+        PathBuf::from(entry),
+        PathBuf::from(output),
+    )
+    .with_window_title(name);
+    let runtime_result = run_live_in_process(
+        &entry_path,
+        Some(&project_root),
+        16_000,
+        None,
+        server,
+        live_config,
+    );
+    let controller_result = controller
+        .join()
+        .map_err(|_| "Gauntlet controller thread panicked".to_string())?;
+    if let Err(error) = runtime_result {
+        mark_failed_if_active(&artifacts, &format!("live runtime failed: {error}"))?;
+        return Err(format!(
+            "Gauntlet live runtime failed: {error}; run artifacts: {}",
+            artifacts.display()
+        ));
+    }
+    let state = match controller_result {
+        Ok(state) => state,
+        Err(error) => {
+            mark_failed_if_active(&artifacts, &error)?;
+            return Err(format!(
+                "Gauntlet controller failed: {error}; run artifacts: {}",
+                artifacts.display()
+            ));
+        }
+    };
+    let successful = matches!(state.phase, GauntletRunPhase::Converged);
+    let human = format_status(&state, &artifacts);
+    let data = json!({
+        "run": state,
+        "artifacts": artifacts,
+        "original_root": original.root,
+        "success": successful,
+    });
+    Ok(CommandResult {
+        code: if successful { 0 } else { 2 },
+        human,
+        data,
+    })
+}
+
+fn mark_failed_if_active(artifacts: &Path, reason: &str) -> Result<(), String> {
+    let mut state = load_state(artifacts)?;
+    if !matches!(
+        state.phase,
+        GauntletRunPhase::Converged
+            | GauntletRunPhase::BudgetExhausted
+            | GauntletRunPhase::Stalled
+            | GauntletRunPhase::Canceled
+            | GauntletRunPhase::Failed
+    ) {
+        finish(&mut state, artifacts, GauntletRunPhase::Failed, reason)?;
+    }
+    Ok(())
+}
+
+fn controller_loop(
+    client: LiveSessionClient,
+    config: GauntletConfigV1,
+    mut state: GauntletRunStateV1,
+    artifacts: &Path,
+) -> Result<GauntletRunStateV1, String> {
+    let started = Instant::now();
+    let canceled = Arc::new(AtomicBool::new(false));
+    let wall_limit = Duration::from_secs(u64::from(config.budget.wall_time_minutes) * 60);
+    let elapsed_before = Duration::from_millis(unix_ms().saturating_sub(state.started_unix_ms));
+    let _stop_watcher = StopWatcher::start(
+        artifacts,
+        Arc::clone(&canceled),
+        wall_limit.saturating_sub(elapsed_before),
+    );
+    let project_root = PathBuf::from(&state.project_root);
+    let goal_path = project_root.join(&config.goal_file);
+    let goal = read_bounded_utf8(&goal_path, MAX_GOAL_BYTES, "Gauntlet goal")?;
+    state.phase = GauntletRunPhase::DiscoveringBar;
+    persist_state(artifacts, &mut state)?;
+    let bar = if artifacts.join(QUALITY_BAR_NAME).is_file() {
+        read_json(&artifacts.join(QUALITY_BAR_NAME))?
+    } else {
+        let bar = bootstrap_bar(&goal, &config, &mut state, artifacts, &canceled)?;
+        persist_state(artifacts, &mut state)?;
+        write_json(&artifacts.join(QUALITY_BAR_NAME), &bar)?;
+        emit_event(
+            artifacts,
+            "quality_bar_frozen",
+            serde_json::to_value(&bar).map_err(|e| e.to_string())?,
+        )?;
+        bar
+    };
+    let reference_images = resolve_reference_images(
+        &bar.references,
+        &project_root,
+        Path::new(&state.original_root),
+    );
+    let scenario_pointer = logical_center(&project_root);
+    request_live(&client, 1, LiveCommand::Pause)?;
+    request_live(&client, 2, LiveCommand::ValidationSnapshot)?;
+    let mut next_request = 3_u64;
+    let (mut baseline, mut baseline_state) = capture_scenario(
+        &client,
+        &project_root,
+        artifacts,
+        "baseline",
+        scenario_pointer,
+        &mut next_request,
+    )?;
+    let mut largest_gap = latest_decision_next_step(artifacts).unwrap_or_else(|| {
+        "Build the first complete playable version of the frozen brief.".to_string()
+    });
+    let mut final_acceptances = 0_u32;
+    loop {
+        if should_stop(artifacts) {
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::Canceled,
+                "stop requested",
+            )?;
+            break;
+        }
+        if elapsed_before.saturating_add(started.elapsed()) >= wall_limit {
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::BudgetExhausted,
+                "wall-time budget exhausted",
+            )?;
+            break;
+        }
+        if state.model_calls >= config.budget.model_calls {
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::BudgetExhausted,
+                "model-call budget exhausted",
+            )?;
+            break;
+        }
+        if state.consecutive_stalls >= config.budget.stalled_candidates {
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::Stalled,
+                "consecutive candidate limit reached",
+            )?;
+            break;
+        }
+        state.phase = GauntletRunPhase::Planning;
+        persist_state(artifacts, &mut state)?;
+        let mut model_calls = state.model_calls;
+        let decision = lead_decision(
+            &goal,
+            &bar,
+            &largest_gap,
+            &state,
+            &mut model_calls,
+            artifacts,
+            &config.models.lead,
+            &canceled,
+        )?;
+        state.model_calls = model_calls;
+        persist_state(artifacts, &mut state)?;
+        emit_event(
+            artifacts,
+            "lead_decision",
+            serde_json::to_value(&decision).map_err(|e| e.to_string())?,
+        )?;
+        append_decision(
+            artifacts,
+            "lead",
+            "work_item_selected",
+            &format!("Selected workstream {}", decision.workstream),
+            &decision.rationale,
+            &format!(
+                "Accepted {} candidates and rejected {}; largest gap: {largest_gap}",
+                state.accepted_candidates, state.rejected_candidates
+            ),
+            &decision.next_step,
+        )?;
+        if decision.done && final_acceptances >= FINAL_ACCEPTANCES {
+            match run_final_gates(&project_root, artifacts) {
+                Ok(()) => {
+                    finish(
+                        &mut state,
+                        artifacts,
+                        GauntletRunPhase::Converged,
+                        "independent evaluations and release gates met the frozen bar",
+                    )?;
+                    break;
+                }
+                Err(error) => {
+                    largest_gap = format!("Final release validation failed: {error}");
+                    final_acceptances = 0;
+                    state.consecutive_stalls = state.consecutive_stalls.saturating_add(1);
+                    emit_event(
+                        artifacts,
+                        "final_validation_failed",
+                        json!({"error": error}),
+                    )?;
+                    append_decision(
+                        artifacts,
+                        "controller",
+                        "final_validation_failed",
+                        "Release validation rejected convergence",
+                        "The frozen completion bar requires every release gate to pass.",
+                        &error,
+                        &largest_gap,
+                    )?;
+                    persist_state(artifacts, &mut state)?;
+                    continue;
+                }
+            }
+        }
+        if decision.builder_prompt.trim().is_empty() || decision.workstream.trim().is_empty() {
+            return fail_state(&mut state, artifacts, "lead returned an empty work item");
+        }
+        state.phase = GauntletRunPhase::Building;
+        state.current_workstream = Some(decision.workstream.clone());
+        persist_state(artifacts, &mut state)?;
+        let remaining_calls = config.budget.model_calls.saturating_sub(state.model_calls);
+        if remaining_calls == 0 {
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::BudgetExhausted,
+                "model-call budget exhausted before builder",
+            )?;
+            break;
+        }
+        let candidate_id = format!(
+            "candidate-{:04}",
+            state.accepted_candidates + state.rejected_candidates + 1
+        );
+        let memory = decision_memory_snapshot(artifacts)?;
+        let prompt = format!(
+            "Frozen game brief:\n{goal}\n\nWorkstream: {}\nTask: {}\nLargest evidenced gap: {largest_gap}\n\nDurable decision memory (explicit conclusions only):\n{memory}\n\nMake one coherent, end-to-end improvement. Preserve deterministic tick semantics. Add or update durable Stasis tests in the same atomic write when behavior changes. Use record_decision for consequential choices and finish after the tested write succeeds.",
+            decision.workstream, decision.builder_prompt
+        );
+        let profile = AgentProfile {
+            role: "Fresh Stasis Gauntlet builder".to_string(),
+            instruction: "Use only the supplied Stasis live-workspace tools. Inspect relevant symbols and references, then make one contiguous atomic semantic edit batch. You may create bounded SVG, PNG, JSON/CSV, or procedural WAV assets; put one contiguous asset-tool group immediately before the related source writes in the same response. Use record_decision during exploration and after consequential tested choices to preserve concise conclusions, tradeoffs, evidence, and next steps for future agents; never record hidden chain-of-thought. The write must compile and run tests. Do not grade your own visual quality. Return done immediately after a successful tested write and decision record.".to_string(),
+            max_turns: usize::try_from(
+                remaining_calls.min(config.execution.builder_max_turns),
+            )
+            .unwrap_or(stasis_ai::DEFAULT_AGENT_TURNS),
+            model: config.models.builder.model.clone(),
+            reasoning_effort: config.models.builder.reasoning_effort.clone(),
+            compaction: config.execution.compaction.enabled.then(|| AgentCompactionPolicy {
+                max_request_bytes: config.execution.compaction.max_request_bytes,
+                retain_recent_turns: config.execution.compaction.retain_recent_turns,
+            }),
+        };
+        let outcome = live_tui::run_scripted_ai_profile(
+            &client,
+            &project_root,
+            &prompt,
+            profile,
+            vec![baseline.clone()],
+            false,
+            true,
+            true,
+            Some(&artifacts.join(DECISIONS_NAME)),
+            &canceled,
+        );
+        match outcome {
+            Ok(outcome) => {
+                state.model_calls = state.model_calls.saturating_add(outcome.model_calls);
+                persist_state(artifacts, &mut state)?;
+                append_usage_file(artifacts, &outcome.usage_trace)?;
+                emit_event(
+                    artifacts,
+                    "builder_completed",
+                    json!({
+                        "candidate": candidate_id,
+                        "summary": outcome.summary,
+                        "trace": outcome.trace,
+                        "usage": outcome.usage_trace,
+                        "model_calls": outcome.model_calls,
+                    }),
+                )?;
+                append_decision(
+                    artifacts,
+                    "builder",
+                    "builder_completed",
+                    &outcome.summary,
+                    "The builder completed a compiler-tested atomic project transaction.",
+                    &format!(
+                        "candidate={candidate_id}; model_calls={}",
+                        outcome.model_calls
+                    ),
+                    "Capture and independently evaluate the candidate.",
+                )?;
+            }
+            Err(error) => {
+                rollback_candidate(
+                    &project_root,
+                    state.best_commit.as_deref().unwrap_or(&state.base_commit),
+                )?;
+                reject(
+                    &mut state,
+                    artifacts,
+                    &candidate_id,
+                    &format!("builder failed: {error}"),
+                )?;
+                largest_gap = format!(
+                    "The previous builder failed before producing a valid candidate: {error}"
+                );
+                continue;
+            }
+        }
+        state.phase = GauntletRunPhase::Evaluating;
+        persist_state(artifacts, &mut state)?;
+        let (candidate, candidate_state) = capture_scenario(
+            &client,
+            &project_root,
+            artifacts,
+            &candidate_id,
+            scenario_pointer,
+            &mut next_request,
+        )?;
+        let candidate_changed = !git_stdout(&project_root, &["status", "--porcelain"])?
+            .trim()
+            .is_empty();
+        if !candidate_changed {
+            reject(
+                &mut state,
+                artifacts,
+                &candidate_id,
+                "builder produced no project change",
+            )?;
+            largest_gap = "The previous work item produced no source or asset change.".to_string();
+            continue;
+        }
+        if state.model_calls >= config.budget.model_calls {
+            rollback_candidate(
+                &project_root,
+                state.best_commit.as_deref().unwrap_or(&state.base_commit),
+            )?;
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::BudgetExhausted,
+                "model-call budget exhausted before visual critique",
+            )?;
+            break;
+        }
+        let candidate_is_a =
+            hex_sha256(format!("{}:{candidate_id}", state.run_id).as_bytes()).as_bytes()[0] % 2
+                == 0;
+        let (a, b) = if candidate_is_a {
+            (&candidate, &baseline)
+        } else {
+            (&baseline, &candidate)
+        };
+        let critique = blind_critic(
+            &goal,
+            &bar,
+            a,
+            b,
+            &reference_images,
+            &mut state.model_calls,
+            artifacts,
+            &config.models.visual_critic,
+            &canceled,
+        )?;
+        persist_state(artifacts, &mut state)?;
+        let preferred_candidate = match critique.preferred.as_str() {
+            "a" => candidate_is_a,
+            "b" => !candidate_is_a,
+            _ => false,
+        };
+        let candidate_score = if candidate_is_a {
+            critique.score_a
+        } else {
+            critique.score_b
+        };
+        if state.model_calls >= config.budget.model_calls {
+            rollback_candidate(
+                &project_root,
+                state.best_commit.as_deref().unwrap_or(&state.base_commit),
+            )?;
+            finish(
+                &mut state,
+                artifacts,
+                GauntletRunPhase::BudgetExhausted,
+                "model-call budget exhausted before gameplay critique",
+            )?;
+            break;
+        }
+        let (state_a, state_b) = if candidate_is_a {
+            (&candidate_state, &baseline_state)
+        } else {
+            (&baseline_state, &candidate_state)
+        };
+        let gameplay = gameplay_critic(
+            &goal,
+            &bar,
+            state_a,
+            state_b,
+            &mut state.model_calls,
+            artifacts,
+            &config.models.gameplay_critic,
+            &canceled,
+        )?;
+        persist_state(artifacts, &mut state)?;
+        let gameplay_passes = match gameplay.preferred.as_str() {
+            "a" => candidate_is_a,
+            "b" => !candidate_is_a,
+            "equivalent" => true,
+            _ => false,
+        };
+        emit_event(
+            artifacts,
+            "critic_completed",
+            json!({
+                "candidate": candidate_id,
+                "blind_mapping_sha256": hex_sha256(format!("{}:{}", state.run_id, candidate_is_a).as_bytes()),
+                "critique": critique,
+                "candidate_score": candidate_score,
+                "preferred_candidate": preferred_candidate,
+                "gameplay": gameplay,
+                "gameplay_passes": gameplay_passes,
+            }),
+        )?;
+        if preferred_candidate && gameplay_passes && candidate_score >= bar.acceptance_score {
+            state.phase = GauntletRunPhase::Checkpointing;
+            persist_state(artifacts, &mut state)?;
+            let commit = checkpoint(&project_root, &candidate_id, &decision.workstream)?;
+            state.best_commit = Some(commit.clone());
+            state.accepted_candidates = state.accepted_candidates.saturating_add(1);
+            state.consecutive_stalls = 0;
+            final_acceptances = final_acceptances.saturating_add(1);
+            baseline = candidate;
+            baseline_state = candidate_state;
+            largest_gap = critique.largest_gap;
+            persist_state(artifacts, &mut state)?;
+            emit_event(
+                artifacts,
+                "candidate_accepted",
+                json!({"candidate": candidate_id, "commit": commit}),
+            )?;
+            append_decision(
+                artifacts,
+                "controller",
+                "candidate_accepted",
+                &format!("Accepted {candidate_id} for {}", decision.workstream),
+                "The blind visual critic preferred the candidate and the gameplay critic found no regression.",
+                &format!("commit={commit}; visual_score={candidate_score}"),
+                &largest_gap,
+            )?;
+            generate_report_shell(artifacts, &state)?;
+        } else {
+            rollback_candidate(
+                &project_root,
+                state.best_commit.as_deref().unwrap_or(&state.base_commit),
+            )?;
+            largest_gap = critique.largest_gap;
+            final_acceptances = 0;
+            reject(
+                &mut state,
+                artifacts,
+                &candidate_id,
+                "blind critic did not prefer the candidate at the required score",
+            )?;
+            append_decision(
+                artifacts,
+                "critic",
+                "largest_gap",
+                &format!("Recorded the largest gap after rejecting {candidate_id}"),
+                "The next builder should address the critic's evidenced gap rather than repeat the rejected approach.",
+                &critique.summary,
+                &largest_gap,
+            )?;
+            generate_report_shell(artifacts, &state)?;
+        }
+    }
+    state.current_workstream = None;
+    persist_state(artifacts, &mut state)?;
+    generate_report(artifacts, &state, &bar)?;
+    Ok(state)
+}
+
+fn bootstrap_bar(
+    goal: &str,
+    config: &GauntletConfigV1,
+    state: &mut GauntletRunStateV1,
+    artifacts: &Path,
+    canceled: &AtomicBool,
+) -> Result<FrozenBar, String> {
+    let mut web_sources = Vec::new();
+    if config.quality_bar.allow_web_discovery
+        && config.budget.model_calls.saturating_sub(state.model_calls) >= 2
+    {
+        let mut provider = provider_for_role(&config.models.scout).with_web_search(true);
+        let prompt = format!(
+            "Act as a read-only visual reference scout for this 2D game brief. Find up to five reputable HTTPS pages whose visual or interaction patterns can form a concrete quality bar. Do not suggest copying protected assets. Return only the requested JSON.\n\n{goal}"
+        );
+        let scout: ScoutResult = provider.respond_structured(&prompt, &scout_schema(), canceled)?;
+        append_provider_usage(artifacts, &mut provider)?;
+        state.model_calls = state.model_calls.saturating_add(provider.call_count());
+        persist_state(artifacts, state)?;
+        web_sources = scout
+            .sources
+            .into_iter()
+            .filter(|source| source.url.starts_with("https://"))
+            .take(5)
+            .collect();
+        emit_event(
+            artifacts,
+            "reference_scout_completed",
+            json!({"summary": scout.summary, "sources": web_sources}),
+        )?;
+    }
+    let mut provider = provider_for_role(&config.models.lead);
+    let prompt = format!(
+        "Act as the lead for an autonomous Stasis 2D game build. Decompose this immutable brief into 4-10 independently improvable workstreams. Use short noun phrases. Return only the requested JSON.\n\n{goal}"
+    );
+    let bootstrap: LeadBootstrap =
+        provider.respond_structured(&prompt, &bootstrap_schema(), canceled)?;
+    append_provider_usage(artifacts, &mut provider)?;
+    state.model_calls = state.model_calls.saturating_add(provider.call_count());
+    persist_state(artifacts, state)?;
+    let workstreams = bootstrap
+        .workstreams
+        .into_iter()
+        .filter(|value| !value.trim().is_empty())
+        .take(10)
+        .collect::<Vec<_>>();
+    if workstreams.is_empty() {
+        return Err("Gauntlet lead produced no usable workstreams".to_string());
+    }
+    append_decision(
+        artifacts,
+        "lead",
+        "quality_bar_bootstrap",
+        "Decomposed the immutable brief into persistent workstreams",
+        "Independent workstreams let builders improve one bounded concern while critics judge the integrated result.",
+        &workstreams.join(", "),
+        "Select the highest-value workstream from runtime evidence.",
+    )?;
+    Ok(FrozenBar {
+        schema_version: 1,
+        goal_sha256: hex_sha256(goal.as_bytes()),
+        goal: goal.to_string(),
+        workstreams,
+        hard_gates: vec![
+            "project compiles".to_string(),
+            "all Stasis tests pass".to_string(),
+            "a real framebuffer capture succeeds".to_string(),
+            "deterministic tick semantics are preserved".to_string(),
+        ],
+        required_scenarios: config
+            .quality_bar
+            .required_scenarios
+            .iter()
+            .map(|scenario| json!({"id": scenario.id, "description": scenario.description}))
+            .collect(),
+        references: config.quality_bar.references.clone(),
+        web_sources,
+        acceptance_score: 65,
+    })
+}
+
+fn provider_for_role(role: &GauntletRoleModel) -> CodexExecProvider {
+    let mut provider = CodexExecProvider::default();
+    if let Some(model) = role.model.as_deref() {
+        provider = provider.with_model(model);
+    }
+    if let Some(reasoning_effort) = role.reasoning_effort.as_deref() {
+        provider = provider.with_reasoning_effort(reasoning_effort);
+    }
+    provider
+}
+
+fn lead_decision(
+    goal: &str,
+    bar: &FrozenBar,
+    largest_gap: &str,
+    state: &GauntletRunStateV1,
+    model_calls: &mut u32,
+    artifacts: &Path,
+    model: &GauntletRoleModel,
+    canceled: &AtomicBool,
+) -> Result<LeadDecision, String> {
+    let mut provider = provider_for_role(model);
+    let memory = decision_memory_snapshot(artifacts)?;
+    let prompt = format!(
+        "Act as the fresh lead for a Stasis Gauntlet. Choose exactly one highest-value next work item from the frozen workstreams. Set done=true only if the largest gap says the bar is fully met; otherwise done=false. Preserve a concise rationale and next step for future fresh agents; do not provide hidden chain-of-thought. Return only JSON.\n\nBrief:\n{goal}\n\nWorkstreams: {}\nAccepted: {} Rejected: {}\nLargest gap: {largest_gap}\n\nDurable decision memory (explicit conclusions only):\n{memory}",
+        bar.workstreams.join(", "), state.accepted_candidates, state.rejected_candidates
+    );
+    let decision: LeadDecision = provider.respond_structured(&prompt, &lead_schema(), canceled)?;
+    append_provider_usage(artifacts, &mut provider)?;
+    *model_calls = model_calls.saturating_add(provider.call_count());
+    if decision.rationale.trim().is_empty() || decision.next_step.trim().is_empty() {
+        return Err("Gauntlet lead returned empty decision memory fields".to_string());
+    }
+    Ok(decision)
+}
+
+fn blind_critic(
+    goal: &str,
+    bar: &FrozenBar,
+    image_a: &Path,
+    image_b: &Path,
+    references: &[PathBuf],
+    model_calls: &mut u32,
+    artifacts: &Path,
+    model: &GauntletRoleModel,
+    canceled: &AtomicBool,
+) -> Result<BlindCritique, String> {
+    let mut images = vec![image_a.to_path_buf(), image_b.to_path_buf()];
+    images.extend(references.iter().take(5).cloned());
+    let mut provider = provider_for_role(model).with_images(images);
+    let prompt = format!(
+        "You are a fresh read-only visual/gameplay critic. The first two attached images are anonymously labeled A then B; any later images are hashed quality references. You do not know which candidate is newer. Compare A and B against the frozen brief and references. Prefer A, B, or neither. Scores are integers 0-100. Identify one largest remaining gap. Do not discuss source code and return only JSON.\n\nBrief:\n{goal}\n\nWorkstreams: {}\nHard gates already passed: {}",
+        bar.workstreams.join(", "), bar.hard_gates.join(", ")
+    );
+    let critique: BlindCritique =
+        provider.respond_structured(&prompt, &critic_schema(), canceled)?;
+    append_provider_usage(artifacts, &mut provider)?;
+    *model_calls = model_calls.saturating_add(provider.call_count());
+    if !matches!(
+        critique.preferred.as_str(),
+        "a" | "b" | "neither" | "equivalent"
+    ) || critique.score_a > 100
+        || critique.score_b > 100
+        || critique.largest_gap.trim().is_empty()
+    {
+        return Err("critic returned an invalid preference, score, or gap".to_string());
+    }
+    Ok(critique)
+}
+
+fn resolve_reference_images(
+    references: &[GauntletReference],
+    project_root: &Path,
+    original_root: &Path,
+) -> Vec<PathBuf> {
+    references
+        .iter()
+        .filter_map(|reference| {
+            let configured = PathBuf::from(&reference.path);
+            let candidates = if configured.is_absolute() {
+                vec![configured]
+            } else {
+                vec![
+                    project_root.join(&configured),
+                    original_root.join(&configured),
+                ]
+            };
+            candidates.into_iter().find(|path| {
+                fs::read(path).is_ok_and(|bytes| hex_sha256(&bytes) == reference.sha256)
+            })
+        })
+        .take(5)
+        .collect()
+}
+
+fn gameplay_critic(
+    goal: &str,
+    bar: &FrozenBar,
+    state_a: &Value,
+    state_b: &Value,
+    model_calls: &mut u32,
+    artifacts: &Path,
+    model: &GauntletRoleModel,
+    canceled: &AtomicBool,
+) -> Result<BlindCritique, String> {
+    let mut provider = provider_for_role(model);
+    let prompt = format!(
+        "You are a fresh read-only gameplay critic. Two anonymous candidates A and B were run from the same runtime snapshot for the same deterministic ticks. Judge only behavioral regressions and evidence relative to the brief. Prefer a, b, equivalent, or neither. Equivalent is appropriate when a visual-only improvement leaves gameplay intact. Return only JSON.\n\nBrief:\n{goal}\n\nRequired scenarios: {}\n\nA evidence:\n{}\n\nB evidence:\n{}",
+        serde_json::to_string(&bar.required_scenarios).map_err(|error| error.to_string())?,
+        serde_json::to_string(state_a).map_err(|error| error.to_string())?,
+        serde_json::to_string(state_b).map_err(|error| error.to_string())?,
+    );
+    let critique: BlindCritique =
+        provider.respond_structured(&prompt, &critic_schema(), canceled)?;
+    append_provider_usage(artifacts, &mut provider)?;
+    *model_calls = model_calls.saturating_add(provider.call_count());
+    if !matches!(
+        critique.preferred.as_str(),
+        "a" | "b" | "neither" | "equivalent"
+    ) || critique.score_a > 100
+        || critique.score_b > 100
+    {
+        return Err("gameplay critic returned an invalid result".to_string());
+    }
+    Ok(critique)
+}
+
+fn capture_scenario(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    artifacts: &Path,
+    id: &str,
+    pointer: Option<(i32, i32)>,
+    request_id: &mut u64,
+) -> Result<(PathBuf, Value), String> {
+    request_live(client, *request_id, LiveCommand::ValidationRestore)?;
+    *request_id = request_id.saturating_add(1);
+    if let Some((x, y)) = pointer {
+        request_live(
+            client,
+            *request_id,
+            LiveCommand::SetInputState {
+                pointers: vec![LivePointerInput {
+                    id: 0,
+                    x,
+                    y,
+                    is_down: true,
+                    went_down: true,
+                    went_up: false,
+                }],
+            },
+        )?;
+        *request_id = request_id.saturating_add(1);
+        request_live(client, *request_id, LiveCommand::Step { ticks: 1 })?;
+        *request_id = request_id.saturating_add(1);
+        wait_for_steps(client, request_id)?;
+        request_live(
+            client,
+            *request_id,
+            LiveCommand::SetInputState {
+                pointers: vec![LivePointerInput {
+                    id: 0,
+                    x,
+                    y,
+                    is_down: false,
+                    went_down: false,
+                    went_up: true,
+                }],
+            },
+        )?;
+        *request_id = request_id.saturating_add(1);
+    }
+    request_live(
+        client,
+        *request_id,
+        LiveCommand::Step {
+            ticks: if pointer.is_some() { 29 } else { 30 },
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    wait_for_steps(client, request_id)?;
+    let frame = capture_frame(client, project_root, artifacts, id, request_id)?;
+    let inspection = request_live(
+        client,
+        *request_id,
+        LiveCommand::InspectAll {
+            limit: 64,
+            concise: true,
+            every_ticks: None,
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    request_live(client, *request_id, LiveCommand::ValidationRestore)?;
+    *request_id = request_id.saturating_add(1);
+    request_live(
+        client,
+        *request_id,
+        LiveCommand::SetInputState {
+            pointers: Vec::new(),
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    Ok((frame, inspection.data.unwrap_or(Value::Null)))
+}
+
+fn logical_center(project_root: &Path) -> Option<(i32, i32)> {
+    let source = fs::read_to_string(project_root.join("assets/manifest.json")).ok()?;
+    let manifest: Value = serde_json::from_str(&source).ok()?;
+    let width = manifest.pointer("/display/logical_width")?.as_i64()?;
+    let height = manifest.pointer("/display/logical_height")?.as_i64()?;
+    Some((
+        i32::try_from(width / 2).ok()?,
+        i32::try_from(height / 2).ok()?,
+    ))
+}
+
+fn wait_for_steps(client: &LiveSessionClient, request_id: &mut u64) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        let response = request_live(client, *request_id, LiveCommand::Status)?;
+        *request_id = request_id.saturating_add(1);
+        let remaining = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("step_remaining"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if remaining == 0 {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    Err("deterministic Gauntlet scenario did not finish within 15 seconds".to_string())
+}
+
+fn capture_frame(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    artifacts: &Path,
+    id: &str,
+    request_id: &mut u64,
+) -> Result<PathBuf, String> {
+    let artifact = id.replace(
+        |character: char| {
+            !character.is_ascii_alphanumeric() && character != '-' && character != '_'
+        },
+        "_",
+    );
+    let scheduled = request_live(
+        client,
+        *request_id,
+        LiveCommand::CaptureFrame {
+            artifact: artifact.clone(),
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    let runtime_path = scheduled
+        .data
+        .as_ref()
+        .and_then(|data| data.get("path"))
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .ok_or_else(|| "live runtime did not return a screenshot path".to_string())?;
+    request_live(client, *request_id, LiveCommand::Step { ticks: 1 })?;
+    *request_id = request_id.saturating_add(1);
+    let deadline = Instant::now() + MAX_CAPTURE_WAIT;
+    while Instant::now() < deadline {
+        if runtime_path.is_file()
+            && fs::metadata(&runtime_path).is_ok_and(|metadata| metadata.len() > 0)
+        {
+            let destination = artifacts.join("artifacts").join(id).join("frame.png");
+            fs::create_dir_all(destination.parent().expect("capture parent")).map_err(|error| {
+                format!("failed creating candidate artifact directory: {error}")
+            })?;
+            fs::copy(&runtime_path, &destination)
+                .map_err(|error| format!("failed retaining runtime capture: {error}"))?;
+            let bytes = fs::read(&destination)
+                .map_err(|error| format!("failed hashing capture: {error}"))?;
+            emit_event(
+                artifacts,
+                "frame_captured",
+                json!({
+                    "candidate": id,
+                    "path": destination,
+                    "sha256": hex_sha256(&bytes),
+                    "project_root": project_root,
+                }),
+            )?;
+            return Ok(destination);
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    Err(format!(
+        "runtime capture did not appear at {}",
+        runtime_path.display()
+    ))
+}
+
+fn request_live(
+    client: &LiveSessionClient,
+    request_id: u64,
+    command: LiveCommand,
+) -> Result<LiveResponse, String> {
+    client.submit(LiveRequest::new(request_id, command))?;
+    loop {
+        let response = client.receive_timeout(Duration::from_secs(300))?;
+        if response.request_id == request_id {
+            if response.ok {
+                return Ok(response);
+            }
+            return Err(response
+                .error
+                .unwrap_or_else(|| "live request failed".to_string()));
+        }
+    }
+}
+
+fn checkpoint(root: &Path, candidate: &str, workstream: &str) -> Result<String, String> {
+    git_ok(root, &["add", "--all"])?;
+    git_ok(
+        root,
+        &[
+            "-c",
+            "user.name=Stasis Gauntlet",
+            "-c",
+            "user.email=gauntlet@stasis.local",
+            "commit",
+            "--no-verify",
+            "-m",
+            &format!("feat: improve {workstream} ({candidate})"),
+        ],
+    )?;
+    git_stdout(root, &["rev-parse", "HEAD"])
+}
+
+fn run_final_gates(project_root: &Path, artifacts: &Path) -> Result<(), String> {
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("failed locating Stasis for final validation: {error}"))?;
+    let commands: &[(&str, &[&str])] = &[
+        ("format", &["format", "--check"]),
+        ("check", &["check"]),
+        ("test", &["test"]),
+        ("build", &["build", "--mode", "release"]),
+        (
+            "package",
+            &["package", "--target", "desktop", "--development-build"],
+        ),
+    ];
+    let logs = artifacts.join("final-validation");
+    fs::create_dir_all(&logs)
+        .map_err(|error| format!("failed creating final validation logs: {error}"))?;
+    for (name, args) in commands {
+        if should_stop(artifacts) {
+            return Err("stop requested during final validation".to_string());
+        }
+        let log_path = logs.join(format!("{name}.log"));
+        let stdout = fs::File::create(&log_path)
+            .map_err(|error| format!("failed creating {}: {error}", log_path.display()))?;
+        let stderr = stdout
+            .try_clone()
+            .map_err(|error| format!("failed cloning final validation log: {error}"))?;
+        let mut command = Command::new(&executable);
+        command
+            .arg("--workspace")
+            .arg(project_root)
+            .args(*args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x08000000);
+        }
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("failed starting final {name}: {error}"))?;
+        let started = Instant::now();
+        let status = loop {
+            if should_stop(artifacts) || started.elapsed() >= Duration::from_secs(900) {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "final {name} was canceled or exceeded 900 seconds; see {}",
+                    log_path.display()
+                ));
+            }
+            match child
+                .try_wait()
+                .map_err(|error| format!("failed waiting for final {name}: {error}"))?
+            {
+                Some(status) => break status,
+                None => thread::sleep(Duration::from_millis(100)),
+            }
+        };
+        if !status.success() {
+            return Err(format!(
+                "final {name} exited with {status}; see {}",
+                log_path.display()
+            ));
+        }
+        emit_event(artifacts, "final_gate_passed", json!({"gate": name}))?;
+    }
+    Ok(())
+}
+
+fn rollback_candidate(root: &Path, commit: &str) -> Result<(), String> {
+    git_ok(
+        root,
+        &[
+            "restore",
+            "--source",
+            commit,
+            "--staged",
+            "--worktree",
+            "--",
+            ".",
+        ],
+    )?;
+    let untracked = git_stdout(root, &["ls-files", "--others", "--exclude-standard"])?;
+    for relative in untracked.lines().filter(|line| !line.trim().is_empty()) {
+        let path = root.join(relative);
+        if path.is_file() {
+            fs::remove_file(&path).map_err(|error| {
+                format!("failed removing rejected file {}: {error}", path.display())
+            })?;
+        } else if path.is_dir() {
+            fs::remove_dir_all(&path).map_err(|error| {
+                format!(
+                    "failed removing rejected directory {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn reject(
+    state: &mut GauntletRunStateV1,
+    artifacts: &Path,
+    candidate: &str,
+    reason: &str,
+) -> Result<(), String> {
+    state.rejected_candidates = state.rejected_candidates.saturating_add(1);
+    state.consecutive_stalls = state.consecutive_stalls.saturating_add(1);
+    persist_state(artifacts, state)?;
+    emit_event(
+        artifacts,
+        "candidate_rejected",
+        json!({"candidate": candidate, "reason": reason}),
+    )?;
+    append_decision(
+        artifacts,
+        "controller",
+        "candidate_rejected",
+        &format!("Rejected {candidate}"),
+        "A candidate must pass its atomic write and independent evidence gates before it can replace the accepted checkpoint.",
+        reason,
+        "Choose a smaller corrective work item that directly addresses the rejection evidence.",
+    )?;
+    generate_report_shell(artifacts, state)
+}
+
+fn finish(
+    state: &mut GauntletRunStateV1,
+    artifacts: &Path,
+    phase: GauntletRunPhase,
+    reason: &str,
+) -> Result<(), String> {
+    state.phase = phase;
+    state.terminal_reason = Some(reason.to_string());
+    emit_event(
+        artifacts,
+        "run_finished",
+        json!({"phase": state.phase, "reason": reason}),
+    )?;
+    persist_state(artifacts, state)
+}
+
+fn fail_state<T>(
+    state: &mut GauntletRunStateV1,
+    artifacts: &Path,
+    reason: &str,
+) -> Result<T, String> {
+    finish(state, artifacts, GauntletRunPhase::Failed, reason)?;
+    Err(reason.to_string())
+}
+
+fn ensure_initial_commit(root: &Path) -> Result<(), String> {
+    if git_stdout(root, &["rev-parse", "--verify", "HEAD"]).is_ok() {
+        return Ok(());
+    }
+    git_ok(root, &["add", "--all"])?;
+    git_ok(
+        root,
+        &[
+            "-c",
+            "user.name=Stasis Gauntlet",
+            "-c",
+            "user.email=gauntlet@stasis.local",
+            "commit",
+            "--no-verify",
+            "-m",
+            "feat: initialize Stasis game",
+        ],
+    )
+}
+
+fn ensure_worktree_ignores(root: &Path) -> Result<String, String> {
+    let path = root.join(".gitignore");
+    let mut source = fs::read_to_string(&path).unwrap_or_default();
+    let mut changed = false;
+    for pattern in ["build/", ".stasis_cache/"] {
+        if !source.lines().any(|line| line.trim() == pattern) {
+            if !source.is_empty() && !source.ends_with('\n') {
+                source.push('\n');
+            }
+            source.push_str(pattern);
+            source.push('\n');
+            changed = true;
+        }
+    }
+    if changed {
+        fs::write(&path, source)
+            .map_err(|error| format!("failed writing isolated Gauntlet ignores: {error}"))?;
+        git_ok(root, &["add", ".gitignore"])?;
+        git_ok(
+            root,
+            &[
+                "-c",
+                "user.name=Stasis Gauntlet",
+                "-c",
+                "user.email=gauntlet@stasis.local",
+                "commit",
+                "--no-verify",
+                "-m",
+                "chore: isolate Gauntlet artifacts",
+            ],
+        )?;
+    }
+    git_stdout(root, &["rev-parse", "HEAD"])
+}
+
+fn require_clean_checkout(root: &Path) -> Result<(), String> {
+    git_ok(root, &["rev-parse", "--show-toplevel"])?;
+    let status = git_stdout(root, &["status", "--porcelain", "--untracked-files=all"])?;
+    if !status.trim().is_empty() {
+        return Err("Gauntlet requires a clean original checkout; commit or stash tracked and untracked files first".to_string());
+    }
+    Ok(())
+}
+
+fn require_clean_checkout_ignoring_runs(root: &Path) -> Result<(), String> {
+    let status = git_stdout(root, &["status", "--porcelain", "--untracked-files=all"])?;
+    let unexpected = status
+        .lines()
+        .filter(|line| {
+            let path = line.get(3..).unwrap_or(line).replace('\\', "/");
+            !path.starts_with("build/gauntlet/")
+        })
+        .collect::<Vec<_>>();
+    if !unexpected.is_empty() {
+        return Err(format!(
+            "promotion requires a clean original checkout; found {}",
+            unexpected.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+fn git_ok(root: &Path, args: &[&str]) -> Result<(), String> {
+    git_output(root, args).map(|_| ())
+}
+
+fn git_stdout(root: &Path, args: &[&str]) -> Result<String, String> {
+    let output = git_output(root, args)?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .map_err(|error| format!("failed to run git {}: {error}", args.join(" ")))?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        let diagnostic = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(format!(
+            "git {} failed{}",
+            args.join(" "),
+            if diagnostic.is_empty() {
+                String::new()
+            } else {
+                format!(": {diagnostic}")
+            }
+        ))
+    }
+}
+
+fn persist_state(artifacts: &Path, state: &mut GauntletRunStateV1) -> Result<(), String> {
+    state.updated_unix_ms = unix_ms();
+    write_json(&artifacts.join(RUN_STATE_NAME), state)?;
+    generate_report_shell(artifacts, state)
+}
+
+fn load_state(artifacts: &Path) -> Result<GauntletRunStateV1, String> {
+    let state: GauntletRunStateV1 = read_json(&artifacts.join(RUN_STATE_NAME))?;
+    if state.schema_version != GAUNTLET_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported persisted Gauntlet schema {}",
+            state.schema_version
+        ));
+    }
+    Ok(state)
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, String> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed reading {}: {error}", path.display()))?;
+    serde_json::from_str(&source)
+        .map_err(|error| format!("invalid JSON {}: {error}", path.display()))
+}
+
+fn append_decision(
+    artifacts: &Path,
+    role: &str,
+    kind: &str,
+    summary: &str,
+    rationale: &str,
+    evidence: &str,
+    next_step: &str,
+) -> Result<(), String> {
+    let record = json!({
+        "schema_version": 1,
+        "unix_ms": unix_ms(),
+        "audience": "lead_builder",
+        "role": bounded_decision_text(role),
+        "kind": bounded_decision_text(kind),
+        "summary": bounded_decision_text(summary),
+        "rationale": bounded_decision_text(rationale),
+        "evidence": bounded_decision_text(evidence),
+        "next_step": bounded_decision_text(next_step),
+    });
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(artifacts.join(DECISIONS_NAME))
+        .map_err(|error| format!("failed opening Gauntlet decision memory: {error}"))?;
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&record).map_err(|error| error.to_string())?
+    )
+    .map_err(|error| format!("failed writing Gauntlet decision memory: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("failed flushing Gauntlet decision memory: {error}"))?;
+    file.sync_data()
+        .map_err(|error| format!("failed syncing Gauntlet decision memory: {error}"))
+}
+
+fn bounded_decision_text(value: &str) -> String {
+    value.chars().take(MAX_DECISION_FIELD_CHARS).collect()
+}
+
+fn decision_memory_snapshot(artifacts: &Path) -> Result<String, String> {
+    let records = read_decision_records(artifacts)?;
+    let mut selected = Vec::new();
+    let mut characters = 0_usize;
+    for record in records.into_iter().rev() {
+        if record.get("audience").and_then(Value::as_str) != Some("lead_builder") {
+            continue;
+        }
+        let rendered = serde_json::to_string(&record).map_err(|error| error.to_string())?;
+        let count = rendered.chars().count().saturating_add(1);
+        if selected.len() >= MAX_MEMORY_RECORDS
+            || characters.saturating_add(count) > MAX_MEMORY_CHARS
+        {
+            break;
+        }
+        characters = characters.saturating_add(count);
+        selected.push(rendered);
+    }
+    selected.reverse();
+    if selected.is_empty() {
+        Ok("(no prior decisions recorded)".to_string())
+    } else {
+        Ok(selected.join("\n"))
+    }
+}
+
+fn latest_decision_next_step(artifacts: &Path) -> Option<String> {
+    read_decision_records(artifacts)
+        .ok()?
+        .into_iter()
+        .rev()
+        .find(|record| record.get("audience").and_then(Value::as_str) == Some("lead_builder"))?
+        .get("next_step")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn read_decision_records(artifacts: &Path) -> Result<Vec<Value>, String> {
+    let path = artifacts.join(DECISIONS_NAME);
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let metadata = fs::metadata(&path)
+        .map_err(|error| format!("failed reading Gauntlet decision memory: {error}"))?;
+    if metadata.len() > 8 * 1024 * 1024 {
+        return Err("Gauntlet decision memory exceeds the 8 MiB safety limit".to_string());
+    }
+    let source = fs::read_to_string(&path)
+        .map_err(|error| format!("failed reading Gauntlet decision memory: {error}"))?;
+    let lines = source
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    let mut records = Vec::with_capacity(lines.len());
+    for (index, line) in lines.iter().enumerate() {
+        match serde_json::from_str::<Value>(line) {
+            Ok(record) => records.push(record),
+            Err(_) if index + 1 == lines.len() => break,
+            Err(error) => return Err(format!("invalid Gauntlet decision record: {error}")),
+        }
+    }
+    Ok(records)
+}
+
+fn emit_event(artifacts: &Path, kind: &str, data: Value) -> Result<(), String> {
+    let event = json!({"schema_version": 1, "unix_ms": unix_ms(), "kind": kind, "data": data});
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(artifacts.join(EVENTS_NAME))
+        .map_err(|error| format!("failed opening Gauntlet event stream: {error}"))?;
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&event).map_err(|error| error.to_string())?
+    )
+    .map_err(|error| format!("failed writing Gauntlet event: {error}"))?;
+    let observer = read_json::<GauntletConfigV1>(&artifacts.join(EFFECTIVE_CONFIG_NAME))
+        .ok()
+        .map(|config| config.execution.observer)
+        .unwrap_or(GauntletObserver::Auto);
+    match observer {
+        GauntletObserver::Jsonl => println!("{}", event),
+        GauntletObserver::Auto | GauntletObserver::Tui => {
+            let detail = match kind {
+                "lead_decision" => event
+                    .pointer("/data/workstream")
+                    .and_then(Value::as_str)
+                    .unwrap_or("planning"),
+                "candidate_accepted" | "candidate_rejected" => event
+                    .pointer("/data/candidate")
+                    .and_then(Value::as_str)
+                    .unwrap_or("candidate"),
+                "run_finished" => event
+                    .pointer("/data/reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("finished"),
+                _ => "",
+            };
+            println!(
+                "[gauntlet] {kind}{}",
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {detail}")
+                }
+            );
+        }
+    }
+    Ok(())
+}
+
+fn append_provider_usage(artifacts: &Path, provider: &mut CodexExecProvider) -> Result<(), String> {
+    if let Some(usage) = provider.take_usage() {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(artifacts.join(USAGE_NAME))
+            .map_err(|error| format!("failed opening Gauntlet usage stream: {error}"))?;
+        writeln!(
+            file,
+            "{}",
+            serde_json::to_string(&usage).map_err(|error| error.to_string())?
+        )
+        .map_err(|error| format!("failed writing Gauntlet usage: {error}"))?;
+    }
+    Ok(())
+}
+
+fn append_usage_file(artifacts: &Path, source: &Path) -> Result<(), String> {
+    let usage = fs::read_to_string(source)
+        .map_err(|error| format!("failed reading builder usage {}: {error}", source.display()))?;
+    if usage.is_empty() {
+        return Ok(());
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(artifacts.join(USAGE_NAME))
+        .map_err(|error| format!("failed opening Gauntlet usage stream: {error}"))?;
+    file.write_all(usage.as_bytes())
+        .map_err(|error| format!("failed appending builder usage: {error}"))
+}
+
+fn generate_report(
+    artifacts: &Path,
+    state: &GauntletRunStateV1,
+    bar: &FrozenBar,
+) -> Result<(), String> {
+    let bar_json = serde_json::to_string_pretty(bar).map_err(|error| error.to_string())?;
+    let events = fs::read_to_string(artifacts.join(EVENTS_NAME)).unwrap_or_default();
+    let decisions = fs::read_to_string(artifacts.join(DECISIONS_NAME)).unwrap_or_default();
+    let mut captures = String::new();
+    if let Ok(entries) = fs::read_dir(artifacts.join("artifacts")) {
+        let mut entries = entries.flatten().collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let id = entry.file_name().to_string_lossy().to_string();
+            if entry.path().join("frame.png").is_file() {
+                captures.push_str(&format!(
+                    "<figure><img loading=\"lazy\" src=\"artifacts/{}/frame.png\" alt=\"{}\"><figcaption>{}</figcaption></figure>",
+                    escape_html(&id),
+                    escape_html(&id),
+                    escape_html(&id)
+                ));
+            }
+        }
+    }
+    let html = format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>Stasis Gauntlet {}</title><style>body{{font:16px system-ui;max-width:1100px;margin:40px auto;padding:0 20px;background:#0b1020;color:#e8eefc}}pre{{white-space:pre-wrap;background:#151d33;padding:16px;border-radius:10px}}figure{{display:inline-block;width:46%;vertical-align:top}}img{{max-width:100%;border-radius:10px}}</style><h1>Stasis Gauntlet {}</h1><p>Phase: {:?} &middot; accepted {} &middot; rejected {} &middot; model calls {}</p><h2>Captures</h2>{}<h2>Frozen quality bar</h2><pre>{}</pre><h2>Decision memory</h2><pre>{}</pre><h2>Event stream</h2><pre>{}</pre>",
+        escape_html(&state.run_id),
+        escape_html(&state.run_id),
+        state.phase,
+        state.accepted_candidates,
+        state.rejected_candidates,
+        state.model_calls,
+        captures,
+        escape_html(&bar_json),
+        escape_html(&decisions),
+        escape_html(&events)
+    );
+    fs::write(artifacts.join(REPORT_NAME), html)
+        .map_err(|error| format!("failed writing Gauntlet report: {error}"))
+}
+
+fn generate_report_shell(artifacts: &Path, state: &GauntletRunStateV1) -> Result<(), String> {
+    if artifacts.join(QUALITY_BAR_NAME).is_file() {
+        let bar: FrozenBar = read_json(&artifacts.join(QUALITY_BAR_NAME))?;
+        generate_report(artifacts, state, &bar)
+    } else {
+        Ok(())
+    }
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn should_stop(artifacts: &Path) -> bool {
+    artifacts.join(STOP_NAME).is_file()
+}
+
+fn run_artifacts(root: &Path, run_id: &str) -> PathBuf {
+    root.join(RUNS_PATH).join(run_id)
+}
+
+fn new_run_id(base_commit: &str) -> String {
+    format!("{}-{}", unix_ms(), &base_commit[..base_commit.len().min(8)])
+}
+
+fn validate_run_id(run_id: &str) -> Result<(), String> {
+    if run_id.is_empty()
+        || run_id.len() > 80
+        || !run_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err("invalid Gauntlet run id".to_string());
+    }
+    Ok(())
+}
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+fn format_status(state: &GauntletRunStateV1, artifacts: &Path) -> String {
+    format!("Gauntlet {}: {:?}\nbranch: {}\nbest: {}\naccepted: {}, rejected: {}, model calls: {}\nworktree: {}\nreport: {}", state.run_id, state.phase, state.branch, state.best_commit.as_deref().unwrap_or("none"), state.accepted_candidates, state.rejected_candidates, state.model_calls, state.project_root, artifacts.join(REPORT_NAME).display())
+}
+
+fn scout_schema() -> Value {
+    json!({"type":"object","required":["summary","sources"],"properties":{"summary":{"type":"string"},"sources":{"type":"array","maxItems":5,"items":{"type":"object","required":["url","relevance"],"properties":{"url":{"type":"string"},"relevance":{"type":"string"}},"additionalProperties":false}}},"additionalProperties":false})
+}
+
+fn bootstrap_schema() -> Value {
+    json!({"type":"object","required":["workstreams"],"properties":{"workstreams":{"type":"array","minItems":4,"maxItems":10,"items":{"type":"string"}}},"additionalProperties":false})
+}
+
+fn lead_schema() -> Value {
+    json!({"type":"object","required":["done","workstream","builder_prompt","rationale","next_step"],"properties":{"done":{"type":"boolean"},"workstream":{"type":"string","maxLength":2000},"builder_prompt":{"type":"string","maxLength":2000},"rationale":{"type":"string","maxLength":2000},"next_step":{"type":"string","maxLength":2000}},"additionalProperties":false})
+}
+
+fn critic_schema() -> Value {
+    json!({"type":"object","required":["preferred","score_a","score_b","largest_gap","summary"],"properties":{"preferred":{"type":"string","enum":["a","b","neither","equivalent"]},"score_a":{"type":"integer","minimum":0,"maximum":100},"score_b":{"type":"integer","minimum":0,"maximum":100},"largest_gap":{"type":"string"},"summary":{"type":"string"}},"additionalProperties":false})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_ids_and_capture_artifacts_are_bounded() {
+        assert!(validate_run_id("1234567890-deadbeef").is_ok());
+        assert!(validate_run_id("../escape").is_err());
+        let value = "candidate 1/evil".replace(
+            |character: char| {
+                !character.is_ascii_alphanumeric() && character != '-' && character != '_'
+            },
+            "_",
+        );
+        assert_eq!(value, "candidate_1_evil");
+    }
+
+    #[test]
+    fn schemas_are_closed_and_role_outputs_are_strict() {
+        let source = r#"{"preferred":"a","score_a":80,"score_b":60,"largest_gap":"audio","summary":"A is clearer","extra":true}"#;
+        assert!(serde_json::from_str::<BlindCritique>(source).is_err());
+        assert_eq!(critic_schema()["additionalProperties"], false);
+    }
+
+    #[test]
+    fn html_report_content_is_escaped() {
+        assert_eq!(escape_html("<script>&\""), "&lt;script&gt;&amp;&quot;");
+    }
+
+    #[test]
+    fn decision_memory_is_bounded_and_restores_the_latest_next_step() {
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_memory_{}_{}",
+            std::process::id(),
+            unix_ms()
+        ));
+        fs::create_dir_all(&root).expect("memory root");
+        for index in 0..55 {
+            append_decision(
+                &root,
+                "builder",
+                "test",
+                &format!("decision-{index}"),
+                "bounded rationale",
+                "bounded evidence",
+                &format!("next-{index}"),
+            )
+            .expect("append decision");
+        }
+        let snapshot = decision_memory_snapshot(&root).expect("memory snapshot");
+        assert!(!snapshot.contains("decision-0\""));
+        assert!(snapshot.contains("decision-54"));
+        assert!(snapshot.lines().count() <= MAX_MEMORY_RECORDS);
+        assert_eq!(latest_decision_next_step(&root).as_deref(), Some("next-54"));
+        OpenOptions::new()
+            .append(true)
+            .open(root.join(DECISIONS_NAME))
+            .expect("decision log")
+            .write_all(b"{\"torn\":")
+            .expect("torn final record");
+        assert_eq!(latest_decision_next_step(&root).as_deref(), Some("next-54"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn frozen_references_remain_relative_and_resume_valid() {
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_reference_{}_{}",
+            std::process::id(),
+            unix_ms()
+        ));
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(root.clone());
+        fs::create_dir_all(root.join("input")).expect("reference input");
+        let bytes = b"bounded-reference-image";
+        fs::write(root.join("input/reference.png"), bytes).expect("reference");
+        let references = freeze_references(
+            &root,
+            "123-deadbeef",
+            vec![GauntletReference {
+                path: "input/reference.png".to_string(),
+                sha256: hex_sha256(bytes),
+                source_url: None,
+            }],
+        )
+        .expect("freeze reference");
+        let config =
+            GauntletConfigV1::new(false, references.clone(), 1, 1, GauntletObserver::Jsonl)
+                .expect("resume-valid config");
+        assert!(config.validate().is_ok());
+        assert!(!Path::new(&references[0].path).is_absolute());
+        assert_eq!(
+            fs::read(root.join(&references[0].path)).expect("frozen reference"),
+            bytes
+        );
+    }
+
+    #[test]
+    fn isolated_worktree_can_live_under_ignored_run_artifacts() {
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_worktree_{}_{}",
+            std::process::id(),
+            unix_ms()
+        ));
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(root.clone());
+        fs::create_dir_all(&root).expect("root");
+        git_ok(&root, &["init", "--quiet"]).expect("git init");
+        fs::write(root.join(".gitignore"), "build/\n").expect("ignore");
+        fs::write(root.join("stasis.json"), "{}\n").expect("manifest");
+        ensure_initial_commit(&root).expect("initial commit");
+        let target = root.join("build/gauntlet/worktrees/test-run");
+        git_ok(
+            &root,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "stasis/gauntlet/test-run",
+                &target.to_string_lossy(),
+                "HEAD",
+            ],
+        )
+        .expect("nested ignored worktree");
+        assert!(target.join("stasis.json").is_file());
+        ensure_worktree_ignores(&target).expect("artifact ignores");
+        assert!(git_stdout(&target, &["status", "--porcelain"])
+            .expect("clean worktree")
+            .is_empty());
+    }
+}

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -10,8 +10,9 @@ use crossterm::terminal::{
 };
 use serde_json::Value;
 use stasis_ai::{
-    live_tool_specs, run_agent, AgentEvent, CodexExecProvider, ToolCall, ToolExecutor,
-    ToolObservation, DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT,
+    gauntlet_tool_specs, live_tool_specs, project_ai_tool_specs, run_agent, run_agent_with_profile,
+    AgentEvent, AgentProfile, CodexExecProvider, ToolCall, ToolExecutor, ToolObservation,
+    DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT,
 };
 use stasis_compiler::frontend::parser::completion_expected_type;
 use stasis_compiler::frontend::workshop::{
@@ -35,6 +36,7 @@ const MAX_UNDO_STATES: usize = 100;
 const COMPLETION_LIMIT: usize = 64;
 const TUI_REQUEST_START: u64 = 1u64 << 61;
 const AI_REQUEST_START: u64 = 1u64 << 62;
+const MAX_DECISION_FIELD_CHARS: usize = 2_000;
 
 enum AiUiEvent {
     InitialContext(Value),
@@ -56,23 +58,113 @@ pub(super) fn run_scripted_ai_with_cancel(
     prompt: &str,
     canceled: &AtomicBool,
 ) -> Result<(String, PathBuf, PathBuf), String> {
-    let mut audit = AiAuditLog::create(project_root, prompt)?;
+    let outcome = run_scripted_ai_profile(
+        client,
+        project_root,
+        prompt,
+        AgentProfile::default(),
+        Vec::new(),
+        false,
+        false,
+        false,
+        None,
+        canceled,
+    )?;
+    Ok((outcome.summary, outcome.trace, outcome.usage_trace))
+}
+
+pub(super) fn run_scripted_project_ai_with_cancel(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    prompt: &str,
+    canceled: &AtomicBool,
+) -> Result<(String, PathBuf, PathBuf), String> {
+    let mut profile = AgentProfile::default();
+    profile.instruction.push_str(" You may create or update project assets with write_svg_asset, write_png_asset, import_png_asset, write_data_asset, and write_procedural_wav. Put one contiguous asset-tool group immediately before source writes that load or use those assets. The combined asset/source change is one rollback-safe transaction; never edit the asset manifest directly.");
+    let outcome = run_scripted_ai_profile(
+        client,
+        project_root,
+        prompt,
+        profile,
+        Vec::new(),
+        false,
+        true,
+        false,
+        None,
+        canceled,
+    )?;
+    Ok((outcome.summary, outcome.trace, outcome.usage_trace))
+}
+
+pub(super) struct ScriptedAiOutcome {
+    pub summary: String,
+    pub trace: PathBuf,
+    pub usage_trace: PathBuf,
+    pub model_calls: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_scripted_ai_profile(
+    client: &LiveSessionClient,
+    project_root: &Path,
+    prompt: &str,
+    profile: AgentProfile,
+    images: Vec<PathBuf>,
+    web_search: bool,
+    allow_project_assets: bool,
+    auto_apply_layout: bool,
+    decision_log: Option<&Path>,
+    canceled: &AtomicBool,
+) -> Result<ScriptedAiOutcome, String> {
+    let mut audit = AiAuditLog::create_with_model(
+        project_root,
+        prompt,
+        profile.model.as_deref(),
+        profile.reasoning_effort.as_deref(),
+    )?;
     let trace_path = audit.path.clone();
     let usage_path = audit.usage_path.clone();
-    let mut provider = CodexExecProvider::default();
-    let mut tools = LiveAiTools::new(client.clone());
+    let mut provider = CodexExecProvider::default()
+        .with_images(images)
+        .with_web_search(web_search);
+    if let Some(model) = profile.model.as_deref() {
+        provider = provider.with_model(model);
+    }
+    if let Some(reasoning_effort) = profile.reasoning_effort.as_deref() {
+        provider = provider.with_reasoning_effort(reasoning_effort);
+    }
+    let mut tools = if allow_project_assets {
+        LiveAiTools::new_project_assets(
+            client.clone(),
+            project_root.to_path_buf(),
+            auto_apply_layout,
+            decision_log.map(Path::to_path_buf),
+            profile.role.clone(),
+        )
+    } else {
+        LiveAiTools::new(client.clone())
+    };
     let initial_context = load_ai_initial_context(&mut tools, canceled)?;
     audit.write(serde_json::json!({
         "event": "initial_context",
         "value": initial_context.clone(),
     }))?;
     let mut audit_error = None;
-    let result = run_agent(
+    let result = run_agent_with_profile(
         &mut provider,
         &mut tools,
+        &profile,
         prompt,
         initial_context,
-        live_tool_specs(),
+        if allow_project_assets {
+            if decision_log.is_some() {
+                gauntlet_tool_specs()
+            } else {
+                project_ai_tool_specs()
+            }
+        } else {
+            live_tool_specs()
+        },
         canceled,
         |event| {
             if audit_error.is_none() {
@@ -93,7 +185,12 @@ pub(super) fn run_scripted_ai_with_cancel(
                 "ok": true,
                 "summary": summary,
             }))?;
-            Ok((summary, trace_path, usage_path))
+            Ok(ScriptedAiOutcome {
+                summary,
+                trace: trace_path,
+                usage_trace: usage_path,
+                model_calls: provider.call_count(),
+            })
         }
         Err(error) => {
             audit.write(serde_json::json!({
@@ -157,6 +254,16 @@ fn audit_agent_event(event: &AgentEvent) -> Value {
             "event": "tool_observations",
             "observations": observations.iter().map(audit_observation).collect::<Vec<_>>(),
         }),
+        AgentEvent::ContextCompacted {
+            turns_compacted,
+            before_bytes,
+            after_bytes,
+        } => serde_json::json!({
+            "event": "context_compacted",
+            "turns_compacted": turns_compacted,
+            "before_bytes": before_bytes,
+            "after_bytes": after_bytes,
+        }),
         AgentEvent::Completed(summary) => {
             serde_json::json!({"event": "model_completed", "summary": summary})
         }
@@ -183,6 +290,15 @@ struct AiAuditLog {
 
 impl AiAuditLog {
     fn create(project_root: &Path, prompt: &str) -> Result<Self, String> {
+        Self::create_with_model(project_root, prompt, None, None)
+    }
+
+    fn create_with_model(
+        project_root: &Path,
+        prompt: &str,
+        model: Option<&str>,
+        reasoning_effort: Option<&str>,
+    ) -> Result<Self, String> {
         let directory = project_root.join("build/ai-traces");
         fs::create_dir_all(&directory)
             .map_err(|error| format!("failed creating AI trace directory: {error}"))?;
@@ -223,10 +339,10 @@ impl AiAuditLog {
         log.write(serde_json::json!({
             "event": "request",
             "provider": "installed_codex_subscription",
-            "model": std::env::var("STASIS_AI_MODEL")
-                .unwrap_or_else(|_| DEFAULT_CODEX_MODEL.to_string()),
-            "reasoning_effort": std::env::var("STASIS_AI_REASONING_EFFORT")
-                .unwrap_or_else(|_| DEFAULT_REASONING_EFFORT.to_string()),
+            "model": model.map(str::to_string).unwrap_or_else(|| std::env::var("STASIS_AI_MODEL")
+                .unwrap_or_else(|_| DEFAULT_CODEX_MODEL.to_string())),
+            "reasoning_effort": reasoning_effort.map(str::to_string).unwrap_or_else(|| std::env::var("STASIS_AI_REASONING_EFFORT")
+                .unwrap_or_else(|_| DEFAULT_REASONING_EFFORT.to_string())),
             "prompt": prompt,
             "payload_logging": "exact agent tool calls and observations; Codex transport envelope omitted",
         }))?;
@@ -273,6 +389,14 @@ impl AiAuditLog {
 
 fn duration_millis(duration: Duration) -> u64 {
     duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
 }
 
 impl Drop for AiRun {
@@ -1371,6 +1495,21 @@ impl LiveTui {
                         "observations": observations.iter().map(audit_observation).collect::<Vec<_>>(),
                     }));
                 }
+                AiUiEvent::Progress(AgentEvent::ContextCompacted {
+                    turns_compacted,
+                    before_bytes,
+                    after_bytes,
+                }) => {
+                    self.status = format!(
+                        "AI compacted {turns_compacted} turns ({before_bytes} -> {after_bytes} bytes)"
+                    );
+                    self.audit(serde_json::json!({
+                        "event": "context_compacted",
+                        "turns_compacted": turns_compacted,
+                        "before_bytes": before_bytes,
+                        "after_bytes": after_bytes,
+                    }));
+                }
                 AiUiEvent::Progress(AgentEvent::Completed(summary)) => {
                     self.push_transcript(format!("AI: {summary}"));
                     self.audit(serde_json::json!({"event": "model_completed", "summary": summary}));
@@ -1962,6 +2101,11 @@ struct LiveAiTools {
     next_request_id: u64,
     last_write: Option<LiveResponse>,
     reference_search_ready: bool,
+    project_root: Option<PathBuf>,
+    asset_transaction: Option<super::gauntlet::assets::AppliedAssetTransaction>,
+    auto_apply_layout: bool,
+    decision_log: Option<PathBuf>,
+    decision_role: Option<String>,
 }
 
 impl LiveAiTools {
@@ -1971,6 +2115,117 @@ impl LiveAiTools {
             next_request_id: AI_REQUEST_START,
             last_write: None,
             reference_search_ready: false,
+            project_root: None,
+            asset_transaction: None,
+            auto_apply_layout: false,
+            decision_log: None,
+            decision_role: None,
+        }
+    }
+
+    fn new_project_assets(
+        client: LiveSessionClient,
+        project_root: PathBuf,
+        auto_apply_layout: bool,
+        decision_log: Option<PathBuf>,
+        decision_role: String,
+    ) -> Self {
+        Self {
+            project_root: Some(project_root),
+            auto_apply_layout,
+            decision_log,
+            decision_role: Some(decision_role),
+            ..Self::new(client)
+        }
+    }
+
+    fn record_decision(&self, call: &ToolCall) -> ToolObservation {
+        let Some(path) = self.decision_log.as_ref() else {
+            return ToolObservation::error(
+                &call.tool,
+                "decision memory is unavailable outside a Gauntlet run",
+            );
+        };
+        let Some(args) = call.args.as_object() else {
+            return ToolObservation::error(&call.tool, "decision args must be an object");
+        };
+        let read = |name: &str| -> Result<String, String> {
+            let value = args
+                .get(name)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| format!("record_decision requires non-empty string arg: {name}"))?;
+            if value.chars().count() > MAX_DECISION_FIELD_CHARS {
+                return Err(format!(
+                    "record_decision arg {name} exceeds {MAX_DECISION_FIELD_CHARS} characters"
+                ));
+            }
+            Ok(value.to_string())
+        };
+        let record = match (
+            read("kind"),
+            read("summary"),
+            read("rationale"),
+            read("evidence"),
+            read("next_step"),
+        ) {
+            (Ok(kind), Ok(summary), Ok(rationale), Ok(evidence), Ok(next_step)) => {
+                serde_json::json!({
+                    "schema_version": 1,
+                    "unix_ms": unix_ms(),
+                    "audience": "lead_builder",
+                    "role": self.decision_role.as_deref().unwrap_or("Gauntlet agent"),
+                    "kind": kind,
+                    "summary": summary,
+                    "rationale": rationale,
+                    "evidence": evidence,
+                    "next_step": next_step,
+                })
+            }
+            values => {
+                let error = [
+                    values.0.err(),
+                    values.1.err(),
+                    values.2.err(),
+                    values.3.err(),
+                    values.4.err(),
+                ]
+                .into_iter()
+                .flatten()
+                .next()
+                .unwrap_or_else(|| "invalid decision memory".to_string());
+                return ToolObservation::error(&call.tool, error);
+            }
+        };
+        let result = (|| -> Result<(), String> {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    format!("failed creating decision memory directory: {error}")
+                })?;
+            }
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .map_err(|error| format!("failed opening decision memory: {error}"))?;
+            writeln!(
+                file,
+                "{}",
+                serde_json::to_string(&record).map_err(|error| error.to_string())?
+            )
+            .map_err(|error| format!("failed writing decision memory: {error}"))?;
+            file.flush()
+                .map_err(|error| format!("failed flushing decision memory: {error}"))?;
+            file.sync_data()
+                .map_err(|error| format!("failed syncing decision memory: {error}"))
+        })();
+        match result {
+            Ok(()) => ToolObservation::result(
+                &call.tool,
+                serde_json::json!({"status":"recorded","path":path}),
+            ),
+            Err(error) => ToolObservation::error(&call.tool, error),
         }
     }
 
@@ -2104,10 +2359,27 @@ impl LiveAiTools {
             canceled,
         ) {
             Ok(response) => {
+                let response =
+                    if self.auto_apply_layout && response.ok && response.kind == "edit_preview" {
+                        match self.request(LiveCommand::Apply { run_tests: true }, canceled) {
+                            Ok(applied) => applied,
+                            Err(error) => {
+                                if let Some(transaction) = self.asset_transaction.take() {
+                                    let _ = transaction.rollback();
+                                }
+                                return failed_write_observations(calls, error);
+                            }
+                        }
+                    } else {
+                        response
+                    };
                 let applied = response.ok && response.kind == "edit_applied";
                 if applied {
                     self.last_write = Some(response.clone());
                     self.reference_search_ready = false;
+                    self.asset_transaction.take();
+                } else if let Some(transaction) = self.asset_transaction.take() {
+                    let _ = transaction.rollback();
                 }
                 if applied {
                     calls
@@ -2127,7 +2399,12 @@ impl LiveAiTools {
                     failed_write_observations(calls, error)
                 }
             }
-            Err(error) => failed_write_observations(calls, error),
+            Err(error) => {
+                if let Some(transaction) = self.asset_transaction.take() {
+                    let _ = transaction.rollback();
+                }
+                failed_write_observations(calls, error)
+            }
         }
     }
 }
@@ -2219,10 +2496,67 @@ impl ToolExecutor for LiveAiTools {
                     .collect()
             }
         };
+        let asset_indexes = calls
+            .iter()
+            .enumerate()
+            .filter_map(|(index, call)| {
+                matches!(
+                    call.tool.as_str(),
+                    "write_svg_asset"
+                        | "write_png_asset"
+                        | "import_png_asset"
+                        | "write_data_asset"
+                        | "write_procedural_wav"
+                )
+                .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let asset_range = asset_indexes.first().copied().map(|first| {
+            let last = *asset_indexes.last().expect("asset index");
+            first..last + 1
+        });
+        if let Some(range) = asset_range.as_ref() {
+            let valid = asset_indexes.len() == range.len()
+                && write_range
+                    .as_ref()
+                    .is_some_and(|writes| range.end == writes.start)
+                && self.project_root.is_some();
+            if !valid {
+                return calls
+                    .iter()
+                    .map(|call| ToolObservation::error(
+                        &call.tool,
+                        "Gauntlet asset tools must be one contiguous batch immediately before related source writes",
+                    ))
+                    .collect();
+            }
+            let asset_calls = calls[range.clone()].iter().collect::<Vec<_>>();
+            match super::gauntlet::assets::apply_asset_calls(
+                self.project_root.as_ref().expect("validated project root"),
+                &asset_calls,
+            ) {
+                Ok(transaction) => self.asset_transaction = Some(transaction),
+                Err(error) => {
+                    return calls
+                        .iter()
+                        .map(|call| ToolObservation::error(&call.tool, error.clone()))
+                        .collect();
+                }
+            }
+        }
         let mut observations = Vec::with_capacity(calls.len());
         let mut index = 0;
         while index < calls.len() {
-            if write_range
+            if asset_range
+                .as_ref()
+                .is_some_and(|range| range.contains(&index))
+            {
+                observations.push(ToolObservation::result(
+                    &calls[index].tool,
+                    serde_json::json!({"status": "staged_for_atomic_source_commit"}),
+                ));
+                index += 1;
+            } else if write_range
                 .as_ref()
                 .is_some_and(|range| range.start == index)
             {
@@ -2230,6 +2564,9 @@ impl ToolExecutor for LiveAiTools {
                 let writes = calls[range.clone()].iter().collect::<Vec<_>>();
                 observations.extend(self.execute_writes(&writes, canceled));
                 index = range.end;
+            } else if calls[index].tool == "record_decision" {
+                observations.push(self.record_decision(&calls[index]));
+                index += 1;
             } else {
                 observations.push(self.execute_read(&calls[index], canceled));
                 index += 1;
@@ -3020,6 +3357,54 @@ mod tests {
             json!({"tests": "passed"}),
         ));
         tools.validate_completion().expect("tested write completes");
+    }
+
+    #[test]
+    fn gauntlet_agent_can_persist_bounded_decision_memory() {
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_decision_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let decision_log = root.join("decisions.jsonl");
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let tools = LiveAiTools::new_project_assets(
+            client,
+            root.clone(),
+            true,
+            Some(decision_log.clone()),
+            "Fresh builder".to_string(),
+        );
+        let observation = tools.record_decision(&ToolCall {
+            tool: "record_decision".to_string(),
+            args: json!({
+                "kind": "architecture",
+                "summary": "Keep movement tick-based",
+                "rationale": "Deterministic replay is a frozen runtime invariant.",
+                "evidence": "The live scenario advances exactly 30 ticks.",
+                "next_step": "Implement collision using the same tick order."
+            }),
+        });
+        assert!(observation.error.is_none());
+        let source = fs::read_to_string(decision_log).expect("decision memory");
+        let record: Value = serde_json::from_str(source.trim()).expect("decision record");
+        assert_eq!(record["role"], "Fresh builder");
+        assert_eq!(record["summary"], "Keep movement tick-based");
+        assert_eq!(record["audience"], "lead_builder");
+        let oversized = tools.record_decision(&ToolCall {
+            tool: "record_decision".to_string(),
+            args: json!({
+                "kind": "architecture",
+                "summary": "x".repeat(MAX_DECISION_FIELD_CHARS + 1),
+                "rationale": "bounded",
+                "evidence": "bounded",
+                "next_step": "bounded"
+            }),
+        });
+        assert!(oversized.error.is_some());
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/stasis_ai/src/lib.rs
+++ b/crates/stasis_ai/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
@@ -8,13 +9,47 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub const MAX_AGENT_TURNS: usize = 15;
+pub const DEFAULT_AGENT_TURNS: usize = 15;
+pub const MAX_AGENT_TURNS: usize = 48;
 pub const MAX_TOOL_CALLS_PER_TURN: usize = 50;
 pub const MAX_WORKING_NOTES_CHARS: usize = 2_000;
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.6-sol";
 pub const DEFAULT_REASONING_EFFORT: &str = "medium";
 pub const MAX_OBSERVATION_BYTES: usize = 1024 * 1024;
+pub const MIN_COMPACTION_BYTES: usize = 256 * 1024;
+pub const MAX_COMPACTION_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_COMPACTION_RETAINED_TURNS: usize = 16;
 const AGENT_INSTRUCTION: &str = "Use only the supplied Stasis tools. The first JSONL record is the immutable request header; every following record is the authoritative append-only transcript of an earlier model response and its tool observations. Do not repeat completed inspection. Start with initial_context.initial_symbols, which is the completed compact default list_symbols result for the entry file and its direct imports. Treat every listed function whose name directly contains the requested behavior noun as a candidate: batch read_symbol and find_references for all of them before editing. Do not skip update, movement, collision, or render candidates merely because one function exposes the visible value. If relevant symbols are missing, batch multiple narrow list_symbols searches directly suggested by the request, such as the behavior noun plus render or update terms; never enumerate the whole project. A reference lookup does not require a prior source read. Call find_references for behavior-bearing symbols before writing. For collision or geometry changes, use rendered rectangle bounds as the coordinate source of truth and derive contact test inputs after the update function's movement order instead of copying old collision constants. Put all related source and requested durable-test changes in one contiguous atomic write batch. The write compiles the batch and runs project tests; if it succeeds, return done immediately without a separate test call. If it fails, correct only the reported defect and retry atomically. Return exactly one JSON object matching the response contract.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentProfile {
+    pub role: String,
+    pub instruction: String,
+    pub max_turns: usize,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub compaction: Option<AgentCompactionPolicy>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCompactionPolicy {
+    pub max_request_bytes: usize,
+    pub retain_recent_turns: usize,
+}
+
+impl Default for AgentProfile {
+    fn default() -> Self {
+        Self {
+            role: "Stasis live-workspace coding agent".to_string(),
+            instruction: AGENT_INSTRUCTION.to_string(),
+            max_turns: DEFAULT_AGENT_TURNS,
+            model: None,
+            reasoning_effort: None,
+            compaction: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -88,11 +123,19 @@ impl ModelResponse {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentEvent {
-    Turn { current: usize, maximum: usize },
+    Turn {
+        current: usize,
+        maximum: usize,
+    },
     ProviderUsage(Value),
     WorkingNotes(String),
     ToolBatch(Vec<ToolCall>),
     Observations(Vec<ToolObservation>),
+    ContextCompacted {
+        turns_compacted: usize,
+        before_bytes: usize,
+        after_bytes: usize,
+    },
     Completed(String),
 }
 
@@ -100,8 +143,8 @@ pub enum AgentEvent {
 struct ModelRequestHeader<'a> {
     record: &'static str,
     schema_version: u32,
-    role: &'static str,
-    instruction: &'static str,
+    role: &'a str,
+    instruction: &'a str,
     user_prompt: &'a str,
     initial_context: &'a Value,
     tool_specs: &'a [ToolSpec],
@@ -131,6 +174,34 @@ pub fn run_agent<P, T, E>(
     initial_context: Value,
     tool_specs: Vec<ToolSpec>,
     canceled: &AtomicBool,
+    emit: E,
+) -> Result<String, String>
+where
+    P: ModelProvider,
+    T: ToolExecutor,
+    E: FnMut(AgentEvent),
+{
+    run_agent_with_profile(
+        provider,
+        executor,
+        &AgentProfile::default(),
+        user_prompt,
+        initial_context,
+        tool_specs,
+        canceled,
+        emit,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_agent_with_profile<P, T, E>(
+    provider: &mut P,
+    executor: &mut T,
+    profile: &AgentProfile,
+    user_prompt: &str,
+    initial_context: Value,
+    tool_specs: Vec<ToolSpec>,
+    canceled: &AtomicBool,
     mut emit: E,
 ) -> Result<String, String>
 where
@@ -141,30 +212,60 @@ where
     if user_prompt.trim().is_empty() {
         return Err("AI request must not be empty".to_string());
     }
+    if profile.role.trim().is_empty() || profile.instruction.trim().is_empty() {
+        return Err("AI agent profile requires a role and instruction".to_string());
+    }
+    if profile.max_turns == 0 || profile.max_turns > MAX_AGENT_TURNS {
+        return Err(format!(
+            "AI agent profile max_turns must be between 1 and {MAX_AGENT_TURNS}"
+        ));
+    }
+    for (field, value) in [
+        ("model", profile.model.as_deref()),
+        ("reasoning_effort", profile.reasoning_effort.as_deref()),
+    ] {
+        if value.is_some_and(|value| value.trim().is_empty() || value.len() > 128) {
+            return Err(format!(
+                "AI agent profile {field} must contain 1..=128 characters when set"
+            ));
+        }
+    }
+    if let Some(compaction) = &profile.compaction {
+        if !(MIN_COMPACTION_BYTES..=MAX_COMPACTION_BYTES).contains(&compaction.max_request_bytes)
+            || compaction.retain_recent_turns == 0
+            || compaction.retain_recent_turns > MAX_COMPACTION_RETAINED_TURNS
+        {
+            return Err(format!(
+                "AI compaction requires max_request_bytes between {MIN_COMPACTION_BYTES} and {MAX_COMPACTION_BYTES} and retain_recent_turns between 1 and {MAX_COMPACTION_RETAINED_TURNS}"
+            ));
+        }
+    }
     let known_tools = tool_specs
         .iter()
         .map(|spec| spec.tool.as_str())
         .collect::<BTreeSet<_>>();
     let response_contract = response_contract();
-    let mut request = serde_json::to_string(&ModelRequestHeader {
+    let header = serde_json::to_string(&ModelRequestHeader {
         record: "request",
         schema_version: 1,
-        role: "Stasis live-workspace coding agent",
-        instruction: AGENT_INSTRUCTION,
+        role: &profile.role,
+        instruction: &profile.instruction,
         user_prompt,
         initial_context: &initial_context,
         tool_specs: &tool_specs,
         response_contract: &response_contract,
     })
     .map_err(|error| format!("failed encoding append-only AI request header: {error}"))?;
-    for turn in 1..=MAX_AGENT_TURNS {
+    let mut transcript = AgentTranscript::new(header);
+    for turn in 1..=profile.max_turns {
         if canceled.load(Ordering::Acquire) {
             return Err("AI request canceled".to_string());
         }
         emit(AgentEvent::Turn {
             current: turn,
-            maximum: MAX_AGENT_TURNS,
+            maximum: profile.max_turns,
         });
+        let request = transcript.render()?;
         let response = provider.respond(&request, canceled)?;
         if let Some(usage) = provider.take_usage() {
             emit(AgentEvent::ProviderUsage(usage));
@@ -180,7 +281,8 @@ where
                 if let Err(error) = executor.validate_completion() {
                     let observations = vec![ToolObservation::error("completion_gate", error)];
                     emit(AgentEvent::Observations(observations.clone()));
-                    append_transcript_entry(&mut request, &response_record, &observations)?;
+                    transcript.append(&response_record, &observations)?;
+                    compact_transcript(&mut transcript, profile.compaction.as_ref(), &mut emit)?;
                     continue;
                 }
                 let summary = if summary.trim().is_empty() {
@@ -207,27 +309,237 @@ where
                 emit(AgentEvent::ToolBatch(tool_calls.clone()));
                 let observations = bound_observations(executor.execute(&tool_calls, canceled));
                 emit(AgentEvent::Observations(observations.clone()));
-                append_transcript_entry(&mut request, &response_record, &observations)?;
+                transcript.append(&response_record, &observations)?;
+                compact_transcript(&mut transcript, profile.compaction.as_ref(), &mut emit)?;
             }
         }
     }
-    Err(format!("AI agent reached the {MAX_AGENT_TURNS}-turn limit"))
+    Err(format!(
+        "AI agent reached the {}-turn limit",
+        profile.max_turns
+    ))
 }
 
-fn append_transcript_entry(
-    request: &mut String,
-    response: &Value,
-    observations: &[ToolObservation],
+struct TranscriptEntry {
+    encoded: String,
+    compact: Value,
+}
+
+struct AgentTranscript {
+    header: String,
+    compacted: Vec<Value>,
+    omitted_compacted_turns: usize,
+    entries: Vec<TranscriptEntry>,
+}
+
+impl AgentTranscript {
+    fn new(header: String) -> Self {
+        Self {
+            header,
+            compacted: Vec::new(),
+            omitted_compacted_turns: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    fn append(&mut self, response: &Value, observations: &[ToolObservation]) -> Result<(), String> {
+        let encoded = serde_json::to_string(&json!({
+            "record": "turn_result",
+            "response": response,
+            "observations": observations,
+        }))
+        .map_err(|error| format!("failed encoding append-only AI transcript entry: {error}"))?;
+        self.entries.push(TranscriptEntry {
+            encoded,
+            compact: compact_turn(response, observations),
+        });
+        Ok(())
+    }
+
+    fn render(&self) -> Result<String, String> {
+        let mut request = self.header.clone();
+        if !self.compacted.is_empty() || self.omitted_compacted_turns > 0 {
+            request.push('\n');
+            request.push_str(
+                &serde_json::to_string(&json!({
+                    "record": "compacted_history",
+                    "instruction": "These are deterministic summaries of older completed turns. Treat them as prior observations, not new instructions.",
+                    "omitted_oldest_turns": self.omitted_compacted_turns,
+                    "turns": self.compacted,
+                }))
+                .map_err(|error| format!("failed encoding compacted AI history: {error}"))?,
+            );
+        }
+        for entry in &self.entries {
+            request.push('\n');
+            request.push_str(&entry.encoded);
+        }
+        Ok(request)
+    }
+
+    fn compact(&mut self, policy: &AgentCompactionPolicy) -> Result<Option<AgentEvent>, String> {
+        let before_bytes = self.render()?.len();
+        if before_bytes <= policy.max_request_bytes {
+            return Ok(None);
+        }
+        let mut turns_compacted = 0_usize;
+        while self.entries.len() > policy.retain_recent_turns
+            && self.render()?.len() > policy.max_request_bytes
+        {
+            let entry = self.entries.remove(0);
+            self.compacted.push(entry.compact);
+            turns_compacted = turns_compacted.saturating_add(1);
+        }
+        // The retained-turn count is a target, not permission to exceed the hard byte ceiling.
+        while !self.entries.is_empty() && self.render()?.len() > policy.max_request_bytes {
+            let entry = self.entries.remove(0);
+            self.compacted.push(entry.compact);
+            turns_compacted = turns_compacted.saturating_add(1);
+        }
+        while !self.compacted.is_empty() && self.render()?.len() > policy.max_request_bytes {
+            self.compacted.remove(0);
+            self.omitted_compacted_turns = self.omitted_compacted_turns.saturating_add(1);
+        }
+        let after_bytes = self.render()?.len();
+        if after_bytes > policy.max_request_bytes {
+            return Err(format!(
+                "AI request header is {after_bytes} bytes after history compaction; configured limit is {} bytes",
+                policy.max_request_bytes
+            ));
+        }
+        Ok(
+            (turns_compacted > 0).then_some(AgentEvent::ContextCompacted {
+                turns_compacted,
+                before_bytes,
+                after_bytes,
+            }),
+        )
+    }
+}
+
+fn compact_transcript<E: FnMut(AgentEvent)>(
+    transcript: &mut AgentTranscript,
+    policy: Option<&AgentCompactionPolicy>,
+    emit: &mut E,
 ) -> Result<(), String> {
-    let entry = serde_json::to_string(&json!({
-        "record": "turn_result",
-        "response": response,
-        "observations": observations,
-    }))
-    .map_err(|error| format!("failed encoding append-only AI transcript entry: {error}"))?;
-    request.push('\n');
-    request.push_str(&entry);
+    if let Some(policy) = policy {
+        if let Some(event) = transcript.compact(policy)? {
+            emit(event);
+        }
+    }
     Ok(())
+}
+
+fn compact_turn(response: &Value, observations: &[ToolObservation]) -> Value {
+    let calls = response
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .map(|calls| {
+            calls
+                .iter()
+                .take(24)
+                .map(|call| {
+                    let args = call.get("args").and_then(Value::as_object);
+                    let selected_args = args
+                        .map(|args| {
+                            [
+                                "name",
+                                "kind",
+                                "file",
+                                "owner",
+                                "signature",
+                                "operation",
+                                "path",
+                                "id",
+                                "source_path",
+                                "query",
+                                "summary",
+                                "rationale",
+                                "evidence",
+                                "next_step",
+                            ]
+                            .into_iter()
+                            .filter_map(|key| {
+                                args.get(key)
+                                    .map(|value| (key.to_string(), bounded_json_value(value, 1000)))
+                            })
+                            .collect::<serde_json::Map<String, Value>>()
+                        })
+                        .unwrap_or_default();
+                    json!({
+                        "tool": call.get("tool").cloned().unwrap_or(Value::Null),
+                        "args": selected_args,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let compact_observations = observations
+        .iter()
+        .take(24)
+        .map(|observation| {
+            let result = observation.result.as_ref().map(compact_observation_result);
+            json!({
+                "tool": observation.tool,
+                "ok": observation.error.is_none(),
+                "error": observation.error.as_deref().map(|value| bounded_chars(value, 500)),
+                "result": result,
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "working_notes": bounded_chars(response.get("working_notes").and_then(Value::as_str).unwrap_or(""), 1000),
+        "summary": bounded_chars(response.get("summary").and_then(Value::as_str).unwrap_or(""), 500),
+        "tool_calls": calls,
+        "tool_calls_omitted": response.get("tool_calls").and_then(Value::as_array).map_or(0, |calls| calls.len().saturating_sub(24)),
+        "observations": compact_observations,
+        "observations_omitted": observations.len().saturating_sub(24),
+    })
+}
+
+fn compact_observation_result(result: &Value) -> Value {
+    let Some(object) = result.as_object() else {
+        return json!({"summary": bounded_chars(&result.to_string(), 500)});
+    };
+    let selected = [
+        "status",
+        "name",
+        "kind",
+        "file",
+        "receipt",
+        "tests",
+        "changed_symbols",
+        "expected_reload",
+        "state_layout_compatible",
+    ]
+    .into_iter()
+    .filter_map(|key| {
+        object
+            .get(key)
+            .map(|value| (key.to_string(), bounded_json_value(value, 1000)))
+    })
+    .collect::<serde_json::Map<String, Value>>();
+    if selected.is_empty() {
+        json!({"summary": bounded_chars(&result.to_string(), 500)})
+    } else {
+        Value::Object(selected)
+    }
+}
+
+fn bounded_json_value(value: &Value, limit: usize) -> Value {
+    let encoded = value.to_string();
+    if encoded.chars().count() <= limit {
+        value.clone()
+    } else {
+        json!({
+            "summary": bounded_chars(&encoded, limit),
+            "truncated": true,
+        })
+    }
+}
+
+fn bounded_chars(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
 }
 
 fn validate_working_notes(notes: &str) -> Result<(), String> {
@@ -270,7 +582,7 @@ fn bound_observations(observations: Vec<ToolObservation>) -> Vec<ToolObservation
     }
     let mut bounded = observations
         .iter()
-        .map(|observation| omitted_observation(observation))
+        .map(omitted_observation)
         .collect::<Vec<_>>();
     for (index, observation) in observations.into_iter().enumerate() {
         let omitted = std::mem::replace(&mut bounded[index], observation);
@@ -381,6 +693,9 @@ pub struct CodexExecProvider {
     reasoning_effort: String,
     last_usage: Option<Value>,
     run: Option<TemporaryRun>,
+    images: Vec<PathBuf>,
+    web_search: bool,
+    call_count: u32,
 }
 
 impl Default for CodexExecProvider {
@@ -399,40 +714,95 @@ impl Default for CodexExecProvider {
                 .unwrap_or_else(|| DEFAULT_REASONING_EFFORT.to_string()),
             last_usage: None,
             run: None,
+            images: Vec::new(),
+            web_search: false,
+            call_count: 0,
         }
     }
 }
 
-fn default_codex_executable() -> PathBuf {
-    #[cfg(windows)]
-    if let Some(app_data) = std::env::var_os("APPDATA") {
-        let npm = PathBuf::from(app_data).join(
-            "npm/node_modules/@openai/codex/node_modules/@openai/codex-win32-x64/\
-             vendor/x86_64-pc-windows-msvc/bin/codex.exe",
-        );
-        if npm.is_file() {
-            return npm;
-        }
-    }
-    PathBuf::from("codex")
+pub fn project_ai_tool_specs() -> Vec<ToolSpec> {
+    let mut tools = live_tool_specs();
+    tools.extend([
+        spec("write_svg_asset", "Stage one bounded SVG under assets/generated and derive its v2 manifest entry. It must be in the same tool batch immediately before source writes that load or use it.", &["id", "path", "source", "width", "height"], &[]),
+        spec("write_png_asset", "Generate and stage one deterministic PNG under assets/generated from a background and bounded rect/circle/line shape array, then derive its v2 manifest entry. It must be in the same tool batch immediately before source writes that load or use it.", &["id", "path", "width", "height", "background", "shapes"], &[]),
+        spec("import_png_asset", "Import a host-generated PNG from build/ai-assets/imagegen or build/gauntlet/imagegen into assets/generated, validate its dimensions and bytes, and derive its v2 manifest entry. It must be in the same tool batch immediately before source writes that load or use it.", &["id", "path", "source_path"], &[]),
+        spec("write_data_asset", "Stage bounded JSON or CSV data under assets/generated. It must be in the same tool batch immediately before related source writes.", &["path", "source"], &[]),
+        spec("write_procedural_wav", "Stage deterministic mono PCM audio under assets/generated and derive its v2 manifest entry. It must be in the same tool batch immediately before related source writes.", &["id", "path", "frequency_hz", "duration_ms"], &[]),
+    ]);
+    tools
 }
 
-impl ModelProvider for CodexExecProvider {
-    fn respond(&mut self, request: &str, canceled: &AtomicBool) -> Result<ModelResponse, String> {
+pub fn gauntlet_tool_specs() -> Vec<ToolSpec> {
+    let mut tools = project_ai_tool_specs();
+    tools.push(spec("record_decision", "Persist one concise Gauntlet decision, rationale, evidence summary, and next step for future fresh agents. Record conclusions and tradeoffs, never hidden chain-of-thought.", &["kind", "summary", "rationale", "evidence", "next_step"], &[]));
+    tools
+}
+
+impl CodexExecProvider {
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_reasoning_effort(mut self, reasoning_effort: impl Into<String>) -> Self {
+        self.reasoning_effort = reasoning_effort.into();
+        self
+    }
+
+    pub fn with_images(mut self, images: Vec<PathBuf>) -> Self {
+        self.images = images;
+        self
+    }
+
+    pub fn with_web_search(mut self, enabled: bool) -> Self {
+        self.web_search = enabled;
+        self
+    }
+
+    pub fn call_count(&self) -> u32 {
+        self.call_count
+    }
+
+    pub fn respond_structured<T: DeserializeOwned>(
+        &mut self,
+        request: &str,
+        schema: &Value,
+        canceled: &AtomicBool,
+    ) -> Result<T, String> {
+        let source = self.run_codex(request, schema, canceled)?;
+        serde_json::from_str(&source)
+            .map_err(|error| format!("Codex returned invalid structured JSON: {error}"))
+    }
+
+    fn run_codex(
+        &mut self,
+        request: &str,
+        schema: &Value,
+        canceled: &AtomicBool,
+    ) -> Result<String, String> {
         self.last_usage = None;
+        self.call_count = self.call_count.saturating_add(1);
         if self.run.is_none() {
             self.run = Some(TemporaryRun::create()?);
         }
         let run = self.run.as_ref().expect("AI temporary run initialized");
         fs::write(
             &run.schema,
-            serde_json::to_vec_pretty(&model_response_schema())
-                .map_err(|error| error.to_string())?,
+            serde_json::to_vec_pretty(schema).map_err(|error| error.to_string())?,
         )
         .map_err(|error| format!("failed writing Codex output schema: {error}"))?;
+        for image in &self.images {
+            if !image.is_file() {
+                return Err(format!("Codex image does not exist: {}", image.display()));
+            }
+        }
         let mut command = Command::new(&self.executable);
         let stderr = fs::File::create(&run.stderr)
             .map_err(|error| format!("failed creating Codex error capture: {error}"))?;
+        if self.web_search {
+            command.arg("--search");
+        }
         command
             .arg("exec")
             .arg("--ephemeral")
@@ -450,6 +820,9 @@ impl ModelProvider for CodexExecProvider {
             .arg(&run.schema)
             .arg("--output-last-message")
             .arg(&run.output);
+        for image in &self.images {
+            command.arg("--image").arg(image);
+        }
         command.arg("--model").arg(&self.model);
         command.arg("--config").arg(format!(
             "model_reasoning_effort=\"{}\"",
@@ -503,8 +876,28 @@ impl ModelProvider for CodexExecProvider {
         self.last_usage = usage_worker
             .join()
             .map_err(|_| "Codex usage reader panicked".to_string())??;
-        let source = fs::read_to_string(&run.output)
-            .map_err(|error| format!("Codex did not produce a final response: {error}"))?;
+        fs::read_to_string(&run.output)
+            .map_err(|error| format!("Codex did not produce a final response: {error}"))
+    }
+}
+
+fn default_codex_executable() -> PathBuf {
+    #[cfg(windows)]
+    if let Some(app_data) = std::env::var_os("APPDATA") {
+        let npm = PathBuf::from(app_data).join(
+            "npm/node_modules/@openai/codex/node_modules/@openai/codex-win32-x64/\
+             vendor/x86_64-pc-windows-msvc/bin/codex.exe",
+        );
+        if npm.is_file() {
+            return npm;
+        }
+    }
+    PathBuf::from("codex")
+}
+
+impl ModelProvider for CodexExecProvider {
+    fn respond(&mut self, request: &str, canceled: &AtomicBool) -> Result<ModelResponse, String> {
+        let source = self.run_codex(request, &model_response_schema(), canceled)?;
         decode_codex_response(&source)
     }
 
@@ -595,9 +988,13 @@ pub fn contract_json() -> Value {
     json!({
         "schema_version": 1,
         "limits": {
-            "agent_turns": MAX_AGENT_TURNS,
+            "default_agent_turns": DEFAULT_AGENT_TURNS,
+            "maximum_profile_turns": MAX_AGENT_TURNS,
             "tool_calls_per_turn": MAX_TOOL_CALLS_PER_TURN,
             "working_notes_characters": MAX_WORKING_NOTES_CHARS,
+            "compaction_minimum_bytes": MIN_COMPACTION_BYTES,
+            "compaction_maximum_bytes": MAX_COMPACTION_BYTES,
+            "compaction_maximum_retained_turns": MAX_COMPACTION_RETAINED_TURNS,
         },
         "tool_specs": workshop_tool_specs(),
     })
@@ -697,10 +1094,52 @@ mod tests {
         )
         .expect("fifty-call batch");
 
-        assert_eq!(MAX_AGENT_TURNS, 15);
+        assert_eq!(DEFAULT_AGENT_TURNS, 15);
+        assert_eq!(MAX_AGENT_TURNS, 48);
         assert_eq!(tools.0, 50);
-        assert_eq!(contract_json()["limits"]["agent_turns"], 15);
+        assert_eq!(contract_json()["limits"]["default_agent_turns"], 15);
+        assert_eq!(contract_json()["limits"]["maximum_profile_turns"], 48);
         assert_eq!(contract_json()["limits"]["tool_calls_per_turn"], 50);
+    }
+
+    #[test]
+    fn explicit_profiles_can_exceed_the_live_ai_default() {
+        let mut responses = (0..16)
+            .map(|index| ModelResponse::ToolCalls {
+                working_notes: format!("Inspect bounded decision input {index}."),
+                summary: String::new(),
+                tool_calls: vec![ToolCall {
+                    tool: "list_symbols".to_string(),
+                    args: json!({"query": format!("symbol-{index}")}),
+                }],
+            })
+            .collect::<Vec<_>>();
+        responses.push(ModelResponse::Done {
+            working_notes: "The extended bounded profile completed.".to_string(),
+            summary: "extended".to_string(),
+        });
+        let mut provider = Responses(responses);
+        let mut tools = Tools::default();
+        let result = run_agent_with_profile(
+            &mut provider,
+            &mut tools,
+            &AgentProfile {
+                role: "Gauntlet builder".to_string(),
+                instruction: "Complete the bounded workstream.".to_string(),
+                max_turns: 20,
+                model: None,
+                reasoning_effort: None,
+                compaction: None,
+            },
+            "extended task",
+            json!({}),
+            workshop_tool_specs(),
+            &AtomicBool::new(false),
+            |_| {},
+        )
+        .expect("extended profile");
+        assert_eq!(result, "extended");
+        assert_eq!(tools.0, 16);
     }
 
     #[test]
@@ -828,6 +1267,106 @@ mod tests {
         assert_eq!(provider.requests[2].lines().count(), 3);
         assert!(provider.requests[1].starts_with(&format!("{}\n", provider.requests[0])));
         assert!(provider.requests[2].starts_with(&format!("{}\n", provider.requests[1])));
+    }
+
+    #[test]
+    fn compaction_replaces_old_payloads_with_deterministic_history() {
+        struct RecordingResponses {
+            responses: Vec<ModelResponse>,
+            requests: Vec<String>,
+        }
+        impl ModelProvider for RecordingResponses {
+            fn respond(
+                &mut self,
+                request: &str,
+                _canceled: &AtomicBool,
+            ) -> Result<ModelResponse, String> {
+                self.requests.push(request.to_string());
+                Ok(self.responses.remove(0))
+            }
+        }
+        struct LargeTools;
+        impl ToolExecutor for LargeTools {
+            fn execute(
+                &mut self,
+                calls: &[ToolCall],
+                _canceled: &AtomicBool,
+            ) -> Vec<ToolObservation> {
+                calls
+                    .iter()
+                    .map(|call| {
+                        ToolObservation::result(
+                            &call.tool,
+                            json!({"name": call.args["name"], "source": "x".repeat(110 * 1024)}),
+                        )
+                    })
+                    .collect()
+            }
+        }
+        let mut responses = (0..4)
+            .map(|index| ModelResponse::ToolCalls {
+                working_notes: format!("Inspected large symbol {index}; preserve the conclusion."),
+                summary: String::new(),
+                tool_calls: vec![ToolCall {
+                    tool: "read_symbol".to_string(),
+                    args: json!({"name": format!("symbol-{index}")}),
+                }],
+            })
+            .collect::<Vec<_>>();
+        responses.push(ModelResponse::Done {
+            working_notes: "The compacted inspection is sufficient.".to_string(),
+            summary: "compacted".to_string(),
+        });
+        let mut provider = RecordingResponses {
+            responses,
+            requests: Vec::new(),
+        };
+        let mut compacted_events = 0;
+        let result = run_agent_with_profile(
+            &mut provider,
+            &mut LargeTools,
+            &AgentProfile {
+                role: "Gauntlet builder".to_string(),
+                instruction: "Inspect bounded symbols.".to_string(),
+                max_turns: 8,
+                model: None,
+                reasoning_effort: None,
+                compaction: Some(AgentCompactionPolicy {
+                    max_request_bytes: MIN_COMPACTION_BYTES,
+                    retain_recent_turns: 4,
+                }),
+            },
+            "inspect large symbols",
+            json!({}),
+            live_tool_specs(),
+            &AtomicBool::new(false),
+            |event| {
+                compacted_events +=
+                    usize::from(matches!(event, AgentEvent::ContextCompacted { .. }));
+            },
+        )
+        .expect("compacted agent");
+        assert_eq!(result, "compacted");
+        assert!(compacted_events > 0);
+        let final_request = provider.requests.last().expect("final compact request");
+        assert!(final_request.contains("\"record\":\"compacted_history\""));
+        let records = final_request
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("request record"))
+            .collect::<Vec<_>>();
+        let compacted = records
+            .iter()
+            .find(|record| record["record"] == "compacted_history")
+            .expect("compacted history record");
+        assert!(!compacted.to_string().contains(&"x".repeat(2_000)));
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record["record"] == "turn_result")
+                .count(),
+            2
+        );
+        assert!(final_request.len() <= MIN_COMPACTION_BYTES);
     }
 
     #[test]
@@ -969,6 +1508,24 @@ mod tests {
             .iter()
             .any(|tool| tool.tool == "validate_runtime_state"));
         assert!(!live.iter().any(|tool| tool.tool == "capture_screenshot"));
+    }
+
+    #[test]
+    fn project_ai_gets_assets_without_gauntlet_decision_memory() {
+        let project = project_ai_tool_specs();
+        for expected in [
+            "write_svg_asset",
+            "write_png_asset",
+            "import_png_asset",
+            "write_data_asset",
+            "write_procedural_wav",
+        ] {
+            assert!(project.iter().any(|tool| tool.tool == expected));
+        }
+        assert!(!project.iter().any(|tool| tool.tool == "record_decision"));
+        assert!(gauntlet_tool_specs()
+            .iter()
+            .any(|tool| tool.tool == "record_decision"));
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1045,6 +1045,7 @@ struct StasisGraphicsAssetsApi {
     stasis_gfx_release_sprite: usize,
     stasis_gfx_dump_bmp: usize,
     stasis_gfx_dump_png: Option<usize>,
+    stasis_host_schedule_screenshot: Option<usize>,
     stasis_gfx_poll_reload: usize,
     stasis_load_font: usize,
     stasis_measure_text: usize,
@@ -1084,6 +1085,9 @@ impl StasisGraphicsAssetsApi {
             // PNG capture was added after the original asset ABI. Keep older runtimes usable for
             // all pre-existing calls and report PNG as unsupported.
             stasis_gfx_dump_png: lib.symbol_address("stasis_gfx_dump_png").ok(),
+            stasis_host_schedule_screenshot: lib
+                .symbol_address("stasis_host_schedule_screenshot")
+                .ok(),
             stasis_gfx_poll_reload: lib.symbol_address("stasis_gfx_poll_reload")?,
             stasis_load_font: lib.symbol_address("stasis_load_font")?,
             stasis_measure_text: lib.symbol_address("stasis_measure_text")?,
@@ -1098,6 +1102,24 @@ impl StasisGraphicsAssetsApi {
             _lib: lib,
         })
     }
+}
+
+pub fn schedule_runtime_screenshot(path: &Path) -> Result<(), String> {
+    let api = stasis_graphics_assets_api()?;
+    let address = api.stasis_host_schedule_screenshot.ok_or_else(|| {
+        "the loaded graphics runtime does not support dynamic screenshots".to_string()
+    })?;
+    let path = CString::new(path.to_string_lossy().as_bytes())
+        .map_err(|_| "screenshot path contains an interior NUL byte".to_string())?;
+    #[cfg(windows)]
+    let callback: extern "system" fn(*const c_char) -> i32 =
+        unsafe { std::mem::transmute(address) };
+    #[cfg(not(windows))]
+    let callback: extern "C" fn(*const c_char) -> i32 = unsafe { std::mem::transmute(address) };
+    if callback(path.as_ptr()) == 0 {
+        return Err("graphics runtime rejected the screenshot path".to_string());
+    }
+    Ok(())
 }
 
 fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, String> {

--- a/crates/stasis_runner/src/live.rs
+++ b/crates/stasis_runner/src/live.rs
@@ -67,6 +67,13 @@ pub enum LiveCommand {
         #[serde(default = "one_tick")]
         ticks: u32,
     },
+    CaptureFrame {
+        artifact: String,
+    },
+    SetInputState {
+        #[serde(default)]
+        pointers: Vec<LivePointerInput>,
+    },
     Cancel {
         request_id: u64,
     },
@@ -248,6 +255,20 @@ pub enum LiveCommand {
         #[serde(default = "default_true")]
         run_tests: bool,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LivePointerInput {
+    pub id: i32,
+    pub x: i32,
+    pub y: i32,
+    #[serde(default)]
+    pub is_down: bool,
+    #[serde(default)]
+    pub went_down: bool,
+    #[serde(default)]
+    pub went_up: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2079,6 +2100,30 @@ mod tests {
         };
         assert_eq!(request.request_id, 42);
         assert_eq!(request.command, LiveCommand::Status);
+    }
+
+    #[test]
+    fn gauntlet_capture_and_input_commands_have_stable_json() {
+        let capture: LiveRequest = serde_json::from_str(
+            r#"{"schema_version":1,"request_id":70,"type":"capture_frame","artifact":"candidate-0001"}"#,
+        )
+        .expect("capture request");
+        assert_eq!(
+            capture.command,
+            LiveCommand::CaptureFrame {
+                artifact: "candidate-0001".to_string()
+            }
+        );
+
+        let input: LiveRequest = serde_json::from_str(
+            r#"{"schema_version":1,"request_id":71,"type":"set_input_state","pointers":[{"id":0,"x":480,"y":270,"is_down":true,"went_down":true}]}"#,
+        )
+        .expect("input request");
+        assert!(matches!(
+            input.command,
+            LiveCommand::SetInputState { ref pointers }
+                if pointers.len() == 1 && pointers[0].x == 480 && pointers[0].went_down
+        ));
     }
 
     #[test]

--- a/docs/gauntlet_loop_harness.md
+++ b/docs/gauntlet_loop_harness.md
@@ -1,0 +1,438 @@
+# Stasis Gauntlet: Autonomous Live Game Creation and Improvement
+
+## Outcome
+
+`stasis gauntlet` creates or improves a complete 2D Stasis game while one
+authoritative graphical runtime remains active. A lead agent freezes a concrete
+quality bar and divides the game into independently judged workstreams. Fresh
+builders make one bounded project change at a time. Separate read-only critics
+inspect real framebuffer captures, runtime evidence, and tests without seeing
+the builder's rationale. Improved candidates become Git checkpoints;
+regressions roll back automatically.
+
+The loop continues until independent critics accept the result, the user stops
+it, progress stalls, or the default eight-hour/100-model-call budget is
+exhausted. A terminal event observer, JSONL stream, and generated progress page
+expose the run without interrupting it.
+
+The first release targets desktop JIT development and existing Stasis 2D
+capabilities. Android Workshop can later reuse the orchestration contracts, but
+its mobile UI and lifecycle remain separate.
+
+## Method translated to Stasis
+
+The useful mechanism in the [Gauntlet Loop
+article](https://somethingbig.ai/gauntlet-loop) is the separation of goal,
+artifact, builder, judge, and stopping authority. The published [Claude of Duty
+prompt](https://github.com/mshumer/Claude-of-Duty/blob/main/prompt.md) leaves
+decomposition to the lead, requires comparison with a real reference, and
+repeatedly sends the largest shortcoming back for repair.
+
+| Gauntlet principle | Stasis implementation |
+| --- | --- |
+| Give the destination, not an architecture | Store the immutable game brief; let the lead derive workstreams and implementation tasks. |
+| Use a concrete bar | Freeze reference images, gameplay scenarios, state assertions, performance limits, and a scored rubric before production edits begin. |
+| Split into independently improvable pieces | Track workstreams such as controls, game loop, enemies, UI, visual language, effects, audio, progression, and polish. |
+| Builder must not grade itself | Builders may edit through controlled tools; critics receive artifacts and evidence but no write tools or builder reasoning. |
+| Judge the real result | Capture the actual framebuffer, execute deterministic input scenarios, inspect runtime state, and run native tests. |
+| Keep iterating | Continue without a fixed round count, bounded by convergence, cancellation, stagnation, or the configured resource budget. |
+| Let the user watch without interrupting | Publish terminal events, JSONL events, and a static progress page with captures, scores, checkpoints, and current gaps. |
+| Smooth independently improved pieces | Run a periodic integration workstream that can improve consistency but cannot redefine the quality bar. |
+
+Stasis does not copy an unconstrained filesystem or self-reported-quality
+workflow. Compiler-owned semantic edits, deterministic tests, state migration,
+between-tick commits, and complete rollback remain authoritative.
+
+## Product contract
+
+### CLI
+
+```text
+stasis gauntlet new NAME --dir PATH --goal-file GOAL.md
+    [--reference FILE]...
+    [--discover-references]
+    [--tui | --jsonl]
+    [--max-hours 8]
+    [--max-model-calls 100]
+
+stasis gauntlet run
+    [--workspace PATH]
+    [--config gauntlet.json]
+    [--reference FILE]...
+    [--discover-references]
+    [--tui | --jsonl]
+
+stasis gauntlet resume RUN_ID [--tui | --jsonl]
+stasis gauntlet status RUN_ID [--json]
+stasis gauntlet stop RUN_ID
+stasis gauntlet promote RUN_ID
+```
+
+`new` creates a Git-backed graphical seed and starts its first run. `run`
+improves an existing project from `HEAD` in a linked isolated worktree.
+Interactive terminals default to the human-readable terminal observer. `stop` cooperatively cancels
+the active model or test, rolls back a provisional candidate, and retains the
+best checkpoint. `promote` is the only operation that integrates an isolated
+result into the user's original branch; it refuses a dirty or ambiguous
+destination.
+
+Convergence exits successfully. Budget exhaustion, stagnation, and an unmet
+bar exit nonzero while preserving the best playable checkpoint and reporting
+its branch and path.
+
+### Configuration
+
+The project root contains a strict, versioned `gauntlet.json`:
+
+```json
+{
+  "schema_version": 1,
+  "goal_file": "GAUNTLET_GOAL.md",
+  "quality_bar": {
+    "allow_web_discovery": true,
+    "references": [],
+    "required_scenarios": []
+  },
+  "budget": {
+    "wall_time_minutes": 480,
+    "model_calls": 100,
+    "stalled_candidates": 5
+  },
+  "execution": {
+    "autonomy": "full",
+    "observer": "auto",
+    "builder_max_turns": 30,
+    "compaction": {
+      "enabled": true,
+      "max_request_bytes": 2097152,
+      "retain_recent_turns": 6
+    }
+  },
+  "models": {
+    "scout": {},
+    "lead": {},
+    "builder": {},
+    "visual_critic": {},
+    "gameplay_critic": {}
+  }
+}
+```
+
+Unknown fields, unsupported versions, paths outside the project, zero budgets,
+and invalid references fail before starting a model call. CLI budget flags
+override one run without rewriting the project configuration. The goal and
+frozen bar cannot be weakened after editing begins. Tests or stricter checks
+may be added, but accepted requirements cannot be removed.
+
+Ordinary `stasis ai` retains its 15-turn default. Gauntlet builders default to
+30 turns and may be configured from 1 through 48, still bounded by the run's
+total model-call and wall-time budgets. This gives a difficult workstream room
+for multiple inspect/test/correct cycles without silently granting an
+unlimited session.
+
+When compaction is enabled, a builder request is compacted after it exceeds
+the configured byte ceiling. Stasis retains up to the configured number of
+recent raw turns and replaces older turns with deterministic summaries of
+explicit working notes, tool names and targets, compile/test receipts, and errors.
+Source bodies and other large observations are omitted from compacted history.
+The immutable request header, current task, durable `decisions.jsonl` memory,
+and recent turns remain available. Compaction consumes no model call and emits
+an auditable `context_compacted` trace event with before/after byte counts.
+Limits are 256 KiB through 16 MiB and 1 through 16 retained turns; the default
+is 2 MiB and six turns.
+
+Every role has an independent optional `model` and `reasoning_effort`. Empty
+objects inherit `STASIS_AI_MODEL`, `STASIS_AI_REASONING_EFFORT`, and ultimately
+the installed defaults. Values are passed directly to the installed Codex
+CLI, so a model identifier must actually be supported there. For example, if
+that installation exposes `luna`, a cost-oriented configuration can use:
+
+```json
+{
+  "scout": {"model": "luna", "reasoning_effort": "low"},
+  "lead": {"model": "gpt-5.6-sol", "reasoning_effort": "high"},
+  "builder": {"model": "luna", "reasoning_effort": "medium"},
+  "visual_critic": {"model": "gpt-5.6-sol", "reasoning_effort": "medium"},
+  "gameplay_critic": {"model": "gpt-5.6-sol", "reasoning_effort": "high"}
+}
+```
+
+This is policy rather than a hardcoded recommendation: cheaper models fit
+reference scouting and bounded implementation work only when their observed
+acceptance rate justifies it. The lead and independent critics can remain on a
+stronger model. Model-call accounting stays global across roles.
+
+Subscription-backed Codex is the first provider. Stasis does not request an API
+key or estimate a dollar cost. The [Codex non-interactive command
+surface](https://learn.chatgpt.com/docs/developer-commands#codex-exec) supplies
+JSONL events, structured output, web search for the reference scout, and image
+attachments for fresh critics.
+
+ImageGen is an optional host capability for concept art, backgrounds, and
+texture sheets. The current `codex exec` child transport accepts image inputs
+but does not expose the in-product ImageGen tool, so the core CLI never assumes
+it is present and never falls back to an API key. A host that can invoke
+the built-in ImageGen tool copies the selected project-bound output into the
+isolated worktree, then submits its PNG bytes plus provider/model/prompt
+provenance to the same bounded PNG import transaction; it must not leave a
+referenced asset only in the host's generated-images directory. Both Gauntlet
+and the one-shot `stasis ai` command can use the import bridge; deterministic
+raster composition remains their always-available fallback. In either case, a
+critic judges the rendered in-game result, not the generator's preview.
+
+The host bridge is `import_png_asset`: the host places a selected PNG under
+`build/gauntlet/imagegen/`, then the same contiguous asset/source transaction
+copies it under `assets/generated/` and derives the manifest entry. Imports
+must be real PNG files, non-symlinks, at most 16 MiB, at most 2048 pixels per
+edge, and at most 4,194,304 pixels total. This bridge is inert when the running
+host has no ImageGen capability. One-shot `stasis ai` uses the equivalent
+`build/ai-assets/imagegen/` inbox.
+
+### Run records
+
+Non-source artifacts live under:
+
+```text
+build/gauntlet/<run-id>/
+  run.json
+  events.jsonl
+  decisions.jsonl
+  usage.jsonl
+  references/manifest.json
+  artifacts/<candidate-id>/
+  checkpoints.json
+  index.html
+  stop.request
+```
+
+`run.json` records the versioned phase, source commit, best checkpoint, current
+workstream, budgets, exact model-call count, critic results, rollbacks, and
+terminal outcome. Writes use atomic replacement. `events.jsonl` is append-only
+and powers both the terminal observer and static report. The report shows reference
+provenance, before/current captures, rubric scores, tests, usage, checkpoints,
+rejected candidates, and the largest remaining gap.
+
+`decisions.jsonl` is durable model working memory, not a dump of private
+chain-of-thought. The `record_decision` tool stores bounded explicit
+conclusions: kind, summary, concise rationale, evidence, and next step. The
+controller also records lead choices, accepted/rejected checkpoints, and final
+gate failures. Each append is flushed and synced so interruption or resume does
+not erase the current theory of the game.
+
+## Execution architecture
+
+### Workspace isolation and seed
+
+For a new game, Stasis creates a target project with a real `main`, `tick`,
+`render`, and `on_code_swap`, a deterministic test, an empty v2 asset manifest,
+and a visible blank-canvas scene. It commits that seed and creates
+`stasis/gauntlet/<run-id>`.
+
+For an existing game, Stasis resolves `HEAD` and creates that branch in a linked
+worktree under the ignored `build/gauntlet/worktrees/` area. Dirty and
+untracked user files are never copied or overwritten. Every compiler, test,
+runtime, and agent action occurs inside the linked worktree. Each accepted
+improvement becomes a narrow Git checkpoint. Tracked files in the original
+checkout change only through explicit promotion.
+
+### Reference and bar bootstrap
+
+Before the first production edit, the harness validates and hashes local
+references. When necessary, a fresh read-only scout runs with web search and
+returns candidate source pages with provenance. Supplied local image
+references are copied into the isolated run record, hashed, and attached to
+the lead and critics. The first release deliberately does not download web
+images: discovered pages establish the bar, while only user-supplied local
+images become frozen visual evidence. References are never packaged or offered
+as builder assets.
+
+A fresh lead then freezes workstreams, rubric dimensions, required scenes,
+input scenarios, state assertions, and completion thresholds. If the scout
+cannot establish at least one usable visual reference and one measurable
+gameplay bar, the run stops before production modification.
+
+### Persistent runtime and live protocol
+
+The controller owns one in-process graphical JIT runtime and one live-session
+client. The observer consumes controller events rather than competing for live
+responses.
+
+The version-one live protocol gains two additive primitives:
+
+- `set_input_state` injects a bounded logical pointer snapshot and temporarily
+  overrides physical input during deterministic scenarios.
+- `capture_frame` schedules a PNG for the next presented frame using a
+  controller-generated artifact identity.
+
+The controller composes existing `snapshot`, `step`, `inspect`, and `restore`
+commands with those primitives into deterministic scenarios. Input is limited
+to eight pointers with valid logical coordinates. Captures occur after drawing
+and post-effects but before presentation, matching the existing screenshot
+acceptance path. Ordinary rendering allocates no capture framebuffer.
+
+### Agent roles and context separation
+
+- The **reference scout** is read-only and web-enabled.
+- The **lead** chooses the single highest-value next work item from the frozen
+  bar, compact project state, and critic outcomes.
+- A **builder** receives one work item, relevant captures, and the prior
+  critic's largest gap. It changes the project through controlled tools only.
+- A **visual critic** receives shuffled candidate images, references, and the
+  frozen visual rubric. It receives no source or write tools.
+- A **gameplay critic** receives deterministic scenarios, captures, state
+  traces, and the gameplay rubric, but no production write tools.
+- An **integration critic** periodically checks that the independently improved
+  systems form one coherent game.
+- A **smoother** is a normal restricted builder assigned only defects reported
+  by the integration critic.
+
+Every builder and critic starts with fresh context. Critics never receive
+builder reasoning or learn which shuffled candidate is newer. Read-only critics
+may run concurrently over immutable evidence; production builders remain
+serialized because one live runtime and one transactional project state are
+authoritative.
+
+Fresh leads and builders receive a compact chronological projection of the
+latest 48 decision records, capped at 32 KiB. Builders may call
+`record_decision` during exploration and after tested choices, so architectural
+decisions and failed approaches survive context boundaries and `resume`.
+Controller outcomes use the same journal, and the latest recorded next step
+restores the working gap after a restart. Blind visual and gameplay critics are
+never given this memory; they receive only anonymous evidence, the frozen bar,
+and reference material.
+
+### Project and asset transaction
+
+A versioned project patch combines compiler-owned source/test edits with SVG,
+deterministically composed PNG, validated host-generated PNG imports, bounded
+JSON/CSV data, deterministic procedural WAV generation, and compiler-derived
+asset-manifest entries. The model never writes the asset manifest directly.
+Deterministic PNG creation uses
+a bounded background plus rectangle/circle/line scene description (maximum
+2048 per dimension, 4,194,304 pixels, and 512 shapes), so the model does not
+need to emit opaque base64 blobs.
+
+The harness stages the complete patch, validates asset preparation, compiles,
+runs all project tests, computes the migration preview, and then publishes
+files, prepared assets, state migration, code pointers, and renderer reload at
+a between-tick boundary. Any failure restores source, assets, manifest, code,
+and state.
+
+Full autonomy may apply a validated layout migration because the run is
+isolated and checkpointed. Existing `stasis ai` and TUI approval behavior does
+not change. Asset updates are synchronized into the prepared play bundle before
+the frame commit. New assets must be loaded by accepted code or
+`on_code_swap`.
+
+The initial scope supports vector art, generated PNG sprites, renderer
+primitives, structured data, and procedural audio. Network references cannot
+become game assets. Photo synthesis and acquisition of third-party raster
+assets are not part of version one.
+
+### Candidate loop
+
+For every selected work item:
+
+1. Capture the best accepted baseline using the relevant deterministic
+   scenarios.
+2. Run one fresh builder and apply its tested patch provisionally.
+3. Capture the candidate with identical inputs and initial state.
+4. Run compile/tests, scenario assertions, renderer diagnostics, missing-asset
+   checks, performance budgets, and state/layout invariants.
+5. Run fresh visual and gameplay critics required by the workstream.
+6. Shuffle baseline/candidate labels for direct A/B comparison.
+7. Accept only when all hard gates pass, no required dimension materially
+   regresses, and the critics prefer the candidate or confirm that it closes a
+   frozen blocker.
+8. Commit an accepted candidate as the next baseline.
+9. Roll back a regression completely and count it toward stagnation.
+10. Feed only the largest evidenced gap into the next lead decision.
+
+Convergence requires all hard gates plus two separate final evaluations that
+mark every required rubric dimension as meeting the frozen bar. A merely
+improved result is not labeled converged. Five consecutive non-improving
+candidates stop as `stalled`; eight hours or 100 model calls stop as
+`budget_exhausted`. Both retain the best checkpoint.
+
+Cancellation is observed between model calls, tool batches, tests, scenario
+steps, and commit boundaries.
+
+## Delivery slices
+
+1. Add strict configuration/run/event/critique/scenario/patch contracts, the
+   CLI family, this document, and the real graphical seed.
+2. Generalize `stasis_ai` for explicit roles, schemas, images, search, model
+   settings, and exact call accounting while preserving live AI behavior.
+3. Add deterministic input injection and dynamic framebuffer capture, then
+   compose those with existing snapshot/step/inspect/restore commands.
+4. Add controlled SVG/data/WAV operations and atomic asset-aware project
+   patches.
+5. Implement reference bootstrap, immutable bars, builders, blind critics,
+   scoring, rollback, Git checkpoints, budgets, and finalization.
+6. Add the event-driven observer, static progress page, stop/resume, and
+   explicit promotion.
+7. Update CLI/live/asset/contributor guidance and remove duplicate or obsolete
+   paths introduced during the slices.
+
+## Test and acceptance plan
+
+Routine orchestration tests use deterministic fake providers and never consume
+subscription calls. Cover:
+
+- strict configuration and path validation;
+- budgets, cancellation, stagnation, convergence, and recovery;
+- reference path validation, hashing, copying, and page provenance;
+- critic label shuffling and source/write isolation;
+- exact model-call and token-usage accounting without dollar estimates;
+- input injection, scenario limits, capture timing, and state restoration;
+- PNG dimensions, hashes, and renderer failure diagnostics;
+- mixed source/test/asset rollback at every failure point;
+- compatible and incompatible migrations under Gauntlet autonomy;
+- existing live AI, TUI, and stdio compatibility;
+- dirty original workspaces remaining byte-for-byte unchanged;
+- stop/resume from every persisted phase; and
+- promotion refusal on dirty or non-fast-forward destinations.
+
+Add a compact playable end-to-end fixture whose baseline intentionally misses
+a visible and behavioral bar. It must compile through the real frontend and
+Cranelift JIT, launch the graphical runtime, execute deterministic input,
+capture a baseline, apply a source-plus-SVG candidate, preserve state, capture
+the improvement, reject and roll back a regression, and package/run the best
+checkpoint as a desktop executable.
+
+Provide an opt-in live-provider acceptance command that creates a small complete
+game, discovers references, accepts at least two workstreams, rejects one
+candidate, and leaves a playable checkpoint plus report. Each individual model
+or test command remains below 15 minutes; the eight-hour limit applies only to
+an explicitly started product run.
+
+Completion requires:
+
+- `gauntlet new` launches a graphical seed before its first improvement;
+- source, tests, and controlled assets commit atomically;
+- compatible swaps preserve the current match;
+- critics inspect real captures and cannot edit production files;
+- regressions restore source, assets, state, and runtime;
+- the frozen bar cannot be relaxed;
+- web references have provenance and are never packaged;
+- stop, budget, stagnation, and recovery retain the best checkpoint;
+- the observer never blocks the game tick;
+- the original checkout remains untouched until promotion; and
+- the final checkpoint passes format, compile, tests, scenarios, desktop build,
+  package, and executable smoke checks.
+
+## Boundaries and defaults
+
+- Version one creates and improves complete 2D desktop games, not 3D or AAA
+  engines.
+- Full autonomy applies only inside the isolated run branch/worktree.
+- Defaults are eight hours, 100 model calls, and five consecutive
+  non-improving candidates.
+- Web discovery is enabled when local references are insufficient; automatic
+  downloading of discovered images is deferred.
+- Mutation is serialized; parallel builder merges are deferred.
+- References guide comparison only and are not shipped.
+- Arbitrary photo synthesis inside the CLI, copyrighted asset acquisition,
+  video understanding, Android execution, and unattended promotion are out of
+  scope. Deterministic PNG composition is included; a capable host may supply
+  ImageGen output through the same validated PNG transaction.

--- a/docs/live_cli_workspace.md
+++ b/docs/live_cli_workspace.md
@@ -88,6 +88,21 @@ batch. A built-in AI change cannot report completion until one such tested batch
 successful write receipt is the completion evidence, so the live AI does not run a second test or
 model-authored runtime-validation loop afterward.
 
+The one-shot `stasis ai` command also receives the controlled project-asset tools used by
+Gauntlet. It can reuse the SVG pipeline, compose deterministic PNG files, import a host-generated
+ImageGen PNG, write bounded JSON/CSV data, and synthesize bounded procedural WAV files. Asset calls
+must form one contiguous group immediately before the source writes that load them. Stasis derives
+the v2 manifest entries, validates the complete bundle, compiles and tests the related source, and
+rolls the asset and source sides back together on failure; the model never edits the manifest.
+
+For ImageGen, a capable host copies the selected project-bound PNG into
+`build/ai-assets/imagegen/`; `import_png_asset` then validates and copies it under
+`assets/generated/`. The installed `codex exec` child still cannot invoke the built-in ImageGen
+tool directly, so this is an explicit host bridge rather than an API-key fallback. Deterministic
+`write_png_asset` remains available without that host capability. One-shot AI does not inherit
+Gauntlet's autonomous layout migration: an asset/source edit requiring a layout change is left
+unapplied and reported as requiring the normal explicit approval workflow.
+
 Human commands intentionally cover every useful live AI capability:
 
 | AI tool | CLI / TUI equivalent |
@@ -96,6 +111,8 @@ Human commands intentionally cover every useful live AI capability:
 | `find_references` | `stasis symbol references SYMBOL` / `:references SYMBOL` |
 | `read_symbol` | `stasis symbol read SYMBOL` / `:read SYMBOL` |
 | `write_symbol`, `delete_symbol` | `stasis symbol add|update|delete` / `:add`, `:update`, `:delete` |
+| `write_svg_asset`, `write_png_asset`, `import_png_asset` | controlled `assets/generated/` transaction (`stasis ai` and Gauntlet) |
+| `write_data_asset`, `write_procedural_wav` | controlled data/audio transaction (`stasis ai` and Gauntlet) |
 | `inspect_runtime_state` | `:inspect`; `stasis validate` exposes fresh-run scalar evidence |
 | `run_frame` | `:step`; `stasis validate --frames N` in an isolated CLI run |
 
@@ -385,6 +402,22 @@ score = 0;
 edit path. Scratch text never silently becomes project source.
 
 ## Automation protocol
+
+Gauntlet adds two schema-v1 JSON commands without changing the human TUI:
+
+```json
+{"schema_version":1,"request_id":70,"type":"set_input_state","pointers":[{"id":0,"x":480,"y":270,"is_down":true,"went_down":true}]}
+{"schema_version":1,"request_id":71,"type":"capture_frame","artifact":"candidate-0001"}
+```
+
+`set_input_state` accepts at most eight logical pointers and overrides physical
+pointer data until replaced (an empty array clears the simulated pointers).
+Edge flags clear after one deterministic tick. `capture_frame` accepts only a
+bounded artifact identity and schedules a PNG for the next presented frame;
+the runtime chooses the path under the configured project output. Gauntlet
+combines these commands with pause, step, validation snapshot/restore, and
+state inspection to run repeatable scenarios. Callers cannot supply a capture
+filesystem path.
 
 Use `--live-json` to print schema-v1 response envelopes as JSON lines. A command file can mix the
 terminal spelling above with request JSON:

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -3173,6 +3173,16 @@ STASIS_EXPORT int stasis_gfx_dump_png(const char* path) {
     return stasis_gfx_dump_image(path, 1, 1);
 }
 
+STASIS_EXPORT int stasis_host_schedule_screenshot(const char* path) {
+    if (!path || !*path || strlen(path) >= sizeof(g_screenshot_path)) return 0;
+    strncpy(g_screenshot_path, path, sizeof(g_screenshot_path) - 1);
+    g_screenshot_path[sizeof(g_screenshot_path) - 1] = 0;
+    g_screenshot_frame = (int)(g_debug_frame_counter + 1);
+    g_screenshot_exit_after = 0;
+    g_screenshot_taken = false;
+    return 1;
+}
+
 static void capture_scheduled_screenshot(void) {
     if (g_screenshot_taken || g_screenshot_path[0] == 0 ||
         g_debug_frame_counter + 1 != g_screenshot_frame) {


### PR DESCRIPTION
## Summary

- add `stasis gauntlet new/run/resume/status/stop/promote` with isolated Git worktrees, checkpoints, rollback, budgets, observers, and independent builder/critic roles
- keep one graphical Stasis runtime active while controlled semantic and asset transactions update the game between ticks
- add framebuffer capture, deterministic scenarios, progress artifacts, and an HTML run report
- add SVG, deterministic PNG, validated host ImageGen PNG import, bounded data, and procedural WAV asset tools to Gauntlet and one-shot `stasis ai`
- add durable explicit decision memory, deterministic transcript compaction, extended bounded agent profiles, and per-role model/reasoning configuration
- document the architecture, safety model, CLI, configuration, ImageGen bridge, recovery behavior, and staged rollout

## Why

Long-running game creation needs more than a single coding-agent invocation. Builders need durable decisions and bounded context, critics must judge the actual running artifact independently, and every accepted edit must preserve Stasis compilation, test, hot-swap, and rollback guarantees.

This creates that harness while reusing compiler-owned semantic edits and the existing live runtime rather than introducing a second mutation pipeline.

## User and developer impact

A project can now run an auditable autonomous improvement loop against a frozen quality bar. Each role may use a different Codex model and reasoning effort, allowing inexpensive models for bounded work and stronger models for planning or criticism. PNG assets from a capable host ImageGen flow enter through the same validated, rollback-safe asset transaction as deterministic assets.

Ordinary interactive AI behavior keeps its existing 15-turn default; the expanded turn and compaction policy is opt-in through explicit profiles.

## Validation

- `cargo test -p stasis_ai --lib` — 13 passed
- `cargo test -p stasis --bin stasis gauntlet --no-fail-fast` — 15 passed
- `cargo check -p stasis`
- `cargo fmt --all -- --check`
- `git diff --check`
- repository pre-commit Stasis formatting gate
- Android Workshop JIT render acceptance and parity capture