### PR TITLE
Fix Windows nightly extraction for VS Code

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -381,7 +381,13 @@ jobs:
       - name: Extract and probe nightly toolchain
         shell: pwsh
         run: |
-          tar -xf "target/vscode-nightly/${{ matrix.archive }}.${{ matrix.ext }}" -C target/vscode-nightly
+          $extractRoot = if ($env:RUNNER_OS -eq "Windows") {
+            $env:STASIS_TOOLCHAIN_DIR
+          } else {
+            "target/vscode-nightly"
+          }
+          New-Item -ItemType Directory -Force $extractRoot | Out-Null
+          tar -xf "target/vscode-nightly/${{ matrix.archive }}.${{ matrix.ext }}" -C $extractRoot
           if (-not (Test-Path $env:STASIS_E2E_EXECUTABLE)) { throw "toolchain executable missing" }
           & $env:STASIS_E2E_EXECUTABLE --json editor-info
 


### PR DESCRIPTION
## Summary
- extract root-layout Windows toolchain ZIPs into the named toolchain directory expected by the VS Code job
- preserve the existing parent extraction path for directory-wrapped Linux/macOS tarballs
- keep the executable probe as the immediate acceptance check

## Validation
- downloaded exact stasis-nightly-win-x64 artifact from run 31128687340
- replayed corrected extraction into stasis-nightly-win-x64/`n- verified stasis.exe --json editor-info succeeds and reports nightly-20260806-178 at source commit 0707acf
- git diff --check: pass

## Theory gained
The build artifacts deliberately differ in their internal root layout: Compress-Archive -Path out/* produces a root-layout Windows ZIP, while Unix tarballs carry the named archive directory. Extraction must normalize those formats into one STASIS_TOOLCHAIN_DIR contract before extension packaging. An adjacent root-layout Windows archive should now probe without changing the release archive itself.

## Reflection
- Good: replaying the exact Actions artifact made the layout mismatch concrete.
- Bad: the extension job assumed archive-root symmetry that the build steps never guaranteed.
- Adjustment: cross-format release consumers should normalize extraction destinations, then assert one canonical directory contract.