### PR TITLE
fix: stage assets for live edit tests

### DIFF
--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -2536,6 +2536,7 @@ fn run_staged_tests(
     fs::create_dir_all(&root)
         .map_err(|error| format!("failed creating live test overlay: {error}"))?;
     let result = (|| {
+        stage_live_test_assets(&config.project_root, &root)?;
         let manifest = config.project_root.join("stasis.json");
         if manifest.is_file() {
             fs::copy(&manifest, root.join("stasis.json"))
@@ -2566,6 +2567,44 @@ fn run_staged_tests(
         (Ok(()), Err(error)) => Err(format!("failed cleaning live test overlay: {error}")),
         (Ok(()), Ok(())) => Ok(()),
     }
+}
+
+fn stage_live_test_assets(project_root: &Path, overlay_root: &Path) -> Result<(), String> {
+    let source = project_root.join("assets");
+    if !source.exists() {
+        return Ok(());
+    }
+    copy_live_test_asset_directory(&source, &overlay_root.join("assets"))
+}
+
+fn copy_live_test_asset_directory(source: &Path, destination: &Path) -> Result<(), String> {
+    fs::create_dir_all(destination)
+        .map_err(|error| format!("failed creating {}: {error}", destination.display()))?;
+    let mut entries = fs::read_dir(source)
+        .map_err(|error| format!("failed reading {}: {error}", source.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed enumerating {}: {error}", source.display()))?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed inspecting {}: {error}", entry.path().display()))?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let target = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_live_test_asset_directory(&entry.path(), &target)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), &target).map_err(|error| {
+                format!(
+                    "failed staging live test asset {}: {error}",
+                    entry.path().display()
+                )
+            })?;
+        }
+    }
+    Ok(())
 }
 
 fn locate_stasis_executable() -> Result<Option<PathBuf>, String> {
@@ -3327,6 +3366,32 @@ mod tests {
             PathBuf::from("build"),
         );
         (root, config)
+    }
+
+    #[test]
+    fn staged_live_tests_receive_project_assets() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project_root = std::env::temp_dir().join(format!("stasis_live_assets_project_{stamp}"));
+        let overlay_root = std::env::temp_dir().join(format!("stasis_live_assets_overlay_{stamp}"));
+        fs::create_dir_all(project_root.join("assets/generated")).expect("generated assets");
+        fs::write(project_root.join("assets/manifest.json"), b"manifest").expect("manifest");
+        fs::write(project_root.join("assets/generated/unit.png"), b"png").expect("png");
+
+        stage_live_test_assets(&project_root, &overlay_root).expect("stage assets");
+
+        assert_eq!(
+            fs::read(overlay_root.join("assets/manifest.json")).expect("staged manifest"),
+            b"manifest"
+        );
+        assert_eq!(
+            fs::read(overlay_root.join("assets/generated/unit.png")).expect("staged png"),
+            b"png"
+        );
+        fs::remove_dir_all(project_root).ok();
+        fs::remove_dir_all(overlay_root).ok();
     }
 
     fn compile(config: &LiveRunConfig) -> (JitProcess, JitEnginePackage) {

--- a/apps/stasis/src/live_workspace.rs
+++ b/apps/stasis/src/live_workspace.rs
@@ -2536,7 +2536,7 @@ fn run_staged_tests(
     fs::create_dir_all(&root)
         .map_err(|error| format!("failed creating live test overlay: {error}"))?;
     let result = (|| {
-        stage_live_test_assets(&config.project_root, &root)?;
+        stage_live_test_assets(&config.project_root, &root, canceled)?;
         let manifest = config.project_root.join("stasis.json");
         if manifest.is_file() {
             fs::copy(&manifest, root.join("stasis.json"))
@@ -2569,15 +2569,25 @@ fn run_staged_tests(
     }
 }
 
-fn stage_live_test_assets(project_root: &Path, overlay_root: &Path) -> Result<(), String> {
+fn stage_live_test_assets(
+    project_root: &Path,
+    overlay_root: &Path,
+    canceled: &AtomicBool,
+) -> Result<(), String> {
+    check_preparation_canceled(canceled)?;
     let source = project_root.join("assets");
     if !source.exists() {
         return Ok(());
     }
-    copy_live_test_asset_directory(&source, &overlay_root.join("assets"))
+    copy_live_test_asset_directory(&source, &overlay_root.join("assets"), canceled)
 }
 
-fn copy_live_test_asset_directory(source: &Path, destination: &Path) -> Result<(), String> {
+fn copy_live_test_asset_directory(
+    source: &Path,
+    destination: &Path,
+    canceled: &AtomicBool,
+) -> Result<(), String> {
+    check_preparation_canceled(canceled)?;
     fs::create_dir_all(destination)
         .map_err(|error| format!("failed creating {}: {error}", destination.display()))?;
     let mut entries = fs::read_dir(source)
@@ -2586,6 +2596,7 @@ fn copy_live_test_asset_directory(source: &Path, destination: &Path) -> Result<(
         .map_err(|error| format!("failed enumerating {}: {error}", source.display()))?;
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
+        check_preparation_canceled(canceled)?;
         let file_type = entry
             .file_type()
             .map_err(|error| format!("failed inspecting {}: {error}", entry.path().display()))?;
@@ -2594,7 +2605,7 @@ fn copy_live_test_asset_directory(source: &Path, destination: &Path) -> Result<(
         }
         let target = destination.join(entry.file_name());
         if file_type.is_dir() {
-            copy_live_test_asset_directory(&entry.path(), &target)?;
+            copy_live_test_asset_directory(&entry.path(), &target, canceled)?;
         } else if file_type.is_file() {
             fs::copy(entry.path(), &target).map_err(|error| {
                 format!(
@@ -2602,6 +2613,7 @@ fn copy_live_test_asset_directory(source: &Path, destination: &Path) -> Result<(
                     entry.path().display()
                 )
             })?;
+            check_preparation_canceled(canceled)?;
         }
     }
     Ok(())
@@ -3380,7 +3392,8 @@ mod tests {
         fs::write(project_root.join("assets/manifest.json"), b"manifest").expect("manifest");
         fs::write(project_root.join("assets/generated/unit.png"), b"png").expect("png");
 
-        stage_live_test_assets(&project_root, &overlay_root).expect("stage assets");
+        stage_live_test_assets(&project_root, &overlay_root, &AtomicBool::new(false))
+            .expect("stage assets");
 
         assert_eq!(
             fs::read(overlay_root.join("assets/manifest.json")).expect("staged manifest"),
@@ -3390,6 +3403,28 @@ mod tests {
             fs::read(overlay_root.join("assets/generated/unit.png")).expect("staged png"),
             b"png"
         );
+        fs::remove_dir_all(project_root).ok();
+        fs::remove_dir_all(overlay_root).ok();
+    }
+
+    #[test]
+    fn staged_live_test_asset_copy_honors_cancellation() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project_root =
+            std::env::temp_dir().join(format!("stasis_canceled_assets_project_{stamp}"));
+        let overlay_root =
+            std::env::temp_dir().join(format!("stasis_canceled_assets_overlay_{stamp}"));
+        fs::create_dir_all(project_root.join("assets/generated")).expect("generated assets");
+        fs::write(project_root.join("assets/generated/unit.png"), b"png").expect("png");
+
+        let error = stage_live_test_assets(&project_root, &overlay_root, &AtomicBool::new(true))
+            .expect_err("canceled staging");
+
+        assert!(error.contains("canceled"));
+        assert!(!overlay_root.join("assets/generated/unit.png").exists());
         fs::remove_dir_all(project_root).ok();
         fs::remove_dir_all(overlay_root).ok();
     }


### PR DESCRIPTION
## Summary
- copy project-local assets into isolated live-test overlays
- let atomic asset/source edits test newly imported PNGs before commit
- keep rollback behavior unchanged and skip symlinked asset entries
- honor Cancel/Quit before, during, and after each asset copy

## Validation
- cargo test --release -p stasis staged_live_tests_receive_project_assets -- --nocapture
- cargo test --release -p stasis staged_live_test_asset_copy_honors_cancellation -- --nocapture --test-threads=1
- cargo test --release -p stasis live_workspace::tests:: -- --nocapture --test-threads=1 (59 passed)
- ustfmt --edition 2021 --check apps/stasis/src/live_workspace.rs

## Live Gauntlet evidence
Bannerfall candidate 0019 exposed the defect when an ImageGen PNG staged successfully but the isolated test process could not resolve ssets/generated/bannerfall_dawn_infantry_rescue_v4.png. The transaction rolled back safely. This change stages the asset tree before running those isolated tests and keeps that preparation cooperatively cancelable.