### PR TITLE
feat: validate source-referenced assets

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -66,7 +66,7 @@ fn stable_absolute_path(path: &Path) -> PathBuf {
     absolute
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelfHostedAotCliSummary {
     pub source_file_count: usize,
     pub linked_image_path: PathBuf,
@@ -74,6 +74,8 @@ pub struct SelfHostedAotCliSummary {
     pub ir_bundle_path: PathBuf,
     pub object_bundle_path: PathBuf,
     pub object_file_names: Vec<String>,
+    #[serde(skip)]
+    pub program_snapshot: Option<ProgramSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4383,6 +4385,7 @@ fn package_engine_bundle_release(
         ir_bundle_path: PathBuf::new(),
         object_bundle_path: bundle.manifest_path.clone(),
         object_file_names,
+        program_snapshot: None,
     })
 }
 
@@ -8372,6 +8375,7 @@ fn run_self_host_aot_cli_with_backend_and_options(
             ir_bundle_path: PathBuf::new(),
             object_bundle_path,
             object_file_names,
+            program_snapshot: None,
         }
     };
 
@@ -8405,7 +8409,14 @@ pub fn run_self_host_aot_cli_with_options(
         summary_file_path.map(PathBuf::from),
         entry_file.map(PathBuf::from),
     );
-    run_self_host_aot_cli_with_backend_and_options(&mut backend, project_dir, output_exe, &options)
+    let mut summary = run_self_host_aot_cli_with_backend_and_options(
+        &mut backend,
+        project_dir,
+        output_exe,
+        &options,
+    )?;
+    summary.program_snapshot = backend.last_program_snapshot.clone();
+    Ok(summary)
 }
 
 pub fn run_self_host_aot_cli(

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -17,6 +17,7 @@ pub use events::RunnerEvent;
 pub use live_workspace::LiveRunConfig;
 pub use stasis_test_runner::{
     run_jit_tests_in_directory, run_jit_tests_in_directory_with_project_root_and_session,
+    run_jit_tests_in_directory_with_project_root_session_and_validator,
     run_jit_tests_in_directory_with_session, StasisTestRunSession, StasisTestRunSummary,
 };
 pub use window_config::WindowConfig;

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -3,7 +3,6 @@
 mod release_assets;
 mod toolchain_cli;
 
-use std::collections::BTreeSet;
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
@@ -26,7 +25,6 @@ use stasis_assets::{
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
 use stasis_compiler::compiler::{source_function_items, source_struct_items};
-use stasis_compiler::frontend::lexer::{lex, TokenKind};
 use stasis_jit::AotTarget;
 use stasis_runner::swap::contracts::TargetMode;
 
@@ -1732,6 +1730,12 @@ fn write_mobile_aot_engine_bundle(
     process
         .compile()
         .map_err(|error| format!("failed to compile mobile AOT bundle: {error:?}"))?;
+    let resolved = load_project_asset_manifest(project_dir, AssetLimits::default())
+        .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
+    let snapshot = process
+        .program_snapshot()
+        .ok_or_else(|| "mobile AOT compile produced no ProgramSnapshot".to_string())?;
+    let resolved = release_assets::retain_snapshot_assets(project_dir, snapshot, &resolved)?;
     let bundle = process.write_engine_bundle(&mobile_engine_entrypoints(), output_dir)?;
     let manifest = fs::read_to_string(&bundle.manifest_path).map_err(|error| {
         format!(
@@ -1760,11 +1764,7 @@ fn write_mobile_aot_engine_bundle(
     } else {
         None
     };
-    let source_base_dir = entry_file
-        .and_then(Path::parent)
-        .unwrap_or_else(|| Path::new("."));
-    let asset_dir =
-        write_mobile_asset_bundle(target, project_dir, source_base_dir, output_dir, &sources)?;
+    let asset_dir = write_mobile_asset_bundle(target, output_dir, &resolved)?;
     let package_manifest = write_mobile_aot_package_manifest(
         target,
         &bundle.manifest_path,
@@ -1790,19 +1790,9 @@ fn write_mobile_aot_engine_bundle(
 
 fn write_mobile_asset_bundle(
     target: MobileAotTarget,
-    project_dir: &Path,
-    source_base_dir: &Path,
     output_dir: &Path,
-    sources: &[(String, String)],
+    resolved: &stasis_assets::ResolvedAssetManifest,
 ) -> Result<PathBuf, String> {
-    let resolved = load_project_asset_manifest(project_dir, AssetLimits::default())
-        .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
-    let resolved = release_assets::retain_source_referenced_assets(
-        project_dir,
-        source_base_dir,
-        sources,
-        &resolved,
-    )?;
     let asset_root = output_dir.join(target.asset_root_dir());
     if asset_root.exists() {
         fs::remove_dir_all(&asset_root).map_err(|error| {
@@ -1813,101 +1803,13 @@ fn write_mobile_asset_bundle(
         })?;
     }
     let game_root = asset_root.join("stasis_game");
-    let mut packaged_paths = resolved
-        .assets
-        .iter()
-        .map(|asset| PathBuf::from(&asset.entry.path))
-        .collect::<BTreeSet<_>>();
     prepare_asset_bundle(
-        &resolved,
+        resolved,
         &game_root,
         output_dir.join("asset-preparation-cache"),
     )
     .map_err(|error| format!("failed to prepare mobile AOT assets: {error}"))?;
-    for (relative_path, source_path) in collect_mobile_source_font_assets(project_dir, sources)? {
-        if !packaged_paths.insert(relative_path.clone()) {
-            continue;
-        }
-        let destination = game_root.join(&relative_path);
-        fs::create_dir_all(destination.parent().expect("font asset parent")).map_err(|error| {
-            format!("failed to create mobile AOT font asset directory: {error}")
-        })?;
-        fs::copy(&source_path, &destination).map_err(|error| {
-            format!(
-                "failed to package mobile AOT font asset {}: {error}",
-                relative_path.display()
-            )
-        })?;
-    }
     Ok(asset_root)
-}
-
-fn collect_mobile_source_font_assets(
-    project_dir: &Path,
-    sources: &[(String, String)],
-) -> Result<Vec<(PathBuf, PathBuf)>, String> {
-    let project_root = project_dir.canonicalize().map_err(|error| {
-        format!(
-            "failed to canonicalize mobile font asset project {}: {error}",
-            project_dir.display()
-        )
-    })?;
-    let asset_root = project_root
-        .join("assets")
-        .canonicalize()
-        .map_err(|error| {
-            format!(
-                "failed to canonicalize mobile font asset root {}: {error}",
-                project_root.join("assets").display()
-            )
-        })?;
-    let mut fonts = Vec::new();
-    for (relative_source_path, source) in sources {
-        let source_parent = project_root
-            .join(relative_source_path)
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| project_root.clone());
-        for token in lex(source).map_err(|error| {
-            format!("failed to scan mobile font paths in {relative_source_path}: {error}")
-        })? {
-            if token.kind != TokenKind::StringLiteral {
-                continue;
-            }
-            let literal: String =
-                serde_json::from_str(&source[token.start..token.end]).map_err(|error| {
-                    format!("failed to decode string literal in {relative_source_path}: {error}")
-                })?;
-            let extension_is_font = Path::new(&literal)
-                .extension()
-                .and_then(|value| value.to_str())
-                .is_some_and(|value| {
-                    value.eq_ignore_ascii_case("ttf") || value.eq_ignore_ascii_case("otf")
-                });
-            if !extension_is_font {
-                continue;
-            }
-            let Ok(absolute_path) = source_parent.join(&literal).canonicalize() else {
-                continue;
-            };
-            if !absolute_path.is_file() || !absolute_path.starts_with(&asset_root) {
-                continue;
-            }
-            let relative_path = absolute_path
-                .strip_prefix(&project_root)
-                .map_err(|_| {
-                    format!(
-                        "mobile font escaped project root: {}",
-                        absolute_path.display()
-                    )
-                })?
-                .to_path_buf();
-            fonts.push((relative_path, absolute_path));
-        }
-    }
-    fonts.sort_by(|left, right| left.0.cmp(&right.0));
-    fonts.dedup_by(|left, right| left.0 == right.0);
-    Ok(fonts)
 }
 
 fn collect_mobile_aot_sources(
@@ -2407,6 +2309,7 @@ fn try_run_aot_cli_subcommand() -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -2423,6 +2326,26 @@ mod tests {
             .expect("clock")
             .as_nanos();
         std::env::temp_dir().join(format!("stasis_lookup_{name}_{stamp}"))
+    }
+
+    fn retained_mobile_assets(
+        project_dir: &Path,
+        sources: &[(String, String)],
+    ) -> stasis_assets::ResolvedAssetManifest {
+        let mut process = AotProcess::new();
+        process.set_import_base_dir(project_dir);
+        for (path, source) in sources {
+            process.upsert_file(path.clone(), source.clone());
+        }
+        process.compile().expect("compile mobile asset fixture");
+        let resolved = load_project_asset_manifest(project_dir, AssetLimits::default())
+            .expect("resolve mobile asset fixture");
+        release_assets::retain_snapshot_assets(
+            project_dir,
+            process.program_snapshot().expect("program snapshot"),
+            &resolved,
+        )
+        .expect("retain source-referenced mobile assets")
     }
 
     #[test]
@@ -3245,33 +3168,37 @@ mod tests {
         let output_dir = root.join("out");
         std::fs::create_dir_all(&src_dir).expect("mkdir src");
         std::fs::create_dir_all(&font_dir).expect("mkdir fonts");
-        std::fs::write(
-            project_dir.join("assets/manifest.json"),
-            r#"{
-  "schema": "stasis-assets",
-  "version": 1,
-  "assets": []
-}
-"#,
-        )
-        .expect("write manifest");
         std::fs::write(font_dir.join("ui.ttf"), b"referenced font").expect("write font");
         std::fs::write(font_dir.join("unused.ttf"), b"unused font").expect("write font");
+        std::fs::write(
+            project_dir.join("assets/manifest.json"),
+            format!(
+                r#"{{
+  "schema": "stasis-assets",
+  "version": 2,
+  "assets": [
+    {{"id":"ui","path":"assets/fonts/ui.ttf","content_sha256":"{}","format":{{"kind":"font","encoding":"ttf"}},"dependencies":[]}},
+    {{"id":"unused","path":"assets/fonts/unused.ttf","content_sha256":"{}","format":{{"kind":"font","encoding":"ttf"}},"dependencies":[]}}
+  ]
+}}
+"#,
+                stasis_assets::sha256_bytes(b"referenced font"),
+                stasis_assets::sha256_bytes(b"unused font")
+            ),
+        )
+        .expect("write manifest");
         let sources = vec![(
             "src/main.stasis".to_string(),
-            r#"function main(): i32 { load_font("../assets/fonts/ui.ttf", 16); return 0; }
+            r#"extern function load_font(path: string, size: i32): i32;
+function main(): i32 { load_font("../assets/fonts/ui.ttf", 16); return 0; }
 "#
             .to_string(),
         )];
 
-        let asset_root = write_mobile_asset_bundle(
-            MobileAotTarget::AndroidArm64,
-            &project_dir,
-            Path::new("src"),
-            &output_dir,
-            &sources,
-        )
-        .expect("package font asset");
+        let resolved = retained_mobile_assets(&project_dir, &sources);
+        let asset_root =
+            write_mobile_asset_bundle(MobileAotTarget::AndroidArm64, &output_dir, &resolved)
+                .expect("package font asset");
 
         assert!(asset_root.join("stasis_game/assets/fonts/ui.ttf").is_file());
         assert!(!asset_root
@@ -3315,21 +3242,19 @@ mod tests {
         .expect("write manifest");
         let sources = vec![(
             "src/main.stasis".to_string(),
-            r#"function main(): void { hero.load_sprite_from("../assets/svg/used.svg", 32, 32); }
+            r#"struct Sprite { handle: i32; width: i32; height: i32; }
+global hero: Sprite;
+function @extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
+function main(): void { hero.load_sprite_from("../assets/svg/used.svg", 32, 32); }
 "#
             .to_string(),
         )];
 
         for target in [MobileAotTarget::AndroidArm64, MobileAotTarget::IosArm64] {
             let output_dir = root.join(target.as_str());
-            let asset_root = write_mobile_asset_bundle(
-                target,
-                &project_dir,
-                Path::new("src"),
-                &output_dir,
-                &sources,
-            )
-            .expect("package filtered assets");
+            let resolved = retained_mobile_assets(&project_dir, &sources);
+            let asset_root = write_mobile_asset_bundle(target, &output_dir, &resolved)
+                .expect("package filtered assets");
             let game_root = asset_root.join("stasis_game");
             assert!(game_root.join("assets/svg/used.svg").is_file());
             assert!(!game_root.join("assets/svg/unused.svg").exists());
@@ -3341,31 +3266,6 @@ mod tests {
             assert_eq!(packaged["assets"].as_array().expect("assets").len(), 1);
             assert_eq!(packaged["assets"][0]["id"], "used");
         }
-        std::fs::remove_dir_all(&root).ok();
-    }
-
-    #[test]
-    fn mobile_source_font_assets_reject_paths_outside_project_assets() {
-        let stamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!("stasis_mobile_font_escape_{stamp}"));
-        let project_dir = root.join("project");
-        std::fs::create_dir_all(project_dir.join("src")).expect("mkdir src");
-        std::fs::create_dir_all(project_dir.join("assets")).expect("mkdir assets");
-        std::fs::write(root.join("outside.ttf"), b"outside font").expect("write outside");
-        let sources = vec![(
-            "src/main.stasis".to_string(),
-            r#"function main(): i32 { load_font("../../outside.ttf", 16); return 0; }
-"#
-            .to_string(),
-        )];
-
-        let fonts = collect_mobile_source_font_assets(&project_dir, &sources)
-            .expect("scan source font assets");
-
-        assert!(fonts.is_empty());
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/apps/stasis/src/release_assets.rs
+++ b/apps/stasis/src/release_assets.rs
@@ -1,130 +1,55 @@
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use stasis_assets::ResolvedAssetManifest;
-use stasis_compiler::frontend::lexer::{lex, TokenKind};
+use stasis_compiler::backend::assets::{
+    validate_asset_references, AssetDiagnostic, AssetValidationResult,
+};
+use stasis_compiler::backend::program_snapshot::ProgramSnapshot;
 
-pub(crate) fn retain_source_referenced_assets(
+pub(crate) const ASSET_DIAGNOSTIC_PREFIX: &str = "stasis_asset_diagnostics:";
+
+pub(crate) fn validate_snapshot_assets(
     project_dir: &Path,
-    source_base_dir: &Path,
-    sources: &[(String, String)],
+    snapshot: &ProgramSnapshot,
+    resolved: Option<&ResolvedAssetManifest>,
+) -> Result<AssetValidationResult, String> {
+    let manifest_paths = resolved.map(|manifest| {
+        manifest
+            .assets
+            .iter()
+            .map(|asset| asset.entry.path.clone())
+            .collect()
+    });
+    let dynamic_paths = resolved
+        .map(|manifest| &manifest.dynamic_assets)
+        .cloned()
+        .unwrap_or_default();
+    let validation = validate_asset_references(
+        project_dir,
+        snapshot.asset_references(),
+        manifest_paths.as_ref(),
+        &dynamic_paths,
+    );
+    if validation.diagnostics.is_empty() {
+        Ok(validation)
+    } else {
+        Err(format_asset_diagnostics(&validation.diagnostics))
+    }
+}
+
+pub(crate) fn retain_snapshot_assets(
+    project_dir: &Path,
+    snapshot: &ProgramSnapshot,
     resolved: &ResolvedAssetManifest,
 ) -> Result<ResolvedAssetManifest, String> {
-    let project_root = project_dir.canonicalize().map_err(|error| {
-        format!(
-            "failed to canonicalize release asset project {}: {error}",
-            project_dir.display()
-        )
-    })?;
-    let asset_root = project_root
-        .join("assets")
-        .canonicalize()
-        .map_err(|error| format!("failed to canonicalize release asset root: {error}"))?;
-    let source_base = canonical_project_path(&project_root, source_base_dir)?;
-    if !source_base.is_dir() {
-        return Err(format!(
-            "release asset source base must be a directory: {}",
-            source_base.display()
-        ));
-    }
-    let mut paths = BTreeSet::new();
-    for (relative_source_path, source) in sources {
-        for token in lex(source).map_err(|error| {
-            format!("failed to scan release asset paths in {relative_source_path}: {error}")
-        })? {
-            if token.kind != TokenKind::StringLiteral {
-                continue;
-            }
-            let literal: String =
-                serde_json::from_str(&source[token.start..token.end]).map_err(|error| {
-                    format!("failed to decode string literal in {relative_source_path}: {error}")
-                })?;
-            let absolute_path = [source_base.join(&literal), project_root.join(&literal)]
-                .into_iter()
-                .filter_map(|candidate| candidate.canonicalize().ok())
-                .find(|candidate| candidate.is_file() && candidate.starts_with(&asset_root));
-            let Some(absolute_path) = absolute_path else {
-                continue;
-            };
-            paths.insert(
-                absolute_path
-                    .strip_prefix(&project_root)
-                    .map_err(|_| {
-                        format!(
-                            "release asset escaped project root: {}",
-                            absolute_path.display()
-                        )
-                    })?
-                    .to_string_lossy()
-                    .replace('\\', "/"),
-            );
-        }
-    }
-    Ok(resolved.retain_paths(&paths))
+    let validation = validate_snapshot_assets(project_dir, snapshot, Some(resolved))?;
+    Ok(resolved.retain_paths(&validation.resolved_paths))
 }
 
-pub(crate) fn load_entry_sources(
-    project_dir: &Path,
-    entry_file: &Path,
-) -> Result<Vec<(String, String)>, String> {
-    let project_root = project_dir.canonicalize().map_err(|error| {
-        format!(
-            "failed to canonicalize release asset project {}: {error}",
-            project_dir.display()
-        )
-    })?;
-    let entry_path = canonical_project_file(&project_root, entry_file)?;
-    let (graph, sources) = stasis_compiler::frontend::module_graph::load_project_module_graph(
-        &project_root,
-        &entry_path,
-    )
-    .map_err(|diagnostic| diagnostic.message)?;
-    let mut out = Vec::new();
-    for relative in graph.modules().keys() {
-        if relative.ends_with(".test.stasis") {
-            continue;
-        }
-        let source = sources
-            .get(relative)
-            .cloned()
-            .ok_or_else(|| format!("module graph source missing for {relative}"))?;
-        out.push((relative.clone(), source));
-    }
-    out.sort_by(|left, right| left.0.cmp(&right.0));
-    Ok(out)
-}
-
-fn canonical_project_file(project_root: &Path, file: &Path) -> Result<PathBuf, String> {
-    let canonical = canonical_project_path(project_root, file)?;
-    if !canonical.is_file() {
-        return Err(format!(
-            "release entry must be a file: {}",
-            canonical.display()
-        ));
-    }
-    Ok(canonical)
-}
-
-fn canonical_project_path(project_root: &Path, path: &Path) -> Result<PathBuf, String> {
-    let candidate = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        project_root.join(path)
-    };
-    let canonical = candidate.canonicalize().map_err(|error| {
-        format!(
-            "failed to canonicalize release entry {}: {error}",
-            candidate.display()
-        )
-    })?;
-    if !canonical.starts_with(project_root) {
-        return Err(format!(
-            "release entry {} must stay under project directory {}",
-            canonical.display(),
-            project_root.display()
-        ));
-    }
-    Ok(canonical)
+pub(crate) fn format_asset_diagnostics(diagnostics: &[AssetDiagnostic]) -> String {
+    let json = serde_json::to_string(diagnostics)
+        .unwrap_or_else(|_| "[{\"code\":\"asset_diagnostic_serialization_failed\"}]".to_string());
+    format!("{ASSET_DIAGNOSTIC_PREFIX}{json}")
 }
 
 #[cfg(test)]
@@ -133,6 +58,7 @@ mod tests {
     use stasis_assets::{
         stable_asset_handle, AssetEntry, AssetFormat, ResolvedAsset, SpriteEncoding,
     };
+    use stasis_compiler::backend::aot::AotProcess;
 
     fn resolved(root: &Path, id: &str, path: &str) -> ResolvedAsset {
         let entry = AssetEntry {
@@ -156,6 +82,30 @@ mod tests {
         }
     }
 
+    fn retain_from_sources(
+        root: &Path,
+        sources: &[(String, String)],
+        manifest: &ResolvedAssetManifest,
+    ) -> ResolvedAssetManifest {
+        let mut process = AotProcess::new();
+        process
+            .set_project_root(root.to_string_lossy().to_string())
+            .expect("project root");
+        for (path, source) in sources {
+            process.upsert_file(
+                root.join(path).to_string_lossy().to_string(),
+                source.clone(),
+            );
+        }
+        process.compile().expect("compile asset fixture");
+        retain_snapshot_assets(
+            root,
+            process.program_snapshot().expect("program snapshot"),
+            manifest,
+        )
+        .expect("retain snapshot assets")
+    }
+
     #[test]
     fn keeps_only_literal_assets_in_the_reachable_source_set() {
         let stamp = std::time::SystemTime::now()
@@ -169,6 +119,7 @@ mod tests {
         std::fs::write(root.join("assets/svg/unused.svg"), "x").unwrap();
         let manifest = ResolvedAssetManifest {
             manifest_path: root.join("assets/manifest.json"),
+            dynamic_assets: Default::default(),
             assets: vec![
                 resolved(&root, "used", "assets/svg/used.svg"),
                 resolved(&root, "unused", "assets/svg/unused.svg"),
@@ -177,15 +128,15 @@ mod tests {
         let sources = vec![(
             "src/main.stasis".to_string(),
             concat!(
+                "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32; ",
                 "function main(): void { ",
-                "hero.load_sprite_from(\"../assets/svg/used.svg\", 32, 32); ",
-                "hero.load_sprite_from(\"assets/svg/used.svg\", 32, 32); }"
+                "gfx_load_sprite(\"../assets/svg/used.svg\", 32, 32); ",
+                "gfx_load_sprite(\"assets/svg/used.svg\", 32, 32); }"
             )
             .to_string(),
         )];
 
-        let retained =
-            retain_source_referenced_assets(&root, Path::new("src"), &sources, &manifest).unwrap();
+        let retained = retain_from_sources(&root, &sources, &manifest);
         assert_eq!(retained.assets.len(), 1);
         assert_eq!(retained.assets[0].entry.id, "used");
         std::fs::remove_dir_all(root).ok();
@@ -204,16 +155,19 @@ mod tests {
         std::fs::write(root.join("src/assets/svg/used.svg"), "source shadow").unwrap();
         let manifest = ResolvedAssetManifest {
             manifest_path: root.join("assets/manifest.json"),
+            dynamic_assets: Default::default(),
             assets: vec![resolved(&root, "used", "assets/svg/used.svg")],
         };
         let sources = vec![(
             "src/main.stasis".to_string(),
-            "function main(): void { hero.load_sprite_from(\"assets/svg/used.svg\", 32, 32); }"
-                .to_string(),
+            concat!(
+                "extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32; ",
+                "function main(): void { gfx_load_sprite(\"assets/svg/used.svg\", 32, 32); }"
+            )
+            .to_string(),
         )];
 
-        let retained =
-            retain_source_referenced_assets(&root, Path::new("src"), &sources, &manifest).unwrap();
+        let retained = retain_from_sources(&root, &sources, &manifest);
         assert_eq!(retained.assets.len(), 1);
         assert_eq!(retained.assets[0].entry.id, "used");
         std::fs::remove_dir_all(root).ok();

--- a/apps/stasis/src/stasis_test_runner.rs
+++ b/apps/stasis/src/stasis_test_runner.rs
@@ -70,6 +70,20 @@ pub fn run_jit_tests_in_directory_with_project_root_and_session(
     project_root: &Path,
     session: &mut StasisTestRunSession,
 ) -> Result<StasisTestRunSummary, String> {
+    run_jit_tests_in_directory_with_project_root_session_and_validator(
+        root,
+        project_root,
+        session,
+        |_| Ok(()),
+    )
+}
+
+pub fn run_jit_tests_in_directory_with_project_root_session_and_validator(
+    root: &Path,
+    project_root: &Path,
+    session: &mut StasisTestRunSession,
+    mut validate: impl FnMut(&JitProcess) -> Result<(), String>,
+) -> Result<StasisTestRunSummary, String> {
     let current_dir = std::env::current_dir()
         .map_err(|error| format!("failed to read current directory: {error}"))?;
     let root = canonical_test_path("test directory", root, &current_dir)?;
@@ -195,6 +209,7 @@ pub fn run_jit_tests_in_directory_with_project_root_and_session(
             session.last_active_path = Some(file_path.clone());
         }
 
+        validate(&entry.process)?;
         entry.process.activate_runtime_state();
         let execute_started = Instant::now();
         run_discovered_tests(&entry.process, &tests, &file_path, &mut summary);

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use stasis::{
-    run_jit_tests_in_directory_with_project_root_and_session, run_live_in_process,
-    run_live_in_process_with_data, run_play_in_process_with_window_title,
+    run_live_in_process, run_live_in_process_with_data, run_play_in_process_with_window_title,
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_assets::{
@@ -781,15 +780,21 @@ pub(super) fn try_run() -> Option<i32> {
         }
         Err(message) => {
             if parsed.json {
-                eprintln!(
-                    "{}",
-                    json!({
-                        "ok": false,
-                        "command": command_name,
-                        "code": "command_failed",
-                        "message": message,
-                    })
-                );
+                let mut error = json!({
+                    "ok": false,
+                    "command": command_name,
+                    "code": "command_failed",
+                    "message": &message,
+                });
+                if let Some(payload) = message
+                    .strip_prefix(crate::release_assets::ASSET_DIAGNOSTIC_PREFIX)
+                    .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+                {
+                    error["code"] = json!("asset_validation_failed");
+                    error["message"] = json!("asset validation failed");
+                    error["diagnostics"] = payload;
+                }
+                eprintln!("{error}");
             } else {
                 eprintln!("stasis {command_name}: {message}");
             }
@@ -1821,6 +1826,7 @@ fn format_files(
 
 fn check_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
     let jit = compile_workspace_jit(workspace)?;
+    validate_compiled_workspace_assets(workspace, &jit)?;
     Ok(CommandResult::success(
         format!("checked {}", workspace.manifest.name),
         json!({
@@ -1829,6 +1835,25 @@ fn check_workspace(workspace: &Workspace) -> Result<CommandResult, String> {
             "functions_emitted": jit.artifacts().len(),
         }),
     ))
+}
+
+fn validate_compiled_workspace_assets(
+    workspace: &Workspace,
+    jit: &JitProcess,
+) -> Result<Option<stasis_assets::ResolvedAssetManifest>, String> {
+    let manifest = if workspace.root.join(DEFAULT_ASSET_MANIFEST_PATH).is_file() {
+        Some(
+            load_project_asset_manifest(&workspace.root, AssetLimits::default())
+                .map_err(|error| format!("failed to resolve project assets: {error}"))?,
+        )
+    } else {
+        None
+    };
+    let snapshot = jit
+        .program_snapshot()
+        .ok_or_else(|| "asset validation compile produced no ProgramSnapshot".to_string())?;
+    crate::release_assets::validate_snapshot_assets(&workspace.root, snapshot, manifest.as_ref())?;
+    Ok(manifest)
 }
 
 fn compile_workspace_jit(workspace: &Workspace) -> Result<JitProcess, String> {
@@ -2058,11 +2083,30 @@ fn test_workspace(workspace: &Workspace, path: Option<&Path>) -> Result<CommandR
         .map(|value| workspace.root.join(value))
         .unwrap_or_else(|| workspace.root.join(&workspace.manifest.tests));
     validate_workspace_destination(workspace, "test directory", &directory)?;
+    let manifest = if workspace.root.join(DEFAULT_ASSET_MANIFEST_PATH).is_file() {
+        Some(
+            load_project_asset_manifest(&workspace.root, AssetLimits::default())
+                .map_err(|error| format!("failed to resolve test assets: {error}"))?,
+        )
+    } else {
+        None
+    };
     let mut session = StasisTestRunSession::new();
-    let summary = run_jit_tests_in_directory_with_project_root_and_session(
+    let summary = stasis::run_jit_tests_in_directory_with_project_root_session_and_validator(
         &directory,
         &workspace.root,
         &mut session,
+        |jit| {
+            let snapshot = jit
+                .program_snapshot()
+                .ok_or_else(|| "test compilation did not publish a program snapshot".to_string())?;
+            crate::release_assets::validate_snapshot_assets(
+                &workspace.root,
+                snapshot,
+                manifest.as_ref(),
+            )
+            .map(|_| ())
+        },
     )?;
     let data = json!({
         "files_discovered": summary.files_discovered,
@@ -3188,6 +3232,7 @@ fn build_workspace(
     match mode {
         BuildMode::Dev => {
             let jit = compile_workspace_jit(workspace)?;
+            let manifest = validate_compiled_workspace_assets(workspace, &jit)?;
             let receipt = output
                 .map(|path| workspace.root.join(path))
                 .unwrap_or_else(|| {
@@ -3209,8 +3254,6 @@ fn build_workspace(
             let mut contents = serde_json::to_string_pretty(&data)
                 .map_err(|error| format!("failed to serialize dev build receipt: {error}"))?;
             contents.push('\n');
-            fs::write(&receipt, contents)
-                .map_err(|error| format!("failed to write {}: {error}", receipt.display()))?;
             stage_workspace_assets(
                 workspace,
                 receipt.parent().ok_or_else(|| {
@@ -3219,15 +3262,19 @@ fn build_workspace(
                         receipt.display()
                     )
                 })?,
-                Path::new("."),
-                None,
+                manifest.as_ref(),
             )?;
+            fs::write(&receipt, contents)
+                .map_err(|error| format!("failed to write {}: {error}", receipt.display()))?;
             Ok(CommandResult::success(
                 format!("built JIT development image: {}", receipt.display()),
                 json!({"backend": "jit", "receipt": display_path(&receipt)}),
             ))
         }
         BuildMode::Release => {
+            let validation_jit = compile_workspace_jit(workspace)?;
+            let manifest = validate_compiled_workspace_assets(workspace, &validation_jit)?;
+            preflight_release_asset_preparation(workspace, &validation_jit, manifest.as_ref())?;
             let output = output
                 .map(|path| workspace.root.join(path))
                 .unwrap_or_else(|| default_release_output(workspace));
@@ -3242,10 +3289,28 @@ fn build_workspace(
                 None,
                 Some(Path::new(&workspace.manifest.entry)),
             )?;
-            let sources = crate::release_assets::load_entry_sources(
-                &workspace.root,
-                Path::new(&workspace.manifest.entry),
-            )?;
+            let build_snapshot = summary.program_snapshot.as_ref().ok_or_else(|| {
+                "release build did not publish its authoritative ProgramSnapshot".to_string()
+            })?;
+            let validation_snapshot = validation_jit.program_snapshot().ok_or_else(|| {
+                "release asset preflight did not publish a ProgramSnapshot".to_string()
+            })?;
+            if build_snapshot.asset_references() != validation_snapshot.asset_references() {
+                return Err(
+                    "release build asset roots changed after successful preflight validation"
+                        .to_string(),
+                );
+            }
+            let retained = manifest
+                .as_ref()
+                .map(|resolved| {
+                    crate::release_assets::retain_snapshot_assets(
+                        &workspace.root,
+                        build_snapshot,
+                        resolved,
+                    )
+                })
+                .transpose()?;
             stage_workspace_assets(
                 workspace,
                 summary.linked_image_path.parent().ok_or_else(|| {
@@ -3254,10 +3319,7 @@ fn build_workspace(
                         summary.linked_image_path.display()
                     )
                 })?,
-                Path::new(&workspace.manifest.entry)
-                    .parent()
-                    .unwrap_or_else(|| Path::new(".")),
-                Some(&sources),
+                retained.as_ref(),
             )?;
             Ok(CommandResult::success(
                 format!(
@@ -3273,6 +3335,47 @@ fn build_workspace(
             ))
         }
     }
+}
+
+fn preflight_release_asset_preparation(
+    workspace: &Workspace,
+    jit: &JitProcess,
+    resolved: Option<&stasis_assets::ResolvedAssetManifest>,
+) -> Result<(), String> {
+    let Some(resolved) = resolved else {
+        return Ok(());
+    };
+    let snapshot = jit
+        .program_snapshot()
+        .ok_or_else(|| "release asset preflight produced no ProgramSnapshot".to_string())?;
+    let retained =
+        crate::release_assets::retain_snapshot_assets(&workspace.root, snapshot, resolved)?;
+    let stamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let destination = workspace
+        .root
+        .join(".stasis_cache")
+        .join(format!("asset-preflight-{}-{stamp}", std::process::id()));
+    let prepared = prepare_asset_bundle(
+        &retained,
+        &destination,
+        workspace.root.join(".stasis_cache/assets"),
+    )
+    .map_err(|error| format!("release asset preparation failed: {error}"));
+    let cleanup = if destination.exists() {
+        fs::remove_dir_all(&destination).map_err(|error| {
+            format!(
+                "failed to remove asset preflight {}: {error}",
+                destination.display()
+            )
+        })
+    } else {
+        Ok(())
+    };
+    prepared?;
+    cleanup
 }
 
 fn package_workspace(
@@ -3415,26 +3518,13 @@ fn nest_windows_desktop_payload(staging_root: &Path, executable: &Path) -> Resul
 fn stage_workspace_assets(
     workspace: &Workspace,
     destination_root: &Path,
-    source_base_dir: &Path,
-    sources: Option<&[(String, String)]>,
+    resolved: Option<&stasis_assets::ResolvedAssetManifest>,
 ) -> Result<(), String> {
     let assets = workspace.root.join("assets");
     validate_workspace_destination(workspace, "assets directory", &assets)?;
-    if workspace.root.join(DEFAULT_ASSET_MANIFEST_PATH).is_file() {
-        let resolved = load_project_asset_manifest(&workspace.root, AssetLimits::default())
-            .map_err(|error| format!("failed to resolve desktop build assets: {error}"))?;
-        let resolved = if let Some(sources) = sources {
-            crate::release_assets::retain_source_referenced_assets(
-                &workspace.root,
-                source_base_dir,
-                sources,
-                &resolved,
-            )?
-        } else {
-            resolved
-        };
+    if let Some(resolved) = resolved {
         prepare_asset_bundle(
-            &resolved,
+            resolved,
             destination_root,
             workspace.root.join(".stasis_cache/assets"),
         )

--- a/apps/stasis/src/toolchain_cli/gauntlet/assets.rs
+++ b/apps/stasis/src/toolchain_cli/gauntlet/assets.rs
@@ -974,6 +974,7 @@ mod tests {
             schema: "stasis-assets".to_string(),
             version: 2,
             display: None,
+            dynamic_assets: Vec::new(),
             assets: vec![AssetEntry {
                 id: "old-unit".to_string(),
                 path: "assets/generated/old-unit.png".to_string(),
@@ -1055,6 +1056,7 @@ mod tests {
             schema: "stasis-assets".to_string(),
             version: 2,
             display: None,
+            dynamic_assets: Vec::new(),
             assets: vec![AssetEntry {
                 id: "unit".to_string(),
                 path: "assets/generated/unit-v1.png".to_string(),

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -144,6 +144,26 @@ fn check_reports_structured_asset_diagnostics_and_build_is_atomic() {
     assert_eq!(checked.status.code(), Some(0));
     assert_eq!(json_stdout(&checked)["result"]["name"], "asset_validation");
 
+    fs::write(
+        project.join("src/main.stasis"),
+        concat!(
+            "extern function @asset_path(path) load_font(path: string, size: i32): i32;\n",
+            "const FONT_PATH: string = \"../assets/fonts/ui.ttf\";\n",
+            "function choose_font(FONT_PATH: string): i32 { return load_font(FONT_PATH, 16); }\n",
+            "function main(): i32 { return choose_font(\"../assets/fonts/ui.ttf\"); }\n"
+        ),
+    )
+    .expect("shadowed asset source");
+    let checked = stasis(&["--json", "check"], &project);
+    assert_eq!(checked.status.code(), Some(1));
+    let error = json_stderr(&checked);
+    assert_eq!(error["code"], "asset_validation_failed");
+    assert_eq!(
+        error["diagnostics"][0]["code"],
+        "asset_dynamic_path_undeclared"
+    );
+    assert_eq!(error["diagnostics"][0]["logical_path"], Value::Null);
+
     fs::create_dir_all(project.join("tests")).expect("test directory");
     fs::write(
         project.join("tests/assets.test.stasis"),

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -93,6 +93,75 @@ fn json_stderr(output: &Output) -> Value {
     serde_json::from_slice(&output.stderr).expect("single JSON stderr object")
 }
 
+#[test]
+fn check_reports_structured_asset_diagnostics_and_build_is_atomic() {
+    let project = temp_dir("asset_validation");
+    fs::create_dir_all(project.join("src")).expect("source directory");
+    fs::create_dir_all(project.join("assets/fonts")).expect("asset directory");
+    fs::write(
+        project.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"asset_validation","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("workspace manifest");
+    fs::write(project.join("assets/fonts/ui.ttf"), b"font").expect("font asset");
+    fs::write(
+        project.join("src/main.stasis"),
+        concat!(
+            "extern function @asset_path(path) load_font(path: string, size: i32): i32;\n",
+            "function main(): i32 { return load_font(\"../assets/fonts/UI.ttf\", 16); }\n"
+        ),
+    )
+    .expect("entry source");
+
+    let checked = stasis(&["--json", "check"], &project);
+    assert_eq!(checked.status.code(), Some(1));
+    let error = json_stderr(&checked);
+    assert_eq!(error["code"], "asset_validation_failed");
+    assert_eq!(error["diagnostics"][0]["code"], "asset_path_case_mismatch");
+    assert_eq!(error["diagnostics"][0]["api"], "load_font");
+    assert_eq!(
+        error["diagnostics"][0]["logical_path"],
+        "../assets/fonts/UI.ttf"
+    );
+    assert!(error["diagnostics"][0]["start"].as_u64().is_some());
+    assert!(error["diagnostics"][0]["attempted_paths"]
+        .as_array()
+        .is_some_and(|paths| paths.len() == 2));
+
+    let built = stasis(&["--json", "build", "--mode", "dev"], &project);
+    assert_eq!(built.status.code(), Some(1));
+    assert!(!project.join("build/dev-build.json").exists());
+
+    fs::write(
+        project.join("src/main.stasis"),
+        concat!(
+            "extern function @asset_path(path) load_font(path: string, size: i32): i32;\n",
+            "function main(): i32 { return load_font(\"../assets/fonts/ui.ttf\", 16); }\n"
+        ),
+    )
+    .expect("corrected entry source");
+    let checked = stasis(&["--json", "check"], &project);
+    assert_eq!(checked.status.code(), Some(0));
+    assert_eq!(json_stdout(&checked)["result"]["name"], "asset_validation");
+
+    fs::create_dir_all(project.join("tests")).expect("test directory");
+    fs::write(
+        project.join("tests/assets.test.stasis"),
+        concat!(
+            "extern function @asset_path(path) load_font(path: string, size: i32): i32;\n",
+            "test `invalid asset is never executed`(): bool {\n",
+            "    return load_font(\"../assets/fonts/missing.ttf\", 16) > 0;\n",
+            "}\n"
+        ),
+    )
+    .expect("asset test source");
+    let tested = stasis(&["--json", "test"], &project);
+    assert_eq!(tested.status.code(), Some(1));
+    assert_eq!(json_stderr(&tested)["code"], "asset_validation_failed");
+
+    fs::remove_dir_all(project).ok();
+}
+
 fn lsp_frame(message: Value) -> String {
     let body = message.to_string();
     format!("Content-Length: {}\r\n\r\n{body}", body.len())

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -844,6 +844,7 @@ fn prepare_embedded_resource_catalog(
     } else {
         ResolvedAssetManifest {
             manifest_path,
+            dynamic_assets: Default::default(),
             assets: Vec::new(),
         }
     };

--- a/crates/stasis_assets/src/lib.rs
+++ b/crates/stasis_assets/src/lib.rs
@@ -34,6 +34,8 @@ pub struct AssetManifest {
     pub version: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display: Option<AssetDisplay>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dynamic_assets: Vec<String>,
     pub assets: Vec<AssetEntry>,
 }
 
@@ -159,6 +161,7 @@ pub struct ResolvedAsset {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedAssetManifest {
     pub manifest_path: PathBuf,
+    pub dynamic_assets: BTreeSet<String>,
     pub assets: Vec<ResolvedAsset>,
 }
 
@@ -193,6 +196,7 @@ impl ResolvedAssetManifest {
         }
         Self {
             manifest_path: self.manifest_path.clone(),
+            dynamic_assets: self.dynamic_assets.intersection(paths).cloned().collect(),
             assets: self
                 .assets
                 .iter()
@@ -324,19 +328,29 @@ pub fn load_project_asset_manifest(
     }
     validate_dependencies(&manifest.assets, &ids)?;
 
+    let asset_root = root.join("assets").canonicalize().map_err(|error| {
+        manifest_error(
+            "asset_root_unavailable",
+            None,
+            Some(Path::new("assets")),
+            error.to_string(),
+        )
+    })?;
     let mut resolved = Vec::with_capacity(manifest.assets.len());
     for entry in manifest.assets {
         let relative = validate_relative_asset_path(&entry.path)
             .map_err(|detail| entry_error("asset_path_invalid", &entry, detail))?;
+        validate_exact_path_case(&root, &relative)
+            .map_err(|detail| entry_error("asset_path_case_mismatch", &entry, detail))?;
         let candidate = root.join(relative);
         let absolute_path = candidate
             .canonicalize()
             .map_err(|error| entry_error("asset_file_missing", &entry, error.to_string()))?;
-        if !absolute_path.starts_with(&root) || !absolute_path.is_file() {
+        if !absolute_path.starts_with(&asset_root) || !absolute_path.is_file() {
             return Err(entry_error(
-                "asset_path_outside_project",
+                "asset_path_outside_assets",
                 &entry,
-                "asset must resolve to a file inside the project root",
+                "asset must resolve to a file inside the project assets directory",
             ));
         }
         let (content_sha256, byte_length) = sha256_file(&absolute_path, limits.max_asset_bytes)
@@ -355,11 +369,69 @@ pub fn load_project_asset_manifest(
             byte_length,
         });
     }
+    let declared_paths = resolved
+        .iter()
+        .map(|asset| asset.entry.path.clone())
+        .collect::<BTreeSet<_>>();
+    let dynamic_assets = manifest
+        .dynamic_assets
+        .iter()
+        .map(|path| path.replace('\\', "/"))
+        .collect::<BTreeSet<_>>();
+    if let Some(path) = dynamic_assets
+        .iter()
+        .find(|path| !declared_paths.contains(*path))
+    {
+        return Err(manifest_error(
+            "asset_dynamic_path_undeclared",
+            None,
+            Some(Path::new(path)),
+            "dynamic_assets entries must name declared manifest asset paths",
+        ));
+    }
     resolved.sort_by(|left, right| left.entry.id.cmp(&right.entry.id));
     Ok(ResolvedAssetManifest {
         manifest_path,
+        dynamic_assets,
         assets: resolved,
     })
+}
+
+fn validate_exact_path_case(root: &Path, relative: &Path) -> Result<(), String> {
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(expected) = component else {
+            return Err("asset path must contain only relative path components".to_string());
+        };
+        let expected_text = expected.to_string_lossy();
+        let mut exact = false;
+        let mut insensitive = false;
+        let entries = fs::read_dir(&current)
+            .map_err(|error| format!("failed to inspect asset path casing: {error}"))?;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_text = name.to_string_lossy();
+            if name_text == expected_text {
+                exact = true;
+                break;
+            }
+            if name_text.eq_ignore_ascii_case(&expected_text) {
+                insensitive = true;
+            }
+        }
+        if !exact {
+            return if insensitive {
+                Err(format!(
+                    "path component '{}' does not exactly match disk casing",
+                    expected_text
+                ))
+            } else {
+                Ok(())
+            };
+        }
+        current.push(expected);
+    }
+    Ok(())
 }
 
 pub fn sha256_bytes(bytes: &[u8]) -> String {
@@ -391,6 +463,9 @@ pub fn prepare_asset_bundle(
     manifest
         .assets
         .retain(|entry| by_id.contains_key(entry.id.as_str()));
+    manifest
+        .dynamic_assets
+        .retain(|path| resolved.dynamic_assets.contains(path));
     let mut summary = PreparedAssetSummary {
         copied_assets: 0,
         resized_assets: 0,
@@ -1045,6 +1120,7 @@ mod tests {
             schema: ASSET_MANIFEST_SCHEMA.to_string(),
             version: ASSET_MANIFEST_VERSION,
             display: None,
+            dynamic_assets: Vec::new(),
             assets: entries,
         };
         fs::write(
@@ -1086,6 +1162,41 @@ mod tests {
             fs::read(root.join("output/assets/fonts/ui.ttf")).unwrap(),
             bytes
         );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn rejects_manifest_entry_with_non_exact_disk_casing() {
+        let root = project("case");
+        let bytes = b"sprite";
+        fs::write(root.join("assets/images/hero.png"), bytes).unwrap();
+        write_manifest(&root, vec![sprite("hero", "assets/Images/hero.png", bytes)]);
+        let error = load_project_asset_manifest(&root, AssetLimits::default()).unwrap_err();
+        assert_eq!(error.code, "asset_path_case_mismatch");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn rejects_manifest_asset_symlink_that_escapes_assets_directory() {
+        let root = project("symlink_escape");
+        fs::create_dir_all(root.join("private")).unwrap();
+        let bytes = b"private sprite";
+        fs::write(root.join("private/hero.png"), bytes).unwrap();
+        let link = root.join("assets/link");
+        #[cfg(unix)]
+        let linked = std::os::unix::fs::symlink(root.join("private"), &link).is_ok();
+        #[cfg(windows)]
+        let linked = std::os::windows::fs::symlink_dir(root.join("private"), &link).is_ok();
+        if !linked {
+            fs::remove_dir_all(root).ok();
+            return;
+        }
+        write_manifest(
+            &root,
+            vec![sprite("private", "assets/link/hero.png", bytes)],
+        );
+        let error = load_project_asset_manifest(&root, AssetLimits::default()).unwrap_err();
+        assert_eq!(error.code, "asset_path_outside_assets");
         fs::remove_dir_all(root).ok();
     }
 
@@ -1298,6 +1409,7 @@ mod tests {
                 max_physical_height: 1000,
                 scale_mode: AssetScaleMode::Fit,
             }),
+            dynamic_assets: Vec::new(),
             assets: vec![hero],
         };
         fs::write(

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -3329,17 +3329,18 @@ function end_frame(): void { return; }
     fn resolve_link_config_for_smoke() -> Option<stasis_jit::AotLinkConfig> {
         if let Some(explicit) = std::env::var_os("STASIS_AOT_LINKER") {
             let explicit = PathBuf::from(explicit);
+            eprintln!("AOT smoke linker: {}", explicit.display());
             return Some(stasis_jit::AotLinkConfig {
                 linker_path: Some(explicit),
                 runtime_lib_paths: vec![],
                 target: stasis_jit::AotTarget::default(),
             });
         }
-        for candidate in ["lld-link.exe", "link.exe"] {
-            let output = Command::new("where").arg(candidate).output().ok()?;
-            if output.status.success() {
+        for candidate in ["link.exe", "lld-link.exe"] {
+            if let Some(linker_path) = resolve_windows_linker_path(candidate) {
+                eprintln!("AOT smoke linker: {}", linker_path.display());
                 return Some(stasis_jit::AotLinkConfig {
-                    linker_path: Some(PathBuf::from(candidate)),
+                    linker_path: Some(linker_path),
                     runtime_lib_paths: vec![],
                     target: stasis_jit::AotTarget::default(),
                 });
@@ -3347,5 +3348,33 @@ function end_frame(): void { return; }
         }
         eprintln!("skipping AOT executable smoke test: no Windows linker found");
         None
+    }
+
+    #[cfg(windows)]
+    fn resolve_windows_linker_path(candidate: &str) -> Option<PathBuf> {
+        let output = Command::new("where").arg(candidate).output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(PathBuf::from)
+            .find(|path| path.is_absolute() && path.is_file())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn aot_smoke_linker_prefers_absolute_msvc_path() {
+        if std::env::var_os("STASIS_AOT_LINKER").is_some() {
+            return;
+        }
+        let Some(expected_msvc) = resolve_windows_linker_path("link.exe") else {
+            return;
+        };
+        let config = resolve_link_config_for_smoke().expect("MSVC linker config");
+        assert_eq!(config.linker_path.as_deref(), Some(expected_msvc.as_path()));
+        assert!(expected_msvc.is_absolute());
     }
 }

--- a/crates/stasis_compiler/src/backend/assets.rs
+++ b/crates/stasis_compiler/src/backend/assets.rs
@@ -9,8 +9,8 @@ use crate::backend::emit::ConstantValue;
 use crate::compiler::{FunctionId, FunctionMeta, SourceFile};
 use crate::frontend::lexer::{lex, Token, TokenKind};
 use crate::frontend::parser::{
-    parse_string_literal_text, parse_top_level_extern_functions,
-    ParsedFunctionAnnotationArgumentKind,
+    parse_local_declarations, parse_string_literal_text, parse_top_level_extern_functions,
+    ParsedFunctionAnnotationArgumentKind, ParsedLocalDeclaration,
 };
 
 const ASSET_ANNOTATION: &str = "asset_path";
@@ -70,6 +70,17 @@ pub(crate) fn discover_asset_references(
     constants: &BTreeMap<String, ConstantValue>,
 ) -> Result<Vec<AssetReference>, String> {
     let loaders = collect_asset_loaders(files)?;
+    let local_declarations = files
+        .iter()
+        .map(|file| {
+            parse_local_declarations(&file.content).map_err(|error| {
+                format!(
+                    "failed parsing scoped bindings for asset discovery in {}: {error}",
+                    file.path
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let mut references = Vec::new();
     for function in functions
         .iter()
@@ -90,6 +101,9 @@ pub(crate) fn discover_asset_references(
             &file.path,
             body,
             body_start,
+            &function.name,
+            &function.param_names,
+            &local_declarations[function.file_id as usize],
             &loaders,
             constants,
             &mut references,
@@ -200,6 +214,9 @@ fn discover_function_references(
     source_path: &str,
     body: &str,
     body_offset: usize,
+    function_name: &str,
+    parameter_names: &[String],
+    local_declarations: &[ParsedLocalDeclaration],
     loaders: &BTreeMap<String, Vec<AssetLoader>>,
     constants: &BTreeMap<String, ConstantValue>,
     out: &mut Vec<AssetReference>,
@@ -268,7 +285,15 @@ fn discover_function_references(
         let leading = body[range.clone()].len() - body[range.clone()].trim_start().len();
         let start = range.start + leading;
         let end = start + expression.len();
-        let logical_path = static_string(expression, constants)?;
+        let expression_start = body_offset + start;
+        let logical_path = static_string(expression, constants, |name| {
+            parameter_names.iter().any(|parameter| parameter == name)
+                || local_declarations.iter().any(|declaration| {
+                    declaration.function_name == function_name
+                        && declaration.name == name
+                        && declaration.visibility_range.contains(&expression_start)
+                })
+        })?;
         out.push(AssetReference {
             api: name.to_string(),
             source_path: source_path.to_string(),
@@ -398,6 +423,7 @@ fn call_argument_ranges(
 fn static_string(
     expression: &str,
     constants: &BTreeMap<String, ConstantValue>,
+    is_scoped_binding: impl Fn(&str) -> bool,
 ) -> Result<Option<String>, String> {
     let expression = strip_parenthesized_expression(expression)?;
     let tokens = lex(expression)?;
@@ -414,12 +440,14 @@ fn static_string(
             parse_string_literal_text(&expression[token.start..token.end]).map(Some)
         }
         TokenKind::Identifier => {
-            Ok(constants
-                .get(&expression[token.start..token.end])
-                .and_then(|value| match value {
-                    ConstantValue::String { value, .. } => Some(value.clone()),
-                    _ => None,
-                }))
+            let name = &expression[token.start..token.end];
+            if is_scoped_binding(name) {
+                return Ok(None);
+            }
+            Ok(constants.get(name).and_then(|value| match value {
+                ConstantValue::String { value, .. } => Some(value.clone()),
+                _ => None,
+            }))
         }
         _ => Ok(None),
     }
@@ -798,8 +826,49 @@ function main(path: string): i32 { return path.load_font(16); }
             },
         )]);
         assert_eq!(
-            static_string("(FONT_PATH)", &constants).expect("parenthesized constant"),
+            static_string("(FONT_PATH)", &constants, |_| false).expect("parenthesized constant"),
             Some("assets/ui.ttf".to_string())
+        );
+    }
+
+    #[test]
+    fn scoped_bindings_shadow_global_asset_constants_at_the_call_site() {
+        let source = r#"
+extern function @asset_path(path) load_font(path: string, size: i32): i32;
+const FONT_PATH: string = "assets/global.ttf";
+function from_parameter(FONT_PATH: string): i32 { return load_font(FONT_PATH, 16); }
+function from_local(): i32 {
+    let result: i32 = 0;
+    if (result == 0) {
+        let FONT_PATH: string = "assets/local.ttf";
+        return load_font(FONT_PATH, 16);
+    }
+    return load_font(FONT_PATH, 16);
+}
+function from_initializer(): i32 {
+    let FONT_PATH: i32 = load_font(FONT_PATH, 16);
+    return FONT_PATH;
+}
+function main(): i32 {
+    return from_parameter("assets/runtime.ttf") + from_local() + from_initializer();
+}
+"#;
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile().expect("compile scoped asset fixture");
+        let references = jit.program_snapshot().expect("snapshot").asset_references();
+        let paths = references
+            .iter()
+            .map(|reference| reference.logical_path.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec![
+                None,
+                None,
+                Some("assets/global.ttf"),
+                Some("assets/global.ttf")
+            ]
         );
     }
 

--- a/crates/stasis_compiler/src/backend/assets.rs
+++ b/crates/stasis_compiler/src/backend/assets.rs
@@ -1,0 +1,953 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::ops::Range;
+use std::path::{Component, Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::backend::emit::ConstantValue;
+use crate::compiler::{FunctionId, FunctionMeta, SourceFile};
+use crate::frontend::lexer::{lex, Token, TokenKind};
+use crate::frontend::parser::{
+    parse_string_literal_text, parse_top_level_extern_functions,
+    ParsedFunctionAnnotationArgumentKind,
+};
+
+const ASSET_ANNOTATION: &str = "asset_path";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct AssetLoader {
+    parameter_count: usize,
+    path_parameter: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum PathOperand {
+    Receiver,
+    Argument(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AssetReference {
+    pub api: String,
+    pub source_path: String,
+    pub start: usize,
+    pub end: usize,
+    pub logical_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedAssetReference {
+    #[serde(flatten)]
+    pub reference: AssetReference,
+    pub project_path: String,
+    pub absolute_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AssetDiagnostic {
+    pub code: String,
+    pub api: String,
+    pub source_path: String,
+    pub start: usize,
+    pub end: usize,
+    pub logical_path: Option<String>,
+    pub attempted_paths: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct AssetValidationResult {
+    pub references: Vec<ResolvedAssetReference>,
+    pub resolved_paths: BTreeSet<String>,
+    pub diagnostics: Vec<AssetDiagnostic>,
+}
+
+pub(crate) fn discover_asset_references(
+    files: &[SourceFile],
+    functions: &[FunctionMeta],
+    reachable: &BTreeSet<FunctionId>,
+    constants: &BTreeMap<String, ConstantValue>,
+) -> Result<Vec<AssetReference>, String> {
+    let loaders = collect_asset_loaders(files)?;
+    let mut references = Vec::new();
+    for function in functions
+        .iter()
+        .filter(|function| reachable.contains(&function.id))
+    {
+        let file = files
+            .get(function.file_id as usize)
+            .ok_or_else(|| format!("asset discovery missing source file {}", function.file_id))?;
+        let body_start = function.source_range.start as usize;
+        let body_end = function.source_range.end as usize;
+        let body = file.content.get(body_start..body_end).ok_or_else(|| {
+            format!(
+                "invalid function range for asset discovery in {}",
+                file.path
+            )
+        })?;
+        discover_function_references(
+            &file.path,
+            body,
+            body_start,
+            &loaders,
+            constants,
+            &mut references,
+        )?;
+    }
+    references.sort_by(|left, right| {
+        (&left.source_path, left.start, left.end, &left.api).cmp(&(
+            &right.source_path,
+            right.start,
+            right.end,
+            &right.api,
+        ))
+    });
+    references.dedup();
+    Ok(references)
+}
+
+fn collect_asset_loaders(
+    files: &[SourceFile],
+) -> Result<BTreeMap<String, Vec<AssetLoader>>, String> {
+    let mut loaders = BTreeMap::new();
+    for file in files {
+        for declaration in parse_top_level_extern_functions(&file.content).map_err(|error| {
+            format!(
+                "failed parsing asset loader declarations in {}: {error}",
+                file.path
+            )
+        })? {
+            if let Some(index) = legacy_asset_parameter(&declaration.name) {
+                if declaration
+                    .params
+                    .get(index)
+                    .is_some_and(|parameter| parameter.type_name == "string")
+                {
+                    insert_loader(
+                        &mut loaders,
+                        &declaration.name,
+                        declaration.params.len(),
+                        index,
+                    );
+                }
+            }
+            for annotation in declaration
+                .annotations
+                .iter()
+                .filter(|annotation| annotation.name == ASSET_ANNOTATION)
+            {
+                if !annotation.has_parentheses || annotation.arguments.len() != 1 {
+                    return Err(format!(
+                        "@asset_path on '{}' must name exactly one path parameter",
+                        declaration.name
+                    ));
+                }
+                let argument = &annotation.arguments[0];
+                if argument.kind != ParsedFunctionAnnotationArgumentKind::Identifier {
+                    return Err(format!(
+                        "@asset_path on '{}' must use a parameter name",
+                        declaration.name
+                    ));
+                }
+                let index = declaration
+                    .params
+                    .iter()
+                    .position(|parameter| parameter.name == argument.text)
+                    .ok_or_else(|| {
+                        format!(
+                            "@asset_path on '{}' names unknown parameter '{}'",
+                            declaration.name, argument.text
+                        )
+                    })?;
+                insert_loader(
+                    &mut loaders,
+                    &declaration.name,
+                    declaration.params.len(),
+                    index,
+                );
+            }
+        }
+    }
+    Ok(loaders)
+}
+
+fn insert_loader(
+    loaders: &mut BTreeMap<String, Vec<AssetLoader>>,
+    name: &str,
+    parameter_count: usize,
+    path_parameter: usize,
+) {
+    let entries = loaders.entry(name.to_string()).or_default();
+    entries.push(AssetLoader {
+        parameter_count,
+        path_parameter,
+    });
+    entries.sort();
+    entries.dedup();
+}
+
+fn legacy_asset_parameter(name: &str) -> Option<usize> {
+    match name {
+        "audio_load_effect" | "audio_load_music" | "audio_load_wav" | "gfx_load_sprite"
+        | "load_font" => Some(0),
+        "load_sprite_from" => Some(1),
+        _ => None,
+    }
+}
+
+fn discover_function_references(
+    source_path: &str,
+    body: &str,
+    body_offset: usize,
+    loaders: &BTreeMap<String, Vec<AssetLoader>>,
+    constants: &BTreeMap<String, ConstantValue>,
+    out: &mut Vec<AssetReference>,
+) -> Result<(), String> {
+    let tokens = lex(body)?;
+    for index in 0..tokens.len() {
+        let token = tokens[index];
+        if token.kind != TokenKind::Identifier {
+            continue;
+        }
+        let name = &body[token.start..token.end];
+        let Some(loader_signatures) = loaders.get(name) else {
+            continue;
+        };
+        let receiver_call = index > 0
+            && token_text_is(body, tokens[index - 1], ".")
+            && tokens
+                .get(index + 1)
+                .is_some_and(|next| next.kind == TokenKind::LParen);
+        let bare_call = !receiver_call
+            && tokens
+                .get(index + 1)
+                .is_some_and(|next| next.kind == TokenKind::LParen);
+        if !receiver_call && !bare_call {
+            continue;
+        }
+        let open = index + 1;
+        let (arguments, _) = call_argument_ranges(&tokens, open)?;
+        let path_operands = loader_signatures
+            .iter()
+            .filter_map(|loader| {
+                if receiver_call {
+                    (loader.parameter_count == arguments.len() + 1).then(|| {
+                        if loader.path_parameter == 0 {
+                            PathOperand::Receiver
+                        } else {
+                            PathOperand::Argument(loader.path_parameter - 1)
+                        }
+                    })
+                } else {
+                    (loader.parameter_count == arguments.len())
+                        .then_some(PathOperand::Argument(loader.path_parameter))
+                }
+            })
+            .collect::<BTreeSet<_>>();
+        let mut path_operands = path_operands.into_iter();
+        let Some(path_operand) = path_operands.next() else {
+            continue;
+        };
+        if path_operands.next().is_some() {
+            return Err(format!(
+                "ambiguous asset path metadata for call target '{name}' with {} argument(s)",
+                arguments.len()
+            ));
+        }
+        let range = match path_operand {
+            PathOperand::Receiver => receiver_expression_range(body, &tokens, index)?,
+            PathOperand::Argument(explicit_index) => {
+                let Some(range) = arguments.get(explicit_index).cloned() else {
+                    continue;
+                };
+                range
+            }
+        };
+        let expression = body[range.clone()].trim();
+        let leading = body[range.clone()].len() - body[range.clone()].trim_start().len();
+        let start = range.start + leading;
+        let end = start + expression.len();
+        let logical_path = static_string(expression, constants)?;
+        out.push(AssetReference {
+            api: name.to_string(),
+            source_path: source_path.to_string(),
+            start: body_offset + start,
+            end: body_offset + end,
+            logical_path,
+        });
+    }
+    Ok(())
+}
+
+fn receiver_expression_range(
+    source: &str,
+    tokens: &[Token],
+    method_index: usize,
+) -> Result<Range<usize>, String> {
+    let dot_index = method_index
+        .checked_sub(1)
+        .ok_or_else(|| "asset receiver is missing its separator".to_string())?;
+    let receiver_index = dot_index
+        .checked_sub(1)
+        .ok_or_else(|| "asset receiver expression is missing".to_string())?;
+    let start_index = postfix_expression_start(source, tokens, receiver_index)?;
+    Ok(tokens[start_index].start..tokens[dot_index].start)
+}
+
+fn postfix_expression_start(
+    source: &str,
+    tokens: &[Token],
+    end_index: usize,
+) -> Result<usize, String> {
+    let token = tokens[end_index];
+    let mut start = match token.kind {
+        TokenKind::Identifier | TokenKind::StringLiteral | TokenKind::Integer => end_index,
+        TokenKind::RParen => {
+            let open = matching_delimiter(source, tokens, end_index, "(", ")")?;
+            if open > 0 && can_end_receiver_callee(source, tokens[open - 1]) {
+                postfix_expression_start(source, tokens, open - 1)?
+            } else {
+                open
+            }
+        }
+        TokenKind::Other if token_text_is(source, token, "]") => {
+            let open = matching_delimiter(source, tokens, end_index, "[", "]")?;
+            let base = open
+                .checked_sub(1)
+                .ok_or_else(|| "asset receiver index is missing its base expression".to_string())?;
+            postfix_expression_start(source, tokens, base)?
+        }
+        _ => {
+            return Err("asset receiver has an unsupported expression shape".to_string());
+        }
+    };
+    while start >= 2 && token_text_is(source, tokens[start - 1], ".") {
+        start = postfix_expression_start(source, tokens, start - 2)?;
+    }
+    Ok(start)
+}
+
+fn can_end_receiver_callee(source: &str, token: Token) -> bool {
+    match token.kind {
+        TokenKind::Identifier => !matches!(
+            &source[token.start..token.end],
+            "return" | "if" | "else" | "while" | "for" | "foreach" | "let"
+        ),
+        TokenKind::RParen => true,
+        TokenKind::Other => token_text_is(source, token, "]"),
+        _ => false,
+    }
+}
+
+fn matching_delimiter(
+    source: &str,
+    tokens: &[Token],
+    close_index: usize,
+    open: &str,
+    close: &str,
+) -> Result<usize, String> {
+    let mut depth = 0usize;
+    for index in (0..=close_index).rev() {
+        if token_text_is(source, tokens[index], close) {
+            depth += 1;
+        } else if token_text_is(source, tokens[index], open) {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return Ok(index);
+            }
+        }
+    }
+    Err(format!("unbalanced '{open}{close}' in asset receiver"))
+}
+
+fn call_argument_ranges(
+    tokens: &[Token],
+    open: usize,
+) -> Result<(Vec<Range<usize>>, usize), String> {
+    let open_token = tokens
+        .get(open)
+        .ok_or_else(|| "missing asset call opening parenthesis".to_string())?;
+    let mut depth = 1usize;
+    let mut argument_start = open_token.end;
+    let mut arguments = Vec::new();
+    let mut cursor = open + 1;
+    while let Some(token) = tokens.get(cursor).copied() {
+        match token.kind {
+            TokenKind::LParen => depth += 1,
+            TokenKind::RParen => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    if token.start > argument_start {
+                        arguments.push(argument_start..token.start);
+                    }
+                    return Ok((arguments, cursor));
+                }
+            }
+            TokenKind::Comma if depth == 1 => {
+                arguments.push(argument_start..token.start);
+                argument_start = token.end;
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    Err("unterminated asset loader call".to_string())
+}
+
+fn static_string(
+    expression: &str,
+    constants: &BTreeMap<String, ConstantValue>,
+) -> Result<Option<String>, String> {
+    let expression = strip_parenthesized_expression(expression)?;
+    let tokens = lex(expression)?;
+    let tokens = tokens
+        .into_iter()
+        .filter(|token| token.kind != TokenKind::Eof)
+        .collect::<Vec<_>>();
+    if tokens.len() != 1 {
+        return Ok(None);
+    }
+    let token = tokens[0];
+    match token.kind {
+        TokenKind::StringLiteral => {
+            parse_string_literal_text(&expression[token.start..token.end]).map(Some)
+        }
+        TokenKind::Identifier => {
+            Ok(constants
+                .get(&expression[token.start..token.end])
+                .and_then(|value| match value {
+                    ConstantValue::String { value, .. } => Some(value.clone()),
+                    _ => None,
+                }))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn strip_parenthesized_expression(mut expression: &str) -> Result<&str, String> {
+    loop {
+        expression = expression.trim();
+        let tokens = lex(expression)?
+            .into_iter()
+            .filter(|token| token.kind != TokenKind::Eof)
+            .collect::<Vec<_>>();
+        if tokens.len() < 2
+            || tokens[0].kind != TokenKind::LParen
+            || tokens
+                .last()
+                .is_none_or(|token| token.kind != TokenKind::RParen)
+            || matching_delimiter(expression, &tokens, tokens.len() - 1, "(", ")")? != 0
+        {
+            return Ok(expression);
+        }
+        expression = &expression[tokens[0].end..tokens[tokens.len() - 1].start];
+    }
+}
+
+fn token_text_is(source: &str, token: Token, expected: &str) -> bool {
+    source.get(token.start..token.end) == Some(expected)
+}
+
+pub fn validate_asset_references(
+    project_root: &Path,
+    references: &[AssetReference],
+    manifest_paths: Option<&BTreeSet<String>>,
+    dynamic_paths: &BTreeSet<String>,
+) -> AssetValidationResult {
+    let mut result = AssetValidationResult::default();
+    let project_root = match project_root.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            for reference in references {
+                result.diagnostics.push(diagnostic(
+                    reference,
+                    "asset_project_root_unavailable",
+                    Vec::new(),
+                    format!("project root is unavailable: {error}"),
+                ));
+            }
+            return result;
+        }
+    };
+    let asset_root = project_root
+        .join("assets")
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.join("assets"));
+    for reference in references {
+        let Some(logical_path) = reference.logical_path.as_deref() else {
+            if dynamic_paths.is_empty() {
+                result.diagnostics.push(diagnostic(
+                    reference,
+                    "asset_dynamic_path_undeclared",
+                    Vec::new(),
+                    "dynamic asset paths require assets/manifest.json dynamic_assets declarations"
+                        .to_string(),
+                ));
+            } else {
+                for path in dynamic_paths {
+                    resolve_one(
+                        &project_root,
+                        &asset_root,
+                        reference,
+                        path,
+                        manifest_paths,
+                        &mut result,
+                    );
+                }
+            }
+            continue;
+        };
+        resolve_one(
+            &project_root,
+            &asset_root,
+            reference,
+            logical_path,
+            manifest_paths,
+            &mut result,
+        );
+    }
+    result.references.sort_by(|left, right| {
+        (
+            &left.reference.source_path,
+            left.reference.start,
+            &left.project_path,
+        )
+            .cmp(&(
+                &right.reference.source_path,
+                right.reference.start,
+                &right.project_path,
+            ))
+    });
+    result.references.dedup();
+    result.diagnostics.sort_by(|left, right| {
+        (&left.source_path, left.start, &left.code).cmp(&(
+            &right.source_path,
+            right.start,
+            &right.code,
+        ))
+    });
+    result
+}
+
+fn resolve_one(
+    project_root: &Path,
+    asset_root: &Path,
+    reference: &AssetReference,
+    logical_path: &str,
+    manifest_paths: Option<&BTreeSet<String>>,
+    result: &mut AssetValidationResult,
+) {
+    if looks_absolute_or_uri(logical_path) {
+        result.diagnostics.push(diagnostic(
+            reference,
+            "asset_path_absolute_or_uri",
+            vec![logical_path.to_string()],
+            "asset paths must be relative filesystem paths".to_string(),
+        ));
+        return;
+    }
+    let source = PathBuf::from(&reference.source_path);
+    let declaring_dir = if source.is_absolute() {
+        source
+            .parent()
+            .unwrap_or(project_root)
+            .canonicalize()
+            .unwrap_or_else(|_| source.parent().unwrap_or(project_root).to_path_buf())
+    } else {
+        project_root
+            .join(source)
+            .parent()
+            .unwrap_or(project_root)
+            .to_path_buf()
+    };
+    let candidates = [
+        declaring_dir.join(logical_path),
+        project_root.join(logical_path),
+    ];
+    let attempted = candidates
+        .iter()
+        .map(|path| path.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let mut case_mismatch = false;
+    for candidate in candidates {
+        let Some(normalized) = normalize_path(&candidate) else {
+            continue;
+        };
+        if !normalized.starts_with(asset_root) {
+            continue;
+        }
+        match exact_case_file(project_root, &normalized) {
+            Ok(true) => {
+                let Ok(canonical) = normalized.canonicalize() else {
+                    continue;
+                };
+                if !canonical.starts_with(asset_root) || !canonical.is_file() {
+                    continue;
+                }
+                let Ok(relative) = normalized.strip_prefix(project_root) else {
+                    continue;
+                };
+                let project_path = relative.to_string_lossy().replace('\\', "/");
+                if manifest_paths.is_some_and(|paths| !paths.contains(&project_path)) {
+                    result.diagnostics.push(diagnostic(
+                        reference,
+                        "asset_not_declared",
+                        attempted,
+                        format!("resolved asset '{project_path}' is not declared in the manifest"),
+                    ));
+                    return;
+                }
+                result.resolved_paths.insert(project_path.clone());
+                result.references.push(ResolvedAssetReference {
+                    reference: reference.clone(),
+                    project_path,
+                    absolute_path: canonical,
+                });
+                return;
+            }
+            Ok(false) => {}
+            Err(()) => case_mismatch = true,
+        }
+    }
+    result.diagnostics.push(diagnostic(
+        reference,
+        if case_mismatch {
+            "asset_path_case_mismatch"
+        } else {
+            "asset_path_missing_or_outside_boundary"
+        },
+        attempted,
+        if case_mismatch {
+            "asset path casing does not exactly match disk".to_string()
+        } else {
+            "asset does not exist as a regular file inside the project assets directory".to_string()
+        },
+    ));
+}
+
+fn diagnostic(
+    reference: &AssetReference,
+    code: &str,
+    attempted_paths: Vec<String>,
+    reason: String,
+) -> AssetDiagnostic {
+    AssetDiagnostic {
+        code: code.to_string(),
+        api: reference.api.clone(),
+        source_path: reference.source_path.clone(),
+        start: reference.start,
+        end: reference.end,
+        logical_path: reference.logical_path.clone(),
+        attempted_paths,
+        reason,
+    }
+}
+
+fn looks_absolute_or_uri(path: &str) -> bool {
+    path.contains("://")
+        || path.starts_with('/')
+        || path.starts_with('\\')
+        || path.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+}
+
+fn normalize_path(path: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    return None;
+                }
+            }
+            Component::Normal(segment) => out.push(segment),
+        }
+    }
+    Some(out)
+}
+
+fn exact_case_file(project_root: &Path, target: &Path) -> Result<bool, ()> {
+    let relative = target.strip_prefix(project_root).map_err(|_| ())?;
+    let mut current = project_root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(expected) = component else {
+            return Ok(false);
+        };
+        let entries = fs::read_dir(&current).map_err(|_| ())?;
+        let mut insensitive = false;
+        let mut exact = false;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy() == expected.to_string_lossy() {
+                exact = true;
+                break;
+            }
+            if name
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&expected.to_string_lossy())
+            {
+                insensitive = true;
+            }
+        }
+        if !exact {
+            return if insensitive { Err(()) } else { Ok(false) };
+        }
+        current.push(expected);
+    }
+    Ok(current.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::aot::AotProcess;
+    use crate::backend::jit::JitProcess;
+
+    #[test]
+    fn custom_loader_metadata_uses_the_named_parameter() {
+        let source = "function @asset_path(file) @extern(\"custom_load\") custom_load(self: i32, file: string): i32;";
+        let files = vec![SourceFile {
+            path: "custom.stasis".into(),
+            content: source.into(),
+            hash: 0,
+            functions: Vec::new(),
+        }];
+        assert_eq!(
+            collect_asset_loaders(&files)
+                .expect("loader metadata")
+                .get("custom_load"),
+            Some(&vec![AssetLoader {
+                parameter_count: 2,
+                path_parameter: 1,
+            }])
+        );
+    }
+
+    #[test]
+    fn snapshot_discovers_only_reachable_annotated_asset_calls() {
+        let source = r#"
+extern function @asset_path(path) load_font(path: string, size: i32): i32;
+const FONT_PATH: string = "assets/ui.ttf";
+function helper(): i32 { return FONT_PATH.load_font(16); }
+function unused(): i32 { return load_font("assets/unused.ttf", 16); }
+function main(): i32 { return helper(); }
+"#;
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile().expect("compile asset fixture");
+        let references = jit.program_snapshot().expect("snapshot").asset_references();
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].api, "load_font");
+        assert_eq!(references[0].logical_path.as_deref(), Some("assets/ui.ttf"));
+        assert_eq!(&source[references[0].start..references[0].end], "FONT_PATH");
+
+        let mut aot = AotProcess::new();
+        aot.upsert_file("main.stasis", source);
+        aot.compile().expect("compile AOT asset fixture");
+        assert_eq!(
+            references,
+            aot.program_snapshot()
+                .expect("AOT snapshot")
+                .asset_references()
+        );
+    }
+
+    #[test]
+    fn receiver_form_reports_dynamic_path_expression_span() {
+        let source = r#"
+extern function @asset_path(path) load_font(path: string, size: i32): i32;
+function main(path: string): i32 { return path.load_font(16); }
+"#;
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source);
+        jit.compile().expect("compile dynamic receiver fixture");
+        let references = jit.program_snapshot().expect("snapshot").asset_references();
+        assert_eq!(references.len(), 1);
+        assert_eq!(references[0].logical_path, None);
+        assert_eq!(&source[references[0].start..references[0].end], "path");
+    }
+
+    #[test]
+    fn compound_receiver_spans_include_calls_and_indexes() {
+        for (source, expected) in [
+            ("(FONT_PATH).load_font(16)", "(FONT_PATH)"),
+            ("choose_path().load_font(16)", "choose_path()"),
+            ("choose_path ().load_font(16)", "choose_path ()"),
+            ("paths[0].load_font(16)", "paths[0]"),
+        ] {
+            let tokens = lex(source).expect("receiver tokens");
+            let method_index = tokens
+                .iter()
+                .position(|token| {
+                    token.kind == TokenKind::Identifier
+                        && &source[token.start..token.end] == "load_font"
+                })
+                .expect("method token");
+            let range = receiver_expression_range(source, &tokens, method_index)
+                .expect("receiver expression range");
+            assert_eq!(&source[range], expected);
+        }
+        let constants = BTreeMap::from([(
+            "FONT_PATH".to_string(),
+            ConstantValue::String {
+                value: "assets/ui.ttf".to_string(),
+                type_id: 0,
+            },
+        )]);
+        assert_eq!(
+            static_string("(FONT_PATH)", &constants).expect("parenthesized constant"),
+            Some("assets/ui.ttf".to_string())
+        );
+    }
+
+    #[test]
+    fn validation_rejects_asset_symlinks_that_escape_the_asset_root() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_asset_symlink_{stamp}"));
+        fs::create_dir_all(root.join("src")).expect("source dir");
+        fs::create_dir_all(root.join("assets")).expect("asset dir");
+        fs::write(root.join("outside.svg"), "outside").expect("outside fixture");
+        let link = root.join("assets/escape.svg");
+        #[cfg(unix)]
+        let linked = std::os::unix::fs::symlink(root.join("outside.svg"), &link).is_ok();
+        #[cfg(windows)]
+        let linked = std::os::windows::fs::symlink_file(root.join("outside.svg"), &link).is_ok();
+        if !linked {
+            fs::remove_dir_all(root).ok();
+            return;
+        }
+        let references = vec![AssetReference {
+            api: "load_font".into(),
+            source_path: root.join("src/main.stasis").to_string_lossy().into_owned(),
+            start: 0,
+            end: 19,
+            logical_path: Some("assets/escape.svg".into()),
+        }];
+        let result = validate_asset_references(
+            &root,
+            &references,
+            Some(&BTreeSet::from(["assets/escape.svg".to_string()])),
+            &BTreeSet::new(),
+        );
+        assert!(result.references.is_empty());
+        assert_eq!(
+            result.diagnostics[0].code,
+            "asset_path_missing_or_outside_boundary"
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn validation_reports_case_dynamic_and_manifest_failures() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_asset_validation_{stamp}"));
+        fs::create_dir_all(root.join("src")).expect("source dir");
+        fs::create_dir_all(root.join("assets/svg")).expect("asset dir");
+        fs::write(root.join("assets/svg/hero.svg"), "svg").expect("asset");
+        let references = vec![
+            AssetReference {
+                api: "load_sprite_from".into(),
+                source_path: root.join("src/main.stasis").to_string_lossy().into_owned(),
+                start: 10,
+                end: 20,
+                logical_path: Some("../assets/Svg/hero.svg".into()),
+            },
+            AssetReference {
+                api: "load_font".into(),
+                source_path: root.join("src/main.stasis").to_string_lossy().into_owned(),
+                start: 30,
+                end: 34,
+                logical_path: None,
+            },
+        ];
+        let result = validate_asset_references(
+            &root,
+            &references,
+            Some(&BTreeSet::from(["assets/other.svg".to_string()])),
+            &BTreeSet::new(),
+        );
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["asset_dynamic_path_undeclared", "asset_path_case_mismatch"])
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn validation_resolves_declaring_module_and_reports_every_path_contract() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_asset_contract_{stamp}"));
+        fs::create_dir_all(root.join("src/ui")).expect("source dir");
+        fs::create_dir_all(root.join("assets/svg")).expect("asset dir");
+        fs::write(root.join("assets/svg/hero.svg"), "svg").expect("asset");
+        fs::write(root.join("outside.svg"), "outside").expect("outside fixture");
+        let source_path = root
+            .join("src/ui/menu.stasis")
+            .to_string_lossy()
+            .into_owned();
+        let reference = |start, logical_path: &str| AssetReference {
+            api: "custom_asset_loader".into(),
+            source_path: source_path.clone(),
+            start,
+            end: start + logical_path.len(),
+            logical_path: Some(logical_path.into()),
+        };
+        let references = vec![
+            reference(0, "../../assets/svg/hero.svg"),
+            reference(10, "assets/svg/hero.svg"),
+            reference(20, "../../outside.svg"),
+            reference(30, "assets/svg/missing.svg"),
+            reference(40, "https://example.com/hero.svg"),
+            reference(50, "C:/assets/hero.svg"),
+        ];
+        let result = validate_asset_references(
+            &root,
+            &references,
+            Some(&BTreeSet::from(["assets/svg/hero.svg".to_string()])),
+            &BTreeSet::new(),
+        );
+        assert_eq!(result.references.len(), 2);
+        assert_eq!(
+            result.resolved_paths,
+            BTreeSet::from(["assets/svg/hero.svg".to_string()])
+        );
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "asset_path_missing_or_outside_boundary",
+                "asset_path_missing_or_outside_boundary",
+                "asset_path_absolute_or_uri",
+                "asset_path_absolute_or_uri",
+            ]
+        );
+
+        let undeclared = validate_asset_references(
+            &root,
+            &[reference(60, "assets/svg/hero.svg")],
+            Some(&BTreeSet::new()),
+            &BTreeSet::new(),
+        );
+        assert_eq!(undeclared.diagnostics[0].code, "asset_not_declared");
+        fs::remove_dir_all(root).ok();
+    }
+}

--- a/crates/stasis_compiler/src/backend/mod.rs
+++ b/crates/stasis_compiler/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod aot;
+pub mod assets;
 pub(crate) mod emit;
 pub mod jit;
 pub mod patch_plan;

--- a/crates/stasis_compiler/src/backend/program_snapshot.rs
+++ b/crates/stasis_compiler/src/backend/program_snapshot.rs
@@ -6,6 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use crate::backend::assets::{discover_asset_references, AssetReference};
 use crate::backend::emit::{
     build_compile_analysis_cache, compute_files_fingerprint,
     resolve_preferred_extern_call_signatures, CompileAnalysisCache,
@@ -93,6 +94,7 @@ pub struct ProgramSnapshot {
     functions: Vec<ProgramFunction>,
     accepted_diagnostics: Vec<crate::SourceDiagnostic>,
     reachable_function_ids: BTreeSet<FunctionId>,
+    asset_references: Vec<AssetReference>,
     state_layout: StateLayout,
     layout_digest: [u8; 32],
     data_flow_summaries: Arc<[FunctionDataFlowSummary]>,
@@ -135,13 +137,21 @@ impl ProgramSnapshot {
             })
             .collect();
         let literal_table = collect_program_literals(files)?;
+        let reachable_function_ids = compute_reachable_function_ids(functions, required_emit_roots);
+        let asset_references = discover_asset_references(
+            files,
+            functions,
+            &reachable_function_ids,
+            &analysis.constant_values,
+        )?;
         Ok(Self {
             source_revision,
             files: files.to_vec(),
             module_graph: module_graph.clone(),
             functions: functions.iter().map(ProgramFunction::from).collect(),
             accepted_diagnostics: Vec::new(),
-            reachable_function_ids: compute_reachable_function_ids(functions, required_emit_roots),
+            reachable_function_ids,
+            asset_references,
             state_layout,
             layout_digest,
             data_flow_summaries,
@@ -180,6 +190,9 @@ impl ProgramSnapshot {
     }
     pub fn reachable_function_ids(&self) -> &BTreeSet<FunctionId> {
         &self.reachable_function_ids
+    }
+    pub fn asset_references(&self) -> &[AssetReference] {
+        &self.asset_references
     }
     pub fn state_layout(&self) -> &StateLayout {
         &self.state_layout

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -61,6 +61,7 @@ pub struct ParsedExternFunctionDeclaration {
     pub name: String,
     pub symbol_name: String,
     pub explicit_symbol: bool,
+    pub annotations: Vec<ParsedFunctionAnnotation>,
     pub params: Vec<ParsedParam>,
     pub return_type_name: String,
 }
@@ -689,7 +690,7 @@ pub fn parse_top_level_extern_functions(
         }
 
         cursor += 1;
-        let (after_annotations, annotation_symbol, _) =
+        let (after_annotations, annotation_symbol, annotations) =
             parse_function_annotations(source, &tokens, cursor)?;
         cursor = after_annotations;
         let name = token_text(source, expect(&tokens, cursor, TokenKind::Identifier)?).to_string();
@@ -744,6 +745,7 @@ pub fn parse_top_level_extern_functions(
                     name,
                     symbol_name,
                     explicit_symbol,
+                    annotations,
                     params,
                     return_type_name,
                 });

--- a/docs/asset_manifest.md
+++ b/docs/asset_manifest.md
@@ -17,6 +17,7 @@ Version 1 manifests remain valid and package their files unchanged. Version 2 ad
     "max_physical_height": 3200,
     "scale_mode": "fit"
   },
+  "dynamic_assets": ["assets/images/seasonal.png"],
   "assets": [
     {
       "id": "white_queen",
@@ -66,7 +67,23 @@ Preparation writes only beneath the build output; project masters and the source
 
 `stasis play` prepares the same bundle beneath `.stasis_cache/play-assets` before guest startup and mirrors the source directory's position relative to the project root. Existing source-relative paths such as `../assets/images/hero.png` therefore resolve to prepared output without source rewriting. Resized cache hits do not decode the master again. Development builds stage the complete declared manifest so iterative and optional paths remain available.
 
-Release builds and mobile packages scan the entry module's reachable import graph and stage only declared assets named by string literals that resolve beneath the project `assets/` directory, plus their transitive manifest dependencies. Paths such as `../assets/images/hero.png` resolve relative to the selected entry file's directory, including when the literal appears in an imported module; project-root paths such as `assets/images/hero.png` are also accepted. These are the same resolution rules used at runtime. The generated manifest is rewritten to the same exact subset. Runtime asset paths therefore need to be static string literals in reachable production source; dynamically constructed paths are not a supported release-packaging contract. Test-only and unreachable modules do not enlarge a release package.
+`stasis check`, tests, development builds, release builds, and mobile/desktop packages
+consume one compiler-owned asset-reference result. Asset loader declarations mark their path
+parameter with `@asset_path(path)`; standard sprite, font, and audio loaders already carry that
+metadata, and supported legacy loader names remain compatible. Arbitrary string literals are not
+treated as assets.
+
+Static references in the entry module's reachable graph are validated before output publication.
+Each path resolves first relative to its declaring source module and then from the project root,
+must remain beneath `assets/`, must name a regular file with exact disk casing on every host, and,
+when a manifest exists, must name a declared entry. Release outputs retain only those validated
+paths plus transitive manifest dependencies. Test roots use the same rules; test-only and
+unreachable production modules do not enlarge a release package.
+
+A dynamically constructed loader argument is rejected unless the manifest supplies a bounded
+`dynamic_assets` list. Every list item must be the exact `assets/...` path of a declared entry.
+When a reachable dynamic loader is present, those entries form its conservative package set.
+This is intentionally a bounded escape hatch, not unrestricted runtime filesystem discovery.
 
 Once a project has an asset manifest, every runtime-loaded asset must be declared. Source-only provenance files may remain elsewhere in the project, but undeclared files are not copied into prepared play or build output.
 
@@ -76,20 +93,20 @@ The package contains only the selected display envelope's output, not multiple r
 
 - IDs are 1-128 ASCII letters, digits, `.`, `_`, or `-` and are unique within a project.
 - Runtime handles are the nonzero FNV-1a 32-bit hash of `<kind>:<id>`. Load fails if two entries collide; platforms must not repair or renumber collisions independently.
-- Paths use forward slashes, start with `assets/`, contain only normal path components, and must resolve to a regular file under the canonical project root.
+- Paths use forward slashes, start with `assets/`, contain only normal path components, and must resolve to a regular file under the canonical project `assets/` directory.
 - SHA-256 is checked against the complete bounded file before the asset is accepted.
 - Declared encodings must match file extensions. Sprite dimensions, audio metadata, font encoding, display dimensions, manifest size, entry count, and individual file size are bounded by the shared resolver.
 - Sprite preparation requires a version 2 manifest and top-level `display` metadata.
 - Dependencies must name manifest entries, cannot repeat or reference themselves, and must be acyclic.
 - Unknown fields, schemas, and future versions fail with stable diagnostic codes.
+- `dynamic_assets` entries must name declared asset paths; undeclared or missing entries fail
+  manifest loading before compilation output is published.
 
 ## Mobile packaging
 
 - The AOT bundle command resolves and verifies the source manifest, then invokes the shared `stasis_assets` preparation path and packages the generated manifest and files under `assets/stasis_game/`.
 - Android and iOS apply the same reachable-source asset closure as desktop release builds; platform packaging does not carry unused manifest entries or alternate prepared sizes.
-- Declared fonts use the shared manifest path. As a compatibility supplement for projects that
-  have not declared their path-based `load_font` assets yet, mobile packaging also scans compiled
-  `.stasis` source string literals for `.ttf` and `.otf` paths and copies only referenced regular
-  font files beneath the canonical project `assets/` directory.
+- Declared fonts use the same compiler-owned reference set and manifest closure as every other
+  asset. Mobile packaging does not scan arbitrary string literals or copy undeclared font files.
 - Android uses one GL texture per resolved sprite and batches only consecutive commands that share texture and clip state. Atlas layout remains backend-private, so atlas coordinates never enter the manifest or render-command ABI.
 - Missing, corrupt, oversized, hash-mismatched, or unsupported packaged sprites render the deterministic magenta checker fallback.

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -40,13 +40,13 @@ Each output contains the same pieces:
 - `stasis_provenance.json`: verified release identity and content hashes
 - `android/` or `ios/`: a thin platform-native app project
 
-Mobile packaging follows the selected entry module's import graph. It includes only
-manifest assets referenced by static string literals in reachable production source,
-plus their transitive manifest dependencies, and emits a manifest containing that same
-subset. Relative literals use the selected entry file's directory as their base, even
-when they appear in imported modules. Keep dynamically chosen release asset paths out of
-string construction; declare the literal paths in reachable source instead. Android and
-iOS use the identical rule.
+Mobile packaging follows the selected entry module's import graph and the same
+compiler-owned `@asset_path` validation used by `stasis check` and desktop builds. It includes
+only validated manifest assets from reachable production calls plus transitive dependencies.
+Relative literals use the declaring module directory, project-root `assets/...` paths are also
+accepted, and casing is checked identically on Windows and Unix. Bounded dynamic loaders must use
+the manifest's `dynamic_assets` declaration; otherwise packaging fails before publishing output.
+Android and iOS use the identical result.
 
 The packaged runtime is the same canonical SDL command interpreter used by the
 desktop distribution. The versioned guest buffer and deterministic trace

--- a/samples/asset_contract/assets/manifest.json
+++ b/samples/asset_contract/assets/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schema": "stasis-assets",
+  "version": 2,
+  "assets": [
+    {
+      "id": "marker",
+      "path": "assets/marker.svg",
+      "content_sha256": "3384e177af0ea77fb90a5754af5ebc10caf63693b1f84b8b652338b7ce1d2644",
+      "format": {
+        "kind": "sprite",
+        "encoding": "svg",
+        "width": 8,
+        "height": 8
+      },
+      "dependencies": []
+    }
+  ]
+}

--- a/samples/asset_contract/assets/marker.svg
+++ b/samples/asset_contract/assets/marker.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="#ff00ff"/></svg>

--- a/samples/asset_contract/src/main.stasis
+++ b/samples/asset_contract/src/main.stasis
@@ -1,0 +1,8 @@
+extern function @asset_path(path) gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+
+function main(): i32 {
+    if (1 == 0) {
+        gfx_load_sprite("../assets/marker.svg", 8, 8);
+    }
+    return 0;
+}

--- a/samples/asset_contract/stasis.json
+++ b/samples/asset_contract/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "asset_contract",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}

--- a/samples/typed_sprite/main.stasis
+++ b/samples/typed_sprite/main.stasis
@@ -13,7 +13,7 @@ function main(): i32 {
     state.invalid_sprite.handle = 99;
     state.invalid_sprite.width = 8;
     state.invalid_sprite.height = 8;
-    if (state.invalid_sprite.load_sprite_from("unused.svg", 0, 92)) {
+    if (state.invalid_sprite.load_sprite_from("assets/__typed_drawable_fixture.svg", 0, 92)) {
         return 1;
     }
     if (state.invalid_sprite.handle != 99) {

--- a/samples/typed_sprite/tests/typed_sprite.test.stasis
+++ b/samples/typed_sprite/tests/typed_sprite.test.stasis
@@ -7,7 +7,7 @@ test `invalid sprite replacement preserves receiver atomically`(): bool {
     tested_sprite.handle = 23;
     tested_sprite.width = 16;
     tested_sprite.height = 16;
-    if (tested_sprite.load_sprite_from("unused.svg", 0, 48)) {
+    if (tested_sprite.load_sprite_from("assets/__typed_drawable_fixture.svg", 0, 48)) {
         return false;
     }
     return tested_sprite.handle == 23 && tested_sprite.width == 16 && tested_sprite.height == 16;

--- a/src/stdlib/audio.stasis
+++ b/src/stdlib/audio.stasis
@@ -15,7 +15,7 @@ extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i3
 // Bounded audio assets are decoded outside deterministic Stasis state. audio_load_wav accepts
 // mono or stereo little-endian PCM16 WAV files. The music/effect helpers accept WAV or MP3.
 // Compressed input stays compressed on disk and is decoded into bounded host memory at load.
-extern function audio_load_wav(path: string): i32;
+extern function @asset_path(path) audio_load_wav(path: string): i32;
 extern function audio_release(asset_handle: i32): void;
 extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
 extern function audio_stop(voice_handle: i32): void;
@@ -24,8 +24,8 @@ extern function audio_voice_set_paused(voice_handle: i32, paused: bool): void;
 extern function audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
 
 // Brickout-compatible category helpers backed by the same SDL host mixer.
-function @extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
-function @extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
+function @asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
+function @asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
 function @extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
 function @extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
 function @extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -27,7 +27,7 @@ function get_time_us(): i32 {
 extern function gfx_poll_reload(handle: i32): bool;
 extern function gfx_dump_bmp(path: string): i32;
 extern function gfx_dump_png(path: string): i32;
-extern function load_font(path: string, size: i32): i32;
+extern function @asset_path(path) load_font(path: string, size: i32): i32;
 extern function measure_text(font: i32, text: string): f32;
 
 struct Sprite {
@@ -43,7 +43,7 @@ struct TextRun {
     height: f32;
 }
 
-function @extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
+function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
     if (self.handle <= 0 || self.width <= 0 || self.height <= 0) {

--- a/tools/verify-typed-drawables.ps1
+++ b/tools/verify-typed-drawables.ps1
@@ -7,12 +7,17 @@ $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 $stasisPath = [System.IO.Path]::GetFullPath((Join-Path $root $Stasis))
 $temporaryManifest = Join-Path $root "stasis.json"
+$temporaryAssetDirectory = Join-Path $root "assets"
+$temporaryAsset = Join-Path $temporaryAssetDirectory "__typed_drawable_fixture.svg"
 
 if (-not (Test-Path -LiteralPath $stasisPath)) {
     throw "Stasis executable not found: $stasisPath"
 }
 if (Test-Path -LiteralPath $temporaryManifest) {
     throw "Refusing to replace existing repository-root manifest: $temporaryManifest"
+}
+if (Test-Path -LiteralPath $temporaryAsset) {
+    throw "Refusing to replace existing typed drawable fixture: $temporaryAsset"
 }
 
 $manifest = @"
@@ -25,10 +30,20 @@ $manifest = @"
 }
 "@
 $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-[System.IO.File]::WriteAllText($temporaryManifest, $manifest, $utf8NoBom)
+$assetDirectoryExisted = Test-Path -LiteralPath $temporaryAssetDirectory
+$locationPushed = $false
 
-Push-Location $root
 try {
+    [System.IO.File]::WriteAllText($temporaryManifest, $manifest, $utf8NoBom)
+    [System.IO.Directory]::CreateDirectory($temporaryAssetDirectory) | Out-Null
+    [System.IO.File]::WriteAllText(
+        $temporaryAsset,
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect width="1" height="1"/></svg>',
+        $utf8NoBom
+    )
+    Push-Location $root
+    $locationPushed = $true
+
     & $stasisPath check --workspace $root
     if ($LASTEXITCODE -ne 0) { throw "Typed drawable check failed with exit code $LASTEXITCODE" }
 
@@ -38,9 +53,19 @@ try {
     & $stasisPath run --workspace $root
     if ($LASTEXITCODE -ne 0) { throw "Typed drawable sample failed with exit code $LASTEXITCODE" }
 } finally {
-    Pop-Location
+    if ($locationPushed) {
+        Pop-Location
+    }
     if (Test-Path -LiteralPath $temporaryManifest) {
         Remove-Item -LiteralPath $temporaryManifest -Force
+    }
+    if (Test-Path -LiteralPath $temporaryAsset) {
+        Remove-Item -LiteralPath $temporaryAsset -Force
+    }
+    if (-not $assetDirectoryExisted -and
+        (Test-Path -LiteralPath $temporaryAssetDirectory) -and
+        -not (Get-ChildItem -LiteralPath $temporaryAssetDirectory -Force)) {
+        Remove-Item -LiteralPath $temporaryAssetDirectory -Force
     }
 }
 


### PR DESCRIPTION
## Summary
- add compiler-owned `@asset_path(parameter)` discovery for reachable JIT/AOT functions with exact expression spans
- validate case-sensitive, manifest-declared, canonical `assets/` paths before check/test/build/package publication
- reuse authoritative program snapshots to prune desktop and mobile release assets, including bounded dynamic assets and dependencies
- add an end-to-end asset contract sample and update asset/mobile documentation

## Tests
- `cargo test -p stasis_compiler backend::assets::tests --lib` (7 passed)
- `cargo test -p stasis_assets --lib` (11 passed)
- `cargo test -p stasis -- --test-threads=1` (266 lib, 184 bin, 22 CLI, 3 Windows launch passed)
- `cargo test -p stasis_android_bridge --lib` (51 passed)
- `cargo check --workspace --all-targets` (passed)
- `samples/asset_contract`: release build succeeded, packaged only `assets/marker.svg`, executable exited 0

## Repository gate notes
- Full compiler suite: 480/481; pre-existing environment-sensitive `local_runtime_resolves_production_preview_externs` returns 2 because host audio/graphics is available, while the test expects 1. Reproduces in isolation.
- Canonical validation shell cannot run verbatim on this Windows host; constituent Python checks pass except existing `check_unsafe_boundaries.py` flags `crates/stasis_ai/src/lib.rs`, and ignore audit finds the existing `STASIS_CHESSTD_ROOT` ignored test.

Maddox task: #195