### PR TITLE
Compact Android performance HUD

### DIFF
--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -41,7 +41,7 @@ public final class MainActivity extends SDLActivity {
     private final float[] nativePerformance = new float[2];
     private final RollingMetric tickMetric = new RollingMetric();
     private final RollingMetric renderMetric = new RollingMetric();
-    private final StringBuilder hudText = new StringBuilder(160);
+    private final StringBuilder hudText = new StringBuilder(96);
     private FrameLayout diagnosticLayer;
     private TextView performanceHud;
     private TextView runtimeError;
@@ -122,9 +122,9 @@ public final class MainActivity extends SDLActivity {
 
         performanceHud = new TextView(this);
         performanceHud.setTextColor(Color.WHITE);
-        performanceHud.setTextSize(12.0f);
-        performanceHud.setSingleLine(false);
-        performanceHud.setPadding(dp(10), dp(6), dp(10), dp(6));
+        performanceHud.setTextSize(10.0f);
+        performanceHud.setSingleLine(true);
+        performanceHud.setPadding(dp(6), dp(4), dp(6), dp(4));
         performanceHud.setBackgroundColor(Color.argb(150, 20, 28, 38));
         performanceHud.setContentDescription("Stasis performance timing overlay");
         performanceHud.setVisibility(View.GONE);
@@ -132,7 +132,7 @@ public final class MainActivity extends SDLActivity {
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 Gravity.TOP | Gravity.START);
-        params.setMargins(dp(8), dp(8), dp(8), 0);
+        params.setMargins(dp(4), dp(4), dp(4), 0);
         diagnosticLayer.addView(performanceHud, params);
 
         runtimeError = new TextView(this);
@@ -188,22 +188,17 @@ public final class MainActivity extends SDLActivity {
         renderMetric.add(now, nativePerformance[1]);
         double tickAverage = tickMetric.average();
         double renderAverage = renderMetric.average();
+        double totalAverage = tickAverage + renderAverage;
         int budgetPercent = Math.max(0,
-                (int)(((tickAverage + renderAverage) * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
+                (int)((totalAverage * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
         hudText.setLength(0);
-        hudText.append("tick avg=");
+        hudText.append("tick=");
         appendMillis(hudText, tickAverage);
-        hudText.append(" p50=");
-        appendMillis(hudText, tickMetric.percentile(50));
-        hudText.append(" p95=");
-        appendMillis(hudText, tickMetric.percentile(95));
-        hudText.append(" ms\nrender avg=");
+        hudText.append("  render=");
         appendMillis(hudText, renderAverage);
-        hudText.append(" p50=");
-        appendMillis(hudText, renderMetric.percentile(50));
-        hudText.append(" p95=");
-        appendMillis(hudText, renderMetric.percentile(95));
-        hudText.append(" ms  budget=").append(budgetPercent).append('%');
+        hudText.append("  total=");
+        appendMillis(hudText, totalAverage);
+        hudText.append(" ms  budget@60fps=").append(budgetPercent).append('%');
         performanceHud.setTextColor(debugColorForBudget(budgetPercent));
         performanceHud.setText(hudText.toString());
     }
@@ -412,20 +407,6 @@ public final class MainActivity extends SDLActivity {
                 }
             }
             return samples == 0 ? 0.0 : total / samples;
-        }
-
-        double percentile(int percentile) {
-            long cutoff = System.nanoTime() - WINDOW_NANOS;
-            double[] active = new double[count];
-            int samples = 0;
-            for (int i = 0; i < count; i++) {
-                if (times[i] >= cutoff) active[samples++] = values[i];
-            }
-            if (samples == 0) return 0.0;
-            java.util.Arrays.sort(active, 0, samples);
-            int index = Math.min(samples - 1,
-                    Math.max(0, (int)Math.ceil(samples * percentile / 100.0) - 1));
-            return active[index];
         }
     }
 }

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -1356,8 +1356,12 @@ def main() -> int:
     assert "event.getPointerCount() >= 3" in release_activity
     assert "nativeReadPerformanceMetrics" in release_activity
     assert "nativeReadRuntimeError" in release_activity
-    assert "tick avg=" in release_activity
-    assert "render avg=" in release_activity
+    assert 'hudText.append("tick=")' in release_activity
+    assert 'hudText.append("  render=")' in release_activity
+    assert 'hudText.append("  total=")' in release_activity
+    assert 'hudText.append(" ms  budget@60fps=")' in release_activity
+    assert "percentile(" not in release_activity
+    assert "performanceHud.setSingleLine(true)" in release_activity
     assert "setOnApplyWindowInsetsListener" in release_activity
     assert "getDisplayCutout" in release_activity
     assert "verifyAssetManifest(staging)" in release_activity


### PR DESCRIPTION
## What changed

- Replace the Android performance overlay's two percentile-heavy rows with one compact line showing five-second rolling tick, render, total, and 60 fps budget utilization.
- Reduce the overlay text size, padding, and margins while preserving safe-area placement and the existing three-finger toggle.
- Remove per-refresh percentile array allocation and sorting from the Android HUD.
- Tighten the Android shell contract checks around the compact layout and metric set.

## Why

The previous phone overlay obscured Gambit Guard's primary status HUD and presented more detail than is useful for routine profiling. This makes the mobile presentation closer to the compact desktop HUD while retaining the values needed for fast device checks.

## Validation

- Generated Android shell compiled with `:app:assembleDebug --no-daemon --max-workers=2`.
- `python tools/ci/check_sdl3_migration.py` passed.
- Focused Android shell contract markers and Python syntax compilation passed.
- All Python validation unit suites and render parity verification passed.
- `python tools/cargo_cache.py run -- cargo test --workspace --all-targets -- --test-threads=1` passed.
- Actual Galaxy S21 gameplay and settings captures completed the required baseline, revision, and final independent visual reviews with zero residual defects.
- The canonical `tools/validate_repo.sh` currently stops at its ignored-test audit because `origin/main` already contains `#[ignore = "requires STASIS_CHESSTD_ROOT"]`; this patch does not touch that test.
- The full `check_android_shell.py` is also blocked on current main by the unrelated missing Workshop marker `allowAiImageGeneration.setChecked(false)`; the release-shell assertions changed here were verified directly.