### PR TITLE
test: cover generated mobile AOT lifecycle

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           cargo test -p stasis_compiler --test jit_aot_host_replay_seam -- --test-threads=1 --nocapture
 
-      - name: Test generated AOT bindings in the C mobile runtime
+      - name: Test generated AOT bindings and lifecycle in the C mobile runtime
         shell: pwsh
         run: |
           cargo test -p stasis --test generated_mobile_aot_runtime_seam -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
+++ b/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
@@ -172,6 +172,9 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
         .expect("harness trace");
     assert_eq!(trace, EXPECTED_TRACE, "first generated render trace");
     assert!(stdout.contains("state=15 frames=1 rects=1"));
+    assert!(stdout.contains(
+        "IT-013 order=123 paused_poll=1 reinit=1 main_stop=11 tick_stop=22 render_stop=33 frames_after_failures=0"
+    ));
 
     let evidence = json!({
         "schema": "stasis.seam_test.v1",
@@ -193,4 +196,23 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
     )
     .expect("write evidence");
     eprintln!("IT-012 evidence: {evidence}");
+
+    let lifecycle_evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-013",
+        "status": "passed",
+        "target": "windows-native-aot+c-mobile-runtime",
+        "entry_order": 123,
+        "paused": {"polls": 1, "tick_or_render_calls": 0},
+        "reinitialize": {"entry_order": 1, "score": 10},
+        "stop_results": {"main": 11, "tick": 22, "render": 33},
+        "frames_after_tick_or_render_failure": 0
+    });
+    let lifecycle_path = evidence_root().join("it-013-generated-mobile-aot-lifecycle.json");
+    fs::write(
+        lifecycle_path,
+        serde_json::to_vec_pretty(&lifecycle_evidence).expect("serialize lifecycle evidence"),
+    )
+    .expect("write lifecycle evidence");
+    eprintln!("IT-013 evidence: {lifecycle_evidence}");
 }

--- a/runtime/tests/stasis_generated_mobile_integration.c
+++ b/runtime/tests/stasis_generated_mobile_integration.c
@@ -24,6 +24,11 @@ extern int32_t stasis_mobile_render_entry(void);
 static int32_t submitted_frames;
 static uint32_t submitted_trace;
 static int32_t submitted_rects;
+static int32_t polled_events;
+static int32_t pause_transitions;
+static int32_t last_pause_value;
+static int32_t shutdowns;
+static int32_t next_bind_mode;
 
 static int32_t hash_path(const char *text) {
     uint32_t hash = 2166136261u;
@@ -38,8 +43,11 @@ int stasis_init_window(int width, int height, const char *title) {
     return width == 320 && height == 180 && title != NULL;
 }
 int stasis_should_quit(void) { return 0; }
-int stasis_mobile_poll_events(void) { return 0; }
-void stasis_mobile_set_paused(int paused) { (void)paused; }
+int stasis_mobile_poll_events(void) { polled_events += 1; return 0; }
+void stasis_mobile_set_paused(int paused) {
+    pause_transitions += 1;
+    last_pause_value = paused;
+}
 void stasis_host_get_frame(int32_t *out_i32, float *out_f32) {
     out_i32[10] += 1;
     out_f32[50] = 320.0f;
@@ -69,7 +77,7 @@ void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us) {
     (void)tick_us;
     (void)render_us;
 }
-void stasis_shutdown(void) {}
+void stasis_shutdown(void) { shutdowns += 1; }
 
 int stasis_audio_init(int rate, int channels, int latency) {
     return rate > 0 && channels > 0 && latency > 0;
@@ -133,22 +141,87 @@ int stasis_clipboard_save_ascii(const char *value, int length) {
     return value != NULL && length >= 0;
 }
 
+static void bind_runtime_with_mode(void) {
+    stasis_aot_bind_runtime_globals();
+    stasis_jit_global_i32_store(hash_path("lifecycle_mode"), next_bind_mode);
+}
+
+static void reset_frame_observations(void) {
+    submitted_frames = 0;
+    submitted_trace = 0;
+    submitted_rects = 0;
+}
+
 int main(void) {
     const StasisMobileRuntimeConfig config = {320, 180, "IT-012 generated mobile AOT"};
     const StasisMobileGameEntries entries = {
-        stasis_aot_bind_runtime_globals,
+        bind_runtime_with_mode,
         stasis_mobile_main_entry,
         stasis_mobile_tick_entry,
         stasis_mobile_render_entry
     };
+    next_bind_mode = 0;
     CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_OK);
     CHECK(stasis_jit_global_i32_load(hash_path("score")) == 10);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 1);
+    CHECK(stasis_jit_global_i32_array_load(hash_path("host_i32"), 0, 10) == 0);
+    stasis_mobile_runtime_set_paused(1);
+    CHECK(pause_transitions == 1);
+    CHECK(last_pause_value == 1);
+    CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(polled_events == 1);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 1);
+    CHECK(stasis_jit_global_i32_load(hash_path("score")) == 10);
+    CHECK(submitted_frames == 0);
+    stasis_mobile_runtime_set_paused(0);
+    CHECK(pause_transitions == 2);
+    CHECK(last_pause_value == 0);
     CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_OK);
     CHECK(stasis_jit_global_i32_load(hash_path("score")) == 15);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 123);
     CHECK(submitted_frames == 1);
     CHECK(submitted_rects == 1);
     CHECK(submitted_trace == IT012_EXPECTED_TRACE);
     printf("stasis.seam_test.v1 IT-012 state=15 frames=1 rects=1 trace=%u\n", submitted_trace);
     stasis_mobile_runtime_shutdown();
+
+    CHECK(stasis_mobile_runtime_is_initialized() == 0);
+    CHECK(stasis_mobile_runtime_last_entry_result() == 0);
+    CHECK(shutdowns == 1);
+    reset_frame_observations();
+    CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(stasis_jit_global_i32_load(hash_path("score")) == 10);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 1);
+    CHECK(stasis_jit_global_i32_array_load(hash_path("host_i32"), 0, 10) == 0);
+    CHECK(submitted_frames == 0);
+    stasis_mobile_runtime_shutdown();
+
+    next_bind_mode = 2;
+    reset_frame_observations();
+    CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    CHECK(stasis_mobile_runtime_last_entry_result() == 22);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 12);
+    CHECK(submitted_frames == 0);
+    stasis_mobile_runtime_shutdown();
+
+    next_bind_mode = 3;
+    reset_frame_observations();
+    CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_OK);
+    CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    CHECK(stasis_mobile_runtime_last_entry_result() == 33);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 123);
+    CHECK(submitted_frames == 0);
+    stasis_mobile_runtime_shutdown();
+
+    next_bind_mode = 1;
+    reset_frame_observations();
+    CHECK(stasis_mobile_runtime_initialize(&config, &entries) == STASIS_MOBILE_RUNTIME_STOP_REQUESTED);
+    CHECK(stasis_mobile_runtime_last_entry_result() == 11);
+    CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 1);
+    CHECK(submitted_frames == 0);
+    stasis_mobile_runtime_shutdown();
+    CHECK(shutdowns == 5);
+    printf("stasis.seam_test.v1 IT-013 order=123 paused_poll=1 reinit=1 main_stop=11 tick_stop=22 render_stop=33 frames_after_failures=0\n");
     return 0;
 }

--- a/tests/stasis/seams/generated_mobile_aot_probe.stasis
+++ b/tests/stasis/seams/generated_mobile_aot_probe.stasis
@@ -8,18 +8,29 @@ global host_req_flags: i32;
 global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
 global score: i32;
+global lifecycle_mode: i32;
+global entry_trace: i32;
 
 function main(): i32 {
+    entry_trace = 1;
     score = 10;
+    if (lifecycle_mode == 1) {
+        return 11;
+    }
     return 0;
 }
 
 function tick(): i32 {
+    entry_trace = entry_trace * 10 + 2;
     score += 5;
+    if (lifecycle_mode == 2) {
+        return 22;
+    }
     return 0;
 }
 
 function render(): i32 {
+    entry_trace = entry_trace * 10 + 3;
     gfx_cmd_i32[0] = 1196967473;
     gfx_cmd_i32[1] = 4;
     gfx_cmd_i32[2] = 3;
@@ -42,6 +53,9 @@ function render(): i32 {
     gfx_cmd_f32[80001] = 0.2;
     gfx_cmd_f32[80002] = 0.1;
     gfx_cmd_f32[80003] = 1.0;
+    if (lifecycle_mode == 3) {
+        return 33;
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary

- extend the real generated AOT fixture/mobile C runtime harness with exact lifecycle entry ordering
- verify paused polling performs no guest tick/render and submits no frame
- verify shutdown/reinitialize resets runtime-owned buffers and reruns generated `main` deterministically
- drive generated `main`, `tick`, and `render` to exact non-zero stop results and prove tick/render failures never submit a frame
- emit separate IT-013 structured evidence in the existing native Windows CI seam

## Validation

- generated mobile AOT runtime seam (MSVC): passed
- exact guest order: `123`
- exact stop results: main `11`, tick `22`, render `33`
- zero submitted frames after tick/render failures
- `cargo check -p stasis --all-targets`
- `cargo fmt --all -- --check`
- Stasis source layout check
- runtime ABI contract: 288 comparisons

Maddox Tasks: #222 (IT-013, child of #209)

Theory gained: the mobile shell's lifecycle contract can be verified without fake entries by using one bound guest control global before each generated `main`, then reading generated state traces and host submissions after each transition. The observation is exact trace `123`, paused trace `1`, reset trace `1`, stop codes 11/22/33, and zero failure submissions; the adjacent prediction is that a future shell reordering or failure-path submission will fail one localized oracle.