### PR TITLE
Fix on-demand presentation lifecycle retries

### DIFF
--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -154,6 +154,8 @@ struct AndroidRuntimeSession {
     display_generation: i32,
     density_scale_bits: u32,
     density_generation: i32,
+    host_presentation_token: i32,
+    presentation_generation: i32,
 }
 
 thread_local! {
@@ -778,7 +780,7 @@ pub fn run_android_workshop_tick(
     entry_file: impl AsRef<Path>,
     input: AndroidBridgeTickInput,
 ) -> Result<AndroidBridgeRunTickResult, String> {
-    run_android_workshop_tick_internal(project_root, entry_file, input, true)
+    run_android_workshop_tick_internal(project_root, entry_file, input, true, 0, 0)
 }
 
 const MAX_EMBEDDED_FONTS: usize = 64;
@@ -1126,6 +1128,8 @@ fn run_android_workshop_tick_internal(
     entry_file: impl AsRef<Path>,
     input: AndroidBridgeTickInput,
     read_legacy_render_commands: bool,
+    host_presentation_token: i32,
+    host_presentation_flags: i32,
 ) -> Result<AndroidBridgeRunTickResult, String> {
     let project_root = project_root.as_ref();
     let entry_file = entry_file.as_ref();
@@ -1157,7 +1161,12 @@ fn run_android_workshop_tick_internal(
         let initialized = if session.initialized {
             false
         } else {
-            write_production_host_frame(session, input)?;
+            write_production_host_frame(
+                session,
+                input,
+                host_presentation_token,
+                host_presentation_flags,
+            )?;
             execute_lifecycle_noarg(&session.jit, "main")?;
             take_embedded_resource_error()?;
             session.initialized = true;
@@ -1166,7 +1175,12 @@ fn run_android_workshop_tick_internal(
             session.density_generation = 0;
             true
         };
-        let metrics = write_production_host_frame(session, input)?;
+        let metrics = write_production_host_frame(
+            session,
+            input,
+            host_presentation_token,
+            host_presentation_flags,
+        )?;
         if read_legacy_render_commands {
             let (touch_x, touch_y) = metrics.native_to_logical(input.touch_x, input.touch_y);
             session
@@ -1239,6 +1253,8 @@ fn hash_global_path(path: &str) -> i32 {
 fn write_production_host_frame(
     session: &mut AndroidRuntimeSession,
     input: AndroidBridgeTickInput,
+    host_presentation_token: i32,
+    host_presentation_flags: i32,
 ) -> Result<AndroidDisplayMetrics, String> {
     const HOST_I32_COUNT: i32 = 768;
     const HOST_F32_COUNT: i32 = 64;
@@ -1281,9 +1297,22 @@ fn write_production_host_frame(
         session.display_signature = signature;
     }
     let raster_scale_bits = metrics.raster_scale.to_bits();
-    if session.density_generation == 0 || raster_scale_bits != session.density_scale_bits {
+    let density_changed =
+        session.density_generation == 0 || raster_scale_bits != session.density_scale_bits;
+    if density_changed {
         session.density_generation = session.density_generation.saturating_add(1);
         session.density_scale_bits = raster_scale_bits;
+    }
+    let host_invalidated =
+        host_presentation_token != 0 && host_presentation_token != session.host_presentation_token;
+    if host_invalidated {
+        session.host_presentation_token = host_presentation_token;
+    }
+    if session.presentation_generation == 0 || resized || density_changed || host_invalidated {
+        session.presentation_generation = session.presentation_generation.wrapping_add(1);
+        if session.presentation_generation == 0 {
+            session.presentation_generation = 1;
+        }
     }
     session.display_metrics = metrics;
 
@@ -1302,12 +1331,14 @@ fn write_production_host_frame(
     host_i32[11] = i32::from(resized);
     host_i32[12] = metrics.native_w;
     host_i32[13] = metrics.native_h;
-    host_i32[14] = 3;
+    host_i32[14] = 4;
     host_i32[15] = 0;
     host_i32[16] = 60;
     host_i32[17] = 1;
     host_i32[18] = 0;
     host_i32[19] = stasis_dynload::stasis_get_time_us();
+    host_i32[20] = session.presentation_generation;
+    host_i32[21] = host_presentation_flags;
     host_i32[22] = metrics.native_w;
     host_i32[23] = metrics.native_h;
     host_i32[24] = metrics.drawable_w;
@@ -1450,6 +1481,8 @@ fn build_runtime_session(
         display_generation: 0,
         density_scale_bits: display_metrics.raster_scale.to_bits(),
         density_generation: 0,
+        host_presentation_token: 0,
+        presentation_generation: 0,
     })
 }
 
@@ -2401,7 +2434,7 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame(
 }
 
 #[no_mangle]
-pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
+pub extern "C" fn stasis_android_bridge_run_tick_frame_v3(
     project_root: *const c_char,
     entry_file: *const c_char,
     touch_x: i32,
@@ -2409,6 +2442,8 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
     touch_active: i32,
     screen_w: i32,
     screen_h: i32,
+    host_presentation_token: i32,
+    host_presentation_flags: i32,
     out_i32: *mut i32,
     out_i32_len: usize,
     out_f32: *mut f32,
@@ -2446,6 +2481,8 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
                 screen_h,
             },
             false,
+            host_presentation_token,
+            host_presentation_flags,
         )?;
         let i32_values = std::slice::from_raw_parts_mut(out_i32, out_i32_len);
         let f32_values = std::slice::from_raw_parts_mut(out_f32, out_f32_len);
@@ -2475,6 +2512,41 @@ pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
             -1
         }
     }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_run_tick_frame_v2(
+    project_root: *const c_char,
+    entry_file: *const c_char,
+    touch_x: i32,
+    touch_y: i32,
+    touch_active: i32,
+    screen_w: i32,
+    screen_h: i32,
+    out_i32: *mut i32,
+    out_i32_len: usize,
+    out_f32: *mut f32,
+    out_f32_len: usize,
+    out_u8: *mut u8,
+    out_u8_len: usize,
+) -> i32 {
+    stasis_android_bridge_run_tick_frame_v3(
+        project_root,
+        entry_file,
+        touch_x,
+        touch_y,
+        touch_active,
+        screen_w,
+        screen_h,
+        0,
+        0,
+        out_i32,
+        out_i32_len,
+        out_f32,
+        out_f32_len,
+        out_u8,
+        out_u8_len,
+    )
 }
 
 #[no_mangle]
@@ -3652,6 +3724,8 @@ mod tests {
             display_generation: 0,
             density_scale_bits: 1.0f32.to_bits(),
             density_generation: 0,
+            host_presentation_token: 0,
+            presentation_generation: 0,
         };
 
         assert!(activate_pending_runtime_candidate(&mut session)
@@ -4186,8 +4260,13 @@ global host_req_window_h_px: i32;
 global gfx_cmd_i32: i32[34608];
 global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
+global observed_presentation_generation: i32;
+global observed_presentation_flags: i32;
 function main(): void { host_req_window_w_px = 360; host_req_window_h_px = 720; }
-function tick(): void {}
+function tick(): void {
+  observed_presentation_generation = host_i32[20];
+  observed_presentation_flags = host_i32[21];
+}
 function render(): void {
   gfx_cmd_i32[0] = 1196967473;
   gfx_cmd_i32[1] = 3;
@@ -4228,7 +4307,7 @@ function render(): void {
         let mut frame_i32 = vec![0i32; ANDROID_RENDER_GFX_I32_CAPACITY];
         let mut frame_f32 = vec![0.0f32; ANDROID_RENDER_GFX_F32_CAPACITY];
         let mut frame_u8 = vec![0u8; ANDROID_RENDER_GFX_U8_CAPACITY];
-        let status = stasis_android_bridge_run_tick_frame_v2(
+        let status = stasis_android_bridge_run_tick_frame_v3(
             root_c.as_ptr(),
             entry_c.as_ptr(),
             540,
@@ -4236,6 +4315,8 @@ function render(): void {
             1,
             1080,
             2400,
+            1,
+            1,
             frame_i32.as_mut_ptr(),
             frame_i32.len(),
             frame_f32.as_mut_ptr(),
@@ -4244,6 +4325,24 @@ function render(): void {
             frame_u8.len(),
         );
         assert_eq!(status, 0);
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                "src/main.stasis",
+                "observed_presentation_generation",
+            )
+            .expect("read presentation generation"),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                "src/main.stasis",
+                "observed_presentation_flags",
+            )
+            .expect("read presentation flags"),
+            1
+        );
         assert_eq!(&frame_i32[..5], &[1196967473, 3, 3, 1, 1]);
         assert_eq!(&frame_i32[10..16], &[360, 720, 1080, 2400, 1080, 2400]);
         assert_eq!(&frame_i32[16..20], &[0, 0, 360, 720]);
@@ -4258,6 +4357,60 @@ function render(): void {
         assert_eq!(&frame_f32[80004..80008], &[10.25, 20.5, 30.75, 40.125]);
         assert_eq!(frame_f32[96388], 12.0);
         assert_eq!(&frame_u8[..2], &[65, 0]);
+        let status = stasis_android_bridge_run_tick_frame_v3(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            540,
+            1200,
+            1,
+            1080,
+            2400,
+            2,
+            0,
+            frame_i32.as_mut_ptr(),
+            frame_i32.len(),
+            frame_f32.as_mut_ptr(),
+            frame_f32.len(),
+            frame_u8.as_mut_ptr(),
+            frame_u8.len(),
+        );
+        assert_eq!(status, 0);
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                "src/main.stasis",
+                "observed_presentation_generation",
+            )
+            .expect("read changed presentation generation"),
+            3
+        );
+        let status = stasis_android_bridge_run_tick_frame_v3(
+            root_c.as_ptr(),
+            entry_c.as_ptr(),
+            540,
+            1200,
+            1,
+            1080,
+            2400,
+            i32::MIN,
+            0,
+            frame_i32.as_mut_ptr(),
+            frame_i32.len(),
+            frame_f32.as_mut_ptr(),
+            frame_f32.len(),
+            frame_u8.as_mut_ptr(),
+            frame_u8.len(),
+        );
+        assert_eq!(status, 0);
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                "src/main.stasis",
+                "observed_presentation_generation",
+            )
+            .expect("read wrapped-token presentation generation"),
+            4
+        );
         fs::remove_dir_all(&root).ok();
     }
 

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -90,6 +90,9 @@ rebuilding the command list. `request_redraw()` marks a semantic game change; a
 monotonic HostFrame presentation generation independently forces the first frame
 and redraws after resize, density, surface, renderer, resume, and capture changes.
 `end_frame()` consumes both sources only when the game submits a present.
+The host keeps the continuous flag set while a restore placeholder, resource
+retry, or capture is pending, so a guest redraw cannot be consumed before the
+surface actually becomes presentable.
 
 This is an explicit invalidation contract, not a command-buffer hash. An empty
 clean submission takes a renderer-free runtime fast path while host input and

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -18,7 +18,7 @@
 typedef char *(*stasis_android_bridge_compile_project_fn)(const char *project_root, const char *entry_file);
 typedef char *(*stasis_android_bridge_run_tests_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_run_tick_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h);
-typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len);
+typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int presentation_generation, int presentation_flags, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len);
 typedef char *(*stasis_android_bridge_last_frame_error_fn)(void);
 typedef char *(*stasis_android_bridge_inspect_runtime_state_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_set_i32_global_fn)(const char *project_root, const char *entry_file, const char *path, int value);
@@ -173,7 +173,7 @@ static RustBridgeApi *load_rust_bridge_api(void) {
     rust_bridge_api.run_tick =
             (stasis_android_bridge_run_tick_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick");
     rust_bridge_api.run_tick_frame =
-            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v2");
+            (stasis_android_bridge_run_tick_frame_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_run_tick_frame_v3");
     rust_bridge_api.last_frame_error =
             (stasis_android_bridge_last_frame_error_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_last_frame_error");
     rust_bridge_api.inspect_runtime_state =
@@ -431,13 +431,13 @@ static int try_rust_bridge_get_i32_global(const char *project_root, const char *
     bridge->free_string(bridge_message);
     return 1;
 }
-static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
+static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int presentation_generation, int presentation_flags, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
     RustBridgeApi *bridge = load_rust_bridge_api();
     if (bridge == NULL || bridge->run_tick_frame == NULL) {
         return -1;
     }
     return bridge->run_tick_frame(project_root, "src/main.stasis", touch_x, touch_y, touch_active,
-            screen_w, screen_h, out_i32, out_i32_len, out_f32, out_f32_len,
+            screen_w, screen_h, presentation_generation, presentation_flags, out_i32, out_i32_len, out_f32, out_f32_len,
             out_u8, out_u8_len);
 }
 JNIEXPORT jstring JNICALL
@@ -748,7 +748,7 @@ Java_com_stasislang_workshop_MainActivity_nativeSemanticEdit(
     return response;
 }
 JNIEXPORT jint JNICALL
-Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h, jobject frame_i32, jobject frame_f32, jobject frame_u8) {
+Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass activity_class, jstring project_root, jint touch_x, jint touch_y, jint touch_active, jint screen_w, jint screen_h, jint presentation_generation, jint presentation_flags, jobject frame_i32, jobject frame_f32, jobject frame_u8) {
     (void)activity_class;
     int32_t *values_i32 = (int32_t *)(*env)->GetDirectBufferAddress(env, frame_i32);
     float *values_f32 = (float *)(*env)->GetDirectBufferAddress(env, frame_f32);
@@ -771,6 +771,7 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
 
     int status = try_rust_bridge_run_tick_frame(
             root, (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h,
+            (int)presentation_generation, (int)presentation_flags,
             values_i32, STASIS_RENDER_I32_COUNT, values_f32, STASIS_RENDER_F32_COUNT,
             values_u8, STASIS_RENDER_U8_COUNT);
     (*env)->ReleaseStringUTFChars(env, project_root, root);

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/RendererResourceLifecycle.java
@@ -5,6 +5,7 @@ final class RendererResourceLifecycle {
 
     private int surfaceGeneration;
     private int rendererGeneration;
+    private int presentationGeneration;
     private int restoreAttempts;
     private int restoreFailures;
     private State state = State.UNAVAILABLE;
@@ -14,6 +15,7 @@ final class RendererResourceLifecycle {
     void onRendererCreated() {
         surfaceGeneration = nextGeneration(surfaceGeneration);
         rendererGeneration = nextGeneration(rendererGeneration);
+        requestRedraw();
         state = State.RESTORE_PENDING;
         reason = "renderer_created";
     }
@@ -21,6 +23,7 @@ final class RendererResourceLifecycle {
     void onSurfaceChanged() {
         if (state == State.UNAVAILABLE) return;
         surfaceGeneration = nextGeneration(surfaceGeneration);
+        requestRedraw();
         reason = "surface_changed";
     }
 
@@ -35,6 +38,11 @@ final class RendererResourceLifecycle {
         if (state != State.PAUSED) return;
         state = stateBeforePause == State.READY ? State.READY : State.RESTORE_PENDING;
         reason = "foreground";
+        requestRedraw();
+    }
+
+    void requestRedraw() {
+        presentationGeneration = nextGeneration(presentationGeneration);
     }
 
     boolean beginRestore() {
@@ -51,29 +59,33 @@ final class RendererResourceLifecycle {
         } else {
             restoreFailures = nextCounter(restoreFailures);
             state = State.RESTORE_FAILED;
+            requestRedraw();
         }
     }
 
     void deferRestore() {
         if (state != State.RESTORING) return;
         state = State.RESTORE_PENDING;
+        requestRedraw();
     }
 
     void resourceFailed() {
         if (state == State.UNAVAILABLE || state == State.PAUSED) return;
         restoreFailures = nextCounter(restoreFailures);
         state = State.RESTORE_FAILED;
+        requestRedraw();
     }
 
     boolean canPresent() { return state == State.READY; }
     int surfaceGeneration() { return surfaceGeneration; }
     int rendererGeneration() { return rendererGeneration; }
+    int presentationGeneration() { return presentationGeneration; }
     int restoreAttempts() { return restoreAttempts; }
     int restoreFailures() { return restoreFailures; }
     State state() { return state; }
     String reason() { return reason; }
 
-    private static int nextGeneration(int value) {
+    static int nextGeneration(int value) {
         value += 1;
         return value == 0 ? 1 : value;
     }

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -273,6 +273,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                             new byte[0], new int[0]));
         }
         pendingCapture = callback;
+        resourceLifecycle.requestRedraw();
     }
 
     synchronized void onHostPaused() {
@@ -281,6 +282,26 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
 
     synchronized void onHostResumed() {
         resourceLifecycle.onResume();
+    }
+
+    synchronized int presentationGeneration() {
+        return resourceLifecycle.presentationGeneration();
+    }
+
+    synchronized int presentationFlags() {
+        return hasPendingPresentationWork(
+                restorePlaceholderPending,
+                resourceLifecycle.canPresent(),
+                pendingCapture != null) ? 1 : 0;
+    }
+
+    synchronized boolean shouldScheduleRender() {
+        return shouldPresent(frameI32) || presentationFlags() != 0;
+    }
+
+    static boolean hasPendingPresentationWork(
+            boolean placeholderPending, boolean canPresent, boolean capturePending) {
+        return placeholderPending || !canPresent || capturePending;
     }
 
     @Override
@@ -381,8 +402,9 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                     }
                 }
             }
-            capture = pendingCapture;
-            pendingCapture = null;
+            capture = hasFrame && restored && resourceLifecycle.canPresent()
+                    ? pendingCapture : null;
+            if (capture != null) pendingCapture = null;
             capturedFrame = capture == null ? null : captureLogicalFrame();
         }
         captureIfRequested(capture, capturedFrame);

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/RendererResourceLifecycleTest.java
@@ -14,11 +14,13 @@ public final class RendererResourceLifecycleTest {
         lifecycle.onSurfaceChanged();
         assertEquals(2, lifecycle.surfaceGeneration());
         assertEquals(1, lifecycle.rendererGeneration());
+        assertEquals(2, lifecycle.presentationGeneration());
         assertFalse(lifecycle.canPresent());
 
         assertTrue(lifecycle.beginRestore());
         lifecycle.finishRestore(false);
         assertFalse(lifecycle.canPresent());
+        assertEquals(3, lifecycle.presentationGeneration());
         assertTrue(lifecycle.beginRestore());
         lifecycle.finishRestore(true);
         assertTrue(lifecycle.canPresent());
@@ -38,10 +40,12 @@ public final class RendererResourceLifecycleTest {
         assertEquals(RendererResourceLifecycle.State.READY, lifecycle.state());
         assertEquals(1, lifecycle.surfaceGeneration());
         assertEquals(1, lifecycle.rendererGeneration());
+        assertEquals(2, lifecycle.presentationGeneration());
         assertEquals("foreground", lifecycle.reason());
         lifecycle.onRendererCreated();
         assertEquals(2, lifecycle.surfaceGeneration());
         assertEquals(2, lifecycle.rendererGeneration());
+        assertEquals(3, lifecycle.presentationGeneration());
         assertFalse(lifecycle.canPresent());
     }
 
@@ -57,8 +61,30 @@ public final class RendererResourceLifecycleTest {
         assertEquals(RendererResourceLifecycle.State.READY, lifecycle.state());
         assertEquals(2, lifecycle.surfaceGeneration());
         assertEquals(1, lifecycle.rendererGeneration());
+        assertEquals(2, lifecycle.presentationGeneration());
         assertTrue(lifecycle.canPresent());
         assertEquals("surface_changed", lifecycle.reason());
+    }
+
+    @Test
+    public void explicitRedrawOnlyAdvancesPresentationGeneration() {
+        RendererResourceLifecycle lifecycle = new RendererResourceLifecycle();
+        lifecycle.onRendererCreated();
+        int surface = lifecycle.surfaceGeneration();
+        int renderer = lifecycle.rendererGeneration();
+
+        lifecycle.requestRedraw();
+
+        assertEquals(surface, lifecycle.surfaceGeneration());
+        assertEquals(renderer, lifecycle.rendererGeneration());
+        assertEquals(2, lifecycle.presentationGeneration());
+    }
+
+    @Test
+    public void presentationGenerationWrapsAcrossSignedRangeWithoutZero() {
+        assertEquals(Integer.MIN_VALUE,
+                RendererResourceLifecycle.nextGeneration(Integer.MAX_VALUE));
+        assertEquals(1, RendererResourceLifecycle.nextGeneration(0));
     }
 
     @Test
@@ -85,6 +111,7 @@ public final class RendererResourceLifecycleTest {
         assertEquals(RendererResourceLifecycle.State.RESTORE_PENDING, lifecycle.state());
         assertFalse(lifecycle.canPresent());
         assertEquals(0, lifecycle.restoreFailures());
+        assertEquals(2, lifecycle.presentationGeneration());
         assertTrue(lifecycle.beginRestore());
     }
 }

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -18,6 +18,14 @@ public final class StasisPreviewRendererSchemaTest {
     }
 
     @Test
+    public void placeholderRestoreAndCaptureKeepSchedulingUntilPresentable() {
+        assertTrue(StasisPreviewRenderer.hasPendingPresentationWork(true, true, false));
+        assertTrue(StasisPreviewRenderer.hasPendingPresentationWork(false, false, false));
+        assertTrue(StasisPreviewRenderer.hasPendingPresentationWork(false, true, true));
+        assertFalse(StasisPreviewRenderer.hasPendingPresentationWork(false, true, false));
+    }
+
+    @Test
     public void replacedCaptureIncludesEmptyTypedSpriteLanes() {
         StasisPreviewRenderer renderer = new StasisPreviewRenderer(
                 new StasisPreviewRenderer.TextureProvider() {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -349,7 +349,8 @@ public final class MainActivity extends Activity {
                                                     boolean dryRun, boolean validate, boolean runTests);
     private static native String nativeRunTick(String projectRoot, int touchX, int touchY, int touchActive, int screenWidth, int screenHeight);
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
-            int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
+            int touchActive, int screenWidth, int screenHeight, int presentationGeneration,
+            int presentationFlags, ByteBuffer frameI32,
             ByteBuffer frameF32, ByteBuffer frameU8);
     private static native String nativeLastFrameError();
     private static native String nativeInspectRuntimeState(String projectRoot);
@@ -11792,12 +11793,14 @@ public final class MainActivity extends Activity {
                 long started = System.nanoTime();
                 lastRendererSyncWaitNanos = started - requested;
                 status = nativeRunFrameInto(projectRoot, inputX, inputY, inputActive,
-                        screenWidth, screenHeight, renderer.frameI32Bytes(),
+                        screenWidth, screenHeight, renderer.presentationGeneration(),
+                        renderer.presentationFlags(),
+                        renderer.frameI32Bytes(),
                         renderer.frameF32Bytes(), renderer.frameU8Bytes());
                 lastNativeFrameDurationNanos = System.nanoTime() - started;
                 renderer.copyFrameHeaderInto(header);
             }
-            if (status == 0) requestRender();
+            if (status == 0 && renderer.shouldScheduleRender()) requestRender();
             return status;
         }
 
@@ -11811,7 +11814,6 @@ public final class MainActivity extends Activity {
 
         void captureFrame(CaptureCallback callback) {
             renderer.requestCapture(callback::onCaptured);
-            requestRender();
         }
 
         StasisPreviewRenderer.LogicalFrameSnapshot logicalFrameSnapshot() {

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -1172,7 +1172,8 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     out_i32[19] = stasis_get_time_us();
 
     out_i32[20] = (int32_t)g_resource_lifecycle.presentation_generation;
-    out_i32[21] = (g_force_debug_overlay ||
+    out_i32[21] = (!stasis_renderer_lifecycle_can_present(&g_resource_lifecycle) ||
+        g_force_debug_overlay ||
         (!g_screenshot_taken && g_screenshot_path[0] != 0 &&
             g_debug_frame_counter + 1 <= g_screenshot_frame)) ? 1 : 0;
     out_i32[22] = g_display_metrics.native_w;

--- a/runtime/stasis_renderer_lifecycle.h
+++ b/runtime/stasis_renderer_lifecycle.h
@@ -114,6 +114,7 @@ static void stasis_renderer_lifecycle_finish_restore(
     } else {
         lifecycle->restore_failures += 1u;
         lifecycle->state = STASIS_RENDERER_RESTORE_FAILED;
+        stasis_renderer_lifecycle_request_redraw(lifecycle);
     }
 }
 

--- a/runtime/tests/stasis_mobile_frame_pacer_test.c
+++ b/runtime/tests/stasis_mobile_frame_pacer_test.c
@@ -20,6 +20,14 @@ static void test_fills_the_remainder_of_a_high_refresh_frame(void) {
     check(stasis_mobile_frame_pacer_wait_ns(&pacer, 1000 + 25000000) == 8333334);
 }
 
+static void test_fills_the_remainder_after_a_ninety_hz_present(void) {
+    StasisMobileFramePacer pacer;
+    stasis_mobile_frame_pacer_reset(&pacer, 1500);
+
+    check(stasis_mobile_frame_pacer_wait_ns(&pacer, 1500 + 11111111) == 5555556);
+    check(pacer.next_deadline_ns == 1500 + 33333334);
+}
+
 static void test_vsync_at_sixty_hz_needs_no_extra_sleep(void) {
     StasisMobileFramePacer pacer;
     stasis_mobile_frame_pacer_reset(&pacer, 2000);
@@ -55,6 +63,7 @@ static void test_long_pause_resets_without_a_catch_up_burst(void) {
 
 int main(void) {
     test_fills_the_remainder_of_a_high_refresh_frame();
+    test_fills_the_remainder_after_a_ninety_hz_present();
     test_vsync_at_sixty_hz_needs_no_extra_sleep();
     test_small_overrun_preserves_the_next_absolute_deadline();
     test_long_pause_resets_without_a_catch_up_burst();

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -29,6 +29,7 @@ static int render_calls;
 static int32_t main_result;
 static int32_t tick_result;
 static int32_t render_result;
+static int render_present;
 static int begin_frame_calls;
 static int end_frame_calls;
 static int host_frame_calls;
@@ -112,6 +113,7 @@ void stasis_gfx_submit_u8(
     assert(cmd_i32[STASIS_RENDER_I_MAGIC] == STASIS_RENDER_V2_MAGIC);
     assert(cmd_i32[STASIS_RENDER_I_VERSION] == STASIS_RENDER_V2_VERSION);
     gfx_submit_calls += 1;
+    if (stasis_render_is_empty_submission(cmd_i32)) return;
     stasis_begin_frame();
     stasis_end_frame();
 }
@@ -240,6 +242,8 @@ static int32_t game_render(void) {
     render_calls += 1;
     game_gfx_cmd_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
     game_gfx_cmd_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V2_VERSION;
+    game_gfx_cmd_i32[STASIS_RENDER_I_FLAGS] =
+        render_present ? STASIS_RENDER_FLAG_PRESENT : 0;
     return render_result;
 }
 
@@ -277,6 +281,7 @@ static void reset_fakes(void) {
     main_result = 0;
     tick_result = 0;
     render_result = 0;
+    render_present = 1;
     begin_frame_calls = 0;
     end_frame_calls = 0;
     host_frame_calls = 0;
@@ -379,6 +384,23 @@ static void test_rejects_duplicate_initialization(void) {
     stasis_mobile_runtime_shutdown();
 }
 
+static void test_clean_submission_keeps_ticks_without_presenting(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+    render_present = 0;
+
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(tick_calls == 2);
+    assert(render_calls == 2);
+    assert(host_frame_calls == 2);
+    assert(gfx_submit_calls == 2);
+    assert(begin_frame_calls == 0);
+    assert(end_frame_calls == 0);
+    stasis_mobile_runtime_shutdown();
+}
+
 static void test_reports_graphics_initialization_failure(void) {
     StasisMobileRuntimeConfig valid_config = config();
     StasisMobileGameEntries valid_entries = entries();
@@ -434,6 +456,8 @@ int main(void) {
     test_runs_mobile_lifecycle();
     reset_fakes();
     test_rejects_duplicate_initialization();
+    reset_fakes();
+    test_clean_submission_keeps_ticks_without_presenting();
     reset_fakes();
     test_reports_graphics_initialization_failure();
     reset_fakes();

--- a/runtime/tests/stasis_renderer_lifecycle_test.c
+++ b/runtime/tests/stasis_renderer_lifecycle_test.c
@@ -29,6 +29,7 @@ static void test_restore_retry_and_generations(void) {
     CHECK(!stasis_renderer_lifecycle_can_present(&lifecycle));
     CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));
     stasis_renderer_lifecycle_finish_restore(&lifecycle, 0);
+    CHECK(lifecycle.presentation_generation == 4u);
     CHECK(lifecycle.restore_attempts == 1u);
     CHECK(lifecycle.restore_failures == 1u);
     CHECK(stasis_renderer_lifecycle_begin_restore(&lifecycle));


### PR DESCRIPTION
## Summary
- complete task #198 Android Workshop HostFrame v4 presentation-generation wiring
- keep placeholder, restore retry, and capture work scheduled until a frame actually presents
- preserve the v2 bridge ABI and add a v3 presentation contract with signed-wrap coverage
- verify static ticks skip GPU presentation while 60/90/120 Hz pacing remains deterministic

This is the required same-task review follow-up to merged core PR #434.

## Validation
- full Cargo workspace/all-target serial suite passed
- native render/lifecycle/mobile runtime/frame pacer contracts: 4/4 passed
- Android Workshop lifecycle/schema JVM tests: 22/22 passed
- Android bridge library suite passed
- Stasis presentation fixture passed in normal and JSON modes
- portable validation: 50/50 Python contract tests plus render parity passed
- canonical validation reaches the unchanged stasis_ai unsafe-boundary gate after layout/SDL3/JIT checks pass

## Review
Independent review found and verified fixes for restore starvation, placeholder scheduling, ABI versioning, and signed generation wrap; final re-review is clean.