### PR TITLE
build: deny Rust warnings by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[build]
+rustflags = ["-D", "warnings"]
+
 [target.'cfg(windows)']
 runner = [".cargo\\stasis-sign-and-run.cmd"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[build]
-rustflags = ["-D", "warnings"]
-
 [target.'cfg(windows)']
 runner = [".cargo\\stasis-sign-and-run.cmd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+[workspace.lints.rust]
+warnings = "deny"
+
 [workspace.dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/apps/stasis/Cargo.toml
+++ b/apps/stasis/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 stasis_runner = { path = "../../crates/stasis_runner" }
 stasis_jit = { path = "../../crates/stasis_jit" }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -6044,7 +6044,7 @@ mod tests {
             &candidate,
             &preview,
             true,
-            || stasis_dynload::invoke_code_swap_hook(mutating_rejecting_hook as usize),
+            || stasis_dynload::invoke_code_swap_hook(mutating_rejecting_hook as *const () as usize),
             Result::is_ok,
         )
         .expect("runtime transaction should execute")
@@ -6150,7 +6150,7 @@ mod tests {
             request_id,
             vec![JitCodePtrOverride {
                 fn_id: hook_fn_id,
-                code_ptr: mutating_rejecting_hook as usize as u64,
+                code_ptr: mutating_rejecting_hook as *const () as usize as u64,
             }],
         )]);
 

--- a/crates/stasis_ai/Cargo.toml
+++ b/crates/stasis_ai/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/stasis_android_bridge/Cargo.toml
+++ b/crates/stasis_android_bridge/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 crate-type = ["rlib", "cdylib"]

--- a/crates/stasis_assets/Cargo.toml
+++ b/crates/stasis_assets/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/stasis_compiler/Cargo.toml
+++ b/crates/stasis_compiler/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 

--- a/crates/stasis_dynload/Cargo.toml
+++ b/crates/stasis_dynload/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 path = "src/lib.rs"
 crate-type = ["rlib", "cdylib", "staticlib"]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -6001,9 +6001,9 @@ mod tests {
         let render_trampoline = jit_host_render_trampoline_ptr();
         begin_jit_host_entry_session(JitHostEntryTargets {
             revision: 41,
-            main: host_entry_one as usize,
-            tick: host_entry_one as usize,
-            render: host_entry_one as usize,
+            main: host_entry_one as *const () as usize,
+            tick: host_entry_one as *const () as usize,
+            render: host_entry_one as *const () as usize,
             on_code_swap: None,
         })
         .expect("publish first host-entry table");
@@ -6012,9 +6012,9 @@ mod tests {
 
         publish_jit_host_entry_targets(JitHostEntryTargets {
             revision: 42,
-            main: host_entry_two as usize,
-            tick: host_entry_two as usize,
-            render: host_entry_two as usize,
+            main: host_entry_two as *const () as usize,
+            tick: host_entry_two as *const () as usize,
+            render: host_entry_two as *const () as usize,
             on_code_swap: None,
         })
         .expect("publish second host-entry table");
@@ -6025,9 +6025,9 @@ mod tests {
         assert_eq!(jit_host_entry_targets().unwrap().revision, 42);
         assert!(publish_jit_host_entry_targets(JitHostEntryTargets {
             revision: 41,
-            main: host_entry_one as usize,
-            tick: host_entry_one as usize,
-            render: host_entry_one as usize,
+            main: host_entry_one as *const () as usize,
+            tick: host_entry_one as *const () as usize,
+            render: host_entry_one as *const () as usize,
             on_code_swap: None,
         })
         .expect_err("stale publication")

--- a/crates/stasis_jit/Cargo.toml
+++ b/crates/stasis_jit/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 stasis_runner = { path = "../stasis_runner" }
 

--- a/crates/stasis_language_service/Cargo.toml
+++ b/crates/stasis_language_service/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 stasis_compiler = { path = "../stasis_compiler" }
 stasis_runner = { path = "../stasis_runner" }

--- a/crates/stasis_lsp/Cargo.toml
+++ b/crates/stasis_lsp/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 lsp-server = "0.10.0"
 lsp-types = "0.97.0"

--- a/crates/stasis_runner/Cargo.toml
+++ b/crates/stasis_runner/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- define `warnings = "deny"` as an inherited workspace Rust lint
- opt every first-party Stasis package into the workspace lint policy
- keep nested/cloned third-party workspaces, including the Android Codex native checkout, outside the policy
- fix the 11 `function_casts_as_integer` warnings exposed by the linked PR CI job by casting function items through `*const ()`
- keep the production ABI and runtime behavior unchanged

## Why

The repository previously denied warnings only in six release-mode crate roots. Debug test builds could therefore succeed while emitting warnings, which is too easy to miss when changes are produced at high volume. Workspace lint inheritance makes warnings actionable immediately for both human and AI contributors while scoping enforcement to Stasis-owned packages.

## Validation

- `python tools/cargo_cache.py run -- cargo check --workspace --all-targets` (passed with workspace warning denial active)
- `python tools/cargo_cache.py run -- cargo test -p stasis_dynload host_entry_trampolines_publish_one_immutable_target_table -- --test-threads=1` (1 passed)
- `python tools/cargo_cache.py run -- cargo test -p stasis --lib rejection_restores -- --test-threads=1` (2 passed)
- `python tools/cargo_cache.py run -- cargo test --workspace --all-targets -- --test-threads=1`
  - affected packages compiled without `function_casts_as_integer` warnings
  - app library target: 268 passed
  - later binary target has one unrelated existing failure: `toolchain_cli::tests::mobile_shells_are_platform_projects_over_one_shared_runtime` expects `tick avg=`

Reviewed run: https://github.com/benwmaddox/StasisLang/actions/runs/31487624537/job/93766545421