### PR TITLE
Emit PIC for native macOS AOT

### DIFF
--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -91,7 +91,7 @@ impl AotTarget {
     }
 
     pub fn requires_position_independent_code(&self) -> bool {
-        !matches!(self, Self::Native)
+        !matches!(self, Self::Native) || cfg!(target_os = "macos")
     }
 }
 
@@ -797,7 +797,10 @@ echo "fake-shared" > "$OUT"
 
     #[test]
     fn aot_target_reports_position_independent_code_requirement() {
-        assert!(!AotTarget::Native.requires_position_independent_code());
+        assert_eq!(
+            AotTarget::Native.requires_position_independent_code(),
+            cfg!(target_os = "macos")
+        );
         assert!(AotTarget::android_arm64_default().requires_position_independent_code());
         assert!(AotTarget::android_x86_64_default().requires_position_independent_code());
         assert!(AotTarget::ios_arm64_default().requires_position_independent_code());


### PR DESCRIPTION
## Summary
- require position-independent Cranelift output for native macOS AOT
- keep native Windows and Linux behavior unchanged
- make the platform expectation explicit in the AOT target regression

## Validation
- focused stasis_jit PIC contract test: pass on Windows (native remains non-PIC)
- cargo fmt --check and git diff --check: pass
- official nightly evidence: Linux passed; macOS reached the bundled CLI smoke and failed specifically on illegal text relocations in the native standalone storage object
- the next macOS nightly run is the end-to-end acceptance gate for native arm64 PIC linking

## Theory gained
AotTarget::Native means the current host ABI, not one universal relocation policy. Native macOS executable links are PIE and therefore need PIC object emission just like explicit mobile targets; native Windows and Linux retain their established policy. An adjacent native macOS object containing any direct data reference should now link without text relocations.

## Reflection
- Good: the platform matrix isolated the macOS relocation contract immediately after the Windows storage fix.
- Bad: the previous API treated Native as if relocation requirements were platform-independent.
- Adjustment: host-native AOT properties must be tested as host-conditional contracts whenever they affect object emission.