### PR TITLE
fix: harden Gauntlet ImageGen handoff

### DIFF
--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -20,6 +20,9 @@ const DEFAULT_STALLED_CANDIDATES: u32 = 5;
 const DEFAULT_BUILDER_MAX_TURNS: u32 = 30;
 const DEFAULT_MODEL_TIMEOUT_MINUTES: u32 = 30;
 const MAX_MODEL_TIMEOUT_MINUTES: u32 = 120;
+const MAX_CAPTURE_SCENARIOS: usize = 4;
+const MAX_SCENARIO_TAPS: usize = 8;
+const MAX_SCENARIO_TICKS_AFTER: u32 = 300;
 const MAX_GOAL_BYTES: u64 = 256 * 1024;
 const MAX_REFERENCE_BYTES: u64 = 16 * 1024 * 1024;
 const GAUNTLET_UI_FONT_BYTES: &[u8] =
@@ -117,6 +120,21 @@ pub(super) struct GauntletReference {
 pub(super) struct GauntletScenarioRequirement {
     pub id: String,
     pub description: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub taps: Vec<GauntletScenarioTap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GauntletScenarioTap {
+    pub x: i32,
+    pub y: i32,
+    #[serde(default = "default_scenario_ticks_after")]
+    pub ticks_after: u32,
+}
+
+const fn default_scenario_ticks_after() -> u32 {
+    1
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -409,9 +427,53 @@ impl GauntletConfigV1 {
             validate_relative_path("reference path", Path::new(&reference.path))?;
             validate_sha256(&reference.sha256)?;
         }
+        let capture_scenarios = self
+            .quality_bar
+            .required_scenarios
+            .iter()
+            .filter(|scenario| !scenario.taps.is_empty())
+            .count();
+        if capture_scenarios > MAX_CAPTURE_SCENARIOS {
+            return Err(format!(
+                "Gauntlet supports at most {MAX_CAPTURE_SCENARIOS} required scenarios with capture taps"
+            ));
+        }
+        let mut scenario_ids = std::collections::HashSet::new();
         for scenario in &self.quality_bar.required_scenarios {
             if scenario.id.trim().is_empty() || scenario.description.trim().is_empty() {
                 return Err("Gauntlet scenarios require non-empty id and description".to_string());
+            }
+            if scenario.id.len() > 64
+                || !scenario.id.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+                })
+            {
+                return Err(
+                    "Gauntlet scenario ids must be portable ASCII names up to 64 characters"
+                        .to_string(),
+                );
+            }
+            if !scenario_ids.insert(scenario.id.as_str()) {
+                return Err("Gauntlet scenario ids must be unique".to_string());
+            }
+            if scenario.taps.len() > MAX_SCENARIO_TAPS {
+                return Err(format!(
+                    "Gauntlet scenario {} exceeds {MAX_SCENARIO_TAPS} taps",
+                    scenario.id
+                ));
+            }
+            for tap in &scenario.taps {
+                if tap.x < 0
+                    || tap.y < 0
+                    || tap.x > 16_384
+                    || tap.y > 16_384
+                    || !(1..=MAX_SCENARIO_TICKS_AFTER).contains(&tap.ticks_after)
+                {
+                    return Err(format!(
+                        "Gauntlet scenario {} taps require coordinates between 0 and 16384 and ticks_after between 1 and {MAX_SCENARIO_TICKS_AFTER}",
+                        scenario.id
+                    ));
+                }
             }
         }
         Ok(())
@@ -1014,6 +1076,50 @@ mod tests {
         config.models.scout.model = Some("gpt-5.6-luna".to_string());
         config.models.scout.timeout_minutes = 0;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn config_validates_deterministic_capture_scenarios() {
+        let mut config = GauntletConfigV1::new(true, Vec::new(), 8, 100, GauntletObserver::Auto)
+            .expect("config");
+        config.quality_bar.required_scenarios = vec![GauntletScenarioRequirement {
+            id: "select-unit".to_string(),
+            description: "Select a ready friendly unit".to_string(),
+            taps: vec![GauntletScenarioTap {
+                x: 150,
+                y: 382,
+                ticks_after: 2,
+            }],
+        }];
+        assert!(config.validate().is_ok());
+
+        config
+            .quality_bar
+            .required_scenarios
+            .push(config.quality_bar.required_scenarios[0].clone());
+        assert!(config
+            .validate()
+            .expect_err("duplicate scenario")
+            .contains("unique"));
+        config.quality_bar.required_scenarios.pop();
+
+        config.quality_bar.required_scenarios[0].taps[0].ticks_after = 0;
+        assert!(config
+            .validate()
+            .expect_err("zero ticks")
+            .contains("ticks_after"));
+        config.quality_bar.required_scenarios[0].taps[0].ticks_after = 1;
+        config.quality_bar.required_scenarios[0].taps[0].x = -1;
+        assert!(config
+            .validate()
+            .expect_err("negative coordinate")
+            .contains("coordinates"));
+        config.quality_bar.required_scenarios[0].taps[0].x = 150;
+        config.quality_bar.required_scenarios[0].id = "../select".to_string();
+        assert!(config
+            .validate()
+            .expect_err("nonportable id")
+            .contains("portable ASCII"));
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
@@ -1080,8 +1080,7 @@ fn controller_loop(
         state.phase = GauntletRunPhase::Building;
         state.current_workstream = Some(decision.workstream.clone());
         persist_state(artifacts, &mut state)?;
-        let remaining_calls = config.budget.model_calls.saturating_sub(state.model_calls);
-        let builder_calls = remaining_calls.saturating_sub(2);
+        let builder_calls = builder_turn_allowance(&config, state.model_calls);
         if builder_calls == 0 {
             finish(
                 &mut state,
@@ -1157,12 +1156,13 @@ fn controller_loop(
                 failure,
             )?;
             latest_failure_evidence = Some(primary_failure_evidence.clone());
-            if let Some(escalation) = config
+            let rescue_calls = builder_turn_allowance(&config, state.model_calls);
+            let escalation = config
                 .models
                 .builder_escalation
                 .as_ref()
-                .filter(|_| should_escalate_builder(failure, &canceled))
-            {
+                .filter(|_| should_escalate_builder(failure, &canceled));
+            if let Some(escalation) = escalation.filter(|_| rescue_calls > 0) {
                 rollback_candidate(
                     &project_root,
                     state.best_commit.as_deref().unwrap_or(&state.base_commit),
@@ -1176,7 +1176,7 @@ fn controller_loop(
                         "to_model": escalation.model,
                         "reason": failure.message,
                         "evidence": primary_failure_evidence,
-                        "fresh_turn_allowance": config.execution.builder_max_turns,
+                        "fresh_turn_allowance": rescue_calls,
                     }),
                 )?;
                 append_decision(
@@ -1198,7 +1198,7 @@ fn controller_loop(
                     &candidate_id,
                     "escalation",
                     escalation,
-                    fresh_builder_escalation_calls(&config),
+                    rescue_calls,
                 )?;
                 completed_attempt = "escalation";
                 outcome = run_builder(
@@ -1206,7 +1206,7 @@ fn controller_loop(
                     "Escalated Stasis Gauntlet builder",
                     escalation_instruction,
                     &rescue_prompt,
-                    fresh_builder_escalation_calls(&config),
+                    rescue_calls,
                 );
                 if let Err(failure) = &outcome {
                     latest_failure_evidence = Some(record_builder_attempt_failure(
@@ -1218,6 +1218,16 @@ fn controller_loop(
                         failure,
                     )?);
                 }
+            } else if escalation.is_some() && rescue_calls == 0 {
+                emit_event(
+                    artifacts,
+                    "builder_escalation_skipped",
+                    json!({
+                        "candidate": candidate_id,
+                        "reason": "model-call budget cannot fund a rescue builder plus both independent critics",
+                        "remaining_calls": config.budget.model_calls.saturating_sub(state.model_calls),
+                    }),
+                )?;
             }
         }
         match outcome {
@@ -2701,8 +2711,13 @@ fn should_escalate_builder(failure: &live_tui::ScriptedAiFailure, canceled: &Ato
     !canceled.load(Ordering::Acquire) && failure.message != "AI request canceled"
 }
 
-fn fresh_builder_escalation_calls(config: &GauntletConfigV1) -> u32 {
-    config.execution.builder_max_turns
+fn builder_turn_allowance(config: &GauntletConfigV1, used_calls: u32) -> u32 {
+    config
+        .budget
+        .model_calls
+        .saturating_sub(used_calls)
+        .saturating_sub(2)
+        .min(config.execution.builder_max_turns)
 }
 
 fn emit_builder_attempt_started(
@@ -4319,11 +4334,21 @@ mod tests {
 
     #[test]
     fn builder_escalation_gets_a_fresh_turn_allowance() {
+        let mut config = GauntletConfigV1::new(false, Vec::new(), 8, 100, GauntletObserver::Jsonl)
+            .expect("config");
+        config.execution.builder_max_turns = 30;
+
+        assert_eq!(builder_turn_allowance(&config, 40), 30);
+    }
+
+    #[test]
+    fn builder_allowance_reserves_both_critic_calls() {
         let mut config = GauntletConfigV1::new(false, Vec::new(), 8, 12, GauntletObserver::Jsonl)
             .expect("config");
         config.execution.builder_max_turns = 30;
 
-        assert_eq!(fresh_builder_escalation_calls(&config), 30);
+        assert_eq!(builder_turn_allowance(&config, 7), 3);
+        assert_eq!(builder_turn_allowance(&config, 10), 0);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet/controller.rs
@@ -2,7 +2,7 @@ use super::{
     atomic_write_bytes, hex_sha256, image_extension, import_references, read_bounded_bytes,
     read_bounded_utf8, write_json, GauntletConfigV1, GauntletIsolation, GauntletObserver,
     GauntletReference, GauntletRoleModel, GauntletRunPhase, GauntletRunStateV1,
-    GAUNTLET_SCHEMA_VERSION, MAX_GOAL_BYTES, MAX_REFERENCE_BYTES,
+    GauntletScenarioRequirement, GAUNTLET_SCHEMA_VERSION, MAX_GOAL_BYTES, MAX_REFERENCE_BYTES,
 };
 use crate::toolchain_cli::live_tui;
 use crate::toolchain_cli::{CommandResult, Workspace};
@@ -339,7 +339,15 @@ struct VisualCritique {
 struct ScenarioCapture {
     initial_frame: PathBuf,
     action_frame: PathBuf,
+    required_frames: Vec<RequiredScenarioFrame>,
     state: Value,
+}
+
+#[derive(Debug, Clone)]
+struct RequiredScenarioFrame {
+    id: String,
+    description: String,
+    frame: PathBuf,
 }
 
 struct PriorRunLesson {
@@ -899,6 +907,7 @@ fn controller_loop(
         artifacts,
         "baseline",
         scenario_pointer,
+        &config.quality_bar.required_scenarios,
         &mut next_request,
     )?;
     let (readiness, baseline_tests) =
@@ -1278,6 +1287,7 @@ fn controller_loop(
             artifacts,
             &candidate_id,
             scenario_pointer,
+            &config.quality_bar.required_scenarios,
             &mut next_request,
         );
         let mut candidate = match candidate_capture {
@@ -2004,14 +2014,12 @@ fn lead_decision(
     let runtime_evidence = serde_json::to_string(&accepted.state)
         .map_err(|error| format!("failed encoding accepted runtime evidence: {error}"))?;
     let creative_direction = creative_direction_context(bar)?;
+    let accepted_image_order = capture_image_order("accepted", accepted);
     let prompt = format!(
-        "Act as the fresh playability and visual-coherence director for a Stasis Gauntlet. The first two attached images are the latest accepted initial frame and its frame after the controller's fixed interaction probe; later images are optional quality references. The controller-owned creative direction below is authoritative: enforce and interpret it, but do not silently rewrite it. Use both frames together with runtime and passing-test evidence. First produce playability_guidance that teaches the next builder exactly how a new player should parse the grid and complete one turn: board and cell boundaries, meaningful terrain, faction and unit-role recognition, selection, legal movement, attack/counterattack preview, objective and economy, turn ownership, end turn, and cancel/reselect. Identify which relationships are unclear from evidence and whether the probe's result is visibly understandable; do not invent mechanics. Then choose exactly one highest-value next work item from the frozen workstreams whose builder prompt improves that comprehension and preserves already-readable relationships. Visual polish is valuable only when it strengthens this hierarchy. The live workspace contains only the latest accepted checkpoint: rejected candidate edits were rolled back, so use their evidence as lessons but never assume their implementation exists. Set done=true only if the largest gap says the bar is fully met; otherwise done=false. Preserve a concise rationale and next step for future fresh agents; do not provide hidden chain-of-thought. Return only JSON.\n\nBrief:\n{goal}\n\nAuthoritative creative direction:\n{creative_direction}\n\nWorkstreams: {}\nAccepted: {} Rejected: {}\nLargest gap: {largest_gap}\n\nAccepted runtime and deterministic-test evidence:\n{runtime_evidence}\n\nDurable decision memory (explicit conclusions only):\n{memory}",
+        "Act as the fresh playability and visual-coherence director for a Stasis Gauntlet. The attached images begin with the latest accepted initial frame, its frame after the controller's fixed interaction probe, and any configured deterministic scenario frames; later images are optional quality references. Accepted image order: {accepted_image_order}. The controller-owned creative direction below is authoritative: enforce and interpret it, but do not silently rewrite it. Use every supplied scenario frame together with runtime and passing-test evidence. First produce playability_guidance that teaches the next builder exactly how a new player should parse the grid and complete one turn: board and cell boundaries, meaningful terrain, faction and unit-role recognition, selection, legal movement, attack/counterattack preview, objective and economy, turn ownership, end turn, and cancel/reselect. Identify which relationships are unclear from evidence and whether each exercised interaction's result is visibly understandable; do not invent mechanics. Then choose exactly one highest-value next work item from the frozen workstreams whose builder prompt improves that comprehension and preserves already-readable relationships. Visual polish is valuable only when it strengthens this hierarchy. The live workspace contains only the latest accepted checkpoint: rejected candidate edits were rolled back, so use their evidence as lessons but never assume their implementation exists. Set done=true only if the largest gap says the bar is fully met; otherwise done=false. Preserve a concise rationale and next step for future fresh agents; do not provide hidden chain-of-thought. Return only JSON.\n\nBrief:\n{goal}\n\nAuthoritative creative direction:\n{creative_direction}\n\nWorkstreams: {}\nAccepted: {} Rejected: {}\nLargest gap: {largest_gap}\n\nAccepted runtime and deterministic-test evidence:\n{runtime_evidence}\n\nDurable decision memory (explicit conclusions only):\n{memory}",
         bar.workstreams.join(", "), state.accepted_candidates, state.rejected_candidates
     );
-    let mut images = vec![
-        accepted.initial_frame.clone(),
-        accepted.action_frame.clone(),
-    ];
+    let mut images = capture_images(accepted);
     images.extend(references.iter().take(4).cloned());
     let decision: LeadDecision = call_structured_role(
         "lead",
@@ -2048,15 +2056,13 @@ fn blind_critic(
     model_call_limit: u32,
     canceled: &AtomicBool,
 ) -> Result<VisualCritique, String> {
-    let mut images = vec![
-        scenario_a.initial_frame.clone(),
-        scenario_a.action_frame.clone(),
-        scenario_b.initial_frame.clone(),
-        scenario_b.action_frame.clone(),
-    ];
+    let mut images = capture_images(scenario_a);
+    images.extend(capture_images(scenario_b));
     images.extend(references.iter().take(5).cloned());
+    let a_image_order = capture_image_order("A", scenario_a);
+    let b_image_order = capture_image_order("B", scenario_b);
     let prompt = format!(
-        "You are a fresh read-only visual and screen-comprehension critic. The first four attached images are anonymous pairs in this exact order: A initial state, A after the controller's fixed input probe, B initial state, B after the same probe. Any later images are hashed quality references. You do not know which candidate is newer. Compare A and B relative to each other and against the frozen brief, authoritative creative direction, and references. Prefer a or b when one is visually better without an evidenced visual regression. Return equivalent when the image pairs are materially indistinguishable; incompleteness against the full brief is not a reason to return neither. Return neither only when both have different material regressions or the evidence is invalid. Scores are integers 0-100 and measure absolute quality against the frozen bar.\n\nFor each pair, independently answer four release-gate questions. current_state_clear means a new player can identify turn/faction, selection, relevant resources/objective, and important ownership or board state. available_actions_clear means the screen itself distinguishes selectable things and the next legal actions, including movement, attack, end turn, and cancel/reselect when relevant. board_semantics_clear means cells, traversable terrain, obstacles, factions, unit roles, structures, and tactical overlays have an understandable hierarchy. action_feedback_clear means comparison of initial and after-input frames makes the result of the fixed probe visible; if the probe caused no meaningful state change, the no-op or unchanged state must still be understandable rather than silently ambiguous. Set a boolean true only when the attached pixels provide affirmative evidence, not merely because runtime behavior may exist. Put concise observed evidence in each assessment. Identify one largest remaining gap that prioritizes failed comprehension questions over decorative polish. Do not discuss source code and return only JSON.\n\nBrief:\n{goal}\n\nAuthoritative creative direction:\n{}\n\nWorkstreams: {}\nHard gates already passed: {}\n\nA runtime evidence after probe:\n{}\n\nB runtime evidence after probe:\n{}",
+        "You are a fresh read-only visual and screen-comprehension critic. The attached images contain anonymous, identically exercised scenario sets. Image order for A: {a_image_order}. Image order for B: {b_image_order}. Any later images are hashed quality references. You do not know which candidate is newer. Compare every corresponding A/B frame relative to each other and against the frozen brief, authoritative creative direction, and references. Prefer a or b when one is visually better without an evidenced visual regression. Return equivalent when the scenario sets are materially indistinguishable; incompleteness against the full brief is not a reason to return neither. Return neither only when both have different material regressions or the evidence is invalid. Scores are integers 0-100 and measure absolute quality against the frozen bar.\n\nFor each scenario set, independently answer four release-gate questions. current_state_clear means a new player can identify turn/faction, selection, relevant resources/objective, and important ownership or board state. available_actions_clear means the screen itself distinguishes selectable things and the next legal actions, including movement, attack, end turn, and cancel/reselect when relevant. board_semantics_clear means cells, traversable terrain, obstacles, factions, unit roles, structures, and tactical overlays have an understandable hierarchy. action_feedback_clear means the exercised frames visibly communicate the result of each configured interaction; if an interaction caused no meaningful state change, the no-op or unchanged state must still be understandable rather than silently ambiguous. Set a boolean true only when the attached pixels provide affirmative evidence, not merely because runtime behavior may exist. Put concise observed evidence in each assessment. Identify one largest remaining gap that prioritizes failed comprehension questions over decorative polish. Do not discuss source code and return only JSON.\n\nBrief:\n{goal}\n\nAuthoritative creative direction:\n{}\n\nWorkstreams: {}\nHard gates already passed: {}\n\nA runtime evidence after probe:\n{}\n\nB runtime evidence after probe:\n{}",
         creative_direction_context(bar)?,
         bar.workstreams.join(", "),
         bar.hard_gates.join(", "),
@@ -2088,6 +2094,31 @@ fn blind_critic(
         return Err("critic returned an invalid preference, score, or gap".to_string());
     }
     Ok(critique)
+}
+
+fn capture_images(capture: &ScenarioCapture) -> Vec<PathBuf> {
+    let mut images = vec![capture.initial_frame.clone(), capture.action_frame.clone()];
+    images.extend(
+        capture
+            .required_frames
+            .iter()
+            .map(|scenario| scenario.frame.clone()),
+    );
+    images
+}
+
+fn capture_image_order(label: &str, capture: &ScenarioCapture) -> String {
+    let mut order = vec![
+        format!("{label} initial state"),
+        format!("{label} after fixed interaction probe"),
+    ];
+    order.extend(capture.required_frames.iter().map(|scenario| {
+        format!(
+            "{label} scenario {} ({})",
+            scenario.id, scenario.description
+        )
+    }));
+    order.join("; ")
 }
 
 fn resolve_reference_images(
@@ -2164,6 +2195,7 @@ fn capture_scenario(
     artifacts: &Path,
     id: &str,
     pointer: Option<(i32, i32)>,
+    required_scenarios: &[GauntletScenarioRequirement],
     request_id: &mut u64,
 ) -> Result<ScenarioCapture, String> {
     request_live(client, *request_id, LiveCommand::ValidationRestore)?;
@@ -2176,49 +2208,12 @@ fn capture_scenario(
         request_id,
     )?;
     if let Some((x, y)) = pointer {
-        request_live(
-            client,
-            *request_id,
-            LiveCommand::SetInputState {
-                pointers: vec![LivePointerInput {
-                    id: 0,
-                    x,
-                    y,
-                    is_down: true,
-                    went_down: true,
-                    went_up: false,
-                }],
-            },
-        )?;
-        *request_id = request_id.saturating_add(1);
-        request_live(client, *request_id, LiveCommand::Step { ticks: 1 })?;
+        apply_pointer_tap(client, request_id, x, y, 29)?;
+    } else {
+        request_live(client, *request_id, LiveCommand::Step { ticks: 30 })?;
         *request_id = request_id.saturating_add(1);
         wait_for_steps(client, request_id)?;
-        request_live(
-            client,
-            *request_id,
-            LiveCommand::SetInputState {
-                pointers: vec![LivePointerInput {
-                    id: 0,
-                    x,
-                    y,
-                    is_down: false,
-                    went_down: false,
-                    went_up: true,
-                }],
-            },
-        )?;
-        *request_id = request_id.saturating_add(1);
     }
-    request_live(
-        client,
-        *request_id,
-        LiveCommand::Step {
-            ticks: if pointer.is_some() { 29 } else { 30 },
-        },
-    )?;
-    *request_id = request_id.saturating_add(1);
-    wait_for_steps(client, request_id)?;
     let action_frame = capture_frame(client, project_root, artifacts, id, request_id)?;
     let inspection = request_live(
         client,
@@ -2230,6 +2225,37 @@ fn capture_scenario(
         },
     )?;
     *request_id = request_id.saturating_add(1);
+    let mut required_frames = Vec::new();
+    for scenario in required_scenarios
+        .iter()
+        .filter(|scenario| !scenario.taps.is_empty())
+    {
+        request_live(client, *request_id, LiveCommand::ValidationRestore)?;
+        *request_id = request_id.saturating_add(1);
+        request_live(
+            client,
+            *request_id,
+            LiveCommand::SetInputState {
+                pointers: Vec::new(),
+            },
+        )?;
+        *request_id = request_id.saturating_add(1);
+        for tap in &scenario.taps {
+            apply_pointer_tap(client, request_id, tap.x, tap.y, tap.ticks_after)?;
+        }
+        let frame = capture_frame(
+            client,
+            project_root,
+            artifacts,
+            &format!("{id}-scenario-{}", scenario.id),
+            request_id,
+        )?;
+        required_frames.push(RequiredScenarioFrame {
+            id: scenario.id.clone(),
+            description: scenario.description.clone(),
+            frame,
+        });
+    }
     request_live(client, *request_id, LiveCommand::ValidationRestore)?;
     *request_id = request_id.saturating_add(1);
     request_live(
@@ -2243,8 +2269,58 @@ fn capture_scenario(
     Ok(ScenarioCapture {
         initial_frame,
         action_frame,
+        required_frames,
         state: inspection.data.unwrap_or(Value::Null),
     })
+}
+
+fn apply_pointer_tap(
+    client: &LiveSessionClient,
+    request_id: &mut u64,
+    x: i32,
+    y: i32,
+    ticks_after: u32,
+) -> Result<(), String> {
+    request_live(
+        client,
+        *request_id,
+        LiveCommand::SetInputState {
+            pointers: vec![LivePointerInput {
+                id: 0,
+                x,
+                y,
+                is_down: true,
+                went_down: true,
+                went_up: false,
+            }],
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    request_live(client, *request_id, LiveCommand::Step { ticks: 1 })?;
+    *request_id = request_id.saturating_add(1);
+    wait_for_steps(client, request_id)?;
+    request_live(
+        client,
+        *request_id,
+        LiveCommand::SetInputState {
+            pointers: vec![LivePointerInput {
+                id: 0,
+                x,
+                y,
+                is_down: false,
+                went_down: false,
+                went_up: true,
+            }],
+        },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    request_live(
+        client,
+        *request_id,
+        LiveCommand::Step { ticks: ticks_after },
+    )?;
+    *request_id = request_id.saturating_add(1);
+    wait_for_steps(client, request_id)
 }
 
 fn gameplay_evidence(runtime: Value, deterministic_tests: Value) -> Value {
@@ -3592,6 +3668,41 @@ mod tests {
         assert!(requires_authored_imagegen("Rendered-frame visual polish"));
         assert!(!requires_authored_imagegen("Grid movement and terrain"));
         assert!(!requires_authored_imagegen("Mobile controls and HUD"));
+    }
+
+    #[test]
+    fn scenario_images_and_labels_keep_the_same_deterministic_order() {
+        let capture = ScenarioCapture {
+            initial_frame: PathBuf::from("initial.png"),
+            action_frame: PathBuf::from("fixed.png"),
+            required_frames: vec![
+                RequiredScenarioFrame {
+                    id: "select".to_string(),
+                    description: "Select a ready unit".to_string(),
+                    frame: PathBuf::from("select.png"),
+                },
+                RequiredScenarioFrame {
+                    id: "move".to_string(),
+                    description: "Move to a legal cell".to_string(),
+                    frame: PathBuf::from("move.png"),
+                },
+            ],
+            state: Value::Null,
+        };
+
+        assert_eq!(
+            capture_images(&capture),
+            vec![
+                PathBuf::from("initial.png"),
+                PathBuf::from("fixed.png"),
+                PathBuf::from("select.png"),
+                PathBuf::from("move.png"),
+            ]
+        );
+        assert_eq!(
+            capture_image_order("A", &capture),
+            "A initial state; A after fixed interaction probe; A scenario select (Select a ready unit); A scenario move (Move to a legal cell)"
+        );
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -41,6 +41,7 @@ const COMPLETION_LIMIT: usize = 64;
 const TUI_REQUEST_START: u64 = 1u64 << 61;
 const AI_REQUEST_START: u64 = 1u64 << 62;
 const MAX_DECISION_FIELD_CHARS: usize = 2_000;
+const MAX_CONSECUTIVE_WRITE_FAILURES: u32 = 3;
 const MAX_STDLIB_API_FILES: usize = 16;
 const MAX_STDLIB_API_ITEMS: usize = 256;
 const MAX_STDLIB_API_FILE_BYTES: u64 = 512 * 1024;
@@ -2330,6 +2331,8 @@ struct LiveAiTools {
     decision_log: Option<PathBuf>,
     decision_role: Option<String>,
     terminal_blocker: Option<String>,
+    last_write_failure_key: Option<String>,
+    consecutive_write_failures: u32,
     require_imagegen: bool,
     imagegen_ready_paths: Vec<String>,
     imagegen_staged: bool,
@@ -2350,6 +2353,8 @@ impl LiveAiTools {
             decision_log: None,
             decision_role: None,
             terminal_blocker: None,
+            last_write_failure_key: None,
+            consecutive_write_failures: 0,
             require_imagegen: false,
             imagegen_ready_paths: Vec::new(),
             imagegen_staged: false,
@@ -2811,15 +2816,9 @@ impl LiveAiTools {
         canceled: &AtomicBool,
     ) -> Vec<ToolObservation> {
         if !self.reference_search_ready {
-            return calls
-                .iter()
-                .map(|call| {
-                    ToolObservation::error(
-                        &call.tool,
-                        "run find_references for a behavior-bearing symbol before a live AI write",
-                    )
-                })
-                .collect();
+            let error = "run find_references for a behavior-bearing symbol before a live AI write";
+            self.note_write_failure(error);
+            return failed_write_observations(calls, error.to_string());
         }
         let edits: Vec<LiveEdit> = calls
             .iter()
@@ -2848,6 +2847,7 @@ impl LiveAiTools {
             .collect();
         if let Some(project_root) = self.project_root.as_ref() {
             if let Err(error) = validate_ai_font_paths(project_root, &edits) {
+                self.note_write_failure(&error);
                 return failed_write_observations(calls, error);
             }
         }
@@ -2880,6 +2880,8 @@ impl LiveAiTools {
                 let applied = response.ok && response.kind == "edit_applied";
                 if applied {
                     self.last_write = Some(response.clone());
+                    self.last_write_failure_key = None;
+                    self.consecutive_write_failures = 0;
                     self.reference_search_ready = false;
                     self.imagegen_committed |= self.imagegen_staged
                         && self.project_root.as_ref().is_some_and(|project_root| {
@@ -2917,6 +2919,7 @@ impl LiveAiTools {
                         &error,
                         "Correct the reported compile or test failure before attempting another atomic write.",
                     );
+                    self.note_write_failure(&error);
                     failed_write_observations(calls, error)
                 }
             }
@@ -2932,9 +2935,35 @@ impl LiveAiTools {
                     &error,
                     "Correct the reported live request failure before attempting another atomic write.",
                 );
+                self.note_write_failure(&error);
                 failed_write_observations(calls, error)
             }
         }
+    }
+
+    fn note_write_failure(&mut self, error: &str) {
+        let key = stable_write_failure_key(error);
+        if self.last_write_failure_key.as_deref() == Some(key.as_str()) {
+            self.consecutive_write_failures = self.consecutive_write_failures.saturating_add(1);
+        } else {
+            self.last_write_failure_key = Some(key.clone());
+            self.consecutive_write_failures = 1;
+        }
+        if self.consecutive_write_failures < MAX_CONSECUTIVE_WRITE_FAILURES
+            || self.terminal_blocker.is_some()
+        {
+            return;
+        }
+        let blocker = format!(
+            "builder stopped after the same atomic write failure repeated {MAX_CONSECUTIVE_WRITE_FAILURES} times: {key}"
+        );
+        self.terminal_blocker = Some(blocker.clone());
+        self.record_durable_failure(
+            "builder_repeated_write_failure",
+            "The builder repeated the same rejected atomic write outcome",
+            &blocker,
+            "Escalate with fresh turns and the repeated failure evidence; do not retry the same approach.",
+        );
     }
 
     fn append_decision_record(&self, path: &Path, record: &Value) -> Result<(), String> {
@@ -3055,6 +3084,20 @@ fn preserve_truncated_applied_write_evidence(mut response: LiveResponse) -> Live
         }));
     }
     response
+}
+
+fn stable_write_failure_key(error: &str) -> String {
+    if let Some((before_result, result)) = error.rsplit_once(" :: returned ") {
+        if let Some((_, test_name)) = before_result.rsplit_once(" :: ") {
+            let result = result
+                .split(['"', ',', '\r', '\n'])
+                .next()
+                .unwrap_or(result)
+                .trim();
+            return format!("test {test_name} returned {result}");
+        }
+    }
+    error.chars().take(512).collect()
 }
 
 fn failed_write_observations(calls: &[&ToolCall], error: String) -> Vec<ToolObservation> {
@@ -4307,6 +4350,68 @@ mod tests {
             observations[1].error.as_deref(),
             Some("atomic write batch failed; see the first write observation")
         );
+    }
+
+    #[test]
+    fn stable_write_failure_key_ignores_volatile_test_paths() {
+        let first = r#"tests failed at C:\temp\candidate-a\tests\main.test.stasis :: Combat preview equals resolution and requires confirmation :: returned false"#;
+        let second = r#"tests failed at D:\other\candidate-b\tests\main.test.stasis :: Combat preview equals resolution and requires confirmation :: returned false, transaction rolled back"#;
+
+        assert_eq!(
+            stable_write_failure_key(first),
+            stable_write_failure_key(second)
+        );
+        assert_eq!(
+            stable_write_failure_key(first),
+            "test Combat preview equals resolution and requires confirmation returned false"
+        );
+    }
+
+    #[test]
+    fn repeated_atomic_write_failure_terminates_on_third_identical_outcome() {
+        let root = std::env::temp_dir().join(format!(
+            "stasis_gauntlet_repeated_write_failure_{}_{}",
+            std::process::id(),
+            unix_ms()
+        ));
+        fs::create_dir_all(&root).expect("failure memory root");
+        let decisions = root.join("decisions.jsonl");
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let mut tools = LiveAiTools::new_project_assets(
+            client,
+            root.clone(),
+            true,
+            Some(decisions.clone()),
+            "builder".to_string(),
+            false,
+        );
+        let failure = "tests/main.test.stasis :: preview remains deterministic :: returned false";
+
+        tools.note_write_failure(failure);
+        tools.note_write_failure(failure);
+        assert!(tools.terminal_blocker.is_none());
+        tools.note_write_failure(failure);
+
+        let blocker = tools.terminal_blocker.as_deref().expect("terminal blocker");
+        assert!(blocker.contains("repeated 3 times"));
+        assert!(blocker.contains("test preview remains deterministic returned false"));
+        let memory = fs::read_to_string(decisions).expect("durable failure memory");
+        assert!(memory.contains("builder_repeated_write_failure"));
+        assert!(memory.contains("Escalate with fresh turns"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn changed_atomic_write_failure_resets_the_repetition_count() {
+        let (client, _server) = stasis_runner::live::live_session(1);
+        let mut tools = LiveAiTools::new(client);
+
+        tools.note_write_failure("tests/main.test.stasis :: first test :: returned false");
+        tools.note_write_failure("tests/main.test.stasis :: first test :: returned false");
+        tools.note_write_failure("tests/main.test.stasis :: second test :: returned false");
+
+        assert_eq!(tools.consecutive_write_failures, 1);
+        assert!(tools.terminal_blocker.is_none());
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -2634,9 +2634,7 @@ impl LiveAiTools {
             }
             if png_path.is_file() {
                 match super::gauntlet::assets::load_imagegen_png(project_root, &relative_png) {
-                    Ok((_, actual_width, actual_height))
-                        if Some(actual_width) == width && Some(actual_height) == height =>
-                    {
+                    Ok((_, actual_width, actual_height)) => {
                         if !self.imagegen_ready_paths.contains(&relative_png) {
                             self.imagegen_ready_paths.push(relative_png.clone());
                         }
@@ -2647,16 +2645,12 @@ impl LiveAiTools {
                                 "source_path": relative_png,
                                 "width": actual_width,
                                 "height": actual_height,
+                                "requested_width": width,
+                                "requested_height": height,
+                                "dimension_adjusted": Some(actual_width) != width || Some(actual_height) != height,
                                 "request_path": request_path,
                             }),
                         );
-                    }
-                    Ok((_, actual_width, actual_height)) => {
-                        last_validation_error = Some(format!(
-                        "host PNG dimensions are {actual_width}x{actual_height}, expected {}x{}",
-                        width.unwrap_or(1024),
-                        height.unwrap_or(1024)
-                    ))
                     }
                     Err(error) => last_validation_error = Some(error),
                 }
@@ -4524,8 +4518,8 @@ mod tests {
         fs::create_dir_all(output.parent().expect("imagegen inbox")).expect("imagegen inbox");
         let mut png = std::io::Cursor::new(Vec::new());
         image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
-            16,
-            12,
+            19,
+            15,
             image::Rgba([20, 40, 60, 255]),
         ))
         .write_to(&mut png, image::ImageFormat::Png)
@@ -4561,6 +4555,13 @@ mod tests {
             observation.result.as_ref().unwrap()["source_path"],
             "build/gauntlet/imagegen/terrain.png"
         );
+        assert_eq!(observation.result.as_ref().unwrap()["width"], 19);
+        assert_eq!(observation.result.as_ref().unwrap()["height"], 15);
+        assert_eq!(observation.result.as_ref().unwrap()["requested_width"], 16);
+        assert_eq!(observation.result.as_ref().unwrap()["requested_height"], 12);
+        assert!(observation.result.as_ref().unwrap()["dimension_adjusted"]
+            .as_bool()
+            .expect("dimension adjustment flag"));
         assert_eq!(
             tools.imagegen_ready_paths,
             vec!["build/gauntlet/imagegen/terrain.png".to_string()]
@@ -4588,8 +4589,8 @@ mod tests {
         fs::create_dir_all(output.parent().expect("AI ImageGen inbox")).expect("AI ImageGen inbox");
         let mut png = std::io::Cursor::new(Vec::new());
         image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
-            10,
-            10,
+            12,
+            9,
             image::Rgba([80, 30, 20, 255]),
         ))
         .write_to(&mut png, image::ImageFormat::Png)
@@ -4624,6 +4625,11 @@ mod tests {
             observation.result.as_ref().unwrap()["source_path"],
             "build/ai-assets/imagegen/unit.png"
         );
+        assert_eq!(observation.result.as_ref().unwrap()["width"], 12);
+        assert_eq!(observation.result.as_ref().unwrap()["height"], 9);
+        assert!(observation.result.as_ref().unwrap()["dimension_adjusted"]
+            .as_bool()
+            .expect("dimension adjustment flag"));
         assert_eq!(
             tools.imagegen_ready_paths,
             vec!["build/ai-assets/imagegen/unit.png".to_string()]

--- a/docs/gauntlet_loop_harness.md
+++ b/docs/gauntlet_loop_harness.md
@@ -116,14 +116,14 @@ The project root contains a strict, versioned `gauntlet.json`:
       {
         "id": "select-unit",
         "description": "A ready friendly unit is selected and legal movement is visible.",
-        "taps": [{"x": 150, "y": 382, "ticks_after": 2}]
+        "taps": [{"x": 147, "y": 466, "ticks_after": 2}]
       },
       {
         "id": "move-unit",
         "description": "The selected unit moves to a legal destination and feedback remains visible.",
         "taps": [
-          {"x": 150, "y": 382, "ticks_after": 1},
-          {"x": 235, "y": 382, "ticks_after": 8}
+          {"x": 147, "y": 466, "ticks_after": 1},
+          {"x": 232, "y": 382, "ticks_after": 8}
         ]
       }
     ]

--- a/docs/gauntlet_loop_harness.md
+++ b/docs/gauntlet_loop_harness.md
@@ -238,6 +238,14 @@ ImageGen inbox. The transactional import may
 copy it unchanged, crop it, or remove a flat background to create the tracked
 game asset without degrading the reusable source.
 
+The requested width and height are generation targets rather than a reason to
+stall on an otherwise valid provider result. The bridge accepts any decodable
+PNG within the bounded import limits and returns both its actual and requested
+dimensions plus `dimension_adjusted`. The builder can then crop or scale its
+runtime presentation deliberately instead of waiting 30 minutes for an exact
+provider size that some host generators do not guarantee. Invalid, oversized,
+or non-PNG results remain rejected.
+
 When a replacement makes an older generated asset obsolete, the builder uses
 `delete_asset` in the same contiguous asset/source transaction. The tool removes
 the controlled file, its matching manifest entry, and any prepared-cache copy;

--- a/docs/gauntlet_loop_harness.md
+++ b/docs/gauntlet_loop_harness.md
@@ -112,7 +112,21 @@ The project root contains a strict, versioned `gauntlet.json`:
   "quality_bar": {
     "allow_web_discovery": true,
     "references": [],
-    "required_scenarios": []
+    "required_scenarios": [
+      {
+        "id": "select-unit",
+        "description": "A ready friendly unit is selected and legal movement is visible.",
+        "taps": [{"x": 150, "y": 382, "ticks_after": 2}]
+      },
+      {
+        "id": "move-unit",
+        "description": "The selected unit moves to a legal destination and feedback remains visible.",
+        "taps": [
+          {"x": 150, "y": 382, "ticks_after": 1},
+          {"x": 235, "y": 382, "ticks_after": 8}
+        ]
+      }
+    ]
   },
   "budget": {
     "wall_time_minutes": 480,
@@ -147,6 +161,17 @@ and invalid references fail before starting a model call. CLI budget flags
 override one run without rewriting the project configuration. The goal and
 frozen bar cannot be weakened after editing begins. Tests or stricter checks
 may be added, but accepted requirements cannot be removed.
+
+Required scenarios remain gameplay requirements when `taps` is omitted. Up to
+four scenarios may also contain one to eight deterministic pointer taps. The
+controller restores the same validation snapshot before each scenario, replays
+the taps in order, and captures the final rendered frame for both the accepted
+checkpoint and every candidate. `ticks_after` defaults to 1 and may be 1-300,
+allowing staged movement or feedback to settle without wall-clock timing. Leads
+and blind critics receive identically ordered, named scenario frames alongside
+the initial and fixed-probe pair, so selection, movement, targeting, endings,
+and other project-specific states can be judged from pixels rather than inferred
+from tests.
 
 Ordinary `stasis ai` retains its 15-turn default. Gauntlet builders default to
 30 turns and may be configured from 1 through 48, still bounded by the run's
@@ -291,6 +316,9 @@ build/gauntlet/<run-id>/
   usage.jsonl
   references/manifest.json
   artifacts/<candidate-id>/
+    frame.png
+  artifacts/<candidate-id>-scenario-<scenario-id>/
+    frame.png
   checkpoints.json
   index.html
   stop.request

--- a/docs/gauntlet_loop_harness.md
+++ b/docs/gauntlet_loop_harness.md
@@ -186,6 +186,14 @@ immediately apply the configured one-shot builder escalation. If the rescue
 builder reports the same non-recoverable condition, the candidate is rejected
 without consuming the rest of its turn allowance.
 
+Stasis also stops an attempt automatically when the same atomic-write outcome
+is rejected three times in a row. Volatile paths are removed from test-failure
+identity, so retries of the same named test and result count together even when
+the candidate workspace changes. A different failure or a successful write
+resets the count. The third rejection is stored in decision memory as
+`builder_repeated_write_failure`, terminates the attempt, and gives the rescue
+builder fresh turns plus the repeated-failure evidence.
+
 When compaction is enabled, a builder request is compacted after it exceeds
 the configured byte ceiling. Stasis retains up to the configured number of
 recent raw turns and replaces older turns with deterministic summaries of
@@ -335,7 +343,9 @@ rejected candidates, and the largest remaining gap.
 chain-of-thought. The `record_decision` tool stores bounded explicit
 conclusions: kind, summary, concise rationale, evidence, and next step. The
 `report_blocked` tool writes the same durable evidence before terminating an
-impossible builder attempt. The
+impossible builder attempt. Three consecutive identical atomic-write failures
+produce the same terminal handoff automatically rather than relying on the
+builder to recognize the loop. The
 controller also records lead choices, accepted/rejected checkpoints, and final
 gate failures. Each append is flushed and synced so interruption or resume does
 not erase the current theory of the game. A failed builder attempt extracts a


### PR DESCRIPTION
## Summary

- accept valid bounded host ImageGen PNG dimensions and report requested versus actual size
- capture configured deterministic tap scenarios for accepted and candidate frames, with identical named evidence for leads and blind critics
- stop repeated identical atomic-write failures after three attempts and persist the blocker for rescue
- preserve fresh rescue turns while enforcing the global model-call budget and reserving both independent critics
- keep ImageGen and scenario behavior shared with the one-shot AI command where applicable

## Validation

- 49 Live AI tests passed
- 36 Gauntlet tests passed
- release-mode PR-head identity validated at source commit 087d0bed
- Bannerfall canary captured distinct selection, movement, and enemy-turn scenario frames
- Bannerfall ImageGen request produced, imported, loaded, and visibly rendered a 1024x1024 PNG
- budget canary skipped rescue with exactly two critic calls remaining and finished below its configured call cap

## Operational evidence

The active eight-hour Bannerfall run remained isolated on its prior packaged toolchain while these changes were built and tested. The private game repository remains separate from StasisLang.