### PR TITLE
Fix play project discovery from nested directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ selected Stasis executable or the checked-in tree differs from that identity, th
 command restores `vendor/stasis` and updates its manifest automatically. Stasis owns that directory;
 review and commit the resulting Git changes with the compiler upgrade.
 
-For a graphical program, `stasis play path\to\main.stasis` keeps the process alive and watches the current import graph. Saving a `.stasis` file compiles a candidate in the background and attempts an all-or-nothing swap between ticks.
+For a graphical program, `stasis play path\to\main.stasis` keeps the process alive and watches the current import graph. From a project directory or any descendant, `stasis play` reads the entry and project name from the nearest ancestor `stasis.json`. Explicit entries still use that manifest root for project-root imports and asset preparation. Saving a `.stasis` file compiles a candidate in the background and attempts an all-or-nothing swap between ticks.
 
 From a project containing `stasis.json`, `stasis tui` opens the manifest entry in the persistent live-workspace interface. Pass an entry path to override the manifest for one invocation.
 

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1752,7 +1752,7 @@ pub fn run_play_in_process_with_input_script(
     tick_sleep_micros: u64,
     max_ticks: Option<u64>,
 ) -> Result<(), String> {
-    run_play_in_process_inner(
+    run_play_in_process_with_input_script_and_window_title(
         watch_file,
         watch_dir,
         data_bind_json,
@@ -1761,6 +1761,29 @@ pub fn run_play_in_process_with_input_script(
         tick_sleep_micros,
         max_ticks,
         None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_play_in_process_with_input_script_and_window_title(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    input_script: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    window_title: Option<&str>,
+) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
+        input_script,
+        tick_sleep_micros,
+        max_ticks,
+        window_title,
         None,
     )
 }
@@ -2419,6 +2442,22 @@ fn resolve_play_project_root(
             root_path.display(),
             watch_dir.display()
         ));
+    }
+    if let Some(manifest_root) = root_path
+        .parent()
+        .and_then(|parent| {
+            parent
+                .ancestors()
+                .find(|ancestor| ancestor.join("stasis.json").is_file())
+        })
+        .map(Path::to_path_buf)
+    {
+        return manifest_root.canonicalize().map_err(|error| {
+            format!(
+                "failed to canonicalize play project root {}: {error}",
+                manifest_root.display()
+            )
+        });
     }
     if root_path.starts_with(repository_root) {
         Ok(repository_root.to_path_buf())
@@ -6061,6 +6100,37 @@ mod tests {
             7
         );
 
+        fs::remove_dir_all(&project).ok();
+    }
+
+    #[test]
+    fn play_project_root_prefers_manifest_above_nested_entry_directory() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project = std::env::temp_dir().join(format!("stasis_play_manifest_root_{stamp}"));
+        let source_dir = project.join("src");
+        fs::create_dir_all(&source_dir).expect("create source directory");
+        fs::write(
+            project.join("stasis.json"),
+            r#"{"manifest_version":1,"name":"fixture","entry":"src/main.stasis"}"#,
+        )
+        .expect("write manifest");
+        let entry = source_dir.join("main.stasis");
+        fs::write(&entry, "function main(): i32 { return 0; }\n").expect("write entry");
+        let entry = entry.canonicalize().expect("canonical entry");
+        let source_dir = source_dir
+            .canonicalize()
+            .expect("canonical source directory");
+        let repository = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("canonical repository");
+
+        let selected = resolve_play_project_root(&entry, &source_dir, &repository)
+            .expect("resolve project root");
+        assert_eq!(selected, project.canonicalize().expect("canonical project"));
         fs::remove_dir_all(&project).ok();
     }
 

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use stasis::{
     build_aot_direct_storage_source, run_jit_tests_in_directory_with_session,
-    run_play_in_process_with_input_script, run_self_host_aot_cli_with_options,
+    run_play_in_process_with_input_script_and_window_title, run_self_host_aot_cli_with_options,
     run_with_default_backend, run_with_real_backend, RunnerConfig, StasisTestRunSession,
 };
 use stasis_assets::{
@@ -112,7 +112,7 @@ struct MobileAotBundleArgs {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PlayCliArgs {
-    watch_file: PathBuf,
+    watch_file: Option<PathBuf>,
     watch_dir: Option<PathBuf>,
     data_bind_json: Option<PathBuf>,
     data_bind_struct_meta: Option<PathBuf>,
@@ -122,6 +122,13 @@ struct PlayCliArgs {
     screenshot: Option<PathBuf>,
     screenshot_frame: u64,
     exit_after_screenshot: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedPlayLaunch {
+    watch_file: PathBuf,
+    watch_dir: PathBuf,
+    window_title: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -601,12 +608,6 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         }
         i += 1;
     }
-    let Some(watch_file) = watch_file else {
-        return Err(
-            "missing entry file. Use `stasis.exe play <path.stasis>` (or --watch-file <path>)"
-                .to_string(),
-        );
-    };
     if screenshot.is_none() && (screenshot_frame_explicit || exit_after_screenshot) {
         return Err(
             "--screenshot-frame and --exit-after-screenshot require --screenshot <path>"
@@ -627,6 +628,146 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         screenshot,
         screenshot_frame,
         exit_after_screenshot,
+    })
+}
+
+fn find_play_manifest_root(start: &Path) -> Option<PathBuf> {
+    let start_dir = if start.is_file() {
+        start.parent()?
+    } else {
+        start
+    };
+    start_dir
+        .ancestors()
+        .find(|ancestor| ancestor.join("stasis.json").is_file())
+        .map(Path::to_path_buf)
+}
+
+fn resolve_existing_play_file(path: &Path, launch_dir: &Path) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        launch_dir.join(path)
+    };
+    let resolved = candidate.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve play entry {}: {error}",
+            candidate.display()
+        )
+    })?;
+    if !resolved.is_file() {
+        return Err(format!("play entry is not a file: {}", resolved.display()));
+    }
+    Ok(resolved)
+}
+
+fn resolve_existing_play_directory(path: &Path, launch_dir: &Path) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        launch_dir.join(path)
+    };
+    let resolved = candidate.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve play watch directory {}: {error}",
+            candidate.display()
+        )
+    })?;
+    if !resolved.is_dir() {
+        return Err(format!(
+            "play watch directory is not a directory: {}",
+            resolved.display()
+        ));
+    }
+    Ok(resolved)
+}
+
+fn load_play_manifest_details(root: &Path) -> Result<(PathBuf, Option<String>), String> {
+    let manifest_path = root.join("stasis.json");
+    let source = fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("failed to read {}: {error}", manifest_path.display()))?;
+    let manifest: serde_json::Value = serde_json::from_str(&source)
+        .map_err(|error| format!("invalid {}: {error}", manifest_path.display()))?;
+    let entry = manifest
+        .get("entry")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("{} has no non-empty entry", manifest_path.display()))?;
+    let entry = Path::new(entry);
+    if entry.is_absolute() {
+        return Err(format!(
+            "{} entry must be project-relative",
+            manifest_path.display()
+        ));
+    }
+    let resolved_entry = resolve_existing_play_file(entry, root)?;
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve project root {}: {error}", root.display()))?;
+    if !resolved_entry.starts_with(&canonical_root) {
+        return Err(format!(
+            "{} entry escapes project root {}",
+            manifest_path.display(),
+            canonical_root.display()
+        ));
+    }
+    let title = manifest
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    Ok((resolved_entry, title))
+}
+
+fn resolve_play_launch(
+    parsed: &PlayCliArgs,
+    launch_dir: &Path,
+) -> Result<ResolvedPlayLaunch, String> {
+    let explicit_entry = parsed
+        .watch_file
+        .as_deref()
+        .map(|path| resolve_existing_play_file(path, launch_dir))
+        .transpose()?;
+    let manifest_root = if let Some(entry) = explicit_entry.as_deref() {
+        find_play_manifest_root(entry)
+    } else {
+        find_play_manifest_root(launch_dir)
+    };
+
+    let (watch_file, window_title) = if let Some(entry) = explicit_entry {
+        let title = manifest_root
+            .as_deref()
+            .and_then(|root| load_play_manifest_details(root).ok())
+            .and_then(|(_, title)| title);
+        (entry, title)
+    } else {
+        let root = manifest_root.as_deref().ok_or_else(|| {
+            format!(
+                "missing entry file and no stasis.json found from {}",
+                launch_dir.display()
+            )
+        })?;
+        load_play_manifest_details(root)?
+    };
+
+    let watch_dir = match parsed
+        .watch_dir
+        .as_deref()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        Some(path) => resolve_existing_play_directory(path, launch_dir)?,
+        None => manifest_root
+            .or_else(|| watch_file.parent().map(Path::to_path_buf))
+            .ok_or_else(|| format!("play entry has no parent: {}", watch_file.display()))?
+            .canonicalize()
+            .map_err(|error| format!("failed to resolve play watch directory: {error}"))?,
+    };
+
+    Ok(ResolvedPlayLaunch {
+        watch_file,
+        watch_dir,
+        window_title,
     })
 }
 
@@ -719,6 +860,20 @@ fn try_run_play_subcommand() -> Option<i32> {
             return Some(2);
         }
     };
+    let launch_dir = match env::current_dir() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("failed to read current directory: {error}");
+            return Some(2);
+        }
+    };
+    let launch = match resolve_play_launch(&parsed, &launch_dir) {
+        Ok(value) => value,
+        Err(message) => {
+            eprintln!("{message}");
+            return Some(2);
+        }
+    };
     let screenshot_environment = match configure_play_screenshot_environment(&parsed) {
         Ok(value) => value,
         Err(message) => {
@@ -727,14 +882,15 @@ fn try_run_play_subcommand() -> Option<i32> {
         }
     };
 
-    let play_result = run_play_in_process_with_input_script(
-        &parsed.watch_file,
-        parsed.watch_dir.as_deref(),
+    let play_result = run_play_in_process_with_input_script_and_window_title(
+        &launch.watch_file,
+        Some(&launch.watch_dir),
         parsed.data_bind_json.as_deref(),
         parsed.data_bind_struct_meta.as_deref(),
         parsed.input_script.as_deref(),
         parsed.tick_sleep_micros,
         parsed.ticks,
+        launch.window_title.as_deref(),
     );
     match play_result {
         Ok(()) => {
@@ -2291,7 +2447,7 @@ mod tests {
         let parsed = parse_play_cli_args(&args).expect("parse should succeed");
         assert_eq!(
             parsed.watch_file,
-            PathBuf::from("samples/bucket_catcher.stasis")
+            Some(PathBuf::from("samples/bucket_catcher.stasis"))
         );
         assert_eq!(parsed.watch_dir, Some(PathBuf::from("samples")));
         assert_eq!(
@@ -2304,6 +2460,134 @@ mod tests {
                 "samples/bucket_catcher/data/config.struct-meta.json"
             ))
         );
+    }
+
+    #[test]
+    fn parse_play_cli_args_accepts_manifest_inferred_entry() {
+        let parsed = parse_play_cli_args(&[]).expect("parse should succeed");
+        assert_eq!(parsed.watch_file, None);
+        assert_eq!(parsed.watch_dir, None);
+    }
+
+    #[test]
+    fn play_launch_infers_manifest_entry_from_nested_directory() {
+        let stamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project = env::temp_dir().join(format!("stasis_play_manifest_{stamp}"));
+        let source_dir = project.join("src");
+        let nested_dir = source_dir.join("nested");
+        fs::create_dir_all(&nested_dir).expect("create project directories");
+        fs::write(
+            project.join("stasis.json"),
+            r#"{"manifest_version":1,"name":"Manifest Game","entry":"src/main.stasis"}"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            source_dir.join("main.stasis"),
+            "function main(): i32 { return 0; }\n",
+        )
+        .expect("write entry");
+
+        let parsed = parse_play_cli_args(&[]).expect("parse arguments");
+        let resolved = resolve_play_launch(&parsed, &nested_dir).expect("resolve manifest entry");
+        assert_eq!(
+            resolved.watch_file,
+            source_dir
+                .join("main.stasis")
+                .canonicalize()
+                .expect("canonical entry")
+        );
+        assert_eq!(
+            resolved.watch_dir,
+            project.canonicalize().expect("canonical project")
+        );
+        assert_eq!(resolved.window_title.as_deref(), Some("Manifest Game"));
+        fs::remove_dir_all(&project).ok();
+    }
+
+    #[test]
+    fn explicit_nested_entry_still_uses_manifest_project_root() {
+        let stamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let project = env::temp_dir().join(format!("stasis_play_explicit_{stamp}"));
+        let source_dir = project.join("src");
+        fs::create_dir_all(&source_dir).expect("create source directory");
+        fs::write(
+            project.join("stasis.json"),
+            r#"{"manifest_version":1,"name":"Explicit Game","entry":"src/main.stasis"}"#,
+        )
+        .expect("write manifest");
+        fs::write(
+            source_dir.join("main.stasis"),
+            "function main(): i32 { return 0; }\n",
+        )
+        .expect("write entry");
+
+        let parsed = parse_play_cli_args(&["main.stasis".to_string()]).expect("parse arguments");
+        let resolved = resolve_play_launch(&parsed, &source_dir).expect("resolve explicit entry");
+        assert_eq!(
+            resolved.watch_dir,
+            project.canonicalize().expect("canonical project")
+        );
+        assert_eq!(resolved.window_title.as_deref(), Some("Explicit Game"));
+        fs::remove_dir_all(&project).ok();
+    }
+
+    #[test]
+    fn explicit_external_entry_does_not_inherit_callers_manifest() {
+        let stamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = env::temp_dir().join(format!("stasis_play_external_{stamp}"));
+        let caller = root.join("caller");
+        let external = root.join("external");
+        fs::create_dir_all(&caller).expect("create caller directory");
+        fs::create_dir_all(&external).expect("create external directory");
+        fs::write(
+            caller.join("stasis.json"),
+            r#"{"manifest_version":1,"name":"Caller","entry":"main.stasis"}"#,
+        )
+        .expect("write caller manifest");
+        fs::write(
+            caller.join("main.stasis"),
+            "function main(): i32 { return 0; }\n",
+        )
+        .expect("write caller entry");
+        let external_entry = external.join("standalone.stasis");
+        fs::write(&external_entry, "function main(): i32 { return 0; }\n")
+            .expect("write external entry");
+
+        let parsed = parse_play_cli_args(&[external_entry.display().to_string()])
+            .expect("parse explicit entry");
+        let resolved = resolve_play_launch(&parsed, &caller).expect("resolve external entry");
+        assert_eq!(
+            resolved.watch_dir,
+            external
+                .canonicalize()
+                .expect("canonical external directory")
+        );
+        assert_eq!(resolved.window_title, None);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn play_without_entry_or_manifest_reports_discovery_root() {
+        let stamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let directory = env::temp_dir().join(format!("stasis_play_no_manifest_{stamp}"));
+        fs::create_dir_all(&directory).expect("create directory");
+        let parsed = parse_play_cli_args(&[]).expect("parse arguments");
+        let error = resolve_play_launch(&parsed, &directory).expect_err("manifest is required");
+        assert!(error.contains("missing entry file and no stasis.json found"));
+        assert!(error.contains(&directory.display().to_string()));
+        fs::remove_dir_all(&directory).ok();
     }
 
     #[test]

--- a/apps/stasis/tests/windows_game_launch.rs
+++ b/apps/stasis/tests/windows_game_launch.rs
@@ -184,14 +184,33 @@ fn every_supported_windows_game_launch_path_loads_assets_and_renders() {
     let project = parent.join("windows_launch_smoke");
     copy_tree(&fixture, &project);
 
-    for case in ["play", "run_watch", "tui"] {
+    let nested_launch_dir = project.join("nested/launch");
+    fs::create_dir_all(&nested_launch_dir).expect("create nested manifest launch directory");
+    for case in ["play", "play_manifest_nested", "run_watch", "tui"] {
         let screenshot = parent.join(format!("{case}.png"));
-        let mut command = stasis_command(&project);
+        let command_dir = if case == "play_manifest_nested" {
+            &nested_launch_dir
+        } else {
+            &project
+        };
+        let mut command = stasis_command(command_dir);
         match case {
             "play" => {
                 command.args([
                     "play",
                     "main.stasis",
+                    "--ticks",
+                    "2",
+                    "--screenshot-frame",
+                    "2",
+                    "--screenshot",
+                    screenshot.to_str().unwrap(),
+                    "--exit-after-screenshot",
+                ]);
+            }
+            "play_manifest_nested" => {
+                command.args([
+                    "play",
                     "--ticks",
                     "2",
                     "--screenshot-frame",

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -115,6 +115,10 @@ cloning a generated repository, reactivate the checked-in hook with
 - `test [PATH]`: run Stasis tests in one isolated JIT session.
 - `run [--headless]`: JIT-compile and execute no-argument `main(): i32` or `main(): void`; an
   `i32` result is the process exit code. Headless execution is the default.
+- `play [ENTRY]`: launch the graphical hot-swap runtime. Without an entry override, discover the
+  nearest ancestor `stasis.json` from the current directory and use its project-relative `entry`
+  and display `name`. Explicit entries discover their own ancestor manifest, so project-root
+  imports and asset preparation remain anchored to the project even when play starts in `src/`.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   The window title uses the manifest project name. Because it is an unbounded graphical session,
   watch mode rejects `--json` and `--headless`.

--- a/docs/windows_game_launch_testing.md
+++ b/docs/windows_game_launch_testing.md
@@ -7,7 +7,7 @@ returns distinct nonzero startup codes when any required resource fails.
 The Windows-only Rust integration test `apps/stasis/tests/windows_game_launch.rs` copies the fixture
 under `target/windows-launch-tests`, gives every child process a 60-second timeout, and exercises:
 
-- `stasis play ENTRY`;
+- `stasis play ENTRY` and manifest-inferred `stasis play` from a nested project directory;
 - `stasis run --watch`;
 - `stasis tui ENTRY` with a deterministic live script;
 - `stasis build --mode release`, followed by the generated AOT executable;


### PR DESCRIPTION
## What changed

- Let stasis play discover the nearest ancestor stasis.json and use its entry and project name when no filename is supplied.
- Anchor explicit nested entries to their manifest project root so project-root imports and prepared assets resolve correctly from directories such as src/.
- Preserve standalone explicit entries and prevent them from inheriting an unrelated caller manifest.
- Add unit, real Windows graphical launch, and documentation coverage.

## Verification

- cargo fmt --all -- --check`n- 184/184 stasis CLI binary tests pass
- Focused play project-root library test passes
- Windows graphical launch matrix passes, including manifest-inferred play from a nested directory
- Real Gambit Guard verification from F:\ChessTD\src passes for both play main.stasis --ticks 0 and play --ticks 0`n- Broad library suite reaches an existing unrelated Windows STATUS_ACCESS_VIOLATION in live_workspace::collection_capacity_shrink_warns_and_copies_only_retained_elements; the touched focused tests pass

## Compatibility

Explicit entry paths remain supported. Manifest inference is used only when the entry is omitted, and an explicit standalone entry without a manifest retains its entry-parent project root.