### PR TITLE
fix(mobile): pace deterministic ticks at 60 Hz

### DIFF
--- a/docs/mobile_packaging_abi.md
+++ b/docs/mobile_packaging_abi.md
@@ -148,7 +148,8 @@ Rules:
 - Android and iOS shells should share the same C runtime ABI wherever platform
   SDK differences do not force a thin adapter.
 - The runtime drives the app lifecycle and calls `main` once, then `tick` and
-  `render` on the fixed tick/frame loop.
+  `render` on the shell-paced 60 Hz tick/frame loop. Display refresh may block
+  presentation, but it must not redefine deterministic game speed.
 - Platform pause, resume, focus, and shutdown events are runtime-owned and must
   not require dynamic game code replacement.
 - Audio and graphics device unavailability must leave gameplay state coherent

--- a/docs/mobile_runtime_core.md
+++ b/docs/mobile_runtime_core.md
@@ -23,11 +23,27 @@ StasisMobileGameEntries game = {
 StasisMobileRuntimeConfig config = {1280, 720, "My Stasis Game"};
 
 int status = stasis_mobile_runtime_initialize(&config, &game);
+StasisMobileFramePacer frame_pacer;
+stasis_mobile_frame_pacer_reset(&frame_pacer, SDL_GetTicksNS());
 while (status == STASIS_MOBILE_RUNTIME_OK) {
     status = stasis_mobile_runtime_step();
+    if (status == STASIS_MOBILE_RUNTIME_OK) {
+        uint64_t wait_ns = stasis_mobile_frame_pacer_wait_ns(
+            &frame_pacer, SDL_GetTicksNS());
+        if (wait_ns > 0) {
+            SDL_DelayPrecise(wait_ns);
+        }
+    }
 }
 stasis_mobile_runtime_shutdown();
 ```
+
+The shared shell targets 60 deterministic steps per second independently of
+the display refresh rate. Vsync time counts toward the frame interval, so a
+60 Hz display does not receive an unconditional extra delay while 90 Hz and
+120 Hz displays cannot accelerate game time. If suspension or overload misses
+a complete interval, the pacer resets its absolute deadline and never runs a
+burst of catch-up ticks.
 
 The generated AOT symbol header declares `main`, `tick`, and `render` as
 `int32_t(void)` and is the source of the actual symbol names. The runtime turns

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -65,9 +65,19 @@ int SDL_main(int argc, char **argv) {
         report_runtime_status("Stasis mobile initialization", status);
         SDL_Log("Stasis mobile initialization stopped with status %d", status);
     }
+    StasisMobileFramePacer frame_pacer;
+    stasis_mobile_frame_pacer_reset(&frame_pacer, SDL_GetTicksNS());
     while (status == STASIS_MOBILE_RUNTIME_OK) {
         status = stasis_mobile_runtime_step();
-        SDL_Delay(1);
+        if (status == STASIS_MOBILE_RUNTIME_OK) {
+            uint64_t wait_ns = stasis_mobile_frame_pacer_wait_ns(
+                &frame_pacer,
+                SDL_GetTicksNS()
+            );
+            if (wait_ns > 0) {
+                SDL_DelayPrecise(wait_ns);
+            }
+        }
     }
     SDL_Log("Stasis mobile loop stopped with status %d", status);
     int32_t game_result = stasis_mobile_runtime_last_entry_result();

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -264,6 +264,12 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
     target_include_directories(stasis_mobile_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(NAME stasis_mobile_runtime_lifecycle COMMAND stasis_mobile_runtime_test)
     add_executable(
+        stasis_mobile_frame_pacer_test
+        tests/stasis_mobile_frame_pacer_test.c
+    )
+    target_include_directories(stasis_mobile_frame_pacer_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_mobile_frame_pacer_contract COMMAND stasis_mobile_frame_pacer_test)
+    add_executable(
         stasis_mobile_aot_runtime_test
         tests/stasis_mobile_aot_runtime_test.c
         stasis_mobile_aot_runtime.c

--- a/runtime/stasis_mobile_runtime.h
+++ b/runtime/stasis_mobile_runtime.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 #define STASIS_MOBILE_RUNTIME_ABI_VERSION 1
+#define STASIS_MOBILE_FRAME_INTERVAL_NS 16666667ULL
 
 enum StasisMobileRuntimeResult {
     STASIS_MOBILE_RUNTIME_OK = 0,
@@ -33,6 +34,40 @@ typedef struct StasisMobileRuntimeConfig {
     int32_t height;
     const char *title;
 } StasisMobileRuntimeConfig;
+
+typedef struct StasisMobileFramePacer {
+    uint64_t next_deadline_ns;
+} StasisMobileFramePacer;
+
+/*
+ * The shell owns wall-clock pacing so a display's refresh rate cannot redefine
+ * the deterministic game tick. Call reset immediately before the loop, then
+ * wait_ns after every successful step and sleep for the returned duration.
+ */
+static inline void stasis_mobile_frame_pacer_reset(
+    StasisMobileFramePacer *pacer,
+    uint64_t now_ns
+) {
+    pacer->next_deadline_ns = now_ns + STASIS_MOBILE_FRAME_INTERVAL_NS;
+}
+
+static inline uint64_t stasis_mobile_frame_pacer_wait_ns(
+    StasisMobileFramePacer *pacer,
+    uint64_t now_ns
+) {
+    uint64_t deadline_ns = pacer->next_deadline_ns;
+    if (now_ns < deadline_ns) {
+        pacer->next_deadline_ns = deadline_ns + STASIS_MOBILE_FRAME_INTERVAL_NS;
+        return deadline_ns - now_ns;
+    }
+    if (now_ns - deadline_ns >= STASIS_MOBILE_FRAME_INTERVAL_NS) {
+        /* A suspended or overloaded app resumes without catch-up ticks. */
+        pacer->next_deadline_ns = now_ns + STASIS_MOBILE_FRAME_INTERVAL_NS;
+    } else {
+        pacer->next_deadline_ns = deadline_ns + STASIS_MOBILE_FRAME_INTERVAL_NS;
+    }
+    return 0;
+}
 
 /* Initializes the SDL-only host APIs and calls the game main entry exactly once. */
 int32_t stasis_mobile_runtime_initialize(

--- a/runtime/tests/stasis_mobile_frame_pacer_test.c
+++ b/runtime/tests/stasis_mobile_frame_pacer_test.c
@@ -1,0 +1,63 @@
+#include "stasis_mobile_runtime.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define check(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+static void test_fills_the_remainder_of_a_high_refresh_frame(void) {
+    StasisMobileFramePacer pacer;
+    stasis_mobile_frame_pacer_reset(&pacer, 1000);
+
+    check(stasis_mobile_frame_pacer_wait_ns(&pacer, 1000 + 8333333) == 8333334);
+    check(pacer.next_deadline_ns == 1000 + 33333334);
+    check(stasis_mobile_frame_pacer_wait_ns(&pacer, 1000 + 25000000) == 8333334);
+}
+
+static void test_vsync_at_sixty_hz_needs_no_extra_sleep(void) {
+    StasisMobileFramePacer pacer;
+    stasis_mobile_frame_pacer_reset(&pacer, 2000);
+
+    check(stasis_mobile_frame_pacer_wait_ns(
+        &pacer,
+        2000 + STASIS_MOBILE_FRAME_INTERVAL_NS
+    ) == 0);
+    check(pacer.next_deadline_ns == 2000 + (2 * STASIS_MOBILE_FRAME_INTERVAL_NS));
+}
+
+static void test_small_overrun_preserves_the_next_absolute_deadline(void) {
+    StasisMobileFramePacer pacer;
+    stasis_mobile_frame_pacer_reset(&pacer, 3000);
+
+    check(stasis_mobile_frame_pacer_wait_ns(
+        &pacer,
+        3000 + STASIS_MOBILE_FRAME_INTERVAL_NS + 1000000
+    ) == 0);
+    check(pacer.next_deadline_ns == 3000 + (2 * STASIS_MOBILE_FRAME_INTERVAL_NS));
+}
+
+static void test_long_pause_resets_without_a_catch_up_burst(void) {
+    StasisMobileFramePacer pacer;
+    stasis_mobile_frame_pacer_reset(&pacer, 4000);
+
+    uint64_t resumed_ns = 4000 + 1000000000ULL;
+    check(stasis_mobile_frame_pacer_wait_ns(&pacer, resumed_ns) == 0);
+    check(pacer.next_deadline_ns == resumed_ns + STASIS_MOBILE_FRAME_INTERVAL_NS);
+    check(stasis_mobile_frame_pacer_wait_ns(&pacer, resumed_ns + 1000000) ==
+        STASIS_MOBILE_FRAME_INTERVAL_NS - 1000000);
+}
+
+int main(void) {
+    test_fills_the_remainder_of_a_high_refresh_frame();
+    test_vsync_at_sixty_hz_needs_no_extra_sleep();
+    test_small_overrun_preserves_the_next_absolute_deadline();
+    test_long_pause_resets_without_a_catch_up_burst();
+    puts("stasis_mobile_frame_pacer_test: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- pace the shared Android/iOS release shell at an absolute 60 Hz deadline instead of adding an unconditional 1 ms delay after every frame
- count vsync/presentation time toward the interval, preventing 90/120 Hz displays from accelerating deterministic game ticks
- reset after a missed full interval so resume/overload never triggers a burst of catch-up ticks
- document the shell-owned cadence and add focused high-refresh, 60 Hz, overrun, and suspension contracts

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- native CMake/CTest runtime matrix: 8/8 passed
- `python -m unittest tools.ci.test_release_provenance tools.ci.test_sdl3_migration`: 10 passed
- `python tools/ci/check_stasis_src_layout.py`
- Android arm64 render-parity release package built through NDK/Gradle and audited: verified AAB, runtime-only, expected `libSDL3.so`, `libSDL3_image.so`, and `libmain.so`, 4 verified assets
- pre-commit Stasis format contract: passed

## Known baseline-only failures
- `cargo test --workspace --all-targets -- --test-threads=1` reached 481 passing compiler tests, then retained the two unchanged Windows-environment failures reproduced on `main`: the qualified AOT module-graph test cannot discover a Windows linker, and the production-preview extern test observes two available hosts where its assertion expects one
- `tools/ci/check_android_shell.py` retains the existing `main` assertion failure for the unrelated missing `allowAiImageGeneration.setChecked(false)` line

## Theory gained
One mobile runtime step is the deterministic gameplay clock, while vsync is only a presentation constraint. An absolute shell-owned deadline preserves that mapping across 60/90/120 Hz displays; therefore a future dirty-presentation optimization should suppress presentation work explicitly, not suppress or multiply simulation ticks.