### PR TITLE
perf: cache read-only struct parameter fields

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -226,6 +226,12 @@ impl AotProcess {
             )
         })?;
         let analysis = &snapshot.analysis;
+        let data_flow_summaries = snapshot.data_flow_summaries();
+        let source_paths = snapshot
+            .files()
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
         self.string_literals = snapshot.literal_table().clone();
         self.collection_max_lengths =
             collect_fixed_collection_max_lengths(&analysis.global_path_types, &analysis_type_table)
@@ -278,6 +284,13 @@ impl AotProcess {
                 type_table.ensure_ascii_view_id()?;
                 let mut function_string_literals = BTreeMap::new();
                 let profile_instrumentation = profile_function_names.contains(&meta.name);
+                let data_flow_summary = source_paths.get(meta.file_id as usize).and_then(|file| {
+                    data_flow_summaries.iter().find(|summary| {
+                        summary.function == meta.name
+                            && summary.file == *file
+                            && summary.source_start == meta.source_range.start
+                    })
+                });
                 let bytes = compile_function_to_object_bytes(
                     meta,
                     hir,
@@ -291,6 +304,7 @@ impl AotProcess {
                     &target,
                     &analysis.collection_infos,
                     &analysis.named_struct_field_types,
+                    data_flow_summary,
                     &direct_storage,
                     profile_instrumentation,
                 )?;
@@ -1206,6 +1220,7 @@ fn compile_function_to_object_bytes(
     target: &stasis_jit::AotTarget,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&crate::data_flow::FunctionDataFlowSummary>,
     direct_storage: &DirectStorageBindings,
     profile_instrumentation: bool,
 ) -> Result<Vec<u8>, String> {
@@ -1255,6 +1270,7 @@ fn compile_function_to_object_bytes(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        data_flow_summary,
         Some(direct_storage),
         None,
         false,
@@ -2279,6 +2295,22 @@ mod tests {
         compile_result.expect("aot compile");
         let captured = captured.lock().expect("lock clif capture").clone();
         captured
+    }
+
+    #[test]
+    fn aot_caches_repeated_readonly_struct_parameter_field() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nfunction read_three(value: Sample): i32 { return value.value + value.value + value.value; }\nfunction main(): i32 { item.value = 3; return read_three(item); }\n",
+        );
+        let clif = capture_aot_clif_by_function(&mut process);
+        let read_three = clif.get("read_three").expect("read_three AOT CLIF");
+        assert_eq!(
+            read_three.matches("brif").count(),
+            1,
+            "AOT read-only field should resolve storage once per call:\n{read_three}"
+        );
     }
 
     fn parity_corpus_cases() -> &'static [ParityCorpusCase] {

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1,5 +1,6 @@
 use crate::backend::runtime_exports::is_aot_runtime_export_symbol;
 use crate::compiler::{FunctionId, FunctionMeta, SourceFile};
+use crate::data_flow::FunctionDataFlowSummary;
 use crate::frontend::parser::{
     parse_top_level_extern_functions, parse_top_level_type_layout, ParsedExternFunctionDeclaration,
     ParsedField,
@@ -1616,6 +1617,55 @@ pub(crate) struct StructViewBinding {
     pub(crate) bounds_proven: bool,
 }
 
+fn readonly_struct_parameter_fields(
+    meta: &FunctionMeta,
+    summary: &FunctionDataFlowSummary,
+    named_struct_field_types: &NamedStructFieldTypeMap,
+    type_table: &TypeTable,
+) -> Vec<(String, String, String, TypeId)> {
+    let mut fields = BTreeSet::new();
+    for (index, base) in meta.param_names.iter().enumerate() {
+        let Some(type_id) = meta.params.get(index).copied() else {
+            continue;
+        };
+        let Some(field_types) = named_struct_field_types.get(&type_id) else {
+            continue;
+        };
+        let is_written = summary.aggregate.parameter_writes.iter().any(|path| {
+            path == base
+                || path
+                    .strip_prefix(base)
+                    .is_some_and(|tail| tail.starts_with('.'))
+        });
+        if is_written {
+            continue;
+        }
+        for path in &summary.direct.parameter_reads {
+            let Some(suffix) = path
+                .strip_prefix(base)
+                .and_then(|tail| tail.strip_prefix('.'))
+            else {
+                continue;
+            };
+            // Nested struct/collection views still require reference identity. Cache
+            // only direct scalar fields that fit the ordinary value ABI.
+            if suffix.contains('.') || suffix.contains('[') {
+                continue;
+            }
+            let Some(field_type) = field_types.get(suffix).copied() else {
+                continue;
+            };
+            if is_struct_view_type(field_type, named_struct_field_types)
+                || is_collection_handle_type(field_type, type_table)
+            {
+                continue;
+            }
+            fields.insert((path.clone(), base.clone(), suffix.to_string(), field_type));
+        }
+    }
+    fields.into_iter().collect()
+}
+
 pub(crate) fn compile_function_with_module<M, T, BeforeStatement, OnFunctionBuilt, Finalize>(
     mut module: M,
     meta: &FunctionMeta,
@@ -1629,6 +1679,7 @@ pub(crate) fn compile_function_with_module<M, T, BeforeStatement, OnFunctionBuil
     constant_values: &ConstantValueMap,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&FunctionDataFlowSummary>,
     direct_storage: Option<&DirectStorageBindings>,
     defined_runtime_helper_trampolines: Option<&mut BTreeSet<String>>,
     debug_instrumentation: bool,
@@ -1837,6 +1888,57 @@ where
                 block_param_cursor,
                 block_params.len()
             ));
+        }
+
+        // A struct parameter is a reference-like view whose backing may be AoS or SoA.
+        // When whole-program effects prove that neither this function nor a transitive
+        // callee writes the parameter, resolve each directly-read scalar field once.
+        // Synthetic full-path locals then let all later uses reuse the SSA value while
+        // preserving the existing view ABI and mixed-storage caller behavior.
+        if let Some(summary) = data_flow_summary {
+            let parameter_fields = readonly_struct_parameter_fields(
+                meta,
+                summary,
+                named_struct_field_types,
+                type_table,
+            );
+            for (path, base, suffix, field_type) in parameter_fields {
+                let local = values_by_name.get(&base).copied().ok_or_else(|| {
+                    format!(
+                        "missing struct parameter '{}' while caching '{}'",
+                        base, path
+                    )
+                })?;
+                let struct_view = local.struct_view.ok_or_else(|| {
+                    format!("struct parameter '{}' is missing view metadata", base)
+                })?;
+                let base_hash = builder.use_var(local.var);
+                let loaded = emit_struct_view_field_load(
+                    &mut builder,
+                    &runtime_call_refs,
+                    type_table,
+                    struct_view,
+                    base_hash,
+                    &suffix,
+                    field_type,
+                )?;
+                let variable = declare_new_variable(
+                    &mut builder,
+                    &mut next_variable,
+                    loaded.value,
+                    loaded.type_id,
+                    type_table,
+                )?;
+                values_by_name.insert(
+                    path,
+                    LocalBinding {
+                        var: variable,
+                        type_id: loaded.type_id,
+                        struct_view: None,
+                        proven_index_upper: None,
+                    },
+                );
+            }
         }
 
         let empty_foreach_bindings = ForeachBindingMap::new();
@@ -7436,6 +7538,12 @@ pub(crate) fn emit_simple_expression(
             })
         }
         SimpleExpr::Identifier(name) => {
+            if let Some(local) = values_by_name.get(name).copied() {
+                return Ok(ValueBinding {
+                    value: builder.use_var(local.var),
+                    type_id: local.type_id,
+                });
+            }
             if let Some((base, suffix)) = name.split_once('.') {
                 if let Some(local) = values_by_name.get(base).copied() {
                     if let Some(kind) = collection_meta_kind_from_suffix(suffix) {
@@ -7515,12 +7623,7 @@ pub(crate) fn emit_simple_expression(
                     }
                 }
             }
-            if let Some(local) = values_by_name.get(name).copied() {
-                Ok(ValueBinding {
-                    value: builder.use_var(local.var),
-                    type_id: local.type_id,
-                })
-            } else if let Some((binding, suffix)) =
+            if let Some((binding, suffix)) =
                 resolve_foreach_binding_for_path(name, foreach_bindings)
             {
                 emit_foreach_binding_load(builder, runtime_call_refs, type_table, binding, &suffix)

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -913,6 +913,7 @@ impl JitProcess {
             .iter()
             .map(|file| file.path.clone())
             .collect::<Vec<_>>();
+        let data_flow_summaries = self.compiler.data_flow_summaries_shared();
         let mut staged_debug_metadata = self.debug_metadata.clone();
         for function_id in &emit_function_ids {
             staged_debug_metadata.remove(function_id);
@@ -967,6 +968,13 @@ impl JitProcess {
                 }
                 let symbol = format!("jit_fn_{}", meta.id);
                 let profile_instrumentation = profile_function_names.contains(&meta.name);
+                let data_flow_summary = source_paths.get(meta.file_id as usize).and_then(|file| {
+                    data_flow_summaries.iter().find(|summary| {
+                        summary.function == meta.name
+                            && summary.file == *file
+                            && summary.source_start == meta.source_range.start
+                    })
+                });
                 let mut type_table = lowered_types.clone();
                 type_table.ensure_utf8_view_id()?;
                 type_table.ensure_ascii_view_id()?;
@@ -985,6 +993,7 @@ impl JitProcess {
                         &analysis.constant_values,
                         &analysis.collection_infos,
                         &analysis.named_struct_field_types,
+                        data_flow_summary,
                         &analysis.extern_symbol_addresses,
                         &direct_storage,
                         local_runtime_helper_trampolines,
@@ -3121,6 +3130,7 @@ fn compile_function_into_jit_module(
     constant_values: &ConstantValueMap,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&crate::data_flow::FunctionDataFlowSummary>,
     extern_symbol_addresses: &ExternSymbolAddressMap,
     direct_storage: &DirectStorageBindings,
     local_runtime_helper_trampolines: bool,
@@ -3157,6 +3167,7 @@ fn compile_function_into_jit_module(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        data_flow_summary,
         Some(direct_storage),
         Some(defined_runtime_helper_trampolines),
         debug_instrumentation,
@@ -4874,6 +4885,51 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_caches_repeated_readonly_struct_parameter_field() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nglobal items: Sample[1];\nfunction read_three(value: Sample): i32 { return value.value + value.value + value.value; }\nfunction main(): i32 {\n    item.value = 3;\n    items[0].value = 6;\n    return read_three(item) + read_three(items[0]);\n}\n",
+        );
+        process.compile().expect("compile");
+        let clif = process
+            .clif_for_function_name("read_three")
+            .expect("read_three CLIF");
+        assert_eq!(
+            clif.matches("brif").count(),
+            1,
+            "read-only field should resolve storage once per call:\n{clif}"
+        );
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 27);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_does_not_cache_transitively_written_struct_parameter_field() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nglobal items: Sample[1];\nfunction mutate(value: Sample) { value.value = 9; }\nfunction read_then_mutate(value: Sample): i32 { let before: i32 = value.value; mutate(value); return before + value.value; }\nfunction main(): i32 {\n    item.value = 2;\n    items[0].value = 4;\n    return read_then_mutate(item) + read_then_mutate(items[0]);\n}\n",
+        );
+        process.compile().expect("compile");
+        let clif = process
+            .clif_for_function_name("read_then_mutate")
+            .expect("read_then_mutate CLIF");
+        assert!(
+            clif.matches("brif").count() >= 2,
+            "transitively written field was incorrectly cached:\n{clif}"
+        );
+        let value = process
+            .execute_i32_noarg_by_name("main")
+            .expect("execute main");
+        assert_eq!(value, 24);
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
- use whole-program data-flow effects to identify struct parameters that are transitively read-only
- cache each directly read scalar field once at function entry, preserving the existing reference/view ABI and mixed AoS/SoA callers
- keep mutable and transitively mutable parameters on the uncached path
- apply the same lowering in JIT and AOT

## Why
A generic struct parameter carries a base/index/length view because callers may provide either AoS or SoA storage. Repeated field reads could therefore repeat the storage-kind branch and runtime field lookup even when the value cannot change during the call.

This is a bounded IR-quality improvement. It removes duplicate resolutions within a function. It does not yet propagate known storage kind across arbitrary helper-call boundaries, so it complements rather than replaces call-site scalarization used in current ChessTD hot helpers.

## Validation
- `cargo check -p stasis_compiler`
- focused signed JIT execution for both AoS and SoA callers: 1 passed
- focused signed transitive-mutation safety execution: 1 passed
- focused signed AOT CLIF test: 1 passed
- full signed compiler binary: 508 passed; two pre-existing/environment failures (`qualified_same_name_calls_use_identical_jit_and_aot_module_graphs` needs a Windows linker, `local_runtime_resolves_production_preview_externs` is the known preview-time expectation mismatch)

## Theory gained
A Stasis struct argument is reference-like; storage ambiguity belongs to the view, not value-copy semantics. Whole-program aggregate writes are sufficient to safely reuse scalar field loads within a callee, while eliminating the remaining cross-callee branch requires an explicit specialized ABI or call-site provenance contract.

## Reflection
- Good: the optimization reuses existing transitive effect analysis and keeps JIT/AOT on one lowering path.
- Bad: the first hypothesis overestimated its effect on ChessTD helper chains, where most individual callees read each field once.
- Adjustment: measure the helper-call topology before claiming a whole-frame impact; pursue cross-call provenance as a separate slice.
