### PR TITLE
fix: preserve Stasis line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ stasis new my_game
 cd my_game
 ```
 
-`stasis new` initializes Git, pins `.stasis` files to CRLF in `.gitattributes`, and activates the
-generated formatting hook. An attempted commit with noncanonical Stasis source formats the files
+`stasis new` initializes Git and activates the generated formatting hook without pinning a
+line-ending style. An attempted commit with noncanonical Stasis source formats the files
 and stops; review and stage those changes, then retry the commit. Git must be installed and `stasis`
 must remain available on `PATH` when committing. The generated `src/main.stasis` imports the
 game-facing standard-library modules for core utilities, graphics, audio, collision, layout,

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -77,7 +77,6 @@ const PROJECT_AGENT_GUIDE: &str = include_str!("../../../docs/agent_workflow.md"
 const PROJECT_CLAUDE_GUIDE: &str = "# CLAUDE.md\n\n@AGENTS.md\n";
 const PROJECT_ARCHITECTURE_GUIDE: &str = include_str!("../../../docs/project_architecture.md");
 const PROJECT_ARCHITECTURE_NAME: &str = "PROJECT_ARCHITECTURE.md";
-const PROJECT_GIT_ATTRIBUTES: &str = "*.stasis text eol=crlf\n";
 const DEFAULT_PROJECT_SOURCE: &str = r#"import "/vendor/stasis/stdlib/stdlib.stasis";
 import "/vendor/stasis/stdlib/graphics.stasis";
 import "/vendor/stasis/stdlib/audio.stasis";
@@ -1092,7 +1091,6 @@ fn create_project_with_options(
         root.join(".vscode/extensions.json"),
     ];
     if initialize_git {
-        reserved_paths.push(root.join(".gitattributes"));
         reserved_paths.push(root.join(".githooks/pre-commit"));
     }
     let vscode_directory = root.join(".vscode");
@@ -1152,7 +1150,6 @@ fn create_project_with_options(
         PROJECT_VSCODE_EXTENSIONS,
     )?;
     if initialize_git {
-        write_new_file(&root.join(".gitattributes"), PROJECT_GIT_ATTRIBUTES)?;
         let hook = root.join(".githooks/pre-commit");
         fs::create_dir_all(hook.parent().expect("hook parent"))
             .map_err(|error| format!("failed to create {}: {error}", hook.display()))?;

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -561,7 +561,7 @@ fn format_alias_applies_canonical_layout_and_fmt_check_enforces_it() {
     assert_eq!(json_stdout(&formatted)["command"], "fmt");
     assert_eq!(
         fs::read_to_string(&entry).expect("read formatted fixture"),
-        crlf("struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu,\n    Playing,\n}\n\nglobal score: i32;\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n")
+        "struct Player {\n    health: i32;\n    active: bool;\n}\n\nenum Mode {\n    Menu,\n    Playing,\n}\n\nglobal score: i32;\nglobal player: Player;\n\nfunction update(amount: i32): void {\n    if (amount > 0) {\n        player.health += amount;\n    } else {\n        player.health = 0;\n    }\n}\n\nfunction main(): i32 {\n    update(1);\n    return player.health;\n}\n"
     );
 
     let fixed_modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
@@ -618,7 +618,7 @@ fn format_accepts_explicit_sources_without_a_project_manifest() {
         .success());
     assert_eq!(
         fs::read_to_string(&source).expect("read standalone formatted source"),
-        "function main(): i32 {\r\n    return 0;\r\n}\r\n"
+        "function main(): i32 {\n    return 0;\n}\n"
     );
 
     fs::remove_dir_all(&root).ok();
@@ -643,9 +643,7 @@ fn format_stdin_returns_only_canonical_source_without_a_manifest() {
     assert!(output.stderr.is_empty());
     assert_eq!(
         String::from_utf8(output.stdout).expect("formatted UTF-8"),
-        crlf(
-            "enum Mode {\n    Menu,\n    Playing,\n}\n\nfunction main(): i32 {\n    return 0;\n}\n"
-        )
+        "enum Mode {\n    Menu,\n    Playing,\n}\n\nfunction main(): i32 {\n    return 0;\n}\n"
     );
 
     let rejected = stasis_with_stdin(&["--json", "format", "--stdin"], &root, "");

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -385,10 +385,7 @@ fn project_commands_emit_stable_json_from_nested_directories() {
     let pre_commit = fs::read_to_string(project.join(".githooks/pre-commit"))
         .expect("read generated pre-commit hook");
     assert!(pre_commit.contains("stasis format --check"));
-    assert_eq!(
-        fs::read_to_string(project.join(".gitattributes")).expect("read generated Git attributes"),
-        "*.stasis text eol=crlf\n"
-    );
+    assert!(!project.join(".gitattributes").exists());
     assert_eq!(
         fs::read_to_string(project.join(".vscode/settings.json"))
             .expect("read generated VS Code settings"),
@@ -496,7 +493,7 @@ fn new_project_blocks_unformatted_commits() {
     );
     assert_eq!(
         fs::read_to_string(project.join("src/main.stasis")).expect("read hook-formatted source"),
-        "function main(): i32 {\r\n    return 0;\r\n}\r\n"
+        "function main(): i32 {\n    return 0;\n}\n"
     );
     let still_blocked = git_with_stasis_on_path(&["commit", "-m", "still unformatted"], &project);
     assert!(!still_blocked.status.success());

--- a/crates/stasis_compiler/src/frontend/formatter.rs
+++ b/crates/stasis_compiler/src/frontend/formatter.rs
@@ -142,7 +142,7 @@ impl Writer {
 
 pub fn format_source(source: &str) -> Result<String, String> {
     let tokens = canonicalize_enum_commas(&scan(source)?)?;
-    let formatted = windows_line_endings(&render(&tokens)?);
+    let formatted = apply_source_line_endings(&render(&tokens)?, source);
     let formatted_tokens = scan(&formatted)?;
     let original_significant = significant_tokens(&tokens);
     let formatted_significant = significant_tokens(&formatted_tokens);
@@ -157,11 +157,41 @@ pub fn format_source(source: &str) -> Result<String, String> {
     Ok(formatted)
 }
 
-fn windows_line_endings(source: &str) -> String {
-    source
-        .replace("\r\n", "\n")
-        .replace('\r', "\n")
-        .replace('\n', "\r\n")
+fn apply_source_line_endings(formatted: &str, source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut line_endings = Vec::new();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n') {
+            line_endings.push("\r\n");
+            index += 2;
+        } else if bytes[index] == b'\r' {
+            line_endings.push("\r");
+            index += 1;
+        } else if bytes[index] == b'\n' {
+            line_endings.push("\n");
+            index += 1;
+        } else {
+            index += 1;
+        }
+    }
+
+    let fallback = line_endings.last().copied().unwrap_or("\n");
+    let mut output = String::with_capacity(formatted.len());
+    let mut line = 0usize;
+    for character in formatted.chars() {
+        if character == '\n' {
+            output.push_str(line_endings.get(line).copied().unwrap_or(fallback));
+            line += 1;
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn normalize_line_endings(source: &str) -> String {
+    source.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 fn compiler_tokens_without_enum_commas(
@@ -204,7 +234,7 @@ fn compiler_tokens_without_enum_commas(
 fn significant_tokens(tokens: &[Token]) -> Vec<(TokenKind, String)> {
     tokens
         .iter()
-        .map(|token| (token.kind, windows_line_endings(&token.text)))
+        .map(|token| (token.kind, normalize_line_endings(&token.text)))
         .collect()
 }
 
@@ -1013,7 +1043,7 @@ fn matching_close(tokens: &[Token], open_index: usize, open: &str, close: &str) 
 
 #[cfg(test)]
 mod tests {
-    use super::{format_source, windows_line_endings, LINE_WIDTH};
+    use super::{format_source, LINE_WIDTH};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -1021,7 +1051,7 @@ mod tests {
     #[test]
     fn formats_declarations_blocks_and_spacing() {
         let source = "struct Player{health :i32;position:Vec2;} enum Screen{Menu Playing} global state :Player; function damage (self:Player,amount:i32):void {if(amount<=0){return;}else{self.health-=amount;}}";
-        let expected = windows_line_endings("struct Player {\n    health: i32;\n    position: Vec2;\n}\n\nenum Screen {\n    Menu,\n    Playing,\n}\n\nglobal state: Player;\n\nfunction damage(self: Player, amount: i32): void {\n    if (amount <= 0) {\n        return;\n    } else {\n        self.health -= amount;\n    }\n}\n");
+        let expected = "struct Player {\n    health: i32;\n    position: Vec2;\n}\n\nenum Screen {\n    Menu,\n    Playing,\n}\n\nglobal state: Player;\n\nfunction damage(self: Player, amount: i32): void {\n    if (amount <= 0) {\n        return;\n    } else {\n        self.health -= amount;\n    }\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
     }
 
@@ -1046,9 +1076,9 @@ mod tests {
             .join(", ");
         let source = format!("function calculate({names}):i32{{return parameter_0;}}");
         let formatted = format_source(&source).expect("format");
-        assert!(formatted.starts_with("function calculate(\r\n"));
-        assert!(formatted.contains("    parameter_0: i32,\r\n"));
-        assert!(formatted.contains("    parameter_17: i32\r\n): i32 {"));
+        assert!(formatted.starts_with("function calculate(\n"));
+        assert!(formatted.contains("    parameter_0: i32,\n"));
+        assert!(formatted.contains("    parameter_17: i32\n): i32 {"));
         assert!(formatted
             .lines()
             .all(|line| line.chars().count() <= LINE_WIDTH));
@@ -1056,16 +1086,28 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_tabs_blank_lines_and_line_endings() {
+    fn preserves_crlf_while_normalizing_whitespace() {
         let source = "function main(): i32 {\r\n\treturn 0;   \r\n\r\n\r\n}\r\n\r\n";
         let expected = "function main(): i32 {\r\n    return 0;\r\n}\r\n";
         assert_eq!(format_source(source).expect("format"), expected);
     }
 
     #[test]
+    fn accepts_any_line_endings_without_rewriting_them() {
+        let lf = "function main(): i32 {\n    return 0;\n}\n";
+        let crlf = "function main(): i32 {\r\n    return 0;\r\n}\r\n";
+        let cr = "function main(): i32 {\r    return 0;\r}\r";
+        let mixed = "function main(): i32 {\r\n    return 0;\n}\r";
+        assert_eq!(format_source(lf).expect("format LF"), lf);
+        assert_eq!(format_source(crlf).expect("format CRLF"), crlf);
+        assert_eq!(format_source(cr).expect("format CR"), cr);
+        assert_eq!(format_source(mixed).expect("format mixed"), mixed);
+    }
+
+    #[test]
     fn formats_annotations_unary_values_and_attached_comments() {
         let source = "function @extern(\"native_tick\")tick(value:i32):i32; enum Phase{Menu// initial\nPlaying} function main():i32{/* first\n * second\n */let value:i32=2*-3;return value;} // entry\n";
-        let expected = windows_line_endings("function @extern(\"native_tick\") tick(value: i32): i32;\n\nenum Phase {\n    Menu, // initial\n    Playing,\n}\n\nfunction main(): i32 {\n    /* first\n * second\n */\n    let value: i32 = 2 * -3;\n    return value;\n} // entry\n");
+        let expected = "function @extern(\"native_tick\") tick(value: i32): i32;\n\nenum Phase {\n    Menu, // initial\n    Playing,\n}\n\nfunction main(): i32 {\n    /* first\n * second\n */\n    let value: i32 = 2 * -3;\n    return value;\n} // entry\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(&expected).expect("reformat"), expected);
     }
@@ -1073,7 +1115,7 @@ mod tests {
     #[test]
     fn keeps_commented_imports_in_one_group() {
         let source = "import\"a.stasis\";// first\nimport \"b.stasis\";/* second */\nfunction main():i32{return 0;}";
-        let expected = windows_line_endings("import \"a.stasis\"; // first\nimport \"b.stasis\"; /* second */\n\nfunction main(): i32 {\n    return 0;\n}\n");
+        let expected = "import \"a.stasis\"; // first\nimport \"b.stasis\"; /* second */\n\nfunction main(): i32 {\n    return 0;\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(&expected).expect("reformat"), expected);
     }
@@ -1081,9 +1123,8 @@ mod tests {
     #[test]
     fn adds_trailing_enum_commas_before_attached_comments() {
         let source = "enum Phase{Ready Running=4// active\n,Finished/* done */}";
-        let expected = windows_line_endings(
-            "enum Phase {\n    Ready,\n    Running = 4, // active\n    Finished, /* done */\n}\n",
-        );
+        let expected =
+            "enum Phase {\n    Ready,\n    Running = 4, // active\n    Finished, /* done */\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(&expected).expect("reformat"), expected);
     }
@@ -1091,7 +1132,7 @@ mod tests {
     #[test]
     fn groups_globals_and_fields_and_keeps_braced_items_separated() {
         let source = "global first:i32;\n\n\nglobal second:i32;\n\nstruct Pair {\n    left:i32;\n\n    right:i32;\n}\n\n// entry\n\nexport function main():i32 {\n\n    // setup\n\n    let value:i32=first;\n\n\n    value+=second;\n\n    return value;\n\n}\n\ntest `pair total`():bool {\n    let total:i32=main();\n\n    if(total>0){\n\n        return true;\n    }\n\n\n    return total>=0;\n}\n";
-        let expected = windows_line_endings("global first: i32;\nglobal second: i32;\n\nstruct Pair {\n    left: i32;\n    right: i32;\n}\n\n// entry\n\nexport function main(): i32 {\n    // setup\n\n    let value: i32 = first;\n\n    value += second;\n\n    return value;\n}\n\ntest `pair total`(): bool {\n    let total: i32 = main();\n\n    if (total > 0) {\n        return true;\n    }\n\n    return total >= 0;\n}\n");
+        let expected = "global first: i32;\nglobal second: i32;\n\nstruct Pair {\n    left: i32;\n    right: i32;\n}\n\n// entry\n\nexport function main(): i32 {\n    // setup\n\n    let value: i32 = first;\n\n    value += second;\n\n    return value;\n}\n\ntest `pair total`(): bool {\n    let total: i32 = main();\n\n    if (total > 0) {\n        return true;\n    }\n\n    return total >= 0;\n}\n";
         assert_eq!(format_source(source).expect("format"), expected);
         assert_eq!(format_source(&expected).expect("reformat"), expected);
     }
@@ -1128,7 +1169,6 @@ mod tests {
             assert!(staged.status.success(), "failed to read staged {path}");
             let source = String::from_utf8(staged.stdout)
                 .unwrap_or_else(|error| panic!("staged source is not UTF-8 for {path}: {error}"));
-            let source = windows_line_endings(&source);
             let formatted = format_source(&source)
                 .unwrap_or_else(|error| panic!("failed to format {path}: {error}"));
             assert_eq!(

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -92,9 +92,9 @@ guide, a minimal `CLAUDE.md` that points to `AGENTS.md`, and a version-matched
 `PROJECT_ARCHITECTURE.md` with practical input, tick, state, and rendering guidance.
 Both `new` and `init` also add language-scoped VS Code settings that recommend the Stasis extension
 and enable its canonical formatter on save without changing the formatter for other languages.
-`stasis new` also initializes a local Git repository, writes `.gitattributes` to keep `.stasis`
-files on CRLF in every checkout, selects the checked-in `.githooks` directory, and installs a
-pre-commit hook. The hook checks formatting, formats noncanonical source when needed, and blocks
+`stasis new` also initializes a local Git repository, selects the checked-in `.githooks`
+directory, and installs a pre-commit hook. The hook checks formatting, formats noncanonical source
+when needed, and blocks
 that first commit so the developer can review and stage the changes. It also blocks partially
 staged Stasis changes. A retry then commits the canonical source. Git must be available when running
 `stasis new`; `stasis init` does not alter an existing repository's hook configuration. After
@@ -213,8 +213,9 @@ The canonical rules are:
 - Keep adjacent imports together and separate other top-level declarations with one blank line.
   Preserve at most one intentional blank line inside a body, but omit a blank line immediately
   before a closing brace.
-- Use Windows CRLF line endings on every platform, remove trailing whitespace and blank lines at
-  end of file, and emit exactly one final newline.
+- Preserve the file's existing line-ending style, remove trailing whitespace and blank lines at
+  end of file, and emit exactly one final newline. LF, CRLF, CR, and mixed line endings are
+  accepted.
 - Treat 160 columns as a soft limit. When a parenthesized signature, call, or condition would exceed
   it, put its comma-separated items on indented lines without adding trailing commas. Wrapped
   boolean conditions may also break before `&&` and `||`. A comment, string, or other indivisible


### PR DESCRIPTION
## Summary

- preserve each existing LF, CRLF, or CR sequence when `stasis format` rewrites a file
- accept mixed line endings without reporting formatting changes
- stop generated projects from pinning `.stasis` files to CRLF through `.gitattributes`
- update formatter, CLI scaffolding, language-service-facing coverage, and documentation

## Why

Line endings are not part of Stasis source formatting. The formatter previously converted every file to CRLF, so otherwise-canonical LF files appeared dirty and formatting caused platform-noise diffs.

## Validation

- `python tools/cargo_cache.py run -- cargo fmt --all -- --check`
- `python tools/cargo_cache.py run -- cargo test -p stasis_compiler frontend::formatter::tests`
- `python tools/cargo_cache.py run -- cargo test -p stasis --test toolchain_cli project_commands_emit_stable_json_from_nested_directories`
- `python tools/cargo_cache.py run -- cargo test -p stasis --test toolchain_cli new_project_blocks_unformatted_commits`
- `python tools/cargo_cache.py run -- cargo test -p stasis source_formatter_is_deterministic`
- `python tools/cargo_cache.py run -- cargo test -p stasis_language_service document_range_and_on_type_formatting_share_canonical_formatter`
- `python tools/cargo_cache.py run -- cargo test -p stasis_lsp standard_document_range_and_on_type_formatting_use_shared_formatter`

## Work summary

Theory gained: line endings are transport/editor representation, not Stasis syntax or canonical layout. Replaying the source newline sequence keeps formatter edits semantic while predicting that CLI, language-service, and LSP callers can share the same formatter without platform-specific output churn.

Good: focused formatter and generated-project tests covered the direct behavior and its main integration boundary.

Bad: the first implementation preserved only the first observed convention and would still rewrite mixed-ending files.

Adjustment: test representation-neutral requirements with mixed inputs, not only one fixture per conventional encoding.