### PR TITLE
fix: flatten vendored Stasis paths

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -73,18 +73,18 @@ const PROJECT_CLAUDE_GUIDE: &str = "# CLAUDE.md\n\n@AGENTS.md\n";
 const PROJECT_ARCHITECTURE_GUIDE: &str = include_str!("../../../docs/project_architecture.md");
 const PROJECT_ARCHITECTURE_NAME: &str = "PROJECT_ARCHITECTURE.md";
 const PROJECT_GIT_ATTRIBUTES: &str = "*.stasis text eol=crlf\n";
-const DEFAULT_PROJECT_SOURCE: &str = r#"import "/vendor/stasis/src/stdlib/stdlib.stasis";
-import "/vendor/stasis/src/stdlib/graphics.stasis";
-import "/vendor/stasis/src/stdlib/audio.stasis";
-import "/vendor/stasis/src/stdlib/collision.stasis";
-import "/vendor/stasis/src/stdlib/flex_layout.stasis";
-import "/vendor/stasis/src/stdlib/frame_timer.stasis";
-import "/vendor/stasis/src/stdlib/hud_table.stasis";
-import "/vendor/stasis/src/stdlib/sdl_scancodes.stasis";
-import "/vendor/stasis/src/stdlib/storage.stasis";
-import "/vendor/stasis/src/stdlib/ui_axis_layout.stasis";
-import "/vendor/stasis/src/stdlib/ui_layout_audit.stasis";
-import "/vendor/stasis/src/stdlib/ui_button_9slice.stasis";
+const DEFAULT_PROJECT_SOURCE: &str = r#"import "/vendor/stasis/stdlib/stdlib.stasis";
+import "/vendor/stasis/stdlib/graphics.stasis";
+import "/vendor/stasis/stdlib/audio.stasis";
+import "/vendor/stasis/stdlib/collision.stasis";
+import "/vendor/stasis/stdlib/flex_layout.stasis";
+import "/vendor/stasis/stdlib/frame_timer.stasis";
+import "/vendor/stasis/stdlib/hud_table.stasis";
+import "/vendor/stasis/stdlib/sdl_scancodes.stasis";
+import "/vendor/stasis/stdlib/storage.stasis";
+import "/vendor/stasis/stdlib/ui_axis_layout.stasis";
+import "/vendor/stasis/stdlib/ui_layout_audit.stasis";
+import "/vendor/stasis/stdlib/ui_button_9slice.stasis";
 
 function main(): i32 {
     return 0;
@@ -1126,8 +1126,8 @@ fn create_project_with_options(
     let mut manifest = ProjectManifest::new(name.clone());
     manifest.vendor = Some(current_vendor_manifest(bundled_source)?);
     write_manifest(&manifest_path, &manifest)?;
-    let vendor_source = root.join("vendor/stasis/src");
-    copy_dir_if_exists(&bundled_stdlib, &vendor_source.join("stdlib"))?;
+    let vendor_package = root.join("vendor/stasis");
+    copy_dir_if_exists(&bundled_stdlib, &vendor_package.join("stdlib"))?;
     write_new_file(&root.join("AGENTS.md"), PROJECT_AGENT_GUIDE)?;
     write_new_file(&root.join("CLAUDE.md"), PROJECT_CLAUDE_GUIDE)?;
     write_new_file(
@@ -1425,21 +1425,22 @@ fn validate_vendor_sources(source_root: &Path) -> Result<(), String> {
             .strip_prefix(source_root)
             .map_err(|_| format!("vendor source escaped {}", source_root.display()))?;
         let logical = format!(
-            "vendor/stasis/src/{}",
+            "vendor/stasis/{}",
             relative.to_string_lossy().replace('\\', "/")
         );
         let imports = stasis_compiler::frontend::module_graph::parse_imports(&logical, &source)
             .map_err(|diagnostic| format!("invalid vendor import in {logical}: {diagnostic:?}"))?;
         for import in imports {
-            let relative_target = import
-                .target
-                .strip_prefix("vendor/stasis/src/")
-                .ok_or_else(|| {
-                    format!(
-                        "vendor import '{}' from {logical} escapes the Stasis package",
-                        import.path
-                    )
-                })?;
+            let relative_target =
+                import
+                    .target
+                    .strip_prefix("vendor/stasis/")
+                    .ok_or_else(|| {
+                        format!(
+                            "vendor import '{}' from {logical} escapes the Stasis package",
+                            import.path
+                        )
+                    })?;
             if !source_root.join(relative_target).is_file() {
                 return Err(format!(
                     "vendor import '{}' from {logical} is missing its target",
@@ -1473,17 +1474,17 @@ fn inspect_project_vendor(
     })?;
     let installed = current_vendor_manifest(bundled_source)?.stasis;
     let recorded = manifest.vendor.as_ref().map(|vendor| vendor.stasis.clone());
-    let vendor_source = workspace_root.join("vendor/stasis/src");
-    let actual_sha256 = if vendor_source.exists() {
-        let metadata = fs::symlink_metadata(&vendor_source)
-            .map_err(|error| format!("failed to inspect {}: {error}", vendor_source.display()))?;
+    let vendor_package = workspace_root.join("vendor/stasis");
+    let actual_sha256 = if vendor_package.exists() {
+        let metadata = fs::symlink_metadata(&vendor_package)
+            .map_err(|error| format!("failed to inspect {}: {error}", vendor_package.display()))?;
         if metadata.file_type().is_symlink() || !metadata.is_dir() {
             return Err(format!(
                 "refusing to inspect vendored sources through {}",
-                vendor_source.display()
+                vendor_package.display()
             ));
         }
-        Some(directory_sha256(&vendor_source)?)
+        Some(directory_sha256(&vendor_package)?)
     } else {
         None
     };
@@ -1570,15 +1571,15 @@ fn update_vendor_snapshot(
     let manifest_staging = workspace_root.join(format!("{MANIFEST_NAME}.vendor-sync-{suffix}"));
     let manifest_backup = workspace_root.join(format!("{MANIFEST_NAME}.vendor-previous-{suffix}"));
 
-    if let Err(error) = copy_dir_if_exists(bundled_source, &staging.join("src")) {
+    if let Err(error) = copy_dir_if_exists(bundled_source, &staging) {
         let _ = fs::remove_dir_all(&staging);
         return Err(error);
     }
-    if let Err(error) = validate_vendor_sources(&staging.join("src")) {
+    if let Err(error) = validate_vendor_sources(&staging) {
         let _ = fs::remove_dir_all(&staging);
         return Err(error);
     }
-    let staged_hash = directory_sha256(&staging.join("src"))?;
+    let staged_hash = directory_sha256(&staging)?;
     if staged_hash != status.installed.sha256 {
         let _ = fs::remove_dir_all(&staging);
         return Err("staged Stasis vendor fingerprint does not match the toolchain".to_string());
@@ -5562,7 +5563,7 @@ mod tests {
             "ui_button_9slice",
         ] {
             assert!(
-                source.contains(&format!("/vendor/stasis/src/stdlib/{module}.stasis")),
+                source.contains(&format!("/vendor/stasis/stdlib/{module}.stasis")),
                 "missing default {module} import"
             );
         }
@@ -5596,22 +5597,39 @@ mod tests {
             current_release_id()
         );
 
-        let older_source = root.join("vendor/stasis/src/stdlib/audio.stasis");
+        let older_source = root.join("vendor/stasis/stdlib/audio.stasis");
         let mut older_contents = fs::read_to_string(&older_source).expect("read vendor source");
         older_contents.push_str("// older clean snapshot\r\n");
         fs::write(&older_source, older_contents).expect("write older clean snapshot");
         let vendor = manifest.vendor.as_mut().expect("tracked vendor");
         vendor.stasis.release_id = current_release_id().to_string();
         vendor.stasis.sha256 =
-            directory_sha256(&root.join("vendor/stasis/src")).expect("hash older clean snapshot");
+            directory_sha256(&root.join("vendor/stasis")).expect("hash older clean snapshot");
         write_manifest(&manifest_path, &manifest).expect("record older content hash");
         let workspace = load_workspace(Some(&root)).expect("content-hash update");
         let updated = workspace.manifest.vendor.expect("updated vendor").stasis;
         assert_eq!(updated.release_id, current_release_id());
         assert_eq!(
             updated.sha256,
-            directory_sha256(&root.join("vendor/stasis/src")).expect("hash updated vendor")
+            directory_sha256(&root.join("vendor/stasis")).expect("hash updated vendor")
         );
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn vendor_upgrade_flattens_the_legacy_src_directory() {
+        let root = temp_dir("vendor_flatten");
+        create_project(root.clone(), "vendor_flatten".to_string()).expect("create project");
+        let vendor_root = root.join("vendor/stasis");
+        let old_contents = root.join("vendor/stasis-old");
+        fs::rename(&vendor_root, &old_contents).expect("stage flat vendor contents");
+        fs::create_dir_all(&vendor_root).expect("recreate vendor root");
+        fs::rename(&old_contents, vendor_root.join("src")).expect("create legacy layout");
+
+        load_workspace(Some(&root)).expect("upgrade legacy vendor layout");
+
+        assert!(vendor_root.join("stdlib/stdlib.stasis").is_file());
+        assert!(!vendor_root.join("src").exists());
         remove_temp(&root);
     }
 
@@ -5619,7 +5637,7 @@ mod tests {
     fn automatic_upgrade_replaces_vendor_edits_owned_by_stasis() {
         let root = temp_dir("vendor_local_edits");
         create_project(root.clone(), "vendor_local_edits".to_string()).expect("create project");
-        let edited = root.join("vendor/stasis/src/stdlib/audio.stasis");
+        let edited = root.join("vendor/stasis/stdlib/audio.stasis");
         fs::write(&edited, "// local vendor edit\n").expect("edit vendor source");
 
         let current = load_workspace(Some(&root)).expect("automatic vendor replacement");
@@ -6154,9 +6172,7 @@ mod tests {
             fs::read_to_string(root.join("vendor/example/keep.txt")).expect("read existing vendor"),
             "keep\n"
         );
-        assert!(root
-            .join("vendor/stasis/src/stdlib/stdlib.stasis")
-            .is_file());
+        assert!(root.join("vendor/stasis/stdlib/stdlib.stasis").is_file());
         remove_temp(&root);
 
         let conflict = temp_dir("vendor_conflict");

--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -770,18 +770,18 @@ fn hex_sha256(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-const GAUNTLET_SEED_SOURCE: &str = r#"import "/vendor/stasis/src/stdlib/stdlib.stasis";
-import "/vendor/stasis/src/stdlib/graphics.stasis";
-import "/vendor/stasis/src/stdlib/audio.stasis";
-import "/vendor/stasis/src/stdlib/collision.stasis";
-import "/vendor/stasis/src/stdlib/flex_layout.stasis";
-import "/vendor/stasis/src/stdlib/frame_timer.stasis";
-import "/vendor/stasis/src/stdlib/hud_table.stasis";
-import "/vendor/stasis/src/stdlib/sdl_scancodes.stasis";
-import "/vendor/stasis/src/stdlib/storage.stasis";
-import "/vendor/stasis/src/stdlib/ui_axis_layout.stasis";
-import "/vendor/stasis/src/stdlib/ui_layout_audit.stasis";
-import "/vendor/stasis/src/stdlib/ui_button_9slice.stasis";
+const GAUNTLET_SEED_SOURCE: &str = r#"import "/vendor/stasis/stdlib/stdlib.stasis";
+import "/vendor/stasis/stdlib/graphics.stasis";
+import "/vendor/stasis/stdlib/audio.stasis";
+import "/vendor/stasis/stdlib/collision.stasis";
+import "/vendor/stasis/stdlib/flex_layout.stasis";
+import "/vendor/stasis/stdlib/frame_timer.stasis";
+import "/vendor/stasis/stdlib/hud_table.stasis";
+import "/vendor/stasis/stdlib/sdl_scancodes.stasis";
+import "/vendor/stasis/stdlib/storage.stasis";
+import "/vendor/stasis/stdlib/ui_axis_layout.stasis";
+import "/vendor/stasis/stdlib/ui_layout_audit.stasis";
+import "/vendor/stasis/stdlib/ui_button_9slice.stasis";
 
 struct Game {
     ticks: i32;
@@ -1128,18 +1128,18 @@ mod tests {
     #[test]
     fn seed_has_the_required_graphical_lifecycle() {
         for required in [
-            "/vendor/stasis/src/stdlib/stdlib.stasis",
-            "/vendor/stasis/src/stdlib/graphics.stasis",
-            "/vendor/stasis/src/stdlib/audio.stasis",
-            "/vendor/stasis/src/stdlib/collision.stasis",
-            "/vendor/stasis/src/stdlib/flex_layout.stasis",
-            "/vendor/stasis/src/stdlib/frame_timer.stasis",
-            "/vendor/stasis/src/stdlib/hud_table.stasis",
-            "/vendor/stasis/src/stdlib/sdl_scancodes.stasis",
-            "/vendor/stasis/src/stdlib/storage.stasis",
-            "/vendor/stasis/src/stdlib/ui_axis_layout.stasis",
-            "/vendor/stasis/src/stdlib/ui_layout_audit.stasis",
-            "/vendor/stasis/src/stdlib/ui_button_9slice.stasis",
+            "/vendor/stasis/stdlib/stdlib.stasis",
+            "/vendor/stasis/stdlib/graphics.stasis",
+            "/vendor/stasis/stdlib/audio.stasis",
+            "/vendor/stasis/stdlib/collision.stasis",
+            "/vendor/stasis/stdlib/flex_layout.stasis",
+            "/vendor/stasis/stdlib/frame_timer.stasis",
+            "/vendor/stasis/stdlib/hud_table.stasis",
+            "/vendor/stasis/stdlib/sdl_scancodes.stasis",
+            "/vendor/stasis/stdlib/storage.stasis",
+            "/vendor/stasis/stdlib/ui_axis_layout.stasis",
+            "/vendor/stasis/stdlib/ui_layout_audit.stasis",
+            "/vendor/stasis/stdlib/ui_button_9slice.stasis",
             "function main(): i32",
             "function tick(): i32",
             "function render(): i32",

--- a/apps/stasis/src/toolchain_cli/live_tui.rs
+++ b/apps/stasis/src/toolchain_cli/live_tui.rs
@@ -331,8 +331,8 @@ fn load_ai_initial_context(
 fn load_stdlib_api_catalog(project_root: &Path) -> Result<Value, String> {
     let candidates = [
         (
-            project_root.join("vendor/stasis/src/stdlib"),
-            "/vendor/stasis/src/stdlib",
+            project_root.join("vendor/stasis/stdlib"),
+            "/vendor/stasis/stdlib",
         ),
         (
             project_root.join(".stasis_cache/toolchain/src/stdlib"),
@@ -4097,7 +4097,7 @@ mod tests {
                 .expect("clock")
                 .as_nanos()
         ));
-        let stdlib = root.join("vendor/stasis/src/stdlib");
+        let stdlib = root.join("vendor/stasis/stdlib");
         fs::create_dir_all(stdlib.join("internal")).expect("stdlib dirs");
         fs::write(
             stdlib.join("stdlib.stasis"),
@@ -4132,7 +4132,7 @@ mod tests {
             "load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool"
         ));
         assert!(rendered.contains("\"extern\":true"));
-        assert!(rendered.contains("/vendor/stasis/src/stdlib/graphics.stasis"));
+        assert!(rendered.contains("/vendor/stasis/stdlib/graphics.stasis"));
         assert!(!rendered.contains("private_counter"));
         assert!(!rendered.contains("host_private"));
         fs::remove_dir_all(root).ok();

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -400,15 +400,14 @@ fn project_commands_emit_stable_json_from_nested_directories() {
         "{\n  \"recommendations\": [\n    \"stasislang.stasis\"\n  ]\n}\n"
     );
     assert!(project
-        .join("vendor/stasis/src/stdlib/internal/host_frame.stasis")
+        .join("vendor/stasis/stdlib/internal/host_frame.stasis")
         .is_file());
     assert!(project
-        .join("vendor/stasis/src/stdlib/internal/gfx_cmd.stasis")
+        .join("vendor/stasis/stdlib/internal/gfx_cmd.stasis")
         .is_file());
-    assert!(!project.join("vendor/stasis/src/runtime").exists());
-    assert!(!project
-        .join("vendor/stasis/src/stdlib/gfx_cmd.stasis")
-        .exists());
+    assert!(!project.join("vendor/stasis/src").exists());
+    assert!(!project.join("vendor/stasis/runtime").exists());
+    assert!(!project.join("vendor/stasis/stdlib/gfx_cmd.stasis").exists());
 
     fs::create_dir_all(project.join("src/game")).expect("create nested game source directory");
     fs::write(
@@ -421,7 +420,7 @@ fn project_commands_emit_stable_json_from_nested_directories() {
     fs::write(
         project.join("src/game/player.stasis"),
         crlf(
-            "import \"/vendor/stasis/src/stdlib/graphics.stasis\";\n\nfunction player_ready(): i32 {\n    return 1;\n}\n",
+            "import \"/vendor/stasis/stdlib/graphics.stasis\";\n\nfunction player_ready(): i32 {\n    return 1;\n}\n",
         ),
     )
     .expect("write nested generated-project package import smoke");
@@ -1284,7 +1283,7 @@ fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
     assert_eq!(created.status.code(), Some(0));
     fs::write(
         project.join("src/main.stasis"),
-        "import \"/vendor/stasis/src/stdlib/graphics.stasis\";\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
+        "import \"/vendor/stasis/stdlib/graphics.stasis\";\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
     )
     .expect("write mobile entry");
     fs::create_dir_all(project.join("assets")).expect("create assets");

--- a/crates/stasis_compiler/src/frontend/module_graph.rs
+++ b/crates/stasis_compiler/src/frontend/module_graph.rs
@@ -660,18 +660,18 @@ mod tests {
     fn project_root_imports_resolve_from_any_source_directory() {
         for importer in ["src/main.stasis", "src/game/player.stasis"] {
             assert_eq!(
-                resolve_import_path(importer, "/vendor/stasis/src/stdlib/storage.stasis")
+                resolve_import_path(importer, "/vendor/stasis/stdlib/storage.stasis")
                     .expect("project-root import"),
-                "vendor/stasis/src/stdlib/storage.stasis"
+                "vendor/stasis/stdlib/storage.stasis"
             );
         }
         assert_eq!(
             resolve_import_path(
-                "vendor/stasis/src/stdlib/graphics.stasis",
+                "vendor/stasis/stdlib/graphics.stasis",
                 "internal/host_frame.stasis"
             )
             .expect("package-internal relative import"),
-            "vendor/stasis/src/stdlib/internal/host_frame.stasis"
+            "vendor/stasis/stdlib/internal/host_frame.stasis"
         );
     }
 

--- a/crates/stasis_compiler/src/frontend/workshop.rs
+++ b/crates/stasis_compiler/src/frontend/workshop.rs
@@ -5187,10 +5187,10 @@ mod workshop_contract_tests {
         assert_eq!(
             resolve_project_import_path(
                 "src/game/player.stasis",
-                "/vendor/stasis/src/stdlib/graphics.stasis"
+                "/vendor/stasis/stdlib/graphics.stasis"
             )
             .expect("project-root import"),
-            "vendor/stasis/src/stdlib/graphics.stasis"
+            "vendor/stasis/stdlib/graphics.stasis"
         );
     }
 

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -41,9 +41,9 @@ stasis inspect --capacity state.enemies=512
 ```
 
 `stasis init --name brick_game .` initializes an existing directory. The built-in template copies
-the version-matched Stasis sources into `vendor/stasis/src/stdlib`, so imports remain
+the version-matched Stasis sources into `vendor/stasis/stdlib`, so imports remain
 offline and project-local. Generated source uses project-root imports such as
-`/vendor/stasis/src/stdlib/stdlib.stasis`, which resolve consistently from nested source files.
+`/vendor/stasis/stdlib/stdlib.stasis`, which resolve consistently from nested source files.
 Commands discover
 `stasis.json` by walking from the selected path toward the filesystem root, so they work from the
 project root and nested directories. `--workspace PATH` selects a project explicitly.
@@ -68,7 +68,7 @@ project root and nested directories. `--workspace PATH` selects a project explic
 }
 ```
 
-The vendor release and hash describe the exact checked-in `vendor/stasis/src` snapshot.
+The vendor release and hash describe the exact checked-in `vendor/stasis` snapshot.
 `manifest_version` versions the JSON schema and is independent of the selected toolchain release.
 On every normal project command, Stasis verifies the on-disk tree against the selected executable.
 A mismatch stages its matching public stdlib and internal host-ABI modules together and publishes the vendor tree and

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/WorkshopAiSymbolDiscoveryTest.java
@@ -16,10 +16,10 @@ public final class WorkshopAiSymbolDiscoveryTest {
     public void resolvesImportsRelativeToTheirSourceFile() {
         assertEquals("src/shared/math.stasis", WorkshopAiSymbolDiscovery.resolveImport(
                 "src/systems/movement.stasis", "../shared/math.stasis"));
-        assertEquals("vendor/stasis/src/stdlib/storage.stasis",
+        assertEquals("vendor/stasis/stdlib/storage.stasis",
                 WorkshopAiSymbolDiscovery.resolveImport(
                         "src/systems/movement.stasis",
-                        "/vendor/stasis/src/stdlib/storage.stasis"));
+                        "/vendor/stasis/stdlib/storage.stasis"));
     }
 
     @Test

--- a/src/stdlib/audio.stasis
+++ b/src/stdlib/audio.stasis
@@ -1,7 +1,7 @@
 @link("stasis_graphics");
 
 // Audio/runtime bindings (marker module).
-// From a generated project: import "/vendor/stasis/src/stdlib/audio.stasis";
+// From a generated project: import "/vendor/stasis/stdlib/audio.stasis";
 
 extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
 extern function audio_shutdown(): void;

--- a/src/stdlib/flex_layout.stasis
+++ b/src/stdlib/flex_layout.stasis
@@ -1,5 +1,5 @@
 // Flex-style layout helpers for simple UI composition.
-// From a generated project: import "/vendor/stasis/src/stdlib/flex_layout.stasis";
+// From a generated project: import "/vendor/stasis/stdlib/flex_layout.stasis";
 //
 // Uses plain f32 arrays for portability across backends.
 // Rect layout: [x, y, w, h]

--- a/src/stdlib/hud_table.stasis
+++ b/src/stdlib/hud_table.stasis
@@ -1,5 +1,5 @@
 // HUD layout helpers for reusable "tables" (rows/columns) over arrays of data.
-// From a generated project: import "/vendor/stasis/src/stdlib/hud_table.stasis";
+// From a generated project: import "/vendor/stasis/stdlib/hud_table.stasis";
 //
 // Cranelift note:
 // - The Cranelift backend does not currently support arbitrary struct member access.

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -1,7 +1,7 @@
 // Stasis standard library (stub).
-// From a generated project: import "/vendor/stasis/src/stdlib/stdlib.stasis";
-// For host-backed APIs, import "/vendor/stasis/src/stdlib/graphics.stasis" and/or
-// "/vendor/stasis/src/stdlib/audio.stasis".
+// From a generated project: import "/vendor/stasis/stdlib/stdlib.stasis";
+// For host-backed APIs, import "/vendor/stasis/stdlib/graphics.stasis" and/or
+// "/vendor/stasis/stdlib/audio.stasis".
 
 import "memory.stasis";
 


### PR DESCRIPTION
## Summary

- install the Stasis source tree directly under `vendor/stasis` instead of `vendor/stasis/src`
- update generated imports, gauntlet seeds, AI catalog paths, docs, and platform fixtures
- migrate legacy vendor snapshots atomically through normal reconciliation

## Why

The repository-local `src` directory is not part of the target package path. Target imports should use `/vendor/stasis/stdlib/...`.

## Validation

- `python tools/cargo_cache.py run -- cargo fmt --all -- --check`
- `python tools/cargo_cache.py run -- cargo test -p stasis toolchain_cli::tests::vendor_upgrade`
- `python tools/cargo_cache.py run -- cargo test -p stasis generated_project_checks_tests_and_runs_through_jit`
- `python tools/cargo_cache.py run -- cargo test -p stasis seed_has_the_required_graphical_lifecycle`
- `python tools/cargo_cache.py run -- cargo test -p stasis --test toolchain_cli project_commands_emit_stable_json_from_nested_directories`
- focused compiler project-root import and AI stdlib catalog tests