### PR TITLE
fix: navigate to local declarations

### DIFF
--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -12,6 +12,7 @@ pub struct ParsedParam {
 pub struct ParsedLocalBinding {
     pub function_name: String,
     pub name: String,
+    pub name_range: Range<usize>,
     pub type_name: String,
     pub visibility_range: Range<usize>,
 }
@@ -142,6 +143,7 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
         bindings.push(ParsedLocalBinding {
             function_name: declaration.function_name,
             name: declaration.name,
+            name_range: declaration.name_range,
             type_name,
             visibility_range: declaration.visibility_range,
         });
@@ -165,6 +167,7 @@ pub fn parse_local_declarations(source: &str) -> Result<Vec<ParsedLocalDeclarati
     for function in parse_top_level_functions(source)? {
         let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
         let loop_ranges = for_scope_ranges(source, &tokens, function.body_range.clone());
+        declarations.extend(foreach_local_declarations(source, &tokens, &function));
         let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
         while let Some(token) = tokens.get(cursor).copied() {
             if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
@@ -181,6 +184,13 @@ pub fn parse_local_declarations(source: &str) -> Result<Vec<ParsedLocalDeclarati
                 cursor += 1;
                 continue;
             }
+            if declarations
+                .iter()
+                .any(|declaration| declaration.name_range == (name.start..name.end))
+            {
+                cursor += 2;
+                continue;
+            }
             let scope_end = scope_ranges
                 .iter()
                 .chain(loop_ranges.iter())
@@ -188,16 +198,105 @@ pub fn parse_local_declarations(source: &str) -> Result<Vec<ParsedLocalDeclarati
                 .min_by_key(|range| range.end.saturating_sub(range.start))
                 .map(|range| range.end)
                 .unwrap_or(function.body_range.end);
+            let Some(visible_from) = tokens[cursor + 2..]
+                .iter()
+                .take_while(|candidate| candidate.start < scope_end)
+                .find(|candidate| candidate.kind == TokenKind::Semicolon)
+                .map(|semicolon| semicolon.end)
+            else {
+                cursor += 2;
+                continue;
+            };
             declarations.push(ParsedLocalDeclaration {
                 function_name: function.name.clone(),
                 name: token_text(source, name).to_string(),
                 name_range: name.start..name.end,
-                visibility_range: name.end..scope_end,
+                visibility_range: visible_from..scope_end,
             });
             cursor += 2;
         }
     }
+    declarations.sort_by_key(|declaration| declaration.name_range.start);
+    declarations.dedup_by_key(|declaration| declaration.name_range.clone());
     Ok(declarations)
+}
+
+fn foreach_local_declarations(
+    source: &str,
+    tokens: &[Token],
+    function: &ParsedFunctionSignature,
+) -> Vec<ParsedLocalDeclaration> {
+    let mut declarations = Vec::new();
+    let mut cursor = tokens.partition_point(|token| token.start < function.body_range.start);
+    while let Some(token) = tokens.get(cursor).copied() {
+        if token.start >= function.body_range.end || token.kind == TokenKind::Eof {
+            break;
+        }
+        if token.kind != TokenKind::Identifier || token_text(source, token) != "foreach" {
+            cursor += 1;
+            continue;
+        }
+        let Some(header_open_index) = tokens
+            .get(cursor + 1)
+            .filter(|token| token.kind == TokenKind::LParen)
+            .map(|_| cursor + 1)
+        else {
+            cursor += 1;
+            continue;
+        };
+        let Some(header_close_index) = matching_token_index(
+            tokens,
+            header_open_index,
+            TokenKind::LParen,
+            TokenKind::RParen,
+        ) else {
+            cursor += 1;
+            continue;
+        };
+        let Some(body_open_index) = tokens
+            .get(header_close_index + 1)
+            .filter(|token| token.kind == TokenKind::LBrace)
+            .map(|_| header_close_index + 1)
+        else {
+            cursor += 1;
+            continue;
+        };
+        let Some(body_close_index) = matching_token_index(
+            tokens,
+            body_open_index,
+            TokenKind::LBrace,
+            TokenKind::RBrace,
+        ) else {
+            cursor += 1;
+            continue;
+        };
+        let header = &tokens[header_open_index + 1..header_close_index];
+        if !header.first().is_some_and(|token| {
+            token.kind == TokenKind::Identifier && token_text(source, *token) == "let"
+        }) {
+            cursor += 1;
+            continue;
+        }
+        let binding_tokens = header
+            .iter()
+            .copied()
+            .skip(1)
+            .take_while(|token| {
+                token.kind != TokenKind::Identifier || token_text(source, *token) != "in"
+            })
+            .filter(|token| token.kind == TokenKind::Identifier)
+            .collect::<Vec<_>>();
+        for binding in binding_tokens.into_iter().take(2) {
+            declarations.push(ParsedLocalDeclaration {
+                function_name: function.name.clone(),
+                name: token_text(source, binding).to_string(),
+                name_range: binding.start..binding.end,
+                visibility_range: tokens[body_open_index].start..tokens[body_close_index].end,
+            });
+        }
+        cursor = body_close_index + 1;
+    }
+    declarations
 }
 
 pub fn completion_expected_type(source: &str, cursor: usize) -> Result<Option<String>, String> {
@@ -1445,6 +1544,35 @@ function tick(): i32 {
                 .find(|binding| binding.name == name)
                 .expect("loop binding");
             assert!(binding.visibility_range.end < after_start);
+        }
+    }
+
+    #[test]
+    fn local_declaration_visibility_excludes_initializers_and_ends_with_foreach() {
+        let source = r#"
+function tick(): i32 {
+    let value = value + 1;
+    foreach (let enemy, index in enemies) {
+        value += enemy + index;
+    }
+    return value;
+}
+"#;
+        let declarations = parse_local_declarations(source).expect("local declarations");
+        let value = declarations
+            .iter()
+            .find(|declaration| declaration.name == "value")
+            .expect("value declaration");
+        assert!(value.visibility_range.start > source.find("value + 1").expect("initializer"));
+
+        let after_loop = source.find("return value").expect("after loop");
+        for name in ["enemy", "index"] {
+            let declaration = declarations
+                .iter()
+                .find(|declaration| declaration.name == name)
+                .expect("foreach declaration");
+            assert!(declaration.visibility_range.start <= source.find("value +=").expect("body"));
+            assert!(declaration.visibility_range.end < after_loop);
         }
     }
 

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -17,6 +17,14 @@ pub struct ParsedLocalBinding {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedLocalDeclaration {
+    pub function_name: String,
+    pub name: String,
+    pub name_range: Range<usize>,
+    pub visibility_range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedFunctionSignature {
     pub name: String,
     pub annotations: Vec<ParsedFunctionAnnotation>,
@@ -117,6 +125,43 @@ pub struct ParsedTypeLayout {
 pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding>, String> {
     let tokens = lex(source)?;
     let mut bindings = Vec::new();
+    for declaration in parse_local_declarations(source)? {
+        let Some(name_index) = tokens
+            .iter()
+            .position(|token| token.start == declaration.name_range.start)
+        else {
+            continue;
+        };
+        if !tokens
+            .get(name_index + 1)
+            .is_some_and(|token| token.kind == TokenKind::Colon)
+        {
+            continue;
+        }
+        let (type_name, _) = parse_type_name(source, &tokens, name_index + 2)?;
+        bindings.push(ParsedLocalBinding {
+            function_name: declaration.function_name,
+            name: declaration.name,
+            type_name,
+            visibility_range: declaration.visibility_range,
+        });
+    }
+    bindings.sort_by_key(|binding| {
+        (
+            binding.function_name.clone(),
+            binding.name.clone(),
+            binding.type_name.clone(),
+            binding.visibility_range.start,
+            binding.visibility_range.end,
+        )
+    });
+    bindings.dedup();
+    Ok(bindings)
+}
+
+pub fn parse_local_declarations(source: &str) -> Result<Vec<ParsedLocalDeclaration>, String> {
+    let tokens = lex(source)?;
+    let mut declarations = Vec::new();
     for function in parse_top_level_functions(source)? {
         let scope_ranges = lexical_scope_ranges(&tokens, function.body_range.clone());
         let loop_ranges = for_scope_ranges(source, &tokens, function.body_range.clone());
@@ -132,14 +177,10 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
             let Some(name) = tokens.get(cursor + 1).copied() else {
                 break;
             };
-            let Some(colon) = tokens.get(cursor + 2).copied() else {
-                break;
-            };
-            if name.kind != TokenKind::Identifier || colon.kind != TokenKind::Colon {
+            if name.kind != TokenKind::Identifier {
                 cursor += 1;
                 continue;
             }
-            let (type_name, next) = parse_type_name(source, &tokens, cursor + 3)?;
             let scope_end = scope_ranges
                 .iter()
                 .chain(loop_ranges.iter())
@@ -147,26 +188,16 @@ pub fn parse_typed_local_bindings(source: &str) -> Result<Vec<ParsedLocalBinding
                 .min_by_key(|range| range.end.saturating_sub(range.start))
                 .map(|range| range.end)
                 .unwrap_or(function.body_range.end);
-            bindings.push(ParsedLocalBinding {
+            declarations.push(ParsedLocalDeclaration {
                 function_name: function.name.clone(),
                 name: token_text(source, name).to_string(),
-                type_name,
+                name_range: name.start..name.end,
                 visibility_range: name.end..scope_end,
             });
-            cursor = next;
+            cursor += 2;
         }
     }
-    bindings.sort_by_key(|binding| {
-        (
-            binding.function_name.clone(),
-            binding.name.clone(),
-            binding.type_name.clone(),
-            binding.visibility_range.start,
-            binding.visibility_range.end,
-        )
-    });
-    bindings.dedup();
-    Ok(bindings)
+    Ok(declarations)
 }
 
 pub fn completion_expected_type(source: &str, cursor: usize) -> Result<Option<String>, String> {

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -8,7 +8,9 @@ use sha2::{Digest, Sha256};
 use crate::compiler::{source_workshop_items, Compiler};
 use crate::data_flow::CompilerLocalType;
 use crate::frontend::lexer::{lex, Token, TokenKind};
-use crate::frontend::parser::{parse_top_level_functions, parse_top_level_type_layout};
+use crate::frontend::parser::{
+    parse_local_declarations, parse_top_level_functions, parse_top_level_type_layout,
+};
 use crate::identity::{
     canonical_source_path, overload_discriminator, CanonicalSourcePath, SymbolId,
 };
@@ -2452,19 +2454,20 @@ pub fn workshop_completion_items(
     let parsed_files = files
         .iter()
         .map(|file| {
-            source_workshop_items(&file.source).map(|records| {
-                (
-                    file,
-                    records.layout,
-                    records.functions,
-                    records.typed_local_bindings,
-                    records.structs,
-                )
-            })
+            let records = source_workshop_items(&file.source)?;
+            let local_declarations = parse_local_declarations(&file.source)?;
+            Ok((
+                file,
+                records.layout,
+                records.functions,
+                records.typed_local_bindings,
+                local_declarations,
+                records.structs,
+            ))
         })
         .collect::<Result<Vec<_>, String>>()?;
     let mut struct_scopes = BTreeMap::<(String, String), WorkshopCompletionScope>::new();
-    for (file, layout, _, _, ranges) in &parsed_files {
+    for (file, layout, _, _, _, ranges) in &parsed_files {
         for definition in &layout.structs {
             struct_fields.insert(
                 definition.name.clone(),
@@ -2526,7 +2529,7 @@ pub fn workshop_completion_items(
     }
 
     let mut typed_bindings = Vec::<WorkshopTypedBinding>::new();
-    for (file, layout, functions, locals, _) in parsed_files {
+    for (file, layout, functions, locals, local_declarations, _) in parsed_files {
         for definition in layout.structs {
             let struct_scope = struct_scopes
                 .get(&(file.path.clone(), definition.name.clone()))
@@ -2638,6 +2641,16 @@ pub fn workshop_completion_items(
                 )
             })
             .collect::<Vec<_>>();
+        let inferred_local_declarations = local_declarations
+            .into_iter()
+            .filter(|declaration| {
+                !locals.iter().any(|local| {
+                    local.function_name == declaration.function_name
+                        && local.name == declaration.name
+                        && local.visibility_range == declaration.visibility_range
+                })
+            })
+            .collect::<Vec<_>>();
         for function in functions {
             let owner_signature = format_function_signature(
                 &function.name,
@@ -2716,6 +2729,36 @@ pub fn workshop_completion_items(
                 file: file.path.clone(),
                 scope: Some(scope),
             });
+        }
+        for local in inferred_local_declarations {
+            let (owner_range, owner_signature) = function_scopes
+                .iter()
+                .find(|(range, _)| {
+                    range.start <= local.visibility_range.start
+                        && local.visibility_range.start <= range.end
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "local {} has no containing function in {}",
+                        local.name, file.path
+                    )
+                })?;
+            items.push(scoped_completion_catalog_item(
+                &local.name,
+                "local",
+                &format!("local in {} [{}]", local.function_name, file.path),
+                &file.path,
+                Some(local.function_name.clone()),
+                None,
+                WorkshopCompletionScope {
+                    owner: local.function_name,
+                    file: file.path.clone(),
+                    owner_signature: Some(owner_signature.clone()),
+                    owner_end: Some(owner_range.end),
+                    visible_from: local.visibility_range.start,
+                    visible_to: local.visibility_range.end,
+                },
+            ));
         }
     }
 

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -1045,6 +1045,10 @@ pub struct WorkshopCompletionScope {
     pub owner_signature: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_end: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declaration_from: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declaration_to: Option<usize>,
     pub visible_from: usize,
     pub visible_to: usize,
 }
@@ -2022,7 +2026,10 @@ fn rename_completion_visible(
     if scope.visible_from <= token.start && token.end <= scope.visible_to {
         return true;
     }
-    if item.kind == "local" && token.end == scope.visible_from {
+    if item.kind == "local"
+        && scope_declaration_range(scope)
+            .is_some_and(|range| range.start <= token.start && token.end <= range.end)
+    {
         return true;
     }
     if item.kind == "parameter" {
@@ -2074,6 +2081,10 @@ fn reject_workshop_rename_collision(
     } else {
         Ok(())
     }
+}
+
+fn scope_declaration_range(scope: &WorkshopCompletionScope) -> Option<Range<usize>> {
+    Some(scope.declaration_from?..scope.declaration_to?)
 }
 
 fn rename_target_references(
@@ -2153,7 +2164,9 @@ fn scoped_binding_references(
         if token.kind != TokenKind::Identifier || token_text(&file.source, token) != target.name {
             continue;
         }
-        let is_local_definition = target.kind == "local" && token.end == scope.visible_from;
+        let is_local_definition = target.kind == "local"
+            && scope_declaration_range(scope)
+                .is_some_and(|range| range.start <= token.start && token.end <= range.end);
         let is_parameter_definition = target.kind == "parameter"
             && token.end <= scope.visible_from
             && functions.iter().any(|function| {
@@ -2486,6 +2499,8 @@ pub fn workshop_completion_items(
                     file: file.path.clone(),
                     owner_signature: Some(format!("struct {}", definition.name)),
                     owner_end: Some(definition.definition_range.end),
+                    declaration_from: None,
+                    declaration_to: None,
                     visible_from: definition.definition_range.start,
                     visible_to: definition.definition_range.end,
                 },
@@ -2663,6 +2678,8 @@ pub fn workshop_completion_items(
                     file: file.path.clone(),
                     owner_signature: Some(owner_signature.clone()),
                     owner_end: Some(function.body_range.end),
+                    declaration_from: None,
+                    declaration_to: None,
                     visible_from: function.body_range.start,
                     visible_to: function.body_range.end,
                 };
@@ -2706,6 +2723,8 @@ pub fn workshop_completion_items(
                 file: file.path.clone(),
                 owner_signature: Some(owner_signature.clone()),
                 owner_end: Some(owner_range.end),
+                declaration_from: Some(local.name_range.start),
+                declaration_to: Some(local.name_range.end),
                 visible_from: local.visibility_range.start,
                 visible_to: local.visibility_range.end,
             };
@@ -2755,6 +2774,8 @@ pub fn workshop_completion_items(
                     file: file.path.clone(),
                     owner_signature: Some(owner_signature.clone()),
                     owner_end: Some(owner_range.end),
+                    declaration_from: Some(local.name_range.start),
+                    declaration_to: Some(local.name_range.end),
                     visible_from: local.visibility_range.start,
                     visible_to: local.visibility_range.end,
                 },

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -2665,11 +2665,11 @@ fn scoped_binding_declaration_range(
         return Ok(None);
     };
     if item.kind == "local" {
-        let start = scope.visible_from.saturating_sub(item.text.len());
-        return Ok(
-            (source.get(start..scope.visible_from) == Some(item.text.as_str()))
-                .then_some(start..scope.visible_from),
-        );
+        let (Some(start), Some(end)) = (scope.declaration_from, scope.declaration_to) else {
+            return Ok(None);
+        };
+        let range = start..end;
+        return Ok((source.get(range.clone()) == Some(item.text.as_str())).then_some(range));
     }
     let Some(owner_end) = scope.owner_end else {
         return Ok(None);
@@ -3918,6 +3918,56 @@ function main(): i32 {
             outer[0].range.start,
             source.find("let value").expect("outer declaration") + "let ".len()
         );
+    }
+
+    #[test]
+    fn local_initializer_and_foreach_navigation_respect_binding_lifetimes() {
+        let root = std::env::temp_dir().join("stasis-language-service-loop-local-navigation");
+        let path = root.join("src/main.stasis");
+        let path_text = path.to_string_lossy().replace('\\', "/");
+        let source = "global value: i32;\nglobal enemy: i32;\nglobal index: i32;\nglobal enemies: i32[2];\nfunction main(): i32 {\n    let value = value + 1;\n    foreach (let enemy, index in enemies) {\n        value += enemy + index;\n    }\n    return value + enemy + index;\n}\n";
+        let mut service = LanguageService::new(root.to_string_lossy()).expect("language service");
+        service.set_disk_document(path_text.clone(), source);
+
+        let initializer_use = source.find("= value").expect("initializer use") + 2;
+        let initializer_definition = service
+            .definition(&path_text, initializer_use)
+            .expect("initializer definition");
+        assert_eq!(initializer_definition.len(), 1);
+        assert_eq!(
+            initializer_definition[0].range.start,
+            source.find("global value").expect("global value") + "global ".len()
+        );
+
+        for name in ["enemy", "index"] {
+            let body_use = source
+                .find(&format!("{name} +"))
+                .unwrap_or_else(|| source.find("index;").expect("index body use"));
+            let body_definition = service
+                .definition(&path_text, body_use)
+                .expect("foreach definition");
+            assert_eq!(body_definition.len(), 1);
+            assert_eq!(
+                body_definition[0].range.start,
+                source.find(&format!("let enemy, {name}")).map_or_else(
+                    || source.find("let enemy").expect("enemy declaration") + "let ".len(),
+                    |start| start + "let enemy, ".len(),
+                )
+            );
+
+            let after_use = source.rfind(name).expect("after-loop use");
+            let after_definition = service
+                .definition(&path_text, after_use)
+                .expect("after-loop definition");
+            assert_eq!(after_definition.len(), 1);
+            assert_eq!(
+                after_definition[0].range.start,
+                source
+                    .find(&format!("global {name}"))
+                    .expect("global declaration")
+                    + "global ".len()
+            );
+        }
     }
 
     #[test]

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use stasis_compiler::compiler::Compiler;
 use stasis_compiler::frontend::formatter::format_source;
 use stasis_compiler::frontend::lexer::{lex, Token, TokenKind};
-use stasis_compiler::frontend::parser::completion_expected_type;
+use stasis_compiler::frontend::parser::{completion_expected_type, parse_top_level_functions};
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, organize_workshop_imports, plan_workshop_rename,
     prepare_workshop_rename, workshop_call_hierarchy, workshop_completion_items,
@@ -1302,17 +1302,42 @@ impl LanguageService {
         let symbol = reference_symbol_at(&document.text, byte_offset)
             .ok_or_else(|| "no Stasis symbol at navigation position".to_string())?;
         let project_root = self.project_root.clone();
-        if let Some(locations) = self.language_index.as_ref().and_then(|index| {
-            index
-                .definitions
-                .definition(&symbol)
-                .and_then(|resolution| {
-                    remap_definition_locations(&project_root, &snapshot, index, &resolution)
-                })
-        }) {
-            return Ok(locations);
+        let relative = canonical_source_path(Some(&self.project_root), path)?;
+        let has_scoped_candidate = self.language_index.as_ref().is_some_and(|index| {
+            index.workshop_items.iter().any(|item| {
+                item.text == symbol
+                    && matches!(item.kind.as_str(), "local" | "parameter")
+                    && item
+                        .scope
+                        .as_ref()
+                        .is_some_and(|scope| scope.file == relative)
+            })
+        });
+        if !has_scoped_candidate {
+            if let Some(locations) = self.language_index.as_ref().and_then(|index| {
+                index
+                    .definitions
+                    .definition(&symbol)
+                    .and_then(|resolution| {
+                        remap_definition_locations(&project_root, &snapshot, index, &resolution)
+                    })
+            }) {
+                return Ok(locations);
+            }
         }
+        let context = self.query_context(&relative, byte_offset, &document.text)?;
         let index = self.language_index()?;
+        if let Some(location) = scoped_binding_definition(
+            &project_root,
+            index,
+            &relative,
+            &document.text,
+            byte_offset,
+            &symbol,
+            &context,
+        )? {
+            return Ok(vec![location]);
+        }
         if let Some(resolution) = index.definitions.definition(&symbol) {
             if let Some(locations) =
                 remap_definition_locations(&project_root, &snapshot, index, &resolution)
@@ -2571,6 +2596,109 @@ fn workshop_completion_specificity<'a>(
     }
 }
 
+fn scoped_binding_definition(
+    project_root: &str,
+    index: &LanguageIndex,
+    relative_path: &str,
+    source: &str,
+    byte_offset: usize,
+    symbol: &str,
+    context: &CompletionContext,
+) -> Result<Option<LanguageLocation>, String> {
+    let Some(file) = index.files.iter().find(|file| file.path == relative_path) else {
+        return Ok(None);
+    };
+    let mut matches = index
+        .workshop_items
+        .iter()
+        .filter(|item| {
+            item.text == symbol
+                && matches!(item.kind.as_str(), "local" | "parameter")
+                && scoped_completion_owner_matches(item, context)
+        })
+        .filter_map(|item| {
+            let declaration = scoped_binding_declaration_range(&file.source, item).ok()??;
+            let visible = item.scope.as_ref().is_some_and(|scope| {
+                scope.visible_from <= byte_offset && byte_offset <= scope.visible_to
+            });
+            let on_declaration = declaration.start <= byte_offset && byte_offset <= declaration.end;
+            (visible || on_declaration).then_some((item, declaration))
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by_key(|(item, _)| workshop_completion_specificity(item, context));
+    let Some((_, indexed_range)) = matches.first() else {
+        return Ok(None);
+    };
+    let Some(range) = UnchangedRegions::new(&file.source, source).remap(
+        &file.source,
+        source,
+        indexed_range.clone(),
+    ) else {
+        return Ok(None);
+    };
+    Ok(Some(LanguageLocation {
+        path: absolute_source_path(project_root, relative_path),
+        range,
+    }))
+}
+
+fn scoped_completion_owner_matches(
+    item: &WorkshopCompletionItem,
+    context: &CompletionContext,
+) -> bool {
+    let Some(scope) = item.scope.as_ref() else {
+        return false;
+    };
+    context.owner.as_deref() == Some(scope.owner.as_str())
+        && context.file.as_deref() == Some(scope.file.as_str())
+        && context
+            .owner_signature
+            .as_deref()
+            .is_none_or(|signature| scope.owner_signature.as_deref() == Some(signature))
+}
+
+fn scoped_binding_declaration_range(
+    source: &str,
+    item: &WorkshopCompletionItem,
+) -> Result<Option<Range<usize>>, String> {
+    let Some(scope) = item.scope.as_ref() else {
+        return Ok(None);
+    };
+    if item.kind == "local" {
+        let start = scope.visible_from.saturating_sub(item.text.len());
+        return Ok(
+            (source.get(start..scope.visible_from) == Some(item.text.as_str()))
+                .then_some(start..scope.visible_from),
+        );
+    }
+    let Some(owner_end) = scope.owner_end else {
+        return Ok(None);
+    };
+    let Some(function) = parse_top_level_functions(source)?
+        .into_iter()
+        .find(|function| function.name == scope.owner && function.body_range.end == owner_end)
+    else {
+        return Ok(None);
+    };
+    let tokens = lex(source)?;
+    Ok(tokens
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, token)| {
+            function.signature_range.start <= token.start
+                && token.end <= function.signature_range.end
+                && token.kind == TokenKind::Identifier
+                && token_text(source, *token) == item.text
+        })
+        .find(|(index, _)| {
+            tokens
+                .get(index + 1)
+                .is_some_and(|next| next.kind == TokenKind::Colon)
+        })
+        .map(|(_, token)| token.start..token.end))
+}
+
 fn item_signature(item: &WorkshopCompletionItem) -> Option<String> {
     item.signature
         .clone()
@@ -3752,6 +3880,44 @@ function main(): i32 {
             .expect("workspace symbols");
         assert_eq!(workspace.len(), 1);
         assert_eq!(workspace[0].name, "spawn_enemy");
+    }
+
+    #[test]
+    fn same_function_bindings_navigate_to_the_lexically_visible_declaration() {
+        let root = std::env::temp_dir().join("stasis-language-service-local-navigation");
+        let path = root.join("src/main.stasis");
+        let path_text = path.to_string_lossy().replace('\\', "/");
+        let source = "global value: i32;\nfunction compute(seed: i32): i32 {\n    let value = seed;\n    {\n        let value: i32 = 2;\n        value += 1;\n    }\n    return value;\n}\n";
+        let mut service = LanguageService::new(root.to_string_lossy()).expect("language service");
+        service.set_disk_document(path_text.clone(), source);
+
+        let parameter_use = source.find("= seed").expect("parameter use") + 3;
+        let parameter = service
+            .definition(&path_text, parameter_use)
+            .expect("parameter definition");
+        assert_eq!(parameter.len(), 1);
+        assert_eq!(&source[parameter[0].range.clone()], "seed");
+        assert!(parameter[0].range.start < source.find('{').expect("function body"));
+
+        let inner_use = source.find("value += 1").expect("inner local use") + 2;
+        let inner = service
+            .definition(&path_text, inner_use)
+            .expect("inner local definition");
+        assert_eq!(inner.len(), 1);
+        assert_eq!(
+            inner[0].range.start,
+            source.rfind("let value").expect("inner declaration") + "let ".len()
+        );
+
+        let outer_use = source.rfind("return value").expect("outer local use") + "return ".len();
+        let outer = service
+            .definition(&path_text, outer_use)
+            .expect("outer local definition");
+        assert_eq!(outer.len(), 1);
+        assert_eq!(
+            outer[0].range.start,
+            source.find("let value").expect("outer declaration") + "let ".len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add parser-owned lexical declaration records for typed and inferred local bindings
- resolve VS Code Go to Definition/Declaration requests to function parameters and the nearest visible local
- preserve lexical shadowing and prefer scoped bindings over same-named globals

## Root cause

The language service indexed top-level symbols and fields for navigation, while local bindings existed only in scoped completion/rename data. Inferred `let` declarations were also absent from that catalog, so navigation could not map local uses back to their declarations.

## Impact

VS Code users can now navigate from a local variable or parameter use to its declaration within the same function, including nested scopes and inferred `let` bindings.

## Validation

- `cargo fmt --check -- crates/stasis_compiler/src/frontend/parser.rs crates/stasis_compiler/src/frontend/workshop.rs crates/stasis_language_service/src/lib.rs`
- `cargo test -p stasis_compiler frontend::parser::tests` (22 passed)
- `cargo test -p stasis_language_service` (32 passed, 1 optional environment-dependent test ignored)
