### PR TITLE
fix: bundle Linux runtime runner nightly

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -141,22 +141,16 @@ jobs:
       - name: Build stasis_graphics runtime (unix)
         if: runner.os != 'Windows'
         run: |
-          runner_build=OFF
-          build_targets=(stasis_graphics)
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            runner_build=ON
-            build_targets+=(stasis_runner)
-          fi
           cmake -S runtime -B runtime/build_ci \
             -DCMAKE_BUILD_TYPE=Release \
             -DSTASIS_GRAPHICS_BUILD_SHARED=ON \
             -DSTASIS_GRAPHICS_BUILD_STATIC=OFF \
             -DSTASIS_GRAPHICS_BUNDLE_SDL=ON \
             -DSTASIS_GRAPHICS_SDL_ONLY=ON \
-            -DSTASIS_BUILD_RUNNER="${runner_build}" \
+            -DSTASIS_BUILD_RUNNER=ON \
             -DSTASIS_BUILD_SYS=OFF \
             -DSTASIS_RELEASE_ID="${{ needs.detect.outputs.nightly_tag }}"
-          cmake --build runtime/build_ci --config Release --target "${build_targets[@]}"
+          cmake --build runtime/build_ci --config Release --target stasis_graphics stasis_runner
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             test "$(plutil -extract NSHighResolutionCapable raw runtime/build_ci/bin/Release/stasis_runner.app/Contents/Info.plist)" = "true"
           fi
@@ -191,6 +185,8 @@ jobs:
           find runtime/build_ci/bin -maxdepth 2 -type f \( -name 'libstasis_graphics.so' -o -name 'libstasis_graphics.dylib' \) -exec cp {} "${out}/bin/" \;
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             cp -R runtime/build_ci/bin/Release/stasis_runner.app "${out}/bin/"
+          else
+            cp runtime/build_ci/bin/stasis_runner "${out}/bin/"
           fi
           cp README.md "${out}/"
           cp LICENSE "${out}/"


### PR DESCRIPTION
## Summary

- build `stasis_runner` for every Unix nightly target
- copy the Linux runner into the nightly archive beside `bin/stasis`
- preserve the existing macOS app-bundle packaging

## Root cause

The Linux nightly archive contained `stasis` and `libstasis_graphics.so` but no `stasis_runner`. The bundled CLI smoke test therefore attempted an on-demand runtime rebuild from packaged sources, which could not discover SDL3.

## Validation

- workflow diff passes `git diff --check`
- failure reproduced from Nightly Release run 31033809515
- the existing nightly bundled CLI smoke test will exercise the fixed Linux archive end to end