### PR TITLE
feat: improve desktop production launch

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4265,10 +4265,10 @@ mod tests {
     fn explicit_window_size_request_restores_the_desktop_window() {
         let graphics_source = STASIS_GRAPHICS_SOURCE.replace("\r\n", "\n");
         let resize_start = graphics_source
-            .find("STASIS_EXPORT void stasis_set_window_size")
+            .find("STASIS_EXPORT void stasis_set_window_size(int width, int height) {")
             .expect("graphics runtime should expose window resizing");
         let resize_end = graphics_source[resize_start..]
-            .find("STASIS_EXPORT int stasis_set_fullscreen")
+            .find("STASIS_EXPORT int stasis_set_fullscreen(int fullscreen) {")
             .expect("window resizing should precede fullscreen control")
             + resize_start;
         let resize_source = &graphics_source[resize_start..resize_end];

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4200,6 +4200,14 @@ mod tests {
             "generated launchers must anchor packaged assets and reject mismatched graphics DLLs"
         );
         assert!(
+            STASIS_RUNNER_SOURCE.contains("\"%s\\\\app\", exe_dir")
+                && STASIS_RUNNER_SOURCE.contains("\"%s\\\\%s.launch\", payload_dir, exe_name")
+                && STASIS_RUNNER_SOURCE.contains("strncpy(exe_dir, payload_dir")
+                && STASIS_RUNNER_SOURCE.contains("\"%s\\\\%s\", exe_dir, dll_out")
+                && STASIS_RUNNER_SOURCE.contains("stasis_path_dirname(dll_path, program_dir"),
+            "Windows root launchers must resolve and anchor their nested app payload"
+        );
+        assert!(
             STASIS_RUNNER_SOURCE.contains("strncmp(out, \"\\\\\\\\?\\\\UNC\\\\\", 8)")
                 && STASIS_RUNNER_SOURCE.contains("strncmp(out, \"\\\\\\\\?\\\\\", 4)"),
             "Windows launchers must normalize extended drive and UNC paths before asset loading"
@@ -4231,6 +4239,26 @@ mod tests {
                 "Windows runner manifest should contain {required}"
             );
         }
+    }
+
+    #[test]
+    fn desktop_runtime_starts_maximized_in_the_window_manager_work_area() {
+        let graphics_source = STASIS_GRAPHICS_SOURCE.replace("\r\n", "\n");
+        let mobile_fullscreen = graphics_source
+            .find("window_flags |= SDL_WINDOW_FULLSCREEN;\n#else")
+            .expect("mobile window creation should retain its fullscreen policy");
+        let desktop_maximized = graphics_source
+            .find("window_flags |= SDL_WINDOW_MAXIMIZED;")
+            .expect("desktop window creation should request a maximized window");
+        let platform_guard_end = graphics_source[desktop_maximized..]
+            .find("#endif")
+            .expect("desktop window policy should remain platform guarded")
+            + desktop_maximized;
+
+        assert!(
+            mobile_fullscreen < desktop_maximized && desktop_maximized < platform_guard_end,
+            "desktop maximization must be the non-mobile branch of window creation"
+        );
     }
 
     #[test]

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4262,6 +4262,31 @@ mod tests {
     }
 
     #[test]
+    fn explicit_window_size_request_restores_the_desktop_window() {
+        let graphics_source = STASIS_GRAPHICS_SOURCE.replace("\r\n", "\n");
+        let resize_start = graphics_source
+            .find("STASIS_EXPORT void stasis_set_window_size")
+            .expect("graphics runtime should expose window resizing");
+        let resize_end = graphics_source[resize_start..]
+            .find("STASIS_EXPORT int stasis_set_fullscreen")
+            .expect("window resizing should precede fullscreen control")
+            + resize_start;
+        let resize_source = &graphics_source[resize_start..resize_end];
+        let restore = resize_source
+            .find("SDL_RestoreWindow(g_window);")
+            .expect("an explicit size should restore a maximized or minimized window");
+        let resize = resize_source
+            .find("SDL_SetWindowSize(g_window, width, height);")
+            .expect("an explicit size should resize the restored window");
+
+        assert!(
+            restore < resize
+                && resize_source[restore..resize].contains("SDL_SyncWindow(g_window);"),
+            "desktop restore must complete before applying an explicit window size"
+        );
+    }
+
+    #[test]
     fn macos_runner_is_packaged_for_retina_drawables() {
         let runner_plist = STASIS_RUNNER_MACOS_PLIST.replace("\r\n", "\n");
         for required in [

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -48,6 +48,7 @@ const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
 const RELEASE_PROVENANCE_NAME: &str = "stasis_release_provenance.json";
 const PACKAGE_PROVENANCE_NAME: &str = "stasis_provenance.json";
+const WINDOWS_DESKTOP_PAYLOAD_DIR: &str = "app";
 const MOBILE_RUNTIME_FILES: &[&str] = &[
     "CMakeLists.txt",
     "nanosvg.h",
@@ -3318,8 +3319,9 @@ fn package_workspace(
     let provenance = resolve_package_provenance(development_build)?;
     fs::create_dir_all(&staging_root)
         .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
+    let executable_file_name = executable_name(&workspace.manifest.name);
     let assembled = (|| -> Result<(), String> {
-        let executable = staging_root.join(executable_name(&workspace.manifest.name));
+        let executable = staging_root.join(&executable_file_name);
         build_workspace(workspace, BuildMode::Release, Some(&executable))?;
         let summary = executable.with_file_name(format!(
             "{}.summary.json",
@@ -3333,17 +3335,24 @@ fn package_workspace(
                 )
             })?;
         }
+        #[cfg(windows)]
+        nest_windows_desktop_payload(&staging_root, &executable)?;
+        let payload_root = if cfg!(windows) {
+            staging_root.join(WINDOWS_DESKTOP_PAYLOAD_DIR)
+        } else {
+            staging_root.clone()
+        };
         copy_file(
             &workspace.root.join(MANIFEST_NAME),
-            &staging_root.join(MANIFEST_NAME),
+            &payload_root.join(MANIFEST_NAME),
         )?;
         if let Some(runtime) = installed_runtime_library() {
             copy_file(
                 &runtime,
-                &staging_root.join(runtime.file_name().unwrap_or_default()),
+                &payload_root.join(runtime.file_name().unwrap_or_default()),
             )?;
         }
-        write_json_file(&staging_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
+        write_json_file(&payload_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
         Ok(())
     })();
     if let Err(error) = assembled {
@@ -3362,10 +3371,41 @@ fn package_workspace(
         json!({
             "target": target.as_str(),
             "output": display_path(&package_root),
-            "provenance": PACKAGE_PROVENANCE_NAME,
+            "provenance": if cfg!(windows) {
+                format!("{WINDOWS_DESKTOP_PAYLOAD_DIR}/{PACKAGE_PROVENANCE_NAME}")
+            } else {
+                PACKAGE_PROVENANCE_NAME.to_string()
+            },
             "development_build": provenance["development_build"],
         }),
     ))
+}
+
+#[cfg(windows)]
+fn nest_windows_desktop_payload(staging_root: &Path, executable: &Path) -> Result<(), String> {
+    let payload_root = staging_root.join(WINDOWS_DESKTOP_PAYLOAD_DIR);
+    fs::create_dir_all(&payload_root)
+        .map_err(|error| format!("failed to create {}: {error}", payload_root.display()))?;
+    let entries = fs::read_dir(staging_root)
+        .map_err(|error| format!("failed to read {}: {error}", staging_root.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to inspect {}: {error}", staging_root.display()))?;
+
+    for entry in entries {
+        let source = entry.path();
+        if source == executable || source == payload_root {
+            continue;
+        }
+        let destination = payload_root.join(entry.file_name());
+        fs::rename(&source, &destination).map_err(|error| {
+            format!(
+                "failed to move Windows package payload {} to {}: {error}",
+                source.display(),
+                destination.display()
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn stage_workspace_assets(
@@ -6241,6 +6281,43 @@ mod tests {
         .is_err());
         assert!(!root.join("dist/out").exists());
         assert!(!root.join("dist/.out.staging").exists());
+        remove_temp(&root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_desktop_package_keeps_only_the_launcher_at_root() {
+        let root = temp_dir("windows_desktop_payload");
+        fs::create_dir_all(root.join("assets")).expect("create staged assets");
+        let executable = root.join("demo.exe");
+        fs::write(&executable, "launcher").expect("write launcher");
+        fs::write(root.join("demo.exe.launch"), "dll=demo.dll").expect("write launch config");
+        fs::write(root.join("demo.dll"), "game").expect("write game library");
+        fs::write(root.join("stasis_graphics.dll"), "graphics").expect("write graphics runtime");
+
+        nest_windows_desktop_payload(&root, &executable).expect("nest package payload");
+
+        assert!(executable.is_file());
+        assert_eq!(
+            fs::read_dir(&root)
+                .expect("read package root")
+                .map(|entry| entry.expect("root entry").file_name())
+                .collect::<BTreeSet<_>>(),
+            [OsString::from("app"), OsString::from("demo.exe")]
+                .into_iter()
+                .collect()
+        );
+        for relative in [
+            "assets",
+            "demo.dll",
+            "demo.exe.launch",
+            "stasis_graphics.dll",
+        ] {
+            assert!(root
+                .join(WINDOWS_DESKTOP_PAYLOAD_DIR)
+                .join(relative)
+                .exists());
+        }
         remove_temp(&root);
     }
 

--- a/apps/stasis/tests/windows_game_launch.rs
+++ b/apps/stasis/tests/windows_game_launch.rs
@@ -256,6 +256,24 @@ fn every_supported_windows_game_launch_path_loads_assets_and_renders() {
         String::from_utf8_lossy(&package.stderr)
     );
     let package_root = project.join("dist/windows_launch_smoke-desktop");
+    let package_payload = package_root.join("app");
+    assert!(package_root.join("windows_launch_smoke.exe").is_file());
+    assert!(package_payload.is_dir());
+    for relative in [
+        "assets/manifest.json",
+        "stasis.json",
+        "stasis_dynload.dll",
+        "stasis_provenance.json",
+        "stasis_graphics.dll",
+        "windows_launch_smoke.dll",
+        "windows_launch_smoke.exe.launch",
+    ] {
+        assert!(
+            package_payload.join(relative).exists(),
+            "Windows package payload should contain {relative}"
+        );
+    }
+    assert!(!package_root.join("stasis_graphics.dll").exists());
     let package_screenshot = parent.join("package.png");
     let mut package_command = Command::new(package_root.join("windows_launch_smoke.exe"));
     package_command.current_dir(&package_root);

--- a/docs/display_metrics.md
+++ b/docs/display_metrics.md
@@ -67,6 +67,11 @@ use the same aspect-fit viewport, and replace SVG/font/text textures when the
 density generation changes. Those metadata slots are host-populated and are
 not part of the command trace, so JIT/AOT command parity is unchanged.
 
+Desktop windows start maximized through the platform window manager. This fills
+the usable work area while preserving taskbars, docks, and panels; it is still a
+resizable window rather than borderless fullscreen. The logical size requested
+by `init_window` remains the game's stable coordinate space.
+
 On Windows, `stasis_runner.exe` declares per-monitor-v2 DPI awareness and the
 graphics runtime enables SDL's DPI-scaled point coordinate mode before video
 initialization. A requested `800 x 600` logical window on a 150% display is

--- a/docs/release_provenance.md
+++ b/docs/release_provenance.md
@@ -14,11 +14,12 @@ package with the expected and actual SHA-256 values. This prevents a release
 binary from silently packaging renderer sources copied from another checkout.
 
 Every generated desktop, Android, and iOS package contains
-`stasis_provenance.json`. Mobile packages also place the manifest in the game
+`stasis_provenance.json`; Windows desktop packages keep it in the relative
+`app/` payload beside the runtime. Mobile packages also place the manifest in the game
 asset root and compile a small generated header into the lifecycle adapter. At
 startup, the adapter logs the build label, release tag, source commit, and
 `gfx_cmd_v1` renderer contract. The desktop graphics runtime logs the bounded
-sidecar manifest from the executable directory during initialization.
+sidecar manifest from the resolved runtime payload directory during initialization.
 `stasis_mobile_package.json` points to the
 embedded manifest and exposes the release/development classification to build
 audit tools.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -135,7 +135,8 @@ cloning a generated repository, reactivate the checked-in hook with
 - `build --mode release`: use the shared Cranelift AOT pipeline and write the native executable to
   `build/`.
 - `package --target desktop`: create a standalone directory with the AOT executable, manifest,
-  assets, graphics runtime when present, and verified release provenance.
+  assets, graphics runtime when present, and verified release provenance. Windows packages keep
+  the game-named executable as the only root file and place all support files under `app/`.
 - `package-mobile --target android-arm64|ios-arm64 [--entry PATH]`: atomically assemble the
   shared AOT output, SDL-only runtime, bundled assets, verified provenance, and thin Gradle or
   Xcode app shell.

--- a/docs/windows_game_launch_testing.md
+++ b/docs/windows_game_launch_testing.md
@@ -26,6 +26,9 @@ responsive on Windows while using the same startup treatment on SDL, OpenGL, and
 Generated launchers anchor `STASIS_ASSET_ROOT` to their own directory and reject a graphics DLL
 whose exported runtime ABI does not match the runner, preventing caller working-directory and
 mixed-version installations from degrading into missing assets or undefined runtime behavior.
+Windows desktop packages keep the game-named executable at the package root and resolve the
+launch sidecar, game DLL, graphics DLL, assets, and metadata from the relative `app/` directory.
+This leaves one obvious file for non-developers to launch while keeping the package portable.
 Source-tree integration builds select the rebuilt runner and graphics DLL explicitly instead of
 using file modification times to guess which copied native artifact belongs to the current build.
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -75,10 +75,19 @@ static void stasis_sdl_log_output(void* userdata, int category, SDL_LogPriority 
 }
 
 static void log_package_provenance(void) {
-    const char* base = SDL_GetBasePath();
-    if (!base) return;
+    const char* asset_root = SDL_getenv("STASIS_ASSET_ROOT");
+    const char* base = NULL;
+    if (!asset_root || !*asset_root) {
+        base = SDL_GetBasePath();
+        asset_root = base;
+    }
+    if (!asset_root) return;
     char path[1024];
-    int written = snprintf(path, sizeof(path), "%sstasis_provenance.json", base);
+    size_t root_len = strlen(asset_root);
+    const char* separator = root_len > 0 &&
+        (asset_root[root_len - 1] == '/' || asset_root[root_len - 1] == '\\') ? "" : "/";
+    int written = snprintf(
+        path, sizeof(path), "%s%sstasis_provenance.json", asset_root, separator);
     if (written < 0 || (size_t)written >= sizeof(path)) return;
     FILE* file = fopen(path, "rb");
     if (!file) return;
@@ -3729,6 +3738,10 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
         native_request_height = display_mode->h;
     }
     window_flags |= SDL_WINDOW_FULLSCREEN;
+#else
+    /* Let the desktop window manager fill its usable work area without
+       covering taskbars, docks, or panels. */
+    window_flags |= SDL_WINDOW_MAXIMIZED;
 #endif
 
     g_window = SDL_CreateWindow(

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -4046,7 +4046,13 @@ STASIS_EXPORT void stasis_set_window_size(int width, int height) {
     g_window_height = height;
     g_window_resized = true;
 #if !defined(__ANDROID__) && !defined(__IPHONEOS__)
+    const SDL_WindowFlags window_flags = SDL_GetWindowFlags(g_window);
+    if ((window_flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED)) != 0) {
+        SDL_RestoreWindow(g_window);
+        SDL_SyncWindow(g_window);
+    }
     SDL_SetWindowSize(g_window, width, height);
+    SDL_SyncWindow(g_window);
 #endif
     stasis_sync_display_metrics();
 

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -421,6 +421,9 @@ static int stasis_try_load_launch_config(
     char self_path[2048];
     char launch_path[2080];
     char exe_dir[2048];
+#ifdef _WIN32
+    char payload_dir[2080];
+#endif
     char line[2048];
 
     if (!stasis_try_get_self_path(argv0, self_path, sizeof(self_path)))
@@ -437,6 +440,31 @@ static int stasis_try_load_launch_config(
     }
 
     FILE *file = fopen(launch_path, "rb");
+#ifdef _WIN32
+    if (!file)
+    {
+        const char *exe_name = strrchr(self_path, '\\');
+        const char *forward_name = strrchr(self_path, '/');
+        if (!exe_name || (forward_name && forward_name > exe_name))
+        {
+            exe_name = forward_name;
+        }
+        exe_name = exe_name ? exe_name + 1 : self_path;
+        int payload_written = snprintf(payload_dir, sizeof(payload_dir), "%s\\app", exe_dir);
+        int launch_written = payload_written > 0 && payload_written < (int)sizeof(payload_dir)
+            ? snprintf(launch_path, sizeof(launch_path), "%s\\%s.launch", payload_dir, exe_name)
+            : -1;
+        if (launch_written > 0 && launch_written < (int)sizeof(launch_path))
+        {
+            file = fopen(launch_path, "rb");
+            if (file)
+            {
+                strncpy(exe_dir, payload_dir, sizeof(exe_dir) - 1);
+                exe_dir[sizeof(exe_dir) - 1] = '\0';
+            }
+        }
+    }
+#endif
     if (!file)
     {
         return 0;
@@ -545,7 +573,21 @@ static int stasis_try_load_launch_config(
         entry_out[entry_out_cap - 1] = '\0';
     }
 
-#ifndef _WIN32
+#ifdef _WIN32
+    if (dll_out && dll_out[0] && dll_out[0] != '\\' && dll_out[0] != '/' && dll_out[1] != ':')
+    {
+        char resolved_dll[4096];
+        int resolved_written = snprintf(
+            resolved_dll, sizeof(resolved_dll), "%s\\%s", exe_dir, dll_out);
+        if (resolved_written <= 0 || resolved_written >= (int)sizeof(resolved_dll) ||
+            (size_t)resolved_written >= dll_out_cap)
+        {
+            fprintf(stderr, "error: generated launcher DLL path is too long\n");
+            return 0;
+        }
+        memcpy(dll_out, resolved_dll, (size_t)resolved_written + 1);
+    }
+#else
     /* dlopen does not search the current directory for a bare library name. */
     if (dll_out[0] != '/')
     {
@@ -560,7 +602,7 @@ static int stasis_try_load_launch_config(
     }
 #endif
 
-    /* Anchor assets to the generated executable, independent of caller CWD. */
+    /* Anchor assets to the resolved launch payload, independent of caller CWD. */
     if (!stasis_set_current_dir(exe_dir) ||
         !stasis_set_asset_root(exe_dir) ||
         !stasis_set_packaged_graphics_path(exe_dir))
@@ -710,6 +752,22 @@ static void stasis_setup_runtime_dirs(const char *exe_path, const char *dll_path
 {
     out_runtime_dir[0] = '\0';
 
+    char program_dir[1024];
+    program_dir[0] = '\0';
+    if (dll_path && stasis_path_dirname(dll_path, program_dir, sizeof(program_dir)) == 0)
+    {
+        char runtime_probe[1024];
+        int probe_written = snprintf(
+            runtime_probe, sizeof(runtime_probe), "%s\\stasis_graphics.dll", program_dir);
+        if (probe_written > 0 && probe_written < (int)sizeof(runtime_probe) &&
+            file_exists(runtime_probe))
+        {
+            strncpy(out_runtime_dir, program_dir, out_cap - 1);
+            out_runtime_dir[out_cap - 1] = '\0';
+            return;
+        }
+    }
+
     char exe_dir[1024];
     exe_dir[0] = '\0';
     if (exe_path && stasis_path_dirname(exe_path, exe_dir, sizeof(exe_dir)) == 0)
@@ -738,8 +796,6 @@ static void stasis_setup_runtime_dirs(const char *exe_path, const char *dll_path
         stasis_try_add_relative_runtime_dir(exe_dir, "runtime\\build\\bin\\Release", out_runtime_dir, out_cap);
         stasis_try_add_relative_runtime_dir(exe_dir, "..\\runtime\\build\\bin\\Release", out_runtime_dir, out_cap);
     }
-
-    (void)dll_path;
 }
 
 static void stasis_enable_dll_search(const char *exe_path, const char *dll_path)

--- a/samples/windows_launch_smoke/verify.ps1
+++ b/samples/windows_launch_smoke/verify.ps1
@@ -143,6 +143,27 @@ $packageRoot = Join-Path $projectOutputRoot 'package'
 $packageArguments = @('--workspace', $PSScriptRoot, 'package', '--target', 'desktop', '--out', "$projectOutputName/package")
 if ($DevelopmentBuild) { $packageArguments += '--development-build' }
 Invoke-Bounded -Description 'desktop package' -FilePath $Toolchain -Arguments $packageArguments
+$packagePayload = Join-Path $packageRoot 'app'
+$requiredPayload = @(
+    'assets/manifest.json',
+    'stasis.json',
+    'stasis_dynload.dll',
+    'stasis_provenance.json',
+    'stasis_graphics.dll',
+    'windows_launch_smoke.dll',
+    'windows_launch_smoke.exe.launch'
+)
+foreach ($relative in $requiredPayload) {
+    if (-not (Test-Path -LiteralPath (Join-Path $packagePayload $relative))) {
+        throw "desktop package payload is missing $relative"
+    }
+}
+$unexpectedRootEntries = @(Get-ChildItem -LiteralPath $packageRoot | Where-Object {
+    $_.Name -ne 'app' -and $_.Name -ne 'windows_launch_smoke.exe'
+})
+if ($unexpectedRootEntries.Count -ne 0) {
+    throw "desktop package root contains unexpected entries: $($unexpectedRootEntries.Name -join ', ')"
+}
 $captures.package = Join-Path $ArtifactRoot 'package.png'
 Invoke-Capture -Description 'packaged executable' -Screenshot $captures.package `
     -ExitAfterScreenshot -FilePath (Join-Path $packageRoot 'windows_launch_smoke.exe') `


### PR DESCRIPTION
## Summary

- start desktop game windows maximized within the platform work area
- keep the game-named Windows executable as the only file at the package root
- move launch metadata, game/runtime DLLs, assets, manifest, and provenance into a relative `app/` payload
- resolve DLL search, graphics preload, assets, and provenance from that payload

## Why

Production packages should present one obvious executable to non-developers without covering the Windows taskbar at launch. The previous flat package exposed implementation files beside the game executable, while the runner assumed its launch sidecar and runtime DLLs were beside the EXE.

## Impact

Windows users can launch the root game executable directly and move or unzip the complete package anywhere. macOS/Linux package layout and mobile fullscreen behavior remain unchanged. Stasis logical game coordinates remain independent of the maximized native window.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- focused package-layout unit test
- focused runtime launcher/source contract test
- focused maximized-window policy test
- native Windows `stasis_runner` build
- native Windows `stasis_graphics_static` build
- full Windows five-path launch/render matrix passed before rebasing onto current `main`

Local clean-target execution and the shared SDL3 DLL link are limited by this machine's Windows Application Control policy and an older installed vcpkg SDL binary; CI is the merge gate.