### PR TITLE
feat: synchronize checked-in Stasis vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ stasis test
 stasis run
 ```
 
+Generated projects track their checked-in `vendor/stasis` snapshot in `stasis.json`. When the
+selected Stasis executable or the checked-in tree differs from that identity, the next project
+command restores `vendor/stasis` and updates its manifest automatically. Stasis owns that directory;
+review and commit the resulting Git changes with the compiler upgrade.
+
 For a graphical program, `stasis play path\to\main.stasis` keeps the process alive and watches the current import graph. Saving a `.stasis` file compiles a candidate in the background and attempts an all-or-nothing swap between ticks.
 
 From a project containing `stasis.json`, `stasis tui` opens the manifest entry in the persistent live-workspace interface. Pass an entry path to override the manifest for one invocation.

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -38,7 +38,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 mod dap;
 mod gauntlet;
@@ -132,6 +132,7 @@ const COMMANDS: &[&str] = &[
     "version",
     "editor-info",
     "env",
+    "vendor",
     "symbol",
     "help",
     "__validate-runtime",
@@ -328,11 +329,24 @@ enum ToolchainCommand {
     EditorInfo,
     /// Print toolchain, workspace, cache, and offline capability information.
     Env,
+    /// Inspect or update the checked-in Stasis vendor snapshot.
+    Vendor {
+        #[command(subcommand)]
+        command: VendorCommand,
+    },
     /// Find and transactionally edit compiler-owned semantic symbols.
     Symbol {
         #[command(subcommand)]
         command: SymbolCommand,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum VendorCommand {
+    /// Compare the checked-in snapshot with its manifest and this executable.
+    Status,
+    /// Atomically replace the checked-in snapshot with this executable's sources.
+    Update,
 }
 
 #[derive(Debug, Subcommand)]
@@ -528,7 +542,20 @@ struct ProjectManifest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     stdlib: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    vendor: Option<VendorManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     android: Option<AndroidProjectManifest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct VendorManifest {
+    stasis: StasisVendorManifest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct StasisVendorManifest {
+    release_id: String,
+    sha256: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -549,6 +576,7 @@ impl ProjectManifest {
             tests: "tests".to_string(),
             output: "build".to_string(),
             stdlib: None,
+            vendor: None,
             android: None,
         }
     }
@@ -574,6 +602,23 @@ impl ProjectManifest {
             .is_some_and(|value| value != "toolchain")
         {
             return Err("stdlib must be 'toolchain' when specified".to_string());
+        }
+        if self.stdlib.is_some() && self.vendor.is_some() {
+            return Err("stdlib and vendor modes cannot be enabled together".to_string());
+        }
+        if let Some(vendor) = &self.vendor {
+            if vendor.stasis.release_id.trim().is_empty() {
+                return Err("vendor.stasis.release_id must not be empty".to_string());
+            }
+            if vendor.stasis.sha256.len() != 64
+                || !vendor
+                    .stasis
+                    .sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            {
+                return Err("vendor.stasis.sha256 must be a lowercase SHA-256 digest".to_string());
+            }
         }
         if let Some(android) = &self.android {
             validate_android_application_id(&android.application_id)?;
@@ -768,6 +813,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Version => "version",
         ToolchainCommand::EditorInfo => "editor-info",
         ToolchainCommand::Env => "env",
+        ToolchainCommand::Vendor { .. } => "vendor",
         ToolchainCommand::Symbol { .. } => "symbol",
     }
 }
@@ -838,7 +884,11 @@ fn execute(
                 ToolchainCommand::Tui { entry, .. } => entry.as_deref(),
                 _ => None,
             });
-            let workspace = load_workspace(workspace_path)?;
+            let vendor_gate = match &other {
+                ToolchainCommand::Vendor { .. } => VendorGate::Inspect,
+                _ => VendorGate::Sync,
+            };
+            let workspace = load_workspace_with_vendor_gate(workspace_path, vendor_gate)?;
             match other {
                 ToolchainCommand::Fmt { check, .. } => format_workspace(&workspace, check),
                 ToolchainCommand::Check => check_workspace(&workspace),
@@ -973,6 +1023,7 @@ fn execute(
                     capacities,
                     mobile_budget_bytes,
                 } => inspect_workspace(&workspace, &capacities, mobile_budget_bytes),
+                ToolchainCommand::Vendor { command } => vendor_command(&workspace, command),
                 ToolchainCommand::Symbol { command } => symbol_workspace(&workspace, command),
                 _ => Err("unsupported command routing".to_string()),
             }
@@ -999,6 +1050,13 @@ fn create_project_with_options(
     }
     let root = absolute_path(&path)?;
     let bundled_stdlib = bundled_stdlib_dir()?;
+    let bundled_runtime = bundled_stasis_runtime_dir(&bundled_stdlib)?;
+    let bundled_source = bundled_stdlib.parent().ok_or_else(|| {
+        format!(
+            "bundled stdlib has no src parent: {}",
+            bundled_stdlib.display()
+        )
+    })?;
     let manifest_path = root.join(MANIFEST_NAME);
     let mut reserved_paths = vec![
         manifest_path.clone(),
@@ -1007,7 +1065,7 @@ fn create_project_with_options(
         root.join(PROJECT_ARCHITECTURE_NAME),
         root.join("src/main.stasis"),
         root.join("tests/main.test.stasis"),
-        root.join("stdlib"),
+        root.join("vendor/stasis"),
         root.join(".vscode/settings.json"),
         root.join(".vscode/extensions.json"),
     ];
@@ -1027,6 +1085,18 @@ fn create_project_with_options(
             ));
         }
     }
+    let vendor_directory = root.join("vendor");
+    if vendor_directory.exists() {
+        let metadata = fs::symlink_metadata(&vendor_directory).map_err(|error| {
+            format!("failed to inspect {}: {error}", vendor_directory.display())
+        })?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(format!(
+                "refusing to write vendored packages through {}",
+                vendor_directory.display()
+            ));
+        }
+    }
     for reserved in &reserved_paths {
         if reserved.exists() {
             return Err(format!("refusing to overwrite {}", reserved.display()));
@@ -1036,9 +1106,12 @@ fn create_project_with_options(
         .map_err(|error| format!("failed to create {}: {error}", root.display()))?;
     fs::create_dir_all(root.join("tests"))
         .map_err(|error| format!("failed to create tests directory: {error}"))?;
-    let manifest = ProjectManifest::new(name.clone());
+    let mut manifest = ProjectManifest::new(name.clone());
+    manifest.vendor = Some(current_vendor_manifest(bundled_source)?);
     write_manifest(&manifest_path, &manifest)?;
-    copy_dir_if_exists(&bundled_stdlib, &root.join("stdlib"))?;
+    let vendor_source = root.join("vendor/stasis/src");
+    copy_dir_if_exists(&bundled_stdlib, &vendor_source.join("stdlib"))?;
+    copy_dir_if_exists(&bundled_runtime, &vendor_source.join("runtime"))?;
     write_new_file(&root.join("AGENTS.md"), PROJECT_AGENT_GUIDE)?;
     write_new_file(&root.join("CLAUDE.md"), PROJECT_CLAUDE_GUIDE)?;
     write_new_file(
@@ -1047,7 +1120,7 @@ fn create_project_with_options(
     )?;
     write_new_file(
         &root.join("src/main.stasis"),
-        "import \"../stdlib/stdlib.stasis\";\r\n\r\nfunction main(): i32 {\r\n    return 0;\r\n}\r\n",
+        "import \"/vendor/stasis/src/stdlib/stdlib.stasis\";\r\n\r\nfunction main(): i32 {\r\n    return 0;\r\n}\r\n",
     )?;
     write_new_file(
         &root.join("tests/main.test.stasis"),
@@ -1152,7 +1225,20 @@ fn write_manifest(path: &Path, manifest: &ProjectManifest) -> Result<(), String>
         .map_err(|error| format!("failed to write {}: {error}", path.display()))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VendorGate {
+    Sync,
+    Inspect,
+}
+
 fn load_workspace(explicit: Option<&Path>) -> Result<Workspace, String> {
+    load_workspace_with_vendor_gate(explicit, VendorGate::Sync)
+}
+
+fn load_workspace_with_vendor_gate(
+    explicit: Option<&Path>,
+    vendor_gate: VendorGate,
+) -> Result<Workspace, String> {
     if let Some(path) = explicit {
         let absolute = absolute_path(path)?;
         if !absolute.exists() {
@@ -1179,11 +1265,14 @@ fn load_workspace(explicit: Option<&Path>) -> Result<Workspace, String> {
     let root = canonical_workspace_root(&discovered_root)?;
     let bytes = fs::read(root.join(MANIFEST_NAME))
         .map_err(|error| format!("failed to read {MANIFEST_NAME}: {error}"))?;
-    let manifest: ProjectManifest = serde_json::from_slice(&bytes)
+    let mut manifest: ProjectManifest = serde_json::from_slice(&bytes)
         .map_err(|error| format!("invalid {MANIFEST_NAME}: {error}"))?;
     manifest.validate()?;
     if manifest.stdlib.as_deref() == Some("toolchain") {
         sync_toolchain_stdlib(&root)?;
+    }
+    if vendor_gate != VendorGate::Inspect {
+        reconcile_project_vendor(&root, &mut manifest)?;
     }
     Ok(Workspace { root, manifest })
 }
@@ -1290,6 +1379,287 @@ fn directory_sha256(root: &Path) -> Result<String, String> {
         digest.update([0]);
     }
     Ok(format!("{:x}", digest.finalize()))
+}
+
+fn current_release_id() -> &'static str {
+    option_env!("STASIS_RELEASE_ID").unwrap_or("development")
+}
+
+fn current_vendor_manifest(source: &Path) -> Result<VendorManifest, String> {
+    Ok(VendorManifest {
+        stasis: StasisVendorManifest {
+            release_id: current_release_id().to_string(),
+            sha256: directory_sha256(source)?,
+        },
+    })
+}
+
+fn validate_vendor_sources(source_root: &Path) -> Result<(), String> {
+    let mut files = Vec::new();
+    collect_stasis_files(source_root, &mut files)?;
+    for file in files {
+        let source = fs::read_to_string(&file)
+            .map_err(|error| format!("failed to read {}: {error}", file.display()))?;
+        let formatted = format_source(&source)
+            .map_err(|error| format!("failed to format {}: {error}", file.display()))?;
+        if formatted != source {
+            return Err(format!(
+                "selected toolchain contains noncanonical vendored source {}",
+                file.display()
+            ));
+        }
+        let relative = file
+            .strip_prefix(source_root)
+            .map_err(|_| format!("vendor source escaped {}", source_root.display()))?;
+        let logical = format!(
+            "vendor/stasis/src/{}",
+            relative.to_string_lossy().replace('\\', "/")
+        );
+        let imports = stasis_compiler::frontend::module_graph::parse_imports(&logical, &source)
+            .map_err(|diagnostic| format!("invalid vendor import in {logical}: {diagnostic:?}"))?;
+        for import in imports {
+            let relative_target = import
+                .target
+                .strip_prefix("vendor/stasis/src/")
+                .ok_or_else(|| {
+                    format!(
+                        "vendor import '{}' from {logical} escapes the Stasis package",
+                        import.path
+                    )
+                })?;
+            if !source_root.join(relative_target).is_file() {
+                return Err(format!(
+                    "vendor import '{}' from {logical} is missing its target",
+                    import.path
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct VendorStatus {
+    recorded: Option<StasisVendorManifest>,
+    installed: StasisVendorManifest,
+    actual_sha256: Option<String>,
+    local_changes: bool,
+    update_available: bool,
+}
+
+fn inspect_project_vendor(
+    workspace_root: &Path,
+    manifest: &ProjectManifest,
+) -> Result<VendorStatus, String> {
+    let bundled_stdlib = bundled_stdlib_dir()?;
+    let bundled_source = bundled_stdlib.parent().ok_or_else(|| {
+        format!(
+            "bundled stdlib has no src parent: {}",
+            bundled_stdlib.display()
+        )
+    })?;
+    let installed = current_vendor_manifest(bundled_source)?.stasis;
+    let recorded = manifest.vendor.as_ref().map(|vendor| vendor.stasis.clone());
+    let vendor_source = workspace_root.join("vendor/stasis/src");
+    let actual_sha256 = if vendor_source.exists() {
+        let metadata = fs::symlink_metadata(&vendor_source)
+            .map_err(|error| format!("failed to inspect {}: {error}", vendor_source.display()))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(format!(
+                "refusing to inspect vendored sources through {}",
+                vendor_source.display()
+            ));
+        }
+        Some(directory_sha256(&vendor_source)?)
+    } else {
+        None
+    };
+    let local_changes = recorded
+        .as_ref()
+        .is_some_and(|recorded| actual_sha256.as_deref() != Some(recorded.sha256.as_str()));
+    let update_available = recorded.as_ref().is_none_or(|recorded| {
+        recorded.release_id != installed.release_id || recorded.sha256 != installed.sha256
+    });
+    Ok(VendorStatus {
+        recorded,
+        installed,
+        actual_sha256,
+        local_changes,
+        update_available,
+    })
+}
+
+fn reconcile_project_vendor(
+    workspace_root: &Path,
+    manifest: &mut ProjectManifest,
+) -> Result<(), String> {
+    if manifest.vendor.is_none() {
+        return Ok(());
+    }
+    let status = inspect_project_vendor(workspace_root, manifest)?;
+    if !status.update_available
+        && status.actual_sha256.as_deref() == Some(status.installed.sha256.as_str())
+    {
+        return Ok(());
+    }
+    update_vendor_snapshot(workspace_root, manifest)?;
+    Ok(())
+}
+
+fn transaction_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    format!("{}-{nanos}", std::process::id())
+}
+
+fn serialized_manifest(manifest: &ProjectManifest) -> Result<String, String> {
+    let mut contents = serde_json::to_string_pretty(manifest)
+        .map_err(|error| format!("failed to serialize manifest: {error}"))?;
+    contents.push('\n');
+    Ok(contents)
+}
+
+fn update_vendor_snapshot(
+    workspace_root: &Path,
+    manifest: &mut ProjectManifest,
+) -> Result<bool, String> {
+    let status = inspect_project_vendor(workspace_root, manifest)?;
+    if !status.update_available
+        && status.actual_sha256.as_deref() == Some(status.installed.sha256.as_str())
+    {
+        return Ok(false);
+    }
+    let bundled_stdlib = bundled_stdlib_dir()?;
+    let bundled_source = bundled_stdlib.parent().ok_or_else(|| {
+        format!(
+            "bundled stdlib has no src parent: {}",
+            bundled_stdlib.display()
+        )
+    })?;
+    let vendor_root = workspace_root.join("vendor");
+    fs::create_dir_all(&vendor_root)
+        .map_err(|error| format!("failed to create {}: {error}", vendor_root.display()))?;
+    let metadata = fs::symlink_metadata(&vendor_root)
+        .map_err(|error| format!("failed to inspect {}: {error}", vendor_root.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(format!(
+            "refusing to write vendored packages through {}",
+            vendor_root.display()
+        ));
+    }
+
+    let suffix = transaction_suffix();
+    let target = vendor_root.join("stasis");
+    let staging = vendor_root.join(format!(".stasis.sync-{suffix}"));
+    let backup = vendor_root.join(format!(".stasis.previous-{suffix}"));
+    let manifest_path = workspace_root.join(MANIFEST_NAME);
+    let manifest_staging = workspace_root.join(format!("{MANIFEST_NAME}.vendor-sync-{suffix}"));
+    let manifest_backup = workspace_root.join(format!("{MANIFEST_NAME}.vendor-previous-{suffix}"));
+
+    if let Err(error) = copy_dir_if_exists(bundled_source, &staging.join("src")) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+    if let Err(error) = validate_vendor_sources(&staging.join("src")) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+    let staged_hash = directory_sha256(&staging.join("src"))?;
+    if staged_hash != status.installed.sha256 {
+        let _ = fs::remove_dir_all(&staging);
+        return Err("staged Stasis vendor fingerprint does not match the toolchain".to_string());
+    }
+
+    manifest.vendor = Some(VendorManifest {
+        stasis: StasisVendorManifest {
+            release_id: status.installed.release_id.clone(),
+            sha256: status.installed.sha256.clone(),
+        },
+    });
+    fs::write(&manifest_staging, serialized_manifest(manifest)?)
+        .map_err(|error| format!("failed to stage {MANIFEST_NAME}: {error}"))?;
+
+    let had_target = target.exists();
+    if had_target {
+        let metadata = fs::symlink_metadata(&target)
+            .map_err(|error| format!("failed to inspect {}: {error}", target.display()))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(format!("refusing to replace {}", target.display()));
+        }
+        fs::rename(&target, &backup)
+            .map_err(|error| format!("failed to stage {}: {error}", target.display()))?;
+    }
+    if let Err(error) = fs::rename(&staging, &target) {
+        if had_target {
+            let _ = fs::rename(&backup, &target);
+        }
+        return Err(format!("failed to publish {}: {error}", target.display()));
+    }
+    if let Err(error) = fs::rename(&manifest_path, &manifest_backup) {
+        let _ = fs::remove_dir_all(&target);
+        if had_target {
+            let _ = fs::rename(&backup, &target);
+        }
+        return Err(format!("failed to stage {MANIFEST_NAME}: {error}"));
+    }
+    if let Err(error) = fs::rename(&manifest_staging, &manifest_path) {
+        let _ = fs::rename(&manifest_backup, &manifest_path);
+        let _ = fs::remove_dir_all(&target);
+        if had_target {
+            let _ = fs::rename(&backup, &target);
+        }
+        return Err(format!("failed to publish {MANIFEST_NAME}: {error}"));
+    }
+    if had_target {
+        fs::remove_dir_all(&backup)
+            .map_err(|error| format!("failed to clear {}: {error}", backup.display()))?;
+    }
+    fs::remove_file(&manifest_backup)
+        .map_err(|error| format!("failed to clear {}: {error}", manifest_backup.display()))?;
+    Ok(true)
+}
+
+fn vendor_command(workspace: &Workspace, command: VendorCommand) -> Result<CommandResult, String> {
+    match command {
+        VendorCommand::Status => {
+            let status = inspect_project_vendor(&workspace.root, &workspace.manifest)?;
+            let current = !status.update_available && !status.local_changes;
+            Ok(CommandResult::success(
+                if current {
+                    "Stasis vendor is current".to_string()
+                } else if status.local_changes {
+                    "Stasis vendor has local changes".to_string()
+                } else {
+                    "Stasis vendor update is available".to_string()
+                },
+                json!({
+                    "current": current,
+                    "update_available": status.update_available,
+                    "local_changes": status.local_changes,
+                    "recorded": status.recorded,
+                    "installed": status.installed,
+                    "actual_sha256": status.actual_sha256,
+                }),
+            ))
+        }
+        VendorCommand::Update => {
+            let mut manifest = workspace.manifest.clone();
+            let changed = update_vendor_snapshot(&workspace.root, &mut manifest)?;
+            Ok(CommandResult::success(
+                if changed {
+                    "updated vendor/stasis from the selected toolchain".to_string()
+                } else {
+                    "Stasis vendor is already current".to_string()
+                },
+                json!({
+                    "changed": changed,
+                    "release_id": manifest.vendor.as_ref().map(|vendor| &vendor.stasis.release_id),
+                    "sha256": manifest.vendor.as_ref().map(|vendor| &vendor.stasis.sha256),
+                }),
+            ))
+        }
+    }
 }
 
 fn canonical_workspace_root(root: &Path) -> Result<PathBuf, String> {
@@ -4426,6 +4796,20 @@ fn bundled_stdlib_dir() -> Result<PathBuf, String> {
     )
 }
 
+fn bundled_stasis_runtime_dir(stdlib: &Path) -> Result<PathBuf, String> {
+    let runtime = stdlib
+        .parent()
+        .ok_or_else(|| format!("bundled stdlib has no src parent: {}", stdlib.display()))?
+        .join("runtime");
+    if runtime.join("host_frame.stasis").is_file() && runtime.join("gfx_cmd.stasis").is_file() {
+        return Ok(runtime);
+    }
+    Err(format!(
+        "installed toolchain is missing src/runtime required by stdlib imports: {}",
+        runtime.display()
+    ))
+}
+
 fn bundled_mobile_assets_dir() -> Result<PathBuf, String> {
     bundled_toolchain_directory("mobile/shells", "mobile shell templates")
 }
@@ -5107,6 +5491,81 @@ mod tests {
     }
 
     #[test]
+    fn vendor_upgrade_is_automatic_and_uses_the_content_hash() {
+        let root = temp_dir("vendor_upgrade");
+        create_project(root.clone(), "vendor_upgrade".to_string()).expect("create project");
+        let manifest_path = root.join(MANIFEST_NAME);
+        let mut manifest: ProjectManifest =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read generated manifest"))
+                .expect("parse generated manifest");
+        let vendor = manifest.vendor.as_mut().expect("tracked vendor");
+        vendor.stasis.release_id = "older-toolchain".to_string();
+        write_manifest(&manifest_path, &manifest).expect("record older vendor");
+        let workspace = load_workspace(Some(&root)).expect("upgrade older vendor automatically");
+        assert_eq!(
+            workspace
+                .manifest
+                .vendor
+                .expect("updated vendor")
+                .stasis
+                .release_id,
+            current_release_id()
+        );
+
+        let older_source = root.join("vendor/stasis/src/stdlib/audio.stasis");
+        let mut older_contents = fs::read_to_string(&older_source).expect("read vendor source");
+        older_contents.push_str("// older clean snapshot\r\n");
+        fs::write(&older_source, older_contents).expect("write older clean snapshot");
+        let vendor = manifest.vendor.as_mut().expect("tracked vendor");
+        vendor.stasis.release_id = current_release_id().to_string();
+        vendor.stasis.sha256 =
+            directory_sha256(&root.join("vendor/stasis/src")).expect("hash older clean snapshot");
+        write_manifest(&manifest_path, &manifest).expect("record older content hash");
+        let workspace = load_workspace(Some(&root)).expect("content-hash update");
+        let updated = workspace.manifest.vendor.expect("updated vendor").stasis;
+        assert_eq!(updated.release_id, current_release_id());
+        assert_eq!(
+            updated.sha256,
+            directory_sha256(&root.join("vendor/stasis/src")).expect("hash updated vendor")
+        );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn automatic_upgrade_replaces_vendor_edits_owned_by_stasis() {
+        let root = temp_dir("vendor_local_edits");
+        create_project(root.clone(), "vendor_local_edits".to_string()).expect("create project");
+        let edited = root.join("vendor/stasis/src/stdlib/audio.stasis");
+        fs::write(&edited, "// local vendor edit\n").expect("edit vendor source");
+
+        let current = load_workspace(Some(&root)).expect("automatic vendor replacement");
+        assert_ne!(
+            fs::read_to_string(&edited).expect("read restored vendor"),
+            "// local vendor edit\n"
+        );
+        assert_eq!(
+            current
+                .manifest
+                .vendor
+                .expect("tracked vendor")
+                .stasis
+                .release_id,
+            current_release_id()
+        );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn vendor_cli_parses_status_and_update() {
+        for args in [
+            vec!["stasis", "vendor", "status"],
+            vec!["stasis", "vendor", "update"],
+        ] {
+            ToolchainCli::try_parse_from(args).expect("parse vendor command");
+        }
+    }
+
+    #[test]
     fn run_accepts_headless_and_watch_modes() {
         let parsed = ToolchainCli::try_parse_from([
             "stasis",
@@ -5507,6 +5966,24 @@ mod tests {
     }
 
     #[test]
+    fn manifest_validates_vendor_identity_and_exclusive_source_mode() {
+        let mut manifest = ProjectManifest::new("demo".to_string());
+        manifest.vendor = Some(VendorManifest {
+            stasis: StasisVendorManifest {
+                release_id: "development".to_string(),
+                sha256: "a".repeat(64),
+            },
+        });
+        assert!(manifest.validate().is_ok());
+
+        manifest.vendor.as_mut().unwrap().stasis.sha256 = "not-a-hash".to_string();
+        assert!(manifest.validate().is_err());
+        manifest.vendor.as_mut().unwrap().stasis.sha256 = "a".repeat(64);
+        manifest.stdlib = Some("toolchain".to_string());
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
     fn loading_opted_in_workspace_materializes_the_active_toolchain_stdlib() {
         let root = temp_dir("toolchain_stdlib");
         create_project(root.clone(), "demo".to_string()).expect("create project");
@@ -5578,6 +6055,38 @@ mod tests {
             "user source\n"
         );
         remove_temp(&root);
+    }
+
+    #[test]
+    fn init_preserves_other_vendors_and_preflights_the_stasis_package() {
+        let root = temp_dir("vendor_preflight");
+        fs::create_dir_all(root.join("vendor/example")).expect("create existing vendor");
+        fs::write(root.join("vendor/example/keep.txt"), "keep\n").expect("write existing vendor");
+
+        create_project(root.clone(), "demo".to_string()).expect("create alongside other vendor");
+        assert_eq!(
+            fs::read_to_string(root.join("vendor/example/keep.txt")).expect("read existing vendor"),
+            "keep\n"
+        );
+        assert!(root
+            .join("vendor/stasis/src/stdlib/stdlib.stasis")
+            .is_file());
+        remove_temp(&root);
+
+        let conflict = temp_dir("vendor_conflict");
+        fs::create_dir_all(conflict.join("vendor/stasis")).expect("create package conflict");
+        fs::write(conflict.join("vendor/stasis/keep.txt"), "keep\n")
+            .expect("write package conflict");
+        let error = create_project(conflict.clone(), "demo".to_string())
+            .expect_err("reject existing stasis package");
+        assert!(error.contains("vendor\\stasis") || error.contains("vendor/stasis"));
+        assert!(!conflict.join(MANIFEST_NAME).exists());
+        assert_eq!(
+            fs::read_to_string(conflict.join("vendor/stasis/keep.txt"))
+                .expect("read preserved package conflict"),
+            "keep\n"
+        );
+        remove_temp(&conflict);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -1,6 +1,4 @@
-use super::{
-    absolute_path, bundled_stdlib_dir, create_new_project, load_workspace, CommandResult, Workspace,
-};
+use super::{absolute_path, create_new_project, load_workspace, CommandResult, Workspace};
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -564,19 +562,6 @@ fn selected_observer(tui: bool, jsonl: bool) -> GauntletObserver {
 fn write_graphical_seed(root: &Path) -> Result<(), String> {
     fs::create_dir_all(root.join("assets"))
         .map_err(|error| format!("failed creating Gauntlet assets: {error}"))?;
-    fs::create_dir_all(root.join("runtime"))
-        .map_err(|error| format!("failed creating Gauntlet runtime source directory: {error}"))?;
-    let stdlib = bundled_stdlib_dir()?;
-    let runtime_gfx = stdlib
-        .parent()
-        .ok_or_else(|| "bundled stdlib has no source parent".to_string())?
-        .join("runtime/gfx_cmd.stasis");
-    fs::copy(&runtime_gfx, root.join("runtime/gfx_cmd.stasis")).map_err(|error| {
-        format!(
-            "failed copying graphical command-buffer module {}: {error}",
-            runtime_gfx.display()
-        )
-    })?;
     fs::write(root.join("src/main.stasis"), GAUNTLET_SEED_SOURCE)
         .map_err(|error| format!("failed writing Gauntlet seed source: {error}"))?;
     fs::write(root.join("tests/main.test.stasis"), GAUNTLET_SEED_TEST)
@@ -694,7 +679,7 @@ fn hex_sha256(bytes: &[u8]) -> String {
 }
 
 const GAUNTLET_SEED_SOURCE: &str = r#"@link("stasis_graphics");
-import "../runtime/gfx_cmd.stasis";
+import "/vendor/stasis/src/runtime/gfx_cmd.stasis";
 
 global host_req_flags: i32;
 global host_req_window_w_px: i32;

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -312,6 +312,20 @@ fn project_commands_emit_stable_json_from_nested_directories() {
     let created_json = json_stdout(&created);
     assert_eq!(created_json["ok"], true);
     assert_eq!(created_json["command"], "new");
+    let manifest: Value = serde_json::from_slice(
+        &fs::read(project.join("stasis.json")).expect("read generated manifest"),
+    )
+    .expect("parse generated manifest");
+    assert!(manifest["vendor"]["stasis"].get("update_policy").is_none());
+    assert_eq!(
+        manifest["vendor"]["stasis"]["sha256"]
+            .as_str()
+            .map(str::len),
+        Some(64)
+    );
+    let vendor_status = stasis(&["--json", "vendor", "status"], &project);
+    assert_eq!(vendor_status.status.code(), Some(0));
+    assert_eq!(json_stdout(&vendor_status)["result"]["current"], true);
     let agent_guide = fs::read_to_string(project.join("AGENTS.md")).expect("read agent guide");
     assert!(agent_guide.contains("stasis --json symbol list"));
     assert!(agent_guide.contains("stasis --json symbol references SYMBOL"));
@@ -354,6 +368,28 @@ fn project_commands_emit_stable_json_from_nested_directories() {
             .expect("read generated VS Code recommendations"),
         "{\n  \"recommendations\": [\n    \"stasislang.stasis\"\n  ]\n}\n"
     );
+    assert!(project
+        .join("vendor/stasis/src/runtime/host_frame.stasis")
+        .is_file());
+    assert!(project
+        .join("vendor/stasis/src/runtime/gfx_cmd.stasis")
+        .is_file());
+
+    fs::create_dir_all(project.join("src/game")).expect("create nested game source directory");
+    fs::write(
+        project.join("src/main.stasis"),
+        crlf(
+            "import \"game/player.stasis\";\n\nfunction main(): i32 {\n    return player_ready();\n}\n",
+        ),
+    )
+    .expect("write generated-project package import smoke entry");
+    fs::write(
+        project.join("src/game/player.stasis"),
+        crlf(
+            "import \"/vendor/stasis/src/stdlib/graphics.stasis\";\n\nfunction player_ready(): i32 {\n    return 1;\n}\n",
+        ),
+    )
+    .expect("write nested generated-project package import smoke");
 
     let formatted = stasis(&["--json", "fmt", "--check"], &project);
     assert_eq!(formatted.status.code(), Some(0));

--- a/crates/stasis_compiler/src/frontend/module_graph.rs
+++ b/crates/stasis_compiler/src/frontend/module_graph.rs
@@ -274,7 +274,7 @@ pub fn parse_imports(path: &str, source: &str) -> Result<Vec<ModuleImport>, Sour
         }
         let import_path = parse_string_literal_text(token_text(source, literal))
             .map_err(|message| diagnostic(path, literal.start..literal.end, "import", message))?;
-        let target = resolve_import(path, &import_path).map_err(|message| {
+        let target = resolve_import_path(path, &import_path).map_err(|message| {
             diagnostic(path, literal.start..literal.end, &import_path, message)
         })?;
         let alias = module_alias(&target);
@@ -336,23 +336,33 @@ fn import_removal_span(source: &str, start: usize, end: usize) -> Range<usize> {
     }
 }
 
-fn resolve_import(importer: &str, import: &str) -> Result<String, String> {
-    if !import.replace('\\', "/").ends_with(".stasis") {
+pub(crate) fn resolve_import_path(importer: &str, import: &str) -> Result<String, String> {
+    let normalized = import.replace('\\', "/");
+    if !normalized.ends_with(".stasis") {
         return Err(format!("import target must end in .stasis: '{import}'"));
     }
-    if import.starts_with('/')
-        || import.starts_with("//")
-        || import.as_bytes().get(1) == Some(&b':')
-    {
+    if normalized.starts_with("//") || import.as_bytes().get(1) == Some(&b':') {
         return Err(format!(
             "import target must be project-relative: '{import}'"
         ));
     }
+    if let Some(project_path) = normalized.strip_prefix('/') {
+        if project_path.is_empty()
+            || project_path
+                .split('/')
+                .any(|component| component.is_empty() || matches!(component, "." | ".."))
+        {
+            return Err(format!(
+                "project-root import must stay within the project: '{import}'"
+            ));
+        }
+        return crate::identity::canonical_source_path(None, project_path);
+    }
     let parent = importer.rsplit_once('/').map_or("", |(parent, _)| parent);
     let joined = if parent.is_empty() {
-        import.to_string()
+        normalized
     } else {
-        format!("{parent}/{import}")
+        format!("{parent}/{normalized}")
     };
     crate::identity::canonical_source_path(None, &joined)
 }
@@ -644,6 +654,32 @@ mod tests {
         assert!(error
             .message
             .contains("duplicate imported module alias 'util'"));
+    }
+
+    #[test]
+    fn project_root_imports_resolve_from_any_source_directory() {
+        for importer in ["src/main.stasis", "src/game/player.stasis"] {
+            assert_eq!(
+                resolve_import_path(importer, "/vendor/stasis/src/stdlib/game_math.stasis")
+                    .expect("project-root import"),
+                "vendor/stasis/src/stdlib/game_math.stasis"
+            );
+        }
+        assert_eq!(
+            resolve_import_path(
+                "vendor/stasis/src/stdlib/graphics.stasis",
+                "../runtime/host_frame.stasis"
+            )
+            .expect("package-internal relative import"),
+            "vendor/stasis/src/runtime/host_frame.stasis"
+        );
+    }
+
+    #[test]
+    fn project_root_imports_cannot_escape_the_project() {
+        let error = resolve_import_path("src/main.stasis", "/vendor/../main.stasis")
+            .expect_err("project-root escape must fail");
+        assert!(error.contains("must stay within the project"));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -3391,7 +3391,7 @@ fn prune_unused_workshop_imports(
         let identifiers = source_identifiers(&body)?;
         let mut kept = Vec::new();
         for import in imports {
-            let imported_path = resolve_project_import_path(&file.path, &import);
+            let imported_path = resolve_project_import_path(&file.path, &import)?;
             let Some(_) = by_path.get(&imported_path) else {
                 kept.push(import);
                 continue;
@@ -3595,7 +3595,7 @@ fn exported_identifiers(
         .map(|symbol| symbol.name)
         .collect::<BTreeSet<_>>();
     for import in parse_workshop_import_paths(&file.source)? {
-        let imported_path = resolve_project_import_path(&file.path, &import);
+        let imported_path = resolve_project_import_path(&file.path, &import)?;
         exports.extend(exported_identifiers(
             &imported_path,
             files,
@@ -3607,11 +3607,8 @@ fn exported_identifiers(
     Ok(exports)
 }
 
-fn resolve_project_import_path(file: &str, import: &str) -> String {
-    let base = Path::new(file).parent().unwrap_or_else(|| Path::new(""));
-    normalize_filesystem_path(&base.join(import))
-        .to_string_lossy()
-        .replace('\\', "/")
+fn resolve_project_import_path(file: &str, import: &str) -> Result<String, String> {
+    crate::frontend::module_graph::resolve_import_path(file, import)
 }
 
 fn validate_source_item_replacement(
@@ -5118,6 +5115,18 @@ mod workshop_contract_tests {
         }
         fs::write(&path, source).expect("write project file");
         path
+    }
+
+    #[test]
+    fn semantic_tooling_resolves_project_root_imports_from_nested_files() {
+        assert_eq!(
+            resolve_project_import_path(
+                "src/game/player.stasis",
+                "/vendor/stasis/src/stdlib/graphics.stasis"
+            )
+            .expect("project-root import"),
+            "vendor/stasis/src/stdlib/graphics.stasis"
+        );
     }
 
     #[test]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -586,10 +586,15 @@ Import syntax:
 
 ```stasis
 import "relative/path/to/file.stasis";
+import "/project/root/path/to/file.stasis";
 ```
 
 Rules:
 - Imports are resolved relative to the importing file.
+- Imports beginning with `/` are resolved from the project root. The leading slash is project-root
+  syntax, not an operating-system absolute path.
+- Project-root imports may not contain empty, `.` or `..` path components and remain confined to
+  the project root.
 - Imported files are included once.
 - Import graphs are compilation graph edges, not textual expansion.
 - Import cycles are hard errors.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -41,7 +41,9 @@ stasis inspect --capacity state.enemies=512
 ```
 
 `stasis init --name brick_game .` initializes an existing directory. The built-in template copies
-the version-matched standard library into `stdlib/`, so imports remain offline and project-local.
+the version-matched Stasis sources into `vendor/stasis/src/{stdlib,runtime}`, so imports remain
+offline and project-local. Generated source uses project-root imports such as
+`/vendor/stasis/src/stdlib/stdlib.stasis`, which resolve consistently from nested source files.
 Commands discover
 `stasis.json` by walking from the selected path toward the filesystem root, so they work from the
 project root and nested directories. `--workspace PATH` selects a project explicitly.
@@ -56,14 +58,29 @@ project root and nested directories. `--workspace PATH` selects a project explic
   "name": "brick_game",
   "entry": "src/main.stasis",
   "tests": "tests",
-  "output": "build"
+  "output": "build",
+  "vendor": {
+    "stasis": {
+      "release_id": "nightly-20260805-123",
+      "sha256": "<lowercase SHA-256>"
+    }
+  }
 }
 ```
 
+The vendor release and hash describe the exact checked-in `vendor/stasis/src` snapshot.
+`manifest_version` versions the JSON schema and is independent of the selected toolchain release.
+On every normal project command, Stasis verifies the on-disk tree against the selected executable.
+A mismatch stages its matching stdlib and runtime together and publishes the vendor tree and
+manifest as one rollback-capable transaction. This detects rebuilt development executables whose
+release ID did not change and repairs edited or missing vendor files. Stasis owns `vendor/stasis`;
+Git is the review and rollback mechanism, so synchronization does not prompt. Review and commit the
+vendor and manifest changes together with the compiler upgrade.
+
 Projects that should always use the standard library shipped with the selected toolchain can add
 `"stdlib": "toolchain"`. Before a workspace command starts, that exact stdlib and its matching
-runtime modules are synchronized transactionally into `.stasis_cache/toolchain/src/`; source under
-`src/` imports it with paths such as `../.stasis_cache/toolchain/src/stdlib/storage.stasis`. This keeps
+runtime modules are synchronized transactionally into `.stasis_cache/toolchain/src/`; source imports
+it with paths such as `/.stasis_cache/toolchain/src/stdlib/storage.stasis`. This keeps
 CLI, LSP, TUI, and VS Code play on one compiler/stdlib build without checking a dated toolchain
 archive into the project.
 
@@ -131,6 +148,9 @@ cloning a generated repository, reactivate the checked-in hook with
   JSON output includes the complete deterministic report; human output emphasizes totals,
   largest pools, projections, and warnings.
 - `version` and `env`: report installation, cache, and workspace locations.
+- `vendor status`: compare the manifest, checked-in vendor tree, and selected executable.
+- `vendor update`: transactionally restore `vendor/stasis` from the selected executable and update
+  its manifest identity immediately.
 
 `replay` and `verify` intentionally return deterministic unsupported diagnostics until the replay
 runtime contract lands; they do not fake successful behavior.

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
@@ -16,6 +16,10 @@ public final class WorkshopAiSymbolDiscoveryTest {
     public void resolvesImportsRelativeToTheirSourceFile() {
         assertEquals("src/shared/math.stasis", WorkshopAiSymbolDiscovery.resolveImport(
                 "src/systems/movement.stasis", "../shared/math.stasis"));
+        assertEquals("vendor/stasis/src/stdlib/game_math.stasis",
+                WorkshopAiSymbolDiscovery.resolveImport(
+                        "src/systems/movement.stasis",
+                        "/vendor/stasis/src/stdlib/game_math.stasis"));
     }
 
     @Test

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiSymbolDiscovery.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopAiSymbolDiscovery.java
@@ -22,6 +22,9 @@ final class WorkshopAiSymbolDiscovery {
     }
 
     static String resolveImport(String sourceFile, String importPath) {
+        if (importPath.replace('\\', '/').startsWith("/")) {
+            return normalize(importPath.substring(1));
+        }
         String normalizedSource = normalize(sourceFile);
         int slash = normalizedSource.lastIndexOf('/');
         String parent = slash < 0 ? "" : normalizedSource.substring(0, slash + 1);

--- a/src/runtime/host_frame.stasis
+++ b/src/runtime/host_frame.stasis
@@ -12,90 +12,205 @@ const HOST_MAX_POINTERS: i32 = 8;
 
 // i32 layout
 const HOST_I_TIME_MS: i32 = 0;
+
 // 1..6 removed with pre-1.0 window/viewport compatibility aliases.
 const HOST_I_POINTER_COUNT: i32 = 7;
+
 const HOST_I_DROPPED_POINTERS: i32 = 8;
+
 const HOST_I_QUIT_REQUESTED: i32 = 9;
+
 const HOST_I_TICK_INDEX: i32 = 10;
+
 const HOST_I_RESIZED: i32 = 11;
+
 const HOST_I_SCREEN_W_PX: i32 = 12;
+
 const HOST_I_SCREEN_H_PX: i32 = 13;
 
 // vNext header
 const HOST_I_VERSION: i32 = 14;
+
 const HOST_I_FLAGS: i32 = 15;
+
 const HOST_I_TICK_HZ: i32 = 16; // 0 if unknown / not provided
 
 // Convenience mirrors (avoid bitwise ops in Stasis source).
 const HOST_I_WINDOW_FOCUSED: i32 = 17;
+
 const HOST_I_WINDOW_MINIMIZED: i32 = 18;
+
 const HOST_I_TIME_US: i32 = 19;
 
 // Physical display metrics. Logical and safe geometry live in the f32 lane.
 const HOST_I_NATIVE_W_PX: i32 = 22;
+
 const HOST_I_NATIVE_H_PX: i32 = 23;
+
 const HOST_I_DRAWABLE_W_PX: i32 = 24;
+
 const HOST_I_DRAWABLE_H_PX: i32 = 25;
+
 // 20,21 and 26..29 removed with integer presentation geometry.
 const HOST_I_DISPLAY_GENERATION: i32 = 30;
+
 const HOST_I_DENSITY_GENERATION: i32 = 31;
 
 // Keyboard state (SDL scancodes), one i32 per scancode (0/1).
 const HOST_I_KEY_BASE: i32 = 32;
+
 const HOST_I_KEY_COUNT: i32 = 512;
 
 // Reserve space for future fields before pointers.
 const HOST_I_POINTER_BASE: i32 = 544; // HOST_I_KEY_BASE + HOST_I_KEY_COUNT
+
 const HOST_I_POINTER_STRIDE: i32 = 4; // id, is_down, went_down, went_up
+
 const HOST_I32_COUNT: i32 = 768;
 
 // f32 layout
 const HOST_F_POINTER_BASE: i32 = 0;
+
 const HOST_F_POINTER_STRIDE: i32 = 6; // x_px, y_px, dx_px, dy_px, x_n, y_n
+
 const HOST_F_CONTENT_SCALE: i32 = 48;
+
 const HOST_F_RASTER_SCALE: i32 = 49;
+
 const HOST_F_LOGICAL_W: i32 = 50;
+
 const HOST_F_LOGICAL_H: i32 = 51;
+
 const HOST_F_SAFE_X: i32 = 52;
+
 const HOST_F_SAFE_Y: i32 = 53;
+
 const HOST_F_SAFE_W: i32 = 54;
+
 const HOST_F_SAFE_H: i32 = 55;
+
 const HOST_F32_COUNT: i32 = 64;
 
 global host_i32: i32[768];
+
 global host_f32: f32[64];
 
-function host_tick_index(): i32 { return host_i32[HOST_I_TICK_INDEX]; }
-function host_time_ms(): i32 { return host_i32[HOST_I_TIME_MS]; }
-function host_pointer_count(): i32 { return host_i32[HOST_I_POINTER_COUNT]; }
-function host_dropped_pointers(): i32 { return host_i32[HOST_I_DROPPED_POINTERS]; }
-function host_quit_requested(): bool { return host_i32[HOST_I_QUIT_REQUESTED] != 0; }
-function host_resized(): bool { return host_i32[HOST_I_RESIZED] != 0; }
-function host_screen_w_px(): i32 { return host_i32[HOST_I_SCREEN_W_PX]; }
-function host_screen_h_px(): i32 { return host_i32[HOST_I_SCREEN_H_PX]; }
-function host_version(): i32 { return host_i32[HOST_I_VERSION]; }
-function host_flags(): i32 { return host_i32[HOST_I_FLAGS]; }
-function host_tick_hz(): i32 { return host_i32[HOST_I_TICK_HZ]; }
-function host_window_focused(): bool { return host_i32[HOST_I_WINDOW_FOCUSED] != 0; }
-function host_window_minimized(): bool { return host_i32[HOST_I_WINDOW_MINIMIZED] != 0; }
-function host_time_us(): i32 { return host_i32[HOST_I_TIME_US]; }
-function host_logical_width(): f32 { return host_f32[HOST_F_LOGICAL_W]; }
-function host_logical_height(): f32 { return host_f32[HOST_F_LOGICAL_H]; }
-function host_native_w_px(): i32 { return host_i32[HOST_I_NATIVE_W_PX]; }
-function host_native_h_px(): i32 { return host_i32[HOST_I_NATIVE_H_PX]; }
-function host_drawable_w_px(): i32 { return host_i32[HOST_I_DRAWABLE_W_PX]; }
-function host_drawable_h_px(): i32 { return host_i32[HOST_I_DRAWABLE_H_PX]; }
-function host_safe_x(): f32 { return host_f32[HOST_F_SAFE_X]; }
-function host_safe_y(): f32 { return host_f32[HOST_F_SAFE_Y]; }
-function host_safe_width(): f32 { return host_f32[HOST_F_SAFE_W]; }
-function host_safe_height(): f32 { return host_f32[HOST_F_SAFE_H]; }
-function host_display_generation(): i32 { return host_i32[HOST_I_DISPLAY_GENERATION]; }
-function host_density_generation(): i32 { return host_i32[HOST_I_DENSITY_GENERATION]; }
-function host_content_scale(): f32 { return host_f32[HOST_F_CONTENT_SCALE]; }
-function host_raster_scale(): f32 { return host_f32[HOST_F_RASTER_SCALE]; }
+function host_tick_index(): i32 {
+    return host_i32[HOST_I_TICK_INDEX];
+}
+
+function host_time_ms(): i32 {
+    return host_i32[HOST_I_TIME_MS];
+}
+
+function host_pointer_count(): i32 {
+    return host_i32[HOST_I_POINTER_COUNT];
+}
+
+function host_dropped_pointers(): i32 {
+    return host_i32[HOST_I_DROPPED_POINTERS];
+}
+
+function host_quit_requested(): bool {
+    return host_i32[HOST_I_QUIT_REQUESTED] != 0;
+}
+
+function host_resized(): bool {
+    return host_i32[HOST_I_RESIZED] != 0;
+}
+
+function host_screen_w_px(): i32 {
+    return host_i32[HOST_I_SCREEN_W_PX];
+}
+
+function host_screen_h_px(): i32 {
+    return host_i32[HOST_I_SCREEN_H_PX];
+}
+
+function host_version(): i32 {
+    return host_i32[HOST_I_VERSION];
+}
+
+function host_flags(): i32 {
+    return host_i32[HOST_I_FLAGS];
+}
+
+function host_tick_hz(): i32 {
+    return host_i32[HOST_I_TICK_HZ];
+}
+
+function host_window_focused(): bool {
+    return host_i32[HOST_I_WINDOW_FOCUSED] != 0;
+}
+
+function host_window_minimized(): bool {
+    return host_i32[HOST_I_WINDOW_MINIMIZED] != 0;
+}
+
+function host_time_us(): i32 {
+    return host_i32[HOST_I_TIME_US];
+}
+
+function host_logical_width(): f32 {
+    return host_f32[HOST_F_LOGICAL_W];
+}
+
+function host_logical_height(): f32 {
+    return host_f32[HOST_F_LOGICAL_H];
+}
+
+function host_native_w_px(): i32 {
+    return host_i32[HOST_I_NATIVE_W_PX];
+}
+
+function host_native_h_px(): i32 {
+    return host_i32[HOST_I_NATIVE_H_PX];
+}
+
+function host_drawable_w_px(): i32 {
+    return host_i32[HOST_I_DRAWABLE_W_PX];
+}
+
+function host_drawable_h_px(): i32 {
+    return host_i32[HOST_I_DRAWABLE_H_PX];
+}
+
+function host_safe_x(): f32 {
+    return host_f32[HOST_F_SAFE_X];
+}
+
+function host_safe_y(): f32 {
+    return host_f32[HOST_F_SAFE_Y];
+}
+
+function host_safe_width(): f32 {
+    return host_f32[HOST_F_SAFE_W];
+}
+
+function host_safe_height(): f32 {
+    return host_f32[HOST_F_SAFE_H];
+}
+
+function host_display_generation(): i32 {
+    return host_i32[HOST_I_DISPLAY_GENERATION];
+}
+
+function host_density_generation(): i32 {
+    return host_i32[HOST_I_DENSITY_GENERATION];
+}
+
+function host_content_scale(): f32 {
+    return host_f32[HOST_F_CONTENT_SCALE];
+}
+
+function host_raster_scale(): f32 {
+    return host_f32[HOST_F_RASTER_SCALE];
+}
 
 function host_key_down(scancode: i32): bool {
-    if (scancode < 0 || scancode >= 512) { return false; }
+    if (scancode < 0 || scancode >= 512) {
+        return false;
+    }
     return host_i32[HOST_I_KEY_BASE + scancode] != 0;
 }
 

--- a/src/runtime/host_window_request.stasis
+++ b/src/runtime/host_window_request.stasis
@@ -6,10 +6,13 @@
 // Ordering: ABI order is the order of fields/globals declared here.
 
 const HOST_REQ_FLAG_WINDOWED: i32 = 1;
+
 const HOST_REQ_FLAG_FULLSCREEN: i32 = 2;
 
 global host_req_seq: i32;
-global host_req_flags: i32;
-global host_req_window_w_px: i32;
-global host_req_window_h_px: i32;
 
+global host_req_flags: i32;
+
+global host_req_window_w_px: i32;
+
+global host_req_window_h_px: i32;

--- a/src/runtime/input_testkit.stasis
+++ b/src/runtime/input_testkit.stasis
@@ -43,15 +43,7 @@ function input_testkit_set_pointer_count_raw(count: i32): void {
     host_i32[HOST_I_POINTER_COUNT] = count;
 }
 
-function input_testkit_set_pointer(
-    index: i32,
-    id: i32,
-    is_down: bool,
-    went_down: bool,
-    went_up: bool,
-    x_px: f32,
-    y_px: f32
-): void {
+function input_testkit_set_pointer(index: i32, id: i32, is_down: bool, went_down: bool, went_up: bool, x_px: f32, y_px: f32): void {
     if (index < 0 || index >= HOST_MAX_POINTERS) {
         return;
     }

--- a/src/stdlib/audio.stasis
+++ b/src/stdlib/audio.stasis
@@ -1,13 +1,20 @@
 @link("stasis_graphics");
+
 // Audio/runtime bindings (marker module).
-// Import explicitly: import "src/stdlib/audio.stasis";
+// From a generated project: import "/vendor/stasis/src/stdlib/audio.stasis";
 
 extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
+
 extern function audio_shutdown(): void;
 
 extern function audio_is_available(): bool;
+
 extern function audio_get_sample_rate(): i32;
+
 extern function audio_get_channels(): i32;
+
 extern function audio_get_queued_frames(): i32;
+
 extern function audio_get_underruns(): i32;
+
 extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;

--- a/src/stdlib/flex_layout.stasis
+++ b/src/stdlib/flex_layout.stasis
@@ -1,5 +1,5 @@
 // Flex-style layout helpers for simple UI composition.
-// Import explicitly: import "src/stdlib/flex_layout.stasis";
+// From a generated project: import "/vendor/stasis/src/stdlib/flex_layout.stasis";
 //
 // Uses plain f32 arrays for portability across backends.
 // Rect layout: [x, y, w, h]
@@ -8,28 +8,42 @@ import "stdlib.stasis";
 import "graphics.stasis";
 
 const FLEX_RECT_STRIDE: i32 = 4;
+
 const FLEX_RECT_X: i32 = 0;
+
 const FLEX_RECT_Y: i32 = 1;
+
 const FLEX_RECT_W: i32 = 2;
+
 const FLEX_RECT_H: i32 = 3;
 
 const FLEX_JUSTIFY_START: i32 = 0;
+
 const FLEX_JUSTIFY_CENTER: i32 = 1;
+
 const FLEX_JUSTIFY_END: i32 = 2;
+
 const FLEX_JUSTIFY_SPACE_BETWEEN: i32 = 3;
 
 const FLEX_ALIGN_START: i32 = 0;
+
 const FLEX_ALIGN_CENTER: i32 = 1;
+
 const FLEX_ALIGN_END: i32 = 2;
+
 const FLEX_ALIGN_STRETCH: i32 = 3;
 
 function flex_max_f32(a: f32, b: f32): f32 {
-    if (a > b) { return a; }
+    if (a > b) {
+        return a;
+    }
     return b;
 }
 
 function flex_min_i32(a: i32, b: i32): i32 {
-    if (a < b) { return a; }
+    if (a < b) {
+        return a;
+    }
     return b;
 }
 
@@ -99,8 +113,10 @@ function flex_row(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[],
 
     let actual_gap: f32 = gap;
     if (justify == FLEX_JUSTIFY_SPACE_BETWEEN && count > 1) {
-        actual_gap = (parent[FLEX_RECT_W] - sum_w) / i32_to_f32(count - 1);
-        if (actual_gap < 0.0) { actual_gap = 0.0; }
+        actual_gap =(parent[FLEX_RECT_W] - sum_w) / i32_to_f32(count - 1);
+        if (actual_gap < 0.0) {
+            actual_gap = 0.0;
+        }
     }
 
     let total_w: f32 = sum_w;
@@ -110,7 +126,7 @@ function flex_row(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[],
 
     let cursor_x: f32 = parent[FLEX_RECT_X];
     if (justify == FLEX_JUSTIFY_CENTER) {
-        cursor_x = parent[FLEX_RECT_X] + (parent[FLEX_RECT_W] - total_w) * 0.5;
+        cursor_x = parent[FLEX_RECT_X] +(parent[FLEX_RECT_W] - total_w) * 0.5;
     }
     if (justify == FLEX_JUSTIFY_END) {
         cursor_x = parent[FLEX_RECT_X] + parent[FLEX_RECT_W] - total_w;
@@ -120,7 +136,7 @@ function flex_row(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[],
         let y: f32 = parent[FLEX_RECT_Y];
         let h: f32 = item_h[i];
         if (align == FLEX_ALIGN_CENTER) {
-            y = parent[FLEX_RECT_Y] + (parent[FLEX_RECT_H] - h) * 0.5;
+            y = parent[FLEX_RECT_Y] +(parent[FLEX_RECT_H] - h) * 0.5;
         }
         if (align == FLEX_ALIGN_END) {
             y = parent[FLEX_RECT_Y] + parent[FLEX_RECT_H] - h;
@@ -143,8 +159,10 @@ function flex_column(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32
 
     let actual_gap: f32 = gap;
     if (justify == FLEX_JUSTIFY_SPACE_BETWEEN && count > 1) {
-        actual_gap = (parent[FLEX_RECT_H] - sum_h) / i32_to_f32(count - 1);
-        if (actual_gap < 0.0) { actual_gap = 0.0; }
+        actual_gap =(parent[FLEX_RECT_H] - sum_h) / i32_to_f32(count - 1);
+        if (actual_gap < 0.0) {
+            actual_gap = 0.0;
+        }
     }
 
     let total_h: f32 = sum_h;
@@ -154,7 +172,7 @@ function flex_column(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32
 
     let cursor_y: f32 = parent[FLEX_RECT_Y];
     if (justify == FLEX_JUSTIFY_CENTER) {
-        cursor_y = parent[FLEX_RECT_Y] + (parent[FLEX_RECT_H] - total_h) * 0.5;
+        cursor_y = parent[FLEX_RECT_Y] +(parent[FLEX_RECT_H] - total_h) * 0.5;
     }
     if (justify == FLEX_JUSTIFY_END) {
         cursor_y = parent[FLEX_RECT_Y] + parent[FLEX_RECT_H] - total_h;
@@ -164,7 +182,7 @@ function flex_column(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32
         let x: f32 = parent[FLEX_RECT_X];
         let w: f32 = item_w[i];
         if (align == FLEX_ALIGN_CENTER) {
-            x = parent[FLEX_RECT_X] + (parent[FLEX_RECT_W] - w) * 0.5;
+            x = parent[FLEX_RECT_X] +(parent[FLEX_RECT_W] - w) * 0.5;
         }
         if (align == FLEX_ALIGN_END) {
             x = parent[FLEX_RECT_X] + parent[FLEX_RECT_W] - w;
@@ -179,7 +197,9 @@ function flex_column(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32
 }
 
 function flex_grid(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[], count: i32, columns: i32, col_gap: f32, row_gap: f32): void {
-    if (count <= 0 || columns <= 0) { return; }
+    if (count <= 0 || columns <= 0) {
+        return;
+    }
 
     let row_start: i32 = 0;
     let row_y: f32 = parent[FLEX_RECT_Y];

--- a/src/stdlib/frame_timer.stasis
+++ b/src/stdlib/frame_timer.stasis
@@ -26,12 +26,18 @@ function frame_timer_init(samples_ms: i32[120]): void {
 
 function frame_timer_push(samples_ms: i32[120], sample_index: i32, value_ms: i32): i32 {
     let idx: i32 = sample_index;
-    if (idx < 0) { idx = 0; }
-    if (idx > (FRAME_TIMER_SAMPLES - 1)) { idx = 0; }
+    if (idx < 0) {
+        idx = 0;
+    }
+    if (idx >(FRAME_TIMER_SAMPLES - 1)) {
+        idx = 0;
+    }
 
     samples_ms[idx] = value_ms;
     idx = idx + 1;
-    if (idx > (FRAME_TIMER_SAMPLES - 1)) { idx = 0; }
+    if (idx >(FRAME_TIMER_SAMPLES - 1)) {
+        idx = 0;
+    }
     return idx;
 }
 
@@ -42,7 +48,7 @@ function frame_timer_avg_tenths(samples_ms: i32[120]): i32 {
     for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
         sum = sum + samples_ms[i];
     }
-    return (sum * 10) / FRAME_TIMER_SAMPLES;
+    return(sum * 10) / FRAME_TIMER_SAMPLES;
 }
 
 function frame_timer_max(samples_ms: i32[120]): i32 {
@@ -51,7 +57,9 @@ function frame_timer_max(samples_ms: i32[120]): i32 {
     let i: i32 = 0;
     for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
         let v: i32 = samples_ms[i];
-        if (v > max_v) { max_v = v; }
+        if (v > max_v) {
+            max_v = v;
+        }
     }
     return max_v;
 }

--- a/src/stdlib/game_camera.stasis
+++ b/src/stdlib/game_camera.stasis
@@ -24,7 +24,9 @@ function game_camera2d_set_center(cam: f32[], center_x: f32, center_y: f32): voi
 
 function game_camera2d_set_zoom(cam: f32[], zoom: f32): void {
     let z: f32 = zoom;
-    if (z <= 0.0001) { z = 0.0001; }
+    if (z <= 0.0001) {
+        z = 0.0001;
+    }
     cam[2] = z;
 }
 
@@ -33,55 +35,37 @@ function game_camera2d_set_viewport(cam: f32[], viewport_w_px: f32, viewport_h_p
     cam[4] = viewport_h_px;
 }
 
-function game_camera2d_world_to_screen(
-    cam: f32[],
-    world_x: f32,
-    world_y: f32,
-    out_screen_x: f32[],
-    out_screen_y: f32[]
-): void {
+function game_camera2d_world_to_screen(cam: f32[], world_x: f32, world_y: f32, out_screen_x: f32[], out_screen_y: f32[]): void {
     let cx: f32 = cam[0];
     let cy: f32 = cam[1];
     let z: f32 = cam[2];
     let vw: f32 = cam[3];
     let vh: f32 = cam[4];
 
-    out_screen_x[0] = (world_x - cx) * z + vw * 0.5;
-    out_screen_y[0] = (world_y - cy) * z + vh * 0.5;
+    out_screen_x[0] =(world_x - cx) * z + vw * 0.5;
+    out_screen_y[0] =(world_y - cy) * z + vh * 0.5;
 }
 
-function game_camera2d_screen_to_world(
-    cam: f32[],
-    screen_x: f32,
-    screen_y: f32,
-    out_world_x: f32[],
-    out_world_y: f32[]
-): void {
+function game_camera2d_screen_to_world(cam: f32[], screen_x: f32, screen_y: f32, out_world_x: f32[], out_world_y: f32[]): void {
     let cx: f32 = cam[0];
     let cy: f32 = cam[1];
     let z: f32 = cam[2];
     let vw: f32 = cam[3];
     let vh: f32 = cam[4];
 
-    out_world_x[0] = (screen_x - vw * 0.5) / z + cx;
-    out_world_y[0] = (screen_y - vh * 0.5) / z + cy;
+    out_world_x[0] =(screen_x - vw * 0.5) / z + cx;
+    out_world_y[0] =(screen_y - vh * 0.5) / z + cy;
 }
 
-function game_camera2d_world_to_screen_i32(
-    cam: f32[],
-    world_x: f32,
-    world_y: f32,
-    out_screen_x: i32[],
-    out_screen_y: i32[]
-): void {
+function game_camera2d_world_to_screen_i32(cam: f32[], world_x: f32, world_y: f32, out_screen_x: i32[], out_screen_y: i32[]): void {
     let cx: f32 = cam[0];
     let cy: f32 = cam[1];
     let z: f32 = cam[2];
     let vw: f32 = cam[3];
     let vh: f32 = cam[4];
 
-    let sx: f32 = (world_x - cx) * z + vw * 0.5;
-    let sy: f32 = (world_y - cy) * z + vh * 0.5;
+    let sx: f32 =(world_x - cx) * z + vw * 0.5;
+    let sy: f32 =(world_y - cy) * z + vh * 0.5;
     out_screen_x[0] = f32_to_i32(sx);
     out_screen_y[0] = f32_to_i32(sy);
 }

--- a/src/stdlib/game_collision.stasis
+++ b/src/stdlib/game_collision.stasis
@@ -1,67 +1,157 @@
 // Game collision helpers (not loaded by default).
 
 function game_aabb_intersects(
-    ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32,
-    bx_min_x: f32, bx_min_y: f32, bx_max_x: f32, bx_max_y: f32
+    ax_min_x: f32,
+    ax_min_y: f32,
+    ax_max_x: f32,
+    ax_max_y: f32,
+    bx_min_x: f32,
+    bx_min_y: f32,
+    bx_max_x: f32,
+    bx_max_y: f32
 ): bool {
-    if (ax_max_x < bx_min_x) { return false; }
-    if (ax_min_x > bx_max_x) { return false; }
-    if (ax_max_y < bx_min_y) { return false; }
-    if (ax_min_y > bx_max_y) { return false; }
+    if (ax_max_x < bx_min_x) {
+        return false;
+    }
+    if (ax_min_x > bx_max_x) {
+        return false;
+    }
+    if (ax_max_y < bx_min_y) {
+        return false;
+    }
+    if (ax_min_y > bx_max_y) {
+        return false;
+    }
     return true;
 }
 
-function game_aabb_contains_point(
-    ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32,
-    px: f32, py: f32
-): bool {
-    if (px < ax_min_x) { return false; }
-    if (px > ax_max_x) { return false; }
-    if (py < ax_min_y) { return false; }
-    if (py > ax_max_y) { return false; }
+function game_aabb_contains_point(ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32, px: f32, py: f32): bool {
+    if (px < ax_min_x) {
+        return false;
+    }
+    if (px > ax_max_x) {
+        return false;
+    }
+    if (py < ax_min_y) {
+        return false;
+    }
+    if (py > ax_max_y) {
+        return false;
+    }
     return true;
 }
 
 function game_aabb_union(
-    ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32,
-    bx_min_x: f32, bx_min_y: f32, bx_max_x: f32, bx_max_y: f32,
-    out_min_x: f32[], out_min_y: f32[], out_max_x: f32[], out_max_y: f32[]
+    ax_min_x: f32,
+    ax_min_y: f32,
+    ax_max_x: f32,
+    ax_max_y: f32,
+    bx_min_x: f32,
+    bx_min_y: f32,
+    bx_max_x: f32,
+    bx_max_y: f32,
+    out_min_x: f32[],
+    out_min_y: f32[],
+    out_max_x: f32[],
+    out_max_y: f32[]
 ) {
-    if (ax_min_x < bx_min_x) { out_min_x[0] = ax_min_x; } else { out_min_x[0] = bx_min_x; }
-    if (ax_min_y < bx_min_y) { out_min_y[0] = ax_min_y; } else { out_min_y[0] = bx_min_y; }
-    if (ax_max_x > bx_max_x) { out_max_x[0] = ax_max_x; } else { out_max_x[0] = bx_max_x; }
-    if (ax_max_y > bx_max_y) { out_max_y[0] = ax_max_y; } else { out_max_y[0] = bx_max_y; }
+    if (ax_min_x < bx_min_x) {
+        out_min_x[0] = ax_min_x;
+    } else {
+        out_min_x[0] = bx_min_x;
+    }
+    if (ax_min_y < bx_min_y) {
+        out_min_y[0] = ax_min_y;
+    } else {
+        out_min_y[0] = bx_min_y;
+    }
+    if (ax_max_x > bx_max_x) {
+        out_max_x[0] = ax_max_x;
+    } else {
+        out_max_x[0] = bx_max_x;
+    }
+    if (ax_max_y > bx_max_y) {
+        out_max_y[0] = ax_max_y;
+    } else {
+        out_max_y[0] = bx_max_y;
+    }
 }
 
 function game_aabb_overlap_depth(
-    ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32,
-    bx_min_x: f32, bx_min_y: f32, bx_max_x: f32, bx_max_y: f32,
-    out_dx: f32[], out_dy: f32[]
+    ax_min_x: f32,
+    ax_min_y: f32,
+    ax_max_x: f32,
+    ax_max_y: f32,
+    bx_min_x: f32,
+    bx_min_y: f32,
+    bx_max_x: f32,
+    bx_max_y: f32,
+    out_dx: f32[],
+    out_dy: f32[]
 ): bool {
-    if (ax_max_x < bx_min_x) { return false; }
-    if (ax_min_x > bx_max_x) { return false; }
-    if (ax_max_y < bx_min_y) { return false; }
-    if (ax_min_y > bx_max_y) { return false; }
+    if (ax_max_x < bx_min_x) {
+        return false;
+    }
+    if (ax_min_x > bx_max_x) {
+        return false;
+    }
+    if (ax_max_y < bx_min_y) {
+        return false;
+    }
+    if (ax_min_y > bx_max_y) {
+        return false;
+    }
 
     let left: f32 = bx_max_x - ax_min_x;
     let right: f32 = ax_max_x - bx_min_x;
     let down: f32 = bx_max_y - ax_min_y;
     let up: f32 = ax_max_y - bx_min_y;
 
-    if (left < right) { out_dx[0] = -left; } else { out_dx[0] = right; }
-    if (down < up) { out_dy[0] = -down; } else { out_dy[0] = up; }
+    if (left < right) {
+        out_dx[0] = -left;
+    } else {
+        out_dx[0] = right;
+    }
+    if (down < up) {
+        out_dy[0] = -down;
+    } else {
+        out_dy[0] = up;
+    }
     return true;
 }
 
 function game_aabb_sweep_resolve(
-    ax_min_x: f32, ax_min_y: f32, ax_max_x: f32, ax_max_y: f32,
-    bx_min_x: f32, bx_min_y: f32, bx_max_x: f32, bx_max_y: f32,
-    out_resolve_x: f32[], out_resolve_y: f32[]
+    ax_min_x: f32,
+    ax_min_y: f32,
+    ax_max_x: f32,
+    ax_max_y: f32,
+    bx_min_x: f32,
+    bx_min_y: f32,
+    bx_max_x: f32,
+    bx_max_y: f32,
+    out_resolve_x: f32[],
+    out_resolve_y: f32[]
 ): bool {
-    if (ax_max_x < bx_min_x) { out_resolve_x[0] = 0.0; out_resolve_y[0] = 0.0; return false; }
-    if (ax_min_x > bx_max_x) { out_resolve_x[0] = 0.0; out_resolve_y[0] = 0.0; return false; }
-    if (ax_max_y < bx_min_y) { out_resolve_x[0] = 0.0; out_resolve_y[0] = 0.0; return false; }
-    if (ax_min_y > bx_max_y) { out_resolve_x[0] = 0.0; out_resolve_y[0] = 0.0; return false; }
+    if (ax_max_x < bx_min_x) {
+        out_resolve_x[0] = 0.0;
+        out_resolve_y[0] = 0.0;
+        return false;
+    }
+    if (ax_min_x > bx_max_x) {
+        out_resolve_x[0] = 0.0;
+        out_resolve_y[0] = 0.0;
+        return false;
+    }
+    if (ax_max_y < bx_min_y) {
+        out_resolve_x[0] = 0.0;
+        out_resolve_y[0] = 0.0;
+        return false;
+    }
+    if (ax_min_y > bx_max_y) {
+        out_resolve_x[0] = 0.0;
+        out_resolve_y[0] = 0.0;
+        return false;
+    }
 
     let left: f32 = bx_max_x - ax_min_x;
     let right: f32 = ax_max_x - bx_min_x;
@@ -70,13 +160,21 @@ function game_aabb_sweep_resolve(
 
     let dx: f32 = right;
     let dy: f32 = up;
-    if (left < right) { dx = -left; }
-    if (down < up) { dy = -down; }
+    if (left < right) {
+        dx = -left;
+    }
+    if (down < up) {
+        dy = -down;
+    }
 
     let abs_dx: f32 = dx;
     let abs_dy: f32 = dy;
-    if (abs_dx < 0.0) { abs_dx = -abs_dx; }
-    if (abs_dy < 0.0) { abs_dy = -abs_dy; }
+    if (abs_dx < 0.0) {
+        abs_dx = -abs_dx;
+    }
+    if (abs_dy < 0.0) {
+        abs_dy = -abs_dy;
+    }
 
     if (abs_dx < abs_dy) {
         out_resolve_x[0] = dx;
@@ -88,22 +186,15 @@ function game_aabb_sweep_resolve(
     return true;
 }
 
-function game_circle_intersects(
-    ax: f32, ay: f32, ar: f32,
-    bx: f32, by: f32, br: f32
-): bool {
+function game_circle_intersects(ax: f32, ay: f32, ar: f32, bx: f32, by: f32, br: f32): bool {
     let dx: f32 = ax - bx;
     let dy: f32 = ay - by;
     let r: f32 = ar + br;
     return dx * dx + dy * dy <= r * r;
 }
 
-function game_circle_contains_point(
-    cx: f32, cy: f32, r: f32,
-    px: f32, py: f32
-): bool {
+function game_circle_contains_point(cx: f32, cy: f32, r: f32, px: f32, py: f32): bool {
     let dx: f32 = px - cx;
     let dy: f32 = py - cy;
     return dx * dx + dy * dy <= r * r;
 }
-

--- a/src/stdlib/game_draw.stasis
+++ b/src/stdlib/game_draw.stasis
@@ -1,4 +1,5 @@
 import "graphics.stasis";
+
 // Game drawing helpers (not loaded by default).
 
 const GAME_PI2: f32 = 6.2831853;
@@ -41,4 +42,3 @@ function game_draw_circle(cx: f32, cy: f32, radius: f32, r: f32, g: f32, b: f32,
         a0 = a1;
     }
 }
-

--- a/src/stdlib/game_input.stasis
+++ b/src/stdlib/game_input.stasis
@@ -16,19 +16,25 @@ function input_key_down(scancode: i32): bool {
 
 // Returns true if the key was down in the previous snapshot buffer.
 function input_key_down_prev(prev_keys: i32[], scancode: i32): bool {
-    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) { return false; }
+    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) {
+        return false;
+    }
     return prev_keys[scancode] != 0;
 }
 
 // Returns true if the key transitioned up->down this tick.
 function input_key_went_down(prev_keys: i32[], scancode: i32): bool {
-    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) { return false; }
+    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) {
+        return false;
+    }
     return host_key_down(scancode) && prev_keys[scancode] == 0;
 }
 
 // Returns true if the key transitioned down->up this tick.
 function input_key_went_up(prev_keys: i32[], scancode: i32): bool {
-    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) { return false; }
+    if (scancode < 0 || scancode >= GAME_INPUT_KEY_COUNT) {
+        return false;
+    }
     return !host_key_down(scancode) && prev_keys[scancode] != 0;
 }
 
@@ -37,8 +43,11 @@ function input_key_went_up(prev_keys: i32[], scancode: i32): bool {
 // `prev_cap` should be 512 for a full snapshot; smaller caps are allowed (copy is clamped).
 function input_keys_commit(prev_keys: i32[], prev_cap: i32): void {
     let n: i32 = prev_cap;
-    if (n > GAME_INPUT_KEY_COUNT) { n = GAME_INPUT_KEY_COUNT; }
-    if (n <= 0) { return; }
+    if (n > GAME_INPUT_KEY_COUNT) {
+        n = GAME_INPUT_KEY_COUNT;
+    }
+    if (n <= 0) {
+        return;
+    }
     mem_copy_i32(prev_keys, prev_cap, 0, host_i32, HOST_I32_COUNT, HOST_I_KEY_BASE, n);
 }
-

--- a/src/stdlib/game_math.stasis
+++ b/src/stdlib/game_math.stasis
@@ -22,39 +22,55 @@ function game_abs(x: f32): f32 {
 }
 
 function game_min(a: i32, b: i32): i32 {
-    if (a < b) { return a; }
+    if (a < b) {
+        return a;
+    }
     return b;
 }
 
 function game_min(a: f32, b: f32): f32 {
-    if (a < b) { return a; }
+    if (a < b) {
+        return a;
+    }
     return b;
 }
 
 function game_max(a: i32, b: i32): i32 {
-    if (a > b) { return a; }
+    if (a > b) {
+        return a;
+    }
     return b;
 }
 
 function game_max(a: f32, b: f32): f32 {
-    if (a > b) { return a; }
+    if (a > b) {
+        return a;
+    }
     return b;
 }
 
 function game_clamp(x: i32, lo: i32, hi: i32): i32 {
-    if (x < lo) { return lo; }
-    if (x > hi) { return hi; }
+    if (x < lo) {
+        return lo;
+    }
+    if (x > hi) {
+        return hi;
+    }
     return x;
 }
 
 function game_clamp(x: f32, lo: f32, hi: f32): f32 {
-    if (x < lo) { return lo; }
-    if (x > hi) { return hi; }
+    if (x < lo) {
+        return lo;
+    }
+    if (x > hi) {
+        return hi;
+    }
     return x;
 }
 
 function game_lerp(a: f32, b: f32, t: f32): f32 {
-    return a + (b - a) * t;
+    return a +(b - a) * t;
 }
 
 // Deterministic RNG (LCG).
@@ -75,17 +91,16 @@ function game_rng_range_i32(state: i32[], min_incl: i32, max_incl: i32): i32 {
         // Avoid INT_MIN overflow on negation (keeps modulo in-range).
         if (r == -2147483648) {
             r = 2147483647;
-        }
-        else {
+        } else {
             r = 0 - r;
         }
     }
 
-    let span: i32 = (max_incl - min_incl) + 1;
+    let span: i32 =(max_incl - min_incl) + 1;
     if (span <= 1) {
         return min_incl;
     }
-    return min_incl + (r % span);
+    return min_incl +(r % span);
 }
 
 function game_rng_f32_01(state: i32[]): f32 {
@@ -94,6 +109,5 @@ function game_rng_f32_01(state: i32[]): f32 {
 }
 
 function game_rng_range_f32(state: i32[], min_incl: f32, max_incl: f32): f32 {
-    return min_incl + game_rng_f32_01(state) * (max_incl - min_incl);
+    return min_incl + game_rng_f32_01(state) *(max_incl - min_incl);
 }
-

--- a/src/stdlib/gfx_cmd.stasis
+++ b/src/stdlib/gfx_cmd.stasis
@@ -8,54 +8,82 @@ import "stdlib.stasis";
 // - Coordinates: logical presentation units.
 
 const GFX_CMD_MAGIC: i32 = 1196967473; // 0x47584631 ('GXF1')
+
 const GFX_CMD_VERSION: i32 = 2;
 
 // i32 header indices
 const GFX_I_MAGIC: i32 = 0;
+
 const GFX_I_VERSION: i32 = 1;
+
 const GFX_I_FLAGS: i32 = 2;
+
 const GFX_I_LINE_COUNT: i32 = 3;
+
 const GFX_I_SPRITE_COUNT: i32 = 4;
+
 const GFX_I_DROPPED_LINES: i32 = 5;
+
 const GFX_I_DROPPED_SPRITES: i32 = 6;
+
 const GFX_I_TEXT_COUNT: i32 = 7;
+
 const GFX_I_DROPPED_TEXT: i32 = 8;
+
 const GFX_I_TEXT_BYTES_USED: i32 = 9;
+
 const GFX_I_SPRITE_BASE: i32 = 32;
 
 // flags
 const GFX_FLAG_CLEAR: i32 = 1;
+
 const GFX_FLAG_PRESENT: i32 = 2;
 
 // capacities (must match runtime clamp in `stasis_gfx_submit`)
 const GFX_MAX_LINES: i32 = 10000;
+
 const GFX_LINE_STRIDE_F32: i32 = 8;
+
 const GFX_MAX_SPRITES: i32 = 4096;
+
 const GFX_SPRITE_STRIDE_I32: i32 = 3; // handle,rot_deg,a
+
 const GFX_SPRITE_STRIDE_F32: i32 = 4; // x,y,w,h
 
 const GFX_MAX_TEXT: i32 = 2048;
+
 const GFX_TEXT_STRIDE_I32: i32 = 3; // font, byte_offset, byte_len
+
 const GFX_TEXT_STRIDE_F32: i32 = 6; // x,y,r,g,b,a
+
 const GFX_TEXT_MAX_BYTES: i32 = 65536;
 
 // f32 layout
 const GFX_F_CLEAR_R: i32 = 0;
+
 const GFX_F_CLEAR_G: i32 = 1;
+
 const GFX_F_CLEAR_B: i32 = 2;
+
 const GFX_F_CLEAR_A: i32 = 3;
+
 const GFX_F_LINE_BASE: i32 = 4;
+
 const GFX_F_SPRITE_BASE: i32 = 80004;
+
 const GFX_F_TEXT_BASE: i32 = 96388;
 
 const GFX_I_TEXT_BASE: i32 = 12320;
 
 const GFX_CMD_I32_COUNT: i32 = 18464;
+
 const GFX_CMD_F32_COUNT: i32 = 108676;
 
 // Array capacities are ABI literals shared with stasis_render_contract.h.
 global gfx_cmd_i32: i32[18464];
+
 global gfx_cmd_f32: f32[108676];
+
 global gfx_cmd_u8: u8[65536];
 
 function gfx_cmd_begin(): void {
@@ -127,11 +155,17 @@ function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b
     }
 
     let byte_len: i32 = length_bytes(text);
-    if (byte_len < 0) { byte_len = 0; }
-    if (byte_len > 1024) { byte_len = 1024; } // hard cap per command to keep worst-case bounded
+    if (byte_len < 0) {
+        byte_len = 0;
+    }
+    if (byte_len > 1024) {
+        byte_len = 1024;
+    } // hard cap per command to keep worst-case bounded
 
     let used: i32 = gfx_cmd_i32[GFX_I_TEXT_BYTES_USED];
-    if (used < 0) { used = 0; }
+    if (used < 0) {
+        used = 0;
+    }
     if (used + byte_len + 1 > GFX_TEXT_MAX_BYTES) {
         gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
         return;

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -1,4 +1,5 @@
 @link("stasis_graphics");
+
 // Graphics/runtime bindings.
 //
 // Policy: Stasis does not call into the host on hot paths.
@@ -12,17 +13,27 @@ import "../runtime/gfx_cmd.stasis";
 import "../runtime/host_window_request.stasis";
 
 extern function time(): i32;
+
 extern function sleep_ms(ms: i32): void;
 
 // Hot-path reads are HostFrame snapshot-only (no host calls).
-function get_time_ms(): i32 { return host_time_ms(); }
-function get_time_us(): i32 { return host_time_us(); }
+function get_time_ms(): i32 {
+    return host_time_ms();
+}
+
+function get_time_us(): i32 {
+    return host_time_us();
+}
 
 // Startup / assets (host calls; avoid in hot paths)
 extern function gfx_poll_reload(handle: i32): bool;
+
 extern function gfx_dump_bmp(path: string): i32;
+
 extern function gfx_dump_png(path: string): i32;
+
 extern function load_font(path: string, size: i32): i32;
+
 extern function measure_text(font: i32, text: string): f32;
 
 struct Sprite {
@@ -41,7 +52,9 @@ struct TextRun {
 function @extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
-    if (self.handle <= 0 || self.width <= 0 || self.height <= 0) { return; }
+    if (self.handle <= 0 || self.width <= 0 || self.height <= 0) {
+        return;
+    }
     let width: f32 = 0.0;
     let height: f32 = 0.0;
     width.from_i32(self.width);
@@ -52,7 +65,9 @@ function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
 function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
 
 function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
-    if (self.font <= 0 || self.handle <= 0) { return; }
+    if (self.font <= 0 || self.handle <= 0) {
+        return;
+    }
     gfx_cmd_text_cached(self.font, self.handle, x, y, r, g, b, a);
 }
 
@@ -60,9 +75,16 @@ function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): vo
 function set_postfx(strength: f32, phase: f32, speed: f32, r: f32, g: f32, b: f32): void {
 }
 
-function gfx_debug_bake_hash(path: string): i32 { return 0; }
-function gfx_debug_enable_hash(enabled: i32): void { }
-function gfx_debug_get_frame_hash(): i32 { return 0; }
+function gfx_debug_bake_hash(path: string): i32 {
+    return 0;
+}
+
+function gfx_debug_enable_hash(enabled: i32): void {
+}
+
+function gfx_debug_get_frame_hash(): i32 {
+    return 0;
+}
 
 function get_desktop_size(out_w: i32[], out_h: i32[]): void {
     out_w[0] = host_screen_w_px();
@@ -119,24 +141,73 @@ function gfx_draw_sprites(cmd_i32: i32[], cmd_f32: f32[], count: i32): void {
     gfx_cmd_sprites_from(cmd_i32, cmd_f32, count);
 }
 
-function gfx_window_resized(): bool { return host_resized(); }
-function gfx_logical_width(): f32 { return host_logical_width(); }
-function gfx_logical_height(): f32 { return host_logical_height(); }
-function gfx_native_width_px(): i32 { return host_native_w_px(); }
-function gfx_native_height_px(): i32 { return host_native_h_px(); }
-function gfx_drawable_width_px(): i32 { return host_drawable_w_px(); }
-function gfx_drawable_height_px(): i32 { return host_drawable_h_px(); }
-function gfx_safe_viewport_x(): f32 { return host_safe_x(); }
-function gfx_safe_viewport_y(): f32 { return host_safe_y(); }
-function gfx_safe_viewport_width(): f32 { return host_safe_width(); }
-function gfx_safe_viewport_height(): f32 { return host_safe_height(); }
-function gfx_content_scale(): f32 { return host_content_scale(); }
-function gfx_raster_scale(): f32 { return host_raster_scale(); }
-function gfx_display_generation(): i32 { return host_display_generation(); }
-function gfx_density_generation(): i32 { return host_density_generation(); }
+function gfx_window_resized(): bool {
+    return host_resized();
+}
 
-function is_key_down(scancode: i32): bool { return host_key_down(scancode); }
-function should_quit(): bool { return host_quit_requested(); }
+function gfx_logical_width(): f32 {
+    return host_logical_width();
+}
+
+function gfx_logical_height(): f32 {
+    return host_logical_height();
+}
+
+function gfx_native_width_px(): i32 {
+    return host_native_w_px();
+}
+
+function gfx_native_height_px(): i32 {
+    return host_native_h_px();
+}
+
+function gfx_drawable_width_px(): i32 {
+    return host_drawable_w_px();
+}
+
+function gfx_drawable_height_px(): i32 {
+    return host_drawable_h_px();
+}
+
+function gfx_safe_viewport_x(): f32 {
+    return host_safe_x();
+}
+
+function gfx_safe_viewport_y(): f32 {
+    return host_safe_y();
+}
+
+function gfx_safe_viewport_width(): f32 {
+    return host_safe_width();
+}
+
+function gfx_safe_viewport_height(): f32 {
+    return host_safe_height();
+}
+
+function gfx_content_scale(): f32 {
+    return host_content_scale();
+}
+
+function gfx_raster_scale(): f32 {
+    return host_raster_scale();
+}
+
+function gfx_display_generation(): i32 {
+    return host_display_generation();
+}
+
+function gfx_density_generation(): i32 {
+    return host_density_generation();
+}
+
+function is_key_down(scancode: i32): bool {
+    return host_key_down(scancode);
+}
+
+function should_quit(): bool {
+    return host_quit_requested();
+}
 
 // Legacy submit calls are no-ops in bulk mode (host pulls command buffers after tick).
 function gfx_submit(cmd_i32: i32[], cmd_f32: f32[]): void {
@@ -148,15 +219,50 @@ function gfx_submit_u8(cmd_i32: i32[], cmd_f32: f32[], cmd_u8: u8[]): void {
 }
 
 // Pointer/query wrappers over HostFrame
-function input_pointer_count(): i32 { return host_pointer_count(); }
-function input_pointer_id(index: i32): i32 { return host_pointer_id(index); }
-function input_pointer_is_down(index: i32): bool { return host_pointer_is_down(index); }
-function input_pointer_went_down(index: i32): bool { return host_pointer_went_down(index); }
-function input_pointer_went_up(index: i32): bool { return host_pointer_went_up(index); }
-function input_pointer_x_logical(index: i32): f32 { return host_pointer_x_logical(index); }
-function input_pointer_y_logical(index: i32): f32 { return host_pointer_y_logical(index); }
-function input_pointer_dx_logical(index: i32): f32 { return host_pointer_dx_logical(index); }
-function input_pointer_dy_logical(index: i32): f32 { return host_pointer_dy_logical(index); }
-function input_pointer_x_n(index: i32): f32 { return host_pointer_x_n(index); }
-function input_pointer_y_n(index: i32): f32 { return host_pointer_y_n(index); }
-function input_dropped_pointers(): i32 { return host_dropped_pointers(); }
+function input_pointer_count(): i32 {
+    return host_pointer_count();
+}
+
+function input_pointer_id(index: i32): i32 {
+    return host_pointer_id(index);
+}
+
+function input_pointer_is_down(index: i32): bool {
+    return host_pointer_is_down(index);
+}
+
+function input_pointer_went_down(index: i32): bool {
+    return host_pointer_went_down(index);
+}
+
+function input_pointer_went_up(index: i32): bool {
+    return host_pointer_went_up(index);
+}
+
+function input_pointer_x_logical(index: i32): f32 {
+    return host_pointer_x_logical(index);
+}
+
+function input_pointer_y_logical(index: i32): f32 {
+    return host_pointer_y_logical(index);
+}
+
+function input_pointer_dx_logical(index: i32): f32 {
+    return host_pointer_dx_logical(index);
+}
+
+function input_pointer_dy_logical(index: i32): f32 {
+    return host_pointer_dy_logical(index);
+}
+
+function input_pointer_x_n(index: i32): f32 {
+    return host_pointer_x_n(index);
+}
+
+function input_pointer_y_n(index: i32): f32 {
+    return host_pointer_y_n(index);
+}
+
+function input_dropped_pointers(): i32 {
+    return host_dropped_pointers();
+}

--- a/src/stdlib/hud_draw.stasis
+++ b/src/stdlib/hud_draw.stasis
@@ -1,21 +1,10 @@
 // HUD helpers (drawing).
-// Import explicitly: import "src/stdlib/hud_draw.stasis";
+// From a generated project: import "/vendor/stasis/src/stdlib/hud_draw.stasis";
 
 import "graphics.stasis";
 import "hud_text.stasis";
 
-function hud_draw_text_from_ascii(
-    font: i32,
-    tmp: ascii[],
-    out: utf8[],
-    out_max: i32,
-    x: f32,
-    y: f32,
-    r: f32,
-    g: f32,
-    b: f32,
-    a: f32
-): void {
+function hud_draw_text_from_ascii(font: i32, tmp: ascii[], out: utf8[], out_max: i32, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     hud_text_commit(out, tmp, out_max);
     gfx_cmd_text(font, out, x, y, r, g, b, a);
 }

--- a/src/stdlib/hud_table.stasis
+++ b/src/stdlib/hud_table.stasis
@@ -1,5 +1,5 @@
 // HUD layout helpers for reusable "tables" (rows/columns) over arrays of data.
-// Import explicitly: import "src/stdlib/hud_table.stasis";
+// From a generated project: import "/vendor/stasis/src/stdlib/hud_table.stasis";
 //
 // Cranelift note:
 // - The Cranelift backend does not currently support arbitrary struct member access.
@@ -7,14 +7,21 @@
 //
 // Rect layout: [x, y, w, h]
 const HUD_RECT_X: i32 = 0;
+
 const HUD_RECT_Y: i32 = 1;
+
 const HUD_RECT_W: i32 = 2;
+
 const HUD_RECT_H: i32 = 3;
 
 // Clamp utility (avoid extra imports).
 function hud_clamp(v: i32, min: i32, max: i32): i32 {
-    if (v < min) { return min; }
-    if (v > max) { return max; }
+    if (v < min) {
+        return min;
+    }
+    if (v > max) {
+        return max;
+    }
     return v;
 }
 
@@ -28,7 +35,9 @@ function hud_rect_set(out_r: f32[], x: f32, y: f32, w: f32, h: f32): void {
 // Compute the total width of a table given column widths and gaps.
 function hud_table_width(col_w: f32[], col_count: i32, col_gap: f32): f32 {
     let n: i32 = col_count;
-    if (n < 0) { n = 0; }
+    if (n < 0) {
+        n = 0;
+    }
     let sum: f32 = 0.0;
     let i: i32 = 0;
     for (i = 0; i < n; i = i + 1) {
@@ -43,7 +52,9 @@ function hud_table_width(col_w: f32[], col_count: i32, col_gap: f32): f32 {
 // Compute the total height of a table given row height and gaps.
 function hud_table_height(row_count: i32, row_h: f32, row_gap: f32): f32 {
     let n: i32 = row_count;
-    if (n < 0) { n = 0; }
+    if (n < 0) {
+        n = 0;
+    }
     let h: f32 = i32_to_f32(n) * row_h;
     if (n > 1) {
         h = h + i32_to_f32(n - 1) * row_gap;
@@ -69,10 +80,10 @@ function hud_table_place(out_table: f32[], parent: f32[], table_w: f32, table_h:
         y = parent[HUD_RECT_Y] + parent[HUD_RECT_H] - pad_y - table_h;
     }
     if (anchor == 4) {
-        x = parent[HUD_RECT_X] + (parent[HUD_RECT_W] - table_w) * 0.5;
+        x = parent[HUD_RECT_X] +(parent[HUD_RECT_W] - table_w) * 0.5;
     }
     if (anchor == 5) {
-        x = parent[HUD_RECT_X] + (parent[HUD_RECT_W] - table_w) * 0.5;
+        x = parent[HUD_RECT_X] +(parent[HUD_RECT_W] - table_w) * 0.5;
         y = parent[HUD_RECT_Y] + parent[HUD_RECT_H] - pad_y - table_h;
     }
 
@@ -96,15 +107,27 @@ function hud_table_cell_w(col_w: f32[], col_count: i32, col: i32): f32 {
 
 function hud_table_cell_y(table: f32[], row_h: f32, row_gap: f32, row: i32): f32 {
     let r: i32 = row;
-    if (r < 0) { r = 0; }
-    return table[HUD_RECT_Y] + i32_to_f32(r) * (row_h + row_gap);
+    if (r < 0) {
+        r = 0;
+    }
+    return table[HUD_RECT_Y] + i32_to_f32(r) *(row_h + row_gap);
 }
 
 function hud_table_cell_h(row_h: f32): f32 {
     return row_h;
 }
 
-function hud_table_cell_rect(out_cell: f32[], table: f32[], col_w: f32[], col_count: i32, col_gap: f32, row_h: f32, row_gap: f32, col: i32, row: i32): void {
+function hud_table_cell_rect(
+    out_cell: f32[],
+    table: f32[],
+    col_w: f32[],
+    col_count: i32,
+    col_gap: f32,
+    row_h: f32,
+    row_gap: f32,
+    col: i32,
+    row: i32
+): void {
     let x: f32 = hud_table_cell_x(table, col_w, col_count, col_gap, col);
     let y: f32 = hud_table_cell_y(table, row_h, row_gap, row);
     let w: f32 = hud_table_cell_w(col_w, col_count, col);

--- a/src/stdlib/hud_text.stasis
+++ b/src/stdlib/hud_text.stasis
@@ -1,5 +1,5 @@
 // HUD helpers (pure formatting / buffer bridging).
-// Import explicitly: import "src/stdlib/hud_text.stasis";
+// From a generated project: import "/vendor/stasis/src/stdlib/hud_text.stasis";
 
 import "stdlib.stasis";
 
@@ -10,4 +10,3 @@ function hud_text_clear(tmp: ascii[]): void {
 function hud_text_commit(out: utf8[], tmp: ascii[], out_max: i32): i32 {
     return utf8_from_ascii(out, tmp, out_max);
 }
-

--- a/src/stdlib/input_snapshot.stasis
+++ b/src/stdlib/input_snapshot.stasis
@@ -2,6 +2,7 @@
 // Keep this struct in stdlib so multiple fixtures can share it.
 
 const INPUT_MAX_KEYS: i32 = 512;
+
 const INPUT_MAX_POINTERS: i32 = 8;
 
 struct InputSnapshot {

--- a/src/stdlib/memory.stasis
+++ b/src/stdlib/memory.stasis
@@ -5,25 +5,39 @@
 // - clamped and/or checked variants
 
 extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+
 extern function sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+
 extern function sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
 
 extern function sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+
 extern function sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+
 extern function sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
 
 // Copy `count` bytes from src to dst, clamped to both buffers.
 // Returns bytes copied.
 function mem_copy_u8(dst: u8[], dst_cap: i32, dst_index: i32, src: u8[], src_cap: i32, src_index: i32, count: i32): i32 {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap || src_index >= src_cap) { return 0; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
 
     let dst_rem: i32 = dst_cap - dst_index;
     let src_rem: i32 = src_cap - src_index;
     let n: i32 = count;
-    if (n > dst_rem) { n = dst_rem; }
-    if (n > src_rem) { n = src_rem; }
-    if (n <= 0) { return 0; }
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
 
     sys_memmove_u8(dst, dst_index, src, src_index, n);
     return n;
@@ -31,22 +45,38 @@ function mem_copy_u8(dst: u8[], dst_cap: i32, dst_index: i32, src: u8[], src_cap
 
 // Copy `count` bytes from src to dst; fails if any bound would be exceeded.
 function mem_copy_u8_checked(dst: u8[], dst_cap: i32, dst_index: i32, src: u8[], src_cap: i32, src_index: i32, count: i32): bool {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) { return false; }
-    if (dst_index + count > dst_cap) { return false; }
-    if (src_index + count > src_cap) { return false; }
-    if (count == 0) { return true; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
     sys_memmove_u8(dst, dst_index, src, src_index, count);
     return true;
 }
 
 // Set `count` bytes to `value`, clamped to the buffer. Returns bytes written.
 function mem_set_u8(dst: u8[], dst_cap: i32, dst_index: i32, value: u8, count: i32): i32 {
-    if (dst_cap < 0 || dst_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap) { return 0; }
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
     let rem: i32 = dst_cap - dst_index;
     let n: i32 = count;
-    if (n > rem) { n = rem; }
-    if (n <= 0) { return 0; }
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
     let i: i32 = 0;
     for (i = 0; i < n; i = i + 1) {
         dst[dst_index + i] = value;
@@ -61,36 +91,62 @@ function mem_zero_u8(dst: u8[], dst_cap: i32, dst_index: i32, count: i32): i32 {
 // Copy `count` elements from src to dst, clamped to both buffers.
 // Returns elements copied.
 function mem_copy_i32(dst: i32[], dst_cap: i32, dst_index: i32, src: i32[], src_cap: i32, src_index: i32, count: i32): i32 {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap || src_index >= src_cap) { return 0; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
 
     let dst_rem: i32 = dst_cap - dst_index;
     let src_rem: i32 = src_cap - src_index;
     let n: i32 = count;
-    if (n > dst_rem) { n = dst_rem; }
-    if (n > src_rem) { n = src_rem; }
-    if (n <= 0) { return 0; }
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
 
     sys_memmove_i32(dst, dst_index, src, src_index, n);
     return n;
 }
 
 function mem_copy_i32_checked(dst: i32[], dst_cap: i32, dst_index: i32, src: i32[], src_cap: i32, src_index: i32, count: i32): bool {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) { return false; }
-    if (dst_index + count > dst_cap) { return false; }
-    if (src_index + count > src_cap) { return false; }
-    if (count == 0) { return true; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
     sys_memmove_i32(dst, dst_index, src, src_index, count);
     return true;
 }
 
 function mem_set_i32(dst: i32[], dst_cap: i32, dst_index: i32, value: i32, count: i32): i32 {
-    if (dst_cap < 0 || dst_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap) { return 0; }
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
     let rem: i32 = dst_cap - dst_index;
     let n: i32 = count;
-    if (n > rem) { n = rem; }
-    if (n <= 0) { return 0; }
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
     let i: i32 = 0;
     for (i = 0; i < n; i = i + 1) {
         dst[dst_index + i] = value;
@@ -105,36 +161,62 @@ function mem_zero_i32(dst: i32[], dst_cap: i32, dst_index: i32, count: i32): i32
 // Copy `count` elements from src to dst, clamped to both buffers.
 // Returns elements copied.
 function mem_copy_f32(dst: f32[], dst_cap: i32, dst_index: i32, src: f32[], src_cap: i32, src_index: i32, count: i32): i32 {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap || src_index >= src_cap) { return 0; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
 
     let dst_rem: i32 = dst_cap - dst_index;
     let src_rem: i32 = src_cap - src_index;
     let n: i32 = count;
-    if (n > dst_rem) { n = dst_rem; }
-    if (n > src_rem) { n = src_rem; }
-    if (n <= 0) { return 0; }
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
 
     sys_memmove_f32(dst, dst_index, src, src_index, n);
     return n;
 }
 
 function mem_copy_f32_checked(dst: f32[], dst_cap: i32, dst_index: i32, src: f32[], src_cap: i32, src_index: i32, count: i32): bool {
-    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) { return false; }
-    if (dst_index + count > dst_cap) { return false; }
-    if (src_index + count > src_cap) { return false; }
-    if (count == 0) { return true; }
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
     sys_memmove_f32(dst, dst_index, src, src_index, count);
     return true;
 }
 
 function mem_set_f32(dst: f32[], dst_cap: i32, dst_index: i32, value: f32, count: i32): i32 {
-    if (dst_cap < 0 || dst_index < 0 || count <= 0) { return 0; }
-    if (dst_index >= dst_cap) { return 0; }
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
     let rem: i32 = dst_cap - dst_index;
     let n: i32 = count;
-    if (n > rem) { n = rem; }
-    if (n <= 0) { return 0; }
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
     let i: i32 = 0;
     for (i = 0; i < n; i = i + 1) {
         dst[dst_index + i] = value;
@@ -145,4 +227,3 @@ function mem_set_f32(dst: f32[], dst_cap: i32, dst_index: i32, value: f32, count
 function mem_zero_f32(dst: f32[], dst_cap: i32, dst_index: i32, count: i32): i32 {
     return mem_set_f32(dst, dst_cap, dst_index, 0, count);
 }
-

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -1,6 +1,7 @@
 // Stasis standard library (stub).
-// Import explicitly: import "src/stdlib/stdlib.stasis";
-// For runtime bindings: import "src/stdlib/graphics.stasis" and/or "src/stdlib/audio.stasis".
+// From a generated project: import "/vendor/stasis/src/stdlib/stdlib.stasis";
+// For runtime bindings, import "/vendor/stasis/src/stdlib/graphics.stasis" and/or
+// "/vendor/stasis/src/stdlib/audio.stasis".
 
 import "memory.stasis";
 
@@ -104,10 +105,10 @@ function char_to_hex(b: u8): i32 {
         return b - 48;
     }
     if (b >= 65 && b <= 70) {
-        return 10 + (b - 65);
+        return 10 +(b - 65);
     }
     if (b >= 97 && b <= 102) {
-        return 10 + (b - 97);
+        return 10 +(b - 97);
     }
     return -1;
 }
@@ -119,7 +120,7 @@ function char_from_hex(d: i32): u8 {
     if (d < 10) {
         return 48 + d;
     }
-    return 65 + (d - 10);
+    return 65 +(d - 10);
 }
 
 function ascii_is_digit(b: u8): bool {
@@ -356,7 +357,7 @@ function ascii_push_i32(dst: ascii[], value: i32): void {
 
     // Emit digits.
     for (i = 0; pow10 > 0; i = i + 1) {
-        let digit: i32 = (v / pow10) % 10;
+        let digit: i32 =(v / pow10) % 10;
         ascii_push(dst, i32_to_u8_trunc(48 + digit));
         pow10 = pow10 / 10;
     }
@@ -474,7 +475,7 @@ function ascii_find(s: ascii[], needle: ascii[]): i32 {
     let i: i32 = 0;
     let j: i32 = 0;
     let match: bool = true;
-    for (i = 0; i < (len_s - len_n + 1); i = i + 1) {
+    for (i = 0; i <(len_s - len_n + 1); i = i + 1) {
         match = true;
         for (j = 0; j < len_n; j = j + 1) {
             if (s[i + j] != needle[j]) {

--- a/src/stdlib/storage.stasis
+++ b/src/stdlib/storage.stasis
@@ -2,4 +2,5 @@
 // Scope and key must be 1..63 ASCII letters, digits, underscores, or hyphens.
 // Missing, invalid, or corrupt values return the caller-provided fallback.
 extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
+
 extern function storage_save_i32(scope: string, key: string, value: i32): bool;

--- a/src/stdlib/ui_axis_layout.stasis
+++ b/src/stdlib/ui_axis_layout.stasis
@@ -12,14 +12,9 @@ enum UiVertical {
     Bottom,
 }
 
-function @inline ui_place_x(
-    parent_x: f32,
-    parent_width: f32,
-    child_width: f32,
-    horizontal: UiHorizontal
-): f32 {
+function @inline ui_place_x(parent_x: f32, parent_width: f32, child_width: f32, horizontal: UiHorizontal): f32 {
     if (horizontal == UiHorizontal.Center) {
-        return parent_x + (parent_width - child_width) * 0.5;
+        return parent_x +(parent_width - child_width) * 0.5;
     }
     if (horizontal == UiHorizontal.Right) {
         return parent_x + parent_width - child_width;
@@ -27,14 +22,9 @@ function @inline ui_place_x(
     return parent_x;
 }
 
-function @inline ui_place_y(
-    parent_y: f32,
-    parent_height: f32,
-    child_height: f32,
-    vertical: UiVertical
-): f32 {
+function @inline ui_place_y(parent_y: f32, parent_height: f32, child_height: f32, vertical: UiVertical): f32 {
     if (vertical == UiVertical.Center) {
-        return parent_y + (parent_height - child_height) * 0.5;
+        return parent_y +(parent_height - child_height) * 0.5;
     }
     if (vertical == UiVertical.Bottom) {
         return parent_y + parent_height - child_height;

--- a/src/stdlib/ui_button_9slice.stasis
+++ b/src/stdlib/ui_button_9slice.stasis
@@ -1,4 +1,5 @@
 import "graphics.stasis";
+
 // Shared 9-slice button helpers for sprite-based UI.
 // Background uses 9 sprites (3x3 grid). Icons are sprites; text uses the command buffer.
 
@@ -8,17 +9,23 @@ function ui_draw_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, a: i32): vo
 
 function ui_row_button_width(available_w: f32, count: i32, gap: f32): f32 {
     let safe_count: i32 = count;
-    if (safe_count < 1) { safe_count = 1; }
+    if (safe_count < 1) {
+        safe_count = 1;
+    }
     let gaps: f32 = gap * i32_to_f32(safe_count - 1);
-    let button_w: f32 = (available_w - gaps) / i32_to_f32(safe_count);
-    if (button_w < 0.0) { button_w = 0.0; }
+    let button_w: f32 =(available_w - gaps) / i32_to_f32(safe_count);
+    if (button_w < 0.0) {
+        button_w = 0.0;
+    }
     return button_w;
 }
 
 function ui_row_button_x(start_x: f32, index: i32, button_w: f32, gap: f32): f32 {
     let idx: i32 = index;
-    if (idx < 0) { idx = 0; }
-    return start_x + i32_to_f32(idx) * (button_w + gap);
+    if (idx < 0) {
+        idx = 0;
+    }
+    return start_x + i32_to_f32(idx) *(button_w + gap);
 }
 
 function ui_draw_9slice(
@@ -42,8 +49,12 @@ function ui_draw_9slice(
     let sh: f32 = slice_h;
     let mid_w: f32 = w - sw * 2.0;
     let mid_h: f32 = h - sh * 2.0;
-    if (mid_w < 0.0) { mid_w = 0.0; }
-    if (mid_h < 0.0) { mid_h = 0.0; }
+    if (mid_w < 0.0) {
+        mid_w = 0.0;
+    }
+    if (mid_h < 0.0) {
+        mid_h = 0.0;
+    }
 
     // Top row
     ui_draw_sprite(top_left, x, y, sw, sh, 255);
@@ -88,28 +99,27 @@ function ui_draw_button_9slice(
     icon_pad: f32,
     text_pad: f32
 ): void {
-    ui_draw_9slice(
-        top_left, top, top_right,
-        left, center, right,
-        bottom_left, bottom, bottom_right,
-        slice_w, slice_h,
-        x, y, w, h);
+    ui_draw_9slice(top_left, top, top_right, left, center, right, bottom_left, bottom, bottom_right, slice_w, slice_h, x, y, w, h);
 
     let content_x: f32 = x + text_pad;
     let content_w: f32 = w - text_pad * 2.0;
-    if (content_w < 0.0) { content_w = 0.0; }
+    if (content_w < 0.0) {
+        content_w = 0.0;
+    }
 
     if (icon_handle != 0) {
         let icon_h: f32 = h * 0.6;
         let icon_w: f32 = icon_h * icon_aspect;
         let icon_x: f32 = x + icon_pad;
-        let icon_y: f32 = y + (h - icon_h) * 0.5;
+        let icon_y: f32 = y +(h - icon_h) * 0.5;
         ui_draw_sprite(icon_handle, icon_x, icon_y, icon_w, icon_h, 255);
 
-        let used_w: f32 = (icon_x - x) + icon_w + icon_pad;
+        let used_w: f32 =(icon_x - x) + icon_w + icon_pad;
         content_x = x + used_w;
         content_w = w - used_w - text_pad;
-        if (content_w < 0.0) { content_w = 0.0; }
+        if (content_w < 0.0) {
+            content_w = 0.0;
+        }
     }
 
     if (font_handle == 0) {
@@ -117,7 +127,7 @@ function ui_draw_button_9slice(
     }
 
     let text_w: f32 = measure_text(font_handle, label);
-    let text_x: f32 = content_x + (content_w - text_w) * 0.5;
-    let text_y: f32 = y + (h * 0.55);
+    let text_x: f32 = content_x +(content_w - text_w) * 0.5;
+    let text_y: f32 = y +(h * 0.55);
     gfx_cmd_text(font_handle, label, text_x, text_y, text_r, text_g, text_b, text_a);
 }


### PR DESCRIPTION
## Summary

- format all standard-library and runtime Stasis sources canonically
- add project-root import resolution for paths such as `/vendor/stasis/...`
- make `stasis new` vendor matching stdlib/runtime sources outside `src`
- record the bundled release ID and source hash in `stasis.json`
- automatically restore the Stasis-owned vendor tree whenever its contents differ from the selected executable
- keep compiler, Workshop, Android symbol discovery, tests, and documentation aligned

## Impact

Generated projects keep `vendor/stasis` checked into Git. Stasis owns and synchronizes that directory without prompts or manual/evergreen policy settings; Git provides review and rollback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p stasis toolchain_cli::tests:: -- --nocapture` (43 passed)
- `cargo test -p stasis_compiler module_graph -- --nocapture` (13 passed)
- generated-project nested-directory CLI integration test
- `stasis format --check src/stdlib src/runtime`
- focused Android import-resolution JUnit tests (4 passed)

The local Android render hook was also attempted. One run logged a successful non-empty Cranelift JIT compile and more than 1,650 active render frames, but its UI-hierarchy assertion was disrupted by a concurrent emulator test. A follow-up fresh-emulator attempt timed out during AVD boot; CI should rerun this environment-sensitive gate.