### PR TITLE
perf: propagate struct view storage provenance

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -226,6 +226,7 @@ impl AotProcess {
             )
         })?;
         let analysis = &snapshot.analysis;
+        let data_flow_summaries = snapshot.data_flow_summaries();
         self.string_literals = snapshot.literal_table().clone();
         self.collection_max_lengths =
             collect_fixed_collection_max_lengths(&analysis.global_path_types, &analysis_type_table)
@@ -278,6 +279,9 @@ impl AotProcess {
                 type_table.ensure_ascii_view_id()?;
                 let mut function_string_literals = BTreeMap::new();
                 let profile_instrumentation = profile_function_names.contains(&meta.name);
+                let data_flow_summary = data_flow_summaries
+                    .iter()
+                    .find(|summary| summary.internal_function_id == meta.storage_index);
                 let bytes = compile_function_to_object_bytes(
                     meta,
                     hir,
@@ -291,6 +295,7 @@ impl AotProcess {
                     &target,
                     &analysis.collection_infos,
                     &analysis.named_struct_field_types,
+                    data_flow_summary,
                     &direct_storage,
                     profile_instrumentation,
                 )?;
@@ -1206,6 +1211,7 @@ fn compile_function_to_object_bytes(
     target: &stasis_jit::AotTarget,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&crate::data_flow::FunctionDataFlowSummary>,
     direct_storage: &DirectStorageBindings,
     profile_instrumentation: bool,
 ) -> Result<Vec<u8>, String> {
@@ -1255,6 +1261,7 @@ fn compile_function_to_object_bytes(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        data_flow_summary,
         Some(direct_storage),
         None,
         false,
@@ -2347,7 +2354,33 @@ mod tests {
                     ("mutate", &["call", "iadd"]),
                 ],
             },
+            ParityCorpusCase {
+                label: "known_soa_struct_helper_chain",
+                source: "struct Sample { value: i32; }\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction middle(value: Sample): i32 { return leaf(value); }\nfunction main(): i32 { items[0].value = 7; return middle(items[0]); }\n",
+                expected_exit: 7,
+                expected_extern_symbols: &[],
+                expected_string_literals: &[],
+                expected_collection_max_lengths: &[("items", 1)],
+                expected_clif_markers: &[("main", &["call"]), ("leaf", &["call"])],
+            },
         ]
+    }
+
+    #[test]
+    fn aot_eliminates_storage_dispatch_through_known_soa_helper_chain() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction middle(value: Sample): i32 { return leaf(value); }\nfunction main(): i32 { items[0].value = 7; return middle(items[0]); }\n",
+        );
+        let captured = capture_aot_clif_by_function(&mut process);
+        for function in ["leaf", "middle"] {
+            let clif = captured.get(function).expect("helper CLIF");
+            assert!(
+                !clif.contains("brif"),
+                "known SoA provenance retained storage dispatch in {function}:\n{clif}"
+            );
+        }
     }
 
     fn run_parity_corpus_case(case: &ParityCorpusCase) {

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1,5 +1,6 @@
 use crate::backend::runtime_exports::is_aot_runtime_export_symbol;
 use crate::compiler::{FunctionId, FunctionMeta, SourceFile};
+use crate::data_flow::{FunctionDataFlowSummary, ParameterStorageKind};
 use crate::frontend::parser::{
     parse_top_level_extern_functions, parse_top_level_type_layout, ParsedExternFunctionDeclaration,
     ParsedField,
@@ -1629,6 +1630,7 @@ pub(crate) fn compile_function_with_module<M, T, BeforeStatement, OnFunctionBuil
     constant_values: &ConstantValueMap,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&FunctionDataFlowSummary>,
     direct_storage: Option<&DirectStorageBindings>,
     defined_runtime_helper_trampolines: Option<&mut BTreeSet<String>>,
     debug_instrumentation: bool,
@@ -1790,7 +1792,13 @@ where
                         Some(StructViewBinding {
                             index_var,
                             len_var,
-                            storage_kind: StructViewStorageKind::Dynamic,
+                            storage_kind: data_flow_summary
+                                .and_then(|summary| summary.parameter_storage_kinds.get(index))
+                                .map_or(StructViewStorageKind::Dynamic, |kind| match kind {
+                                    ParameterStorageKind::Dynamic => StructViewStorageKind::Dynamic,
+                                    ParameterStorageKind::Aos => StructViewStorageKind::Aos,
+                                    ParameterStorageKind::Soa => StructViewStorageKind::Soa,
+                                }),
                             known_collection_hash: None,
                             bounds_proven: false,
                         }),

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -222,8 +222,9 @@ fn collect_statement_references(
 fn function_lowering_contract_hash(
     references: &FunctionLoweringReferences,
     analysis: &CompileAnalysisCache,
+    parameter_storage_kinds: Option<&[crate::data_flow::ParameterStorageKind]>,
 ) -> u64 {
-    let mut facts = Vec::new();
+    let mut facts = vec![format!("parameter_storage:{parameter_storage_kinds:?}")];
     for path in &references.paths {
         if let Some(value) = analysis.constant_values.get(path) {
             facts.push(format!("constant:{path}:{value:?}"));
@@ -874,7 +875,15 @@ impl JitProcess {
                 lowered_contract_changes.insert(key.clone());
             }
             if let Some(references) = self.accepted_lowering_references.get(key) {
-                let hash = function_lowering_contract_hash(references, &analysis);
+                let hash = function_lowering_contract_hash(
+                    references,
+                    &analysis,
+                    self.compiler
+                        .function_data_flow_summaries()
+                        .iter()
+                        .find(|summary| summary.internal_function_id == function.storage_index)
+                        .map(|summary| summary.parameter_storage_kinds.as_slice()),
+                );
                 if self.accepted_lowering_contracts.get(key) != Some(&hash) {
                     lowered_contract_changes.insert(key.clone());
                 }
@@ -913,6 +922,7 @@ impl JitProcess {
             .iter()
             .map(|file| file.path.clone())
             .collect::<Vec<_>>();
+        let data_flow_summaries = self.compiler.data_flow_summaries_shared();
         let mut staged_debug_metadata = self.debug_metadata.clone();
         for function_id in &emit_function_ids {
             staged_debug_metadata.remove(function_id);
@@ -967,6 +977,9 @@ impl JitProcess {
                 }
                 let symbol = format!("jit_fn_{}", meta.id);
                 let profile_instrumentation = profile_function_names.contains(&meta.name);
+                let data_flow_summary = data_flow_summaries
+                    .iter()
+                    .find(|summary| summary.internal_function_id == meta.storage_index);
                 let mut type_table = lowered_types.clone();
                 type_table.ensure_utf8_view_id()?;
                 type_table.ensure_ascii_view_id()?;
@@ -985,6 +998,7 @@ impl JitProcess {
                         &analysis.constant_values,
                         &analysis.collection_infos,
                         &analysis.named_struct_field_types,
+                        data_flow_summary,
                         &analysis.extern_symbol_addresses,
                         &direct_storage,
                         local_runtime_helper_trampolines,
@@ -1013,7 +1027,11 @@ impl JitProcess {
                     .cloned()
                     .ok_or_else(|| format!("emitted function '{}' has no stable key", meta.name))?;
                 let references = collect_function_lowering_references(meta, hir);
-                let contract_hash = function_lowering_contract_hash(&references, &analysis);
+                let contract_hash = function_lowering_contract_hash(
+                    &references,
+                    &analysis,
+                    data_flow_summary.map(|summary| summary.parameter_storage_kinds.as_slice()),
+                );
                 lowering_references.insert(function_key.clone(), references);
                 lowering_contracts.insert(function_key.clone(), contract_hash);
                 staged_functions.push((
@@ -3121,6 +3139,7 @@ fn compile_function_into_jit_module(
     constant_values: &ConstantValueMap,
     collection_infos: &CollectionInfoMap,
     named_struct_field_types: &NamedStructFieldTypeMap,
+    data_flow_summary: Option<&crate::data_flow::FunctionDataFlowSummary>,
     extern_symbol_addresses: &ExternSymbolAddressMap,
     direct_storage: &DirectStorageBindings,
     local_runtime_helper_trampolines: bool,
@@ -3157,6 +3176,7 @@ fn compile_function_into_jit_module(
         constant_values,
         collection_infos,
         named_struct_field_types,
+        data_flow_summary,
         Some(direct_storage),
         Some(defined_runtime_helper_trampolines),
         debug_instrumentation,
@@ -4874,6 +4894,190 @@ mod tests {
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
         assert_eq!(value, 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_propagates_soa_struct_parameter_through_helper_chain() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction middle(value: Sample): i32 { return leaf(value); }\nfunction main(): i32 { items[0].value = 7; return middle(items[0]); }\n",
+        );
+        process.compile().expect("compile");
+        let summaries = process.compiler.data_flow_summaries_shared();
+        for function in ["leaf", "middle"] {
+            let summary = summaries
+                .iter()
+                .find(|summary| summary.function == function)
+                .expect("helper summary");
+            assert_eq!(
+                summary.parameter_storage_kinds,
+                vec![crate::data_flow::ParameterStorageKind::Soa],
+                "unexpected {function} provenance; summaries={summaries:#?}"
+            );
+        }
+        for function in ["leaf", "middle"] {
+            let clif = process
+                .clif_for_function_name(function)
+                .expect("helper CLIF");
+            assert!(
+                !clif.contains("brif"),
+                "known SoA provenance retained storage dispatch in {function}:\n{clif}"
+            );
+        }
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute main"),
+            7
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_propagates_aos_struct_parameter_through_helper_chain() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction middle(value: Sample): i32 { return leaf(value); }\nfunction main(): i32 { item.value = 8; return middle(item); }\n",
+        );
+        process.compile().expect("compile");
+        let summaries = process.compiler.data_flow_summaries_shared();
+        for function in ["leaf", "middle"] {
+            let summary = summaries
+                .iter()
+                .find(|summary| summary.function == function)
+                .expect("helper summary");
+            assert_eq!(
+                summary.parameter_storage_kinds,
+                vec![crate::data_flow::ParameterStorageKind::Aos],
+                "unexpected {function} provenance; summaries={summaries:#?}"
+            );
+            let clif = process
+                .clif_for_function_name(function)
+                .expect("helper CLIF");
+            assert!(
+                !clif.contains("brif"),
+                "known AoS provenance retained storage dispatch in {function}:\n{clif}"
+            );
+        }
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute main"),
+            8
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_keeps_mixed_struct_parameter_provenance_dynamic() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction middle(value: Sample): i32 { return leaf(value); }\nfunction main(): i32 { item.value = 3; items[0].value = 4; return middle(item) + middle(items[0]); }\n",
+        );
+        process.compile().expect("compile");
+        let summaries = process.compiler.data_flow_summaries_shared();
+        for function in ["leaf", "middle"] {
+            let summary = summaries
+                .iter()
+                .find(|summary| summary.function == function)
+                .expect("helper summary");
+            assert_eq!(
+                summary.parameter_storage_kinds,
+                vec![crate::data_flow::ParameterStorageKind::Dynamic],
+                "unexpected {function} provenance; summaries={summaries:#?}"
+            );
+        }
+        let leaf_clif = process.clif_for_function_name("leaf").expect("leaf CLIF");
+        assert!(
+            leaf_clif.contains("brif"),
+            "mixed provenance incorrectly specialized leaf:\n{leaf_clif}"
+        );
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute main"),
+            7
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_storage_specialization_preserves_live_aliases() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nfunction observe(first: Sample, second: Sample): i32 { let before: i32 = first.value; second.value = 9; return before + first.value; }\nfunction main(): i32 { item.value = 2; return observe(item, item); }\n",
+        );
+        process.compile().expect("compile");
+        let summary = process
+            .compiler
+            .data_flow_summaries_shared()
+            .iter()
+            .find(|summary| summary.function == "observe")
+            .cloned()
+            .expect("observe summary");
+        assert_eq!(
+            summary.parameter_storage_kinds,
+            vec![
+                crate::data_flow::ParameterStorageKind::Aos,
+                crate::data_flow::ParameterStorageKind::Aos,
+            ]
+        );
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute main"),
+            11
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_process_recompiles_helper_when_call_storage_provenance_changes() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction main(): i32 { items[0].value = 7; return leaf(items[0]); }\n",
+        );
+        process.compile().expect("initial compile");
+        let initial_leaf_ptr = process
+            .artifacts()
+            .iter()
+            .find(|artifact| artifact.function_key.name == "leaf")
+            .expect("initial leaf artifact")
+            .code_ptr;
+        assert!(!process
+            .clif_for_function_name("leaf")
+            .expect("initial leaf CLIF")
+            .contains("brif"));
+
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal item: Sample;\nglobal items: Sample[1];\nfunction leaf(value: Sample): i32 { return value.value; }\nfunction main(): i32 { item.value = 3; items[0].value = 4; return leaf(item) + leaf(items[0]); }\n",
+        );
+        let report = process.compile().expect("mixed-provenance patch");
+        assert_eq!(report.emit.emitted_functions, 2);
+        let patched_leaf_ptr = process
+            .artifacts()
+            .iter()
+            .find(|artifact| artifact.function_key.name == "leaf")
+            .expect("patched leaf artifact")
+            .code_ptr;
+        assert_ne!(initial_leaf_ptr, patched_leaf_ptr);
+        assert!(process
+            .clif_for_function_name("leaf")
+            .expect("patched leaf CLIF")
+            .contains("brif"));
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute patched main"),
+            7
+        );
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -4972,6 +4972,35 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_process_propagates_soa_struct_parameter_through_recursive_cycle() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "sample.stasis",
+            "struct Sample { value: i32; }\nglobal items: Sample[1];\nfunction even(value: Sample, depth: i32): i32 { if (depth <= 0) { return value.value; } return odd(value, depth - 1); }\nfunction odd(value: Sample, depth: i32): i32 { if (depth <= 0) { return value.value; } return even(value, depth - 1); }\nfunction main(): i32 { items[0].value = 9; return even(items[0], 3); }\n",
+        );
+        process.compile().expect("compile");
+        let summaries = process.compiler.data_flow_summaries_shared();
+        for function in ["even", "odd"] {
+            let summary = summaries
+                .iter()
+                .find(|summary| summary.function == function)
+                .expect("recursive helper summary");
+            assert_eq!(
+                summary.parameter_storage_kinds[0],
+                crate::data_flow::ParameterStorageKind::Soa,
+                "unexpected {function} provenance; summaries={summaries:#?}"
+            );
+        }
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute main"),
+            9
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_process_keeps_mixed_struct_parameter_provenance_dynamic() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -66,9 +66,19 @@ pub struct FunctionDataFlowSummary {
     #[serde(skip)]
     pub(crate) internal_syntax_fingerprint: u64,
     #[serde(skip)]
-    internal_function_id: u32,
+    pub(crate) internal_function_id: u32,
     #[serde(skip)]
     internal_signature_hash: u64,
+    #[serde(skip)]
+    pub(crate) parameter_storage_kinds: Vec<ParameterStorageKind>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub(crate) enum ParameterStorageKind {
+    #[default]
+    Dynamic,
+    Aos,
+    Soa,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -373,11 +383,20 @@ pub(crate) fn build_function_data_flow_summaries(
     {
         return Ok((None, context.fingerprint));
     }
+    if can_reuse_aggregates {
+        for function in functions {
+            if included_function_ids.contains(&function.id) {
+                direct_by_id[function.storage_index as usize] =
+                    analyze_function_effects(function, statements_by_id, &context)?;
+            }
+        }
+    }
     let aggregate_by_id = if can_reuse_aggregates {
         None
     } else {
         Some(build_aggregate_effects(&direct_by_id)?)
     };
+    let parameter_storage_kinds = infer_parameter_storage_kinds(functions, &direct_by_id, &context);
     let mut out = Vec::with_capacity(functions.len());
     for function in functions {
         if !included_function_ids.contains(&function.id) {
@@ -434,6 +453,10 @@ pub(crate) fn build_function_data_flow_summaries(
             // Explicitly internal dense storage position; the public compiler identity is FnId.
             internal_function_id: function.storage_index,
             internal_signature_hash: function.signature_hash,
+            parameter_storage_kinds: parameter_storage_kinds
+                .get(function.storage_index as usize)
+                .cloned()
+                .unwrap_or_default(),
         });
     }
     out.sort_by(|left, right| {
@@ -443,6 +466,108 @@ pub(crate) fn build_function_data_flow_summaries(
             .then(left.function.cmp(&right.function))
     });
     Ok((Some(out), context.fingerprint))
+}
+
+fn infer_parameter_storage_kinds(
+    functions: &[FunctionMeta],
+    direct_by_id: &[EffectSets],
+    context: &AnalysisContext<'_>,
+) -> Vec<Vec<ParameterStorageKind>> {
+    #[derive(Clone, Copy, Default, PartialEq, Eq)]
+    enum Evidence {
+        #[default]
+        Unknown,
+        Aos,
+        Soa,
+        Dynamic,
+    }
+
+    fn merge(current: Evidence, next: Evidence) -> Evidence {
+        match (current, next) {
+            (Evidence::Dynamic, _) | (_, Evidence::Dynamic) => Evidence::Dynamic,
+            (Evidence::Unknown, value) | (value, Evidence::Unknown) => value,
+            (Evidence::Aos, Evidence::Aos) => Evidence::Aos,
+            (Evidence::Soa, Evidence::Soa) => Evidence::Soa,
+            _ => Evidence::Dynamic,
+        }
+    }
+
+    fn source_parameter_index(path: &str) -> Option<usize> {
+        let symbolic = path.strip_prefix('$')?;
+        let digits = symbolic.bytes().take_while(u8::is_ascii_digit).count();
+        (digits > 0)
+            .then(|| symbolic[..digits].parse().ok())
+            .flatten()
+    }
+
+    let mut evidence = functions
+        .iter()
+        .map(|function| vec![Evidence::Unknown; function.params.len()])
+        .collect::<Vec<_>>();
+    let mut has_callers = functions
+        .iter()
+        .map(|function| vec![false; function.params.len()])
+        .collect::<Vec<_>>();
+
+    loop {
+        let previous = evidence.clone();
+        for (caller_index, effects) in direct_by_id.iter().enumerate() {
+            for call_site in &effects.call_sites {
+                let Some(target_views) = context
+                    .view_parameters_by_function
+                    .get(&call_site.target_id)
+                else {
+                    continue;
+                };
+                for &parameter_index in target_views {
+                    let Some(target) = evidence
+                        .get_mut(call_site.target_id as usize)
+                        .and_then(|parameters| parameters.get_mut(parameter_index))
+                    else {
+                        continue;
+                    };
+                    has_callers[call_site.target_id as usize][parameter_index] = true;
+                    let next = match call_site
+                        .arguments
+                        .get(parameter_index)
+                        .and_then(Option::as_deref)
+                    {
+                        Some(path) if path.contains("[*]") => Evidence::Soa,
+                        Some(path) if path.starts_with('$') => source_parameter_index(path)
+                            .and_then(|index| previous.get(caller_index)?.get(index).copied())
+                            .unwrap_or(Evidence::Unknown),
+                        Some(path) if context.path_types.contains_key(path) => Evidence::Aos,
+                        _ => Evidence::Dynamic,
+                    };
+                    *target = merge(*target, next);
+                }
+            }
+        }
+        if evidence == previous {
+            break;
+        }
+    }
+
+    evidence
+        .into_iter()
+        .enumerate()
+        .map(|(function_index, parameters)| {
+            parameters
+                .into_iter()
+                .enumerate()
+                .map(|(parameter_index, kind)| {
+                    if !has_callers[function_index][parameter_index] {
+                        return ParameterStorageKind::Dynamic;
+                    }
+                    match kind {
+                        Evidence::Aos => ParameterStorageKind::Aos,
+                        Evidence::Soa => ParameterStorageKind::Soa,
+                        Evidence::Unknown | Evidence::Dynamic => ParameterStorageKind::Dynamic,
+                    }
+                })
+                .collect()
+        })
+        .collect()
 }
 
 fn analyze_function_effects(
@@ -1378,6 +1503,12 @@ fn expression_type(
             suffix,
             ..
         } => {
+            if let Some(type_id) = context
+                .path_types
+                .get(&indexed_state_path(collection_path, suffix))
+            {
+                return Some(*type_id);
+            }
             let collection = path_type(collection_path, context, local_types, aliases)?;
             let element = context.types.indexed_element_type_id(collection)?;
             field_suffix_type(element, suffix, &context.field_types)


### PR DESCRIPTION
## Summary

- infer AoS, SoA, or dynamic backing for struct-view parameters from every reachable internal call site
- propagate provenance through helper chains to a fixed point while preserving the existing three-word live-view ABI
- remove per-field storage dispatch in JIT and AOT when all callers agree on a backing kind
- include the inferred kind in JIT lowering contracts so caller edits recompile unchanged affected callees

## Why

Struct parameters are live references, but field lowering previously treated every parameter as dynamically backed even when the program proved every call used AoS or every call used SoA. Hot render helpers could therefore repeat the same runtime storage-kind branch for every field access.

This optimization specializes addressing only. It does not copy or hoist field values, so aliases remain live and mutations through another reference are observed.

## Validation

- focused JIT AoS helper-chain IR + execution
- focused JIT SoA helper-chain IR + execution
- mixed AoS/SoA callers retain dynamic dispatch
- aliased parameters preserve live mutation semantics (expected result 11)
- caller-only edit changes provenance and recompiles the unchanged helper
- focused AOT IR verifies known SoA helpers have no storage-dispatch branch
- expanded JIT/AOT parity corpus includes the SoA helper chain
- full compiler suite: 508 passed; two pre-existing machine/environment failures remain:
  - qualified module-graph AOT test requires a discoverable Windows linker
  - production preview extern test expects the older preview-time result

## Performance scope

The eliminated branch is visible directly in Cranelift IR for monomorphic helper chains. Current ChessTD already scalarizes its hottest cached-text helper fields, while some shared TextRun helpers are genuinely called with both AoS and SoA values, so the expected whole-render impact on current main is small. An exact candidate game profile was blocked by a local compiler/runtime checkout mismatch for the new performance-HUD export; no performance number is claimed here.

## Theory gained

A struct argument's backing representation can be specialized independently from the value's mutability or aliasing: address provenance is stable across a call, while field values must remain live. A future extension can multiversion genuinely mixed callees by storage kind without changing source semantics.