### PR TITLE
feat: expose dynamic UTF-8 text runs

### DIFF
--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -3195,6 +3195,12 @@ fn jit_text_arg_bytes(value_id: i32) -> Option<Vec<u8>> {
     guard.get(&value_id).map(|text| text.as_bytes().to_vec())
 }
 
+fn validated_jit_text_arg_bytes(value_id: i32) -> Option<Vec<u8>> {
+    let bytes = jit_text_arg_bytes(value_id)?;
+    std::str::from_utf8(&bytes).ok()?;
+    Some(bytes)
+}
+
 thread_local! {
     static JIT_TEXT_SCRATCH: std::cell::RefCell<Vec<u8>> =
         const { std::cell::RefCell::new(Vec::new()) };
@@ -3760,10 +3766,13 @@ pub extern "C" fn stasis_jit_measure_text(font: i32, text_id: i32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_jit_gfx_cache_text(font: i32, text_id: i32) -> i32 {
-    if let (Some(host), Some(text)) = (embedded_graphics_host(), jit_text_arg_bytes(text_id)) {
+    let Some(text) = validated_jit_text_arg_bytes(text_id) else {
+        return 0;
+    };
+    if let Some(host) = embedded_graphics_host() {
         return (host.cache_text)(font, &text);
     }
-    let Ok(text) = jit_text_arg_to_cstring(text_id) else {
+    let Ok(text) = CString::new(text) else {
         return 0;
     };
     let Ok(api) = stasis_graphics_assets_api() else {
@@ -5679,6 +5688,45 @@ mod tests {
         stasis_jit_global_i32_array_store(collection_hash, 0, 3, i32::from(b'h'));
 
         assert_eq!(jit_text_arg_bytes(collection_hash), Some(b"path".to_vec()));
+    }
+
+    #[test]
+    fn validated_jit_text_arg_bytes_accepts_localized_price_utf8() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_i32_array_global_table();
+
+        let collection_hash = 0x5566_7788i32;
+        let price = "€2.99".as_bytes();
+        stasis_jit_collection_i32_store(collection_hash, 1, price.len() as i32);
+        stasis_jit_collection_i32_store(collection_hash, 2, 16);
+        stasis_jit_collection_i32_store(collection_hash, 3, 5);
+        for (index, byte) in price.iter().copied().enumerate() {
+            stasis_jit_global_i32_array_store(collection_hash, 0, index as i32, i32::from(byte));
+        }
+
+        assert_eq!(
+            validated_jit_text_arg_bytes(collection_hash),
+            Some(price.to_vec())
+        );
+    }
+
+    #[test]
+    fn validated_jit_text_arg_bytes_rejects_malformed_utf8() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_i32_array_global_table();
+
+        let collection_hash = 0x6677_8899i32;
+        stasis_jit_collection_i32_store(collection_hash, 1, 2);
+        stasis_jit_collection_i32_store(collection_hash, 2, 2);
+        stasis_jit_collection_i32_store(collection_hash, 3, 1);
+        stasis_jit_global_i32_array_store(collection_hash, 0, 0, 0xc3);
+        stasis_jit_global_i32_array_store(collection_hash, 0, 1, 0x28);
+
+        assert_eq!(validated_jit_text_arg_bytes(collection_hash), None);
     }
 
     #[test]

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -409,6 +409,45 @@ static char *resolve_text(int32_t id) {
     return text;
 }
 
+static int stasis_valid_utf8(const unsigned char *text) {
+    const unsigned char *cursor = text;
+    if (cursor == NULL) return 0;
+    while (*cursor != 0) {
+        uint32_t codepoint;
+        uint32_t minimum;
+        int remaining;
+        if (*cursor <= 0x7f) {
+            cursor += 1;
+            continue;
+        }
+        if (*cursor >= 0xc2 && *cursor <= 0xdf) {
+            codepoint = (uint32_t)(*cursor & 0x1f);
+            minimum = 0x80;
+            remaining = 1;
+        } else if (*cursor >= 0xe0 && *cursor <= 0xef) {
+            codepoint = (uint32_t)(*cursor & 0x0f);
+            minimum = 0x800;
+            remaining = 2;
+        } else if (*cursor >= 0xf0 && *cursor <= 0xf4) {
+            codepoint = (uint32_t)(*cursor & 0x07);
+            minimum = 0x10000;
+            remaining = 3;
+        } else {
+            return 0;
+        }
+        cursor += 1;
+        while (remaining > 0) {
+            if (*cursor < 0x80 || *cursor > 0xbf) return 0;
+            codepoint = (codepoint << 6) | (uint32_t)(*cursor & 0x3f);
+            cursor += 1;
+            remaining -= 1;
+        }
+        if (codepoint < minimum || (codepoint >= 0xd800 && codepoint <= 0xdfff) ||
+            codepoint > 0x10ffff) return 0;
+    }
+    return 1;
+}
+
 int stasis_jit_audio_init(int32_t rate, int32_t channels, int32_t latency) {
     return stasis_audio_init(rate, channels, latency);
 }
@@ -492,7 +531,9 @@ int stasis_jit_gfx_dump_png(int32_t path) {
 }
 int stasis_jit_gfx_cache_text(int32_t font, int32_t text) {
     char *value = resolve_text(text);
-    int result = value == NULL ? 0 : stasis_gfx_cache_text(font, value);
+    int result = value == NULL || !stasis_valid_utf8((const unsigned char *)value)
+        ? 0
+        : stasis_gfx_cache_text(font, value);
     free(value);
     return result;
 }

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -29,6 +29,7 @@ static int32_t hash_text(const char *text) {
 static char last_sprite_path[64];
 static int sprite_handle_to_load = 1;
 static int released_sprite_handle;
+static char last_cached_text[64];
 static char saved_scope[64];
 static char saved_key[64];
 static int saved_value;
@@ -83,7 +84,13 @@ int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) {
 void stasis_gfx_release_sprite(int handle) { released_sprite_handle = handle; }
 int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
 int stasis_gfx_dump_png(const char *path) { return path != NULL; }
-int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
+int stasis_gfx_cache_text(int font, const char *text) {
+    if (text != NULL) {
+        strncpy(last_cached_text, text, sizeof(last_cached_text) - 1);
+        last_cached_text[sizeof(last_cached_text) - 1] = '\0';
+    }
+    return font + (text != NULL);
+}
 int stasis_gfx_poll_reload(int handle) { return handle; }
 float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
 float stasis_gfx_measure_text_cached_height(int handle) { return (float)handle + 1.0f; }
@@ -141,6 +148,8 @@ int main(void) {
     float overlapping_f32[5] = {1, 2, 3, 4, 5};
     uint8_t external_u8[4] = {1, 2, 3, 4};
     uint8_t dynamic_path[] = "sprite.bmp";
+    uint8_t dynamic_price[] = {0xe2, 0x82, 0xac, '2', '.', '9', '9'};
+    uint8_t malformed_utf8[] = {0xc3, 0x28};
     uint8_t ascii_value[] = "GG1-test";
     uint8_t ascii_out[32] = {0};
     int32_t sprite_handle[1] = {0};
@@ -212,6 +221,17 @@ int main(void) {
     CHECK(stasis_jit_text_run_load_from(101, 0, 1, 7, 23) == 1);
     CHECK(text_font[0] == 7 && text_handle[0] == 8);
     CHECK(text_width[0] == 8.0f && text_height[0] == 9.0f);
+
+    stasis_jit_register_global_u8_array(26, 0, dynamic_price, sizeof(dynamic_price));
+    stasis_jit_collection_i32_store(26, 1, sizeof(dynamic_price));
+    CHECK(stasis_jit_text_run_load_from(101, 0, 1, 7, 26) == 1);
+    CHECK(memcmp(last_cached_text, dynamic_price, sizeof(dynamic_price)) == 0);
+    CHECK(last_cached_text[sizeof(dynamic_price)] == '\0');
+
+    stasis_jit_register_global_u8_array(27, 0, malformed_utf8, sizeof(malformed_utf8));
+    stasis_jit_collection_i32_store(27, 1, sizeof(malformed_utf8));
+    CHECK(stasis_jit_text_run_load_from(101, 0, 1, 7, 27) == 0);
+    CHECK(text_font[0] == 7 && text_handle[0] == 8);
 
     stasis_jit_upsert_string_literal(40, "sample_game");
     stasis_jit_upsert_string_literal(41, "unlocked_tier");

--- a/samples/typed_sprite/tests/typed_sprite.test.stasis
+++ b/samples/typed_sprite/tests/typed_sprite.test.stasis
@@ -2,6 +2,7 @@ import "../../../src/stdlib/graphics.stasis";
 
 global tested_sprite: Sprite;
 global tested_text: TextRun;
+global tested_runtime_text: utf8[16];
 
 test `invalid sprite replacement preserves receiver atomically`(): bool {
     tested_sprite.handle = 23;
@@ -95,6 +96,27 @@ test `invalid cached text replacement preserves receiver atomically`(): bool {
     tested_text.width = 72.5;
     tested_text.height = 18.0;
     if (tested_text.load_text_from(0, "unused")) {
+        return false;
+    }
+    if (tested_text.font != 4 || tested_text.handle != 12) {
+        return false;
+    }
+    return tested_text.width == 72.5 && tested_text.height == 18.0;
+}
+
+test `runtime utf8 text uses the cached text receiver contract`(): bool {
+    tested_runtime_text[0] = 36;
+    tested_runtime_text[1] = 50;
+    tested_runtime_text[2] = 46;
+    tested_runtime_text[3] = 57;
+    tested_runtime_text[4] = 57;
+    utf8_set_len_ascii(tested_runtime_text, 5);
+
+    tested_text.font = 4;
+    tested_text.handle = 12;
+    tested_text.width = 72.5;
+    tested_text.height = 18.0;
+    if (tested_text.load_utf8_from(0, tested_runtime_text)) {
         return false;
     }
     if (tested_text.font != 4 || tested_text.handle != 12) {

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -58,6 +58,13 @@ function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
 
 function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
 
+// Runtime-owned display text, such as a localized store price, uses the same cached
+// UTF-8 path as string literals. The named wrapper makes the bounded-buffer contract
+// explicit at call sites while preserving the existing source-compatible API.
+function load_utf8_from(self: TextRun, font: i32, text: utf8[]): bool {
+    return self.load_text_from(font, text);
+}
+
 function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     if (self.font <= 0 || self.handle <= 0) {
         return;


### PR DESCRIPTION
## What changed

- adds TextRun.load_utf8_from as the explicit bounded-buffer entry point for runtime-owned display text
- validates UTF-8 before cached text reaches embedded JIT or mobile AOT graphics hosts
- preserves the existing TextRun atomically when validation or caching fails
- covers localized €2.99 bytes and malformed UTF-8 in Rust, Stasis, and native mobile-AOT contracts

## Why

The existing string ABI already transports mutable UTF-8 buffers, but the capability was implicit and malformed runtime bytes could reach the graphics cache. Localized platform prices need an explicit, portable contract without a second rendering path.

## Impact

Existing load_text_from call sites remain source-compatible. JIT, desktop-host, and mobile-AOT cached text now reject malformed UTF-8 consistently.

## Checks

- focused stasis_dynload UTF-8 tests: 2 passed
- dynamic API semantic check through shared stasis.exe: passed
- native stasis_mobile_aot_runtime_contract: passed
- affected production-preview extern regression: passed after generated runtime artifact cleanup
- Stasis and Rust formatter checks: passed
- repository policy Python checks: passed
- full workspace: 473 passed, 1 pre-existing failure (qualified_same_name_calls_use_identical_jit_and_aot_module_graphs cannot discover a Windows linker); the same failure reproduces on detached origin/main
- ignored-test audit: pre-existing main failure at stasis_language_service ChessTD-dependent ignored test

## Good / Bad / Adjustment

- **Good:** traced literal and mutable text through the same cache and metrics path before changing the API.
- **Bad:** an initial semantic check generated a local runtime DLL that changed one environment-sensitive test result.
- **Adjustment:** removed the generated runtime, reran the affected test successfully, and preserved the remaining baseline failures explicitly.

## Theory gained

string and utf8[] already share the host text-handle ABI. Making that ownership explicit and validating at the cache boundary gives platform-supplied text parity without duplicating rendering; the same path should support future localized accessibility labels.