### PR TITLE
fix: preserve Windows AOT exit results

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -482,7 +482,9 @@ impl AotProcess {
     }
 
     /// Builds the storage definitions and entry wrapper required when a
-    /// standalone executable references program globals directly.
+    /// standalone executable references program globals directly. Native
+    /// Windows executables always use the wrapper so their Stasis result is
+    /// passed to ExitProcess instead of returning from the raw PE entry point.
     pub fn compile_standalone_storage_object(
         &self,
         entry_symbol: &str,
@@ -498,7 +500,9 @@ impl AotProcess {
         }
 
         let layout = self.state_layout();
-        if layout.scalars.is_empty() && layout.collections.is_empty() {
+        let exits_windows_process =
+            cfg!(windows) && matches!(self.target, stasis_jit::AotTarget::Native);
+        if layout.scalars.is_empty() && layout.collections.is_empty() && !exits_windows_process {
             return Ok(None);
         }
         let mut flag_builder = settings::builder();
@@ -596,6 +600,17 @@ impl AotProcess {
         let entry_id = module
             .declare_function(entry_symbol, Linkage::Import, &entry_signature)
             .map_err(|error| format!("failed to declare standalone entry: {error}"))?;
+        let exit_process_id = if exits_windows_process {
+            let mut signature = module.make_signature();
+            signature.params.push(AbiParam::new(types::I32));
+            Some(
+                module
+                    .declare_function("ExitProcess", Linkage::Import, &signature)
+                    .map_err(|error| format!("failed to declare ExitProcess: {error}"))?,
+            )
+        } else {
+            None
+        };
         let wrapper_symbol = "stasis_aot_standalone_entry".to_string();
         let wrapper_id = module
             .declare_function(&wrapper_symbol, Linkage::Export, &entry_signature)
@@ -641,6 +656,8 @@ impl AotProcess {
         let mut context = module.make_context();
         context.func.signature = entry_signature;
         let entry_ref = module.declare_func_in_func(entry_id, &mut context.func);
+        let exit_process_ref =
+            exit_process_id.map(|id| module.declare_func_in_func(id, &mut context.func));
         let register_refs: BTreeMap<_, _> = register_functions
             .into_iter()
             .map(|(key, id)| (key, module.declare_func_in_func(id, &mut context.func)))
@@ -690,6 +707,9 @@ impl AotProcess {
             }
             let call = builder.ins().call(entry_ref, &[]);
             let result = builder.inst_results(call)[0];
+            if let Some(exit_process_ref) = exit_process_ref {
+                builder.ins().call(exit_process_ref, &[result]);
+            }
             builder.ins().return_(&[result]);
             builder.finalize();
         }
@@ -1975,6 +1995,36 @@ mod tests {
                 "standalone storage object missing symbol '{expected}': {symbols:?}"
             );
         }
+        #[cfg(windows)]
+        assert!(
+            symbols.contains("ExitProcess"),
+            "native Windows wrapper must terminate with the Stasis result: {symbols:?}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn standalone_windows_entry_wraps_stateless_programs() {
+        let mut process = AotProcess::new();
+        process.upsert_file("main.stasis", "function main(): i32 { return 14; }\n");
+        process.compile().expect("compile stateless program");
+
+        let (bytes, wrapper) = process
+            .compile_standalone_storage_object("aot_fn_0")
+            .expect("standalone entry object")
+            .expect("native Windows entry wrapper required");
+        let object = File::parse(bytes.as_slice()).expect("parse entry object");
+        let symbols: BTreeSet<String> = object
+            .symbols()
+            .filter_map(|symbol| symbol.name().ok().map(str::to_string))
+            .collect();
+
+        assert_eq!(wrapper, "stasis_aot_standalone_entry");
+        assert!(symbols.contains("aot_fn_0"), "missing Stasis entry import");
+        assert!(
+            symbols.contains("ExitProcess"),
+            "missing deterministic Windows process termination import"
+        );
     }
 
     #[test]

--- a/crates/stasis_jit/src/lib.rs
+++ b/crates/stasis_jit/src/lib.rs
@@ -354,6 +354,7 @@ pub fn link_objects_to_executable(
         args.push(format!("/OUT:{}", output_executable.display()));
         args.push(format!("/ENTRY:{entry_symbol}"));
         args.push("/SUBSYSTEM:CONSOLE".to_string());
+        args.push("kernel32.lib".to_string());
         let windows_lib_paths = resolve_windows_link_lib_paths();
         for lib_path in &windows_lib_paths {
             args.push(format!("/LIBPATH:{}", lib_path.display()));


### PR DESCRIPTION
## Summary

- route native Windows AOT executables through the generated entry wrapper even when they have no globals
- pass the Stasis `i32` result to `ExitProcess` instead of returning from a raw `/ENTRY` function
- link `kernel32.lib` explicitly and cover stateful/stateless wrapper imports

Fixes the CI failure tracked by Maddox #243, where `struct_view_abi` occasionally completed successfully with exit code `0` instead of `14`.

## Validation

- real MSVC-linked `parity_corpus_covers_shared_lowering_shapes` (all six fixtures): passed
- native Windows wrapper regression: passed
- `cargo test -p stasis_jit -- --test-threads=1`: 17 passed
- `cargo fmt --all -- --check`: passed
- full serialized compiler run: all AOT/linking tests passed; two unrelated workstation-only checks remained (configured preview runtime state and sandbox-denied temp directory). The temp-directory test passed outside the sandbox.

## Theory gained

A Stasis `i32` function is an application entry value, not a valid raw Windows PE termination contract. The Windows launcher must own the mapping from that value to `ExitProcess`; therefore adjacent Windows executable entry shapes should use the same wrapper rather than exposing generated functions directly through `/ENTRY`.

## Reflection

- Good: the successful-but-wrong process result pointed to the launcher seam rather than lowering, and the linked corpus verified that distinction.
- Bad: the old test path relied on undocumented return behavior from a raw PE entry point, so repeated passes falsely suggested determinism.
- Adjustment: executable seam tests should assert the platform launcher contract explicitly, including stateless programs that previously skipped wrapper generation.