### PR TITLE
Fix ambiguous receiver AOT object retention

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -4246,8 +4246,7 @@ fn package_engine_bundle_release(
         &function_aliases,
         &string_literals,
     )?;
-    let mut object_paths: Vec<PathBuf> =
-        bundle.object_paths_by_function.values().cloned().collect();
+    let mut object_paths: Vec<PathBuf> = bundle.object_paths().cloned().collect();
     object_paths.push(bridge_object);
     let export_symbols: Vec<String> = export_symbols.into_iter().collect();
     let initial_link = link_objects_to_dynamic_library(
@@ -6727,8 +6726,7 @@ mod tests {
             .map(|row| row.symbol.clone())
             .expect("manifest should include tick");
 
-        let object_paths: Vec<PathBuf> =
-            bundle.object_paths_by_function.values().cloned().collect();
+        let object_paths: Vec<PathBuf> = bundle.object_paths().cloned().collect();
         assert!(
             !object_paths.is_empty(),
             "expected engine bundle to include object files"
@@ -7599,11 +7597,7 @@ mod tests {
             &[],
         )
         .expect("compile direct storage bridge");
-        let mut objects = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut objects = bundle.object_paths().cloned().collect::<Vec<_>>();
         objects.push(bridge);
         let linked = temp_root.join("direct_storage.dll");
         let dynload = ensure_stasis_dynload_link_library().expect("stasis dynload link library");
@@ -7705,11 +7699,7 @@ mod tests {
             &[],
         )
         .expect("compile runtime bridge");
-        let mut objects = bundle
-            .object_paths_by_function
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut objects = bundle.object_paths().cloned().collect::<Vec<_>>();
         objects.push(bridge);
         let linked = temp_root.join("bounded_performance.dll");
         let dynload = ensure_stasis_dynload_link_library().expect("stasis dynload link library");

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1598,7 +1598,7 @@ fn write_mobile_aot_engine_bundle(
         MobileAotTarget::AndroidArm64 | MobileAotTarget::AndroidX86_64
     ) {
         let path = output_dir.join("published_aot_objects.cmake");
-        write_android_aot_cmake_file(&bundle.object_paths_by_function, &path)?;
+        write_android_aot_cmake_file(&bundle.object_paths_by_function_id, &path)?;
         Some(path)
     } else {
         None
@@ -1607,8 +1607,9 @@ fn write_mobile_aot_engine_bundle(
     let package_manifest = write_mobile_aot_package_manifest(
         target,
         &bundle.manifest_path,
+        &manifest_json,
         &asset_dir,
-        &bundle.object_paths_by_function,
+        &bundle.object_paths_by_function_id,
         &symbols_header,
         &bindings_source,
         cmake_file.as_deref(),
@@ -1617,7 +1618,7 @@ fn write_mobile_aot_engine_bundle(
     Ok(MobileAotBundleSummary {
         target,
         bundle_dir: bundle.output_dir,
-        object_count: bundle.object_paths_by_function.len(),
+        object_count: bundle.object_paths_by_function_id.len(),
         symbols_header,
         bindings_source,
         cmake_file,
@@ -2089,18 +2090,30 @@ fn mobile_aot_c_return_type(function: &serde_json::Value) -> Result<&'static str
 fn write_mobile_aot_package_manifest(
     target: MobileAotTarget,
     engine_manifest_path: &Path,
+    engine_manifest: &serde_json::Value,
     asset_dir: &Path,
-    object_paths_by_function: &std::collections::BTreeMap<String, PathBuf>,
+    object_paths_by_function_id: &std::collections::BTreeMap<u32, PathBuf>,
     symbols_header: &Path,
     bindings_source: &Path,
     cmake_file: Option<&Path>,
     output_dir: &Path,
 ) -> Result<PathBuf, String> {
-    let objects = object_paths_by_function
+    let manifest_functions = engine_manifest["functions"]
+        .as_array()
+        .ok_or_else(|| "mobile AOT engine manifest missing functions".to_string())?;
+    let objects = object_paths_by_function_id
         .iter()
-        .map(|(name, path)| {
+        .map(|(function_id, path)| {
+            let name = manifest_functions
+                .iter()
+                .find(|function| function["function_id"].as_u64() == Some(u64::from(*function_id)))
+                .and_then(|function| function["name"].as_str())
+                .ok_or_else(|| {
+                    format!("mobile AOT engine manifest missing function id {function_id}")
+                })?;
             Ok(serde_json::json!({
                 "function": name,
+                "function_id": function_id,
                 "path": mobile_aot_relative_path(output_dir, path)?
             }))
         })
@@ -2153,7 +2166,7 @@ fn mobile_aot_relative_path(output_dir: &Path, path: &Path) -> Result<String, St
 }
 
 fn write_android_aot_cmake_file(
-    object_paths_by_function: &std::collections::BTreeMap<String, PathBuf>,
+    object_paths_by_function_id: &std::collections::BTreeMap<u32, PathBuf>,
     output_path: &Path,
 ) -> Result<(), String> {
     let output_dir = output_path.parent().ok_or_else(|| {
@@ -2164,7 +2177,7 @@ fn write_android_aot_cmake_file(
     })?;
     let mut out = String::new();
     out.push_str("set(STASIS_PUBLISHED_AOT_OBJECTS\n");
-    for path in object_paths_by_function.values() {
+    for path in object_paths_by_function_id.values() {
         let relative = mobile_aot_relative_path(output_dir, path)?;
         out.push_str(&format!("  \"${{CMAKE_CURRENT_LIST_DIR}}/{relative}\"\n"));
     }

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -56,6 +56,17 @@ pub struct AotEngineBundle {
     pub optimization_profile: AotOptimizationProfile,
 }
 
+impl AotEngineBundle {
+    /// Enumerates every emitted object by its canonical function identity.
+    ///
+    /// `object_paths_by_function` is only a convenience lookup for unique source
+    /// names. Ambiguous overload names are intentionally absent from that map, so
+    /// whole-bundle link and package paths must enumerate this FnId-backed map.
+    pub fn object_paths(&self) -> impl ExactSizeIterator<Item = &PathBuf> {
+        self.object_paths_by_function_id.values()
+    }
+}
+
 impl AotProcess {
     pub fn new() -> Self {
         Self::with_optimization_profile(AotOptimizationProfile::Speed)
@@ -389,8 +400,9 @@ impl AotProcess {
                     )
                 })?;
             let object_path = object_dir.join(format!(
-                "{}_{}.obj",
+                "{}_fn{}_{}.obj",
                 sanitize_file_token(&artifact_function.name),
+                artifact_function.id,
                 artifact.object_index
             ));
             fs::write(&object_path, object_bytes).map_err(|error| {
@@ -728,8 +740,9 @@ impl AotProcess {
                     )
                 })?;
             let object_file_name = format!(
-                "{}_{}.{}",
+                "{}_fn{}_{}.{}",
                 sanitize_file_token(&function.name),
+                function.id,
                 artifact.object_index,
                 object_file_extension(&self.target)
             );
@@ -862,8 +875,9 @@ impl AotProcess {
                 })?;
 
             let object_file_name = format!(
-                "{}_{}.{}",
+                "{}_fn{}_{}.{}",
                 sanitize_file_token(&function.name),
+                function.id,
                 artifact.object_index,
                 object_file_extension(&self.target)
             );
@@ -2353,7 +2367,7 @@ mod tests {
         let mut process = AotProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "function draw(value: i32): i32 { return value; }\nfunction draw(value: f32): i32 { return 2; }\nfunction tick(): void { let first: i32 = draw(1); let second: i32 = draw(1.0); return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n",
+            "struct Sprite { handle: i32; }\nstruct TextRun { handle: i32; }\nglobal sprite: Sprite;\nglobal text: TextRun;\nfunction draw(self: Sprite, value: i32): void { self.handle = value; }\nfunction draw(self: TextRun, value: i32): void { self.handle = value + 7; }\nfunction main(): i32 { sprite.draw(30); text.draw(5); return sprite.handle + text.handle; }\nfunction tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n",
         );
         process.compile().expect("compile overload bundle");
 
@@ -2371,8 +2385,76 @@ mod tests {
             "both draw overload objects must remain in the bundle"
         );
         assert!(!bundle.object_paths_by_function.contains_key("draw"));
+        assert_eq!(bundle.object_paths().len(), process.artifacts().len());
+        let draw_objects = bundle
+            .object_paths()
+            .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+            .filter(|name| name.starts_with("draw_fn"))
+            .collect::<Vec<_>>();
+        assert_eq!(draw_objects.len(), 2);
+        assert_ne!(draw_objects[0], draw_objects[1]);
 
         let _ = fs::remove_dir_all(&bundle_dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn aot_engine_bundle_links_and_executes_same_named_receiver_methods() {
+        let Some(mut link_config) = resolve_link_config_for_smoke() else {
+            return;
+        };
+        let source = "function draw(self: i32, value: i32): i32 { return value; }\nfunction draw(self: f32, value: i32): i32 { return value + 7; }\nfunction main(): i32 { let sprite: i32 = 1; let text: f32 = 1.0; return sprite.draw(30) + text.draw(5); }\nfunction tick(): void { return; }\nfunction render(): void { return; }\nfunction on_code_swap(): void { return; }\n";
+        let mut process = AotProcess::new();
+        process.upsert_file("sample.stasis", source);
+        process.compile().expect("compile receiver overload bundle");
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp_root = std::env::temp_dir().join(format!("stasis_aot_receiver_bundle_{stamp}"));
+        let bundle = process
+            .write_engine_bundle(&EngineEntrypoints::runtime_default(), &temp_root)
+            .expect("write receiver overload bundle");
+        let main_id = process
+            .compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("main function")
+            .id;
+        let main_symbol = process
+            .artifacts()
+            .iter()
+            .find(|artifact| artifact.function_id == main_id)
+            .expect("main artifact")
+            .symbol_name
+            .clone();
+
+        let deps_dir = std::env::current_exe()
+            .expect("current test executable")
+            .parent()
+            .expect("Cargo deps directory")
+            .to_path_buf();
+        let (import_library, runtime_dll) = ensure_test_dynload_artifacts(&deps_dir);
+        link_config.runtime_lib_paths.push(import_library);
+        fs::copy(&runtime_dll, temp_root.join("stasis_dynload.dll"))
+            .expect("copy AOT test runtime");
+        let executable = temp_root.join("receiver_bundle.exe");
+        let object_paths = bundle.object_paths().cloned().collect::<Vec<_>>();
+        stasis_jit::link_objects_to_executable(
+            &object_paths,
+            &executable,
+            &main_symbol,
+            &link_config,
+        )
+        .expect("link every receiver overload object");
+        let status = Command::new(&executable)
+            .status()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", executable.display()));
+        assert_eq!(status.code(), Some(42));
+
+        let _ = fs::remove_dir_all(&temp_root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep every emitted AOT object addressable through canonical FnId-backed bundle enumeration
- qualify generated object filenames with stable FnId identities while preserving source-name aliases for unique entrypoint lookup only
- use the canonical object set for desktop dynamic-library links and Android/iOS package manifests
- add a receiver-overload engine-bundle regression that links and runs both same-named methods

## Tests
- `cargo test -p stasis_compiler aot_engine_bundle_links_and_executes_same_named_receiver_methods -- --test-threads=1` with `STASIS_AOT_LINKER` set to Visual Studio `lld-link.exe` (1 passed; linked executable returned 42)
- `cargo test -p stasis_compiler aot_engine_bundle_ -- --test-threads=1` (6 passed)
- `cargo check -p stasis`
- `cargo test -p stasis mobile_aot_bundle -- --test-threads=1` (5 passed)
- `cargo test -p stasis --all-targets -- --test-threads=1` (all targets passed: 260 + 175 + 21 + 1 + 2 tests)
- canonical Python validator stages passed except the pre-existing `check_unsafe_boundaries.py` origin/main failure for `crates/stasis_ai/src/lib.rs`
- canonical ignore audit also reports the pre-existing `#[ignore]` at `crates/stasis_language_service/src/lib.rs:3999`
- full compiler run reached 467 passed with the new regression passing; the remaining failure was host Application Control blocking a generated renderer parity executable (OS error 4551)
- `cargo fmt --all -- --check`
- `git diff --check`

## Theory / reflection
- Theory gained: an AOT engine bundle is an identity-indexed set of emitted functions; source names are only optional aliases. The manifest already proved both receiver overloads existed, and the real linked regression proves FnId enumeration retains both. Adjacent prediction: any future same-name overload family will package correctly without receiver-specific special cases.
- Good: tracing emission through final linker input isolated the loss to one convenience map.
- Bad: the existing bundle test checked emitted files but never linked the bundle, so omission survived.
- Adjustment: overload retention tests must exercise the same whole-bundle enumeration used by desktop/mobile packaging and run the linked result.

Maddox Tasks: #191