### PR TITLE
test: cover desktop input frame seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -128,6 +128,12 @@ jobs:
           python tools/ci/verify_render_parity.py --capture target/render-parity-ci/frame.png --runtime-log target/render-parity-ci/runtime.log --evidence target/render-parity-ci/evidence.json --write-evidence --require-load-details --profile portable --stage second_frame
           cargo test -p stasis --test windows_game_launch -- --test-threads=1 --nocapture
 
+      - name: Test desktop SDL input to JIT frame seam
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          cargo test -p stasis --test desktop_input_frame_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/desktop_input_frame_seam.rs
+++ b/apps/stasis/tests/desktop_input_frame_seam.rs
@@ -1,0 +1,319 @@
+#![cfg(windows)]
+
+use serde_json::json;
+use stasis_compiler::backend::jit::JitProcess;
+use stasis_dynload::{
+    global_path_hash, register_global_f32_array, register_global_i32_array,
+    register_global_u8_array, Library, StasisGraphicsApi,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const FIXTURE: &str = include_str!("../../../tests/stasis/seams/desktop_input_frame_probe.stasis");
+const KEY_SPACE: i32 = 44;
+const EVENT_KEY_DOWN: i32 = 1;
+const EVENT_KEY_UP: i32 = 2;
+const EVENT_POINTER_DOWN: i32 = 3;
+const EVENT_POINTER_MOVE: i32 = 4;
+const EVENT_POINTER_UP: i32 = 5;
+const TOUCH_ID: i32 = 73;
+
+struct NativeInputInjector {
+    _library: Library,
+    push: extern "system" fn(i32, i32, f32, f32) -> i32,
+}
+
+impl NativeInputInjector {
+    fn load(path: &Path) -> Self {
+        let library = Library::load(path).expect("load graphics runtime for input injection");
+        let address = library
+            .symbol_address("stasis_test_push_input_event")
+            .expect("graphics runtime must expose the gated SDL input test seam");
+        let push = unsafe { std::mem::transmute(address) };
+        Self {
+            _library: library,
+            push,
+        }
+    }
+
+    fn event(&self, kind: i32, code: i32, x: f32, y: f32) {
+        assert_eq!(
+            (self.push)(kind, code, x, y),
+            1,
+            "native SDL input injection failed: kind={kind} code={code} x={x} y={y}"
+        );
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+fn evidence_path() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests/it-006-desktop-input-frame.json")
+}
+
+fn scalar_i32(path: &str) -> i32 {
+    stasis_dynload::stasis_jit_global_i32_load(global_path_hash(path))
+}
+
+fn scalar_f32(path: &str) -> f32 {
+    stasis_dynload::stasis_jit_global_f32_load(global_path_hash(path))
+}
+
+fn assert_close(actual: f32, expected: f32, field: &str) {
+    assert!(
+        (actual - expected).abs() <= 0.01,
+        "{field} mismatch: expected={expected} actual={actual}"
+    );
+}
+
+fn run_guest_frame(
+    gfx: &StasisGraphicsApi,
+    jit: &mut JitProcess,
+    host_i32: &mut [i32],
+    host_f32: &mut [f32],
+    gfx_i32: &[i32],
+    gfx_f32: &[f32],
+    gfx_u8: &[u8],
+    phase: i32,
+    checksum: i32,
+    x: f32,
+    y: f32,
+    clear: [f32; 4],
+) -> i32 {
+    gfx.host_get_frame(host_i32, host_f32)
+        .expect("snapshot native HostFrame");
+    eprintln!(
+        "IT-006 snapshot phase={phase} key={} pointers={} slot1={:?} xy=({},{}) dxy=({},{})",
+        host_i32[32 + KEY_SPACE as usize],
+        host_i32[7],
+        &host_i32[548..552],
+        host_f32[6],
+        host_f32[7],
+        host_f32[8],
+        host_f32[9]
+    );
+    assert_eq!(
+        jit.execute_i32_noarg_by_name("tick"),
+        Ok(0),
+        "execute guest tick"
+    );
+    assert_eq!(
+        jit.execute_i32_noarg_by_name("render"),
+        Ok(0),
+        "execute guest render"
+    );
+
+    assert_eq!(scalar_i32("seam_phase"), phase, "guest phase");
+    assert_eq!(
+        scalar_i32("seam_transition_count"),
+        phase,
+        "each native edge must mutate guest state exactly once"
+    );
+    assert_eq!(scalar_i32("seam_state_checksum"), checksum);
+    assert_close(scalar_f32("seam_pointer_x"), x, "guest pointer x");
+    assert_close(scalar_f32("seam_pointer_y"), y, "guest pointer y");
+
+    assert_eq!(&gfx_i32[0..4], &[1196967473, 4, 3, 0]);
+    assert_eq!(gfx_i32[22], 1, "render order count");
+    assert_eq!(gfx_i32[24], 1, "render rectangle count");
+    for (index, expected) in clear.iter().enumerate() {
+        assert_close(gfx_f32[index], *expected, "clear color");
+    }
+    assert_close(gfx_f32[79996], x, "render marker x");
+    assert_close(gfx_f32[79997], y, "render marker y");
+
+    let trace = unsafe {
+        stasis_dynload::stasis_jit_render_v2_trace(
+            global_path_hash("gfx_cmd_i32"),
+            gfx_i32.len() as i32,
+            global_path_hash("gfx_cmd_f32"),
+            gfx_f32.len() as i32,
+            global_path_hash("gfx_cmd_u8"),
+            gfx_u8.len() as i32,
+        )
+    };
+    assert_ne!(trace, 0, "native render trace must accept the guest frame");
+    gfx.gfx_submit_u8(gfx_i32, gfx_f32, gfx_u8)
+        .expect("submit guest command buffers to native graphics host");
+    trace
+}
+
+#[test]
+fn desktop_sdl_input_changes_jit_state_and_submitted_frame_on_the_intended_tick() {
+    let runtime_path = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    std::env::set_var("STASIS_ENABLE_TEST_INPUT", "1");
+    std::env::set_var("STASIS_USE_SDL", "1");
+
+    let gfx = StasisGraphicsApi::load(&runtime_path).expect("load graphics runtime");
+    assert!(gfx
+        .init_window(320, 180, "Stasis IT-006 desktop input seam")
+        .expect("initialize native window"));
+    let injector = NativeInputInjector::load(&runtime_path);
+
+    let mut host_i32 = vec![0; 768];
+    let mut host_f32 = vec![0.0; 64];
+    let mut gfx_i32 = vec![0; 34608];
+    let mut gfx_f32 = vec![0.0; 108676];
+    let mut gfx_u8 = vec![0; 65536];
+    register_global_i32_array(
+        global_path_hash("host_i32"),
+        0,
+        host_i32.as_mut_ptr(),
+        host_i32.len(),
+    );
+    register_global_f32_array(
+        global_path_hash("host_f32"),
+        0,
+        host_f32.as_mut_ptr(),
+        host_f32.len(),
+    );
+    register_global_i32_array(
+        global_path_hash("gfx_cmd_i32"),
+        0,
+        gfx_i32.as_mut_ptr(),
+        gfx_i32.len(),
+    );
+    register_global_f32_array(
+        global_path_hash("gfx_cmd_f32"),
+        0,
+        gfx_f32.as_mut_ptr(),
+        gfx_f32.len(),
+    );
+    register_global_u8_array(
+        global_path_hash("gfx_cmd_u8"),
+        0,
+        gfx_u8.as_mut_ptr(),
+        gfx_u8.len(),
+    );
+
+    let mut jit = JitProcess::new();
+    jit.set_project_root(repository_root().to_string_lossy())
+        .expect("set fixture project root");
+    jit.upsert_file(
+        "tests/stasis/seams/desktop_input_frame_probe.stasis",
+        FIXTURE,
+    );
+    jit.compile().expect("compile desktop input fixture");
+    assert_eq!(jit.execute_i32_noarg_by_name("main"), Ok(0));
+
+    injector.event(EVENT_KEY_DOWN, KEY_SPACE, 0.0, 0.0);
+    injector.event(EVENT_POINTER_DOWN, TOUCH_ID, 80.0, 45.0);
+    let down_trace = run_guest_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        1,
+        108045,
+        80.0,
+        45.0,
+        [0.8, 0.1, 0.1, 1.0],
+    );
+    assert_eq!(host_i32[32 + KEY_SPACE as usize], 1);
+    assert_eq!(host_i32[7], 2);
+    assert_eq!(&host_i32[548..552], &[1, 1, 1, 0]);
+    assert_close(host_f32[6], 80.0, "HostFrame down x");
+    assert_close(host_f32[7], 45.0, "HostFrame down y");
+    assert_close(host_f32[10], 0.25, "HostFrame down normalized x");
+    assert_close(host_f32[11], 0.25, "HostFrame down normalized y");
+
+    injector.event(EVENT_KEY_DOWN, KEY_SPACE, 0.0, 0.0);
+    injector.event(EVENT_POINTER_MOVE, TOUCH_ID, 120.0, 70.0);
+    let move_trace = run_guest_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        2,
+        212070,
+        120.0,
+        70.0,
+        [0.1, 0.8, 0.1, 1.0],
+    );
+    assert_eq!(host_i32[32 + KEY_SPACE as usize], 1);
+    assert_eq!(&host_i32[548..552], &[1, 1, 0, 0]);
+    assert_close(host_f32[8], 40.0, "HostFrame move dx");
+    assert_close(host_f32[9], 25.0, "HostFrame move dy");
+    assert_close(host_f32[10], 0.375, "HostFrame move normalized x");
+    assert_close(host_f32[11], 70.0 / 180.0, "HostFrame move normalized y");
+
+    injector.event(EVENT_KEY_UP, KEY_SPACE, 0.0, 0.0);
+    injector.event(EVENT_POINTER_UP, TOUCH_ID, 120.0, 70.0);
+    let up_trace = run_guest_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        3,
+        312070,
+        120.0,
+        70.0,
+        [0.1, 0.1, 0.8, 1.0],
+    );
+    assert_eq!(host_i32[32 + KEY_SPACE as usize], 0);
+    assert_eq!(&host_i32[548..552], &[1, 0, 0, 1]);
+    assert_eq!(
+        [down_trace, move_trace, up_trace],
+        [-1596497517, 610004423, -1115252597],
+        "guest state markers must produce the locked native frame traces"
+    );
+
+    gfx.host_get_frame(&mut host_i32, &mut host_f32)
+        .expect("snapshot quiet frame");
+    assert_eq!(
+        host_i32[7], 1,
+        "released touch must leave the next snapshot"
+    );
+    assert_eq!(scalar_i32("seam_transition_count"), 3);
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-006",
+        "status": "passed",
+        "target": "windows-sdl-jit",
+        "input": {
+            "keyboard_scancode": KEY_SPACE,
+            "pointer_slot": 1,
+            "ticks": [
+                {"tick": 1, "event": "down", "x": 80.0, "y": 45.0},
+                {"tick": 2, "event": "move", "x": 120.0, "y": 70.0, "dx": 40.0, "dy": 25.0},
+                {"tick": 3, "event": "up", "x": 120.0, "y": 70.0}
+            ]
+        },
+        "oracle": {
+            "state_checksums": [108045, 212070, 312070],
+            "transition_count": 3,
+            "render_traces": [down_trace, move_trace, up_trace],
+            "quiet_pointer_count": 1
+        }
+    });
+    let path = evidence_path();
+    fs::create_dir_all(path.parent().expect("evidence directory"))
+        .expect("create evidence directory");
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize evidence"),
+    )
+    .expect("write evidence");
+    eprintln!("IT-006 evidence: {}", evidence);
+}

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -242,6 +242,7 @@ typedef struct {
 
 static StasisInputFrame g_input_frame;
 static int g_events_pumped_this_frame = 0;
+static int8_t g_keyboard_event_state[SDL_SCANCODE_COUNT];
 static float g_prev_x_px[STASIS_MAX_POINTERS];
 static float g_prev_y_px[STASIS_MAX_POINTERS];
 static SDL_FingerID g_finger_ids[STASIS_MAX_POINTERS - 1];
@@ -603,6 +604,42 @@ static void stasis_window_to_logical(float native_x, float native_y, float* logi
         &g_display_metrics, native_x, native_y, logical_x, logical_y);
 }
 
+/*
+ * Native integration-test input enters through SDL's event queue. The explicit
+ * environment gate prevents shipped applications from synthesizing host input.
+ */
+STASIS_EXPORT int stasis_test_push_input_event(
+    int kind, int code, float logical_x, float logical_y) {
+    const char* enabled = SDL_getenv("STASIS_ENABLE_TEST_INPUT");
+    if (!g_window || !enabled || enabled[0] != '1' || enabled[1] != '\0') return 0;
+
+    SDL_Event event;
+    SDL_zero(event);
+    if (kind == 1 || kind == 2) {
+        if (code < 0 || code >= SDL_SCANCODE_COUNT) return 0;
+        event.type = kind == 1 ? SDL_EVENT_KEY_DOWN : SDL_EVENT_KEY_UP;
+        event.key.scancode = (SDL_Scancode)code;
+        event.key.repeat = false;
+    } else if (kind >= 3 && kind <= 5) {
+        if (code < 0 || g_display_metrics.native_w <= 0 || g_display_metrics.native_h <= 0) {
+            return 0;
+        }
+        float native_x = 0.0f;
+        float native_y = 0.0f;
+        stasis_display_logical_to_native_xy(
+            &g_display_metrics, logical_x, logical_y, &native_x, &native_y);
+        event.type = kind == 3 ? SDL_EVENT_FINGER_DOWN :
+            (kind == 4 ? SDL_EVENT_FINGER_MOTION : SDL_EVENT_FINGER_UP);
+        event.tfinger.touchID = 1;
+        event.tfinger.fingerID = (SDL_FingerID)code;
+        event.tfinger.x = native_x / (float)g_display_metrics.native_w;
+        event.tfinger.y = native_y / (float)g_display_metrics.native_h;
+    } else {
+        return 0;
+    }
+    return SDL_PushEvent(&event) ? 1 : 0;
+}
+
 static float stasis_clampf(float v, float minv, float maxv) {
     if (v < minv) return minv;
     if (v > maxv) return maxv;
@@ -732,6 +769,7 @@ static void stasis_pump_events(void) {
     }
 
     g_input_frame.dropped_pointers = 0;
+    memset(g_keyboard_event_state, -1, sizeof(g_keyboard_event_state));
     g_input_frame.viewport_x_px = 0;
     g_input_frame.viewport_y_px = 0;
     g_input_frame.viewport_w_px = g_window_width;
@@ -746,6 +784,9 @@ static void stasis_pump_events(void) {
                 g_should_quit = true;
                 break;
             case SDL_EVENT_KEY_DOWN:
+                if (event.key.scancode >= 0 && event.key.scancode < SDL_SCANCODE_COUNT) {
+                    g_keyboard_event_state[event.key.scancode] = 1;
+                }
                 if (event.key.key == SDLK_ESCAPE) {
                     SDL_Log("Stasis quit requested: Escape key");
                     g_should_quit = true;
@@ -754,6 +795,11 @@ static void stasis_pump_events(void) {
                     g_force_debug_overlay = !g_force_debug_overlay;
                     if (g_force_debug_overlay) (void)stasis_perf_font();
                     SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
+                }
+                break;
+            case SDL_EVENT_KEY_UP:
+                if (event.key.scancode >= 0 && event.key.scancode < SDL_SCANCODE_COUNT) {
+                    g_keyboard_event_state[event.key.scancode] = 0;
                 }
                 break;
             case SDL_EVENT_WINDOW_RESIZED:
@@ -1125,13 +1171,14 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     const int32_t host_version = 3;
     const int i32_key_base = 32;
     const int i32_key_count = 512;
+    const int should_quit = stasis_should_quit();
 
     /* i32 header */
     out_i32[0] = stasis_get_time_ms();
     for (int index = 1; index <= 6; index++) out_i32[index] = 0;
     out_i32[7] = g_input_frame.pointer_count;
     out_i32[8] = g_input_frame.dropped_pointers;
-    out_i32[9] = stasis_should_quit();
+    out_i32[9] = should_quit;
 
     out_i32[10] = g_host_tick_index++;
 
@@ -1181,7 +1228,9 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32) {
     int num_keys = 0;
     const bool* keys = SDL_GetKeyboardState(&num_keys);
     for (int i = 0; i < i32_key_count; i++) {
-        out_i32[i32_key_base + i] = (keys && i < num_keys && keys[i]) ? 1 : 0;
+        out_i32[i32_key_base + i] = g_keyboard_event_state[i] >= 0
+            ? g_keyboard_event_state[i]
+            : ((keys && i < num_keys && keys[i]) ? 1 : 0);
     }
 
     const int i32_base = i32_key_base + i32_key_count;
@@ -3895,6 +3944,7 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     g_line_count = 0;
     g_events_pumped_this_frame = 0;
     memset(&g_input_frame, 0, sizeof(g_input_frame));
+    memset(g_keyboard_event_state, -1, sizeof(g_keyboard_event_state));
     memset(g_finger_active, 0, sizeof(g_finger_active));
     memset(g_finger_ids, 0, sizeof(g_finger_ids));
     for (int i = 0; i < STASIS_MAX_POINTERS; i++) {

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -67,6 +67,7 @@ EXPORTS
     stasis_input_pointer_y_n
     stasis_input_dropped_pointers
     stasis_host_get_frame
+    stasis_test_push_input_event
     stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite
     stasis_gfx_release_sprite

--- a/tests/stasis/seams/desktop_input_frame_probe.stasis
+++ b/tests/stasis/seams/desktop_input_frame_probe.stasis
@@ -1,0 +1,60 @@
+import "../../../src/stdlib/internal/host_frame.stasis";
+import "../../../src/stdlib/internal/gfx_cmd.stasis";
+
+global seam_phase: i32;
+global seam_transition_count: i32;
+global seam_state_checksum: i32;
+global seam_pointer_x: f32;
+global seam_pointer_y: f32;
+
+function main(): i32 {
+    seam_phase = 0;
+    seam_transition_count = 0;
+    seam_state_checksum = 0;
+    seam_pointer_x = 0.0;
+    seam_pointer_y = 0.0;
+    return 0;
+}
+
+function tick(): i32 {
+    if (seam_phase == 0 && host_key_down(44) && host_pointer_count() == 2 && host_pointer_went_down(1)) {
+        seam_phase = 1;
+        seam_transition_count += 1;
+        seam_state_checksum = 108045;
+        seam_pointer_x = host_pointer_x_logical(1);
+        seam_pointer_y = host_pointer_y_logical(1);
+        return 0;
+    }
+    if (seam_phase == 1 && host_key_down(44) && host_pointer_is_down(1) && host_pointer_dx_logical(1) > 0.0) {
+        seam_phase = 2;
+        seam_transition_count += 1;
+        seam_state_checksum = 212070;
+        seam_pointer_x = host_pointer_x_logical(1);
+        seam_pointer_y = host_pointer_y_logical(1);
+        return 0;
+    }
+    if (seam_phase == 2 && !host_key_down(44) && host_pointer_went_up(1)) {
+        seam_phase = 3;
+        seam_transition_count += 1;
+        seam_state_checksum = 312070;
+        seam_pointer_x = host_pointer_x_logical(1);
+        seam_pointer_y = host_pointer_y_logical(1);
+    }
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_begin();
+    if (seam_phase == 1) {
+        gfx_cmd_clear(0.8, 0.1, 0.1, 1.0);
+    } else if (seam_phase == 2) {
+        gfx_cmd_clear(0.1, 0.8, 0.1, 1.0);
+    } else if (seam_phase == 3) {
+        gfx_cmd_clear(0.1, 0.1, 0.8, 1.0);
+    } else {
+        gfx_cmd_clear(0.0, 0.0, 0.0, 1.0);
+    }
+    gfx_cmd_rect(seam_pointer_x, seam_pointer_y, 8.0, 6.0, 1.0, 1.0, 1.0, 1.0);
+    gfx_cmd_mark_present();
+    return 0;
+}

--- a/tools/ci/check_stasis_src_layout.py
+++ b/tools/ci/check_stasis_src_layout.py
@@ -107,6 +107,7 @@ def main() -> int:
                 integration_test = rel_path.as_posix() in {
                     "tests/stasis/rust_native_tick_input_snapshot.stasis",
                     "tests/stasis/seams/gfx_cmd_capacity_probe.stasis",
+                    "tests/stasis/seams/desktop_input_frame_probe.stasis",
                     "tests/stasis/seams/window_request_mailbox_probe.stasis",
                 }
                 if not inside_stdlib and not integration_test:


### PR DESCRIPTION
## Summary
- add IT-006, a Windows SDL event queue -> HostFrame -> JIT state -> gfx_cmd/native trace integration seam
- inject gated keyboard and touch down/move/up events and verify logical/normalized coordinates, per-tick state checksums, exact frame traces, and JSON evidence
- fix the inconsistent HostFrame exposed by the test by pumping native events before copying pointer counts
- run the dedicated seam explicitly in Windows PR CI

## Tests
- `cargo test -p stasis --test desktop_input_frame_seam -- --test-threads=1 --nocapture`
- `cargo test -p stasis --test windows_game_launch -- --test-threads=1 --nocapture`
- Windows SDL runtime Release build
- `python tools/ci/check_runtime_abi_contract.py`
- `python tools/ci/check_stasis_src_layout.py`
- `python tools/ci/check_sdl3_migration.py`
- `cargo fmt --all -- --check`
- `git diff --check`

## Maddox
- Maddox #215 / IT-006

Theory gained: HostFrame is one atomic per-tick snapshot; native event pumping must precede every field copy, because mixing pre-pump counts with post-pump pointer slots creates an internally impossible frame. A resize or focus-event seam should make the same prediction: all event-derived header fields and payload fields must come from one pump generation.

Good: driving the actual SDL queue exposed a real ordering defect that direct HostFrame fixtures could not see.
Bad: the first harness run assumed the snapshot producer pumped before copying counts.
Adjustment: native seam tests should assert both collection counts and terminal payload entries from the same snapshot before invoking guest code.