### PR TITLE
test: round-trip Android orientation metrics

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -45,3 +45,20 @@ jobs:
           name: android-touch-roundtrip-seam
           path: artifacts/android_touch_roundtrip/e
           if-no-files-found: warn
+
+      - name: Run Android release orientation metrics seam
+        shell: powershell
+        run: >-
+          & ./mobile/android/test_release_shell.ps1
+          -Serial "$env:ANDROID_SERIAL"
+          -ProjectPath "samples/android_orientation_seam"
+          -OutputPath "artifacts/android_orientation_metrics"
+          -TotalTimeoutSeconds 840
+
+      - name: Upload Android orientation metrics evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-orientation-metrics-seam
+          path: artifacts/android_orientation_metrics/e
+          if-no-files-found: warn

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generated-release-shell:
     runs-on: [self-hosted, Windows, android-device]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/mobile/shells/android/README.md
+++ b/mobile/shells/android/README.md
@@ -47,3 +47,18 @@ normalized coordinates, one Stasis state transition, and the resulting frame:
 mobile/android/test_release_shell.ps1 -Serial <device-serial> `
     -ProjectPath samples/android_touch_seam
 ```
+
+IT-019 drives an odd `1001 x 1601` display override through portrait,
+landscape, and restored portrait. Each stage waits for the AOT guest to observe
+the new HostFrame display generation during `tick`, injects a logical-coordinate
+touch, and verifies the same frame's guest metrics, pointer transform, command
+trace, and named pixel regions:
+
+```powershell
+mobile/android/test_release_shell.ps1 -Serial <device-serial> `
+    -ProjectPath samples/android_orientation_seam
+```
+
+The driver independently restores any prior display-size override, user and
+accelerometer rotation settings, immersive confirmation, package installation,
+and process state even when an assertion fails.

--- a/mobile/shells/common/stasis_mobile_main.c
+++ b/mobile/shells/common/stasis_mobile_main.c
@@ -35,8 +35,8 @@ static float seam_f32(const char *path) {
 }
 
 static void log_seam_marker(const char *test_id, const char *event, int32_t frame) {
-    int32_t render[5] = {0};
-    int has_render = stasis_test_get_render_submission_state(render, 5);
+    int32_t render[7] = {0};
+    int has_render = stasis_test_get_render_submission_state(render, 7);
     int32_t checksum = seam_i32("seam_state_checksum");
     SDL_Log(
         "Stasis seam: {\"schema\":\"stasis.seam_test.v1\",\"test_id\":\"%s\","
@@ -49,7 +49,13 @@ static void log_seam_marker(const char *test_id, const char *event, int32_t fram
         "\"move_count\":%d,\"up_count\":%d,\"state_transitions\":%d,"
         "\"input_phase\":%d,\"x\":%.3f,\"y\":%.3f,"
         "\"dx\":%.3f,\"dy\":%.3f,\"x_n\":%.4f,\"y_n\":%.4f,"
-        "\"safe_x\":%.3f,\"safe_y\":%.3f,\"safe_w\":%.3f,\"safe_h\":%.3f}",
+        "\"safe_x\":%.3f,\"safe_y\":%.3f,\"safe_w\":%.3f,\"safe_h\":%.3f,"
+        "\"logical_w\":%.3f,\"logical_h\":%.3f,"
+        "\"native_w\":%d,\"native_h\":%d,"
+        "\"drawable_w\":%d,\"drawable_h\":%d,"
+        "\"display_generation\":%d,\"density_generation\":%d,"
+        "\"frame_display_generation\":%d,\"frame_density_generation\":%d,"
+        "\"content_scale\":%.4f,\"raster_scale\":%.4f}",
         test_id,
         event,
         frame,
@@ -81,7 +87,19 @@ static void log_seam_marker(const char *test_id, const char *event, int32_t fram
         seam_f32("seam_safe_x"),
         seam_f32("seam_safe_y"),
         seam_f32("seam_safe_w"),
-        seam_f32("seam_safe_h")
+        seam_f32("seam_safe_h"),
+        seam_f32("seam_logical_w"),
+        seam_f32("seam_logical_h"),
+        seam_i32("seam_native_w"),
+        seam_i32("seam_native_h"),
+        seam_i32("seam_drawable_w"),
+        seam_i32("seam_drawable_h"),
+        seam_i32("seam_display_generation"),
+        seam_i32("seam_density_generation"),
+        has_render ? render[5] : 0,
+        has_render ? render[6] : 0,
+        seam_f32("seam_content_scale"),
+        seam_f32("seam_raster_scale")
     );
 }
 #endif

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -161,6 +161,8 @@ static uint32_t g_render_rejected_frames = 0;
 static uint32_t g_render_presented_frames = 0;
 static uint32_t g_render_last_trace = 0;
 static StasisRenderValidation g_render_last_validation = STASIS_RENDER_VALID;
+static int32_t g_render_last_display_generation = 0;
+static int32_t g_render_last_density_generation = 0;
 static uint32_t g_render_logged_validation_mask = 0;
 static bool g_render_contract_logged = false;
 typedef struct {
@@ -4857,6 +4859,10 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
     g_render_last_validation = STASIS_RENDER_VALID;
     g_render_last_trace = stasis_render_trace(cmd_i32, cmd_f32, cmd_u8);
     stasis_stamp_display_metadata(cmd_i32);
+    g_render_last_display_generation =
+        cmd_i32[STASIS_RENDER_I_DISPLAY_GENERATION];
+    g_render_last_density_generation =
+        cmd_i32[STASIS_RENDER_I_DENSITY_GENERATION];
     g_perf_render_started_counter = SDL_GetPerformanceCounter();
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
@@ -4975,6 +4981,10 @@ STASIS_EXPORT int stasis_test_get_render_submission_state(int32_t* out_i32, int3
     out_i32[2] = (int32_t)g_render_presented_frames;
     out_i32[3] = (int32_t)g_render_last_validation;
     out_i32[4] = (int32_t)g_render_last_trace;
+    if (capacity >= 7) {
+        out_i32[5] = g_render_last_display_generation;
+        out_i32[6] = g_render_last_density_generation;
+    }
     return 1;
 }
 
@@ -6152,6 +6162,8 @@ STASIS_EXPORT void stasis_shutdown(void) {
     g_render_presented_frames = 0;
     g_render_last_trace = 0;
     g_render_last_validation = STASIS_RENDER_VALID;
+    g_render_last_display_generation = 0;
+    g_render_last_density_generation = 0;
     g_render_logged_validation_mask = 0;
     g_render_contract_logged = false;
     g_resource_frame_ready = false;

--- a/samples/android_orientation_seam/android_seam_expectations.json
+++ b/samples/android_orientation_seam/android_seam_expectations.json
@@ -1,0 +1,57 @@
+{
+  "schema": "stasis.android_seam_expectations.v1",
+  "test_id": "IT-019",
+  "stable_frame": 30,
+  "state_checksum": 4000,
+  "logical_size": [360, 720],
+  "orientation": {
+    "display_size": [1001, 1601],
+    "coordinate_tolerance": 16.0,
+    "surface_tolerance": 2,
+    "safe_viewport": [0, 0, 360, 720],
+    "touch": [270, 540],
+    "stages": [
+      {
+        "name": "portrait",
+        "rotation": 0,
+        "sequence": 1,
+        "kind": 1,
+        "orientation": "portrait",
+        "regions": [
+          {"name": "outside_letterbox", "location": "outside_letterbox", "rgb": [0, 0, 0], "tolerance": 12},
+          {"name": "portrait_state", "center": [180, 360], "rgb": [31, 214, 92], "tolerance": 30},
+          {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
+        ]
+      },
+      {
+        "name": "landscape",
+        "rotation": 1,
+        "sequence": 2,
+        "kind": 2,
+        "orientation": "landscape",
+        "regions": [
+          {"name": "outside_letterbox", "location": "outside_letterbox", "rgb": [0, 0, 0], "tolerance": 12},
+          {"name": "landscape_state", "center": [180, 360], "rgb": [36, 107, 235], "tolerance": 30},
+          {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
+        ]
+      },
+      {
+        "name": "restored_portrait",
+        "rotation": 0,
+        "sequence": 3,
+        "kind": 1,
+        "orientation": "portrait",
+        "regions": [
+          {"name": "outside_letterbox", "location": "outside_letterbox", "rgb": [0, 0, 0], "tolerance": 12},
+          {"name": "restored_state", "center": [180, 360], "rgb": [235, 92, 41], "tolerance": 30},
+          {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
+        ]
+      }
+    ]
+  },
+  "regions": [
+    {"name": "outside_letterbox", "location": "outside_letterbox", "rgb": [0, 0, 0], "tolerance": 12},
+    {"name": "restored_state", "center": [180, 360], "rgb": [235, 92, 41], "tolerance": 30},
+    {"name": "pointer_marker", "center": [270, 540], "rgb": [242, 51, 204], "tolerance": 30}
+  ]
+}

--- a/samples/android_orientation_seam/assets/manifest.json
+++ b/samples/android_orientation_seam/assets/manifest.json
@@ -1,0 +1,5 @@
+{
+  "schema": "stasis-assets",
+  "version": 1,
+  "assets": []
+}

--- a/samples/android_orientation_seam/main.stasis
+++ b/samples/android_orientation_seam/main.stasis
@@ -1,0 +1,125 @@
+import "/vendor/stasis/src/stdlib/graphics.stasis";
+
+global seam_state_checksum: i32;
+global seam_probe_sequence: i32;
+global seam_probe_kind: i32;
+global seam_probe_tick: i32;
+global seam_pointer_id: i32;
+global seam_pointer_count: i32;
+global seam_pointer_is_down: i32;
+global seam_pointer_went_down: i32;
+global seam_pointer_went_up: i32;
+global seam_pointer_x: f32;
+global seam_pointer_y: f32;
+global seam_pointer_x_n: f32;
+global seam_pointer_y_n: f32;
+global seam_safe_x: f32;
+global seam_safe_y: f32;
+global seam_safe_w: f32;
+global seam_safe_h: f32;
+global seam_logical_w: f32;
+global seam_logical_h: f32;
+global seam_native_w: i32;
+global seam_native_h: i32;
+global seam_drawable_w: i32;
+global seam_drawable_h: i32;
+global seam_display_generation: i32;
+global seam_density_generation: i32;
+global seam_content_scale: f32;
+global seam_raster_scale: f32;
+global seam_pending_generation: i32;
+global seam_last_generation: i32;
+
+// Copy HostFrame display lanes into guest-owned evidence before rendering.
+function snapshot_host_frame_display(): void {
+    seam_logical_w = gfx_logical_width();
+    seam_logical_h = gfx_logical_height();
+    seam_native_w = gfx_native_width_px();
+    seam_native_h = gfx_native_height_px();
+    seam_drawable_w = gfx_drawable_width_px();
+    seam_drawable_h = gfx_drawable_height_px();
+    seam_display_generation = gfx_display_generation();
+    seam_density_generation = gfx_density_generation();
+    seam_content_scale = gfx_content_scale();
+    seam_raster_scale = gfx_raster_scale();
+    seam_safe_x = gfx_safe_viewport_x();
+    seam_safe_y = gfx_safe_viewport_y();
+    seam_safe_w = gfx_safe_viewport_width();
+    seam_safe_h = gfx_safe_viewport_height();
+}
+
+function record_probe(pointer: i32): void {
+    snapshot_host_frame_display();
+    seam_probe_sequence += 1;
+    seam_probe_kind = 1;
+    if (seam_native_w > seam_native_h) {
+        seam_probe_kind = 2;
+    }
+    seam_probe_tick = host_tick_index();
+    seam_pointer_id = input_pointer_id(pointer);
+    seam_pointer_count = input_pointer_count();
+    seam_pointer_is_down = 0;
+    if (input_pointer_is_down(pointer)) {
+        seam_pointer_is_down = 1;
+    }
+    seam_pointer_went_down = 0;
+    if (input_pointer_went_down(pointer)) {
+        seam_pointer_went_down = 1;
+    }
+    seam_pointer_went_up = 0;
+    if (input_pointer_went_up(pointer)) {
+        seam_pointer_went_up = 1;
+    }
+    seam_pointer_x = input_pointer_x_logical(pointer);
+    seam_pointer_y = input_pointer_y_logical(pointer);
+    seam_pointer_x_n = input_pointer_x_n(pointer);
+    seam_pointer_y_n = input_pointer_y_n(pointer);
+    seam_pending_generation = 0;
+    seam_state_checksum = 4000 + seam_probe_sequence * 100 + seam_probe_kind * 10 + seam_display_generation;
+}
+
+function main(): i32 {
+    init_window(360, 720, "Stasis Android Orientation Seam");
+    seam_state_checksum = 4000;
+    seam_probe_sequence = 0;
+    seam_pending_generation = 0;
+    seam_last_generation = 0;
+    return 0;
+}
+
+function tick(): i32 {
+    let generation: i32 = gfx_display_generation();
+    if (generation > 0 && generation != seam_last_generation) {
+        snapshot_host_frame_display();
+        seam_last_generation = generation;
+        seam_pending_generation = generation;
+    }
+    if (seam_pending_generation > 0 && input_pointer_count() > 1 && input_pointer_went_up(1)) {
+        record_probe(1);
+    }
+    return 0;
+}
+
+function render(): i32 {
+    begin_frame();
+    clear(0.0, 0.0, 0.0, 1.0);
+    fill_rect(20.0, 20.0, 320.0, 680.0, 0.10, 0.12, 0.16, 1.0);
+    if (seam_probe_sequence == 1) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.12, 0.84, 0.36, 1.0);
+    } else if (seam_probe_sequence == 2) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.14, 0.42, 0.92, 1.0);
+    } else if (seam_probe_sequence >= 3) {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.92, 0.36, 0.16, 1.0);
+    } else {
+        fill_rect(60.0, 260.0, 240.0, 200.0, 0.72, 0.16, 0.18, 1.0);
+    }
+    if (seam_probe_sequence > 0) {
+        fill_rect(seam_pointer_x - 18.0, seam_pointer_y - 18.0, 36.0, 36.0, 0.95, 0.20, 0.80, 1.0);
+    }
+    end_frame();
+    return 0;
+}
+
+function on_code_swap(): void {
+    return;
+}

--- a/samples/android_orientation_seam/stasis.json
+++ b/samples/android_orientation_seam/stasis.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 1,
+  "name": "android_orientation_seam",
+  "entry": "main.stasis",
+  "tests": "tests",
+  "output": "build",
+  "android": {
+    "application_id": "com.stasislang.seam.it019",
+    "label": "Stasis Android Orientation Seam",
+    "orientation": "unspecified",
+    "version_code": 1,
+    "version_name": "1.0.0"
+  }
+}

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -185,6 +185,174 @@ def validate_touch_markers(markers: list[dict], expectations: dict) -> list[dict
     return observed
 
 
+def validate_orientation_markers(
+    markers: list[dict], expectations: dict, surfaces: dict[str, tuple[int, int]]
+) -> list[dict]:
+    orientation = expectations["orientation"]
+    probes = {
+        item.get("probe_sequence"): item
+        for item in markers
+        if item.get("event") == "probe"
+    }
+    logical_width, logical_height = expectations["logical_size"]
+    coordinate_tolerance = orientation["coordinate_tolerance"]
+    surface_tolerance = orientation["surface_tolerance"]
+    touch_x, touch_y = orientation["touch"]
+    configured_width, configured_height = orientation["display_size"]
+    observed = []
+    for stage in orientation["stages"]:
+        sequence = stage["sequence"]
+        marker = probes.get(sequence)
+        if marker is None:
+            raise SeamError(
+                f"Android orientation seam is missing probe sequence {sequence}"
+            )
+        if marker.get("probe_kind") != stage["kind"]:
+            raise SeamError(
+                f"Android orientation probe {sequence} kind mismatch: "
+                f"expected={stage['kind']} actual={marker.get('probe_kind')}"
+            )
+        for field, expected, tolerance in (
+            ("logical_w", logical_width, 0.01),
+            ("logical_h", logical_height, 0.01),
+            ("x", touch_x, coordinate_tolerance),
+            ("y", touch_y, coordinate_tolerance),
+            ("x_n", touch_x / logical_width, 0.05),
+            ("y_n", touch_y / logical_height, 0.05),
+        ):
+            if abs(marker.get(field, 0.0) - expected) > tolerance:
+                raise SeamError(
+                    f"Android orientation probe {sequence} {field} mismatch: "
+                    f"expected={expected} actual={marker.get(field)} "
+                    f"tolerance={tolerance}"
+                )
+        if (
+            marker.get("pointer_id") != 1
+            or marker.get("pointer_count", 0) < 2
+            or marker.get("went_up") != 1
+        ):
+            raise SeamError(
+                f"Android orientation probe {sequence} pointer mismatch: "
+                f"id={marker.get('pointer_id')} count={marker.get('pointer_count')} "
+                f"went_up={marker.get('went_up')}"
+            )
+        surface = surfaces.get(stage["name"])
+        if surface is None:
+            raise SeamError(f"Android orientation stage {stage['name']} has no capture")
+        surface_width, surface_height = surface
+        expected_surface = (
+            (configured_width, configured_height)
+            if stage["orientation"] == "portrait"
+            else (configured_height, configured_width)
+        )
+        if any(
+            abs(actual - expected) > surface_tolerance
+            for actual, expected in zip(surface, expected_surface)
+        ):
+            raise SeamError(
+                f"Android orientation stage {stage['name']} configured size mismatch: "
+                f"expected={expected_surface[0]}x{expected_surface[1]} "
+                f"actual={surface_width}x{surface_height} "
+                f"tolerance={surface_tolerance}"
+            )
+        if surface_width % 2 == 0 or surface_height % 2 == 0:
+            raise SeamError(
+                f"Android orientation stage {stage['name']} is not odd-sized: "
+                f"{surface_width}x{surface_height}"
+            )
+        is_portrait = surface_height > surface_width
+        if is_portrait != (stage["orientation"] == "portrait"):
+            raise SeamError(
+                f"Android orientation stage {stage['name']} surface mismatch: "
+                f"{surface_width}x{surface_height}"
+            )
+        for prefix in ("native", "drawable"):
+            actual_width = marker.get(f"{prefix}_w", 0)
+            actual_height = marker.get(f"{prefix}_h", 0)
+            if (
+                abs(actual_width - surface_width) > surface_tolerance
+                or abs(actual_height - surface_height) > surface_tolerance
+            ):
+                raise SeamError(
+                    f"Android orientation probe {sequence} {prefix} size mismatch: "
+                    f"expected={surface_width}x{surface_height} "
+                    f"actual={actual_width}x{actual_height} "
+                    f"tolerance={surface_tolerance}"
+                )
+        expected_scale = min(
+            surface_width / logical_width, surface_height / logical_height
+        )
+        if abs(marker.get("content_scale", 0.0) - expected_scale) > 0.02:
+            raise SeamError(
+                f"Android orientation probe {sequence} content_scale mismatch: "
+                f"expected={expected_scale:.4f} actual={marker.get('content_scale')}"
+            )
+        expected_raster = max(1.0, min(8.0, expected_scale))
+        if abs(marker.get("raster_scale", 0.0) - expected_raster) > 0.02:
+            raise SeamError(
+                f"Android orientation probe {sequence} raster_scale mismatch: "
+                f"expected={expected_raster:.4f} actual={marker.get('raster_scale')}"
+            )
+        for field, expected in zip(
+            ("safe_x", "safe_y", "safe_w", "safe_h"),
+            orientation["safe_viewport"],
+        ):
+            if abs(marker.get(field, 0.0) - expected) > coordinate_tolerance:
+                raise SeamError(
+                    f"Android orientation probe {sequence} {field} mismatch: "
+                    f"expected={expected} actual={marker.get(field)}"
+                )
+        expected_checksum = (
+            4000
+            + sequence * 100
+            + stage["kind"] * 10
+            + marker.get("display_generation", 0)
+        )
+        if marker.get("state_checksum") != expected_checksum:
+            raise SeamError(
+                f"Android orientation probe {sequence} state_checksum mismatch: "
+                f"expected={expected_checksum} actual={marker.get('state_checksum')}"
+            )
+        for field in ("display_generation", "density_generation"):
+            frame_field = f"frame_{field}"
+            if marker.get(frame_field) != marker.get(field):
+                raise SeamError(
+                    f"Android orientation probe {sequence} {frame_field} mismatch: "
+                    f"guest={marker.get(field)} frame={marker.get(frame_field)}"
+                )
+        if not marker.get("command_trace"):
+            raise SeamError(
+                f"Android orientation probe {sequence} has an empty command trace"
+            )
+        observed.append(marker)
+    ticks = [item.get("probe_tick") for item in observed]
+    display_generations = [item.get("display_generation") for item in observed]
+    density_generations = [item.get("density_generation") for item in observed]
+    if any(not isinstance(value, int) for value in ticks) or any(
+        current >= following for current, following in zip(ticks, ticks[1:])
+    ):
+        raise SeamError(f"Android orientation probe ticks are not ordered: {ticks}")
+    if any(not isinstance(value, int) or value <= 0 for value in display_generations) or any(
+        current >= following
+        for current, following in zip(display_generations, display_generations[1:])
+    ):
+        raise SeamError(
+            "Android orientation display generations are not strictly ordered: "
+            f"{display_generations}"
+        )
+    if any(not isinstance(value, int) or value <= 0 for value in density_generations) or any(
+        current >= following
+        for current, following in zip(density_generations, density_generations[1:])
+    ):
+        raise SeamError(
+            "Android orientation density generations are not strictly ordered: "
+            f"{density_generations}"
+        )
+    if len({item["command_trace"] for item in observed}) != len(observed):
+        raise SeamError("Android orientation stages did not produce distinct frame traces")
+    return observed
+
+
 def logical_to_native(
     logical: list[float], logical_size: list[int], native_size: tuple[int, int]
 ) -> tuple[int, int]:
@@ -322,12 +490,48 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     return observed
 
 
+def parse_wm_size_override(output: str) -> str | None:
+    match = re.search(r"^Override size:\s*(\d+x\d+)\s*$", output, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def wait_for_surface(
+    adb: Path,
+    serial: str | None,
+    orientation: str,
+    expected_size: tuple[int, int],
+    tolerance: int,
+    deadline: float,
+    capture: Path,
+) -> tuple[int, int]:
+    last_size = None
+    while time.monotonic() < deadline:
+        capture.write_bytes(
+            _run(adb, serial, "exec-out", "screencap", "-p", text=False)
+        )
+        width, height, _ = read_png_rgb(capture)
+        last_size = (width, height)
+        matches = (height > width) == (orientation == "portrait")
+        expected = all(
+            abs(actual - target) <= tolerance
+            for actual, target in zip(last_size, expected_size)
+        )
+        if matches and expected and width % 2 == 1 and height % 2 == 1:
+            return last_size
+        time.sleep(0.25)
+    raise SeamError(
+        f"Android surface did not reach odd {orientation} dimensions "
+        f"{expected_size[0]}x{expected_size[1]}: {last_size}"
+    )
+
+
 def restore_device_state(
     adb: Path,
     serial: str | None,
     package_id: str,
     installed: bool,
     immersive_confirmation: str,
+    device_state: dict | None = None,
 ) -> list[str]:
     errors = []
     operations = []
@@ -338,6 +542,24 @@ def restore_device_state(
                 ("uninstall", ("uninstall", package_id)),
             )
         )
+    if device_state is not None:
+        size = device_state.get("wm_size_override")
+        operations.append(
+            (
+                "restore display size",
+                ("shell", "wm", "size", size if size else "reset"),
+            )
+        )
+        for namespace, key in (
+            ("system", "user_rotation"),
+            ("system", "accelerometer_rotation"),
+        ):
+            value = device_state.get(key, "null")
+            action = "delete" if not value or value == "null" else "put"
+            arguments = ("shell", "settings", action, namespace, key)
+            if action == "put":
+                arguments += (value,)
+            operations.append((f"restore {key}", arguments))
     if immersive_confirmation and immersive_confirmation != "null":
         operations.append(
             (
@@ -421,6 +643,34 @@ def main() -> int:
         "immersive_mode_confirmations",
         required=False,
     ).strip()
+    orientation = expectations.get("orientation")
+    device_state = None
+    if orientation is not None:
+        device_state = {
+            "wm_size_override": parse_wm_size_override(
+                _run(args.adb, args.serial, "shell", "wm", "size")
+            ),
+            "accelerometer_rotation": _run(
+                args.adb,
+                args.serial,
+                "shell",
+                "settings",
+                "get",
+                "system",
+                "accelerometer_rotation",
+                required=False,
+            ).strip(),
+            "user_rotation": _run(
+                args.adb,
+                args.serial,
+                "shell",
+                "settings",
+                "get",
+                "system",
+                "user_rotation",
+                required=False,
+            ).strip(),
+        }
     evidence = {
         "schema": SCHEMA,
         "test_id": test_id,
@@ -441,6 +691,8 @@ def main() -> int:
         },
         "artifacts": {"log": str(log_path), "capture": str(capture_path)},
     }
+    if device_state is not None:
+        evidence["original_device_state"] = device_state
     installed = False
     try:
         _run(
@@ -453,6 +705,37 @@ def main() -> int:
             "immersive_mode_confirmations",
             "confirmed",
         )
+        if orientation is not None:
+            first_stage = orientation["stages"][0]
+            display_width, display_height = orientation["display_size"]
+            _run(
+                args.adb,
+                args.serial,
+                "shell",
+                "settings",
+                "put",
+                "system",
+                "accelerometer_rotation",
+                "0",
+            )
+            _run(
+                args.adb,
+                args.serial,
+                "shell",
+                "wm",
+                "size",
+                f"{display_width}x{display_height}",
+            )
+            _run(
+                args.adb,
+                args.serial,
+                "shell",
+                "settings",
+                "put",
+                "system",
+                "user_rotation",
+                str(first_stage["rotation"]),
+            )
         _run(args.adb, args.serial, "install", "-r", str(args.apk))
         installed = True
         _run(args.adb, args.serial, "logcat", "-c")
@@ -495,6 +778,8 @@ def main() -> int:
         if not first_pid:
             raise SeamError("generated Android shell exited before capture")
         touch_probes = []
+        orientation_probes = []
+        orientation_evidence = []
         if "touch" in expectations:
             initial_capture_path.write_bytes(
                 _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
@@ -571,6 +856,107 @@ def main() -> int:
                     )
             touch_probes = validate_touch_markers(markers, expectations)
             evidence["injected_gestures"] = injected_gestures
+        if orientation is not None:
+            surfaces = {}
+            for index, stage in enumerate(orientation["stages"]):
+                if index > 0:
+                    _run(
+                        args.adb,
+                        args.serial,
+                        "shell",
+                        "settings",
+                        "put",
+                        "system",
+                        "user_rotation",
+                        str(stage["rotation"]),
+                    )
+                stage_capture_path = args.output / f"{stage['name']}-frame.png"
+                configured_width, configured_height = orientation["display_size"]
+                expected_surface = (
+                    (configured_width, configured_height)
+                    if stage["orientation"] == "portrait"
+                    else (configured_height, configured_width)
+                )
+                surface = wait_for_surface(
+                    args.adb,
+                    args.serial,
+                    stage["orientation"],
+                    expected_surface,
+                    orientation["surface_tolerance"],
+                    min(deadline, time.monotonic() + 15),
+                    stage_capture_path,
+                )
+                surfaces[stage["name"]] = surface
+                touch_x, touch_y = logical_to_native(
+                    orientation["touch"], expectations["logical_size"], surface
+                )
+                _run(
+                    args.adb,
+                    args.serial,
+                    "shell",
+                    "input",
+                    "touchscreen",
+                    "swipe",
+                    str(touch_x),
+                    str(touch_y),
+                    str(touch_x),
+                    str(touch_y),
+                    "250",
+                )
+                probe_deadline = min(deadline, time.monotonic() + 10)
+                while time.monotonic() < probe_deadline:
+                    log = _run(
+                        args.adb,
+                        args.serial,
+                        "logcat",
+                        "-d",
+                        "-v",
+                        "brief",
+                        "Stasis:I",
+                        "*:S",
+                    )
+                    markers = parse_markers(log, test_id)
+                    if any(
+                        item.get("probe_sequence") == stage["sequence"]
+                        for item in markers
+                    ):
+                        break
+                    time.sleep(0.25)
+                else:
+                    raise SeamError(
+                        f"Android orientation stage {stage['name']} did not reach "
+                        f"probe sequence {stage['sequence']}"
+                    )
+                stage_capture_path.write_bytes(
+                    _run(
+                        args.adb,
+                        args.serial,
+                        "exec-out",
+                        "screencap",
+                        "-p",
+                        text=False,
+                    )
+                )
+                stage_expectations = {
+                    "logical_size": expectations["logical_size"],
+                    "regions": stage["regions"],
+                }
+                stage_regions = validate_regions(
+                    stage_capture_path, stage_expectations
+                )
+                orientation_evidence.append(
+                    {
+                        "name": stage["name"],
+                        "rotation": stage["rotation"],
+                        "surface": list(surface),
+                        "touch": [touch_x, touch_y],
+                        "capture": str(stage_capture_path),
+                        "regions": stage_regions,
+                    }
+                )
+            orientation_probes = validate_orientation_markers(
+                markers, expectations, surfaces
+            )
         log_path.write_text(log, encoding="utf-8")
         capture_path.write_bytes(
             _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
@@ -593,6 +979,9 @@ def main() -> int:
         )
         if touch_probes:
             evidence["touch_probes"] = touch_probes
+        if orientation_probes:
+            evidence["orientation_probes"] = orientation_probes
+            evidence["orientation_stages"] = orientation_evidence
     except (OSError, KeyError, ValueError, SeamError, zlib.error) as error:
         evidence["failure"] = str(error)
         raise
@@ -621,6 +1010,7 @@ def main() -> int:
                 package_id,
                 installed,
                 immersive_confirmation,
+                device_state,
             )
         )
         evidence["device_state_restored"] = not cleanup_errors

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -211,6 +211,164 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
                 },
             )
 
+    def test_validates_ordered_orientation_metrics_and_pointer_mapping(self):
+        stages = [
+            (1, 1, 40, 1, 1001, 1601, 0x101),
+            (2, 2, 80, 2, 1601, 1001, 0x202),
+            (3, 1, 120, 3, 1001, 1601, 0x303),
+        ]
+        markers = []
+        for sequence, kind, tick, generation, width, height, trace in stages:
+            scale = min(width / 360, height / 720)
+            markers.append(
+                {
+                    "event": "probe",
+                    "probe_sequence": sequence,
+                    "probe_kind": kind,
+                    "probe_tick": tick,
+                    "pointer_id": 1,
+                    "pointer_count": 2,
+                    "went_up": 1,
+                    "x": 270.0,
+                    "y": 540.0,
+                    "x_n": 0.75,
+                    "y_n": 0.75,
+                    "safe_x": 0.0,
+                    "safe_y": 0.0,
+                    "safe_w": 360.0,
+                    "safe_h": 720.0,
+                    "logical_w": 360.0,
+                    "logical_h": 720.0,
+                    "native_w": width,
+                    "native_h": height,
+                    "drawable_w": width,
+                    "drawable_h": height,
+                    "display_generation": generation,
+                    "density_generation": generation,
+                    "frame_display_generation": generation,
+                    "frame_density_generation": generation,
+                    "content_scale": scale,
+                    "raster_scale": max(1.0, min(8.0, scale)),
+                    "state_checksum": 4000 + sequence * 100 + kind * 10 + generation,
+                    "command_trace": trace,
+                }
+            )
+        expectations = {
+            "logical_size": [360, 720],
+            "orientation": {
+                "coordinate_tolerance": 1.0,
+                "surface_tolerance": 0,
+                "display_size": [1001, 1601],
+                "safe_viewport": [0, 0, 360, 720],
+                "touch": [270, 540],
+                "stages": [
+                    {"name": "portrait", "sequence": 1, "kind": 1, "orientation": "portrait"},
+                    {"name": "landscape", "sequence": 2, "kind": 2, "orientation": "landscape"},
+                    {"name": "restored_portrait", "sequence": 3, "kind": 1, "orientation": "portrait"},
+                ],
+            },
+        }
+        observed = seam.validate_orientation_markers(
+            markers,
+            expectations,
+            {
+                "portrait": (1001, 1601),
+                "landscape": (1601, 1001),
+                "restored_portrait": (1001, 1601),
+            },
+        )
+        self.assertEqual([1, 2, 3], [item["probe_sequence"] for item in observed])
+        with self.assertRaisesRegex(seam.SeamError, "configured size mismatch"):
+            seam.validate_orientation_markers(
+                markers,
+                expectations,
+                {
+                    "portrait": (999, 1599),
+                    "landscape": (1599, 999),
+                    "restored_portrait": (999, 1599),
+                },
+            )
+        markers[1]["frame_display_generation"] = 1
+        with self.assertRaisesRegex(seam.SeamError, "frame_display_generation"):
+            seam.validate_orientation_markers(
+                markers,
+                expectations,
+                {
+                    "portrait": (1001, 1601),
+                    "landscape": (1601, 1001),
+                    "restored_portrait": (1001, 1601),
+                },
+            )
+
+    def test_rejects_regressing_orientation_generation(self):
+        expectations = {
+            "logical_size": [360, 720],
+            "orientation": {
+                "coordinate_tolerance": 1.0,
+                "surface_tolerance": 0,
+                "display_size": [1001, 1601],
+                "safe_viewport": [0, 0, 360, 720],
+                "touch": [270, 540],
+                "stages": [
+                    {"name": "portrait", "sequence": 1, "kind": 1, "orientation": "portrait"},
+                    {"name": "restored", "sequence": 2, "kind": 1, "orientation": "portrait"},
+                ],
+            },
+        }
+        marker = {
+            "event": "probe",
+            "probe_kind": 1,
+            "pointer_id": 1,
+            "pointer_count": 2,
+            "went_up": 1,
+            "x": 270.0,
+            "y": 540.0,
+            "x_n": 0.75,
+            "y_n": 0.75,
+            "safe_x": 0.0,
+            "safe_y": 0.0,
+            "safe_w": 360.0,
+            "safe_h": 720.0,
+            "logical_w": 360.0,
+            "logical_h": 720.0,
+            "native_w": 1001,
+            "native_h": 1601,
+            "drawable_w": 1001,
+            "drawable_h": 1601,
+            "display_generation": 2,
+            "density_generation": 1,
+            "frame_display_generation": 2,
+            "frame_density_generation": 1,
+            "content_scale": 1601 / 720,
+            "raster_scale": 1601 / 720,
+            "command_trace": 1,
+        }
+        markers = []
+        for sequence, tick in ((1, 10), (2, 20)):
+            value = dict(marker)
+            value.update(
+                probe_sequence=sequence,
+                probe_tick=tick,
+                state_checksum=4000 + sequence * 100 + 10 + 2,
+                command_trace=sequence,
+            )
+            markers.append(value)
+        with self.assertRaisesRegex(seam.SeamError, "not strictly ordered"):
+            seam.validate_orientation_markers(
+                markers,
+                expectations,
+                {"portrait": (1001, 1601), "restored": (1001, 1601)},
+            )
+
+    def test_parses_only_an_explicit_wm_size_override(self):
+        self.assertEqual(
+            "1001x1601",
+            seam.parse_wm_size_override(
+                "Physical size: 1080x2400\nOverride size: 1001x1601\n"
+            ),
+        )
+        self.assertIsNone(seam.parse_wm_size_override("Physical size: 1080x2400\n"))
+
     def test_cleanup_continues_after_force_stop_failure(self):
         calls = []
 
@@ -222,12 +380,64 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
 
         with mock.patch.object(seam, "_run", side_effect=fake_run):
             errors = seam.restore_device_state(
-                Path("adb"), "device", "com.example.seam", True, "null"
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                True,
+                "null",
+                {
+                    "wm_size_override": None,
+                    "user_rotation": "3",
+                    "accelerometer_rotation": "1",
+                },
             )
 
         self.assertEqual(len(errors), 1)
         self.assertIn("force-stop", errors[0])
         self.assertIn(("uninstall", "com.example.seam"), calls)
+        self.assertIn(("shell", "wm", "size", "reset"), calls)
+        self.assertIn(
+            ("shell", "settings", "put", "system", "user_rotation", "3"),
+            calls,
+        )
+
+    def test_cleanup_restores_orientation_and_prior_display_override(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_kwargs):
+            calls.append(arguments)
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            errors = seam.restore_device_state(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                False,
+                "null",
+                {
+                    "wm_size_override": "901x1501",
+                    "user_rotation": "3",
+                    "accelerometer_rotation": "1",
+                },
+            )
+        self.assertEqual([], errors)
+        self.assertIn(("shell", "wm", "size", "901x1501"), calls)
+        self.assertIn(
+            ("shell", "settings", "put", "system", "user_rotation", "3"),
+            calls,
+        )
+        self.assertIn(
+            (
+                "shell",
+                "settings",
+                "put",
+                "system",
+                "accelerometer_rotation",
+                "1",
+            ),
+            calls,
+        )
         self.assertIn(
             (
                 "shell",


### PR DESCRIPTION
## Summary
- add an Android release-shell AOT fixture that snapshots orientation-related HostFrame lanes before rendering
- prove guest-observed display/density generations equal accepted gfx frame metadata across odd portrait, landscape, and restored portrait surfaces
- verify logical-canvas stability, fitted pointer mapping, named pixel regions, and independent restoration of modified device state

## Tests
- `python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_runtime_abi_contract` (18 passed)
- public Stasis check for `samples/android_orientation_seam` (64 functions emitted)
- `stasis package-mobile --target android-arm64` on isolated fixture (passed; reviewed oracle present in packaged C sources)
- `cargo test -p stasis --test toolchain_cli package_mobile_builds_android_and_ios_projects_from_one_entry -- --exact --test-threads=1` (1 passed)
- `cargo test -p stasis toolchain_cli::tests::mobile_shells_are_platform_projects_over_one_shared_runtime -- --exact --test-threads=1` (1 passed)
- `cargo check -p stasis --all-targets` (passed)
- canonical Stasis fmt and `git diff --check` (passed)

## Review
Independent gpt-5.6-sol medium review found one exact-size false-positive risk. The driver now waits for and independently validates the configured display override, including transposition in landscape; the negative regression passes and re-review is clean.

## Baseline notes
- `tools/ci/check_android_shell.py` stops on the unchanged Workshop `allowAiImageGeneration.setChecked(false)` assertion.
- `cargo fmt --all -- --check` reports unchanged formatting drift in `apps/stasis/src/lib.rs`.

## Reflection
Good: one guest snapshot plus accepted-frame metadata proves the complete HostFrame transaction.
Bad: the first validator let the observed screenshot become its own expected-size oracle.
Adjustment: device seams must validate requested platform state independently from every downstream observation.

Theory gained: orientation is derived HostFrame state, not a separate guest input. When SDL dimensions, guest snapshot, accepted gfx generations, pointer transform, and pixels agree in one frame, the release-shell mapping is observable end to end. An adjacent lifecycle test can reuse the same generation/frame pairing for surface restoration.