### PR TITLE
test: cover packaged mobile asset seam

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -168,6 +168,12 @@ jobs:
         run: |
           cargo test -p stasis --test generated_mobile_aot_runtime_seam -- --test-threads=1 --nocapture
 
+      - name: Test packaged mobile assets through linked AOT and shared native hosts
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          python tools/cargo_cache.py run -- cargo test -p stasis --test mobile_packaged_assets_seam -- --test-threads=1 --nocapture
+
       - name: Bootstrap Compile Smoke (compiler .stasis)
         # Compiler/JIT tests share process-global dispatch and runtime registration state.
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture

--- a/apps/stasis/tests/mobile_packaged_assets_seam.rs
+++ b/apps/stasis/tests/mobile_packaged_assets_seam.rs
@@ -1,0 +1,309 @@
+#![cfg(windows)]
+
+use serde_json::json;
+use stasis::{audit_mobile_aot_bindings, write_mobile_aot_bindings_source};
+use stasis_assets::{load_project_asset_manifest, prepare_asset_bundle, sha256_bytes, AssetLimits};
+use stasis_compiler::backend::aot::AotProcess;
+use stasis_compiler::backend::EngineEntrypoints;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const FIXTURE: &str =
+    include_str!("../../../tests/stasis/seams/mobile_packaged_assets_probe.stasis");
+const EXPECTED_RENDER_TRACE: u32 = 4_249_029_299;
+
+struct TestTree(PathBuf);
+
+impl Drop for TestTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    let canonical = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root");
+    let display = canonical.to_string_lossy();
+    PathBuf::from(display.strip_prefix(r"\\?\").unwrap_or(&display))
+}
+
+fn evidence_root() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join("seam-tests")
+}
+
+fn locate_cl() -> PathBuf {
+    if let Some(path) = std::env::var_os("STASIS_C_COMPILER").map(PathBuf::from) {
+        assert!(
+            path.is_file(),
+            "STASIS_C_COMPILER must name a compiler file"
+        );
+        return path;
+    }
+    let output = Command::new("where.exe")
+        .arg("cl.exe")
+        .output()
+        .expect("locate MSVC compiler");
+    assert!(
+        output.status.success(),
+        "MSVC cl.exe is required for IT-015"
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .expect("cl.exe path")
+}
+
+fn wav_fixture() -> Vec<u8> {
+    let samples = [0_i16, 16_384, -16_384, 8_192];
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"RIFF");
+    bytes.extend_from_slice(&(36_u32 + (samples.len() * 2) as u32).to_le_bytes());
+    bytes.extend_from_slice(b"WAVEfmt ");
+    bytes.extend_from_slice(&16_u32.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.extend_from_slice(&24_000_u32.to_le_bytes());
+    bytes.extend_from_slice(&48_000_u32.to_le_bytes());
+    bytes.extend_from_slice(&2_u16.to_le_bytes());
+    bytes.extend_from_slice(&16_u16.to_le_bytes());
+    bytes.extend_from_slice(b"data");
+    bytes.extend_from_slice(&((samples.len() * 2) as u32).to_le_bytes());
+    for sample in samples {
+        bytes.extend_from_slice(&sample.to_le_bytes());
+    }
+    bytes
+}
+
+#[test]
+fn packaged_mobile_assets_reach_real_native_hosts_from_linked_aot() {
+    let runtime_dll = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    let runtime_import = runtime_dll.with_file_name("stasis_graphics.lib");
+    assert!(runtime_dll.is_file(), "graphics runtime DLL is missing");
+    assert!(
+        runtime_import.is_file(),
+        "graphics runtime import library is missing"
+    );
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let tree = TestTree(
+        std::env::temp_dir().join(format!("stasis-it-015-{}-{stamp}", std::process::id())),
+    );
+    let project = tree.0.join("project");
+    let bundle_root = tree.0.join("package/stasis_game");
+    let engine_root = tree.0.join("engine");
+    fs::create_dir_all(project.join("src")).expect("create source directory");
+    fs::create_dir_all(project.join("assets")).expect("create asset directory");
+    fs::write(project.join("src/main.stasis"), FIXTURE).expect("write AOT fixture");
+    fs::copy(
+        repository_root().join("samples/windows_launch_smoke/assets/smoke.png"),
+        project.join("assets/sprite.png"),
+    )
+    .expect("copy sprite fixture");
+    fs::copy(
+        repository_root().join("samples/windows_launch_smoke/assets/smoke.ttf"),
+        project.join("assets/ui.ttf"),
+    )
+    .expect("copy font fixture");
+    let wav = wav_fixture();
+    fs::write(project.join("assets/tone.wav"), &wav).expect("write audio fixture");
+    fs::copy(project.join("assets/ui.ttf"), tree.0.join("outside.ttf"))
+        .expect("write traversal sentinel");
+
+    let sprite = fs::read(project.join("assets/sprite.png")).expect("read sprite fixture");
+    let font = fs::read(project.join("assets/ui.ttf")).expect("read font fixture");
+    let source_hashes = [
+        sha256_bytes(&sprite),
+        sha256_bytes(&font),
+        sha256_bytes(&wav),
+    ];
+    let manifest = json!({
+        "schema": "stasis-assets",
+        "version": 1,
+        "assets": [
+            {"id":"sprite","path":"assets/sprite.png","content_sha256":source_hashes[0],"format":{"kind":"sprite","encoding":"png","width":64,"height":64},"dependencies":[]},
+            {"id":"ui","path":"assets/ui.ttf","content_sha256":source_hashes[1],"format":{"kind":"font","encoding":"ttf"},"dependencies":[]},
+            {"id":"tone","path":"assets/tone.wav","content_sha256":source_hashes[2],"format":{"kind":"audio","encoding":"wav","sample_rate":24000,"channels":1,"duration_frames":4},"dependencies":[]}
+        ]
+    });
+    fs::write(
+        project.join("assets/manifest.json"),
+        serde_json::to_vec_pretty(&manifest).expect("encode manifest"),
+    )
+    .expect("write manifest");
+    fs::write(
+        project.join("stasis.json"),
+        "{\"manifest_version\":1,\"name\":\"it015\",\"entry\":\"src/main.stasis\",\"tests\":\"tests\",\"output\":\"build\"}\n",
+    )
+    .expect("write project manifest");
+
+    let resolved = load_project_asset_manifest(&project, AssetLimits::default())
+        .expect("validate source asset identities and hashes");
+    assert_eq!(resolved.assets.len(), 3);
+    let prepared = prepare_asset_bundle(&resolved, &bundle_root, tree.0.join("asset-cache"))
+        .expect("prepare mobile stasis_game bundle");
+    assert_eq!(prepared.copied_assets, 3);
+    let packaged = load_project_asset_manifest(&bundle_root, AssetLimits::default())
+        .expect("validate packaged asset identities and hashes");
+    assert_eq!(
+        packaged
+            .by_id("sprite")
+            .expect("packaged sprite")
+            .entry
+            .content_sha256,
+        source_hashes[0]
+    );
+    assert_eq!(
+        packaged
+            .by_id("ui")
+            .expect("packaged font")
+            .entry
+            .content_sha256,
+        source_hashes[1]
+    );
+    assert_eq!(
+        packaged
+            .by_id("tone")
+            .expect("packaged audio")
+            .entry
+            .content_sha256,
+        source_hashes[2]
+    );
+
+    let mut process = AotProcess::new();
+    process
+        .set_project_root(project.to_string_lossy())
+        .expect("set AOT project root");
+    process.upsert_file("src/main.stasis", FIXTURE);
+    process
+        .compile()
+        .expect("compile packaged asset AOT fixture");
+    let engine = process
+        .write_engine_bundle(&EngineEntrypoints::runtime_default(), &engine_root)
+        .expect("write engine bundle");
+    let engine_manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&engine.manifest_path).expect("read engine manifest"),
+    )
+    .expect("decode engine manifest");
+    let bindings = engine_root.join("published_aot_bindings.c");
+    write_mobile_aot_bindings_source(
+        &engine_manifest,
+        &process.state_layout(),
+        &project,
+        &bindings,
+    )
+    .expect("write mobile AOT bindings");
+    audit_mobile_aot_bindings(
+        &engine_manifest,
+        &fs::read_to_string(&bindings).expect("read bindings"),
+    )
+    .expect("audit mobile AOT bindings");
+
+    let root = repository_root();
+    let runtime = root.join("runtime");
+    let executable = tree.0.join("it015_mobile_packaged_assets.exe");
+    let mut command = Command::new(locate_cl());
+    command
+        .current_dir(&tree.0)
+        .args([
+            "/nologo",
+            "/W4",
+            "/WX",
+            "/wd4244",
+            "/wd4267",
+            "/wd4456",
+            "/D_CRT_SECURE_NO_WARNINGS",
+        ])
+        .arg(format!("/I{}", runtime.display()))
+        .arg(runtime.join("tests/stasis_mobile_packaged_assets_integration.c"))
+        .arg(runtime.join("stasis_mobile_aot_runtime.c"))
+        .arg(runtime.join("stasis_audio_assets.c"))
+        .arg(&bindings);
+    for path in engine.object_paths_by_function_id.values() {
+        command.arg(path);
+    }
+    let link = command
+        .arg(&runtime_import)
+        .arg(format!("/Fe:{}", executable.display()))
+        .output()
+        .expect("compile linked mobile asset harness");
+    assert!(
+        link.status.success(),
+        "mobile asset harness link failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&link.stdout),
+        String::from_utf8_lossy(&link.stderr)
+    );
+
+    let run = Command::new(&executable)
+        .arg(&bundle_root)
+        .current_dir(runtime_dll.parent().expect("runtime DLL directory"))
+        .env("SDL_VIDEODRIVER", "dummy")
+        .env("SDL_RENDER_DRIVER", "software")
+        .env("SDL_AUDIODRIVER", "dummy")
+        .output()
+        .expect("run linked mobile asset harness");
+    assert!(
+        run.status.success(),
+        "mobile asset harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8(run.stdout).expect("UTF-8 harness output");
+    assert!(stdout.contains("stasis.seam_test.v1 IT-015"));
+    assert!(stdout.contains("samples=0.125:0.125 offline_active=1"));
+    assert!(stdout.contains("../../missing.wav"));
+    let trace = stdout
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("trace="))
+        .and_then(|value| value.parse::<u32>().ok())
+        .expect("render trace");
+    assert_eq!(
+        trace, EXPECTED_RENDER_TRACE,
+        "exact packaged asset frame trace"
+    );
+
+    let evidence = json!({
+        "schema": "stasis.seam_test.v1",
+        "test_id": "IT-015",
+        "status": "passed",
+        "target": "windows-native-aot+mobile-package+shared-sdl-runtime",
+        "bundle_root": bundle_root,
+        "manifest": packaged.assets.iter().map(|asset| json!({
+            "id": asset.entry.id,
+            "path": asset.entry.path,
+            "sha256": asset.entry.content_sha256
+        })).collect::<Vec<_>>(),
+        "native_handles": {"sprite": "positive", "font": "positive", "cached_text": "positive", "audio": "positive", "voice": "positive"},
+        "render_trace": trace,
+        "offline_audio": {"output_lr_frame_1": [0.125, 0.125], "voice_active_after_4_output_frames": true},
+        "containment": {
+            "font_request": "../../outside.ttf",
+            "outside_valid_font_loaded": false,
+            "audio_request": "../../missing.wav",
+            "diagnostics_preserved_requests": true
+        }
+    });
+    let evidence_path = evidence_root().join("it-015-mobile-packaged-assets.json");
+    fs::create_dir_all(evidence_path.parent().expect("evidence parent"))
+        .expect("create evidence directory");
+    fs::write(
+        &evidence_path,
+        serde_json::to_vec_pretty(&evidence).expect("encode evidence"),
+    )
+    .expect("write evidence");
+    eprintln!("IT-015 evidence: {evidence}");
+}

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -5783,11 +5783,17 @@ STASIS_EXPORT int stasis_clipboard_save_ascii(const char* value, int length) {
  */
 STASIS_EXPORT int stasis_audio_load_wav(const char* path) {
     char resolved[1024];
-    if (!path || !*path || !resolve_asset_path(path, resolved, sizeof(resolved))) return 0;
+    if (!path || !*path || !resolve_asset_path(path, resolved, sizeof(resolved))) {
+        stasis_report_runtime_errorf("Audio path could not be resolved: %s", path ? path : "");
+        return 0;
+    }
     if (!stasis_audio_ensure_init()) goto fail;
     SDL_LockAudioStream(g_audio_stream);
     int handle = stasis_audio_assets_load_wav(&g_audio_assets, resolved);
     SDL_UnlockAudioStream(g_audio_stream);
+    if (handle == 0) {
+        stasis_report_runtime_errorf("Audio failed to load: %s", path);
+    }
     return handle;
 
 fail:
@@ -5796,11 +5802,17 @@ fail:
 
 static int stasis_audio_load_asset(const char* path) {
     char resolved[1024];
-    if (!path || !*path || !resolve_asset_path(path, resolved, sizeof(resolved))) return 0;
+    if (!path || !*path || !resolve_asset_path(path, resolved, sizeof(resolved))) {
+        stasis_report_runtime_errorf("Audio path could not be resolved: %s", path ? path : "");
+        return 0;
+    }
     if (!stasis_audio_ensure_init()) return 0;
     SDL_LockAudioStream(g_audio_stream);
     int handle = stasis_audio_assets_load(&g_audio_assets, resolved);
     SDL_UnlockAudioStream(g_audio_stream);
+    if (handle == 0) {
+        stasis_report_runtime_errorf("Audio failed to load: %s", path);
+    }
     return handle;
 }
 

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -6,6 +6,7 @@ EXPORTS
     stasis_host_bulk_init
     stasis_host_bulk_apply_requests
     stasis_host_bulk_step
+    stasis_host_copy_runtime_error
     stasis_init_window
     stasis_get_window_size
     stasis_get_display_metrics

--- a/runtime/tests/stasis_mobile_packaged_assets_integration.c
+++ b/runtime/tests/stasis_mobile_packaged_assets_integration.c
@@ -1,0 +1,110 @@
+#include "stasis_audio_assets.h"
+#include "stasis_mobile_aot_runtime.h"
+#include "stasis_render_contract.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "IT-015 check failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+extern void stasis_aot_bind_runtime_globals(void);
+extern int32_t stasis_mobile_main_entry(void);
+extern int32_t stasis_mobile_tick_entry(void);
+extern int32_t stasis_mobile_render_entry(void);
+extern int stasis_set_asset_root(const char *path);
+extern int stasis_init_window(int width, int height, const char *title);
+extern void stasis_gfx_submit_u8(int32_t *i32s, const float *f32s, const uint8_t *u8s);
+extern int stasis_load_font(const char *path, int size);
+extern int stasis_audio_load_wav(const char *path);
+extern int stasis_host_copy_runtime_error(char *output, size_t output_size);
+
+/* The production function is intentionally not part of the shared-library ABI yet.
+ * The generated bridge references it even when the fixture does not call it. */
+float stasis_gfx_measure_text_cached_height(int handle) {
+    (void)handle;
+    return 0.0f;
+}
+
+static int32_t hash_path(const char *text) {
+    uint32_t hash = 2166136261u;
+    while (*text != '\0') {
+        hash ^= (uint8_t)*text++;
+        hash *= 16777619u;
+    }
+    return (int32_t)hash;
+}
+
+static int near(float actual, float expected) {
+    return fabsf(actual - expected) < 0.001f;
+}
+
+static void join_path(char *out, size_t capacity, const char *root, const char *relative) {
+    int written = snprintf(out, capacity, "%s/%s", root, relative);
+    CHECK(written > 0 && (size_t)written < capacity);
+}
+
+int main(int argc, char **argv) {
+    int32_t *gfx_i32;
+    float *gfx_f32;
+    uint8_t *gfx_u8;
+    char audio_path[1024];
+    char diagnostic[512];
+    StasisAudioAssetStore store;
+    float output[8];
+
+    CHECK(argc == 2);
+    CHECK(stasis_set_asset_root(argv[1]) == 1);
+    CHECK(stasis_init_window(320, 180, "IT-015 mobile packaged assets") == 1);
+    stasis_aot_bind_runtime_globals();
+    CHECK(stasis_mobile_main_entry() == 0);
+    CHECK(stasis_mobile_tick_entry() == 0);
+    CHECK(stasis_mobile_render_entry() == 0);
+
+    gfx_i32 = stasis_jit_global_i32_array_ptr(hash_path("gfx_cmd_i32"), 0, 34608);
+    gfx_f32 = stasis_jit_global_f32_array_ptr(hash_path("gfx_cmd_f32"), 0, 108676);
+    gfx_u8 = stasis_jit_global_u8_array_ptr(hash_path("gfx_cmd_u8"), 0, 65536);
+    CHECK(gfx_i32 != NULL && gfx_f32 != NULL && gfx_u8 != NULL);
+    CHECK(gfx_i32[4] == 1 && gfx_i32[7] == 2 && gfx_i32[22] == 3);
+    CHECK(memcmp(gfx_u8, "BUNDLE", 6) == 0);
+    stasis_gfx_submit_u8(gfx_i32, gfx_f32, gfx_u8);
+
+    memset(&store, 0, sizeof(store));
+    stasis_audio_assets_reset(&store);
+    join_path(audio_path, sizeof(audio_path), argv[1], "assets/tone.wav");
+    int offline_asset = stasis_audio_assets_load_wav(&store, audio_path);
+    CHECK(offline_asset > 0);
+    int offline_voice = stasis_audio_assets_play(&store, offline_asset, 0, 0.5f, 0.0f);
+    CHECK(offline_voice > 0);
+    memset(output, 0, sizeof(output));
+    stasis_audio_assets_mix(&store, output, 4, 48000);
+    CHECK(near(output[2], 0.125f) && near(output[3], 0.125f));
+    CHECK(stasis_audio_assets_voice_is_playing(&store, offline_voice) == 1);
+
+    CHECK(stasis_load_font("../../outside.ttf", 18) == 0);
+    CHECK(stasis_host_copy_runtime_error(diagnostic, sizeof(diagnostic)) == 1);
+    CHECK(strstr(diagnostic, "../../outside.ttf") != NULL);
+    CHECK(stasis_audio_load_wav("../../missing.wav") == 0);
+    CHECK(stasis_host_copy_runtime_error(diagnostic, sizeof(diagnostic)) == 1);
+    CHECK(strstr(diagnostic, "../../missing.wav") != NULL);
+
+    printf(
+        "stasis.seam_test.v1 IT-015 sprite=%d font=%d cached=%d audio=%d voice=%d "
+        "trace=%u samples=%.3f:%.3f offline_active=1 diagnostic=%s\n",
+        stasis_jit_global_i32_load(hash_path("seam_sprite_handle")),
+        stasis_jit_global_i32_load(hash_path("seam_font_handle")),
+        stasis_jit_global_i32_load(hash_path("seam_cached_handle")),
+        stasis_jit_global_i32_load(hash_path("seam_audio_handle")),
+        stasis_jit_global_i32_load(hash_path("seam_voice_handle")),
+        stasis_render_trace(gfx_i32, gfx_f32, gfx_u8),
+        output[2], output[3], diagnostic);
+    stasis_audio_assets_reset(&store);
+    return 0;
+}

--- a/tests/stasis/seams/mobile_packaged_assets_probe.stasis
+++ b/tests/stasis/seams/mobile_packaged_assets_probe.stasis
@@ -1,0 +1,93 @@
+@link("stasis_graphics");
+
+extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
+extern function load_font(path: string, size: i32): i32;
+extern function measure_text(font: i32, text: string): f32;
+function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
+function @extern("stasis_jit_gfx_measure_text_cached") gfx_measure_text_cached(handle: i32): f32;
+extern function audio_load_wav(path: string): i32;
+extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
+
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[108676];
+global gfx_cmd_u8: u8[65536];
+global seam_sprite_handle: i32;
+global seam_font_handle: i32;
+global seam_cached_handle: i32;
+global seam_audio_handle: i32;
+global seam_voice_handle: i32;
+global seam_direct_width: f32;
+global seam_cached_width: f32;
+
+function main(): i32 {
+    seam_sprite_handle = gfx_load_sprite("assets/sprite.png", 64, 64);
+    if (seam_sprite_handle == 0) { return 21; }
+    seam_font_handle = load_font("assets/ui.ttf", 24);
+    if (seam_font_handle == 0) { return 22; }
+    seam_cached_handle = gfx_cache_text(seam_font_handle, "MOBILE");
+    if (seam_cached_handle == 0) { return 23; }
+    seam_direct_width = measure_text(seam_font_handle, "BUNDLE");
+    seam_cached_width = gfx_measure_text_cached(seam_cached_handle);
+    if (seam_direct_width <= 0.0 || seam_cached_width <= 0.0) { return 24; }
+    seam_audio_handle = audio_load_wav("assets/tone.wav");
+    if (seam_audio_handle == 0) { return 25; }
+    seam_voice_handle = audio_play(seam_audio_handle, false, 0.5, 0.0);
+    if (seam_voice_handle == 0) { return 26; }
+    return 0;
+}
+
+function tick(): i32 { return 0; }
+
+function render(): i32 {
+    gfx_cmd_i32[0] = 1196967473;
+    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[2] = 3;
+    gfx_cmd_i32[3] = 0;
+    gfx_cmd_i32[4] = 1;
+    gfx_cmd_i32[7] = 2;
+    gfx_cmd_i32[9] = 7;
+    gfx_cmd_i32[22] = 3;
+    gfx_cmd_f32[0] = 0.04;
+    gfx_cmd_f32[1] = 0.07;
+    gfx_cmd_f32[2] = 0.12;
+    gfx_cmd_f32[3] = 1.0;
+
+    gfx_cmd_i32[32] = seam_sprite_handle;
+    gfx_cmd_i32[34] = 255;
+    gfx_cmd_f32[80004] = 52.0;
+    gfx_cmd_f32[80005] = 28.0;
+    gfx_cmd_f32[80006] = 64.0;
+    gfx_cmd_f32[80007] = 64.0;
+
+    gfx_cmd_i32[12320] = seam_font_handle;
+    gfx_cmd_i32[12321] = 0;
+    gfx_cmd_i32[12322] = 6;
+    gfx_cmd_f32[96388] = 30.0;
+    gfx_cmd_f32[96389] = 112.0;
+    gfx_cmd_f32[96390] = 1.0;
+    gfx_cmd_f32[96391] = 0.8;
+    gfx_cmd_f32[96392] = 0.1;
+    gfx_cmd_f32[96393] = 1.0;
+
+    gfx_cmd_i32[12323] = seam_font_handle;
+    gfx_cmd_i32[12324] = 0 - seam_cached_handle;
+    gfx_cmd_f32[96394] = 175.0;
+    gfx_cmd_f32[96395] = 112.0;
+    gfx_cmd_f32[96396] = 0.1;
+    gfx_cmd_f32[96397] = 0.9;
+    gfx_cmd_f32[96398] = 1.0;
+    gfx_cmd_f32[96399] = 1.0;
+
+    gfx_cmd_u8[0] = 66;
+    gfx_cmd_u8[1] = 85;
+    gfx_cmd_u8[2] = 78;
+    gfx_cmd_u8[3] = 68;
+    gfx_cmd_u8[4] = 76;
+    gfx_cmd_u8[5] = 69;
+    gfx_cmd_i32[18464] = 32768;
+    gfx_cmd_i32[18465] = 49152;
+    gfx_cmd_i32[18466] = 49153;
+    return 0;
+}
+
+function on_code_swap(): void { return; }


### PR DESCRIPTION
## Summary
- package sprite, font, and WAV fixtures into the same stasis_game layout used by Android and iOS
- run a linked Cranelift AOT guest through real shared native sprite, font, cached-text, render, and audio APIs
- verify manifest identities/hashes, exact render trace, deterministic offline audio samples, containment, and actionable path diagnostics
- add the focused IT-015 seam to Windows PR CI

## Validation
- IT-015 linked AOT + shared SDL runtime: passed
- desktop manifest asset seam (IT-008): passed
- generated mobile AOT lifecycle/frame seams (IT-012/013/014): passed
- native SDL-only runtime build: passed
- cargo fmt --all -- --check: passed

## Theory gained
Packaged mobile asset behavior is owned by one root mapping: the shell publishes stasis_game, the runtime resolves project-relative identities under that root, and every graphical/audio host consumes the resulting file. The linked-AOT run observed positive real native handles, render trace 4249029299, and offline samples 0.125/0.125. An adjacent prediction is that changing Android extraction or iOS bundle-base selection will now fail before a guest can render or play an asset.

## Reflection
- Good: linking the generated guest directly to the CI-built runtime avoided test-only host behavior.
- Bad: manifest iteration order initially leaked into the oracle even though identity, not insertion order, is the contract.
- Adjustment: compare packaged evidence by stable asset ID and reserve ordering assertions for contracts that explicitly promise order.

Maddox #224