### PR TITLE
test: audit final Android native library

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -37,6 +37,7 @@ jobs:
           python tools/ci/check_runtime_abi_contract.py
           python -m unittest tools.ci.test_cargo_cache
           python -m unittest tools.ci.test_runtime_abi_contract
+          python -m unittest tools.ci.test_verify_android_native_library
           python -m unittest tools.ci.test_sdl3_migration
           python -m unittest tools.ci.test_windows_vs_generator
 
@@ -334,3 +335,19 @@ jobs:
           cargo run -p stasis -- --workspace samples/mobile_storage_link package-mobile --target android-arm64 --out dist/android --development-build
           gradle -p samples/mobile_storage_link/dist/android/android :app:assembleDebug --no-daemon --max-workers=2 --console=plain
           test -f samples/mobile_storage_link/dist/android/android/app/build/outputs/apk/debug/app-debug.apk
+          native_library=$(find samples/mobile_storage_link/dist/android/android/app/build/intermediates/cxx/Debug -path '*/obj/arm64-v8a/libmain.so' -print -quit)
+          link_map=$(find samples/mobile_storage_link/dist/android/android/app/.cxx/Debug -name libmain.map -print -quit)
+          test -n "$native_library"
+          test -n "$link_map"
+          python tools/ci/verify_android_native_library.py \
+            --library "$native_library" \
+            --bundle-manifest samples/mobile_storage_link/dist/android/aot/mobile_aot_bundle_manifest.json \
+            --link-map "$link_map" \
+            --readelf "$ANDROID_HOME/ndk/27.0.12077973/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf" \
+            --evidence target/android-native-link-evidence.json
+
+      - name: Upload Android native-link evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-native-link-evidence
+          path: target/android-native-link-evidence.json

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -6053,7 +6053,10 @@ mod tests {
             fs::read_to_string(android.join("android/app/src/main/cpp/CMakeLists.txt"))
                 .expect("read Android CMake");
         assert!(android_cmake.contains("stasis_mobile_runtime"));
-        assert!(android_cmake.contains("STASIS_AOT_OBJECTS"));
+        assert!(android_cmake.contains("published_aot_objects.cmake"));
+        assert!(android_cmake.contains("STASIS_PUBLISHED_AOT_OBJECTS"));
+        assert!(!android_cmake.contains("file(GLOB STASIS_AOT_OBJECTS"));
+        assert!(android_cmake.contains("libmain.map"));
         assert!(!android_cmake.contains("stasis_dynload"));
         let android_gradle = fs::read_to_string(android.join("android/app/build.gradle"))
             .expect("read Android Gradle");

--- a/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
@@ -23,16 +23,17 @@ set(SDLIMAGE_PNG_LIBPNG OFF CACHE BOOL "" FORCE)
 add_subdirectory("${STASIS_SDL3_IMAGE_SOURCE}" "${CMAKE_BINARY_DIR}/sdl3_image")
 add_subdirectory("${STASIS_ROOT}/runtime" "${CMAKE_BINARY_DIR}/stasis_runtime")
 
-file(GLOB STASIS_AOT_OBJECTS CONFIGURE_DEPENDS "${STASIS_AOT_DIR}/*.o")
-if(NOT STASIS_AOT_OBJECTS)
-    message(FATAL_ERROR "No Android AOT objects found in ${STASIS_AOT_DIR}")
+include("${STASIS_AOT_DIR}/published_aot_objects.cmake")
+if(NOT STASIS_PUBLISHED_AOT_OBJECTS)
+    message(FATAL_ERROR "No published Android AOT objects found in ${STASIS_AOT_DIR}")
 endif()
 
 add_library(main SHARED
     "${STASIS_ROOT}/common/stasis_mobile_main.c"
     "${CMAKE_CURRENT_LIST_DIR}/stasis_android_assets.c"
     "${STASIS_AOT_DIR}/published_aot_bindings.c"
-    ${STASIS_AOT_OBJECTS}
+    ${STASIS_PUBLISHED_AOT_OBJECTS}
 )
 target_include_directories(main PRIVATE "${STASIS_AOT_DIR}" "${STASIS_ROOT}/runtime")
 target_link_libraries(main PRIVATE stasis_mobile_runtime SDL3::SDL3 SDL3_image::SDL3_image log android)
+target_link_options(main PRIVATE "-Wl,-Map,${CMAKE_CURRENT_BINARY_DIR}/libmain.map")

--- a/tools/ci/test_verify_android_native_library.py
+++ b/tools/ci/test_verify_android_native_library.py
@@ -1,0 +1,129 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.ci import verify_android_native_library as verifier
+
+
+HEADER = """ELF Header:
+  Class:                             ELF64
+  Type:                              DYN (Shared object file)
+  Machine:                           AArch64
+"""
+DYNAMIC = """Dynamic section:
+  (NEEDED) Shared library: [libSDL3.so]
+  (NEEDED) Shared library: [libSDL3_image.so]
+  (NEEDED) Shared library: [liblog.so]
+  (NEEDED) Shared library: [libandroid.so]
+  (NEEDED) Shared library: [libc.so]
+"""
+
+
+def symbol_table(*defined: str, undefined: tuple[str, ...] = ()) -> str:
+    lines = ["Symbol table '.dynsym':"]
+    for index, name in enumerate(undefined, 1):
+        lines.append(f" {index}: 0000000000000000 0 FUNC GLOBAL DEFAULT UND {name}")
+    offset = len(undefined) + 1
+    for index, name in enumerate(defined, offset):
+        lines.append(f" {index}: 0000000000001000 4 FUNC GLOBAL DEFAULT 12 {name}")
+    return "\n".join(lines)
+
+
+class AndroidNativeLibraryAuditTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.library = self.root / "libmain.so"
+        self.library.write_bytes(b"elf")
+        self.readelf = self.root / "llvm-readelf"
+        self.readelf.write_text("fixture", encoding="utf-8")
+        (self.root / "main_1.o").write_bytes(b"object")
+        (self.root / "tick_2.o").write_bytes(b"object")
+        (self.root / "published_aot_bindings.c").write_text("bindings", encoding="utf-8")
+        (self.root / "published_aot_objects.cmake").write_text(
+            "set(STASIS_PUBLISHED_AOT_OBJECTS\n"
+            '  "${CMAKE_CURRENT_LIST_DIR}/main_1.o"\n'
+            '  "${CMAKE_CURRENT_LIST_DIR}/tick_2.o"\n'
+            ")\n",
+            encoding="utf-8",
+        )
+        engine = {
+            "functions": [
+                {"function_id": 1, "symbol": "aot_fn_1"},
+                {"function_id": 2, "symbol": "aot_fn_2"},
+            ]
+        }
+        (self.root / "engine_bundle_manifest.json").write_text(
+            json.dumps(engine), encoding="utf-8"
+        )
+        bundle = {
+            "schema": "stasis.mobile_aot_bundle.v1",
+            "target": "android-arm64",
+            "engine_manifest": "engine_bundle_manifest.json",
+            "bindings_source": "published_aot_bindings.c",
+            "android_cmake_file": "published_aot_objects.cmake",
+            "objects": [
+                {"function": "main", "function_id": 1, "path": "main_1.o"},
+                {"function": "tick", "function_id": 2, "path": "tick_2.o"},
+            ],
+        }
+        self.bundle = self.root / "mobile_aot_bundle_manifest.json"
+        self.bundle.write_text(json.dumps(bundle), encoding="utf-8")
+        self.link_map = self.root / "libmain.map"
+        self.link_map.write_text(
+            "main_1.o\ntick_2.o\npublished_aot_bindings.c.o\n", encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def readelf_output(self, _readelf, _library, *options):
+        if options == ("-h",):
+            return HEADER
+        if options == ("-d",):
+            return DYNAMIC
+        if options == ("-Ws",):
+            return symbol_table(
+                *sorted(verifier.REQUIRED_DEFINED), "aot_fn_1", "aot_fn_2", undefined=("SDL_Log",)
+            )
+        self.fail(f"unexpected readelf options: {options}")
+
+    @mock.patch.object(verifier, "_run_readelf")
+    def test_audit_cross_checks_manifest_map_and_final_elf(self, run_readelf):
+        run_readelf.side_effect = self.readelf_output
+        evidence = verifier.audit(self.library, self.bundle, self.link_map, self.readelf)
+        self.assertEqual(evidence["test_id"], "IT-016")
+        self.assertEqual(evidence["generated_objects"], 2)
+        self.assertEqual(evidence["unresolved_stasis_symbols"], [])
+
+    @mock.patch.object(verifier, "_run_readelf")
+    def test_missing_manifest_object_names_the_link_map_gap(self, run_readelf):
+        run_readelf.side_effect = self.readelf_output
+        self.link_map.write_text("main_1.o\npublished_aot_bindings.c.o\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            verifier.AuditError, r"link map is missing packaged AOT objects: \['tick_2.o'\]"
+        ):
+            verifier.audit(self.library, self.bundle, self.link_map, self.readelf)
+
+    @mock.patch.object(verifier, "_run_readelf")
+    def test_unresolved_generated_symbol_is_actionable(self, run_readelf):
+        def output(_readelf, _library, *options):
+            if options == ("-h",):
+                return HEADER
+            if options == ("-d",):
+                return DYNAMIC
+            return symbol_table(
+                *sorted(verifier.REQUIRED_DEFINED), "aot_fn_1", undefined=("aot_fn_2",)
+            )
+
+        run_readelf.side_effect = output
+        with self.assertRaisesRegex(
+            verifier.AuditError, r"missing generated/mobile symbols: \['aot_fn_2'\]"
+        ):
+            verifier.audit(self.library, self.bundle, self.link_map, self.readelf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/verify_android_native_library.py
+++ b/tools/ci/verify_android_native_library.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Audit the generated Android game manifest, link map, and final libmain.so."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA = "stasis.seam_test.v1"
+REQUIRED_DEFINED = {
+    "SDL_main",
+    "stasis_aot_bind_runtime_globals",
+    "stasis_mobile_main_entry",
+    "stasis_mobile_tick_entry",
+    "stasis_mobile_render_entry",
+    "stasis_mobile_runtime_initialize",
+    "stasis_mobile_runtime_step",
+}
+REQUIRED_NEEDED = {"libSDL3.so", "libSDL3_image.so", "liblog.so", "libandroid.so"}
+FORBIDDEN_LINK_MARKERS = (
+    "stasis_dynload",
+    "stasis_runner.c",
+    "cranelift_jit",
+    "inotify_",
+    "ReadDirectoryChangesW",
+)
+
+
+class AuditError(RuntimeError):
+    pass
+
+
+def _load_json(path: Path, label: str) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AuditError(f"{label} could not be read from {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise AuditError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _relative_file(root: Path, value: object, field: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise AuditError(f"bundle manifest field '{field}' must be a non-empty path")
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise AuditError(f"bundle manifest field '{field}' escapes the AOT directory: {value}")
+    path = root / relative
+    if not path.is_file():
+        raise AuditError(f"bundle manifest field '{field}' is missing: {path}")
+    return path
+
+
+def _run_readelf(readelf: Path, library: Path, *options: str) -> str:
+    result = subprocess.run(
+        [str(readelf), *options, str(library)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AuditError(
+            f"llvm-readelf {' '.join(options)} failed for {library}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout
+
+
+def _symbols(text: str) -> tuple[set[str], set[str]]:
+    defined: set[str] = set()
+    undefined: set[str] = set()
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) < 8 or not fields[0].rstrip(":").isdigit():
+            continue
+        name = fields[7].split("@", 1)[0]
+        if not name:
+            continue
+        if fields[6] == "UND":
+            undefined.add(name)
+        else:
+            defined.add(name)
+    return defined, undefined
+
+
+def _needed_libraries(text: str) -> set[str]:
+    return set(re.findall(r"\(NEEDED\).*?\[([^]]+)\]", text))
+
+
+def _cmake_objects(text: str) -> set[str]:
+    return set(re.findall(r'\$\{CMAKE_CURRENT_LIST_DIR\}/([^"\r\n]+\.o)', text))
+
+
+def audit(
+    library: Path,
+    bundle_manifest_path: Path,
+    link_map_path: Path,
+    readelf: Path,
+) -> dict:
+    if not library.is_file():
+        raise AuditError(f"final Android native library is missing: {library}")
+    if not link_map_path.is_file():
+        raise AuditError(f"Android libmain link map is missing: {link_map_path}")
+    if not readelf.is_file():
+        raise AuditError(f"Android llvm-readelf is missing: {readelf}")
+
+    bundle = _load_json(bundle_manifest_path, "mobile AOT bundle manifest")
+    if bundle.get("schema") != "stasis.mobile_aot_bundle.v1":
+        raise AuditError(f"unexpected mobile AOT bundle schema: {bundle.get('schema')!r}")
+    if bundle.get("target") != "android-arm64":
+        raise AuditError(f"mobile AOT bundle target must be android-arm64, got {bundle.get('target')!r}")
+    aot_root = bundle_manifest_path.parent
+    engine_path = _relative_file(aot_root, bundle.get("engine_manifest"), "engine_manifest")
+    bindings_path = _relative_file(aot_root, bundle.get("bindings_source"), "bindings_source")
+    cmake_path = _relative_file(aot_root, bundle.get("android_cmake_file"), "android_cmake_file")
+    engine = _load_json(engine_path, "engine bundle manifest")
+
+    objects = bundle.get("objects")
+    if not isinstance(objects, list) or not objects:
+        raise AuditError("mobile AOT bundle manifest must list at least one object")
+    manifest_objects: set[str] = set()
+    manifest_function_ids: set[int] = set()
+    for index, entry in enumerate(objects):
+        if not isinstance(entry, dict):
+            raise AuditError(f"bundle object {index} must be an object")
+        path = _relative_file(aot_root, entry.get("path"), f"objects[{index}].path")
+        manifest_objects.add(path.name)
+        function_id = entry.get("function_id")
+        if not isinstance(function_id, int):
+            raise AuditError(f"bundle object {index} is missing integer function_id")
+        manifest_function_ids.add(function_id)
+
+    cmake_objects = _cmake_objects(cmake_path.read_text(encoding="utf-8"))
+    if cmake_objects != manifest_objects:
+        raise AuditError(
+            "published Android AOT object list differs from bundle manifest: "
+            f"missing={sorted(manifest_objects - cmake_objects)} "
+            f"extra={sorted(cmake_objects - manifest_objects)}"
+        )
+
+    engine_functions = engine.get("functions")
+    if not isinstance(engine_functions, list):
+        raise AuditError("engine bundle manifest is missing functions")
+    engine_symbols: set[str] = set()
+    engine_function_ids: set[int] = set()
+    for entry in engine_functions:
+        if not isinstance(entry, dict):
+            continue
+        function_id = entry.get("function_id")
+        symbol = entry.get("symbol")
+        if isinstance(function_id, int) and isinstance(symbol, str):
+            engine_function_ids.add(function_id)
+            engine_symbols.add(symbol)
+    if engine_function_ids != manifest_function_ids:
+        raise AuditError(
+            "engine functions differ from packaged object identities: "
+            f"missing={sorted(manifest_function_ids - engine_function_ids)} "
+            f"extra={sorted(engine_function_ids - manifest_function_ids)}"
+        )
+
+    header = _run_readelf(readelf, library, "-h")
+    if "Class:                             ELF64" not in header:
+        raise AuditError("libmain.so must be ELF64")
+    if "Type:                              DYN" not in header:
+        raise AuditError("libmain.so must be a shared ELF object (DYN)")
+    if "Machine:                           AArch64" not in header:
+        raise AuditError("libmain.so must target AArch64")
+
+    dynamic = _run_readelf(readelf, library, "-d")
+    needed = _needed_libraries(dynamic)
+    missing_needed = REQUIRED_NEEDED - needed
+    if missing_needed:
+        raise AuditError(f"libmain.so is missing native dependencies: {sorted(missing_needed)}")
+    forbidden_dependencies = sorted(
+        name for name in needed if any(marker.lower() in name.lower() for marker in FORBIDDEN_LINK_MARKERS)
+    )
+    if forbidden_dependencies:
+        raise AuditError(f"libmain.so retained desktop-only dependencies: {forbidden_dependencies}")
+
+    symbol_text = _run_readelf(readelf, library, "-Ws")
+    defined, undefined = _symbols(symbol_text)
+    expected_defined = REQUIRED_DEFINED | engine_symbols
+    missing_defined = sorted(expected_defined - defined)
+    if missing_defined:
+        raise AuditError(f"libmain.so is missing generated/mobile symbols: {missing_defined}")
+    unresolved_stasis = sorted(
+        symbol for symbol in undefined if symbol.startswith("stasis_") or symbol.startswith("aot_fn_")
+    )
+    if unresolved_stasis:
+        raise AuditError(f"libmain.so retains unresolved Stasis symbols: {unresolved_stasis}")
+
+    link_map = link_map_path.read_text(encoding="utf-8", errors="replace")
+    missing_link_inputs = sorted(name for name in manifest_objects if name not in link_map)
+    if missing_link_inputs:
+        raise AuditError(f"link map is missing packaged AOT objects: {missing_link_inputs}")
+    bindings_object = f"{bindings_path.name}.o"
+    if bindings_object not in link_map:
+        raise AuditError(f"link map is missing generated bindings object: {bindings_object}")
+    forbidden_map_markers = sorted(marker for marker in FORBIDDEN_LINK_MARKERS if marker in link_map)
+    if forbidden_map_markers:
+        raise AuditError(f"link map retained desktop-only inputs: {forbidden_map_markers}")
+
+    return {
+        "schema": SCHEMA,
+        "test_id": "IT-016",
+        "status": "passed",
+        "target": "android-arm64-libmain",
+        "library": str(library),
+        "elf": {"class": "ELF64", "type": "DYN", "machine": "AArch64"},
+        "needed_libraries": sorted(needed),
+        "generated_objects": len(manifest_objects),
+        "manifest_objects": sorted(manifest_objects),
+        "generated_symbols": len(engine_symbols),
+        "engine_symbols": sorted(engine_symbols),
+        "mobile_symbols": sorted(REQUIRED_DEFINED),
+        "bindings_object": bindings_object,
+        "bundle_manifest": str(bundle_manifest_path),
+        "link_map": str(link_map_path),
+        "unresolved_stasis_symbols": [],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--library", type=Path, required=True)
+    parser.add_argument("--bundle-manifest", type=Path, required=True)
+    parser.add_argument("--link-map", type=Path, required=True)
+    parser.add_argument("--readelf", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        evidence = audit(args.library, args.bundle_manifest, args.link_map, args.readelf)
+        args.evidence.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(json.dumps(evidence, sort_keys=True))
+        return 0
+    except AuditError as error:
+        print(f"Android native library audit failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make the generated Android AOT object list authoritative for CMake linking
- audit the final ARM64 libmain ELF, native dependencies, exported/generated symbols, and link-map inputs
- publish machine-readable IT-016 evidence from Android package-link CI

## Validation
- python -m unittest tools.ci.test_verify_android_native_library
- cargo fmt --all -- --check
- mobile_shells_are_platform_projects_over_one_shared_runtime (direct focused test binary)
- real Android package-mobile + Gradle assembleDebug + final ELF/link-map verifier

Theory gained: The package manifest and generated CMake object list form one identity contract; the link map proves those exact objects and bindings entered libmain, while ELF inspection proves the final mobile dependency closure. A stray object, omitted wrapper, unresolved Stasis symbol, or desktop dependency should now fail before APK acceptance.

Good: Replacing the object glob with the generated list gives packaging and linking one authority.
Bad: The first local artifact lookup assumed the linker map lived beside the packaged native library, but Gradle retains it under .cxx.
Adjustment: Treat build-system evidence and packaged artifacts as separate locations and verify both explicitly.

Maddox: #225