### PR TITLE
perf: recover Workshop preview rendering

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Test render parity fixture and capture gate
         run: |
+          python -m unittest tools.ci.test_verify_android_render_performance
           python -m unittest tools.ci.test_verify_render_parity
           python tools/ci/verify_render_parity.py
 

--- a/docs/android_preview_render_performance.md
+++ b/docs/android_preview_render_performance.md
@@ -1,0 +1,48 @@
+# Android preview render performance
+
+The Android Workshop performance gate uses the canonical `samples/render_parity`
+scene. It exercises every gfx_cmd v4 category transition through the real x86_64
+JIT, the embedded GLES renderer, and three pixel-verified captures. Timing starts
+inside `StasisPreviewRenderer.onDrawFrame`; work is not deferred outside the
+measured action.
+
+Run the bounded gate on the repository API 35 emulator after building with
+`-RenderAcceptance`:
+
+```powershell
+mobile/android/test_render_emulator.ps1 -Headless -SkipBuild `
+  -MaxRenderP50Millis 1.05 -MaxRenderP95Millis 8.94
+```
+
+The gate discards 60 warm-up frames, measures 180 frames, records total,
+resource-preparation, and ordered-draw p50/p95, and writes device fingerprint,
+AVD, package version, Git revision, and APK SHA-256 beside the screenshots and
+logcat. The driver verifies the observed AVD and Android API and refuses dirty
+tracked source, so the recorded revision identifies the tested APK inputs.
+`tools/ci/verify_android_render_performance.py` rejects missing, duplicated,
+unexpected, malformed, dirty-source, or out-of-budget evidence.
+
+## 2026-08-12 baseline and result
+
+Both runs used `Stasis_API_35`, API 35 x86_64 fingerprint
+`google/sdk_gphone64_x86_64/emu64xa:15/AE3A.240806.043/12960925:userdebug/dev-keys`,
+the same 640x360 parity scene, 60 warm-up frames, and 180 measured frames.
+
+| Build | Total p50 | Total p95 | Resource p50/p95 | Draw p50/p95 | Draw calls |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `origin/main` baseline | 0.846 ms | 7.152 ms | 0.080 / 0.557 ms | 0.739 / 5.862 ms | 9 |
+| cached-resource/pipeline result | 0.456 ms | 4.169 ms | 0.080 / 0.271 ms | 0.324 / 3.905 ms | 9 |
+
+The emulator-normalized p50 ceiling is 1.05 ms: 25% above the observed baseline.
+The 8.94 ms p95 ceiling uses the same margin but remains a scheduling tripwire,
+not a physical-device claim. The result also returns near the historical 0.4 ms
+device observation. Physical-device evidence may establish a tighter device-class
+threshold later.
+
+Profiling showed ordered GLES submission dominated, while resource preparation
+was already small. The renderer therefore keeps all nine semantically required
+draw calls and their order. It resolves each sprite/text resource once into fixed
+per-frame arrays, then reuses that identity during submission. Adjacent runs keep
+compatible shader/uniform/attribute-enable state, while client-buffer pointers
+are rebound after every refill as GLES requires. No frame allocation, texture
+upload, command reordering, or deferred draw work was introduced.

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -128,6 +128,13 @@ Run the blocking render end-to-end gate directly with:
 
 This builds the canonical `samples/render_parity` fixture in Workshop with the real x86_64 development JIT. It captures the OpenGL surface, normalizes the letterboxed 640x360 viewport, and checks Android regions for the background, procedural fallback, opaque/translucent/rotated SVG sprites, a filled rectangle, crossing lines, direct text, and cached text. Three spaced captures, at least 30 rendered frames, and a successful non-empty JIT compile are required. Release packages are checked separately by `build_release.ps1` and can be run on an arm64 device with `validate_device.ps1 -Release`.
 
+Render-acceptance builds also emit one bounded performance sample after 60
+warm-up and 180 measured frames. Enforce the API 35 emulator thresholds with
+`-MaxRenderP50Millis 1.05 -MaxRenderP95Millis 8.94`; the output directory then
+contains device/build identity, stage percentiles, logcat, and pixel captures.
+See `docs/android_preview_render_performance.md` for the baseline and ownership
+of the hardware-normalized limits.
+
 ## Hosted release-shell emulator
 
 The `Android Emulator Seams` GitHub Actions workflow provisions an API 35

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final String LOG_TAG = "StasisRenderer";
@@ -81,8 +82,13 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final int TEXTURE_VERTEX_FLOATS = 8;
     private static final int COLOR_VERTEX_BYTES = COLOR_VERTEX_FLOATS * 4;
     private static final int TEXTURE_VERTEX_BYTES = TEXTURE_VERTEX_FLOATS * 4;
+    private static final int PIPELINE_NONE = 0;
+    private static final int PIPELINE_COLOR = 1;
+    private static final int PIPELINE_TEXTURE = 2;
     private static final int MAX_CAPTURE_PIXELS = 8_000_000;
     private static final long MIN_RESTORE_LABEL_NANOS = 250_000_000L;
+    private static final int PERFORMANCE_WARMUP_FRAMES = 60;
+    private static final int PERFORMANCE_SAMPLE_FRAMES = 180;
     private static final String[] RESTORE_LABEL = {
             "   01110 11111 01110 01110 11111 01110   ",
             "   10001 00100 10001 10001 00100 10001   ",
@@ -188,6 +194,63 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         }
     }
 
+    static final class FramePerformanceSamples {
+        private final int warmupFrames;
+        private final long[] totalNanos;
+        private final long[] resourceNanos;
+        private final long[] drawNanos;
+        private int seenFrames;
+        private int sampleCount;
+        private int minimumDrawCalls = Integer.MAX_VALUE;
+        private int maximumDrawCalls;
+        private boolean reported;
+
+        FramePerformanceSamples(int warmupFrames, int sampleFrames) {
+            if (warmupFrames < 0 || sampleFrames <= 0) {
+                throw new IllegalArgumentException("render performance sample bounds are invalid");
+            }
+            this.warmupFrames = warmupFrames;
+            totalNanos = new long[sampleFrames];
+            resourceNanos = new long[sampleFrames];
+            drawNanos = new long[sampleFrames];
+        }
+
+        String add(long total, long resources, long draw, int drawCalls,
+                int lines, int rectangles, int sprites, int text, int order) {
+            if (reported) return null;
+            seenFrames += 1;
+            if (seenFrames <= warmupFrames) return null;
+            totalNanos[sampleCount] = Math.max(0L, total);
+            resourceNanos[sampleCount] = Math.max(0L, resources);
+            drawNanos[sampleCount] = Math.max(0L, draw);
+            minimumDrawCalls = Math.min(minimumDrawCalls, drawCalls);
+            maximumDrawCalls = Math.max(maximumDrawCalls, drawCalls);
+            sampleCount += 1;
+            if (sampleCount < totalNanos.length) return null;
+            reported = true;
+            return "RenderPerformance: schema=1 warmup=" + warmupFrames
+                    + " samples=" + sampleCount
+                    + " total_p50_us=" + percentileMicros(totalNanos, 50)
+                    + " total_p95_us=" + percentileMicros(totalNanos, 95)
+                    + " resource_p50_us=" + percentileMicros(resourceNanos, 50)
+                    + " resource_p95_us=" + percentileMicros(resourceNanos, 95)
+                    + " draw_p50_us=" + percentileMicros(drawNanos, 50)
+                    + " draw_p95_us=" + percentileMicros(drawNanos, 95)
+                    + " draw_calls_min=" + minimumDrawCalls
+                    + " draw_calls_max=" + maximumDrawCalls
+                    + " lines=" + lines + " rects=" + rectangles
+                    + " sprites=" + sprites + " text=" + text + " order=" + order;
+        }
+
+        private static long percentileMicros(long[] values, int percentile) {
+            long[] ordered = values.clone();
+            Arrays.sort(ordered);
+            int rank = Math.min(ordered.length - 1,
+                    Math.max(0, (ordered.length * percentile + 99) / 100 - 1));
+            return ordered[rank] / 1_000L;
+        }
+    }
+
     private static final String VERTEX_SHADER =
             "attribute vec2 aPosition;" +
             "attribute vec4 aColor;" +
@@ -211,6 +274,9 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private final TextureProvider textures;
     private final TimingListener timing;
     private final RendererResourceLifecycle resourceLifecycle = new RendererResourceLifecycle();
+    private final FramePerformanceSamples performanceSamples = BuildConfig.STASIS_RENDER_ACCEPTANCE
+            ? new FramePerformanceSamples(PERFORMANCE_WARMUP_FRAMES, PERFORMANCE_SAMPLE_FRAMES)
+            : null;
     private final ByteBuffer frameI32Bytes = directBytes(FRAME_I32_CAPACITY * 4);
     private final ByteBuffer frameF32Bytes = directBytes(FRAME_F32_CAPACITY * 4);
     private final ByteBuffer frameU8Bytes = directBytes(TEXT_U8_CAPACITY);
@@ -220,8 +286,9 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             LINE_CHUNK_SIZE * 2 * COLOR_VERTEX_FLOATS * 4).asFloatBuffer();
     private final FloatBuffer spriteVertices = directBytes(
             SPRITE_CHUNK_SIZE * VERTICES_PER_QUAD * TEXTURE_VERTEX_FLOATS * 4).asFloatBuffer();
-    private final FloatBuffer textVertices = directBytes(
-            VERTICES_PER_QUAD * TEXTURE_VERTEX_FLOATS * 4).asFloatBuffer();
+    private final int[] frameSpriteTextures = new int[MAX_SPRITES];
+    private final int[] frameSpriteFilters = new int[MAX_SPRITES];
+    private final long[] frameTextTextures = new long[MAX_TEXT];
     private int colorProgram;
     private int colorPosition;
     private int colorValue;
@@ -243,6 +310,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private boolean restorePlaceholderPending;
     private long restorePlaceholderUntilNanos;
     private int renderAcceptanceFrameCount;
+    private int frameDrawCalls;
+    private int activePipeline;
 
     StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
         this.textures = textures;
@@ -333,6 +402,15 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         long started = System.nanoTime();
         CaptureCallback capture;
         LogicalFrameSnapshot capturedFrame;
+        long resourceNanos = 0L;
+        long drawNanos = 0L;
+        int drawCalls = 0;
+        int lineCount = 0;
+        int rectCount = 0;
+        int spriteCount = 0;
+        int textCount = 0;
+        int orderCount = 0;
+        boolean presented = false;
         synchronized (this) {
             if (restorePlaceholderPending
                     && System.nanoTime() < restorePlaceholderUntilNanos) {
@@ -341,13 +419,16 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                 return;
             }
             restorePlaceholderPending = false;
+            long resourceStarted = performanceSamples == null ? 0L : System.nanoTime();
             boolean restoring = resourceLifecycle.beginRestore();
             textures.beginRestoreAttempt();
-            while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
+            if (restoring) {
+                while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
+            }
             boolean hasFrame = shouldPresent(frameI32);
             if (hasFrame) prepareFrameResources();
             String resourceFailure = textures.consumeFailure();
-            int glError = GLES20.glGetError();
+            int glError = restoring ? GLES20.glGetError() : GLES20.GL_NO_ERROR;
             boolean restoreComplete = textures.isRestoreComplete();
             boolean restored = resourceFailure == null && glError == GLES20.GL_NO_ERROR
                     && restoreComplete;
@@ -380,7 +461,22 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             if (!restoreComplete && resourceFailure == null
                     && glError == GLES20.GL_NO_ERROR) drawRestorePlaceholder();
             if (hasFrame && restored && resourceLifecycle.canPresent()) {
+                lineCount = clampCount(frameI32.get(I_LINE_COUNT), MAX_LINES);
+                rectCount = clampedRectCount(
+                        frameI32.get(I_VERSION), lineCount, frameI32.get(I_RECT_COUNT));
+                spriteCount = clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES);
+                textCount = clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT);
+                orderCount = frameI32.get(I_VERSION) >= RENDER_V3_VERSION
+                        ? clampCount(frameI32.get(I_ORDER_COUNT), MAX_ORDER) : 0;
+                resourceNanos = performanceSamples == null
+                        ? 0L : System.nanoTime() - resourceStarted;
+                long drawStarted = performanceSamples == null ? 0L : System.nanoTime();
+                frameDrawCalls = 0;
                 drawFrame();
+                drawNanos = performanceSamples == null
+                        ? 0L : System.nanoTime() - drawStarted;
+                drawCalls = frameDrawCalls;
+                presented = true;
                 if (BuildConfig.STASIS_RENDER_ACCEPTANCE) {
                     renderAcceptanceFrameCount += 1;
                     if (renderAcceptanceFrameCount == 1 || renderAcceptanceFrameCount % 30 == 0) {
@@ -393,7 +489,13 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             capturedFrame = capture == null ? null : captureLogicalFrame();
         }
         captureIfRequested(capture, capturedFrame);
-        timing.onRendered(System.nanoTime() - started);
+        long totalNanos = System.nanoTime() - started;
+        if (performanceSamples != null && presented) {
+            String report = performanceSamples.add(totalNanos, resourceNanos, drawNanos,
+                    drawCalls, lineCount, rectCount, spriteCount, textCount, orderCount);
+            if (report != null) Log.i(LOG_TAG, report);
+        }
+        timing.onRendered(totalNanos);
     }
 
     private void drawRestorePlaceholder() {
@@ -435,6 +537,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void drawFrame() {
+        activePipeline = PIPELINE_NONE;
         GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
         GLES20.glViewport(0, 0, surfaceWidth, surfaceHeight);
         clearLetterboxBars();
@@ -456,14 +559,14 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                 frameI32.get(I_VERSION), lineCount, frameI32.get(I_RECT_COUNT));
         int spriteCount = clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES);
         int textCount = clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT);
-        int textBytes = clampCount(frameI32.get(I_TEXT_BYTES_USED), TEXT_U8_CAPACITY);
         int orderCount = frameI32.get(I_VERSION) >= RENDER_V3_VERSION
                 ? clampCount(frameI32.get(I_ORDER_COUNT), MAX_ORDER) : 0;
         if (orderCount == 0) {
             drawLines(0, lineCount);
             drawRects(0, rectCount);
             drawSprites(0, spriteCount);
-            drawText(0, textCount, textBytes);
+            drawText(0, textCount);
+            finishPipeline();
             return;
         }
         int position = 0;
@@ -488,18 +591,29 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             if (kind == ORDER_LINE) drawLines(index, run);
             else if (kind == ORDER_RECT) drawRects(index, run);
             else if (kind == ORDER_SPRITE) drawSprites(index, run);
-            else drawText(index, run, textBytes);
+            else drawText(index, run);
             position += run;
         }
+        finishPipeline();
     }
 
     private void prepareFrameResources() {
         updateDisplayMetrics();
         textures.onFrameStart();
+        resolveFrameResources(textures, frameI32, frameU8Bytes,
+                frameSpriteTextures, frameSpriteFilters, frameTextTextures);
+    }
+
+    static void resolveFrameResources(TextureProvider textures, IntBuffer frameI32,
+            ByteBuffer frameU8Bytes, int[] spriteTextures, int[] spriteFilters,
+            long[] textTextures) {
         int spriteCount = clampCount(frameI32.get(I_SPRITE_COUNT), MAX_SPRITES);
         for (int index = 0; index < spriteCount; index += 1) {
             int base = I_SPRITE_BASE + index * SPRITE_I32_STRIDE;
-            spriteTextureFor(frameI32.get(base));
+            int handle = frameI32.get(base);
+            int texture = textures.textureFor(handle);
+            spriteTextures[index] = texture == 0 ? textures.fallbackTexture() : texture;
+            spriteFilters[index] = textures.filterFor(handle);
         }
         int textCount = clampCount(frameI32.get(I_TEXT_COUNT), MAX_TEXT);
         int bytesUsed = clampCount(frameI32.get(I_TEXT_BYTES_USED), TEXT_U8_CAPACITY);
@@ -508,12 +622,15 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             int font = frameI32.get(meta);
             int offset = frameI32.get(meta + 1);
             int length = frameI32.get(meta + 2);
-            if (font <= 0) continue;
+            long texture = 0L;
             if (offset < 0) {
-                if (offset != Integer.MIN_VALUE) textures.cachedTextTextureFor(-offset);
-            } else if (isValidTextSpan(offset, length, bytesUsed)) {
-                textures.textTextureFor(font, frameU8Bytes, offset, length);
+                if (font > 0 && offset != Integer.MIN_VALUE) {
+                    texture = textures.cachedTextTextureFor(-offset);
+                }
+            } else if (font > 0 && isValidTextSpan(offset, length, bytesUsed)) {
+                texture = textures.textTextureFor(font, frameU8Bytes, offset, length);
             }
+            textTextures[index] = texture;
         }
     }
 
@@ -709,21 +826,19 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
 
     private void drawSprites(int first, int count) {
         if (count == 0) return;
-        beginTextureBatches(spriteVertices);
         int index = first;
         int end = first + count;
         while (index < end) {
             int base = I_SPRITE_BASE + index * SPRITE_I32_STRIDE;
-            int handle = frameI32.get(base);
-            int texture = spriteTextureFor(handle);
-            int filter = textures.filterFor(handle);
+            int texture = frameSpriteTextures[index];
+            int filter = frameSpriteFilters[index];
             spriteVertices.clear();
             appendSprite(base);
             int chunk = 1;
             while (index + chunk < end && chunk < SPRITE_CHUNK_SIZE) {
+                if (frameSpriteTextures[index + chunk] != texture
+                        || frameSpriteFilters[index + chunk] != filter) break;
                 int next = I_SPRITE_BASE + (index + chunk) * SPRITE_I32_STRIDE;
-                int nextHandle = frameI32.get(next);
-                if (spriteTextureFor(nextHandle) != texture || textures.filterFor(nextHandle) != filter) break;
                 appendSprite(next);
                 chunk += 1;
             }
@@ -731,7 +846,6 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             drawPreparedTextureBatch(chunk * VERTICES_PER_QUAD, texture);
             index += chunk;
         }
-        endTextureBatches();
     }
 
     private void appendSprite(int base) {
@@ -755,29 +869,11 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         putTextureVertex(spriteVertices, left, bottom, centerX, centerY, cosine, sine, 0, 1, 1, 1, 1, alpha);
     }
 
-    private int spriteTextureFor(int handle) {
-        int texture = textures.textureFor(handle);
-        return texture == 0 ? textures.fallbackTexture() : texture;
-    }
-
-    private void drawText(int first, int count, int bytesUsed) {
+    private void drawText(int first, int count) {
         if (count == 0) return;
-        beginTextureBatches(textVertices);
         int end = first + count;
         for (int index = first; index < end; index += 1) {
-            int meta = I_TEXT_BASE + index * TEXT_I32_STRIDE;
-            int font = frameI32.get(meta);
-            int offset = frameI32.get(meta + 1);
-            int length = frameI32.get(meta + 2);
-            if (font <= 0) continue;
-            long packed;
-            if (offset < 0) {
-                packed = offset == Integer.MIN_VALUE ? 0L
-                        : textures.cachedTextTextureFor(-offset);
-            } else {
-                if (!isValidTextSpan(offset, length, bytesUsed)) continue;
-                packed = textures.textTextureFor(font, frameU8Bytes, offset, length);
-            }
+            long packed = frameTextTextures[index];
             int texture = (int)packed;
             int width = (int)((packed >>> 32) & 0xffffL);
             int height = (int)((packed >>> 48) & 0xffffL);
@@ -785,14 +881,13 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             int values = F_TEXT_BASE + index * TEXT_F32_STRIDE;
             float left = frameF32.get(values);
             float top = frameF32.get(values + 1);
-            textVertices.clear();
-            appendAxisAlignedQuad(textVertices, left, top, left + width, top + height,
+            spriteVertices.clear();
+            appendAxisAlignedQuad(spriteVertices, left, top, left + width, top + height,
                     clampUnit(frameF32.get(values + 2)), clampUnit(frameF32.get(values + 3)),
                     clampUnit(frameF32.get(values + 4)), clampUnit(frameF32.get(values + 5)));
-            textVertices.flip();
+            spriteVertices.flip();
             drawPreparedTextureBatch(VERTICES_PER_QUAD, texture);
         }
-        endTextureBatches();
     }
 
     private static void appendAxisAlignedQuad(FloatBuffer output, float left, float top,
@@ -816,30 +911,41 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void drawColorBatch(FloatBuffer vertices, int vertexCount, int mode) {
-        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
-        GLES20.glUseProgram(colorProgram);
-        GLES20.glUniform2f(colorResolution, logicalWidth, logicalHeight);
-        GLES20.glEnableVertexAttribArray(colorPosition);
-        GLES20.glEnableVertexAttribArray(colorValue);
+        beginColorBatches(vertices);
+        GLES20.glDrawArrays(mode, 0, vertexCount);
+        frameDrawCalls += 1;
+    }
+
+    private void beginColorBatches(FloatBuffer vertices) {
+        if (activePipeline != PIPELINE_COLOR) {
+            finishPipeline();
+            GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
+            GLES20.glUseProgram(colorProgram);
+            GLES20.glUniform2f(colorResolution, logicalWidth, logicalHeight);
+            GLES20.glEnableVertexAttribArray(colorPosition);
+            GLES20.glEnableVertexAttribArray(colorValue);
+            activePipeline = PIPELINE_COLOR;
+        }
         vertices.position(0);
         GLES20.glVertexAttribPointer(colorPosition, 2, GLES20.GL_FLOAT, false, COLOR_VERTEX_BYTES, vertices);
         vertices.position(2);
         GLES20.glVertexAttribPointer(colorValue, 4, GLES20.GL_FLOAT, false, COLOR_VERTEX_BYTES, vertices);
-        GLES20.glDrawArrays(mode, 0, vertexCount);
         vertices.position(0);
-        GLES20.glDisableVertexAttribArray(colorValue);
-        GLES20.glDisableVertexAttribArray(colorPosition);
     }
 
     private void beginTextureBatches(FloatBuffer vertices) {
-        GLES20.glBlendFunc(GLES20.GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA);
-        GLES20.glUseProgram(textureProgram);
-        GLES20.glUniform2f(textureResolution, logicalWidth, logicalHeight);
-        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-        GLES20.glUniform1i(textureSampler, 0);
-        GLES20.glEnableVertexAttribArray(texturePosition);
-        GLES20.glEnableVertexAttribArray(textureCoordinate);
-        GLES20.glEnableVertexAttribArray(textureColor);
+        if (activePipeline != PIPELINE_TEXTURE) {
+            finishPipeline();
+            GLES20.glBlendFunc(GLES20.GL_ONE, GLES20.GL_ONE_MINUS_SRC_ALPHA);
+            GLES20.glUseProgram(textureProgram);
+            GLES20.glUniform2f(textureResolution, logicalWidth, logicalHeight);
+            GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+            GLES20.glUniform1i(textureSampler, 0);
+            GLES20.glEnableVertexAttribArray(texturePosition);
+            GLES20.glEnableVertexAttribArray(textureCoordinate);
+            GLES20.glEnableVertexAttribArray(textureColor);
+            activePipeline = PIPELINE_TEXTURE;
+        }
         vertices.position(0);
         GLES20.glVertexAttribPointer(texturePosition, 2, GLES20.GL_FLOAT, false, TEXTURE_VERTEX_BYTES, vertices);
         vertices.position(2);
@@ -850,15 +956,23 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     }
 
     private void drawPreparedTextureBatch(int vertexCount, int texture) {
+        beginTextureBatches(spriteVertices);
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texture);
         GLES20.glDrawArrays(GLES20.GL_TRIANGLES, 0, vertexCount);
+        frameDrawCalls += 1;
     }
 
-    private void endTextureBatches() {
-        GLES20.glDisableVertexAttribArray(textureColor);
-        GLES20.glDisableVertexAttribArray(textureCoordinate);
-        GLES20.glDisableVertexAttribArray(texturePosition);
-        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+    private void finishPipeline() {
+        if (activePipeline == PIPELINE_COLOR) {
+            GLES20.glDisableVertexAttribArray(colorValue);
+            GLES20.glDisableVertexAttribArray(colorPosition);
+        } else if (activePipeline == PIPELINE_TEXTURE) {
+            GLES20.glDisableVertexAttribArray(textureColor);
+            GLES20.glDisableVertexAttribArray(textureCoordinate);
+            GLES20.glDisableVertexAttribArray(texturePosition);
+            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+        }
+        activePipeline = PIPELINE_NONE;
     }
 
     static int clampCount(int value, int maximum) {

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -4,10 +4,12 @@ import android.opengl.GLES20;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.IntBuffer;
 import java.nio.FloatBuffer;
+import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
@@ -269,6 +271,83 @@ public final class StasisPreviewRendererSchemaTest {
         assertEquals(2, StasisPreviewRenderer.horizontalRunLength(lines, 0, 4));
         assertEquals(1, StasisPreviewRenderer.horizontalRunLength(lines, 2, 4));
         assertEquals(1, StasisPreviewRenderer.horizontalRunLength(lines, 3, 4));
+    }
+
+    @Test
+    public void performanceSamplesExcludeWarmupAndUseNearestRankPercentiles() {
+        StasisPreviewRenderer.FramePerformanceSamples samples =
+                new StasisPreviewRenderer.FramePerformanceSamples(2, 4);
+        assertNull(samples.add(99_000, 90_000, 9_000, 9, 1, 2, 3, 4, 5));
+        assertNull(samples.add(98_000, 80_000, 8_000, 8, 1, 2, 3, 4, 5));
+        assertNull(samples.add(10_000, 4_000, 5_000, 3, 1, 2, 3, 4, 5));
+        assertNull(samples.add(20_000, 8_000, 10_000, 4, 1, 2, 3, 4, 5));
+        assertNull(samples.add(30_000, 12_000, 15_000, 5, 1, 2, 3, 4, 5));
+
+        String report = samples.add(40_000, 16_000, 20_000, 6, 1, 2, 3, 4, 5);
+
+        assertTrue(report.contains("warmup=2 samples=4"));
+        assertTrue(report.contains("total_p50_us=20 total_p95_us=40"));
+        assertTrue(report.contains("resource_p50_us=8 resource_p95_us=16"));
+        assertTrue(report.contains("draw_p50_us=10 draw_p95_us=20"));
+        assertTrue(report.contains("draw_calls_min=3 draw_calls_max=6"));
+        assertTrue(report.endsWith("lines=1 rects=2 sprites=3 text=4 order=5"));
+        assertNull(samples.add(1, 1, 1, 1, 0, 0, 0, 0, 0));
+    }
+
+    @Test
+    public void frameResourcesResolveOnceBeforeOrderedSubmission() {
+        IntBuffer frame = IntBuffer.allocate(StasisPreviewRenderer.FRAME_I32_CAPACITY);
+        ByteBuffer textBytes = ByteBuffer.allocate(StasisPreviewRenderer.TEXT_U8_CAPACITY);
+        frame.put(StasisPreviewRenderer.I_SPRITE_COUNT, 2);
+        frame.put(StasisPreviewRenderer.I_SPRITE_BASE, 7);
+        frame.put(StasisPreviewRenderer.I_SPRITE_BASE + StasisPreviewRenderer.SPRITE_I32_STRIDE, 0);
+        frame.put(StasisPreviewRenderer.I_TEXT_COUNT, 2);
+        frame.put(StasisPreviewRenderer.I_TEXT_BYTES_USED, 4);
+        frame.put(StasisPreviewRenderer.I_TEXT_BASE, 11);
+        frame.put(StasisPreviewRenderer.I_TEXT_BASE + 1, 0);
+        frame.put(StasisPreviewRenderer.I_TEXT_BASE + 2, 3);
+        frame.put(StasisPreviewRenderer.I_TEXT_BASE + StasisPreviewRenderer.TEXT_I32_STRIDE, 11);
+        frame.put(StasisPreviewRenderer.I_TEXT_BASE + StasisPreviewRenderer.TEXT_I32_STRIDE + 1, -9);
+        int[] calls = new int[4];
+        StasisPreviewRenderer.TextureProvider provider = new StasisPreviewRenderer.TextureProvider() {
+            @Override public void onResourceGenerationChanged(int surfaceGeneration,
+                    int rendererGeneration, boolean discardGpuHandles, String transitionReason) {}
+            @Override public int textureFor(int handle) {
+                calls[0] += 1;
+                return handle == 0 ? 0 : 70;
+            }
+            @Override public int fallbackTexture() { return 99; }
+            @Override public int filterFor(int handle) {
+                calls[1] += 1;
+                return 100 + handle;
+            }
+            @Override public long textTextureFor(
+                    int font, ByteBuffer utf8, int offset, int length) {
+                calls[2] += 1;
+                return StasisPreviewRenderer.packTexture(12, 30, 10);
+            }
+            @Override public long cachedTextTextureFor(int runHandle) {
+                calls[3] += 1;
+                return StasisPreviewRenderer.packTexture(13, 31, 11);
+            }
+        };
+        int[] textures = new int[StasisPreviewRenderer.MAX_SPRITES];
+        int[] filters = new int[StasisPreviewRenderer.MAX_SPRITES];
+        long[] textTextures = new long[StasisPreviewRenderer.MAX_TEXT];
+
+        StasisPreviewRenderer.resolveFrameResources(
+                provider, frame, textBytes, textures, filters, textTextures);
+
+        assertEquals(2, calls[0]);
+        assertEquals(2, calls[1]);
+        assertEquals(1, calls[2]);
+        assertEquals(1, calls[3]);
+        assertEquals(70, textures[0]);
+        assertEquals(99, textures[1]);
+        assertEquals(107, filters[0]);
+        assertEquals(100, filters[1]);
+        assertEquals(12, (int)textTextures[0]);
+        assertEquals(13, (int)textTextures[1]);
     }
 
     private static void putLine(FloatBuffer lines, int index, float x1, float y1,

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -502,6 +502,7 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
+        while (GLES20.glGetError() != GLES20.GL_NO_ERROR) {}
         GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, 2, 2, 0,
                 GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixels);
         int error = GLES20.glGetError();

--- a/mobile/android/test_render_emulator.ps1
+++ b/mobile/android/test_render_emulator.ps1
@@ -5,6 +5,8 @@ param(
     [switch]$SkipBuild,
     [int]$RenderTimeoutSeconds = 45,
     [int]$TotalTimeoutSeconds = 900,
+    [double]$MaxRenderP50Millis = 0,
+    [double]$MaxRenderP95Millis = 0,
     [string]$OutputPath = ""
 )
 
@@ -374,6 +376,48 @@ function Assert-RenderedVariant(
     }
     if ($RequireJit -and -not ($log -match 'CompileReady: backend=cranelift-jit reload=InitialCompile status=0 functions=[1-9][0-9]*')) {
         throw "$Name did not log a successful non-empty Workshop JIT compile; see $logFile"
+    }
+    $observedAvd = (Invoke-Adb @("emu", "avd", "name") | Select-Object -First 1).Trim()
+    $observedSdk = (Invoke-Adb @("shell", "getprop", "ro.build.version.sdk") | Select-Object -First 1).Trim()
+    if ($observedAvd -ne $AvdName -or $observedSdk -ne "35") {
+        throw "$Name benchmark identity mismatch: requested=$AvdName/API35 observed=$observedAvd/API$observedSdk"
+    }
+    $sourceStatus = @(& git -C $repoRoot status --porcelain)
+    if ($LASTEXITCODE -ne 0) { throw "Git source status could not be read for benchmark evidence" }
+    if ($sourceStatus) {
+        throw "$Name benchmark source is dirty; commit or remove source changes before publishing evidence"
+    }
+    $packageDump = @(Invoke-Adb @("shell", "dumpsys", "package", $Package)) -join "`n"
+    $versionName = [regex]::Match($packageDump, '(?m)^\s*versionName=([^\r\n]+)').Groups[1].Value.Trim()
+    $versionCode = [regex]::Match($packageDump, '(?m)^\s*versionCode=(\d+)').Groups[1].Value
+    $metadataPath = Join-Path $artifactRoot "$Name-performance-metadata.json"
+    @{
+        scene = "render_parity"
+        git_revision = (& git -C $repoRoot rev-parse HEAD).Trim()
+        source_dirty = $false
+        apk_sha256 = (Get-FileHash -LiteralPath $Apk -Algorithm SHA256).Hash.ToLowerInvariant()
+        package_version = "$versionName ($versionCode)"
+        device_model = (Invoke-Adb @("shell", "getprop", "ro.product.model") | Select-Object -First 1).Trim()
+        device_fingerprint = (Invoke-Adb @("shell", "getprop", "ro.build.fingerprint") | Select-Object -First 1).Trim()
+        serial = $serial
+        avd = $observedAvd
+        android_sdk = [int]$observedSdk
+    } | ConvertTo-Json | Set-Content -LiteralPath $metadataPath -Encoding UTF8
+    $performanceArguments = @(
+        (Join-Path $repoRoot "tools\ci\verify_android_render_performance.py"),
+        "--log", $logFile,
+        "--metadata", $metadataPath,
+        "--evidence", (Join-Path $artifactRoot "$Name-performance.json")
+    )
+    if ($MaxRenderP50Millis -gt 0) {
+        $performanceArguments += @("--max-p50-ms", "$MaxRenderP50Millis")
+    }
+    if ($MaxRenderP95Millis -gt 0) {
+        $performanceArguments += @("--max-p95-ms", "$MaxRenderP95Millis")
+    }
+    & python @performanceArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Name render performance evidence failed; see $logFile"
     }
     if (-not $renderPassed) {
         throw "$Name render acceptance timed out: $lastFailure; see $artifactRoot"

--- a/tools/ci/test_verify_android_render_performance.py
+++ b/tools/ci/test_verify_android_render_performance.py
@@ -1,0 +1,88 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.ci.verify_android_render_performance import build_evidence, main, parse_report
+
+
+REPORT = (
+    "08-12 StasisRenderer: RenderPerformance: schema=1 warmup=60 samples=180 "
+    "total_p50_us=410 total_p95_us=620 resource_p50_us=120 resource_p95_us=180 "
+    "draw_p50_us=270 draw_p95_us=410 draw_calls_min=4 draw_calls_max=4 "
+    "lines=2 rects=1 sprites=3 text=2 order=8"
+)
+
+
+class VerifyAndroidRenderPerformanceTest(unittest.TestCase):
+    def test_parses_bounded_stage_metrics(self):
+        metrics = parse_report(REPORT)
+        self.assertEqual(410, metrics["total_p50_us"])
+        self.assertEqual(180, metrics["samples"])
+        self.assertEqual(4, metrics["draw_calls_max"])
+
+    def test_requires_exactly_one_complete_report(self):
+        with self.assertRaisesRegex(ValueError, "expected one"):
+            parse_report("")
+        with self.assertRaisesRegex(ValueError, "expected one"):
+            parse_report(REPORT + "\n" + REPORT)
+        with self.assertRaisesRegex(ValueError, "missing"):
+            parse_report("RenderPerformance: schema=1 warmup=60 samples=180")
+        with self.assertRaisesRegex(ValueError, "duplicate.*total_p50_us"):
+            parse_report(REPORT.replace(
+                "total_p50_us=410", "total_p50_us=9999 total_p50_us=410"))
+        with self.assertRaisesRegex(ValueError, "unexpected.*invented"):
+            parse_report(REPORT + " invented=1")
+
+    def test_evidence_requires_device_and_build_identity(self):
+        metadata = {
+            "scene": "render_parity",
+            "git_revision": "abc123",
+            "source_dirty": False,
+            "apk_sha256": "f" * 64,
+            "package_version": "0.1.0 (1)",
+            "device_model": "emulator",
+            "device_fingerprint": "stasis/test/device",
+            "serial": "emulator-5554",
+            "avd": "Stasis_API_35",
+            "android_sdk": 35,
+        }
+        evidence = build_evidence(REPORT, metadata)
+        self.assertEqual("android_workshop_preview_render", evidence["benchmark"])
+        self.assertEqual(620, evidence["metrics"]["total_p95_us"])
+        del metadata["apk_sha256"]
+        with self.assertRaisesRegex(ValueError, "apk_sha256"):
+            build_evidence(REPORT, metadata)
+
+    def test_cli_accepts_powershell_utf8_bom_metadata(self):
+        metadata = {
+            "scene": "render_parity",
+            "git_revision": "abc123",
+            "source_dirty": False,
+            "apk_sha256": "f" * 64,
+            "package_version": "0.1.0 (1)",
+            "device_model": "emulator",
+            "device_fingerprint": "stasis/test/device",
+            "serial": "emulator-5554",
+            "avd": "Stasis_API_35",
+            "android_sdk": 35,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "log.txt"
+            source = root / "metadata.json"
+            evidence = root / "evidence.json"
+            log.write_text(REPORT, encoding="utf-8")
+            source.write_text(json.dumps(metadata), encoding="utf-8-sig")
+            with mock.patch(
+                "sys.argv",
+                ["verify", "--log", str(log), "--metadata", str(source),
+                 "--evidence", str(evidence)],
+            ):
+                self.assertEqual(0, main())
+            self.assertEqual(410, json.loads(evidence.read_text())["metrics"]["total_p50_us"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/verify_android_render_performance.py
+++ b/tools/ci/verify_android_render_performance.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Parse one bounded Workshop renderer benchmark from Android logcat."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+PREFIX = "RenderPerformance: "
+REQUIRED_METRICS = {
+    "schema",
+    "warmup",
+    "samples",
+    "total_p50_us",
+    "total_p95_us",
+    "resource_p50_us",
+    "resource_p95_us",
+    "draw_p50_us",
+    "draw_p95_us",
+    "draw_calls_min",
+    "draw_calls_max",
+    "lines",
+    "rects",
+    "sprites",
+    "text",
+    "order",
+}
+
+
+def parse_report(log: str) -> dict[str, int]:
+    reports = []
+    for line in log.splitlines():
+        if PREFIX not in line:
+            continue
+        fields = line.split(PREFIX, 1)[1].strip().split()
+        report: dict[str, int] = {}
+        for field in fields:
+            match = re.fullmatch(r"([a-z0-9_]+)=([0-9]+)", field)
+            if not match:
+                raise ValueError(f"invalid render performance field: {field}")
+            key = match.group(1)
+            if key in report:
+                raise ValueError(f"duplicate render performance field: {key}")
+            if key not in REQUIRED_METRICS:
+                raise ValueError(f"unexpected render performance field: {key}")
+            report[key] = int(match.group(2))
+        reports.append(report)
+    if len(reports) != 1:
+        raise ValueError(f"expected one render performance report, found {len(reports)}")
+    missing = REQUIRED_METRICS - reports[0].keys()
+    if missing:
+        raise ValueError(f"render performance report is missing: {', '.join(sorted(missing))}")
+    report = reports[0]
+    if report["schema"] != 1 or report["warmup"] < 30 or report["samples"] < 120:
+        raise ValueError("render performance report has invalid schema or sample bounds")
+    if report["total_p50_us"] <= 0 or report["total_p95_us"] < report["total_p50_us"]:
+        raise ValueError("render performance total percentiles are invalid")
+    if report["draw_calls_min"] <= 0 or report["draw_calls_max"] < report["draw_calls_min"]:
+        raise ValueError("render performance draw-call bounds are invalid")
+    return report
+
+
+def build_evidence(log: str, metadata: dict[str, object]) -> dict[str, object]:
+    required_metadata = {
+        "scene",
+        "git_revision",
+        "source_dirty",
+        "apk_sha256",
+        "package_version",
+        "device_model",
+        "device_fingerprint",
+        "serial",
+        "avd",
+        "android_sdk",
+    }
+    missing = required_metadata - metadata.keys()
+    if missing:
+        raise ValueError(f"render performance metadata is missing: {', '.join(sorted(missing))}")
+    if any(not str(metadata[key]).strip() for key in required_metadata):
+        raise ValueError("render performance metadata contains an empty identity")
+    if metadata["source_dirty"] is not False:
+        raise ValueError("render performance evidence must identify a clean committed source tree")
+    if metadata["android_sdk"] != 35:
+        raise ValueError("render performance evidence must use Android API 35")
+    return {
+        "schema_version": 1,
+        "benchmark": "android_workshop_preview_render",
+        "metadata": metadata,
+        "metrics": parse_report(log),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--max-p50-ms", type=float)
+    parser.add_argument("--max-p95-ms", type=float)
+    args = parser.parse_args()
+    try:
+        evidence = build_evidence(
+            args.log.read_text(encoding="utf-8", errors="replace"),
+            json.loads(args.metadata.read_text(encoding="utf-8-sig")),
+        )
+        metrics = evidence["metrics"]
+        if args.max_p50_ms is not None and metrics["total_p50_us"] > args.max_p50_ms * 1000:
+            raise ValueError(
+                f"render p50 {metrics['total_p50_us'] / 1000:.3f}ms exceeds "
+                f"{args.max_p50_ms:.3f}ms"
+            )
+        if args.max_p95_ms is not None and metrics["total_p95_us"] > args.max_p95_ms * 1000:
+            raise ValueError(
+                f"render p95 {metrics['total_p95_us'] / 1000:.3f}ms exceeds "
+                f"{args.max_p95_ms:.3f}ms"
+            )
+        args.evidence.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        print(
+            "Android Workshop render performance passed: "
+            f"p50={metrics['total_p50_us'] / 1000:.3f}ms "
+            f"p95={metrics['total_p95_us'] / 1000:.3f}ms"
+        )
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Android Workshop render performance failed: {error}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -20,6 +20,7 @@ python3 -m unittest tools.ci.test_unsafe_boundaries
 python3 -m unittest tools.ci.test_stasis_ai_efficiency_matrix
 python3 -m unittest tools.ci.test_release_provenance
 python3 -m unittest tools.ci.test_sdl3_migration
+python3 -m unittest tools.ci.test_verify_android_render_performance
 python3 -m unittest tools.ci.test_verify_render_parity
 python3 tools/ci/verify_render_parity.py
 


### PR DESCRIPTION
## Summary

- add acceptance-only render timing for total, resource, and draw phases while preserving the nine-call parity scene
- resolve stable texture resources once per frame and cache compatible GLES pipeline state across adjacent ordered runs
- keep client-array pointers bound to each current buffer fill and isolate GLES error handling to restore/upload operations
- add clean, device-identified emulator evidence plus a strict performance report verifier wired into repository validation and PR CI

## Verification

- Android Workshop JVM suite: 146 tests, 0 failures
- `python -m unittest tools.ci.test_verify_android_render_performance tools.ci.test_verify_render_parity`: 11 passed
- `python tools/cargo_cache.py run -- cargo check --workspace --all-targets`: passed
- clean committed API 35 emulator run: total p50 0.317 ms, p95 0.834 ms; 3/3 parity captures identical; non-empty JIT output verified
- `git diff --check` and PowerShell parser check: passed

The canonical validation entrypoint also passed its Android/JIT/ABI stages, then stopped on the repository's pre-existing unsafe-boundary allowlist. The Android shell checker separately reports a pre-existing missing `allowAiImageGeneration.setChecked(false)` assertion on both this branch and `origin/main`.

Maddox task: #170