### PR TITLE
test: run generated Android release shell

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generated-release-shell:
     runs-on: [self-hosted, Windows, android-device]
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -19,6 +19,7 @@ jobs:
           & ./mobile/android/test_release_shell.ps1
           -Serial "$env:ANDROID_SERIAL"
           -OutputPath "artifacts/android_release_shell"
+          -TotalTimeoutSeconds 840
 
       - name: Upload Android release-shell evidence
         if: always()

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -1,0 +1,29 @@
+name: Android Device Seams
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generated-release-shell:
+    runs-on: [self-hosted, Windows, android-device]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run generated Android AOT release shell seam
+        shell: powershell
+        run: >-
+          & ./mobile/android/test_release_shell.ps1
+          -Serial "$env:ANDROID_SERIAL"
+          -OutputPath "artifacts/android_release_shell"
+
+      - name: Upload Android release-shell evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-shell-seam
+          path: artifacts/android_release_shell/e
+          if-no-files-found: warn

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -37,6 +37,7 @@ jobs:
           python tools/ci/check_runtime_abi_contract.py
           python -m unittest tools.ci.test_cargo_cache
           python -m unittest tools.ci.test_runtime_abi_contract
+          python -m unittest tools.ci.test_run_android_release_shell_seam
           python -m unittest tools.ci.test_verify_android_native_library
           python -m unittest tools.ci.test_sdl3_migration
           python -m unittest tools.ci.test_windows_vs_generator

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -6079,11 +6079,19 @@ mod tests {
         )
         .expect("read Android activity");
         assert!(android_activity.contains("stasis.seam_test_id"));
+        assert!(android_activity.contains("BuildConfig.STASIS_SEAM_TESTS"));
         assert!(android_activity.contains("nativeSetSeamTestId"));
         let android_jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
                 .expect("read Android JNI bridge");
         assert!(android_jni.contains("STASIS_ENABLE_TEST_INPUT"));
+        let android_gradle = fs::read_to_string(android.join("android/app/build.gradle"))
+            .expect("read Android Gradle build");
+        assert!(android_gradle.contains("stasisSeamTests"));
+        let android_cmake =
+            fs::read_to_string(android.join("android/app/src/main/cpp/CMakeLists.txt"))
+                .expect("read Android CMake project");
+        assert!(android_cmake.contains("STASIS_ENABLE_SEAM_TESTS"));
         assert!(android_jni.contains("STASIS_SEAM_TEST_ID"));
         let runtime_header = fs::read_to_string(android.join("runtime/stasis_mobile_runtime.h"))
             .expect("read shared mobile runtime header");

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -6071,6 +6071,20 @@ mod tests {
         let mobile_main = fs::read_to_string(android.join("common/stasis_mobile_main.c"))
             .expect("read shared mobile main");
         assert!(mobile_main.contains("stasis_mobile_runtime_last_entry_result"));
+        assert!(mobile_main.contains("Stasis seam:"));
+        assert!(mobile_main.contains("seam_state_checksum"));
+        assert!(mobile_main.contains("frame == 30"));
+        let android_activity = fs::read_to_string(
+            android.join("android/app/src/main/java/com/stasislang/game/MainActivity.java"),
+        )
+        .expect("read Android activity");
+        assert!(android_activity.contains("stasis.seam_test_id"));
+        assert!(android_activity.contains("nativeSetSeamTestId"));
+        let android_jni =
+            fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
+                .expect("read Android JNI bridge");
+        assert!(android_jni.contains("STASIS_ENABLE_TEST_INPUT"));
+        assert!(android_jni.contains("STASIS_SEAM_TEST_ID"));
         let runtime_header = fs::read_to_string(android.join("runtime/stasis_mobile_runtime.h"))
             .expect("read shared mobile runtime header");
         assert!(runtime_header.contains("typedef int32_t (*StasisMobileI32Entry)(void)"));

--- a/mobile/android/test_release_shell.ps1
+++ b/mobile/android/test_release_shell.ps1
@@ -1,0 +1,99 @@
+param(
+    [string]$Serial = $env:ANDROID_SERIAL,
+    [string]$OutputPath = "",
+    [int]$TotalTimeoutSeconds = 900
+)
+
+$ErrorActionPreference = "Stop"
+$startedAt = [System.Diagnostics.Stopwatch]::StartNew()
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$androidHome = if ($env:ANDROID_HOME) {
+    $env:ANDROID_HOME
+} elseif ($env:ANDROID_SDK_ROOT) {
+    $env:ANDROID_SDK_ROOT
+} else {
+    "C:\Android\Sdk"
+}
+$adb = Join-Path $androidHome "platform-tools\adb.exe"
+if (-not (Test-Path $adb)) { throw "adb.exe was not found: $adb" }
+if (-not $Serial) { throw "Pass -Serial or set ANDROID_SERIAL to one arm64 Android device" }
+
+$stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $repoRoot "target\it017\$stamp"
+}
+$artifactRoot = [System.IO.Path]::GetFullPath($OutputPath)
+$workspaceRoot = Join-Path $artifactRoot "w"
+$packageRoot = Join-Path $workspaceRoot "d"
+$evidenceRoot = Join-Path $artifactRoot "e"
+New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot "samples\android_aot_seam") `
+    -Destination $workspaceRoot -Recurse
+$vendorRoot = Join-Path $workspaceRoot "vendor\stasis\src"
+New-Item -ItemType Directory -Force -Path $vendorRoot | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot "src\stdlib") `
+    -Destination (Join-Path $vendorRoot "stdlib") -Recurse
+
+function Assert-In-Time([string]$Step) {
+    if ($startedAt.Elapsed.TotalSeconds -gt $TotalTimeoutSeconds) {
+        throw "Android release-shell seam exceeded ${TotalTimeoutSeconds}s after $Step"
+    }
+}
+
+function Resolve-Gradle {
+    $command = Get-Command gradle -ErrorAction SilentlyContinue
+    if ($command) { return $command.Source }
+    if ($env:ChocolateyInstall) {
+        $installed = Get-ChildItem (Join-Path $env:ChocolateyInstall "lib\gradle\tools") `
+            -Recurse -Filter gradle.bat -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+        if ($installed) { return $installed.FullName }
+    }
+    throw "Gradle was not found; install Gradle 8.9 or newer"
+}
+
+$abi = (& $adb -s $Serial shell getprop ro.product.cpu.abi).Trim()
+if ($LASTEXITCODE -ne 0) { throw "Unable to inspect Android device $Serial" }
+$abiList = (& $adb -s $Serial shell getprop ro.product.cpu.abilist).Trim() -split ','
+if ($LASTEXITCODE -ne 0 -or "arm64-v8a" -notin $abiList) {
+    throw "IT-017 requires arm64-v8a support; $Serial reports '$abi' ($($abiList -join ','))"
+}
+if (-not $env:STASIS_SDL3_SOURCE -or -not $env:STASIS_SDL3_IMAGE_SOURCE) {
+    throw "Set STASIS_SDL3_SOURCE and STASIS_SDL3_IMAGE_SOURCE to the pinned source trees"
+}
+
+Push-Location $repoRoot
+try {
+    python tools/cargo_cache.py run -- cargo build -p stasis
+    if ($LASTEXITCODE -ne 0) { throw "IT-017 compiler build failed with exit code $LASTEXITCODE" }
+    $commonGit = (& git rev-parse --path-format=absolute --git-common-dir).Trim()
+    if ($LASTEXITCODE -ne 0) { throw "Unable to resolve the shared Cargo target" }
+    $compiler = Join-Path (Split-Path -Parent $commonGit) "build\codex-cargo-target\debug\stasis.exe"
+    if (-not (Test-Path $compiler)) { throw "Built Stasis compiler is missing: $compiler" }
+    & $compiler --workspace $workspaceRoot package-mobile `
+        --target android-arm64 --out d --development-build
+    if ($LASTEXITCODE -ne 0) { throw "IT-017 package-mobile failed with exit code $LASTEXITCODE" }
+    Assert-In-Time "package-mobile"
+
+    $gradle = Resolve-Gradle
+    & $gradle -p (Join-Path $packageRoot "android") `
+        :app:assembleDebug --no-daemon --max-workers=2 --console=plain
+    if ($LASTEXITCODE -ne 0) { throw "IT-017 Gradle build failed with exit code $LASTEXITCODE" }
+    Assert-In-Time "Gradle build"
+
+    $apk = Join-Path $packageRoot "android\app\build\outputs\apk\debug\app-debug.apk"
+    if (-not (Test-Path $apk)) { throw "Generated Android APK is missing: $apk" }
+    python tools/ci/run_android_release_shell_seam.py `
+        --adb $adb `
+        --serial $Serial `
+        --apk $apk `
+        --package-manifest (Join-Path $packageRoot "stasis_mobile_package.json") `
+        --expectations samples/android_aot_seam/android_seam_expectations.json `
+        --output $evidenceRoot `
+        --timeout-seconds ([math]::Max(15, $TotalTimeoutSeconds - [math]::Floor($startedAt.Elapsed.TotalSeconds)))
+    if ($LASTEXITCODE -ne 0) { throw "IT-017 device acceptance failed with exit code $LASTEXITCODE" }
+    Assert-In-Time "device acceptance"
+} finally {
+    Pop-Location
+}

--- a/mobile/android/test_release_shell.ps1
+++ b/mobile/android/test_release_shell.ps1
@@ -53,8 +53,11 @@ function Resolve-Gradle {
     throw "Gradle was not found; install Gradle 8.9 or newer"
 }
 
-$abi = (& $adb -s $Serial shell getprop ro.product.cpu.abi).Trim()
-if ($LASTEXITCODE -ne 0) { throw "Unable to inspect Android device $Serial" }
+$abiOutput = @(& $adb -s $Serial shell getprop ro.product.cpu.abi)
+if ($LASTEXITCODE -ne 0 -or $abiOutput.Count -eq 0) {
+    throw "Unable to inspect Android device $Serial"
+}
+$abi = ($abiOutput -join "").Trim()
 $abiList = (& $adb -s $Serial shell getprop ro.product.cpu.abilist).Trim() -split ','
 if ($LASTEXITCODE -ne 0 -or "arm64-v8a" -notin $abiList) {
     throw "IT-017 requires arm64-v8a support; $Serial reports '$abi' ($($abiList -join ','))"
@@ -78,7 +81,7 @@ try {
 
     $gradle = Resolve-Gradle
     & $gradle -p (Join-Path $packageRoot "android") `
-        :app:assembleDebug --no-daemon --max-workers=2 --console=plain
+        :app:assembleDebug -PstasisSeamTests=true --no-daemon --max-workers=2 --console=plain
     if ($LASTEXITCODE -ne 0) { throw "IT-017 Gradle build failed with exit code $LASTEXITCODE" }
     Assert-In-Time "Gradle build"
 

--- a/mobile/shells/android/README.md
+++ b/mobile/shells/android/README.md
@@ -21,3 +21,18 @@ safe-inset-aware overlay layer presents startup/runtime resource failures, and
 startup verifies every packaged asset against its manifest SHA-256 before
 replacing the last validated app-private copy. Future candidates are recorded
 in `docs/android_release_shell_backlog.md`.
+
+The generated shell also supports an opt-in integration-test launch extra,
+`stasis.seam_test_id`. It enables bounded `stasis.seam_test.v1` log markers for
+initialization, the first frame, and stable frame 30; ordinary app launches do
+not enable the markers. Run IT-017 against an attached device whose ABI list
+includes `arm64-v8a` with:
+
+```powershell
+mobile/android/test_release_shell.ps1 -Serial <device-serial>
+```
+
+The driver builds a fresh generated package, verifies lifecycle/checksum/trace
+markers and named capture regions, retains JSON/log/screenshot evidence, then
+force-stops the app, removes a test-only install, and restores the device's
+prior immersive-confirmation setting.

--- a/mobile/shells/android/app/build.gradle
+++ b/mobile/shells/android/app/build.gradle
@@ -6,6 +6,9 @@ def sdl3Source = providers.gradleProperty('stasisSdl3Source')
         .orElse(providers.environmentVariable('STASIS_SDL3_SOURCE'))
 def sdl3ImageSource = providers.gradleProperty('stasisSdl3ImageSource')
         .orElse(providers.environmentVariable('STASIS_SDL3_IMAGE_SOURCE'))
+def seamTests = providers.gradleProperty('stasisSeamTests')
+        .orElse('false')
+        .map { it.toBoolean() }
 if (!sdl3Source.isPresent() || !sdl3ImageSource.isPresent()) {
     throw new GradleException('Set STASIS_SDL3_SOURCE and STASIS_SDL3_IMAGE_SOURCE to SDL3 and SDL3_image source trees')
 }
@@ -26,9 +29,15 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DSTASIS_SDL3_SOURCE=' + sdl3Source.get(),
-                        '-DSTASIS_SDL3_IMAGE_SOURCE=' + sdl3ImageSource.get()
+                        '-DSTASIS_SDL3_IMAGE_SOURCE=' + sdl3ImageSource.get(),
+                        '-DSTASIS_ENABLE_SEAM_TESTS=' + (seamTests.get() ? 'ON' : 'OFF')
             }
         }
+        buildConfigField 'boolean', 'STASIS_SEAM_TESTS', seamTests.get().toString()
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     sourceSets.main.java.srcDir(new File(sdl3Source.get(), 'android-project/app/src/main/java'))

--- a/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/shells/android/app/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(stasis_mobile_android C)
 
+option(STASIS_ENABLE_SEAM_TESTS "Enable generated release-shell seam hooks" OFF)
+
 if(NOT STASIS_SDL3_SOURCE OR NOT STASIS_SDL3_IMAGE_SOURCE)
     message(FATAL_ERROR "STASIS_SDL3_SOURCE and STASIS_SDL3_IMAGE_SOURCE are required")
 endif()
@@ -34,6 +36,9 @@ add_library(main SHARED
     "${STASIS_AOT_DIR}/published_aot_bindings.c"
     ${STASIS_PUBLISHED_AOT_OBJECTS}
 )
+if(STASIS_ENABLE_SEAM_TESTS)
+    target_compile_definitions(main PRIVATE STASIS_ENABLE_SEAM_TESTS=1)
+endif()
 target_include_directories(main PRIVATE "${STASIS_AOT_DIR}" "${STASIS_ROOT}/runtime")
 target_link_libraries(main PRIVATE stasis_mobile_runtime SDL3::SDL3 SDL3_image::SDL3_image log android)
 target_link_options(main PRIVATE "-Wl,-Map,${CMAKE_CURRENT_BINARY_DIR}/libmain.map")

--- a/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
+++ b/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
@@ -6,6 +6,7 @@
 void stasis_host_get_latest_performance_metrics(uint32_t *tick_us, uint32_t *render_us);
 int stasis_host_copy_runtime_error(char *output, size_t output_size);
 
+#if defined(STASIS_ENABLE_SEAM_TESTS)
 JNIEXPORT void JNICALL
 Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetSeamTestId(
     JNIEnv *env,
@@ -33,6 +34,7 @@ Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetSeamTestId(
     }
     (*env)->ReleaseStringUTFChars(env, value, test_id);
 }
+#endif
 
 JNIEXPORT void JNICALL
 Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetAssetRoot(

--- a/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
+++ b/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
@@ -1,9 +1,38 @@
 #include <jni.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 void stasis_host_get_latest_performance_metrics(uint32_t *tick_us, uint32_t *render_us);
 int stasis_host_copy_runtime_error(char *output, size_t output_size);
+
+JNIEXPORT void JNICALL
+Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetSeamTestId(
+    JNIEnv *env,
+    jclass activity,
+    jstring value
+) {
+    (void)activity;
+    if (value == NULL) {
+        return;
+    }
+    const char *test_id = (*env)->GetStringUTFChars(env, value, NULL);
+    if (test_id == NULL) {
+        return;
+    }
+    size_t length = strlen(test_id);
+    int valid = length > 0 && length <= 32;
+    for (size_t index = 0; valid && index < length; index++) {
+        char byte = test_id[index];
+        valid = (byte >= 'A' && byte <= 'Z') ||
+            (byte >= '0' && byte <= '9') || byte == '-';
+    }
+    if (valid) {
+        setenv("STASIS_SEAM_TEST_ID", test_id, 1);
+        setenv("STASIS_ENABLE_TEST_INPUT", "1", 1);
+    }
+    (*env)->ReleaseStringUTFChars(env, value, test_id);
+}
 
 JNIEXPORT void JNICALL
 Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetAssetRoot(

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -55,7 +55,9 @@ public final class MainActivity extends SDLActivity {
         System.loadLibrary("SDL3_image");
         System.loadLibrary("main");
         String seamTestId = getIntent().getStringExtra("stasis.seam_test_id");
-        if (seamTestId != null) nativeSetSeamTestId(seamTestId);
+        if (BuildConfig.STASIS_SEAM_TESTS && seamTestId != null) {
+            nativeSetSeamTestId(seamTestId);
+        }
         File root = new File(getFilesDir(), "stasis_game");
         File staging = new File(getFilesDir(), ".stasis_game.staging");
         String startupError = null;

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -34,6 +34,7 @@ public final class MainActivity extends SDLActivity {
     private static final long MAX_TOTAL_ASSET_BYTES = 150L * 1024L * 1024L;
 
     private static native void nativeSetAssetRoot(String path);
+    private static native void nativeSetSeamTestId(String testId);
     private static native boolean nativeReadPerformanceMetrics(float[] output);
     private static native String nativeReadRuntimeError();
 
@@ -53,6 +54,8 @@ public final class MainActivity extends SDLActivity {
         System.loadLibrary("SDL3");
         System.loadLibrary("SDL3_image");
         System.loadLibrary("main");
+        String seamTestId = getIntent().getStringExtra("stasis.seam_test_id");
+        if (seamTestId != null) nativeSetSeamTestId(seamTestId);
         File root = new File(getFilesDir(), "stasis_game");
         File staging = new File(getFilesDir(), ".stasis_game.staging");
         String startupError = null;

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -8,10 +8,13 @@
 
 #include "published_aot_symbols.h"
 #include "stasis_package_provenance.h"
+#if defined(STASIS_ENABLE_SEAM_TESTS)
 #include "stasis_mobile_aot_runtime.h"
+#endif
 #include "stasis_mobile_runtime.h"
 
 void stasis_host_report_runtime_error(const char *message);
+#if defined(STASIS_ENABLE_SEAM_TESTS)
 int stasis_test_get_render_submission_state(int32_t *out_i32, int32_t capacity);
 
 static int32_t hash_global_path(const char *path) {
@@ -43,6 +46,7 @@ static void log_seam_marker(const char *test_id, const char *event, int32_t fram
         has_render ? (uint32_t)render[4] : 0U
     );
 }
+#endif
 
 static void report_runtime_status(const char *stage, int status) {
     char message[256];
@@ -93,24 +97,33 @@ int SDL_main(int argc, char **argv) {
         STASIS_AOT_RENDER,
     };
     StasisMobileRuntimeConfig config = {1280, 720, "@STASIS_APP_NAME@"};
+#if defined(STASIS_ENABLE_SEAM_TESTS)
     const char *seam_test_id = SDL_getenv("STASIS_SEAM_TEST_ID");
+#endif
     int status = stasis_mobile_runtime_initialize(&config, &game);
     if (status != STASIS_MOBILE_RUNTIME_OK) {
         report_runtime_status("Stasis mobile initialization", status);
         SDL_Log("Stasis mobile initialization stopped with status %d", status);
-    } else if (seam_test_id != NULL && seam_test_id[0] != '\0') {
+    }
+#if defined(STASIS_ENABLE_SEAM_TESTS)
+    else if (seam_test_id != NULL && seam_test_id[0] != '\0') {
         log_seam_marker(seam_test_id, "initialized", 0);
     }
+#endif
     StasisMobileFramePacer frame_pacer;
+#if defined(STASIS_ENABLE_SEAM_TESTS)
     int32_t frame = 0;
+#endif
     stasis_mobile_frame_pacer_reset(&frame_pacer, SDL_GetTicksNS());
     while (status == STASIS_MOBILE_RUNTIME_OK) {
         status = stasis_mobile_runtime_step();
         if (status == STASIS_MOBILE_RUNTIME_OK) {
+#if defined(STASIS_ENABLE_SEAM_TESTS)
             frame++;
             if (seam_test_id != NULL && (frame == 1 || frame == 30)) {
                 log_seam_marker(seam_test_id, frame == 30 ? "stable" : "frame", frame);
             }
+#endif
             uint64_t wait_ns = stasis_mobile_frame_pacer_wait_ns(
                 &frame_pacer,
                 SDL_GetTicksNS()

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -3,13 +3,46 @@
 #include <SDL3/SDL_main.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "published_aot_symbols.h"
 #include "stasis_package_provenance.h"
+#include "stasis_mobile_aot_runtime.h"
 #include "stasis_mobile_runtime.h"
 
 void stasis_host_report_runtime_error(const char *message);
+int stasis_test_get_render_submission_state(int32_t *out_i32, int32_t capacity);
+
+static int32_t hash_global_path(const char *path) {
+    uint32_t hash = 2166136261U;
+    while (*path != '\0') {
+        hash ^= (uint8_t)*path++;
+        hash *= 16777619U;
+    }
+    return (int32_t)hash;
+}
+
+static void log_seam_marker(const char *test_id, const char *event, int32_t frame) {
+    int32_t render[5] = {0};
+    int has_render = stasis_test_get_render_submission_state(render, 5);
+    int32_t checksum = stasis_jit_global_i32_load(hash_global_path("seam_state_checksum"));
+    SDL_Log(
+        "Stasis seam: {\"schema\":\"stasis.seam_test.v1\",\"test_id\":\"%s\","
+        "\"event\":\"%s\",\"frame\":%d,\"state_checksum\":%d,"
+        "\"accepted\":%d,\"rejected\":%d,\"presented\":%d,"
+        "\"validation\":%d,\"command_trace\":%u}",
+        test_id,
+        event,
+        frame,
+        checksum,
+        has_render ? render[0] : 0,
+        has_render ? render[1] : 0,
+        has_render ? render[2] : 0,
+        has_render ? render[3] : 0,
+        has_render ? (uint32_t)render[4] : 0U
+    );
+}
 
 static void report_runtime_status(const char *stage, int status) {
     char message[256];
@@ -60,16 +93,24 @@ int SDL_main(int argc, char **argv) {
         STASIS_AOT_RENDER,
     };
     StasisMobileRuntimeConfig config = {1280, 720, "@STASIS_APP_NAME@"};
+    const char *seam_test_id = SDL_getenv("STASIS_SEAM_TEST_ID");
     int status = stasis_mobile_runtime_initialize(&config, &game);
     if (status != STASIS_MOBILE_RUNTIME_OK) {
         report_runtime_status("Stasis mobile initialization", status);
         SDL_Log("Stasis mobile initialization stopped with status %d", status);
+    } else if (seam_test_id != NULL && seam_test_id[0] != '\0') {
+        log_seam_marker(seam_test_id, "initialized", 0);
     }
     StasisMobileFramePacer frame_pacer;
+    int32_t frame = 0;
     stasis_mobile_frame_pacer_reset(&frame_pacer, SDL_GetTicksNS());
     while (status == STASIS_MOBILE_RUNTIME_OK) {
         status = stasis_mobile_runtime_step();
         if (status == STASIS_MOBILE_RUNTIME_OK) {
+            frame++;
+            if (seam_test_id != NULL && (frame == 1 || frame == 30)) {
+                log_seam_marker(seam_test_id, frame == 30 ? "stable" : "frame", frame);
+            }
             uint64_t wait_ns = stasis_mobile_frame_pacer_wait_ns(
                 &frame_pacer,
                 SDL_GetTicksNS()

--- a/samples/android_aot_seam/android_seam_expectations.json
+++ b/samples/android_aot_seam/android_seam_expectations.json
@@ -1,0 +1,13 @@
+{
+  "schema": "stasis.android_seam_expectations.v1",
+  "test_id": "IT-017",
+  "stable_frame": 30,
+  "state_checksum": 1210,
+  "command_trace": 1947640508,
+  "logical_size": [640, 360],
+  "regions": [
+    {"name": "left_red", "center": [160, 180], "rgb": [230, 31, 41], "tolerance": 30},
+    {"name": "center_yellow", "center": [320, 180], "rgb": [242, 230, 77], "tolerance": 30},
+    {"name": "right_teal", "center": [480, 180], "rgb": [26, 199, 184], "tolerance": 30}
+  ]
+}

--- a/samples/android_aot_seam/assets/manifest.json
+++ b/samples/android_aot_seam/assets/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stasis-assets",
+  "version": 1,
+  "assets": []
+}

--- a/samples/android_aot_seam/main.stasis
+++ b/samples/android_aot_seam/main.stasis
@@ -1,0 +1,31 @@
+import "/vendor/stasis/src/stdlib/graphics.stasis";
+
+global ticks: i32;
+global seam_state_checksum: i32;
+
+function main(): i32 {
+    init_window(640, 360, "Stasis Android Seam");
+    ticks = 0;
+    seam_state_checksum = 1000;
+    return 0;
+}
+
+function tick(): i32 {
+    ticks = ticks + 1;
+    seam_state_checksum = 1000 + ticks * 7;
+    return 0;
+}
+
+function render(): i32 {
+    begin_frame();
+    clear(0.04, 0.07, 0.12, 1.0);
+    fill_rect(64.0, 72.0, 192.0, 216.0, 0.90, 0.12, 0.16, 1.0);
+    fill_rect(384.0, 72.0, 192.0, 216.0, 0.10, 0.78, 0.72, 1.0);
+    fill_rect(296.0, 156.0, 48.0, 48.0, 0.95, 0.90, 0.30, 1.0);
+    end_frame();
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/samples/android_aot_seam/stasis.json
+++ b/samples/android_aot_seam/stasis.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 1,
+  "name": "android_aot_seam",
+  "entry": "main.stasis",
+  "tests": "tests",
+  "output": "build",
+  "android": {
+    "application_id": "com.stasislang.seam.it017",
+    "label": "Stasis Android Seam",
+    "orientation": "sensorLandscape",
+    "version_code": 1,
+    "version_name": "1.0.0"
+  }
+}

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Install and verify a generated Android AOT shell through structured markers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import struct
+import subprocess
+import time
+import zlib
+from pathlib import Path
+
+
+SCHEMA = "stasis.seam_test.v1"
+MARKER = re.compile(r"Stasis seam: (\{[^\r\n]+\})")
+
+
+class SeamError(RuntimeError):
+    pass
+
+
+def _run(
+    adb: Path,
+    serial: str | None,
+    *arguments: str,
+    text: bool = True,
+    required: bool = True,
+):
+    command = [str(adb)]
+    if serial:
+        command.extend(("-s", serial))
+    command.extend(arguments)
+    result = subprocess.run(command, capture_output=True, text=text, check=False)
+    if required and result.returncode != 0:
+        stderr = (
+            result.stderr.strip()
+            if text
+            else result.stderr.decode(errors="replace").strip()
+        )
+        raise SeamError(f"adb {' '.join(arguments)} failed: {stderr}")
+    return result.stdout
+
+
+def parse_markers(log: str, test_id: str) -> list[dict]:
+    markers = []
+    for match in MARKER.finditer(log):
+        try:
+            value = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if value.get("schema") == SCHEMA and value.get("test_id") == test_id:
+            markers.append(value)
+    return markers
+
+
+def validate_markers(markers: list[dict], expectations: dict) -> dict:
+    stable_frame = expectations["stable_frame"]
+    events = {(item.get("event"), item.get("frame")): item for item in markers}
+    if ("initialized", 0) not in events or ("frame", 1) not in events:
+        raise SeamError("Android shell did not emit initialized and first-frame markers")
+    stable = events.get(("stable", stable_frame))
+    if stable is None:
+        raise SeamError(f"Android shell did not reach stable frame {stable_frame}")
+    expected = {
+        "state_checksum": expectations["state_checksum"],
+        "command_trace": expectations["command_trace"],
+        "rejected": 0,
+        "validation": 0,
+    }
+    mismatches = {
+        key: {"expected": value, "actual": stable.get(key)}
+        for key, value in expected.items()
+        if stable.get(key) != value
+    }
+    if (
+        stable.get("accepted", 0) < stable_frame
+        or stable.get("presented", 0) < stable_frame
+    ):
+        mismatches["stable_frames"] = {
+            "expected": stable_frame,
+            "accepted": stable.get("accepted"),
+            "presented": stable.get("presented"),
+        }
+    if mismatches:
+        raise SeamError(f"Android stable-frame marker mismatch: {mismatches}")
+    return stable
+
+
+def read_png_rgb(path: Path) -> tuple[int, int, list[tuple[int, int, int]]]:
+    data = path.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise SeamError(f"capture is not a PNG: {path}")
+    offset = 8
+    width = height = color_type = bit_depth = None
+    compressed = bytearray()
+    while offset + 12 <= len(data):
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        kind = data[offset + 4 : offset + 8]
+        payload = data[offset + 8 : offset + 8 + length]
+        offset += length + 12
+        if kind == b"IHDR":
+            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(
+                ">IIBBBBB", payload
+            )
+            if bit_depth != 8 or color_type not in (2, 6) or interlace != 0:
+                raise SeamError("capture must be a non-interlaced 8-bit RGB/RGBA PNG")
+        elif kind == b"IDAT":
+            compressed.extend(payload)
+        elif kind == b"IEND":
+            break
+    if width is None or height is None or color_type is None:
+        raise SeamError("capture PNG is missing IHDR")
+    channels = 3 if color_type == 2 else 4
+    raw = zlib.decompress(bytes(compressed))
+    stride = width * channels
+    rows: list[bytearray] = []
+    cursor = 0
+    for _ in range(height):
+        filter_kind = raw[cursor]
+        cursor += 1
+        row = bytearray(raw[cursor : cursor + stride])
+        cursor += stride
+        prior = rows[-1] if rows else bytearray(stride)
+        for index in range(stride):
+            left = row[index - channels] if index >= channels else 0
+            above = prior[index]
+            upper_left = prior[index - channels] if index >= channels else 0
+            if filter_kind == 1:
+                row[index] = (row[index] + left) & 0xFF
+            elif filter_kind == 2:
+                row[index] = (row[index] + above) & 0xFF
+            elif filter_kind == 3:
+                row[index] = (row[index] + ((left + above) // 2)) & 0xFF
+            elif filter_kind == 4:
+                estimate = left + above - upper_left
+                distances = (
+                    abs(estimate - left),
+                    abs(estimate - above),
+                    abs(estimate - upper_left),
+                )
+                predictor = (left, above, upper_left)[distances.index(min(distances))]
+                row[index] = (row[index] + predictor) & 0xFF
+            elif filter_kind != 0:
+                raise SeamError(f"capture PNG uses unsupported filter {filter_kind}")
+        rows.append(row)
+    pixels = []
+    for row in rows:
+        pixels.extend(
+            tuple(row[index : index + 3]) for index in range(0, stride, channels)
+        )
+    return width, height, pixels
+
+
+def validate_regions(capture: Path, expectations: dict) -> list[dict]:
+    width, height, pixels = read_png_rgb(capture)
+    logical_width, logical_height = expectations["logical_size"]
+    scale = min(width / logical_width, height / logical_height)
+    offset_x = (width - logical_width * scale) / 2.0
+    offset_y = (height - logical_height * scale) / 2.0
+    observed = []
+    for region in expectations["regions"]:
+        x = max(0, min(width - 1, round(offset_x + region["center"][0] * scale)))
+        y = max(0, min(height - 1, round(offset_y + region["center"][1] * scale)))
+        radius = max(2, round(scale * 3))
+        samples = [
+            pixels[row * width + column]
+            for row in range(max(0, y - radius), min(height, y + radius + 1))
+            for column in range(max(0, x - radius), min(width, x + radius + 1))
+        ]
+        average = [
+            round(sum(pixel[channel] for pixel in samples) / len(samples))
+            for channel in range(3)
+        ]
+        if any(
+            abs(average[index] - region["rgb"][index]) > region["tolerance"]
+            for index in range(3)
+        ):
+            raise SeamError(
+                f"capture region {region['name']} color mismatch: "
+                f"expected={region['rgb']} observed={average} tolerance={region['tolerance']}"
+            )
+        observed.append({"name": region["name"], "pixel": [x, y], "rgb": average})
+    return observed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--adb", type=Path, required=True)
+    parser.add_argument("--serial")
+    parser.add_argument("--apk", type=Path, required=True)
+    parser.add_argument("--package-manifest", type=Path, required=True)
+    parser.add_argument("--expectations", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=90)
+    args = parser.parse_args()
+
+    started = time.monotonic()
+    package = json.loads(args.package_manifest.read_text(encoding="utf-8"))
+    provenance_path = args.package_manifest.parent / package["provenance"]
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    expectations = json.loads(args.expectations.read_text(encoding="utf-8"))
+    package_id = package["package_id"]
+    test_id = expectations["test_id"]
+    args.output.mkdir(parents=True, exist_ok=True)
+    log_path = args.output / "logcat.txt"
+    capture_path = args.output / "stable-frame.png"
+    evidence_path = args.output / "evidence.json"
+    preinstalled = bool(
+        _run(
+            args.adb,
+            args.serial,
+            "shell",
+            "pm",
+            "path",
+            package_id,
+            required=False,
+        ).strip()
+    )
+    if preinstalled:
+        raise SeamError(
+            f"refusing to replace preinstalled test package {package_id}; remove it explicitly"
+        )
+    immersive_confirmation = _run(
+        args.adb,
+        args.serial,
+        "shell",
+        "settings",
+        "get",
+        "secure",
+        "immersive_mode_confirmations",
+        required=False,
+    ).strip()
+    evidence = {
+        "schema": SCHEMA,
+        "test_id": test_id,
+        "status": "failed",
+        "target": "android-arm64-release-shell",
+        "package_id": package_id,
+        "package": package,
+        "build_identity": {
+            key: provenance.get(key)
+            for key in (
+                "schema",
+                "development_build",
+                "release_tag",
+                "source_commit",
+                "dirty_state",
+                "command_buffer",
+            )
+        },
+        "artifacts": {"log": str(log_path), "capture": str(capture_path)},
+    }
+    installed = False
+    try:
+        _run(
+            args.adb,
+            args.serial,
+            "shell",
+            "settings",
+            "put",
+            "secure",
+            "immersive_mode_confirmations",
+            "confirmed",
+        )
+        _run(args.adb, args.serial, "install", "-r", str(args.apk))
+        installed = True
+        _run(args.adb, args.serial, "logcat", "-c")
+        component = f"{package_id}/.MainActivity"
+        _run(
+            args.adb,
+            args.serial,
+            "shell",
+            "am",
+            "start",
+            "-W",
+            "-n",
+            component,
+            "--es",
+            "stasis.seam_test_id",
+            test_id,
+        )
+        deadline = time.monotonic() + args.timeout_seconds
+        log = ""
+        markers: list[dict] = []
+        while time.monotonic() < deadline:
+            log = _run(
+                args.adb,
+                args.serial,
+                "logcat",
+                "-d",
+                "-v",
+                "brief",
+                "Stasis:I",
+                "*:S",
+            )
+            markers = parse_markers(log, test_id)
+            if any(item.get("event") == "stable" for item in markers):
+                break
+            time.sleep(1)
+        log_path.write_text(log, encoding="utf-8")
+        stable = validate_markers(markers, expectations)
+        first_pid = _run(
+            args.adb, args.serial, "shell", "pidof", package_id, required=False
+        ).strip()
+        if not first_pid:
+            raise SeamError("generated Android shell exited before capture")
+        capture_path.write_bytes(
+            _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
+        )
+        regions = validate_regions(capture_path, expectations)
+        time.sleep(1)
+        second_pid = _run(
+            args.adb, args.serial, "shell", "pidof", package_id, required=False
+        ).strip()
+        if second_pid != first_pid:
+            raise SeamError("generated Android shell did not remain alive after stable frames")
+        evidence.update(
+            {
+                "status": "passed",
+                "stable_marker": stable,
+                "lifecycle_events": [item["event"] for item in markers],
+                "process_id": first_pid,
+                "regions": regions,
+            }
+        )
+    except (OSError, KeyError, ValueError, SeamError, zlib.error) as error:
+        evidence["failure"] = str(error)
+        raise
+    finally:
+        cleanup_errors = []
+        if installed and not log_path.is_file():
+            diagnostic_log = _run(
+                args.adb,
+                args.serial,
+                "logcat",
+                "-d",
+                "-v",
+                "brief",
+                "Stasis:I",
+                "*:S",
+                required=False,
+            )
+            log_path.write_text(diagnostic_log, encoding="utf-8")
+        try:
+            if installed:
+                _run(args.adb, args.serial, "shell", "am", "force-stop", package_id)
+                _run(args.adb, args.serial, "uninstall", package_id)
+        except SeamError as cleanup_error:
+            cleanup_errors.append(str(cleanup_error))
+        try:
+            if immersive_confirmation and immersive_confirmation != "null":
+                _run(
+                    args.adb,
+                    args.serial,
+                    "shell",
+                    "settings",
+                    "put",
+                    "secure",
+                    "immersive_mode_confirmations",
+                    immersive_confirmation,
+                )
+            else:
+                _run(
+                    args.adb,
+                    args.serial,
+                    "shell",
+                    "settings",
+                    "delete",
+                    "secure",
+                    "immersive_mode_confirmations",
+                )
+        except SeamError as cleanup_error:
+            cleanup_errors.append(str(cleanup_error))
+        evidence["device_state_restored"] = not cleanup_errors
+        evidence["elapsed_ms"] = round((time.monotonic() - started) * 1000)
+        evidence["timeout_seconds"] = args.timeout_seconds
+        if cleanup_errors:
+            evidence["status"] = "failed"
+            evidence["cleanup_errors"] = cleanup_errors
+        evidence_path.write_text(
+            json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if cleanup_errors:
+            raise SeamError(f"Android seam cleanup failed: {cleanup_errors}")
+    print(json.dumps(evidence, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -185,6 +185,57 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     return observed
 
 
+def restore_device_state(
+    adb: Path,
+    serial: str | None,
+    package_id: str,
+    installed: bool,
+    immersive_confirmation: str,
+) -> list[str]:
+    errors = []
+    operations = []
+    if installed:
+        operations.extend(
+            (
+                ("force-stop", ("shell", "am", "force-stop", package_id)),
+                ("uninstall", ("uninstall", package_id)),
+            )
+        )
+    if immersive_confirmation and immersive_confirmation != "null":
+        operations.append(
+            (
+                "restore immersive confirmation",
+                (
+                    "shell",
+                    "settings",
+                    "put",
+                    "secure",
+                    "immersive_mode_confirmations",
+                    immersive_confirmation,
+                ),
+            )
+        )
+    else:
+        operations.append(
+            (
+                "restore immersive confirmation",
+                (
+                    "shell",
+                    "settings",
+                    "delete",
+                    "secure",
+                    "immersive_mode_confirmations",
+                ),
+            )
+        )
+    for name, arguments in operations:
+        try:
+            _run(adb, serial, *arguments)
+        except (OSError, SeamError) as error:
+            errors.append(f"{name}: {error}")
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--adb", type=Path, required=True)
@@ -331,48 +382,30 @@ def main() -> int:
     finally:
         cleanup_errors = []
         if installed and not log_path.is_file():
-            diagnostic_log = _run(
+            try:
+                diagnostic_log = _run(
+                    args.adb,
+                    args.serial,
+                    "logcat",
+                    "-d",
+                    "-v",
+                    "brief",
+                    "Stasis:I",
+                    "*:S",
+                    required=False,
+                )
+                log_path.write_text(diagnostic_log, encoding="utf-8")
+            except (OSError, SeamError) as cleanup_error:
+                cleanup_errors.append(f"diagnostic log: {cleanup_error}")
+        cleanup_errors.extend(
+            restore_device_state(
                 args.adb,
                 args.serial,
-                "logcat",
-                "-d",
-                "-v",
-                "brief",
-                "Stasis:I",
-                "*:S",
-                required=False,
+                package_id,
+                installed,
+                immersive_confirmation,
             )
-            log_path.write_text(diagnostic_log, encoding="utf-8")
-        try:
-            if installed:
-                _run(args.adb, args.serial, "shell", "am", "force-stop", package_id)
-                _run(args.adb, args.serial, "uninstall", package_id)
-        except SeamError as cleanup_error:
-            cleanup_errors.append(str(cleanup_error))
-        try:
-            if immersive_confirmation and immersive_confirmation != "null":
-                _run(
-                    args.adb,
-                    args.serial,
-                    "shell",
-                    "settings",
-                    "put",
-                    "secure",
-                    "immersive_mode_confirmations",
-                    immersive_confirmation,
-                )
-            else:
-                _run(
-                    args.adb,
-                    args.serial,
-                    "shell",
-                    "settings",
-                    "delete",
-                    "secure",
-                    "immersive_mode_confirmations",
-                )
-        except SeamError as cleanup_error:
-            cleanup_errors.append(str(cleanup_error))
+        )
         evidence["device_state_restored"] = not cleanup_errors
         evidence["elapsed_ms"] = round((time.monotonic() - started) * 1000)
         evidence["timeout_seconds"] = args.timeout_seconds

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 import zlib
 from pathlib import Path
+from unittest import mock
 
 from tools.ci import run_android_release_shell_seam as seam
 
@@ -112,6 +113,34 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
                 },
             )
             self.assertEqual([item["name"] for item in observed], ["red", "teal"])
+
+    def test_cleanup_continues_after_force_stop_failure(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments[:3] == ("shell", "am", "force-stop"):
+                raise seam.SeamError("injected force-stop failure")
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            errors = seam.restore_device_state(
+                Path("adb"), "device", "com.example.seam", True, "null"
+            )
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("force-stop", errors[0])
+        self.assertIn(("uninstall", "com.example.seam"), calls)
+        self.assertIn(
+            (
+                "shell",
+                "settings",
+                "delete",
+                "secure",
+                "immersive_mode_confirmations",
+            ),
+            calls,
+        )
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -1,0 +1,118 @@
+import json
+import struct
+import tempfile
+import unittest
+import zlib
+from pathlib import Path
+
+from tools.ci import run_android_release_shell_seam as seam
+
+
+def write_rgb_png(
+    path: Path, width: int, height: int, rows: list[list[tuple[int, int, int]]]
+):
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + kind
+            + payload
+            + struct.pack(">I", zlib.crc32(kind + payload))
+        )
+
+    raw = b"".join(b"\0" + b"".join(bytes(pixel) for pixel in row) for row in rows)
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", header)
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+class AndroidReleaseShellSeamTests(unittest.TestCase):
+    def test_parses_and_validates_stable_marker(self):
+        values = [
+            {
+                "schema": seam.SCHEMA,
+                "test_id": "IT-017",
+                "event": "initialized",
+                "frame": 0,
+            },
+            {
+                "schema": seam.SCHEMA,
+                "test_id": "IT-017",
+                "event": "frame",
+                "frame": 1,
+            },
+            {
+                "schema": seam.SCHEMA,
+                "test_id": "IT-017",
+                "event": "stable",
+                "frame": 30,
+                "state_checksum": 1210,
+                "command_trace": 77,
+                "accepted": 30,
+                "presented": 30,
+                "rejected": 0,
+                "validation": 0,
+            },
+        ]
+        log = "\n".join(f"I/Stasis: Stasis seam: {json.dumps(value)}" for value in values)
+        markers = seam.parse_markers(log, "IT-017")
+        stable = seam.validate_markers(
+            markers,
+            {"stable_frame": 30, "state_checksum": 1210, "command_trace": 77},
+        )
+        self.assertEqual(stable["presented"], 30)
+
+    def test_marker_mismatch_names_the_field(self):
+        markers = [
+            {"event": "initialized", "frame": 0},
+            {"event": "frame", "frame": 1},
+            {
+                "event": "stable",
+                "frame": 30,
+                "state_checksum": 5,
+                "command_trace": 77,
+                "accepted": 30,
+                "presented": 30,
+                "rejected": 0,
+                "validation": 0,
+            },
+        ]
+        with self.assertRaisesRegex(seam.SeamError, "state_checksum"):
+            seam.validate_markers(
+                markers,
+                {"stable_frame": 30, "state_checksum": 1210, "command_trace": 77},
+            )
+
+    def test_validates_named_capture_regions(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "capture.png"
+            rows = [[(230, 31, 41)] * 5 + [(26, 199, 184)] * 5 for _ in range(6)]
+            write_rgb_png(path, 10, 6, rows)
+            observed = seam.validate_regions(
+                path,
+                {
+                    "logical_size": [10, 6],
+                    "regions": [
+                        {
+                            "name": "red",
+                            "center": [1, 3],
+                            "rgb": [230, 31, 41],
+                            "tolerance": 0,
+                        },
+                        {
+                            "name": "teal",
+                            "center": [8, 3],
+                            "rgb": [26, 199, 184],
+                            "tolerance": 0,
+                        },
+                    ],
+                },
+            )
+            self.assertEqual([item["name"] for item in observed], ["red", "teal"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an opt-in structured marker path to the generated Android AOT shell
- add a deterministic non-empty IT-017 Stasis fixture and dependency-free ADB/capture verifier
- add a bounded arm64-compatible device workflow with cleanup and evidence artifacts

## Validation
- python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_verify_android_native_library
- cargo fmt --all -- --check
- python tools/ci/check_stasis_src_layout.py
- focused generated-shell Rust test (direct built test binary)
- real package-mobile + Gradle assembleDebug
- full mobile/android/test_release_shell.ps1 on Stasis_API_35 with arm64 translation: frame 30, checksum 1210, trace 1947640508, 30 accepted/presented, zero rejected, three named pixel regions, process alive, device restored

Theory gained: The generated release shell needs one opt-in observation point after the existing mobile runtime submits a frame. The fixture owns state/checksum intent, the graphics runtime owns accepted/presented/trace facts, and the driver owns device state and pixels. This predicts later touch and lifecycle seams can reuse the same launch/evidence/cleanup boundary without creating another host path.

Good: The real emulator exposed both the immersive tutorial overlay and Windows CMake path limit before publication.
Bad: The first wrapper nested descriptive temporary directories deeply enough to exceed Ninja's Windows object path limit.
Adjustment: Device-build harnesses use short internal paths and preserve descriptive identity in evidence rather than directory depth.

Maddox: #226