### PR TITLE
Add bounded ASCII storage and clipboard APIs

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1414,6 +1414,14 @@ fn prepare_play_asset_working_dir(watch_dir: &Path) -> Result<PathBuf, String> {
     Ok(prepared_watch_dir)
 }
 
+fn resolve_play_asset_source_dir(watch_file: &Path, watch_dir: &Path) -> PathBuf {
+    watch_file
+        .parent()
+        .filter(|parent| parent.starts_with(watch_dir))
+        .unwrap_or(watch_dir)
+        .to_path_buf()
+}
+
 const PLAY_INPUT_MAX_FRAMES: usize = 10_000;
 const PLAY_INPUT_MAX_POINTERS: usize = 8;
 const PLAY_INPUT_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
@@ -1829,8 +1837,8 @@ fn run_play_in_process_inner(
         validate_play_input_script_ticks(max_ticks, timeline)?;
     }
 
-    // Make relative asset paths (e.g. "assets/ball.svg") resolve against the game directory.
-    // Use the watch dir so dev workflows stay consistent across `stasis.exe` launch locations.
+    // Watch the requested project scope, but resolve source-relative assets from the entry
+    // module's directory. These differ for root-scoped QA runs whose entry lives under tests/.
     let watch_dir_abs = watch_dir
         .canonicalize()
         .unwrap_or_else(|_| watch_dir.clone());
@@ -1878,7 +1886,8 @@ fn run_play_in_process_inner(
         resolve_play_project_root(&root_path, &watch_dir_abs, &canonical_repository)?
     };
 
-    let asset_working_dir = prepare_play_asset_working_dir(&watch_dir_abs)?;
+    let asset_source_dir = resolve_play_asset_source_dir(&root_path, &watch_dir_abs);
+    let asset_working_dir = prepare_play_asset_working_dir(&asset_source_dir)?;
     std::env::set_current_dir(&asset_working_dir).map_err(|error| {
         format!(
             "failed to set current directory to {}: {error}",
@@ -6061,6 +6070,20 @@ mod tests {
         );
         assert!(root.join(".stasis_cache/assets").is_dir());
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn play_asset_source_directory_follows_entry_with_root_scoped_watching() {
+        let root = PathBuf::from("project");
+        let entry = root.join("tests/qa_scenario.stasis");
+        assert_eq!(
+            resolve_play_asset_source_dir(&entry, &root),
+            root.join("tests")
+        );
+        assert_eq!(
+            resolve_play_asset_source_dir(Path::new("outside/game.stasis"), &root),
+            root
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2500,7 +2500,7 @@ mod tests {
         let mut process = AotProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;\nextern function gfx_release_sprite(handle: i32): void;\nextern function load_font(path: string, size: i32): i32;\nextern function measure_text(font: i32, text: string): f32;\nfunction @extern(\"stasis_gfx_cache_text\") gfx_cache_text(font: i32, text: string): i32;\nextern function storage_load_i32(scope: string, key: string, fallback: i32): i32;\nextern function storage_save_i32(scope: string, key: string, value: i32): bool;\nfunction main(): i32 { gfx_release_sprite(0); return 0; }\n",
+            "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;\nextern function gfx_release_sprite(handle: i32): void;\nextern function load_font(path: string, size: i32): i32;\nextern function measure_text(font: i32, text: string): f32;\nfunction @extern(\"stasis_gfx_cache_text\") gfx_cache_text(font: i32, text: string): i32;\nextern function storage_load_i32(scope: string, key: string, fallback: i32): i32;\nextern function storage_save_i32(scope: string, key: string, value: i32): bool;\nfunction @extern(\"stasis_jit_storage_load_ascii\") storage_load_ascii(scope: string, key: string, out: ascii[], capacity: i32): i32;\nfunction @extern(\"stasis_jit_storage_save_ascii\") storage_save_ascii(scope: string, key: string, value: ascii[], length: i32): i32;\nfunction @extern(\"stasis_jit_clipboard_load_ascii\") clipboard_load_ascii(out: ascii[], capacity: i32): i32;\nfunction @extern(\"stasis_jit_clipboard_save_ascii\") clipboard_save_ascii(value: ascii[], length: i32): i32;\nfunction main(): i32 { gfx_release_sprite(0); return 0; }\n",
         );
         process.compile().expect("compile");
 
@@ -2542,6 +2542,22 @@ mod tests {
         assert_eq!(
             resolved.get("storage_save_i32").copied(),
             Some("stasis_jit_storage_save_i32")
+        );
+        assert_eq!(
+            resolved.get("storage_load_ascii").copied(),
+            Some("stasis_jit_storage_load_ascii")
+        );
+        assert_eq!(
+            resolved.get("storage_save_ascii").copied(),
+            Some("stasis_jit_storage_save_ascii")
+        );
+        assert_eq!(
+            resolved.get("clipboard_load_ascii").copied(),
+            Some("stasis_jit_clipboard_load_ascii")
+        );
+        assert_eq!(
+            resolved.get("clipboard_save_ascii").copied(),
+            Some("stasis_jit_clipboard_save_ascii")
         );
     }
 

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2879,8 +2879,24 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "sleep_ms" | "stasis_sleep_ms" | "stasis_jit_sleep_ms" => {
             function_address(stasis_dynload::stasis_jit_sleep_ms as *const ())
         }
+        "clipboard_load_ascii"
+        | "stasis_clipboard_load_ascii"
+        | "stasis_jit_clipboard_load_ascii" => {
+            function_address(stasis_dynload::stasis_jit_clipboard_load_ascii as *const ())
+        }
+        "clipboard_save_ascii"
+        | "stasis_clipboard_save_ascii"
+        | "stasis_jit_clipboard_save_ascii" => {
+            function_address(stasis_dynload::stasis_jit_clipboard_save_ascii as *const ())
+        }
+        "storage_load_ascii" | "stasis_storage_load_ascii" | "stasis_jit_storage_load_ascii" => {
+            function_address(stasis_dynload::stasis_jit_storage_load_ascii as *const ())
+        }
         "storage_load_i32" | "stasis_storage_load_i32" | "stasis_jit_storage_load_i32" => {
             function_address(stasis_dynload::stasis_jit_storage_load_i32 as *const ())
+        }
+        "storage_save_ascii" | "stasis_storage_save_ascii" | "stasis_jit_storage_save_ascii" => {
+            function_address(stasis_dynload::stasis_jit_storage_save_ascii as *const ())
         }
         "storage_save_i32" | "stasis_storage_save_i32" | "stasis_jit_storage_save_i32" => {
             function_address(stasis_dynload::stasis_jit_storage_save_i32 as *const ())

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -48,7 +48,11 @@ pub(crate) const AOT_RUNTIME_EXPORT_SYMBOLS: &[&str] = &[
     "stasis_jit_reject_code_swap",
     "stasis_jit_sin_fast",
     "stasis_jit_sleep_ms",
+    "stasis_jit_clipboard_load_ascii",
+    "stasis_jit_clipboard_save_ascii",
+    "stasis_jit_storage_load_ascii",
     "stasis_jit_storage_load_i32",
+    "stasis_jit_storage_save_ascii",
     "stasis_jit_storage_save_i32",
     "stasis_jit_sys_memcpy_f32",
     "stasis_jit_sys_memcpy_i32",
@@ -70,6 +74,9 @@ mod tests {
     fn aot_runtime_export_contract_requires_exact_symbol_matches() {
         assert!(is_aot_runtime_export_symbol("stasis_jit_gfx_load_sprite"));
         assert!(is_aot_runtime_export_symbol("stasis_jit_storage_load_i32"));
+        assert!(is_aot_runtime_export_symbol(
+            "stasis_jit_clipboard_load_ascii"
+        ));
         assert!(is_aot_runtime_export_symbol(
             "stasis_jit_gfx_release_sprite"
         ));

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1052,8 +1052,14 @@ struct StasisGraphicsAssetsApi {
     stasis_gfx_cache_text: usize,
     stasis_gfx_measure_text_cached: usize,
     stasis_gfx_measure_text_cached_height: usize,
+    stasis_clipboard_load_ascii: Option<usize>,
+    stasis_clipboard_save_ascii: Option<usize>,
+    #[cfg(windows)]
+    stasis_storage_load_ascii: Option<usize>,
     #[cfg(windows)]
     stasis_storage_load_i32: Option<usize>,
+    #[cfg(windows)]
+    stasis_storage_save_ascii: Option<usize>,
     #[cfg(windows)]
     stasis_storage_save_i32: Option<usize>,
 }
@@ -1095,8 +1101,14 @@ impl StasisGraphicsAssetsApi {
             stasis_gfx_measure_text_cached: lib.symbol_address("stasis_gfx_measure_text_cached")?,
             stasis_gfx_measure_text_cached_height: lib
                 .symbol_address("stasis_gfx_measure_text_cached_height")?,
+            stasis_clipboard_load_ascii: lib.symbol_address("stasis_clipboard_load_ascii").ok(),
+            stasis_clipboard_save_ascii: lib.symbol_address("stasis_clipboard_save_ascii").ok(),
+            #[cfg(windows)]
+            stasis_storage_load_ascii: lib.symbol_address("stasis_storage_load_ascii").ok(),
             #[cfg(windows)]
             stasis_storage_load_i32: lib.symbol_address("stasis_storage_load_i32").ok(),
+            #[cfg(windows)]
+            stasis_storage_save_ascii: lib.symbol_address("stasis_storage_save_ascii").ok(),
             #[cfg(windows)]
             stasis_storage_save_i32: lib.symbol_address("stasis_storage_save_i32").ok(),
             _lib: lib,
@@ -3299,7 +3311,7 @@ fn preference_component_valid(value: &[u8]) -> bool {
 }
 
 #[cfg(not(windows))]
-fn preference_i32_path(scope: &[u8], key: &[u8]) -> Option<PathBuf> {
+fn preference_path(scope: &[u8], key: &[u8], extension: &str) -> Option<PathBuf> {
     if !preference_component_valid(scope) || !preference_component_valid(key) {
         return None;
     }
@@ -3308,13 +3320,13 @@ fn preference_i32_path(scope: &[u8], key: &[u8]) -> Option<PathBuf> {
     Some(
         preference_storage_root()?
             .join(scope)
-            .join(format!("{key}.i32")),
+            .join(format!("{key}.{extension}")),
     )
 }
 
 #[cfg(not(windows))]
 fn portable_storage_load_i32(scope: &[u8], key: &[u8], fallback: i32) -> i32 {
-    let Some(path) = preference_i32_path(scope, key) else {
+    let Some(path) = preference_path(scope, key, "i32") else {
         return fallback;
     };
     let Ok(bytes) = std::fs::read(path) else {
@@ -3331,7 +3343,7 @@ fn portable_storage_load_i32(scope: &[u8], key: &[u8], fallback: i32) -> i32 {
 
 #[cfg(not(windows))]
 fn portable_storage_save_i32(scope: &[u8], key: &[u8], value: i32) -> bool {
-    let Some(path) = preference_i32_path(scope, key) else {
+    let Some(path) = preference_path(scope, key, "i32") else {
         return false;
     };
     let Some(directory) = path.parent() else {
@@ -3352,6 +3364,208 @@ fn portable_storage_save_i32(scope: &[u8], key: &[u8], value: i32) -> bool {
         return false;
     }
     true
+}
+
+fn printable_ascii(bytes: &[u8]) -> bool {
+    bytes.iter().all(|byte| (32..=126).contains(byte))
+}
+
+fn write_jit_ascii_buffer(out_id: i32, capacity: i32, bytes: &[u8]) -> i32 {
+    let Ok(capacity) = usize::try_from(capacity) else {
+        return -1;
+    };
+    if bytes.len() > capacity || !printable_ascii(bytes) {
+        return -1;
+    }
+    for (index, byte) in bytes.iter().enumerate() {
+        stasis_jit_global_i32_array_store(out_id, 0, index as i32, i32::from(*byte));
+    }
+    bytes.len() as i32
+}
+
+#[cfg(not(windows))]
+fn portable_storage_load_ascii(scope: &[u8], key: &[u8], capacity: i32) -> Option<Vec<u8>> {
+    let path = preference_path(scope, key, "ascii")?;
+    let bytes = std::fs::read(path).ok()?;
+    if bytes.len() > usize::try_from(capacity).ok()? || !printable_ascii(&bytes) {
+        return None;
+    }
+    Some(bytes)
+}
+
+#[cfg(not(windows))]
+fn portable_storage_save_ascii(scope: &[u8], key: &[u8], value: &[u8]) -> bool {
+    if !printable_ascii(value) {
+        return false;
+    }
+    let Some(path) = preference_path(scope, key, "ascii") else {
+        return false;
+    };
+    let Some(directory) = path.parent() else {
+        return false;
+    };
+    if std::fs::create_dir_all(directory).is_err() {
+        return false;
+    }
+    let temporary = path.with_extension("ascii.tmp");
+    let result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&temporary)?;
+        file.write_all(value)?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, &path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(temporary);
+        return false;
+    }
+    true
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_storage_load_ascii(
+    scope_id: i32,
+    key_id: i32,
+    out_id: i32,
+    capacity: i32,
+) -> i32 {
+    if capacity <= 0 {
+        return -1;
+    }
+    #[cfg(windows)]
+    {
+        let (Ok(scope), Ok(key)) = (
+            jit_text_arg_to_cstring(scope_id),
+            jit_text_arg_to_cstring(key_id),
+        ) else {
+            return -1;
+        };
+        let Ok(api) = stasis_graphics_assets_api() else {
+            return -1;
+        };
+        let Some(address) = api.stasis_storage_load_ascii else {
+            return -1;
+        };
+        let mut bytes = vec![0_u8; capacity as usize];
+        let callback: extern "system" fn(*const c_char, *const c_char, *mut c_char, i32) -> i32 =
+            unsafe { std::mem::transmute(address) };
+        let loaded = callback(
+            scope.as_ptr(),
+            key.as_ptr(),
+            bytes.as_mut_ptr().cast::<c_char>(),
+            capacity,
+        );
+        if loaded < 0 || loaded > capacity {
+            return -1;
+        }
+        return write_jit_ascii_buffer(out_id, capacity, &bytes[..loaded as usize]);
+    }
+    #[cfg(not(windows))]
+    {
+        let (Some(scope), Some(key)) = (jit_text_arg_bytes(scope_id), jit_text_arg_bytes(key_id))
+        else {
+            return -1;
+        };
+        let Some(bytes) = portable_storage_load_ascii(&scope, &key, capacity) else {
+            return -1;
+        };
+        write_jit_ascii_buffer(out_id, capacity, &bytes)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_storage_save_ascii(
+    scope_id: i32,
+    key_id: i32,
+    value_id: i32,
+    length: i32,
+) -> i32 {
+    let (Some(scope), Some(key), Some(value)) = (
+        jit_text_arg_bytes(scope_id),
+        jit_text_arg_bytes(key_id),
+        jit_text_arg_bytes(value_id),
+    ) else {
+        return 0;
+    };
+    let Ok(length) = usize::try_from(length) else {
+        return 0;
+    };
+    if length > value.len() || !printable_ascii(&value[..length]) {
+        return 0;
+    }
+    #[cfg(windows)]
+    {
+        let (Ok(scope), Ok(key)) = (CString::new(scope), CString::new(key)) else {
+            return 0;
+        };
+        let Ok(api) = stasis_graphics_assets_api() else {
+            return 0;
+        };
+        let Some(address) = api.stasis_storage_save_ascii else {
+            return 0;
+        };
+        let callback: extern "system" fn(*const c_char, *const c_char, *const c_char, i32) -> i32 =
+            unsafe { std::mem::transmute(address) };
+        return callback(
+            scope.as_ptr(),
+            key.as_ptr(),
+            value.as_ptr().cast::<c_char>(),
+            length as i32,
+        );
+    }
+    #[cfg(not(windows))]
+    {
+        portable_storage_save_ascii(&scope, &key, &value[..length]) as i32
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_clipboard_load_ascii(out_id: i32, capacity: i32) -> i32 {
+    if capacity <= 0 {
+        return -1;
+    }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return -1;
+    };
+    let Some(address) = api.stasis_clipboard_load_ascii else {
+        return -1;
+    };
+    let mut bytes = vec![0_u8; capacity as usize];
+    #[cfg(windows)]
+    let callback: extern "system" fn(*mut c_char, i32) -> i32 =
+        unsafe { std::mem::transmute(address) };
+    #[cfg(not(windows))]
+    let callback: extern "C" fn(*mut c_char, i32) -> i32 = unsafe { std::mem::transmute(address) };
+    let loaded = callback(bytes.as_mut_ptr().cast::<c_char>(), capacity);
+    if loaded < 0 || loaded > capacity {
+        return -1;
+    }
+    write_jit_ascii_buffer(out_id, capacity, &bytes[..loaded as usize])
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_clipboard_save_ascii(value_id: i32, length: i32) -> i32 {
+    let Some(value) = jit_text_arg_bytes(value_id) else {
+        return 0;
+    };
+    let Ok(length) = usize::try_from(length) else {
+        return 0;
+    };
+    if length > value.len() || !printable_ascii(&value[..length]) {
+        return 0;
+    }
+    let Ok(api) = stasis_graphics_assets_api() else {
+        return 0;
+    };
+    let Some(address) = api.stasis_clipboard_save_ascii else {
+        return 0;
+    };
+    #[cfg(windows)]
+    let callback: extern "system" fn(*const c_char, i32) -> i32 =
+        unsafe { std::mem::transmute(address) };
+    #[cfg(not(windows))]
+    let callback: extern "C" fn(*const c_char, i32) -> i32 =
+        unsafe { std::mem::transmute(address) };
+    callback(value.as_ptr().cast::<c_char>(), length as i32)
 }
 
 #[no_mangle]

--- a/docs/runtime_storage.md
+++ b/docs/runtime_storage.md
@@ -1,4 +1,4 @@
-# Runtime integer storage
+# Runtime preference storage
 
 Import `src/stdlib/storage.stasis` when a game needs a small durable integer such as an unlocked level, high score, or settings version.
 
@@ -16,3 +16,27 @@ The graphical desktop host stores values under SDL's app-private preference dire
 Every host uses the explicit game scope. Scope and key are restricted to 1-63 ASCII letters, digits, underscores, or hyphens; invalid names fail closed. A missing, invalid, or corrupt value returns the supplied fallback. Save returns `true` only after the complete integer value has been written and atomically published.
 
 This API is intentionally narrow. It does not expose arbitrary filesystem paths, enumerate other games' values, serialize game memory, or provide a general document store. A future typed preference should extend the same scoped host boundary rather than exposing platform paths to Stasis code.
+
+Small printable-ASCII values use the same scoped boundary. The caller owns the
+buffer and therefore the maximum accepted size:
+
+```stasis
+import "../src/stdlib/storage.stasis";
+
+global share_code: ascii[4096];
+
+if (storage_load_ascii("my_game", "draft_level", share_code) >= 0) {
+    // share_code.length is set to the loaded byte count.
+}
+storage_save_ascii("my_game", "draft_level", share_code);
+```
+
+Only bytes 32-126 are accepted. Loading returns `-1` when the value is missing,
+invalid, unavailable, or larger than the destination. Saving rejects invalid
+scope/key components and non-printable bytes and atomically publishes the
+complete value.
+
+For explicit player sharing, `src/stdlib/clipboard.stasis` exposes the matching
+bounded `clipboard_load_ascii` and `clipboard_save_ascii` calls. Clipboard
+access is supported by graphical SDL hosts; unavailable or invalid clipboard
+contents fail closed without changing the destination length.

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -109,7 +109,11 @@ STASIS_EXPORT int stasis_gfx_cache_text(int font_handle, const char* text);
 STASIS_EXPORT void stasis_gfx_draw_text_cached(int run_handle, float x, float y, float r, float g, float b, float a);
 STASIS_EXPORT float stasis_gfx_measure_text_cached(int run_handle);
 STASIS_EXPORT float stasis_gfx_measure_text_cached_height(int run_handle);
+STASIS_EXPORT int stasis_clipboard_load_ascii(char* out, int capacity);
+STASIS_EXPORT int stasis_clipboard_save_ascii(const char* value, int length);
+STASIS_EXPORT int stasis_storage_load_ascii(const char* scope, const char* key, char* out, int capacity);
 STASIS_EXPORT int stasis_storage_load_i32(const char* scope, const char* key, int fallback);
+STASIS_EXPORT int stasis_storage_save_ascii(const char* scope, const char* key, const char* value, int length);
 STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, int value);
 
 STASIS_EXPORT int stasis_graphics_runtime_abi_version(void) {
@@ -5189,9 +5193,10 @@ static int stasis_storage_component_valid(const char* value) {
     return 1;
 }
 
-static int stasis_storage_i32_path(
+static int stasis_storage_path(
     const char* scope,
     const char* key,
+    const char* extension,
     char* path,
     size_t capacity,
     char** owned_root
@@ -5204,7 +5209,7 @@ static int stasis_storage_i32_path(
     }
     root = SDL_GetPrefPath("StasisLang", scope);
     if (!root) return 0;
-    written = snprintf(path, capacity, "%s%s.i32", root, key);
+    written = snprintf(path, capacity, "%s%s.%s", root, key, extension);
     if (written < 0 || (size_t)written >= capacity) {
         SDL_free(root);
         return 0;
@@ -5221,7 +5226,7 @@ STASIS_EXPORT int stasis_storage_load_i32(const char* scope, const char* key, in
     long long parsed;
     FILE* file;
     int trailing;
-    if (!stasis_storage_i32_path(scope, key, path, sizeof(path), &root)) return fallback;
+    if (!stasis_storage_path(scope, key, "i32", path, sizeof(path), &root)) return fallback;
     file = fopen(path, "rb");
     SDL_free(root);
     if (!file) return fallback;
@@ -5249,7 +5254,7 @@ STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, in
     int path_written;
     int text_written;
     int ok = 1;
-    if (!stasis_storage_i32_path(scope, key, path, sizeof(path), &root)) return 0;
+    if (!stasis_storage_path(scope, key, "i32", path, sizeof(path), &root)) return 0;
     SDL_free(root);
     path_written = snprintf(temp_path, sizeof(temp_path), "%s.tmp", path);
     text_written = snprintf(text, sizeof(text), "%d\n", value);
@@ -5278,6 +5283,116 @@ STASIS_EXPORT int stasis_storage_save_i32(const char* scope, const char* key, in
     }
 #endif
     return 1;
+}
+
+STASIS_EXPORT int stasis_storage_load_ascii(const char* scope, const char* key, char* out, int capacity) {
+    char path[1024];
+    char* root = NULL;
+    FILE* file;
+    int count;
+    int trailing;
+    int index;
+    if (!out || capacity <= 0 ||
+        !stasis_storage_path(scope, key, "ascii", path, sizeof(path), &root)) return -1;
+    file = fopen(path, "rb");
+    SDL_free(root);
+    if (!file) return -1;
+    count = (int)fread(out, 1, (size_t)capacity, file);
+    trailing = fgetc(file);
+    fclose(file);
+    if (trailing != EOF) return -1;
+    for (index = 0; index < count; index += 1) {
+        unsigned char ch = (unsigned char)out[index];
+        if (ch < 32 || ch > 126) return -1;
+    }
+    return count;
+}
+
+STASIS_EXPORT int stasis_storage_save_ascii(
+    const char* scope,
+    const char* key,
+    const char* value,
+    int length
+) {
+    char path[1024];
+    char temp_path[1032];
+    char* root = NULL;
+    FILE* file;
+    int path_written;
+    int index;
+    int ok = 1;
+    if (!value || length < 0 ||
+        !stasis_storage_path(scope, key, "ascii", path, sizeof(path), &root)) return 0;
+    SDL_free(root);
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (ch < 32 || ch > 126) return 0;
+    }
+    path_written = snprintf(temp_path, sizeof(temp_path), "%s.tmp", path);
+    if (path_written < 0 || (size_t)path_written >= sizeof(temp_path)) return 0;
+    file = fopen(temp_path, "wb");
+    if (!file) return 0;
+    if (fwrite(value, 1, (size_t)length, file) != (size_t)length) ok = 0;
+    if (ok && fflush(file) != 0) ok = 0;
+    if (fclose(file) != 0) ok = 0;
+    if (!ok) {
+        remove(temp_path);
+        return 0;
+    }
+#if defined(_WIN32)
+    if (!MoveFileExA(temp_path, path, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        remove(temp_path);
+        return 0;
+    }
+#else
+    if (rename(temp_path, path) != 0) {
+        remove(temp_path);
+        return 0;
+    }
+#endif
+    return 1;
+}
+
+STASIS_EXPORT int stasis_clipboard_load_ascii(char* out, int capacity) {
+    char* text;
+    size_t count;
+    size_t index;
+    if (!out || capacity <= 0) return -1;
+    text = SDL_GetClipboardText();
+    if (!text) return -1;
+    count = strlen(text);
+    if (count > (size_t)capacity) {
+        SDL_free(text);
+        return -1;
+    }
+    for (index = 0; index < count; index += 1) {
+        unsigned char ch = (unsigned char)text[index];
+        if (ch < 32 || ch > 126) {
+            SDL_free(text);
+            return -1;
+        }
+    }
+    memcpy(out, text, count);
+    SDL_free(text);
+    return (int)count;
+}
+
+STASIS_EXPORT int stasis_clipboard_save_ascii(const char* value, int length) {
+    char* text;
+    int index;
+    int result;
+    if (!value || length < 0) return 0;
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (ch < 32 || ch > 126) return 0;
+    }
+    text = (char*)malloc((size_t)length + 1);
+    if (!text) return 0;
+    memcpy(text, value, (size_t)length);
+    text[length] = '\0';
+    result = SDL_SetClipboardText(text) ? 1 : 0;
+    free(text);
+    return result;
 }
 
 /*

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -22,7 +22,11 @@ EXPORTS
     stasis_get_time_ms
     stasis_get_time_us
     stasis_sleep_ms
+    stasis_clipboard_load_ascii
+    stasis_clipboard_save_ascii
+    stasis_storage_load_ascii
     stasis_storage_load_i32
+    stasis_storage_save_ascii
     stasis_storage_save_i32
     stasis_audio_init
     stasis_audio_shutdown

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -33,6 +33,10 @@ float stasis_measure_text(int font, const char *text);
 void stasis_sleep_ms(int ms);
 int stasis_storage_load_i32(const char *scope, const char *key, int fallback);
 int stasis_storage_save_i32(const char *scope, const char *key, int value);
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity);
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length);
+int stasis_clipboard_load_ascii(char *out, int capacity);
+int stasis_clipboard_save_ascii(const char *value, int length);
 
 typedef union StasisScalarValue {
     int32_t i32_value;
@@ -517,6 +521,69 @@ float stasis_jit_measure_text(int32_t font, int32_t text) {
     return result;
 }
 void stasis_jit_sleep_ms(int32_t ms) { stasis_sleep_ms(ms); }
+static int stasis_write_ascii_result(int32_t out, const char *value, int length, int capacity) {
+    int index;
+    if (length < 0 || length > capacity) return -1;
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (ch < 32 || ch > 126) return -1;
+        stasis_jit_global_i32_array_store(out, 0, index, (int32_t)ch);
+    }
+    return length;
+}
+int stasis_jit_storage_load_ascii(int32_t scope, int32_t key, int32_t out, int32_t capacity) {
+    char *scope_value;
+    char *key_value;
+    char *buffer;
+    int loaded;
+    if (capacity <= 0) return -1;
+    scope_value = resolve_text(scope);
+    key_value = resolve_text(key);
+    buffer = (char *)malloc((size_t)capacity);
+    if (scope_value == NULL || key_value == NULL || buffer == NULL) {
+        free(scope_value);
+        free(key_value);
+        free(buffer);
+        return -1;
+    }
+    loaded = stasis_storage_load_ascii(scope_value, key_value, buffer, capacity);
+    loaded = stasis_write_ascii_result(out, buffer, loaded, capacity);
+    free(scope_value);
+    free(key_value);
+    free(buffer);
+    return loaded;
+}
+int stasis_jit_storage_save_ascii(int32_t scope, int32_t key, int32_t value, int32_t length) {
+    char *scope_value = resolve_text(scope);
+    char *key_value = resolve_text(key);
+    char *text_value = resolve_text(value);
+    int result = scope_value == NULL || key_value == NULL || text_value == NULL || length < 0
+        ? 0
+        : stasis_storage_save_ascii(scope_value, key_value, text_value, length);
+    free(scope_value);
+    free(key_value);
+    free(text_value);
+    return result;
+}
+int stasis_jit_clipboard_load_ascii(int32_t out, int32_t capacity) {
+    char *buffer;
+    int loaded;
+    if (capacity <= 0) return -1;
+    buffer = (char *)malloc((size_t)capacity);
+    if (buffer == NULL) return -1;
+    loaded = stasis_clipboard_load_ascii(buffer, capacity);
+    loaded = stasis_write_ascii_result(out, buffer, loaded, capacity);
+    free(buffer);
+    return loaded;
+}
+int stasis_jit_clipboard_save_ascii(int32_t value, int32_t length) {
+    char *text_value = resolve_text(value);
+    int result = text_value == NULL || length < 0
+        ? 0
+        : stasis_clipboard_save_ascii(text_value, length);
+    free(text_value);
+    return result;
+}
 int stasis_jit_storage_load_i32(int32_t scope, int32_t key, int32_t fallback) {
     char *scope_value = resolve_text(scope);
     char *key_value = resolve_text(key);

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -98,7 +98,11 @@ int stasis_jit_text_run_load_from(int32_t base, int32_t index, int32_t len, int3
 int stasis_jit_load_font(int32_t path, int32_t size);
 float stasis_jit_measure_text(int32_t font, int32_t text);
 void stasis_jit_sleep_ms(int32_t ms);
+int stasis_jit_clipboard_load_ascii(int32_t out, int32_t capacity);
+int stasis_jit_clipboard_save_ascii(int32_t value, int32_t length);
+int stasis_jit_storage_load_ascii(int32_t scope, int32_t key, int32_t out, int32_t capacity);
 int stasis_jit_storage_load_i32(int32_t scope, int32_t key, int32_t fallback);
+int stasis_jit_storage_save_ascii(int32_t scope, int32_t key, int32_t value, int32_t length);
 int stasis_jit_storage_save_i32(int32_t scope, int32_t key, int32_t value);
 int stasis_mobile_json_escape(const char *input, char *output, size_t capacity);
 void stasis_mobile_aot_reset(void);

--- a/runtime/stasis_platform_storage.c
+++ b/runtime/stasis_platform_storage.c
@@ -42,9 +42,10 @@ int stasis_storage_set_root(const char *root) {
     return stasis_storage_ensure_directory(stasis_storage_root);
 }
 
-static int stasis_storage_i32_path(
+static int stasis_storage_path(
     const char *scope,
     const char *key,
+    const char *extension,
     char *path,
     size_t capacity
 ) {
@@ -56,7 +57,7 @@ static int stasis_storage_i32_path(
     directory_written = snprintf(directory, sizeof(directory), "%s/%s", stasis_storage_root, scope);
     if (directory_written < 0 || (size_t)directory_written >= sizeof(directory) ||
         !stasis_storage_ensure_directory(directory)) return 0;
-    path_written = snprintf(path, capacity, "%s/%s.i32", directory, key);
+    path_written = snprintf(path, capacity, "%s/%s.%s", directory, key, extension);
     return path_written >= 0 && (size_t)path_written < capacity;
 }
 
@@ -67,7 +68,7 @@ int stasis_storage_load_i32(const char *scope, const char *key, int fallback) {
     long long parsed;
     FILE *file;
     int trailing;
-    if (!stasis_storage_i32_path(scope, key, path, sizeof(path))) return fallback;
+    if (!stasis_storage_path(scope, key, "i32", path, sizeof(path))) return fallback;
     file = fopen(path, "rb");
     if (file == NULL) return fallback;
     if (fgets(buffer, sizeof(buffer), file) == NULL) {
@@ -91,12 +92,60 @@ int stasis_storage_save_i32(const char *scope, const char *key, int value) {
     FILE *file;
     int temporary_written;
     int ok = 1;
-    if (!stasis_storage_i32_path(scope, key, path, sizeof(path))) return 0;
+    if (!stasis_storage_path(scope, key, "i32", path, sizeof(path))) return 0;
     temporary_written = snprintf(temporary, sizeof(temporary), "%s.tmp", path);
     if (temporary_written < 0 || (size_t)temporary_written >= sizeof(temporary)) return 0;
     file = fopen(temporary, "wb");
     if (file == NULL) return 0;
     if (fprintf(file, "%d\n", value) < 0) ok = 0;
+    if (ok && fflush(file) != 0) ok = 0;
+    if (fclose(file) != 0) ok = 0;
+    if (!ok || rename(temporary, path) != 0) {
+        remove(temporary);
+        return 0;
+    }
+    return 1;
+}
+
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity) {
+    char path[STASIS_STORAGE_PATH_CAPACITY];
+    FILE *file;
+    int count;
+    int trailing;
+    int index;
+    if (out == NULL || capacity <= 0 ||
+        !stasis_storage_path(scope, key, "ascii", path, sizeof(path))) return -1;
+    file = fopen(path, "rb");
+    if (file == NULL) return -1;
+    count = (int)fread(out, 1, (size_t)capacity, file);
+    trailing = fgetc(file);
+    fclose(file);
+    if (trailing != EOF) return -1;
+    for (index = 0; index < count; index += 1) {
+        unsigned char ch = (unsigned char)out[index];
+        if (ch < 32 || ch > 126) return -1;
+    }
+    return count;
+}
+
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length) {
+    char path[STASIS_STORAGE_PATH_CAPACITY];
+    char temporary[STASIS_STORAGE_PATH_CAPACITY + 8];
+    FILE *file;
+    int temporary_written;
+    int index;
+    int ok = 1;
+    if (value == NULL || length < 0 ||
+        !stasis_storage_path(scope, key, "ascii", path, sizeof(path))) return 0;
+    for (index = 0; index < length; index += 1) {
+        unsigned char ch = (unsigned char)value[index];
+        if (ch < 32 || ch > 126) return 0;
+    }
+    temporary_written = snprintf(temporary, sizeof(temporary), "%s.tmp", path);
+    if (temporary_written < 0 || (size_t)temporary_written >= sizeof(temporary)) return 0;
+    file = fopen(temporary, "wb");
+    if (file == NULL) return 0;
+    if (fwrite(value, 1, (size_t)length, file) != (size_t)length) ok = 0;
     if (ok && fflush(file) != 0) ok = 0;
     if (fclose(file) != 0) ok = 0;
     if (!ok || rename(temporary, path) != 0) {

--- a/runtime/stasis_platform_storage.h
+++ b/runtime/stasis_platform_storage.h
@@ -4,5 +4,7 @@
 int stasis_storage_set_root(const char *root);
 int stasis_storage_load_i32(const char *scope, const char *key, int fallback);
 int stasis_storage_save_i32(const char *scope, const char *key, int value);
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity);
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length);
 
 #endif

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -33,6 +33,9 @@ static char saved_scope[64];
 static char saved_key[64];
 static int saved_value;
 static int has_saved_value;
+static char saved_ascii[64];
+static int saved_ascii_length;
+static char clipboard_ascii[64] = "GG1-clipboard";
 
 int stasis_audio_init(int rate, int channels, int latency) {
     return rate > 0 && channels == 2 && latency > 0;
@@ -82,6 +85,30 @@ int stasis_storage_save_i32(const char *scope, const char *key, int value) {
     has_saved_value = 1;
     return 1;
 }
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity) {
+    int count = saved_ascii_length;
+    if (scope == NULL || key == NULL || count > capacity) return -1;
+    memcpy(out, saved_ascii, (size_t)count);
+    return count;
+}
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length) {
+    if (scope == NULL || key == NULL || value == NULL || length < 0 || length > 63) return 0;
+    memcpy(saved_ascii, value, (size_t)length);
+    saved_ascii_length = length;
+    return 1;
+}
+int stasis_clipboard_load_ascii(char *out, int capacity) {
+    int count = (int)strlen(clipboard_ascii);
+    if (out == NULL || count > capacity) return -1;
+    memcpy(out, clipboard_ascii, (size_t)count);
+    return count;
+}
+int stasis_clipboard_save_ascii(const char *value, int length) {
+    if (value == NULL || length < 0 || length > 63) return 0;
+    memcpy(clipboard_ascii, value, (size_t)length);
+    clipboard_ascii[length] = '\0';
+    return 1;
+}
 
 int main(void) {
     int32_t external = 4;
@@ -90,6 +117,8 @@ int main(void) {
     float overlapping_f32[5] = {1, 2, 3, 4, 5};
     uint8_t external_u8[4] = {1, 2, 3, 4};
     uint8_t dynamic_path[] = "sprite.bmp";
+    uint8_t ascii_value[] = "GG1-test";
+    uint8_t ascii_out[32] = {0};
     int32_t sprite_handle[1] = {0};
     int32_t sprite_width[1] = {0};
     int32_t sprite_height[1] = {0};
@@ -167,6 +196,16 @@ int main(void) {
     CHECK(stasis_jit_storage_load_i32(40, 41, 1) == 4);
     CHECK(strcmp(saved_scope, "sample_game") == 0);
     CHECK(strcmp(saved_key, "unlocked_tier") == 0);
+    stasis_jit_register_global_u8_array(42, 0, ascii_value, sizeof(ascii_value) - 1);
+    stasis_jit_collection_i32_store(42, 1, sizeof(ascii_value) - 1);
+    stasis_jit_register_global_u8_array(43, 0, ascii_out, sizeof(ascii_out));
+    CHECK(stasis_jit_storage_save_ascii(40, 41, 42, sizeof(ascii_value) - 1) == 1);
+    CHECK(stasis_jit_storage_load_ascii(40, 41, 43, sizeof(ascii_out)) == 8);
+    CHECK(memcmp(ascii_out, "GG1-test", 8) == 0);
+    CHECK(stasis_jit_clipboard_save_ascii(42, sizeof(ascii_value) - 1) == 1);
+    memset(ascii_out, 0, sizeof(ascii_out));
+    CHECK(stasis_jit_clipboard_load_ascii(43, sizeof(ascii_out)) == 8);
+    CHECK(memcmp(ascii_out, "GG1-test", 8) == 0);
 
     owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
     CHECK(owned != NULL);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -161,6 +161,22 @@ int stasis_storage_save_i32(const char *scope, const char *key, int value) {
     (void)value;
     return scope && key;
 }
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity) {
+    (void)scope; (void)key; (void)out; (void)capacity;
+    return -1;
+}
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length) {
+    (void)value; (void)length;
+    return scope && key;
+}
+int stasis_clipboard_load_ascii(char *out, int capacity) {
+    (void)out; (void)capacity;
+    return -1;
+}
+int stasis_clipboard_save_ascii(const char *value, int length) {
+    (void)value; (void)length;
+    return 1;
+}
 
 static int32_t hash_path(const char *path);
 

--- a/runtime/tests/stasis_platform_storage_test.c
+++ b/runtime/tests/stasis_platform_storage_test.c
@@ -10,6 +10,7 @@
 int main(void) {
     char root[256];
     char corrupt_path[320];
+    char ascii[16];
     FILE *corrupt;
     snprintf(root, sizeof(root), "/tmp/stasis_platform_storage_%ld", (long)getpid());
     assert(mkdir(root, 0700) == 0);
@@ -18,6 +19,12 @@ int main(void) {
     assert(stasis_storage_save_i32("game", "tier", 4) == 1);
     assert(stasis_storage_load_i32("game", "tier", 1) == 4);
     assert(stasis_storage_save_i32("../game", "tier", 5) == 0);
+    assert(stasis_storage_load_ascii("game", "code", ascii, sizeof(ascii)) == -1);
+    assert(stasis_storage_save_ascii("game", "code", "GG1-abc_123", 11) == 1);
+    assert(stasis_storage_load_ascii("game", "code", ascii, sizeof(ascii)) == 11);
+    assert(memcmp(ascii, "GG1-abc_123", 11) == 0);
+    assert(stasis_storage_load_ascii("game", "code", ascii, 4) == -1);
+    assert(stasis_storage_save_ascii("game", "code", "bad\ncode", 8) == 0);
 
     snprintf(corrupt_path, sizeof(corrupt_path), "%s/game/tier.i32", root);
     corrupt = fopen(corrupt_path, "wb");
@@ -26,6 +33,8 @@ int main(void) {
     assert(fclose(corrupt) == 0);
     assert(stasis_storage_load_i32("game", "tier", 2) == 2);
 
+    assert(remove(corrupt_path) == 0);
+    snprintf(corrupt_path, sizeof(corrupt_path), "%s/game/code.ascii", root);
     assert(remove(corrupt_path) == 0);
     snprintf(corrupt_path, sizeof(corrupt_path), "%s/game", root);
     assert(rmdir(corrupt_path) == 0);

--- a/src/stdlib/clipboard.stasis
+++ b/src/stdlib/clipboard.stasis
@@ -1,0 +1,27 @@
+// Bounded printable-ASCII clipboard access for player-entered share codes.
+// Loading returns the byte length, or -1 when unavailable, invalid, or too large.
+function @extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
+function @extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
+
+function clipboard_load_ascii(out: ascii[]): i32 {
+    out.length = 0;
+    let capacity: i32 = out.max_length;
+    if (capacity <= 0) {
+        return -1;
+    }
+    let loaded: i32 = clipboard_load_ascii_raw(out, capacity);
+    if (loaded < 0 || loaded > capacity) {
+        out.length = 0;
+        return -1;
+    }
+    out.length = loaded;
+    return loaded;
+}
+
+function clipboard_save_ascii(value: ascii[]): bool {
+    let count: i32 = value.length;
+    if (count < 0 || count > value.max_length) {
+        return false;
+    }
+    return clipboard_save_ascii_raw(value, count) != 0;
+}

--- a/src/stdlib/storage.stasis
+++ b/src/stdlib/storage.stasis
@@ -3,3 +3,31 @@
 // Missing, invalid, or corrupt values return the caller-provided fallback.
 extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
 extern function storage_save_i32(scope: string, key: string, value: i32): bool;
+
+// Bounded durable ASCII values for share codes and other small text payloads.
+// Returns the byte length, or -1 when the value is missing, invalid, or does not fit.
+function @extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
+function @extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
+
+function storage_load_ascii(scope: string, key: string, out: ascii[]): i32 {
+    out.length = 0;
+    let capacity: i32 = out.max_length;
+    if (capacity <= 0) {
+        return -1;
+    }
+    let loaded: i32 = storage_load_ascii_raw(scope, key, out, capacity);
+    if (loaded < 0 || loaded > capacity) {
+        out.length = 0;
+        return -1;
+    }
+    out.length = loaded;
+    return loaded;
+}
+
+function storage_save_ascii(scope: string, key: string, value: ascii[]): bool {
+    let count: i32 = value.length;
+    if (count < 0 || count > value.max_length) {
+        return false;
+    }
+    return storage_save_ascii_raw(scope, key, value, count) != 0;
+}


### PR DESCRIPTION
Adds caller-bounded printable-ASCII storage and SDL clipboard APIs across JIT and mobile AOT hosts. Includes atomic scoped persistence, compiler export mappings, standard-library wrappers, runtime contract tests, and documentation. Verified with cargo fmt, targeted compiler tests, cargo check, and a real Stasis wrapper compile. Native C contract execution is deferred on this machine because no desktop C compiler is installed.