### PR TITLE
test: link iOS arm64 package in CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -353,3 +353,31 @@ jobs:
         with:
           name: android-native-link-evidence
           path: target/android-native-link-evidence.json
+
+  ios-package-link:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Stasis
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Package and link generated iOS game
+        env:
+          STASIS_IOS_BUILD_ROOT: ${{ github.workspace }}/target/ios-package-link
+        run: bash tools/ci/build_ios_package.sh
+
+      - name: Upload iOS package-link evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-package-link-evidence
+          if-no-files-found: warn
+          path: |
+            target/ios-package-link/evidence.txt
+            target/ios-package-link/xcode-version.txt
+            target/ios-package-link/xcodebuild.log
+            target/ios-package-link/linked-libraries.txt

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -101,7 +101,9 @@ and the generated release app.
 ## iOS arm64
 
 On macOS install Xcode and obtain device-capable `SDL3.xcframework` and
-`SDL3_image.xcframework` bundles in one directory. From generated `ios/` run:
+`SDL3_image.xcframework` bundles in one directory. The supported inputs are
+the official SDL3 3.4.10 and SDL3_image 3.4.4 release DMGs, matching the
+runtime's pinned source versions. From generated `ios/` run:
 
 ```text
 xcodebuild -project StasisMobile.xcodeproj -scheme StasisMobile \
@@ -113,4 +115,8 @@ xcodebuild -project StasisMobile.xcodeproj -scheme StasisMobile \
 The checked-in Xcode shell compiles the same runtime, links the iOS AOT objects,
 and copies `StasisMobile/stasis_game` into the app resources. Device arm64 is
 the v1 target; simulator and multi-architecture packaging are intentionally out
-of scope.
+of scope. Pull requests run `tools/ci/build_ios_package.sh` on macOS with code
+signing disabled; the driver builds `samples/mobile_storage_link` and verifies
+the arm64 executable, embedded SDL frameworks, packaged assets and provenance,
+and absence of Stasis source. A signed device install still requires the
+developer's `DEVELOPMENT_TEAM` and provisioning profile.

--- a/mobile/shells/ios/README.md
+++ b/mobile/shells/ios/README.md
@@ -1,8 +1,10 @@
 # iOS arm64 package
 
 On macOS, install Xcode and place device-capable `SDL3.xcframework` and
-`SDL3_image.xcframework` in one directory. Build the checked-in thin Xcode
-project with your signing team:
+`SDL3_image.xcframework` in one directory. The validated inputs are the
+official SDL3 3.4.10 and SDL3_image 3.4.4 release DMGs; their versions match
+the native runtime pins. Build the checked-in thin Xcode project with your
+signing team:
 
 ```text
 xcodebuild -project StasisMobile.xcodeproj -scheme StasisMobile \
@@ -15,3 +17,9 @@ The target links the AOT objects from `../aot`, compiles the shared SDL-only
 runtime from `../runtime`, and copies `StasisMobile/stasis_game` into the app
 resources. It contains no JIT, hot swap, dynamic game loader, or writable
 Stasis source.
+
+Pull requests run `tools/ci/build_ios_package.sh` on macOS. That check verifies
+the published DMG hashes, packages `samples/mobile_storage_link`, performs an
+unsigned `iphoneos` arm64 Xcode build, and inspects the resulting app's
+architecture, embedded SDL frameworks, game assets, provenance, and source
+exclusion. Signing and installation remain a developer-owned Xcode handoff.

--- a/tools/ci/build_ios_package.sh
+++ b/tools/ci/build_ios_package.sh
@@ -116,7 +116,7 @@ test -d "${app}/Frameworks/SDL3.framework"
 test -d "${app}/Frameworks/SDL3_image.framework"
 test -f "${app}/stasis_game/assets/manifest.json"
 test -f "${app}/stasis_game/stasis_provenance.json"
-lipo -verify_arch arm64 "${executable}"
+lipo "${executable}" -verify_arch arm64
 otool -L "${executable}" | tee "${build_root}/linked-libraries.txt"
 grep -Fq '@rpath/SDL3.framework/SDL3' "${build_root}/linked-libraries.txt"
 grep -Fq '@rpath/SDL3_image.framework/SDL3_image' "${build_root}/linked-libraries.txt"
@@ -133,7 +133,7 @@ fi
 {
   xcodebuild -version
   printf 'app=%s\n' "${app}"
-  printf 'architectures=%s\n' "$(lipo -archs "${executable}")"
+  printf 'architectures=%s\n' "$(lipo "${executable}" -archs)"
   printf 'asset_manifest=%s\n' "${app}/stasis_game/assets/manifest.json"
   printf 'provenance=%s\n' "${app}/stasis_game/stasis_provenance.json"
   printf 'stasis_sources=0\n'

--- a/tools/ci/build_ios_package.sh
+++ b/tools/ci/build_ios_package.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "iOS package validation requires macOS with Xcode" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workspace="${1:-${repo_root}/samples/mobile_storage_link}"
+workspace="$(cd "${workspace}" && pwd)"
+package_output="${2:-dist/ios-ci}"
+build_root="${STASIS_IOS_BUILD_ROOT:-${repo_root}/target/ios-package-link}"
+framework_root="${build_root}/frameworks"
+download_root="${build_root}/downloads"
+derived_data="${build_root}/derived-data"
+
+if [[ "${package_output}" = /* || "${package_output}" = *..* ]]; then
+  echo "package output must be a confined workspace-relative path" >&2
+  exit 1
+fi
+if [[ -e "${workspace}/${package_output}" ]]; then
+  echo "mobile package output already exists: ${workspace}/${package_output}" >&2
+  exit 1
+fi
+
+mkdir -p "${framework_root}" "${download_root}"
+active_mount=""
+package_created=0
+cleanup() {
+  local status=$?
+  if [[ -n "${active_mount}" ]]; then
+    hdiutil detach "${active_mount}" >/dev/null 2>&1 || true
+  fi
+  if [[ ${status} -ne 0 && ${package_created} -eq 1 ]]; then
+    rm -rf -- "${workspace:?}/${package_output:?}"
+  fi
+  trap - EXIT
+  exit "${status}"
+}
+trap cleanup EXIT
+
+install_xcframework() {
+  local name="$1"
+  local version="$2"
+  local archive_name="$3"
+  local digest="$4"
+  local repository="$5"
+  local archive="${download_root}/${archive_name}"
+  local mount_point="${build_root}/mount-${name}"
+  local framework
+
+  curl --fail --location --retry 3 --output "${archive}" \
+    "https://github.com/libsdl-org/${repository}/releases/download/release-${version}/${archive_name}"
+  printf '%s  %s\n' "${digest}" "${archive}" | shasum -a 256 --check
+  mkdir -p "${mount_point}"
+  hdiutil attach "${archive}" -readonly -nobrowse -mountpoint "${mount_point}" >/dev/null
+  active_mount="${mount_point}"
+  framework=""
+  while IFS= read -r candidate; do
+    framework="${candidate}"
+    break
+  done < <(find "${mount_point}" -type d -name "${name}.xcframework" -print)
+  if [[ -z "${framework}" ]]; then
+    echo "${name}.xcframework was not present in ${archive}" >&2
+    exit 1
+  fi
+  ditto "${framework}" "${framework_root}/${name}.xcframework"
+  hdiutil detach "${mount_point}" >/dev/null
+  active_mount=""
+}
+
+install_xcframework \
+  SDL3 \
+  3.4.10 \
+  SDL3-3.4.10.dmg \
+  36f78737dcd13a6e47ee066a6e460501a3de7fca678fe97fc3deab7d5ebc8b0f \
+  SDL
+install_xcframework \
+  SDL3_image \
+  3.4.4 \
+  SDL3_image-3.4.4.dmg \
+  7481d597f90be0d92546a0189008c14a1e6d7b86eaa56beace2ed9f631d85282 \
+  SDL_image
+
+cd "${repo_root}"
+python tools/cargo_cache.py run -- cargo run -p stasis -- \
+  --workspace "${workspace}" \
+  package-mobile \
+  --target ios-arm64 \
+  --out "${package_output}" \
+  --development-build
+package_created=1
+
+package_root="${workspace}/${package_output}"
+project_root="${package_root}/ios"
+mkdir -p "${build_root}"
+xcodebuild -version | tee "${build_root}/xcode-version.txt"
+set -o pipefail
+xcodebuild \
+  -project "${project_root}/StasisMobile.xcodeproj" \
+  -scheme StasisMobile \
+  -configuration Debug \
+  -sdk iphoneos \
+  -arch arm64 \
+  -derivedDataPath "${derived_data}" \
+  STASIS_SDL_FRAMEWORKS="${framework_root}" \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  build | tee "${build_root}/xcodebuild.log"
+
+app="${derived_data}/Build/Products/Debug-iphoneos/StasisMobile.app"
+executable="${app}/StasisMobile"
+test -f "${executable}"
+test -d "${app}/Frameworks/SDL3.framework"
+test -d "${app}/Frameworks/SDL3_image.framework"
+test -f "${app}/stasis_game/assets/manifest.json"
+test -f "${app}/stasis_game/stasis_provenance.json"
+lipo -verify_arch arm64 "${executable}"
+otool -L "${executable}" | tee "${build_root}/linked-libraries.txt"
+grep -Fq '@rpath/SDL3.framework/SDL3' "${build_root}/linked-libraries.txt"
+grep -Fq '@rpath/SDL3_image.framework/SDL3_image' "${build_root}/linked-libraries.txt"
+stasis_source=""
+while IFS= read -r candidate; do
+  stasis_source="${candidate}"
+  break
+done < <(find "${app}" -type f -name '*.stasis' -print)
+if [[ -n "${stasis_source}" ]]; then
+  echo "generated iOS app contains Stasis source" >&2
+  exit 1
+fi
+
+{
+  xcodebuild -version
+  printf 'app=%s\n' "${app}"
+  printf 'architectures=%s\n' "$(lipo -archs "${executable}")"
+  printf 'asset_manifest=%s\n' "${app}/stasis_game/assets/manifest.json"
+  printf 'provenance=%s\n' "${app}/stasis_game/stasis_provenance.json"
+  printf 'stasis_sources=0\n'
+} > "${build_root}/evidence.txt"
+
+cat "${build_root}/evidence.txt"

--- a/tools/ci/check_sdl3_migration.py
+++ b/tools/ci/check_sdl3_migration.py
@@ -41,6 +41,16 @@ PINNED = {
         "STASIS_GRAPHICS_BUNDLE_SDL=ON",
         "libx11-dev",
         "libxrandr-dev",
+        "tools/ci/build_ios_package.sh",
+        "ios-package-link-evidence",
+    ),
+    "tools/ci/build_ios_package.sh": (
+        "SDL3-3.4.10.dmg",
+        "36f78737dcd13a6e47ee066a6e460501a3de7fca678fe97fc3deab7d5ebc8b0f",
+        "SDL3_image-3.4.4.dmg",
+        "7481d597f90be0d92546a0189008c14a1e6d7b86eaa56beace2ed9f631d85282",
+        "-sdk iphoneos",
+        "-arch arm64",
     ),
     "scripts/build_local_editor_release.ps1": (
         "STASIS_GRAPHICS_BUNDLE_SDL=ON",

--- a/tools/ci/test_sdl3_migration.py
+++ b/tools/ci/test_sdl3_migration.py
@@ -76,6 +76,24 @@ class Sdl3MigrationContractTests(unittest.TestCase):
                 any("SDL3 must own the iOS main wrapper" in error for error in validate(root))
             )
 
+    def test_ios_ci_dependency_drift_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            for relative, markers in PINNED.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("\n".join(markers) + "\n", encoding="utf-8")
+            driver = root / "tools/ci/build_ios_package.sh"
+            driver.write_text(
+                driver.read_text(encoding="utf-8").replace(
+                    "SDL3-3.4.10.dmg", "SDL3-rolling.dmg"
+                ),
+                encoding="utf-8",
+            )
+            self.assertTrue(
+                any("SDL3-3.4.10.dmg" in error for error in validate(root))
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate the generated iOS arm64 shell through a real unsigned Xcode device build on macOS CI
- verify pinned SDL xcframework hashes, linked/embedded frameworks, AOT app architecture, assets, provenance, and source exclusion
- document the signed-device handoff while keeping simulator, JIT, and hot swap out of scope

## Tests
- `python -m unittest tools.ci.test_sdl3_migration` (6 passed)
- `python tools/ci/check_sdl3_migration.py` (passed)
- `python tools/cargo_cache.py run -- cargo check -p stasis --all-targets` (passed)
- `bash -n tools/ci/build_ios_package.sh` via Git Bash (passed)
- `python tools/ci/check_stasis_src_layout.py` (passed)
- `git diff --check` (passed)
- `tools/validate_repo.sh` passed layout, SDL3, JIT generation, and 291 runtime ABI comparisons, then stopped at the unchanged audited unsafe-boundary gate
- focused mobile packaging integration compiled, but local Windows launch was blocked by the host SignTool certificate environment; the new macOS job is the authoritative Xcode acceptance

Maddox task #114.