### PR TITLE
ci: serialize Windows compiler tests

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -114,7 +114,8 @@ jobs:
           cargo test -p stasis --test windows_game_launch -- --test-threads=1 --nocapture
 
       - name: Bootstrap Compile Smoke (compiler .stasis)
-        run: cargo test -p stasis_compiler -- --nocapture
+        # Compiler/JIT tests share process-global dispatch and runtime registration state.
+        run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture
 
   vscode-extension-e2e:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}


### PR DESCRIPTION
## Summary

- serialize the Windows compiler bootstrap test suite
- prevent process-global JIT dispatch and runtime registration state from leaking between concurrent tests
- track the transient PR #444 nested-struct linked-AOT failure as Maddox #242

## Evidence

- PR CI run 757 attempt 1: `aot_process_links_and_executes_nested_struct_receiver_call` returned 0 instead of 42; unchanged rerun passed
- isolated linked-AOT test passed under the local MSVC environment
- default-parallel full binary reproduced process-global interference (`local_runtime_resolves_production_preview_externs`: 2 instead of 1)
- repository source-layout check and `git diff --check` pass

## Scope

CI-only stabilization. No compiler or runtime behavior changes.