### PR TITLE
fix: keep LSP startup output protocol-safe

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -966,9 +966,9 @@ fn maybe_cleanup_stale_stasis_cache() {
     match cleanup_stale_stasis_cache(cache_root, ttl) {
         Ok(summary) => {
             if summary.removed_files > 0 || summary.removed_dirs > 0 {
-                println!("cache_cleanup_removed_files={}", summary.removed_files);
-                println!("cache_cleanup_removed_dirs={}", summary.removed_dirs);
-                println!("cache_cleanup_ttl_days={ttl_days}");
+                eprintln!("cache_cleanup_removed_files={}", summary.removed_files);
+                eprintln!("cache_cleanup_removed_dirs={}", summary.removed_dirs);
+                eprintln!("cache_cleanup_ttl_days={ttl_days}");
             }
         }
         Err(message) => {

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -143,6 +143,21 @@ fn lsp_stdio_publishes_and_clears_compiler_diagnostics() {
     .expect("write LSP manifest");
     let source_path = project.join("src/main.stasis");
     fs::write(&source_path, "function main(): i32 { return 0; }\n").expect("write LSP source");
+    let stale_cache = project.join(".stasis_cache/toolchain/stale.bin");
+    fs::create_dir_all(stale_cache.parent().expect("stale cache parent"))
+        .expect("create stale cache fixture");
+    fs::write(&stale_cache, "stale").expect("write stale cache fixture");
+    let stale_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+    fs::File::options()
+        .write(true)
+        .open(&stale_cache)
+        .expect("open stale cache fixture")
+        .set_times(
+            fs::FileTimes::new()
+                .set_accessed(stale_time)
+                .set_modified(stale_time),
+        )
+        .expect("age stale cache fixture");
     let uri = file_uri(&source_path);
     let fixed_source = "// Adds two values.\nfunction add_score(amount: i32, bonus: i32): i32 { return amount + bonus; }\nfunction main(): i32 { return add_score(1, 2); }\n";
     let input = [
@@ -220,6 +235,15 @@ fn lsp_stdio_publishes_and_clears_compiler_diagnostics() {
         })),
         lsp_frame(json!({
             "jsonrpc": "2.0",
+            "id": 7,
+            "method": "textDocument/definition",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": 0, "character": 0 }
+            }
+        })),
+        lsp_frame(json!({
+            "jsonrpc": "2.0",
             "id": 2,
             "method": "shutdown",
             "params": null
@@ -241,6 +265,7 @@ fn lsp_stdio_publishes_and_clears_compiler_diagnostics() {
         String::from_utf8_lossy(&output.stderr)
     );
     let messages = lsp_messages(&output.stdout);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cache_cleanup_removed_files=1"));
     assert_eq!(messages[0]["id"], 1);
     assert_eq!(
         messages[0]["result"]["capabilities"]["positionEncoding"],
@@ -295,6 +320,12 @@ fn lsp_stdio_publishes_and_clears_compiler_diagnostics() {
         hints.iter().any(|hint| hint["label"] == "amount:")
             && hints.iter().any(|hint| hint["label"] == "bonus:")
     }));
+    let definition_miss = messages
+        .iter()
+        .find(|message| message["id"] == 7)
+        .expect("definition response");
+    assert_eq!(definition_miss["result"], Value::Null);
+    assert!(definition_miss.get("error").is_none());
     assert!(messages
         .iter()
         .any(|message| message["id"] == 2 && message["result"].is_null()));

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -1299,8 +1299,9 @@ impl LanguageService {
         let document = snapshot
             .document(path)
             .ok_or_else(|| format!("navigation document is not indexed: '{path}'"))?;
-        let symbol = reference_symbol_at(&document.text, byte_offset)
-            .ok_or_else(|| "no Stasis symbol at navigation position".to_string())?;
+        let Some(symbol) = reference_symbol_at(&document.text, byte_offset) else {
+            return Ok(Vec::new());
+        };
         let project_root = self.project_root.clone();
         if let Some(locations) = self.language_index.as_ref().and_then(|index| {
             index
@@ -3728,6 +3729,11 @@ function main(): i32 {
     #[test]
     fn navigation_and_symbols_share_compiler_owned_spans() {
         let (mut service, path, source) = intelligence_service();
+        let punctuation = source.find('{').expect("struct body");
+        assert!(service
+            .definition(&path, punctuation)
+            .expect("definition miss")
+            .is_empty());
         let call = source.find("spawn_enemy(1").expect("function call") + 2;
         let definitions = service.definition(&path, call).expect("definition");
         assert_eq!(definitions.len(), 1);


### PR DESCRIPTION
## Summary

- keep cache-cleanup diagnostics off stdout so stdio LSP framing remains valid
- return an empty definition result when the cursor is not on a Stasis symbol
- cover stale-cache startup and definition misses through the real CLI LSP boundary

## Root cause

Cache cleanup ran before toolchain command dispatch and wrote status lines to stdout. In `lsp --stdio` mode, VS Code interpreted those lines as protocol headers and rejected the connection because no valid `Content-Length` header was present. Definition requests on whitespace or punctuation also surfaced a normal navigation miss as JSON-RPC internal error `-32603`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p stasis_language_service navigation_and_symbols_share_compiler_owned_spans`
- `cargo test -p stasis --test toolchain_cli lsp_stdio_publishes_and_clears_compiler_diagnostics -- --exact`
- repository pre-commit validation
