### PR TITLE
test: cover malformed render recovery seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -146,6 +146,12 @@ jobs:
           $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
           cargo test -p stasis --test desktop_manifest_assets_seam -- --test-threads=1 --nocapture
 
+      - name: Test malformed render buffer recovery seam
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          cargo test -p stasis --test desktop_render_recovery_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/desktop_render_recovery_seam.rs
+++ b/apps/stasis/tests/desktop_render_recovery_seam.rs
@@ -1,0 +1,201 @@
+#![cfg(windows)]
+
+use image::RgbaImage;
+use serde_json::json;
+use stasis_dynload::{Library, StasisGraphicsApi};
+use std::ffi::CString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MAGIC: i32 = 1_196_967_473;
+const VERSION: i32 = 4;
+const FLAGS_CLEAR_PRESENT: i32 = 3;
+const MAX_SPRITES: i32 = 4096;
+const ORDER_RECT: i32 = 4 * 16_384;
+const VALID_TRACE: i32 = 1_247_641_392;
+const I32_COUNT: usize = 34_608;
+const F32_COUNT: usize = 108_676;
+const U8_COUNT: usize = 65_536;
+const RECT_F32_BASE: usize = 79_996;
+const TEXT_I32_BASE: usize = 12_320;
+const ORDER_I32_BASE: usize = 18_464;
+
+type ScheduleScreenshot = extern "system" fn(*const std::ffi::c_char) -> i32;
+type GetSubmissionState = extern "system" fn(*mut i32, i32) -> i32;
+
+struct NativeRecoveryHarness {
+    _library: Library,
+    schedule_screenshot: ScheduleScreenshot,
+    get_submission_state: GetSubmissionState,
+}
+
+impl NativeRecoveryHarness {
+    fn load(path: &Path) -> Self {
+        let library = Library::load(path).expect("load graphics runtime for recovery seam");
+        let schedule_screenshot = unsafe {
+            std::mem::transmute(
+                library
+                    .symbol_address("stasis_host_schedule_screenshot")
+                    .expect("resolve screenshot scheduler"),
+            )
+        };
+        let get_submission_state = unsafe {
+            std::mem::transmute(
+                library
+                    .symbol_address("stasis_test_get_render_submission_state")
+                    .expect("resolve gated submission state"),
+            )
+        };
+        Self {
+            _library: library,
+            schedule_screenshot,
+            get_submission_state,
+        }
+    }
+
+    fn state(&self) -> [i32; 5] {
+        let mut state = [0; 5];
+        assert_eq!((self.get_submission_state)(state.as_mut_ptr(), 5), 1);
+        state
+    }
+
+    fn screenshot(&self, path: &Path) {
+        let path = CString::new(path.to_string_lossy().as_bytes()).expect("screenshot CString");
+        assert_eq!((self.schedule_screenshot)(path.as_ptr()), 1);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn valid_frame() -> (Vec<i32>, Vec<f32>, Vec<u8>) {
+    let mut i32s = vec![0; I32_COUNT];
+    let mut f32s = vec![0.0; F32_COUNT];
+    let u8s = vec![0; U8_COUNT];
+    i32s[0] = MAGIC;
+    i32s[1] = VERSION;
+    i32s[2] = FLAGS_CLEAR_PRESENT;
+    i32s[22] = 1;
+    i32s[24] = 1;
+    i32s[ORDER_I32_BASE] = ORDER_RECT;
+    f32s[0..4].copy_from_slice(&[0.03, 0.06, 0.12, 1.0]);
+    f32s[RECT_F32_BASE..RECT_F32_BASE + 8]
+        .copy_from_slice(&[80.0, 45.0, 160.0, 90.0, 0.9, 0.15, 0.08, 1.0]);
+    (i32s, f32s, u8s)
+}
+
+fn red_pixels(image: &RgbaImage) -> usize {
+    image
+        .pixels()
+        .filter(|pixel| pixel[0] > 170 && pixel[1] < 90 && pixel[2] < 80)
+        .count()
+}
+
+#[test]
+fn malformed_frames_are_rejected_without_poisoning_the_next_valid_frame() {
+    let runtime_path = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    std::env::set_var("STASIS_USE_SDL", "1");
+    std::env::set_var("STASIS_ENABLE_TEST_INPUT", "1");
+    let gfx = StasisGraphicsApi::load(&runtime_path).expect("load graphics runtime");
+    assert!(gfx
+        .init_window(320, 180, "Stasis IT-009 render recovery seam")
+        .expect("initialize native window"));
+    let native = NativeRecoveryHarness::load(&runtime_path);
+    let (mut valid_i32, valid_f32, valid_u8) = valid_frame();
+
+    gfx.gfx_submit_u8(&mut valid_i32, &valid_f32, &valid_u8)
+        .expect("submit initial valid frame");
+    let initial = native.state();
+    assert_eq!(&initial[0..4], &[1, 0, 1, 0]);
+    assert_eq!(initial[4], VALID_TRACE, "exact valid frame trace");
+
+    let mut rejection_evidence = Vec::new();
+    for (name, expected_validation, mutate) in [
+        ("bad_magic", 3, 0),
+        ("bad_version", 4, 1),
+        ("negative_count", 5, 2),
+        ("excessive_count", 6, 3),
+        ("bad_text_span", 7, 4),
+        ("bad_order_reference", 8, 5),
+    ] {
+        let (mut bad_i32, bad_f32, bad_u8) = valid_frame();
+        match mutate {
+            0 => bad_i32[0] = 0,
+            1 => bad_i32[1] = 99,
+            2 => bad_i32[3] = -1,
+            3 => bad_i32[4] = MAX_SPRITES + 1,
+            4 => {
+                bad_i32[7] = 1;
+                bad_i32[9] = 2;
+                bad_i32[TEXT_I32_BASE] = 1;
+                bad_i32[TEXT_I32_BASE + 1] = 1;
+                bad_i32[TEXT_I32_BASE + 2] = 1;
+            }
+            5 => bad_i32[ORDER_I32_BASE] = 3 * 16_384,
+            _ => unreachable!(),
+        }
+        gfx.gfx_submit_u8(&mut bad_i32, &bad_f32, &bad_u8)
+            .expect("submit malformed frame");
+        let state = native.state();
+        assert_eq!(state[0], 1, "{name} must not be accepted");
+        assert_eq!(state[1], rejection_evidence.len() as i32 + 1);
+        assert_eq!(state[2], 1, "{name} must not present");
+        assert_eq!(state[3], expected_validation, "{name} diagnostic");
+        assert_eq!(
+            state[4], initial[4],
+            "{name} must preserve last valid trace"
+        );
+        rejection_evidence.push(json!({"case": name, "validation": expected_validation}));
+    }
+
+    let screenshot = evidence_root().join("it-009-recovered-valid-frame.png");
+    fs::create_dir_all(screenshot.parent().expect("screenshot parent"))
+        .expect("create evidence directory");
+    native.screenshot(&screenshot);
+    let (mut final_i32, final_f32, final_u8) = valid_frame();
+    gfx.gfx_submit_u8(&mut final_i32, &final_f32, &final_u8)
+        .expect("submit final valid frame");
+    let final_state = native.state();
+    assert_eq!(&final_state[0..4], &[2, 6, 2, 0]);
+    assert_eq!(final_state[4], initial[4], "final valid trace recovery");
+    let image = image::open(&screenshot)
+        .expect("open recovered frame screenshot")
+        .to_rgba8();
+    let recovered_red_pixels = red_pixels(&image);
+    assert!(
+        recovered_red_pixels > (image.width() * image.height()) as usize / 8,
+        "recovered frame must contain its red center region"
+    );
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-009",
+        "status": "passed",
+        "target": "windows-sdl-native",
+        "initial_valid": initial,
+        "rejections": rejection_evidence,
+        "final_valid": final_state,
+        "oracle": {"recovered_red_pixels": recovered_red_pixels, "screenshot": screenshot}
+    });
+    let evidence_path = evidence_root().join("it-009-render-recovery.json");
+    fs::write(
+        evidence_path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize seam evidence"),
+    )
+    .expect("write seam evidence");
+    eprintln!("IT-009 evidence: {evidence}");
+}

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -156,6 +156,13 @@ static int g_display_generation = 0;
 static int g_density_generation = 0;
 static bool g_window_resized = false;
 static bool g_window_minimized = false;
+static uint32_t g_render_accepted_frames = 0;
+static uint32_t g_render_rejected_frames = 0;
+static uint32_t g_render_presented_frames = 0;
+static uint32_t g_render_last_trace = 0;
+static StasisRenderValidation g_render_last_validation = STASIS_RENDER_VALID;
+static uint32_t g_render_logged_validation_mask = 0;
+static bool g_render_contract_logged = false;
 typedef struct {
     int active;
     int logical_w;
@@ -267,6 +274,7 @@ STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32);
 STASIS_EXPORT int stasis_set_fullscreen(int fullscreen);
 STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, float x, float y, float w, float h, int rot_degrees, int a);
 STASIS_EXPORT void stasis_gfx_submit_u8(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8);
+STASIS_EXPORT int stasis_test_get_render_submission_state(int32_t* out_i32, int32_t capacity);
 STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, float y, float r, float g, float b, float a);
 
 /* Forward decls for internal helpers used before their definitions. */
@@ -4826,22 +4834,28 @@ static void stasis_stamp_display_metadata(int32_t* cmd_i32) {
 }
 
 static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
-    static int contract_logged = 0;
     StasisRenderValidation validation = stasis_render_validate(cmd_i32, cmd_f32);
     if (validation != STASIS_RENDER_VALID) {
-        if (!contract_logged) {
+        g_render_rejected_frames++;
+        g_render_last_validation = validation;
+        const uint32_t validation_mask = 1u << (uint32_t)validation;
+        if ((g_render_logged_validation_mask & validation_mask) == 0) {
             SDL_Log(
-                "Stasis renderer rejected frame: stage=command_header failure=%s magic=%d version=%d backend=%s surface_generation=%u renderer_generation=%u",
+                "Stasis renderer rejected frame: stage=%s failure=%s magic=%d version=%d backend=%s surface_generation=%u renderer_generation=%u",
+                stasis_render_validation_stage(validation),
                 stasis_render_validation_name(validation),
                 cmd_i32 ? cmd_i32[STASIS_RENDER_I_MAGIC] : 0,
                 cmd_i32 ? cmd_i32[STASIS_RENDER_I_VERSION] : 0,
                 g_use_sdl_renderer ? "sdl" : "gl",
                 g_resource_lifecycle.surface_generation,
                 g_resource_lifecycle.renderer_generation);
-            contract_logged = 1;
+            g_render_logged_validation_mask |= validation_mask;
         }
         return;
     }
+    g_render_accepted_frames++;
+    g_render_last_validation = STASIS_RENDER_VALID;
+    g_render_last_trace = stasis_render_trace(cmd_i32, cmd_f32, cmd_u8);
     stasis_stamp_display_metadata(cmd_i32);
     g_perf_render_started_counter = SDL_GetPerformanceCounter();
 
@@ -4867,7 +4881,7 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
     if (text_count > gfx_cmd_max_text) text_count = gfx_cmd_max_text;
     if (text_bytes_used > gfx_cmd_max_text_bytes) text_bytes_used = gfx_cmd_max_text_bytes;
 
-    if (!contract_logged) {
+    if (!g_render_contract_logged) {
         SDL_Log(
             "Stasis render contract v%d trace=%u flags=%d lines=%d rects=%d sprites=%d text=%d",
             cmd_i32[STASIS_RENDER_I_VERSION],
@@ -4877,7 +4891,7 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
             rect_count,
             sprite_count,
             text_count);
-        contract_logged = 1;
+        g_render_contract_logged = true;
     }
 
     stasis_begin_frame();
@@ -4945,9 +4959,23 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
     if ((flags & STASIS_RENDER_FLAG_PRESENT) != 0) {
         stasis_perf_draw_overlay();
         stasis_end_frame();
+        g_render_presented_frames++;
     } else {
         g_perf_render_started_counter = 0;
     }
+}
+
+STASIS_EXPORT int stasis_test_get_render_submission_state(int32_t* out_i32, int32_t capacity) {
+    const char* enabled = SDL_getenv("STASIS_ENABLE_TEST_INPUT");
+    if (!out_i32 || capacity < 5 || !enabled || enabled[0] != '1' || enabled[1] != '\0') {
+        return 0;
+    }
+    out_i32[0] = (int32_t)g_render_accepted_frames;
+    out_i32[1] = (int32_t)g_render_rejected_frames;
+    out_i32[2] = (int32_t)g_render_presented_frames;
+    out_i32[3] = (int32_t)g_render_last_validation;
+    out_i32[4] = (int32_t)g_render_last_trace;
+    return 1;
 }
 
 STASIS_EXPORT void stasis_gfx_submit(int32_t* cmd_i32, const float* cmd_f32) {
@@ -6107,6 +6135,13 @@ STASIS_EXPORT void stasis_shutdown(void) {
     memset(&g_resource_lifecycle, 0, sizeof(g_resource_lifecycle));
     memset(&g_test_display_override, 0, sizeof(g_test_display_override));
     g_window_minimized = false;
+    g_render_accepted_frames = 0;
+    g_render_rejected_frames = 0;
+    g_render_presented_frames = 0;
+    g_render_last_trace = 0;
+    g_render_last_validation = STASIS_RENDER_VALID;
+    g_render_logged_validation_mask = 0;
+    g_render_contract_logged = false;
     g_resource_frame_ready = false;
     SDL_Log("Stasis graphics shutdown");
 }

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -69,6 +69,7 @@ EXPORTS
     stasis_host_get_frame
     stasis_test_push_input_event
     stasis_test_push_display_event
+    stasis_test_get_render_submission_state
     stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite
     stasis_gfx_release_sprite

--- a/runtime/stasis_render_contract.h
+++ b/runtime/stasis_render_contract.h
@@ -97,8 +97,22 @@ typedef enum StasisRenderValidation {
     STASIS_RENDER_NULL_I32 = 1,
     STASIS_RENDER_NULL_F32 = 2,
     STASIS_RENDER_BAD_MAGIC = 3,
-    STASIS_RENDER_BAD_VERSION = 4
+    STASIS_RENDER_BAD_VERSION = 4,
+    STASIS_RENDER_NEGATIVE_COUNT = 5,
+    STASIS_RENDER_EXCESSIVE_COUNT = 6,
+    STASIS_RENDER_BAD_TEXT_SPAN = 7,
+    STASIS_RENDER_BAD_ORDER_REFERENCE = 8
 } StasisRenderValidation;
+
+static inline int stasis_render_text_span_is_valid(
+    int32_t byte_offset,
+    int32_t byte_length,
+    int32_t text_bytes_used
+) {
+    return byte_offset >= 0 && byte_length >= 0 &&
+        byte_offset < text_bytes_used &&
+        byte_length < text_bytes_used - byte_offset;
+}
 
 static inline StasisRenderValidation stasis_render_validate(
     const int32_t *cmd_i32,
@@ -114,6 +128,53 @@ static inline StasisRenderValidation stasis_render_validate(
         cmd_i32[STASIS_RENDER_I_VERSION] != STASIS_RENDER_V4_VERSION) {
         return STASIS_RENDER_BAD_VERSION;
     }
+    const int32_t version = cmd_i32[STASIS_RENDER_I_VERSION];
+    const int32_t line_count = cmd_i32[STASIS_RENDER_I_LINE_COUNT];
+    const int32_t sprite_count = cmd_i32[STASIS_RENDER_I_SPRITE_COUNT];
+    const int32_t text_count = cmd_i32[STASIS_RENDER_I_TEXT_COUNT];
+    const int32_t text_bytes_used = cmd_i32[STASIS_RENDER_I_TEXT_BYTES_USED];
+    const int32_t rect_count = version == STASIS_RENDER_V4_VERSION
+        ? cmd_i32[STASIS_RENDER_I_RECT_COUNT] : 0;
+    const int32_t order_count = version >= STASIS_RENDER_V3_VERSION
+        ? cmd_i32[STASIS_RENDER_I_ORDER_COUNT] : 0;
+    if (line_count < 0 || sprite_count < 0 || text_count < 0 ||
+        text_bytes_used < 0 || rect_count < 0 || order_count < 0) {
+        return STASIS_RENDER_NEGATIVE_COUNT;
+    }
+    if (line_count > STASIS_RENDER_MAX_LINES ||
+        rect_count > STASIS_RENDER_MAX_GEOMETRY - line_count ||
+        sprite_count > STASIS_RENDER_MAX_SPRITES ||
+        text_count > STASIS_RENDER_MAX_TEXT ||
+        text_bytes_used > STASIS_RENDER_TEXT_MAX_BYTES ||
+        order_count > STASIS_RENDER_MAX_ORDER) {
+        return STASIS_RENDER_EXCESSIVE_COUNT;
+    }
+    for (int32_t index = 0; index < text_count; index++) {
+        const int32_t base = STASIS_RENDER_I_TEXT_BASE +
+            index * STASIS_RENDER_TEXT_I32_STRIDE;
+        const int32_t offset = cmd_i32[base + 1];
+        const int32_t length = cmd_i32[base + 2];
+        if (offset < 0) {
+            if (offset == INT32_MIN || length != 0) {
+                return STASIS_RENDER_BAD_TEXT_SPAN;
+            }
+        } else if (!stasis_render_text_span_is_valid(
+                offset, length, text_bytes_used)) {
+            return STASIS_RENDER_BAD_TEXT_SPAN;
+        }
+    }
+    for (int32_t order = 0; order < order_count; order++) {
+        const int32_t entry = cmd_i32[STASIS_RENDER_I_ORDER_BASE + order];
+        if (entry < 0) return STASIS_RENDER_BAD_ORDER_REFERENCE;
+        const int32_t kind = entry / STASIS_RENDER_ORDER_KIND_SCALE;
+        const int32_t index = entry % STASIS_RENDER_ORDER_KIND_SCALE;
+        const int valid =
+            (kind == STASIS_RENDER_ORDER_LINE && index < line_count) ||
+            (kind == STASIS_RENDER_ORDER_RECT && index < rect_count) ||
+            (kind == STASIS_RENDER_ORDER_SPRITE && index < sprite_count) ||
+            (kind == STASIS_RENDER_ORDER_TEXT && index < text_count);
+        if (!valid) return STASIS_RENDER_BAD_ORDER_REFERENCE;
+    }
     return STASIS_RENDER_VALID;
 }
 
@@ -126,7 +187,32 @@ static inline const char *stasis_render_validation_name(
         case STASIS_RENDER_NULL_F32: return "missing_f32_buffer";
         case STASIS_RENDER_BAD_MAGIC: return "invalid_magic";
         case STASIS_RENDER_BAD_VERSION: return "unsupported_version";
+        case STASIS_RENDER_NEGATIVE_COUNT: return "negative_count";
+        case STASIS_RENDER_EXCESSIVE_COUNT: return "excessive_count";
+        case STASIS_RENDER_BAD_TEXT_SPAN: return "invalid_text_span";
+        case STASIS_RENDER_BAD_ORDER_REFERENCE: return "invalid_order_reference";
         default: return "unknown_validation_failure";
+    }
+}
+
+static inline const char *stasis_render_validation_stage(
+    StasisRenderValidation validation
+) {
+    switch (validation) {
+        case STASIS_RENDER_BAD_MAGIC:
+        case STASIS_RENDER_BAD_VERSION:
+        case STASIS_RENDER_NULL_I32:
+        case STASIS_RENDER_NULL_F32:
+            return "command_header";
+        case STASIS_RENDER_NEGATIVE_COUNT:
+        case STASIS_RENDER_EXCESSIVE_COUNT:
+            return "command_counts";
+        case STASIS_RENDER_BAD_TEXT_SPAN:
+            return "text_span";
+        case STASIS_RENDER_BAD_ORDER_REFERENCE:
+            return "order_reference";
+        default:
+            return "none";
     }
 }
 
@@ -151,16 +237,6 @@ static inline int32_t stasis_render_rect_count(
     return stasis_render_clamp_count(
         cmd_i32[STASIS_RENDER_I_RECT_COUNT],
         STASIS_RENDER_MAX_GEOMETRY - line_count);
-}
-
-static inline int stasis_render_text_span_is_valid(
-    int32_t byte_offset,
-    int32_t byte_length,
-    int32_t text_bytes_used
-) {
-    return byte_offset >= 0 && byte_length >= 0 &&
-        byte_offset < text_bytes_used &&
-        byte_length < text_bytes_used - byte_offset;
 }
 
 static inline uint32_t stasis_render_trace_mix_u32(uint32_t hash, uint32_t value) {
@@ -277,7 +353,7 @@ static inline uint32_t stasis_render_trace(
     const float *cmd_f32,
     const uint8_t *cmd_u8
 ) {
-    if (!stasis_render_is_valid(cmd_i32) || cmd_f32 == NULL) return 0;
+    if (stasis_render_validate(cmd_i32, cmd_f32) != STASIS_RENDER_VALID) return 0;
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
     const int32_t line_count = stasis_render_clamp_count(

--- a/runtime/tests/stasis_render_contract_test.c
+++ b/runtime/tests/stasis_render_contract_test.c
@@ -139,7 +139,23 @@ int main(void) {
     CHECK(!stasis_render_text_span_is_valid(1, INT32_MAX, 5));
     CHECK(stasis_render_text_span_is_valid(0, 4, 5));
     CHECK(!stasis_render_text_span_is_valid(0, 5, 5));
-    CHECK(stasis_render_trace(second_i32, second_f32, second_u8) != 0);
+    CHECK(stasis_render_validate(second_i32, second_f32) == STASIS_RENDER_BAD_TEXT_SPAN);
+    CHECK(strcmp(stasis_render_validation_name(STASIS_RENDER_BAD_TEXT_SPAN), "invalid_text_span") == 0);
+    CHECK(strcmp(stasis_render_validation_stage(STASIS_RENDER_BAD_TEXT_SPAN), "text_span") == 0);
+    CHECK(stasis_render_trace(second_i32, second_f32, second_u8) == 0);
+
+    build_representative_frame(second_i32, second_f32, second_u8);
+    second_i32[STASIS_RENDER_I_LINE_COUNT] = -1;
+    CHECK(stasis_render_validate(second_i32, second_f32) == STASIS_RENDER_NEGATIVE_COUNT);
+    CHECK(strcmp(stasis_render_validation_stage(STASIS_RENDER_NEGATIVE_COUNT), "command_counts") == 0);
+    build_representative_frame(second_i32, second_f32, second_u8);
+    second_i32[STASIS_RENDER_I_SPRITE_COUNT] = STASIS_RENDER_MAX_SPRITES + 1;
+    CHECK(stasis_render_validate(second_i32, second_f32) == STASIS_RENDER_EXCESSIVE_COUNT);
+    build_representative_frame(second_i32, second_f32, second_u8);
+    second_i32[STASIS_RENDER_I_ORDER_BASE] =
+        STASIS_RENDER_ORDER_TEXT * STASIS_RENDER_ORDER_KIND_SCALE + 2;
+    CHECK(stasis_render_validate(second_i32, second_f32) == STASIS_RENDER_BAD_ORDER_REFERENCE);
+    CHECK(strcmp(stasis_render_validation_stage(STASIS_RENDER_BAD_ORDER_REFERENCE), "order_reference") == 0);
 
     free(first_i32); free(first_f32); free(first_u8);
     free(second_i32); free(second_f32); free(second_u8);


### PR DESCRIPTION
## Summary

- add IT-009, a Windows SDL native integration sequence that submits valid, six malformed, then valid command buffers
- reject negative/excessive counts, invalid direct/cached text spans, and invalid order references before any draw/present, alongside existing header validation
- emit stage-specific diagnostics bounded once per validation category
- expose gated submission counters/last validation/last valid trace for exact integration evidence
- prove rejected frames do not present or replace the last valid trace and the final valid frame recovers identical pixels
- run the seam explicitly in Windows PR CI

## Validation

- native `stasis_render_contract_test`
- `cargo test -p stasis --test desktop_render_recovery_seam -- --test-threads=1 --nocapture`
- all 22 `stasis_dynload` tests
- gfx command-capacity JIT/AOT seam
- IT-006, IT-007, and IT-008 against the rebuilt runtime
- all three Windows game-launch tests
- runtime ABI contract (271 comparisons), SDL3 migration, source layout, formatting, and diff checks

## Theory gained

The renderer command buffer is an untrusted bounded protocol, so structural validity must be established completely before `begin_frame`; clamping or skipping malformed structures turns corruption into ambiguous partial frames. Rejection must leave accepted/presented state and the last valid trace untouched, making the next valid submission independent. An adjacent prediction is that future command categories should add validation in this same pre-frame pass and receive a distinct bounded diagnostic category.

## Reflection

- Good: the valid→malformed matrix→valid sequence made state poisoning and accidental presents directly observable.
- Bad: header validation created a false sense of full protocol validation while counts, spans, and order references were silently normalized later.
- Adjustment: versioned buffer contracts should validate every field that controls an indexed read before any renderer state mutation.