### PR TITLE
Add on-demand presentation contract

### DIFF
--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -3845,7 +3845,9 @@ STASIS_EXPORT int32_t host_req_window_h_px = 0;\n",
             "STASIS_EXPORT void stasis_init(int width, int height) {\n\
     host_i32[12] = width;\n\
     host_i32[13] = height;\n\
-    host_i32[14] = 3;\n\
+    host_i32[14] = 4;\n\
+    host_i32[20] = 1;\n\
+    host_i32[21] = 0;\n\
     host_i32[22] = width;\n\
     host_i32[23] = height;\n\
     host_i32[24] = width;\n\
@@ -5132,7 +5134,8 @@ mod tests {
 
         assert!(!source.contains("StasisDirectStorageSlot"));
         assert!(source.contains("STASIS_EXPORT void stasis_init(int width, int height)"));
-        assert!(source.contains("host_i32[14] = 3;"));
+        assert!(source.contains("host_i32[14] = 4;"));
+        assert!(source.contains("host_i32[20] = 1;"));
         assert!(source.contains("host_f32[50] = (float)width;"));
         assert!(source.contains("STASIS_EXPORT void stasis_tick(float dt)"));
         assert!(source.contains("host_i32[10] = host_i32[10] + 1;"));

--- a/docs/renderer_resource_lifecycle.md
+++ b/docs/renderer_resource_lifecycle.md
@@ -24,6 +24,13 @@ Android pause/resume is a visibility transition: the Workshop asks GLSurfaceView
 preserve its EGL context and retains textures when that context survives. A later
 `onSurfaceCreated` callback is the authoritative signal that the context was lost.
 
+The lifecycle also owns a separate `presentation_generation`. It advances for
+surface or renderer invalidation and foreground resume without pretending that
+every visibility change invalidated GPU resources. Display/density changes and
+capture requests advance the same HostFrame-visible presentation contract. A
+game using on-demand presentation must redraw when this generation differs from
+the generation consumed by its last `end_frame()`.
+
 The native SDL runtime retains sprite paths, logical raster requests, decoded font
 bytes, font metrics, and cached text bytes/quads. Android Workshop and release
 previews retain their project or packaged manifest, asset identities, content

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -80,3 +80,26 @@ shipping renderer. It performs no per-command JNI calls and adds no additional
 full-frame copy. The old desktop GL adapter is available only when CMake is
 explicitly configured with `STASIS_GRAPHICS_SDL_ONLY=OFF`; it is not packaged or
 exercised as the canonical process.
+
+## On-demand presentation
+
+Games with static presentation state can call `begin_frame_if_needed()` instead
+of `begin_frame()`. The helper always clears the guest command counts, then
+returns `false` after a clean frame so the game can return from `render` without
+rebuilding the command list. `request_redraw()` marks a semantic game change; a
+monotonic HostFrame presentation generation independently forces the first frame
+and redraws after resize, density, surface, renderer, resume, and capture changes.
+`end_frame()` consumes both sources only when the game submits a present.
+
+This is an explicit invalidation contract, not a command-buffer hash. An empty
+clean submission takes a renderer-free runtime fast path while host input and
+lifecycle polling continue at tick cadence. Existing games remain continuous:
+their ordinary `begin_frame()` / `end_frame()` pair still presents every tick.
+Games with animation either retain that pair or call `request_redraw()` from
+each animated tick.
+
+Presentation never defines simulation time. Desktop, Android, and iOS continue
+to collect input and execute deterministic ticks when a frame is clean. The
+shared mobile frame pacer keeps that cadence independent of 60, 90, or 120 Hz
+display presentation. Physical-device verification remains necessary because
+drivers differ in whether and how long presentation blocks.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -120,6 +120,9 @@ cloning a generated repository, reactivate the checked-in hook with
   nearest ancestor `stasis.json` from the current directory and use its project-relative `entry`
   and display `name`. Explicit entries discover their own ancestor manifest, so project-root
   imports and asset preparation remain anchored to the project even when play starts in `src/`.
+  Static screens may use the graphics stdlib's explicit `request_redraw()` and
+  `begin_frame_if_needed()` contract. Skipping a clean presentation never skips host input,
+  deterministic ticks, file watching, or lifecycle handling.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   The window title uses the manifest project name. Because it is an unbounded graphical session,
   watch mode rejects `--json` and `--headless`.

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -164,6 +164,7 @@ static bool g_screenshot_taken = false;
 static char g_screenshot_path[1024] = {0};
 static int g_screenshot_exit_after = 0;
 static int g_screenshot_frame = 1;
+static int g_debug_frame_counter = 0;
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
 static GLuint g_postfx_program = 0;
 static GLint g_postfx_time_loc = -1;
@@ -504,6 +505,7 @@ static void stasis_mark_density_resources_dirty(void) {
     for (int i = 0; i < MAX_FONTS; i++) {
         if (g_fonts[i].active) g_fonts[i].needs_reraster = 1;
     }
+    stasis_renderer_lifecycle_request_redraw(&g_resource_lifecycle);
 }
 
 static void stasis_sync_display_metrics(void) {
@@ -556,6 +558,7 @@ static void stasis_sync_display_metrics(void) {
     if (g_display_generation == 0 || dimensions_changed) {
         g_display_generation++;
         g_window_resized = true;
+        stasis_renderer_lifecycle_request_redraw(&g_resource_lifecycle);
     }
     g_display_metrics = next;
     g_drawable_width = drawable_w;
@@ -752,6 +755,7 @@ static void stasis_pump_events(void) {
                 }
                 if (event.key.key == SDLK_F3 && !event.key.repeat) {
                     g_force_debug_overlay = !g_force_debug_overlay;
+                    stasis_renderer_lifecycle_request_redraw(&g_resource_lifecycle);
                     if (g_force_debug_overlay) (void)stasis_perf_font();
                     SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
                 }
@@ -1122,7 +1126,7 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     if (!out_i32 || !out_f32) return;
 
     static int32_t g_host_tick_index = 0;
-    const int32_t host_version = 3;
+    const int32_t host_version = 4;
     const int i32_key_base = 32;
     const int i32_key_count = 512;
 
@@ -1167,8 +1171,10 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     out_i32[18] = minimized;
     out_i32[19] = stasis_get_time_us();
 
-    out_i32[20] = 0;
-    out_i32[21] = 0;
+    out_i32[20] = (int32_t)g_resource_lifecycle.presentation_generation;
+    out_i32[21] = (g_force_debug_overlay ||
+        (!g_screenshot_taken && g_screenshot_path[0] != 0 &&
+            g_debug_frame_counter + 1 <= g_screenshot_frame)) ? 1 : 0;
     out_i32[22] = g_display_metrics.native_w;
     out_i32[23] = g_display_metrics.native_h;
     out_i32[24] = g_display_metrics.drawable_w;
@@ -1400,7 +1406,6 @@ static struct {
 } g_lines[MAX_LINES];
 static LineVertex g_line_vertices[MAX_LINES * 2];
 static int g_line_count = 0;
-static int g_debug_frame_counter = 0;
 
 /* Simple shader + buffer for line rendering */
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -3249,6 +3254,7 @@ STASIS_EXPORT int stasis_host_schedule_screenshot(const char* path) {
     g_screenshot_frame = (int)(g_debug_frame_counter + 1);
     g_screenshot_exit_after = 0;
     g_screenshot_taken = false;
+    stasis_renderer_lifecycle_request_redraw(&g_resource_lifecycle);
     return 1;
 }
 
@@ -4703,6 +4709,19 @@ static void stasis_gfx_submit_v2(const int32_t* cmd_i32, const float* cmd_f32, c
     if (text_count > gfx_cmd_max_text) text_count = gfx_cmd_max_text;
     if (text_bytes_used > gfx_cmd_max_text_bytes) text_bytes_used = gfx_cmd_max_text_bytes;
 
+    const int32_t version = cmd_i32[STASIS_RENDER_I_VERSION];
+    const int32_t order_count = version >= STASIS_RENDER_V3_VERSION
+        ? stasis_render_clamp_count(
+            cmd_i32[STASIS_RENDER_I_ORDER_COUNT], STASIS_RENDER_MAX_ORDER)
+        : 0;
+
+    if (stasis_render_is_empty_submission(cmd_i32)) {
+        g_perf_render_started_counter = 0;
+        g_line_count = 0;
+        g_events_pumped_this_frame = 0;
+        return;
+    }
+
     if (!contract_logged) {
         SDL_Log(
             "Stasis render contract v%d trace=%u flags=%d lines=%d rects=%d sprites=%d text=%d",
@@ -4722,11 +4741,6 @@ static void stasis_gfx_submit_v2(const int32_t* cmd_i32, const float* cmd_f32, c
         stasis_clear(cmd_f32[0], cmd_f32[1], cmd_f32[2], cmd_f32[3]);
     }
 
-    const int32_t version = cmd_i32[STASIS_RENDER_I_VERSION];
-    const int32_t order_count = version >= STASIS_RENDER_V3_VERSION
-        ? stasis_render_clamp_count(
-            cmd_i32[STASIS_RENDER_I_ORDER_COUNT], STASIS_RENDER_MAX_ORDER)
-        : 0;
     if (order_count > 0) {
         int32_t pending_kind = 0;
         for (int32_t order_index = 0; order_index < order_count; order_index++) {

--- a/runtime/stasis_render_contract.h
+++ b/runtime/stasis_render_contract.h
@@ -150,6 +150,25 @@ static inline int32_t stasis_render_rect_count(
         STASIS_RENDER_MAX_GEOMETRY - line_count);
 }
 
+static inline int stasis_render_is_empty_submission(const int32_t *cmd_i32) {
+    if (!stasis_render_is_valid(cmd_i32)) return 0;
+    const int32_t line_count = stasis_render_clamp_count(
+        cmd_i32[STASIS_RENDER_I_LINE_COUNT], STASIS_RENDER_MAX_LINES);
+    const int32_t version = cmd_i32[STASIS_RENDER_I_VERSION];
+    const int32_t order_count = version >= STASIS_RENDER_V3_VERSION
+        ? stasis_render_clamp_count(
+            cmd_i32[STASIS_RENDER_I_ORDER_COUNT], STASIS_RENDER_MAX_ORDER)
+        : 0;
+    return cmd_i32[STASIS_RENDER_I_FLAGS] == 0 &&
+        line_count == 0 &&
+        stasis_render_rect_count(cmd_i32, line_count) == 0 &&
+        stasis_render_clamp_count(
+            cmd_i32[STASIS_RENDER_I_SPRITE_COUNT], STASIS_RENDER_MAX_SPRITES) == 0 &&
+        stasis_render_clamp_count(
+            cmd_i32[STASIS_RENDER_I_TEXT_COUNT], STASIS_RENDER_MAX_TEXT) == 0 &&
+        order_count == 0;
+}
+
 static inline int stasis_render_text_span_is_valid(
     int32_t byte_offset,
     int32_t byte_length,

--- a/runtime/stasis_renderer_lifecycle.h
+++ b/runtime/stasis_renderer_lifecycle.h
@@ -24,6 +24,7 @@ typedef enum {
 typedef struct {
     uint32_t surface_generation;
     uint32_t renderer_generation;
+    uint32_t presentation_generation;
     uint32_t restore_attempts;
     uint32_t restore_failures;
     StasisRendererResourceState state;
@@ -40,6 +41,7 @@ static void stasis_renderer_lifecycle_initialize(StasisRendererLifecycle* lifecy
     if (!lifecycle) return;
     lifecycle->surface_generation = 1u;
     lifecycle->renderer_generation = 1u;
+    lifecycle->presentation_generation = 1u;
     lifecycle->restore_attempts = 0u;
     lifecycle->restore_failures = 0u;
     lifecycle->state = STASIS_RENDERER_READY;
@@ -47,10 +49,17 @@ static void stasis_renderer_lifecycle_initialize(StasisRendererLifecycle* lifecy
     lifecycle->reason = STASIS_RENDERER_REASON_NONE;
 }
 
+static void stasis_renderer_lifecycle_request_redraw(StasisRendererLifecycle* lifecycle) {
+    if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
+    lifecycle->presentation_generation =
+        stasis_renderer_next_generation(lifecycle->presentation_generation);
+}
+
 static void stasis_renderer_lifecycle_surface_changed(StasisRendererLifecycle* lifecycle) {
     if (!lifecycle || lifecycle->state == STASIS_RENDERER_UNAVAILABLE) return;
     lifecycle->surface_generation =
         stasis_renderer_next_generation(lifecycle->surface_generation);
+    stasis_renderer_lifecycle_request_redraw(lifecycle);
     lifecycle->reason = STASIS_RENDERER_REASON_SURFACE_CHANGED;
 }
 
@@ -63,6 +72,7 @@ static void stasis_renderer_lifecycle_renderer_reset(
         stasis_renderer_next_generation(lifecycle->surface_generation);
     lifecycle->renderer_generation =
         stasis_renderer_next_generation(lifecycle->renderer_generation);
+    stasis_renderer_lifecycle_request_redraw(lifecycle);
     lifecycle->state = STASIS_RENDERER_RESTORE_PENDING;
     lifecycle->reason = reason;
 }
@@ -80,6 +90,7 @@ static void stasis_renderer_lifecycle_resume(StasisRendererLifecycle* lifecycle)
         ? STASIS_RENDERER_READY
         : STASIS_RENDERER_RESTORE_PENDING;
     lifecycle->reason = STASIS_RENDERER_REASON_FOREGROUND;
+    stasis_renderer_lifecycle_request_redraw(lifecycle);
 }
 
 static int stasis_renderer_lifecycle_begin_restore(StasisRendererLifecycle* lifecycle) {

--- a/runtime/tests/stasis_render_contract_test.c
+++ b/runtime/tests/stasis_render_contract_test.c
@@ -83,10 +83,26 @@ int main(void) {
     CHECK(stasis_render_validate(NULL, first_f32) == STASIS_RENDER_NULL_I32);
     CHECK(stasis_render_validate(first_i32, NULL) == STASIS_RENDER_NULL_F32);
     CHECK(stasis_render_is_valid(first_i32));
+    CHECK(!stasis_render_is_empty_submission(first_i32));
     uint32_t first_trace = stasis_render_trace(first_i32, first_f32, first_u8);
     uint32_t second_trace = stasis_render_trace(second_i32, second_f32, second_u8);
     CHECK(first_trace != 0);
     CHECK(first_trace == second_trace);
+
+    memset(second_i32, 0, STASIS_RENDER_I32_COUNT * sizeof(*second_i32));
+    second_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
+    second_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_CURRENT_VERSION;
+    CHECK(stasis_render_is_empty_submission(second_i32));
+    second_i32[STASIS_RENDER_I_FLAGS] = STASIS_RENDER_FLAG_PRESENT;
+    CHECK(!stasis_render_is_empty_submission(second_i32));
+    second_i32[STASIS_RENDER_I_FLAGS] = 0;
+    second_i32[STASIS_RENDER_I_LINE_COUNT] = 1;
+    CHECK(!stasis_render_is_empty_submission(second_i32));
+    second_i32[STASIS_RENDER_I_LINE_COUNT] = 0;
+    second_i32[STASIS_RENDER_I_ORDER_COUNT] = 1;
+    CHECK(!stasis_render_is_empty_submission(second_i32));
+
+    build_representative_frame(second_i32, second_f32, second_u8);
 
     second_i32[STASIS_RENDER_I_ORDER_BASE + 0] =
         STASIS_RENDER_ORDER_TEXT * STASIS_RENDER_ORDER_KIND_SCALE;

--- a/runtime/tests/stasis_renderer_lifecycle_test.c
+++ b/runtime/tests/stasis_renderer_lifecycle_test.c
@@ -16,13 +16,16 @@ static void test_restore_retry_and_generations(void) {
     CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(lifecycle.surface_generation == 1u);
     CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(lifecycle.presentation_generation == 1u);
 
     stasis_renderer_lifecycle_surface_changed(&lifecycle);
     CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(lifecycle.surface_generation == 2u);
     CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(lifecycle.presentation_generation == 2u);
     stasis_renderer_lifecycle_renderer_reset(
         &lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
+    CHECK(lifecycle.presentation_generation == 3u);
     CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
     stasis_renderer_lifecycle_finish_restore(&lifecycle, 0);
@@ -43,20 +46,36 @@ static void test_pause_reset_and_wrap(void) {
     CHECK(lifecycle.reason == STASIS_RENDERER_REASON_FOREGROUND);
     CHECK(lifecycle.surface_generation == 1u);
     CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(lifecycle.presentation_generation == 2u);
     CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
 
     stasis_renderer_lifecycle_renderer_reset(
         &lifecycle, STASIS_RENDERER_REASON_DEVICE_RESET);
     CHECK(lifecycle.surface_generation == 2u);
     CHECK(lifecycle.renderer_generation == 2u);
+    CHECK(lifecycle.presentation_generation == 3u);
     CHECK(lifecycle.reason == STASIS_RENDERER_REASON_DEVICE_RESET);
 
     lifecycle.surface_generation = UINT32_MAX;
     lifecycle.renderer_generation = UINT32_MAX;
+    lifecycle.presentation_generation = UINT32_MAX;
     stasis_renderer_lifecycle_renderer_reset(
         &lifecycle, STASIS_RENDERER_REASON_TARGETS_RESET);
     CHECK(lifecycle.surface_generation == 1u);
     CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(lifecycle.presentation_generation == 1u);
+}
+
+static void test_explicit_redraw_changes_only_presentation_generation(void) {
+    StasisRendererLifecycle lifecycle = {0};
+    stasis_renderer_lifecycle_initialize(&lifecycle);
+
+    stasis_renderer_lifecycle_request_redraw(&lifecycle);
+
+    CHECK(lifecycle.surface_generation == 1u);
+    CHECK(lifecycle.renderer_generation == 1u);
+    CHECK(lifecycle.presentation_generation == 2u);
+    CHECK(stasis_renderer_lifecycle_can_present(&lifecycle));
 }
 
 static void test_pause_before_restore_preserves_pending_state(void) {
@@ -74,6 +93,7 @@ int main(void) {
     test_restore_retry_and_generations();
     test_pause_reset_and_wrap();
     test_pause_before_restore_preserves_pending_state();
+    test_explicit_redraw_changes_only_presentation_generation();
     puts("stasis_renderer_lifecycle_test: ok");
     return 0;
 }

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -43,6 +43,10 @@ struct TextRun {
     height: f32;
 }
 
+global gfx_redraw_requested: bool;
+global gfx_has_presented_frame: bool;
+global gfx_last_presented_generation: i32;
+
 function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
@@ -94,8 +98,30 @@ function begin_frame(): void {
     gfx_cmd_begin();
 }
 
+function request_redraw(): void {
+    gfx_redraw_requested = true;
+}
+
+function presentation_needs_redraw(): bool {
+    if (!gfx_has_presented_frame || gfx_redraw_requested) {
+        return true;
+    }
+    if (gfx_last_presented_generation != host_presentation_generation()) {
+        return true;
+    }
+    return host_presentation_continuous();
+}
+
+function begin_frame_if_needed(): bool {
+    gfx_cmd_begin();
+    return presentation_needs_redraw();
+}
+
 function end_frame(): void {
     gfx_cmd_mark_present();
+    gfx_redraw_requested = false;
+    gfx_has_presented_frame = true;
+    gfx_last_presented_generation = host_presentation_generation();
 }
 
 function clear(r: f32, g: f32, b: f32, a: f32): void {

--- a/src/stdlib/internal/host_frame.stasis
+++ b/src/stdlib/internal/host_frame.stasis
@@ -37,8 +37,11 @@ const HOST_I_NATIVE_W_PX: i32 = 22;
 const HOST_I_NATIVE_H_PX: i32 = 23;
 const HOST_I_DRAWABLE_W_PX: i32 = 24;
 const HOST_I_DRAWABLE_H_PX: i32 = 25;
+const HOST_I_PRESENTATION_GENERATION: i32 = 20;
+const HOST_I_PRESENTATION_FLAGS: i32 = 21;
+const HOST_PRESENTATION_FLAG_CONTINUOUS: i32 = 1;
 
-// 20,21 and 26..29 removed with integer presentation geometry.
+// 26..29 removed with integer presentation geometry.
 const HOST_I_DISPLAY_GENERATION: i32 = 30;
 const HOST_I_DENSITY_GENERATION: i32 = 31;
 
@@ -124,6 +127,14 @@ function host_window_minimized(): bool {
 
 function host_time_us(): i32 {
     return host_i32[HOST_I_TIME_US];
+}
+
+function host_presentation_generation(): i32 {
+    return host_i32[HOST_I_PRESENTATION_GENERATION];
+}
+
+function host_presentation_continuous(): bool {
+    return host_i32[HOST_I_PRESENTATION_FLAGS] != 0;
 }
 
 function host_logical_width(): f32 {

--- a/tests/stasis/presentation.test.stasis
+++ b/tests/stasis/presentation.test.stasis
@@ -1,0 +1,54 @@
+import "../../src/stdlib/graphics.stasis";
+
+function reset_presentation_test_state(): void {
+    gfx_redraw_requested = false;
+    gfx_has_presented_frame = false;
+    gfx_last_presented_generation = 0;
+    host_i32[HOST_I_PRESENTATION_GENERATION] = 1;
+    host_i32[HOST_I_PRESENTATION_FLAGS] = 0;
+}
+
+test `presentation renders once and then stays clean`(): bool {
+    reset_presentation_test_state();
+    if (!begin_frame_if_needed()) {
+        return false;
+    }
+    end_frame();
+    if (begin_frame_if_needed()) {
+        return false;
+    }
+    return gfx_cmd_i32[GFX_I_FLAGS] == 0 && gfx_cmd_order_count() == 0;
+}
+
+test `semantic request redraws exactly one frame`(): bool {
+    reset_presentation_test_state();
+    end_frame();
+    request_redraw();
+    if (!begin_frame_if_needed()) {
+        return false;
+    }
+    end_frame();
+    return !begin_frame_if_needed();
+}
+
+test `host generation forces lifecycle redraw`(): bool {
+    reset_presentation_test_state();
+    end_frame();
+    host_i32[HOST_I_PRESENTATION_GENERATION] = 2;
+    if (!begin_frame_if_needed()) {
+        return false;
+    }
+    end_frame();
+    return !begin_frame_if_needed();
+}
+
+test `continuous host presentation remains dirty`(): bool {
+    reset_presentation_test_state();
+    end_frame();
+    host_i32[HOST_I_PRESENTATION_FLAGS] = HOST_PRESENTATION_FLAG_CONTINUOUS;
+    if (!begin_frame_if_needed()) {
+        return false;
+    }
+    end_frame();
+    return begin_frame_if_needed();
+}


### PR DESCRIPTION
## What changed

- add `request_redraw()` and `begin_frame_if_needed()` so static screens can return from `render()` before clearing the framebuffer or rebuilding their command stream
- expose a monotonic HostFrame presentation generation that invalidates frames after resize, density, surface, renderer, resume, and capture changes
- keep debug overlays and scheduled captures continuously presentable while active
- bypass renderer setup and presentation for a valid empty command submission
- initialize the version 4 HostFrame presentation fields in generated Android bridges

## Why

Static game screens currently rebuild and submit the full graphics command list at display cadence. On Android this wastes CPU/GPU time, battery, and thermal headroom. The new contract keeps simulation and input cadence independent while allowing presentation only when semantic or host lifecycle state changes.

The command header is still reset on every `begin_frame_if_needed()` call, so a skipped frame cannot replay stale counts or a stale `PRESENT` flag. The framebuffer clear remains behind the returned decision in game code.

## Validation

- focused Stasis presentation tests: 4/4 passed
- native runtime CTest suite: 8/8 passed
- full SDL `stasis_graphics` DLL build passed
- focused generated Android bridge Rust test passed
- `cargo check --workspace --all-targets` passed
- `cargo fmt --all -- --check` passed
- `stasis fmt --check` passed for touched Stasis files
- `git diff --check` passed
- full serial Stasis lib suite: 262 passed; 4 unrelated self-host AOT tests failed only because the configured local signing script returned status 1

Physical-device validation of driver presentation blocking and 60/90/120 Hz behavior remains follow-up work when the downstream game adopts the API.
