### PR TITLE
perf: remove hidden render instrumentation

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2453,11 +2453,15 @@ fn run_play_in_process_inner(
         )?;
 
         let run_tick = live.as_ref().is_none_or(LiveWorkspace::should_run_tick);
+        let measure_hud = gfx.host_performance_metrics_enabled()?;
         let mut tick_micros = 0;
         if run_tick {
-            let tick_started = Instant::now();
+            let measure_tick = measure_hud || tick_budget.is_some();
+            let tick_started = measure_tick.then(Instant::now);
             let tick_rc = stasis_dynload::invoke_noarg_i32(tick_code_ptr as usize)?;
-            tick_micros = tick_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
+            if let Some(tick_started) = tick_started {
+                tick_micros = tick_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
+            }
             if let Some(budget) = tick_budget.as_mut() {
                 budget.record(tick_micros);
             }
@@ -2465,14 +2469,18 @@ fn run_play_in_process_inner(
                 break;
             }
         }
-        let render_started = Instant::now();
+        let render_started = measure_hud.then(Instant::now);
         let render_rc = stasis_dynload::invoke_noarg_i32(render_code_ptr as usize)?;
-        let render_micros = render_started.elapsed().as_micros().min(u64::MAX as u128) as u64;
+        let render_micros = render_started
+            .map(|started| started.elapsed().as_micros().min(u64::MAX as u128) as u64)
+            .unwrap_or(0);
         if render_rc != 0 {
             break;
         }
 
-        gfx.host_set_performance_metrics(tick_micros, render_micros)?;
+        if measure_hud {
+            gfx.host_set_performance_metrics(tick_micros, render_micros)?;
+        }
         gfx.gfx_submit_u8(&mut gfx_cmd_i32, &gfx_cmd_f32, &gfx_cmd_u8)?;
         if let Some(evidence) = frame_evidence.as_mut() {
             let submission = gfx.test_render_submission_state()?.ok_or_else(|| {
@@ -4194,6 +4202,7 @@ mod tests {
     fn windows_performance_hud_uses_frame_work_and_60_fps_budget() {
         for required in [
             "event.key.key == SDLK_F3",
+            "stasis_host_performance_metrics_enabled",
             "stasis_host_set_performance_metrics",
             "g_perf_pending_guest_render_us",
             "stasis_perf_elapsed_us(g_perf_render_started_counter, now)",
@@ -4206,8 +4215,12 @@ mod tests {
             );
         }
         assert!(
-            STASIS_RUNNER_SOURCE.contains("host_set_performance_metrics(tick_us, render_us)"),
-            "Windows AOT runner should feed tick and render timing into the shared HUD"
+            STASIS_RUNNER_SOURCE.contains("const int measure_hud = host_performance_metrics_enabled")
+                && STASIS_RUNNER_SOURCE.contains("if (measure_hud) QueryPerformanceCounter")
+                && STASIS_RUNNER_SOURCE.contains(
+                    "if (measure_hud && host_set_performance_metrics)"
+                ),
+            "Windows AOT runner should only measure tick and render while the shared HUD is visible"
         );
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -6265,6 +6265,7 @@ mod tests {
         assert!(java.contains("new File(root, \".\")"));
         assert!(java.contains("event.getPointerCount() >= 3"));
         assert!(java.contains("nativeReadPerformanceMetrics"));
+        assert!(java.contains("nativeSetPerformanceMetricsEnabled(show)"));
         assert!(java.contains("nativeReadRuntimeError"));
         assert!(java.contains("hudText.append(\"tick=\")"));
         assert!(java.contains("hudText.append(\"  render=\")"));
@@ -6281,6 +6282,9 @@ mod tests {
                 .expect("read Android asset bridge");
         assert!(jni.contains("Java_com_example_mobile_MainActivity_nativeSetAssetRoot"));
         assert!(jni.contains("Java_com_example_mobile_MainActivity_nativeReadPerformanceMetrics"));
+        assert!(
+            jni.contains("Java_com_example_mobile_MainActivity_nativeSetPerformanceMetricsEnabled")
+        );
         assert!(jni.contains("Java_com_example_mobile_MainActivity_nativeReadRuntimeError"));
         assert!(!jni.contains("@STASIS_"));
         let runtime_source = fs::read_to_string(android.join("runtime/stasis_mobile_runtime.c"))

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1006,6 +1006,7 @@ pub struct StasisGraphicsApi {
     stasis_host_get_frame: usize,
     stasis_host_bulk_init: usize,
     stasis_host_bulk_apply_requests: usize,
+    stasis_host_performance_metrics_enabled: usize,
     stasis_host_set_performance_metrics: usize,
     stasis_gfx_submit_u8: usize,
     stasis_test_get_render_submission_state: Option<usize>,
@@ -1040,6 +1041,8 @@ impl StasisGraphicsApi {
             lib.symbol_address("stasis_host_bulk_apply_requests")?;
         let stasis_host_set_performance_metrics =
             lib.symbol_address("stasis_host_set_performance_metrics")?;
+        let stasis_host_performance_metrics_enabled =
+            lib.symbol_address("stasis_host_performance_metrics_enabled")?;
         let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
         let stasis_test_get_render_submission_state = lib
             .symbol_address("stasis_test_get_render_submission_state")
@@ -1051,6 +1054,7 @@ impl StasisGraphicsApi {
             stasis_host_get_frame,
             stasis_host_bulk_init,
             stasis_host_bulk_apply_requests,
+            stasis_host_performance_metrics_enabled,
             stasis_host_set_performance_metrics,
             stasis_gfx_submit_u8,
             stasis_test_get_render_submission_state,
@@ -1163,6 +1167,21 @@ impl StasisGraphicsApi {
                 unsafe { std::mem::transmute(self.stasis_host_set_performance_metrics) };
             callback(tick_micros, render_micros);
             Ok(())
+        }
+    }
+
+    pub fn host_performance_metrics_enabled(&self) -> Result<bool, String> {
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn() -> i32 =
+                unsafe { std::mem::transmute(self.stasis_host_performance_metrics_enabled) };
+            return Ok(callback() != 0);
+        }
+        #[cfg(not(windows))]
+        {
+            let callback: extern "C" fn() -> i32 =
+                unsafe { std::mem::transmute(self.stasis_host_performance_metrics_enabled) };
+            Ok(callback() != 0)
         }
     }
 

--- a/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
+++ b/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 void stasis_host_get_latest_performance_metrics(uint32_t *tick_us, uint32_t *render_us);
+void stasis_host_set_performance_metrics_enabled(int enabled);
 int stasis_host_copy_runtime_error(char *output, size_t output_size);
 
 #if defined(STASIS_ENABLE_SEAM_TESTS)
@@ -67,6 +68,17 @@ Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeReadPerformanceMetrics(
     jfloat values[2] = {(jfloat)tick_us / 1000.0f, (jfloat)render_us / 1000.0f};
     (*env)->SetFloatArrayRegion(env, output, 0, 2, values);
     return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeSetPerformanceMetricsEnabled(
+    JNIEnv *env,
+    jclass activity,
+    jboolean enabled
+) {
+    (void)env;
+    (void)activity;
+    stasis_host_set_performance_metrics_enabled(enabled == JNI_TRUE ? 1 : 0);
 }
 
 JNIEXPORT jstring JNICALL

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -36,6 +36,7 @@ public final class MainActivity extends SDLActivity {
     private static native void nativeSetAssetRoot(String path);
     private static native void nativeSetSeamTestId(String testId);
     private static native boolean nativeReadPerformanceMetrics(float[] output);
+    private static native void nativeSetPerformanceMetricsEnabled(boolean enabled);
     private static native String nativeReadRuntimeError();
 
     private final Handler hudHandler = new Handler(Looper.getMainLooper());
@@ -101,6 +102,7 @@ public final class MainActivity extends SDLActivity {
 
     @Override
     protected void onDestroy() {
+        nativeSetPerformanceMetricsEnabled(false);
         stopPerformanceHudUpdates();
         super.onDestroy();
     }
@@ -159,8 +161,11 @@ public final class MainActivity extends SDLActivity {
     private void togglePerformanceHud() {
         if (performanceHud == null) return;
         boolean show = performanceHud.getVisibility() != View.VISIBLE;
+        nativeSetPerformanceMetricsEnabled(show);
         performanceHud.setVisibility(show ? View.VISIBLE : View.GONE);
         if (show) {
+            tickMetric.clear();
+            renderMetric.clear();
             updatePerformanceHud();
         }
     }
@@ -399,6 +404,11 @@ public final class MainActivity extends SDLActivity {
             values[next] = value;
             next = (next + 1) % CAPACITY;
             if (count < CAPACITY) count++;
+        }
+
+        void clear() {
+            next = 0;
+            count = 0;
         }
 
         double average() {

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -169,6 +169,7 @@ static int32_t g_render_last_display_generation = 0;
 static int32_t g_render_last_density_generation = 0;
 static uint32_t g_render_logged_validation_mask = 0;
 static bool g_render_contract_logged = false;
+static int g_render_trace_enabled = -1;
 typedef struct {
     int active;
     int logical_w;
@@ -893,6 +894,9 @@ static void stasis_pump_events(void) {
                 }
                 if (event.key.key == SDLK_F3 && !event.key.repeat) {
                     g_force_debug_overlay = !g_force_debug_overlay;
+                    g_perf_sample_count = 0;
+                    g_perf_sample_next = 0;
+                    g_perf_render_started_counter = 0;
                     if (g_force_debug_overlay) (void)stasis_perf_font();
                     SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
                 }
@@ -1178,8 +1182,14 @@ STASIS_EXPORT void stasis_host_bulk_apply_requests(
 
 STASIS_EXPORT void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us)
 {
+    if (!g_force_debug_overlay) return;
     g_perf_pending_tick_us = tick_us;
     g_perf_pending_guest_render_us = render_us;
+}
+
+STASIS_EXPORT int stasis_host_performance_metrics_enabled(void)
+{
+    return g_force_debug_overlay ? 1 : 0;
 }
 
 STASIS_EXPORT void stasis_host_report_runtime_error(const char* message)
@@ -4381,12 +4391,14 @@ STASIS_EXPORT void stasis_begin_frame(void) {
 }
 
 static uint64_t stasis_perf_elapsed_us(uint64_t started_counter, uint64_t finished_counter) {
+    if (started_counter == 0 || finished_counter < started_counter) return 0;
     const uint64_t frequency = SDL_GetPerformanceFrequency();
-    if (started_counter == 0 || finished_counter < started_counter || frequency == 0) return 0;
+    if (frequency == 0) return 0;
     return ((finished_counter - started_counter) * 1000000u) / frequency;
 }
 
 STASIS_EXPORT uint64_t stasis_host_performance_counter(void) {
+    if (!g_force_debug_overlay) return 0;
     return SDL_GetPerformanceCounter();
 }
 
@@ -4397,6 +4409,10 @@ STASIS_EXPORT uint64_t stasis_host_performance_elapsed_us(
 }
 
 static void stasis_perf_finish_render_sample(void) {
+    if (!g_force_debug_overlay) {
+        g_perf_render_started_counter = 0;
+        return;
+    }
     const uint64_t now = SDL_GetPerformanceCounter();
     StasisPerfSample* sample = &g_perf_samples[g_perf_sample_next];
     sample->captured_counter = now;
@@ -4839,6 +4855,15 @@ static void stasis_stamp_display_metadata(int32_t* cmd_i32) {
     cmd_i32[STASIS_RENDER_I_DENSITY_GENERATION] = g_density_generation;
 }
 
+static bool stasis_render_trace_is_enabled(void) {
+    if (g_render_trace_enabled < 0) {
+        const char* enabled = SDL_getenv("STASIS_ENABLE_TEST_INPUT");
+        g_render_trace_enabled =
+            enabled && enabled[0] == '1' && enabled[1] == '\0';
+    }
+    return g_render_trace_enabled != 0;
+}
+
 static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
     StasisRenderValidation validation = stasis_render_validate(cmd_i32, cmd_f32);
     if (validation != STASIS_RENDER_VALID) {
@@ -4861,13 +4886,17 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
     }
     g_render_accepted_frames++;
     g_render_last_validation = STASIS_RENDER_VALID;
-    g_render_last_trace = stasis_render_trace(cmd_i32, cmd_f32, cmd_u8);
+    if (!g_render_contract_logged || stasis_render_trace_is_enabled()) {
+        g_render_last_trace = stasis_render_trace(cmd_i32, cmd_f32, cmd_u8);
+    }
     stasis_stamp_display_metadata(cmd_i32);
     g_render_last_display_generation =
         cmd_i32[STASIS_RENDER_I_DISPLAY_GENERATION];
     g_render_last_density_generation =
         cmd_i32[STASIS_RENDER_I_DENSITY_GENERATION];
-    g_perf_render_started_counter = SDL_GetPerformanceCounter();
+    g_perf_render_started_counter = g_force_debug_overlay
+        ? SDL_GetPerformanceCounter()
+        : 0;
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
     const int32_t gfx_cmd_max_lines = STASIS_RENDER_MAX_LINES;
@@ -4895,7 +4924,7 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
         SDL_Log(
             "Stasis render contract v%d trace=%u flags=%d lines=%d rects=%d sprites=%d text=%d",
             cmd_i32[STASIS_RENDER_I_VERSION],
-            (unsigned int)stasis_render_trace(cmd_i32, cmd_f32, cmd_u8),
+            (unsigned int)g_render_last_trace,
             flags,
             line_count,
             rect_count,
@@ -6170,6 +6199,7 @@ STASIS_EXPORT void stasis_shutdown(void) {
     g_render_last_density_generation = 0;
     g_render_logged_validation_mask = 0;
     g_render_contract_logged = false;
+    g_render_trace_enabled = -1;
     g_resource_frame_ready = false;
     SDL_Log("Stasis graphics shutdown");
 }

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -184,6 +184,7 @@ static StasisTestDisplayOverride g_test_display_override;
 static StasisRendererLifecycle g_resource_lifecycle;
 static bool g_resource_frame_ready = false;
 static bool g_force_debug_overlay = false;
+static SDL_AtomicInt g_performance_metrics_requested;
 static bool g_postfx_enabled = false;
 static bool g_postfx_applied_this_frame = false;
 static bool g_screenshot_taken = false;
@@ -278,6 +279,8 @@ static int g_finger_active[STASIS_MAX_POINTERS - 1];
 STASIS_EXPORT int stasis_get_time_ms(void);
 STASIS_EXPORT int stasis_should_quit(void);
 STASIS_EXPORT void stasis_host_get_frame(int32_t* out_i32, float* out_f32);
+STASIS_EXPORT int stasis_host_performance_metrics_enabled(void);
+STASIS_EXPORT void stasis_host_set_performance_metrics_enabled(int enabled);
 STASIS_EXPORT int stasis_set_fullscreen(int fullscreen);
 STASIS_EXPORT void stasis_gfx_draw_sprite(int handle, float x, float y, float w, float h, int rot_degrees, int a);
 STASIS_EXPORT void stasis_gfx_submit_u8(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8);
@@ -897,6 +900,8 @@ static void stasis_pump_events(void) {
                     g_perf_sample_count = 0;
                     g_perf_sample_next = 0;
                     g_perf_render_started_counter = 0;
+                    stasis_host_set_performance_metrics_enabled(
+                        g_force_debug_overlay ? 1 : 0);
                     if (g_force_debug_overlay) (void)stasis_perf_font();
                     SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
                 }
@@ -1182,14 +1187,23 @@ STASIS_EXPORT void stasis_host_bulk_apply_requests(
 
 STASIS_EXPORT void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us)
 {
-    if (!g_force_debug_overlay) return;
+    if (!stasis_host_performance_metrics_enabled()) return;
     g_perf_pending_tick_us = tick_us;
     g_perf_pending_guest_render_us = render_us;
 }
 
 STASIS_EXPORT int stasis_host_performance_metrics_enabled(void)
 {
-    return g_force_debug_overlay ? 1 : 0;
+    return (g_force_debug_overlay || SDL_GetAtomicInt(&g_performance_metrics_requested) != 0)
+        ? 1
+        : 0;
+}
+
+STASIS_EXPORT void stasis_host_set_performance_metrics_enabled(int enabled)
+{
+    SDL_SetAtomicInt(&g_performance_metrics_requested, enabled != 0);
+    SDL_SetAtomicInt(&g_perf_latest_tick_us, 0);
+    SDL_SetAtomicInt(&g_perf_latest_render_us, 0);
 }
 
 STASIS_EXPORT void stasis_host_report_runtime_error(const char* message)
@@ -1261,17 +1275,20 @@ STASIS_EXPORT int stasis_host_bulk_step(
 
     stasis_host_bulk_apply_requests(host_req_seq, host_req_flags, host_req_window_w_px, host_req_window_h_px);
 
-    const uint64_t tick_started = SDL_GetPerformanceCounter();
+    const int measure_frame = stasis_host_performance_metrics_enabled();
+    const uint64_t tick_started = measure_frame ? SDL_GetPerformanceCounter() : 0;
     const int tick_result = tick_fn();
-    const uint64_t tick_finished = SDL_GetPerformanceCounter();
+    const uint64_t tick_finished = measure_frame ? SDL_GetPerformanceCounter() : 0;
     if (tick_result != 0)
     {
         return tick_result;
     }
 
-    stasis_host_set_performance_metrics(
-        stasis_perf_elapsed_us(tick_started, tick_finished),
-        0);
+    if (measure_frame) {
+        stasis_host_set_performance_metrics(
+            stasis_perf_elapsed_us(tick_started, tick_finished),
+            0);
+    }
     stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
     return 0;
 }
@@ -4398,7 +4415,7 @@ static uint64_t stasis_perf_elapsed_us(uint64_t started_counter, uint64_t finish
 }
 
 STASIS_EXPORT uint64_t stasis_host_performance_counter(void) {
-    if (!g_force_debug_overlay) return 0;
+    if (!stasis_host_performance_metrics_enabled()) return 0;
     return SDL_GetPerformanceCounter();
 }
 
@@ -4409,7 +4426,7 @@ STASIS_EXPORT uint64_t stasis_host_performance_elapsed_us(
 }
 
 static void stasis_perf_finish_render_sample(void) {
-    if (!g_force_debug_overlay) {
+    if (!stasis_host_performance_metrics_enabled()) {
         g_perf_render_started_counter = 0;
         return;
     }
@@ -4894,7 +4911,7 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
         cmd_i32[STASIS_RENDER_I_DISPLAY_GENERATION];
     g_render_last_density_generation =
         cmd_i32[STASIS_RENDER_I_DENSITY_GENERATION];
-    g_perf_render_started_counter = g_force_debug_overlay
+    g_perf_render_started_counter = stasis_host_performance_metrics_enabled()
         ? SDL_GetPerformanceCounter()
         : 0;
 
@@ -6200,6 +6217,7 @@ STASIS_EXPORT void stasis_shutdown(void) {
     g_render_logged_validation_mask = 0;
     g_render_contract_logged = false;
     g_render_trace_enabled = -1;
+    SDL_SetAtomicInt(&g_performance_metrics_requested, 0);
     g_resource_frame_ready = false;
     SDL_Log("Stasis graphics shutdown");
 }

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -8,6 +8,7 @@ EXPORTS
     stasis_host_bulk_step
     stasis_host_copy_runtime_error
     stasis_host_performance_metrics_enabled
+    stasis_host_set_performance_metrics_enabled
     stasis_init_window
     stasis_get_window_size
     stasis_get_display_metrics

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -7,6 +7,7 @@ EXPORTS
     stasis_host_bulk_apply_requests
     stasis_host_bulk_step
     stasis_host_copy_runtime_error
+    stasis_host_performance_metrics_enabled
     stasis_init_window
     stasis_get_window_size
     stasis_get_display_metrics

--- a/runtime/stasis_mobile_runtime.c
+++ b/runtime/stasis_mobile_runtime.c
@@ -26,6 +26,7 @@ void stasis_gfx_submit_u8(
 uint64_t stasis_host_performance_counter(void);
 uint64_t stasis_host_performance_elapsed_us(uint64_t started, uint64_t finished);
 void stasis_host_set_performance_metrics(uint64_t tick_us, uint64_t render_us);
+int stasis_host_performance_metrics_enabled(void);
 void stasis_shutdown(void);
 
 static int32_t *host_i32;
@@ -147,25 +148,28 @@ int32_t stasis_mobile_runtime_step(void) {
     stasis_host_get_frame(host_i32, host_f32);
     apply_guest_host_requests();
     stasis_jit_profile_frame_begin();
-    uint64_t tick_started = stasis_host_performance_counter();
+    const int measure_frame = stasis_host_performance_metrics_enabled();
+    uint64_t tick_started = measure_frame ? stasis_host_performance_counter() : 0;
     runtime_state.last_entry_result = runtime_state.entries.tick_entry();
-    uint64_t tick_finished = stasis_host_performance_counter();
+    uint64_t tick_finished = measure_frame ? stasis_host_performance_counter() : 0;
     if (runtime_state.last_entry_result != 0) {
         fprintf(stderr, "Stasis mobile tick entry requested stop with code %d\n",
             runtime_state.last_entry_result);
         return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
     }
-    uint64_t render_started = stasis_host_performance_counter();
+    uint64_t render_started = measure_frame ? stasis_host_performance_counter() : 0;
     runtime_state.last_entry_result = runtime_state.entries.render_entry();
-    uint64_t render_finished = stasis_host_performance_counter();
+    uint64_t render_finished = measure_frame ? stasis_host_performance_counter() : 0;
     if (runtime_state.last_entry_result != 0) {
         fprintf(stderr, "Stasis mobile render entry requested stop with code %d\n",
             runtime_state.last_entry_result);
         return STASIS_MOBILE_RUNTIME_STOP_REQUESTED;
     }
-    stasis_host_set_performance_metrics(
-        stasis_host_performance_elapsed_us(tick_started, tick_finished),
-        stasis_host_performance_elapsed_us(render_started, render_finished));
+    if (measure_frame) {
+        stasis_host_set_performance_metrics(
+            stasis_host_performance_elapsed_us(tick_started, tick_finished),
+            stasis_host_performance_elapsed_us(render_started, render_finished));
+    }
     /* Submission owns begin/present according to the guest command-buffer flags. */
     stasis_gfx_submit_u8(gfx_cmd_i32, gfx_cmd_f32, gfx_cmd_u8);
     stasis_jit_profile_frame_end();

--- a/runtime/stasis_runner.c
+++ b/runtime/stasis_runner.c
@@ -52,6 +52,7 @@ typedef void (*stasis_host_bulk_apply_requests_fn)(
     const int32_t *host_req_window_w_px,
     const int32_t *host_req_window_h_px);
 typedef void (*stasis_host_set_performance_metrics_fn)(uint64_t tick_us, uint64_t render_us);
+typedef int (*stasis_host_performance_metrics_enabled_fn)(void);
 typedef int (*stasis_host_bulk_step_fn)(
     int32_t *host_i32,
     float *host_f32,
@@ -2214,6 +2215,7 @@ int main(int argc, char **argv)
 
         stasis_host_get_frame_fn host_get_frame = NULL;
         stasis_host_set_performance_metrics_fn host_set_performance_metrics = NULL;
+        stasis_host_performance_metrics_enabled_fn host_performance_metrics_enabled = NULL;
         stasis_gfx_submit_u8_fn gfx_submit_u8 = NULL;
         int32_t last_req_seq = host_req_seq ? *host_req_seq : 0;
 
@@ -2230,6 +2232,10 @@ int main(int argc, char **argv)
             host_set_performance_metrics = (stasis_host_set_performance_metrics_fn)GetProcAddress(
                 gfx,
                 "stasis_host_set_performance_metrics");
+            host_performance_metrics_enabled =
+                (stasis_host_performance_metrics_enabled_fn)GetProcAddress(
+                    gfx,
+                    "stasis_host_performance_metrics_enabled");
             gfx_submit_u8 = (stasis_gfx_submit_u8_fn)GetProcAddress(gfx, "stasis_gfx_submit_u8");
         }
 
@@ -2610,16 +2616,21 @@ int main(int argc, char **argv)
                 }
 
                 int step_result = 0;
+                const int measure_hud = host_performance_metrics_enabled &&
+                    host_performance_metrics_enabled();
                 uint64_t tick_us = 0;
                 uint64_t render_us = 0;
                 if (tick)
                 {
                     LARGE_INTEGER phase_started;
                     LARGE_INTEGER phase_finished;
-                    QueryPerformanceCounter(&phase_started);
+                    if (measure_hud) QueryPerformanceCounter(&phase_started);
                     step_result = tick();
-                    QueryPerformanceCounter(&phase_finished);
-                    tick_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
+                    if (measure_hud)
+                    {
+                        QueryPerformanceCounter(&phase_finished);
+                        tick_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
+                    }
                     if (step_result != 0)
                     {
                         result = step_result == 1 ? 0 : step_result;
@@ -2631,10 +2642,13 @@ int main(int argc, char **argv)
                 {
                     LARGE_INTEGER phase_started;
                     LARGE_INTEGER phase_finished;
-                    QueryPerformanceCounter(&phase_started);
+                    if (measure_hud) QueryPerformanceCounter(&phase_started);
                     step_result = render();
-                    QueryPerformanceCounter(&phase_finished);
-                    render_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
+                    if (measure_hud)
+                    {
+                        QueryPerformanceCounter(&phase_finished);
+                        render_us = (uint64_t)((phase_finished.QuadPart - phase_started.QuadPart) * 1000000LL / freq.QuadPart);
+                    }
                     if (step_result != 0)
                     {
                         result = step_result == 1 ? 0 : step_result;
@@ -2651,7 +2665,7 @@ int main(int argc, char **argv)
 
                 if (gfx_submit_u8 && gfx_cmd_i32 && gfx_cmd_f32 && gfx_cmd_u8)
                 {
-                    if (host_set_performance_metrics)
+                    if (measure_hud && host_set_performance_metrics)
                     {
                         host_set_performance_metrics(tick_us, render_us);
                     }

--- a/runtime/tests/stasis_generated_mobile_integration.c
+++ b/runtime/tests/stasis_generated_mobile_integration.c
@@ -84,6 +84,7 @@ void stasis_gfx_submit_u8(int32_t *i32s, const float *f32s, const uint8_t *u8s) 
     submit_render_score = stasis_jit_global_i32_load(hash_path("render_score"));
 }
 uint64_t stasis_host_performance_counter(void) { return 100; }
+int stasis_host_performance_metrics_enabled(void) { return 1; }
 uint64_t stasis_host_performance_elapsed_us(uint64_t started, uint64_t finished) {
     return finished - started;
 }

--- a/runtime/tests/stasis_mobile_runtime_test.c
+++ b/runtime/tests/stasis_mobile_runtime_test.c
@@ -37,6 +37,7 @@ static int32_t host_request_sequences[8];
 static int gfx_submit_calls;
 static int shutdown_calls;
 static uint64_t performance_counter;
+static int performance_metrics_enabled = 1;
 static int performance_metrics_calls;
 static uint64_t reported_tick_us;
 static uint64_t reported_render_us;
@@ -128,6 +129,10 @@ void stasis_shutdown(void) {
 uint64_t stasis_host_performance_counter(void) {
     performance_counter += 10;
     return performance_counter;
+}
+
+int stasis_host_performance_metrics_enabled(void) {
+    return performance_metrics_enabled;
 }
 
 uint64_t stasis_host_performance_elapsed_us(uint64_t started, uint64_t finished) {
@@ -311,6 +316,7 @@ static void reset_fakes(void) {
     gfx_submit_calls = 0;
     shutdown_calls = 0;
     performance_counter = 0;
+    performance_metrics_enabled = 1;
     performance_metrics_calls = 0;
     reported_tick_us = 0;
     reported_render_us = 0;
@@ -390,6 +396,20 @@ static void test_runs_mobile_lifecycle(void) {
     assert(shutdown_calls == 1);
     assert(stasis_mobile_runtime_is_initialized() == 0);
     assert(stasis_mobile_runtime_step() == STASIS_MOBILE_RUNTIME_NOT_INITIALIZED);
+}
+
+static void test_skips_hidden_performance_hud_measurement(void) {
+    StasisMobileRuntimeConfig valid_config = config();
+    StasisMobileGameEntries valid_entries = entries();
+    performance_metrics_enabled = 0;
+
+    assert(stasis_mobile_runtime_initialize(&valid_config, &valid_entries) == 0);
+    assert(stasis_mobile_runtime_step() == 0);
+    assert(tick_calls == 1);
+    assert(render_calls == 1);
+    assert(performance_counter == 0);
+    assert(performance_metrics_calls == 0);
+    stasis_mobile_runtime_shutdown();
 }
 
 static void test_rejects_duplicate_initialization(void) {
@@ -477,6 +497,8 @@ int main(void) {
     reset_fakes();
     test_rejects_invalid_configuration();
     test_runs_mobile_lifecycle();
+    reset_fakes();
+    test_skips_hidden_performance_hud_measurement();
     reset_fakes();
     test_rejects_duplicate_initialization();
     reset_fakes();


### PR DESCRIPTION
## Summary
- skip tick/render counter reads and metric submission on Android and desktop while their performance HUD is hidden
- have Android's Java-owned three-finger HUD explicitly control native measurement through a thread-safe JNI/runtime flag
- start fresh Android and native sample windows when the HUD is enabled
- compute command-stream diagnostic traces once in production instead of traversing active commands every frame; retain per-frame traces under test input

## Desktop coverage
- in-process desktop play queries native F3 visibility before measuring tick/render
- standalone Windows AOT runner gates QueryPerformanceCounter and metric submission on the same visibility query
- tick-budget enforcement remains timed independently because it is correctness enforcement, not HUD instrumentation

## Validation
- built the Windows SDL graphics DLL and standalone runner
- focused desktop HUD source contract
- generated Android shell/package JNI contract
- native render-contract and mobile-runtime lifecycle tests
- hidden-HUD mobile regression proves zero performance counter calls and metric submissions
- stasis_dynload tests
- runtime ABI contract: 291 comparisons passed
- cargo fmt and git diff --check

## Review feedback
Addressed the Android ownership issue: Java now enables native collection when the three-finger HUD becomes visible and disables it when hidden/destroyed.

## Theory gained
HUD visibility is owned by the presenting platform, while timing occurs in the execution host. A shared thread-safe runtime query connects those owners so diagnostics add no frame work while hidden without breaking platform-specific toggles.