### PR TITLE
fix: copy Linux runner from release output

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -186,7 +186,7 @@ jobs:
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             cp -R runtime/build_ci/bin/Release/stasis_runner.app "${out}/bin/"
           else
-            cp runtime/build_ci/bin/stasis_runner "${out}/bin/"
+            cp runtime/build_ci/bin/Release/stasis_runner "${out}/bin/"
           fi
           cp README.md "${out}/"
           cp LICENSE "${out}/"


### PR DESCRIPTION
## Summary
- copy the successfully built Linux stasis_runner from CMake's Release output directory
- preserve the existing macOS app-bundle path

## Evidence
Nightly run 31036225773 built stasis_runner at runtime/build_ci/bin/Release/stasis_runner, then failed only because the archive step looked in runtime/build_ci/bin/stasis_runner.

## Validation
- git diff --check
- repository Stasis format hook passed
- GitHub PR CI required before merge