### PR TITLE
Fix packaged Unix desktop launchers

### DIFF
--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -305,6 +305,9 @@ pub fn link_objects_to_dynamic_library(
     for runtime_lib in &config.runtime_lib_paths {
         args.push(runtime_lib.display().to_string());
     }
+    if matches!(config.target, AotTarget::Native) && !cfg!(windows) {
+        args.push("-lm".to_string());
+    }
 
     run_link_command_with_args(
         &linker,
@@ -732,6 +735,7 @@ exit /b 0
         } else {
             let path = temp_dir.join("fake-link.sh");
             let script = r#"#!/usr/bin/env sh
+ALL_ARGS="$*"
 OUT=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -746,6 +750,7 @@ if [ -z "$OUT" ]; then
   exit 2
 fi
 echo "fake-shared" > "$OUT"
+printf '%s\n' "$ALL_ARGS" > "$OUT.args"
 "#;
             fs::write(&path, script).expect("write fake unix linker");
             let status = Command::new("chmod")
@@ -780,6 +785,14 @@ echo "fake-shared" > "$OUT"
         )
         .expect("fake linker should succeed");
         assert!(output_library.exists(), "fake linker should create output");
+        if !cfg!(windows) {
+            let args = fs::read_to_string(format!("{}.args", output_library.display()))
+                .expect("read captured Unix linker arguments");
+            assert!(
+                args.split_ascii_whitespace().any(|arg| arg == "-lm"),
+                "native Unix dynamic libraries must link libm: {args}"
+            );
+        }
 
         fs::remove_dir_all(&temp_dir).ok();
     }

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -309,4 +309,20 @@ if(STASIS_BUILD_RUNNER)
         RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release"
         RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/Debug"
     )
+    if(UNIX AND STASIS_MOBILE_RUNTIME_BUILD_TESTS)
+        add_library(stasis_runner_package_graphics SHARED tests/stasis_runner_package_graphics.c)
+        set_target_properties(stasis_runner_package_graphics PROPERTIES OUTPUT_NAME stasis_graphics)
+        add_library(stasis_runner_package_game SHARED tests/stasis_runner_package_game.c)
+        target_link_libraries(stasis_runner_package_game PRIVATE m)
+        set_target_properties(stasis_runner_package_game PROPERTIES PREFIX "")
+        add_test(
+            NAME stasis_runner_packaged_unix_contract
+            COMMAND ${CMAKE_COMMAND}
+                -DTEST_ROOT=${CMAKE_CURRENT_BINARY_DIR}/runner-package-test
+                -DRUNNER=$<TARGET_FILE:stasis_runner>
+                -DGRAPHICS=$<TARGET_FILE:stasis_runner_package_graphics>
+                -DGAME=$<TARGET_FILE:stasis_runner_package_game>
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/stasis_runner_package_test.cmake
+        )
+    endif()
 endif()

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -378,8 +378,8 @@ static int stasis_set_asset_root(const char *path)
 
 static int stasis_set_packaged_graphics_path(const char *exe_dir)
 {
-#ifdef _WIN32
     char path[2080];
+#ifdef _WIN32
     if (!exe_dir || !exe_dir[0] ||
         snprintf(path, sizeof(path), "%s\\stasis_graphics.dll", exe_dir) >= (int)sizeof(path))
     {
@@ -388,8 +388,17 @@ static int stasis_set_packaged_graphics_path(const char *exe_dir)
     return SetEnvironmentVariableA("STASIS_RUNTIME_DLL_PATH", path) != 0 &&
            _putenv_s("STASIS_RUNTIME_DLL_PATH", path) == 0;
 #else
-    (void)exe_dir;
-    return 1;
+#if defined(__APPLE__)
+    const char *runtime_name = "libstasis_graphics.dylib";
+#else
+    const char *runtime_name = "libstasis_graphics.so";
+#endif
+    if (!exe_dir || !exe_dir[0] ||
+        snprintf(path, sizeof(path), "%s/%s", exe_dir, runtime_name) >= (int)sizeof(path))
+    {
+        return 0;
+    }
+    return setenv("STASIS_RUNTIME_LIBRARY_PATH", path, 1) == 0;
 #endif
 }
 
@@ -535,6 +544,21 @@ static int stasis_try_load_launch_config(
         strncpy(entry_out, "main", entry_out_cap - 1);
         entry_out[entry_out_cap - 1] = '\0';
     }
+
+#ifndef _WIN32
+    /* dlopen does not search the current directory for a bare library name. */
+    if (dll_out[0] != '/')
+    {
+        char absolute_dll[4096];
+        int written = snprintf(absolute_dll, sizeof(absolute_dll), "%s/%s", exe_dir, dll_out);
+        if (written < 0 || (size_t)written >= sizeof(absolute_dll) ||
+            (size_t)written >= dll_out_cap)
+        {
+            return 0;
+        }
+        memcpy(dll_out, absolute_dll, (size_t)written + 1);
+    }
+#endif
 
     /* Anchor assets to the generated executable, independent of caller CWD. */
     if (!stasis_set_current_dir(exe_dir) ||
@@ -2656,6 +2680,52 @@ int main(int argc, char **argv)
         fflush(stderr);
     }
 
+    const char *graphics_path = getenv("STASIS_RUNTIME_LIBRARY_PATH");
+    void *gfx_lib = NULL;
+    if (graphics_path && graphics_path[0])
+    {
+        gfx_lib = dlopen(graphics_path, RTLD_NOW | RTLD_GLOBAL);
+        if (!gfx_lib)
+        {
+            fprintf(stderr, "error: failed to load packaged graphics runtime %s: %s\n",
+                    graphics_path, dlerror());
+            return 1;
+        }
+        stasis_graphics_runtime_abi_version_fn graphics_abi =
+            (stasis_graphics_runtime_abi_version_fn)dlsym(gfx_lib, "stasis_graphics_runtime_abi_version");
+        if (!graphics_abi || graphics_abi() != STASIS_GRAPHICS_RUNTIME_ABI_VERSION)
+        {
+            fprintf(stderr, "error: incompatible packaged graphics runtime (expected ABI %d)\n",
+                    STASIS_GRAPHICS_RUNTIME_ABI_VERSION);
+            dlclose(gfx_lib);
+            return 1;
+        }
+        stasis_graphics_set_asset_root_fn set_graphics_asset_root =
+            (stasis_graphics_set_asset_root_fn)dlsym(gfx_lib, "stasis_set_asset_root");
+        const char *launcher_asset_root = getenv("STASIS_ASSET_ROOT");
+        if (!set_graphics_asset_root || !launcher_asset_root ||
+            !set_graphics_asset_root(launcher_asset_root))
+        {
+            fprintf(stderr, "error: packaged graphics runtime rejected the launcher asset root\n");
+            dlclose(gfx_lib);
+            return 1;
+        }
+        stasis_init_window_fn init_window =
+            (stasis_init_window_fn)dlsym(gfx_lib, "stasis_init_window");
+        stasis_set_fullscreen_fn set_fullscreen =
+            (stasis_set_fullscreen_fn)dlsym(gfx_lib, "stasis_set_fullscreen");
+        if (init_window)
+        {
+            const char *start_fs = getenv("STASIS_START_FULLSCREEN");
+            int want_fullscreen = (start_fs && strcmp(start_fs, "1") == 0) ? 1 : 0;
+            (void)init_window(640, 360, "Stasis");
+            if (want_fullscreen && set_fullscreen)
+            {
+                (void)set_fullscreen(1);
+            }
+        }
+    }
+
     void *lib = dlopen(dll_path, RTLD_NOW);
     if (!lib)
     {
@@ -2785,18 +2855,13 @@ int main(int argc, char **argv)
         stasis_host_get_frame_fn host_get_frame = NULL;
         stasis_gfx_submit_u8_fn gfx_submit_u8 = NULL;
 
-        void *gfx_lib = dlopen("libstasis_graphics.so", RTLD_NOW | RTLD_GLOBAL);
+        if (!gfx_lib)
+        {
+            gfx_lib = dlopen("libstasis_graphics.so", RTLD_NOW | RTLD_GLOBAL);
+        }
         if (!gfx_lib)
         {
             gfx_lib = dlopen("stasis_graphics.so", RTLD_NOW | RTLD_GLOBAL);
-        }
-        if (!gfx_lib)
-        {
-            gfx_lib = dlopen("libstasis_graphics.so", RTLD_NOW | RTLD_NOLOAD);
-        }
-        if (!gfx_lib)
-        {
-            gfx_lib = dlopen("stasis_graphics.so", RTLD_NOW | RTLD_NOLOAD);
         }
         if (!gfx_lib)
         {

--- a/runtime/tests/stasis_runner_package_game.c
+++ b/runtime/tests/stasis_runner_package_game.c
@@ -1,0 +1,25 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined(_WIN32)
+#define STASIS_TEST_EXPORT __declspec(dllexport)
+#else
+#define STASIS_TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+STASIS_TEST_EXPORT void stasis_aot_bind_runtime_globals(void) {}
+
+STASIS_TEST_EXPORT int main(void) {
+    const char *asset_root = getenv("STASIS_ASSET_ROOT");
+    const char *runtime_path = getenv("STASIS_RUNTIME_LIBRARY_PATH");
+    const char *window_ready = getenv("STASIS_TEST_WINDOW_READY");
+    volatile float value = sinf(0.5f);
+    if (!asset_root || asset_root[0] != '/' ||
+        !runtime_path || runtime_path[0] != '/' ||
+        !window_ready || window_ready[0] != '1' || value == 0.0f) {
+        return 17;
+    }
+    puts("PACKAGED_RUNNER_OK");
+    return 0;
+}

--- a/runtime/tests/stasis_runner_package_graphics.c
+++ b/runtime/tests/stasis_runner_package_graphics.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+
+#if defined(_WIN32)
+#define STASIS_TEST_EXPORT __declspec(dllexport)
+#else
+#define STASIS_TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+STASIS_TEST_EXPORT int stasis_graphics_runtime_abi_version(void) {
+    return 1;
+}
+
+STASIS_TEST_EXPORT int stasis_set_asset_root(const char *path) {
+    return path && path[0];
+}
+
+STASIS_TEST_EXPORT int stasis_init_window(int width, int height, const char *title) {
+    (void)width;
+    (void)height;
+    (void)title;
+    return setenv("STASIS_TEST_WINDOW_READY", "1", 1) == 0;
+}
+
+STASIS_TEST_EXPORT int stasis_set_fullscreen(int enabled) {
+    (void)enabled;
+    return 1;
+}

--- a/runtime/tests/stasis_runner_package_test.cmake
+++ b/runtime/tests/stasis_runner_package_test.cmake
@@ -1,0 +1,24 @@
+if(NOT DEFINED TEST_ROOT OR NOT DEFINED RUNNER OR NOT DEFINED GRAPHICS OR NOT DEFINED GAME)
+    message(FATAL_ERROR "packaged runner smoke test paths are required")
+endif()
+
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY "${TEST_ROOT}/package" "${TEST_ROOT}/caller")
+file(COPY_FILE "${RUNNER}" "${TEST_ROOT}/package/game")
+file(CHMOD "${TEST_ROOT}/package/game" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+get_filename_component(GRAPHICS_NAME "${GRAPHICS}" NAME)
+file(COPY_FILE "${GRAPHICS}" "${TEST_ROOT}/package/${GRAPHICS_NAME}")
+get_filename_component(GAME_NAME "${GAME}" NAME)
+file(COPY_FILE "${GAME}" "${TEST_ROOT}/package/${GAME_NAME}")
+file(WRITE "${TEST_ROOT}/package/game.launch" "dll=${GAME_NAME}\nentry=main\nfps=60\n")
+
+execute_process(
+    COMMAND "${TEST_ROOT}/package/game"
+    WORKING_DIRECTORY "${TEST_ROOT}/caller"
+    RESULT_VARIABLE RESULT
+    OUTPUT_VARIABLE STDOUT
+    ERROR_VARIABLE STDERR
+)
+if(NOT RESULT EQUAL 0 OR NOT STDOUT MATCHES "PACKAGED_RUNNER_OK")
+    message(FATAL_ERROR "packaged runner failed (${RESULT})\nstdout=${STDOUT}\nstderr=${STDERR}")
+endif()


### PR DESCRIPTION
## Summary
- link native Unix AOT shared libraries with libm
- anchor packaged game and graphics libraries to the generated launcher directory
- initialize the packaged graphics runtime before the game entrypoint, matching Windows behavior
- add a cross-Unix packaged-launcher regression test and verify linker arguments include libm

## Verification
- cargo fmt --all -- --check
- cargo test -p stasis_jit --release
- stasis_runner_packaged_unix_contract under Ubuntu/WSL
- Gambit Guard: stasis check; 76 tests; native Linux release build; clean startup with fonts/assets loaded and render contract emitted