### PR TITLE
fix: avoid release-only vendor rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ stasis run
 ```
 
 Generated projects track their checked-in `vendor/stasis` snapshot in `stasis.json`. When the
-selected Stasis executable or the checked-in tree differs from that identity, the next project
-command restores `vendor/stasis` and updates its manifest automatically. Stasis owns that directory;
+selected Stasis executable has different vendor content, or the checked-in tree differs from its
+recorded hash, the next project command restores `vendor/stasis` and updates its manifest automatically.
+A release-label change alone leaves an unchanged vendor snapshot and manifest untouched. Stasis owns that directory;
 review and commit the resulting Git changes with the compiler upgrade.
 
 For a graphical program, `stasis play path\to\main.stasis` keeps the process alive and watches the current import graph. From a project directory or any descendant, `stasis play` reads the entry and project name from the nearest ancestor `stasis.json`. Explicit entries still use that manifest root for project-root imports and asset preparation. Saving a `.stasis` file compiles a candidate in the background and attempts an all-or-nothing swap between ticks.

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -1496,9 +1496,9 @@ fn inspect_project_vendor(
     let local_changes = recorded
         .as_ref()
         .is_some_and(|recorded| actual_sha256.as_deref() != Some(recorded.sha256.as_str()));
-    let update_available = recorded.as_ref().is_none_or(|recorded| {
-        recorded.release_id != installed.release_id || recorded.sha256 != installed.sha256
-    });
+    let update_available = recorded
+        .as_ref()
+        .is_none_or(|recorded| recorded.sha256 != installed.sha256);
     Ok(VendorStatus {
         recorded,
         installed,
@@ -5581,7 +5581,7 @@ mod tests {
     }
 
     #[test]
-    fn vendor_upgrade_is_automatic_and_uses_the_content_hash() {
+    fn vendor_upgrade_only_rewrites_the_release_when_content_changes() {
         let root = temp_dir("vendor_upgrade");
         create_project(root.clone(), "vendor_upgrade".to_string()).expect("create project");
         let manifest_path = root.join(MANIFEST_NAME);
@@ -5591,15 +5591,21 @@ mod tests {
         let vendor = manifest.vendor.as_mut().expect("tracked vendor");
         vendor.stasis.release_id = "older-toolchain".to_string();
         write_manifest(&manifest_path, &manifest).expect("record older vendor");
-        let workspace = load_workspace(Some(&root)).expect("upgrade older vendor automatically");
+        let unchanged_manifest = fs::read(&manifest_path).expect("read manifest before load");
+        let workspace = load_workspace(Some(&root)).expect("load with a new toolchain release");
         assert_eq!(
             workspace
                 .manifest
                 .vendor
-                .expect("updated vendor")
+                .expect("tracked vendor")
                 .stasis
                 .release_id,
-            current_release_id()
+            "older-toolchain"
+        );
+        assert_eq!(
+            fs::read(&manifest_path).expect("read manifest after load"),
+            unchanged_manifest,
+            "a release-only toolchain rebuild must not rewrite the vendor manifest"
         );
 
         let older_source = root.join("vendor/stasis/stdlib/audio.stasis");
@@ -5607,7 +5613,6 @@ mod tests {
         older_contents.push_str("// older clean snapshot\r\n");
         fs::write(&older_source, older_contents).expect("write older clean snapshot");
         let vendor = manifest.vendor.as_mut().expect("tracked vendor");
-        vendor.stasis.release_id = current_release_id().to_string();
         vendor.stasis.sha256 =
             directory_sha256(&root.join("vendor/stasis")).expect("hash older clean snapshot");
         write_manifest(&manifest_path, &manifest).expect("record older content hash");

--- a/apps/stasis/src/toolchain_cli/gauntlet.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet.rs
@@ -1016,9 +1016,17 @@ mod tests {
         let mut manifest: Value =
             serde_json::from_slice(&fs::read(&manifest_path).expect("read generated manifest"))
                 .expect("parse generated manifest");
+        let older_source = root.join("vendor/stasis/stdlib/audio.stasis");
+        let mut older_contents = fs::read_to_string(&older_source).expect("read vendor source");
+        older_contents.push_str("// older clean snapshot\r\n");
+        fs::write(&older_source, older_contents).expect("write older vendor source");
         manifest["vendor"]["stasis"]["release_id"] = Value::String("older-toolchain".into());
+        manifest["vendor"]["stasis"]["sha256"] = Value::String(
+            super::super::directory_sha256(&root.join("vendor/stasis"))
+                .expect("hash older vendor snapshot"),
+        );
         write_json(&manifest_path, &manifest).expect("record older toolchain");
-        git(&["add", "stasis.json"]);
+        git(&["add", "stasis.json", "vendor/stasis/stdlib/audio.stasis"]);
         git(&[
             "-c",
             "user.name=Gauntlet Test",

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -71,9 +71,10 @@ project root and nested directories. `--workspace PATH` selects a project explic
 The vendor release and hash describe the exact checked-in `vendor/stasis` snapshot.
 `manifest_version` versions the JSON schema and is independent of the selected toolchain release.
 On every normal project command, Stasis verifies the on-disk tree against the selected executable.
-A mismatch stages its matching public stdlib and internal host-ABI modules together and publishes the vendor tree and
-manifest as one rollback-capable transaction. This detects rebuilt development executables whose
-release ID did not change and repairs edited or missing vendor files. Stasis owns `vendor/stasis`;
+A content mismatch stages its matching public stdlib and internal host-ABI modules together and publishes the vendor tree and
+manifest as one rollback-capable transaction. The recorded release ID changes only with that vendor content;
+building or selecting an executable with a different release ID does not rewrite an unchanged snapshot.
+The content hash still detects rebuilt development executables whose release ID did not change and repairs edited or missing vendor files. Stasis owns `vendor/stasis`;
 Git is the review and rollback mechanism, so synchronization does not prompt. Review and commit the
 vendor and manifest changes together with the compiler upgrade.
 


### PR DESCRIPTION
## Summary

- drive automatic vendor synchronization from the bundled content hash instead of the executable release label
- preserve `stasis.json` byte-for-byte when only a label such as `local-development` changes
- continue updating the vendor snapshot and its recorded release when vendor content actually changes
- document the content-based behavior

## Why

A locally rebuilt Stasis executable could carry a different release ID while shipping identical vendor files. The release-ID comparison treated that build-only difference as an available vendor update, republishing `vendor/stasis` and rewriting the project manifest unnecessarily.

## Impact

Local development builds no longer create vendor or manifest churn unless their bundled Stasis sources differ. Edited, missing, or genuinely outdated vendor trees are still repaired automatically.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `python tools/cargo_cache.py run -- cargo test -p stasis vendor_upgrade_only_rewrites_the_release_when_content_changes -- --nocapture`
- repository pre-commit hook