### PR TITLE
Fold fixed collection max lengths

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -3522,6 +3522,24 @@ function end_frame(): void { return; }
 
     #[cfg(windows)]
     #[test]
+    fn aot_fixed_and_view_max_length_link_and_execute() {
+        let Some(link_config) = resolve_link_config_for_smoke() else {
+            return;
+        };
+
+        let source = "global storage: i32[4];\nfunction capacity(values: i32[]): i32 { return values.max_length; }\nfunction main(): i32 { return storage.max_length * 10 + capacity(storage); }\n";
+        let mut process = AotProcess::new();
+        process.upsert_file("max_length.stasis", source);
+        process.compile().expect("compile max_length fixture");
+        if let Some(exit_code) =
+            run_linked_i32_noarg_fixture(&process, "main", "max_length", &link_config)
+        {
+            assert_eq!(exit_code, 44);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn aot_and_jit_execute_receiver_overloads_with_different_arities() {
         let Some(link_config) = resolve_link_config_for_smoke() else {
             return;

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -7527,6 +7527,17 @@ pub(crate) fn emit_simple_expression(
             } else if let Some(constant) = constant_values.get(name) {
                 emit_constant_value(builder, constant)
             } else {
+                if let Some(collection_path) = name.strip_suffix(".max_length") {
+                    if let Some(max_length) = global_path_types
+                        .get(collection_path)
+                        .and_then(|type_id| type_table.fixed_collection_len(*type_id))
+                    {
+                        return Ok(ValueBinding {
+                            value: builder.ins().iconst(types::I32, i64::from(max_length)),
+                            type_id: TYPE_ID_I32,
+                        });
+                    }
+                }
                 let Some(path_type) = global_path_types.get(name).copied() else {
                     return Err(format!("unknown identifier '{}' in current jit path", name));
                 };

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3267,7 +3267,7 @@ mod tests {
     fn collection_contract_edit_rejits_only_consumers_and_callers() {
         fn source(capacity: usize) -> String {
             format!(
-                "global values: i32[{capacity}];\nfunction read_value(): i32 {{ return values[0]; }}\nfunction untouched(): i32 {{ return 7; }}\nfunction tick(): i32 {{ return read_value(); }}\nfunction render(): i32 {{ return untouched(); }}\nfunction main(): i32 {{ return tick() + render(); }}\n"
+                "global values: i32[{capacity}];\nfunction read_value(): i32 {{ return values.max_length; }}\nfunction untouched(): i32 {{ return 7; }}\nfunction tick(): i32 {{ return read_value(); }}\nfunction render(): i32 {{ return untouched(); }}\nfunction main(): i32 {{ return tick() + render(); }}\n"
             )
         }
 
@@ -3331,7 +3331,7 @@ mod tests {
             process
                 .execute_i32_noarg_by_name("main")
                 .expect("execute changed layout"),
-            7
+            10
         );
     }
 
@@ -5675,6 +5675,35 @@ mod tests {
         assert!(
             !clif.contains("trapz"),
             "proven loop retained array bounds trap:\n{clif}"
+        );
+        let loop_bound_loads = clif
+            .lines()
+            .filter(|line| line.trim_start().contains("load.i32"))
+            .count();
+        assert_eq!(
+            loop_bound_loads, 1,
+            "fixed max_length should be an immediate, leaving only the element load:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_keeps_view_max_length_dynamic() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "view_capacity.stasis",
+            "global storage: i32[4];\nfunction capacity(values: i32[]): i32 { return values.max_length; }\nfunction main(): i32 { return capacity(storage); }\n",
+        );
+        process.compile().expect("compile view capacity fixture");
+        let clif = process
+            .clif_for_function_name("capacity")
+            .expect("capacity CLIF");
+        assert!(
+            clif.lines().any(|line| {
+                let line = line.trim_start();
+                line.starts_with("call ") || line.contains(" = call ")
+            }),
+            "view max_length incorrectly became a static constant:\n{clif}"
         );
     }
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -99,6 +99,8 @@ Header access:
 `Type[]` call-site compatibility:
 - A `Type[]` parameter is a view/reference type and may accept storage values with different fixed capacities (`Type[N]`, `Type[M]`, ...).
 - The storage header still carries `max_length` so bounds metadata remains available at runtime.
+- Reads of `.max_length` through a statically named fixed collection are compile-time constants. Views
+  retain runtime `.max_length` metadata because their capacity belongs to the referenced collection.
 
 `ascii[N]` layout:
 - header `byte_length: i32`


### PR DESCRIPTION
## Summary
- fold `.max_length` reads on statically named fixed collections to Cranelift immediates
- preserve runtime metadata loads for collection views, whose capacity belongs to the referenced value
- verify layout edits selectively recompile the accessor and its callers while reusing unrelated hot functions

## Why
Fixed collection capacity is part of the declared type, but generated code still loaded its seeded state header at each `.max_length` use. Canonical fixed-array loops therefore retained an invariant state-memory load in their loop condition even after bounds checks were proven redundant.

## Impact
The compiler now emits `iconst` for fixed collection capacity and removes one invariant load per fixed-array loop condition. View behavior and runtime metadata remain unchanged. ChessTD Android AOT profiling after 3,000 warmup frames and a 600-frame sample showed no frame-level delta distinguishable from emulator noise (render 88.93 us versus prior 85.78 us; piece draw 1.98 us versus 1.92 us), so this is presented as a small general IR-quality improvement rather than a claimed game-level speedup.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p stasis_compiler`
- exact JIT IR tests for fixed and view `.max_length`
- exact hot-reload invalidation test
- linked and executed MSVC AOT fixture returning 44 from fixed + view capacity reads
- compiler library suite: 504/506 passed in full serial run; the two failures were unrelated existing environment/harness issues (one Windows Application Control temp-executable block, one production-preview extern test returning 2 in isolation on current main behavior)
- Android x86_64 package/build/install/profile completed successfully

Theory gained: fixed collection capacity belongs to static type identity until storage crosses a view boundary; layout dependency invalidation is therefore the correctness seam for embedding capacity, while views must retain runtime metadata.

## Compiler slice reflection
- Good: reused existing type metadata and layout invalidation; no new analysis map or runtime path.
- Bad: the first view test fixture was unreachable, and the broad suite exposed unrelated environment/global-recorder instability.
- Adjustment: make IR fixtures reachable from `main`, run exact binaries to prove filters execute, and distinguish executable-policy/harness failures from slice regressions with isolated reruns.