### PR TITLE
Fix release asset closure and Android manifest startup

### DIFF
--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 
+mod release_assets;
 mod toolchain_cli;
 
 use std::collections::BTreeSet;
@@ -1603,7 +1604,11 @@ fn write_mobile_aot_engine_bundle(
     } else {
         None
     };
-    let asset_dir = write_mobile_asset_bundle(target, project_dir, output_dir, &sources)?;
+    let source_base_dir = entry_file
+        .and_then(Path::parent)
+        .unwrap_or_else(|| Path::new("."));
+    let asset_dir =
+        write_mobile_asset_bundle(target, project_dir, source_base_dir, output_dir, &sources)?;
     let package_manifest = write_mobile_aot_package_manifest(
         target,
         &bundle.manifest_path,
@@ -1630,11 +1635,18 @@ fn write_mobile_aot_engine_bundle(
 fn write_mobile_asset_bundle(
     target: MobileAotTarget,
     project_dir: &Path,
+    source_base_dir: &Path,
     output_dir: &Path,
     sources: &[(String, String)],
 ) -> Result<PathBuf, String> {
     let resolved = load_project_asset_manifest(project_dir, AssetLimits::default())
         .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
+    let resolved = release_assets::retain_source_referenced_assets(
+        project_dir,
+        source_base_dir,
+        sources,
+        &resolved,
+    )?;
     let asset_root = output_dir.join(target.asset_root_dir());
     if asset_root.exists() {
         fs::remove_dir_all(&asset_root).map_err(|error| {
@@ -2971,6 +2983,7 @@ mod tests {
         let asset_root = write_mobile_asset_bundle(
             MobileAotTarget::AndroidArm64,
             &project_dir,
+            Path::new("src"),
             &output_dir,
             &sources,
         )
@@ -2980,6 +2993,70 @@ mod tests {
         assert!(!asset_root
             .join("stasis_game/assets/fonts/unused.ttf")
             .exists());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn mobile_asset_bundle_packages_only_reachable_manifest_assets_for_both_targets() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_mobile_asset_closure_{stamp}"));
+        let project_dir = root.join("project");
+        let src_dir = project_dir.join("src");
+        let svg_dir = project_dir.join("assets/svg");
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::create_dir_all(&svg_dir).expect("mkdir svg");
+        let used_svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"/>"#;
+        let unused_svg = br#"<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M0 0"/></svg>"#;
+        std::fs::write(svg_dir.join("used.svg"), used_svg).expect("write used svg");
+        std::fs::write(svg_dir.join("unused.svg"), unused_svg).expect("write unused svg");
+        std::fs::write(
+            project_dir.join("assets/manifest.json"),
+            format!(
+                r#"{{
+  "schema": "stasis-assets",
+  "version": 2,
+  "assets": [
+    {{"id":"used","path":"assets/svg/used.svg","content_sha256":"{}","format":{{"kind":"sprite","encoding":"svg","width":32,"height":32}},"dependencies":[]}},
+    {{"id":"unused","path":"assets/svg/unused.svg","content_sha256":"{}","format":{{"kind":"sprite","encoding":"svg","width":32,"height":32}},"dependencies":[]}}
+  ]
+}}
+"#,
+                stasis_assets::sha256_bytes(used_svg),
+                stasis_assets::sha256_bytes(unused_svg)
+            ),
+        )
+        .expect("write manifest");
+        let sources = vec![(
+            "src/main.stasis".to_string(),
+            r#"function main(): void { hero.load_sprite_from("../assets/svg/used.svg", 32, 32); }
+"#
+            .to_string(),
+        )];
+
+        for target in [MobileAotTarget::AndroidArm64, MobileAotTarget::IosArm64] {
+            let output_dir = root.join(target.as_str());
+            let asset_root = write_mobile_asset_bundle(
+                target,
+                &project_dir,
+                Path::new("src"),
+                &output_dir,
+                &sources,
+            )
+            .expect("package filtered assets");
+            let game_root = asset_root.join("stasis_game");
+            assert!(game_root.join("assets/svg/used.svg").is_file());
+            assert!(!game_root.join("assets/svg/unused.svg").exists());
+            let packaged: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(game_root.join("assets/manifest.json"))
+                    .expect("read packaged manifest"),
+            )
+            .expect("parse packaged manifest");
+            assert_eq!(packaged["assets"].as_array().expect("assets").len(), 1);
+            assert_eq!(packaged["assets"][0]["id"], "used");
+        }
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/apps/stasis/src/release_assets.rs
+++ b/apps/stasis/src/release_assets.rs
@@ -1,0 +1,195 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use stasis_assets::ResolvedAssetManifest;
+use stasis_compiler::frontend::lexer::{lex, TokenKind};
+
+pub(crate) fn retain_source_referenced_assets(
+    project_dir: &Path,
+    source_base_dir: &Path,
+    sources: &[(String, String)],
+    resolved: &ResolvedAssetManifest,
+) -> Result<ResolvedAssetManifest, String> {
+    let project_root = project_dir.canonicalize().map_err(|error| {
+        format!(
+            "failed to canonicalize release asset project {}: {error}",
+            project_dir.display()
+        )
+    })?;
+    let asset_root = project_root
+        .join("assets")
+        .canonicalize()
+        .map_err(|error| format!("failed to canonicalize release asset root: {error}"))?;
+    let source_base = canonical_project_path(&project_root, source_base_dir)?;
+    if !source_base.is_dir() {
+        return Err(format!(
+            "release asset source base must be a directory: {}",
+            source_base.display()
+        ));
+    }
+    let mut paths = BTreeSet::new();
+    for (relative_source_path, source) in sources {
+        for token in lex(source).map_err(|error| {
+            format!("failed to scan release asset paths in {relative_source_path}: {error}")
+        })? {
+            if token.kind != TokenKind::StringLiteral {
+                continue;
+            }
+            let literal: String =
+                serde_json::from_str(&source[token.start..token.end]).map_err(|error| {
+                    format!("failed to decode string literal in {relative_source_path}: {error}")
+                })?;
+            let absolute_path = [source_base.join(&literal), project_root.join(&literal)]
+                .into_iter()
+                .find_map(|candidate| candidate.canonicalize().ok());
+            let Some(absolute_path) = absolute_path else {
+                continue;
+            };
+            if !absolute_path.is_file() || !absolute_path.starts_with(&asset_root) {
+                continue;
+            }
+            paths.insert(
+                absolute_path
+                    .strip_prefix(&project_root)
+                    .map_err(|_| {
+                        format!(
+                            "release asset escaped project root: {}",
+                            absolute_path.display()
+                        )
+                    })?
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+    Ok(resolved.retain_paths(&paths))
+}
+
+pub(crate) fn load_entry_sources(
+    project_dir: &Path,
+    entry_file: &Path,
+) -> Result<Vec<(String, String)>, String> {
+    let project_root = project_dir.canonicalize().map_err(|error| {
+        format!(
+            "failed to canonicalize release asset project {}: {error}",
+            project_dir.display()
+        )
+    })?;
+    let entry_path = canonical_project_file(&project_root, entry_file)?;
+    let (graph, sources) = stasis_compiler::frontend::module_graph::load_project_module_graph(
+        &project_root,
+        &entry_path,
+    )
+    .map_err(|diagnostic| diagnostic.message)?;
+    let mut out = Vec::new();
+    for relative in graph.modules().keys() {
+        if relative.ends_with(".test.stasis") {
+            continue;
+        }
+        let source = sources
+            .get(relative)
+            .cloned()
+            .ok_or_else(|| format!("module graph source missing for {relative}"))?;
+        out.push((relative.clone(), source));
+    }
+    out.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(out)
+}
+
+fn canonical_project_file(project_root: &Path, file: &Path) -> Result<PathBuf, String> {
+    let canonical = canonical_project_path(project_root, file)?;
+    if !canonical.is_file() {
+        return Err(format!(
+            "release entry must be a file: {}",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+fn canonical_project_path(project_root: &Path, path: &Path) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    };
+    let canonical = candidate.canonicalize().map_err(|error| {
+        format!(
+            "failed to canonicalize release entry {}: {error}",
+            candidate.display()
+        )
+    })?;
+    if !canonical.starts_with(project_root) {
+        return Err(format!(
+            "release entry {} must stay under project directory {}",
+            canonical.display(),
+            project_root.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stasis_assets::{
+        stable_asset_handle, AssetEntry, AssetFormat, ResolvedAsset, SpriteEncoding,
+    };
+
+    fn resolved(root: &Path, id: &str, path: &str) -> ResolvedAsset {
+        let entry = AssetEntry {
+            id: id.to_string(),
+            path: path.to_string(),
+            content_sha256: "0".repeat(64),
+            prepared_from_sha256: None,
+            format: AssetFormat::Sprite {
+                encoding: SpriteEncoding::Svg,
+                width: 32,
+                height: 32,
+            },
+            prepare: None,
+            dependencies: vec![],
+        };
+        ResolvedAsset {
+            handle: stable_asset_handle(&entry),
+            entry,
+            absolute_path: root.join(path),
+            byte_length: 1,
+        }
+    }
+
+    #[test]
+    fn keeps_only_literal_assets_in_the_reachable_source_set() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_release_assets_{stamp}"));
+        std::fs::create_dir_all(root.join("assets/svg")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("assets/svg/used.svg"), "u").unwrap();
+        std::fs::write(root.join("assets/svg/unused.svg"), "x").unwrap();
+        let manifest = ResolvedAssetManifest {
+            manifest_path: root.join("assets/manifest.json"),
+            assets: vec![
+                resolved(&root, "used", "assets/svg/used.svg"),
+                resolved(&root, "unused", "assets/svg/unused.svg"),
+            ],
+        };
+        let sources = vec![(
+            "src/main.stasis".to_string(),
+            concat!(
+                "function main(): void { ",
+                "hero.load_sprite_from(\"../assets/svg/used.svg\", 32, 32); ",
+                "hero.load_sprite_from(\"assets/svg/used.svg\", 32, 32); }"
+            )
+            .to_string(),
+        )];
+
+        let retained =
+            retain_source_referenced_assets(&root, Path::new("src"), &sources, &manifest).unwrap();
+        assert_eq!(retained.assets.len(), 1);
+        assert_eq!(retained.assets[0].entry.id, "used");
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/apps/stasis/src/release_assets.rs
+++ b/apps/stasis/src/release_assets.rs
@@ -41,13 +41,11 @@ pub(crate) fn retain_source_referenced_assets(
                 })?;
             let absolute_path = [source_base.join(&literal), project_root.join(&literal)]
                 .into_iter()
-                .find_map(|candidate| candidate.canonicalize().ok());
+                .filter_map(|candidate| candidate.canonicalize().ok())
+                .find(|candidate| candidate.is_file() && candidate.starts_with(&asset_root));
             let Some(absolute_path) = absolute_path else {
                 continue;
             };
-            if !absolute_path.is_file() || !absolute_path.starts_with(&asset_root) {
-                continue;
-            }
             paths.insert(
                 absolute_path
                     .strip_prefix(&project_root)
@@ -184,6 +182,34 @@ mod tests {
                 "hero.load_sprite_from(\"assets/svg/used.svg\", 32, 32); }"
             )
             .to_string(),
+        )];
+
+        let retained =
+            retain_source_referenced_assets(&root, Path::new("src"), &sources, &manifest).unwrap();
+        assert_eq!(retained.assets.len(), 1);
+        assert_eq!(retained.assets[0].entry.id, "used");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn project_root_literal_skips_existing_non_asset_source_candidate() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_release_asset_shadow_{stamp}"));
+        std::fs::create_dir_all(root.join("assets/svg")).unwrap();
+        std::fs::create_dir_all(root.join("src/assets/svg")).unwrap();
+        std::fs::write(root.join("assets/svg/used.svg"), "project asset").unwrap();
+        std::fs::write(root.join("src/assets/svg/used.svg"), "source shadow").unwrap();
+        let manifest = ResolvedAssetManifest {
+            manifest_path: root.join("assets/manifest.json"),
+            assets: vec![resolved(&root, "used", "assets/svg/used.svg")],
+        };
+        let sources = vec![(
+            "src/main.stasis".to_string(),
+            "function main(): void { hero.load_sprite_from(\"assets/svg/used.svg\", 32, 32); }"
+                .to_string(),
         )];
 
         let retained =

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3214,6 +3214,8 @@ fn build_workspace(
                         receipt.display()
                     )
                 })?,
+                Path::new("."),
+                None,
             )?;
             Ok(CommandResult::success(
                 format!("built JIT development image: {}", receipt.display()),
@@ -3235,6 +3237,10 @@ fn build_workspace(
                 None,
                 Some(Path::new(&workspace.manifest.entry)),
             )?;
+            let sources = crate::release_assets::load_entry_sources(
+                &workspace.root,
+                Path::new(&workspace.manifest.entry),
+            )?;
             stage_workspace_assets(
                 workspace,
                 summary.linked_image_path.parent().ok_or_else(|| {
@@ -3243,6 +3249,10 @@ fn build_workspace(
                         summary.linked_image_path.display()
                     )
                 })?,
+                Path::new(&workspace.manifest.entry)
+                    .parent()
+                    .unwrap_or_else(|| Path::new(".")),
+                Some(&sources),
             )?;
             Ok(CommandResult::success(
                 format!(
@@ -3358,12 +3368,27 @@ fn package_workspace(
     ))
 }
 
-fn stage_workspace_assets(workspace: &Workspace, destination_root: &Path) -> Result<(), String> {
+fn stage_workspace_assets(
+    workspace: &Workspace,
+    destination_root: &Path,
+    source_base_dir: &Path,
+    sources: Option<&[(String, String)]>,
+) -> Result<(), String> {
     let assets = workspace.root.join("assets");
     validate_workspace_destination(workspace, "assets directory", &assets)?;
     if workspace.root.join(DEFAULT_ASSET_MANIFEST_PATH).is_file() {
         let resolved = load_project_asset_manifest(&workspace.root, AssetLimits::default())
             .map_err(|error| format!("failed to resolve desktop build assets: {error}"))?;
+        let resolved = if let Some(sources) = sources {
+            crate::release_assets::retain_source_referenced_assets(
+                &workspace.root,
+                source_base_dir,
+                sources,
+                &resolved,
+            )?
+        } else {
+            resolved
+        };
         prepare_asset_bundle(
             &resolved,
             destination_root,
@@ -5921,6 +5946,8 @@ mod tests {
         assert!(java.contains("nativeReadRuntimeError"));
         assert!(java.contains("tick avg="));
         assert!(java.contains("verifyAssetManifest(staging)"));
+        assert!(java.contains("manifestVersion != 1 && manifestVersion != 2"));
+        assert!(java.contains("Asset verification failed before runtime startup"));
         assert!(java.contains("setOnApplyWindowInsetsListener"));
         let jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))

--- a/crates/stasis_assets/src/lib.rs
+++ b/crates/stasis_assets/src/lib.rs
@@ -170,6 +170,37 @@ impl ResolvedAssetManifest {
     pub fn by_handle(&self, handle: AssetHandle) -> Option<&ResolvedAsset> {
         self.assets.iter().find(|asset| asset.handle == handle)
     }
+
+    pub fn retain_paths(&self, paths: &BTreeSet<String>) -> Self {
+        let mut retained_ids = self
+            .assets
+            .iter()
+            .filter(|asset| paths.contains(&asset.entry.path))
+            .map(|asset| asset.entry.id.clone())
+            .collect::<BTreeSet<_>>();
+        loop {
+            let dependency_ids = self
+                .assets
+                .iter()
+                .filter(|asset| retained_ids.contains(&asset.entry.id))
+                .flat_map(|asset| asset.entry.dependencies.iter().cloned())
+                .collect::<BTreeSet<_>>();
+            let before = retained_ids.len();
+            retained_ids.extend(dependency_ids);
+            if retained_ids.len() == before {
+                break;
+            }
+        }
+        Self {
+            manifest_path: self.manifest_path.clone(),
+            assets: self
+                .assets
+                .iter()
+                .filter(|asset| retained_ids.contains(&asset.entry.id))
+                .cloned()
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -357,6 +388,9 @@ pub fn prepare_asset_bundle(
         .iter()
         .map(|asset| (asset.entry.id.as_str(), asset))
         .collect::<BTreeMap<_, _>>();
+    manifest
+        .assets
+        .retain(|entry| by_id.contains_key(entry.id.as_str()));
     let mut summary = PreparedAssetSummary {
         copied_assets: 0,
         resized_assets: 0,
@@ -1030,6 +1064,57 @@ mod tests {
         assert_eq!(
             resolved.by_handle(expected_handle).unwrap().byte_length,
             ball.len() as u64
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn retained_paths_include_dependencies_and_prepare_only_the_subset() {
+        let root = project("retained_paths");
+        let ball = b"ball png";
+        let paddle = b"paddle png";
+        let unused = b"unused png";
+        fs::write(root.join("assets/images/ball.png"), ball).unwrap();
+        fs::write(root.join("assets/images/paddle.png"), paddle).unwrap();
+        fs::write(root.join("assets/images/unused.png"), unused).unwrap();
+        let mut paddle_entry = sprite("paddle", "assets/images/paddle.png", paddle);
+        paddle_entry.dependencies.push("ball".to_string());
+        write_manifest(
+            &root,
+            vec![
+                sprite("ball", "assets/images/ball.png", ball),
+                paddle_entry,
+                sprite("unused", "assets/images/unused.png", unused),
+            ],
+        );
+
+        let resolved = load_project_asset_manifest(&root, AssetLimits::default()).unwrap();
+        let retained =
+            resolved.retain_paths(&BTreeSet::from(["assets/images/paddle.png".to_string()]));
+        assert_eq!(
+            retained
+                .assets
+                .iter()
+                .map(|asset| asset.entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ball", "paddle"]
+        );
+
+        let output = root.join("output");
+        prepare_asset_bundle(&retained, &output, root.join("cache")).unwrap();
+        assert!(output.join("assets/images/ball.png").is_file());
+        assert!(output.join("assets/images/paddle.png").is_file());
+        assert!(!output.join("assets/images/unused.png").exists());
+        let output_manifest: AssetManifest =
+            serde_json::from_slice(&fs::read(output.join(DEFAULT_ASSET_MANIFEST_PATH)).unwrap())
+                .unwrap();
+        assert_eq!(
+            output_manifest
+                .assets
+                .iter()
+                .map(|asset| asset.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ball", "paddle"]
         );
         fs::remove_dir_all(root).ok();
     }

--- a/docs/asset_manifest.md
+++ b/docs/asset_manifest.md
@@ -58,7 +58,9 @@ preparation metadata is not valid for fonts.
 
 Preparation writes only beneath the build output; project masters and the source manifest are never changed. The packaged manifest records the prepared dimensions and content hash. A resized entry also records `prepared_from_sha256`, which is the master hash. Preparation cache identity includes the master hash, algorithm version, and output dimensions, so unchanged assets can be reused deterministically.
 
-`stasis play` prepares the same bundle beneath `.stasis_cache/play-assets` before guest startup and mirrors the source directory's position relative to the project root. Existing source-relative paths such as `../assets/images/hero.png` therefore resolve to prepared output without source rewriting. Resized cache hits do not decode the master again. Both development and release `stasis build` commands stage the same prepared bundle beside their build output.
+`stasis play` prepares the same bundle beneath `.stasis_cache/play-assets` before guest startup and mirrors the source directory's position relative to the project root. Existing source-relative paths such as `../assets/images/hero.png` therefore resolve to prepared output without source rewriting. Resized cache hits do not decode the master again. Development builds stage the complete declared manifest so iterative and optional paths remain available.
+
+Release builds and mobile packages scan the entry module's reachable import graph and stage only declared assets named by string literals that resolve beneath the project `assets/` directory, plus their transitive manifest dependencies. Paths such as `../assets/images/hero.png` resolve relative to the selected entry file's directory, including when the literal appears in an imported module; project-root paths such as `assets/images/hero.png` are also accepted. These are the same resolution rules used at runtime. The generated manifest is rewritten to the same exact subset. Runtime asset paths therefore need to be static string literals in reachable production source; dynamically constructed paths are not a supported release-packaging contract. Test-only and unreachable modules do not enlarge a release package.
 
 Once a project has an asset manifest, every runtime-loaded asset must be declared. Source-only provenance files may remain elsewhere in the project, but undeclared files are not copied into prepared play or build output.
 
@@ -78,6 +80,7 @@ The package contains only the selected display envelope's output, not multiple r
 ## Mobile packaging
 
 - The AOT bundle command resolves and verifies the source manifest, then invokes the shared `stasis_assets` preparation path and packages the generated manifest and files under `assets/stasis_game/`.
+- Android and iOS apply the same reachable-source asset closure as desktop release builds; platform packaging does not carry unused manifest entries or alternate prepared sizes.
 - Declared fonts use the shared manifest path. As a compatibility supplement for projects that
   have not declared their path-based `load_font` assets yet, mobile packaging also scans compiled
   `.stasis` source string literals for `.ttf` and `.otf` paths and copies only referenced regular

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -40,6 +40,14 @@ Each output contains the same pieces:
 - `stasis_provenance.json`: verified release identity and content hashes
 - `android/` or `ios/`: a thin platform-native app project
 
+Mobile packaging follows the selected entry module's import graph. It includes only
+manifest assets referenced by static string literals in reachable production source,
+plus their transitive manifest dependencies, and emits a manifest containing that same
+subset. Relative literals use the selected entry file's directory as their base, even
+when they appear in imported modules. Keep dynamically chosen release asset paths out of
+string construction; declare the literal paths in reachable source instead. Android and
+iOS use the identical rule.
+
 The packaged runtime is the same canonical SDL command interpreter used by the
 desktop distribution. The versioned guest buffer and deterministic trace
 contract are documented in `shared_renderer_process.md`.

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -64,6 +65,7 @@ public final class MainActivity extends SDLActivity {
                 throw new IOException("Unable to publish " + root);
             }
         } catch (IOException error) {
+            Log.e("Stasis", "Asset verification failed before runtime startup", error);
             try {
                 deleteTree(staging);
             } catch (IOException ignored) {
@@ -243,8 +245,9 @@ public final class MainActivity extends SDLActivity {
         byte[] manifestBytes = readBounded(manifestFile, MAX_MANIFEST_BYTES);
         try {
             JSONObject manifest = new JSONObject(new String(manifestBytes, "UTF-8"));
+            int manifestVersion = manifest.optInt("version", -1);
             if (!"stasis-assets".equals(manifest.optString("schema"))
-                    || manifest.optInt("version", -1) != 1) {
+                    || (manifestVersion != 1 && manifestVersion != 2)) {
                 throw new IOException("Unsupported packaged asset manifest");
             }
             JSONArray assets = manifest.getJSONArray("assets");


### PR DESCRIPTION
## Summary
- filter desktop release, Android, and iOS bundles to static asset literals reachable from the selected entry import graph
- retain transitive manifest dependencies and rewrite the packaged manifest to the exact file subset
- keep development builds expansive
- accept current manifest v2 in the Android shell and log verification failures before startup

## Verification
- cargo test -p stasis_assets: 7 passed
- cargo test -p stasis --bin stasis: 177 passed
- Gambit Guard Windows/Android/iOS audits: 50 entries each (15 prepared PNG, 33 referenced SVG, 2 TTF); 24 unused SVGs omitted
- wireless Android diagnostic: JNI package fix plus manifest v2 acceptance stays alive and renders the tier screen

## Theory and reflection
Good: one source-graph closure now feeds every release platform, with dependency retention in the manifest layer.
Bad: the first real-project audit exposed that imported modules resolve asset literals from the selected entry directory, not their own source directory; the initial unit fixture did not model that.
Adjustment: the scanner now takes the runtime source base explicitly, docs state the rule, and real Gambit Guard packages are part of the evidence. A future dynamically selected asset should enter through an explicit manifest/runtime dependency mechanism rather than path construction.