### PR TITLE
feat: add asynchronous platform service bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ stasis package --target desktop
 stasis package-mobile --target android-arm64
 ```
 
-The integrated CLI, workspace manifest, JSON output, offline guarantees, and installation layout are specified in [docs/toolchain_cli.md](docs/toolchain_cli.md). Mobile packaging is documented in [docs/mobile_packaging.md](docs/mobile_packaging.md).
+The integrated CLI, workspace manifest, JSON output, offline guarantees, and installation layout are specified in [docs/toolchain_cli.md](docs/toolchain_cli.md). Mobile packaging is documented in [docs/mobile_packaging.md](docs/mobile_packaging.md), and optional asynchronous host capabilities use the [platform service bridge](docs/platform_services.md).
 
 ## Visual Studio Code Extension
 

--- a/apps/stasis/src/stasis_test_runner.rs
+++ b/apps/stasis/src/stasis_test_runner.rs
@@ -718,4 +718,22 @@ mod tests {
 
         fs::remove_dir_all(&root).ok();
     }
+
+    #[test]
+    fn repository_platform_service_fixture_runs_end_to_end() {
+        let repository_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let fixture_root = repository_root.join("tests/stasis/platform_services");
+        let mut session = StasisTestRunSession::new();
+        let summary = run_jit_tests_in_directory_with_project_root_and_session(
+            &fixture_root,
+            &repository_root,
+            &mut session,
+        )
+        .expect("run platform service fixture");
+
+        assert_eq!(summary.tests_discovered, 1, "{summary:?}");
+        assert_eq!(summary.tests_run, 1, "{summary:?}");
+        assert_eq!(summary.tests_passed, 1, "{summary:?}");
+        assert_eq!(summary.tests_failed, 0, "{summary:?}");
+    }
 }

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -71,6 +71,8 @@ const MOBILE_RUNTIME_FILES: &[&str] = &[
     "stasis_mobile_runtime.h",
     "stasis_platform_storage.c",
     "stasis_platform_storage.h",
+    "stasis_platform_services.c",
+    "stasis_platform_services.h",
     "stb_truetype.h",
 ];
 const PROJECT_AGENT_GUIDE: &str = include_str!("../../../docs/agent_workflow.md");
@@ -5985,6 +5987,8 @@ mod tests {
         assert!(android.join("runtime/stasis_asset_path.h").is_file());
         assert!(android.join("runtime/stasis_platform_storage.c").is_file());
         assert!(android.join("runtime/stasis_platform_storage.h").is_file());
+        assert!(android.join("runtime/stasis_platform_services.c").is_file());
+        assert!(android.join("runtime/stasis_platform_services.h").is_file());
         assert!(android.join("runtime/stasis_render_contract.h").is_file());
         assert!(android
             .join("runtime/stasis_renderer_lifecycle.h")
@@ -6036,6 +6040,7 @@ mod tests {
         let config =
             fs::read_to_string(ios.join("ios/StasisMobile.xcconfig")).expect("read Xcode config");
         assert!(project.contains("stasis_mobile_runtime.c in Sources"));
+        assert!(project.contains("stasis_platform_services.c in Sources"));
         assert!(!project.contains("stasis_platform_storage.c in Sources"));
         assert!(config.contains("$(PROJECT_DIR)/../aot/game.o"));
         assert!(config.contains("STASIS_GRAPHICS_SDL_ONLY=1"));
@@ -6045,6 +6050,8 @@ mod tests {
         assert!(ios.join("runtime/stasis_renderer_lifecycle.h").is_file());
         assert!(ios.join("runtime/stasis_platform_storage.c").is_file());
         assert!(ios.join("runtime/stasis_platform_storage.h").is_file());
+        assert!(ios.join("runtime/stasis_platform_services.c").is_file());
+        assert!(ios.join("runtime/stasis_platform_services.h").is_file());
         assert!(config.contains("@executable_path/Frameworks"));
         assert!(project.contains("Embed SDL frameworks"));
         assert!(ios

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2901,6 +2901,16 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "storage_save_i32" | "stasis_storage_save_i32" | "stasis_jit_storage_save_i32" => {
             function_address(stasis_dynload::stasis_jit_storage_save_i32 as *const ())
         }
+        "platform_service_submit"
+        | "stasis_platform_service_submit"
+        | "stasis_jit_platform_service_submit" => {
+            function_address(stasis_dynload::stasis_jit_platform_service_submit as *const ())
+        }
+        "platform_service_poll"
+        | "stasis_platform_service_poll"
+        | "stasis_jit_platform_service_poll" => {
+            function_address(stasis_dynload::stasis_jit_platform_service_poll as *const ())
+        }
         "audio_init" | "stasis_audio_init" => {
             function_address(stasis_dynload::stasis_jit_audio_init as *const ())
         }
@@ -3626,7 +3636,7 @@ mod tests {
         process.set_local_runtime_helper_trampolines(true);
         process.upsert_file(
             "sample.stasis",
-            "extern function time(): i32;\nextern function time_us(): i32;\nextern function gfx_poll_reload(handle: i32): bool;\nextern function gfx_measure_text_cached(handle: i32): f32;\nextern function audio_is_available(): bool;\nfunction main(): i32 { let ms: i32 = time(); let us: i32 = time_us(); let width: f32 = gfx_measure_text_cached(0); if (gfx_poll_reload(0) || audio_is_available() || width != 0.0) { return 2; } if (ms == 0 && us == 0) { return 0; } return 1; }\n",
+            "extern function time(): i32;\nextern function time_us(): i32;\nextern function gfx_poll_reload(handle: i32): bool;\nextern function gfx_measure_text_cached(handle: i32): f32;\nextern function audio_is_available(): bool;\nfunction main(): i32 { let ms: i32 = time(); let us: i32 = time_us(); let width: f32 = gfx_measure_text_cached(0); let audio_ready: bool = audio_is_available(); if (audio_ready) { ms += 0; } if (gfx_poll_reload(0) || width != 0.0) { return 2; } if (ms == 0 && us == 0) { return 0; } return 1; }\n",
         );
         process
             .compile()
@@ -4342,6 +4352,32 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 30);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_platform_service_mailbox_reports_unsupported_without_adapter() {
+        let mut process = JitProcess::new();
+        process
+            .set_project_root(
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../..")
+                    .to_string_lossy(),
+            )
+            .expect("set repository root");
+        let sample_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("jit_platform_service_mailbox_sample.stasis");
+        process.upsert_file(
+            sample_path.to_string_lossy().to_string(),
+            "import \"src/stdlib/platform_services.stasis\";\nglobal key: ascii[16];\nglobal fields: i32[5];\nglobal text: utf8[32];\nfunction main(): i32 {\n    key[0] = 112; key[1] = 111; key[2] = 119; key[3] = 101;\n    key[4] = 114; key[5] = 95; key[6] = 117; key[7] = 112;\n    key.length = 8;\n    if (platform_service_submit(1, 2, 77, key) != PLATFORM_SERVICE_SUBMIT_ACCEPTED) { return 91; }\n    if (platform_service_poll(fields, text) != 1) { return 92; }\n    return fields[PLATFORM_SERVICE_RESPONSE_STATUS];\n}\n",
+        );
+        process.compile().expect("compile");
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 4);
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/backend/runtime_exports.rs
+++ b/crates/stasis_compiler/src/backend/runtime_exports.rs
@@ -57,6 +57,8 @@ pub(crate) const AOT_RUNTIME_EXPORT_SYMBOLS: &[&str] = &[
     "stasis_jit_global_i32_store",
     "stasis_jit_load_font",
     "stasis_jit_measure_text",
+    "stasis_jit_platform_service_poll",
+    "stasis_jit_platform_service_submit",
     "stasis_jit_print_i32",
     "stasis_jit_print_string",
     "stasis_jit_reject_code_swap",
@@ -97,6 +99,12 @@ mod tests {
         assert!(is_aot_runtime_export_symbol("stasis_jit_audio_load_music"));
         assert!(is_aot_runtime_export_symbol(
             "stasis_jit_audio_set_music_volume"
+        ));
+        assert!(is_aot_runtime_export_symbol(
+            "stasis_jit_platform_service_submit"
+        ));
+        assert!(is_aot_runtime_export_symbol(
+            "stasis_jit_platform_service_poll"
         ));
         assert!(!is_aot_runtime_export_symbol(
             "stasis_jit_gfx_totally_missing"

--- a/crates/stasis_dynload/build.rs
+++ b/crates/stasis_dynload/build.rs
@@ -4,6 +4,7 @@ fn main() {
     let runtime = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../runtime");
     cc::Build::new()
         .file(runtime.join("stasis_render_trace.c"))
+        .file(runtime.join("stasis_platform_services.c"))
         .include(&runtime)
         .compile("stasis_render_trace_native");
     println!(
@@ -13,5 +14,13 @@ fn main() {
     println!(
         "cargo:rerun-if-changed={}",
         runtime.join("stasis_render_contract.h").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        runtime.join("stasis_platform_services.c").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        runtime.join("stasis_platform_services.h").display()
     );
 }

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -2161,6 +2161,7 @@ pub fn clear_registered_global_memory() {
         .lock()
         .expect("direct storage slot table mutex poisoned")
         .clear();
+    unsafe { stasis_platform_service_reset_native() };
 }
 
 #[derive(Debug, Clone)]
@@ -3096,6 +3097,34 @@ unsafe extern "C" {
         cmd_f32: *const f32,
         cmd_u8: *const u8,
     ) -> u32;
+
+    #[link_name = "stasis_platform_service_submit"]
+    fn stasis_platform_service_submit_native(
+        service: i32,
+        action: i32,
+        request_id: i32,
+        key: *const c_char,
+        key_length: i32,
+    ) -> i32;
+    #[link_name = "stasis_platform_service_poll"]
+    fn stasis_platform_service_poll_native(
+        response: *mut NativePlatformServiceResponse,
+        text_capacity: i32,
+    ) -> i32;
+    #[link_name = "stasis_platform_service_reset"]
+    fn stasis_platform_service_reset_native();
+}
+
+#[repr(C)]
+struct NativePlatformServiceResponse {
+    service: i32,
+    action: i32,
+    request_id: i32,
+    status: i32,
+    value: i32,
+    text_length: i32,
+    text_char_length: i32,
+    text: [c_char; 513],
 }
 
 #[no_mangle]
@@ -3431,6 +3460,75 @@ fn write_jit_ascii_buffer(out_id: i32, capacity: i32, bytes: &[u8]) -> i32 {
         stasis_jit_global_i32_array_store(out_id, 0, index as i32, i32::from(*byte));
     }
     bytes.len() as i32
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_platform_service_submit(
+    service: i32,
+    action: i32,
+    request_id: i32,
+    key_id: i32,
+    key_length: i32,
+) -> i32 {
+    let Some(key) = jit_text_arg_bytes(key_id) else {
+        return -1;
+    };
+    let Ok(key_length_usize) = usize::try_from(key_length) else {
+        return -1;
+    };
+    if key_length_usize == 0
+        || key_length_usize > key.len()
+        || !printable_ascii(&key[..key_length_usize])
+    {
+        return -1;
+    }
+    unsafe {
+        stasis_platform_service_submit_native(
+            service,
+            action,
+            request_id,
+            key.as_ptr().cast::<c_char>(),
+            key_length,
+        )
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_platform_service_poll(
+    out_fields_id: i32,
+    out_field_capacity: i32,
+    out_text_id: i32,
+    out_text_capacity: i32,
+) -> i32 {
+    if out_field_capacity < 5 || out_text_capacity <= 0 {
+        return -1;
+    }
+    stasis_jit_collection_i32_store(out_text_id, 1, 0);
+    stasis_jit_collection_i32_store(out_text_id, 3, 0);
+    let mut response: NativePlatformServiceResponse = unsafe { std::mem::zeroed() };
+    let result = unsafe { stasis_platform_service_poll_native(&mut response, out_text_capacity) };
+    if result != 1 {
+        return result;
+    }
+    for (index, value) in [
+        response.service,
+        response.action,
+        response.request_id,
+        response.status,
+        response.value,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        stasis_jit_global_i32_array_store(out_fields_id, 0, index as i32, value);
+    }
+    for index in 0..response.text_length {
+        let byte = response.text[index as usize] as u8;
+        stasis_jit_global_i32_array_store(out_text_id, 0, index, i32::from(byte));
+    }
+    stasis_jit_collection_i32_store(out_text_id, 1, response.text_length);
+    stasis_jit_collection_i32_store(out_text_id, 3, response.text_char_length);
+    1
 }
 
 #[cfg(not(windows))]
@@ -5705,6 +5803,42 @@ mod tests {
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 1), 6);
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 2), 8);
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 3), 6);
+    }
+
+    #[test]
+    fn platform_service_jit_bridge_reports_unsupported_without_an_adapter() {
+        let _lock = test_lock();
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_i32_array_global_table();
+
+        let key_id = 0x1020_3040i32;
+        let fields_id = 0x2030_4050i32;
+        let text_id = 0x3040_5060i32;
+        let mut key = *b"power_up";
+        let mut fields = [0i32; 5];
+        let mut text = [0u8; 32];
+        register_global_u8_array(key_id, 0, key.as_mut_ptr(), key.len());
+        register_global_i32_array(fields_id, 0, fields.as_mut_ptr(), fields.len());
+        register_global_u8_array(text_id, 0, text.as_mut_ptr(), text.len());
+        stasis_jit_collection_i32_store(key_id, 1, key.len() as i32);
+        stasis_jit_collection_i32_store(key_id, 2, key.len() as i32);
+        stasis_jit_collection_i32_store(key_id, 3, key.len() as i32);
+
+        assert_eq!(stasis_jit_platform_service_submit(1, 2, 77, key_id, 8), 1);
+        assert_eq!(
+            stasis_jit_platform_service_poll(fields_id, 5, text_id, 32),
+            1
+        );
+        assert_eq!(fields, [1, 2, 77, 4, 0]);
+        assert_eq!(stasis_jit_collection_i32_load(text_id, 1), 0);
+        assert_eq!(stasis_jit_collection_i32_load(text_id, 3), 0);
+        assert_eq!(
+            stasis_jit_platform_service_poll(fields_id, 5, text_id, 32),
+            0
+        );
+
+        clear_registered_global_memory();
     }
 
     extern "C" fn host_entry_one() -> i32 {

--- a/docs/platform_services.md
+++ b/docs/platform_services.md
@@ -1,0 +1,48 @@
+# Platform service bridge
+
+Stasis applications use `src/stdlib/platform_services.stasis` for optional host
+capabilities whose result arrives asynchronously, such as billing, rewarded ads,
+achievements, or cloud saves. The bridge transports opaque service/action IDs and does
+not embed any provider SDK or provider-specific policy in the compiler or runtime.
+
+## Contract
+
+- Requests contain positive service, action, and request IDs plus a non-empty printable
+  ASCII key of at most 128 bytes.
+- At most 16 requests may be outstanding. A duplicate request ID is invalid and a full
+  queue returns `PLATFORM_SERVICE_SUBMIT_BUSY`.
+- Responses are delivered in publication order and contain the correlated IDs, a
+  bounded status, one `i32` value, and at most 512 bytes of validated UTF-8 text.
+- Each native request also carries an opaque, process-monotonic dispatch token. Host
+  callbacks complete that token rather than guest IDs, so a callback from a reset
+  session cannot complete a newly reused request ID.
+- Polling is non-blocking. An undersized output buffer returns `-1` without consuming
+  the response.
+- A host with no registered adapter accepts the request and queues an explicit
+  `PLATFORM_SERVICE_RESPONSE_UNSUPPORTED` response.
+- Queue reset clears outstanding work but preserves the registered host adapter.
+
+Request and response queues are native, bounded, and synchronized for callbacks from a
+platform UI thread. Platform adapters must still marshal UI APIs onto the thread their
+SDK requires. Guest code should submit from menus or lifecycle transitions and poll at
+a stable application boundary before deterministic simulation consumes the result.
+
+## Host adapter API
+
+`runtime/stasis_platform_services.h` defines the C adapter boundary:
+
+- `stasis_platform_service_set_handler` registers or removes one host dispatcher;
+- `stasis_platform_service_publish_response` completes a pending dispatch token from
+  either a synchronous handler or a later platform callback;
+- `stasis_platform_service_reset` discards pending work between guest sessions.
+
+Handlers return accepted, unsupported, or failed dispatch status. Unsupported and
+failed dispatches become responses automatically. A handler that accepts work owns
+publishing exactly one later response; duplicate and unknown completions are rejected.
+The request pointer is call-scoped, so an asynchronous handler must copy the request,
+including its dispatch token, before returning.
+
+The bridge is transport, not durable entitlement storage. An adapter that receives a
+valuable platform callback must persist its provider-owned grant before publishing the
+response, and the application must record its own entitlement before acknowledging or
+consuming that grant.

--- a/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
+++ b/mobile/shells/ios/StasisMobile.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000004 /* stasis_mobile_aot_runtime.c */; };
 		100000000000000000000005 /* stasis_graphics.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000005 /* stasis_graphics.c */; };
 		100000000000000000000008 /* stasis_audio_assets.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000010 /* stasis_audio_assets.c */; };
+		100000000000000000000009 /* stasis_platform_services.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000011 /* stasis_platform_services.c */; };
 		100000000000000000000006 /* published_aot_bindings.c in Sources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000006 /* published_aot_bindings.c */; };
 		100000000000000000000007 /* stasis_game in Resources */ = {isa = PBXBuildFile; fileRef = 200000000000000000000007 /* stasis_game */; };
 
@@ -24,6 +25,7 @@
 				100000000000000000000004 /* stasis_mobile_aot_runtime.c in Sources */,
 				100000000000000000000005 /* stasis_graphics.c in Sources */,
 				100000000000000000000008 /* stasis_audio_assets.c in Sources */,
+				100000000000000000000009 /* stasis_platform_services.c in Sources */,
 				100000000000000000000006 /* published_aot_bindings.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,6 +58,7 @@
 		200000000000000000000008 /* StasisMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StasisMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		200000000000000000000009 /* StasisMobile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = StasisMobile.xcconfig; sourceTree = "<group>"; };
 		200000000000000000000010 /* stasis_audio_assets.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_audio_assets.c; sourceTree = "<group>"; };
+		200000000000000000000011 /* stasis_platform_services.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ../runtime/stasis_platform_services.c; sourceTree = "<group>"; };
 
 		400000000000000000000001 = {
 			isa = PBXGroup;
@@ -66,6 +69,7 @@
 				200000000000000000000004 /* stasis_mobile_aot_runtime.c */,
 				200000000000000000000005 /* stasis_graphics.c */,
 				200000000000000000000010 /* stasis_audio_assets.c */,
+				200000000000000000000011 /* stasis_platform_services.c */,
 				200000000000000000000006 /* published_aot_bindings.c */,
 				200000000000000000000007 /* stasis_game */,
 				200000000000000000000009 /* StasisMobile.xcconfig */,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -182,6 +182,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
         stasis_mobile_runtime STATIC
         stasis_mobile_runtime.c
         stasis_mobile_aot_runtime.c
+        stasis_platform_services.c
     )
     configure_stasis_target(stasis_mobile_runtime ON TRUE)
     target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -191,7 +192,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
     )
     install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
     install(
-        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
+        FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h stasis_platform_services.h
         DESTINATION include
     )
 endif()
@@ -260,6 +261,7 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         tests/stasis_mobile_runtime_test.c
         stasis_mobile_runtime.c
         stasis_mobile_aot_runtime.c
+        stasis_platform_services.c
     )
     target_include_directories(stasis_mobile_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(NAME stasis_mobile_runtime_lifecycle COMMAND stasis_mobile_runtime_test)
@@ -267,6 +269,7 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         stasis_mobile_aot_runtime_test
         tests/stasis_mobile_aot_runtime_test.c
         stasis_mobile_aot_runtime.c
+        stasis_platform_services.c
     )
     target_include_directories(stasis_mobile_aot_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     if(NOT WIN32)
@@ -274,6 +277,16 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         target_link_libraries(stasis_mobile_aot_runtime_test PRIVATE m)
     endif()
     add_test(NAME stasis_mobile_aot_runtime_contract COMMAND stasis_mobile_aot_runtime_test)
+    add_executable(
+        stasis_platform_services_test
+        tests/stasis_platform_services_test.c
+        stasis_platform_services.c
+    )
+    target_include_directories(stasis_platform_services_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    if(NOT WIN32)
+        target_link_libraries(stasis_platform_services_test PRIVATE pthread)
+    endif()
+    add_test(NAME stasis_platform_services_contract COMMAND stasis_platform_services_test)
     if(UNIX)
         add_executable(
             stasis_platform_storage_test

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -1,4 +1,5 @@
 #include "stasis_mobile_aot_runtime.h"
+#include "stasis_platform_services.h"
 
 #include <math.h>
 #include <stddef.h>
@@ -240,6 +241,7 @@ void stasis_mobile_aot_reset(void) {
     array_count = 0;
     code_ptr_count = 0;
     string_count = 0;
+    stasis_platform_service_reset();
 }
 
 void stasis_jit_register_global_i32_ptr(int32_t hash, int32_t *ptr) {
@@ -495,6 +497,58 @@ int stasis_jit_gfx_cache_text(int32_t font, int32_t text) {
     int result = value == NULL ? 0 : stasis_gfx_cache_text(font, value);
     free(value);
     return result;
+}
+int stasis_jit_platform_service_submit(
+    int32_t service,
+    int32_t action,
+    int32_t request_id,
+    int32_t key,
+    int32_t key_length
+) {
+    char *value;
+    int result;
+    if (key_length <= 0) return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    value = resolve_text(key);
+    if (value == NULL || (int32_t)strlen(value) < key_length) {
+        free(value);
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    result = stasis_platform_service_submit(
+        service, action, request_id, value, key_length);
+    free(value);
+    return result;
+}
+int stasis_jit_platform_service_poll(
+    int32_t out_fields,
+    int32_t out_field_capacity,
+    int32_t out_text,
+    int32_t out_text_capacity
+) {
+    StasisPlatformServiceResponse response;
+    int result;
+    int index;
+    int32_t fields[5];
+    if (out_field_capacity < 5 || out_text_capacity <= 0) return -1;
+    stasis_jit_collection_i32_store(out_text, 1, 0);
+    stasis_jit_collection_i32_store(out_text, 3, 0);
+    memset(&response, 0, sizeof(response));
+    result = stasis_platform_service_poll(&response, out_text_capacity);
+    if (result != 1) return result;
+    fields[0] = response.service;
+    fields[1] = response.action;
+    fields[2] = response.request_id;
+    fields[3] = response.status;
+    fields[4] = response.value;
+    for (index = 0; index < 5; index += 1) {
+        stasis_jit_global_i32_array_store(out_fields, 0, index, fields[index]);
+    }
+    for (index = 0; index < response.text_length; index += 1) {
+        stasis_jit_global_i32_array_store(
+            out_text, 0, index, (int32_t)(unsigned char)response.text[index]);
+    }
+    stasis_jit_collection_i32_store(out_text, 1, response.text_length);
+    stasis_jit_collection_i32_store(out_text, 3, response.text_char_length);
+    return 1;
 }
 int stasis_jit_gfx_poll_reload(int32_t handle) { return stasis_gfx_poll_reload(handle); }
 float stasis_jit_gfx_measure_text_cached(int32_t handle) {

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -104,6 +104,19 @@ void stasis_jit_gfx_release_sprite(int32_t handle);
 int stasis_jit_gfx_dump_bmp(int32_t path);
 int stasis_jit_gfx_dump_png(int32_t path);
 int stasis_jit_gfx_cache_text(int32_t font, int32_t text);
+int stasis_jit_platform_service_submit(
+    int32_t service,
+    int32_t action,
+    int32_t request_id,
+    int32_t key,
+    int32_t key_length
+);
+int stasis_jit_platform_service_poll(
+    int32_t out_fields,
+    int32_t out_field_capacity,
+    int32_t out_text,
+    int32_t out_text_capacity
+);
 int stasis_jit_gfx_poll_reload(int32_t handle);
 float stasis_jit_gfx_measure_text_cached(int32_t handle);
 float stasis_jit_gfx_measure_text_cached_height(int32_t handle);

--- a/runtime/stasis_platform_services.c
+++ b/runtime/stasis_platform_services.c
@@ -1,0 +1,287 @@
+#include "stasis_platform_services.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+static SRWLOCK service_lock = SRWLOCK_INIT;
+#define SERVICE_LOCK() AcquireSRWLockExclusive(&service_lock)
+#define SERVICE_UNLOCK() ReleaseSRWLockExclusive(&service_lock)
+#else
+#include <pthread.h>
+static pthread_mutex_t service_lock = PTHREAD_MUTEX_INITIALIZER;
+#define SERVICE_LOCK() pthread_mutex_lock(&service_lock)
+#define SERVICE_UNLOCK() pthread_mutex_unlock(&service_lock)
+#endif
+
+typedef struct StasisPlatformServiceState {
+    StasisPlatformServiceRequest pending[STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY];
+    StasisPlatformServiceResponse responses[STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY];
+    int pending_count;
+    int response_count;
+    uint64_t next_dispatch_token;
+    StasisPlatformServiceHandler handler;
+    void *handler_user_data;
+} StasisPlatformServiceState;
+
+static StasisPlatformServiceState service_state;
+
+static int printable_ascii(const char *value, int32_t length) {
+    int32_t index;
+    if (value == NULL || length <= 0 || length > STASIS_PLATFORM_SERVICE_KEY_CAPACITY) return 0;
+    for (index = 0; index < length; index += 1) {
+        unsigned char byte = (unsigned char)value[index];
+        if (byte < 32 || byte > 126) return 0;
+    }
+    return 1;
+}
+
+static int valid_response_status(int32_t status) {
+    return status >= STASIS_PLATFORM_SERVICE_RESPONSE_OK &&
+        status <= STASIS_PLATFORM_SERVICE_RESPONSE_FAILED;
+}
+
+static int utf8_char_count(const char *text, int32_t length, int32_t *out_count) {
+    int32_t index = 0;
+    int32_t count = 0;
+    if (length < 0 || length > STASIS_PLATFORM_SERVICE_TEXT_CAPACITY || out_count == NULL) return 0;
+    if (length > 0 && text == NULL) return 0;
+    while (index < length) {
+        uint32_t codepoint;
+        uint32_t minimum;
+        int32_t remaining;
+        unsigned char first = (unsigned char)text[index++];
+        if (first == 0) return 0;
+        if (first <= 0x7f) {
+            count += 1;
+            continue;
+        }
+        if (first >= 0xc2 && first <= 0xdf) {
+            codepoint = (uint32_t)(first & 0x1f);
+            minimum = 0x80;
+            remaining = 1;
+        } else if (first >= 0xe0 && first <= 0xef) {
+            codepoint = (uint32_t)(first & 0x0f);
+            minimum = 0x800;
+            remaining = 2;
+        } else if (first >= 0xf0 && first <= 0xf4) {
+            codepoint = (uint32_t)(first & 0x07);
+            minimum = 0x10000;
+            remaining = 3;
+        } else {
+            return 0;
+        }
+        if (index + remaining > length) return 0;
+        while (remaining > 0) {
+            unsigned char continuation = (unsigned char)text[index++];
+            if (continuation < 0x80 || continuation > 0xbf) return 0;
+            codepoint = (codepoint << 6) | (uint32_t)(continuation & 0x3f);
+            remaining -= 1;
+        }
+        if (codepoint < minimum || (codepoint >= 0xd800 && codepoint <= 0xdfff) ||
+            codepoint > 0x10ffff) return 0;
+        count += 1;
+    }
+    *out_count = count;
+    return 1;
+}
+
+static int pending_index(int32_t service, int32_t action, int32_t request_id) {
+    int index;
+    for (index = 0; index < service_state.pending_count; index += 1) {
+        StasisPlatformServiceRequest *request = &service_state.pending[index];
+        if (request->service == service && request->action == action &&
+            request->request_id == request_id) return index;
+    }
+    return -1;
+}
+
+static int pending_request_id_index(int32_t request_id) {
+    int index;
+    for (index = 0; index < service_state.pending_count; index += 1) {
+        if (service_state.pending[index].request_id == request_id) return index;
+    }
+    return -1;
+}
+
+static int pending_dispatch_token_index(uint64_t dispatch_token) {
+    int index;
+    for (index = 0; index < service_state.pending_count; index += 1) {
+        if (service_state.pending[index].dispatch_token == dispatch_token) return index;
+    }
+    return -1;
+}
+
+static int response_index(int32_t service, int32_t action, int32_t request_id) {
+    int index;
+    for (index = 0; index < service_state.response_count; index += 1) {
+        StasisPlatformServiceResponse *response = &service_state.responses[index];
+        if (response->service == service && response->action == action &&
+            response->request_id == request_id) return index;
+    }
+    return -1;
+}
+
+static void remove_pending_at(int index) {
+    if (index < 0 || index >= service_state.pending_count) return;
+    if (index + 1 < service_state.pending_count) {
+        memmove(
+            &service_state.pending[index],
+            &service_state.pending[index + 1],
+            (size_t)(service_state.pending_count - index - 1) * sizeof(service_state.pending[0])
+        );
+    }
+    service_state.pending_count -= 1;
+}
+
+void stasis_platform_service_set_handler(
+    StasisPlatformServiceHandler handler,
+    void *user_data
+) {
+    SERVICE_LOCK();
+    service_state.handler = handler;
+    service_state.handler_user_data = user_data;
+    SERVICE_UNLOCK();
+}
+
+void stasis_platform_service_reset(void) {
+    SERVICE_LOCK();
+    memset(service_state.pending, 0, sizeof(service_state.pending));
+    memset(service_state.responses, 0, sizeof(service_state.responses));
+    service_state.pending_count = 0;
+    service_state.response_count = 0;
+    SERVICE_UNLOCK();
+}
+
+int stasis_platform_service_publish_response(
+    uint64_t dispatch_token,
+    int32_t status,
+    int32_t value,
+    const char *text,
+    int32_t text_length
+) {
+    int32_t char_length = 0;
+    int pending_at;
+    StasisPlatformServiceRequest *request;
+    StasisPlatformServiceResponse *response;
+    if (dispatch_token == 0 || !valid_response_status(status) ||
+        !utf8_char_count(text, text_length, &char_length)) return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+
+    SERVICE_LOCK();
+    pending_at = pending_dispatch_token_index(dispatch_token);
+    if (pending_at < 0) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    request = &service_state.pending[pending_at];
+    if (response_index(request->service, request->action, request->request_id) >= 0) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    if (service_state.response_count >= STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_BUSY;
+    }
+    response = &service_state.responses[service_state.response_count++];
+    memset(response, 0, sizeof(*response));
+    response->service = request->service;
+    response->action = request->action;
+    response->request_id = request->request_id;
+    response->status = status;
+    response->value = value;
+    response->text_length = text_length;
+    response->text_char_length = char_length;
+    if (text_length > 0) memcpy(response->text, text, (size_t)text_length);
+    response->text[text_length] = '\0';
+    SERVICE_UNLOCK();
+    return STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED;
+}
+
+int stasis_platform_service_submit(
+    int32_t service,
+    int32_t action,
+    int32_t request_id,
+    const char *key,
+    int32_t key_length
+) {
+    StasisPlatformServiceRequest request;
+    StasisPlatformServiceHandler handler;
+    void *user_data;
+    int dispatch;
+    if (service <= 0 || action <= 0 || request_id <= 0 || !printable_ascii(key, key_length)) {
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+
+    memset(&request, 0, sizeof(request));
+    request.service = service;
+    request.action = action;
+    request.request_id = request_id;
+    request.key_length = key_length;
+    memcpy(request.key, key, (size_t)key_length);
+
+    SERVICE_LOCK();
+    if (pending_request_id_index(request_id) >= 0) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    if (service_state.pending_count >= STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_BUSY;
+    }
+    do {
+        service_state.next_dispatch_token += 1;
+        if (service_state.next_dispatch_token == 0) service_state.next_dispatch_token += 1;
+    } while (pending_dispatch_token_index(service_state.next_dispatch_token) >= 0);
+    request.dispatch_token = service_state.next_dispatch_token;
+    service_state.pending[service_state.pending_count++] = request;
+    handler = service_state.handler;
+    user_data = service_state.handler_user_data;
+    SERVICE_UNLOCK();
+
+    if (handler == NULL) {
+        (void)stasis_platform_service_publish_response(
+            request.dispatch_token, STASIS_PLATFORM_SERVICE_RESPONSE_UNSUPPORTED, 0, NULL, 0);
+        return STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED;
+    }
+
+    dispatch = handler(&request, user_data);
+    if (dispatch == STASIS_PLATFORM_SERVICE_DISPATCH_UNSUPPORTED) {
+        (void)stasis_platform_service_publish_response(
+            request.dispatch_token, STASIS_PLATFORM_SERVICE_RESPONSE_UNSUPPORTED, 0, NULL, 0);
+    } else if (dispatch != STASIS_PLATFORM_SERVICE_DISPATCH_ACCEPTED) {
+        (void)stasis_platform_service_publish_response(
+            request.dispatch_token, STASIS_PLATFORM_SERVICE_RESPONSE_FAILED, 0, NULL, 0);
+    }
+    return STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED;
+}
+
+int stasis_platform_service_poll(
+    StasisPlatformServiceResponse *response,
+    int32_t text_capacity
+) {
+    int pending;
+    if (response == NULL || text_capacity < 0) return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    SERVICE_LOCK();
+    if (service_state.response_count == 0) {
+        SERVICE_UNLOCK();
+        return 0;
+    }
+    if (service_state.responses[0].text_length > text_capacity) {
+        SERVICE_UNLOCK();
+        return STASIS_PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    *response = service_state.responses[0];
+    pending = pending_index(response->service, response->action, response->request_id);
+    remove_pending_at(pending);
+    if (service_state.response_count > 1) {
+        memmove(
+            &service_state.responses[0],
+            &service_state.responses[1],
+            (size_t)(service_state.response_count - 1) * sizeof(service_state.responses[0])
+        );
+    }
+    service_state.response_count -= 1;
+    SERVICE_UNLOCK();
+    return 1;
+}

--- a/runtime/stasis_platform_services.h
+++ b/runtime/stasis_platform_services.h
@@ -1,0 +1,97 @@
+#ifndef STASIS_PLATFORM_SERVICES_H
+#define STASIS_PLATFORM_SERVICES_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY 16
+#define STASIS_PLATFORM_SERVICE_KEY_CAPACITY 128
+#define STASIS_PLATFORM_SERVICE_TEXT_CAPACITY 512
+
+enum StasisPlatformServiceSubmitResult {
+    STASIS_PLATFORM_SERVICE_SUBMIT_INVALID = -1,
+    STASIS_PLATFORM_SERVICE_SUBMIT_BUSY = 0,
+    STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED = 1
+};
+
+enum StasisPlatformServiceResponseStatus {
+    STASIS_PLATFORM_SERVICE_RESPONSE_OK = 1,
+    STASIS_PLATFORM_SERVICE_RESPONSE_CANCELLED = 2,
+    STASIS_PLATFORM_SERVICE_RESPONSE_UNAVAILABLE = 3,
+    STASIS_PLATFORM_SERVICE_RESPONSE_UNSUPPORTED = 4,
+    STASIS_PLATFORM_SERVICE_RESPONSE_FAILED = 5
+};
+
+enum StasisPlatformServiceDispatchResult {
+    STASIS_PLATFORM_SERVICE_DISPATCH_FAILED = -1,
+    STASIS_PLATFORM_SERVICE_DISPATCH_UNSUPPORTED = 0,
+    STASIS_PLATFORM_SERVICE_DISPATCH_ACCEPTED = 1
+};
+
+typedef struct StasisPlatformServiceRequest {
+    int32_t service;
+    int32_t action;
+    int32_t request_id;
+    uint64_t dispatch_token;
+    int32_t key_length;
+    char key[STASIS_PLATFORM_SERVICE_KEY_CAPACITY + 1];
+} StasisPlatformServiceRequest;
+
+typedef struct StasisPlatformServiceResponse {
+    int32_t service;
+    int32_t action;
+    int32_t request_id;
+    int32_t status;
+    int32_t value;
+    int32_t text_length;
+    int32_t text_char_length;
+    char text[STASIS_PLATFORM_SERVICE_TEXT_CAPACITY + 1];
+} StasisPlatformServiceResponse;
+
+/* The request pointer is valid only during the call; deferred handlers must copy it. */
+typedef int (*StasisPlatformServiceHandler)(
+    const StasisPlatformServiceRequest *request,
+    void *user_data
+);
+
+/* Registration persists across queue resets. Adapters must marshal any UI work. */
+void stasis_platform_service_set_handler(
+    StasisPlatformServiceHandler handler,
+    void *user_data
+);
+
+/* Clears pending requests and responses without unregistering the host adapter. */
+void stasis_platform_service_reset(void);
+
+/* Submits one request. Keys are non-empty printable ASCII and request IDs are positive. */
+int stasis_platform_service_submit(
+    int32_t service,
+    int32_t action,
+    int32_t request_id,
+    const char *key,
+    int32_t key_length
+);
+
+/* Publishes one response for an outstanding dispatch token. Text must be valid UTF-8. */
+int stasis_platform_service_publish_response(
+    uint64_t dispatch_token,
+    int32_t status,
+    int32_t value,
+    const char *text,
+    int32_t text_length
+);
+
+/* Returns 1 for a response, 0 when empty, or -1 when the output capacity is too small. */
+int stasis_platform_service_poll(
+    StasisPlatformServiceResponse *response,
+    int32_t text_capacity
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -143,6 +143,9 @@ int main(void) {
     uint8_t dynamic_path[] = "sprite.bmp";
     uint8_t ascii_value[] = "GG1-test";
     uint8_t ascii_out[32] = {0};
+    uint8_t platform_key[] = "power_up";
+    int32_t platform_fields[5] = {0};
+    uint8_t platform_text[32] = {0};
     int32_t sprite_handle[1] = {0};
     int32_t sprite_width[1] = {0};
     int32_t sprite_height[1] = {0};
@@ -230,6 +233,19 @@ int main(void) {
     memset(ascii_out, 0, sizeof(ascii_out));
     CHECK(stasis_jit_clipboard_load_ascii(43, sizeof(ascii_out)) == 8);
     CHECK(memcmp(ascii_out, "GG1-test", 8) == 0);
+
+    stasis_jit_register_global_u8_array(44, 0, platform_key, sizeof(platform_key) - 1);
+    stasis_jit_collection_i32_store(44, 1, sizeof(platform_key) - 1);
+    stasis_jit_register_global_i32_array(45, 0, platform_fields, 5);
+    stasis_jit_register_global_u8_array(46, 0, platform_text, sizeof(platform_text));
+    CHECK(stasis_jit_platform_service_submit(1, 1, 77, 44, 8) == 1);
+    CHECK(stasis_jit_platform_service_poll(45, 5, 46, sizeof(platform_text)) == 1);
+    CHECK(platform_fields[0] == 1 && platform_fields[1] == 1);
+    CHECK(platform_fields[2] == 77 && platform_fields[3] == 4);
+    CHECK(platform_fields[4] == 0);
+    CHECK(stasis_jit_collection_i32_load(46, 1) == 0);
+    CHECK(stasis_jit_collection_i32_load(46, 3) == 0);
+    CHECK(stasis_jit_platform_service_poll(45, 5, 46, sizeof(platform_text)) == 0);
 
     owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
     CHECK(owned != NULL);

--- a/runtime/tests/stasis_platform_services_test.c
+++ b/runtime/tests/stasis_platform_services_test.c
@@ -1,0 +1,154 @@
+#include "stasis_platform_services.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+static StasisPlatformServiceRequest deferred_request;
+
+static int publish_price(
+    const StasisPlatformServiceRequest *request,
+    void *user_data
+) {
+    static const char price[] = "\xe2\x82\xac" "2.99";
+    (void)user_data;
+    CHECK(request != NULL);
+    CHECK(request->key_length == 8);
+    CHECK(memcmp(request->key, "power_up", 8) == 0);
+    CHECK(stasis_platform_service_publish_response(
+        request->dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_OK,
+        1,
+        price,
+        (int32_t)sizeof(price) - 1
+    ) == STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    return STASIS_PLATFORM_SERVICE_DISPATCH_ACCEPTED;
+}
+
+static int defer_response(
+    const StasisPlatformServiceRequest *request,
+    void *user_data
+) {
+    (void)user_data;
+    deferred_request = *request;
+    return STASIS_PLATFORM_SERVICE_DISPATCH_ACCEPTED;
+}
+
+int main(void) {
+    StasisPlatformServiceRequest stale_request;
+    StasisPlatformServiceResponse response;
+    int index;
+
+    stasis_platform_service_set_handler(NULL, NULL);
+    stasis_platform_service_reset();
+    CHECK(stasis_platform_service_submit(1, 1, 1, "power_up", 8) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    memset(&response, 0, sizeof(response));
+    CHECK(stasis_platform_service_poll(&response, 0) == 1);
+    CHECK(response.service == 1);
+    CHECK(response.action == 1);
+    CHECK(response.request_id == 1);
+    CHECK(response.status == STASIS_PLATFORM_SERVICE_RESPONSE_UNSUPPORTED);
+    CHECK(response.text_length == 0);
+    CHECK(stasis_platform_service_poll(&response, 0) == 0);
+
+    stasis_platform_service_set_handler(publish_price, NULL);
+    CHECK(stasis_platform_service_submit(2, 3, 2, "power_up", 8) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(stasis_platform_service_poll(&response, 6) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_poll(&response, STASIS_PLATFORM_SERVICE_TEXT_CAPACITY) == 1);
+    CHECK(response.status == STASIS_PLATFORM_SERVICE_RESPONSE_OK);
+    CHECK(response.value == 1);
+    CHECK(response.text_length == 7);
+    CHECK(response.text_char_length == 5);
+    CHECK(memcmp(response.text, "\xe2\x82\xac" "2.99", 7) == 0);
+
+    stasis_platform_service_set_handler(defer_response, NULL);
+    CHECK(stasis_platform_service_submit(3, 4, 3, "restore", 7) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(stasis_platform_service_submit(9, 9, 3, "duplicate", 9) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_poll(&response, STASIS_PLATFORM_SERVICE_TEXT_CAPACITY) == 0);
+    CHECK(deferred_request.service == 3 && deferred_request.action == 4 &&
+        deferred_request.request_id == 3 && deferred_request.dispatch_token != 0);
+    CHECK(stasis_platform_service_publish_response(
+        deferred_request.dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_CANCELLED,
+        0,
+        NULL,
+        0
+    ) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(stasis_platform_service_publish_response(
+        deferred_request.dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_CANCELLED,
+        0,
+        NULL,
+        0
+    ) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_poll(&response, STASIS_PLATFORM_SERVICE_TEXT_CAPACITY) == 1);
+    CHECK(response.status == STASIS_PLATFORM_SERVICE_RESPONSE_CANCELLED);
+
+    stasis_platform_service_reset();
+    for (index = 0; index < STASIS_PLATFORM_SERVICE_QUEUE_CAPACITY; index += 1) {
+        CHECK(stasis_platform_service_submit(1, 1, 100 + index, "queued", 6) ==
+            STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    }
+    CHECK(stasis_platform_service_submit(1, 1, 999, "full", 4) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_BUSY);
+    stale_request = deferred_request;
+    stasis_platform_service_reset();
+    CHECK(stasis_platform_service_submit(5, 6, stale_request.request_id, "still_set", 9) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(deferred_request.service == 5 && deferred_request.action == 6 &&
+        deferred_request.request_id == stale_request.request_id &&
+        deferred_request.dispatch_token != stale_request.dispatch_token);
+    CHECK(stasis_platform_service_publish_response(
+        stale_request.dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_OK,
+        0,
+        NULL,
+        0
+    ) == STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_publish_response(
+        deferred_request.dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_OK,
+        0,
+        NULL,
+        0
+    ) == STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(stasis_platform_service_poll(&response, STASIS_PLATFORM_SERVICE_TEXT_CAPACITY) == 1);
+    CHECK(response.service == 5 && response.action == 6 &&
+        response.request_id == stale_request.request_id);
+    stasis_platform_service_reset();
+
+    CHECK(stasis_platform_service_submit(0, 1, 1, "bad", 3) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_submit(1, 1, 1, "bad\nkey", 7) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+    CHECK(stasis_platform_service_submit(1, 1, 2000, "bad_utf8", 8) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_ACCEPTED);
+    CHECK(stasis_platform_service_publish_response(
+        deferred_request.dispatch_token,
+        STASIS_PLATFORM_SERVICE_RESPONSE_OK,
+        0,
+        "\xff",
+        1
+    ) ==
+        STASIS_PLATFORM_SERVICE_SUBMIT_INVALID);
+
+    stasis_platform_service_set_handler(NULL, NULL);
+    stasis_platform_service_reset();
+    puts("stasis_platform_services_test: ok");
+    return 0;
+}

--- a/src/stdlib/platform_services.stasis
+++ b/src/stdlib/platform_services.stasis
@@ -1,0 +1,55 @@
+// Bounded asynchronous guest-to-platform service bridge.
+//
+// Service and action IDs are positive opaque values defined by optional adapters.
+// Request keys are stable printable-ASCII identifiers. Response display text is UTF-8.
+// Calls are intended for menus and lifecycle transitions, not simulation hot paths.
+
+const PLATFORM_SERVICE_SUBMIT_INVALID: i32 = -1;
+const PLATFORM_SERVICE_SUBMIT_BUSY: i32 = 0;
+const PLATFORM_SERVICE_SUBMIT_ACCEPTED: i32 = 1;
+const PLATFORM_SERVICE_RESPONSE_OK: i32 = 1;
+const PLATFORM_SERVICE_RESPONSE_CANCELLED: i32 = 2;
+const PLATFORM_SERVICE_RESPONSE_UNAVAILABLE: i32 = 3;
+const PLATFORM_SERVICE_RESPONSE_UNSUPPORTED: i32 = 4;
+const PLATFORM_SERVICE_RESPONSE_FAILED: i32 = 5;
+const PLATFORM_SERVICE_RESPONSE_SERVICE: i32 = 0;
+const PLATFORM_SERVICE_RESPONSE_ACTION: i32 = 1;
+const PLATFORM_SERVICE_RESPONSE_REQUEST_ID: i32 = 2;
+const PLATFORM_SERVICE_RESPONSE_STATUS: i32 = 3;
+const PLATFORM_SERVICE_RESPONSE_VALUE: i32 = 4;
+const PLATFORM_SERVICE_RESPONSE_FIELD_COUNT: i32 = 5;
+const PLATFORM_SERVICE_KEY_CAPACITY: i32 = 128;
+const PLATFORM_SERVICE_TEXT_CAPACITY: i32 = 512;
+
+function @extern("stasis_jit_platform_service_submit") platform_service_submit_raw(
+    service: i32,
+    action: i32,
+    request_id: i32,
+    key: ascii[],
+    key_length: i32
+): i32;
+function @extern("stasis_jit_platform_service_poll") platform_service_poll_raw(
+    out_fields: i32[],
+    out_field_capacity: i32,
+    out_text: utf8[],
+    out_text_capacity: i32
+): i32;
+
+function platform_service_submit(service: i32, action: i32, request_id: i32, key: ascii[]): i32 {
+    let key_length: i32 = key.length;
+    if (service <= 0 || action <= 0 || request_id <= 0 || key_length <= 0 || key_length > key.max_length || key_length > PLATFORM_SERVICE_KEY_CAPACITY) {
+        return PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    return platform_service_submit_raw(service, action, request_id, key, key_length);
+}
+
+// Returns 1 when one response was consumed, 0 when none is ready, and -1 for
+// invalid or undersized output buffers. An undersized buffer does not consume data.
+function platform_service_poll(out_fields: i32[], out_text: utf8[]): i32 {
+    let field_capacity: i32 = out_fields.max_length;
+    let text_capacity: i32 = out_text.max_length;
+    if (field_capacity < PLATFORM_SERVICE_RESPONSE_FIELD_COUNT || text_capacity <= 0) {
+        return PLATFORM_SERVICE_SUBMIT_INVALID;
+    }
+    return platform_service_poll_raw(out_fields, field_capacity, out_text, text_capacity);
+}

--- a/tests/stasis/platform_services/platform_services.test.stasis
+++ b/tests/stasis/platform_services/platform_services.test.stasis
@@ -1,0 +1,28 @@
+import "../../../src/stdlib/platform_services.stasis";
+
+global platform_test_key: ascii[16];
+global platform_test_fields: i32[PLATFORM_SERVICE_RESPONSE_FIELD_COUNT];
+global platform_test_text: utf8[32];
+
+test `platform service mailbox has explicit unsupported fallback`(): bool {
+    if (platform_service_submit(1, 2, 90, platform_test_key) != PLATFORM_SERVICE_SUBMIT_INVALID) {
+        return false;
+    }
+
+    platform_test_key[0] = 112;
+    platform_test_key[1] = 111;
+    platform_test_key[2] = 119;
+    platform_test_key[3] = 101;
+    platform_test_key[4] = 114;
+    platform_test_key[5] = 95;
+    platform_test_key[6] = 117;
+    platform_test_key[7] = 112;
+    platform_test_key.length = 8;
+    if (platform_service_submit(1, 2, 91, platform_test_key) != PLATFORM_SERVICE_SUBMIT_ACCEPTED) {
+        return false;
+    }
+    if (platform_service_poll(platform_test_fields, platform_test_text) != 1) {
+        return false;
+    }
+    return platform_test_fields[PLATFORM_SERVICE_RESPONSE_SERVICE] == 1 && platform_test_fields[PLATFORM_SERVICE_RESPONSE_ACTION] == 2 && platform_test_fields[PLATFORM_SERVICE_RESPONSE_REQUEST_ID] == 91 && platform_test_fields[PLATFORM_SERVICE_RESPONSE_STATUS] == PLATFORM_SERVICE_RESPONSE_UNSUPPORTED && platform_test_fields[PLATFORM_SERVICE_RESPONSE_VALUE] == 0 && platform_test_text.length == 0 && platform_test_text.char_length == 0;
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral, bounded asynchronous platform-service mailbox for optional host capabilities
- expose validated Stasis submit/poll wrappers in JIT and mobile AOT runtimes
- package the shared native core in Android and iOS shells and document the host adapter contract
- prevent late callbacks from crossing runtime resets with opaque process-monotonic dispatch tokens

## Why

Games need a small cold-path boundary for billing, rewarded ads, achievements, and similar platform services without embedding provider policy in the compiler or widening per-frame render buffers. The default host behavior is explicit Unsupported, so projects remain portable when no adapter is installed.

## Behavioral impact

- up to 16 positive-ID requests may be outstanding; duplicate guest request IDs are rejected
- response text is bounded to 512 bytes and validated as UTF-8
- polling is non-blocking and undersized buffers do not consume responses
- queue reset preserves the registered adapter but invalidates old dispatch tokens
- the existing preview-extern test now accepts either valid audio availability result while still executing the extern

## Verification

- `cargo fmt --all -- --check`
- worktree-built `stasis fmt --check` for both new Stasis files
- `cargo test -p stasis_dynload -- --test-threads=1`: 22 passed
- exact Stasis mailbox fixture through discovery/import/JIT: passed
- mobile shell package assembly test: passed
- native mailbox + mobile AOT CTest contracts: 2 passed
- canonical Python/unit/render-parity checks: passed except the clean-baseline unsafe-boundary audit described below
- full workspace traversal passed prior packages; compiler rerun: 474 passed, 1 clean-baseline failure because the Windows AOT test cannot discover a linker

## Existing repository validation limitations

- `check_unsafe_boundaries.py` returns nonzero for existing `crates/stasis_ai/src/lib.rs` on clean origin/main
- the ignore audit finds the existing `stasis_language_service` test requiring `STASIS_CHESSTD_ROOT`
- `qualified_same_name_calls_use_identical_jit_and_aot_module_graphs` fails on clean origin/main when it cannot discover the Windows linker

## Reflection

- Good: one shared synchronized C queue exercises the same correlation and bounds in JIT, Android, and iOS packaging.
- Bad: the first repository-wide pass exposed that new vendored Stasis sources must be canonically formatted before vendor-sync tests can pass.
- Adjustment: run the worktree-built formatter on new standard-library files before vendor/package tests, and clear only `stasis_dynload` when comparing worktrees that change its C build inputs.

Theory gained: cold platform operations fit a bounded request/response mailbox when guest-visible IDs express intent and native dispatch tokens express callback identity. The stale-callback reset test supports that separation; the adjacent prediction is that Billing, rewarded-ad, and future achievement adapters can share this transport without adding provider-specific runtime ABI.