### PR TITLE
test: round-trip Android release touch input

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generated-release-shell:
     runs-on: [self-hosted, Windows, android-device]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -27,4 +27,21 @@ jobs:
         with:
           name: android-release-shell-seam
           path: artifacts/android_release_shell/e
+          if-no-files-found: warn
+
+      - name: Run Android release touch round-trip seam
+        shell: powershell
+        run: >-
+          & ./mobile/android/test_release_shell.ps1
+          -Serial "$env:ANDROID_SERIAL"
+          -ProjectPath "samples/android_touch_seam"
+          -OutputPath "artifacts/android_touch_roundtrip"
+          -TotalTimeoutSeconds 840
+
+      - name: Upload Android touch round-trip evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-touch-roundtrip-seam
+          path: artifacts/android_touch_roundtrip/e
           if-no-files-found: warn

--- a/mobile/android/test_release_shell.ps1
+++ b/mobile/android/test_release_shell.ps1
@@ -1,6 +1,8 @@
 param(
     [string]$Serial = $env:ANDROID_SERIAL,
     [string]$OutputPath = "",
+    [string]$ProjectPath = "samples/android_aot_seam",
+    [string]$ExpectationsPath = "",
     [int]$TotalTimeoutSeconds = 900
 )
 
@@ -18,18 +20,36 @@ $androidHome = if ($env:ANDROID_HOME) {
 $adb = Join-Path $androidHome "platform-tools\adb.exe"
 if (-not (Test-Path $adb)) { throw "adb.exe was not found: $adb" }
 if (-not $Serial) { throw "Pass -Serial or set ANDROID_SERIAL to one arm64 Android device" }
+$projectRoot = if ([System.IO.Path]::IsPathRooted($ProjectPath)) {
+    [System.IO.Path]::GetFullPath($ProjectPath)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path $repoRoot $ProjectPath))
+}
+if (-not (Test-Path (Join-Path $projectRoot "stasis.json"))) {
+    throw "Android seam project is missing stasis.json: $projectRoot"
+}
+if (-not $ExpectationsPath) {
+    $ExpectationsPath = Join-Path $projectRoot "android_seam_expectations.json"
+} elseif (-not [System.IO.Path]::IsPathRooted($ExpectationsPath)) {
+    $ExpectationsPath = Join-Path $repoRoot $ExpectationsPath
+}
+$ExpectationsPath = [System.IO.Path]::GetFullPath($ExpectationsPath)
+if (-not (Test-Path $ExpectationsPath)) {
+    throw "Android seam expectations are missing: $ExpectationsPath"
+}
+$testId = (Get-Content -Raw $ExpectationsPath | ConvertFrom-Json).test_id
+if (-not $testId) { throw "Android seam expectations do not name test_id" }
 
 $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
 if (-not $OutputPath) {
-    $OutputPath = Join-Path $repoRoot "target\it017\$stamp"
+    $OutputPath = Join-Path $repoRoot "target\$($testId.ToLowerInvariant().Replace('-', ''))\$stamp"
 }
 $artifactRoot = [System.IO.Path]::GetFullPath($OutputPath)
 $workspaceRoot = Join-Path $artifactRoot "w"
 $packageRoot = Join-Path $workspaceRoot "d"
 $evidenceRoot = Join-Path $artifactRoot "e"
 New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
-Copy-Item -LiteralPath (Join-Path $repoRoot "samples\android_aot_seam") `
-    -Destination $workspaceRoot -Recurse
+Copy-Item -LiteralPath $projectRoot -Destination $workspaceRoot -Recurse
 $vendorRoot = Join-Path $workspaceRoot "vendor\stasis\src"
 New-Item -ItemType Directory -Force -Path $vendorRoot | Out-Null
 Copy-Item -LiteralPath (Join-Path $repoRoot "src\stdlib") `
@@ -60,7 +80,7 @@ if ($LASTEXITCODE -ne 0 -or $abiOutput.Count -eq 0) {
 $abi = ($abiOutput -join "").Trim()
 $abiList = (& $adb -s $Serial shell getprop ro.product.cpu.abilist).Trim() -split ','
 if ($LASTEXITCODE -ne 0 -or "arm64-v8a" -notin $abiList) {
-    throw "IT-017 requires arm64-v8a support; $Serial reports '$abi' ($($abiList -join ','))"
+    throw "$testId requires arm64-v8a support; $Serial reports '$abi' ($($abiList -join ','))"
 }
 if (-not $env:STASIS_SDL3_SOURCE -or -not $env:STASIS_SDL3_IMAGE_SOURCE) {
     throw "Set STASIS_SDL3_SOURCE and STASIS_SDL3_IMAGE_SOURCE to the pinned source trees"
@@ -69,20 +89,20 @@ if (-not $env:STASIS_SDL3_SOURCE -or -not $env:STASIS_SDL3_IMAGE_SOURCE) {
 Push-Location $repoRoot
 try {
     python tools/cargo_cache.py run -- cargo build -p stasis
-    if ($LASTEXITCODE -ne 0) { throw "IT-017 compiler build failed with exit code $LASTEXITCODE" }
+    if ($LASTEXITCODE -ne 0) { throw "$testId compiler build failed with exit code $LASTEXITCODE" }
     $commonGit = (& git rev-parse --path-format=absolute --git-common-dir).Trim()
     if ($LASTEXITCODE -ne 0) { throw "Unable to resolve the shared Cargo target" }
     $compiler = Join-Path (Split-Path -Parent $commonGit) "build\codex-cargo-target\debug\stasis.exe"
     if (-not (Test-Path $compiler)) { throw "Built Stasis compiler is missing: $compiler" }
     & $compiler --workspace $workspaceRoot package-mobile `
         --target android-arm64 --out d --development-build
-    if ($LASTEXITCODE -ne 0) { throw "IT-017 package-mobile failed with exit code $LASTEXITCODE" }
+    if ($LASTEXITCODE -ne 0) { throw "$testId package-mobile failed with exit code $LASTEXITCODE" }
     Assert-In-Time "package-mobile"
 
     $gradle = Resolve-Gradle
     & $gradle -p (Join-Path $packageRoot "android") `
         :app:assembleDebug -PstasisSeamTests=true --no-daemon --max-workers=2 --console=plain
-    if ($LASTEXITCODE -ne 0) { throw "IT-017 Gradle build failed with exit code $LASTEXITCODE" }
+    if ($LASTEXITCODE -ne 0) { throw "$testId Gradle build failed with exit code $LASTEXITCODE" }
     Assert-In-Time "Gradle build"
 
     $apk = Join-Path $packageRoot "android\app\build\outputs\apk\debug\app-debug.apk"
@@ -92,10 +112,10 @@ try {
         --serial $Serial `
         --apk $apk `
         --package-manifest (Join-Path $packageRoot "stasis_mobile_package.json") `
-        --expectations samples/android_aot_seam/android_seam_expectations.json `
+        --expectations $ExpectationsPath `
         --output $evidenceRoot `
         --timeout-seconds ([math]::Max(15, $TotalTimeoutSeconds - [math]::Floor($startedAt.Elapsed.TotalSeconds)))
-    if ($LASTEXITCODE -ne 0) { throw "IT-017 device acceptance failed with exit code $LASTEXITCODE" }
+    if ($LASTEXITCODE -ne 0) { throw "$testId device acceptance failed with exit code $LASTEXITCODE" }
     Assert-In-Time "device acceptance"
 } finally {
     Pop-Location

--- a/mobile/shells/android/README.md
+++ b/mobile/shells/android/README.md
@@ -24,9 +24,10 @@ in `docs/android_release_shell_backlog.md`.
 
 The generated shell also supports an opt-in integration-test launch extra,
 `stasis.seam_test_id`. It enables bounded `stasis.seam_test.v1` log markers for
-initialization, the first frame, and stable frame 30; ordinary app launches do
-not enable the markers. Run IT-017 against an attached device whose ABI list
-includes `arm64-v8a` with:
+initialization, the first frame, stable frame 30, and fixture-owned probe
+sequence changes; ordinary app launches do not compile or enable the marker
+hooks. Run IT-017 against an attached device whose ABI list includes
+`arm64-v8a` with:
 
 ```powershell
 mobile/android/test_release_shell.ps1 -Serial <device-serial>
@@ -36,3 +37,13 @@ The driver builds a fresh generated package, verifies lifecycle/checksum/trace
 markers and named capture regions, retains JSON/log/screenshot evidence, then
 force-stops the app, removes a test-only install, and restores the device's
 prior immersive-confirmation setting.
+
+IT-018 reuses that driver with a portrait logical fixture on the landscape
+surface. It injects Android touchscreen gestures in the real pillarbox and
+content regions, then verifies ordered SDL/HostFrame pointer edges, logical and
+normalized coordinates, one Stasis state transition, and the resulting frame:
+
+```powershell
+mobile/android/test_release_shell.ps1 -Serial <device-serial> `
+    -ProjectPath samples/android_touch_seam
+```

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -26,15 +26,30 @@ static int32_t hash_global_path(const char *path) {
     return (int32_t)hash;
 }
 
+static int32_t seam_i32(const char *path) {
+    return stasis_jit_global_i32_load(hash_global_path(path));
+}
+
+static float seam_f32(const char *path) {
+    return stasis_jit_global_f32_load(hash_global_path(path));
+}
+
 static void log_seam_marker(const char *test_id, const char *event, int32_t frame) {
     int32_t render[5] = {0};
     int has_render = stasis_test_get_render_submission_state(render, 5);
-    int32_t checksum = stasis_jit_global_i32_load(hash_global_path("seam_state_checksum"));
+    int32_t checksum = seam_i32("seam_state_checksum");
     SDL_Log(
         "Stasis seam: {\"schema\":\"stasis.seam_test.v1\",\"test_id\":\"%s\","
         "\"event\":\"%s\",\"frame\":%d,\"state_checksum\":%d,"
         "\"accepted\":%d,\"rejected\":%d,\"presented\":%d,"
-        "\"validation\":%d,\"command_trace\":%u}",
+        "\"validation\":%d,\"command_trace\":%u,"
+        "\"probe_sequence\":%d,\"probe_kind\":%d,\"probe_tick\":%d,"
+        "\"pointer_id\":%d,\"pointer_count\":%d,\"is_down\":%d,"
+        "\"went_down\":%d,\"went_up\":%d,\"down_count\":%d,"
+        "\"move_count\":%d,\"up_count\":%d,\"state_transitions\":%d,"
+        "\"input_phase\":%d,\"x\":%.3f,\"y\":%.3f,"
+        "\"dx\":%.3f,\"dy\":%.3f,\"x_n\":%.4f,\"y_n\":%.4f,"
+        "\"safe_x\":%.3f,\"safe_y\":%.3f,\"safe_w\":%.3f,\"safe_h\":%.3f}",
         test_id,
         event,
         frame,
@@ -43,7 +58,30 @@ static void log_seam_marker(const char *test_id, const char *event, int32_t fram
         has_render ? render[1] : 0,
         has_render ? render[2] : 0,
         has_render ? render[3] : 0,
-        has_render ? (uint32_t)render[4] : 0U
+        has_render ? (uint32_t)render[4] : 0U,
+        seam_i32("seam_probe_sequence"),
+        seam_i32("seam_probe_kind"),
+        seam_i32("seam_probe_tick"),
+        seam_i32("seam_pointer_id"),
+        seam_i32("seam_pointer_count"),
+        seam_i32("seam_pointer_is_down"),
+        seam_i32("seam_pointer_went_down"),
+        seam_i32("seam_pointer_went_up"),
+        seam_i32("seam_down_count"),
+        seam_i32("seam_move_count"),
+        seam_i32("seam_up_count"),
+        seam_i32("seam_state_transitions"),
+        seam_i32("seam_input_phase"),
+        seam_f32("seam_pointer_x"),
+        seam_f32("seam_pointer_y"),
+        seam_f32("seam_pointer_dx"),
+        seam_f32("seam_pointer_dy"),
+        seam_f32("seam_pointer_x_n"),
+        seam_f32("seam_pointer_y_n"),
+        seam_f32("seam_safe_x"),
+        seam_f32("seam_safe_y"),
+        seam_f32("seam_safe_w"),
+        seam_f32("seam_safe_h")
     );
 }
 #endif
@@ -113,6 +151,7 @@ int SDL_main(int argc, char **argv) {
     StasisMobileFramePacer frame_pacer;
 #if defined(STASIS_ENABLE_SEAM_TESTS)
     int32_t frame = 0;
+    int32_t last_probe_sequence = 0;
 #endif
     stasis_mobile_frame_pacer_reset(&frame_pacer, SDL_GetTicksNS());
     while (status == STASIS_MOBILE_RUNTIME_OK) {
@@ -122,6 +161,13 @@ int SDL_main(int argc, char **argv) {
             frame++;
             if (seam_test_id != NULL && (frame == 1 || frame == 30)) {
                 log_seam_marker(seam_test_id, frame == 30 ? "stable" : "frame", frame);
+            }
+            if (seam_test_id != NULL) {
+                int32_t probe_sequence = seam_i32("seam_probe_sequence");
+                if (probe_sequence != last_probe_sequence) {
+                    log_seam_marker(seam_test_id, "probe", frame);
+                    last_probe_sequence = probe_sequence;
+                }
             }
 #endif
             uint64_t wait_ns = stasis_mobile_frame_pacer_wait_ns(

--- a/samples/android_touch_seam/android_seam_expectations.json
+++ b/samples/android_touch_seam/android_seam_expectations.json
@@ -12,9 +12,8 @@
     "final_command_trace": 2551385997,
     "gestures": [
       {
-        "name": "outside_top_letterbox",
-        "start": [180, -20],
-        "end": [180, -20],
+        "name": "outside_letterbox",
+        "location": "outside_letterbox",
         "duration_ms": 400,
         "after_sequence": 2
       },
@@ -27,15 +26,15 @@
       }
     ],
     "probes": [
-      {"sequence": 1, "kind": 1, "down_count": 1, "move_count": 0, "up_count": 0, "state_transitions": 0, "is_down": 1, "went_down": 1, "went_up": 0, "x": 180, "y": 0, "x_n": 0.5, "y_n": 0.0},
-      {"sequence": 2, "kind": 2, "down_count": 1, "move_count": 0, "up_count": 1, "state_transitions": 0, "is_down": 0, "went_down": 0, "went_up": 1, "x": 180, "y": 0, "x_n": 0.5, "y_n": 0.0},
+      {"sequence": 1, "kind": 1, "down_count": 1, "move_count": 0, "up_count": 0, "state_transitions": 0, "is_down": 1, "went_down": 1, "went_up": 0, "on_boundary": true},
+      {"sequence": 2, "kind": 2, "down_count": 1, "move_count": 0, "up_count": 1, "state_transitions": 0, "is_down": 0, "went_down": 0, "went_up": 1, "on_boundary": true},
       {"sequence": 3, "kind": 3, "down_count": 2, "move_count": 0, "up_count": 1, "state_transitions": 1, "input_phase": 1, "is_down": 1, "went_down": 1, "went_up": 0, "x": 90, "y": 180, "x_n": 0.25, "y_n": 0.25},
       {"sequence": 4, "kind": 4, "down_count": 2, "move_count": 1, "up_count": 1, "state_transitions": 1, "input_phase": 2, "is_down": 1, "went_down": 0, "went_up": 0, "x_min": 240, "y_min": 480},
       {"sequence": 5, "kind": 5, "down_count": 2, "move_count": 1, "up_count": 2, "state_transitions": 1, "input_phase": 3, "is_down": 0, "went_down": 0, "went_up": 1, "x": 270, "y": 540, "x_n": 0.75, "y_n": 0.75, "state_checksum": 3215}
     ]
   },
   "regions": [
-    {"name": "top_letterbox", "center": [180, -20], "rgb": [0, 0, 0], "tolerance": 12},
+    {"name": "outside_letterbox", "location": "outside_letterbox", "rgb": [0, 0, 0], "tolerance": 12},
     {"name": "released_green_state", "center": [180, 360], "rgb": [31, 214, 92], "tolerance": 30},
     {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
   ]

--- a/samples/android_touch_seam/android_seam_expectations.json
+++ b/samples/android_touch_seam/android_seam_expectations.json
@@ -1,0 +1,42 @@
+{
+  "schema": "stasis.android_seam_expectations.v1",
+  "test_id": "IT-018",
+  "stable_frame": 30,
+  "state_checksum": 2000,
+  "command_trace": 2065138741,
+  "logical_size": [360, 720],
+  "touch": {
+    "completion_sequence": 5,
+    "coordinate_tolerance": 16.0,
+    "safe_viewport": [0, 0, 360, 720],
+    "final_command_trace": 2551385997,
+    "gestures": [
+      {
+        "name": "outside_top_letterbox",
+        "start": [180, -20],
+        "end": [180, -20],
+        "duration_ms": 400,
+        "after_sequence": 2
+      },
+      {
+        "name": "inside_drag",
+        "start": [90, 180],
+        "end": [270, 540],
+        "duration_ms": 700,
+        "after_sequence": 5
+      }
+    ],
+    "probes": [
+      {"sequence": 1, "kind": 1, "down_count": 1, "move_count": 0, "up_count": 0, "state_transitions": 0, "is_down": 1, "went_down": 1, "went_up": 0, "x": 180, "y": 0, "x_n": 0.5, "y_n": 0.0},
+      {"sequence": 2, "kind": 2, "down_count": 1, "move_count": 0, "up_count": 1, "state_transitions": 0, "is_down": 0, "went_down": 0, "went_up": 1, "x": 180, "y": 0, "x_n": 0.5, "y_n": 0.0},
+      {"sequence": 3, "kind": 3, "down_count": 2, "move_count": 0, "up_count": 1, "state_transitions": 1, "input_phase": 1, "is_down": 1, "went_down": 1, "went_up": 0, "x": 90, "y": 180, "x_n": 0.25, "y_n": 0.25},
+      {"sequence": 4, "kind": 4, "down_count": 2, "move_count": 1, "up_count": 1, "state_transitions": 1, "input_phase": 2, "is_down": 1, "went_down": 0, "went_up": 0, "x_min": 240, "y_min": 480},
+      {"sequence": 5, "kind": 5, "down_count": 2, "move_count": 1, "up_count": 2, "state_transitions": 1, "input_phase": 3, "is_down": 0, "went_down": 0, "went_up": 1, "x": 270, "y": 540, "x_n": 0.75, "y_n": 0.75, "state_checksum": 3215}
+    ]
+  },
+  "regions": [
+    {"name": "top_letterbox", "center": [180, -20], "rgb": [0, 0, 0], "tolerance": 12},
+    {"name": "released_green_state", "center": [180, 360], "rgb": [31, 214, 92], "tolerance": 30},
+    {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
+  ]
+}

--- a/samples/android_touch_seam/assets/manifest.json
+++ b/samples/android_touch_seam/assets/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stasis-assets",
+  "version": 1,
+  "assets": []
+}

--- a/samples/android_touch_seam/main.stasis
+++ b/samples/android_touch_seam/main.stasis
@@ -1,0 +1,130 @@
+import "/vendor/stasis/src/stdlib/graphics.stasis";
+
+global seam_state_checksum: i32;
+global seam_probe_sequence: i32;
+global seam_probe_kind: i32;
+global seam_probe_tick: i32;
+global seam_pointer_id: i32;
+global seam_pointer_count: i32;
+global seam_pointer_is_down: i32;
+global seam_pointer_went_down: i32;
+global seam_pointer_went_up: i32;
+global seam_down_count: i32;
+global seam_move_count: i32;
+global seam_up_count: i32;
+global seam_state_transitions: i32;
+global seam_input_phase: i32;
+global seam_pointer_x: f32;
+global seam_pointer_y: f32;
+global seam_pointer_dx: f32;
+global seam_pointer_dy: f32;
+global seam_pointer_x_n: f32;
+global seam_pointer_y_n: f32;
+global seam_safe_x: f32;
+global seam_safe_y: f32;
+global seam_safe_w: f32;
+global seam_safe_h: f32;
+
+function record_probe(kind: i32, pointer: i32): void {
+    seam_probe_sequence += 1;
+    seam_probe_kind = kind;
+    seam_probe_tick = host_tick_index();
+    seam_pointer_id = input_pointer_id(pointer);
+    seam_pointer_count = input_pointer_count();
+    seam_pointer_is_down = 0;
+    if (input_pointer_is_down(pointer)) {
+        seam_pointer_is_down = 1;
+    }
+    seam_pointer_went_down = 0;
+    if (input_pointer_went_down(pointer)) {
+        seam_pointer_went_down = 1;
+    }
+    seam_pointer_went_up = 0;
+    if (input_pointer_went_up(pointer)) {
+        seam_pointer_went_up = 1;
+    }
+    seam_pointer_x = input_pointer_x_logical(pointer);
+    seam_pointer_y = input_pointer_y_logical(pointer);
+    seam_pointer_dx = input_pointer_dx_logical(pointer);
+    seam_pointer_dy = input_pointer_dy_logical(pointer);
+    seam_pointer_x_n = input_pointer_x_n(pointer);
+    seam_pointer_y_n = input_pointer_y_n(pointer);
+    seam_safe_x = gfx_safe_viewport_x();
+    seam_safe_y = gfx_safe_viewport_y();
+    seam_safe_w = gfx_safe_viewport_width();
+    seam_safe_h = gfx_safe_viewport_height();
+}
+
+function main(): i32 {
+    init_window(360, 720, "Stasis Android Touch Seam");
+    seam_state_checksum = 2000;
+    seam_probe_sequence = 0;
+    seam_down_count = 0;
+    seam_move_count = 0;
+    seam_up_count = 0;
+    seam_state_transitions = 0;
+    seam_input_phase = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    if (input_pointer_count() > 1) {
+        let pointer: i32 = 1;
+        if (input_pointer_went_down(pointer)) {
+            seam_down_count += 1;
+            if (input_pointer_x_n(pointer) <= 0.001 ||
+                input_pointer_y_n(pointer) <= 0.001) {
+                record_probe(1, pointer);
+            } else {
+                if (seam_state_transitions == 0) {
+                    seam_state_transitions = 1;
+                    seam_input_phase = 1;
+                }
+                record_probe(3, pointer);
+            }
+        }
+        if (input_pointer_is_down(pointer) && seam_state_transitions == 1 &&
+            seam_move_count == 0 && input_pointer_x_logical(pointer) >= 240.0 &&
+            input_pointer_y_logical(pointer) >= 480.0) {
+            seam_move_count = 1;
+            seam_input_phase = 2;
+            record_probe(4, pointer);
+        }
+        if (input_pointer_went_up(pointer)) {
+            seam_up_count += 1;
+            if (seam_state_transitions == 0) {
+                record_probe(2, pointer);
+            } else {
+                seam_input_phase = 3;
+                record_probe(5, pointer);
+            }
+        }
+    }
+    seam_state_checksum = 2000 + seam_down_count * 100 + seam_move_count * 10 +
+        seam_up_count + seam_state_transitions * 1000 + seam_input_phase;
+    return 0;
+}
+
+function render(): i32 {
+    begin_frame();
+    clear(0.02, 0.03, 0.05, 1.0);
+    fill_rect(20.0, 20.0, 320.0, 680.0, 0.10, 0.12, 0.16, 1.0);
+    if (seam_input_phase == 0) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.72, 0.16, 0.18, 1.0);
+    } else if (seam_input_phase == 1) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.94, 0.76, 0.18, 1.0);
+    } else if (seam_input_phase == 2) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.14, 0.42, 0.92, 1.0);
+    } else {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.12, 0.84, 0.36, 1.0);
+    }
+    if (seam_state_transitions > 0) {
+        fill_rect(252.0, 522.0, 36.0, 36.0, 0.95, 0.20, 0.80, 1.0);
+    }
+    end_frame();
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/samples/android_touch_seam/stasis.json
+++ b/samples/android_touch_seam/stasis.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 1,
+  "name": "android_touch_seam",
+  "entry": "main.stasis",
+  "tests": "tests",
+  "output": "build",
+  "android": {
+    "application_id": "com.stasislang.seam.it018",
+    "label": "Stasis Android Touch Seam",
+    "orientation": "sensorLandscape",
+    "version_code": 1,
+    "version_name": "1.0.0"
+  }
+}

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -144,6 +144,18 @@ def validate_touch_markers(markers: list[dict], expectations: dict) -> list[dict
                     f"Android touch probe {sequence} {field} mismatch: "
                     f"expected={expected[field]} actual={marker.get(field)}"
                 )
+        if expected.get("on_boundary"):
+            normalized = (marker.get("x_n", 0.5), marker.get("y_n", 0.5))
+            boundary_distance = min(
+                abs(value - boundary)
+                for value in normalized
+                for boundary in (0.0, 1.0)
+            )
+            if boundary_distance > 0.02:
+                raise SeamError(
+                    f"Android touch probe {sequence} did not clamp to a viewport "
+                    f"boundary: x_n={normalized[0]} y_n={normalized[1]}"
+                )
         ticks.append(marker.get("probe_tick"))
         observed.append(marker)
     safe_viewport = touch.get("safe_viewport")
@@ -184,6 +196,23 @@ def logical_to_native(
     return (
         max(0, min(native_width - 1, round(offset_x + logical[0] * scale))),
         max(0, min(native_height - 1, round(offset_y + logical[1] * scale))),
+    )
+
+
+def outside_letterbox_point(
+    logical_size: list[int], native_size: tuple[int, int]
+) -> tuple[int, int]:
+    logical_width, logical_height = logical_size
+    native_width, native_height = native_size
+    scale = min(native_width / logical_width, native_height / logical_height)
+    offset_x = (native_width - logical_width * scale) / 2.0
+    offset_y = (native_height - logical_height * scale) / 2.0
+    if offset_x >= 2.0:
+        return round(offset_x / 2.0), native_height // 2
+    if offset_y >= 2.0:
+        return native_width // 2, round(offset_y / 2.0)
+    raise SeamError(
+        "Android touch fixture requires a real letterbox bar on the captured surface"
     )
 
 
@@ -260,8 +289,17 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     offset_y = (height - logical_height * scale) / 2.0
     observed = []
     for region in expectations["regions"]:
-        x = max(0, min(width - 1, round(offset_x + region["center"][0] * scale)))
-        y = max(0, min(height - 1, round(offset_y + region["center"][1] * scale)))
+        if region.get("location") == "outside_letterbox":
+            x, y = outside_letterbox_point(
+                expectations["logical_size"], (width, height)
+            )
+        else:
+            x = max(
+                0, min(width - 1, round(offset_x + region["center"][0] * scale))
+            )
+            y = max(
+                0, min(height - 1, round(offset_y + region["center"][1] * scale))
+            )
         radius = max(2, round(scale * 3))
         samples = [
             pixels[row * width + column]
@@ -469,16 +507,23 @@ def main() -> int:
             }
             injected_gestures = []
             for gesture in expectations["touch"]["gestures"]:
-                start_x, start_y = logical_to_native(
-                    gesture["start"],
-                    expectations["logical_size"],
-                    (native_width, native_height),
-                )
-                end_x, end_y = logical_to_native(
-                    gesture["end"],
-                    expectations["logical_size"],
-                    (native_width, native_height),
-                )
+                if gesture.get("location") == "outside_letterbox":
+                    start_x, start_y = outside_letterbox_point(
+                        expectations["logical_size"],
+                        (native_width, native_height),
+                    )
+                    end_x, end_y = start_x, start_y
+                else:
+                    start_x, start_y = logical_to_native(
+                        gesture["start"],
+                        expectations["logical_size"],
+                        (native_width, native_height),
+                    )
+                    end_x, end_y = logical_to_native(
+                        gesture["end"],
+                        expectations["logical_size"],
+                        (native_width, native_height),
+                    )
                 _run(
                     args.adb,
                     args.serial,

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -63,12 +63,10 @@ def validate_markers(markers: list[dict], expectations: dict) -> dict:
     stable = events.get(("stable", stable_frame))
     if stable is None:
         raise SeamError(f"Android shell did not reach stable frame {stable_frame}")
-    expected = {
-        "state_checksum": expectations["state_checksum"],
-        "command_trace": expectations["command_trace"],
-        "rejected": 0,
-        "validation": 0,
-    }
+    expected = {"rejected": 0, "validation": 0}
+    for key in ("state_checksum", "command_trace"):
+        if key in expectations:
+            expected[key] = expectations[key]
     mismatches = {
         key: {"expected": value, "actual": stable.get(key)}
         for key, value in expected.items()
@@ -86,6 +84,107 @@ def validate_markers(markers: list[dict], expectations: dict) -> dict:
     if mismatches:
         raise SeamError(f"Android stable-frame marker mismatch: {mismatches}")
     return stable
+
+
+def validate_touch_markers(markers: list[dict], expectations: dict) -> list[dict]:
+    touch = expectations["touch"]
+    probes = {
+        item.get("probe_sequence"): item
+        for item in markers
+        if item.get("event") == "probe"
+    }
+    observed = []
+    ticks = []
+    exact_fields = (
+        "probe_kind",
+        "down_count",
+        "move_count",
+        "up_count",
+        "state_transitions",
+        "input_phase",
+        "is_down",
+        "went_down",
+        "went_up",
+        "state_checksum",
+    )
+    tolerance = touch["coordinate_tolerance"]
+    for expected in touch["probes"]:
+        sequence = expected["sequence"]
+        marker = probes.get(sequence)
+        if marker is None:
+            raise SeamError(f"Android touch seam is missing probe sequence {sequence}")
+        for field in exact_fields:
+            expected_key = "kind" if field == "probe_kind" else field
+            if expected_key in expected and marker.get(field) != expected[expected_key]:
+                raise SeamError(
+                    f"Android touch probe {sequence} {field} mismatch: "
+                    f"expected={expected[expected_key]} actual={marker.get(field)}"
+                )
+        if marker.get("pointer_id") != 1 or marker.get("pointer_count", 0) < 2:
+            raise SeamError(
+                f"Android touch probe {sequence} pointer identity mismatch: "
+                f"id={marker.get('pointer_id')} count={marker.get('pointer_count')}"
+            )
+        for field in ("x", "y"):
+            if field in expected and abs(marker.get(field, 0.0) - expected[field]) > tolerance:
+                raise SeamError(
+                    f"Android touch probe {sequence} {field} mismatch: "
+                    f"expected={expected[field]} actual={marker.get(field)} "
+                    f"tolerance={tolerance}"
+                )
+            minimum = expected.get(f"{field}_min")
+            if minimum is not None and marker.get(field, 0.0) < minimum:
+                raise SeamError(
+                    f"Android touch probe {sequence} {field} below minimum: "
+                    f"expected>={minimum} actual={marker.get(field)}"
+                )
+        for field in ("x_n", "y_n"):
+            if field in expected and abs(marker.get(field, 0.0) - expected[field]) > 0.05:
+                raise SeamError(
+                    f"Android touch probe {sequence} {field} mismatch: "
+                    f"expected={expected[field]} actual={marker.get(field)}"
+                )
+        ticks.append(marker.get("probe_tick"))
+        observed.append(marker)
+    safe_viewport = touch.get("safe_viewport")
+    if safe_viewport:
+        for marker in observed:
+            for field, expected in zip(
+                ("safe_x", "safe_y", "safe_w", "safe_h"), safe_viewport
+            ):
+                if abs(marker.get(field, 0.0) - expected) > tolerance:
+                    raise SeamError(
+                        f"Android touch probe {marker['probe_sequence']} {field} mismatch: "
+                        f"expected={expected} actual={marker.get(field)} tolerance={tolerance}"
+                    )
+    if any(not isinstance(tick, int) for tick in ticks) or any(
+        current >= following for current, following in zip(ticks, ticks[1:])
+    ):
+        raise SeamError(f"Android touch probe ticks are not strictly ordered: {ticks}")
+    final = observed[-1]
+    if (
+        "final_command_trace" in touch
+        and final.get("command_trace") != touch["final_command_trace"]
+    ):
+        raise SeamError(
+            "Android touch final command trace mismatch: "
+            f"expected={touch['final_command_trace']} actual={final.get('command_trace')}"
+        )
+    return observed
+
+
+def logical_to_native(
+    logical: list[float], logical_size: list[int], native_size: tuple[int, int]
+) -> tuple[int, int]:
+    logical_width, logical_height = logical_size
+    native_width, native_height = native_size
+    scale = min(native_width / logical_width, native_height / logical_height)
+    offset_x = (native_width - logical_width * scale) / 2.0
+    offset_y = (native_height - logical_height * scale) / 2.0
+    return (
+        max(0, min(native_width - 1, round(offset_x + logical[0] * scale))),
+        max(0, min(native_height - 1, round(offset_y + logical[1] * scale))),
+    )
 
 
 def read_png_rgb(path: Path) -> tuple[int, int, list[tuple[int, int, int]]]:
@@ -256,6 +355,7 @@ def main() -> int:
     test_id = expectations["test_id"]
     args.output.mkdir(parents=True, exist_ok=True)
     log_path = args.output / "logcat.txt"
+    initial_capture_path = args.output / "initial-frame.png"
     capture_path = args.output / "stable-frame.png"
     evidence_path = args.output / "evidence.json"
     preinstalled = bool(
@@ -350,13 +450,83 @@ def main() -> int:
             if any(item.get("event") == "stable" for item in markers):
                 break
             time.sleep(1)
-        log_path.write_text(log, encoding="utf-8")
         stable = validate_markers(markers, expectations)
         first_pid = _run(
             args.adb, args.serial, "shell", "pidof", package_id, required=False
         ).strip()
         if not first_pid:
             raise SeamError("generated Android shell exited before capture")
+        touch_probes = []
+        if "touch" in expectations:
+            initial_capture_path.write_bytes(
+                _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
+            )
+            native_width, native_height, _ = read_png_rgb(initial_capture_path)
+            evidence["artifacts"]["initial_capture"] = str(initial_capture_path)
+            evidence["input_surface"] = {
+                "width": native_width,
+                "height": native_height,
+            }
+            injected_gestures = []
+            for gesture in expectations["touch"]["gestures"]:
+                start_x, start_y = logical_to_native(
+                    gesture["start"],
+                    expectations["logical_size"],
+                    (native_width, native_height),
+                )
+                end_x, end_y = logical_to_native(
+                    gesture["end"],
+                    expectations["logical_size"],
+                    (native_width, native_height),
+                )
+                _run(
+                    args.adb,
+                    args.serial,
+                    "shell",
+                    "input",
+                    "touchscreen",
+                    "swipe",
+                    str(start_x),
+                    str(start_y),
+                    str(end_x),
+                    str(end_y),
+                    str(gesture["duration_ms"]),
+                )
+                injected_gestures.append(
+                    {
+                        "name": gesture["name"],
+                        "start": [start_x, start_y],
+                        "end": [end_x, end_y],
+                        "duration_ms": gesture["duration_ms"],
+                    }
+                )
+                gesture_deadline = min(deadline, time.monotonic() + 10)
+                while time.monotonic() < gesture_deadline:
+                    log = _run(
+                        args.adb,
+                        args.serial,
+                        "logcat",
+                        "-d",
+                        "-v",
+                        "brief",
+                        "Stasis:I",
+                        "*:S",
+                    )
+                    markers = parse_markers(log, test_id)
+                    if any(
+                        item.get("probe_sequence") == gesture["after_sequence"]
+                        for item in markers
+                    ):
+                        break
+                    time.sleep(0.25)
+                else:
+                    raise SeamError(
+                        f"Android gesture {gesture['name']} did not reach probe "
+                        f"sequence {gesture['after_sequence']}"
+                    )
+            touch_probes = validate_touch_markers(markers, expectations)
+            evidence["injected_gestures"] = injected_gestures
+        log_path.write_text(log, encoding="utf-8")
         capture_path.write_bytes(
             _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
         )
@@ -376,6 +546,8 @@ def main() -> int:
                 "regions": regions,
             }
         )
+        if touch_probes:
+            evidence["touch_probes"] = touch_probes
     except (OSError, KeyError, ValueError, SeamError, zlib.error) as error:
         evidence["failure"] = str(error)
         raise

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -114,6 +114,99 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             )
             self.assertEqual([item["name"] for item in observed], ["red", "teal"])
 
+    def test_maps_logical_touch_points_through_letterbox(self):
+        self.assertEqual(
+            seam.logical_to_native([180, -20], [360, 720], (1080, 2400)),
+            (540, 60),
+        )
+        self.assertEqual(
+            seam.logical_to_native([270, 540], [360, 720], (1080, 2400)),
+            (810, 1740),
+        )
+
+    def test_validates_ordered_android_touch_probes(self):
+        markers = []
+        expected_probes = []
+        kinds = [1, 2, 3, 4, 5]
+        counts = [(1, 0, 0), (1, 0, 1), (2, 0, 1), (2, 1, 1), (2, 1, 2)]
+        for index, (kind, count) in enumerate(zip(kinds, counts), start=1):
+            marker = {
+                "event": "probe",
+                "probe_sequence": index,
+                "probe_kind": kind,
+                "probe_tick": 40 + index * 5,
+                "pointer_id": 1,
+                "pointer_count": 2,
+                "down_count": count[0],
+                "move_count": count[1],
+                "up_count": count[2],
+                "state_transitions": int(index >= 3),
+                "is_down": int(index in (1, 3, 4)),
+                "went_down": int(index in (1, 3)),
+                "went_up": int(index in (2, 5)),
+                "input_phase": max(0, index - 2),
+                "x": 0.0 if index < 3 else 90.0 * (index - 2),
+                "y": 360.0 if index < 3 else 180.0 * (index - 2),
+                "x_n": 0.0 if index < 3 else 0.25 * (index - 2),
+                "y_n": 0.5 if index < 3 else 0.25 * (index - 2),
+                "state_checksum": 3215 if index == 5 else 0,
+                "command_trace": 77,
+            }
+            markers.append(marker)
+            expected = {
+                "sequence": index,
+                "kind": kind,
+                "down_count": count[0],
+                "move_count": count[1],
+                "up_count": count[2],
+                "state_transitions": int(index >= 3),
+                "is_down": marker["is_down"],
+                "went_down": marker["went_down"],
+                "went_up": marker["went_up"],
+            }
+            if index == 5:
+                expected["state_checksum"] = 3215
+            expected_probes.append(expected)
+        observed = seam.validate_touch_markers(
+            markers,
+            {
+                "touch": {
+                    "coordinate_tolerance": 16.0,
+                    "final_command_trace": 77,
+                    "probes": expected_probes,
+                }
+            },
+        )
+        self.assertEqual(
+            [item["probe_sequence"] for item in observed], [1, 2, 3, 4, 5]
+        )
+
+    def test_rejects_touch_probes_on_the_same_tick(self):
+        markers = [
+            {
+                "event": "probe",
+                "probe_sequence": sequence,
+                "probe_kind": sequence,
+                "probe_tick": 42,
+                "pointer_id": 1,
+                "pointer_count": 2,
+            }
+            for sequence in (1, 2)
+        ]
+        with self.assertRaisesRegex(seam.SeamError, "strictly ordered"):
+            seam.validate_touch_markers(
+                markers,
+                {
+                    "touch": {
+                        "coordinate_tolerance": 1.0,
+                        "probes": [
+                            {"sequence": 1, "kind": 1},
+                            {"sequence": 2, "kind": 2},
+                        ],
+                    }
+                },
+            )
+
     def test_cleanup_continues_after_force_stop_failure(self):
         calls = []
 

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -114,10 +114,14 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             )
             self.assertEqual([item["name"] for item in observed], ["red", "teal"])
 
-    def test_maps_logical_touch_points_through_letterbox(self):
+    def test_selects_real_letterbox_for_each_surface_orientation(self):
         self.assertEqual(
-            seam.logical_to_native([180, -20], [360, 720], (1080, 2400)),
+            seam.outside_letterbox_point([360, 720], (1080, 2400)),
             (540, 60),
+        )
+        self.assertEqual(
+            seam.outside_letterbox_point([360, 720], (1920, 1080)),
+            (345, 540),
         )
         self.assertEqual(
             seam.logical_to_native([270, 540], [360, 720], (1080, 2400)),


### PR DESCRIPTION
## Summary

- reuse the generated Android release-shell harness for descriptor-selected seam fixtures
- inject real Android touchscreen gestures through SDL into HostFrame and generated AOT Stasis
- verify ordered pointer edges/ticks, logical and normalized coordinates, safe viewport, one state transition, deterministic frame traces, named capture regions, and cleanup
- register IT-018 in the bounded self-hosted Android device workflow

## Validation

- `python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_verify_android_native_library` (10 passed)
- generated-shell assembly test passed by direct execution of the freshly built Rust test binary
- `cargo fmt --all -- --check`
- `git diff --check`
- IT-018 full build/install/device flow passed on `Stasis_API_35`; repeated device acceptance against the identical APK reproduced final checksum `3215` and trace `2551385997`
- IT-017 full regression flow passed: checksum `1210`, trace `1947640508`, 30 accepted/presented frames
- both test packages removed, device setting restored, owned emulator stopped

## Work summary

Good: reusing one descriptor-driven package/install/capture/cleanup driver kept Android seam ownership explicit and made IT-017 regression verification cheap.

Bad: the first geometry assumption treated the device as landscape, and the first rendered marker embedded variable raw touch coordinates in the trace.

Adjustment: derive injection coordinates from the captured surface and logical viewport, preserve raw coordinates as tolerance-checked evidence, and render a semantic state marker for deterministic trace assertions.

Theory gained: Android orientation metadata does not determine the captured SDL surface geometry; the fixture logical canvas and observed surface jointly define letterbox input mapping. A real outside-bar gesture clamps at HostFrame without changing Stasis state, while a content gesture advances exactly one semantic transition. The adjacent prediction is that rotation testing must recompute injection geometry from each post-rotation capture rather than reuse orientation assumptions.