### PR TITLE
Add machine-readable UI layout audits

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -83,6 +83,7 @@ import "/vendor/stasis/src/stdlib/hud_table.stasis";
 import "/vendor/stasis/src/stdlib/sdl_scancodes.stasis";
 import "/vendor/stasis/src/stdlib/storage.stasis";
 import "/vendor/stasis/src/stdlib/ui_axis_layout.stasis";
+import "/vendor/stasis/src/stdlib/ui_layout_audit.stasis";
 import "/vendor/stasis/src/stdlib/ui_button_9slice.stasis";
 
 function main(): i32 {
@@ -5557,6 +5558,7 @@ mod tests {
             "sdl_scancodes",
             "storage",
             "ui_axis_layout",
+            "ui_layout_audit",
             "ui_button_9slice",
         ] {
             assert!(

--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -780,6 +780,7 @@ import "/vendor/stasis/src/stdlib/hud_table.stasis";
 import "/vendor/stasis/src/stdlib/sdl_scancodes.stasis";
 import "/vendor/stasis/src/stdlib/storage.stasis";
 import "/vendor/stasis/src/stdlib/ui_axis_layout.stasis";
+import "/vendor/stasis/src/stdlib/ui_layout_audit.stasis";
 import "/vendor/stasis/src/stdlib/ui_button_9slice.stasis";
 
 struct Game {
@@ -1137,6 +1138,7 @@ mod tests {
             "/vendor/stasis/src/stdlib/sdl_scancodes.stasis",
             "/vendor/stasis/src/stdlib/storage.stasis",
             "/vendor/stasis/src/stdlib/ui_axis_layout.stasis",
+            "/vendor/stasis/src/stdlib/ui_layout_audit.stasis",
             "/vendor/stasis/src/stdlib/ui_button_9slice.stasis",
             "function main(): i32",
             "function tick(): i32",

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2877,6 +2877,10 @@ mod tests {
             include_str!("../../../../src/stdlib/ui_axis_layout.stasis"),
         );
         process.upsert_file(
+            "src/stdlib/ui_layout_audit.stasis",
+            include_str!("../../../../src/stdlib/ui_layout_audit.stasis"),
+        );
+        process.upsert_file(
             "samples/immediate_axis_layout/placement.stasis",
             include_str!("../../../../samples/immediate_axis_layout/placement.stasis"),
         );

--- a/docs/immediate_layout_prd.md
+++ b/docs/immediate_layout_prd.md
@@ -836,3 +836,9 @@ A future rectangle type can call the same axis functions internally. Existing fl
 ### Prediction
 
 If this model is sufficient, menu titles, button labels, corner icons, HUD counters, and content inside flex-generated boxes will share `ui_place_x` and `ui_place_y` without needing a general rectangle framework. A request for rectangle values should arise only when multiple downstream consumers genuinely need to pass or store the complete box as one value.
+
+Machine-readable review is a separate concern from placement. The debug-facing
+`ui_layout_audit.stasis` module consumes the final scalar rectangles and measured
+text bounds without changing them, then emits deterministic geometry and
+relationship checks for automated or AI review. See
+`docs/ui_layout_audit.md` and `samples/immediate_axis_layout/audit.stasis`.

--- a/docs/ui_layout_audit.md
+++ b/docs/ui_layout_audit.md
@@ -1,0 +1,84 @@
+# Machine-readable UI layout audits
+
+`src/stdlib/ui_layout_audit.stasis` complements framebuffer review with exact
+logical geometry. It reports the final rectangles that drawing and hit testing
+consume, including runtime `TextRun.width` and `TextRun.height`, then evaluates
+declared relationships such as centering, containment, padding, baselines, and
+overlap.
+
+The audit is allocation-free. Numeric output uses signed thousandths of one
+logical layout unit (`*_milli`) so tools receive deterministic integers without
+losing subpixel placement. Audit calls belong in development or QA paths; they
+do not alter placement or rendering.
+
+## Example
+
+The complete executable example is
+`samples/immediate_axis_layout/`. After the normal layout function has produced
+the rectangles used for drawing and hit testing, it emits the same geometry:
+
+```stasis
+import "../../src/stdlib/ui_layout_audit.stasis";
+
+ui_audit_rect("play_button", "button", button_x, button_y, button_w, button_h);
+ui_audit_text("play_label", label_x, label_y, play.width, play.height, 24);
+
+ui_audit_center_check(
+    "x",
+    "play_label",
+    "play_button",
+    ui_audit_center_delta_x(button_x, button_w, label_x, play.width),
+    0.5
+);
+ui_audit_center_check(
+    "y",
+    "play_label",
+    "play_button",
+    ui_audit_center_delta_y(button_y, button_h, label_y, play.height),
+    1.0
+);
+ui_audit_padding_axis("x", "play_label", "play_button", button_x, button_w, label_x, play.width, 0.5);
+ui_audit_padding_axis("y", "play_label", "play_button", button_y, button_h, label_y, play.height, 0.5);
+```
+
+Representative output is one record per line:
+
+```text
+UI_LAYOUT|rect|id=play_button|role=button|x_milli=90000|y_milli=504000|w_milli=180000|h_milli=56000
+UI_LAYOUT|text|id=play_label|x_milli=151000|y_milli=520000|w_milli=58000|h_milli=24000|font_size=24
+UI_LAYOUT|check|kind=center_x|child=play_label|parent=play_button|delta_milli=0|tolerance_milli=500|pass=1
+UI_LAYOUT|check|kind=center_y|child=play_label|parent=play_button|delta_milli=0|tolerance_milli=1000|pass=1
+UI_LAYOUT|padding|axis=x|id=play_label|parent=play_button|start_milli=61000|end_milli=61000|contained=1
+```
+
+Values in documentation illustrate the schema; a real run reports the loaded
+font's measured bounds and the current safe viewport.
+
+## AI review workflow
+
+1. Emit every visible panel, button, icon, and text box once after layout.
+2. Give stable IDs to corresponding draw and hit-test elements.
+3. Add checks for the design intent: shared centers, repeated baselines, equal
+   gaps, parent containment, safe-edge clearance, and expected/non-expected
+   overlap.
+4. Capture stdout to a text artifact and provide it to the reviewer with the
+   intended logical resolution and tolerances.
+5. Ask the reviewer to report every `pass=0`, compare repeated rows/columns,
+   identify asymmetric padding, and flag rectangles that are present without a
+   declared relationship.
+6. Keep framebuffer review. Geometry cannot judge contrast, rasterization,
+   optical weight, imagery, or whether a mathematically valid composition feels
+   crowded.
+
+Suggested review prompt:
+
+```text
+Review this UI_LAYOUT trace at 360x720. Report failed checks first. Then compare
+repeated controls for equal dimensions, centers, baselines, gaps, padding, edge
+clearance, containment, and unexpected overlap. Distinguish exact geometric
+defects from visual questions that still require the framebuffer.
+```
+
+For intentional optical nudges, audit both the mathematical placement and the
+final draw rectangle. Give the nudge a named ID or role so a reviewer does not
+mistake it for unexplained drift.

--- a/samples/immediate_axis_layout/audit.stasis
+++ b/samples/immediate_axis_layout/audit.stasis
@@ -1,0 +1,20 @@
+import "../../src/stdlib/ui_layout_audit.stasis";
+
+function menu_emit_layout_audit(safe_x: f32, safe_y: f32, safe_w: f32, safe_h: f32, title_w: f32, title_h: f32, label_w: f32, label_h: f32): void {
+    ui_audit_rect("safe_viewport", "viewport", safe_x, safe_y, safe_w, safe_h);
+    ui_audit_rect("menu_title", "text_box", menu_title_x, menu_title_y, title_w, title_h);
+    ui_audit_text("menu_title", menu_title_x, menu_title_y, title_w, title_h, 24);
+    ui_audit_rect("play_button", "button", menu_button_x, menu_button_y, menu_button_w, menu_button_h);
+    ui_audit_rect("play_label", "text_box", menu_label_x, menu_label_y, label_w, label_h);
+    ui_audit_text("play_label", menu_label_x, menu_label_y, label_w, label_h, 24);
+
+    ui_audit_center_check("x", "menu_title", "safe_viewport", ui_audit_center_delta_x(safe_x, safe_w, menu_title_x, title_w), 0.5);
+    ui_audit_center_check("x", "play_label", "play_button", ui_audit_center_delta_x(menu_button_x, menu_button_w, menu_label_x, label_w), 0.5);
+    ui_audit_center_check("y", "play_label", "play_button", ui_audit_center_delta_y(menu_button_y, menu_button_h, menu_label_y, label_h), 1.0);
+    ui_audit_padding_axis("x", "play_label", "play_button", menu_button_x, menu_button_w, menu_label_x, label_w, 0.5);
+    ui_audit_padding_axis("y", "play_label", "play_button", menu_button_y, menu_button_h, menu_label_y, label_h, 0.5);
+    ui_audit_padding_axis("x", "play_button", "safe_viewport", safe_x, safe_w, menu_button_x, menu_button_w, 0.5);
+    ui_audit_padding_axis("y", "play_button", "safe_viewport", safe_y, safe_h, menu_button_y, menu_button_h, 0.5);
+    ui_audit_overlap_axis("x", "menu_title", "play_button", menu_title_x, title_w, menu_button_x, menu_button_w, true);
+    ui_audit_overlap_axis("y", "menu_title", "play_button", menu_title_y, title_h, menu_button_y, menu_button_h, false);
+}

--- a/samples/immediate_axis_layout/main.stasis
+++ b/samples/immediate_axis_layout/main.stasis
@@ -1,5 +1,6 @@
 import "../../src/stdlib/graphics.stasis";
 import "layout.stasis";
+import "audit.stasis";
 
 struct MenuState {
     font: i32;
@@ -9,6 +10,7 @@ struct MenuState {
     play_width: f32;
     button: Sprite;
     play_clicked: bool;
+    audit_emitted: bool;
 }
 
 global state: MenuState;
@@ -22,6 +24,7 @@ function main(): i32 {
     state.play_width = state.play.width;
     state.button.load_sprite_from("../render_parity/assets/opaque.svg", 180, 56);
     state.play_clicked = false;
+    state.audit_emitted = false;
     if (state.font == 0 || state.title.handle == 0 || state.play.handle == 0 || state.button.handle == 0) {
         return 1;
     }
@@ -41,6 +44,19 @@ function update_menu_layout(): void {
 
 function tick(): i32 {
     update_menu_layout();
+    if (!state.audit_emitted) {
+        menu_emit_layout_audit(
+            gfx_safe_viewport_x(),
+            gfx_safe_viewport_y(),
+            gfx_safe_viewport_width(),
+            gfx_safe_viewport_height(),
+            state.title.width,
+            state.title.height,
+            state.play.width,
+            state.play.height
+        );
+        state.audit_emitted = true;
+    }
     state.play_clicked = false;
     let pointer_count: i32 = input_pointer_count();
     let i: i32 = 0;

--- a/samples/immediate_axis_layout/verify.stasis
+++ b/samples/immediate_axis_layout/verify.stasis
@@ -1,4 +1,5 @@
 import "placement.stasis";
+import "../../src/stdlib/ui_layout_audit.stasis";
 
 function main(): i32 {
     let title_x: f32 = menu_title_x_for(0.0, 360.0, 180.0);
@@ -23,6 +24,18 @@ function main(): i32 {
     }
     if (menu_point_in_button(200.0, 196.0, button_x, button_y, 180.0, 56.0)) {
         return 6;
+    }
+    if (!ui_audit_centered_x(20.0, 180.0, label_x, 64.0, 0.01)) {
+        return 7;
+    }
+    if (!ui_audit_centered_y(140.0, 56.0, label_y, 26.0, 0.01)) {
+        return 8;
+    }
+    if (!ui_audit_contains_axis(20.0, 180.0, label_x, 64.0, 0.01)) {
+        return 9;
+    }
+    if (ui_audit_overlap_x(90.0, 180.0, 20.0, 180.0) != 110.0) {
+        return 10;
     }
     return 0;
 }

--- a/samples/immediate_axis_layout/verify_jit.stasis
+++ b/samples/immediate_axis_layout/verify_jit.stasis
@@ -1,4 +1,5 @@
 import "layout.stasis";
+import "../../src/stdlib/ui_layout_audit.stasis";
 
 function main(): i32 {
     menu_layout(0.0, 0.0, 360.0, 720.0, 180.0, 64.0);
@@ -19,6 +20,12 @@ function main(): i32 {
     }
     if (menu_button_contains(200.0, 196.0)) {
         return 6;
+    }
+    if (!ui_audit_centered_x(menu_button_x, menu_button_w, menu_label_x, 64.0, 0.01)) {
+        return 7;
+    }
+    if (!ui_audit_centered_y(menu_button_y, menu_button_h, menu_label_y, 26.0, 0.01)) {
+        return 8;
     }
     return 0;
 }

--- a/src/stdlib/ui_layout_audit.stasis
+++ b/src/stdlib/ui_layout_audit.stasis
@@ -1,0 +1,231 @@
+// Allocation-free geometry checks and machine-readable UI layout reporting.
+// Values are emitted as signed thousandths of one logical layout unit.
+
+function ui_audit_abs(value: f32): f32 {
+    if (value < 0.0) {
+        return 0.0 - value;
+    }
+    return value;
+}
+
+function ui_audit_center_delta_x(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32): f32 {
+    return(child_x + child_width * 0.5) -(parent_x + parent_width * 0.5);
+}
+
+function ui_audit_center_delta_y(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32): f32 {
+    return(child_y + child_height * 0.5) -(parent_y + parent_height * 0.5);
+}
+
+function ui_audit_left_gap(parent_x: f32, child_x: f32): f32 {
+    return child_x - parent_x;
+}
+
+function ui_audit_right_gap(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32): f32 {
+    return parent_x + parent_width -(child_x + child_width);
+}
+
+function ui_audit_top_gap(parent_y: f32, child_y: f32): f32 {
+    return child_y - parent_y;
+}
+
+function ui_audit_bottom_gap(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32): f32 {
+    return parent_y + parent_height -(child_y + child_height);
+}
+
+function ui_audit_equal(a: f32, b: f32, tolerance: f32): bool {
+    return ui_audit_abs(a - b) <= tolerance;
+}
+
+function ui_audit_centered_x(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32, tolerance: f32): bool {
+    return ui_audit_abs(ui_audit_center_delta_x(parent_x, parent_width, child_x, child_width)) <= tolerance;
+}
+
+function ui_audit_centered_y(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32, tolerance: f32): bool {
+    return ui_audit_abs(ui_audit_center_delta_y(parent_y, parent_height, child_y, child_height)) <= tolerance;
+}
+
+function ui_audit_contains_axis(parent_start: f32, parent_length: f32, child_start: f32, child_length: f32, tolerance: f32): bool {
+    return child_start >= parent_start - tolerance && child_start + child_length <= parent_start + parent_length + tolerance;
+}
+
+function ui_audit_overlap_x(first_x: f32, first_width: f32, second_x: f32, second_width: f32): f32 {
+    let start: f32 = first_x;
+    if (second_x > start) {
+        start = second_x;
+    }
+    let end: f32 = first_x + first_width;
+    if (second_x + second_width < end) {
+        end = second_x + second_width;
+    }
+    if (end <= start) {
+        return 0.0;
+    }
+    return end - start;
+}
+
+function ui_audit_overlap_y(first_y: f32, first_height: f32, second_y: f32, second_height: f32): f32 {
+    let start: f32 = first_y;
+    if (second_y > start) {
+        start = second_y;
+    }
+    let end: f32 = first_y + first_height;
+    if (second_y + second_height < end) {
+        end = second_y + second_height;
+    }
+    if (end <= start) {
+        return 0.0;
+    }
+    return end - start;
+}
+
+function ui_audit_rects_overlap(
+    first_x: f32,
+    first_y: f32,
+    first_width: f32,
+    first_height: f32,
+    second_x: f32,
+    second_y: f32,
+    second_width: f32,
+    second_height: f32
+): bool {
+    return ui_audit_overlap_x(first_x, first_width, second_x, second_width) > 0.0 && ui_audit_overlap_y(first_y, first_height, second_y, second_height) > 0.0;
+}
+
+function ui_audit_milli(value: f32): i32 {
+    let result: i32 = 0;
+    if (value < 0.0) {
+        result.from_f32(value * 1000.0 - 0.5);
+    } else {
+        result.from_f32(value * 1000.0 + 0.5);
+    }
+    return result;
+}
+
+function ui_audit_print_bool(value: bool): void {
+    if (value) {
+        print_int(1);
+    } else {
+        print_int(0);
+    }
+}
+
+function ui_audit_rect(id: string, role: string, x: f32, y: f32, width: f32, height: f32): void {
+    print_string("UI_LAYOUT|rect|id=");
+    print_string(id);
+    print_string("|role=");
+    print_string(role);
+    print_string("|x_milli=");
+    print_int(ui_audit_milli(x));
+    print_string("|y_milli=");
+    print_int(ui_audit_milli(y));
+    print_string("|w_milli=");
+    print_int(ui_audit_milli(width));
+    print_string("|h_milli=");
+    print_int(ui_audit_milli(height));
+    print_string("\n");
+}
+
+function ui_audit_text(id: string, x: f32, y: f32, width: f32, height: f32, font_size: i32): void {
+    print_string("UI_LAYOUT|text|id=");
+    print_string(id);
+    print_string("|x_milli=");
+    print_int(ui_audit_milli(x));
+    print_string("|y_milli=");
+    print_int(ui_audit_milli(y));
+    print_string("|w_milli=");
+    print_int(ui_audit_milli(width));
+    print_string("|h_milli=");
+    print_int(ui_audit_milli(height));
+    print_string("|font_size=");
+    print_int(font_size);
+    print_string("\n");
+}
+
+function ui_audit_baseline_check(first_id: string, second_id: string, first_y: f32, second_y: f32, tolerance: f32): void {
+    let delta: f32 = second_y - first_y;
+    let passes: bool = ui_audit_abs(delta) <= tolerance;
+    print_string("UI_LAYOUT|check|kind=baseline|first=");
+    print_string(first_id);
+    print_string("|second=");
+    print_string(second_id);
+    print_string("|delta_milli=");
+    print_int(ui_audit_milli(delta));
+    print_string("|tolerance_milli=");
+    print_int(ui_audit_milli(tolerance));
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}
+
+function ui_audit_center_check(axis: string, child_id: string, parent_id: string, delta: f32, tolerance: f32): void {
+    let passes: bool = ui_audit_abs(delta) <= tolerance;
+    print_string("UI_LAYOUT|check|kind=center_");
+    print_string(axis);
+    print_string("|child=");
+    print_string(child_id);
+    print_string("|parent=");
+    print_string(parent_id);
+    print_string("|delta_milli=");
+    print_int(ui_audit_milli(delta));
+    print_string("|tolerance_milli=");
+    print_int(ui_audit_milli(tolerance));
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}
+
+function ui_audit_padding_axis(
+    axis: string,
+    id: string,
+    parent_id: string,
+    parent_start: f32,
+    parent_length: f32,
+    child_start: f32,
+    child_length: f32,
+    tolerance: f32
+): void {
+    let contained: bool = ui_audit_contains_axis(parent_start, parent_length, child_start, child_length, tolerance);
+    print_string("UI_LAYOUT|padding|axis=");
+    print_string(axis);
+    print_string("|id=");
+    print_string(id);
+    print_string("|parent=");
+    print_string(parent_id);
+    print_string("|start_milli=");
+    print_int(ui_audit_milli(child_start - parent_start));
+    print_string("|end_milli=");
+    print_int(ui_audit_milli(parent_start + parent_length -(child_start + child_length)));
+    print_string("|contained=");
+    ui_audit_print_bool(contained);
+    print_string("\n");
+}
+
+function ui_audit_overlap_axis(
+    axis: string,
+    first_id: string,
+    second_id: string,
+    first_start: f32,
+    first_length: f32,
+    second_start: f32,
+    second_length: f32,
+    overlap_expected: bool
+): void {
+    let overlap: f32 = ui_audit_overlap_x(first_start, first_length, second_start, second_length);
+    let passes: bool = overlap <= 0.0;
+    if (overlap_expected) {
+        passes = overlap > 0.0;
+    }
+    print_string("UI_LAYOUT|check|kind=overlap|axis=");
+    print_string(axis);
+    print_string("|first=");
+    print_string(first_id);
+    print_string("|second=");
+    print_string(second_id);
+    print_string("|overlap_milli=");
+    print_int(ui_audit_milli(overlap));
+    print_string("|expected=");
+    ui_audit_print_bool(overlap_expected);
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}

--- a/tests/stasis/ui_layout_audit.test.stasis
+++ b/tests/stasis/ui_layout_audit.test.stasis
@@ -1,0 +1,65 @@
+import "../../src/stdlib/ui_layout_audit.stasis";
+
+test `ui audit reports exact center deltas and padding`(): bool {
+    if (ui_audit_center_delta_x(10.0, 100.0, 35.0, 50.0) != 0.0) {
+        return false;
+    }
+    if (ui_audit_center_delta_y(20.0, 80.0, 45.0, 30.0) != 0.0) {
+        return false;
+    }
+    if (ui_audit_left_gap(10.0, 35.0) != 25.0 || ui_audit_right_gap(10.0, 100.0, 35.0, 50.0) != 25.0) {
+        return false;
+    }
+    if (ui_audit_top_gap(20.0, 45.0) != 25.0 || ui_audit_bottom_gap(20.0, 80.0, 45.0, 30.0) != 25.0) {
+        return false;
+    }
+    return true;
+}
+
+test `ui audit applies tolerance to alignment and containment`(): bool {
+    if (!ui_audit_centered_x(0.0, 100.0, 25.4, 50.0, 0.5)) {
+        return false;
+    }
+    if (ui_audit_centered_x(0.0, 100.0, 25.6, 50.0, 0.5)) {
+        return false;
+    }
+    if (!ui_audit_contains_axis(0.0, 100.0, -0.25, 50.0, 0.25)) {
+        return false;
+    }
+    if (ui_audit_contains_axis(0.0, 100.0, -0.26, 50.0, 0.25)) {
+        return false;
+    }
+    return true;
+}
+
+test `ui audit distinguishes contact from overlap`(): bool {
+    if (ui_audit_overlap_x(0.0, 20.0, 20.0, 10.0) != 0.0) {
+        return false;
+    }
+    if (ui_audit_rects_overlap(0.0, 0.0, 20.0, 20.0, 20.0, 0.0, 10.0, 20.0)) {
+        return false;
+    }
+    if (!ui_audit_rects_overlap(0.0, 0.0, 20.0, 20.0, 19.0, 1.0, 10.0, 10.0)) {
+        return false;
+    }
+    if (ui_audit_overlap_x(0.0, 20.0, 19.0, 10.0) != 1.0 || ui_audit_overlap_y(0.0, 20.0, 1.0, 10.0) != 10.0) {
+        return false;
+    }
+    return true;
+}
+
+test `ui audit converts logical values to signed milli units`(): bool {
+    return ui_audit_milli(12.3454) == 12345 && ui_audit_milli(12.3456) == 12346 && ui_audit_milli(-1.2344) == -1234 && ui_audit_milli(-1.2346) == -1235;
+}
+
+test `ui audit emitters accept a complete button trace`(): bool {
+    ui_audit_rect("play_button", "button", 90.0, 504.0, 180.0, 56.0);
+    ui_audit_text("play_label", 151.0, 520.0, 58.0, 24.0, 24);
+    ui_audit_center_check("x", "play_label", "play_button", 0.0, 0.5);
+    ui_audit_center_check("y", "play_label", "play_button", 0.0, 1.0);
+    ui_audit_baseline_check("left_value", "right_value", 520.0, 520.25, 0.5);
+    ui_audit_padding_axis("x", "play_label", "play_button", 90.0, 180.0, 151.0, 58.0, 0.5);
+    ui_audit_padding_axis("y", "play_label", "play_button", 504.0, 56.0, 520.0, 24.0, 0.5);
+    ui_audit_overlap_axis("y", "menu_title", "play_button", 120.0, 28.0, 504.0, 56.0, false);
+    return true;
+}


### PR DESCRIPTION
## Summary

- adds allocation-free `ui_layout_audit.stasis` geometry calculations and stable `UI_LAYOUT` trace records
- reports rectangles, runtime text bounds, centering deltas, baselines, axis padding/containment, and expected overlap
- wires the helper into generated projects and the AI Gauntlet seed
- extends the immediate-axis-layout sample with a complete AI-review example and documentation

## Why

Framebuffer review remains necessary for contrast, rasterization, and optical judgment, but source inspection alone cannot reliably reconstruct runtime text metrics, safe-area placement, or the exact rectangles shared by drawing and hit testing. This helper makes those final calculations reviewable without images.

## Validation

- 5 Stasis helper tests passed and emitted the documented machine-readable trace
- graphical immediate-layout project passed `stasis check`
- JIT verification sample exited 0
- generated-project JIT regression passed
- Gauntlet seed regression passed
- AOT compiler accepted the helper-backed sample; the executable smoke test skipped because the test host did not discover a Windows linker
- pre-commit Stasis format hook and targeted AOT test passed
- broad `cargo test -p stasis` was attempted; the Windows test runner exited with `STATUS_ACCESS_VIOLATION` after many unrelated tests passed