### PR TITLE
fix: hash MP3 decoder files in releases

### DIFF
--- a/tools/ci/test_release_provenance.py
+++ b/tools/ci/test_release_provenance.py
@@ -14,7 +14,10 @@ VERIFY = ROOT / "tools" / "verify_package_provenance.py"
 
 
 class ReleaseProvenanceTests(unittest.TestCase):
-    def test_wav_mixer_is_part_of_release_provenance(self):
+    def test_audio_asset_decoder_is_part_of_release_provenance(self):
+        self.assertIn("MINIMP3-LICENSE.txt", RUNTIME_FILES)
+        self.assertIn("minimp3.h", RUNTIME_FILES)
+        self.assertIn("minimp3_ex.h", RUNTIME_FILES)
         self.assertIn("stasis_audio_assets.c", RUNTIME_FILES)
         self.assertIn("stasis_audio_assets.h", RUNTIME_FILES)
 

--- a/tools/generate_release_provenance.py
+++ b/tools/generate_release_provenance.py
@@ -19,6 +19,9 @@ PINNED_SDL_DEPENDENCIES = {
 
 RUNTIME_FILES = (
     "CMakeLists.txt",
+    "MINIMP3-LICENSE.txt",
+    "minimp3.h",
+    "minimp3_ex.h",
     "nanosvg.h",
     "nanosvgrast.h",
     "stasis_display_scale.h",


### PR DESCRIPTION
## Summary\n- include the pinned minimp3 headers and CC0 license in release provenance hashes\n- assert the compressed-audio decoder payload remains content-addressed\n\n## Failure fixed\nNightly 187 assembled the files but bundled CLI packaging failed because MOBILE_RUNTIME_FILES required hashes absent from 	ools/generate_release_provenance.py.\n\n## Verification\n- python -m unittest tools.ci.test_release_provenance\n- pre-commit Stasis formatting test\n