### PR TITLE
perf: elide proven constant bounds checks

### DIFF
--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2517,7 +2517,7 @@ mod tests {
         let mut process = AotProcess::new();
         process.upsert_file(
             "literal_bounds.stasis",
-            "global values: i32[4];\nfunction valid(): i32 { values[0] = 3; return values[3]; }\nfunction invalid(): i32 { return values[4]; }\nfunction main(): i32 { if (valid() < 0) { return invalid(); } return 0; }\n",
+            "global values: i32[4];\nfunction valid(): i32 { values[0] = 3; return values[1 + 2]; }\nfunction invalid(): i32 { return values[2 * 2]; }\nfunction main(): i32 { if (valid() < 0) { return invalid(); } return 0; }\n",
         );
         let captured = capture_aot_clif_by_function(&mut process);
         let valid = captured.get("valid").expect("valid CLIF");

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2513,6 +2513,26 @@ mod tests {
     }
 
     #[test]
+    fn aot_elides_static_array_checks_only_for_in_bounds_literals() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "literal_bounds.stasis",
+            "global values: i32[4];\nfunction valid(): i32 { values[0] = 3; return values[3]; }\nfunction invalid(): i32 { return values[4]; }\nfunction main(): i32 { if (valid() < 0) { return invalid(); } return 0; }\n",
+        );
+        let captured = capture_aot_clif_by_function(&mut process);
+        let valid = captured.get("valid").expect("valid CLIF");
+        let invalid = captured.get("invalid").expect("invalid CLIF");
+        assert!(
+            !valid.contains("trapz"),
+            "in-bounds AOT literal retained bounds trap:\n{valid}"
+        );
+        assert!(
+            invalid.contains("trapz"),
+            "out-of-bounds AOT literal omitted fatal check:\n{invalid}"
+        );
+    }
+
+    #[test]
     fn aot_dynamic_global_array_fallback_uses_runtime_helper_signature() {
         let mut process = AotProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -9586,8 +9586,10 @@ fn static_index_bounds_proven(
     collection_len: usize,
     values_by_name: &BTreeMap<String, LocalBinding>,
 ) -> bool {
+    if let Some(value) = eval_const_i64(index) {
+        return usize::try_from(value).is_ok_and(|value| value < collection_len);
+    }
     match index {
-        SimpleExpr::Int(value) => usize::try_from(*value).is_ok_and(|value| value < collection_len),
         SimpleExpr::Identifier(name) => {
             values_by_name
                 .get(name)

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -4180,6 +4180,10 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
             target_collection, source_collection
         ));
     }
+    let source_bounds_proven =
+        static_index_bounds_proven(source_index, source_info.len as usize, values_by_name);
+    let target_bounds_proven =
+        static_index_bounds_proven(target_index, target_info.len as usize, values_by_name);
 
     for field_name in target_info.field_types.keys() {
         let source_value = emit_indexed_collection_load(
@@ -4190,7 +4194,7 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
             source_info,
             field_name,
             source_index_binding,
-            false,
+            source_bounds_proven,
         )?;
         emit_indexed_collection_assignment(
             builder,
@@ -4200,7 +4204,7 @@ pub(crate) fn try_emit_indexed_struct_copy_assignment(
             target_info,
             field_name,
             target_index_binding,
-            false,
+            target_bounds_proven,
             AssignOp::Set,
             source_value,
         )?;
@@ -4412,6 +4416,8 @@ pub(crate) fn try_emit_struct_copy_from_indexed_to_global(
         named_struct_field_types,
         foreach_bindings,
     )?;
+    let source_bounds_proven =
+        static_index_bounds_proven(source_index, source_info.len as usize, values_by_name);
     for (field_name, field_type) in &source_info.field_types {
         let source_value = emit_indexed_collection_load(
             builder,
@@ -4421,7 +4427,7 @@ pub(crate) fn try_emit_struct_copy_from_indexed_to_global(
             source_info,
             field_name,
             source_index_binding,
-            false,
+            source_bounds_proven,
         )?;
         let target_field = format!("{target_prefix}{field_name}");
         emit_global_assignment(
@@ -4528,6 +4534,8 @@ pub(crate) fn try_emit_struct_copy_from_global_to_indexed(
         named_struct_field_types,
         foreach_bindings,
     )?;
+    let target_bounds_proven =
+        static_index_bounds_proven(target_index, target_info.len as usize, values_by_name);
     for (field_name, field_type) in &target_info.field_types {
         let source_field = format!("{source_prefix}{field_name}");
         let source_value = emit_global_load(
@@ -4545,7 +4553,7 @@ pub(crate) fn try_emit_struct_copy_from_global_to_indexed(
             target_info,
             field_name,
             target_index_binding,
-            false,
+            target_bounds_proven,
             AssignOp::Set,
             source_value,
         )?;
@@ -5485,9 +5493,11 @@ pub(crate) fn emit_simple_statements(
                             named_struct_field_types,
                             foreach_bindings,
                         )?;
-                        let bounds_proven = matches!(index, SimpleExpr::Identifier(name)
-                            if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
-                                == Some(collection_info.len as usize));
+                        let bounds_proven = static_index_bounds_proven(
+                            index,
+                            collection_info.len as usize,
+                            values_by_name,
+                        );
                         emit_indexed_collection_assignment(
                             builder,
                             runtime_call_refs,
@@ -5604,9 +5614,11 @@ pub(crate) fn emit_simple_statements(
                             named_struct_field_types,
                             foreach_bindings,
                         )?;
-                        let bounds_proven = matches!(index, SimpleExpr::Identifier(name)
-                            if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
-                                == Some(collection_info.len as usize));
+                        let bounds_proven = static_index_bounds_proven(
+                            index,
+                            collection_info.len as usize,
+                            values_by_name,
+                        );
                         emit_indexed_collection_assignment(
                             builder,
                             runtime_call_refs,
@@ -7338,9 +7350,7 @@ pub(crate) fn try_emit_struct_view_value(
                 known_collection_hash: (!values_by_name.contains_key(collection_path))
                     .then(|| hash_global_path(collection_path)),
                 bounds_proven: known_len.is_some_and(|len| {
-                    matches!(index.as_ref(), SimpleExpr::Identifier(name)
-                        if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
-                            == Some(len as usize))
+                    static_index_bounds_proven(index, len as usize, values_by_name)
                 }),
             }))
         }
@@ -7613,9 +7623,8 @@ pub(crate) fn emit_simple_expression(
                 named_struct_field_types,
                 foreach_bindings,
             )?;
-            let bounds_proven = matches!(index.as_ref(), SimpleExpr::Identifier(name)
-                if values_by_name.get(name).and_then(|binding| binding.proven_index_upper)
-                    == Some(collection_info.len as usize));
+            let bounds_proven =
+                static_index_bounds_proven(index, collection_info.len as usize, values_by_name);
             emit_indexed_collection_load(
                 builder,
                 runtime_call_refs,
@@ -9570,6 +9579,23 @@ fn emit_array_bounds_trap(builder: &mut FunctionBuilder<'_>, index: Value, len: 
     let below_len = builder.ins().icmp(IntCC::UnsignedLessThan, index, len);
     let valid = builder.ins().band(non_negative, below_len);
     builder.ins().trapz(valid, TrapCode::HEAP_OUT_OF_BOUNDS);
+}
+
+fn static_index_bounds_proven(
+    index: &SimpleExpr,
+    collection_len: usize,
+    values_by_name: &BTreeMap<String, LocalBinding>,
+) -> bool {
+    match index {
+        SimpleExpr::Int(value) => usize::try_from(*value).is_ok_and(|value| value < collection_len),
+        SimpleExpr::Identifier(name) => {
+            values_by_name
+                .get(name)
+                .and_then(|binding| binding.proven_index_upper)
+                == Some(collection_len)
+        }
+        _ => false,
+    }
 }
 
 fn statement_assigns_local(statement: &SimpleStmt, name: &str) -> bool {

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -6046,6 +6046,48 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
+    fn jit_elides_static_array_checks_for_in_bounds_literal_indexes() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "literal_bounds.stasis",
+            "global values: i32[4];\nfunction main(): i32 { values[0] = 3; values[3] = 4; return values[0] + values[3]; }\n",
+        );
+        process.compile().expect("compile literal bounds fixture");
+        assert_eq!(
+            process
+                .execute_i32_noarg_by_name("main")
+                .expect("execute literal bounds fixture"),
+            7
+        );
+        let clif = process.clif_for_function_name("main").expect("main CLIF");
+        assert!(clif.contains("load.i32"), "expected direct loads:\n{clif}");
+        assert!(clif.contains("store"), "expected direct stores:\n{clif}");
+        assert!(
+            !clif.contains("trapz"),
+            "in-bounds literal indexes retained array bounds traps:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_retains_fatal_check_for_out_of_bounds_literal_index() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "literal_bounds.stasis",
+            "global values: i32[4];\nfunction read(): i32 { return values[4]; }\nfunction main(): i32 { if (values[0] < 0) { return read(); } return 0; }\n",
+        );
+        process
+            .compile()
+            .expect("compile invalid literal bounds fixture");
+        let clif = process.clif_for_function_name("read").expect("read CLIF");
+        assert!(
+            clif.contains("trapz"),
+            "out-of-bounds literal index omitted fatal check:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
     fn jit_rejects_backing_shorter_than_compiled_fixed_array() {
         let mut process = JitProcess::new();
         process.upsert_file(

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -6050,7 +6050,7 @@ mod tests {
         let mut process = JitProcess::new();
         process.upsert_file(
             "literal_bounds.stasis",
-            "global values: i32[4];\nfunction main(): i32 { values[0] = 3; values[3] = 4; return values[0] + values[3]; }\n",
+            "global values: i32[4];\nfunction main(): i32 { values[0] = 3; values[1 + 2] = 4; return values[0] + values[6 / 2]; }\n",
         );
         process.compile().expect("compile literal bounds fixture");
         assert_eq!(
@@ -6084,6 +6084,46 @@ mod tests {
             clif.contains("trapz"),
             "out-of-bounds literal index omitted fatal check:\n{clif}"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_does_not_prove_unevaluable_constant_array_index() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "constant_bounds.stasis",
+            "global values: i32[4];\nfunction divide_by_zero(): i32 { return values[1 / 0]; }\nfunction main(): i32 { if (values[0] < 0) { return divide_by_zero(); } return 0; }\n",
+        );
+        process
+            .compile()
+            .expect("compile invalid constant bounds fixture");
+        let clif = process
+            .clif_for_function_name("divide_by_zero")
+            .expect("unevaluable constant function CLIF");
+        assert!(
+            clif.contains("trap"),
+            "unevaluable constant index was incorrectly proven safe:\n{clif}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn jit_rejects_negative_constant_array_index() {
+        let mut process = JitProcess::new();
+        process.upsert_file(
+            "constant_bounds.stasis",
+            "global values: i32[4];\nfunction main(): i32 { return values[0 - 1]; }\n",
+        );
+        let error = process
+            .compile()
+            .expect_err("reject negative constant index");
+        match error {
+            crate::compiler::CompileError::Backend(message) => assert!(
+                message.contains("negative collection indices"),
+                "unexpected negative-index diagnostic: {message}"
+            ),
+            other => panic!("unexpected negative-index error: {other:?}"),
+        }
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
﻿## What changed

- recognize statically in-bounds integer constant expressions for fixed global arrays
- reuse the existing bounds-proof path across loads, stores, struct views, conversions, and whole-struct indexed copies
- keep dynamic, negative, and out-of-range accesses checked with the fatal `heap_oob` trap
- cover the shared lowering in both JIT and AOT CLIF tests

## Why

Stasis already knows both the literal index and fixed collection capacity. Emitting comparison, boolean, and trap instructions for an access such as `values[0]` made the input CLIF larger and asked Cranelift to rediscover a source-level fact.

This is deliberately a small proof: checked constant expression `0 <= index < capacity`, or the existing canonical-loop proof. It does not add collection identity or cross-function provenance.

## Impact

- Cleaner pre-optimization Cranelift IR: the representative four-access fixture drops four complete bounds-check sequences.
- Lower compiler optimization work for literal-heavy projects. ChessTD has 268 literal-index occurrences in view source, including nine in `gameplay.stasis`; generated level initialization contains many more.
- No claimed frame-time or final code-size win: Cranelift already folded the representative constant checks, and optimized machine code remained 136 bytes before and after.
- Fatal bounds semantics remain intact for invalid literal and dynamic indexes.

## Validation

- Focused JIT valid constant-expression execution and CLIF assertion: pass
- Focused JIT invalid constant-expression fatal-trap/rejection assertions: pass
- Focused AOT valid/invalid CLIF parity assertion: pass
- Existing dynamic-index fatal-trap assertion: pass
- Full serialized compiler suite: 516/518 pass
  - known environment failure: qualified module graph acceptance requires a Windows linker
  - known machine mismatch: production preview extern clock returns 2 instead of expected 1
- `git diff --check`: pass


