### PR TITLE
compiler: implement eligible @inline lowering

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -3032,6 +3032,27 @@ function end_frame(): void { return; }
         let _ = fs::remove_dir_all(&temp_root);
     }
 
+    #[test]
+    fn aot_inlines_eligible_expression_and_keeps_real_function_object() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function @inline helper(value: i32): i32 { return value + 1; }\nfunction main(): i32 { return helper(9); }\n",
+        );
+        let captured = capture_aot_clif_by_function(&mut process);
+        let main = captured.get("main").expect("main CLIF");
+        assert!(
+            !main.lines().any(|line| line.contains("call fn")),
+            "eligible @inline call remained in AOT CLIF:\n{main}"
+        );
+        assert!(captured.contains_key("helper"));
+        assert_eq!(
+            process.artifacts().len(),
+            2,
+            "AOT must retain a real object for an inline function"
+        );
+    }
+
     #[cfg(windows)]
     #[test]
     fn aot_and_jit_match_internal_call_fixture_results() {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3844,6 +3844,45 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_inlines_eligible_expression_and_keeps_real_function() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "function @inline helper(value: i32): i32 { return value + 1; }\nfunction main(): i32 { return helper(9); }\n",
+        );
+        process.compile().expect("compile inline fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute inline fixture"),
+            10
+        );
+        let main = process.clif_for_function_name("main").expect("main CLIF");
+        assert!(
+            !main.lines().any(|line| line.contains("call fn")),
+            "eligible @inline call remained in JIT CLIF:\n{main}"
+        );
+        assert!(
+            process.clif_for_function_name("helper").is_some(),
+            "the real inline function must remain independently callable"
+        );
+
+        process.upsert_file(
+            "sample.stasis",
+            "function @inline helper(value: i32): i32 { return value + 2; }\nfunction main(): i32 { return helper(9); }\n",
+        );
+        process.compile().expect("hot patch inline callee");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute patched inline fixture"),
+            11,
+            "changing an inline callee must regenerate callers that embed its body"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_process_executes_print_string_literal_statement() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3883,6 +3883,28 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_inline_preserves_overloads_and_indexed_struct_fields() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Enemy { hp: i32; }\nstruct Player { score: i32; }\nglobal enemies: Enemy[2];\nglobal player: Player;\nfunction @inline hp(enemy: Enemy): i32 { return enemy.hp; }\nfunction @inline value(item: Enemy): i32 { return item.hp + 100; }\nfunction value(item: Player): i32 { return item.score; }\nfunction main(): i32 { enemies[0].hp = 7; player.score = 5; return hp(enemies[0]) + value(player); }\n",
+        );
+        process.compile().expect("compile inline review fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute inline review fixture"),
+            12
+        );
+        let main = process.clif_for_function_name("main").expect("main CLIF");
+        assert!(
+            main.lines().any(|line| line.contains("call fn")),
+            "same-arity overload call must remain for typed backend selection:\n{main}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_process_executes_print_string_literal_statement() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -44,6 +44,8 @@ pub struct FunctionMeta {
     pub param_names: Vec<String>,
     pub params: Vec<TypeId>,
     pub return_type: TypeId,
+    /// Requests body substitution at eligible call sites. The real function is still emitted.
+    pub inline: bool,
     pub dependencies: Vec<FunctionId>,
     pub dependents: Vec<FunctionId>,
     pub call_sites: Vec<FunctionCallSite>,
@@ -669,6 +671,7 @@ impl Compiler {
                     param_names: indexed_function.param_names,
                     params: indexed_function.params,
                     return_type: indexed_function.return_type,
+                    inline: indexed_function.inline,
                     dependencies: Vec::new(),
                     dependents: Vec::new(),
                     call_sites: Vec::new(),
@@ -1067,6 +1070,43 @@ impl Compiler {
             &self.module_resolution,
         )
         .map_err(CompileError::Frontend)?;
+        let mut inline_candidates = Vec::new();
+        for candidate in self.functions.iter().filter(|candidate| candidate.inline) {
+            let Some(candidate_statements) =
+                self.parsed_statements.get(candidate.storage_index as usize)
+            else {
+                continue;
+            };
+            let [SimpleStmt::Return(expression)] = candidate_statements.as_slice() else {
+                continue;
+            };
+            let candidate_file = self.files.get(candidate.file_id as usize).ok_or_else(|| {
+                CompileError::Invariant(format!(
+                    "inline function '{}' references missing file",
+                    candidate.name
+                ))
+            })?;
+            let mut qualified_body = vec![SimpleStmt::Return(expression.clone())];
+            qualify_module_calls(
+                &mut qualified_body,
+                &candidate_file.path,
+                &self.module_graph,
+                &self.files,
+                &self.functions,
+                &self.module_resolution,
+            )
+            .map_err(CompileError::Frontend)?;
+            let SimpleStmt::Return(expression) = qualified_body.remove(0) else {
+                unreachable!("inline candidate shape was already checked")
+            };
+            inline_candidates.push(InlineExpressionCandidate {
+                id: candidate.id,
+                qualified_name: format!("{}.{}", candidate.module_alias, candidate.name),
+                param_names: candidate.param_names.clone(),
+                expression,
+            });
+        }
+        inline_expression_calls(&mut statements, &inline_candidates, function.id);
         Ok(FunctionHIR {
             blocks: vec![Block { source: body }],
             statements,
@@ -1363,6 +1403,222 @@ fn compile_error_message(error: &CompileError) -> &str {
 struct PreviousFunctionHashes {
     signature_hash: u64,
     body_hash: u64,
+}
+
+#[derive(Clone)]
+struct InlineExpressionCandidate {
+    id: FunctionId,
+    qualified_name: String,
+    param_names: Vec<String>,
+    expression: SimpleExpr,
+}
+
+fn inline_expression_calls(
+    statements: &mut [SimpleStmt],
+    candidates: &[InlineExpressionCandidate],
+    caller_id: FunctionId,
+) {
+    fn substitute_identifier(path: &str, arguments: &BTreeMap<String, SimpleExpr>) -> SimpleExpr {
+        if let Some(argument) = arguments.get(path) {
+            return argument.clone();
+        }
+        if let Some((root, suffix)) = path.split_once('.') {
+            if let Some(SimpleExpr::Identifier(argument_root)) = arguments.get(root) {
+                return SimpleExpr::Identifier(format!("{argument_root}.{suffix}"));
+            }
+        }
+        SimpleExpr::Identifier(path.to_string())
+    }
+
+    fn is_safe_argument(expression: &SimpleExpr) -> bool {
+        match expression {
+            SimpleExpr::Int(_)
+            | SimpleExpr::Float(_)
+            | SimpleExpr::Bool(_)
+            | SimpleExpr::StringLiteral(_)
+            | SimpleExpr::Identifier(_) => true,
+            SimpleExpr::IndexedPath { index, .. } => is_safe_argument(index),
+            SimpleExpr::Binary { lhs, rhs, .. } => is_safe_argument(lhs) && is_safe_argument(rhs),
+            SimpleExpr::Condition(condition) => is_safe_condition(condition),
+            SimpleExpr::Call { .. } => false,
+        }
+    }
+
+    fn is_safe_condition(condition: &SimpleCondition) -> bool {
+        match condition {
+            SimpleCondition::Comparison { lhs, rhs, .. } => {
+                is_safe_argument(lhs) && is_safe_argument(rhs)
+            }
+            SimpleCondition::Expr(expression) => is_safe_argument(expression),
+            SimpleCondition::And(lhs, rhs) | SimpleCondition::Or(lhs, rhs) => {
+                is_safe_condition(lhs) && is_safe_condition(rhs)
+            }
+            SimpleCondition::Not(inner) => is_safe_condition(inner),
+        }
+    }
+
+    fn condition(
+        value: &mut SimpleCondition,
+        candidates: &[InlineExpressionCandidate],
+        caller_id: FunctionId,
+        arguments: Option<&BTreeMap<String, SimpleExpr>>,
+        stack: &mut Vec<FunctionId>,
+    ) {
+        match value {
+            SimpleCondition::Comparison { lhs, rhs, .. } => {
+                expression(lhs, candidates, caller_id, arguments, stack);
+                expression(rhs, candidates, caller_id, arguments, stack);
+            }
+            SimpleCondition::Expr(value) => {
+                expression(value, candidates, caller_id, arguments, stack)
+            }
+            SimpleCondition::And(lhs, rhs) | SimpleCondition::Or(lhs, rhs) => {
+                condition(lhs, candidates, caller_id, arguments, stack);
+                condition(rhs, candidates, caller_id, arguments, stack);
+            }
+            SimpleCondition::Not(inner) => {
+                condition(inner, candidates, caller_id, arguments, stack)
+            }
+        }
+    }
+
+    fn expression(
+        value: &mut SimpleExpr,
+        candidates: &[InlineExpressionCandidate],
+        caller_id: FunctionId,
+        arguments: Option<&BTreeMap<String, SimpleExpr>>,
+        stack: &mut Vec<FunctionId>,
+    ) {
+        match value {
+            SimpleExpr::Identifier(path) => {
+                if let Some(arguments) = arguments {
+                    *value = substitute_identifier(path, arguments);
+                }
+            }
+            SimpleExpr::IndexedPath {
+                collection_path,
+                index,
+                ..
+            } => {
+                if let Some(arguments) = arguments {
+                    if let Some(SimpleExpr::Identifier(argument_path)) =
+                        arguments.get(collection_path)
+                    {
+                        *collection_path = argument_path.clone();
+                    }
+                }
+                expression(index, candidates, caller_id, arguments, stack);
+            }
+            SimpleExpr::Call { target, args } => {
+                for argument in args.iter_mut() {
+                    expression(argument, candidates, caller_id, arguments, stack);
+                }
+                let matches = candidates
+                    .iter()
+                    .filter(|candidate| {
+                        candidate.qualified_name == *target
+                            && candidate.param_names.len() == args.len()
+                            && candidate.id != caller_id
+                            && !stack.contains(&candidate.id)
+                    })
+                    .collect::<Vec<_>>();
+                if matches.len() != 1 || !args.iter().all(is_safe_argument) {
+                    return;
+                }
+                let candidate = matches[0];
+                let replacements = candidate
+                    .param_names
+                    .iter()
+                    .cloned()
+                    .zip(args.iter().cloned())
+                    .collect::<BTreeMap<_, _>>();
+                let mut inlined = candidate.expression.clone();
+                stack.push(candidate.id);
+                expression(
+                    &mut inlined,
+                    candidates,
+                    caller_id,
+                    Some(&replacements),
+                    stack,
+                );
+                stack.pop();
+                *value = inlined;
+            }
+            SimpleExpr::Binary { lhs, rhs, .. } => {
+                expression(lhs, candidates, caller_id, arguments, stack);
+                expression(rhs, candidates, caller_id, arguments, stack);
+            }
+            SimpleExpr::Condition(value) => {
+                condition(value, candidates, caller_id, arguments, stack)
+            }
+            SimpleExpr::Int(_)
+            | SimpleExpr::Float(_)
+            | SimpleExpr::Bool(_)
+            | SimpleExpr::StringLiteral(_) => {}
+        }
+    }
+
+    fn statement(
+        value: &mut SimpleStmt,
+        candidates: &[InlineExpressionCandidate],
+        caller_id: FunctionId,
+        stack: &mut Vec<FunctionId>,
+    ) {
+        match value {
+            SimpleStmt::Let {
+                expression: value, ..
+            }
+            | SimpleStmt::Assign {
+                expression: value, ..
+            }
+            | SimpleStmt::Expr(value)
+            | SimpleStmt::Return(value) => expression(value, candidates, caller_id, None, stack),
+            SimpleStmt::Convert { source, .. } => {
+                expression(source, candidates, caller_id, None, stack)
+            }
+            SimpleStmt::If {
+                condition: condition_value,
+                then_statements,
+                else_statements,
+            } => {
+                condition(condition_value, candidates, caller_id, None, stack);
+                for nested in then_statements {
+                    statement(nested, candidates, caller_id, stack);
+                }
+                if let Some(nested) = else_statements {
+                    for statement_value in nested {
+                        statement(statement_value, candidates, caller_id, stack);
+                    }
+                }
+            }
+            SimpleStmt::For {
+                init,
+                condition: condition_value,
+                step,
+                body_statements,
+            } => {
+                statement(init, candidates, caller_id, stack);
+                condition(condition_value, candidates, caller_id, None, stack);
+                statement(step, candidates, caller_id, stack);
+                for nested in body_statements {
+                    statement(nested, candidates, caller_id, stack);
+                }
+            }
+            SimpleStmt::Foreach {
+                body_statements, ..
+            } => {
+                for nested in body_statements {
+                    statement(nested, candidates, caller_id, stack);
+                }
+            }
+            SimpleStmt::Noop | SimpleStmt::Continue | SimpleStmt::ReturnVoid => {}
+        }
+    }
+
+    let mut stack = Vec::new();
+    for statement_value in statements {
+        statement(statement_value, candidates, caller_id, &mut stack);
+    }
 }
 
 #[cfg(test)]

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -1099,11 +1099,19 @@ impl Compiler {
             let SimpleStmt::Return(expression) = qualified_body.remove(0) else {
                 unreachable!("inline candidate shape was already checked")
             };
+            let qualified_name = format!("{}.{}", candidate.module_alias, candidate.name);
+            let has_same_arity_overload = self.functions.iter().any(|other| {
+                other.id != candidate.id
+                    && other.module_alias == candidate.module_alias
+                    && other.name == candidate.name
+                    && other.params.len() == candidate.params.len()
+            });
             inline_candidates.push(InlineExpressionCandidate {
                 id: candidate.id,
-                qualified_name: format!("{}.{}", candidate.module_alias, candidate.name),
+                qualified_name,
                 param_names: candidate.param_names.clone(),
                 expression,
+                has_same_arity_overload,
             });
         }
         inline_expression_calls(&mut statements, &inline_candidates, function.id);
@@ -1411,6 +1419,7 @@ struct InlineExpressionCandidate {
     qualified_name: String,
     param_names: Vec<String>,
     expression: SimpleExpr,
+    has_same_arity_overload: bool,
 }
 
 fn inline_expression_calls(
@@ -1423,8 +1432,27 @@ fn inline_expression_calls(
             return argument.clone();
         }
         if let Some((root, suffix)) = path.split_once('.') {
-            if let Some(SimpleExpr::Identifier(argument_root)) = arguments.get(root) {
-                return SimpleExpr::Identifier(format!("{argument_root}.{suffix}"));
+            match arguments.get(root) {
+                Some(SimpleExpr::Identifier(argument_root)) => {
+                    return SimpleExpr::Identifier(format!("{argument_root}.{suffix}"));
+                }
+                Some(SimpleExpr::IndexedPath {
+                    collection_path,
+                    index,
+                    suffix: argument_suffix,
+                }) => {
+                    let combined_suffix = if argument_suffix.is_empty() {
+                        suffix.to_string()
+                    } else {
+                        format!("{argument_suffix}.{suffix}")
+                    };
+                    return SimpleExpr::IndexedPath {
+                        collection_path: collection_path.clone(),
+                        index: index.clone(),
+                        suffix: combined_suffix,
+                    };
+                }
+                _ => {}
             }
         }
         SimpleExpr::Identifier(path.to_string())
@@ -1518,6 +1546,7 @@ fn inline_expression_calls(
                     .filter(|candidate| {
                         candidate.qualified_name == *target
                             && candidate.param_names.len() == args.len()
+                            && !candidate.has_same_arity_overload
                             && candidate.id != caller_id
                             && !stack.contains(&candidate.id)
                     })
@@ -1658,6 +1687,48 @@ mod tests {
             .map(|offset| body[offset..].split_whitespace().next().unwrap_or_default())
             .collect::<Vec<_>>();
         assert_eq!(starts, vec!["let", "if", "value", "return"]);
+    }
+
+    #[test]
+    fn inline_keeps_same_arity_overload_calls_for_typed_backend_resolution() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "sample.stasis",
+            "struct Enemy { hp: i32; }\nstruct Player { score: i32; }\nglobal player: Player;\nfunction @inline value(item: Enemy): i32 { return item.hp + 100; }\nfunction value(item: Player): i32 { return item.score; }\nfunction main(): i32 { return value(player); }\n",
+        );
+        compiler.index_pass().expect("index overload fixture");
+        let function = function_by_name(&compiler, "main").clone();
+        let hir = compiler
+            .lower_function_to_hir(&function)
+            .expect("lower overload caller");
+        assert!(matches!(
+            &hir.statements[0],
+            SimpleStmt::Return(SimpleExpr::Call { target, .. }) if target.ends_with(".value")
+        ));
+    }
+
+    #[test]
+    fn inline_composes_indexed_argument_with_callee_field_suffix() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "sample.stasis",
+            "struct Enemy { hp: i32; }\nglobal enemies: Enemy[2];\nfunction @inline hp(enemy: Enemy): i32 { return enemy.hp; }\nfunction main(): i32 { return hp(enemies[0]); }\n",
+        );
+        compiler.index_pass().expect("index indexed-view fixture");
+        let function = function_by_name(&compiler, "main").clone();
+        let hir = compiler
+            .lower_function_to_hir(&function)
+            .expect("lower indexed-view caller");
+        assert!(matches!(
+            &hir.statements[0],
+            SimpleStmt::Return(SimpleExpr::IndexedPath {
+                collection_path,
+                index,
+                suffix,
+            }) if collection_path == "enemies"
+                && matches!(index.as_ref(), SimpleExpr::Int(0))
+                && suffix == "hp"
+        ));
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/indexer.rs
+++ b/crates/stasis_compiler/src/frontend/indexer.rs
@@ -16,6 +16,7 @@ pub struct IndexedFunction {
     pub params: Vec<TypeId>,
     pub param_type_names: Vec<String>,
     pub return_type: TypeId,
+    pub inline: bool,
     pub dependencies: Vec<IndexedCallDependency>,
 }
 
@@ -65,7 +66,11 @@ pub fn index_file(source: &str, types: &mut TypeTable) -> Result<Vec<IndexedFunc
         }
         let return_type = types.resolve_or_intern(&function.return_type_name)?;
         let name_hash = hash_text(&function.name);
-        let signature_hash = hash_signature(name_hash, &params, return_type);
+        let inline = function
+            .annotations
+            .iter()
+            .any(|annotation| annotation.name == "inline");
+        let signature_hash = hash_signature(name_hash, &params, return_type, inline);
         let body_text = source
             .get(function.body_range.clone())
             .ok_or_else(|| "invalid function body range".to_string())?;
@@ -83,6 +88,7 @@ pub fn index_file(source: &str, types: &mut TypeTable) -> Result<Vec<IndexedFunc
             params,
             param_type_names,
             return_type,
+            inline,
             dependencies,
         });
     }
@@ -98,7 +104,7 @@ pub fn hash_text(text: &str) -> u64 {
     hash
 }
 
-fn hash_signature(name_hash: u64, params: &[TypeId], return_type: TypeId) -> u64 {
+fn hash_signature(name_hash: u64, params: &[TypeId], return_type: TypeId, inline: bool) -> u64 {
     let mut hash = name_hash;
     hash = hash
         .wrapping_mul(1099511628211)
@@ -108,6 +114,9 @@ fn hash_signature(name_hash: u64, params: &[TypeId], return_type: TypeId) -> u64
             .wrapping_mul(1099511628211)
             .wrapping_add(u64::from(*param));
     }
+    hash = hash
+        .wrapping_mul(1099511628211)
+        .wrapping_add(u64::from(inline));
     hash
 }
 
@@ -182,6 +191,25 @@ mod tests {
             indexed[0].return_type,
             types.resolve("i32").unwrap_or_default()
         );
+        assert!(!indexed[0].inline);
+    }
+
+    #[test]
+    fn indexes_inline_as_part_of_the_lowering_contract() {
+        let mut types = TypeTable::new();
+        let plain = index_file(
+            "function helper(value: i32): i32 { return value; }\n",
+            &mut types,
+        )
+        .expect("plain index");
+        let annotated = index_file(
+            "function @inline helper(value: i32): i32 { return value; }\n",
+            &mut types,
+        )
+        .expect("inline index");
+        assert!(!plain[0].inline);
+        assert!(annotated[0].inline);
+        assert_ne!(plain[0].signature_hash, annotated[0].signature_hash);
     }
 
     #[test]

--- a/docs/jit_generation_contract.md
+++ b/docs/jit_generation_contract.md
@@ -48,6 +48,11 @@ closure. Patch size is a measured graph property, not a fixed promise.
 11. JIT and AOT share semantic analysis and per-function lowering. JIT selects a patch closure;
     AOT emits the complete reachable program.
 
+An eligible `@inline` call is still represented by the ordinary caller-to-callee dependency edge.
+The shared lowering path may embed the callee expression in both AOT and JIT machine code while a
+real callee body remains emitted. A body or annotation change therefore seeds the normal reverse
+caller closure; selective JIT must never retain a caller containing stale embedded code.
+
 `FnId` remains a stable compiler identity for call graphs, hashes, diagnostics, patch plans, and
 metadata. It is not an internal runtime dispatch key.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -850,6 +850,20 @@ about final signed APK/IPA compression or store metadata.
 mixed-width particle fields, capacity, host call, and tick budget provide deterministic acceptance
 evidence for the report.
 
+### 14.3.3 Inline function hint
+
+`function @inline helper(...): T` asks the shared AOT/JIT lowering path to substitute the helper's
+body at eligible call sites. The annotation is a performance hint rather than a different function
+kind: the compiler still emits the real typed function symbol so ordinary calls, recursive edges,
+exports, and future address-taking remain valid. Current eligibility covers a single returned
+expression whose arguments can be substituted without duplicating or reordering calls. Other body
+shapes retain the ordinary direct call.
+
+Inlining never weakens live-update correctness. The annotated bit participates in the lowering
+contract, and an edited inline callee invalidates its reverse caller closure before a JIT patch is
+published. Recursive expansion is rejected at the call site and continues through the real
+function.
+
 ### 14.4 Development File-Change Boundary Contracts
 
 During development, file-change handling uses explicit role ownership and message boundaries.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -857,7 +857,9 @@ body at eligible call sites. The annotation is a performance hint rather than a 
 kind: the compiler still emits the real typed function symbol so ordinary calls, recursive edges,
 exports, and future address-taking remain valid. Current eligibility covers a single returned
 expression whose arguments can be substituted without duplicating or reordering calls. Other body
-shapes retain the ordinary direct call.
+shapes retain the ordinary direct call. Calls into a same-name, same-arity overload family also
+retain direct calls until typed overload selection, so an inline hint can never preempt the typed
+callee chosen by the backend.
 
 Inlining never weakens live-update correctness. The annotated bit participates in the lowering
 contract, and an edited inline callee invalidates its reverse caller closure before a JIT patch is


### PR DESCRIPTION
## Summary
- make `@inline` perform real shared-HIR substitution for eligible single-expression functions in both AOT and JIT
- retain the real typed function symbol/object for ordinary calls and future address-taking
- preserve selective JIT correctness by keeping normal call-graph dependencies and regenerating callers after inline-callee edits
- document eligibility and hot-patch invariants

## Validation
- focused AOT CLIF test proves the caller has no call while the helper object remains
- focused JIT execution/CLIF test proves initial inlining, real helper retention, and caller regeneration after a callee edit
- debug and release `stasis` builds passed
- Gambit Guard `fmt`, `check`, and 110 tests passed with the release compiler
- compiler suite: 483/486 passed in the initial run; the filesystem/linker failures passed individually with required access and explicit MSVC linker. One unrelated `local_runtime_resolves_production_preview_externs` assertion remains environment-dependent (`2` observed vs `1` expected); its fixture has no inline function or internal call.