### PR TITLE
Fix mobile AOT string literal overflow

### DIFF
--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -9,7 +9,7 @@
 #define STASIS_MOBILE_MAX_SCALARS 2048
 #define STASIS_MOBILE_MAX_ARRAYS 512
 #define STASIS_MOBILE_MAX_FUNCTIONS 1024
-#define STASIS_MOBILE_MAX_STRINGS 512
+#define STASIS_MOBILE_INITIAL_STRING_CAPACITY 512
 #define STASIS_MOBILE_MAX_ARRAY_LENGTH 1048576
 
 int stasis_audio_init(int sample_rate, int channels, int target_latency_frames);
@@ -99,8 +99,9 @@ static StasisArray arrays[STASIS_MOBILE_MAX_ARRAYS];
 static size_t array_count;
 static StasisCodePtr code_ptrs[STASIS_MOBILE_MAX_FUNCTIONS];
 static size_t code_ptr_count;
-static StasisStringLiteral strings[STASIS_MOBILE_MAX_STRINGS];
+static StasisStringLiteral *strings;
 static size_t string_count;
+static size_t string_capacity;
 
 int stasis_mobile_json_escape(const char *input, char *output, size_t capacity) {
     static const char hex[] = "0123456789abcdef";
@@ -235,11 +236,13 @@ void stasis_mobile_aot_reset(void) {
     memset(scalars, 0, sizeof(scalars));
     memset(arrays, 0, sizeof(arrays));
     memset(code_ptrs, 0, sizeof(code_ptrs));
-    memset(strings, 0, sizeof(strings));
+    free(strings);
+    strings = NULL;
     scalar_count = 0;
     array_count = 0;
     code_ptr_count = 0;
     string_count = 0;
+    string_capacity = 0;
 }
 
 void stasis_jit_register_global_i32_ptr(int32_t hash, int32_t *ptr) {
@@ -351,19 +354,35 @@ float stasis_jit_call_f32_8(int32_t fn, float a0, float a1, float a2, float a3, 
 float stasis_jit_call_f32_i32_1(int32_t fn, int32_t a0) { CALL_OR_ZERO(fn, F32I32Call1, target(a0)); }
 
 void stasis_jit_clear_string_literal_table(void) {
-    memset(strings, 0, sizeof(strings));
+    if (strings != NULL && string_count > 0) {
+        memset(strings, 0, string_count * sizeof(*strings));
+    }
     string_count = 0;
 }
 
 void stasis_jit_upsert_string_literal(int32_t id, const char *value) {
     size_t index;
+    size_t next_capacity;
+    StasisStringLiteral *next;
     for (index = 0; index < string_count; index += 1) {
         if (strings[index].id == id) {
             strings[index].value = value;
             return;
         }
     }
-    if (string_count >= STASIS_MOBILE_MAX_STRINGS) return;
+    if (string_count >= string_capacity) {
+        next_capacity = string_capacity == 0
+            ? STASIS_MOBILE_INITIAL_STRING_CAPACITY
+            : string_capacity * 2;
+        if (next_capacity <= string_capacity ||
+            next_capacity > SIZE_MAX / sizeof(*strings)) {
+            return;
+        }
+        next = (StasisStringLiteral *)realloc(strings, next_capacity * sizeof(*strings));
+        if (next == NULL) return;
+        strings = next;
+        string_capacity = next_capacity;
+    }
     strings[string_count++] = (StasisStringLiteral){id, value};
 }
 

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -135,6 +135,7 @@ int stasis_clipboard_save_ascii(const char *value, int length) {
 }
 
 int main(void) {
+    enum { STRESS_LITERAL_COUNT = 640 };
     int32_t external = 4;
     int32_t external_array[3] = {7, 8, 9};
     int32_t overlapping_i32[5] = {1, 2, 3, 4, 5};
@@ -151,6 +152,8 @@ int main(void) {
     float text_width[1] = {0};
     float text_height[1] = {0};
     int32_t *owned;
+    char stress_literals[STRESS_LITERAL_COUNT][32];
+    int stress_index;
     char escaped_json[64];
     const char json_controls[] = {'"', '\\', '\b', '\f', '\n', '\r', '\t', 1, 'A', 0};
 
@@ -230,6 +233,17 @@ int main(void) {
     memset(ascii_out, 0, sizeof(ascii_out));
     CHECK(stasis_jit_clipboard_load_ascii(43, sizeof(ascii_out)) == 8);
     CHECK(memcmp(ascii_out, "GG1-test", 8) == 0);
+
+    for (stress_index = 0; stress_index < STRESS_LITERAL_COUNT; stress_index += 1) {
+        snprintf(stress_literals[stress_index], sizeof(stress_literals[stress_index]),
+            "asset/path/%d.ttf", stress_index);
+        stasis_jit_upsert_string_literal(1000 + stress_index, stress_literals[stress_index]);
+    }
+    CHECK(stasis_jit_load_font(1000 + STRESS_LITERAL_COUNT - 1, 19) == 19);
+    stasis_jit_clear_string_literal_table();
+    CHECK(stasis_jit_load_font(1000 + STRESS_LITERAL_COUNT - 1, 19) == 0);
+    stasis_jit_upsert_string_literal(2000, "asset/path/rebound.ttf");
+    CHECK(stasis_jit_load_font(2000, 23) == 23);
 
     owned = stasis_jit_global_i32_array_ptr(21, 0, 4);
     CHECK(owned != NULL);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -49,6 +49,7 @@ static int32_t game_host_req_seq;
 static int32_t game_host_req_flags;
 static int32_t game_host_req_window_w_px;
 static int32_t game_host_req_window_h_px;
+static char game_string_literals[640][32];
 
 int stasis_init_window(int width, int height, const char *title) {
     assert(width == 1280);
@@ -206,6 +207,7 @@ static int32_t hash_path(const char *path);
 
 static int32_t game_main(void) {
     main_calls += 1;
+    assert(stasis_jit_load_font(1639, 19) == 19);
     game_host_req_seq = 1;
     game_host_req_flags = 1;
     game_host_req_window_w_px = 960;
@@ -214,7 +216,14 @@ static int32_t game_main(void) {
 }
 
 static void bind_runtime(void) {
+    int literal_index;
     bind_runtime_calls += 1;
+    stasis_jit_clear_string_literal_table();
+    for (literal_index = 0; literal_index < 640; literal_index += 1) {
+        snprintf(game_string_literals[literal_index], sizeof(game_string_literals[literal_index]),
+            "asset/path/%d.ttf", literal_index);
+        stasis_jit_upsert_string_literal(1000 + literal_index, game_string_literals[literal_index]);
+    }
     stasis_jit_register_global_i32_array(hash_path("host_i32"), 0, game_host_i32, 768);
     stasis_jit_register_global_f32_array(hash_path("host_f32"), 0, game_host_f32, 64);
     stasis_jit_register_global_i32_array(


### PR DESCRIPTION
## What changed

- replace the mobile AOT runtime's fixed 512-entry string-literal table with growable storage
- release the table during runtime reset while retaining allocated capacity across ordinary table clears
- add direct runtime and full mobile lifecycle coverage with 640 registered literals

## Why

Gambit Guard's Android bundle grew to 638 string literals. The generated binder emitted all of them, but `stasis_jit_upsert_string_literal` silently discarded every entry after 512. Font path literals were beyond that boundary, so `load_font` received unresolved IDs and game startup exited before sprite loading.

The fixed limit made otherwise valid programs fail based only on literal count. Growing the table preserves the AOT invariant that every emitted literal remains resolvable.

## Validation

- `cargo fmt --check`
- `stasis_mobile_aot_runtime_contract` (640 literals, final font lookup, clear, and rebound lookup)
- `stasis_mobile_runtime_lifecycle` (640 literals bound before `game_main`, final font loaded inside `game_main`)
- clean release build of `stasis`
- regenerated and audited Gambit Guard Android APK containing 638 literals
- installed on Samsung SM-G991U1 with 27 existing `.i32` save values restored; process remained alive with a stable PID and the game loaded successfully
