### PR TITLE
test: cover desktop hot-swap generation seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -152,6 +152,12 @@ jobs:
           $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
           cargo test -p stasis --test desktop_render_recovery_seam -- --test-threads=1 --nocapture
 
+      - name: Test desktop hot-swap generation seam
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          cargo test -p stasis --test desktop_hot_swap_generation_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -46,7 +46,7 @@ use stasis_runner::swap::contracts::{
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
@@ -55,6 +55,49 @@ use watch::WatchService;
 
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
 const TICK_BUDGET_SAMPLE_LIMIT: usize = 4096;
+const DESKTOP_FRAME_EVIDENCE_ENV: &str = "STASIS_DESKTOP_FRAME_EVIDENCE";
+
+struct DesktopFrameEvidence {
+    file: fs::File,
+}
+
+impl DesktopFrameEvidence {
+    fn from_env() -> Result<Option<Self>, String> {
+        let Some(path) = std::env::var_os(DESKTOP_FRAME_EVIDENCE_ENV).map(PathBuf::from) else {
+            return Ok(None);
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create frame evidence directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        let file = fs::File::create(&path).map_err(|error| {
+            format!(
+                "failed to create frame evidence {}: {error}",
+                path.display()
+            )
+        })?;
+        Ok(Some(Self { file }))
+    }
+
+    fn record(
+        &mut self,
+        frame: u64,
+        entry_revision: u64,
+        submission: [i32; 5],
+    ) -> Result<(), String> {
+        writeln!(
+            self.file,
+            "{{\"schema\":\"stasis.desktop_frame.v1\",\"frame\":{frame},\"entry_revision\":{entry_revision},\"accepted\":{},\"rejected\":{},\"presented\":{},\"validation\":{},\"trace\":{}}}",
+            submission[0], submission[1], submission[2], submission[3], submission[4] as u32
+        )
+        .and_then(|_| self.file.flush())
+        .map_err(|error| format!("failed to write desktop frame evidence: {error}"))
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TickBudgetDiagnostics {
@@ -1980,6 +2023,7 @@ fn run_play_in_process_inner(
     );
 
     let gfx = stasis_dynload::StasisGraphicsApi::load_default()?;
+    let mut frame_evidence = DesktopFrameEvidence::from_env()?;
     let configured_title = window_title.or_else(|| {
         live.as_ref()
             .and_then(|(_, config)| config.window_title.as_deref())
@@ -2259,6 +2303,17 @@ fn run_play_in_process_inner(
 
         gfx.host_set_performance_metrics(tick_micros, render_micros)?;
         gfx.gfx_submit_u8(&mut gfx_cmd_i32, &gfx_cmd_f32, &gfx_cmd_u8)?;
+        if let Some(evidence) = frame_evidence.as_mut() {
+            let submission = gfx.test_render_submission_state()?.ok_or_else(|| {
+                format!(
+                    "{DESKTOP_FRAME_EVIDENCE_ENV} requires a graphics runtime with STASIS_ENABLE_TEST_INPUT=1"
+                )
+            })?;
+            let entry_revision = stasis_dynload::jit_host_entry_targets()
+                .map(|targets| targets.revision)
+                .ok_or_else(|| "desktop frame has no published JIT entry table".to_string())?;
+            evidence.record(ticks_executed.saturating_add(1), entry_revision, submission)?;
+        }
         if tick_sleep_micros > 0 {
             let ms = (tick_sleep_micros / 1000) as i32;
             if ms > 0 {

--- a/apps/stasis/tests/desktop_hot_swap_generation_seam.rs
+++ b/apps/stasis/tests/desktop_hot_swap_generation_seam.rs
@@ -1,0 +1,259 @@
+#![cfg(windows)]
+
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const V1: &str = include_str!("../../../tests/stasis/seams/desktop_hot_swap_generation_v1.stasis");
+const V2: &str = include_str!("../../../tests/stasis/seams/desktop_hot_swap_generation_v2.stasis");
+const INVALID: &str =
+    include_str!("../../../tests/stasis/seams/desktop_hot_swap_generation_invalid.stasis");
+const REJECT: &str =
+    include_str!("../../../tests/stasis/seams/desktop_hot_swap_generation_reject.stasis");
+
+#[derive(Clone, Debug, Deserialize)]
+struct FrameEvidence {
+    frame: u64,
+    entry_revision: u64,
+    accepted: i32,
+    rejected: i32,
+    presented: i32,
+    validation: i32,
+    trace: u32,
+}
+
+struct TestTree(PathBuf);
+
+impl Drop for TestTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn read_frames(path: &Path) -> Vec<FrameEvidence> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+fn read_log(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+fn wait_for(
+    description: &str,
+    child: &mut Child,
+    log_path: &Path,
+    frames_path: &Path,
+    predicate: impl Fn(&str, &[FrameEvidence]) -> bool,
+) -> (String, Vec<FrameEvidence>) {
+    let deadline = Instant::now() + Duration::from_secs(45);
+    loop {
+        let log = read_log(log_path);
+        let frames = read_frames(frames_path);
+        if predicate(&log, &frames) {
+            return (log, frames);
+        }
+        if let Some(status) = child.try_wait().expect("poll stasis play") {
+            panic!(
+                "stasis play exited before {description}: status={status} log={log} frames={frames:?}"
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {description}: log={log} frames={frames:?}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn sole_trace(frames: &[FrameEvidence], revision: u64) -> u32 {
+    let traces = frames
+        .iter()
+        .filter(|frame| frame.entry_revision == revision)
+        .map(|frame| frame.trace)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(traces.len(), 1, "revision {revision} emitted mixed traces");
+    *traces.iter().next().expect("revision trace")
+}
+
+#[test]
+fn desktop_watch_frames_never_mix_tick_and_render_generations() {
+    let runtime_path = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let tree = TestTree(
+        std::env::temp_dir().join(format!("stasis-it-010-{}-{stamp}", std::process::id())),
+    );
+    fs::create_dir_all(&tree.0).expect("create seam project");
+    let source = tree.0.join("main.stasis");
+    let frames_path = tree.0.join("frames.jsonl");
+    let log_path = tree.0.join("play.log");
+    fs::write(&source, V1).expect("write v1 source");
+
+    let log_file = fs::File::create(&log_path).expect("create play log");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_stasis"))
+        .args([
+            "play",
+            source.to_str().expect("source path"),
+            "--watch-dir",
+            tree.0.to_str().expect("project path"),
+            "--ticks",
+            "6000",
+            "--tick-sleep-us",
+            "5000",
+        ])
+        .current_dir(&tree.0)
+        .env("STASIS_RUNTIME_LIBRARY_PATH", &runtime_path)
+        .env("STASIS_RUNTIME_DLL_PATH", &runtime_path)
+        .env("STASIS_USE_SDL", "1")
+        .env("STASIS_ENABLE_TEST_INPUT", "1")
+        .env("STASIS_DESKTOP_FRAME_EVIDENCE", &frames_path)
+        .stdout(Stdio::from(log_file.try_clone().expect("clone stdout log")))
+        .stderr(Stdio::from(log_file))
+        .spawn()
+        .expect("launch stasis play");
+
+    let (_, initial_frames) = wait_for(
+        "eight initial frames",
+        &mut child,
+        &log_path,
+        &frames_path,
+        |_, frames| frames.len() >= 8,
+    );
+    let v1_trace = sole_trace(&initial_frames, 1);
+    assert_ne!(v1_trace, 0);
+
+    fs::write(&source, V2).expect("write v2 source");
+    let (_, v2_frames) = wait_for(
+        "published v2 and eight v2 frames",
+        &mut child,
+        &log_path,
+        &frames_path,
+        |log, frames| {
+            log.contains("[swap] revision 1 published")
+                && frames
+                    .iter()
+                    .filter(|frame| frame.entry_revision == 2)
+                    .count()
+                    >= 8
+        },
+    );
+    let v2_trace = sole_trace(&v2_frames, 2);
+    assert_ne!(
+        v2_trace, v1_trace,
+        "the accepted edit must change the frame"
+    );
+
+    fs::write(&source, INVALID).expect("write malformed source");
+    let (_, after_compile_failure) = wait_for(
+        "compile rejection and continued v2 frames",
+        &mut child,
+        &log_path,
+        &frames_path,
+        |log, frames| {
+            log.contains("[swap] revision 2 rejected")
+                && frames
+                    .iter()
+                    .rev()
+                    .take(8)
+                    .all(|frame| frame.entry_revision == 2 && frame.trace == v2_trace)
+        },
+    );
+    let failure_frame = after_compile_failure.last().expect("failure frame").frame;
+
+    fs::write(&source, REJECT).expect("write hook-rejecting source");
+    let (final_log, final_frames) = wait_for(
+        "on_code_swap abort and continued v2 frames",
+        &mut child,
+        &log_path,
+        &frames_path,
+        |log, frames| {
+            log.contains("[swap] revision 3 aborted")
+                && frames
+                    .last()
+                    .is_some_and(|frame| frame.frame >= failure_frame + 8)
+                && frames
+                    .iter()
+                    .rev()
+                    .take(8)
+                    .all(|frame| frame.entry_revision == 2 && frame.trace == v2_trace)
+        },
+    );
+
+    child.kill().expect("stop completed seam runner");
+    let _ = child.wait().expect("reap seam runner");
+
+    assert!(
+        final_log.contains("rejection"),
+        "hook failure must be explicit"
+    );
+    assert!(final_frames.iter().all(|frame| {
+        frame.rejected == 0
+            && frame.validation == 0
+            && frame.accepted == frame.presented
+            && match frame.entry_revision {
+                1 => frame.trace == v1_trace,
+                2 => frame.trace == v2_trace,
+                _ => false,
+            }
+    }));
+    assert!(
+        final_frames
+            .windows(2)
+            .all(|pair| pair[0].entry_revision <= pair[1].entry_revision),
+        "entry-table revisions must publish monotonically"
+    );
+
+    let evidence_dir = evidence_root();
+    fs::create_dir_all(&evidence_dir).expect("create evidence directory");
+    let frame_evidence_path = evidence_dir.join("it-010-desktop-hot-swap-frames.jsonl");
+    fs::copy(&frames_path, &frame_evidence_path).expect("retain per-frame evidence");
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-010",
+        "status": "passed",
+        "target": "windows-sdl-native-jit-watch",
+        "frames": final_frames.len(),
+        "entry_trace_pairs": [
+            {"entry_revision": 1, "trace": v1_trace},
+            {"entry_revision": 2, "trace": v2_trace}
+        ],
+        "compile_failure_preserved_revision": 2,
+        "hook_rejection_preserved_revision": 2,
+        "oracle": {"mixed_generation_frames": 0, "source_frames": frame_evidence_path}
+    });
+    let evidence_path = evidence_dir.join("it-010-desktop-hot-swap-generations.json");
+    fs::write(
+        evidence_path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize evidence"),
+    )
+    .expect("write evidence");
+    eprintln!("IT-010 evidence: {evidence}");
+}

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -843,6 +843,7 @@ pub struct StasisGraphicsApi {
     stasis_host_bulk_apply_requests: usize,
     stasis_host_set_performance_metrics: usize,
     stasis_gfx_submit_u8: usize,
+    stasis_test_get_render_submission_state: Option<usize>,
     stasis_sleep_ms: usize,
 }
 
@@ -875,6 +876,9 @@ impl StasisGraphicsApi {
         let stasis_host_set_performance_metrics =
             lib.symbol_address("stasis_host_set_performance_metrics")?;
         let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
+        let stasis_test_get_render_submission_state = lib
+            .symbol_address("stasis_test_get_render_submission_state")
+            .ok();
         let stasis_sleep_ms = lib.symbol_address("stasis_sleep_ms")?;
         Ok(Self {
             _lib: lib,
@@ -884,6 +888,7 @@ impl StasisGraphicsApi {
             stasis_host_bulk_apply_requests,
             stasis_host_set_performance_metrics,
             stasis_gfx_submit_u8,
+            stasis_test_get_render_submission_state,
             stasis_sleep_ms,
         })
     }
@@ -1015,6 +1020,25 @@ impl StasisGraphicsApi {
                 unsafe { std::mem::transmute(self.stasis_gfx_submit_u8) };
             callback(cmd_i32.as_mut_ptr(), cmd_f32.as_ptr(), cmd_u8.as_ptr());
             Ok(())
+        }
+    }
+
+    pub fn test_render_submission_state(&self) -> Result<Option<[i32; 5]>, String> {
+        let Some(address) = self.stasis_test_get_render_submission_state else {
+            return Ok(None);
+        };
+        let mut state = [0; 5];
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn(*mut i32, i32) -> i32 =
+                unsafe { std::mem::transmute(address) };
+            return Ok((callback(state.as_mut_ptr(), state.len() as i32) != 0).then_some(state));
+        }
+        #[cfg(not(windows))]
+        {
+            let callback: extern "C" fn(*mut i32, i32) -> i32 =
+                unsafe { std::mem::transmute(address) };
+            Ok((callback(state.as_mut_ptr(), state.len() as i32) != 0).then_some(state))
         }
     }
 

--- a/tests/stasis/seams/desktop_hot_swap_generation_invalid.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_invalid.stasis
@@ -1,0 +1,21 @@
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global tick_generation: i32;
+
+function main(): i32 {
+    return missing_generation;
+}
+
+function tick(): i32 {
+    tick_generation = 404;
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/tests/stasis/seams/desktop_hot_swap_generation_reject.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_reject.stasis
@@ -1,0 +1,43 @@
+extern function reject_code_swap(): void;
+
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global tick_generation: i32;
+
+function main(): i32 {
+    tick_generation = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    tick_generation = 303;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 0;
+    gfx_cmd_i32[7] = 0;
+    gfx_cmd_i32[9] = 0;
+    gfx_cmd_i32[22] = 0;
+    if (tick_generation == 303) {
+        gfx_cmd_f32[0] = 0.33;
+        gfx_cmd_f32[1] = 0.63;
+    } else {
+        gfx_cmd_f32[0] = 0.93;
+        gfx_cmd_f32[1] = 0.03;
+    }
+    gfx_cmd_f32[2] = 0.83;
+    gfx_cmd_f32[3] = 1.0;
+    return 0;
+}
+
+function on_code_swap(): void {
+    tick_generation = 999;
+    reject_code_swap();
+    return;
+}

--- a/tests/stasis/seams/desktop_hot_swap_generation_v1.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_v1.stasis
@@ -1,0 +1,39 @@
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global tick_generation: i32;
+
+function main(): i32 {
+    tick_generation = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    tick_generation = 101;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 0;
+    gfx_cmd_i32[7] = 0;
+    gfx_cmd_i32[9] = 0;
+    gfx_cmd_i32[22] = 0;
+    if (tick_generation == 101) {
+        gfx_cmd_f32[0] = 0.11;
+        gfx_cmd_f32[1] = 0.21;
+    } else {
+        gfx_cmd_f32[0] = 0.91;
+        gfx_cmd_f32[1] = 0.01;
+    }
+    gfx_cmd_f32[2] = 0.31;
+    gfx_cmd_f32[3] = 1.0;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/tests/stasis/seams/desktop_hot_swap_generation_v2.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_v2.stasis
@@ -1,0 +1,39 @@
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global tick_generation: i32;
+
+function main(): i32 {
+    tick_generation = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    tick_generation = 202;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 0;
+    gfx_cmd_i32[7] = 0;
+    gfx_cmd_i32[9] = 0;
+    gfx_cmd_i32[22] = 0;
+    if (tick_generation == 202) {
+        gfx_cmd_f32[0] = 0.22;
+        gfx_cmd_f32[1] = 0.42;
+    } else {
+        gfx_cmd_f32[0] = 0.92;
+        gfx_cmd_f32[1] = 0.02;
+    }
+    gfx_cmd_f32[2] = 0.62;
+    gfx_cmd_f32[3] = 1.0;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}


### PR DESCRIPTION
## Summary
- record opt-in per-frame desktop evidence at the production play boundary, pairing the published host-entry revision with the native render trace
- run a real Windows SDL play/watch integration across an accepted tick/render edit, a malformed compile, and an on_code_swap rejection
- assert every frame is wholly revision 1 or revision 2, with failed candidates preserving the accepted revision, state, and trace

## Validation
- IT-010 direct integration test: 36 frames, zero mixed-generation frames
- focused between-tick publication and rejection tests
- all 22 stasis_dynload tests
- IT-009 render recovery regression
- runtime ABI contract: 283 comparisons
- cargo fmt, source-layout, SDL3 migration, and selective-JIT contract checks

The broad local stasis library run passed 260/267; the seven remaining failures are pre-existing workstation-only signing-certificate and sandbox temp-directory failures. The latest main GitHub CI baseline is green.