### PR TITLE
test: replay host snapshots across JIT and AOT

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -158,6 +158,11 @@ jobs:
           $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
           cargo test -p stasis --test desktop_hot_swap_generation_seam -- --test-threads=1 --nocapture
 
+      - name: Test JIT and linked-AOT host replay seam
+        shell: pwsh
+        run: |
+          cargo test -p stasis_compiler --test jit_aot_host_replay_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/crates/stasis_compiler/tests/jit_aot_host_replay_seam.rs
+++ b/crates/stasis_compiler/tests/jit_aot_host_replay_seam.rs
@@ -1,0 +1,276 @@
+#![cfg(windows)]
+
+use serde::Serialize;
+use serde_json::json;
+use stasis_compiler::backend::aot::AotProcess;
+use stasis_compiler::backend::jit::JitProcess;
+use stasis_jit::{AotLinkConfig, AotTarget};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const FIXTURE_PATH: &str = "tests/stasis/seams/jit_aot_host_replay_probe.stasis";
+const FIXTURE: &str = include_str!("../../../tests/stasis/seams/jit_aot_host_replay_probe.stasis");
+const FIELDS: [&str; 5] = [
+    "entry_results",
+    "state_checksum",
+    "lifecycle",
+    "command_counts",
+    "trace",
+];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct TickRecord {
+    tick: usize,
+    entry_results: i32,
+    state_checksum: i32,
+    lifecycle: i32,
+    command_counts: i32,
+    trace: i32,
+}
+
+impl TickRecord {
+    fn values(&self) -> [i32; 5] {
+        [
+            self.entry_results,
+            self.state_checksum,
+            self.lifecycle,
+            self.command_counts,
+            self.trace,
+        ]
+    }
+}
+
+struct TestTree(PathBuf);
+
+impl Drop for TestTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn roots() -> Vec<String> {
+    (1..=3)
+        .flat_map(|tick| {
+            ["entry", "state", "lifecycle", "counts", "trace"]
+                .map(move |field| format!("it011_t{tick}_{field}"))
+        })
+        .collect()
+}
+
+fn configured_jit(source: &str) -> JitProcess {
+    let mut process = JitProcess::new();
+    process
+        .set_project_root(repository_root().to_string_lossy())
+        .expect("set JIT project root");
+    process.set_required_emit_roots(&roots());
+    process.upsert_file(FIXTURE_PATH, source);
+    process.compile().expect("compile JIT replay fixture");
+    process
+}
+
+fn configured_aot() -> AotProcess {
+    let mut process = AotProcess::new();
+    process
+        .set_project_root(repository_root().to_string_lossy())
+        .expect("set AOT project root");
+    process.set_required_emit_roots(&roots());
+    process.upsert_file(FIXTURE_PATH, FIXTURE);
+    process.compile().expect("compile AOT replay fixture");
+    process
+}
+
+fn read_jit_records(process: &JitProcess) -> Vec<TickRecord> {
+    (1..=3)
+        .map(|tick| {
+            let run = |field: &str| {
+                process
+                    .execute_i32_noarg_by_name(&format!("it011_t{tick}_{field}"))
+                    .unwrap_or_else(|error| panic!("execute JIT tick {tick} {field}: {error}"))
+            };
+            TickRecord {
+                tick,
+                entry_results: run("entry"),
+                state_checksum: run("state"),
+                lifecycle: run("lifecycle"),
+                command_counts: run("counts"),
+                trace: run("trace"),
+            }
+        })
+        .collect()
+}
+
+fn ensure_dynload_artifacts() -> (PathBuf, PathBuf) {
+    let deps_dir = std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("Cargo deps directory")
+        .to_path_buf();
+    let find = || {
+        [
+            &deps_dir,
+            deps_dir.parent().expect("Cargo profile directory"),
+        ]
+        .into_iter()
+        .find_map(|directory| {
+            let import_library = directory.join("stasis_dynload.dll.lib");
+            let runtime = directory.join("stasis_dynload.dll");
+            (import_library.is_file() && runtime.is_file()).then_some((import_library, runtime))
+        })
+    };
+    if let Some(paths) = find() {
+        return paths;
+    }
+    let profile = deps_dir.parent().expect("Cargo profile directory");
+    let target = profile.parent().expect("Cargo target directory");
+    let output = Command::new("cargo")
+        .args(["build", "-p", "stasis_dynload"])
+        .current_dir(repository_root())
+        .env("CARGO_TARGET_DIR", target)
+        .output()
+        .expect("build stasis_dynload runtime");
+    assert!(
+        output.status.success(),
+        "stasis_dynload build failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    find().expect("stasis_dynload build must produce its DLL and import library")
+}
+
+fn linker_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("STASIS_AOT_LINKER").map(PathBuf::from) {
+        assert!(path.is_file(), "STASIS_AOT_LINKER must name a linker file");
+        return path;
+    }
+    let output = Command::new("where.exe")
+        .arg("link.exe")
+        .output()
+        .expect("locate MSVC linker");
+    assert!(
+        output.status.success(),
+        "MSVC link.exe is required for IT-011"
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .expect("link.exe path")
+}
+
+fn read_aot_records(process: &AotProcess, tree: &Path) -> Vec<TickRecord> {
+    let (import_library, runtime) = ensure_dynload_artifacts();
+    fs::copy(&runtime, tree.join("stasis_dynload.dll")).expect("copy linked-AOT runtime");
+    let config = AotLinkConfig {
+        linker_path: Some(linker_path()),
+        runtime_lib_paths: vec![import_library],
+        target: AotTarget::Native,
+    };
+    let run = |tick: usize, field: &str| {
+        let root = format!("it011_t{tick}_{field}");
+        let executable = tree.join(format!("{root}.exe"));
+        process
+            .link_executable_for_i32_noarg_function(&root, &executable, &config)
+            .unwrap_or_else(|error| panic!("link AOT tick {tick} {field}: {error}"));
+        Command::new(&executable)
+            .current_dir(tree)
+            .status()
+            .unwrap_or_else(|error| panic!("run {}: {error}", executable.display()))
+            .code()
+            .expect("linked AOT exit code")
+    };
+    (1..=3)
+        .map(|tick| TickRecord {
+            tick,
+            entry_results: run(tick, "entry"),
+            state_checksum: run(tick, "state"),
+            lifecycle: run(tick, "lifecycle"),
+            command_counts: run(tick, "counts"),
+            trace: run(tick, "trace"),
+        })
+        .collect()
+}
+
+fn compare_records(expected: &[TickRecord], actual: &[TickRecord]) -> Result<(), String> {
+    for (expected_tick, actual_tick) in expected.iter().zip(actual) {
+        for (index, (expected_value, actual_value)) in expected_tick
+            .values()
+            .into_iter()
+            .zip(actual_tick.values())
+            .enumerate()
+        {
+            if expected_value != actual_value {
+                return Err(format!(
+                    "JIT/AOT replay divergence: tick={} field={} jit={} aot={}",
+                    expected_tick.tick, FIELDS[index], expected_value, actual_value
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn identical_host_snapshots_match_jit_and_linked_aot_each_tick() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let tree = TestTree(
+        std::env::temp_dir().join(format!("stasis-it-011-{}-{stamp}", std::process::id())),
+    );
+    fs::create_dir_all(&tree.0).expect("create linked-AOT directory");
+
+    let jit = read_jit_records(&configured_jit(FIXTURE));
+    let aot = read_aot_records(&configured_aot(), &tree.0);
+    compare_records(&jit, &aot).expect("canonical per-tick JIT/AOT replay parity");
+
+    let mutated = FIXTURE.replacen("score -= 2;", "score -= 3;", 1);
+    assert_ne!(mutated, FIXTURE, "diagnostic mutation must apply");
+    let mutation = read_jit_records(&configured_jit(&mutated));
+    let diagnostic = compare_records(&mutation, &aot).expect_err("mutation must diverge");
+    assert!(
+        diagnostic.starts_with("JIT/AOT replay divergence: tick=2 field=entry_results"),
+        "first divergence must name tick and field: {diagnostic}"
+    );
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-011",
+        "status": "passed",
+        "target": "windows-jit+linked-aot",
+        "snapshots": [
+            {"tick": 1, "keyboard": "down", "pointer": "down", "logical": [320, 180], "resized": false},
+            {"tick": 2, "keyboard": "up", "pointer": "move", "logical": [641, 359], "resized": true},
+            {"tick": 3, "keyboard": "down", "pointer": "up", "logical": [641, 359], "resized": false}
+        ],
+        "jit": jit,
+        "linked_aot": aot,
+        "checks": 15,
+        "oracle": {"first_divergence_diagnostic": diagnostic}
+    });
+    let path = evidence_root().join("it-011-jit-aot-host-replay.json");
+    fs::create_dir_all(path.parent().expect("evidence parent")).expect("create evidence directory");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize evidence"),
+    )
+    .expect("write evidence");
+    eprintln!("IT-011 evidence: {evidence}");
+}

--- a/tests/stasis/seams/jit_aot_host_replay_probe.stasis
+++ b/tests/stasis/seams/jit_aot_host_replay_probe.stasis
@@ -1,0 +1,249 @@
+import "../../../src/stdlib/graphics.stasis";
+
+function @extern("stasis_jit_render_v2_trace") native_render_trace(
+    cmd_i32: i32[],
+    cmd_i32_len: i32,
+    cmd_f32: f32[],
+    cmd_f32_len: i32,
+    cmd_u8: u8[],
+    cmd_u8_len: i32
+): i32;
+
+global score: i32;
+global pointer_marks: i32;
+global resize_marks: i32;
+global main_calls: i32;
+global tick_calls: i32;
+global render_calls: i32;
+global last_tick_result: i32;
+global last_render_result: i32;
+global last_trace: i32;
+
+function main(): i32 {
+    score = 5;
+    pointer_marks = 0;
+    resize_marks = 0;
+    main_calls = 1;
+    tick_calls = 0;
+    render_calls = 0;
+    last_tick_result = 0;
+    last_render_result = 0;
+    last_trace = 0;
+    host_i32[32 + 44] = 0;
+    return 0;
+}
+
+function apply_snapshot(index: i32): void {
+    host_i32[10] = index + 1;
+    host_i32[11] = 0;
+    host_i32[12] = 320;
+    host_i32[13] = 180;
+    host_i32[14] = 3;
+    host_i32[16] = 60;
+    host_i32[17] = 1;
+    host_i32[18] = 0;
+    host_i32[22] = 320;
+    host_i32[23] = 180;
+    host_i32[24] = 320;
+    host_i32[25] = 180;
+    host_i32[30] = 1;
+    host_i32[31] = 1;
+    host_i32[8] = 1;
+    host_i32[544] = 77;
+    host_i32[545] = 1;
+    host_i32[546] = 0;
+    host_i32[547] = 0;
+    host_f32[48] = 1.0;
+    host_f32[49] = 1.0;
+    host_f32[50] = 320.0;
+    host_f32[51] = 180.0;
+    host_f32[52] = 0.0;
+    host_f32[53] = 0.0;
+    host_f32[54] = 320.0;
+    host_f32[55] = 180.0;
+
+    if (index == 0) {
+        host_i32[32 + 44] = 1;
+        host_i32[546] = 1;
+        host_f32[42] = 10.5;
+        host_f32[43] = 20.0;
+        host_f32[46] = 0.0328125;
+        host_f32[47] = 0.11111111;
+    } else if (index == 1) {
+        host_i32[32 + 44] = 0;
+        host_i32[11] = 1;
+        host_i32[12] = 641;
+        host_i32[13] = 359;
+        host_i32[22] = 1282;
+        host_i32[23] = 718;
+        host_i32[24] = 1282;
+        host_i32[25] = 718;
+        host_i32[30] = 2;
+        host_i32[31] = 2;
+        host_f32[42] = 18.25;
+        host_f32[43] = 28.5;
+        host_f32[44] = 7.75;
+        host_f32[45] = 8.5;
+        host_f32[46] = 0.02847114;
+        host_f32[47] = 0.07938719;
+        host_f32[49] = 2.0;
+        host_f32[50] = 641.0;
+        host_f32[51] = 359.0;
+        host_f32[54] = 641.0;
+        host_f32[55] = 359.0;
+    } else {
+        host_i32[32 + 44] = 1;
+        host_i32[545] = 0;
+        host_i32[547] = 1;
+        host_i32[12] = 641;
+        host_i32[13] = 359;
+        host_i32[22] = 1282;
+        host_i32[23] = 718;
+        host_i32[24] = 1282;
+        host_i32[25] = 718;
+        host_i32[30] = 2;
+        host_i32[31] = 2;
+        host_f32[42] = 21.0;
+        host_f32[43] = 31.0;
+        host_f32[44] = 2.75;
+        host_f32[45] = 2.5;
+        host_f32[46] = 0.03276131;
+        host_f32[47] = 0.08635098;
+        host_f32[49] = 2.0;
+        host_f32[50] = 641.0;
+        host_f32[51] = 359.0;
+        host_f32[54] = 641.0;
+        host_f32[55] = 359.0;
+    }
+}
+
+function tick(): i32 {
+    tick_calls += 1;
+    if (host_key_down(44)) {
+        score += 7;
+    } else {
+        score -= 2;
+    }
+    if (host_pointer_count() > 0) {
+        if (host_pointer_x_logical(0) > 15.0) {
+            pointer_marks += 3;
+        } else {
+            pointer_marks += 1;
+        }
+        if (host_pointer_went_down(0)) {
+            pointer_marks += 10;
+        }
+        if (host_pointer_went_up(0)) {
+            pointer_marks += 20;
+        }
+    }
+    if (host_resized()) {
+        resize_marks += host_screen_w_px() + host_screen_h_px();
+    }
+    return score + pointer_marks + resize_marks + tick_calls;
+}
+
+function render(): i32 {
+    render_calls += 1;
+    gfx_cmd_begin();
+    gfx_cmd_clear(0.05, 0.10, 0.15, 1.0);
+    gfx_cmd_rect(4.0, 5.0, 20.0, 12.0, 0.2, 0.4, 0.6, 1.0);
+    if (host_pointer_is_down(0)) {
+        gfx_cmd_rect(30.0, 8.0, 9.0, 7.0, 0.8, 0.3, 0.1, 1.0);
+    }
+    last_trace = native_render_trace(
+        gfx_cmd_i32,
+        34608,
+        gfx_cmd_f32,
+        108676,
+        gfx_cmd_u8,
+        65536
+    );
+    return render_calls * 10 + gfx_cmd_i32[24];
+}
+
+function replay(ticks: i32): void {
+    main();
+    for (let index: i32 = 0; index < ticks; index += 1) {
+        apply_snapshot(index);
+        last_tick_result = tick();
+        last_render_result = render();
+    }
+}
+
+function replay_metric(ticks: i32, metric: i32): i32 {
+    replay(ticks);
+    if (metric == 0) {
+        return last_tick_result * 100 + last_render_result;
+    }
+    if (metric == 1) {
+        return score * 100000 + pointer_marks * 1000 + resize_marks + tick_calls;
+    }
+    if (metric == 2) {
+        return main_calls * 10000 + tick_calls * 100 + render_calls;
+    }
+    if (metric == 3) {
+        return gfx_cmd_i32[3] * 1000000 + gfx_cmd_i32[24] * 1000 + gfx_cmd_i32[22];
+    }
+    return last_trace;
+}
+
+function it011_t1_entry(): i32 {
+    return replay_metric(1, 0);
+}
+
+function it011_t1_state(): i32 {
+    return replay_metric(1, 1);
+}
+
+function it011_t1_lifecycle(): i32 {
+    return replay_metric(1, 2);
+}
+
+function it011_t1_counts(): i32 {
+    return replay_metric(1, 3);
+}
+
+function it011_t1_trace(): i32 {
+    return replay_metric(1, 4);
+}
+
+function it011_t2_entry(): i32 {
+    return replay_metric(2, 0);
+}
+
+function it011_t2_state(): i32 {
+    return replay_metric(2, 1);
+}
+
+function it011_t2_lifecycle(): i32 {
+    return replay_metric(2, 2);
+}
+
+function it011_t2_counts(): i32 {
+    return replay_metric(2, 3);
+}
+
+function it011_t2_trace(): i32 {
+    return replay_metric(2, 4);
+}
+
+function it011_t3_entry(): i32 {
+    return replay_metric(3, 0);
+}
+
+function it011_t3_state(): i32 {
+    return replay_metric(3, 1);
+}
+
+function it011_t3_lifecycle(): i32 {
+    return replay_metric(3, 2);
+}
+
+function it011_t3_counts(): i32 {
+    return replay_metric(3, 3);
+}
+
+function it011_t3_trace(): i32 {
+    return replay_metric(3, 4);
+}


### PR DESCRIPTION
## Summary
- replay one deterministic three-tick keyboard, pointer, and resize timeline through the same public-stdlib Stasis fixture in JIT and linked AOT
- compare entry results, state checksum, lifecycle markers, command counts, and native render trace at every tick
- emit structured evidence and prove divergence diagnostics identify the first tick and field

## Validation
- IT-011: all 15 per-tick observations match; mutation first diverges at tick 2 / entry_results
- existing IT-003 JIT/AOT native render-trace regression
- runtime ABI contract: 283 comparisons
- cargo fmt, source-layout, SDL3 migration, selective-JIT contract, and diff checks

No product behavior changes; this is one Windows native compiler/runtime seam and its deterministic fixture.