### PR TITLE
test: cover desktop manifest asset seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -140,6 +140,12 @@ jobs:
           $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
           cargo test -p stasis --test desktop_display_metrics_seam -- --test-threads=1 --nocapture
 
+      - name: Test desktop manifest asset rendering seam
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          cargo test -p stasis --test desktop_manifest_assets_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/desktop_manifest_assets_seam.rs
+++ b/apps/stasis/tests/desktop_manifest_assets_seam.rs
@@ -1,0 +1,306 @@
+#![cfg(windows)]
+
+use image::RgbaImage;
+use serde_json::json;
+use stasis_assets::{load_project_asset_manifest, AssetLimits};
+use stasis_compiler::backend::jit::JitProcess;
+use stasis_dynload::{
+    global_path_hash, register_global_f32_array, register_global_i32_array,
+    register_global_u8_array, runtime_library_candidate_paths, Library, StasisGraphicsApi,
+};
+use std::ffi::CString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const FIXTURE: &str =
+    include_str!("../../../tests/stasis/seams/desktop_manifest_assets_probe.stasis");
+const LOGICAL_SIZE: [u32; 2] = [320, 180];
+const PNG_SHA256: &str = "98d61197c8db539121336207a1cc722093a0d3e0acd5ef5196c1eda3e9b92d72";
+const FONT_SHA256: &str = "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47";
+const PNG_MANIFEST_HANDLE: i32 = 1_221_991_035;
+const FONT_MANIFEST_HANDLE: i32 = 623_275_877;
+const RENDER_TRACE: i32 = -2_088_676_722;
+
+type SetAssetRoot = extern "system" fn(*const std::ffi::c_char) -> i32;
+type ScheduleScreenshot = extern "system" fn(*const std::ffi::c_char) -> i32;
+
+struct NativeAssetHarness {
+    _library: Library,
+    set_asset_root: SetAssetRoot,
+    schedule_screenshot: ScheduleScreenshot,
+}
+
+impl NativeAssetHarness {
+    fn load(path: &Path) -> Self {
+        let library = Library::load(path).expect("load graphics runtime for asset seam");
+        let set_asset_root = unsafe {
+            std::mem::transmute(
+                library
+                    .symbol_address("stasis_set_asset_root")
+                    .expect("resolve native asset-root setter"),
+            )
+        };
+        let schedule_screenshot = unsafe {
+            std::mem::transmute(
+                library
+                    .symbol_address("stasis_host_schedule_screenshot")
+                    .expect("resolve native screenshot scheduler"),
+            )
+        };
+        Self {
+            _library: library,
+            set_asset_root,
+            schedule_screenshot,
+        }
+    }
+
+    fn asset_root(&self, path: &Path) {
+        let path = CString::new(path.to_string_lossy().as_bytes()).expect("asset root CString");
+        assert_eq!((self.set_asset_root)(path.as_ptr()), 1, "set asset root");
+    }
+
+    fn screenshot(&self, path: &Path) {
+        let path = CString::new(path.to_string_lossy().as_bytes()).expect("screenshot CString");
+        assert_eq!(
+            (self.schedule_screenshot)(path.as_ptr()),
+            1,
+            "schedule native screenshot"
+        );
+    }
+}
+
+struct WorkingDirectoryGuard(PathBuf);
+
+impl Drop for WorkingDirectoryGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).expect("restore test working directory");
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn scalar_i32(path: &str) -> i32 {
+    stasis_dynload::stasis_jit_global_i32_load(global_path_hash(path))
+}
+
+fn scalar_f32(path: &str) -> f32 {
+    stasis_dynload::stasis_jit_global_f32_load(global_path_hash(path))
+}
+
+fn colored_pixels(
+    image: &RgbaImage,
+    logical_region: [u32; 4],
+    predicate: impl Fn([u8; 4]) -> bool,
+) -> usize {
+    let x0 = logical_region[0] * image.width() / LOGICAL_SIZE[0];
+    let y0 = logical_region[1] * image.height() / LOGICAL_SIZE[1];
+    let x1 = (logical_region[0] + logical_region[2]) * image.width() / LOGICAL_SIZE[0];
+    let y1 = (logical_region[1] + logical_region[3]) * image.height() / LOGICAL_SIZE[1];
+    (y0..y1)
+        .flat_map(|y| (x0..x1).map(move |x| image.get_pixel(x, y).0))
+        .filter(|pixel| predicate(*pixel))
+        .count()
+}
+
+#[test]
+fn manifest_assets_survive_wrong_cwd_and_render_sprite_direct_and_cached_text() {
+    let repository = repository_root();
+    let project = repository.join("samples/windows_launch_smoke");
+    let manifest = load_project_asset_manifest(&project, AssetLimits::default())
+        .expect("load checked desktop asset manifest");
+    let png = manifest.by_id("smoke_png").expect("manifest PNG identity");
+    let font = manifest
+        .by_id("smoke_font")
+        .expect("manifest font identity");
+    assert_eq!(png.entry.path, "assets/smoke.png");
+    assert_eq!(png.entry.content_sha256, PNG_SHA256);
+    assert_eq!(png.handle.as_i32(), PNG_MANIFEST_HANDLE);
+    assert_eq!(
+        png.absolute_path,
+        project
+            .join("assets/smoke.png")
+            .canonicalize()
+            .expect("canonical PNG path")
+    );
+    assert_eq!(font.entry.path, "assets/smoke.ttf");
+    assert_eq!(font.entry.content_sha256, FONT_SHA256);
+    assert_eq!(font.handle.as_i32(), FONT_MANIFEST_HANDLE);
+    assert_eq!(
+        font.absolute_path,
+        project
+            .join("assets/smoke.ttf")
+            .canonicalize()
+            .expect("canonical font path")
+    );
+
+    let evidence_root = evidence_root();
+    let wrong_cwd = evidence_root.join("it-008-wrong-working-directory");
+    fs::create_dir_all(&wrong_cwd).expect("create isolated wrong working directory");
+    let original_cwd = std::env::current_dir().expect("read original working directory");
+    let _cwd_guard = WorkingDirectoryGuard(original_cwd);
+    std::env::set_current_dir(&wrong_cwd).expect("enter wrong working directory");
+
+    let runtime_path = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    let selected_runtime = runtime_library_candidate_paths()
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .expect("select configured graphics runtime");
+    assert_eq!(
+        selected_runtime
+            .canonicalize()
+            .expect("canonical selected runtime"),
+        runtime_path
+            .canonicalize()
+            .expect("canonical configured runtime"),
+        "explicit runtime must outrank repository development fallbacks"
+    );
+    std::env::set_var("STASIS_USE_SDL", "1");
+    std::env::set_var("STASIS_GFX_LOG_SPRITES", "1");
+    let gfx = StasisGraphicsApi::load(&runtime_path).expect("load graphics runtime");
+    assert!(gfx
+        .init_window(320, 180, "Stasis IT-008 manifest assets seam")
+        .expect("initialize native window"));
+    let native = NativeAssetHarness::load(&runtime_path);
+
+    let mut gfx_i32 = vec![0; 34608];
+    let mut gfx_f32 = vec![0.0; 108676];
+    let mut gfx_u8 = vec![0; 65536];
+    register_global_i32_array(
+        global_path_hash("gfx_cmd_i32"),
+        0,
+        gfx_i32.as_mut_ptr(),
+        gfx_i32.len(),
+    );
+    register_global_f32_array(
+        global_path_hash("gfx_cmd_f32"),
+        0,
+        gfx_f32.as_mut_ptr(),
+        gfx_f32.len(),
+    );
+    register_global_u8_array(
+        global_path_hash("gfx_cmd_u8"),
+        0,
+        gfx_u8.as_mut_ptr(),
+        gfx_u8.len(),
+    );
+
+    let mut jit = JitProcess::new();
+    jit.set_project_root(repository.to_string_lossy())
+        .expect("set fixture project root");
+    jit.upsert_file(
+        "tests/stasis/seams/desktop_manifest_assets_probe.stasis",
+        FIXTURE,
+    );
+    jit.compile().expect("compile manifest asset fixture");
+
+    let wrong_cwd_result = jit
+        .execute_i32_noarg_by_name("main")
+        .expect("execute wrong-working-directory probe");
+    assert_eq!(
+        wrong_cwd_result, 21,
+        "relative sprite lookup must fail before the host supplies its asset root"
+    );
+
+    native.asset_root(&project);
+    assert_eq!(jit.execute_i32_noarg_by_name("main"), Ok(0));
+    let sprite_handle = scalar_i32("seam_sprite_handle");
+    let font_handle = scalar_i32("seam_font_handle");
+    let cached_handle = scalar_i32("seam_cached_handle");
+    let direct_width = scalar_f32("seam_direct_width");
+    let cached_width = scalar_f32("seam_cached_width");
+    assert_eq!(sprite_handle, 1, "first native sprite handle");
+    assert_eq!(font_handle, 1, "first native font handle");
+    assert_eq!(cached_handle, 1, "first native cached-text handle");
+    assert!(direct_width > 0.0 && cached_width > 0.0);
+
+    assert_eq!(jit.execute_i32_noarg_by_name("tick"), Ok(0));
+    assert_eq!(jit.execute_i32_noarg_by_name("render"), Ok(0));
+    assert_eq!(gfx_i32[4], 1, "one sprite command");
+    assert_eq!(gfx_i32[7], 2, "direct and cached text commands");
+    assert_eq!(gfx_i32[22], 3, "ordered sprite and text commands");
+    assert_eq!(&gfx_u8[0..7], b"DIRECT\0", "direct UTF-8 command bytes");
+    assert_eq!(gfx_i32[12321], 0, "direct text byte offset");
+    assert_eq!(gfx_i32[12322], 6, "direct text byte length");
+    assert_eq!(gfx_i32[12324], -cached_handle, "cached text handle tag");
+    let trace = unsafe {
+        stasis_dynload::stasis_jit_render_v2_trace(
+            global_path_hash("gfx_cmd_i32"),
+            gfx_i32.len() as i32,
+            global_path_hash("gfx_cmd_f32"),
+            gfx_f32.len() as i32,
+            global_path_hash("gfx_cmd_u8"),
+            gfx_u8.len() as i32,
+        )
+    };
+    assert_eq!(trace, RENDER_TRACE, "exact manifest asset frame trace");
+
+    let screenshot = evidence_root.join("it-008-desktop-manifest-assets.png");
+    native.screenshot(&screenshot);
+    gfx.gfx_submit_u8(&mut gfx_i32, &gfx_f32, &gfx_u8)
+        .expect("submit manifest asset frame");
+    let image = image::open(&screenshot)
+        .expect("open native asset screenshot")
+        .to_rgba8();
+    let regions = [
+        (
+            "sprite_magenta",
+            colored_pixels(&image, [52, 28, 64, 64], |p| {
+                p[0] > 170 && p[2] > 170 && p[1] < 150
+            }),
+        ),
+        (
+            "direct_text_yellow",
+            colored_pixels(&image, [24, 106, 125, 38], |p| {
+                p[0] > 140 && p[1] > 110 && p[2] < 130
+            }),
+        ),
+        (
+            "cached_text_cyan",
+            colored_pixels(&image, [169, 106, 125, 38], |p| {
+                p[0] < 150 && p[1] > 130 && p[2] > 150
+            }),
+        ),
+    ];
+    for (name, count) in regions {
+        assert!(
+            count >= 8,
+            "named pixel region {name} contained only {count} matching pixels"
+        );
+    }
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-008",
+        "status": "passed",
+        "target": "windows-sdl-jit",
+        "wrong_working_directory_main_result": wrong_cwd_result,
+        "manifest": [
+            {"id": png.entry.id, "path": png.entry.path, "resolved_path": png.absolute_path, "sha256": png.entry.content_sha256, "manifest_handle": png.handle.as_i32(), "runtime_handle": sprite_handle},
+            {"id": font.entry.id, "path": font.entry.path, "resolved_path": font.absolute_path, "sha256": font.entry.content_sha256, "manifest_handle": font.handle.as_i32(), "runtime_handle": font_handle}
+        ],
+        "text": {"direct_width": direct_width, "cached_width": cached_width, "cached_handle": cached_handle},
+        "render": {"trace": trace, "screenshot": screenshot, "regions": regions.into_iter().collect::<std::collections::BTreeMap<_, _>>()}
+    });
+    let evidence_path = evidence_root.join("it-008-desktop-manifest-assets.json");
+    fs::write(
+        &evidence_path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize seam evidence"),
+    )
+    .expect("write seam evidence");
+    eprintln!("IT-008 evidence: {evidence}");
+}

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1194,36 +1194,42 @@ fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, Stri
 
 pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
     let mut out = Vec::new();
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(exe_dir) = exe.parent() {
-            // A release bundle is one unit. Never let an environment override replace its sibling
-            // runtime with a different build.
-            for file_name in runtime_library_file_names() {
-                out.push(exe_dir.join(file_name));
-            }
+    let configured = [
+        std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH"),
+        // Preserve the original variable as a compatibility alias for existing Windows workflows.
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH"),
+    ]
+    .into_iter()
+    .flatten()
+    .map(PathBuf::from)
+    .collect::<Vec<_>>();
+    let executable_dir = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf));
+    if let Some(exe_dir) = executable_dir {
+        // A release bundle is one unit. Never let an environment override replace its sibling
+        // runtime with a different build.
+        for file_name in runtime_library_file_names() {
+            out.push(exe_dir.join(file_name));
+        }
+        out.extend(configured.iter().cloned());
 
-            // Dev-friendly default: locate the runtime built under the repo tree by
-            // walking a few parents from the executable location.
-            for ancestor in exe_dir.ancestors().take(6) {
-                for file_name in runtime_library_file_names() {
-                    for configuration in [None, Some("Release"), Some("Debug")] {
-                        let mut candidate = ancestor.join("runtime").join("build").join("bin");
-                        if let Some(configuration) = configuration {
-                            candidate.push(configuration);
-                        }
-                        candidate.push(file_name);
-                        out.push(candidate);
+        // Dev-friendly default: locate the runtime built under the repo tree by
+        // walking a few parents from the executable location.
+        for ancestor in exe_dir.ancestors().take(6) {
+            for file_name in runtime_library_file_names() {
+                for configuration in [None, Some("Release"), Some("Debug")] {
+                    let mut candidate = ancestor.join("runtime").join("build").join("bin");
+                    if let Some(configuration) = configuration {
+                        candidate.push(configuration);
                     }
+                    candidate.push(file_name);
+                    out.push(candidate);
                 }
             }
         }
-    }
-    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
-        out.push(PathBuf::from(configured));
-    }
-    // Preserve the original variable as a compatibility alias for existing Windows workflows.
-    if let Some(configured) = std::env::var_os("STASIS_RUNTIME_DLL_PATH") {
-        out.push(PathBuf::from(configured));
+    } else {
+        out.extend(configured);
     }
 
     // Allow loading from the current working directory too (handy for ad-hoc runs).

--- a/tests/stasis/seams/desktop_manifest_assets_probe.stasis
+++ b/tests/stasis/seams/desktop_manifest_assets_probe.stasis
@@ -1,0 +1,106 @@
+@link("stasis_graphics");
+
+extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+extern function load_font(path: string, size: i32): i32;
+extern function measure_text(font: i32, text: string): f32;
+function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
+function @extern("stasis_jit_gfx_measure_text_cached") gfx_measure_text_cached(handle: i32): f32;
+
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global seam_sprite_handle: i32;
+global seam_font_handle: i32;
+global seam_cached_handle: i32;
+global seam_direct_width: f32;
+global seam_cached_width: f32;
+
+function main(): i32 {
+    seam_sprite_handle = gfx_load_sprite("assets/smoke.png", 64, 64);
+    if (seam_sprite_handle == 0) {
+        return 21;
+    }
+    seam_font_handle = load_font("assets/smoke.ttf", 24);
+    if (seam_font_handle == 0) {
+        return 22;
+    }
+    seam_cached_handle = gfx_cache_text(seam_font_handle, "CACHED");
+    if (seam_cached_handle == 0) {
+        return 23;
+    }
+    seam_direct_width = measure_text(seam_font_handle, "DIRECT");
+    seam_cached_width = gfx_measure_text_cached(seam_cached_handle);
+    if (seam_direct_width <= 0.0 || seam_cached_width <= 0.0) {
+        return 24;
+    }
+    return 0;
+}
+
+function tick(): i32 {
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 1;
+    gfx_cmd_i32[5] = 0;
+    gfx_cmd_i32[6] = 0;
+    gfx_cmd_i32[7] = 2;
+    gfx_cmd_i32[8] = 0;
+    gfx_cmd_i32[9] = 7;
+    gfx_cmd_i32[22] = 3;
+    gfx_cmd_i32[23] = 0;
+    gfx_cmd_i32[24] = 0;
+    gfx_cmd_i32[25] = 0;
+    gfx_cmd_f32[0] = 0.04;
+    gfx_cmd_f32[1] = 0.07;
+    gfx_cmd_f32[2] = 0.12;
+    gfx_cmd_f32[3] = 1.0;
+
+    gfx_cmd_i32[32] = seam_sprite_handle;
+    gfx_cmd_i32[33] = 0;
+    gfx_cmd_i32[34] = 255;
+    gfx_cmd_f32[80004] = 52.0;
+    gfx_cmd_f32[80005] = 28.0;
+    gfx_cmd_f32[80006] = 64.0;
+    gfx_cmd_f32[80007] = 64.0;
+
+    gfx_cmd_i32[12320] = seam_font_handle;
+    gfx_cmd_i32[12321] = 0;
+    gfx_cmd_i32[12322] = 6;
+    gfx_cmd_f32[96388] = 30.0;
+    gfx_cmd_f32[96389] = 112.0;
+    gfx_cmd_f32[96390] = 1.0;
+    gfx_cmd_f32[96391] = 0.8;
+    gfx_cmd_f32[96392] = 0.1;
+    gfx_cmd_f32[96393] = 1.0;
+
+    gfx_cmd_i32[12323] = seam_font_handle;
+    gfx_cmd_i32[12324] = 0 - seam_cached_handle;
+    gfx_cmd_i32[12325] = 0;
+    gfx_cmd_f32[96394] = 175.0;
+    gfx_cmd_f32[96395] = 112.0;
+    gfx_cmd_f32[96396] = 0.1;
+    gfx_cmd_f32[96397] = 0.9;
+    gfx_cmd_f32[96398] = 1.0;
+    gfx_cmd_f32[96399] = 1.0;
+
+    gfx_cmd_u8[0] = 68;
+    gfx_cmd_u8[1] = 73;
+    gfx_cmd_u8[2] = 82;
+    gfx_cmd_u8[3] = 69;
+    gfx_cmd_u8[4] = 67;
+    gfx_cmd_u8[5] = 84;
+
+    gfx_cmd_i32[18464] = 32768;
+    gfx_cmd_i32[18465] = 49152;
+    gfx_cmd_i32[18466] = 49153;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/tools/ci/check_stasis_src_layout.py
+++ b/tools/ci/check_stasis_src_layout.py
@@ -109,6 +109,7 @@ def main() -> int:
                     "tests/stasis/seams/gfx_cmd_capacity_probe.stasis",
                     "tests/stasis/seams/desktop_input_frame_probe.stasis",
                     "tests/stasis/seams/desktop_display_metrics_probe.stasis",
+                    "tests/stasis/seams/desktop_manifest_assets_probe.stasis",
                     "tests/stasis/seams/window_request_mailbox_probe.stasis",
                 }
                 if not inside_stdlib and not integration_test:


### PR DESCRIPTION
## Summary

- add IT-008, a Windows SDL/JIT integration seam using checked manifest sprite and font assets
- reproduce relative asset lookup failure from an isolated working directory, then prove the host asset root fixes the same compiled guest
- verify exact manifest IDs, paths, SHA-256 values, stable handles, native sprite/font/cache handles, direct UTF-8 and cached text commands, exact frame trace, and named screenshot regions
- ensure explicitly configured runtime libraries outrank repository development fallbacks, while packaged sibling runtimes remain first
- emit structured `stasis.seam_test.v1` evidence and add the focused test to Windows PR CI

## Validation

- `cargo test -p stasis --test desktop_manifest_assets_seam -- --test-threads=1 --nocapture`
- `cargo test -p stasis_dynload -- --test-threads=1`
- `cargo test -p stasis_compiler startup_asset_externs_match_jit_and_linked_aot_recording_host -- --test-threads=1 --nocapture`
- `cargo test -p stasis --test windows_game_launch -- --test-threads=1 --nocapture`
- Stasis source layout, SDL3 migration, formatting, and diff checks

## Theory gained

Desktop asset externs and host rendering must share one loaded native runtime instance: the host sets asset-root state there, and JIT externs consume that same state. A packaged sibling runtime remains authoritative, but in development/CI an explicit runtime path must precede repository discovery. Once that identity is shared, manifest validation and native resource caching form one observable path from checked bytes to pixels. An adjacent prediction is that sprite reload polling must also resolve against the same runtime instance and canonical asset path.

## Reflection

- Good: beginning from a deliberately wrong working directory made the hidden dual-runtime state split deterministic.
- Bad: candidate discovery accepted the explicit runtime but ranked it too late, allowing a valid yet different development DLL to silently win.
- Adjustment: integration seams that share native process-global state should assert the selected binary identity before testing state transfer.