### PR TITLE
Validate fixed struct views once

### DIFF
--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -4192,6 +4192,7 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
             target_info,
             field_name,
             target_index_binding,
+            false,
             AssignOp::Set,
             source_value,
         )?;
@@ -4536,6 +4537,7 @@ pub(crate) fn try_emit_struct_copy_from_global_to_indexed(
             target_info,
             field_name,
             target_index_binding,
+            false,
             AssignOp::Set,
             source_value,
         )?;
@@ -4742,6 +4744,18 @@ pub(crate) fn emit_simple_statements(
                             name, local_type_id, struct_view.type_id
                         ));
                     }
+                    let mut view_bounds_proven = struct_view.bounds_proven;
+                    // A fixed global struct-array view with an arbitrary index must still fail
+                    // fatally, but the check belongs to creation of the alias rather than every
+                    // field access through that alias. Once validated, all loads and stores from
+                    // the same {base,index,len} view may reuse the fact.
+                    if !view_bounds_proven
+                        && struct_view.storage_kind == StructViewStorageKind::Soa
+                        && struct_view.known_collection_hash.is_some()
+                    {
+                        emit_array_bounds_trap(builder, struct_view.index, struct_view.len);
+                        view_bounds_proven = true;
+                    }
                     let variable = declare_new_variable(
                         builder,
                         next_variable,
@@ -4773,7 +4787,7 @@ pub(crate) fn emit_simple_statements(
                                 len_var,
                                 storage_kind: struct_view.storage_kind,
                                 known_collection_hash: struct_view.known_collection_hash,
-                                bounds_proven: struct_view.bounds_proven,
+                                bounds_proven: view_bounds_proven,
                             }),
                             proven_index_upper: None,
                         },
@@ -5463,6 +5477,9 @@ pub(crate) fn emit_simple_statements(
                             named_struct_field_types,
                             foreach_bindings,
                         )?;
+                        let bounds_proven = matches!(index, SimpleExpr::Identifier(name)
+                            if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
+                                == Some(collection_info.len as usize));
                         emit_indexed_collection_assignment(
                             builder,
                             runtime_call_refs,
@@ -5471,6 +5488,7 @@ pub(crate) fn emit_simple_statements(
                             collection_info,
                             suffix,
                             index_binding,
+                            bounds_proven,
                             *op,
                             rhs,
                         )?;
@@ -5578,6 +5596,9 @@ pub(crate) fn emit_simple_statements(
                             named_struct_field_types,
                             foreach_bindings,
                         )?;
+                        let bounds_proven = matches!(index, SimpleExpr::Identifier(name)
+                            if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
+                                == Some(collection_info.len as usize));
                         emit_indexed_collection_assignment(
                             builder,
                             runtime_call_refs,
@@ -5586,6 +5607,7 @@ pub(crate) fn emit_simple_statements(
                             collection_info,
                             suffix,
                             index_binding,
+                            bounds_proven,
                             AssignOp::Set,
                             converted,
                         )?;
@@ -8894,6 +8916,7 @@ fn emit_struct_view_field_assignment_for_storage(
             field_type,
             direct.storage_bytes,
             direct.static_len,
+            bounds_proven,
         );
     }
 
@@ -9474,6 +9497,7 @@ fn emit_direct_array_store(
     _type_id: TypeId,
     storage_bytes: u8,
     static_len: Option<usize>,
+    bounds_proven: bool,
 ) -> Result<(), String> {
     let data = emit_direct_slot_data_ptr(builder, slot_ref);
     let len = if let Some(len) = static_len {
@@ -9487,13 +9511,15 @@ fn emit_direct_array_store(
             stasis_dynload::JitStorageSlot::LEN_OFFSET,
         )
     };
-    let non_negative = builder
-        .ins()
-        .icmp_imm(IntCC::SignedGreaterThanOrEqual, index, 0);
     let index_i64 = builder.ins().sextend(types::I64, index);
-    let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index_i64, len);
-    let valid = builder.ins().band(non_negative, below_len);
-    builder.ins().trapz(valid, TrapCode::HEAP_OUT_OF_BOUNDS);
+    if !bounds_proven {
+        let non_negative = builder
+            .ins()
+            .icmp_imm(IntCC::SignedGreaterThanOrEqual, index, 0);
+        let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index_i64, len);
+        let valid = builder.ins().band(non_negative, below_len);
+        builder.ins().trapz(valid, TrapCode::HEAP_OUT_OF_BOUNDS);
+    }
     let shift = match storage_bytes {
         1 => 0,
         2 => 1,
@@ -9516,6 +9542,15 @@ fn emit_direct_array_store(
     };
     builder.ins().store(MemFlags::new(), stored, address, 0);
     Ok(())
+}
+
+fn emit_array_bounds_trap(builder: &mut FunctionBuilder<'_>, index: Value, len: Value) {
+    let non_negative = builder
+        .ins()
+        .icmp_imm(IntCC::SignedGreaterThanOrEqual, index, 0);
+    let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index, len);
+    let valid = builder.ins().band(non_negative, below_len);
+    builder.ins().trapz(valid, TrapCode::HEAP_OUT_OF_BOUNDS);
 }
 
 fn statement_assigns_local(statement: &SimpleStmt, name: &str) -> bool {
@@ -9696,6 +9731,7 @@ pub(crate) fn emit_indexed_collection_assignment(
     collection_info: &ForeachCollectionInfo,
     suffix: &str,
     index_binding: ValueBinding,
+    bounds_proven: bool,
     op: AssignOp,
     rhs: ValueBinding,
 ) -> Result<(), String> {
@@ -9752,6 +9788,7 @@ pub(crate) fn emit_indexed_collection_assignment(
                 path_type,
                 direct.storage_bytes,
                 direct.static_len,
+                bounds_proven,
             )?;
         } else {
             builder.ins().call(
@@ -9777,6 +9814,7 @@ pub(crate) fn emit_indexed_collection_assignment(
                 path_type,
                 direct.storage_bytes,
                 direct.static_len,
+                bounds_proven,
             )?;
         } else {
             builder.ins().call(
@@ -9861,6 +9899,7 @@ pub(crate) fn emit_indexed_collection_assignment(
                 path_type,
                 direct.storage_bytes,
                 direct.static_len,
+                bounds_proven,
             )?;
         } else {
             builder.ins().call(
@@ -9945,6 +9984,7 @@ pub(crate) fn emit_indexed_collection_assignment(
                 path_type,
                 direct.storage_bytes,
                 direct.static_len,
+                bounds_proven,
             )?;
         } else {
             builder.ins().call(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -5680,6 +5680,25 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_elides_static_array_store_checks_for_canonical_max_length_loop() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "bounds.stasis",
+            "global values: i32[4];\nfunction main(): i32 {\n    let i: i32 = 0;\n    for (i = 0; i < values.max_length; i = i + 1) {\n        values[i] = i;\n    }\n    return 0;\n}\n",
+        );
+        process
+            .compile()
+            .expect("compile proven store bounds fixture");
+        let clif = process.clif_for_function_name("main").expect("main CLIF");
+        assert!(clif.contains("store"), "expected direct store:\n{clif}");
+        assert!(
+            !clif.contains("trapz"),
+            "proven loop retained array store bounds trap:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_preserves_proven_bounds_through_struct_element_alias() {
         let mut process = JitProcess::new();
         process.upsert_file(
@@ -5711,6 +5730,51 @@ mod tests {
         assert!(
             clif.contains("trapz"),
             "unproven static array index omitted fatal check:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_retains_fatal_check_for_unproven_static_array_store() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "bounds.stasis",
+            "global values: i32[4];\nfunction write(index: i32): i32 { values[index] = 7; return 0; }\nfunction main(): i32 { return write(0); }\n",
+        );
+        process
+            .compile()
+            .expect("compile checked store bounds fixture");
+        let clif = process.clif_for_function_name("write").expect("write CLIF");
+        assert!(
+            clif.contains("trapz"),
+            "unproven static array store omitted fatal check:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_checks_unproven_static_struct_view_once() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "bounds.stasis",
+            "struct Draw { x: f32; y: f32; opacity: i32; }\nglobal draws: Draw[4];\nfunction write(index: i32): i32 {\n    let draw: Draw = draws[index];\n    draw.x = 1.0;\n    draw.y = 2.0;\n    draw.opacity = 255;\n    return draw.opacity;\n}\nfunction main(): i32 { return write(0); }\n",
+        );
+        process
+            .compile()
+            .expect("compile checked struct view fixture");
+        let clif = process.clif_for_function_name("write").expect("write CLIF");
+        assert_eq!(
+            clif.matches("trapz").count(),
+            1,
+            "static struct view did not consolidate bounds checks at alias creation:\n{clif}"
+        );
+        assert!(
+            clif.contains("store"),
+            "expected direct field stores:\n{clif}"
+        );
+        assert!(
+            clif.contains("load.i32"),
+            "expected direct field load:\n{clif}"
         );
     }
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -490,6 +490,10 @@ Field access on a struct view:
   collection identity through local aliases. Field access can then use the collection's direct
   storage slot instead of re-entering the hash-based runtime registry. Aliases of local collection
   parameters retain the generic path because their concrete backing is supplied by the caller.
+- Creating an alias to an arbitrarily indexed element of a statically named fixed collection
+  performs the fatal bounds check once. Every field load or store through that unchanged alias
+  reuses the validated `{base, index, len}` provenance instead of repeating the check. A compiler-
+  proven index omits even the alias-creation check.
 
 Rationale:
 - This allows the same function signature to accept either a single global struct or an element view from a struct array.


### PR DESCRIPTION
## Summary
- validate an arbitrarily indexed fixed global struct-array alias once at alias creation
- reuse that proven `{base,index,len}` fact for every field load and store through the unchanged alias
- thread canonical-loop bounds provenance through direct fixed-array stores
- retain fatal heap-out-of-bounds traps for every unproven direct load or store

## Why
Compact tick-produced render records naturally fill several fields through one indexed alias. Previously Stasis repeated the same bounds trap for every field store even though the alias target could not change. This produced noisy IR and made presentation snapshots disproportionately expensive.

## Verification
- full `stasis_compiler` library suite passed
- focused direct-binary IR tests prove canonical stores omit traps, arbitrary stores retain fatal traps, and an arbitrary struct alias with multiple loads/stores emits exactly one trap
- `cargo check -p stasis_compiler`
- release Stasis CLI build
- ChessTD format/check/130 tests using this compiler
- Android emulator instrumented AOT, 3000 warmup + 600 active-game frames: tick 25.9 us, render 85.8 us, draw_pieces 1.92 us

## Impact
Compared with the earlier active-enemy baseline, ChessTD draw_pieces falls from about 16.0 us to 1.92 us. Tick intentionally owns compact-list derivation at 25.9 us; combined guest tick+render is about 111.6 us versus 132.6 us previously, roughly 16% lower in this coarse emulator comparison.