### PR TITLE
test: verify mobile frame ordering

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           cargo test -p stasis_compiler --test jit_aot_host_replay_seam -- --test-threads=1 --nocapture
 
-      - name: Test generated AOT bindings and lifecycle in the C mobile runtime
+      - name: Test generated AOT bindings, lifecycle, and frame order in the C mobile runtime
         shell: pwsh
         run: |
           cargo test -p stasis --test generated_mobile_aot_runtime_seam -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
+++ b/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
@@ -175,6 +175,9 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
     assert!(stdout.contains(
         "IT-013 order=123 paused_poll=1 reinit=1 main_stop=11 tick_stop=22 render_stop=33 frames_after_failures=0"
     ));
+    assert!(
+        stdout.contains("IT-014 order=123 marker=77 request=41:5:640:360 render_score=15 frames=1")
+    );
 
     let evidence = json!({
         "schema": "stasis.seam_test.v1",
@@ -215,4 +218,23 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
     )
     .expect("write lifecycle evidence");
     eprintln!("IT-013 evidence: {lifecycle_evidence}");
+
+    let ordering_evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-014",
+        "status": "passed",
+        "target": "windows-native-aot+c-mobile-runtime",
+        "host_apply_submit_order": 123,
+        "host_frame_marker_seen_by_tick": 77,
+        "request_applied": {"sequence": 41, "flags": 5, "width": 640, "height": 360},
+        "tick_score_seen_by_render": 15,
+        "submitted_frames": 1
+    });
+    let ordering_path = evidence_root().join("it-014-mobile-host-frame-order.json");
+    fs::write(
+        ordering_path,
+        serde_json::to_vec_pretty(&ordering_evidence).expect("serialize ordering evidence"),
+    )
+    .expect("write ordering evidence");
+    eprintln!("IT-014 evidence: {ordering_evidence}");
 }

--- a/runtime/tests/stasis_generated_mobile_integration.c
+++ b/runtime/tests/stasis_generated_mobile_integration.c
@@ -29,6 +29,14 @@ static int32_t pause_transitions;
 static int32_t last_pause_value;
 static int32_t shutdowns;
 static int32_t next_bind_mode;
+static int32_t record_step_order;
+static int32_t step_order;
+static int32_t applied_seq;
+static int32_t applied_flags;
+static int32_t applied_width;
+static int32_t applied_height;
+static int32_t submit_tick_marker;
+static int32_t submit_render_score;
 
 static int32_t hash_path(const char *text) {
     uint32_t hash = 2166136261u;
@@ -49,7 +57,9 @@ void stasis_mobile_set_paused(int paused) {
     last_pause_value = paused;
 }
 void stasis_host_get_frame(int32_t *out_i32, float *out_f32) {
+    if (record_step_order) step_order = step_order * 10 + 1;
     out_i32[10] += 1;
+    out_i32[100] = 77;
     out_f32[50] = 320.0f;
     out_f32[51] = 180.0f;
 }
@@ -59,15 +69,19 @@ void stasis_host_bulk_apply_requests(
     const int32_t *width,
     const int32_t *height
 ) {
-    (void)seq;
-    (void)flags;
-    (void)width;
-    (void)height;
+    if (record_step_order) step_order = step_order * 10 + 2;
+    applied_seq = *seq;
+    applied_flags = *flags;
+    applied_width = *width;
+    applied_height = *height;
 }
 void stasis_gfx_submit_u8(int32_t *i32s, const float *f32s, const uint8_t *u8s) {
+    if (record_step_order) step_order = step_order * 10 + 3;
     submitted_frames += 1;
     submitted_trace = stasis_render_trace(i32s, f32s, u8s);
     submitted_rects = i32s[STASIS_RENDER_I_RECT_COUNT];
+    submit_tick_marker = stasis_jit_global_i32_load(hash_path("tick_host_marker"));
+    submit_render_score = stasis_jit_global_i32_load(hash_path("render_score"));
 }
 uint64_t stasis_host_performance_counter(void) { return 100; }
 uint64_t stasis_host_performance_elapsed_us(uint64_t started, uint64_t finished) {
@@ -176,13 +190,26 @@ int main(void) {
     stasis_mobile_runtime_set_paused(0);
     CHECK(pause_transitions == 2);
     CHECK(last_pause_value == 0);
+    stasis_jit_global_i32_store(hash_path("host_req_seq"), 41);
+    stasis_jit_global_i32_store(hash_path("host_req_flags"), 5);
+    stasis_jit_global_i32_store(hash_path("host_req_window_w_px"), 640);
+    stasis_jit_global_i32_store(hash_path("host_req_window_h_px"), 360);
+    record_step_order = 1;
     CHECK(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_OK);
+    record_step_order = 0;
     CHECK(stasis_jit_global_i32_load(hash_path("score")) == 15);
     CHECK(stasis_jit_global_i32_load(hash_path("entry_trace")) == 123);
+    CHECK(stasis_jit_global_i32_load(hash_path("tick_host_marker")) == 77);
+    CHECK(stasis_jit_global_i32_load(hash_path("render_score")) == 15);
+    CHECK(step_order == 123);
+    CHECK(applied_seq == 41 && applied_flags == 5);
+    CHECK(applied_width == 640 && applied_height == 360);
+    CHECK(submit_tick_marker == 77 && submit_render_score == 15);
     CHECK(submitted_frames == 1);
     CHECK(submitted_rects == 1);
     CHECK(submitted_trace == IT012_EXPECTED_TRACE);
     printf("stasis.seam_test.v1 IT-012 state=15 frames=1 rects=1 trace=%u\n", submitted_trace);
+    printf("stasis.seam_test.v1 IT-014 order=123 marker=77 request=41:5:640:360 render_score=15 frames=1\n");
     stasis_mobile_runtime_shutdown();
 
     CHECK(stasis_mobile_runtime_is_initialized() == 0);

--- a/tests/stasis/seams/generated_mobile_aot_probe.stasis
+++ b/tests/stasis/seams/generated_mobile_aot_probe.stasis
@@ -10,6 +10,8 @@ global host_req_window_h_px: i32;
 global score: i32;
 global lifecycle_mode: i32;
 global entry_trace: i32;
+global tick_host_marker: i32;
+global render_score: i32;
 
 function main(): i32 {
     entry_trace = 1;
@@ -22,6 +24,7 @@ function main(): i32 {
 
 function tick(): i32 {
     entry_trace = entry_trace * 10 + 2;
+    tick_host_marker = host_i32[100];
     score += 5;
     if (lifecycle_mode == 2) {
         return 22;
@@ -31,6 +34,7 @@ function tick(): i32 {
 
 function render(): i32 {
     entry_trace = entry_trace * 10 + 3;
+    render_score = score;
     gfx_cmd_i32[0] = 1196967473;
     gfx_cmd_i32[1] = 4;
     gfx_cmd_i32[2] = 3;


### PR DESCRIPTION
## Summary

- extend the real generated-AOT/mobile-runtime harness with a host-frame marker and guest mailbox request
- assert exact host snapshot → mailbox apply → graphics submit order (`123`)
- prove generated tick sees marker `77`, generated render sees tick-updated score `15`, and submit observes both
- verify the exact mailbox payload `41:5:640:360` and one successful frame
- emit structured IT-014 evidence in the existing Windows native seam lane

## Validation

- generated mobile AOT runtime seam (MSVC): passed
- `cargo check -p stasis --all-targets`
- `cargo fmt --all -- --check`
- Stasis source layout check

Maddox Tasks: #223 (IT-014, child of #209)

Theory gained: one mobile step has an observable ownership chain—host snapshot, pending request application, generated tick, generated render, then submit—and guest state plus host callback order can jointly detect any inversion without instrumenting production code.