### PR TITLE
test: cover gfx command capacity seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Test HostFrame desktop JIT seam
         run: cargo test -p stasis_compiler --test host_frame_jit_seam -- --test-threads=1
 
+      - name: Test gfx command capacity seam
+        run: cargo test -p stasis_compiler gfx_cmd_capacity_overflow_matches_jit_and_linked_aot_trace -- --test-threads=1
+
       - name: Run Cargo Test
         # The in-process JIT test runner mutates process-global dispatch tables; keep CI deterministic.
         run: cargo test --workspace --all-targets -- --test-threads=1

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1499,6 +1499,272 @@ mod tests {
 
     static CLIF_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 
+    const GFX_CAPACITY_FIXTURE: &str =
+        include_str!("../../../../tests/stasis/seams/gfx_cmd_capacity_probe.stasis");
+    const GFX_CMD_SOURCE: &str = include_str!("../../../../src/stdlib/internal/gfx_cmd.stasis");
+    const GFX_CAPACITY_TRACE_ROOTS: [&str; 10] = [
+        "trace_geometry_capacity",
+        "trace_sprite_capacity",
+        "trace_cached_text_capacity",
+        "probe_raw_text_source",
+        "probe_direct_memcpy_destination",
+        "probe_parameter_memcpy_destination",
+        "probe_raw_text_metadata",
+        "probe_raw_text_destination",
+        "trace_raw_text_capacity",
+        "trace_text_capacity",
+    ];
+
+    struct GfxCapacityResult {
+        trace: i32,
+        i32s: Vec<i32>,
+        f32s: Vec<f32>,
+        u8s: Vec<u8>,
+        canaries_intact: bool,
+        stage_traces: Vec<i32>,
+    }
+
+    fn run_gfx_capacity_jit(gfx_source: &str) -> GfxCapacityResult {
+        const I32_COUNT: usize = 34_608;
+        const F32_COUNT: usize = 108_676;
+        const U8_COUNT: usize = 65_536;
+        let project_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut jit = JitProcess::new();
+        jit.set_required_emit_roots(&GFX_CAPACITY_TRACE_ROOTS.map(str::to_string));
+        jit.set_project_root(project_root.to_string_lossy())
+            .expect("set project root");
+        jit.upsert_file(
+            "tests/stasis/seams/gfx_cmd_capacity_probe.stasis",
+            GFX_CAPACITY_FIXTURE,
+        );
+        jit.upsert_file("src/stdlib/internal/gfx_cmd.stasis", gfx_source);
+        jit.compile().expect("compile gfx capacity JIT fixture");
+
+        let mut i32_storage = vec![0; I32_COUNT + 2];
+        i32_storage[0] = 0x1357_2468;
+        i32_storage[I32_COUNT + 1] = 0x1357_2468;
+        let i32s = Box::leak(i32_storage.into_boxed_slice());
+        let mut f32_storage = vec![0.0; F32_COUNT + 2];
+        f32_storage[0] = f32::from_bits(0x4a55_aa55);
+        f32_storage[F32_COUNT + 1] = f32::from_bits(0x4a55_aa55);
+        let f32s = Box::leak(f32_storage.into_boxed_slice());
+        let mut u8_storage = vec![0; U8_COUNT + 2];
+        u8_storage[0] = 0xa5;
+        u8_storage[U8_COUNT + 1] = 0xa5;
+        let u8s = Box::leak(u8_storage.into_boxed_slice());
+        stasis_dynload::register_global_i32_array(
+            stasis_dynload::global_path_hash("gfx_cmd_i32"),
+            0,
+            i32s[1..=I32_COUNT].as_mut_ptr(),
+            I32_COUNT,
+        );
+        stasis_dynload::register_global_f32_array(
+            stasis_dynload::global_path_hash("gfx_cmd_f32"),
+            0,
+            f32s[1..=F32_COUNT].as_mut_ptr(),
+            F32_COUNT,
+        );
+        stasis_dynload::register_global_u8_array(
+            stasis_dynload::global_path_hash("gfx_cmd_u8"),
+            0,
+            u8s[1..=U8_COUNT].as_mut_ptr(),
+            U8_COUNT,
+        );
+        let trace = jit
+            .execute_i32_noarg_by_name("main")
+            .expect("execute gfx capacity JIT fixture");
+        let result_i32s = i32s[1..=I32_COUNT].to_vec();
+        let result_f32s = f32s[1..=F32_COUNT].to_vec();
+        let result_u8s = u8s[1..=U8_COUNT].to_vec();
+        let stage_traces = GFX_CAPACITY_TRACE_ROOTS
+            .iter()
+            .map(|name| {
+                jit.execute_i32_noarg_by_name(name)
+                    .unwrap_or_else(|error| panic!("execute {name}: {error}"))
+            })
+            .collect();
+        let canaries_intact = i32s[0] == 0x1357_2468
+            && i32s[I32_COUNT + 1] == 0x1357_2468
+            && f32s[0].to_bits() == 0x4a55_aa55
+            && f32s[F32_COUNT + 1].to_bits() == 0x4a55_aa55
+            && u8s[0] == 0xa5
+            && u8s[U8_COUNT + 1] == 0xa5;
+        GfxCapacityResult {
+            trace,
+            i32s: result_i32s,
+            f32s: result_f32s,
+            u8s: result_u8s,
+            canaries_intact,
+            stage_traces,
+        }
+    }
+
+    fn verify_gfx_capacity(result: &GfxCapacityResult) -> Result<(), String> {
+        let checks = [
+            ("line_count", 3, 5_000),
+            ("dropped_lines", 5, 1),
+            ("sprite_count", 4, 4_096),
+            ("dropped_sprites", 6, 1),
+            ("text_count", 7, 2_048),
+            ("dropped_text", 8, 2),
+            ("text_bytes_used", 9, 65_536),
+            ("order_count", 22, 16_144),
+            ("dropped_order", 23, 1),
+            ("rect_count", 24, 5_000),
+            ("dropped_rects", 25, 1),
+        ];
+        for (field, index, expected) in checks {
+            let actual = result.i32s[index];
+            if actual != expected {
+                return Err(format!("gfx capacity mismatch: producer=gfx_cmd.stasis consumer=native_render_trace field={field} expected={expected} actual={actual}"));
+            }
+        }
+        if !result.canaries_intact {
+            return Err("gfx capacity mismatch: producer=gfx_cmd.stasis consumer=host_buffers field=canaries expected=intact actual=modified".to_string());
+        }
+        if result.f32s[40_003].to_bits() != 1.0f32.to_bits()
+            || result.f32s[40_004].to_bits() != 5.0f32.to_bits()
+        {
+            return Err("gfx capacity mismatch: producer=gfx_cmd.stasis consumer=native_render_trace field=geometry_arena_boundary expected=adjacent actual=overlap".to_string());
+        }
+        if result.i32s[34_607] != 51_199 || result.u8s[65_535] != 0 {
+            return Err("gfx capacity mismatch: producer=gfx_cmd.stasis consumer=native_render_trace field=terminal_entries expected=written actual=missing".to_string());
+        }
+        if result.trace == 0 {
+            return Err("gfx capacity mismatch: producer=gfx_cmd.stasis consumer=native_render_trace field=trace expected=nonzero actual=0".to_string());
+        }
+        Ok(())
+    }
+
+    fn gfx_capacity_evidence_path() -> PathBuf {
+        std::env::var_os("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("../..")
+                    .join("target")
+            })
+            .join("seam-tests/it-003-gfx-capacity.json")
+    }
+
+    #[test]
+    fn gfx_cmd_capacity_overflow_matches_jit_and_linked_aot_trace() {
+        use sha2::{Digest, Sha256};
+
+        let jit_result = run_gfx_capacity_jit(GFX_CMD_SOURCE);
+        verify_gfx_capacity(&jit_result).expect("canonical gfx capacity probe");
+
+        let mutated = GFX_CMD_SOURCE.replacen(
+            "const GFX_MAX_SPRITES: i32 = 4096;",
+            "const GFX_MAX_SPRITES: i32 = 4095;",
+            1,
+        );
+        assert_ne!(mutated, GFX_CMD_SOURCE, "capacity mutation must apply");
+        let mutation_error = verify_gfx_capacity(&run_gfx_capacity_jit(&mutated))
+            .expect_err("capacity drift must fail");
+        assert_eq!(
+            mutation_error,
+            "gfx capacity mismatch: producer=gfx_cmd.stasis consumer=native_render_trace field=sprite_count expected=4096 actual=4095"
+        );
+
+        let project_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut aot = AotProcess::new();
+        aot.set_required_emit_roots(&GFX_CAPACITY_TRACE_ROOTS.map(str::to_string));
+        aot.set_project_root(project_root.to_string_lossy())
+            .expect("set AOT project root");
+        aot.upsert_file(
+            "tests/stasis/seams/gfx_cmd_capacity_probe.stasis",
+            GFX_CAPACITY_FIXTURE,
+        );
+        aot.upsert_file("src/stdlib/internal/gfx_cmd.stasis", GFX_CMD_SOURCE);
+        aot.compile().expect("compile gfx capacity AOT fixture");
+        let state_layout = aot.state_layout();
+        for (path, expected) in [("full_text", 1_024), ("tail_text", 960)] {
+            let collection = state_layout
+                .collections
+                .iter()
+                .find(|collection| collection.path == path)
+                .unwrap_or_else(|| panic!("missing fixed-text storage layout for {path}"));
+            assert_eq!(
+                collection.capacity, expected,
+                "fixed-text storage capacity drift for {path}"
+            );
+            assert_eq!(
+                collection.fields[0].storage_type_name, "u8",
+                "fixed-text standalone storage lane drift for {path}"
+            );
+        }
+
+        #[allow(unused_mut)]
+        let mut linked_aot_checks = 0usize;
+        #[cfg(windows)]
+        if let Some(link_config) = resolve_link_config_for_smoke() {
+            for (index, name) in GFX_CAPACITY_TRACE_ROOTS.iter().enumerate() {
+                if let Some(aot_trace) =
+                    run_linked_i32_noarg_fixture(&aot, name, name, &link_config)
+                {
+                    assert_eq!(
+                        aot_trace, jit_result.stage_traces[index],
+                        "JIT/AOT native trace drift in {name}"
+                    );
+                    linked_aot_checks += 1;
+                }
+            }
+            if let Some(aot_trace) =
+                run_linked_i32_noarg_fixture(&aot, "main", "gfx_capacity", &link_config)
+            {
+                assert_eq!(aot_trace, jit_result.trace, "JIT/AOT native trace drift");
+                linked_aot_checks += 1;
+            }
+        }
+
+        let stage_traces: BTreeMap<_, _> = GFX_CAPACITY_TRACE_ROOTS
+            .iter()
+            .copied()
+            .zip(jit_result.stage_traces.iter().copied())
+            .collect();
+        let fixture_revision = format!(
+            "{:x}",
+            Sha256::digest([GFX_CMD_SOURCE, GFX_CAPACITY_FIXTURE].concat())
+        );
+        let evidence = serde_json::json!({
+            "schema": "stasis.seam_test.v1",
+            "test_id": "IT-003",
+            "status": "passed",
+            "target": "jit+aot+native-trace",
+            "fixture_revision": fixture_revision,
+            "checks": 20 + linked_aot_checks,
+            "linked_aot_checks": linked_aot_checks,
+            "oracle": {
+                "line_count": 5000,
+                "rect_count": 5000,
+                "sprite_count": 4096,
+                "text_count": 2048,
+                "text_bytes_used": 65536,
+                "order_count": 16144,
+                "dropped": {
+                    "lines": 1,
+                    "rects": 1,
+                    "sprites": 1,
+                    "text": 2,
+                    "order": 1
+                },
+                "native_trace": jit_result.trace,
+                "stage_traces": stage_traces,
+                "canaries": "intact",
+                "mutation_diagnostic": mutation_error
+            }
+        });
+        let path = gfx_capacity_evidence_path();
+        fs::create_dir_all(path.parent().expect("evidence directory"))
+            .expect("create evidence directory");
+        fs::write(
+            path,
+            serde_json::to_vec_pretty(&evidence).expect("serialize evidence"),
+        )
+        .expect("write evidence");
+    }
+
     #[test]
     fn aot_failed_candidate_preserves_accepted_snapshot_and_artifacts() {
         let mut process = AotProcess::new();

--- a/crates/stasis_compiler/src/backend/state_layout.rs
+++ b/crates/stasis_compiler/src/backend/state_layout.rs
@@ -488,7 +488,14 @@ pub(crate) fn build_state_layout(
             .iter_mut()
             .find(|collection| collection.path == *path)
         {
-            if !collection.fields.iter().any(|field| field.field.is_empty()) {
+            if let Some(field) = collection
+                .fields
+                .iter_mut()
+                .find(|field| field.field.is_empty())
+            {
+                field.type_name = "u8".to_string();
+                field.storage_type_name = "u8".to_string();
+            } else {
                 collection.fields.push(StateCollectionFieldLayout {
                     field: String::new(),
                     type_name: "u8".to_string(),
@@ -647,10 +654,13 @@ mod tests {
         let layout = jit.state_layout();
         assert_eq!(layout, aot.state_layout());
         assert!(layout.scalars.iter().any(|field| field.path == "score"));
-        assert!(layout
+        let title = layout
             .collections
             .iter()
-            .any(|collection| collection.path == "title" && collection.capacity == 8));
+            .find(|collection| collection.path == "title")
+            .expect("fixed UTF-8 collection layout");
+        assert_eq!(title.capacity, 8);
+        assert_eq!(title.fields[0].storage_type_name(), "u8");
         assert!(layout
             .collections
             .iter()

--- a/tests/stasis/seams/gfx_cmd_capacity_probe.stasis
+++ b/tests/stasis/seams/gfx_cmd_capacity_probe.stasis
@@ -1,0 +1,154 @@
+import "../../../src/stdlib/internal/gfx_cmd.stasis";
+
+function @extern("stasis_jit_render_v2_trace") native_render_trace(
+    cmd_i32: i32[],
+    cmd_i32_len: i32,
+    cmd_f32: f32[],
+    cmd_f32_len: i32,
+    cmd_u8: u8[],
+    cmd_u8_len: i32
+): i32;
+
+global full_text: utf8[1024];
+global tail_text: utf8[960];
+
+function prepare_text(): void {
+    for (let i: i32 = 0; i < 1024; i += 1) {
+        full_text[i] = 65;
+    }
+    utf8_set_len_ascii(full_text, 1024);
+    for (let i: i32 = 0; i < 960; i += 1) {
+        tail_text[i] = 66;
+    }
+    utf8_set_len_ascii(tail_text, 960);
+}
+
+function fill_geometry(): void {
+    for (let i: i32 = 0; i < 5000; i += 1) {
+        gfx_cmd_line(1.0, 2.0, 3.0, 4.0, 0.1, 0.2, 0.3, 1.0);
+    }
+    for (let i: i32 = 0; i < 5000; i += 1) {
+        gfx_cmd_rect(5.0, 6.0, 7.0, 8.0, 0.4, 0.5, 0.6, 1.0);
+    }
+}
+
+function fill_sprites(): void {
+    for (let i: i32 = 0; i < 4096; i += 1) {
+        gfx_cmd_sprite(i + 1, 9.0, 10.0, 11.0, 12.0, i, 255);
+    }
+}
+
+function fill_raw_text(): void {
+    for (let i: i32 = 0; i < 63; i += 1) {
+        gfx_cmd_text(1, full_text, 13.0, 14.0, 0.7, 0.8, 0.9, 1.0);
+    }
+    gfx_cmd_text(1, tail_text, 13.0, 14.0, 0.7, 0.8, 0.9, 1.0);
+    gfx_cmd_text(1, tail_text, 13.0, 14.0, 0.7, 0.8, 0.9, 1.0);
+}
+
+function fill_cached_text(): void {
+    for (let i: i32 = 64; i < 2048; i += 1) {
+        gfx_cmd_text_cached(1, i + 1, 15.0, 16.0, 1.0, 1.0, 1.0, 1.0);
+    }
+}
+
+function fill_text(): void {
+    fill_raw_text();
+    fill_cached_text();
+}
+
+function trace_commands(): i32 {
+    return native_render_trace(
+        gfx_cmd_i32,
+        34608,
+        gfx_cmd_f32,
+        108676,
+        gfx_cmd_u8,
+        65536
+    );
+}
+
+function trace_geometry_capacity(): i32 {
+    gfx_cmd_begin();
+    fill_geometry();
+    return trace_commands();
+}
+
+function trace_sprite_capacity(): i32 {
+    gfx_cmd_begin();
+    fill_sprites();
+    return trace_commands();
+}
+
+function trace_text_capacity(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    fill_text();
+    return trace_commands();
+}
+
+function trace_raw_text_capacity(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    fill_raw_text();
+    return trace_commands();
+}
+
+function trace_cached_text_capacity(): i32 {
+    gfx_cmd_begin();
+    fill_cached_text();
+    return trace_commands();
+}
+
+function probe_raw_text_source(): i32 {
+    prepare_text();
+    return full_text[0] * 1000000 + full_text[1023] * 10000 + full_text.byte_length;
+}
+
+function probe_direct_memcpy_destination(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    sys_memcpy_u8(gfx_cmd_u8, 0, full_text, 0, 1024);
+    return gfx_cmd_u8[0] * 1000 + gfx_cmd_u8[1023];
+}
+
+function copy_text_probe(text: utf8[]): void {
+    sys_memcpy_u8(gfx_cmd_u8, 0, text, 0, 1024);
+}
+
+function probe_parameter_memcpy_destination(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    copy_text_probe(full_text);
+    return gfx_cmd_u8[0] * 1000 + gfx_cmd_u8[1023];
+}
+
+function probe_raw_text_destination(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    fill_raw_text();
+    return gfx_cmd_u8[0] * 1000000 + gfx_cmd_u8[1023] * 10000 + gfx_cmd_u8[64575] * 100 + gfx_cmd_u8[65534];
+}
+
+function probe_raw_text_metadata(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    fill_raw_text();
+    return gfx_cmd_i32[7] * 1000000 + gfx_cmd_i32[9] * 100 + gfx_cmd_i32[12322] + gfx_cmd_i32[12511];
+}
+
+function main(): i32 {
+    prepare_text();
+    gfx_cmd_begin();
+    fill_geometry();
+    fill_sprites();
+    fill_text();
+
+    gfx_cmd_append_order(GFX_ORDER_LINE, 0);
+    gfx_cmd_line(1.0, 2.0, 3.0, 4.0, 0.1, 0.2, 0.3, 1.0);
+    gfx_cmd_rect(5.0, 6.0, 7.0, 8.0, 0.4, 0.5, 0.6, 1.0);
+    gfx_cmd_sprite(1, 9.0, 10.0, 11.0, 12.0, 0, 255);
+    gfx_cmd_text_cached(1, 1, 15.0, 16.0, 1.0, 1.0, 1.0, 1.0);
+
+    return trace_commands();
+}

--- a/tools/ci/check_stasis_src_layout.py
+++ b/tools/ci/check_stasis_src_layout.py
@@ -104,9 +104,10 @@ def main() -> int:
             imports_internal = "/internal/" in norm or norm.startswith("internal/")
             if imports_internal:
                 inside_stdlib = rel_path.parts[:2] == ("src", "stdlib")
-                integration_test = rel_path.as_posix() == (
-                    "tests/stasis/rust_native_tick_input_snapshot.stasis"
-                )
+                integration_test = rel_path.as_posix() in {
+                    "tests/stasis/rust_native_tick_input_snapshot.stasis",
+                    "tests/stasis/seams/gfx_cmd_capacity_probe.stasis",
+                }
                 if not inside_stdlib and not integration_test:
                     errors.append(
                         f'{rel_path.as_posix()}:{line_no}: private ABI import "{import_path}" '


### PR DESCRIPTION
## Summary

- add IT-003, a real Stasis -> JIT/AOT -> native render-trace capacity and overflow test
- drive geometry, sprite, copied-text, cached-text, order, and text-byte arenas to their exact limits and one past
- emit `stasis.seam_test.v1` evidence with category-level traces, dropped counts, canaries, and a deliberate capacity-drift diagnostic
- normalize fixed ASCII/UTF-8 state-layout storage lanes to `u8` so linked AOT runtime helpers see the same byte storage as direct AOT code
- register the focused seam in fast PR CI; Windows bootstrap exercises all linked-AOT comparisons serially

## Bug caught by the test

The first linked-AOT run found fixed UTF-8 buffers were allocated and accessed directly as bytes, but standalone storage registered their existing generic empty field as `i32`. Runtime memcpy therefore read four-byte strides and diverged from JIT. The narrow layout normalization converts that existing fixed-text field to `u8`; no graphics behavior was special-cased.

## Validation

- focused IT-003 JIT/AOT/native-trace test: pass, 31 checks, 11 linked-AOT comparisons
- fixed-text canonical state-layout tests: 5 pass
- native render-trace tests: 2 pass
- source-layout gate: pass
- runtime ABI gate: 268 comparisons pass
- `git diff --check`: pass

## Theory gained

Fixed text has one byte-oriented storage identity across direct compiled access and runtime helper registration. Capacity metadata alone is insufficient if the registered lane width differs.