### PR TITLE
JIT: rebuild coherent generation on layout changes

### DIFF
--- a/crates/stasis_compiler/examples/project_selective_jit_bench.rs
+++ b/crates/stasis_compiler/examples/project_selective_jit_bench.rs
@@ -248,6 +248,7 @@ fn main() -> Result<(), String> {
                         | PatchReason::AddedOrSignatureChanged
                         | PatchReason::BecameReachable
                         | PatchReason::LoweredContractChanged
+                        | PatchReason::CompilerLayoutChanged
                 )
             })
             .count();

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -3,7 +3,8 @@ use crate::backend::emit::{
     DirectStorageBindings, RuntimeHelperLinkage, SimpleCondition, SimpleExpr, SimpleStmt,
 };
 use crate::backend::patch_plan::{
-    capture_accepted_program, plan_patch, AcceptedProgram, FunctionKey, PatchReasonChain,
+    capture_accepted_program, plan_patch, AcceptedProgram, FunctionKey, PatchReason,
+    PatchReasonChain,
 };
 use crate::backend::program_snapshot::{ProgramArtifactMapping, ProgramFunction, ProgramSnapshot};
 use crate::backend::state_layout::{build_state_memory_report, is_named_scalar_state_path};
@@ -55,7 +56,6 @@ fn elapsed_micros(started: Instant) -> u64 {
 struct FunctionLoweringReferences {
     paths: BTreeSet<String>,
     calls: BTreeSet<String>,
-    type_ids: BTreeSet<crate::frontend::types::TypeId>,
 }
 
 fn path_is_local(path: &str, scopes: &[BTreeSet<String>]) -> bool {
@@ -136,29 +136,8 @@ fn collect_target_references(
     scopes: &[BTreeSet<String>],
 ) {
     match target {
-        AssignTarget::Local(path) => {
-            if !path_is_local(path, scopes) {
-                references.paths.insert(path.clone());
-            }
-        }
-        AssignTarget::GlobalPath(path) => {
-            if !path_is_local(path, scopes) {
-                references.paths.insert(path.clone());
-            }
-        }
-        AssignTarget::IndexedPath {
-            collection_path,
-            index,
-            suffix,
-        } => {
-            if !path_is_local(collection_path, scopes) {
-                references.paths.insert(collection_path.clone());
-                if !suffix.is_empty() {
-                    references
-                        .paths
-                        .insert(format!("{collection_path}.{suffix}"));
-                }
-            }
+        AssignTarget::Local(_) | AssignTarget::GlobalPath(_) => {}
+        AssignTarget::IndexedPath { index, .. } => {
             collect_expression_references(index, references, scopes);
         }
     }
@@ -172,12 +151,9 @@ fn collect_statement_references(
     for statement in statements {
         match statement {
             SimpleStmt::Let {
-                name,
-                type_id,
-                expression,
+                name, expression, ..
             } => {
                 collect_expression_references(expression, references, scopes);
-                references.type_ids.extend(*type_id);
                 scopes
                     .last_mut()
                     .expect("function dependency scope")
@@ -229,12 +205,9 @@ fn collect_statement_references(
             SimpleStmt::Foreach {
                 item_name,
                 index_name,
-                collection_path,
                 body_statements,
+                ..
             } => {
-                if !path_is_local(collection_path, scopes) {
-                    references.paths.insert(collection_path.clone());
-                }
                 scopes.push(BTreeSet::from_iter(
                     std::iter::once(item_name.clone()).chain(index_name.clone()),
                 ));
@@ -246,85 +219,25 @@ fn collect_statement_references(
     }
 }
 
-fn paths_overlap(reference: &str, contract_path: &str) -> bool {
-    reference == contract_path
-        || contract_path
-            .strip_prefix(reference)
-            .is_some_and(|suffix| suffix.starts_with('.'))
-        || reference
-            .strip_prefix(contract_path)
-            .is_some_and(|suffix| suffix.starts_with('.'))
-}
-
 fn function_lowering_contract_hash(
-    function: &FunctionMeta,
     references: &FunctionLoweringReferences,
     analysis: &CompileAnalysisCache,
-    type_table: &TypeTable,
 ) -> u64 {
-    let mut type_ids: BTreeSet<_> = function
-        .params
-        .iter()
-        .copied()
-        .chain(std::iter::once(function.return_type))
-        .chain(references.type_ids.iter().copied())
-        .collect();
-
     let mut facts = Vec::new();
     for path in &references.paths {
         if let Some(value) = analysis.constant_values.get(path) {
             facts.push(format!("constant:{path}:{value:?}"));
         }
     }
-    for (path, type_id) in &analysis.global_path_types {
-        if references
-            .paths
-            .iter()
-            .any(|reference| paths_overlap(reference, path))
-        {
-            facts.push(format!("global:{path}:{type_id:?}"));
-            type_ids.insert(*type_id);
-        }
-    }
-    for (path, info) in &analysis.collection_infos {
-        if references
-            .paths
-            .iter()
-            .any(|reference| paths_overlap(reference, path))
-        {
-            facts.push(format!("collection:{path}:{info:?}"));
-            type_ids.extend(info.element_type);
-            type_ids.extend(info.field_types.values().copied());
-        }
-    }
     for signature in &analysis.resolved_extern_signatures {
         if references.calls.contains(&signature.name) {
             facts.push(format!("extern:{signature:?}"));
-            type_ids.extend(signature.params.iter().copied());
-            type_ids.insert(signature.return_type);
             if let Some(address) = analysis.extern_symbol_addresses.get(&signature.symbol) {
                 facts.push(format!("extern_address:{}:{address}", signature.symbol));
             }
         }
     }
 
-    let mut pending_types: Vec<_> = type_ids.iter().copied().collect();
-    let mut seen_types = BTreeSet::new();
-    while let Some(type_id) = pending_types.pop() {
-        if !seen_types.insert(type_id) {
-            continue;
-        }
-        if let Some(info) = type_table.type_info(type_id) {
-            facts.push(format!("type:{type_id:?}:{info:?}"));
-        }
-        if let Some(element_type) = type_table.indexed_element_type_id(type_id) {
-            pending_types.push(element_type);
-        }
-        if let Some(fields) = analysis.named_struct_field_types.get(&type_id) {
-            facts.push(format!("struct:{type_id:?}:{fields:?}"));
-            pending_types.extend(fields.values().copied());
-        }
-    }
     facts.sort();
     hash_text(&facts.join("\n"))
 }
@@ -934,6 +847,12 @@ impl JitProcess {
         let mut lowering_references = BTreeMap::new();
         let mut lowering_contracts = BTreeMap::new();
         let mut lowered_contract_changes = BTreeSet::new();
+        let compiler_layout_changed =
+            self.active_program_snapshot
+                .as_ref()
+                .is_some_and(|accepted| {
+                    accepted.compiler_layout_digest() != snapshot.compiler_layout_digest()
+                });
         for function_id in &reachable_ids {
             let function = self
                 .compiler
@@ -951,13 +870,11 @@ impl JitProcess {
                     function.name
                 ))
             })?;
+            if compiler_layout_changed {
+                lowered_contract_changes.insert(key.clone());
+            }
             if let Some(references) = self.accepted_lowering_references.get(key) {
-                let hash = function_lowering_contract_hash(
-                    function,
-                    references,
-                    &analysis,
-                    self.compiler.types(),
-                );
+                let hash = function_lowering_contract_hash(references, &analysis);
                 if self.accepted_lowering_contracts.get(key) != Some(&hash) {
                     lowered_contract_changes.insert(key.clone());
                 }
@@ -981,6 +898,13 @@ impl JitProcess {
             &lowered_contract_changes,
         )
         .map_err(crate::compiler::CompileError::Backend)?;
+        let mut patch_plan = patch_plan;
+        if compiler_layout_changed {
+            for reason in &mut patch_plan.reasons {
+                reason.reason = PatchReason::CompilerLayoutChanged;
+                reason.path_from_change.clear();
+            }
+        }
         let plan_micros = elapsed_micros(plan_started);
         let emit_function_ids = patch_plan.re_jit_ids.clone();
         let source_paths = self
@@ -1089,8 +1013,7 @@ impl JitProcess {
                     .cloned()
                     .ok_or_else(|| format!("emitted function '{}' has no stable key", meta.name))?;
                 let references = collect_function_lowering_references(meta, hir);
-                let contract_hash =
-                    function_lowering_contract_hash(meta, &references, &analysis, lowered_types);
+                let contract_hash = function_lowering_contract_hash(&references, &analysis);
                 lowering_references.insert(function_key.clone(), references);
                 lowering_contracts.insert(function_key.clone(), contract_hash);
                 staged_functions.push((
@@ -3264,7 +3187,7 @@ mod tests {
     use crate::backend::EngineEntrypoints;
 
     #[test]
-    fn collection_contract_edit_rejits_only_consumers_and_callers() {
+    fn collection_layout_edit_rejits_every_reachable_function() {
         fn source(capacity: usize) -> String {
             format!(
                 "global values: i32[{capacity}];\nfunction read_value(): i32 {{ return values.max_length; }}\nfunction untouched(): i32 {{ return 7; }}\nfunction tick(): i32 {{ return read_value(); }}\nfunction render(): i32 {{ return untouched(); }}\nfunction main(): i32 {{ return tick() + render(); }}\n"
@@ -3299,8 +3222,12 @@ mod tests {
             .collect();
         assert_eq!(
             emitted_names,
-            BTreeSet::from(["main", "read_value", "tick"])
+            BTreeSet::from(["main", "read_value", "render", "tick", "untouched"])
         );
+        assert!(metadata
+            .patch_reasons
+            .iter()
+            .all(|reason| reason.reason == PatchReason::CompilerLayoutChanged));
         let reused_names: BTreeSet<_> = metadata
             .reused_function_ids
             .iter()
@@ -3315,7 +3242,7 @@ mod tests {
                     .as_str()
             })
             .collect();
-        assert_eq!(reused_names, BTreeSet::from(["render", "untouched"]));
+        assert!(reused_names.is_empty());
         for artifact in process.artifacts() {
             if reused_names.contains(artifact.function_key.name.as_str()) {
                 assert_eq!(
@@ -3326,12 +3253,61 @@ mod tests {
                 );
             }
         }
-        assert_eq!(report.emit.emitted_functions, 3);
+        assert_eq!(report.emit.emitted_functions, 5);
         assert_eq!(
             process
                 .execute_i32_noarg_by_name("main")
                 .expect("execute changed layout"),
             10
+        );
+    }
+
+    #[test]
+    fn non_state_struct_layout_edit_rejits_every_reachable_function() {
+        fn source(extra_field: bool) -> String {
+            let fields = if extra_field {
+                "value: i32; extra: f32;"
+            } else {
+                "value: i32;"
+            };
+            format!(
+                "struct LocalOnly {{ {fields} }}\nfunction tick(): i32 {{ return 1; }}\nfunction render(): i32 {{ return 2; }}\nfunction main(): i32 {{ return tick() + render(); }}\n"
+            )
+        }
+
+        let mut process = JitProcess::new();
+        process.upsert_file("local_layout.stasis", source(false));
+        process.compile().expect("compile initial local layout");
+        process.upsert_file("local_layout.stasis", source(true));
+        let report = process.compile().expect("compile changed local layout");
+
+        let metadata = process.generation_metadata().expect("generation metadata");
+        let emitted_names: BTreeSet<_> = metadata
+            .emitted_function_ids
+            .iter()
+            .map(|id| {
+                process
+                    .compiler
+                    .functions()
+                    .iter()
+                    .find(|function| function.id == *id)
+                    .expect("emitted identity")
+                    .name
+                    .as_str()
+            })
+            .collect();
+        assert_eq!(emitted_names, BTreeSet::from(["main", "render", "tick"]));
+        assert!(metadata
+            .patch_reasons
+            .iter()
+            .all(|reason| reason.reason == PatchReason::CompilerLayoutChanged));
+        assert!(metadata.reused_function_ids.is_empty());
+        assert_eq!(report.emit.emitted_functions, 3);
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute changed local layout"),
+            3
         );
     }
 
@@ -3382,7 +3358,7 @@ mod tests {
     }
 
     #[test]
-    fn dotted_local_assignment_does_not_depend_on_same_named_global() {
+    fn global_struct_layout_change_rejits_local_and_global_consumers() {
         fn source(extra_field: bool) -> String {
             let global_fields = if extra_field {
                 "flag: i32; extra: i32;"
@@ -3397,11 +3373,6 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file("local_global.stasis", source(false));
         process.compile().expect("compile initial global layout");
-        let old_pointers: BTreeMap<_, _> = process
-            .artifacts()
-            .iter()
-            .map(|artifact| (artifact.function_key.name.clone(), artifact.code_ptr))
-            .collect();
         process.upsert_file("local_global.stasis", source(true));
         process.compile().expect("compile changed global layout");
 
@@ -3420,17 +3391,11 @@ mod tests {
                     .as_str()
             })
             .collect();
-        assert_eq!(emitted_names, BTreeSet::from(["main", "render"]));
-        for artifact in process.artifacts() {
-            if matches!(artifact.function_key.name.as_str(), "local_user" | "tick") {
-                assert_eq!(
-                    old_pointers.get(&artifact.function_key.name),
-                    Some(&artifact.code_ptr),
-                    "{} pointer",
-                    artifact.function_key.name
-                );
-            }
-        }
+        assert_eq!(
+            emitted_names,
+            BTreeSet::from(["local_user", "main", "render", "tick"])
+        );
+        assert!(metadata.reused_function_ids.is_empty());
     }
 
     #[test]

--- a/crates/stasis_compiler/src/backend/patch_plan.rs
+++ b/crates/stasis_compiler/src/backend/patch_plan.rs
@@ -44,6 +44,7 @@ pub enum PatchReason {
     BodyChanged,
     AddedOrSignatureChanged,
     BecameReachable,
+    CompilerLayoutChanged,
     LoweredContractChanged,
     SccPeer { changed: FunctionKey },
     DirectCaller { callee: FunctionKey },

--- a/crates/stasis_compiler/src/backend/program_snapshot.rs
+++ b/crates/stasis_compiler/src/backend/program_snapshot.rs
@@ -22,6 +22,7 @@ use crate::frontend::{
     parser::parse_string_literal_text,
 };
 use crate::identity::SymbolId;
+use sha2::{Digest, Sha256};
 use std::ops::Range;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,6 +98,7 @@ pub struct ProgramSnapshot {
     asset_references: Vec<AssetReference>,
     state_layout: StateLayout,
     layout_digest: [u8; 32],
+    compiler_layout_digest: [u8; 32],
     data_flow_summaries: Arc<[FunctionDataFlowSummary]>,
     global_type_ids: BTreeMap<String, u16>,
     collections: Vec<ProgramCollectionMetadata>,
@@ -107,6 +109,54 @@ pub struct ProgramSnapshot {
     // Lowering-only detail remains private to the backend. Public consumers use the
     // typed snapshot records above instead of reconstructing parser metadata.
     pub(crate) analysis: CompileAnalysisCache,
+}
+
+fn compiler_layout_digest(
+    analysis: &CompileAnalysisCache,
+    functions: &[FunctionMeta],
+    types: &TypeTable,
+) -> [u8; 32] {
+    let mut facts = Vec::new();
+    let mut pending_type_ids = Vec::new();
+    for (type_id, fields) in &analysis.named_struct_field_types {
+        facts.push(format!("struct:{type_id}:{fields:?}"));
+        pending_type_ids.push(*type_id);
+        pending_type_ids.extend(fields.values().copied());
+    }
+    for (path, type_id) in &analysis.global_path_types {
+        facts.push(format!("global:{path}:{type_id}"));
+        pending_type_ids.push(*type_id);
+    }
+    for (path, info) in &analysis.collection_infos {
+        facts.push(format!("collection:{path}:{info:?}"));
+        pending_type_ids.extend(info.element_type);
+        pending_type_ids.extend(info.field_types.values().copied());
+    }
+    for function in functions {
+        pending_type_ids.extend(function.params.iter().copied());
+        pending_type_ids.push(function.return_type);
+    }
+    for signature in &analysis.resolved_extern_signatures {
+        pending_type_ids.extend(signature.params.iter().copied());
+        pending_type_ids.push(signature.return_type);
+    }
+    let mut seen_type_ids = BTreeSet::new();
+    while let Some(type_id) = pending_type_ids.pop() {
+        if !seen_type_ids.insert(type_id) {
+            continue;
+        }
+        if let Some(info) = types.type_info(type_id) {
+            facts.push(format!("type:{type_id}:{info:?}"));
+        }
+        if let Some(element_type) = types.indexed_element_type_id(type_id) {
+            pending_type_ids.push(element_type);
+        }
+    }
+    facts.sort();
+    let digest = Sha256::digest(facts.join("\n").as_bytes());
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&digest);
+    bytes
 }
 
 impl ProgramSnapshot {
@@ -126,6 +176,7 @@ impl ProgramSnapshot {
             types,
         );
         let layout_digest = state_layout_digest(&state_layout)?;
+        let compiler_layout_digest = compiler_layout_digest(&analysis, functions, types);
         let collections = analysis
             .collection_infos
             .iter()
@@ -154,6 +205,7 @@ impl ProgramSnapshot {
             asset_references,
             state_layout,
             layout_digest,
+            compiler_layout_digest,
             data_flow_summaries,
             global_type_ids: analysis.global_path_types.clone(),
             collections,
@@ -199,6 +251,12 @@ impl ProgramSnapshot {
     }
     pub fn layout_digest(&self) -> [u8; 32] {
         self.layout_digest
+    }
+    /// Digest of compiler-visible storage and type layouts that may be embedded in machine code.
+    /// This is intentionally distinct from `layout_digest`, which versions persistent state and
+    /// governs migration compatibility.
+    pub(crate) fn compiler_layout_digest(&self) -> [u8; 32] {
+        self.compiler_layout_digest
     }
     pub fn data_flow_summaries(&self) -> &[FunctionDataFlowSummary] {
         &self.data_flow_summaries
@@ -433,6 +491,35 @@ mod tests {
             original,
             jit.program_snapshot().expect("snapshot").layout_digest()
         );
+    }
+
+    #[test]
+    fn non_state_struct_change_only_changes_compiler_layout_digest() {
+        fn source(extra_field: bool) -> String {
+            let fields = if extra_field {
+                "value: i32; extra: f32;"
+            } else {
+                "value: i32;"
+            };
+            format!(
+                "struct LocalOnly {{ {fields} }}\nglobal score: i32;\nfunction main(): i32 {{ return score; }}\n"
+            )
+        }
+
+        let mut jit = JitProcess::new();
+        jit.upsert_file("main.stasis", source(false));
+        jit.compile().expect("compile original local layout");
+        let original_state = jit.program_snapshot().expect("snapshot").layout_digest();
+        let original_compiler = jit
+            .program_snapshot()
+            .expect("snapshot")
+            .compiler_layout_digest();
+
+        jit.upsert_file("main.stasis", source(true));
+        jit.compile().expect("compile changed local layout");
+        let changed = jit.program_snapshot().expect("snapshot");
+        assert_eq!(original_state, changed.layout_digest());
+        assert_ne!(original_compiler, changed.compiler_layout_digest());
     }
 
     #[test]

--- a/docs/jit_generation_contract.md
+++ b/docs/jit_generation_contract.md
@@ -75,9 +75,9 @@ The compiler retains the accepted revision's canonical function identities, sign
 hashes, reachability, forward call graph, reverse caller graph, layout facts, and active body
 addresses. After whole-file checking it builds an immutable `PatchPlan`.
 
-The seed set contains reachable functions whose body, signature, or lowered contract changed;
-affected SCC peers; newly reachable functions; and functions whose embedded layout/global access
-facts changed. The planner then adds reverse direct callers whenever the callee address, ABI, or
+When the accepted and candidate compiler-layout digests differ, the seed set is every reachable
+function. Otherwise it contains reachable functions whose body, signature, or non-layout lowered
+contract changed; affected SCC peers; and newly reachable functions. The planner then adds reverse direct callers whenever the callee address, ABI, or
 lowered call contract requires a new caller body. A host-entry trampoline ends propagation only for
 the external host caller, which is not a Stasis call-graph node. If another Stasis function directly
 calls a host-entry function, that real reverse edge continues through the normal closure.
@@ -204,10 +204,12 @@ the compiler-owned bounded migration plan and isolated candidate storage. The st
 `on_code_swap(): void` target runs after migration and before publication against candidate state.
 It may reject the patch. Failure destroys candidate state; active code/state were never modified.
 
-Layout invalidation is precise where compiler facts prove which bodies embed changed offsets or
-storage contracts. If precision is unavailable, the planner conservatively seeds every reachable
-body that may access the changed storage, then applies the normal reverse-caller closure. It does
-not silently fall back to whole-program warm emission without reporting the reason and affected set.
+The compiler-layout digest covers named-struct fields, global path types, collection shapes, and
+their transitively referenced type layouts, including types not stored in persistent state. Any
+change rebuilds every reachable body before publication. The separate state-layout digest remains
+the authority for whether isolated state migration is required and compatible. This explicit
+generation boundary favors coherent embedded offsets and simpler lowering over layout-edit latency;
+body-only, constant, and extern-contract edits remain selective.
 
 ## Code lifetime and restart reclamation
 

--- a/docs/live-compilation-prd.md
+++ b/docs/live-compilation-prd.md
@@ -128,9 +128,11 @@ Each function produces:
 Rules:
 
 - If `fnBodyHash` is unchanged -> reuse target-independent analysis/lowering inputs when safe
-- If a layout-affecting semantic fact changes -> seed every function whose lowered storage facts
-  changed, then expand its reverse caller closure
+- If any compiler-visible layout fact changes -> recompile every reachable function into one
+  coherent generation
 - Unchanged reachable functions may reuse their accepted live machine code and addresses in JIT dev
+  only while the compiler-layout digest is unchanged. This keeps ordinary body and constant edits
+  selective without requiring per-function proofs for embedded struct offsets or collection shapes.
 
 ### 4.4 Generation Compatibility Rule
 


### PR DESCRIPTION
## Summary
- add a compiler-layout digest distinct from the persistent-state migration digest
- rebuild every reachable JIT function when named structs, global storage, collection shapes, or transitively referenced type layouts change
- retain selective recompilation for body-only, constant, and extern-contract edits
- simplify per-function lowering contracts to non-layout constant and extern facts
- report the explicit `CompilerLayoutChanged` patch reason and document the generation boundary

## Why
Machine code may embed offsets and collection layout facts even for structs used only by locals or parameters. Treating a layout edit as one coherent generation removes the need to prove per-function layout overlap and closes the non-state-struct invalidation gap. State migration remains independently precise and transactional.

## Verification
- `cargo fmt --check`
- `cargo check -p stasis_compiler --all-targets`
- 198/198 JIT tests pass when excluding the independently reproduced, environment-sensitive `local_runtime_resolves_production_preview_externs` test
- 12/12 program-snapshot tests pass
- 4/4 state-migration tests pass
- focused tests prove collection and non-state struct layout edits rebuild all reachable functions
- body-only and constant-only edits retain selective recompilation
- layout rebuilds are reported as `CompilerLayoutChanged`

The excluded preview-time test also fails on current main because wall-clock time crosses its expected bucket; this branch does not touch that runtime seam.

## Performance impact
No steady-state runtime or AOT cost is added: the digest comparison occurs only during compilation. Layout edits intentionally perform a full reachable JIT rebuild, increasing only live-edit compile latency for those comparatively rare edits.
