### PR TITLE
test: link generated AOT into mobile runtime

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -163,6 +163,11 @@ jobs:
         run: |
           cargo test -p stasis_compiler --test jit_aot_host_replay_seam -- --test-threads=1 --nocapture
 
+      - name: Test generated AOT bindings in the C mobile runtime
+        shell: pwsh
+        run: |
+          cargo test -p stasis --test generated_mobile_aot_runtime_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -5,6 +5,7 @@ mod compiler_backend;
 mod events;
 mod host_set_registry;
 mod live_workspace;
+mod mobile_aot_bindings;
 mod runtime_exec;
 mod stasis_test_runner;
 mod watch;
@@ -15,6 +16,10 @@ pub use compiler_backend::run_self_host_aot_cli;
 pub use compiler_backend::run_self_host_aot_cli_with_options;
 pub use events::RunnerEvent;
 pub use live_workspace::LiveRunConfig;
+pub use mobile_aot_bindings::{
+    audit_mobile_aot_bindings, escape_mobile_c_string_literal, mobile_aot_function_for,
+    write_mobile_aot_bindings_source,
+};
 pub use stasis_test_runner::{
     run_jit_tests_in_directory, run_jit_tests_in_directory_with_project_root_and_session,
     run_jit_tests_in_directory_with_project_root_session_and_validator,

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -13,14 +13,16 @@ use std::time::SystemTime;
 use std::time::{Duration, Instant};
 
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+#[cfg(test)]
+use stasis::escape_mobile_c_string_literal;
 use stasis::{
-    build_aot_direct_storage_source, run_jit_tests_in_directory_with_session,
+    mobile_aot_function_for, run_jit_tests_in_directory_with_session,
     run_play_in_process_with_input_script_and_window_title, run_self_host_aot_cli_with_options,
-    run_with_default_backend, run_with_real_backend, RunnerConfig, StasisTestRunSession,
+    run_with_default_backend, run_with_real_backend, write_mobile_aot_bindings_source,
+    RunnerConfig, StasisTestRunSession,
 };
 use stasis_assets::{
-    load_project_asset_manifest, prepare_asset_bundle, AssetFormat, AssetLimits,
-    DEFAULT_ASSET_MANIFEST_PATH,
+    load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
 };
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::{AotOptimizationProfile, EngineEntrypoints};
@@ -1975,136 +1977,6 @@ fn write_mobile_aot_symbols_header(
     })
 }
 
-fn write_mobile_aot_bindings_source(
-    manifest: &serde_json::Value,
-    state_layout: &stasis_compiler::backend::state_layout::StateLayout,
-    project_dir: &Path,
-    output_path: &Path,
-) -> Result<(), String> {
-    let functions = manifest
-        .get("functions")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
-    let literals = manifest
-        .get("string_literals")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
-    let mut out = String::from(
-        "#include <stdint.h>\n#include <string.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n",
-    );
-    let (direct_storage_source, direct_storage_register_lines) =
-        build_aot_direct_storage_source(state_layout)?;
-    out.push_str(&direct_storage_source);
-    for function in functions {
-        let symbol = function
-            .get("symbol")
-            .and_then(serde_json::Value::as_str)
-            .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
-        let return_type = mobile_aot_c_return_type(function)?;
-        out.push_str(&format!("extern {return_type} {symbol}(void);\n"));
-    }
-    for (name, wrapper) in [
-        ("main", "stasis_mobile_main_entry"),
-        ("tick", "stasis_mobile_tick_entry"),
-        ("render", "stasis_mobile_render_entry"),
-    ] {
-        let (symbol, return_type) = mobile_aot_function_for(manifest, name)?;
-        if return_type == 0 {
-            out.push_str(&format!(
-                "int32_t {wrapper}(void) {{ {symbol}(); return 0; }}\n"
-            ));
-        } else if return_type == 1 {
-            out.push_str(&format!(
-                "int32_t {wrapper}(void) {{ return {symbol}(); }}\n"
-            ));
-        } else {
-            return Err(format!(
-                "mobile AOT entry '{name}' must return void or i32, found type id {return_type}"
-            ));
-        }
-    }
-    for literal in literals {
-        let id = literal
-            .get("id")
-            .and_then(serde_json::Value::as_i64)
-            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
-        let value = literal
-            .get("value")
-            .and_then(serde_json::Value::as_str)
-            .ok_or_else(|| "mobile AOT string literal missing value".to_string())?;
-        out.push_str(&format!(
-            "static const char stasis_mobile_literal_{}[] = \"{}\";\n",
-            id.unsigned_abs(),
-            escape_mobile_c_string_literal(value)
-        ));
-    }
-    let assets = load_project_asset_manifest(project_dir, AssetLimits::default())
-        .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
-    out.push_str("\ntypedef struct { const char *path; int32_t handle; } StasisPublishedSprite;\n");
-    out.push_str("static const StasisPublishedSprite stasis_published_sprites[] = {\n");
-    for asset in assets
-        .assets
-        .iter()
-        .filter(|asset| matches!(asset.entry.format, AssetFormat::Sprite { .. }))
-    {
-        out.push_str(&format!(
-            "    {{\"{}\", {}}},\n",
-            escape_mobile_c_string_literal(&asset.entry.path),
-            asset.handle.as_i32()
-        ));
-    }
-    out.push_str("    {0, 0},\n};\n");
-    out.push_str(
-        "int32_t stasis_published_sprite_handle_for_path(const char *path) {\n\
-         \x20   if (path == 0) return 0;\n\
-         \x20   while (path[0] == '.' && path[1] == '/') path += 2;\n\
-         \x20   while (path[0] == '.' && path[1] == '.' && path[2] == '/') path += 3;\n\
-         \x20   for (uintptr_t index = 0; index < sizeof(stasis_published_sprites) / sizeof(stasis_published_sprites[0]); index += 1) {\n\
-         \x20       if (stasis_published_sprites[index].path != 0 && strcmp(path, stasis_published_sprites[index].path) == 0) return stasis_published_sprites[index].handle;\n\
-         \x20   }\n\
-         \x20   return 0;\n\
-         }\n",
-    );
-    out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
-    for line in direct_storage_register_lines {
-        out.push_str(&format!("    {line}\n"));
-    }
-    out.push_str("    stasis_jit_clear_string_literal_table();\n");
-    for literal in literals {
-        let id = literal
-            .get("id")
-            .and_then(serde_json::Value::as_i64)
-            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
-        out.push_str(&format!(
-            "    stasis_jit_upsert_string_literal({id}, stasis_mobile_literal_{});\n",
-            id.unsigned_abs()
-        ));
-    }
-    out.push_str("}\n");
-    fs::write(output_path, out).map_err(|error| {
-        format!(
-            "failed to write mobile AOT bindings source {}: {error}",
-            output_path.display()
-        )
-    })
-}
-
-fn escape_mobile_c_string_literal(value: &str) -> String {
-    let mut escaped = String::new();
-    for byte in value.bytes() {
-        match byte {
-            b'\\' => escaped.push_str("\\\\"),
-            b'"' => escaped.push_str("\\\""),
-            b'\n' => escaped.push_str("\\n"),
-            b'\r' => escaped.push_str("\\r"),
-            b'\t' => escaped.push_str("\\t"),
-            b' '..=b'~' => escaped.push(char::from(byte)),
-            _ => escaped.push_str(&format!("\\{byte:03o}")),
-        }
-    }
-    escaped
-}
-
 fn mobile_aot_symbol_for(
     manifest: &serde_json::Value,
     function_name: &str,
@@ -2119,42 +1991,6 @@ fn mobile_aot_symbol_for(
         .and_then(|entry| entry.get("symbol").and_then(serde_json::Value::as_str))
         .map(str::to_string)
         .ok_or_else(|| format!("mobile AOT manifest missing symbol for function '{function_name}'"))
-}
-
-fn mobile_aot_function_for(
-    manifest: &serde_json::Value,
-    function_name: &str,
-) -> Result<(String, u64), String> {
-    let functions = manifest
-        .get("functions")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
-    let function = functions
-        .iter()
-        .find(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(function_name))
-        .ok_or_else(|| format!("mobile AOT manifest missing function '{function_name}'"))?;
-    let symbol = function
-        .get("symbol")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing symbol"))?;
-    let return_type = function
-        .get("return_type")
-        .and_then(serde_json::Value::as_u64)
-        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing return_type"))?;
-    Ok((symbol.to_string(), return_type))
-}
-
-fn mobile_aot_c_return_type(function: &serde_json::Value) -> Result<&'static str, String> {
-    match function
-        .get("return_type")
-        .and_then(serde_json::Value::as_u64)
-    {
-        Some(0) => Ok("void"),
-        Some(2) => Ok("float"),
-        Some(4) => Ok("double"),
-        Some(_) => Ok("int32_t"),
-        None => Err("mobile AOT function missing return_type".to_string()),
-    }
 }
 
 fn write_mobile_aot_package_manifest(

--- a/apps/stasis/src/mobile_aot_bindings.rs
+++ b/apps/stasis/src/mobile_aot_bindings.rs
@@ -1,0 +1,216 @@
+use crate::build_aot_direct_storage_source;
+use stasis_assets::{load_project_asset_manifest, AssetFormat, AssetLimits};
+use stasis_compiler::backend::state_layout::StateLayout;
+use std::fs;
+use std::path::Path;
+
+pub fn write_mobile_aot_bindings_source(
+    manifest: &serde_json::Value,
+    state_layout: &StateLayout,
+    project_dir: &Path,
+    output_path: &Path,
+) -> Result<(), String> {
+    let functions = manifest
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
+    let literals = manifest
+        .get("string_literals")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing string_literals array".to_string())?;
+    let mut out = String::from(
+        "#include <stdint.h>\n#include <string.h>\n#include \"stasis_mobile_aot_runtime.h\"\n\n",
+    );
+    let (direct_storage_source, direct_storage_register_lines) =
+        build_aot_direct_storage_source(state_layout)?;
+    out.push_str(&direct_storage_source);
+    for function in functions {
+        let symbol = function
+            .get("symbol")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
+        let return_type = mobile_aot_c_return_type(function)?;
+        out.push_str(&format!("extern {return_type} {symbol}(void);\n"));
+    }
+    for (name, wrapper) in [
+        ("main", "stasis_mobile_main_entry"),
+        ("tick", "stasis_mobile_tick_entry"),
+        ("render", "stasis_mobile_render_entry"),
+    ] {
+        let (symbol, return_type) = mobile_aot_function_for(manifest, name)?;
+        if return_type == 0 {
+            out.push_str(&format!(
+                "int32_t {wrapper}(void) {{ {symbol}(); return 0; }}\n"
+            ));
+        } else if return_type == 1 {
+            out.push_str(&format!(
+                "int32_t {wrapper}(void) {{ return {symbol}(); }}\n"
+            ));
+        } else {
+            return Err(format!(
+                "mobile AOT entry '{name}' must return void or i32, found type id {return_type}"
+            ));
+        }
+    }
+    for literal in literals {
+        let id = literal
+            .get("id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
+        let value = literal
+            .get("value")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT string literal missing value".to_string())?;
+        out.push_str(&format!(
+            "static const char stasis_mobile_literal_{}[] = \"{}\";\n",
+            id.unsigned_abs(),
+            escape_mobile_c_string_literal(value)
+        ));
+    }
+    let assets = load_project_asset_manifest(project_dir, AssetLimits::default())
+        .map_err(|error| format!("failed to resolve mobile AOT assets: {error}"))?;
+    out.push_str("\ntypedef struct { const char *path; int32_t handle; } StasisPublishedSprite;\n");
+    out.push_str("static const StasisPublishedSprite stasis_published_sprites[] = {\n");
+    for asset in assets
+        .assets
+        .iter()
+        .filter(|asset| matches!(asset.entry.format, AssetFormat::Sprite { .. }))
+    {
+        out.push_str(&format!(
+            "    {{\"{}\", {}}},\n",
+            escape_mobile_c_string_literal(&asset.entry.path),
+            asset.handle.as_i32()
+        ));
+    }
+    out.push_str("    {0, 0},\n};\n");
+    out.push_str(
+        "int32_t stasis_published_sprite_handle_for_path(const char *path) {\n\
+         \x20   if (path == 0) return 0;\n\
+         \x20   while (path[0] == '.' && path[1] == '/') path += 2;\n\
+         \x20   while (path[0] == '.' && path[1] == '.' && path[2] == '/') path += 3;\n\
+         \x20   for (uintptr_t index = 0; index < sizeof(stasis_published_sprites) / sizeof(stasis_published_sprites[0]); index += 1) {\n\
+         \x20       if (stasis_published_sprites[index].path != 0 && strcmp(path, stasis_published_sprites[index].path) == 0) return stasis_published_sprites[index].handle;\n\
+         \x20   }\n\
+         \x20   return 0;\n\
+         }\n",
+    );
+    out.push_str("\nvoid stasis_aot_bind_runtime_globals(void) {\n");
+    for line in direct_storage_register_lines {
+        out.push_str(&format!("    {line}\n"));
+    }
+    out.push_str("    stasis_jit_clear_string_literal_table();\n");
+    for literal in literals {
+        let id = literal
+            .get("id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or_else(|| "mobile AOT string literal missing id".to_string())?;
+        out.push_str(&format!(
+            "    stasis_jit_upsert_string_literal({id}, stasis_mobile_literal_{});\n",
+            id.unsigned_abs()
+        ));
+    }
+    out.push_str("}\n");
+    audit_mobile_aot_bindings(manifest, &out)?;
+    fs::write(output_path, out).map_err(|error| {
+        format!(
+            "failed to write mobile AOT bindings source {}: {error}",
+            output_path.display()
+        )
+    })
+}
+
+pub fn audit_mobile_aot_bindings(
+    manifest: &serde_json::Value,
+    bindings_source: &str,
+) -> Result<(), String> {
+    let functions = manifest
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
+    for function in functions {
+        let symbol = function
+            .get("symbol")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "mobile AOT function missing symbol".to_string())?;
+        let return_type = mobile_aot_c_return_type(function)?;
+        let declaration = format!("extern {return_type} {symbol}(void);");
+        if !bindings_source.contains(&declaration) {
+            return Err(format!(
+                "mobile AOT bindings missing declaration for generated symbol '{symbol}'"
+            ));
+        }
+    }
+    for (name, wrapper) in [
+        ("main", "stasis_mobile_main_entry"),
+        ("tick", "stasis_mobile_tick_entry"),
+        ("render", "stasis_mobile_render_entry"),
+    ] {
+        let (symbol, return_type) = mobile_aot_function_for(manifest, name)?;
+        let expected = if return_type == 0 {
+            format!("int32_t {wrapper}(void) {{ {symbol}(); return 0; }}")
+        } else {
+            format!("int32_t {wrapper}(void) {{ return {symbol}(); }}")
+        };
+        if !bindings_source.contains(&expected) {
+            return Err(format!(
+                "mobile AOT bindings wrapper '{wrapper}' does not target generated symbol '{symbol}'"
+            ));
+        }
+    }
+    if !bindings_source.contains("void stasis_aot_bind_runtime_globals(void)") {
+        return Err("mobile AOT bindings missing runtime-global binding entry".to_string());
+    }
+    Ok(())
+}
+
+pub fn mobile_aot_function_for(
+    manifest: &serde_json::Value,
+    function_name: &str,
+) -> Result<(String, u64), String> {
+    let functions = manifest
+        .get("functions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "mobile AOT manifest missing functions array".to_string())?;
+    let function = functions
+        .iter()
+        .find(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(function_name))
+        .ok_or_else(|| format!("mobile AOT manifest missing function '{function_name}'"))?;
+    let symbol = function
+        .get("symbol")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing symbol"))?;
+    let return_type = function
+        .get("return_type")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| format!("mobile AOT function '{function_name}' missing return_type"))?;
+    Ok((symbol.to_string(), return_type))
+}
+
+fn mobile_aot_c_return_type(function: &serde_json::Value) -> Result<&'static str, String> {
+    match function
+        .get("return_type")
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(0) => Ok("void"),
+        Some(2) => Ok("float"),
+        Some(4) => Ok("double"),
+        Some(_) => Ok("int32_t"),
+        None => Err("mobile AOT function missing return_type".to_string()),
+    }
+}
+
+pub fn escape_mobile_c_string_literal(value: &str) -> String {
+    let mut escaped = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'\\' => escaped.push_str("\\\\"),
+            b'"' => escaped.push_str("\\\""),
+            b'\n' => escaped.push_str("\\n"),
+            b'\r' => escaped.push_str("\\r"),
+            b'\t' => escaped.push_str("\\t"),
+            b' '..=b'~' => escaped.push(char::from(byte)),
+            _ => escaped.push_str(&format!("\\{byte:03o}")),
+        }
+    }
+    escaped
+}

--- a/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
+++ b/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
@@ -1,0 +1,196 @@
+#![cfg(windows)]
+
+use serde_json::json;
+use stasis::{
+    audit_mobile_aot_bindings, mobile_aot_function_for, write_mobile_aot_bindings_source,
+};
+use stasis_compiler::backend::aot::AotProcess;
+use stasis_compiler::backend::EngineEntrypoints;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const FIXTURE: &str = include_str!("../../../tests/stasis/seams/generated_mobile_aot_probe.stasis");
+const EXPECTED_TRACE: u32 = 3_312_025_514;
+
+struct TestTree(PathBuf);
+
+impl Drop for TestTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    let canonical = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root");
+    let display = canonical.to_string_lossy();
+    PathBuf::from(display.strip_prefix(r"\\?\").unwrap_or(&display))
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn locate_cl() -> PathBuf {
+    if let Some(path) = std::env::var_os("STASIS_C_COMPILER").map(PathBuf::from) {
+        assert!(
+            path.is_file(),
+            "STASIS_C_COMPILER must name a compiler file"
+        );
+        return path;
+    }
+    let output = Command::new("where.exe")
+        .arg("cl.exe")
+        .output()
+        .expect("locate MSVC compiler");
+    assert!(
+        output.status.success(),
+        "MSVC cl.exe is required for IT-012"
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .expect("cl.exe path")
+}
+
+#[test]
+fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let tree = TestTree(
+        std::env::temp_dir().join(format!("stasis-it-012-{}-{stamp}", std::process::id())),
+    );
+    let project = tree.0.join("project");
+    let bundle_dir = tree.0.join("bundle");
+    fs::create_dir_all(project.join("src")).expect("create fixture source directory");
+    fs::create_dir_all(project.join("assets")).expect("create fixture asset directory");
+    fs::write(
+        project.join("stasis.json"),
+        "{\"manifest_version\":1,\"name\":\"it012\",\"entry\":\"src/main.stasis\",\"tests\":\"tests\",\"output\":\"build\"}\n",
+    )
+    .expect("write fixture manifest");
+    fs::write(
+        project.join("assets/manifest.json"),
+        "{\"schema\":\"stasis-assets\",\"version\":1,\"assets\":[]}\n",
+    )
+    .expect("write empty asset manifest");
+    fs::write(project.join("src/main.stasis"), FIXTURE).expect("write fixture source");
+
+    let mut process = AotProcess::new();
+    process
+        .set_project_root(project.to_string_lossy())
+        .expect("set native AOT project root");
+    process.upsert_file("src/main.stasis", FIXTURE);
+    process.compile().expect("compile native mobile fixture");
+    let bundle = process
+        .write_engine_bundle(&EngineEntrypoints::runtime_default(), &bundle_dir)
+        .expect("write native engine bundle");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&bundle.manifest_path).expect("read engine manifest"),
+    )
+    .expect("parse engine manifest");
+    let bindings_path = bundle_dir.join("published_aot_bindings.c");
+    write_mobile_aot_bindings_source(&manifest, &process.state_layout(), &project, &bindings_path)
+        .expect("write generated mobile bindings");
+    let bindings = fs::read_to_string(&bindings_path).expect("read generated bindings");
+    audit_mobile_aot_bindings(&manifest, &bindings).expect("audit generated bindings");
+
+    let (tick_symbol, _) = mobile_aot_function_for(&manifest, "tick").expect("tick symbol");
+    let declaration = format!("extern int32_t {tick_symbol}(void);");
+    let wrong = bindings.replacen(
+        &declaration,
+        "extern int32_t stasis_it012_missing_tick(void);",
+        1,
+    );
+    assert_ne!(wrong, bindings, "symbol mutation must apply");
+    let audit_error = audit_mobile_aot_bindings(&manifest, &wrong)
+        .expect_err("missing generated tick declaration must fail audit");
+    assert_eq!(
+        audit_error,
+        format!("mobile AOT bindings missing declaration for generated symbol '{tick_symbol}'")
+    );
+
+    let root = repository_root();
+    let runtime = root.join("runtime");
+    let executable = tree.0.join("it012_generated_mobile.exe");
+    let mut command = Command::new(locate_cl());
+    command
+        .current_dir(&tree.0)
+        .args([
+            "/nologo",
+            "/W4",
+            "/WX",
+            "/wd4204",
+            "/D_CRT_SECURE_NO_WARNINGS",
+        ])
+        .arg(format!("/I{}", runtime.display()))
+        .arg(runtime.join("tests/stasis_generated_mobile_integration.c"))
+        .arg(runtime.join("stasis_mobile_runtime.c"))
+        .arg(runtime.join("stasis_mobile_aot_runtime.c"))
+        .arg(runtime.join("stasis_render_trace.c"))
+        .arg(&bindings_path);
+    for path in bundle.object_paths_by_function_id.values() {
+        command.arg(path);
+    }
+    let output = command
+        .arg(format!("/Fe:{}", executable.display()))
+        .output()
+        .expect("compile and link generated mobile runtime harness");
+    assert!(
+        output.status.success(),
+        "generated mobile harness link failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let run = Command::new(&executable)
+        .current_dir(&tree.0)
+        .output()
+        .expect("run generated mobile runtime harness");
+    assert!(
+        run.status.success(),
+        "generated mobile harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8(run.stdout).expect("UTF-8 harness output");
+    let trace = stdout
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("trace="))
+        .and_then(|value| value.parse::<u32>().ok())
+        .expect("harness trace");
+    assert_eq!(trace, EXPECTED_TRACE, "first generated render trace");
+    assert!(stdout.contains("state=15 frames=1 rects=1"));
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-012",
+        "status": "passed",
+        "target": "windows-native-aot+c-mobile-runtime",
+        "generated_objects": bundle.object_paths_by_function_id.len(),
+        "bindings": bindings_path,
+        "main_state": 10,
+        "first_tick_state": 15,
+        "first_render": {"frames": 1, "rects": 1, "trace": trace},
+        "oracle": {"symbol_audit_failure": audit_error}
+    });
+    let path = evidence_root().join("it-012-generated-mobile-aot-runtime.json");
+    fs::create_dir_all(path.parent().expect("evidence parent")).expect("create evidence directory");
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&evidence).expect("serialize evidence"),
+    )
+    .expect("write evidence");
+    eprintln!("IT-012 evidence: {evidence}");
+}

--- a/runtime/tests/stasis_generated_mobile_integration.c
+++ b/runtime/tests/stasis_generated_mobile_integration.c
@@ -1,0 +1,154 @@
+#include "stasis_mobile_runtime.h"
+#include "stasis_mobile_aot_runtime.h"
+#include "stasis_render_contract.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define IT012_EXPECTED_TRACE 3312025514u
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "IT-012 check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+extern void stasis_aot_bind_runtime_globals(void);
+extern int32_t stasis_mobile_main_entry(void);
+extern int32_t stasis_mobile_tick_entry(void);
+extern int32_t stasis_mobile_render_entry(void);
+
+static int32_t submitted_frames;
+static uint32_t submitted_trace;
+static int32_t submitted_rects;
+
+static int32_t hash_path(const char *text) {
+    uint32_t hash = 2166136261u;
+    while (*text != '\0') {
+        hash ^= (uint8_t)*text++;
+        hash *= 16777619u;
+    }
+    return (int32_t)hash;
+}
+
+int stasis_init_window(int width, int height, const char *title) {
+    return width == 320 && height == 180 && title != NULL;
+}
+int stasis_should_quit(void) { return 0; }
+int stasis_mobile_poll_events(void) { return 0; }
+void stasis_mobile_set_paused(int paused) { (void)paused; }
+void stasis_host_get_frame(int32_t *out_i32, float *out_f32) {
+    out_i32[10] += 1;
+    out_f32[50] = 320.0f;
+    out_f32[51] = 180.0f;
+}
+void stasis_host_bulk_apply_requests(
+    const int32_t *seq,
+    const int32_t *flags,
+    const int32_t *width,
+    const int32_t *height
+) {
+    (void)seq;
+    (void)flags;
+    (void)width;
+    (void)height;
+}
+void stasis_gfx_submit_u8(int32_t *i32s, const float *f32s, const uint8_t *u8s) {
+    submitted_frames += 1;
+    submitted_trace = stasis_render_trace(i32s, f32s, u8s);
+    submitted_rects = i32s[STASIS_RENDER_I_RECT_COUNT];
+}
+uint64_t stasis_host_performance_counter(void) { return 100; }
+uint64_t stasis_host_performance_elapsed_us(uint64_t started, uint64_t finished) {
+    return finished - started;
+}
+void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us) {
+    (void)tick_us;
+    (void)render_us;
+}
+void stasis_shutdown(void) {}
+
+int stasis_audio_init(int rate, int channels, int latency) {
+    return rate > 0 && channels > 0 && latency > 0;
+}
+void stasis_audio_shutdown(void) {}
+int stasis_audio_is_available(void) { return 0; }
+int stasis_audio_get_sample_rate(void) { return 48000; }
+int stasis_audio_get_channels(void) { return 2; }
+int stasis_audio_get_queued_frames(void) { return 0; }
+int stasis_audio_get_underruns(void) { return 0; }
+int stasis_audio_push_f32_interleaved(const float *samples, int frames) {
+    return samples == NULL ? 0 : frames;
+}
+int stasis_audio_load_wav(const char *path) { return path == NULL ? 0 : 1; }
+void stasis_audio_release(int handle) { (void)handle; }
+int stasis_audio_play(int handle, int loop, float volume, float pan) {
+    (void)loop; (void)volume; (void)pan; return handle;
+}
+void stasis_audio_stop(int handle) { (void)handle; }
+int stasis_audio_voice_is_playing(int handle) { return handle > 0; }
+void stasis_audio_voice_set_paused(int handle, int paused) { (void)handle; (void)paused; }
+void stasis_audio_voice_set_volume_pan(int handle, float volume, float pan) {
+    (void)handle; (void)volume; (void)pan;
+}
+int stasis_audio_load_music(const char *path) { return path == NULL ? 0 : 1; }
+int stasis_audio_load_effect(const char *path) { return path == NULL ? 0 : 1; }
+int stasis_audio_play_music(int handle, int loop, float volume) {
+    (void)loop; (void)volume; return handle;
+}
+void stasis_audio_stop_music(int handle) { (void)handle; }
+void stasis_audio_pause_music(int handle, int paused) { (void)handle; (void)paused; }
+void stasis_audio_set_music_volume(int handle, float volume) { (void)handle; (void)volume; }
+int stasis_audio_play_effect(int handle, float volume) { (void)volume; return handle; }
+int stasis_gfx_load_sprite(const char *path, int max_w, int max_h) {
+    return path != NULL && max_w > 0 && max_h > 0;
+}
+void stasis_gfx_release_sprite(int handle) { (void)handle; }
+int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
+int stasis_gfx_dump_png(const char *path) { return path != NULL; }
+int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
+int stasis_gfx_poll_reload(int handle) { return handle; }
+float stasis_gfx_measure_text_cached(int handle) { return (float)handle; }
+float stasis_gfx_measure_text_cached_height(int handle) { return (float)handle; }
+int stasis_load_font(const char *path, int size) { return path == NULL ? 0 : size; }
+float stasis_measure_text(int font, const char *text) { return text == NULL ? 0.0f : (float)font; }
+void stasis_sleep_ms(int ms) { (void)ms; }
+int stasis_storage_load_i32(const char *scope, const char *key, int fallback) {
+    (void)scope; (void)key; return fallback;
+}
+int stasis_storage_save_i32(const char *scope, const char *key, int value) {
+    (void)value; return scope != NULL && key != NULL;
+}
+int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int capacity) {
+    (void)scope; (void)key; (void)out; (void)capacity; return 0;
+}
+int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length) {
+    (void)value; (void)length; return scope != NULL && key != NULL;
+}
+int stasis_clipboard_load_ascii(char *out, int capacity) { (void)out; (void)capacity; return 0; }
+int stasis_clipboard_save_ascii(const char *value, int length) {
+    return value != NULL && length >= 0;
+}
+
+int main(void) {
+    const StasisMobileRuntimeConfig config = {320, 180, "IT-012 generated mobile AOT"};
+    const StasisMobileGameEntries entries = {
+        stasis_aot_bind_runtime_globals,
+        stasis_mobile_main_entry,
+        stasis_mobile_tick_entry,
+        stasis_mobile_render_entry
+    };
+    CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(stasis_jit_global_i32_load(hash_path("score")) == 10);
+    CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(stasis_jit_global_i32_load(hash_path("score")) == 15);
+    CHECK(submitted_frames == 1);
+    CHECK(submitted_rects == 1);
+    CHECK(submitted_trace == IT012_EXPECTED_TRACE);
+    printf("stasis.seam_test.v1 IT-012 state=15 frames=1 rects=1 trace=%u\n", submitted_trace);
+    stasis_mobile_runtime_shutdown();
+    return 0;
+}

--- a/tests/stasis/seams/generated_mobile_aot_probe.stasis
+++ b/tests/stasis/seams/generated_mobile_aot_probe.stasis
@@ -1,0 +1,50 @@
+global host_i32: i32[768];
+global host_f32: f32[64];
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global host_req_seq: i32;
+global host_req_flags: i32;
+global host_req_window_w_px: i32;
+global host_req_window_h_px: i32;
+global score: i32;
+
+function main(): i32 {
+    score = 10;
+    return 0;
+}
+
+function tick(): i32 {
+    score += 5;
+    return 0;
+}
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 0;
+    gfx_cmd_i32[7] = 0;
+    gfx_cmd_i32[9] = 0;
+    gfx_cmd_i32[22] = 1;
+    gfx_cmd_i32[24] = 1;
+    gfx_cmd_i32[18464] = 65536;
+    gfx_cmd_f32[0] = 0.05;
+    gfx_cmd_f32[1] = 0.10;
+    gfx_cmd_f32[2] = 0.15;
+    gfx_cmd_f32[3] = 1.0;
+    gfx_cmd_f32[79996] = 12.0;
+    gfx_cmd_f32[79997] = 14.0;
+    gfx_cmd_f32[79998] = 30.0;
+    gfx_cmd_f32[79999] = 18.0;
+    gfx_cmd_f32[80000] = 0.8;
+    gfx_cmd_f32[80001] = 0.2;
+    gfx_cmd_f32[80002] = 0.1;
+    gfx_cmd_f32[80003] = 1.0;
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}


### PR DESCRIPTION
## Summary

- extract the production mobile AOT binding generator into the `stasis` library and add a deterministic manifest/source audit
- compile a real Stasis fixture to native AOT objects, link generated bindings and objects into the real C mobile runtime, and execute `main` plus the first tick/render
- verify exact state and render-trace evidence, plus a deterministic wrong-symbol failure oracle
- add IT-012 to the Windows PR CI seam lane

## Validation

- generated mobile AOT runtime seam (MSVC): passed, exact trace `3312025514`
- existing Android AOT bundle symbol-header test: passed
- existing mobile C string escaping test: passed
- `cargo check -p stasis --all-targets`
- `cargo fmt --all -- --check`
- Stasis source layout check
- runtime ABI contract: 288 comparisons

Maddox Tasks: #221 (child of #209)

Theory gained: generated AOT linkage is trustworthy only when the compiler's manifest, production binding source, native objects, runtime-global registration, and real mobile lifecycle entrypoints are exercised as one link-and-run unit. The observation is that four fixture objects linked and produced state 15 plus trace 3312025514 through `stasis_mobile_runtime_step`; an adjacent prediction is that an entry-symbol or storage-binding drift will now fail at audit, link, or the first deterministic state/trace oracle.