### PR TITLE
fix: anchor packaged Unix runner paths

### DIFF
--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -305,8 +305,19 @@ static int stasis_try_get_self_path(const char *argv0, char *out, size_t out_cap
     {
         return 0;
     }
-    strncpy(out, argv0, out_cap - 1);
-    out[out_cap - 1] = '\0';
+    if (argv0[0] == '/')
+    {
+        strncpy(out, argv0, out_cap - 1);
+        out[out_cap - 1] = '\0';
+        return 1;
+    }
+
+    char current_dir[2048];
+    if (!getcwd(current_dir, sizeof(current_dir)) ||
+        snprintf(out, out_cap, "%s/%s", current_dir, argv0) >= (int)out_cap)
+    {
+        return 0;
+    }
     return 1;
 #endif
 }

--- a/runtime/tests/stasis_runner_package_test.cmake
+++ b/runtime/tests/stasis_runner_package_test.cmake
@@ -13,7 +13,7 @@ file(COPY_FILE "${GAME}" "${TEST_ROOT}/package/${GAME_NAME}")
 file(WRITE "${TEST_ROOT}/package/game.launch" "dll=${GAME_NAME}\nentry=main\nfps=60\n")
 
 execute_process(
-    COMMAND "${TEST_ROOT}/package/game"
+    COMMAND "../package/game"
     WORKING_DIRECTORY "${TEST_ROOT}/caller"
     RESULT_VARIABLE RESULT
     OUTPUT_VARIABLE STDOUT


### PR DESCRIPTION
## Summary
- anchor relative Unix launcher paths to the process starting directory
- keep packaged game and graphics library paths absolute before the runner changes directories
- exercise the packaged launcher contract through a relative invocation

## Failure reproduced
Gambit Guard Linux and macOS packages built successfully but failed immediately when CI launched them with repository-relative paths: the runner changed directories before loading a repository-relative STASIS_RUNTIME_LIBRARY_PATH.

## Verification
- focused WSL CMake build succeeded
- stasis_runner_packaged_unix_contract passed using ../package/game`n- Stasis pre-commit regression test passed