### PR TITLE
Add selective JIT function profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,23 @@ review and commit the resulting Git changes with the compiler upgrade.
 
 For a graphical program, `stasis play path\to\main.stasis` keeps the process alive and watches the current import graph. From a project directory or any descendant, `stasis play` reads the entry and project name from the nearest ancestor `stasis.json`. Explicit entries still use that manifest root for project-root imports and asset preparation. Saving a `.stasis` file compiles a candidate in the background and attempts an all-or-nothing swap between ticks.
 
+`play` can selectively profile named Stasis functions in the JIT hot path:
+
+```powershell
+stasis play game.stasis --ticks 600 `
+  --profile-functions render,draw_board,draw_enemies `
+  --profile-warmup 120 `
+  --profile-output artifacts\render-profile.json
+```
+
+The report ranks functions by exclusive time and also includes calls, inclusive time, average
+inclusive time, and maximum inclusive time. Only the named functions are instrumented, keeping the
+measurement overhead bounded and making nested exclusive time meaningful. The warmup is reset after
+the requested number of ticks so startup compilation and asset loading do not contaminate the sample.
+Nested stacks remain thread-local, while completed counters are merged process-wide across threads.
+This profiler currently applies to the JIT-backed `play` command, not AOT packages; aggressively
+inlined functions may need their caller selected instead.
+
 From a project containing `stasis.json`, `stasis tui` opens the manifest entry in the persistent live-workspace interface. Pass an entry path to override the manifest for one invocation.
 
 Build distributable output with:

--- a/README.md
+++ b/README.md
@@ -256,8 +256,22 @@ inclusive time, and maximum inclusive time. Only the named functions are instrum
 measurement overhead bounded and making nested exclusive time meaningful. The warmup is reset after
 the requested number of ticks so startup compilation and asset loading do not contaminate the sample.
 Nested stacks remain thread-local, while completed counters are merged process-wide across threads.
-This profiler currently applies to the JIT-backed `play` command, not AOT packages; aggressively
-inlined functions may need their caller selected instead.
+The desktop CLI path applies to the JIT-backed `play` command; aggressively inlined functions may
+need their caller selected instead.
+
+Development mobile packages can profile the same named functions in AOT code:
+
+```powershell
+stasis package-mobile --target android-x86_64 --development-build `
+  --profile-functions render,draw_board,draw_enemies `
+  --profile-warmup-frames 600 `
+  --profile-sample-frames 300
+```
+
+The mobile runtime writes one bounded `STASIS_PROFILE_START`, one `STASIS_PROFILE` row per selected
+function, and `STASIS_PROFILE_DONE` to the platform log. Android reports are available through
+logcat's `Stasis` tag. Mobile profiling is rejected for non-development packages so production
+artifacts remain uninstrumented.
 
 From a project containing `stasis.json`, `stasis tui` opens the manifest entry in the persistent live-workspace interface. Pass an entry path to override the manifest for one invocation.
 

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -30,7 +30,7 @@ pub use window_config::WindowConfig;
 use compiler_backend::{IncrementalCompilerBackend, PreparedJitSwap};
 use live_workspace::LiveWorkspace;
 use runtime_exec::RuntimeLauncher;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use stasis_assets::{
     load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
@@ -61,6 +61,118 @@ use watch::WatchService;
 const SWAP_FLASH_TICKS_MAX: u32 = 180;
 const TICK_BUDGET_SAMPLE_LIMIT: usize = 4096;
 const DESKTOP_FRAME_EVIDENCE_ENV: &str = "STASIS_DESKTOP_FRAME_EVIDENCE";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayProfileConfig {
+    pub functions: Vec<String>,
+    pub warmup_ticks: u64,
+    pub output_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct PlayProfileRow {
+    function_id: u32,
+    function: String,
+    source: String,
+    calls: u64,
+    inclusive_ns: u64,
+    exclusive_ns: u64,
+    average_inclusive_ns: u64,
+    max_inclusive_ns: u64,
+}
+
+struct JitProfilerGuard;
+
+impl Drop for JitProfilerGuard {
+    fn drop(&mut self) {
+        stasis_dynload::disable_jit_profiler();
+    }
+}
+
+fn finish_play_profile(jit: &JitProcess, config: &PlayProfileConfig) -> Result<(), String> {
+    stasis_dynload::disable_jit_profiler();
+    let snapshot = jit
+        .program_snapshot()
+        .ok_or_else(|| "profiled play session has no program snapshot".to_string())?;
+    let functions_by_id: BTreeMap<u32, (&str, &str)> = snapshot
+        .functions()
+        .iter()
+        .filter_map(|function| {
+            snapshot
+                .files()
+                .get(function.file_id as usize)
+                .map(|file| (function.id, (function.name.as_str(), file.path.as_str())))
+        })
+        .collect();
+    let mut rows: Vec<PlayProfileRow> = stasis_dynload::jit_profile_snapshot()
+        .into_iter()
+        .filter_map(|sample| {
+            let (name, source) = functions_by_id.get(&sample.function_id).copied()?;
+            Some(PlayProfileRow {
+                function_id: sample.function_id,
+                function: name.to_string(),
+                source: source.to_string(),
+                calls: sample.calls,
+                inclusive_ns: sample.inclusive_ns,
+                exclusive_ns: sample.exclusive_ns,
+                average_inclusive_ns: sample.inclusive_ns / sample.calls.max(1),
+                max_inclusive_ns: sample.max_inclusive_ns,
+            })
+        })
+        .collect();
+    rows.sort_by(|left, right| {
+        right
+            .exclusive_ns
+            .cmp(&left.exclusive_ns)
+            .then_with(|| right.inclusive_ns.cmp(&left.inclusive_ns))
+            .then_with(|| left.function.cmp(&right.function))
+    });
+
+    println!("PROFILE|function|calls|inclusive_us|exclusive_us|avg_inclusive_ns|max_inclusive_ns");
+    for row in &rows {
+        println!(
+            "PROFILE|{}|{}|{}|{}|{}|{}",
+            row.function,
+            row.calls,
+            row.inclusive_ns / 1_000,
+            row.exclusive_ns / 1_000,
+            row.average_inclusive_ns,
+            row.max_inclusive_ns
+        );
+    }
+    for requested in &config.functions {
+        if !rows.iter().any(|row| row.function == *requested) {
+            eprintln!(
+                "PROFILE_WARNING|function={requested}|reason=no completed calls; verify spelling, reachability, warmup, and @inline lowering"
+            );
+        }
+    }
+    if let Some(path) = config.output_path.as_ref() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create profile output directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        let document = serde_json::json!({
+            "schema_version": 1,
+            "clock": "native_monotonic",
+            "units": "nanoseconds",
+            "warmup_ticks": config.warmup_ticks,
+            "functions": rows,
+        });
+        fs::write(
+            path,
+            serde_json::to_vec_pretty(&document)
+                .map_err(|error| format!("failed to encode profile report: {error}"))?,
+        )
+        .map_err(|error| format!("failed to write profile report {}: {error}", path.display()))?;
+        println!("PROFILE_OUTPUT|{}", path.display());
+    }
+    Ok(())
+}
 
 struct DesktopFrameEvidence {
     file: fs::File,
@@ -1754,6 +1866,7 @@ pub fn run_play_in_process(
         max_ticks,
         None,
         None,
+        None,
     )
 }
 
@@ -1788,6 +1901,7 @@ pub fn run_play_in_process_with_window_title(
         tick_sleep_micros,
         max_ticks,
         Some(window_title),
+        None,
         None,
     )
 }
@@ -1824,6 +1938,31 @@ pub fn run_play_in_process_with_input_script_and_window_title(
     max_ticks: Option<u64>,
     window_title: Option<&str>,
 ) -> Result<(), String> {
+    run_play_in_process_with_input_script_window_title_and_profile(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
+        input_script,
+        tick_sleep_micros,
+        max_ticks,
+        window_title,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_play_in_process_with_input_script_window_title_and_profile(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    input_script: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    window_title: Option<&str>,
+    profile: Option<PlayProfileConfig>,
+) -> Result<(), String> {
     run_play_in_process_inner(
         watch_file,
         watch_dir,
@@ -1833,6 +1972,7 @@ pub fn run_play_in_process_with_input_script_and_window_title(
         tick_sleep_micros,
         max_ticks,
         window_title,
+        profile,
         None,
     )
 }
@@ -1877,6 +2017,7 @@ pub fn run_live_in_process_with_data(
         tick_sleep_micros,
         max_ticks,
         None,
+        None,
         Some((server, config)),
     )
 }
@@ -1891,11 +2032,20 @@ fn run_play_in_process_inner(
     tick_sleep_micros: u64,
     max_ticks: Option<u64>,
     window_title: Option<&str>,
+    mut profile: Option<PlayProfileConfig>,
     live: Option<(stasis_runner::live::LiveSessionServer, LiveRunConfig)>,
 ) -> Result<(), String> {
     let watch_dir = resolve_play_watch_dir(watch_file, watch_dir);
     let launch_dir = std::env::current_dir()
         .map_err(|error| format!("failed to read current directory before play launch: {error}"))?;
+    if let Some(output_path) = profile
+        .as_mut()
+        .and_then(|profile| profile.output_path.as_mut())
+    {
+        if output_path.is_relative() {
+            *output_path = launch_dir.join(&*output_path);
+        }
+    }
     let data_binding_paths = resolve_play_data_binding_paths(
         watch_file,
         &launch_dir,
@@ -2039,6 +2189,9 @@ fn run_play_in_process_inner(
     let _ = gfx.init_window(800, 600, &title)?;
 
     let mut jit = JitProcess::new();
+    if let Some(profile) = profile.as_ref() {
+        jit.set_profile_functions(profile.functions.clone())?;
+    }
     jit.set_project_root(project_root.to_string_lossy())?;
     let root_source = fs::read_to_string(&root_path)
         .map_err(|error| format!("failed to read {}: {error}", root_path.display()))?;
@@ -2079,6 +2232,11 @@ fn run_play_in_process_inner(
     if max_ticks == Some(0) {
         return Ok(());
     }
+
+    let _profiler_guard = profile.as_ref().map(|_| {
+        stasis_dynload::enable_jit_profiler();
+        JitProfilerGuard
+    });
 
     stasis_dynload::begin_jit_host_entry_session(package.host_entry_targets(1)?)?;
     let mut tick_code_ptr = stasis_dynload::jit_host_tick_trampoline_ptr() as u64;
@@ -2155,6 +2313,13 @@ fn run_play_in_process_inner(
                             Ok(entrypoints) => {
                                 tick_code_ptr = entrypoints.tick_code_ptr;
                                 render_code_ptr = entrypoints.render_code_ptr;
+                                if profile.is_some() {
+                                    stasis_dynload::reset_jit_profile();
+                                    eprintln!(
+                                        "PROFILE_RESET|reason=code_swap|revision={}",
+                                        prepared.revision
+                                    );
+                                }
                                 if let Ok(Some(candidate_tick_budget)) = candidate_tick_budget {
                                     if let Some(report) = update_tick_budget_after_swap(
                                         &mut tick_budget,
@@ -2340,6 +2505,12 @@ fn run_play_in_process_inner(
                 break;
             }
         }
+        if profile
+            .as_ref()
+            .is_some_and(|profile| ticks_executed == profile.warmup_ticks)
+        {
+            stasis_dynload::reset_jit_profile();
+        }
     }
 
     if let Some(job) = watch_patch_job.take() {
@@ -2347,6 +2518,9 @@ fn run_play_in_process_inner(
     }
     if let Some(budget) = tick_budget {
         println!("{}", budget.report());
+    }
+    if let Some(profile) = profile.as_ref() {
+        finish_play_profile(&jit, profile)?;
     }
 
     Ok(())
@@ -4827,9 +5001,7 @@ mod tests {
             .map(|offset| cached_start + offset)
             .expect("cached text draw boundary");
         let cached_draw = &STASIS_GRAPHICS_SOURCE[cached_start..cached_end];
-        assert!(cached_draw.contains(
-            "run, font, x, y, color_r, color_g, color_b, color_a);"
-        ));
+        assert!(cached_draw.contains("run, font, x, y, color_r, color_g, color_b, color_a);"));
     }
 
     #[test]

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -18,7 +18,7 @@ pub use events::RunnerEvent;
 pub use live_workspace::LiveRunConfig;
 pub use mobile_aot_bindings::{
     audit_mobile_aot_bindings, escape_mobile_c_string_literal, mobile_aot_function_for,
-    write_mobile_aot_bindings_source,
+    write_mobile_aot_bindings_source, write_mobile_aot_bindings_source_with_profile,
 };
 pub use stasis_test_runner::{
     run_jit_tests_in_directory, run_jit_tests_in_directory_with_project_root_and_session,

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -17,9 +17,9 @@ use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watche
 use stasis::escape_mobile_c_string_literal;
 use stasis::{
     mobile_aot_function_for, run_jit_tests_in_directory_with_session,
-    run_play_in_process_with_input_script_and_window_title, run_self_host_aot_cli_with_options,
-    run_with_default_backend, run_with_real_backend, write_mobile_aot_bindings_source,
-    RunnerConfig, StasisTestRunSession,
+    run_play_in_process_with_input_script_window_title_and_profile,
+    run_self_host_aot_cli_with_options, run_with_default_backend, run_with_real_backend,
+    write_mobile_aot_bindings_source, PlayProfileConfig, RunnerConfig, StasisTestRunSession,
 };
 use stasis_assets::{
     load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
@@ -122,6 +122,9 @@ struct PlayCliArgs {
     screenshot: Option<PathBuf>,
     screenshot_frame: u64,
     exit_after_screenshot: bool,
+    profile_functions: Vec<String>,
+    profile_warmup_ticks: u64,
+    profile_output: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -513,6 +516,10 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
     let mut screenshot_frame: u64 = 1;
     let mut screenshot_frame_explicit = false;
     let mut exit_after_screenshot = false;
+    let mut profile_functions = Vec::new();
+    let mut profile_warmup_ticks = 60_u64;
+    let mut profile_warmup_explicit = false;
+    let mut profile_output: Option<PathBuf> = None;
     let mut i: usize = 0;
     while i < args.len() {
         let arg = args[i].as_str();
@@ -606,6 +613,39 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
             i += 1;
             continue;
         }
+        if arg == "--profile-functions" {
+            if i + 1 >= args.len() {
+                return Err("missing value for --profile-functions <name[,name...]>".to_string());
+            }
+            profile_functions.extend(
+                args[i + 1]
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_string),
+            );
+            i += 2;
+            continue;
+        }
+        if arg == "--profile-warmup" {
+            if i + 1 >= args.len() {
+                return Err("missing value for --profile-warmup <ticks>".to_string());
+            }
+            profile_warmup_ticks = args[i + 1]
+                .parse::<u64>()
+                .map_err(|error| format!("invalid value for --profile-warmup: {error}"))?;
+            profile_warmup_explicit = true;
+            i += 2;
+            continue;
+        }
+        if arg == "--profile-output" {
+            if i + 1 >= args.len() {
+                return Err("missing value for --profile-output <path>".to_string());
+            }
+            profile_output = Some(PathBuf::from(args[i + 1].clone()));
+            i += 2;
+            continue;
+        }
         i += 1;
     }
     if screenshot.is_none() && (screenshot_frame_explicit || exit_after_screenshot) {
@@ -616,6 +656,16 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
     }
     if screenshot.is_some() && ticks.is_some_and(|count| count < screenshot_frame) {
         return Err("--ticks must be at least --screenshot-frame when capturing".to_string());
+    }
+    if profile_functions.is_empty() && (profile_warmup_explicit || profile_output.is_some()) {
+        return Err(
+            "--profile-warmup and --profile-output require --profile-functions".to_string(),
+        );
+    }
+    if !profile_functions.is_empty() && ticks.is_some_and(|count| count <= profile_warmup_ticks) {
+        return Err(
+            "--ticks must exceed --profile-warmup so at least one frame is measured".to_string(),
+        );
     }
     Ok(PlayCliArgs {
         watch_file,
@@ -628,6 +678,9 @@ fn parse_play_cli_args(args: &[String]) -> Result<PlayCliArgs, String> {
         screenshot,
         screenshot_frame,
         exit_after_screenshot,
+        profile_functions,
+        profile_warmup_ticks,
+        profile_output,
     })
 }
 
@@ -882,7 +935,12 @@ fn try_run_play_subcommand() -> Option<i32> {
         }
     };
 
-    let play_result = run_play_in_process_with_input_script_and_window_title(
+    let profile = (!parsed.profile_functions.is_empty()).then(|| PlayProfileConfig {
+        functions: parsed.profile_functions.clone(),
+        warmup_ticks: parsed.profile_warmup_ticks,
+        output_path: parsed.profile_output.clone(),
+    });
+    let play_result = run_play_in_process_with_input_script_window_title_and_profile(
         &launch.watch_file,
         Some(&launch.watch_dir),
         parsed.data_bind_json.as_deref(),
@@ -891,6 +949,7 @@ fn try_run_play_subcommand() -> Option<i32> {
         parsed.tick_sleep_micros,
         parsed.ticks,
         launch.window_title.as_deref(),
+        profile,
     );
     match play_result {
         Ok(()) => {
@@ -2219,6 +2278,42 @@ mod tests {
                 "samples/bucket_catcher/data/config.struct-meta.json"
             ))
         );
+    }
+
+    #[test]
+    fn parse_play_cli_args_accepts_selective_function_profiling() {
+        let args = vec![
+            "main.stasis".to_string(),
+            "--ticks".to_string(),
+            "240".to_string(),
+            "--profile-functions".to_string(),
+            "render,draw_board, draw_enemies".to_string(),
+            "--profile-warmup".to_string(),
+            "40".to_string(),
+            "--profile-output".to_string(),
+            "profile.json".to_string(),
+        ];
+        let parsed = parse_play_cli_args(&args).expect("parse profiling arguments");
+        assert_eq!(
+            parsed.profile_functions,
+            vec!["render", "draw_board", "draw_enemies"]
+        );
+        assert_eq!(parsed.profile_warmup_ticks, 40);
+        assert_eq!(parsed.profile_output, Some(PathBuf::from("profile.json")));
+    }
+
+    #[test]
+    fn parse_play_cli_args_requires_a_measured_frame_after_profile_warmup() {
+        let args = vec![
+            "main.stasis".to_string(),
+            "--ticks".to_string(),
+            "60".to_string(),
+            "--profile-functions".to_string(),
+            "render".to_string(),
+        ];
+        assert!(parse_play_cli_args(&args)
+            .expect_err("warmup consumes the bounded run")
+            .contains("must exceed --profile-warmup"));
     }
 
     #[test]

--- a/apps/stasis/src/main.rs
+++ b/apps/stasis/src/main.rs
@@ -19,7 +19,8 @@ use stasis::{
     mobile_aot_function_for, run_jit_tests_in_directory_with_session,
     run_play_in_process_with_input_script_window_title_and_profile,
     run_self_host_aot_cli_with_options, run_with_default_backend, run_with_real_backend,
-    write_mobile_aot_bindings_source, PlayProfileConfig, RunnerConfig, StasisTestRunSession,
+    write_mobile_aot_bindings_source_with_profile, PlayProfileConfig, RunnerConfig,
+    StasisTestRunSession,
 };
 use stasis_assets::{
     load_project_asset_manifest, prepare_asset_bundle, AssetLimits, DEFAULT_ASSET_MANIFEST_PATH,
@@ -108,6 +109,9 @@ struct MobileAotBundleArgs {
     project_dir: PathBuf,
     entry_file: Option<PathBuf>,
     output_dir: PathBuf,
+    profile_functions: Vec<String>,
+    profile_warmup_frames: u32,
+    profile_sample_frames: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1573,6 +1577,9 @@ fn parse_mobile_aot_bundle_args(args: &[String]) -> Result<MobileAotBundleArgs, 
     let mut project_dir: Option<PathBuf> = None;
     let mut entry_file: Option<PathBuf> = None;
     let mut output_dir: Option<PathBuf> = None;
+    let mut profile_functions = Vec::new();
+    let mut profile_warmup_frames = 120_u32;
+    let mut profile_sample_frames = 300_u32;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -1604,6 +1611,37 @@ fn parse_mobile_aot_bundle_args(args: &[String]) -> Result<MobileAotBundleArgs, 
                 output_dir = Some(PathBuf::from(args[i + 1].clone()));
                 i += 2;
             }
+            "--profile-functions" => {
+                if i + 1 >= args.len() {
+                    return Err("missing value for --profile-functions".to_string());
+                }
+                profile_functions.extend(
+                    args[i + 1]
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                        .map(str::to_string),
+                );
+                i += 2;
+            }
+            "--profile-warmup-frames" => {
+                if i + 1 >= args.len() {
+                    return Err("missing value for --profile-warmup-frames".to_string());
+                }
+                profile_warmup_frames = args[i + 1]
+                    .parse()
+                    .map_err(|error| format!("invalid --profile-warmup-frames: {error}"))?;
+                i += 2;
+            }
+            "--profile-sample-frames" => {
+                if i + 1 >= args.len() {
+                    return Err("missing value for --profile-sample-frames".to_string());
+                }
+                profile_sample_frames = args[i + 1]
+                    .parse()
+                    .map_err(|error| format!("invalid --profile-sample-frames: {error}"))?;
+                i += 2;
+            }
             other if other.starts_with("--") => {
                 return Err(format!("unknown mobile AOT bundle flag '{other}'"));
             }
@@ -1628,6 +1666,9 @@ fn parse_mobile_aot_bundle_args(args: &[String]) -> Result<MobileAotBundleArgs, 
         project_dir,
         entry_file,
         output_dir,
+        profile_functions,
+        profile_warmup_frames,
+        profile_sample_frames,
     })
 }
 
@@ -1651,6 +1692,9 @@ fn try_run_mobile_aot_bundle_subcommand() -> Option<i32> {
         &parsed.project_dir,
         parsed.entry_file.as_deref(),
         &parsed.output_dir,
+        &parsed.profile_functions,
+        parsed.profile_warmup_frames,
+        parsed.profile_sample_frames,
     ) {
         Ok(summary) => {
             println!("mobile_aot_target={}", summary.target.as_str());
@@ -1761,6 +1805,9 @@ fn write_android_aot_engine_bundle(
         project_dir,
         entry_file,
         output_dir,
+        &[],
+        0,
+        0,
     )?;
     let cmake_file = summary
         .cmake_file
@@ -1780,10 +1827,14 @@ fn write_mobile_aot_engine_bundle(
     project_dir: &Path,
     entry_file: Option<&Path>,
     output_dir: &Path,
+    profile_functions: &[String],
+    profile_warmup_frames: u32,
+    profile_sample_frames: u32,
 ) -> Result<MobileAotBundleSummary, String> {
     let mut process = AotProcess::with_optimization_profile(AotOptimizationProfile::SpeedAndSize);
     process.set_import_base_dir(project_dir);
     process.set_target(target.aot_target());
+    process.set_profile_functions(profile_functions.iter().cloned())?;
     let sources = collect_mobile_aot_sources(project_dir, entry_file)?;
     for (path, source) in &sources {
         process.upsert_file(path.clone(), source.clone());
@@ -1809,11 +1860,14 @@ fn write_mobile_aot_engine_bundle(
     let symbols_header = output_dir.join("published_aot_symbols.h");
     write_mobile_aot_symbols_header(&manifest_json, &symbols_header)?;
     let bindings_source = output_dir.join("published_aot_bindings.c");
-    write_mobile_aot_bindings_source(
+    write_mobile_aot_bindings_source_with_profile(
         &manifest_json,
         &process.state_layout(),
         project_dir,
         &bindings_source,
+        profile_functions,
+        profile_warmup_frames,
+        profile_sample_frames,
     )?;
     let cmake_file = if matches!(
         target,
@@ -2878,6 +2932,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_mobile_aot_bundle_args_accepts_bounded_function_profile() {
+        let args = vec![
+            "--target".to_string(),
+            "android-x86_64".to_string(),
+            "--project-dir".to_string(),
+            "samples/render_parity".to_string(),
+            "--out-dir".to_string(),
+            "target/profiled-mobile-aot".to_string(),
+            "--profile-functions".to_string(),
+            "render,draw_board".to_string(),
+            "--profile-warmup-frames".to_string(),
+            "30".to_string(),
+            "--profile-sample-frames".to_string(),
+            "90".to_string(),
+        ];
+        let parsed = parse_mobile_aot_bundle_args(&args).expect("parse profile flags");
+        assert_eq!(parsed.profile_functions, ["render", "draw_board"]);
+        assert_eq!(parsed.profile_warmup_frames, 30);
+        assert_eq!(parsed.profile_sample_frames, 90);
+    }
+
+    #[test]
     fn android_aot_bundle_writes_pong_symbols_header() {
         use object::{Object, ObjectSymbol};
 
@@ -3251,6 +3327,9 @@ function frame_width(): i32 { return 360; }
             &project_dir,
             Some(Path::new("src/main.stasis")),
             &output_dir,
+            &[],
+            0,
+            0,
         ) {
             Ok(_) => panic!("cyclic imports must be rejected by the compiler graph"),
             Err(error) => error,
@@ -3290,6 +3369,9 @@ function frame_width(): i32 { return 360; }
             &project_dir,
             Some(Path::new("src/main.stasis")),
             &output_dir,
+            &[],
+            0,
+            0,
         )
         .expect("missing on_code_swap should be accepted for mobile");
         let header = fs::read_to_string(&summary.symbols_header).expect("read symbols header");
@@ -3330,6 +3412,9 @@ function frame_width(): i32 { return 360; }
             &project_dir,
             Some(Path::new("src/main.stasis")),
             &output_dir,
+            &[],
+            0,
+            0,
         )
         .expect("write iOS mobile AOT bundle");
 

--- a/apps/stasis/src/mobile_aot_bindings.rs
+++ b/apps/stasis/src/mobile_aot_bindings.rs
@@ -10,6 +10,26 @@ pub fn write_mobile_aot_bindings_source(
     project_dir: &Path,
     output_path: &Path,
 ) -> Result<(), String> {
+    write_mobile_aot_bindings_source_with_profile(
+        manifest,
+        state_layout,
+        project_dir,
+        output_path,
+        &[],
+        0,
+        0,
+    )
+}
+
+pub fn write_mobile_aot_bindings_source_with_profile(
+    manifest: &serde_json::Value,
+    state_layout: &StateLayout,
+    project_dir: &Path,
+    output_path: &Path,
+    profile_functions: &[String],
+    profile_warmup_frames: u32,
+    profile_sample_frames: u32,
+) -> Result<(), String> {
     let functions = manifest
         .get("functions")
         .and_then(serde_json::Value::as_array)
@@ -107,6 +127,25 @@ pub fn write_mobile_aot_bindings_source(
         out.push_str(&format!(
             "    stasis_jit_upsert_string_literal({id}, stasis_mobile_literal_{});\n",
             id.unsigned_abs()
+        ));
+    }
+    for name in profile_functions {
+        let function = functions
+            .iter()
+            .find(|entry| entry.get("name").and_then(serde_json::Value::as_str) == Some(name))
+            .ok_or_else(|| format!("mobile AOT profile function '{name}' was not emitted"))?;
+        let function_id = function
+            .get("function_id")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| format!("mobile AOT profile function '{name}' missing function_id"))?;
+        out.push_str(&format!(
+            "    stasis_jit_profile_register_function((int32_t)UINT32_C({function_id}), \"{}\");\n",
+            escape_mobile_c_string_literal(name)
+        ));
+    }
+    if !profile_functions.is_empty() {
+        out.push_str(&format!(
+            "    stasis_jit_profile_configure({profile_warmup_frames}, {profile_sample_frames});\n"
         ));
     }
     out.push_str("}\n");

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -330,6 +330,13 @@ enum ToolchainCommand {
         /// Permit a visibly labeled package from a local/source toolchain.
         #[arg(long)]
         development_build: bool,
+        /// Select named Stasis functions for bounded mobile AOT profiling.
+        #[arg(long, value_delimiter = ',', value_name = "NAME[,NAME...]")]
+        profile_functions: Vec<String>,
+        #[arg(long, default_value_t = 120)]
+        profile_warmup_frames: u32,
+        #[arg(long, default_value_t = 300)]
+        profile_sample_frames: u32,
     },
     /// Report compiler-owned state memory, layout, and mobile budget information.
     Inspect {
@@ -1045,6 +1052,9 @@ fn execute(
                     entry,
                     out,
                     development_build,
+                    profile_functions,
+                    profile_warmup_frames,
+                    profile_sample_frames,
                 } => {
                     validate_optional_workspace_path(
                         &workspace,
@@ -1062,6 +1072,9 @@ fn execute(
                         entry.as_deref(),
                         out.as_deref(),
                         development_build,
+                        &profile_functions,
+                        profile_warmup_frames,
+                        profile_sample_frames,
                     )
                 }
                 ToolchainCommand::Inspect {
@@ -3425,6 +3438,9 @@ fn package_workspace(
             Path::new(&workspace.manifest.entry),
             &package_root,
             development_build,
+            &[],
+            0,
+            0,
         );
     }
     let staging_name = format!(
@@ -3559,6 +3575,9 @@ fn package_mobile_command(
     entry: Option<&Path>,
     output: Option<&Path>,
     development_build: bool,
+    profile_functions: &[String],
+    profile_warmup_frames: u32,
+    profile_sample_frames: u32,
 ) -> Result<CommandResult, String> {
     let target = target.package_target();
     let entry = entry.unwrap_or_else(|| Path::new(&workspace.manifest.entry));
@@ -3572,7 +3591,16 @@ fn package_mobile_command(
             ))
         });
     validate_workspace_destination(workspace, "package output", &package_root)?;
-    package_mobile_workspace(workspace, target, entry, &package_root, development_build)
+    package_mobile_workspace(
+        workspace,
+        target,
+        entry,
+        &package_root,
+        development_build,
+        profile_functions,
+        profile_warmup_frames,
+        profile_sample_frames,
+    )
 }
 
 fn package_mobile_workspace(
@@ -3581,11 +3609,28 @@ fn package_mobile_workspace(
     entry: &Path,
     package_root: &Path,
     development_build: bool,
+    profile_functions: &[String],
+    profile_warmup_frames: u32,
+    profile_sample_frames: u32,
 ) -> Result<CommandResult, String> {
     if matches!(target, PackageTarget::AndroidX86_64) && !development_build {
         return Err(
             "android-x86_64 is a test-only emulator target; pass --development-build".to_string(),
         );
+    }
+    if !profile_functions.is_empty() && !development_build {
+        return Err("mobile function profiling requires --development-build".to_string());
+    }
+    if profile_functions.len() > 64 {
+        return Err("mobile function profiling supports at most 64 functions".to_string());
+    }
+    if !profile_functions.is_empty() && profile_sample_frames == 0 {
+        return Err("mobile function profiling requires at least one sample frame".to_string());
+    }
+    let unique_profile_functions: BTreeSet<&str> =
+        profile_functions.iter().map(String::as_str).collect();
+    if unique_profile_functions.len() != profile_functions.len() {
+        return Err("mobile function profiling function names must be unique".to_string());
     }
     if package_root.exists() {
         return Err(format!(
@@ -3613,7 +3658,8 @@ fn package_mobile_workspace(
         let aot_root = staging_root.join("aot");
         let executable = env::current_exe()
             .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
-        let child = Command::new(executable)
+        let mut child_command = Command::new(executable);
+        child_command
             .arg("mobile-aot-bundle")
             .arg("--target")
             .arg(target.as_str())
@@ -3622,7 +3668,17 @@ fn package_mobile_workspace(
             .arg("--entry-file")
             .arg(entry)
             .arg("--out-dir")
-            .arg(&aot_root)
+            .arg(&aot_root);
+        if !profile_functions.is_empty() {
+            child_command
+                .arg("--profile-functions")
+                .arg(profile_functions.join(","))
+                .arg("--profile-warmup-frames")
+                .arg(profile_warmup_frames.to_string())
+                .arg("--profile-sample-frames")
+                .arg(profile_sample_frames.to_string());
+        }
+        let child = child_command
             .output()
             .map_err(|error| format!("failed to launch mobile AOT packaging: {error}"))?;
         if !child.status.success() {
@@ -5916,6 +5972,7 @@ mod tests {
                 entry: Some(ref entry),
                 out: Some(ref out),
                 development_build: false,
+                ..
             } if entry == Path::new("src/mobile.stasis") && out == Path::new("dist/ios")
         ));
     }

--- a/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
+++ b/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
@@ -146,6 +146,8 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
             "/W4",
             "/WX",
             "/wd4204",
+            "/std:c11",
+            "/experimental:c11atomics",
             "/D_CRT_SECURE_NO_WARNINGS",
         ])
         .arg(format!("/I{}", runtime.display()))

--- a/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
+++ b/apps/stasis/tests/generated_mobile_aot_runtime_seam.rs
@@ -2,7 +2,8 @@
 
 use serde_json::json;
 use stasis::{
-    audit_mobile_aot_bindings, mobile_aot_function_for, write_mobile_aot_bindings_source,
+    audit_mobile_aot_bindings, mobile_aot_function_for,
+    write_mobile_aot_bindings_source_with_profile,
 };
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::EngineEntrypoints;
@@ -91,6 +92,9 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
     process
         .set_project_root(project.to_string_lossy())
         .expect("set native AOT project root");
+    process
+        .set_profile_functions(["render".to_string()])
+        .expect("configure native AOT profiler");
     process.upsert_file("src/main.stasis", FIXTURE);
     process.compile().expect("compile native mobile fixture");
     let bundle = process
@@ -101,10 +105,20 @@ fn generated_aot_objects_and_bindings_run_through_real_mobile_runtime() {
     )
     .expect("parse engine manifest");
     let bindings_path = bundle_dir.join("published_aot_bindings.c");
-    write_mobile_aot_bindings_source(&manifest, &process.state_layout(), &project, &bindings_path)
-        .expect("write generated mobile bindings");
+    write_mobile_aot_bindings_source_with_profile(
+        &manifest,
+        &process.state_layout(),
+        &project,
+        &bindings_path,
+        &["render".to_string()],
+        1,
+        2,
+    )
+    .expect("write generated mobile bindings");
     let bindings = fs::read_to_string(&bindings_path).expect("read generated bindings");
     audit_mobile_aot_bindings(&manifest, &bindings).expect("audit generated bindings");
+    assert!(bindings.contains("stasis_jit_profile_register_function"));
+    assert!(bindings.contains("stasis_jit_profile_configure(1, 2);"));
 
     let (tick_symbol, _) = mobile_aot_function_for(&manifest, "tick").expect("tick symbol");
     let declaration = format!("extern int32_t {tick_symbol}(void);");

--- a/apps/stasis/tests/mobile_packaged_assets_seam.rs
+++ b/apps/stasis/tests/mobile_packaged_assets_seam.rs
@@ -223,6 +223,8 @@ fn packaged_mobile_assets_reach_real_native_hosts_from_linked_aot() {
             "/nologo",
             "/W4",
             "/WX",
+            "/std:c11",
+            "/experimental:c11atomics",
             "/wd4244",
             "/wd4267",
             "/wd4456",

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1233,6 +1233,7 @@ fn compile_function_to_object_bytes(
         Some(direct_storage),
         None,
         false,
+        false,
         |statement| record_string_literals_in_stmt(statement, referenced_string_literals),
         |_meta, _func| {
             #[cfg(test)]

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -46,6 +46,7 @@ pub struct AotProcess {
     program_snapshot: Option<ProgramSnapshot>,
     last_failed_source_diagnostic: Option<crate::SourceDiagnostic>,
     required_emit_roots: Vec<String>,
+    profile_function_names: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +92,7 @@ impl AotProcess {
             program_snapshot: None,
             last_failed_source_diagnostic: None,
             required_emit_roots: Vec::new(),
+            profile_function_names: BTreeSet::new(),
         }
     }
 
@@ -114,6 +116,24 @@ impl AotProcess {
         self.required_emit_roots.clear();
         self.required_emit_roots.extend_from_slice(roots);
         self.compiler.set_analysis_required_roots(roots);
+    }
+
+    pub fn set_profile_functions(
+        &mut self,
+        names: impl IntoIterator<Item = String>,
+    ) -> Result<(), String> {
+        if self.program_snapshot.is_some() || !self.artifacts.is_empty() {
+            return Err(
+                "AOT function profiling must be configured before the first compilation"
+                    .to_string(),
+            );
+        }
+        self.profile_function_names = names
+            .into_iter()
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .collect();
+        Ok(())
     }
 
     pub fn compile(&mut self) -> CompileResult<CompileReport> {
@@ -236,6 +256,7 @@ impl AotProcess {
             optimization_profile,
             referenced_string_literals,
             target,
+            profile_function_names,
         ) = (
             &mut self.compiler,
             &mut self.next_object_index,
@@ -244,6 +265,7 @@ impl AotProcess {
             self.optimization_profile,
             &mut self.referenced_string_literals,
             self.target.clone(),
+            self.profile_function_names.clone(),
         );
         let emit = compiler.emit_pass_for_ids_with(
             &emit_function_ids,
@@ -255,6 +277,7 @@ impl AotProcess {
                 type_table.ensure_utf8_view_id()?;
                 type_table.ensure_ascii_view_id()?;
                 let mut function_string_literals = BTreeMap::new();
+                let profile_instrumentation = profile_function_names.contains(&meta.name);
                 let bytes = compile_function_to_object_bytes(
                     meta,
                     hir,
@@ -269,6 +292,7 @@ impl AotProcess {
                     &analysis.collection_infos,
                     &analysis.named_struct_field_types,
                     &direct_storage,
+                    profile_instrumentation,
                 )?;
                 referenced_string_literals
                     .insert(meta.id, function_string_literals.keys().copied().collect());
@@ -1183,6 +1207,7 @@ fn compile_function_to_object_bytes(
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
     direct_storage: &DirectStorageBindings,
+    profile_instrumentation: bool,
 ) -> Result<Vec<u8>, String> {
     let mut flag_builder = settings::builder();
     flag_builder
@@ -1233,7 +1258,7 @@ fn compile_function_to_object_bytes(
         Some(direct_storage),
         None,
         false,
-        false,
+        profile_instrumentation,
         |statement| record_string_literals_in_stmt(statement, referenced_string_literals),
         |_meta, _func| {
             #[cfg(test)]
@@ -2511,6 +2536,27 @@ mod tests {
         assert_eq!(
             undefined_runtime_symbols(&process),
             BTreeSet::from(["stasis_jit_print_i32".to_string()])
+        );
+    }
+
+    #[test]
+    fn selectively_profiled_aot_exposes_hooks_only_for_named_function() {
+        let mut process = AotProcess::new();
+        process
+            .set_profile_functions(["helper".to_string()])
+            .expect("configure AOT profiler");
+        process.upsert_file(
+            "profile.stasis",
+            "function helper(): i32 { return 7; }\nfunction main(): i32 { return helper(); }\n",
+        );
+        process.compile().expect("compile profiled AOT fixture");
+
+        assert_eq!(
+            undefined_runtime_symbols(&process),
+            BTreeSet::from([
+                "stasis_jit_profile_frame_enter".to_string(),
+                "stasis_jit_profile_frame_leave".to_string(),
+            ])
         );
     }
 

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1413,6 +1413,8 @@ pub(crate) struct RuntimeCallImportIds {
     pub(crate) debug_values_begin: Option<FuncId>,
     pub(crate) debug_value_i64: Option<FuncId>,
     pub(crate) debug_value_f64: Option<FuncId>,
+    pub(crate) profile_frame_enter: Option<FuncId>,
+    pub(crate) profile_frame_leave: Option<FuncId>,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncId>,
 }
 
@@ -1439,6 +1441,7 @@ pub(crate) struct RuntimeCallRefs {
     pub(crate) collection_i32_load: FuncRef,
     pub(crate) collection_i32_store: FuncRef,
     pub(crate) debug: Option<DebugRuntimeRefs>,
+    pub(crate) profile: Option<ProfileRuntimeRefs>,
     pub(crate) extern_calls: BTreeMap<ExternImportKey, FuncRef>,
     pub(crate) direct_storage: Option<DirectStorageRefs>,
 }
@@ -1614,6 +1617,7 @@ pub(crate) fn compile_function_with_module<M, T, BeforeStatement, OnFunctionBuil
     direct_storage: Option<&DirectStorageBindings>,
     defined_runtime_helper_trampolines: Option<&mut BTreeSet<String>>,
     debug_instrumentation: bool,
+    profile_instrumentation: bool,
     mut before_statement: BeforeStatement,
     on_function_built: OnFunctionBuilt,
     finalize: Finalize,
@@ -1670,6 +1674,7 @@ where
                 type_table,
                 named_struct_field_types,
                 debug_instrumentation,
+                profile_instrumentation,
             )?
         }
     };
@@ -1838,6 +1843,9 @@ where
             }
             emit_debug_frame_boundary(&mut builder, debug.frame_enter, meta.id);
         }
+        if let Some(profile) = runtime_call_refs.profile.as_ref() {
+            emit_function_frame_boundary(&mut builder, profile.frame_enter, meta.id);
+        }
         let mut terminated = false;
         for (index, statement) in hir.statements.iter().enumerate() {
             if terminated {
@@ -1872,6 +1880,9 @@ where
             if meta.return_type == TYPE_ID_VOID {
                 if let Some(debug) = runtime_call_refs.debug.as_ref() {
                     emit_debug_frame_boundary(&mut builder, debug.frame_leave, meta.id);
+                }
+                if let Some(profile) = runtime_call_refs.profile.as_ref() {
+                    emit_function_frame_boundary(&mut builder, profile.frame_leave, meta.id);
                 }
                 builder.ins().return_(&[]);
             } else {
@@ -2506,6 +2517,12 @@ pub(crate) struct DebugRuntimeRefs {
     pub(crate) values_begin: FuncRef,
     pub(crate) value_i64: FuncRef,
     pub(crate) value_f64: FuncRef,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ProfileRuntimeRefs {
+    pub(crate) frame_enter: FuncRef,
+    pub(crate) frame_leave: FuncRef,
 }
 
 pub(crate) fn parse_simple_statements_with_debug(
@@ -4508,13 +4525,21 @@ pub(crate) fn debug_variable_slot(name: &str) -> u32 {
     hash
 }
 
-fn emit_debug_frame_boundary(
+fn emit_function_frame_boundary(
     builder: &mut FunctionBuilder<'_>,
     function: FuncRef,
     function_id: FunctionId,
 ) {
     let function_id = builder.ins().iconst(types::I32, i64::from(function_id));
     builder.ins().call(function, &[function_id]);
+}
+
+fn emit_debug_frame_boundary(
+    builder: &mut FunctionBuilder<'_>,
+    function: FuncRef,
+    function_id: FunctionId,
+) {
+    emit_function_frame_boundary(builder, function, function_id);
 }
 
 fn emit_debug_statement(
@@ -5692,6 +5717,9 @@ pub(crate) fn emit_simple_statements(
                 if let Some(debug) = debug_refs {
                     emit_debug_frame_boundary(builder, debug.frame_leave, function_id);
                 }
+                if let Some(profile) = runtime_call_refs.profile.as_ref() {
+                    emit_function_frame_boundary(builder, profile.frame_leave, function_id);
+                }
                 builder.ins().return_(&[value]);
                 return Ok(true);
             }
@@ -5699,6 +5727,9 @@ pub(crate) fn emit_simple_statements(
                 if expected_return_type == TYPE_ID_VOID {
                     if let Some(debug) = debug_refs {
                         emit_debug_frame_boundary(builder, debug.frame_leave, function_id);
+                    }
+                    if let Some(profile) = runtime_call_refs.profile.as_ref() {
+                        emit_function_frame_boundary(builder, profile.frame_leave, function_id);
                     }
                     builder.ins().return_(&[]);
                     return Ok(true);
@@ -10269,6 +10300,7 @@ fn build_direct_runtime_call_import_ids(
     type_table: &TypeTable,
     named_struct_field_types: &NamedStructFieldTypeMap,
     debug_instrumentation: bool,
+    profile_instrumentation: bool,
 ) -> Result<RuntimeCallImportIds, String> {
     let print_i32 = if referenced_call_targets
         .iter()
@@ -10401,6 +10433,12 @@ fn build_direct_runtime_call_import_ids(
         debug_value_f64: debug_instrumentation
             .then(|| declare_debug_value_f64_import(module, linkage))
             .transpose()?,
+        profile_frame_enter: profile_instrumentation
+            .then(|| declare_void_call_import(module, "stasis_jit_profile_frame_enter", linkage, 1))
+            .transpose()?,
+        profile_frame_leave: profile_instrumentation
+            .then(|| declare_void_call_import(module, "stasis_jit_profile_frame_leave", linkage, 1))
+            .transpose()?,
         extern_calls: declare_extern_call_imports(
             module,
             &referenced_extern_signatures,
@@ -10439,6 +10477,13 @@ pub(crate) fn build_runtime_call_refs(
                 }
             },
         );
+    let profile = imports
+        .profile_frame_enter
+        .zip(imports.profile_frame_leave)
+        .map(|(frame_enter, frame_leave)| ProfileRuntimeRefs {
+            frame_enter: module.declare_func_in_func(frame_enter, func),
+            frame_leave: module.declare_func_in_func(frame_leave, func),
+        });
     Ok(RuntimeCallRefs {
         print_i32: module.declare_func_in_func(imports.print_i32, func),
         print_string: module.declare_func_in_func(imports.print_string, func),
@@ -10462,6 +10507,7 @@ pub(crate) fn build_runtime_call_refs(
         collection_i32_load: module.declare_func_in_func(imports.collection_i32_load, func),
         collection_i32_store: module.declare_func_in_func(imports.collection_i32_store, func),
         debug,
+        profile,
         extern_calls: imports
             .extern_calls
             .iter()

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -511,6 +511,7 @@ pub struct JitProcess {
     required_emit_roots: Vec<String>,
     local_runtime_helper_trampolines: bool,
     debug_instrumentation: bool,
+    profile_function_names: BTreeSet<String>,
     debug_metadata: BTreeMap<FunctionId, JitDebugFunctionMetadata>,
     #[cfg(test)]
     _test_guard: Option<MutexGuard<'static, ()>>,
@@ -609,6 +610,7 @@ impl JitProcess {
             required_emit_roots: Vec::new(),
             local_runtime_helper_trampolines: false,
             debug_instrumentation: false,
+            profile_function_names: BTreeSet::new(),
             debug_metadata: BTreeMap::new(),
             #[cfg(test)]
             _test_guard,
@@ -623,6 +625,24 @@ impl JitProcess {
             );
         }
         self.debug_instrumentation = enabled;
+        Ok(())
+    }
+
+    pub fn set_profile_functions(
+        &mut self,
+        names: impl IntoIterator<Item = String>,
+    ) -> Result<(), String> {
+        if self.program_snapshot.is_some() || self.active_program_snapshot.is_some() {
+            return Err(
+                "JIT function profiling must be configured before the first compilation"
+                    .to_string(),
+            );
+        }
+        self.profile_function_names = names
+            .into_iter()
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .collect();
         Ok(())
     }
 
@@ -657,6 +677,7 @@ impl JitProcess {
             .set_analysis_required_roots(&candidate.required_emit_roots);
         candidate.local_runtime_helper_trampolines = self.local_runtime_helper_trampolines;
         candidate.debug_instrumentation = self.debug_instrumentation;
+        candidate.profile_function_names = self.profile_function_names.clone();
         candidate.debug_metadata = self.debug_metadata.clone();
         candidate
     }
@@ -998,6 +1019,7 @@ impl JitProcess {
         }
         let local_runtime_helper_trampolines = self.local_runtime_helper_trampolines;
         let debug_instrumentation = self.debug_instrumentation;
+        let profile_function_names = self.profile_function_names.clone();
         let mut staged_module = if emit_function_ids.is_empty() {
             None
         } else {
@@ -1020,6 +1042,7 @@ impl JitProcess {
                         .insert(meta.id, debug_function_metadata(meta, hir, file)?);
                 }
                 let symbol = format!("jit_fn_{}", meta.id);
+                let profile_instrumentation = profile_function_names.contains(&meta.name);
                 let mut type_table = lowered_types.clone();
                 type_table.ensure_utf8_view_id()?;
                 type_table.ensure_ascii_view_id()?;
@@ -1042,6 +1065,7 @@ impl JitProcess {
                         &direct_storage,
                         local_runtime_helper_trampolines,
                         debug_instrumentation,
+                        profile_instrumentation,
                         &mut defined_runtime_helper_trampolines,
                     )
                 }));
@@ -3135,6 +3159,8 @@ fn runtime_helper_addresses() -> BTreeMap<String, usize> {
         stasis_jit_debug_values_begin,
         stasis_jit_debug_value_i64,
         stasis_jit_debug_value_f64,
+        stasis_jit_profile_frame_enter,
+        stasis_jit_profile_frame_leave,
     );
     out
 }
@@ -3176,6 +3202,7 @@ fn compile_function_into_jit_module(
     direct_storage: &DirectStorageBindings,
     local_runtime_helper_trampolines: bool,
     debug_instrumentation: bool,
+    profile_instrumentation: bool,
     defined_runtime_helper_trampolines: &mut BTreeSet<String>,
 ) -> Result<(JITModule, cranelift_module::FuncId, String, usize), String> {
     let runtime_helper_addresses = local_runtime_helper_trampolines.then(|| {
@@ -3210,6 +3237,7 @@ fn compile_function_into_jit_module(
         Some(direct_storage),
         Some(defined_runtime_helper_trampolines),
         debug_instrumentation,
+        profile_instrumentation,
         |_| Ok(()),
         move |_, function| {
             *clif_capture.borrow_mut() = function.display().to_string();
@@ -5881,6 +5909,42 @@ mod tests {
         assert_eq!(report.index.parsed_functions, 1);
         assert_eq!(report.emit.emitted_functions, 1);
         assert!(process.artifacts()[0].code_ptr != 0);
+    }
+
+    #[test]
+    fn selectively_profiled_jit_reports_only_named_functions() {
+        let mut process = JitProcess::new();
+        process
+            .set_profile_functions(vec!["helper".to_string()])
+            .expect("configure profiler");
+        process.upsert_file(
+            "src/main.stasis",
+            "function helper(value: i32): i32 { return value * 2; }\nfunction main(): i32 { return helper(3) + helper(4); }\n",
+        );
+        process.compile().expect("profiled compile");
+        let helper_id = process
+            .program_snapshot()
+            .expect("program snapshot")
+            .functions()
+            .iter()
+            .find(|function| function.name == "helper")
+            .map(|function| function.id)
+            .expect("helper id");
+
+        stasis_dynload::enable_jit_profiler();
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute profiled main"),
+            14
+        );
+        stasis_dynload::disable_jit_profiler();
+        let samples = stasis_dynload::jit_profile_snapshot();
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].function_id, helper_id);
+        assert_eq!(samples[0].calls, 2);
+        assert!(samples[0].inclusive_ns >= samples[0].exclusive_ns);
+        stasis_dynload::reset_jit_profile();
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -6,8 +6,8 @@ use std::ffi::{c_char, c_void, CString};
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Condvar, Mutex, MutexGuard, OnceLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
@@ -38,6 +38,171 @@ pub struct JitHostEntryTargets {
 static JIT_HOST_ENTRY_TARGETS: AtomicUsize = AtomicUsize::new(0);
 
 static JIT_DEBUG_ENABLED: AtomicBool = AtomicBool::new(false);
+static JIT_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
+static JIT_PROFILE_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JitProfileSample {
+    pub function_id: u32,
+    pub calls: u64,
+    pub inclusive_ns: u64,
+    pub exclusive_ns: u64,
+    pub max_inclusive_ns: u64,
+}
+
+struct JitProfileFrame {
+    function_id: u32,
+    generation: u64,
+    started: Instant,
+    child_ns: u64,
+}
+
+#[derive(Default)]
+struct JitProfileAggregate {
+    calls: AtomicU64,
+    inclusive_ns: AtomicU64,
+    exclusive_ns: AtomicU64,
+    max_inclusive_ns: AtomicU64,
+}
+
+#[derive(Default)]
+struct JitProfileState {
+    generation: u64,
+    frames: Vec<JitProfileFrame>,
+    aggregate_cache: HashMap<u32, Arc<JitProfileAggregate>>,
+}
+
+thread_local! {
+    static JIT_PROFILE_STATE: RefCell<JitProfileState> = RefCell::new(JitProfileState::default());
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn jit_profile_aggregates() -> &'static RwLock<HashMap<u32, Arc<JitProfileAggregate>>> {
+    static AGGREGATES: OnceLock<RwLock<HashMap<u32, Arc<JitProfileAggregate>>>> = OnceLock::new();
+    AGGREGATES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn sync_jit_profile_generation(state: &mut JitProfileState, generation: u64) {
+    if state.generation != generation {
+        state.generation = generation;
+        state.frames.clear();
+        state.aggregate_cache.clear();
+    }
+}
+
+pub fn enable_jit_profiler() {
+    reset_jit_profile();
+    JIT_PROFILE_ENABLED.store(true, Ordering::Release);
+}
+
+pub fn disable_jit_profiler() {
+    JIT_PROFILE_ENABLED.store(false, Ordering::Release);
+    JIT_PROFILE_STATE.with(|state| state.borrow_mut().frames.clear());
+}
+
+pub fn reset_jit_profile() {
+    JIT_PROFILE_GENERATION.fetch_add(1, Ordering::AcqRel);
+    let aggregates = jit_profile_aggregates()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for aggregate in aggregates.values() {
+        aggregate.calls.store(0, Ordering::Relaxed);
+        aggregate.inclusive_ns.store(0, Ordering::Relaxed);
+        aggregate.exclusive_ns.store(0, Ordering::Relaxed);
+        aggregate.max_inclusive_ns.store(0, Ordering::Relaxed);
+    }
+}
+
+pub fn jit_profile_snapshot() -> Vec<JitProfileSample> {
+    let aggregates = jit_profile_aggregates()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut samples: Vec<JitProfileSample> = aggregates
+        .iter()
+        .map(|(function_id, aggregate)| JitProfileSample {
+            function_id: *function_id,
+            calls: aggregate.calls.load(Ordering::Relaxed),
+            inclusive_ns: aggregate.inclusive_ns.load(Ordering::Relaxed),
+            exclusive_ns: aggregate.exclusive_ns.load(Ordering::Relaxed),
+            max_inclusive_ns: aggregate.max_inclusive_ns.load(Ordering::Relaxed),
+        })
+        .filter(|sample| sample.calls > 0)
+        .collect();
+    samples.sort_by_key(|sample| sample.function_id);
+    samples
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_profile_frame_enter(function_id: i32) {
+    if !JIT_PROFILE_ENABLED.load(Ordering::Acquire) {
+        return;
+    }
+    let generation = JIT_PROFILE_GENERATION.load(Ordering::Acquire);
+    let started = Instant::now();
+    JIT_PROFILE_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        sync_jit_profile_generation(&mut state, generation);
+        state.frames.push(JitProfileFrame {
+            function_id: function_id as u32,
+            generation,
+            started,
+            child_ns: 0,
+        });
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_profile_frame_leave(function_id: i32) {
+    if !JIT_PROFILE_ENABLED.load(Ordering::Acquire) {
+        return;
+    }
+    let generation = JIT_PROFILE_GENERATION.load(Ordering::Acquire);
+    JIT_PROFILE_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        sync_jit_profile_generation(&mut state, generation);
+        let Some(frame) = state.frames.pop() else {
+            return;
+        };
+        if frame.generation != generation || frame.function_id != function_id as u32 {
+            state.frames.clear();
+            return;
+        }
+        let inclusive_ns = elapsed_ns(frame.started);
+        let exclusive_ns = inclusive_ns.saturating_sub(frame.child_ns);
+        if let Some(parent) = state.frames.last_mut() {
+            parent.child_ns = parent.child_ns.saturating_add(inclusive_ns);
+        }
+        let aggregate = if let Some(aggregate) = state.aggregate_cache.get(&frame.function_id) {
+            Arc::clone(aggregate)
+        } else {
+            let mut aggregates = jit_profile_aggregates()
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let aggregate = Arc::clone(
+                aggregates
+                    .entry(frame.function_id)
+                    .or_insert_with(|| Arc::new(JitProfileAggregate::default())),
+            );
+            state
+                .aggregate_cache
+                .insert(frame.function_id, Arc::clone(&aggregate));
+            aggregate
+        };
+        aggregate.calls.fetch_add(1, Ordering::Relaxed);
+        aggregate
+            .inclusive_ns
+            .fetch_add(inclusive_ns, Ordering::Relaxed);
+        aggregate
+            .exclusive_ns
+            .fetch_add(exclusive_ns, Ordering::Relaxed);
+        aggregate
+            .max_inclusive_ns
+            .fetch_max(inclusive_ns, Ordering::Relaxed);
+    });
+}
 
 fn jit_output_capture() -> &'static Mutex<Option<String>> {
     static CAPTURE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
@@ -5984,6 +6149,71 @@ mod tests {
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 1), 6);
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 2), 8);
         assert_eq!(stasis_jit_collection_i32_load(shared_id, 3), 6);
+    }
+
+    #[test]
+    fn jit_profiler_aggregates_nested_inclusive_and_exclusive_time() {
+        let _lock = test_lock();
+        enable_jit_profiler();
+        stasis_jit_profile_frame_enter(11);
+        stasis_jit_profile_frame_enter(22);
+        let mut value = 0_u64;
+        for i in 0..10_000_u64 {
+            value = std::hint::black_box(value.wrapping_add(i));
+        }
+        stasis_jit_profile_frame_leave(22);
+        stasis_jit_profile_frame_leave(11);
+        std::hint::black_box(value);
+        disable_jit_profiler();
+
+        let samples = jit_profile_snapshot();
+        let parent = samples
+            .iter()
+            .find(|sample| sample.function_id == 11)
+            .expect("parent sample");
+        let child = samples
+            .iter()
+            .find(|sample| sample.function_id == 22)
+            .expect("child sample");
+        assert_eq!(parent.calls, 1);
+        assert_eq!(child.calls, 1);
+        assert!(parent.inclusive_ns >= child.inclusive_ns);
+        assert!(parent.inclusive_ns >= parent.exclusive_ns);
+        assert!(child.inclusive_ns >= child.exclusive_ns);
+        assert_eq!(parent.max_inclusive_ns, parent.inclusive_ns);
+
+        reset_jit_profile();
+        assert!(jit_profile_snapshot().is_empty());
+    }
+
+    #[test]
+    fn jit_profiler_merges_samples_from_multiple_threads() {
+        let _lock = test_lock();
+        enable_jit_profiler();
+        let workers: Vec<_> = (0..4)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    for _ in 0..25 {
+                        stasis_jit_profile_frame_enter(33);
+                        std::hint::black_box(33);
+                        stasis_jit_profile_frame_leave(33);
+                    }
+                })
+            })
+            .collect();
+        for worker in workers {
+            worker.join().expect("profile worker");
+        }
+        disable_jit_profiler();
+
+        let samples = jit_profile_snapshot();
+        let sample = samples
+            .iter()
+            .find(|sample| sample.function_id == 33)
+            .expect("cross-thread sample");
+        assert_eq!(sample.calls, 100);
+        assert!(sample.inclusive_ns >= sample.exclusive_ns);
+        assert!(sample.max_inclusive_ns > 0);
     }
 
     extern "C" fn host_entry_one() -> i32 {

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -184,6 +184,9 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
         stasis_mobile_aot_runtime.c
     )
     configure_stasis_target(stasis_mobile_runtime ON TRUE)
+    if(MSVC)
+        target_compile_options(stasis_mobile_runtime PRIVATE /experimental:c11atomics)
+    endif()
     target_include_directories(stasis_mobile_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
     set_target_properties(stasis_mobile_runtime PROPERTIES
         POSITION_INDEPENDENT_CODE ON
@@ -261,6 +264,11 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         stasis_mobile_runtime.c
         stasis_mobile_aot_runtime.c
     )
+    set_property(TARGET stasis_mobile_runtime_test PROPERTY C_STANDARD 11)
+    set_property(TARGET stasis_mobile_runtime_test PROPERTY C_STANDARD_REQUIRED ON)
+    if(MSVC)
+        target_compile_options(stasis_mobile_runtime_test PRIVATE /experimental:c11atomics)
+    endif()
     target_include_directories(stasis_mobile_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(NAME stasis_mobile_runtime_lifecycle COMMAND stasis_mobile_runtime_test)
     add_executable(
@@ -274,6 +282,11 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
         tests/stasis_mobile_aot_runtime_test.c
         stasis_mobile_aot_runtime.c
     )
+    set_property(TARGET stasis_mobile_aot_runtime_test PROPERTY C_STANDARD 11)
+    set_property(TARGET stasis_mobile_aot_runtime_test PROPERTY C_STANDARD_REQUIRED ON)
+    if(MSVC)
+        target_compile_options(stasis_mobile_aot_runtime_test PRIVATE /experimental:c11atomics)
+    endif()
     target_include_directories(stasis_mobile_aot_runtime_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     if(NOT WIN32)
         target_link_libraries(stasis_mobile_runtime_test PRIVATE m)

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -112,6 +112,10 @@ static void log_package_provenance(void) {
 #define STASIS_EXPORT __attribute__((visibility("default")))
 #endif
 
+STASIS_EXPORT void stasis_host_log_message(const char* message) {
+    if (message && *message) SDL_Log("%s", message);
+}
+
 STASIS_EXPORT void stasis_set_window_size(int width, int height);
 STASIS_EXPORT int stasis_set_maximized(int maximized);
 STASIS_EXPORT int stasis_get_time_us(void);

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -1,16 +1,24 @@
 #include "stasis_mobile_aot_runtime.h"
 
 #include <math.h>
+#include <inttypes.h>
 #include <stddef.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
 
 #define STASIS_MOBILE_MAX_SCALARS 2048
 #define STASIS_MOBILE_MAX_ARRAYS 512
 #define STASIS_MOBILE_MAX_FUNCTIONS 1024
 #define STASIS_MOBILE_INITIAL_STRING_CAPACITY 512
 #define STASIS_MOBILE_MAX_ARRAY_LENGTH 1048576
+#define STASIS_MOBILE_MAX_PROFILE_FUNCTIONS 64
+#define STASIS_MOBILE_MAX_PROFILE_DEPTH 256
 
 int stasis_audio_init(int sample_rate, int channels, int target_latency_frames);
 void stasis_audio_shutdown(void);
@@ -51,6 +59,7 @@ int stasis_storage_load_ascii(const char *scope, const char *key, char *out, int
 int stasis_storage_save_ascii(const char *scope, const char *key, const char *value, int length);
 int stasis_clipboard_load_ascii(char *out, int capacity);
 int stasis_clipboard_save_ascii(const char *value, int length);
+void stasis_host_log_message(const char *message);
 
 typedef union StasisScalarValue {
     int32_t i32_value;
@@ -102,6 +111,178 @@ static size_t code_ptr_count;
 static StasisStringLiteral *strings;
 static size_t string_count;
 static size_t string_capacity;
+
+typedef struct StasisProfileAggregate {
+    int32_t function_id;
+    const char *name;
+    _Atomic uint64_t calls;
+    _Atomic uint64_t inclusive_ns;
+    _Atomic uint64_t exclusive_ns;
+    _Atomic uint64_t max_inclusive_ns;
+} StasisProfileAggregate;
+
+typedef struct StasisProfileFrame {
+    size_t aggregate_index;
+    uint64_t started_ns;
+    uint64_t child_ns;
+} StasisProfileFrame;
+
+static StasisProfileAggregate profile_aggregates[STASIS_MOBILE_MAX_PROFILE_FUNCTIONS];
+static size_t profile_aggregate_count;
+static int32_t profile_warmup_frames;
+static int32_t profile_sample_frames;
+static int32_t profile_frame_index;
+static _Atomic int profile_enabled;
+static _Thread_local StasisProfileFrame profile_stack[STASIS_MOBILE_MAX_PROFILE_DEPTH];
+static _Thread_local size_t profile_stack_depth;
+
+static uint64_t stasis_profile_now_ns(void) {
+#if defined(_WIN32)
+    LARGE_INTEGER counter;
+    LARGE_INTEGER frequency;
+    if (!QueryPerformanceCounter(&counter) || !QueryPerformanceFrequency(&frequency) ||
+        frequency.QuadPart <= 0) return 0;
+    return (uint64_t)(counter.QuadPart / frequency.QuadPart) * UINT64_C(1000000000) +
+        (uint64_t)((counter.QuadPart % frequency.QuadPart) * UINT64_C(1000000000) /
+            frequency.QuadPart);
+#else
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return 0;
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+#endif
+}
+
+static void stasis_profile_reset_samples(void) {
+    size_t index;
+    for (index = 0; index < profile_aggregate_count; index += 1) {
+        atomic_store_explicit(&profile_aggregates[index].calls, 0, memory_order_relaxed);
+        atomic_store_explicit(&profile_aggregates[index].inclusive_ns, 0, memory_order_relaxed);
+        atomic_store_explicit(&profile_aggregates[index].exclusive_ns, 0, memory_order_relaxed);
+        atomic_store_explicit(&profile_aggregates[index].max_inclusive_ns, 0, memory_order_relaxed);
+    }
+}
+
+static void stasis_profile_reset(void) {
+    atomic_store_explicit(&profile_enabled, 0, memory_order_release);
+    memset(profile_aggregates, 0, sizeof(profile_aggregates));
+    profile_aggregate_count = 0;
+    profile_warmup_frames = 0;
+    profile_sample_frames = 0;
+    profile_frame_index = 0;
+    profile_stack_depth = 0;
+}
+
+static size_t stasis_profile_find(int32_t function_id) {
+    size_t index;
+    for (index = 0; index < profile_aggregate_count; index += 1) {
+        if (profile_aggregates[index].function_id == function_id) return index;
+    }
+    return STASIS_MOBILE_MAX_PROFILE_FUNCTIONS;
+}
+
+void stasis_jit_profile_register_function(int32_t function_id, const char *name) {
+    StasisProfileAggregate *aggregate;
+    if (name == NULL || stasis_profile_find(function_id) < profile_aggregate_count ||
+        profile_aggregate_count >= STASIS_MOBILE_MAX_PROFILE_FUNCTIONS) return;
+    aggregate = &profile_aggregates[profile_aggregate_count++];
+    aggregate->function_id = function_id;
+    aggregate->name = name;
+}
+
+void stasis_jit_profile_configure(int32_t warmup_frames, int32_t sample_frames) {
+    profile_warmup_frames = warmup_frames < 0 ? 0 : warmup_frames;
+    profile_sample_frames = sample_frames < 0 ? 0 : sample_frames;
+    profile_frame_index = 0;
+    profile_stack_depth = 0;
+    stasis_profile_reset_samples();
+    atomic_store_explicit(&profile_enabled, 0, memory_order_release);
+}
+
+void stasis_jit_profile_frame_begin(void) {
+    char line[160];
+    if (profile_aggregate_count == 0 || profile_sample_frames <= 0) return;
+    if (profile_frame_index == profile_warmup_frames) {
+        profile_stack_depth = 0;
+        stasis_profile_reset_samples();
+        atomic_store_explicit(&profile_enabled, 1, memory_order_release);
+        snprintf(line, sizeof(line),
+            "STASIS_PROFILE_START|warmup_frames=%d|sample_frames=%d|functions=%zu",
+            profile_warmup_frames, profile_sample_frames, profile_aggregate_count);
+        stasis_host_log_message(line);
+    }
+}
+
+static void stasis_profile_report(void) {
+    size_t index;
+    char line[512];
+    for (index = 0; index < profile_aggregate_count; index += 1) {
+        StasisProfileAggregate *aggregate = &profile_aggregates[index];
+        snprintf(line, sizeof(line),
+            "STASIS_PROFILE|%s|%" PRIu64 "|%" PRIu64 "|%" PRIu64 "|%" PRIu64,
+            aggregate->name,
+            atomic_load_explicit(&aggregate->calls, memory_order_relaxed),
+            atomic_load_explicit(&aggregate->inclusive_ns, memory_order_relaxed),
+            atomic_load_explicit(&aggregate->exclusive_ns, memory_order_relaxed),
+            atomic_load_explicit(&aggregate->max_inclusive_ns, memory_order_relaxed));
+        stasis_host_log_message(line);
+    }
+    snprintf(line, sizeof(line), "STASIS_PROFILE_DONE|frames=%d", profile_sample_frames);
+    stasis_host_log_message(line);
+}
+
+void stasis_jit_profile_frame_end(void) {
+    if (profile_aggregate_count == 0 || profile_sample_frames <= 0) return;
+    profile_frame_index += 1;
+    if (profile_frame_index == profile_warmup_frames + profile_sample_frames) {
+        atomic_store_explicit(&profile_enabled, 0, memory_order_release);
+        profile_stack_depth = 0;
+        stasis_profile_report();
+    }
+}
+
+void stasis_jit_profile_frame_enter(int32_t function_id) {
+    size_t aggregate_index;
+    StasisProfileFrame *frame;
+    if (!atomic_load_explicit(&profile_enabled, memory_order_acquire) ||
+        profile_stack_depth >= STASIS_MOBILE_MAX_PROFILE_DEPTH) return;
+    aggregate_index = stasis_profile_find(function_id);
+    if (aggregate_index >= profile_aggregate_count) return;
+    frame = &profile_stack[profile_stack_depth++];
+    frame->aggregate_index = aggregate_index;
+    frame->started_ns = stasis_profile_now_ns();
+    frame->child_ns = 0;
+}
+
+void stasis_jit_profile_frame_leave(int32_t function_id) {
+    StasisProfileFrame frame;
+    StasisProfileAggregate *aggregate;
+    uint64_t finished_ns;
+    uint64_t inclusive_ns;
+    uint64_t exclusive_ns;
+    uint64_t observed_max;
+    if (!atomic_load_explicit(&profile_enabled, memory_order_acquire) ||
+        profile_stack_depth == 0) return;
+    frame = profile_stack[--profile_stack_depth];
+    aggregate = &profile_aggregates[frame.aggregate_index];
+    if (aggregate->function_id != function_id) {
+        profile_stack_depth = 0;
+        return;
+    }
+    finished_ns = stasis_profile_now_ns();
+    inclusive_ns = finished_ns >= frame.started_ns ? finished_ns - frame.started_ns : 0;
+    exclusive_ns = inclusive_ns >= frame.child_ns ? inclusive_ns - frame.child_ns : 0;
+    if (profile_stack_depth > 0) {
+        profile_stack[profile_stack_depth - 1].child_ns += inclusive_ns;
+    }
+    atomic_fetch_add_explicit(&aggregate->calls, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&aggregate->inclusive_ns, inclusive_ns, memory_order_relaxed);
+    atomic_fetch_add_explicit(&aggregate->exclusive_ns, exclusive_ns, memory_order_relaxed);
+    observed_max = atomic_load_explicit(&aggregate->max_inclusive_ns, memory_order_relaxed);
+    while (observed_max < inclusive_ns &&
+        !atomic_compare_exchange_weak_explicit(
+            &aggregate->max_inclusive_ns, &observed_max, inclusive_ns,
+            memory_order_relaxed, memory_order_relaxed)) {}
+}
 
 int stasis_mobile_json_escape(const char *input, char *output, size_t capacity) {
     static const char hex[] = "0123456789abcdef";
@@ -230,6 +411,7 @@ static void register_array(
 
 void stasis_mobile_aot_reset(void) {
     size_t index;
+    stasis_profile_reset();
     for (index = 0; index < array_count; index += 1) {
         if (!arrays[index].external) free(arrays[index].data);
     }

--- a/runtime/stasis_mobile_aot_runtime.h
+++ b/runtime/stasis_mobile_aot_runtime.h
@@ -24,6 +24,12 @@ void stasis_jit_register_global_u16_array(
 void stasis_jit_register_code_ptr(int32_t fn_id, int64_t code_ptr);
 void stasis_jit_clear_string_literal_table(void);
 void stasis_jit_upsert_string_literal(int32_t id, const char *value);
+void stasis_jit_profile_register_function(int32_t function_id, const char *name);
+void stasis_jit_profile_configure(int32_t warmup_frames, int32_t sample_frames);
+void stasis_jit_profile_frame_begin(void);
+void stasis_jit_profile_frame_end(void);
+void stasis_jit_profile_frame_enter(int32_t function_id);
+void stasis_jit_profile_frame_leave(int32_t function_id);
 int64_t stasis_jit_lookup_code_ptr(int32_t fn_id);
 int32_t stasis_jit_global_i32_load(int32_t hash);
 void stasis_jit_global_i32_store(int32_t hash, int32_t value);

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -146,6 +146,7 @@ int32_t stasis_mobile_runtime_step(void) {
 
     stasis_host_get_frame(host_i32, host_f32);
     apply_guest_host_requests();
+    stasis_jit_profile_frame_begin();
     uint64_t tick_started = stasis_host_performance_counter();
     runtime_state.last_entry_result = runtime_state.entries.tick_entry();
     uint64_t tick_finished = stasis_host_performance_counter();
@@ -167,6 +168,7 @@ int32_t stasis_mobile_runtime_step(void) {
         stasis_host_performance_elapsed_us(render_started, render_finished));
     /* Submission owns begin/present according to the guest command-buffer flags. */
     stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
+    stasis_jit_profile_frame_end();
     return STASIS_MOBILE_RUNTIME_OK;
 }
 

--- a/runtime/tests/stasis_generated_mobile_integration.c
+++ b/runtime/tests/stasis_generated_mobile_integration.c
@@ -91,6 +91,8 @@ void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us) {
     (void)tick_us;
     (void)render_us;
 }
+
+void stasis_host_log_message(const char *message) { (void)message; }
 void stasis_shutdown(void) { shutdowns += 1; }
 
 int stasis_audio_init(int rate, int channels, int latency) {

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -36,6 +36,20 @@ static int has_saved_value;
 static char saved_ascii[64];
 static int saved_ascii_length;
 static char clipboard_ascii[64] = "GG1-clipboard";
+static int profile_start_logs;
+static int profile_row_logs;
+static int profile_done_logs;
+static char profile_row[256];
+
+void stasis_host_log_message(const char *message) {
+    if (message == NULL) return;
+    if (strncmp(message, "STASIS_PROFILE_START|", 21) == 0) profile_start_logs += 1;
+    if (strncmp(message, "STASIS_PROFILE|", 15) == 0) {
+        profile_row_logs += 1;
+        snprintf(profile_row, sizeof(profile_row), "%s", message);
+    }
+    if (strncmp(message, "STASIS_PROFILE_DONE|", 20) == 0) profile_done_logs += 1;
+}
 
 int stasis_audio_init(int rate, int channels, int latency) {
     return rate > 0 && channels == 2 && latency > 0;
@@ -253,6 +267,17 @@ int main(void) {
     stasis_jit_register_code_ptr(30, (int64_t)(uintptr_t)&add_two);
     CHECK(stasis_jit_call_i32_2(30, 5, 7) == 12);
     CHECK(stasis_jit_call_i32_0(999) == 0);
+
+    stasis_jit_profile_register_function(77, "render");
+    stasis_jit_profile_configure(0, 1);
+    stasis_jit_profile_frame_begin();
+    stasis_jit_profile_frame_enter(77);
+    stasis_jit_profile_frame_leave(77);
+    stasis_jit_profile_frame_end();
+    CHECK(profile_start_logs == 1);
+    CHECK(profile_row_logs == 1);
+    CHECK(strncmp(profile_row, "STASIS_PROFILE|render|1|", 24) == 0);
+    CHECK(profile_done_logs == 1);
 
     stasis_mobile_aot_reset();
     CHECK(stasis_jit_global_i32_load(10) == 0);

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -40,6 +40,10 @@ static uint64_t performance_counter;
 static int performance_metrics_calls;
 static uint64_t reported_tick_us;
 static uint64_t reported_render_us;
+static int profile_start_logs;
+static int profile_row_logs;
+static int profile_done_logs;
+static char profile_row[256];
 static int32_t game_host_i32[768];
 static float game_host_f32[64];
 static int32_t game_gfx_cmd_i32[STASIS_RENDER_I32_COUNT];
@@ -134,6 +138,15 @@ void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us) {
     performance_metrics_calls += 1;
     reported_tick_us = tick_us;
     reported_render_us = render_us;
+}
+
+void stasis_host_log_message(const char *message) {
+    if (strncmp(message, "STASIS_PROFILE_START|", 21) == 0) profile_start_logs += 1;
+    if (strncmp(message, "STASIS_PROFILE|", 15) == 0) {
+        profile_row_logs += 1;
+        snprintf(profile_row, sizeof(profile_row), "%s", message);
+    }
+    if (strncmp(message, "STASIS_PROFILE_DONE|", 20) == 0) profile_done_logs += 1;
 }
 
 int stasis_audio_init(int rate, int channels, int latency) { return rate + channels + latency; }
@@ -238,6 +251,8 @@ static void bind_runtime(void) {
         hash_path("host_req_window_w_px"), &game_host_req_window_w_px);
     stasis_jit_register_global_i32_ptr(
         hash_path("host_req_window_h_px"), &game_host_req_window_h_px);
+    stasis_jit_profile_register_function(77, "render");
+    stasis_jit_profile_configure(1, 2);
 }
 
 static int32_t game_tick(void) {
@@ -246,9 +261,11 @@ static int32_t game_tick(void) {
 }
 
 static int32_t game_render(void) {
+    stasis_jit_profile_frame_enter(77);
     render_calls += 1;
     game_gfx_cmd_i32[STASIS_RENDER_I_MAGIC] = STASIS_RENDER_V2_MAGIC;
     game_gfx_cmd_i32[STASIS_RENDER_I_VERSION] = STASIS_RENDER_V2_VERSION;
+    stasis_jit_profile_frame_leave(77);
     return render_result;
 }
 
@@ -297,6 +314,10 @@ static void reset_fakes(void) {
     performance_metrics_calls = 0;
     reported_tick_us = 0;
     reported_render_us = 0;
+    profile_start_logs = 0;
+    profile_row_logs = 0;
+    profile_done_logs = 0;
+    profile_row[0] = '\0';
     memset(game_host_i32, 0, sizeof(game_host_i32));
     memset(game_host_f32, 0, sizeof(game_host_f32));
     memset(game_gfx_cmd_i32, 0, sizeof(game_gfx_cmd_i32));
@@ -388,6 +409,21 @@ static void test_rejects_duplicate_initialization(void) {
     stasis_mobile_runtime_shutdown();
 }
 
+static void test_reports_bounded_profile_after_warmup(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(profile_start_logs == 0 && profile_row_logs == 0 && profile_done_logs == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(profile_start_logs == 1 && profile_row_logs == 0 && profile_done_logs == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(profile_row_logs == 1 && profile_done_logs == 1);
+    assert(strstr(profile_row, "STASIS_PROFILE|render|2|") == profile_row);
+    stasis_mobile_runtime_shutdown();
+}
+
 static void test_reports_graphics_initialization_failure(void) {
     StasisMobileRuntimeConfig valid_config = config();
     StasisMobileGameEntries valid_entries = entries();
@@ -443,6 +479,8 @@ int main(void) {
     test_runs_mobile_lifecycle();
     reset_fakes();
     test_rejects_duplicate_initialization();
+    reset_fakes();
+    test_reports_bounded_profile_after_warmup();
     reset_fakes();
     test_reports_graphics_initialization_failure();
     reset_fakes();

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -509,6 +509,29 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     return observed
 
 
+def capture_until_regions_match(
+    adb: Path,
+    serial: str | None,
+    capture: Path,
+    expectations: dict,
+    deadline: float,
+) -> list[dict]:
+    """Wait for the stable marker's frame to reach Android's compositor."""
+    last_error: SeamError | None = None
+    while time.monotonic() < deadline:
+        capture.write_bytes(
+            _run(adb, serial, "exec-out", "screencap", "-p", text=False)
+        )
+        try:
+            return validate_regions(capture, expectations)
+        except SeamError as error:
+            last_error = error
+            time.sleep(0.25)
+    if last_error is not None:
+        raise last_error
+    raise SeamError("capture region deadline expired before the first frame")
+
+
 def parse_wm_size_override(output: str) -> str | None:
     match = re.search(r"^Override size:\s*(\d+x\d+)\s*$", output, re.MULTILINE)
     return match.group(1) if match else None
@@ -946,22 +969,16 @@ def main() -> int:
                         f"Android orientation stage {stage['name']} did not reach "
                         f"probe sequence {stage['sequence']}"
                     )
-                stage_capture_path.write_bytes(
-                    _run(
-                        args.adb,
-                        args.serial,
-                        "exec-out",
-                        "screencap",
-                        "-p",
-                        text=False,
-                    )
-                )
                 stage_expectations = {
                     "logical_size": expectations["logical_size"],
                     "regions": stage["regions"],
                 }
-                stage_regions = validate_regions(
-                    stage_capture_path, stage_expectations
+                stage_regions = capture_until_regions_match(
+                    args.adb,
+                    args.serial,
+                    stage_capture_path,
+                    stage_expectations,
+                    min(deadline, time.monotonic() + 10),
                 )
                 orientation_evidence.append(
                     {
@@ -977,10 +994,13 @@ def main() -> int:
                 markers, expectations, surfaces
             )
         log_path.write_text(log, encoding="utf-8")
-        capture_path.write_bytes(
-            _run(args.adb, args.serial, "exec-out", "screencap", "-p", text=False)
+        regions = capture_until_regions_match(
+            args.adb,
+            args.serial,
+            capture_path,
+            expectations,
+            min(deadline, time.monotonic() + 10),
         )
-        regions = validate_regions(capture_path, expectations)
         time.sleep(1)
         second_pid = _run(
             args.adb, args.serial, "shell", "pidof", package_id, required=False


### PR DESCRIPTION
## What changed

- Adds opt-in Cranelift entry/exit instrumentation for named Stasis functions on desktop JIT and mobile AOT builds.
- Adds desktop `stasis play --profile-functions`, `--profile-warmup`, and `--profile-output` support.
- Adds development-only mobile packaging flags for selected functions plus bounded warmup/sample frame counts.
- Reports calls, inclusive time, exclusive time, average inclusive time, and maximum inclusive time; mobile reports through the existing host log seam for logcat capture.
- Keeps nesting state thread-local while merging completed counters process-wide with relaxed atomics, so the design does not assume one runtime thread and recurring calls do not take a cross-thread mutex.
- Rejects profiling in production mobile packages and bounds selections to 64 unique names.

## Why

Whole-frame timing could not distinguish Stasis draw-command construction from native renderer work. Selective instrumentation provides reusable per-function measurements with low enough overhead for hot-path comparison on both desktop JIT and Android AOT builds.

A failed first prototype treated opaque function IDs as dense vector indices and attempted a 209 GB allocation. The implementation now treats IDs as sparse and uses explicit selected-function registration.

## Performance evidence

On Gambit Guard, the profiler isolated repeated piece-rank discovery as the dominant Stasis rendering cost. That informed a cache which subsequently reduced `draw_pieces` by 66% on both desktop and the API 35 x86_64 emulator, while exact desktop draw-command tracing remained unchanged.

## Validation

- `cargo fmt --all -- --check`
- `python tools/cargo_cache.py run -- cargo check --workspace`
- focused `stasis_compiler` selective AOT hook test
- focused generated mobile AOT runtime seam test
- full Gambit Guard x86_64 Android development build through NDK/Gradle
- API 35 emulator profile completed after 600 warmup and 300 sample frames
- existing desktop profiler tests and end-to-end JSON profiles
- `git diff --check`