### PR TITLE
feat: package Stasis games for WebAssembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ out/
 
 # Build artifacts
 dist/stasis-editor-release-*/
+samples/*/dist/
 *.dll
 *.exe
 *.so

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3580,6 +3580,83 @@ const WEB_INDEX_HTML: &str = include_str!("../../../runtime/web/index.html");
 const WEB_STANDALONE_HTML: &str = include_str!("../../../runtime/web/standalone.html");
 const WEB_RUNTIME_JS: &str = include_str!("../../../runtime/web/game.js");
 
+struct WebWasmArtifact {
+    bytes: Vec<u8>,
+    optimized: bool,
+    input_bytes: usize,
+}
+
+fn prepare_web_wasm(
+    module_bytes: &[u8],
+    staging_root: &Path,
+    development_build: bool,
+) -> Result<WebWasmArtifact, String> {
+    if development_build {
+        return Ok(WebWasmArtifact {
+            bytes: module_bytes.to_vec(),
+            optimized: false,
+            input_bytes: module_bytes.len(),
+        });
+    }
+
+    let configured = env::var_os("STASIS_WASM_OPT");
+    let executable = configured
+        .clone()
+        .unwrap_or_else(|| OsString::from("wasm-opt"));
+    let input_path = staging_root.join(".game.unoptimized.wasm");
+    let output_path = staging_root.join(".game.optimized.wasm");
+    fs::write(&input_path, module_bytes)
+        .map_err(|error| format!("failed to stage {}: {error}", input_path.display()))?;
+    let result = Command::new(&executable)
+        .arg("-Oz")
+        .arg(&input_path)
+        .arg("-o")
+        .arg(&output_path)
+        .output();
+    let _ = fs::remove_file(&input_path);
+
+    let output = match result {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::NotFound && configured.is_none() => {
+            return Ok(WebWasmArtifact {
+                bytes: module_bytes.to_vec(),
+                optimized: false,
+                input_bytes: module_bytes.len(),
+            });
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to run wasm-opt at {}: {error}",
+                Path::new(&executable).display()
+            ));
+        }
+    };
+    if !output.status.success() {
+        let _ = fs::remove_file(&output_path);
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "wasm-opt failed with status {}{}",
+            output.status,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let bytes = fs::read(&output_path)
+        .map_err(|error| format!("failed to read {}: {error}", output_path.display()))?;
+    let _ = fs::remove_file(&output_path);
+    if !bytes.starts_with(b"\0asm\x01\0\0\0") {
+        return Err("wasm-opt produced an invalid WebAssembly module header".to_string());
+    }
+    Ok(WebWasmArtifact {
+        bytes,
+        optimized: true,
+        input_bytes: module_bytes.len(),
+    })
+}
+
 fn package_web_workspace(
     workspace: &Workspace,
     package_root: &Path,
@@ -3603,7 +3680,7 @@ fn package_web_workspace(
     fs::create_dir_all(&staging_root)
         .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
 
-    let assembled = (|| -> Result<PathBuf, String> {
+    let assembled = (|| -> Result<(PathBuf, bool, usize, usize), String> {
         let files =
             load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
         let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
@@ -3638,6 +3715,7 @@ fn package_web_workspace(
                 format!("{error:?}")
             }
         })?;
+        let wasm = prepare_web_wasm(process.module_bytes(), &staging_root, development_build)?;
 
         let validation_jit = compile_workspace_jit(workspace)?;
         let resolved = validate_compiled_workspace_assets(workspace, &validation_jit)?;
@@ -3669,7 +3747,7 @@ fn package_web_workspace(
             .map_err(|error| format!("failed to create {}: {error}", play_root.display()))?;
 
         let wasm_path = play_root.join("game.wasm");
-        fs::write(&wasm_path, process.module_bytes())
+        fs::write(&wasm_path, &wasm.bytes)
             .map_err(|error| format!("failed to write {}: {error}", wasm_path.display()))?;
         fs::write(play_root.join("game.js"), &runtime_bundle)
             .map_err(|error| format!("failed to write web runtime: {error}"))?;
@@ -3683,15 +3761,20 @@ fn package_web_workspace(
         let standalone_path = staging_root.join(&standalone_name);
         let standalone = WEB_STANDALONE_HTML
             .replace("__STASIS_GAME_TITLE__", &workspace.manifest.name)
-            .replace("__STASIS_WASM_BASE64__", &base64(process.module_bytes()))
+            .replace("__STASIS_WASM_BASE64__", &base64(&wasm.bytes))
             .replace("__STASIS_RUNTIME_JS__", &embedded_runtime_bundle);
         fs::write(&standalone_path, standalone)
             .map_err(|error| format!("failed to write {}: {error}", standalone_path.display()))?;
         write_json_file(&staging_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
-        Ok(PathBuf::from(standalone_name))
+        Ok((
+            PathBuf::from(standalone_name),
+            wasm.optimized,
+            wasm.input_bytes,
+            wasm.bytes.len(),
+        ))
     })();
-    let standalone = match assembled {
-        Ok(path) => path,
+    let (standalone, wasm_optimized, wasm_input_bytes, wasm_output_bytes) = match assembled {
+        Ok(package) => package,
         Err(error) => {
             let _ = fs::remove_dir_all(&staging_root);
             return Err(error);
@@ -3704,14 +3787,27 @@ fn package_web_workspace(
             package_root.display()
         )
     })?;
+    let optimization = if wasm_optimized {
+        "wasm-opt -Oz"
+    } else if development_build {
+        "development Wasm"
+    } else {
+        "unoptimized Wasm; wasm-opt not found"
+    };
     Ok(CommandResult::success(
-        format!("packaged web at {}", package_root.display()),
+        format!(
+            "packaged web at {} ({optimization})",
+            package_root.display()
+        ),
         json!({
             "target": "web",
             "output": display_path(package_root),
             "standalone": relative_display(package_root, &package_root.join(&standalone)),
             "play": "play/index.html",
             "wasm": "play/game.wasm",
+            "wasm_optimized": wasm_optimized,
+            "wasm_input_bytes": wasm_input_bytes,
+            "wasm_output_bytes": wasm_output_bytes,
             "provenance": PACKAGE_PROVENANCE_NAME,
             "development_build": provenance["development_build"],
         }),
@@ -5978,6 +6074,34 @@ mod tests {
 
     fn remove_temp(path: &Path) {
         let _ = fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn development_web_wasm_keeps_diagnostic_module_unchanged() {
+        let root = temp_dir("development_web_wasm");
+        fs::create_dir_all(&root).expect("create optimizer fixture");
+        let module = b"\0asm\x01\0\0\0diagnostic-names";
+        let artifact = prepare_web_wasm(module, &root, true).expect("prepare development Wasm");
+        assert!(!artifact.optimized);
+        assert_eq!(artifact.input_bytes, module.len());
+        assert_eq!(artifact.bytes, module);
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn configured_wasm_opt_produces_a_valid_release_module() {
+        if env::var_os("STASIS_WASM_OPT").is_none() {
+            return;
+        }
+        let root = temp_dir("release_web_wasm");
+        fs::create_dir_all(&root).expect("create optimizer fixture");
+        let module = b"\0asm\x01\0\0\0";
+        let artifact = prepare_web_wasm(module, &root, false).expect("optimize release Wasm");
+        assert!(artifact.optimized);
+        assert!(artifact.bytes.starts_with(b"\0asm\x01\0\0\0"));
+        assert!(!root.join(".game.unoptimized.wasm").exists());
+        assert!(!root.join(".game.optimized.wasm").exists());
+        remove_temp(&root);
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3608,6 +3608,7 @@ fn package_web_workspace(
             load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
         let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
         let mut process = WasmProcess::new();
+        process.set_debug_symbols(development_build);
         process.set_project_root(display_path(&workspace.root))?;
         process.set_required_emit_roots(&[
             "main".to_string(),
@@ -3638,20 +3639,42 @@ fn package_web_workspace(
             }
         })?;
 
-        let runtime_config = web_runtime_config(workspace, &process)?;
-        let runtime_json = serde_json::to_string(&runtime_config)
+        let validation_jit = compile_workspace_jit(workspace)?;
+        let resolved = validate_compiled_workspace_assets(workspace, &validation_jit)?;
+        let retained = resolved
+            .as_ref()
+            .map(|manifest| {
+                let snapshot = validation_jit.program_snapshot().ok_or_else(|| {
+                    "web asset validation produced no ProgramSnapshot".to_string()
+                })?;
+                crate::release_assets::retain_snapshot_assets(&workspace.root, snapshot, manifest)
+            })
+            .transpose()?;
+        stage_workspace_assets(workspace, &staging_root, retained.as_ref())?;
+        let runtime_config = web_runtime_config(workspace, &process, &staging_root.join("assets"))?;
+        let embedded_runtime_json = serde_json::to_string(&runtime_config)
             .map_err(|error| format!("failed to encode web runtime metadata: {error}"))?
             .replace("</", "<\\/");
-        let runtime_bundle = format!("window.STASIS_GAME = {runtime_json};\n{WEB_RUNTIME_JS}");
-        copy_dir_if_exists(&workspace.root.join("assets"), &staging_root.join("assets"))?;
+        let mut static_runtime_config = runtime_config.clone();
+        static_runtime_config["assets"] = json!({});
+        let static_runtime_json = serde_json::to_string(&static_runtime_config)
+            .map_err(|error| format!("failed to encode static web runtime metadata: {error}"))?
+            .replace("</", "<\\/");
+        let runtime_bundle =
+            format!("window.STASIS_GAME = {static_runtime_json};\n{WEB_RUNTIME_JS}");
+        let embedded_runtime_bundle =
+            format!("window.STASIS_GAME = {embedded_runtime_json};\n{WEB_RUNTIME_JS}");
+        let play_root = staging_root.join("play");
+        fs::create_dir_all(&play_root)
+            .map_err(|error| format!("failed to create {}: {error}", play_root.display()))?;
 
-        let wasm_path = staging_root.join("game.wasm");
+        let wasm_path = play_root.join("game.wasm");
         fs::write(&wasm_path, process.module_bytes())
             .map_err(|error| format!("failed to write {}: {error}", wasm_path.display()))?;
-        fs::write(staging_root.join("game.js"), &runtime_bundle)
+        fs::write(play_root.join("game.js"), &runtime_bundle)
             .map_err(|error| format!("failed to write web runtime: {error}"))?;
         fs::write(
-            staging_root.join("index.html"),
+            play_root.join("index.html"),
             WEB_INDEX_HTML.replace("__STASIS_GAME_TITLE__", &workspace.manifest.name),
         )
         .map_err(|error| format!("failed to write web index: {error}"))?;
@@ -3661,7 +3684,7 @@ fn package_web_workspace(
         let standalone = WEB_STANDALONE_HTML
             .replace("__STASIS_GAME_TITLE__", &workspace.manifest.name)
             .replace("__STASIS_WASM_BASE64__", &base64(process.module_bytes()))
-            .replace("__STASIS_RUNTIME_JS__", &runtime_bundle);
+            .replace("__STASIS_RUNTIME_JS__", &embedded_runtime_bundle);
         fs::write(&standalone_path, standalone)
             .map_err(|error| format!("failed to write {}: {error}", standalone_path.display()))?;
         write_json_file(&staging_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
@@ -3687,14 +3710,19 @@ fn package_web_workspace(
             "target": "web",
             "output": display_path(package_root),
             "standalone": relative_display(package_root, &package_root.join(&standalone)),
-            "wasm": "game.wasm",
+            "play": "play/index.html",
+            "wasm": "play/game.wasm",
             "provenance": PACKAGE_PROVENANCE_NAME,
             "development_build": provenance["development_build"],
         }),
     ))
 }
 
-fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Result<Value, String> {
+fn web_runtime_config(
+    workspace: &Workspace,
+    process: &WasmProcess,
+    asset_root: &Path,
+) -> Result<Value, String> {
     fn collect_assets(
         root: &Path,
         directory: &Path,
@@ -3771,11 +3799,7 @@ fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Result<Va
     }
 
     let mut assets = BTreeMap::new();
-    collect_assets(
-        &workspace.root.join("assets"),
-        &workspace.root.join("assets"),
-        &mut assets,
-    )?;
+    collect_assets(asset_root, asset_root, &mut assets)?;
     let strings = process
         .string_literals()
         .iter()
@@ -3791,7 +3815,23 @@ fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Result<Va
                     "offset": layout.offset,
                     "type_id": layout.type_id,
                     "length": layout.length,
+                    "stride": layout.stride,
                 }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    let views = process
+        .struct_views()
+        .iter()
+        .map(|(base, fields)| (base.to_string(), json!(fields)))
+        .collect::<serde_json::Map<_, _>>();
+    let globals = process
+        .global_types()
+        .iter()
+        .map(|(path, type_id)| {
+            (
+                path.clone(),
+                json!({"hash": stasis_compiler::backend::wasm::wasm_global_hash(path), "type_id": type_id}),
             )
         })
         .collect::<serde_json::Map<_, _>>();
@@ -3799,6 +3839,8 @@ fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Result<Va
         "name": workspace.manifest.name,
         "strings": strings,
         "memory": memory,
+        "views": views,
+        "globals": globals,
         "assets": assets,
     }))
 }

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -12,6 +12,7 @@ use stasis_assets::{
 use stasis_compiler::backend::aot::AotProcess;
 use stasis_compiler::backend::jit::JitProcess;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
+use stasis_compiler::backend::wasm::WasmProcess;
 use stasis_compiler::frontend::formatter::format_source;
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
@@ -538,6 +539,7 @@ enum BuildMode {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum PackageTarget {
     Desktop,
+    Web,
     AndroidArm64,
     #[value(name = "android-x86_64")]
     AndroidX86_64,
@@ -566,6 +568,7 @@ impl PackageTarget {
     fn as_str(self) -> &'static str {
         match self {
             Self::Desktop => "desktop",
+            Self::Web => "web",
             Self::AndroidArm64 => "android-arm64",
             Self::AndroidX86_64 => "android-x86_64",
             Self::IosArm64 => "ios-arm64",
@@ -580,7 +583,7 @@ impl PackageTarget {
         match self {
             Self::AndroidArm64 => Some("arm64-v8a"),
             Self::AndroidX86_64 => Some("x86_64"),
-            Self::Desktop | Self::IosArm64 => None,
+            Self::Desktop | Self::Web | Self::IosArm64 => None,
         }
     }
 }
@@ -3479,6 +3482,9 @@ fn package_workspace(
             package_root.display()
         ));
     }
+    if matches!(target, PackageTarget::Web) {
+        return package_web_workspace(workspace, &package_root, development_build);
+    }
     if !matches!(target, PackageTarget::Desktop) {
         return package_mobile_workspace(
             workspace,
@@ -3568,6 +3574,140 @@ fn package_workspace(
             "development_build": provenance["development_build"],
         }),
     ))
+}
+
+const WEB_INDEX_HTML: &str = include_str!("../../../runtime/web/index.html");
+const WEB_STANDALONE_HTML: &str = include_str!("../../../runtime/web/standalone.html");
+const WEB_RUNTIME_JS: &str = include_str!("../../../runtime/web/game.js");
+
+fn package_web_workspace(
+    workspace: &Workspace,
+    package_root: &Path,
+    development_build: bool,
+) -> Result<CommandResult, String> {
+    let staging_name = format!(
+        ".{}.staging",
+        package_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("stasis-web-package")
+    );
+    let staging_root = package_root.with_file_name(staging_name);
+    if staging_root.exists() {
+        return Err(format!(
+            "package staging output already exists: {}",
+            staging_root.display()
+        ));
+    }
+    let provenance = resolve_package_provenance(development_build)?;
+    fs::create_dir_all(&staging_root)
+        .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
+
+    let assembled = (|| -> Result<PathBuf, String> {
+        let files =
+            load_workshop_edit_workspace(&workspace.root, Path::new(&workspace.manifest.entry))?;
+        let files = workshop_reachable_files(&files, Path::new(&workspace.manifest.entry))?;
+        let mut process = WasmProcess::new();
+        process.set_project_root(display_path(&workspace.root))?;
+        process.set_required_emit_roots(&[
+            "main".to_string(),
+            "tick".to_string(),
+            "render".to_string(),
+        ]);
+        let mut sources = BTreeMap::new();
+        for file in files {
+            let path = workspace.root.join(&file.path);
+            let path = path.canonicalize().unwrap_or(path);
+            let compiler_path = path.to_string_lossy().to_string();
+            sources.insert(compiler_path.clone(), file.source.clone());
+            process.upsert_file(compiler_path, file.source);
+        }
+        process.compile().map_err(|error| {
+            if let Some(diagnostic) = process.last_source_diagnostic() {
+                let source = sources
+                    .get(&diagnostic.path)
+                    .map(String::as_str)
+                    .unwrap_or("");
+                let (line, column) = line_column(source, diagnostic.start);
+                format!(
+                    "{}:{}:{}: {}",
+                    diagnostic.path, line, column, diagnostic.message
+                )
+            } else {
+                format!("{error:?}")
+            }
+        })?;
+
+        let wasm_path = staging_root.join("game.wasm");
+        fs::write(&wasm_path, process.module_bytes())
+            .map_err(|error| format!("failed to write {}: {error}", wasm_path.display()))?;
+        fs::write(staging_root.join("game.js"), WEB_RUNTIME_JS)
+            .map_err(|error| format!("failed to write web runtime: {error}"))?;
+        fs::write(
+            staging_root.join("index.html"),
+            WEB_INDEX_HTML.replace("__STASIS_GAME_TITLE__", &workspace.manifest.name),
+        )
+        .map_err(|error| format!("failed to write web index: {error}"))?;
+
+        let standalone_name = format!("{}.html", workspace.manifest.name);
+        let standalone_path = staging_root.join(&standalone_name);
+        let standalone = WEB_STANDALONE_HTML
+            .replace("__STASIS_GAME_TITLE__", &workspace.manifest.name)
+            .replace("__STASIS_WASM_BASE64__", &base64(process.module_bytes()))
+            .replace("__STASIS_RUNTIME_JS__", WEB_RUNTIME_JS);
+        fs::write(&standalone_path, standalone)
+            .map_err(|error| format!("failed to write {}: {error}", standalone_path.display()))?;
+        write_json_file(&staging_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
+        Ok(PathBuf::from(standalone_name))
+    })();
+    let standalone = match assembled {
+        Ok(path) => path,
+        Err(error) => {
+            let _ = fs::remove_dir_all(&staging_root);
+            return Err(error);
+        }
+    };
+    fs::rename(&staging_root, package_root).map_err(|error| {
+        let _ = fs::remove_dir_all(&staging_root);
+        format!(
+            "failed to publish package {}: {error}",
+            package_root.display()
+        )
+    })?;
+    Ok(CommandResult::success(
+        format!("packaged web at {}", package_root.display()),
+        json!({
+            "target": "web",
+            "output": display_path(package_root),
+            "standalone": relative_display(package_root, &package_root.join(&standalone)),
+            "wasm": "game.wasm",
+            "provenance": PACKAGE_PROVENANCE_NAME,
+            "development_build": provenance["development_build"],
+        }),
+    ))
+}
+
+fn base64(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut output = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let a = chunk[0];
+        let b = chunk.get(1).copied().unwrap_or(0);
+        let c = chunk.get(2).copied().unwrap_or(0);
+        output.push(ALPHABET[(a >> 2) as usize] as char);
+        output.push(ALPHABET[(((a & 0x03) << 4) | (b >> 4)) as usize] as char);
+        output.push(if chunk.len() > 1 {
+            ALPHABET[(((b & 0x0f) << 2) | (c >> 6)) as usize] as char
+        } else {
+            '='
+        });
+        output.push(if chunk.len() > 2 {
+            ALPHABET[(c & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    output
 }
 
 #[cfg(windows)]
@@ -3760,7 +3900,7 @@ fn package_mobile_workspace(
             "project": match target {
                 PackageTarget::AndroidArm64 | PackageTarget::AndroidX86_64 => "android",
                 PackageTarget::IosArm64 => "ios/StasisMobile.xcodeproj",
-                PackageTarget::Desktop => unreachable!(),
+                PackageTarget::Desktop | PackageTarget::Web => unreachable!(),
             },
             "provenance": PACKAGE_PROVENANCE_NAME,
             "development_build": provenance["development_build"],
@@ -3780,7 +3920,9 @@ fn assemble_mobile_shell(
     let platform = match target {
         PackageTarget::AndroidArm64 | PackageTarget::AndroidX86_64 => "android",
         PackageTarget::IosArm64 => "ios",
-        PackageTarget::Desktop => return Err("desktop is not a mobile package target".to_string()),
+        PackageTarget::Desktop | PackageTarget::Web => {
+            return Err("selected target is not a mobile package target".to_string())
+        }
     };
     let common_destination = staging_root.join("common");
     let platform_destination = staging_root.join(platform);
@@ -3795,14 +3937,14 @@ fn assemble_mobile_shell(
             aot_root.join("apk_assets/stasis_game")
         }
         PackageTarget::IosArm64 => aot_root.join("ios_assets/stasis_game"),
-        PackageTarget::Desktop => unreachable!(),
+        PackageTarget::Desktop | PackageTarget::Web => unreachable!(),
     };
     let asset_destination = match target {
         PackageTarget::AndroidArm64 | PackageTarget::AndroidX86_64 => {
             staging_root.join("android/app/src/main/assets/stasis_game")
         }
         PackageTarget::IosArm64 => staging_root.join("ios/StasisMobile/stasis_game"),
-        PackageTarget::Desktop => unreachable!(),
+        PackageTarget::Desktop | PackageTarget::Web => unreachable!(),
     };
     let android_manifest = if target.is_android() {
         workspace.manifest.android.as_ref()
@@ -3876,7 +4018,7 @@ fn assemble_mobile_shell(
                     "android/app/src/main/assets/stasis_game"
                 }
                 PackageTarget::IosArm64 => "ios/StasisMobile/stasis_game",
-                PackageTarget::Desktop => unreachable!(),
+                PackageTarget::Desktop | PackageTarget::Web => unreachable!(),
             },
         }))
         .map_err(|error| format!("failed to encode mobile package manifest: {error}"))?

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3638,10 +3638,17 @@ fn package_web_workspace(
             }
         })?;
 
+        let runtime_config = web_runtime_config(workspace, &process)?;
+        let runtime_json = serde_json::to_string(&runtime_config)
+            .map_err(|error| format!("failed to encode web runtime metadata: {error}"))?
+            .replace("</", "<\\/");
+        let runtime_bundle = format!("window.STASIS_GAME = {runtime_json};\n{WEB_RUNTIME_JS}");
+        copy_dir_if_exists(&workspace.root.join("assets"), &staging_root.join("assets"))?;
+
         let wasm_path = staging_root.join("game.wasm");
         fs::write(&wasm_path, process.module_bytes())
             .map_err(|error| format!("failed to write {}: {error}", wasm_path.display()))?;
-        fs::write(staging_root.join("game.js"), WEB_RUNTIME_JS)
+        fs::write(staging_root.join("game.js"), &runtime_bundle)
             .map_err(|error| format!("failed to write web runtime: {error}"))?;
         fs::write(
             staging_root.join("index.html"),
@@ -3654,7 +3661,7 @@ fn package_web_workspace(
         let standalone = WEB_STANDALONE_HTML
             .replace("__STASIS_GAME_TITLE__", &workspace.manifest.name)
             .replace("__STASIS_WASM_BASE64__", &base64(process.module_bytes()))
-            .replace("__STASIS_RUNTIME_JS__", WEB_RUNTIME_JS);
+            .replace("__STASIS_RUNTIME_JS__", &runtime_bundle);
         fs::write(&standalone_path, standalone)
             .map_err(|error| format!("failed to write {}: {error}", standalone_path.display()))?;
         write_json_file(&staging_root.join(PACKAGE_PROVENANCE_NAME), &provenance)?;
@@ -3685,6 +3692,115 @@ fn package_web_workspace(
             "development_build": provenance["development_build"],
         }),
     ))
+}
+
+fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Result<Value, String> {
+    fn collect_assets(
+        root: &Path,
+        directory: &Path,
+        out: &mut BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        if !directory.exists() {
+            return Ok(());
+        }
+        let mut entries = fs::read_dir(directory)
+            .map_err(|error| format!("failed to read web assets {}: {error}", directory.display()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| format!("failed to enumerate web assets: {error}"))?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let file_type = entry.file_type().map_err(|error| {
+                format!(
+                    "failed to inspect web asset {}: {error}",
+                    entry.path().display()
+                )
+            })?;
+            if file_type.is_symlink() {
+                return Err(format!(
+                    "web package assets cannot contain symlinks: {}",
+                    entry.path().display()
+                ));
+            }
+            if file_type.is_dir() {
+                collect_assets(root, &entry.path(), out)?;
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .map_err(|_| format!("web asset escaped {}", root.display()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let bytes = fs::read(entry.path()).map_err(|error| {
+                format!(
+                    "failed to read web asset {}: {error}",
+                    entry.path().display()
+                )
+            })?;
+            let mime = match entry
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("")
+                .to_ascii_lowercase()
+                .as_str()
+            {
+                "png" => "image/png",
+                "svg" => "image/svg+xml",
+                "jpg" | "jpeg" => "image/jpeg",
+                "gif" => "image/gif",
+                "webp" => "image/webp",
+                "ttf" => "font/ttf",
+                "otf" => "font/otf",
+                "woff" => "font/woff",
+                "woff2" => "font/woff2",
+                "wav" => "audio/wav",
+                "mp3" => "audio/mpeg",
+                "ogg" => "audio/ogg",
+                _ => "application/octet-stream",
+            };
+            out.insert(
+                format!("assets/{relative}"),
+                format!("data:{mime};base64,{}", base64(&bytes)),
+            );
+        }
+        Ok(())
+    }
+
+    let mut assets = BTreeMap::new();
+    collect_assets(
+        &workspace.root.join("assets"),
+        &workspace.root.join("assets"),
+        &mut assets,
+    )?;
+    let strings = process
+        .string_literals()
+        .iter()
+        .map(|(id, value)| (id.to_string(), Value::String(value.clone())))
+        .collect::<serde_json::Map<_, _>>();
+    let memory = process
+        .memory_layout()
+        .iter()
+        .map(|(path, layout)| {
+            (
+                path.clone(),
+                json!({
+                    "offset": layout.offset,
+                    "type_id": layout.type_id,
+                    "length": layout.length,
+                }),
+            )
+        })
+        .collect::<serde_json::Map<_, _>>();
+    Ok(json!({
+        "name": workspace.manifest.name,
+        "strings": strings,
+        "memory": memory,
+        "assets": assets,
+    }))
 }
 
 fn base64(bytes: &[u8]) -> String {

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repository root")
+        .to_path_buf()
+}
+
+#[test]
+fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
+    let workspace = repo_root().join("samples/web_export_smoke");
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let relative_output = PathBuf::from(format!("build/web-package-test-{stamp}"));
+    let output = workspace.join(&relative_output);
+
+    let result = Command::new(env!("CARGO_BIN_EXE_stasis"))
+        .arg("package")
+        .arg("--workspace")
+        .arg(&workspace)
+        .arg("--target")
+        .arg("web")
+        .arg("--development-build")
+        .arg("--out")
+        .arg(&relative_output)
+        .arg("--json")
+        .output()
+        .expect("run web package");
+    assert!(
+        result.status.success(),
+        "web package failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let wasm = fs::read(output.join("game.wasm")).expect("game.wasm");
+    assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
+    for export in ["main", "tick", "render", "player_x"] {
+        assert!(
+            wasm.windows(export.len())
+                .any(|window| window == export.as_bytes()),
+            "missing Wasm export {export}"
+        );
+    }
+    let runtime = fs::read_to_string(output.join("game.js")).expect("game.js");
+    assert!(runtime.contains("requestAnimationFrame(frame)"));
+    assert!(runtime.contains("web_play_tone"));
+    assert!(runtime.contains("dataset.underBudget"));
+    let standalone =
+        fs::read_to_string(output.join("web_export_smoke.html")).expect("standalone web package");
+    assert!(standalone.contains("window.STASIS_WASM_BASE64"));
+    assert!(!standalone.contains("__STASIS_"));
+    assert!(output.join("index.html").is_file());
+    assert!(output.join("stasis_provenance.json").is_file());
+
+    fs::remove_dir_all(&output).expect("clean web package test output");
+}

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -38,6 +38,11 @@ fn package(workspace: &Path, relative_output: &Path) -> PathBuf {
         String::from_utf8_lossy(&result.stdout),
         String::from_utf8_lossy(&result.stderr)
     );
+    assert!(
+        String::from_utf8_lossy(&result.stdout).contains("\"wasm_optimized\":false"),
+        "development package unexpectedly optimized Wasm: {}",
+        String::from_utf8_lossy(&result.stdout)
+    );
     output
 }
 

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -67,7 +67,7 @@ fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
     let relative_output = PathBuf::from(format!("build/web-package-test-{stamp}"));
     let output = package(&workspace, &relative_output);
 
-    let wasm = fs::read(output.join("game.wasm")).expect("game.wasm");
+    let wasm = fs::read(output.join("play/game.wasm")).expect("play/game.wasm");
     assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
     for export in ["main", "tick", "render", "player_x"] {
         assert!(
@@ -76,15 +76,28 @@ fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
             "missing Wasm export {export}"
         );
     }
-    let runtime = fs::read_to_string(output.join("game.js")).expect("game.js");
-    assert!(runtime.contains("requestAnimationFrame(frame)"));
-    assert!(runtime.contains("web_play_tone"));
-    assert!(runtime.contains("dataset.underBudget"));
+    let runtime = fs::read_to_string(output.join("play/game.js")).expect("play/game.js");
+    for expected in [
+        "requestAnimationFrame(frame)",
+        "web_play_tone",
+        "dataset.underBudget",
+        "\"host_i32\"",
+        "\"host_f32\"",
+        "audio_push_f32_interleaved",
+        "function writeHostFrame",
+        "function applyWindowRequest",
+        "function sdlScancode",
+    ] {
+        assert!(
+            runtime.contains(expected),
+            "missing web runtime data {expected}"
+        );
+    }
     let standalone =
         fs::read_to_string(output.join("web_export_smoke.html")).expect("standalone web package");
     assert!(standalone.contains("window.STASIS_WASM_BASE64"));
     assert!(!standalone.contains("__STASIS_"));
-    assert!(output.join("index.html").is_file());
+    assert!(output.join("play/index.html").is_file());
     assert!(output.join("stasis_provenance.json").is_file());
 
     fs::remove_dir_all(&output).expect("clean web package test output");
@@ -96,21 +109,30 @@ fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
     let relative_output = PathBuf::from(format!("build/web-package-test-{}", stamp()));
     let output = package(&workspace, &relative_output);
 
-    let wasm = fs::read(output.join("game.wasm")).expect("existing game Wasm");
+    let wasm = fs::read(output.join("play/game.wasm")).expect("existing game Wasm");
     assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
     assert!(wasm.windows(6).any(|window| window == b"memory"));
-    let runtime = fs::read_to_string(output.join("game.js")).expect("existing game runtime");
+    let runtime = fs::read_to_string(output.join("play/game.js")).expect("existing game runtime");
+    let standalone = fs::read_to_string(output.join("windows_launch_smoke.html"))
+        .expect("existing game standalone runtime");
+    for expected in ["gfx_cmd_i32", "gfx_cmd_f32", "stasis_jit_gfx_cache_text"] {
+        assert!(
+            runtime.contains(expected),
+            "missing web runtime data {expected}"
+        );
+    }
     for expected in [
         "data:image/png;base64,",
         "data:image/svg+xml;base64,",
         "data:font/ttf;base64,",
-        "gfx_cmd_i32",
-        "gfx_cmd_f32",
-        "stasis_jit_gfx_cache_text",
     ] {
         assert!(
-            runtime.contains(expected),
-            "missing web runtime data {expected}"
+            standalone.contains(expected),
+            "missing embedded asset {expected}"
+        );
+        assert!(
+            !runtime.contains(expected),
+            "static runtime embedded {expected}"
         );
     }
     assert!(output.join("assets/smoke.png").is_file());
@@ -130,10 +152,10 @@ fn existing_audio_game_packages_wav_and_mp3_for_web_audio() {
     copy_tree(&root.join("src"), &workspace.join("vendor/stasis/src"));
     let output = package(&workspace, Path::new("build/web-package"));
 
-    let runtime = fs::read_to_string(output.join("game.js")).expect("audio game runtime");
+    let runtime = fs::read_to_string(output.join("play/game.js")).expect("audio game runtime");
+    let standalone = fs::read_to_string(output.join("audio_asset_playback.html"))
+        .expect("audio standalone runtime");
     for expected in [
-        "data:audio/mpeg;base64,",
-        "data:audio/wav;base64,",
         "stasis_jit_audio_load_music",
         "stasis_jit_audio_load_effect",
         "decodeAudioData",
@@ -141,6 +163,16 @@ fn existing_audio_game_packages_wav_and_mp3_for_web_audio() {
         assert!(
             runtime.contains(expected),
             "missing web audio data {expected}"
+        );
+    }
+    for expected in ["data:audio/mpeg;base64,", "data:audio/wav;base64,"] {
+        assert!(
+            standalone.contains(expected),
+            "missing embedded audio {expected}"
+        );
+        assert!(
+            !runtime.contains(expected),
+            "static runtime embedded {expected}"
         );
     }
     assert!(output.join("assets/tone.mp3").is_file());

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -11,25 +11,24 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-#[test]
-fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
-    let workspace = repo_root().join("samples/web_export_smoke");
-    let stamp = SystemTime::now()
+fn stamp() -> u128 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock")
-        .as_nanos();
-    let relative_output = PathBuf::from(format!("build/web-package-test-{stamp}"));
-    let output = workspace.join(&relative_output);
+        .as_nanos()
+}
 
+fn package(workspace: &Path, relative_output: &Path) -> PathBuf {
+    let output = workspace.join(relative_output);
     let result = Command::new(env!("CARGO_BIN_EXE_stasis"))
         .arg("package")
         .arg("--workspace")
-        .arg(&workspace)
+        .arg(workspace)
         .arg("--target")
         .arg("web")
         .arg("--development-build")
         .arg("--out")
-        .arg(&relative_output)
+        .arg(relative_output)
         .arg("--json")
         .output()
         .expect("run web package");
@@ -39,6 +38,34 @@ fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
         String::from_utf8_lossy(&result.stdout),
         String::from_utf8_lossy(&result.stderr)
     );
+    output
+}
+
+fn copy_tree(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).expect("create copied fixture directory");
+    let mut entries = fs::read_dir(source)
+        .expect("read copied fixture")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("enumerate copied fixture");
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let file_type = entry.file_type().expect("copied fixture file type");
+        assert!(!file_type.is_symlink(), "fixture symlinks are unsupported");
+        let target = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), target).expect("copy fixture file");
+        }
+    }
+}
+
+#[test]
+fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
+    let workspace = repo_root().join("samples/web_export_smoke");
+    let stamp = stamp();
+    let relative_output = PathBuf::from(format!("build/web-package-test-{stamp}"));
+    let output = package(&workspace, &relative_output);
 
     let wasm = fs::read(output.join("game.wasm")).expect("game.wasm");
     assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
@@ -61,4 +88,63 @@ fn web_package_contains_runnable_wasm_static_bundle_and_standalone_file() {
     assert!(output.join("stasis_provenance.json").is_file());
 
     fs::remove_dir_all(&output).expect("clean web package test output");
+}
+
+#[test]
+fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
+    let workspace = repo_root().join("samples/windows_launch_smoke");
+    let relative_output = PathBuf::from(format!("build/web-package-test-{}", stamp()));
+    let output = package(&workspace, &relative_output);
+
+    let wasm = fs::read(output.join("game.wasm")).expect("existing game Wasm");
+    assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
+    assert!(wasm.windows(6).any(|window| window == b"memory"));
+    let runtime = fs::read_to_string(output.join("game.js")).expect("existing game runtime");
+    for expected in [
+        "data:image/png;base64,",
+        "data:image/svg+xml;base64,",
+        "data:font/ttf;base64,",
+        "gfx_cmd_i32",
+        "gfx_cmd_f32",
+        "stasis_jit_gfx_cache_text",
+    ] {
+        assert!(
+            runtime.contains(expected),
+            "missing web runtime data {expected}"
+        );
+    }
+    assert!(output.join("assets/smoke.png").is_file());
+    assert!(output.join("assets/smoke.svg").is_file());
+    assert!(output.join("assets/smoke.ttf").is_file());
+
+    fs::remove_dir_all(&output).expect("clean existing game web package");
+}
+
+#[test]
+fn existing_audio_game_packages_wav_and_mp3_for_web_audio() {
+    let root = repo_root();
+    let workspace = root
+        .join("build")
+        .join(format!("web-audio-test-{}", stamp()));
+    copy_tree(&root.join("samples/audio_asset_playback"), &workspace);
+    copy_tree(&root.join("src"), &workspace.join("vendor/stasis/src"));
+    let output = package(&workspace, Path::new("build/web-package"));
+
+    let runtime = fs::read_to_string(output.join("game.js")).expect("audio game runtime");
+    for expected in [
+        "data:audio/mpeg;base64,",
+        "data:audio/wav;base64,",
+        "stasis_jit_audio_load_music",
+        "stasis_jit_audio_load_effect",
+        "decodeAudioData",
+    ] {
+        assert!(
+            runtime.contains(expected),
+            "missing web audio data {expected}"
+        );
+    }
+    assert!(output.join("assets/tone.mp3").is_file());
+    assert!(output.join("assets/tone.wav").is_file());
+
+    fs::remove_dir_all(&workspace).expect("clean existing audio web fixture");
 }

--- a/crates/stasis_compiler/src/backend/mod.rs
+++ b/crates/stasis_compiler/src/backend/mod.rs
@@ -9,6 +9,7 @@ mod runtime_exports;
 pub mod state_layout;
 pub mod state_migration;
 mod state_query;
+pub mod wasm;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EngineEntrypoints {

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -1,0 +1,834 @@
+//! Browser WebAssembly emission for the scalar Stasis lane.
+//!
+//! This intentionally consumes the same parsed HIR as JIT/AOT. Unsupported
+//! storage or expression shapes fail at package time instead of receiving a
+//! target-specific substitute implementation.
+
+use crate::backend::emit::{
+    build_compile_analysis_cache, compute_files_fingerprint, resolve_extern_call_signatures_with,
+    AssignOp, AssignTarget, ComparisonOp, ConstantValue, SimpleCondition, SimpleExpr, SimpleStmt,
+};
+use crate::compiler::{CompileError, CompileReport, CompileResult, Compiler, FunctionMeta};
+use crate::frontend::types::{
+    TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_I32, TYPE_ID_U16, TYPE_ID_U32, TYPE_ID_U8,
+    TYPE_ID_VOID,
+};
+use crate::ir::hir::FunctionHIR;
+use std::collections::{BTreeMap, BTreeSet};
+
+const I32: u8 = 0x7f;
+
+#[derive(Debug, Clone, Default)]
+pub struct WasmProcess {
+    compiler: Compiler,
+    required_roots: Vec<String>,
+    module: Vec<u8>,
+}
+
+impl WasmProcess {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_project_root(&mut self, root: impl Into<String>) -> Result<(), String> {
+        self.compiler.set_project_root(root)
+    }
+
+    pub fn set_required_emit_roots(&mut self, roots: &[String]) {
+        self.required_roots = roots.to_vec();
+        self.compiler.set_analysis_required_roots(roots);
+    }
+
+    pub fn upsert_file(&mut self, path: impl Into<String>, content: impl Into<String>) {
+        self.compiler.upsert_file(path, content);
+    }
+
+    pub fn module_bytes(&self) -> &[u8] {
+        &self.module
+    }
+
+    pub fn last_source_diagnostic(&self) -> Option<&crate::SourceDiagnostic> {
+        self.compiler.last_source_diagnostic()
+    }
+
+    pub fn compile(&mut self) -> CompileResult<CompileReport> {
+        let index = self.compiler.index_pass()?;
+        let mut types = self.compiler.types().clone();
+        let analysis = build_compile_analysis_cache(
+            self.compiler.files(),
+            self.compiler.functions(),
+            &mut types,
+            compute_files_fingerprint(self.compiler.files()),
+            |signatures| {
+                resolve_extern_call_signatures_with(signatures, |_signature, _candidate| Some(0))
+            },
+        )
+        .map_err(CompileError::Backend)?;
+        *self.compiler.types_mut() = types.clone();
+
+        let function_ids = self
+            .compiler
+            .functions()
+            .iter()
+            .map(|function| function.id)
+            .collect::<Vec<_>>();
+        let mut lowered = Vec::new();
+        let emit = self
+            .compiler
+            .emit_pass_for_ids_with(&function_ids, &mut |meta, hir, _| {
+                lowered.push((meta.clone(), hir.clone()));
+                Ok(())
+            })?;
+
+        for root in &self.required_roots {
+            if root == "on_code_swap" {
+                continue;
+            }
+            if !lowered.iter().any(|(function, _)| &function.name == root) {
+                return Err(CompileError::Backend(format!(
+                    "web package requires entry function '{root}'"
+                )));
+            }
+        }
+
+        self.module = encode_module(&lowered, &analysis, &types).map_err(CompileError::Backend)?;
+        Ok(CompileReport { index, emit })
+    }
+}
+
+#[derive(Clone)]
+struct Signature {
+    params: Vec<TypeId>,
+    result: TypeId,
+}
+
+fn is_i32_lane(type_id: TypeId) -> bool {
+    matches!(
+        type_id,
+        TYPE_ID_I32 | TYPE_ID_BOOL | TYPE_ID_U8 | TYPE_ID_U16 | TYPE_ID_U32
+    )
+}
+
+fn validate_signature(name: &str, signature: &Signature) -> Result<(), String> {
+    if signature.params.iter().any(|value| !is_i32_lane(*value))
+        || (signature.result != TYPE_ID_VOID && !is_i32_lane(signature.result))
+    {
+        return Err(format!(
+            "web scalar lane does not yet support non-i32 signature for '{name}'"
+        ));
+    }
+    Ok(())
+}
+
+fn encode_module(
+    functions: &[(FunctionMeta, FunctionHIR)],
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+    types: &TypeTable,
+) -> Result<Vec<u8>, String> {
+    let mut internal_by_name = BTreeMap::new();
+    for (index, (function, _)) in functions.iter().enumerate() {
+        if internal_by_name
+            .insert(function.name.clone(), index)
+            .is_some()
+        {
+            return Err(format!(
+                "web scalar lane requires unique function names; '{}' is overloaded",
+                function.name
+            ));
+        }
+    }
+
+    let mut called = BTreeSet::new();
+    for (_, hir) in functions {
+        collect_calls(&hir.statements, &mut called);
+    }
+    let mut imports = Vec::new();
+    for signature in &analysis.resolved_extern_signatures {
+        if !called.contains(&signature.name) {
+            continue;
+        }
+        let value = Signature {
+            params: signature.params.clone(),
+            result: signature.return_type,
+        };
+        validate_signature(&signature.name, &value)?;
+        imports.push((signature.name.clone(), signature.symbol.clone(), value));
+    }
+    imports.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let imported_names = imports
+        .iter()
+        .map(|(name, _, _)| name.clone())
+        .collect::<BTreeSet<_>>();
+    for target in &called {
+        if !internal_by_name.contains_key(target) && !imported_names.contains(target) {
+            return Err(format!("unresolved web call target '{target}'"));
+        }
+    }
+
+    let mut signatures = imports
+        .iter()
+        .map(|(_, _, signature)| signature.clone())
+        .collect::<Vec<_>>();
+    for (function, _) in functions {
+        let signature = Signature {
+            params: function.params.clone(),
+            result: function.return_type,
+        };
+        validate_signature(&function.name, &signature)?;
+        signatures.push(signature);
+    }
+
+    let mut globals = Vec::new();
+    for (name, type_id) in &analysis.global_path_types {
+        if name.contains('.') {
+            return Err(format!(
+                "web scalar lane does not yet support structured state path '{name}'"
+            ));
+        }
+        if !is_i32_lane(*type_id) {
+            return Err(format!(
+                "web scalar lane does not yet support global '{name}' with type {}",
+                types
+                    .type_info(*type_id)
+                    .map_or("unknown", |info| info.name.as_str())
+            ));
+        }
+        globals.push((name.clone(), *type_id));
+    }
+    let global_indices = globals
+        .iter()
+        .enumerate()
+        .map(|(index, (name, _))| (name.clone(), index as u32))
+        .collect::<BTreeMap<_, _>>();
+
+    let import_indices = imports
+        .iter()
+        .enumerate()
+        .map(|(index, (name, _, _))| (name.clone(), index as u32))
+        .collect::<BTreeMap<_, _>>();
+    let internal_indices = functions
+        .iter()
+        .enumerate()
+        .map(|(index, (function, _))| (function.name.clone(), (imports.len() + index) as u32))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut module = b"\0asm\x01\0\0\0".to_vec();
+
+    let mut type_section = Vec::new();
+    uleb(signatures.len() as u32, &mut type_section);
+    for signature in &signatures {
+        type_section.push(0x60);
+        uleb(signature.params.len() as u32, &mut type_section);
+        type_section.extend(std::iter::repeat_n(I32, signature.params.len()));
+        if signature.result == TYPE_ID_VOID {
+            type_section.push(0);
+        } else {
+            type_section.extend([1, I32]);
+        }
+    }
+    section(1, type_section, &mut module);
+
+    if !imports.is_empty() {
+        let mut import_section = Vec::new();
+        uleb(imports.len() as u32, &mut import_section);
+        for (_, symbol, _) in &imports {
+            string("env", &mut import_section);
+            string(symbol, &mut import_section);
+            import_section.push(0);
+            uleb(
+                import_section_type_index(&imports, symbol)?,
+                &mut import_section,
+            );
+        }
+        section(2, import_section, &mut module);
+    }
+
+    let mut function_section = Vec::new();
+    uleb(functions.len() as u32, &mut function_section);
+    for index in 0..functions.len() {
+        uleb((imports.len() + index) as u32, &mut function_section);
+    }
+    section(3, function_section, &mut module);
+
+    if !globals.is_empty() {
+        let mut global_section = Vec::new();
+        uleb(globals.len() as u32, &mut global_section);
+        for _ in &globals {
+            global_section.extend([I32, 1, 0x41, 0, 0x0b]);
+        }
+        section(6, global_section, &mut module);
+    }
+
+    let mut export_section = Vec::new();
+    uleb(
+        functions.len() as u32 + globals.len() as u32,
+        &mut export_section,
+    );
+    for (index, (function, _)) in functions.iter().enumerate() {
+        string(&function.name, &mut export_section);
+        export_section.push(0);
+        uleb((imports.len() + index) as u32, &mut export_section);
+    }
+    for (index, (name, _)) in globals.iter().enumerate() {
+        string(name, &mut export_section);
+        export_section.push(3);
+        uleb(index as u32, &mut export_section);
+    }
+    section(7, export_section, &mut module);
+
+    let mut code_section = Vec::new();
+    uleb(functions.len() as u32, &mut code_section);
+    for (function, hir) in functions {
+        let body = encode_function(
+            function,
+            hir,
+            &analysis.constant_values,
+            &global_indices,
+            &import_indices,
+            &internal_indices,
+            &signatures,
+        )?;
+        uleb(body.len() as u32, &mut code_section);
+        code_section.extend(body);
+    }
+    section(10, code_section, &mut module);
+    Ok(module)
+}
+
+fn import_section_type_index(
+    imports: &[(String, String, Signature)],
+    symbol: &str,
+) -> Result<u32, String> {
+    imports
+        .iter()
+        .position(|(_, candidate, _)| candidate == symbol)
+        .map(|index| index as u32)
+        .ok_or_else(|| format!("missing web import type for '{symbol}'"))
+}
+
+fn collect_calls(statements: &[SimpleStmt], out: &mut BTreeSet<String>) {
+    fn expression(value: &SimpleExpr, out: &mut BTreeSet<String>) {
+        match value {
+            SimpleExpr::Call { target, args } => {
+                out.insert(target.clone());
+                for arg in args {
+                    expression(arg, out);
+                }
+            }
+            SimpleExpr::Binary { lhs, rhs, .. } => {
+                expression(lhs, out);
+                expression(rhs, out);
+            }
+            SimpleExpr::Condition(condition) => condition_calls(condition, out),
+            SimpleExpr::IndexedPath { index, .. } => expression(index, out),
+            _ => {}
+        }
+    }
+    fn condition_calls(value: &SimpleCondition, out: &mut BTreeSet<String>) {
+        match value {
+            SimpleCondition::Comparison { lhs, rhs, .. } => {
+                expression(lhs, out);
+                expression(rhs, out);
+            }
+            SimpleCondition::Expr(value) => expression(value, out),
+            SimpleCondition::And(lhs, rhs) | SimpleCondition::Or(lhs, rhs) => {
+                condition_calls(lhs, out);
+                condition_calls(rhs, out);
+            }
+            SimpleCondition::Not(value) => condition_calls(value, out),
+        }
+    }
+    for statement in statements {
+        match statement {
+            SimpleStmt::Let {
+                expression: value, ..
+            }
+            | SimpleStmt::Assign {
+                expression: value, ..
+            }
+            | SimpleStmt::Expr(value)
+            | SimpleStmt::Return(value) => expression(value, out),
+            SimpleStmt::Convert { source, .. } => expression(source, out),
+            SimpleStmt::If {
+                condition,
+                then_statements,
+                else_statements,
+            } => {
+                condition_calls(condition, out);
+                collect_calls(then_statements, out);
+                if let Some(values) = else_statements {
+                    collect_calls(values, out);
+                }
+            }
+            SimpleStmt::For {
+                init,
+                condition,
+                step,
+                body_statements,
+            } => {
+                collect_calls(std::slice::from_ref(init), out);
+                condition_calls(condition, out);
+                collect_calls(std::slice::from_ref(step), out);
+                collect_calls(body_statements, out);
+            }
+            SimpleStmt::Foreach {
+                body_statements, ..
+            } => collect_calls(body_statements, out),
+            SimpleStmt::Noop | SimpleStmt::Continue | SimpleStmt::ReturnVoid => {}
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_function(
+    function: &FunctionMeta,
+    hir: &FunctionHIR,
+    constants: &BTreeMap<String, ConstantValue>,
+    globals: &BTreeMap<String, u32>,
+    imports: &BTreeMap<String, u32>,
+    internals: &BTreeMap<String, u32>,
+    signatures: &[Signature],
+) -> Result<Vec<u8>, String> {
+    let mut local_names = Vec::new();
+    collect_locals(&hir.statements, &mut local_names)?;
+    let mut locals = function
+        .param_names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| (name.clone(), index as u32))
+        .collect::<BTreeMap<_, _>>();
+    for name in &local_names {
+        if locals.contains_key(name) {
+            return Err(format!("duplicate local '{name}' in '{}'", function.name));
+        }
+        locals.insert(name.clone(), locals.len() as u32);
+    }
+
+    let mut body = Vec::new();
+    if local_names.is_empty() {
+        body.push(0);
+    } else {
+        body.push(1);
+        uleb(local_names.len() as u32, &mut body);
+        body.push(I32);
+    }
+    let context = EncodeContext {
+        locals: &locals,
+        globals,
+        constants,
+        imports,
+        internals,
+        signatures,
+    };
+    encode_statements(&hir.statements, &context, &mut body)?;
+    if function.return_type != TYPE_ID_VOID {
+        body.extend([0x41, 0]);
+    }
+    body.push(0x0b);
+    Ok(body)
+}
+
+fn collect_locals(statements: &[SimpleStmt], out: &mut Vec<String>) -> Result<(), String> {
+    for statement in statements {
+        match statement {
+            SimpleStmt::Let { name, type_id, .. } => {
+                if type_id.is_some_and(|value| !is_i32_lane(value)) {
+                    return Err(format!(
+                        "web scalar lane requires i32-compatible local '{name}'"
+                    ));
+                }
+                out.push(name.clone());
+            }
+            SimpleStmt::If {
+                then_statements,
+                else_statements,
+                ..
+            } => {
+                collect_locals(then_statements, out)?;
+                if let Some(values) = else_statements {
+                    collect_locals(values, out)?;
+                }
+            }
+            SimpleStmt::For {
+                init,
+                step,
+                body_statements,
+                ..
+            } => {
+                collect_locals(std::slice::from_ref(init), out)?;
+                collect_locals(std::slice::from_ref(step), out)?;
+                collect_locals(body_statements, out)?;
+            }
+            SimpleStmt::Foreach { .. } => {
+                return Err("web scalar lane does not yet support foreach".to_string())
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+struct EncodeContext<'a> {
+    locals: &'a BTreeMap<String, u32>,
+    globals: &'a BTreeMap<String, u32>,
+    constants: &'a BTreeMap<String, ConstantValue>,
+    imports: &'a BTreeMap<String, u32>,
+    internals: &'a BTreeMap<String, u32>,
+    signatures: &'a [Signature],
+}
+
+fn encode_statements(
+    statements: &[SimpleStmt],
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    for statement in statements {
+        match statement {
+            SimpleStmt::Noop => {}
+            SimpleStmt::Let {
+                name, expression, ..
+            } => {
+                encode_expr(expression, context, out)?;
+                out.push(0x21);
+                uleb(local(context, name)?, out);
+            }
+            SimpleStmt::Assign {
+                target,
+                op,
+                expression,
+            } => {
+                if *op != AssignOp::Set {
+                    encode_target_get(target, context, out)?;
+                }
+                encode_expr(expression, context, out)?;
+                if *op != AssignOp::Set {
+                    out.push(arithmetic_opcode(*op)?);
+                }
+                encode_target_set(target, context, out)?;
+            }
+            SimpleStmt::Expr(expression) => {
+                encode_expr(expression, context, out)?;
+                if expression_returns_value(expression, context)? {
+                    out.push(0x1a);
+                }
+            }
+            SimpleStmt::Return(expression) => {
+                encode_expr(expression, context, out)?;
+                out.push(0x0f);
+            }
+            SimpleStmt::ReturnVoid => out.push(0x0f),
+            SimpleStmt::If {
+                condition,
+                then_statements,
+                else_statements,
+            } => {
+                encode_condition(condition, context, out)?;
+                out.extend([0x04, 0x40]);
+                encode_statements(then_statements, context, out)?;
+                if let Some(values) = else_statements {
+                    out.push(0x05);
+                    encode_statements(values, context, out)?;
+                }
+                out.push(0x0b);
+            }
+            SimpleStmt::For {
+                init,
+                condition,
+                step,
+                body_statements,
+            } => {
+                encode_statements(std::slice::from_ref(init), context, out)?;
+                out.extend([0x02, 0x40, 0x03, 0x40]);
+                encode_condition(condition, context, out)?;
+                out.extend([0x45, 0x0d, 0x01]);
+                encode_statements(body_statements, context, out)?;
+                encode_statements(std::slice::from_ref(step), context, out)?;
+                out.extend([0x0c, 0x00, 0x0b, 0x0b]);
+            }
+            SimpleStmt::Continue => {
+                return Err("web scalar lane does not yet support continue".to_string())
+            }
+            SimpleStmt::Convert { .. } => {
+                return Err("web scalar lane does not yet support conversions".to_string())
+            }
+            SimpleStmt::Foreach { .. } => {
+                return Err("web scalar lane does not yet support foreach".to_string())
+            }
+        }
+    }
+    Ok(())
+}
+
+fn arithmetic_opcode(op: AssignOp) -> Result<u8, String> {
+    match op {
+        AssignOp::Add => Ok(0x6a),
+        AssignOp::Sub => Ok(0x6b),
+        AssignOp::Mul => Ok(0x6c),
+        AssignOp::Div => Ok(0x6d),
+        AssignOp::Mod => Ok(0x6f),
+        AssignOp::Set => Err("set has no arithmetic opcode".to_string()),
+    }
+}
+
+fn encode_target_get(
+    target: &AssignTarget,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    match target {
+        AssignTarget::Local(name) => {
+            if let Some(index) = context.locals.get(name) {
+                out.push(0x20);
+                uleb(*index, out);
+                Ok(())
+            } else {
+                out.push(0x23);
+                uleb(global(context, name)?, out);
+                Ok(())
+            }
+        }
+        AssignTarget::GlobalPath(name) => {
+            out.push(0x23);
+            uleb(global(context, name)?, out);
+            Ok(())
+        }
+        AssignTarget::IndexedPath { .. } => {
+            Err("web scalar lane does not yet support indexed assignment".to_string())
+        }
+    }
+}
+
+fn encode_target_set(
+    target: &AssignTarget,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    match target {
+        AssignTarget::Local(name) => {
+            if let Some(index) = context.locals.get(name) {
+                out.push(0x21);
+                uleb(*index, out);
+                Ok(())
+            } else {
+                out.push(0x24);
+                uleb(global(context, name)?, out);
+                Ok(())
+            }
+        }
+        AssignTarget::GlobalPath(name) => {
+            out.push(0x24);
+            uleb(global(context, name)?, out);
+            Ok(())
+        }
+        AssignTarget::IndexedPath { .. } => {
+            Err("web scalar lane does not yet support indexed assignment".to_string())
+        }
+    }
+}
+
+fn local(context: &EncodeContext<'_>, name: &str) -> Result<u32, String> {
+    context
+        .locals
+        .get(name)
+        .copied()
+        .ok_or_else(|| format!("unknown web local '{name}'"))
+}
+
+fn global(context: &EncodeContext<'_>, name: &str) -> Result<u32, String> {
+    context
+        .globals
+        .get(name)
+        .copied()
+        .ok_or_else(|| format!("unknown web global '{name}'"))
+}
+
+fn encode_expr(
+    value: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    match value {
+        SimpleExpr::Int(value) => {
+            out.push(0x41);
+            sleb(*value as i32, out);
+        }
+        SimpleExpr::Bool(value) => out.extend([0x41, u8::from(*value)]),
+        SimpleExpr::Identifier(name) => {
+            if let Some(index) = context.locals.get(name) {
+                out.push(0x20);
+                uleb(*index, out);
+            } else if let Some(index) = context.globals.get(name) {
+                out.push(0x23);
+                uleb(*index, out);
+            } else if let Some(value) = context.constants.get(name) {
+                encode_constant(value, out)?;
+            } else {
+                return Err(format!("unknown web value '{name}'"));
+            }
+        }
+        SimpleExpr::Call { target, args } => {
+            for arg in args {
+                encode_expr(arg, context, out)?;
+            }
+            out.push(0x10);
+            let index = context
+                .imports
+                .get(target)
+                .or_else(|| context.internals.get(target))
+                .copied()
+                .ok_or_else(|| format!("unknown web call '{target}'"))?;
+            uleb(index, out);
+        }
+        SimpleExpr::Binary { lhs, op, rhs } => {
+            encode_expr(lhs, context, out)?;
+            encode_expr(rhs, context, out)?;
+            out.push(match op {
+                '+' => 0x6a,
+                '-' => 0x6b,
+                '*' => 0x6c,
+                '/' => 0x6d,
+                '%' => 0x6f,
+                other => return Err(format!("unsupported web binary operator '{other}'")),
+            });
+        }
+        SimpleExpr::Condition(condition) => encode_condition(condition, context, out)?,
+        SimpleExpr::Float(_) => {
+            return Err("web scalar lane does not yet support float expressions".to_string())
+        }
+        SimpleExpr::StringLiteral(_) => {
+            return Err("web scalar lane does not yet support string expressions".to_string())
+        }
+        SimpleExpr::IndexedPath { .. } => {
+            return Err("web scalar lane does not yet support indexed expressions".to_string())
+        }
+    }
+    Ok(())
+}
+
+fn encode_constant(value: &ConstantValue, out: &mut Vec<u8>) -> Result<(), String> {
+    let value = match value {
+        ConstantValue::I32 { value, .. } => *value,
+        ConstantValue::Bool(value) => i32::from(*value),
+        _ => return Err("web scalar lane only supports i32-compatible constants".to_string()),
+    };
+    out.push(0x41);
+    sleb(value, out);
+    Ok(())
+}
+
+fn encode_condition(
+    value: &SimpleCondition,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    match value {
+        SimpleCondition::Comparison { lhs, op, rhs } => {
+            encode_expr(lhs, context, out)?;
+            encode_expr(rhs, context, out)?;
+            out.push(match op {
+                ComparisonOp::Eq => 0x46,
+                ComparisonOp::Ne => 0x47,
+                ComparisonOp::Lt => 0x48,
+                ComparisonOp::Le => 0x4c,
+                ComparisonOp::Gt => 0x4a,
+                ComparisonOp::Ge => 0x4e,
+            });
+        }
+        SimpleCondition::Expr(value) => encode_expr(value, context, out)?,
+        SimpleCondition::And(lhs, rhs) => {
+            encode_condition(lhs, context, out)?;
+            encode_condition(rhs, context, out)?;
+            out.push(0x71);
+        }
+        SimpleCondition::Or(lhs, rhs) => {
+            encode_condition(lhs, context, out)?;
+            encode_condition(rhs, context, out)?;
+            out.push(0x72);
+        }
+        SimpleCondition::Not(value) => {
+            encode_condition(value, context, out)?;
+            out.push(0x45);
+        }
+    }
+    Ok(())
+}
+
+fn expression_returns_value(
+    value: &SimpleExpr,
+    context: &EncodeContext<'_>,
+) -> Result<bool, String> {
+    if let SimpleExpr::Call { target, .. } = value {
+        let index = context
+            .imports
+            .get(target)
+            .or_else(|| context.internals.get(target))
+            .copied()
+            .ok_or_else(|| format!("unknown web call '{target}'"))? as usize;
+        return Ok(context.signatures[index].result != TYPE_ID_VOID);
+    }
+    Ok(true)
+}
+
+fn section(id: u8, payload: Vec<u8>, module: &mut Vec<u8>) {
+    if payload.is_empty() {
+        return;
+    }
+    module.push(id);
+    uleb(payload.len() as u32, module);
+    module.extend(payload);
+}
+
+fn string(value: &str, out: &mut Vec<u8>) {
+    uleb(value.len() as u32, out);
+    out.extend(value.as_bytes());
+}
+
+fn uleb(mut value: u32, out: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn sleb(mut value: i32, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        let done = (value == 0 && byte & 0x40 == 0) || (value == -1 && byte & 0x40 != 0);
+        out.push(if done { byte } else { byte | 0x80 });
+        if done {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_valid_wasm_header_and_real_entry_exports() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "web.stasis",
+            "global x: i32; function main(): i32 { x = 3; return x; } function tick(): i32 { x += 1; return x; } function render(): i32 { return x; }",
+        );
+        process.compile().expect("compile web module");
+        assert!(process.module_bytes().starts_with(b"\0asm\x01\0\0\0"));
+        for name in ["main", "tick", "render"] {
+            assert!(process
+                .module_bytes()
+                .windows(name.len())
+                .any(|window| window == name.as_bytes()));
+        }
+    }
+}

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -10,19 +10,23 @@ use crate::backend::emit::{
 };
 use crate::compiler::{CompileError, CompileReport, CompileResult, Compiler, FunctionMeta};
 use crate::frontend::types::{
-    TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_I32, TYPE_ID_U16, TYPE_ID_U32, TYPE_ID_U8,
-    TYPE_ID_VOID,
+    TypeCategory, TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
+    TYPE_ID_U16, TYPE_ID_U32, TYPE_ID_U8, TYPE_ID_VOID,
 };
 use crate::ir::hir::FunctionHIR;
 use std::collections::{BTreeMap, BTreeSet};
 
 const I32: u8 = 0x7f;
+const F32: u8 = 0x7d;
+const F64: u8 = 0x7c;
 
 #[derive(Debug, Clone, Default)]
 pub struct WasmProcess {
     compiler: Compiler,
     required_roots: Vec<String>,
     module: Vec<u8>,
+    string_literals: BTreeMap<i32, String>,
+    memory_layout: BTreeMap<String, WasmMemoryLayout>,
 }
 
 impl WasmProcess {
@@ -47,6 +51,14 @@ impl WasmProcess {
         &self.module
     }
 
+    pub fn string_literals(&self) -> &BTreeMap<i32, String> {
+        &self.string_literals
+    }
+
+    pub fn memory_layout(&self) -> &BTreeMap<String, WasmMemoryLayout> {
+        &self.memory_layout
+    }
+
     pub fn last_source_diagnostic(&self) -> Option<&crate::SourceDiagnostic> {
         self.compiler.last_source_diagnostic()
     }
@@ -66,10 +78,15 @@ impl WasmProcess {
         .map_err(CompileError::Backend)?;
         *self.compiler.types_mut() = types.clone();
 
+        let reachable = crate::backend::reachability::compute_reachable_function_ids(
+            self.compiler.functions(),
+            &self.required_roots,
+        );
         let function_ids = self
             .compiler
             .functions()
             .iter()
+            .filter(|function| reachable.contains(&function.id))
             .map(|function| function.id)
             .collect::<Vec<_>>();
         let mut lowered = Vec::new();
@@ -91,6 +108,22 @@ impl WasmProcess {
             }
         }
 
+        self.string_literals = collect_string_literals(&lowered);
+        let (memory_bindings, _) =
+            build_memory_bindings(&analysis).map_err(CompileError::Backend)?;
+        self.memory_layout = memory_bindings
+            .into_iter()
+            .map(|(path, binding)| {
+                (
+                    path,
+                    WasmMemoryLayout {
+                        offset: binding.offset,
+                        type_id: binding.type_id,
+                        length: binding.len,
+                    },
+                )
+            })
+            .collect();
         self.module = encode_module(&lowered, &analysis, &types).map_err(CompileError::Backend)?;
         Ok(CompileReport { index, emit })
     }
@@ -109,15 +142,115 @@ fn is_i32_lane(type_id: TypeId) -> bool {
     )
 }
 
+fn wasm_value_type(type_id: TypeId) -> Result<u8, String> {
+    if is_i32_lane(type_id) {
+        Ok(I32)
+    } else if type_id == TYPE_ID_F32 {
+        Ok(F32)
+    } else if type_id == TYPE_ID_F64 {
+        Ok(F64)
+    } else if type_id != TYPE_ID_VOID {
+        // String/view handles and opaque host handles cross the web ABI as i32.
+        Ok(I32)
+    } else {
+        Err("void is not a WebAssembly value".to_string())
+    }
+}
+
 fn validate_signature(name: &str, signature: &Signature) -> Result<(), String> {
-    if signature.params.iter().any(|value| !is_i32_lane(*value))
-        || (signature.result != TYPE_ID_VOID && !is_i32_lane(signature.result))
-    {
-        return Err(format!(
-            "web scalar lane does not yet support non-i32 signature for '{name}'"
-        ));
+    for type_id in &signature.params {
+        wasm_value_type(*type_id)
+            .map_err(|_| format!("web backend does not support parameter type for '{name}'"))?;
+    }
+    if signature.result != TYPE_ID_VOID {
+        wasm_value_type(signature.result)
+            .map_err(|_| format!("web backend does not support return type for '{name}'"))?;
     }
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct MemoryBinding {
+    offset: u32,
+    type_id: TypeId,
+    len: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmMemoryLayout {
+    pub offset: u32,
+    pub type_id: TypeId,
+    pub length: i32,
+}
+
+fn storage_width(type_id: TypeId) -> Result<u32, String> {
+    match type_id {
+        TYPE_ID_BOOL | TYPE_ID_U8 => Ok(1),
+        TYPE_ID_U16 => Ok(2),
+        TYPE_ID_I32 | TYPE_ID_U32 | TYPE_ID_F32 => Ok(4),
+        TYPE_ID_F64 => Ok(8),
+        _ => Err(format!(
+            "web memory does not support element type id {type_id}"
+        )),
+    }
+}
+
+fn align_up(value: u32, alignment: u32) -> Result<u32, String> {
+    value
+        .checked_add(alignment - 1)
+        .map(|value| value / alignment * alignment)
+        .ok_or_else(|| "web memory layout overflow".to_string())
+}
+
+fn build_memory_bindings(
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+) -> Result<(BTreeMap<String, MemoryBinding>, u32), String> {
+    let mut offset = 0u32;
+    let mut bindings = BTreeMap::new();
+    for (path, collection) in &analysis.collection_infos {
+        if let Some(type_id) = collection.element_type {
+            let width = storage_width(type_id)?;
+            offset = align_up(offset, width)?;
+            bindings.insert(
+                path.clone(),
+                MemoryBinding {
+                    offset,
+                    type_id,
+                    len: collection.len,
+                },
+            );
+            offset = offset
+                .checked_add(
+                    u32::try_from(collection.len)
+                        .map_err(|_| format!("negative web collection length for '{path}'"))?
+                        .checked_mul(width)
+                        .ok_or_else(|| "web memory layout overflow".to_string())?,
+                )
+                .ok_or_else(|| "web memory layout overflow".to_string())?;
+        }
+        for (field, type_id) in &collection.field_types {
+            let width = storage_width(*type_id)?;
+            offset = align_up(offset, width)?;
+            let field_path = format!("{path}.{field}");
+            bindings.insert(
+                field_path,
+                MemoryBinding {
+                    offset,
+                    type_id: *type_id,
+                    len: collection.len,
+                },
+            );
+            offset = offset
+                .checked_add(
+                    u32::try_from(collection.len)
+                        .map_err(|_| format!("negative web collection length for '{path}'"))?
+                        .checked_mul(width)
+                        .ok_or_else(|| "web memory layout overflow".to_string())?,
+                )
+                .ok_or_else(|| "web memory layout overflow".to_string())?;
+        }
+    }
+    Ok((bindings, offset))
 }
 
 fn encode_module(
@@ -125,17 +258,16 @@ fn encode_module(
     analysis: &crate::backend::emit::CompileAnalysisCache,
     types: &TypeTable,
 ) -> Result<Vec<u8>, String> {
-    let mut internal_by_name = BTreeMap::new();
+    let mut internal_by_name: BTreeMap<String, Vec<usize>> = BTreeMap::new();
     for (index, (function, _)) in functions.iter().enumerate() {
-        if internal_by_name
-            .insert(function.name.clone(), index)
-            .is_some()
-        {
-            return Err(format!(
-                "web scalar lane requires unique function names; '{}' is overloaded",
-                function.name
-            ));
-        }
+        internal_by_name
+            .entry(function.name.clone())
+            .or_default()
+            .push(index);
+        internal_by_name
+            .entry(format!("{}.{}", function.module_alias, function.name))
+            .or_default()
+            .push(index);
     }
 
     let mut called = BTreeSet::new();
@@ -164,6 +296,14 @@ fn encode_module(
         if !internal_by_name.contains_key(target) && !imported_names.contains(target) {
             return Err(format!("unresolved web call target '{target}'"));
         }
+        if internal_by_name
+            .get(target)
+            .is_some_and(|candidates| candidates.len() > 1)
+        {
+            return Err(format!(
+                "web backend cannot yet resolve called overload family '{target}'"
+            ));
+        }
     }
 
     let mut signatures = imports
@@ -179,27 +319,47 @@ fn encode_module(
         signatures.push(signature);
     }
 
+    let (memory_bindings, memory_bytes) = build_memory_bindings(analysis)?;
     let mut globals = Vec::new();
     for (name, type_id) in &analysis.global_path_types {
-        if name.contains('.') {
+        if memory_bindings.contains_key(name) {
+            continue;
+        }
+        let Some(info) = types.type_info(*type_id) else {
             return Err(format!(
-                "web scalar lane does not yet support structured state path '{name}'"
+                "web backend found unknown global type id {type_id}"
+            ));
+        };
+        if info.category == TypeCategory::Named
+            || matches!(
+                info.category,
+                TypeCategory::ArrayFixed
+                    | TypeCategory::ArrayView
+                    | TypeCategory::AsciiFixed
+                    | TypeCategory::AsciiView
+                    | TypeCategory::Utf8Fixed
+                    | TypeCategory::Utf8View
+            )
+        {
+            continue;
+        }
+        if wasm_value_type(*type_id).is_err() {
+            return Err(format!(
+                "web backend does not support global '{name}' with type {}",
+                info.name
             ));
         }
-        if !is_i32_lane(*type_id) {
-            return Err(format!(
-                "web scalar lane does not yet support global '{name}' with type {}",
-                types
-                    .type_info(*type_id)
-                    .map_or("unknown", |info| info.name.as_str())
-            ));
-        }
-        globals.push((name.clone(), *type_id));
+        let initial_i32 = [".length", ".max_length"].iter().find_map(|suffix| {
+            name.strip_suffix(suffix)
+                .and_then(|path| analysis.collection_infos.get(path))
+                .map(|collection| collection.len)
+        });
+        globals.push((name.clone(), *type_id, initial_i32));
     }
     let global_indices = globals
         .iter()
         .enumerate()
-        .map(|(index, (name, _))| (name.clone(), index as u32))
+        .map(|(index, (name, _, _))| (name.clone(), index as u32))
         .collect::<BTreeMap<_, _>>();
 
     let import_indices = imports
@@ -207,11 +367,21 @@ fn encode_module(
         .enumerate()
         .map(|(index, (name, _, _))| (name.clone(), index as u32))
         .collect::<BTreeMap<_, _>>();
-    let internal_indices = functions
-        .iter()
-        .enumerate()
-        .map(|(index, (function, _))| (function.name.clone(), (imports.len() + index) as u32))
-        .collect::<BTreeMap<_, _>>();
+    let mut internal_indices = BTreeMap::new();
+    for (index, (function, _)) in functions.iter().enumerate() {
+        let function_index = (imports.len() + index) as u32;
+        for name in [
+            function.name.clone(),
+            format!("{}.{}", function.module_alias, function.name),
+        ] {
+            if internal_by_name
+                .get(&name)
+                .is_some_and(|candidates| candidates.len() == 1)
+            {
+                internal_indices.insert(name, function_index);
+            }
+        }
+    }
 
     let mut module = b"\0asm\x01\0\0\0".to_vec();
 
@@ -220,11 +390,13 @@ fn encode_module(
     for signature in &signatures {
         type_section.push(0x60);
         uleb(signature.params.len() as u32, &mut type_section);
-        type_section.extend(std::iter::repeat_n(I32, signature.params.len()));
+        for type_id in &signature.params {
+            type_section.push(wasm_value_type(*type_id)?);
+        }
         if signature.result == TYPE_ID_VOID {
             type_section.push(0);
         } else {
-            type_section.extend([1, I32]);
+            type_section.extend([1, wasm_value_type(signature.result)?]);
         }
     }
     section(1, type_section, &mut module);
@@ -251,29 +423,63 @@ fn encode_module(
     }
     section(3, function_section, &mut module);
 
+    if memory_bytes > 0 {
+        let mut memory_section = vec![1, 0];
+        uleb(memory_bytes.div_ceil(65_536).max(1), &mut memory_section);
+        section(5, memory_section, &mut module);
+    }
+
     if !globals.is_empty() {
         let mut global_section = Vec::new();
         uleb(globals.len() as u32, &mut global_section);
-        for _ in &globals {
-            global_section.extend([I32, 1, 0x41, 0, 0x0b]);
+        for (_, type_id, initial_i32) in &globals {
+            global_section.extend([wasm_value_type(*type_id)?, 1]);
+            if let Some(value) = initial_i32 {
+                global_section.push(0x41);
+                sleb(*value, &mut global_section);
+            } else {
+                encode_zero(*type_id, &mut global_section)?;
+            }
+            global_section.push(0x0b);
         }
         section(6, global_section, &mut module);
     }
 
     let mut export_section = Vec::new();
     uleb(
-        functions.len() as u32 + globals.len() as u32,
+        functions
+            .iter()
+            .filter(|(function, _)| {
+                matches!(
+                    function.name.as_str(),
+                    "main" | "tick" | "render" | "on_code_swap"
+                )
+            })
+            .count() as u32
+            + globals.len() as u32
+            + u32::from(memory_bytes > 0),
         &mut export_section,
     );
     for (index, (function, _)) in functions.iter().enumerate() {
+        if !matches!(
+            function.name.as_str(),
+            "main" | "tick" | "render" | "on_code_swap"
+        ) {
+            continue;
+        }
         string(&function.name, &mut export_section);
         export_section.push(0);
         uleb((imports.len() + index) as u32, &mut export_section);
     }
-    for (index, (name, _)) in globals.iter().enumerate() {
+    for (index, (name, _, _)) in globals.iter().enumerate() {
         string(name, &mut export_section);
         export_section.push(3);
         uleb(index as u32, &mut export_section);
+    }
+    if memory_bytes > 0 {
+        string("memory", &mut export_section);
+        export_section.push(2);
+        uleb(0, &mut export_section);
     }
     section(7, export_section, &mut module);
 
@@ -285,6 +491,8 @@ fn encode_module(
             hir,
             &analysis.constant_values,
             &global_indices,
+            &analysis.global_path_types,
+            &memory_bindings,
             &import_indices,
             &internal_indices,
             &signatures,
@@ -386,59 +594,91 @@ fn encode_function(
     hir: &FunctionHIR,
     constants: &BTreeMap<String, ConstantValue>,
     globals: &BTreeMap<String, u32>,
+    global_types: &BTreeMap<String, TypeId>,
+    memory: &BTreeMap<String, MemoryBinding>,
     imports: &BTreeMap<String, u32>,
     internals: &BTreeMap<String, u32>,
     signatures: &[Signature],
 ) -> Result<Vec<u8>, String> {
-    let mut local_names = Vec::new();
-    collect_locals(&hir.statements, &mut local_names)?;
+    let mut local_declarations = Vec::new();
+    collect_locals(&hir.statements, &mut local_declarations)?;
     let mut locals = function
         .param_names
         .iter()
+        .zip(function.params.iter())
         .enumerate()
-        .map(|(index, name)| (name.clone(), index as u32))
+        .map(|(index, (name, type_id))| {
+            (
+                name.clone(),
+                LocalBinding {
+                    index: index as u32,
+                    type_id: *type_id,
+                },
+            )
+        })
         .collect::<BTreeMap<_, _>>();
-    for name in &local_names {
+    for (name, type_id) in &local_declarations {
         if locals.contains_key(name) {
             return Err(format!("duplicate local '{name}' in '{}'", function.name));
         }
-        locals.insert(name.clone(), locals.len() as u32);
+        locals.insert(
+            name.clone(),
+            LocalBinding {
+                index: locals.len() as u32,
+                type_id: *type_id,
+            },
+        );
     }
 
     let mut body = Vec::new();
-    if local_names.is_empty() {
-        body.push(0);
-    } else {
-        body.push(1);
-        uleb(local_names.len() as u32, &mut body);
-        body.push(I32);
+    uleb(local_declarations.len() as u32 + 4, &mut body);
+    for (_, type_id) in &local_declarations {
+        uleb(1, &mut body);
+        body.push(wasm_value_type(*type_id)?);
+    }
+    let scratch_index = locals.len() as u32;
+    let scratch_i32 = scratch_index + 1;
+    let scratch_f32 = scratch_index + 2;
+    let scratch_f64 = scratch_index + 3;
+    for value_type in [I32, I32, F32, F64] {
+        uleb(1, &mut body);
+        body.push(value_type);
     }
     let context = EncodeContext {
         locals: &locals,
         globals,
+        global_types,
+        memory,
         constants,
         imports,
         internals,
         signatures,
+        scratch_index,
+        return_type: function.return_type,
+        scratch_i32,
+        scratch_f32,
+        scratch_f64,
     };
     encode_statements(&hir.statements, &context, &mut body)?;
     if function.return_type != TYPE_ID_VOID {
-        body.extend([0x41, 0]);
+        encode_zero(function.return_type, &mut body)?;
     }
     body.push(0x0b);
     Ok(body)
 }
 
-fn collect_locals(statements: &[SimpleStmt], out: &mut Vec<String>) -> Result<(), String> {
+fn collect_locals(
+    statements: &[SimpleStmt],
+    out: &mut Vec<(String, TypeId)>,
+) -> Result<(), String> {
     for statement in statements {
         match statement {
             SimpleStmt::Let { name, type_id, .. } => {
-                if type_id.is_some_and(|value| !is_i32_lane(value)) {
-                    return Err(format!(
-                        "web scalar lane requires i32-compatible local '{name}'"
-                    ));
-                }
-                out.push(name.clone());
+                let type_id = type_id.ok_or_else(|| {
+                    format!("web backend requires an explicit type for local '{name}'")
+                })?;
+                wasm_value_type(type_id)?;
+                out.push((name.clone(), type_id));
             }
             SimpleStmt::If {
                 then_statements,
@@ -470,12 +710,25 @@ fn collect_locals(statements: &[SimpleStmt], out: &mut Vec<String>) -> Result<()
 }
 
 struct EncodeContext<'a> {
-    locals: &'a BTreeMap<String, u32>,
+    locals: &'a BTreeMap<String, LocalBinding>,
     globals: &'a BTreeMap<String, u32>,
+    global_types: &'a BTreeMap<String, TypeId>,
+    memory: &'a BTreeMap<String, MemoryBinding>,
     constants: &'a BTreeMap<String, ConstantValue>,
     imports: &'a BTreeMap<String, u32>,
     internals: &'a BTreeMap<String, u32>,
     signatures: &'a [Signature],
+    scratch_index: u32,
+    return_type: TypeId,
+    scratch_i32: u32,
+    scratch_f32: u32,
+    scratch_f64: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LocalBinding {
+    index: u32,
+    type_id: TypeId,
 }
 
 fn encode_statements(
@@ -489,21 +742,25 @@ fn encode_statements(
             SimpleStmt::Let {
                 name, expression, ..
             } => {
-                encode_expr(expression, context, out)?;
+                let binding = local_binding(context, name)?;
+                let value_type = encode_expr_as(expression, Some(binding.type_id), context, out)?;
+                require_same_type(binding.type_id, value_type, "local initializer")?;
                 out.push(0x21);
-                uleb(local(context, name)?, out);
+                uleb(binding.index, out);
             }
             SimpleStmt::Assign {
                 target,
                 op,
                 expression,
             } => {
+                let target_type = target_type(target, context)?;
                 if *op != AssignOp::Set {
                     encode_target_get(target, context, out)?;
                 }
-                encode_expr(expression, context, out)?;
+                let value_type = encode_expr_as(expression, Some(target_type), context, out)?;
+                require_same_type(target_type, value_type, "assignment")?;
                 if *op != AssignOp::Set {
-                    out.push(arithmetic_opcode(*op)?);
+                    out.push(arithmetic_opcode(*op, target_type)?);
                 }
                 encode_target_set(target, context, out)?;
             }
@@ -514,7 +771,7 @@ fn encode_statements(
                 }
             }
             SimpleStmt::Return(expression) => {
-                encode_expr(expression, context, out)?;
+                encode_expr_as(expression, Some(context.return_type), context, out)?;
                 out.push(0x0f);
             }
             SimpleStmt::ReturnVoid => out.push(0x0f),
@@ -549,8 +806,11 @@ fn encode_statements(
             SimpleStmt::Continue => {
                 return Err("web scalar lane does not yet support continue".to_string())
             }
-            SimpleStmt::Convert { .. } => {
-                return Err("web scalar lane does not yet support conversions".to_string())
+            SimpleStmt::Convert { target, source, .. } => {
+                let target_type = target_type(target, context)?;
+                let source_type = encode_expr(source, context, out)?;
+                encode_conversion(source_type, target_type, out)?;
+                encode_target_set(target, context, out)?;
             }
             SimpleStmt::Foreach { .. } => {
                 return Err("web scalar lane does not yet support foreach".to_string())
@@ -560,14 +820,42 @@ fn encode_statements(
     Ok(())
 }
 
-fn arithmetic_opcode(op: AssignOp) -> Result<u8, String> {
-    match op {
-        AssignOp::Add => Ok(0x6a),
-        AssignOp::Sub => Ok(0x6b),
-        AssignOp::Mul => Ok(0x6c),
-        AssignOp::Div => Ok(0x6d),
-        AssignOp::Mod => Ok(0x6f),
-        AssignOp::Set => Err("set has no arithmetic opcode".to_string()),
+fn encode_conversion(from: TypeId, to: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
+    let from = wasm_value_type(from)?;
+    let to = wasm_value_type(to)?;
+    if from == to {
+        return Ok(());
+    }
+    out.push(match (from, to) {
+        (I32, F32) => 0xb2,
+        (I32, F64) => 0xb7,
+        (F32, I32) => 0xa8,
+        (F64, I32) => 0xaa,
+        (F32, F64) => 0xbb,
+        (F64, F32) => 0xb6,
+        _ => return Err("unsupported web conversion".to_string()),
+    });
+    Ok(())
+}
+
+fn arithmetic_opcode(op: AssignOp, type_id: TypeId) -> Result<u8, String> {
+    match (op, wasm_value_type(type_id)?) {
+        (AssignOp::Add, I32) => Ok(0x6a),
+        (AssignOp::Sub, I32) => Ok(0x6b),
+        (AssignOp::Mul, I32) => Ok(0x6c),
+        (AssignOp::Div, I32) => Ok(0x6d),
+        (AssignOp::Mod, I32) => Ok(0x6f),
+        (AssignOp::Add, F32) => Ok(0x92),
+        (AssignOp::Sub, F32) => Ok(0x93),
+        (AssignOp::Mul, F32) => Ok(0x94),
+        (AssignOp::Div, F32) => Ok(0x95),
+        (AssignOp::Add, F64) => Ok(0xa0),
+        (AssignOp::Sub, F64) => Ok(0xa1),
+        (AssignOp::Mul, F64) => Ok(0xa2),
+        (AssignOp::Div, F64) => Ok(0xa3),
+        (AssignOp::Mod, F32 | F64) => Err("web float remainder is unsupported".to_string()),
+        (AssignOp::Set, _) => Err("set has no arithmetic opcode".to_string()),
+        _ => Err("unsupported web arithmetic lane".to_string()),
     }
 }
 
@@ -575,26 +863,33 @@ fn encode_target_get(
     target: &AssignTarget,
     context: &EncodeContext<'_>,
     out: &mut Vec<u8>,
-) -> Result<(), String> {
+) -> Result<TypeId, String> {
     match target {
         AssignTarget::Local(name) => {
-            if let Some(index) = context.locals.get(name) {
+            if let Some(binding) = context.locals.get(name) {
                 out.push(0x20);
-                uleb(*index, out);
-                Ok(())
+                uleb(binding.index, out);
+                Ok(binding.type_id)
             } else {
                 out.push(0x23);
                 uleb(global(context, name)?, out);
-                Ok(())
+                global_type(context, name)
             }
         }
         AssignTarget::GlobalPath(name) => {
             out.push(0x23);
             uleb(global(context, name)?, out);
-            Ok(())
+            global_type(context, name)
         }
-        AssignTarget::IndexedPath { .. } => {
-            Err("web scalar lane does not yet support indexed assignment".to_string())
+        AssignTarget::IndexedPath {
+            collection_path,
+            index,
+            suffix,
+        } => {
+            let binding = memory_binding(context, collection_path, suffix)?;
+            encode_memory_address(binding, index, context, out)?;
+            encode_memory_load(binding.type_id, out)?;
+            Ok(binding.type_id)
         }
     }
 }
@@ -606,9 +901,9 @@ fn encode_target_set(
 ) -> Result<(), String> {
     match target {
         AssignTarget::Local(name) => {
-            if let Some(index) = context.locals.get(name) {
+            if let Some(binding) = context.locals.get(name) {
                 out.push(0x21);
-                uleb(*index, out);
+                uleb(binding.index, out);
                 Ok(())
             } else {
                 out.push(0x24);
@@ -621,13 +916,33 @@ fn encode_target_set(
             uleb(global(context, name)?, out);
             Ok(())
         }
-        AssignTarget::IndexedPath { .. } => {
-            Err("web scalar lane does not yet support indexed assignment".to_string())
+        AssignTarget::IndexedPath {
+            collection_path,
+            index,
+            suffix,
+        } => {
+            let binding = memory_binding(context, collection_path, suffix)?;
+            let temp_index = scratch_local(context, binding.type_id)?;
+            out.push(0x21);
+            uleb(temp_index, out);
+            encode_memory_address(binding, index, context, out)?;
+            out.push(0x20);
+            uleb(temp_index, out);
+            encode_memory_store(binding.type_id, out)
         }
     }
 }
 
-fn local(context: &EncodeContext<'_>, name: &str) -> Result<u32, String> {
+fn scratch_local(context: &EncodeContext<'_>, type_id: TypeId) -> Result<u32, String> {
+    match wasm_value_type(type_id)? {
+        I32 => Ok(context.scratch_i32),
+        F32 => Ok(context.scratch_f32),
+        F64 => Ok(context.scratch_f64),
+        _ => Err("unsupported web scratch type".to_string()),
+    }
+}
+
+fn local_binding(context: &EncodeContext<'_>, name: &str) -> Result<LocalBinding, String> {
     context
         .locals
         .get(name)
@@ -643,78 +958,266 @@ fn global(context: &EncodeContext<'_>, name: &str) -> Result<u32, String> {
         .ok_or_else(|| format!("unknown web global '{name}'"))
 }
 
+fn global_type(context: &EncodeContext<'_>, name: &str) -> Result<TypeId, String> {
+    context
+        .global_types
+        .get(name)
+        .copied()
+        .ok_or_else(|| format!("unknown web global type '{name}'"))
+}
+
+fn target_type(target: &AssignTarget, context: &EncodeContext<'_>) -> Result<TypeId, String> {
+    match target {
+        AssignTarget::Local(name) => context
+            .locals
+            .get(name)
+            .map(|binding| binding.type_id)
+            .or_else(|| context.global_types.get(name).copied())
+            .ok_or_else(|| format!("unknown web assignment target '{name}'")),
+        AssignTarget::GlobalPath(name) => global_type(context, name),
+        AssignTarget::IndexedPath {
+            collection_path,
+            suffix,
+            ..
+        } => Ok(memory_binding(context, collection_path, suffix)?.type_id),
+    }
+}
+
+fn memory_binding<'a>(
+    context: &'a EncodeContext<'_>,
+    collection_path: &str,
+    suffix: &str,
+) -> Result<&'a MemoryBinding, String> {
+    let path = if suffix.is_empty() {
+        collection_path.to_string()
+    } else {
+        format!("{collection_path}.{suffix}")
+    };
+    context
+        .memory
+        .get(&path)
+        .ok_or_else(|| format!("unknown web collection storage '{path}'"))
+}
+
+fn encode_memory_address(
+    binding: &MemoryBinding,
+    index: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let index_type = encode_expr(index, context, out)?;
+    if !is_i32_lane(index_type) {
+        return Err("web collection index must be i32-compatible".to_string());
+    }
+    out.push(0x21);
+    uleb(context.scratch_index, out);
+    out.push(0x20);
+    uleb(context.scratch_index, out);
+    out.extend([0x41, 0, 0x48, 0x04, 0x40, 0x00, 0x0b]);
+    out.push(0x20);
+    uleb(context.scratch_index, out);
+    out.push(0x41);
+    sleb(binding.len, out);
+    out.extend([0x4e, 0x04, 0x40, 0x00, 0x0b]);
+    out.push(0x41);
+    sleb(binding.offset as i32, out);
+    out.push(0x20);
+    uleb(context.scratch_index, out);
+    out.push(0x41);
+    sleb(storage_width(binding.type_id)? as i32, out);
+    out.push(0x6c);
+    out.push(0x6a);
+    Ok(())
+}
+
+fn encode_memory_load(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
+    let (opcode, align) = match type_id {
+        TYPE_ID_BOOL | TYPE_ID_U8 => (0x2d, 0),
+        TYPE_ID_U16 => (0x2f, 1),
+        TYPE_ID_I32 | TYPE_ID_U32 => (0x28, 2),
+        TYPE_ID_F32 => (0x2a, 2),
+        TYPE_ID_F64 => (0x2b, 3),
+        _ => return Err(format!("unsupported web memory load type id {type_id}")),
+    };
+    out.push(opcode);
+    uleb(align, out);
+    uleb(0, out);
+    Ok(())
+}
+
+fn encode_memory_store(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
+    let (opcode, align) = match type_id {
+        TYPE_ID_BOOL | TYPE_ID_U8 => (0x3a, 0),
+        TYPE_ID_U16 => (0x3b, 1),
+        TYPE_ID_I32 | TYPE_ID_U32 => (0x36, 2),
+        TYPE_ID_F32 => (0x38, 2),
+        TYPE_ID_F64 => (0x39, 3),
+        _ => return Err(format!("unsupported web memory store type id {type_id}")),
+    };
+    out.push(opcode);
+    uleb(align, out);
+    uleb(0, out);
+    Ok(())
+}
+
+fn require_same_type(expected: TypeId, actual: TypeId, context: &str) -> Result<(), String> {
+    if wasm_value_type(expected)? == wasm_value_type(actual)? {
+        Ok(())
+    } else {
+        Err(format!(
+            "web {context} type mismatch: expected {expected}, found {actual}"
+        ))
+    }
+}
+
 fn encode_expr(
     value: &SimpleExpr,
     context: &EncodeContext<'_>,
     out: &mut Vec<u8>,
-) -> Result<(), String> {
+) -> Result<TypeId, String> {
+    encode_expr_as(value, None, context, out)
+}
+
+fn encode_expr_as(
+    value: &SimpleExpr,
+    expected: Option<TypeId>,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
     match value {
         SimpleExpr::Int(value) => {
             out.push(0x41);
             sleb(*value as i32, out);
+            Ok(expected
+                .filter(|type_id| is_i32_lane(*type_id))
+                .unwrap_or(TYPE_ID_I32))
         }
-        SimpleExpr::Bool(value) => out.extend([0x41, u8::from(*value)]),
+        SimpleExpr::Float(value) => {
+            let type_id = expected
+                .filter(|type_id| matches!(*type_id, TYPE_ID_F32 | TYPE_ID_F64))
+                .unwrap_or(TYPE_ID_F32);
+            if type_id == TYPE_ID_F64 {
+                out.push(0x44);
+                out.extend(value.to_le_bytes());
+            } else {
+                out.push(0x43);
+                out.extend((*value as f32).to_le_bytes());
+            }
+            Ok(type_id)
+        }
+        SimpleExpr::Bool(value) => {
+            out.extend([0x41, u8::from(*value)]);
+            Ok(TYPE_ID_BOOL)
+        }
+        SimpleExpr::StringLiteral(value) => {
+            out.push(0x41);
+            sleb(crate::backend::emit::hash_string_literal(value), out);
+            Ok(expected.unwrap_or(TYPE_ID_I32))
+        }
         SimpleExpr::Identifier(name) => {
-            if let Some(index) = context.locals.get(name) {
+            if let Some(binding) = context.locals.get(name) {
                 out.push(0x20);
-                uleb(*index, out);
+                uleb(binding.index, out);
+                Ok(binding.type_id)
             } else if let Some(index) = context.globals.get(name) {
                 out.push(0x23);
                 uleb(*index, out);
+                global_type(context, name)
             } else if let Some(value) = context.constants.get(name) {
-                encode_constant(value, out)?;
+                encode_constant(value, expected, out)
             } else {
-                return Err(format!("unknown web value '{name}'"));
+                Err(format!("unknown web value '{name}'"))
             }
         }
         SimpleExpr::Call { target, args } => {
-            for arg in args {
-                encode_expr(arg, context, out)?;
-            }
-            out.push(0x10);
             let index = context
                 .imports
                 .get(target)
                 .or_else(|| context.internals.get(target))
                 .copied()
                 .ok_or_else(|| format!("unknown web call '{target}'"))?;
+            let signature = context
+                .signatures
+                .get(index as usize)
+                .ok_or_else(|| format!("missing web signature for '{target}'"))?;
+            if args.len() != signature.params.len() {
+                return Err(format!(
+                    "web call '{target}' expected {} arguments, found {}",
+                    signature.params.len(),
+                    args.len()
+                ));
+            }
+            for (arg, param_type) in args.iter().zip(signature.params.iter()) {
+                let actual = encode_expr_as(arg, Some(*param_type), context, out)?;
+                require_same_type(*param_type, actual, "call argument")?;
+            }
+            out.push(0x10);
             uleb(index, out);
+            Ok(signature.result)
         }
         SimpleExpr::Binary { lhs, op, rhs } => {
-            encode_expr(lhs, context, out)?;
-            encode_expr(rhs, context, out)?;
-            out.push(match op {
-                '+' => 0x6a,
-                '-' => 0x6b,
-                '*' => 0x6c,
-                '/' => 0x6d,
-                '%' => 0x6f,
+            let lhs_type = encode_expr_as(lhs, expected, context, out)?;
+            let rhs_type = encode_expr_as(rhs, Some(lhs_type), context, out)?;
+            require_same_type(lhs_type, rhs_type, "binary expression")?;
+            let assign_op = match op {
+                '+' => AssignOp::Add,
+                '-' => AssignOp::Sub,
+                '*' => AssignOp::Mul,
+                '/' => AssignOp::Div,
+                '%' => AssignOp::Mod,
                 other => return Err(format!("unsupported web binary operator '{other}'")),
-            });
+            };
+            out.push(arithmetic_opcode(assign_op, lhs_type)?);
+            Ok(lhs_type)
         }
-        SimpleExpr::Condition(condition) => encode_condition(condition, context, out)?,
-        SimpleExpr::Float(_) => {
-            return Err("web scalar lane does not yet support float expressions".to_string())
+        SimpleExpr::Condition(condition) => {
+            encode_condition(condition, context, out)?;
+            Ok(TYPE_ID_BOOL)
         }
-        SimpleExpr::StringLiteral(_) => {
-            return Err("web scalar lane does not yet support string expressions".to_string())
-        }
-        SimpleExpr::IndexedPath { .. } => {
-            return Err("web scalar lane does not yet support indexed expressions".to_string())
+        SimpleExpr::IndexedPath {
+            collection_path,
+            index,
+            suffix,
+        } => {
+            let binding = memory_binding(context, collection_path, suffix)?;
+            encode_memory_address(binding, index, context, out)?;
+            encode_memory_load(binding.type_id, out)?;
+            Ok(binding.type_id)
         }
     }
-    Ok(())
 }
 
-fn encode_constant(value: &ConstantValue, out: &mut Vec<u8>) -> Result<(), String> {
-    let value = match value {
-        ConstantValue::I32 { value, .. } => *value,
-        ConstantValue::Bool(value) => i32::from(*value),
-        _ => return Err("web scalar lane only supports i32-compatible constants".to_string()),
-    };
-    out.push(0x41);
-    sleb(value, out);
-    Ok(())
+fn encode_constant(
+    value: &ConstantValue,
+    expected: Option<TypeId>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    match value {
+        ConstantValue::I32 { value, type_id } => {
+            out.push(0x41);
+            sleb(*value, out);
+            Ok(*type_id)
+        }
+        ConstantValue::Bool(value) => {
+            out.extend([0x41, u8::from(*value)]);
+            Ok(TYPE_ID_BOOL)
+        }
+        ConstantValue::F32(value) => {
+            out.push(0x43);
+            out.extend(value.to_le_bytes());
+            Ok(TYPE_ID_F32)
+        }
+        ConstantValue::F64(value) => {
+            out.push(0x44);
+            out.extend(value.to_le_bytes());
+            Ok(TYPE_ID_F64)
+        }
+        ConstantValue::String { value, type_id } => {
+            out.push(0x41);
+            sleb(crate::backend::emit::hash_string_literal(value), out);
+            Ok(expected.unwrap_or(*type_id))
+        }
+    }
 }
 
 fn encode_condition(
@@ -724,18 +1227,14 @@ fn encode_condition(
 ) -> Result<(), String> {
     match value {
         SimpleCondition::Comparison { lhs, op, rhs } => {
-            encode_expr(lhs, context, out)?;
-            encode_expr(rhs, context, out)?;
-            out.push(match op {
-                ComparisonOp::Eq => 0x46,
-                ComparisonOp::Ne => 0x47,
-                ComparisonOp::Lt => 0x48,
-                ComparisonOp::Le => 0x4c,
-                ComparisonOp::Gt => 0x4a,
-                ComparisonOp::Ge => 0x4e,
-            });
+            let lhs_type = encode_expr(lhs, context, out)?;
+            let rhs_type = encode_expr_as(rhs, Some(lhs_type), context, out)?;
+            require_same_type(lhs_type, rhs_type, "comparison")?;
+            out.push(comparison_opcode(*op, lhs_type)?);
         }
-        SimpleCondition::Expr(value) => encode_expr(value, context, out)?,
+        SimpleCondition::Expr(value) => {
+            encode_expr(value, context, out)?;
+        }
         SimpleCondition::And(lhs, rhs) => {
             encode_condition(lhs, context, out)?;
             encode_condition(rhs, context, out)?;
@@ -754,6 +1253,30 @@ fn encode_condition(
     Ok(())
 }
 
+fn comparison_opcode(op: ComparisonOp, type_id: TypeId) -> Result<u8, String> {
+    match (op, wasm_value_type(type_id)?) {
+        (ComparisonOp::Eq, I32) => Ok(0x46),
+        (ComparisonOp::Ne, I32) => Ok(0x47),
+        (ComparisonOp::Lt, I32) => Ok(0x48),
+        (ComparisonOp::Gt, I32) => Ok(0x4a),
+        (ComparisonOp::Le, I32) => Ok(0x4c),
+        (ComparisonOp::Ge, I32) => Ok(0x4e),
+        (ComparisonOp::Eq, F32) => Ok(0x5b),
+        (ComparisonOp::Ne, F32) => Ok(0x5c),
+        (ComparisonOp::Lt, F32) => Ok(0x5d),
+        (ComparisonOp::Gt, F32) => Ok(0x5e),
+        (ComparisonOp::Le, F32) => Ok(0x5f),
+        (ComparisonOp::Ge, F32) => Ok(0x60),
+        (ComparisonOp::Eq, F64) => Ok(0x61),
+        (ComparisonOp::Ne, F64) => Ok(0x62),
+        (ComparisonOp::Lt, F64) => Ok(0x63),
+        (ComparisonOp::Gt, F64) => Ok(0x64),
+        (ComparisonOp::Le, F64) => Ok(0x65),
+        (ComparisonOp::Ge, F64) => Ok(0x66),
+        _ => Err("unsupported web comparison lane".to_string()),
+    }
+}
+
 fn expression_returns_value(
     value: &SimpleExpr,
     context: &EncodeContext<'_>,
@@ -768,6 +1291,107 @@ fn expression_returns_value(
         return Ok(context.signatures[index].result != TYPE_ID_VOID);
     }
     Ok(true)
+}
+
+fn encode_zero(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
+    match wasm_value_type(type_id)? {
+        I32 => out.extend([0x41, 0]),
+        F32 => {
+            out.push(0x43);
+            out.extend(0.0f32.to_le_bytes());
+        }
+        F64 => {
+            out.push(0x44);
+            out.extend(0.0f64.to_le_bytes());
+        }
+        _ => return Err("unsupported web zero value".to_string()),
+    }
+    Ok(())
+}
+
+fn collect_string_literals(functions: &[(FunctionMeta, FunctionHIR)]) -> BTreeMap<i32, String> {
+    fn expression(value: &SimpleExpr, out: &mut BTreeMap<i32, String>) {
+        match value {
+            SimpleExpr::StringLiteral(value) => {
+                out.insert(
+                    crate::backend::emit::hash_string_literal(value),
+                    value.clone(),
+                );
+            }
+            SimpleExpr::Condition(value) => condition(value, out),
+            SimpleExpr::IndexedPath { index, .. } => expression(index, out),
+            SimpleExpr::Call { args, .. } => {
+                for arg in args {
+                    expression(arg, out);
+                }
+            }
+            SimpleExpr::Binary { lhs, rhs, .. } => {
+                expression(lhs, out);
+                expression(rhs, out);
+            }
+            _ => {}
+        }
+    }
+    fn condition(value: &SimpleCondition, out: &mut BTreeMap<i32, String>) {
+        match value {
+            SimpleCondition::Comparison { lhs, rhs, .. } => {
+                expression(lhs, out);
+                expression(rhs, out);
+            }
+            SimpleCondition::Expr(value) => expression(value, out),
+            SimpleCondition::And(lhs, rhs) | SimpleCondition::Or(lhs, rhs) => {
+                condition(lhs, out);
+                condition(rhs, out);
+            }
+            SimpleCondition::Not(value) => condition(value, out),
+        }
+    }
+    fn statements(values: &[SimpleStmt], out: &mut BTreeMap<i32, String>) {
+        for value in values {
+            match value {
+                SimpleStmt::Let {
+                    expression: value, ..
+                }
+                | SimpleStmt::Assign {
+                    expression: value, ..
+                }
+                | SimpleStmt::Expr(value)
+                | SimpleStmt::Return(value) => expression(value, out),
+                SimpleStmt::Convert { source, .. } => expression(source, out),
+                SimpleStmt::If {
+                    condition: value,
+                    then_statements,
+                    else_statements,
+                } => {
+                    condition(value, out);
+                    statements(then_statements, out);
+                    if let Some(values) = else_statements {
+                        statements(values, out);
+                    }
+                }
+                SimpleStmt::For {
+                    init,
+                    condition: value,
+                    step,
+                    body_statements,
+                } => {
+                    statements(std::slice::from_ref(init), out);
+                    condition(value, out);
+                    statements(std::slice::from_ref(step), out);
+                    statements(body_statements, out);
+                }
+                SimpleStmt::Foreach {
+                    body_statements, ..
+                } => statements(body_statements, out),
+                SimpleStmt::Noop | SimpleStmt::Continue | SimpleStmt::ReturnVoid => {}
+            }
+        }
+    }
+    let mut out = BTreeMap::new();
+    for (_, hir) in functions {
+        statements(&hir.statements, &mut out);
+    }
+    out
 }
 
 fn section(id: u8, payload: Vec<u8>, module: &mut Vec<u8>) {

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -5,8 +5,9 @@
 //! target-specific substitute implementation.
 
 use crate::backend::emit::{
-    build_compile_analysis_cache, compute_files_fingerprint, resolve_extern_call_signatures_with,
-    AssignOp, AssignTarget, ComparisonOp, ConstantValue, SimpleCondition, SimpleExpr, SimpleStmt,
+    build_compile_analysis_cache, compute_files_fingerprint, hash_global_path,
+    resolve_extern_call_signatures_with, AssignOp, AssignTarget, ComparisonOp, ConstantValue,
+    SimpleCondition, SimpleExpr, SimpleStmt,
 };
 use crate::compiler::{CompileError, CompileReport, CompileResult, Compiler, FunctionMeta};
 use crate::frontend::types::{
@@ -20,6 +21,10 @@ const I32: u8 = 0x7f;
 const F32: u8 = 0x7d;
 const F64: u8 = 0x7c;
 
+pub fn wasm_global_hash(path: &str) -> i32 {
+    hash_global_path(path)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct WasmProcess {
     compiler: Compiler,
@@ -27,6 +32,9 @@ pub struct WasmProcess {
     module: Vec<u8>,
     string_literals: BTreeMap<i32, String>,
     memory_layout: BTreeMap<String, WasmMemoryLayout>,
+    struct_views: BTreeMap<i32, BTreeMap<String, String>>,
+    debug_symbols: bool,
+    global_types: BTreeMap<String, TypeId>,
 }
 
 impl WasmProcess {
@@ -43,6 +51,10 @@ impl WasmProcess {
         self.compiler.set_analysis_required_roots(roots);
     }
 
+    pub fn set_debug_symbols(&mut self, enabled: bool) {
+        self.debug_symbols = enabled;
+    }
+
     pub fn upsert_file(&mut self, path: impl Into<String>, content: impl Into<String>) {
         self.compiler.upsert_file(path, content);
     }
@@ -57,6 +69,14 @@ impl WasmProcess {
 
     pub fn memory_layout(&self) -> &BTreeMap<String, WasmMemoryLayout> {
         &self.memory_layout
+    }
+
+    pub fn struct_views(&self) -> &BTreeMap<i32, BTreeMap<String, String>> {
+        &self.struct_views
+    }
+
+    pub fn global_types(&self) -> &BTreeMap<String, TypeId> {
+        &self.global_types
     }
 
     pub fn last_source_diagnostic(&self) -> Option<&crate::SourceDiagnostic> {
@@ -110,7 +130,7 @@ impl WasmProcess {
 
         self.string_literals = collect_string_literals(&lowered);
         let (memory_bindings, _) =
-            build_memory_bindings(&analysis).map_err(CompileError::Backend)?;
+            build_memory_bindings(&analysis, &types).map_err(CompileError::Backend)?;
         self.memory_layout = memory_bindings
             .into_iter()
             .map(|(path, binding)| {
@@ -120,11 +140,38 @@ impl WasmProcess {
                         offset: binding.offset,
                         type_id: binding.type_id,
                         length: binding.len,
+                        stride: binding.stride,
                     },
                 )
             })
             .collect();
-        self.module = encode_module(&lowered, &analysis, &types).map_err(CompileError::Backend)?;
+        self.struct_views.clear();
+        self.global_types = analysis.global_path_types.clone();
+        for (path, collection) in &analysis.collection_infos {
+            if !collection.field_types.is_empty() {
+                self.struct_views.insert(
+                    hash_global_path(path),
+                    collection
+                        .field_types
+                        .keys()
+                        .map(|suffix| (suffix.clone(), format!("{path}.{suffix}")))
+                        .collect(),
+                );
+            }
+        }
+        for (path, type_id) in &analysis.global_path_types {
+            if let Some(fields) = analysis.named_struct_field_types.get(type_id) {
+                self.struct_views.insert(
+                    hash_global_path(path),
+                    fields
+                        .keys()
+                        .map(|suffix| (suffix.clone(), format!("{path}.{suffix}")))
+                        .collect(),
+                );
+            }
+        }
+        self.module = encode_module(&lowered, &analysis, &types, self.debug_symbols)
+            .map_err(CompileError::Backend)?;
         Ok(CompileReport { index, emit })
     }
 }
@@ -140,6 +187,12 @@ fn is_i32_lane(type_id: TypeId) -> bool {
         type_id,
         TYPE_ID_I32 | TYPE_ID_BOOL | TYPE_ID_U8 | TYPE_ID_U16 | TYPE_ID_U32
     )
+}
+
+fn is_web_index_type(type_id: TypeId, context: &EncodeContext<'_>) -> bool {
+    wasm_value_type(type_id).is_ok_and(|value_type| value_type == I32)
+        && !is_struct_view_type(type_id, context.named_structs)
+        && context.types.indexed_element_type_id(type_id).is_none()
 }
 
 fn wasm_value_type(type_id: TypeId) -> Result<u8, String> {
@@ -169,11 +222,80 @@ fn validate_signature(name: &str, signature: &Signature) -> Result<(), String> {
     Ok(())
 }
 
+fn is_struct_view_type(
+    type_id: TypeId,
+    named_structs: &crate::backend::emit::NamedStructFieldTypeMap,
+) -> bool {
+    named_structs.contains_key(&type_id)
+}
+
+fn physical_param_count(
+    params: &[TypeId],
+    named_structs: &crate::backend::emit::NamedStructFieldTypeMap,
+) -> usize {
+    params
+        .iter()
+        .map(|type_id| {
+            usize::from(!is_struct_view_type(*type_id, named_structs))
+                + 3 * usize::from(is_struct_view_type(*type_id, named_structs))
+        })
+        .sum()
+}
+
 #[derive(Debug, Clone)]
 struct MemoryBinding {
     offset: u32,
     type_id: TypeId,
     len: i32,
+    width: u32,
+    stride: u32,
+}
+
+#[derive(Debug, Clone)]
+struct StructCollectionBinding {
+    base: i32,
+    type_id: TypeId,
+    len: i32,
+    fields: BTreeMap<String, MemoryBinding>,
+}
+
+#[derive(Debug, Clone)]
+struct StructScalarBinding {
+    base: i32,
+    type_id: TypeId,
+    fields: BTreeMap<String, (u32, TypeId)>,
+}
+
+fn build_struct_scalars(
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+    globals: &BTreeMap<String, u32>,
+) -> BTreeMap<String, StructScalarBinding> {
+    let mut out = BTreeMap::new();
+    for (path, type_id) in &analysis.global_path_types {
+        let Some(field_types) = analysis.named_struct_field_types.get(type_id) else {
+            continue;
+        };
+        let fields = field_types
+            .iter()
+            .filter_map(|(suffix, field_type)| {
+                globals
+                    .get(&format!("{path}.{suffix}"))
+                    .copied()
+                    .map(|index| (suffix.clone(), (index, *field_type)))
+            })
+            .collect::<BTreeMap<_, _>>();
+        if !fields.is_empty() {
+            out.insert(
+                path.clone(),
+                StructScalarBinding {
+                    base: hash_global_path(path),
+                    type_id: *type_id,
+                    fields,
+                },
+            );
+        }
+    }
+    out
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -181,17 +303,34 @@ pub struct WasmMemoryLayout {
     pub offset: u32,
     pub type_id: TypeId,
     pub length: i32,
+    pub stride: u32,
 }
 
-fn storage_width(type_id: TypeId) -> Result<u32, String> {
+fn storage_width(
+    type_id: TypeId,
+    types: &TypeTable,
+    named_structs: &crate::backend::emit::NamedStructFieldTypeMap,
+) -> Result<u32, String> {
     match type_id {
         TYPE_ID_BOOL | TYPE_ID_U8 => Ok(1),
         TYPE_ID_U16 => Ok(2),
         TYPE_ID_I32 | TYPE_ID_U32 | TYPE_ID_F32 => Ok(4),
         TYPE_ID_F64 => Ok(8),
-        _ => Err(format!(
-            "web memory does not support element type id {type_id}"
+        _ if named_structs.contains_key(&type_id) => Err(format!(
+            "web memory requires flattened fields for struct type id {type_id}"
         )),
+        _ => match types.type_info(type_id).map(|info| info.category) {
+            Some(TypeCategory::Named)
+            | Some(TypeCategory::ArrayView)
+            | Some(TypeCategory::AsciiView)
+            | Some(TypeCategory::Utf8View) => Ok(4),
+            Some(category) => Err(format!(
+                "web memory does not support {category:?} element type id {type_id}"
+            )),
+            None => Err(format!(
+                "web memory found unknown element type id {type_id}"
+            )),
+        },
     }
 }
 
@@ -204,12 +343,15 @@ fn align_up(value: u32, alignment: u32) -> Result<u32, String> {
 
 fn build_memory_bindings(
     analysis: &crate::backend::emit::CompileAnalysisCache,
+    types: &TypeTable,
 ) -> Result<(BTreeMap<String, MemoryBinding>, u32), String> {
     let mut offset = 0u32;
     let mut bindings = BTreeMap::new();
     for (path, collection) in &analysis.collection_infos {
         if let Some(type_id) = collection.element_type {
-            let width = storage_width(type_id)?;
+            let width = storage_width(type_id, types, &analysis.named_struct_field_types).map_err(
+                |error| format!("web collection '{path}' has unsupported element storage: {error}"),
+            )?;
             offset = align_up(offset, width)?;
             bindings.insert(
                 path.clone(),
@@ -217,6 +359,8 @@ fn build_memory_bindings(
                     offset,
                     type_id,
                     len: collection.len,
+                    width,
+                    stride: width,
                 },
             );
             offset = offset
@@ -229,7 +373,12 @@ fn build_memory_bindings(
                 .ok_or_else(|| "web memory layout overflow".to_string())?;
         }
         for (field, type_id) in &collection.field_types {
-            let width = storage_width(*type_id)?;
+            let width = storage_width(*type_id, types, &analysis.named_struct_field_types)
+                .map_err(|error| {
+                    format!(
+                        "web collection '{path}.{field}' has unsupported field storage: {error}"
+                    )
+                })?;
             offset = align_up(offset, width)?;
             let field_path = format!("{path}.{field}");
             bindings.insert(
@@ -238,6 +387,8 @@ fn build_memory_bindings(
                     offset,
                     type_id: *type_id,
                     len: collection.len,
+                    width,
+                    stride: width,
                 },
             );
             offset = offset
@@ -253,10 +404,58 @@ fn build_memory_bindings(
     Ok((bindings, offset))
 }
 
+fn build_struct_collections(
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+    types: &TypeTable,
+    memory: &BTreeMap<String, MemoryBinding>,
+) -> Result<BTreeMap<String, StructCollectionBinding>, String> {
+    let mut out = BTreeMap::new();
+    for (path, collection) in &analysis.collection_infos {
+        if collection.field_types.is_empty() {
+            continue;
+        }
+        let collection_type = analysis
+            .global_path_types
+            .get(path)
+            .copied()
+            .ok_or_else(|| format!("web struct collection '{path}' has no declared type"))?;
+        let type_id = types
+            .indexed_element_type_id(collection_type)
+            .ok_or_else(|| format!("web struct collection '{path}' has no indexed element type"))?;
+        if !analysis.named_struct_field_types.contains_key(&type_id) {
+            return Err(format!(
+                "web struct collection '{path}' element type {type_id} has no field layout"
+            ));
+        }
+        let mut fields = BTreeMap::new();
+        for suffix in collection.field_types.keys() {
+            let field_path = format!("{path}.{suffix}");
+            fields.insert(
+                suffix.clone(),
+                memory
+                    .get(&field_path)
+                    .cloned()
+                    .ok_or_else(|| format!("missing web SoA field plane '{field_path}'"))?,
+            );
+        }
+        out.insert(
+            path.clone(),
+            StructCollectionBinding {
+                base: hash_global_path(path),
+                type_id,
+                len: collection.len,
+                fields,
+            },
+        );
+    }
+    Ok(out)
+}
+
 fn encode_module(
     functions: &[(FunctionMeta, FunctionHIR)],
     analysis: &crate::backend::emit::CompileAnalysisCache,
     types: &TypeTable,
+    debug_symbols: bool,
 ) -> Result<Vec<u8>, String> {
     let mut internal_by_name: BTreeMap<String, Vec<usize>> = BTreeMap::new();
     for (index, (function, _)) in functions.iter().enumerate() {
@@ -286,6 +485,30 @@ fn encode_module(
         validate_signature(&signature.name, &value)?;
         imports.push((signature.name.clone(), signature.symbol.clone(), value));
     }
+    for name in ["sin_fast", "cos_fast"] {
+        if called.contains(name) {
+            imports.push((
+                name.to_string(),
+                name.to_string(),
+                Signature {
+                    params: vec![TYPE_ID_F32],
+                    result: TYPE_ID_F32,
+                },
+            ));
+        }
+    }
+    for name in ["print_i32", "print_int", "print_char", "print_string"] {
+        if called.contains(name) {
+            imports.push((
+                name.to_string(),
+                name.to_string(),
+                Signature {
+                    params: vec![TYPE_ID_I32],
+                    result: TYPE_ID_VOID,
+                },
+            ));
+        }
+    }
     imports.sort_by(|left, right| left.0.cmp(&right.0));
 
     let imported_names = imports
@@ -293,7 +516,10 @@ fn encode_module(
         .map(|(name, _, _)| name.clone())
         .collect::<BTreeSet<_>>();
     for target in &called {
-        if !internal_by_name.contains_key(target) && !imported_names.contains(target) {
+        if !internal_by_name.contains_key(target)
+            && !imported_names.contains(target)
+            && !is_inline_intrinsic(target)
+        {
             return Err(format!("unresolved web call target '{target}'"));
         }
         if internal_by_name
@@ -319,7 +545,8 @@ fn encode_module(
         signatures.push(signature);
     }
 
-    let (memory_bindings, memory_bytes) = build_memory_bindings(analysis)?;
+    let (memory_bindings, memory_bytes) = build_memory_bindings(analysis, types)?;
+    let struct_collections = build_struct_collections(analysis, types, &memory_bindings)?;
     let mut globals = Vec::new();
     for (name, type_id) in &analysis.global_path_types {
         if memory_bindings.contains_key(name) {
@@ -330,7 +557,8 @@ fn encode_module(
                 "web backend found unknown global type id {type_id}"
             ));
         };
-        if info.category == TypeCategory::Named
+        if (info.category == TypeCategory::Named
+            && analysis.named_struct_field_types.contains_key(type_id))
             || matches!(
                 info.category,
                 TypeCategory::ArrayFixed
@@ -361,6 +589,7 @@ fn encode_module(
         .enumerate()
         .map(|(index, (name, _, _))| (name.clone(), index as u32))
         .collect::<BTreeMap<_, _>>();
+    let struct_scalars = build_struct_scalars(analysis, &global_indices);
 
     let import_indices = imports
         .iter()
@@ -386,18 +615,36 @@ fn encode_module(
     let mut module = b"\0asm\x01\0\0\0".to_vec();
 
     let mut type_section = Vec::new();
-    uleb(signatures.len() as u32, &mut type_section);
+    uleb(signatures.len() as u32 + 4, &mut type_section);
     for signature in &signatures {
         type_section.push(0x60);
-        uleb(signature.params.len() as u32, &mut type_section);
+        uleb(
+            physical_param_count(&signature.params, &analysis.named_struct_field_types) as u32,
+            &mut type_section,
+        );
         for type_id in &signature.params {
-            type_section.push(wasm_value_type(*type_id)?);
+            if is_struct_view_type(*type_id, &analysis.named_struct_field_types) {
+                type_section.extend([I32, I32, I32]);
+            } else {
+                type_section.push(wasm_value_type(*type_id)?);
+            }
         }
         if signature.result == TYPE_ID_VOID {
             type_section.push(0);
         } else {
             type_section.extend([1, wasm_value_type(signature.result)?]);
         }
+    }
+    for (params, result) in [
+        (&[I32][..], I32),
+        (&[I32, I32][..], I32),
+        (&[I32][..], F32),
+        (&[I32, F32][..], I32),
+    ] {
+        type_section.push(0x60);
+        uleb(params.len() as u32, &mut type_section);
+        type_section.extend(params);
+        type_section.extend([1, result]);
     }
     section(1, type_section, &mut module);
 
@@ -417,9 +664,12 @@ fn encode_module(
     }
 
     let mut function_section = Vec::new();
-    uleb(functions.len() as u32, &mut function_section);
+    uleb(functions.len() as u32 + 4, &mut function_section);
     for index in 0..functions.len() {
         uleb((imports.len() + index) as u32, &mut function_section);
+    }
+    for index in 0..4 {
+        uleb(signatures.len() as u32 + index, &mut function_section);
     }
     section(3, function_section, &mut module);
 
@@ -456,8 +706,13 @@ fn encode_module(
                 )
             })
             .count() as u32
-            + globals.len() as u32
-            + u32::from(memory_bytes > 0),
+            + if debug_symbols {
+                globals.len() as u32
+            } else {
+                0
+            }
+            + u32::from(memory_bytes > 0)
+            + 4,
         &mut export_section,
     );
     for (index, (function, _)) in functions.iter().enumerate() {
@@ -471,20 +726,36 @@ fn encode_module(
         export_section.push(0);
         uleb((imports.len() + index) as u32, &mut export_section);
     }
-    for (index, (name, _, _)) in globals.iter().enumerate() {
-        string(name, &mut export_section);
-        export_section.push(3);
-        uleb(index as u32, &mut export_section);
+    if debug_symbols {
+        for (index, (name, _, _)) in globals.iter().enumerate() {
+            string(name, &mut export_section);
+            export_section.push(3);
+            uleb(index as u32, &mut export_section);
+        }
     }
     if memory_bytes > 0 {
         string("memory", &mut export_section);
         export_section.push(2);
         uleb(0, &mut export_section);
     }
+    let accessor_base = (imports.len() + functions.len()) as u32;
+    for (offset, name) in [
+        "__stasis_global_get_i32",
+        "__stasis_global_set_i32",
+        "__stasis_global_get_f32",
+        "__stasis_global_set_f32",
+    ]
+    .iter()
+    .enumerate()
+    {
+        string(name, &mut export_section);
+        export_section.push(0);
+        uleb(accessor_base + offset as u32, &mut export_section);
+    }
     section(7, export_section, &mut module);
 
     let mut code_section = Vec::new();
-    uleb(functions.len() as u32, &mut code_section);
+    uleb(functions.len() as u32 + 4, &mut code_section);
     for (function, hir) in functions {
         let body = encode_function(
             function,
@@ -493,6 +764,10 @@ fn encode_module(
             &global_indices,
             &analysis.global_path_types,
             &memory_bindings,
+            &struct_collections,
+            &struct_scalars,
+            &analysis.named_struct_field_types,
+            types,
             &import_indices,
             &internal_indices,
             &signatures,
@@ -500,8 +775,104 @@ fn encode_module(
         uleb(body.len() as u32, &mut code_section);
         code_section.extend(body);
     }
+    for (lane, setter) in [(I32, false), (I32, true), (F32, false), (F32, true)] {
+        let body = encode_global_accessor(&globals, lane, setter)?;
+        uleb(body.len() as u32, &mut code_section);
+        code_section.extend(body);
+    }
     section(10, code_section, &mut module);
+    let function_names = if debug_symbols {
+        let mut names = imports
+            .iter()
+            .enumerate()
+            .map(|(index, (_, symbol, _))| (index as u32, symbol.clone()))
+            .collect::<Vec<_>>();
+        names.extend(functions.iter().enumerate().map(|(index, (function, _))| {
+            (
+                (imports.len() + index) as u32,
+                format!("{}.{}", function.module_alias, function.name),
+            )
+        }));
+        names
+    } else {
+        functions
+            .iter()
+            .enumerate()
+            .filter(|(_, (function, _))| {
+                matches!(
+                    function.name.as_str(),
+                    "main" | "tick" | "render" | "on_code_swap"
+                )
+            })
+            .map(|(index, (function, _))| ((imports.len() + index) as u32, function.name.clone()))
+            .collect()
+    };
+    append_name_section(&function_names, &mut module);
     Ok(module)
+}
+
+fn encode_global_accessor(
+    globals: &[(String, TypeId, Option<i32>)],
+    lane: u8,
+    setter: bool,
+) -> Result<Vec<u8>, String> {
+    fn branch(
+        globals: &[(usize, &(String, TypeId, Option<i32>))],
+        lane: u8,
+        setter: bool,
+        out: &mut Vec<u8>,
+    ) -> Result<(), String> {
+        let Some(((index, (name, type_id, _)), rest)) = globals.split_first() else {
+            if setter || lane == I32 {
+                out.extend([0x41, 0]);
+            } else {
+                out.push(0x43);
+                out.extend(0.0f32.to_le_bytes());
+            }
+            return Ok(());
+        };
+        out.extend([0x20, 0, 0x41]);
+        sleb(hash_global_path(name), out);
+        out.extend([0x46, 0x04, if setter { I32 } else { lane }]);
+        if setter {
+            out.extend([0x20, 1, 0x24]);
+            uleb(*index as u32, out);
+            out.extend([0x41, 1]);
+        } else {
+            out.push(0x23);
+            uleb(*index as u32, out);
+        }
+        out.push(0x05);
+        branch(rest, lane, setter, out)?;
+        out.push(0x0b);
+        let _ = type_id;
+        Ok(())
+    }
+
+    let matching = globals
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, type_id, _))| wasm_value_type(*type_id).is_ok_and(|value| value == lane))
+        .collect::<Vec<_>>();
+    let mut body = vec![0];
+    branch(&matching, lane, setter, &mut body)?;
+    body.push(0x0b);
+    Ok(body)
+}
+
+fn append_name_section(function_names: &[(u32, String)], module: &mut Vec<u8>) {
+    let mut function_subsection = Vec::new();
+    uleb(function_names.len() as u32, &mut function_subsection);
+    for (index, name) in function_names {
+        uleb(*index, &mut function_subsection);
+        string(name, &mut function_subsection);
+    }
+    let mut payload = Vec::new();
+    string("name", &mut payload);
+    payload.push(1);
+    uleb(function_subsection.len() as u32, &mut payload);
+    payload.extend(function_subsection);
+    section(0, payload, module);
 }
 
 fn import_section_type_index(
@@ -596,27 +967,34 @@ fn encode_function(
     globals: &BTreeMap<String, u32>,
     global_types: &BTreeMap<String, TypeId>,
     memory: &BTreeMap<String, MemoryBinding>,
+    struct_collections: &BTreeMap<String, StructCollectionBinding>,
+    struct_scalars: &BTreeMap<String, StructScalarBinding>,
+    named_structs: &crate::backend::emit::NamedStructFieldTypeMap,
+    types: &TypeTable,
     imports: &BTreeMap<String, u32>,
     internals: &BTreeMap<String, u32>,
     signatures: &[Signature],
 ) -> Result<Vec<u8>, String> {
     let mut local_declarations = Vec::new();
     collect_locals(&hir.statements, &mut local_declarations)?;
-    let mut locals = function
-        .param_names
-        .iter()
-        .zip(function.params.iter())
-        .enumerate()
-        .map(|(index, (name, type_id))| {
-            (
-                name.clone(),
-                LocalBinding {
-                    index: index as u32,
-                    type_id: *type_id,
-                },
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
+    let mut locals = BTreeMap::new();
+    let mut physical_cursor = 0u32;
+    for (name, type_id) in function.param_names.iter().zip(function.params.iter()) {
+        let struct_view =
+            is_struct_view_type(*type_id, named_structs).then_some(StructViewBinding {
+                index: physical_cursor + 1,
+                len: physical_cursor + 2,
+            });
+        locals.insert(
+            name.clone(),
+            LocalBinding {
+                index: physical_cursor,
+                type_id: *type_id,
+                struct_view,
+            },
+        );
+        physical_cursor += if struct_view.is_some() { 3 } else { 1 };
+    }
     for (name, type_id) in &local_declarations {
         if locals.contains_key(name) {
             return Err(format!("duplicate local '{name}' in '{}'", function.name));
@@ -624,23 +1002,53 @@ fn encode_function(
         locals.insert(
             name.clone(),
             LocalBinding {
-                index: locals.len() as u32,
+                index: physical_cursor,
                 type_id: *type_id,
+                struct_view: is_struct_view_type(*type_id, named_structs).then_some(
+                    StructViewBinding {
+                        index: physical_cursor + 1,
+                        len: physical_cursor + 2,
+                    },
+                ),
             },
         );
+        physical_cursor += if is_struct_view_type(*type_id, named_structs) {
+            3
+        } else {
+            1
+        };
     }
 
     let mut body = Vec::new();
-    uleb(local_declarations.len() as u32 + 4, &mut body);
+    let physical_local_count = local_declarations
+        .iter()
+        .map(|(_, type_id)| {
+            if is_struct_view_type(*type_id, named_structs) {
+                3
+            } else {
+                1
+            }
+        })
+        .sum::<usize>();
+    uleb(physical_local_count as u32 + 6, &mut body);
     for (_, type_id) in &local_declarations {
-        uleb(1, &mut body);
-        body.push(wasm_value_type(*type_id)?);
+        if is_struct_view_type(*type_id, named_structs) {
+            for _ in 0..3 {
+                uleb(1, &mut body);
+                body.push(I32);
+            }
+        } else {
+            uleb(1, &mut body);
+            body.push(wasm_value_type(*type_id)?);
+        }
     }
-    let scratch_index = locals.len() as u32;
+    let scratch_index = physical_cursor;
     let scratch_i32 = scratch_index + 1;
-    let scratch_f32 = scratch_index + 2;
-    let scratch_f64 = scratch_index + 3;
-    for value_type in [I32, I32, F32, F64] {
+    let scratch_i32_b = scratch_index + 2;
+    let scratch_i32_c = scratch_index + 3;
+    let scratch_f32 = scratch_index + 4;
+    let scratch_f64 = scratch_index + 5;
+    for value_type in [I32, I32, I32, I32, F32, F64] {
         uleb(1, &mut body);
         body.push(value_type);
     }
@@ -649,6 +1057,10 @@ fn encode_function(
         globals,
         global_types,
         memory,
+        struct_collections,
+        struct_scalars,
+        named_structs,
+        types,
         constants,
         imports,
         internals,
@@ -656,8 +1068,11 @@ fn encode_function(
         scratch_index,
         return_type: function.return_type,
         scratch_i32,
+        scratch_i32_b,
+        scratch_i32_c,
         scratch_f32,
         scratch_f64,
+        foreach: BTreeMap::new(),
     };
     encode_statements(&hir.statements, &context, &mut body)?;
     if function.return_type != TYPE_ID_VOID {
@@ -678,7 +1093,7 @@ fn collect_locals(
                     format!("web backend requires an explicit type for local '{name}'")
                 })?;
                 wasm_value_type(type_id)?;
-                out.push((name.clone(), type_id));
+                collect_local(name, type_id, out)?;
             }
             SimpleStmt::If {
                 then_statements,
@@ -700,8 +1115,15 @@ fn collect_locals(
                 collect_locals(std::slice::from_ref(step), out)?;
                 collect_locals(body_statements, out)?;
             }
-            SimpleStmt::Foreach { .. } => {
-                return Err("web scalar lane does not yet support foreach".to_string())
+            SimpleStmt::Foreach {
+                item_name,
+                index_name,
+                body_statements,
+                ..
+            } => {
+                let index_name = foreach_index_name(item_name, index_name.as_deref());
+                collect_local(&index_name, TYPE_ID_I32, out)?;
+                collect_locals(body_statements, out)?;
             }
             _ => {}
         }
@@ -709,11 +1131,33 @@ fn collect_locals(
     Ok(())
 }
 
+fn collect_local(
+    name: &str,
+    type_id: TypeId,
+    out: &mut Vec<(String, TypeId)>,
+) -> Result<(), String> {
+    if let Some((_, existing)) = out.iter().find(|(existing, _)| existing == name) {
+        if *existing == type_id {
+            return Ok(());
+        }
+        return Err(format!(
+            "web local '{name}' is redeclared with conflicting types {existing} and {type_id}"
+        ));
+    }
+    out.push((name.to_string(), type_id));
+    Ok(())
+}
+
+#[derive(Clone)]
 struct EncodeContext<'a> {
     locals: &'a BTreeMap<String, LocalBinding>,
     globals: &'a BTreeMap<String, u32>,
     global_types: &'a BTreeMap<String, TypeId>,
     memory: &'a BTreeMap<String, MemoryBinding>,
+    struct_collections: &'a BTreeMap<String, StructCollectionBinding>,
+    struct_scalars: &'a BTreeMap<String, StructScalarBinding>,
+    named_structs: &'a crate::backend::emit::NamedStructFieldTypeMap,
+    types: &'a TypeTable,
     constants: &'a BTreeMap<String, ConstantValue>,
     imports: &'a BTreeMap<String, u32>,
     internals: &'a BTreeMap<String, u32>,
@@ -721,14 +1165,53 @@ struct EncodeContext<'a> {
     scratch_index: u32,
     return_type: TypeId,
     scratch_i32: u32,
+    scratch_i32_b: u32,
+    scratch_i32_c: u32,
     scratch_f32: u32,
     scratch_f64: u32,
+    foreach: BTreeMap<String, WebForeachBinding>,
+}
+
+#[derive(Debug, Clone)]
+struct WebForeachBinding {
+    collection_path: String,
+    index_name: String,
+}
+
+fn foreach_index_name(item_name: &str, index_name: Option<&str>) -> String {
+    index_name
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("__web_foreach_index_{item_name}"))
 }
 
 #[derive(Debug, Clone, Copy)]
 struct LocalBinding {
     index: u32,
     type_id: TypeId,
+    struct_view: Option<StructViewBinding>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StructViewBinding {
+    index: u32,
+    len: u32,
+}
+
+fn set_struct_view_locals(base: u32, view: StructViewBinding, out: &mut Vec<u8>) {
+    for index in [view.len, view.index, base] {
+        out.push(0x21);
+        uleb(index, out);
+    }
+}
+
+fn require_same_struct_type(expected: TypeId, actual: TypeId, context: &str) -> Result<(), String> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(format!(
+            "web {context} struct type mismatch: expected {expected}, found {actual}"
+        ))
+    }
 }
 
 fn encode_statements(
@@ -743,6 +1226,12 @@ fn encode_statements(
                 name, expression, ..
             } => {
                 let binding = local_binding(context, name)?;
+                if let Some(view) = binding.struct_view {
+                    let value_type = encode_struct_view_expr(expression, context, out)?;
+                    require_same_struct_type(binding.type_id, value_type, "local initializer")?;
+                    set_struct_view_locals(binding.index, view, out);
+                    continue;
+                }
                 let value_type = encode_expr_as(expression, Some(binding.type_id), context, out)?;
                 require_same_type(binding.type_id, value_type, "local initializer")?;
                 out.push(0x21);
@@ -753,7 +1242,43 @@ fn encode_statements(
                 op,
                 expression,
             } => {
+                if *op == AssignOp::Set {
+                    if let AssignTarget::IndexedPath {
+                        collection_path,
+                        index,
+                        suffix,
+                    } = target
+                    {
+                        if suffix.is_empty()
+                            && context.struct_collections.contains_key(collection_path)
+                        {
+                            encode_struct_collection_copy(
+                                collection_path,
+                                index,
+                                expression,
+                                context,
+                                out,
+                            )?;
+                            continue;
+                        }
+                    }
+                }
                 let target_type = target_type(target, context)?;
+                if *op == AssignOp::Set && is_struct_view_type(target_type, context.named_structs) {
+                    let AssignTarget::Local(name) = target else {
+                        return Err(
+                            "web struct views can only be assigned to local bindings".to_string()
+                        );
+                    };
+                    let binding = local_binding(context, name)?;
+                    let view = binding.struct_view.ok_or_else(|| {
+                        format!("web struct local '{name}' is missing view storage")
+                    })?;
+                    let value_type = encode_struct_view_expr(expression, context, out)?;
+                    require_same_struct_type(target_type, value_type, "assignment")?;
+                    set_struct_view_locals(binding.index, view, out);
+                    continue;
+                }
                 if *op != AssignOp::Set {
                     encode_target_get(target, context, out)?;
                 }
@@ -812,8 +1337,36 @@ fn encode_statements(
                 encode_conversion(source_type, target_type, out)?;
                 encode_target_set(target, context, out)?;
             }
-            SimpleStmt::Foreach { .. } => {
-                return Err("web scalar lane does not yet support foreach".to_string())
+            SimpleStmt::Foreach {
+                item_name,
+                index_name,
+                collection_path,
+                body_statements,
+            } => {
+                let index_name = foreach_index_name(item_name, index_name.as_deref());
+                let index = local_binding(context, &index_name)?;
+                let len = collection_len(context, collection_path)?;
+                out.extend([0x41, 0, 0x21]);
+                uleb(index.index, out);
+                out.extend([0x02, 0x40, 0x03, 0x40, 0x20]);
+                uleb(index.index, out);
+                out.push(0x41);
+                sleb(len, out);
+                out.extend([0x4e, 0x0d, 0x01]);
+                let mut nested = context.clone();
+                nested.foreach.insert(
+                    item_name.clone(),
+                    WebForeachBinding {
+                        collection_path: collection_path.clone(),
+                        index_name: index_name.clone(),
+                    },
+                );
+                encode_statements(body_statements, &nested, out)?;
+                out.extend([0x20]);
+                uleb(index.index, out);
+                out.extend([0x41, 1, 0x6a, 0x21]);
+                uleb(index.index, out);
+                out.extend([0x0c, 0x00, 0x0b, 0x0b]);
             }
         }
     }
@@ -866,7 +1419,15 @@ fn encode_target_get(
 ) -> Result<TypeId, String> {
     match target {
         AssignTarget::Local(name) => {
-            if let Some(binding) = context.locals.get(name) {
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                encode_foreach_load(binding, suffix, context, out)
+            } else if let Some((binding, suffix)) = local_collection_meta(context, name) {
+                let candidates = collection_meta_candidates(context, suffix);
+                encode_collection_meta_load(binding.index, suffix, &candidates, out);
+                Ok(TYPE_ID_I32)
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                encode_struct_field_load(binding, suffix, context, out)
+            } else if let Some(binding) = context.locals.get(name) {
                 out.push(0x20);
                 uleb(binding.index, out);
                 Ok(binding.type_id)
@@ -877,15 +1438,32 @@ fn encode_target_get(
             }
         }
         AssignTarget::GlobalPath(name) => {
-            out.push(0x23);
-            uleb(global(context, name)?, out);
-            global_type(context, name)
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                encode_foreach_load(binding, suffix, context, out)
+            } else if let Some((binding, suffix)) = local_collection_meta(context, name) {
+                let candidates = collection_meta_candidates(context, suffix);
+                encode_collection_meta_load(binding.index, suffix, &candidates, out);
+                Ok(TYPE_ID_I32)
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                encode_struct_field_load(binding, suffix, context, out)
+            } else {
+                out.push(0x23);
+                uleb(global(context, name)?, out);
+                global_type(context, name)
+            }
         }
         AssignTarget::IndexedPath {
             collection_path,
             index,
             suffix,
         } => {
+            if suffix.is_empty() {
+                if let Some(local) = context.locals.get(collection_path).copied() {
+                    let element_type = encode_local_collection_address(local, index, context, out)?;
+                    encode_memory_load(element_type, out)?;
+                    return Ok(element_type);
+                }
+            }
             let binding = memory_binding(context, collection_path, suffix)?;
             encode_memory_address(binding, index, context, out)?;
             encode_memory_load(binding.type_id, out)?;
@@ -901,7 +1479,29 @@ fn encode_target_set(
 ) -> Result<(), String> {
     match target {
         AssignTarget::Local(name) => {
-            if let Some(binding) = context.locals.get(name) {
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                encode_foreach_store(binding, suffix, context, out)
+            } else if let Some((binding, suffix)) = local_collection_meta(context, name) {
+                if suffix != "length" {
+                    return Err("web collection max_length is read-only".to_string());
+                }
+                out.push(0x21);
+                uleb(context.scratch_i32, out);
+                let candidates = collection_meta_candidates(context, suffix);
+                encode_collection_length_store(
+                    binding.index,
+                    context.scratch_i32,
+                    &candidates,
+                    out,
+                );
+                Ok(())
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                let field_type = context.named_structs[&binding.type_id][suffix];
+                let temp = scratch_local(context, field_type)?;
+                out.push(0x21);
+                uleb(temp, out);
+                encode_struct_field_store_from_local(binding, suffix, temp, context, out)
+            } else if let Some(binding) = context.locals.get(name) {
                 out.push(0x21);
                 uleb(binding.index, out);
                 Ok(())
@@ -912,15 +1512,56 @@ fn encode_target_set(
             }
         }
         AssignTarget::GlobalPath(name) => {
-            out.push(0x24);
-            uleb(global(context, name)?, out);
-            Ok(())
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                encode_foreach_store(binding, suffix, context, out)
+            } else if let Some((binding, suffix)) = local_collection_meta(context, name) {
+                if suffix != "length" {
+                    return Err("web collection max_length is read-only".to_string());
+                }
+                out.push(0x21);
+                uleb(context.scratch_i32, out);
+                let candidates = collection_meta_candidates(context, suffix);
+                encode_collection_length_store(
+                    binding.index,
+                    context.scratch_i32,
+                    &candidates,
+                    out,
+                );
+                Ok(())
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                let field_type = context.named_structs[&binding.type_id][suffix];
+                let temp = scratch_local(context, field_type)?;
+                out.push(0x21);
+                uleb(temp, out);
+                encode_struct_field_store_from_local(binding, suffix, temp, context, out)
+            } else {
+                out.push(0x24);
+                uleb(global(context, name)?, out);
+                Ok(())
+            }
         }
         AssignTarget::IndexedPath {
             collection_path,
             index,
             suffix,
         } => {
+            if suffix.is_empty() {
+                if let Some(local) = context.locals.get(collection_path).copied() {
+                    let element_type = context
+                        .types
+                        .indexed_element_type_id(local.type_id)
+                        .ok_or_else(|| {
+                            format!("web local type {} is not indexable", local.type_id)
+                        })?;
+                    let temp = scratch_local(context, element_type)?;
+                    out.push(0x21);
+                    uleb(temp, out);
+                    encode_local_collection_address(local, index, context, out)?;
+                    out.push(0x20);
+                    uleb(temp, out);
+                    return encode_memory_store(element_type, out);
+                }
+            }
             let binding = memory_binding(context, collection_path, suffix)?;
             let temp_index = scratch_local(context, binding.type_id)?;
             out.push(0x21);
@@ -968,18 +1609,60 @@ fn global_type(context: &EncodeContext<'_>, name: &str) -> Result<TypeId, String
 
 fn target_type(target: &AssignTarget, context: &EncodeContext<'_>) -> Result<TypeId, String> {
     match target {
-        AssignTarget::Local(name) => context
-            .locals
-            .get(name)
-            .map(|binding| binding.type_id)
-            .or_else(|| context.global_types.get(name).copied())
-            .ok_or_else(|| format!("unknown web assignment target '{name}'")),
-        AssignTarget::GlobalPath(name) => global_type(context, name),
+        AssignTarget::Local(name) => {
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                Ok(memory_binding(context, &binding.collection_path, suffix)?.type_id)
+            } else if local_collection_meta(context, name).is_some() {
+                Ok(TYPE_ID_I32)
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                context.named_structs[&binding.type_id]
+                    .get(suffix)
+                    .copied()
+                    .ok_or_else(|| {
+                        format!("unknown web struct field '{}.{suffix}'", binding.type_id)
+                    })
+            } else {
+                context
+                    .locals
+                    .get(name)
+                    .map(|binding| binding.type_id)
+                    .or_else(|| context.global_types.get(name).copied())
+                    .ok_or_else(|| format!("unknown web assignment target '{name}'"))
+            }
+        }
+        AssignTarget::GlobalPath(name) => {
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                Ok(memory_binding(context, &binding.collection_path, suffix)?.type_id)
+            } else if local_collection_meta(context, name).is_some() {
+                Ok(TYPE_ID_I32)
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                context.named_structs[&binding.type_id]
+                    .get(suffix)
+                    .copied()
+                    .ok_or_else(|| {
+                        format!("unknown web struct field '{}.{suffix}'", binding.type_id)
+                    })
+            } else {
+                global_type(context, name)
+            }
+        }
         AssignTarget::IndexedPath {
             collection_path,
             suffix,
             ..
-        } => Ok(memory_binding(context, collection_path, suffix)?.type_id),
+        } => {
+            if suffix.is_empty() {
+                if let Some(local) = context.locals.get(collection_path) {
+                    return context
+                        .types
+                        .indexed_element_type_id(local.type_id)
+                        .ok_or_else(|| {
+                            format!("web local type {} is not indexable", local.type_id)
+                        });
+                }
+            }
+            Ok(memory_binding(context, collection_path, suffix)?.type_id)
+        }
     }
 }
 
@@ -999,6 +1682,506 @@ fn memory_binding<'a>(
         .ok_or_else(|| format!("unknown web collection storage '{path}'"))
 }
 
+fn collection_len(context: &EncodeContext<'_>, collection_path: &str) -> Result<i32, String> {
+    context
+        .memory
+        .get(collection_path)
+        .or_else(|| {
+            let prefix = format!("{collection_path}.");
+            context
+                .memory
+                .iter()
+                .find_map(|(path, binding)| path.starts_with(&prefix).then_some(binding))
+        })
+        .map(|binding| binding.len)
+        .ok_or_else(|| format!("unknown web foreach collection '{collection_path}'"))
+}
+
+fn foreach_path<'a>(
+    context: &'a EncodeContext<'_>,
+    path: &'a str,
+) -> Option<(&'a WebForeachBinding, &'a str)> {
+    let (alias, suffix) = path.split_once('.').unwrap_or((path, ""));
+    context.foreach.get(alias).map(|binding| (binding, suffix))
+}
+
+fn local_struct_path<'a>(
+    context: &'a EncodeContext<'_>,
+    path: &'a str,
+) -> Option<(&'a LocalBinding, &'a str)> {
+    let (name, suffix) = path.split_once('.')?;
+    let binding = context.locals.get(name)?;
+    binding.struct_view.map(|_| (binding, suffix))
+}
+
+fn local_collection_meta<'a>(
+    context: &'a EncodeContext<'_>,
+    path: &'a str,
+) -> Option<(&'a LocalBinding, &'a str)> {
+    let (name, suffix) = path.split_once('.')?;
+    if !matches!(suffix, "length" | "max_length") {
+        return None;
+    }
+    let binding = context.locals.get(name)?;
+    context
+        .types
+        .indexed_element_type_id(binding.type_id)
+        .map(|_| (binding, suffix))
+}
+
+fn collection_meta_candidates<'a>(
+    context: &'a EncodeContext<'_>,
+    suffix: &str,
+) -> Vec<(&'a MemoryBinding, Option<u32>)> {
+    context
+        .memory
+        .iter()
+        .filter(|(path, _)| {
+            context
+                .global_types
+                .get(*path)
+                .is_some_and(|type_id| context.types.indexed_element_type_id(*type_id).is_some())
+        })
+        .map(|(path, memory)| {
+            (
+                memory,
+                (suffix == "length")
+                    .then(|| context.globals.get(&format!("{path}.length")).copied())
+                    .flatten(),
+            )
+        })
+        .collect()
+}
+
+fn encode_collection_meta_load(
+    base_local: u32,
+    suffix: &str,
+    candidates: &[(&MemoryBinding, Option<u32>)],
+    out: &mut Vec<u8>,
+) {
+    let Some(((memory, global), rest)) = candidates.split_first() else {
+        out.push(0x00);
+        return;
+    };
+    out.push(0x20);
+    uleb(base_local, out);
+    out.push(0x41);
+    sleb(memory.offset as i32, out);
+    out.extend([0x46, 0x04, I32]);
+    if suffix == "length" {
+        if let Some(global) = global {
+            out.push(0x23);
+            uleb(*global, out);
+        } else {
+            out.push(0x41);
+            sleb(memory.len, out);
+        }
+    } else {
+        out.push(0x41);
+        sleb(memory.len, out);
+    }
+    out.push(0x05);
+    encode_collection_meta_load(base_local, suffix, rest, out);
+    out.push(0x0b);
+}
+
+fn encode_collection_length_store(
+    base_local: u32,
+    value_local: u32,
+    candidates: &[(&MemoryBinding, Option<u32>)],
+    out: &mut Vec<u8>,
+) {
+    let Some(((memory, global), rest)) = candidates.split_first() else {
+        out.push(0x00);
+        return;
+    };
+    out.push(0x20);
+    uleb(base_local, out);
+    out.push(0x41);
+    sleb(memory.offset as i32, out);
+    out.extend([0x46, 0x04, 0x40]);
+    if let Some(global) = global {
+        out.push(0x20);
+        uleb(value_local, out);
+        out.push(0x24);
+        uleb(*global, out);
+    } else {
+        out.push(0x00);
+    }
+    out.push(0x05);
+    encode_collection_length_store(base_local, value_local, rest, out);
+    out.push(0x0b);
+}
+
+fn encode_struct_view_expr(
+    value: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    match value {
+        SimpleExpr::Identifier(name) => {
+            if let Some(binding) = context.locals.get(name) {
+                let view = binding
+                    .struct_view
+                    .ok_or_else(|| format!("web value '{name}' is not a struct view"))?;
+                for index in [binding.index, view.index, view.len] {
+                    out.push(0x20);
+                    uleb(index, out);
+                }
+                return Ok(binding.type_id);
+            }
+            if let Some(binding) = context.foreach.get(name) {
+                let collection = context
+                    .struct_collections
+                    .get(&binding.collection_path)
+                    .ok_or_else(|| {
+                        format!("web foreach '{name}' is not over a struct collection")
+                    })?;
+                out.push(0x41);
+                sleb(collection.base, out);
+                let index = local_binding(context, &binding.index_name)?;
+                out.push(0x20);
+                uleb(index.index, out);
+                out.push(0x41);
+                sleb(collection.len, out);
+                return Ok(collection.type_id);
+            }
+            if let Some(binding) = context.struct_scalars.get(name) {
+                out.push(0x41);
+                sleb(binding.base, out);
+                out.push(0x41);
+                sleb(-1, out);
+                out.extend([0x41, 0]);
+                return Ok(binding.type_id);
+            }
+            Err(format!("unknown web struct view '{name}'"))
+        }
+        SimpleExpr::IndexedPath {
+            collection_path,
+            index,
+            suffix,
+        } if suffix.is_empty() => {
+            let collection = context
+                .struct_collections
+                .get(collection_path)
+                .ok_or_else(|| format!("unknown web struct collection '{collection_path}'"))?;
+            out.push(0x41);
+            sleb(collection.base, out);
+            let index_type = encode_expr_as(index, Some(TYPE_ID_I32), context, out)?;
+            if !is_web_index_type(index_type, context) {
+                return Err("web struct collection index must be i32-compatible".to_string());
+            }
+            out.push(0x41);
+            sleb(collection.len, out);
+            Ok(collection.type_id)
+        }
+        _ => Err("web struct value must be a collection element or existing view".to_string()),
+    }
+}
+
+fn encode_struct_collection_copy(
+    collection_path: &str,
+    target_index: &SimpleExpr,
+    source: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let collection = context
+        .struct_collections
+        .get(collection_path)
+        .ok_or_else(|| format!("unknown web struct collection '{collection_path}'"))?;
+    let source_type = encode_struct_view_expr(source, context, out)?;
+    require_same_struct_type(collection.type_id, source_type, "collection assignment")?;
+    for local in [
+        context.scratch_i32_c,
+        context.scratch_i32_b,
+        context.scratch_i32,
+    ] {
+        out.push(0x21);
+        uleb(local, out);
+    }
+    let target_type = encode_expr_as(target_index, Some(TYPE_ID_I32), context, out)?;
+    if !is_web_index_type(target_type, context) {
+        return Err("web struct collection index must be i32-compatible".to_string());
+    }
+    out.push(0x21);
+    uleb(context.scratch_index, out);
+    emit_index_bounds_check(context.scratch_index, collection.len, out);
+
+    let source_binding = LocalBinding {
+        index: context.scratch_i32,
+        type_id: source_type,
+        struct_view: Some(StructViewBinding {
+            index: context.scratch_i32_b,
+            len: context.scratch_i32_c,
+        }),
+    };
+    for (suffix, target_field) in &collection.fields {
+        out.push(0x41);
+        sleb(target_field.offset as i32, out);
+        out.push(0x20);
+        uleb(context.scratch_index, out);
+        out.push(0x41);
+        sleb(target_field.stride as i32, out);
+        out.extend([0x6c, 0x6a]);
+        let source_field = encode_struct_field_address(&source_binding, suffix, context, out)?;
+        encode_memory_load(source_field.type_id, out)?;
+        encode_memory_store(target_field.type_id, out)?;
+    }
+    Ok(())
+}
+
+fn emit_index_bounds_check(index_local: u32, len: i32, out: &mut Vec<u8>) {
+    out.push(0x20);
+    uleb(index_local, out);
+    out.extend([0x41, 0, 0x48, 0x04, 0x40, 0x00, 0x0b]);
+    out.push(0x20);
+    uleb(index_local, out);
+    out.push(0x41);
+    sleb(len, out);
+    out.extend([0x4e, 0x04, 0x40, 0x00, 0x0b]);
+}
+
+fn struct_field_binding<'a>(
+    context: &'a EncodeContext<'_>,
+    type_id: TypeId,
+    suffix: &str,
+) -> Result<Vec<&'a StructCollectionBinding>, String> {
+    let field_type = context
+        .named_structs
+        .get(&type_id)
+        .and_then(|fields| fields.get(suffix))
+        .copied()
+        .ok_or_else(|| format!("unknown web struct field type {type_id}.{suffix}"))?;
+    let candidates = context
+        .struct_collections
+        .values()
+        .filter(|collection| {
+            collection.type_id == type_id
+                && collection
+                    .fields
+                    .get(suffix)
+                    .is_some_and(|field| field.type_id == field_type)
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return Err(format!(
+            "web struct field {type_id}.{suffix} has no reachable SoA storage"
+        ));
+    }
+    Ok(candidates)
+}
+
+fn encode_selected_field_offset(
+    base_local: u32,
+    suffix: &str,
+    candidates: &[&StructCollectionBinding],
+    out: &mut Vec<u8>,
+) -> Result<MemoryBinding, String> {
+    let first = candidates[0]
+        .fields
+        .get(suffix)
+        .cloned()
+        .ok_or_else(|| format!("missing web SoA field '{suffix}'"))?;
+    fn branch(
+        base_local: u32,
+        suffix: &str,
+        candidates: &[&StructCollectionBinding],
+        out: &mut Vec<u8>,
+    ) -> Result<(), String> {
+        let Some((candidate, rest)) = candidates.split_first() else {
+            out.push(0x00);
+            return Ok(());
+        };
+        out.push(0x20);
+        uleb(base_local, out);
+        out.push(0x41);
+        sleb(candidate.base, out);
+        out.extend([0x46, 0x04, I32]);
+        out.push(0x41);
+        sleb(candidate.fields[suffix].offset as i32, out);
+        out.push(0x05);
+        branch(base_local, suffix, rest, out)?;
+        out.push(0x0b);
+        Ok(())
+    }
+    branch(base_local, suffix, candidates, out)?;
+    Ok(first)
+}
+
+fn encode_struct_field_address(
+    binding: &LocalBinding,
+    suffix: &str,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<MemoryBinding, String> {
+    let view = binding
+        .struct_view
+        .ok_or_else(|| "web struct binding has no view metadata".to_string())?;
+    out.push(0x20);
+    uleb(view.index, out);
+    out.extend([0x41, 0, 0x48, 0x04, 0x40, 0x00, 0x0b]);
+    out.push(0x20);
+    uleb(view.index, out);
+    out.push(0x20);
+    uleb(view.len, out);
+    out.extend([0x4e, 0x04, 0x40, 0x00, 0x0b]);
+    let candidates = struct_field_binding(context, binding.type_id, suffix)?;
+    let field = encode_selected_field_offset(binding.index, suffix, &candidates, out)?;
+    out.push(0x20);
+    uleb(view.index, out);
+    out.push(0x41);
+    sleb(field.stride as i32, out);
+    out.extend([0x6c, 0x6a]);
+    Ok(field)
+}
+
+fn scalar_field_candidates<'a>(
+    binding: &LocalBinding,
+    suffix: &str,
+    context: &'a EncodeContext<'_>,
+) -> Vec<&'a StructScalarBinding> {
+    context
+        .struct_scalars
+        .values()
+        .filter(|scalar| scalar.type_id == binding.type_id && scalar.fields.contains_key(suffix))
+        .collect()
+}
+
+fn encode_scalar_field_load(
+    base_local: u32,
+    suffix: &str,
+    candidates: &[&StructScalarBinding],
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let Some((candidate, rest)) = candidates.split_first() else {
+        out.push(0x00);
+        return Ok(());
+    };
+    let (global_index, type_id) = candidate.fields[suffix];
+    out.push(0x20);
+    uleb(base_local, out);
+    out.push(0x41);
+    sleb(candidate.base, out);
+    out.extend([0x46, 0x04, wasm_value_type(type_id)?]);
+    out.push(0x23);
+    uleb(global_index, out);
+    out.push(0x05);
+    encode_scalar_field_load(base_local, suffix, rest, out)?;
+    out.push(0x0b);
+    Ok(())
+}
+
+fn encode_struct_field_load(
+    binding: &LocalBinding,
+    suffix: &str,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    let field_type = context.named_structs[&binding.type_id][suffix];
+    let view = binding
+        .struct_view
+        .ok_or_else(|| "web struct binding has no view metadata".to_string())?;
+    out.push(0x20);
+    uleb(view.index, out);
+    out.extend([0x41, 0, 0x48, 0x04, wasm_value_type(field_type)?]);
+    let scalar_candidates = scalar_field_candidates(binding, suffix, context);
+    encode_scalar_field_load(binding.index, suffix, &scalar_candidates, out)?;
+    out.push(0x05);
+    let field = encode_struct_field_address(binding, suffix, context, out)?;
+    encode_memory_load(field.type_id, out)?;
+    out.push(0x0b);
+    Ok(field_type)
+}
+
+fn encode_scalar_field_store(
+    base_local: u32,
+    suffix: &str,
+    value_local: u32,
+    candidates: &[&StructScalarBinding],
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let Some((candidate, rest)) = candidates.split_first() else {
+        out.push(0x00);
+        return Ok(());
+    };
+    let (global_index, _) = candidate.fields[suffix];
+    out.push(0x20);
+    uleb(base_local, out);
+    out.push(0x41);
+    sleb(candidate.base, out);
+    out.extend([0x46, 0x04, 0x40, 0x20]);
+    uleb(value_local, out);
+    out.push(0x24);
+    uleb(global_index, out);
+    out.push(0x05);
+    encode_scalar_field_store(base_local, suffix, value_local, rest, out)?;
+    out.push(0x0b);
+    Ok(())
+}
+
+fn encode_struct_field_store_from_local(
+    binding: &LocalBinding,
+    suffix: &str,
+    value_local: u32,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let view = binding
+        .struct_view
+        .ok_or_else(|| "web struct binding has no view metadata".to_string())?;
+    out.push(0x20);
+    uleb(view.index, out);
+    out.extend([0x41, 0, 0x48, 0x04, 0x40]);
+    let scalar_candidates = scalar_field_candidates(binding, suffix, context);
+    encode_scalar_field_store(binding.index, suffix, value_local, &scalar_candidates, out)?;
+    out.push(0x05);
+    let field = encode_struct_field_address(binding, suffix, context, out)?;
+    out.push(0x20);
+    uleb(value_local, out);
+    encode_memory_store(field.type_id, out)?;
+    out.push(0x0b);
+    Ok(())
+}
+
+fn encode_foreach_load(
+    binding: &WebForeachBinding,
+    suffix: &str,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    let memory = memory_binding(context, &binding.collection_path, suffix)?;
+    encode_memory_address(
+        memory,
+        &SimpleExpr::Identifier(binding.index_name.clone()),
+        context,
+        out,
+    )?;
+    encode_memory_load(memory.type_id, out)?;
+    Ok(memory.type_id)
+}
+
+fn encode_foreach_store(
+    binding: &WebForeachBinding,
+    suffix: &str,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let memory = memory_binding(context, &binding.collection_path, suffix)?;
+    let temp_index = scratch_local(context, memory.type_id)?;
+    out.push(0x21);
+    uleb(temp_index, out);
+    encode_memory_address(
+        memory,
+        &SimpleExpr::Identifier(binding.index_name.clone()),
+        context,
+        out,
+    )?;
+    out.push(0x20);
+    uleb(temp_index, out);
+    encode_memory_store(memory.type_id, out)
+}
+
 fn encode_memory_address(
     binding: &MemoryBinding,
     index: &SimpleExpr,
@@ -1006,8 +2189,10 @@ fn encode_memory_address(
     out: &mut Vec<u8>,
 ) -> Result<(), String> {
     let index_type = encode_expr(index, context, out)?;
-    if !is_i32_lane(index_type) {
-        return Err("web collection index must be i32-compatible".to_string());
+    if !is_web_index_type(index_type, context) {
+        return Err(format!(
+            "web collection index must be i32-compatible, found type {index_type}"
+        ));
     }
     out.push(0x21);
     uleb(context.scratch_index, out);
@@ -1024,10 +2209,40 @@ fn encode_memory_address(
     out.push(0x20);
     uleb(context.scratch_index, out);
     out.push(0x41);
-    sleb(storage_width(binding.type_id)? as i32, out);
+    sleb(binding.width as i32, out);
     out.push(0x6c);
     out.push(0x6a);
     Ok(())
+}
+
+fn encode_local_collection_address(
+    binding: LocalBinding,
+    index: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    let element_type = context
+        .types
+        .indexed_element_type_id(binding.type_id)
+        .ok_or_else(|| format!("web local type {} is not indexable", binding.type_id))?;
+    let width = storage_width(element_type, context.types, context.named_structs)?;
+    let index_type = encode_expr_as(index, Some(TYPE_ID_I32), context, out)?;
+    if !is_web_index_type(index_type, context) {
+        return Err("web local collection index must be i32-compatible".to_string());
+    }
+    out.push(0x21);
+    uleb(context.scratch_index, out);
+    out.push(0x20);
+    uleb(context.scratch_index, out);
+    out.extend([0x41, 0, 0x48, 0x04, 0x40, 0x00, 0x0b]);
+    out.push(0x20);
+    uleb(binding.index, out);
+    out.push(0x20);
+    uleb(context.scratch_index, out);
+    out.push(0x41);
+    sleb(width as i32, out);
+    out.extend([0x6c, 0x6a]);
+    Ok(element_type)
 }
 
 fn encode_memory_load(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
@@ -1037,6 +2252,7 @@ fn encode_memory_load(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> 
         TYPE_ID_I32 | TYPE_ID_U32 => (0x28, 2),
         TYPE_ID_F32 => (0x2a, 2),
         TYPE_ID_F64 => (0x2b, 3),
+        _ if wasm_value_type(type_id)? == I32 => (0x28, 2),
         _ => return Err(format!("unsupported web memory load type id {type_id}")),
     };
     out.push(opcode);
@@ -1052,6 +2268,7 @@ fn encode_memory_store(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String>
         TYPE_ID_I32 | TYPE_ID_U32 => (0x36, 2),
         TYPE_ID_F32 => (0x38, 2),
         TYPE_ID_F64 => (0x39, 3),
+        _ if wasm_value_type(type_id)? == I32 => (0x36, 2),
         _ => return Err(format!("unsupported web memory store type id {type_id}")),
     };
     out.push(opcode);
@@ -1115,10 +2332,27 @@ fn encode_expr_as(
             Ok(expected.unwrap_or(TYPE_ID_I32))
         }
         SimpleExpr::Identifier(name) => {
-            if let Some(binding) = context.locals.get(name) {
+            if let Some((binding, suffix)) = foreach_path(context, name) {
+                encode_foreach_load(binding, suffix, context, out)
+            } else if let Some((binding, suffix)) = local_collection_meta(context, name) {
+                let candidates = collection_meta_candidates(context, suffix);
+                encode_collection_meta_load(binding.index, suffix, &candidates, out);
+                Ok(TYPE_ID_I32)
+            } else if let Some((binding, suffix)) = local_struct_path(context, name) {
+                encode_struct_field_load(binding, suffix, context, out)
+            } else if let Some(binding) = context.locals.get(name) {
+                if binding.struct_view.is_some() {
+                    return Err(format!(
+                        "web struct view '{name}' requires a struct parameter or field access"
+                    ));
+                }
                 out.push(0x20);
                 uleb(binding.index, out);
                 Ok(binding.type_id)
+            } else if let Some(binding) = context.memory.get(name) {
+                out.push(0x41);
+                sleb(binding.offset as i32, out);
+                Ok(expected.unwrap_or(TYPE_ID_I32))
             } else if let Some(index) = context.globals.get(name) {
                 out.push(0x23);
                 uleb(*index, out);
@@ -1130,6 +2364,9 @@ fn encode_expr_as(
             }
         }
         SimpleExpr::Call { target, args } => {
+            if is_inline_intrinsic(target) {
+                return encode_inline_intrinsic(target, args, context, out);
+            }
             let index = context
                 .imports
                 .get(target)
@@ -1148,8 +2385,13 @@ fn encode_expr_as(
                 ));
             }
             for (arg, param_type) in args.iter().zip(signature.params.iter()) {
-                let actual = encode_expr_as(arg, Some(*param_type), context, out)?;
-                require_same_type(*param_type, actual, "call argument")?;
+                if is_struct_view_type(*param_type, context.named_structs) {
+                    let actual = encode_struct_view_expr(arg, context, out)?;
+                    require_same_struct_type(*param_type, actual, "call argument")?;
+                } else {
+                    let actual = encode_expr_as(arg, Some(*param_type), context, out)?;
+                    require_same_type(*param_type, actual, "call argument")?;
+                }
             }
             out.push(0x10);
             uleb(index, out);
@@ -1179,12 +2421,118 @@ fn encode_expr_as(
             index,
             suffix,
         } => {
+            if suffix.is_empty()
+                && expected
+                    .is_some_and(|type_id| is_struct_view_type(type_id, context.named_structs))
+            {
+                return Err(format!(
+                    "web struct collection element '{collection_path}' requires view context"
+                ));
+            }
+            if suffix.is_empty() {
+                if let Some(local) = context.locals.get(collection_path).copied() {
+                    let element_type = encode_local_collection_address(local, index, context, out)?;
+                    encode_memory_load(element_type, out)?;
+                    return Ok(element_type);
+                }
+            }
             let binding = memory_binding(context, collection_path, suffix)?;
             encode_memory_address(binding, index, context, out)?;
             encode_memory_load(binding.type_id, out)?;
             Ok(binding.type_id)
         }
     }
+}
+
+fn is_inline_intrinsic(target: &str) -> bool {
+    matches!(
+        target,
+        "i32_to_f32"
+            | "f32_to_i32"
+            | "fixed32_from_i32"
+            | "fixed32_to_i32"
+            | "fixed32_mul"
+            | "fixed32_div"
+            | "fixed32_from_ratio"
+    )
+}
+
+fn encode_inline_intrinsic(
+    target: &str,
+    args: &[SimpleExpr],
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<TypeId, String> {
+    let expected = if matches!(target, "fixed32_mul" | "fixed32_div" | "fixed32_from_ratio") {
+        2
+    } else {
+        1
+    };
+    if args.len() != expected {
+        return Err(format!(
+            "web intrinsic '{target}' expects {expected} argument(s), found {}",
+            args.len()
+        ));
+    }
+    match target {
+        "i32_to_f32" => {
+            let actual = encode_expr_as(&args[0], Some(TYPE_ID_I32), context, out)?;
+            require_same_type(TYPE_ID_I32, actual, "intrinsic argument")?;
+            out.push(0xb2);
+            Ok(TYPE_ID_F32)
+        }
+        "f32_to_i32" => {
+            let actual = encode_expr_as(&args[0], Some(TYPE_ID_F32), context, out)?;
+            require_same_type(TYPE_ID_F32, actual, "intrinsic argument")?;
+            out.push(0xa8);
+            Ok(TYPE_ID_I32)
+        }
+        "fixed32_from_i32" => {
+            encode_exact_i32_arg(&args[0], context, out)?;
+            out.extend([0x41, 16, 0x74]);
+            Ok(TYPE_ID_I32)
+        }
+        "fixed32_to_i32" => {
+            encode_exact_i32_arg(&args[0], context, out)?;
+            out.push(0x41);
+            sleb(65_536, out);
+            out.push(0x6d);
+            Ok(TYPE_ID_I32)
+        }
+        "fixed32_mul" => {
+            encode_exact_i32_arg(&args[0], context, out)?;
+            out.push(0xac);
+            encode_exact_i32_arg(&args[1], context, out)?;
+            out.extend([0xac, 0x7e, 0x42]);
+            sleb64(65_536, out);
+            out.extend([0x7f, 0xa7]);
+            Ok(TYPE_ID_I32)
+        }
+        "fixed32_div" | "fixed32_from_ratio" => {
+            encode_exact_i32_arg(&args[0], context, out)?;
+            out.extend([0xac, 0x42]);
+            sleb64(16, out);
+            out.push(0x86);
+            encode_exact_i32_arg(&args[1], context, out)?;
+            out.extend([0xac, 0x7f, 0xa7]);
+            Ok(TYPE_ID_I32)
+        }
+        _ => Err(format!("unknown web intrinsic '{target}'")),
+    }
+}
+
+fn encode_exact_i32_arg(
+    value: &SimpleExpr,
+    context: &EncodeContext<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), String> {
+    let actual = encode_expr_as(value, Some(TYPE_ID_I32), context, out)?;
+    if actual != TYPE_ID_I32 {
+        return Err(format!(
+            "web deterministic numeric intrinsic requires exact i32 argument, found {actual}"
+        ));
+    }
+    Ok(())
 }
 
 fn encode_constant(
@@ -1237,13 +2585,15 @@ fn encode_condition(
         }
         SimpleCondition::And(lhs, rhs) => {
             encode_condition(lhs, context, out)?;
+            out.extend([0x04, I32]);
             encode_condition(rhs, context, out)?;
-            out.push(0x71);
+            out.extend([0x05, 0x41, 0, 0x0b]);
         }
         SimpleCondition::Or(lhs, rhs) => {
             encode_condition(lhs, context, out)?;
+            out.extend([0x04, I32, 0x41, 1, 0x05]);
             encode_condition(rhs, context, out)?;
-            out.push(0x72);
+            out.push(0x0b);
         }
         SimpleCondition::Not(value) => {
             encode_condition(value, context, out)?;
@@ -1434,6 +2784,18 @@ fn sleb(mut value: i32, out: &mut Vec<u8>) {
     }
 }
 
+fn sleb64(mut value: i64, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        let done = (value == 0 && byte & 0x40 == 0) || (value == -1 && byte & 0x40 != 0);
+        out.push(if done { byte } else { byte | 0x80 });
+        if done {
+            break;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1454,5 +2816,119 @@ mod tests {
                 .windows(name.len())
                 .any(|window| window == name.as_bytes()));
         }
+    }
+
+    #[test]
+    fn release_wasm_keeps_internal_global_names_private() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "release.stasis",
+            "global internal_score: i32; function main(): i32 { internal_score = 4; return internal_score; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile release web module");
+        assert!(!process
+            .module_bytes()
+            .windows("internal_score".len())
+            .any(|window| window == b"internal_score"));
+        for exported in [
+            "__stasis_global_get_i32",
+            "__stasis_global_set_i32",
+            "main",
+            "tick",
+            "render",
+        ] {
+            assert!(process
+                .module_bytes()
+                .windows(exported.len())
+                .any(|window| window == exported.as_bytes()));
+        }
+    }
+
+    #[test]
+    fn passes_fixed_collection_offsets_to_array_view_host_imports() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "audio.stasis",
+            "global samples: f32[4]; extern function audio_push_f32_interleaved(values: f32[], frames: i32): i32; function main(): i32 { samples[0] = 0.25; return audio_push_f32_interleaved(samples, 2); } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile web audio view module");
+        assert_eq!(process.memory_layout()["samples"].offset, 0);
+        assert!(process
+            .module_bytes()
+            .windows("audio_push_f32_interleaved".len())
+            .any(|window| window == b"audio_push_f32_interleaved"));
+    }
+
+    #[test]
+    fn indexes_and_updates_internal_collection_views() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "views.stasis",
+            "global text: ascii[8]; function update(s: ascii[]): i32 { s[0] = 65; s.length = 1; return s[0] + s.length + s.max_length; } function main(): i32 { return update(text); } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile web collection views");
+    }
+
+    #[test]
+    fn lowers_foreach_over_struct_collection_storage() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "foreach.stasis",
+            "struct Item { value: i32, active: bool } global items: Item[4]; function main(): i32 { items[2].value = 7; items[2].active = true; return 0; } function tick(): i32 { foreach (let item, i in items) { if (item.active) { item.value += i; } } return items[2].value; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile web foreach module");
+        assert_eq!(process.memory_layout()["items.value"].length, 4);
+        assert_eq!(process.memory_layout()["items.active"].length, 4);
+    }
+
+    #[test]
+    fn passes_struct_collection_elements_as_native_shape_views() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "views.stasis",
+            "struct Item { value: i32, active: bool } global items: Item[4]; global chosen: Item; function read(item: Item): i32 { if (item.active) { return item.value; } return 0; } function main(): i32 { chosen.value = 3; chosen.active = true; items[2].value = 7; items[2].active = true; items[1] = items[2]; let selected: Item = items[1]; selected.value += read(chosen); return read(selected); } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile web struct views");
+        assert_eq!(process.memory_layout()["items.value"].length, 4);
+        assert!(process.module_bytes().starts_with(b"\0asm\x01\0\0\0"));
+    }
+
+    #[test]
+    fn lowers_numeric_intrinsics_without_fake_host_calls() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "intrinsics.stasis",
+            "function main(): i32 { let scaled: i32 = fixed32_mul(fixed32_from_i32(3), fixed32_from_ratio(1, 2)); let value: f32 = i32_to_f32(fixed32_to_i32(scaled)); return f32_to_i32(value); } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile web intrinsic module");
+        assert!(process.module_bytes().starts_with(b"\0asm\x01\0\0\0"));
+    }
+
+    #[test]
+    fn reuses_same_typed_local_names_from_disjoint_scopes() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "scopes.stasis",
+            "function main(): i32 { if (true) { let row: i32 = 2; } else { let row: i32 = 3; } if (true) { let row: i32 = 4; return row; } return 0; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile repeated scoped locals");
+    }
+
+    #[test]
+    fn lowers_boolean_conditions_with_native_short_circuit_semantics() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "short_circuit.stasis",
+            "global values: i32[2]; function main(): i32 { let index: i32 = -1; if (index >= 0 && values[index] == 0) { return 1; } if (index < 0 || values[index] == 0) { return 2; } return 0; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process.compile().expect("compile short-circuit conditions");
     }
 }

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -79,20 +79,6 @@ writes the existing command buffers; JavaScript owns only browser policy and hos
 same mapping predicts that another bounded renderer command can be added in the browser without
 changing gameplay code or introducing a second compiler path.
 
-ChessTD scale-gate reflection:
-
-- Good: compiling ChessTD unchanged exposed struct-view, short-circuit, storage, clipboard, portrait
-  window, and release-asset behavior that small fixtures could not represent.
-- Bad: copying the source asset tree initially produced a 92.5 MB standalone and duplicated embedded
-  assets into the static runtime.
-- Adjustment: Web packages now use the shared retained/prepared asset pipeline and keep embedded
-  data URLs exclusive to the standalone file.
-
-Theory gained: matching native collection layout is not sufficient by itself; control-flow
-semantics and host-visible view mutation are also part of the cross-target ABI. The observed
-negative-region guard predicts any future sentinel-index pattern will remain safe because Web now
-short-circuits before bounded memory access.
-
 Release optimization reflection:
 
 - Good: optimizing the already-linked Wasm module preserves a single compiler/runtime path while

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -27,17 +27,42 @@ The HUD reports current and worst observed `tick` and `render` time separately. 
 below 16 ms. Browser audio is unlocked by the **Enable sound** user gesture; subsequent
 `web_play_tone` calls originate in Stasis game logic.
 
-## Current compiler lane
+## Current compiler and host lane
 
-The first production web lane supports i32-compatible scalars (`i32`, `bool`, `u8`, `u16`, and
-`u32`), scalar globals, local variables, calls, arithmetic, conditions, `if`, and `for`. It emits a
-real WebAssembly module from the same compiler HIR used by JIT and AOT.
+The web backend emits a real WebAssembly module from the same reachable HIR used by JIT and AOT. It
+supports integer, boolean, `f32`, and `f64` values; scalar and structured-global fields; fixed
+primitive/SoA collection storage in exported Wasm memory; strings as stable compiler handles;
+conversions; calls; arithmetic; conditions; `if`; and `for`. Every indexed access receives a bounded
+Wasm trap check.
 
-Structured state, indexed collections, floating-point expressions, strings, `foreach`, and Stasis
-conversion statements currently fail with a deterministic `web scalar lane does not yet support`
-diagnostic. They are not substituted or interpreted in JavaScript. Expand this backend lane before
-packaging games that use those shapes.
+The browser reads the existing `gfx_cmd_i32`, `gfx_cmd_f32`, and `gfx_cmd_u8` command buffers. This
+keeps clear, line, rectangle, ordered sprite, and cached/dynamic text rendering on the same guest ABI
+as desktop/mobile. PNG, SVG, TTF, WAV, and MP3 assets are copied into the static bundle and embedded
+as data URLs in the standalone file. WebAudio playback requested during `main()` is queued until the
+required user gesture unlocks the audio context.
+
+`foreach`, general array-view parameters, native system helpers, and called overload families that
+cannot yet be selected from HIR identity still fail with deterministic web-backend diagnostics. They
+are not substituted or interpreted in JavaScript.
 
 `samples/web_export_smoke` is the end-to-end acceptance project. It verifies compiled movement,
 keyboard and pointer input, Canvas rendering, a Stasis-triggered WebAudio tone, the performance HUD,
 and the static plus standalone package layouts.
+
+The existing `samples/windows_launch_smoke` and `samples/audio_asset_playback` fixtures are also web
+package gates. Together they cover the shared graphics command buffers, PNG/SVG/font assets, and
+decoded WAV/MP3 WebAudio playback.
+
+## Slice reflection (2026-08-13)
+
+- Good: compiling the unchanged Windows rendering and audio fixtures exposed the exact storage,
+  qualified-call, asset, and browser-policy seams needed for a credible export target.
+- Bad: the first scalar slice treated parser assignment labels as semantic storage and emitted all
+  indexed functions, which hid global resolution and overload/reachability constraints.
+- Adjustment: every web lowering addition is now gated through reachable compiler HIR, semantic
+  global/collection tables, bounded memory accesses, and at least one existing-game package.
+
+Theory gained: the durable cross-platform boundary is a reachable Wasm guest that owns state and
+writes the existing command buffers; JavaScript owns only browser policy and host resources. The
+same mapping predicts that another bounded renderer command can be added in the browser without
+changing gameplay code or introducing a second compiler path.

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -10,7 +10,8 @@ Release toolchains omit `--development-build`. The default output is
 `dist/<project-name>-web/` and contains:
 
 - `<project-name>.html`: one self-contained package file that embeds the Wasm guest and browser runtime;
-- `index.html`, `game.js`, and `game.wasm`: an inspectable static-hosting bundle;
+- `play/index.html`, `play/game.js`, and `play/game.wasm`: an inspectable static-hosting bundle;
+- `assets/`: the same reachable, prepared release assets selected for Android/desktop packaging;
 - `stasis_provenance.json`: the normal package provenance receipt.
 
 The static bundle must be served over HTTP. The self-contained HTML package does not fetch local
@@ -20,8 +21,9 @@ files and can also be opened directly.
 
 The browser owns `requestAnimationFrame`, input collection, Canvas 2D command execution, WebAudio,
 and the performance HUD. The compiled Wasm guest owns `main`, `tick`, `render`, and game state.
-Browser calls are explicit `@extern` functions in the `web_*` namespace. Draw imports enqueue
-commands and the host executes the queue after `render()` returns.
+The browser populates the canonical HostFrame arrays and consumes the existing graphics command
+buffers, matching Android/Windows. Browser policy (fullscreen gestures, Clipboard API, local
+storage, and WebAudio unlocking) remains in JavaScript.
 
 The HUD reports current and worst observed `tick` and `render` time separately. Both must remain
 below 16 ms. Browser audio is unlocked by the **Enable sound** user gesture; subsequent
@@ -31,19 +33,21 @@ below 16 ms. Browser audio is unlocked by the **Enable sound** user gesture; sub
 
 The web backend emits a real WebAssembly module from the same reachable HIR used by JIT and AOT. It
 supports integer, boolean, `f32`, and `f64` values; scalar and structured-global fields; fixed
-primitive/SoA collection storage in exported Wasm memory; strings as stable compiler handles;
-conversions; calls; arithmetic; conditions; `if`; and `for`. Every indexed access receives a bounded
-Wasm trap check.
+primitive/SoA collection storage; native-shape three-word struct views; internal collection views;
+strings as stable compiler handles; conversions; calls; arithmetic; short-circuit conditions;
+`if`; `for`; and `foreach`. Every indexed access receives a bounded Wasm trap check.
 
 The browser reads the existing `gfx_cmd_i32`, `gfx_cmd_f32`, and `gfx_cmd_u8` command buffers. This
 keeps clear, line, rectangle, ordered sprite, and cached/dynamic text rendering on the same guest ABI
-as desktop/mobile. PNG, SVG, TTF, WAV, and MP3 assets are copied into the static bundle and embedded
-as data URLs in the standalone file. WebAudio playback requested during `main()` is queued until the
-required user gesture unlocks the audio context.
+as desktop/mobile. Release asset validation and preparation retain only reachable manifest assets;
+PNG, SVG, TTF, WAV, and MP3 files are placed under `assets/` and embedded as data URLs only in the
+standalone file. WebAudio playback requested during `main()` is queued until the required user
+gesture unlocks the audio context.
 
-`foreach`, general array-view parameters, native system helpers, and called overload families that
-cannot yet be selected from HIR identity still fail with deterministic web-backend diagnostics. They
-are not substituted or interpreted in JavaScript.
+Release Wasm exports lifecycle/host-access functions and memory, but keeps Stasis globals private.
+Development packages additionally export globals and full reachable function names for diagnostics;
+release name metadata retains only exported function names. Called overload families that cannot be
+selected from HIR identity still fail with deterministic diagnostics.
 
 `samples/web_export_smoke` is the end-to-end acceptance project. It verifies compiled movement,
 keyboard and pointer input, Canvas rendering, a Stasis-triggered WebAudio tone, the performance HUD,
@@ -66,3 +70,17 @@ Theory gained: the durable cross-platform boundary is a reachable Wasm guest tha
 writes the existing command buffers; JavaScript owns only browser policy and host resources. The
 same mapping predicts that another bounded renderer command can be added in the browser without
 changing gameplay code or introducing a second compiler path.
+
+ChessTD scale-gate reflection:
+
+- Good: compiling ChessTD unchanged exposed struct-view, short-circuit, storage, clipboard, portrait
+  window, and release-asset behavior that small fixtures could not represent.
+- Bad: copying the source asset tree initially produced a 92.5 MB standalone and duplicated embedded
+  assets into the static runtime.
+- Adjustment: Web packages now use the shared retained/prepared asset pipeline and keep embedded
+  data URLs exclusive to the standalone file.
+
+Theory gained: matching native collection layout is not sufficient by itself; control-flow
+semantics and host-visible view mutation are also part of the cross-target ABI. The observed
+negative-region guard predicts any future sentinel-index pattern will remain safe because Web now
+short-circuits before bounded memory access.

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -1,0 +1,43 @@
+# Web packaging
+
+Stasis packages a browser game with the same `package` command used for desktop and mobile:
+
+```text
+stasis package --target web --development-build
+```
+
+Release toolchains omit `--development-build`. The default output is
+`dist/<project-name>-web/` and contains:
+
+- `<project-name>.html`: one self-contained package file that embeds the Wasm guest and browser runtime;
+- `index.html`, `game.js`, and `game.wasm`: an inspectable static-hosting bundle;
+- `stasis_provenance.json`: the normal package provenance receipt.
+
+The static bundle must be served over HTTP. The self-contained HTML package does not fetch local
+files and can also be opened directly.
+
+## Runtime contract
+
+The browser owns `requestAnimationFrame`, input collection, Canvas 2D command execution, WebAudio,
+and the performance HUD. The compiled Wasm guest owns `main`, `tick`, `render`, and game state.
+Browser calls are explicit `@extern` functions in the `web_*` namespace. Draw imports enqueue
+commands and the host executes the queue after `render()` returns.
+
+The HUD reports current and worst observed `tick` and `render` time separately. Both must remain
+below 16 ms. Browser audio is unlocked by the **Enable sound** user gesture; subsequent
+`web_play_tone` calls originate in Stasis game logic.
+
+## Current compiler lane
+
+The first production web lane supports i32-compatible scalars (`i32`, `bool`, `u8`, `u16`, and
+`u32`), scalar globals, local variables, calls, arithmetic, conditions, `if`, and `for`. It emits a
+real WebAssembly module from the same compiler HIR used by JIT and AOT.
+
+Structured state, indexed collections, floating-point expressions, strings, `foreach`, and Stasis
+conversion statements currently fail with a deterministic `web scalar lane does not yet support`
+diagnostic. They are not substituted or interpreted in JavaScript. Expand this backend lane before
+packaging games that use those shapes.
+
+`samples/web_export_smoke` is the end-to-end acceptance project. It verifies compiled movement,
+keyboard and pointer input, Canvas rendering, a Stasis-triggered WebAudio tone, the performance HUD,
+and the static plus standalone package layouts.

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -14,6 +14,13 @@ Release toolchains omit `--development-build`. The default output is
 - `assets/`: the same reachable, prepared release assets selected for Android/desktop packaging;
 - `stasis_provenance.json`: the normal package provenance receipt.
 
+Release packaging runs Binaryen's `wasm-opt -Oz` when `wasm-opt` is on `PATH`. Set
+`STASIS_WASM_OPT` to an explicit executable path for pinned toolchains or CI. A configured
+optimizer that fails aborts packaging; when no optimizer is discoverable, packaging succeeds with
+the original module and reports `wasm_optimized: false` in JSON output. Development packages skip
+optimization so their full diagnostic names remain available. The optimized bytes are shared by
+`play/game.wasm` and the self-contained HTML file.
+
 The static bundle must be served over HTTP. The self-contained HTML package does not fetch local
 files and can also be opened directly.
 
@@ -46,8 +53,9 @@ gesture unlocks the audio context.
 
 Release Wasm exports lifecycle/host-access functions and memory, but keeps Stasis globals private.
 Development packages additionally export globals and full reachable function names for diagnostics;
-release name metadata retains only exported function names. Called overload families that cannot be
-selected from HIR identity still fail with deterministic diagnostics.
+release export names remain in the Wasm export section while `wasm-opt` may discard the optional
+custom name section. Called overload families that cannot be selected from HIR identity still fail
+with deterministic diagnostics.
 
 `samples/web_export_smoke` is the end-to-end acceptance project. It verifies compiled movement,
 keyboard and pointer input, Canvas rendering, a Stasis-triggered WebAudio tone, the performance HUD,
@@ -84,3 +92,15 @@ Theory gained: matching native collection layout is not sufficient by itself; co
 semantics and host-visible view mutation are also part of the cross-target ABI. The observed
 negative-region guard predicts any future sentinel-index pattern will remain safe because Web now
 short-circuits before bounded memory access.
+
+Release optimization reflection:
+
+- Good: optimizing the already-linked Wasm module preserves a single compiler/runtime path while
+  reducing both the hosted payload and the standalone base64 payload.
+- Bad: relying only on process `PATH` makes long-running build agents miss newly installed tools.
+- Adjustment: release packaging accepts an explicit `STASIS_WASM_OPT` path and reports whether
+  optimization was actually applied, including before/after byte counts.
+
+Theory gained: Wasm size optimization belongs after semantic lowering and linking but before either
+package layout is assembled. The same optimized byte vector can therefore feed both outputs without
+creating target-specific behavior, and a browser acceptance pass validates the preserved host ABI.

--- a/docs/webassembly-game-requirements.md
+++ b/docs/webassembly-game-requirements.md
@@ -8,11 +8,12 @@ This is based on the current `main` codebase, not on a hypothetical redesign.
 
 ## Executive Summary
 
-Implementation status (2026-08-13): the first scalar web export lane is implemented. `stasis
-package --target web` emits a real Wasm guest, a browser host, and both static and self-contained
-HTML packages. See `docs/web_packaging.md` for the supported compiler lane and acceptance project.
-Structured state, collections, float/string expressions, and packaged asset APIs remain explicit
-follow-on work.
+Implementation status (2026-08-13): `stasis package --target web` emits a real Wasm guest, a browser
+host, and both static and self-contained HTML packages. The web backend now covers scalar and
+structured-global fields, fixed collection memory, integer/float expressions, stable string
+handles, and the existing graphics command-buffer ABI. The browser host packages PNG/SVG/font and
+WAV/MP3 assets and implements Canvas and WebAudio. See `docs/web_packaging.md` for remaining compiler
+limits and acceptance fixtures.
 
 Stasis game code is already structurally close to a browser-friendly model:
 

--- a/docs/webassembly-game-requirements.md
+++ b/docs/webassembly-game-requirements.md
@@ -8,6 +8,12 @@ This is based on the current `main` codebase, not on a hypothetical redesign.
 
 ## Executive Summary
 
+Implementation status (2026-08-13): the first scalar web export lane is implemented. `stasis
+package --target web` emits a real Wasm guest, a browser host, and both static and self-contained
+HTML packages. See `docs/web_packaging.md` for the supported compiler lane and acceptance project.
+Structured state, collections, float/string expressions, and packaged asset APIs remain explicit
+follow-on work.
+
 Stasis game code is already structurally close to a browser-friendly model:
 
 - gameplay state is explicit

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -6,7 +6,7 @@
   const audioButton = document.getElementById("stasis-audio");
   const errorBox = document.getElementById("stasis-error");
   const keys = new Set();
-  const pointer = { x: 0, down: false };
+  const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, down: false, wentDown: false, wentUp: false };
   const commands = [];
   const game = window.STASIS_GAME || { strings: {}, memory: {}, assets: {} };
   const sprites = new Map();
@@ -16,16 +16,82 @@
   let instance;
   let audioContext;
   let audioEvents = 0;
+  let audioSampleRate = 48000;
+  let audioChannels = 2;
+  let audioNextStart = 0;
+  let audioUnderruns = 0;
   const audioAssets = new Map();
   const audioVoices = new Map();
   const pendingAudio = [];
+  const volatileStorage = new Map();
+  let clipboardText = "";
   let frames = 0;
+  let tickIndex = 0;
+  let resized = true;
+  let displayGeneration = 1;
+  let densityGeneration = 1;
+  let lastWindowRequest = -1;
+  let pendingFullscreen;
   let worstTick = 0;
   let worstRender = 0;
+  const startedAt = performance.now();
 
   const color = (r, g, b) => `rgb(${r & 255} ${g & 255} ${b & 255})`;
   const stringValue = id => game.strings[String(id)] || "";
-  const assetValue = id => game.assets[stringValue(id)] || stringValue(id);
+  const assetKey = value => value.replace(/^(?:\.\.\/|\.\/)+/, "");
+  const assetValue = id => {
+    const value = stringValue(id);
+    return game.assets[assetKey(value)] || value;
+  };
+  const storageKey = (scopeId, keyId) => `stasis:${stringValue(scopeId)}:${stringValue(keyId)}`;
+  const storageGet = key => {
+    try { return localStorage.getItem(key); } catch (_) { return volatileStorage.get(key) ?? null; }
+  };
+  const storageSet = (key, value) => {
+    try { localStorage.setItem(key, value); } catch (_) { volatileStorage.set(key, value); }
+    return 1;
+  };
+  const readAscii = (offset, length) => {
+    if (!instance?.exports.memory || offset < 0 || length < 0) return "";
+    const bytes = new Uint8Array(instance.exports.memory.buffer, offset, length);
+    return String.fromCharCode(...bytes);
+  };
+  const writeAscii = (offset, capacity, value) => {
+    if (!instance?.exports.memory || offset < 0 || capacity <= 0) return -1;
+    const bytes = Array.from(value, character => character.codePointAt(0));
+    if (bytes.some(value => value < 32 || value > 126) || bytes.length >= capacity) return -1;
+    const target = new Uint8Array(instance.exports.memory.buffer, offset, capacity);
+    target.fill(0);
+    target.set(bytes);
+    return bytes.length;
+  };
+  const setViewField = (base, index, field, value) => {
+    const path = game.views?.[String(base)]?.[field];
+    if (!path) return false;
+    if (index < 0) {
+      const global = instance?.exports?.[path];
+      if (global instanceof WebAssembly.Global) {
+        global.value = value;
+        return true;
+      }
+      const metadata = game.globals?.[path];
+      if (!metadata) return false;
+      const setter = metadata.type_id === 2
+        ? instance?.exports?.__stasis_global_set_f32
+        : instance?.exports?.__stasis_global_set_i32;
+      return typeof setter === "function" && setter(metadata.hash, value) !== 0;
+    }
+    const layout = game.memory?.[path];
+    if (!layout || index >= layout.length || !instance?.exports.memory) return false;
+    const offset = layout.offset + index * layout.stride;
+    const view = new DataView(instance.exports.memory.buffer);
+    if (layout.type_id === 2) view.setFloat32(offset, value, true);
+    else if (layout.type_id === 4) view.setFloat64(offset, value, true);
+    else if (layout.type_id === 5 || layout.type_id === 3) view.setUint8(offset, value);
+    else if (layout.type_id === 6) view.setUint16(offset, value, true);
+    else view.setInt32(offset, value, true);
+    return true;
+  };
   const loadSprite = pathId => {
     const handle = nextHandle++;
     const image = new Image();
@@ -86,7 +152,41 @@
     if (voice) voice.source.stop();
     audioVoices.delete(handle);
   };
+  const pushAudio = (byteOffset, frameCount) => {
+    if (!instance?.exports.memory || frameCount <= 0) return 0;
+    const sampleCount = frameCount * audioChannels;
+    if (byteOffset < 0 || byteOffset + sampleCount * 4 > instance.exports.memory.buffer.byteLength) return 0;
+    const samples = new Float32Array(instance.exports.memory.buffer, byteOffset, sampleCount).slice();
+    const start = async () => {
+      const audio = ensureAudio();
+      const buffer = audio.createBuffer(audioChannels, frameCount, audioSampleRate);
+      for (let channel = 0; channel < audioChannels; channel += 1) {
+        const output = buffer.getChannelData(channel);
+        for (let frame = 0; frame < frameCount; frame += 1) output[frame] = samples[frame * audioChannels + channel];
+      }
+      const source = audio.createBufferSource();
+      source.buffer = buffer;
+      source.connect(audio.destination);
+      const earliest = audio.currentTime + 0.005;
+      if (audioNextStart > 0 && audioNextStart < audio.currentTime) audioUnderruns += 1;
+      const startAt = Math.max(earliest, audioNextStart);
+      source.start(startAt);
+      audioNextStart = startAt + frameCount / audioSampleRate;
+      audioEvents += 1;
+      document.body.dataset.audioEvents = String(audioEvents);
+      document.body.dataset.audioMode = "stream";
+    };
+    if (!audioContext || audioContext.state !== "running") pendingAudio.push(start);
+    else void start();
+    return frameCount;
+  };
   const imports = { env: {
+    sin_fast: value => Math.sin(value),
+    cos_fast: value => Math.cos(value),
+    print_i32: value => console.log(value),
+    print_int: value => console.log(value),
+    print_char: value => console.log(String.fromCodePoint(value)),
+    print_string: value => console.log(stringValue(value)),
     web_input_axis: () => (keys.has("ArrowRight") || keys.has("KeyD") ? 1 : 0) - (keys.has("ArrowLeft") || keys.has("KeyA") ? 1 : 0),
     web_input_fire: () => keys.has("Space") || pointer.down ? 1 : 0,
     web_pointer_x: () => pointer.x | 0,
@@ -112,17 +212,81 @@
     stasis_gfx_load_sprite: pathId => loadSprite(pathId),
     load_font: (pathId, size) => loadFont(pathId, size),
     stasis_load_font: (pathId, size) => loadFont(pathId, size),
+    stasis_jit_sprite_load_from: (base, index, _len, pathId, width, height) => {
+      const handle = loadSprite(pathId);
+      return setViewField(base, index, "handle", handle)
+        && setViewField(base, index, "width", width)
+        && setViewField(base, index, "height", height) ? 1 : 0;
+    },
     stasis_jit_gfx_cache_text: (font, textId) => {
       const handle = nextHandle++;
       cachedText.set(handle, { font, text: stringValue(textId) });
       return handle;
     },
-    audio_init: () => { ensureAudio(); return 1; },
+    stasis_jit_text_run_load_from: (base, index, _len, font, textId) => {
+      const handle = nextHandle++;
+      const text = stringValue(textId);
+      cachedText.set(handle, { font, text });
+      const fontInfo = fonts.get(font) || { size: 16 };
+      return setViewField(base, index, "font", font)
+        && setViewField(base, index, "handle", handle)
+        && setViewField(base, index, "width", text.length * fontInfo.size * 0.6)
+        && setViewField(base, index, "height", fontInfo.size) ? 1 : 0;
+    },
+    storage_load_i32: (scope, key, fallback) => {
+      const value = storageGet(storageKey(scope, key));
+      if (value === null || !/^-?\d+$/.test(value)) return fallback;
+      const parsed = Number(value);
+      return Number.isSafeInteger(parsed) ? parsed | 0 : fallback;
+    },
+    storage_save_i32: (scope, key, value) => storageSet(storageKey(scope, key), String(value | 0)),
+    stasis_jit_storage_load_ascii: (scope, key, out, capacity) => {
+      const value = storageGet(storageKey(scope, key));
+      return value === null ? -1 : writeAscii(out, capacity, value);
+    },
+    stasis_jit_storage_save_ascii: (scope, key, value, length) =>
+      storageSet(storageKey(scope, key), readAscii(value, length)),
+    stasis_jit_clipboard_load_ascii: (out, capacity) =>
+      clipboardText ? writeAscii(out, capacity, clipboardText) : -1,
+    stasis_jit_clipboard_save_ascii: (value, length) => {
+      clipboardText = readAscii(value, length);
+      if (navigator.clipboard?.writeText) void navigator.clipboard.writeText(clipboardText).catch(() => {});
+      return 1;
+    },
+    audio_init: (sampleRate, channels) => {
+      audioSampleRate = Math.max(8000, Math.min(sampleRate || 48000, 192000));
+      audioChannels = Math.max(1, Math.min(channels || 2, 2));
+      ensureAudio();
+      return 1;
+    },
+    audio_shutdown: () => {
+      for (const handle of Array.from(audioVoices.keys())) stopAudio(handle);
+      if (audioContext) void audioContext.close();
+      audioContext = undefined;
+      audioNextStart = 0;
+    },
     audio_is_available: () => 1,
-    audio_get_sample_rate: () => 48000,
-    audio_get_channels: () => 2,
-    audio_get_queued_frames: () => 0,
-    audio_get_underruns: () => 0,
+    audio_get_sample_rate: () => audioSampleRate,
+    audio_get_channels: () => audioChannels,
+    audio_get_queued_frames: () => audioContext ? Math.max(0, Math.round((audioNextStart - audioContext.currentTime) * audioSampleRate)) : 0,
+    audio_get_underruns: () => audioUnderruns,
+    audio_push_f32_interleaved: (byteOffset, frameCount) => pushAudio(byteOffset, frameCount),
+    audio_load_wav: pathId => loadAudio(pathId),
+    audio_release: handle => { audioAssets.delete(handle); stopAudio(handle); },
+    audio_play: (handle, loop, volume) => startAudio(handle, loop, volume) ? handle : 0,
+    audio_stop: handle => stopAudio(handle),
+    audio_voice_is_playing: handle => audioVoices.has(handle) ? 1 : 0,
+    audio_voice_set_paused: (handle, paused) => {
+      const voice = audioVoices.get(handle);
+      if (!voice || voice.paused === Boolean(paused)) return;
+      if (paused) voice.source.disconnect();
+      else voice.source.connect(voice.gain);
+      voice.paused = Boolean(paused);
+    },
+    audio_voice_set_volume_pan: (handle, volume) => {
+      const voice = audioVoices.get(handle);
+      if (voice) voice.gain.gain.value = Math.max(0, Math.min(1, volume));
+    },
     stasis_jit_audio_load_music: pathId => loadAudio(pathId),
     stasis_jit_audio_load_effect: pathId => loadAudio(pathId),
     stasis_jit_audio_play_music: (handle, loop, volume) => startAudio(handle, loop, volume) ? 1 : 0,
@@ -140,6 +304,10 @@
       if (voice) voice.gain.gain.value = Math.max(0, Math.min(1, volume));
     }
   }};
+
+  document.addEventListener("paste", event => {
+    clipboardText = event.clipboardData?.getData("text/plain") || clipboardText;
+  });
 
   function executeCommands() {
     for (const command of commands) {
@@ -252,7 +420,156 @@
     }
   }
 
-  function frame() {
+  function sdlScancode(code) {
+    if (/^Key[A-Z]$/.test(code)) return code.charCodeAt(3) - 65 + 4;
+    if (/^Digit[1-9]$/.test(code)) return Number(code[5]) + 29;
+    const values = {
+      Digit0: 39, Enter: 40, Escape: 41, Backspace: 42, Tab: 43, Space: 44,
+      Minus: 45, Equal: 46, BracketLeft: 47, BracketRight: 48, Backslash: 49,
+      Semicolon: 51, Quote: 52, Backquote: 53, Comma: 54, Period: 55, Slash: 56,
+      CapsLock: 57, PrintScreen: 70, ScrollLock: 71, Pause: 72, Insert: 73,
+      Home: 74, PageUp: 75, Delete: 76, End: 77, PageDown: 78,
+      ArrowRight: 79, ArrowLeft: 80, ArrowDown: 81, ArrowUp: 82,
+      NumLock: 83, NumpadDivide: 84, NumpadMultiply: 85, NumpadSubtract: 86,
+      NumpadAdd: 87, NumpadEnter: 88, NumpadDecimal: 99, IntlBackslash: 100,
+      ContextMenu: 101, ControlLeft: 224, ShiftLeft: 225, AltLeft: 226,
+      MetaLeft: 227, ControlRight: 228, ShiftRight: 229, AltRight: 230, MetaRight: 231
+    };
+    if (/^F(?:[1-9]|1[0-2])$/.test(code)) return Number(code.slice(1)) + 57;
+    if (/^Numpad[1-9]$/.test(code)) return Number(code[6]) + 88;
+    if (code === "Numpad0") return 98;
+    return values[code];
+  }
+
+  function writeHostFrame(timestamp) {
+    const iLayout = game.memory.host_i32;
+    const fLayout = game.memory.host_f32;
+    if (!iLayout || !fLayout || !instance.exports.memory) return;
+    const i32 = new Int32Array(instance.exports.memory.buffer, iLayout.offset, iLayout.length);
+    const f32 = new Float32Array(instance.exports.memory.buffer, fLayout.offset, fLayout.length);
+    i32.fill(0);
+    f32.fill(0);
+    const elapsedMs = timestamp - startedAt;
+    const bounds = canvas.getBoundingClientRect();
+    const ratio = devicePixelRatio || 1;
+    const focused = document.hasFocus() ? 1 : 0;
+    const pointerCount = pointer.down || pointer.wentDown || pointer.wentUp ? 1 : 0;
+    i32[0] = Math.floor(elapsedMs) | 0;
+    i32[7] = pointerCount;
+    i32[8] = 0;
+    i32[9] = 0;
+    i32[10] = tickIndex++;
+    i32[11] = resized ? 1 : 0;
+    i32[12] = Math.round(screen.width * ratio);
+    i32[13] = Math.round(screen.height * ratio);
+    i32[14] = 3;
+    i32[15] = (focused ? 2 : 0) | (document.hidden ? 4 : 0) | (resized ? 8 : 0);
+    i32[16] = 0;
+    i32[17] = focused;
+    i32[18] = document.hidden ? 1 : 0;
+    i32[19] = Math.floor(elapsedMs * 1000) | 0;
+    i32[22] = Math.round(screen.width * ratio);
+    i32[23] = Math.round(screen.height * ratio);
+    i32[24] = Math.round(bounds.width * ratio);
+    i32[25] = Math.round(bounds.height * ratio);
+    i32[30] = displayGeneration;
+    i32[31] = densityGeneration;
+    for (const code of keys) {
+      const scancode = sdlScancode(code);
+      if (scancode !== undefined && scancode < 512) i32[32 + scancode] = 1;
+    }
+    if (pointerCount) {
+      i32[544] = pointer.id;
+      i32[545] = pointer.down ? 1 : 0;
+      i32[546] = pointer.wentDown ? 1 : 0;
+      i32[547] = pointer.wentUp ? 1 : 0;
+      f32[0] = pointer.x;
+      f32[1] = pointer.y;
+      f32[2] = pointer.dx;
+      f32[3] = pointer.dy;
+      f32[4] = canvas.width ? pointer.x / canvas.width : 0;
+      f32[5] = canvas.height ? pointer.y / canvas.height : 0;
+    }
+    f32[48] = ratio;
+    f32[49] = ratio;
+    f32[50] = canvas.width;
+    f32[51] = canvas.height;
+    f32[52] = 0;
+    f32[53] = 0;
+    f32[54] = canvas.width;
+    f32[55] = canvas.height;
+    document.body.dataset.hostTick = String(i32[10]);
+    document.body.dataset.hostTimeMs = String(i32[0]);
+    if (resized) document.body.dataset.resizeTick = String(i32[10]);
+    resized = false;
+  }
+
+  function finishHostFrame() {
+    pointer.wentDown = false;
+    pointer.wentUp = false;
+    pointer.dx = 0;
+    pointer.dy = 0;
+  }
+
+  function exportedI32(name) {
+    const value = instance?.exports[name];
+    if (value && typeof value.value === "number") return value.value;
+    const metadata = game.globals?.[name];
+    const getter = instance?.exports?.__stasis_global_get_i32;
+    return metadata && typeof getter === "function" ? getter(metadata.hash) : undefined;
+  }
+
+  function setCanvasSize(width, height) {
+    width = Math.max(1, Math.min(width | 0, 8192));
+    height = Math.max(1, Math.min(height | 0, 8192));
+    if (canvas.width === width && canvas.height === height) return;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.aspectRatio = `${width} / ${height}`;
+    canvas.parentElement.style.width = `min(100vw, calc(100vh * ${width} / ${height}))`;
+    resized = true;
+    displayGeneration += 1;
+  }
+
+  function applyWindowRequest() {
+    const sequence = exportedI32("host_req_seq");
+    if (sequence === undefined || sequence === lastWindowRequest) return;
+    lastWindowRequest = sequence;
+    const flags = exportedI32("host_req_flags") || 0;
+    const width = exportedI32("host_req_window_w_px") || canvas.width;
+    const height = exportedI32("host_req_window_h_px") || canvas.height;
+    if (flags & 1) {
+      canvas.style.width = "";
+      canvas.style.height = "";
+      setCanvasSize(width, height);
+      pendingFullscreen = false;
+      document.body.dataset.windowMode = "windowed";
+    } else if (flags & 2) {
+      pendingFullscreen = true;
+      document.body.dataset.windowMode = "fullscreen-pending";
+    } else if (flags & 4) {
+      setCanvasSize(width, height);
+      document.body.dataset.windowMode = "maximized";
+      resized = true;
+    }
+    document.body.dataset.windowRequestSeq = String(sequence);
+  }
+
+  async function applyFullscreenGesture() {
+    if (pendingFullscreen === undefined) return;
+    try {
+      if (pendingFullscreen && !document.fullscreenElement) await canvas.requestFullscreen();
+      if (!pendingFullscreen && document.fullscreenElement) await document.exitFullscreen();
+      document.body.dataset.windowMode = pendingFullscreen ? "fullscreen" : "windowed";
+      pendingFullscreen = undefined;
+    } catch (error) {
+      document.body.dataset.fullscreenError = String(error);
+    }
+  }
+
+  function frame(timestamp) {
+    applyWindowRequest();
+    writeHostFrame(timestamp);
     const tickStart = performance.now();
     instance.exports.tick();
     const tickMs = performance.now() - tickStart;
@@ -274,20 +591,45 @@
     document.body.dataset.worstRenderMs = worstRender.toFixed(3);
     document.body.dataset.underBudget = String(underBudget);
     if (instance.exports.player_x) document.body.dataset.playerX = String(instance.exports.player_x.value);
+    finishHostFrame();
     requestAnimationFrame(frame);
   }
 
   function updatePointer(event) {
     const bounds = canvas.getBoundingClientRect();
-    pointer.x = Math.round((event.clientX - bounds.left) * canvas.width / bounds.width);
+    const x = Math.round((event.clientX - bounds.left) * canvas.width / bounds.width);
+    const y = Math.round((event.clientY - bounds.top) * canvas.height / bounds.height);
+    pointer.dx += x - pointer.x;
+    pointer.dy += y - pointer.y;
+    pointer.x = x;
+    pointer.y = y;
+    pointer.id = event.pointerId | 0;
   }
-  addEventListener("keydown", event => { keys.add(event.code); if (["ArrowLeft", "ArrowRight", "Space"].includes(event.code)) event.preventDefault(); });
-  addEventListener("keyup", event => keys.delete(event.code));
+  addEventListener("keydown", event => {
+    keys.add(event.code);
+    void applyFullscreenGesture();
+    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"].includes(event.code)) event.preventDefault();
+  });
+  addEventListener("keyup", event => { keys.delete(event.code); void applyFullscreenGesture(); });
   canvas.addEventListener("pointermove", updatePointer);
-  canvas.addEventListener("pointerdown", event => { updatePointer(event); pointer.down = true; canvas.setPointerCapture(event.pointerId); canvas.focus(); });
-  canvas.addEventListener("pointerup", event => { updatePointer(event); pointer.down = false; });
-  canvas.addEventListener("pointercancel", () => { pointer.down = false; });
+  canvas.addEventListener("pointerdown", event => {
+    updatePointer(event);
+    pointer.down = true;
+    pointer.wentDown = true;
+    canvas.setPointerCapture(event.pointerId);
+    canvas.focus();
+    void applyFullscreenGesture();
+  });
+  canvas.addEventListener("pointerup", event => {
+    updatePointer(event);
+    pointer.down = false;
+    pointer.wentUp = true;
+  });
+  canvas.addEventListener("pointercancel", () => { pointer.down = false; pointer.wentUp = true; });
+  addEventListener("resize", () => { resized = true; displayGeneration += 1; });
+  document.addEventListener("fullscreenchange", () => { resized = true; displayGeneration += 1; });
   audioButton.addEventListener("click", async () => {
+    await applyFullscreenGesture();
     audioContext ||= new AudioContext();
     await audioContext.resume();
     for (const start of pendingAudio.splice(0)) await start();
@@ -311,16 +653,10 @@
     try {
       const result = await WebAssembly.instantiate(await wasmBytes(), imports);
       instance = result.instance;
+      writeHostFrame(performance.now());
       const mainResult = instance.exports.main();
-      if (instance.exports.host_req_window_w_px && instance.exports.host_req_window_h_px) {
-        const width = instance.exports.host_req_window_w_px.value;
-        const height = instance.exports.host_req_window_h_px.value;
-        if (width > 0 && height > 0) {
-          canvas.width = width;
-          canvas.height = height;
-          canvas.style.aspectRatio = `${width} / ${height}`;
-        }
-      }
+      finishHostFrame();
+      applyWindowRequest();
       await Promise.all([
         ...Array.from(sprites.values(), image => image.decode().catch(() => undefined)),
         document.fonts.ready
@@ -331,6 +667,16 @@
       requestAnimationFrame(frame);
     } catch (error) {
       document.body.dataset.ready = "false";
+      if (instance) {
+        for (const [label, name] of [
+          ["debugPhaseCount", "state.active_run_definition.phase_count"],
+          ["debugSimulationTicks", "state.game.simulation_ticks"],
+          ["debugRunEnabled", "state.active_run_definition.enabled"]
+        ]) {
+          const value = instance.exports[name];
+          if (value instanceof WebAssembly.Global) document.body.dataset[label] = String(value.value);
+        }
+      }
       errorBox.textContent = String(error && error.stack || error);
       throw error;
     }

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -1,0 +1,127 @@
+(() => {
+  "use strict";
+  const canvas = document.getElementById("stasis-canvas");
+  const context = canvas.getContext("2d", { alpha: false });
+  const hud = document.getElementById("stasis-hud");
+  const audioButton = document.getElementById("stasis-audio");
+  const errorBox = document.getElementById("stasis-error");
+  const keys = new Set();
+  const pointer = { x: 0, down: false };
+  const commands = [];
+  let instance;
+  let audioContext;
+  let audioEvents = 0;
+  let frames = 0;
+  let worstTick = 0;
+  let worstRender = 0;
+
+  const color = (r, g, b) => `rgb(${r & 255} ${g & 255} ${b & 255})`;
+  const imports = { env: {
+    web_input_axis: () => (keys.has("ArrowRight") || keys.has("KeyD") ? 1 : 0) - (keys.has("ArrowLeft") || keys.has("KeyA") ? 1 : 0),
+    web_input_fire: () => keys.has("Space") || pointer.down ? 1 : 0,
+    web_pointer_x: () => pointer.x | 0,
+    web_pointer_down: () => pointer.down ? 1 : 0,
+    web_begin_frame: (r, g, b) => { commands.length = 0; commands.push([0, r, g, b]); },
+    web_draw_rect: (x, y, width, height, r, g, b) => commands.push([1, x, y, width, height, r, g, b]),
+    web_draw_text: (x, y, value) => commands.push([2, x, y, value]),
+    web_play_tone: (frequency, durationMs) => {
+      if (!audioContext || audioContext.state !== "running") return;
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      const duration = Math.max(20, Math.min(durationMs, 1000)) / 1000;
+      oscillator.frequency.value = Math.max(40, Math.min(frequency, 4000));
+      gain.gain.setValueAtTime(0.08, audioContext.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + duration);
+      oscillator.connect(gain).connect(audioContext.destination);
+      oscillator.start();
+      oscillator.stop(audioContext.currentTime + duration);
+      audioEvents += 1;
+      document.body.dataset.audioEvents = String(audioEvents);
+    }
+  }};
+
+  function executeCommands() {
+    for (const command of commands) {
+      if (command[0] === 0) {
+        context.fillStyle = color(command[1], command[2], command[3]);
+        context.fillRect(0, 0, canvas.width, canvas.height);
+      } else if (command[0] === 1) {
+        context.fillStyle = color(command[5], command[6], command[7]);
+        context.fillRect(command[1], command[2], command[3], command[4]);
+      } else if (command[0] === 2) {
+        context.fillStyle = "#dff6ff";
+        context.font = "18px ui-monospace, Consolas, monospace";
+        context.fillText(`score ${command[3]}`, command[1], command[2]);
+      }
+    }
+  }
+
+  function frame() {
+    const tickStart = performance.now();
+    instance.exports.tick();
+    const tickMs = performance.now() - tickStart;
+    const renderStart = performance.now();
+    instance.exports.render();
+    executeCommands();
+    const renderMs = performance.now() - renderStart;
+    frames += 1;
+    if (frames > 5) {
+      worstTick = Math.max(worstTick, tickMs);
+      worstRender = Math.max(worstRender, renderMs);
+    }
+    const underBudget = tickMs < 16 && renderMs < 16;
+    hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nrender ${renderMs.toFixed(3)} ms (worst ${worstRender.toFixed(3)})\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
+    document.body.dataset.frames = String(frames);
+    document.body.dataset.tickMs = tickMs.toFixed(3);
+    document.body.dataset.renderMs = renderMs.toFixed(3);
+    document.body.dataset.worstTickMs = worstTick.toFixed(3);
+    document.body.dataset.worstRenderMs = worstRender.toFixed(3);
+    document.body.dataset.underBudget = String(underBudget);
+    if (instance.exports.player_x) document.body.dataset.playerX = String(instance.exports.player_x.value);
+    requestAnimationFrame(frame);
+  }
+
+  function updatePointer(event) {
+    const bounds = canvas.getBoundingClientRect();
+    pointer.x = Math.round((event.clientX - bounds.left) * canvas.width / bounds.width);
+  }
+  addEventListener("keydown", event => { keys.add(event.code); if (["ArrowLeft", "ArrowRight", "Space"].includes(event.code)) event.preventDefault(); });
+  addEventListener("keyup", event => keys.delete(event.code));
+  canvas.addEventListener("pointermove", updatePointer);
+  canvas.addEventListener("pointerdown", event => { updatePointer(event); pointer.down = true; canvas.setPointerCapture(event.pointerId); canvas.focus(); });
+  canvas.addEventListener("pointerup", event => { updatePointer(event); pointer.down = false; });
+  canvas.addEventListener("pointercancel", () => { pointer.down = false; });
+  audioButton.addEventListener("click", async () => {
+    audioContext ||= new AudioContext();
+    await audioContext.resume();
+    audioButton.textContent = "Sound enabled";
+    audioButton.disabled = true;
+    document.body.dataset.audioState = audioContext.state;
+    canvas.focus();
+  });
+
+  async function wasmBytes() {
+    if (window.STASIS_WASM_BASE64) {
+      const binary = atob(window.STASIS_WASM_BASE64);
+      return Uint8Array.from(binary, value => value.charCodeAt(0));
+    }
+    const response = await fetch("game.wasm");
+    if (!response.ok) throw new Error(`failed to load game.wasm: ${response.status}`);
+    return response.arrayBuffer();
+  }
+
+  (async () => {
+    try {
+      const result = await WebAssembly.instantiate(await wasmBytes(), imports);
+      instance = result.instance;
+      instance.exports.main();
+      document.body.dataset.ready = "true";
+      document.body.dataset.runtime = "wasm";
+      requestAnimationFrame(frame);
+    } catch (error) {
+      document.body.dataset.ready = "false";
+      errorBox.textContent = String(error && error.stack || error);
+      throw error;
+    }
+  })();
+})();

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -8,14 +8,84 @@
   const keys = new Set();
   const pointer = { x: 0, down: false };
   const commands = [];
+  const game = window.STASIS_GAME || { strings: {}, memory: {}, assets: {} };
+  const sprites = new Map();
+  const fonts = new Map();
+  const cachedText = new Map();
+  let nextHandle = 1;
   let instance;
   let audioContext;
   let audioEvents = 0;
+  const audioAssets = new Map();
+  const audioVoices = new Map();
+  const pendingAudio = [];
   let frames = 0;
   let worstTick = 0;
   let worstRender = 0;
 
   const color = (r, g, b) => `rgb(${r & 255} ${g & 255} ${b & 255})`;
+  const stringValue = id => game.strings[String(id)] || "";
+  const assetValue = id => game.assets[stringValue(id)] || stringValue(id);
+  const loadSprite = pathId => {
+    const handle = nextHandle++;
+    const image = new Image();
+    image.src = assetValue(pathId);
+    sprites.set(handle, image);
+    return handle;
+  };
+  const loadFont = (pathId, size) => {
+    const handle = nextHandle++;
+    const family = `stasis-font-${handle}`;
+    const font = new FontFace(family, `url(${assetValue(pathId)})`);
+    fonts.set(handle, { family, size });
+    font.load().then(loaded => document.fonts.add(loaded)).catch(error => console.error(error));
+    return handle;
+  };
+  const ensureAudio = () => {
+    audioContext ||= new AudioContext();
+    return audioContext;
+  };
+  const loadAudio = pathId => {
+    const handle = nextHandle++;
+    const uri = assetValue(pathId);
+    const decoded = fetch(uri)
+      .then(response => response.arrayBuffer())
+      .then(bytes => ensureAudio().decodeAudioData(bytes));
+    audioAssets.set(handle, decoded);
+    return handle;
+  };
+  const startAudio = (handle, loop, volume) => {
+    const start = async () => {
+      const audio = ensureAudio();
+      const buffer = await audioAssets.get(handle);
+      if (!buffer) return false;
+      const source = audio.createBufferSource();
+      const gain = audio.createGain();
+      source.buffer = buffer;
+      source.loop = Boolean(loop);
+      gain.gain.value = Math.max(0, Math.min(1, volume));
+      source.connect(gain).connect(audio.destination);
+      source.start();
+      audioVoices.set(handle, { source, gain, paused: false });
+      source.addEventListener("ended", () => {
+        if (audioVoices.get(handle)?.source === source) audioVoices.delete(handle);
+      });
+      audioEvents += 1;
+      document.body.dataset.audioEvents = String(audioEvents);
+      return true;
+    };
+    if (!audioContext || audioContext.state !== "running") {
+      pendingAudio.push(start);
+      return true;
+    }
+    void start();
+    return true;
+  };
+  const stopAudio = handle => {
+    const voice = audioVoices.get(handle);
+    if (voice) voice.source.stop();
+    audioVoices.delete(handle);
+  };
   const imports = { env: {
     web_input_axis: () => (keys.has("ArrowRight") || keys.has("KeyD") ? 1 : 0) - (keys.has("ArrowLeft") || keys.has("KeyA") ? 1 : 0),
     web_input_fire: () => keys.has("Space") || pointer.down ? 1 : 0,
@@ -37,6 +107,37 @@
       oscillator.stop(audioContext.currentTime + duration);
       audioEvents += 1;
       document.body.dataset.audioEvents = String(audioEvents);
+    },
+    gfx_load_sprite: pathId => loadSprite(pathId),
+    stasis_gfx_load_sprite: pathId => loadSprite(pathId),
+    load_font: (pathId, size) => loadFont(pathId, size),
+    stasis_load_font: (pathId, size) => loadFont(pathId, size),
+    stasis_jit_gfx_cache_text: (font, textId) => {
+      const handle = nextHandle++;
+      cachedText.set(handle, { font, text: stringValue(textId) });
+      return handle;
+    },
+    audio_init: () => { ensureAudio(); return 1; },
+    audio_is_available: () => 1,
+    audio_get_sample_rate: () => 48000,
+    audio_get_channels: () => 2,
+    audio_get_queued_frames: () => 0,
+    audio_get_underruns: () => 0,
+    stasis_jit_audio_load_music: pathId => loadAudio(pathId),
+    stasis_jit_audio_load_effect: pathId => loadAudio(pathId),
+    stasis_jit_audio_play_music: (handle, loop, volume) => startAudio(handle, loop, volume) ? 1 : 0,
+    stasis_jit_audio_play_effect: (handle, volume) => startAudio(handle, false, volume) ? 1 : 0,
+    stasis_jit_audio_stop_music: handle => stopAudio(handle),
+    stasis_jit_audio_pause_music: (handle, paused) => {
+      const voice = audioVoices.get(handle);
+      if (!voice || voice.paused === Boolean(paused)) return;
+      if (paused) voice.source.disconnect();
+      else voice.source.connect(voice.gain);
+      voice.paused = Boolean(paused);
+    },
+    stasis_jit_audio_set_music_volume: (handle, volume) => {
+      const voice = audioVoices.get(handle);
+      if (voice) voice.gain.gain.value = Math.max(0, Math.min(1, volume));
     }
   }};
 
@@ -54,6 +155,101 @@
         context.fillText(`score ${command[3]}`, command[1], command[2]);
       }
     }
+    executeStasisBuffer();
+  }
+
+  function executeStasisBuffer() {
+    const iLayout = game.memory.gfx_cmd_i32;
+    const fLayout = game.memory.gfx_cmd_f32;
+    if (!iLayout || !fLayout || !instance.exports.memory) return;
+    const i32 = new Int32Array(instance.exports.memory.buffer, iLayout.offset, iLayout.length);
+    const f32 = new Float32Array(instance.exports.memory.buffer, fLayout.offset, fLayout.length);
+    if (i32[0] !== 1196967473) return;
+    const flags = i32[2];
+    if (flags & 1) {
+      context.save();
+      context.globalAlpha = Math.max(0, Math.min(1, f32[3]));
+      context.fillStyle = `rgb(${Math.round(f32[0] * 255)} ${Math.round(f32[1] * 255)} ${Math.round(f32[2] * 255)})`;
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.restore();
+    }
+    const drawLine = index => {
+      const base = 4 + index * 8;
+      context.save();
+      context.globalAlpha = f32[base + 7];
+      context.strokeStyle = `rgb(${Math.round(f32[base + 4] * 255)} ${Math.round(f32[base + 5] * 255)} ${Math.round(f32[base + 6] * 255)})`;
+      context.beginPath();
+      context.moveTo(f32[base], f32[base + 1]);
+      context.lineTo(f32[base + 2], f32[base + 3]);
+      context.stroke();
+      context.restore();
+    };
+    const drawRect = index => {
+      const base = 79996 - index * 8;
+      context.save();
+      context.globalAlpha = f32[base + 7];
+      context.fillStyle = `rgb(${Math.round(f32[base + 4] * 255)} ${Math.round(f32[base + 5] * 255)} ${Math.round(f32[base + 6] * 255)})`;
+      context.fillRect(f32[base], f32[base + 1], f32[base + 2], f32[base + 3]);
+      context.restore();
+    };
+    const drawSprite = index => {
+      const baseI = 32 + index * 3;
+      const baseF = 80004 + index * 4;
+      const image = sprites.get(i32[baseI]);
+      if (!image || !image.complete || !image.naturalWidth) return;
+      const x = f32[baseF];
+      const y = f32[baseF + 1];
+      const width = f32[baseF + 2];
+      const height = f32[baseF + 3];
+      context.save();
+      context.globalAlpha = Math.max(0, Math.min(1, i32[baseI + 2] / 255));
+      context.translate(x + width / 2, y + height / 2);
+      context.rotate(i32[baseI + 1] * Math.PI / 180);
+      context.drawImage(image, -width / 2, -height / 2, width, height);
+      context.restore();
+    };
+    const drawText = index => {
+      const baseI = 12320 + index * 3;
+      const baseF = 96388 + index * 6;
+      const offset = i32[baseI + 1];
+      const cached = offset < 0 ? cachedText.get(-offset) : null;
+      const fontHandle = cached ? cached.font : i32[baseI];
+      const font = fonts.get(fontHandle) || { family: "ui-monospace", size: 18 };
+      let text = cached ? cached.text : "";
+      if (!cached && game.memory.gfx_cmd_u8) {
+        const bytesLayout = game.memory.gfx_cmd_u8;
+        const bytes = new Uint8Array(instance.exports.memory.buffer, bytesLayout.offset + offset, i32[baseI + 2]);
+        text = new TextDecoder().decode(bytes);
+      }
+      context.save();
+      context.globalAlpha = f32[baseF + 5];
+      context.fillStyle = `rgb(${Math.round(f32[baseF + 2] * 255)} ${Math.round(f32[baseF + 3] * 255)} ${Math.round(f32[baseF + 4] * 255)})`;
+      context.font = `${font.size}px ${font.family}`;
+      context.textBaseline = "top";
+      context.fillText(text, f32[baseF], f32[baseF + 1]);
+      context.restore();
+    };
+    const lineCount = Math.max(0, Math.min(i32[3], 10000));
+    const spriteCount = Math.max(0, Math.min(i32[4], 4096));
+    const textCount = Math.max(0, Math.min(i32[7], 2048));
+    const rectCount = Math.max(0, Math.min(i32[24], 10000 - lineCount));
+    const orderCount = Math.max(0, Math.min(i32[22], 16144));
+    if (orderCount > 0) {
+      for (let order = 0; order < orderCount; order += 1) {
+        const encoded = i32[18464 + order];
+        const kind = Math.floor(encoded / 16384);
+        const index = encoded % 16384;
+        if (kind === 1 && index < lineCount) drawLine(index);
+        else if (kind === 2 && index < spriteCount) drawSprite(index);
+        else if (kind === 3 && index < textCount) drawText(index);
+        else if (kind === 4 && index < rectCount) drawRect(index);
+      }
+    } else {
+      for (let index = 0; index < lineCount; index += 1) drawLine(index);
+      for (let index = 0; index < rectCount; index += 1) drawRect(index);
+      for (let index = 0; index < spriteCount; index += 1) drawSprite(index);
+      for (let index = 0; index < textCount; index += 1) drawText(index);
+    }
   }
 
   function frame() {
@@ -69,7 +265,7 @@
       worstTick = Math.max(worstTick, tickMs);
       worstRender = Math.max(worstRender, renderMs);
     }
-    const underBudget = tickMs < 16 && renderMs < 16;
+    const underBudget = worstTick < 16 && worstRender < 16;
     hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nrender ${renderMs.toFixed(3)} ms (worst ${worstRender.toFixed(3)})\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
     document.body.dataset.frames = String(frames);
     document.body.dataset.tickMs = tickMs.toFixed(3);
@@ -94,6 +290,7 @@
   audioButton.addEventListener("click", async () => {
     audioContext ||= new AudioContext();
     await audioContext.resume();
+    for (const start of pendingAudio.splice(0)) await start();
     audioButton.textContent = "Sound enabled";
     audioButton.disabled = true;
     document.body.dataset.audioState = audioContext.state;
@@ -114,9 +311,23 @@
     try {
       const result = await WebAssembly.instantiate(await wasmBytes(), imports);
       instance = result.instance;
-      instance.exports.main();
+      const mainResult = instance.exports.main();
+      if (instance.exports.host_req_window_w_px && instance.exports.host_req_window_h_px) {
+        const width = instance.exports.host_req_window_w_px.value;
+        const height = instance.exports.host_req_window_h_px.value;
+        if (width > 0 && height > 0) {
+          canvas.width = width;
+          canvas.height = height;
+          canvas.style.aspectRatio = `${width} / ${height}`;
+        }
+      }
+      await Promise.all([
+        ...Array.from(sprites.values(), image => image.decode().catch(() => undefined)),
+        document.fonts.ready
+      ]);
       document.body.dataset.ready = "true";
       document.body.dataset.runtime = "wasm";
+      document.body.dataset.mainResult = String(mainResult);
       requestAnimationFrame(frame);
     } catch (error) {
       document.body.dataset.ready = "false";

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="data:,">
+  <title>__STASIS_GAME_TITLE__</title>
+  <style>
+    :root { color-scheme: dark; font-family: ui-monospace, Consolas, monospace; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; color: #dff6ff; }
+    main { position: relative; width: min(960px, 100vw); }
+    canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
+    #stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }
+    #stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }
+    #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <main>
+    <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
+    <div id="stasis-hud" role="status">Starting Wasm…</div>
+    <button id="stasis-audio" type="button">Enable sound</button>
+    <pre id="stasis-error"></pre>
+  </main>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/runtime/web/standalone.html
+++ b/runtime/web/standalone.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="data:,">
+  <title>__STASIS_GAME_TITLE__</title>
+  <style>
+    :root { color-scheme: dark; font-family: ui-monospace, Consolas, monospace; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; color: #dff6ff; }
+    main { position: relative; width: min(960px, 100vw); }
+    canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
+    #stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }
+    #stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }
+    #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <main>
+    <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
+    <div id="stasis-hud" role="status">Starting Wasm…</div>
+    <button id="stasis-audio" type="button">Enable sound</button>
+    <pre id="stasis-error"></pre>
+  </main>
+  <script>window.STASIS_WASM_BASE64 = "__STASIS_WASM_BASE64__";</script>
+  <script>__STASIS_RUNTIME_JS__</script>
+</body>
+</html>

--- a/samples/web_export_smoke/src/main.stasis
+++ b/samples/web_export_smoke/src/main.stasis
@@ -4,28 +4,71 @@ const PLAYER_WIDTH: i32 = 64;
 global player_x: i32;
 global score: i32;
 global tone_latched: bool;
+global fullscreen_latched: bool;
+global fullscreen_enabled: bool;
+global host_i32: i32[768];
+global host_f32: f32[64];
+global host_req_seq: i32;
+global host_req_flags: i32;
+global host_req_window_w_px: i32;
+global host_req_window_h_px: i32;
+global audio_samples: f32[4800];
 
-function @extern("web_input_axis") web_input_axis(): i32;
-function @extern("web_input_fire") web_input_fire(): bool;
-function @extern("web_pointer_x") web_pointer_x(): i32;
-function @extern("web_pointer_down") web_pointer_down(): bool;
 function @extern("web_begin_frame") web_begin_frame(red: i32, green: i32, blue: i32): void;
 function @extern("web_draw_rect") web_draw_rect(x: i32, y: i32, width: i32, height: i32, red: i32, green: i32, blue: i32): void;
 function @extern("web_draw_text") web_draw_text(x: i32, y: i32, value: i32): void;
-function @extern("web_play_tone") web_play_tone(frequency: i32, duration_ms: i32): void;
+extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
+extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
 
 function main(): i32 {
     player_x = 288;
     score = 0;
     tone_latched = false;
+    fullscreen_latched = false;
+    fullscreen_enabled = false;
+    host_req_flags = 1;
+    host_req_window_w_px = 640;
+    host_req_window_h_px = 360;
+    host_req_seq = host_req_seq + 1;
+    let i: i32 = 0;
+    for (i = 0; i < 4800; i = i + 1) {
+        if (i % 120 < 60) {
+            audio_samples[i] = 0.08;
+        } else {
+            audio_samples[i] = -0.08;
+        }
+    }
+    audio_init(48000, 2, 2048);
     return 0;
 }
 
 function tick(): i32 {
-    if (web_pointer_down()) {
-        player_x = web_pointer_x() - PLAYER_WIDTH / 2;
+    if (host_i32[32 + 9] != 0) {
+        if (!fullscreen_latched) {
+            if (fullscreen_enabled) {
+                fullscreen_enabled = false;
+                host_req_flags = 1;
+            } else {
+                fullscreen_enabled = true;
+                host_req_flags = 2;
+            }
+            host_req_seq = host_req_seq + 1;
+            fullscreen_latched = true;
+        }
     } else {
-        player_x += web_input_axis() * 5;
+        fullscreen_latched = false;
+    }
+    if (host_i32[545] != 0) {
+        let pointer_x: i32 = 0;
+        pointer_x.from_f32(host_f32[0]);
+        player_x = pointer_x - PLAYER_WIDTH / 2;
+    } else {
+        if (host_i32[32 + 80] != 0) {
+            player_x -= 5;
+        }
+        if (host_i32[32 + 79] != 0) {
+            player_x += 5;
+        }
     }
     if (player_x < 0) {
         player_x = 0;
@@ -33,9 +76,9 @@ function tick(): i32 {
     if (player_x > SCREEN_WIDTH - PLAYER_WIDTH) {
         player_x = SCREEN_WIDTH - PLAYER_WIDTH;
     }
-    if (web_input_fire()) {
+    if (host_i32[32 + 44] != 0 || host_i32[545] != 0) {
         if (!tone_latched) {
-            web_play_tone(440 + score * 20, 100);
+            audio_push_f32_interleaved(audio_samples, 2400);
             score += 1;
             tone_latched = true;
         }

--- a/samples/web_export_smoke/src/main.stasis
+++ b/samples/web_export_smoke/src/main.stasis
@@ -1,0 +1,54 @@
+const SCREEN_WIDTH: i32 = 640;
+const PLAYER_WIDTH: i32 = 64;
+
+global player_x: i32;
+global score: i32;
+global tone_latched: bool;
+
+function @extern("web_input_axis") web_input_axis(): i32;
+function @extern("web_input_fire") web_input_fire(): bool;
+function @extern("web_pointer_x") web_pointer_x(): i32;
+function @extern("web_pointer_down") web_pointer_down(): bool;
+function @extern("web_begin_frame") web_begin_frame(red: i32, green: i32, blue: i32): void;
+function @extern("web_draw_rect") web_draw_rect(x: i32, y: i32, width: i32, height: i32, red: i32, green: i32, blue: i32): void;
+function @extern("web_draw_text") web_draw_text(x: i32, y: i32, value: i32): void;
+function @extern("web_play_tone") web_play_tone(frequency: i32, duration_ms: i32): void;
+
+function main(): i32 {
+    player_x = 288;
+    score = 0;
+    tone_latched = false;
+    return 0;
+}
+
+function tick(): i32 {
+    if (web_pointer_down()) {
+        player_x = web_pointer_x() - PLAYER_WIDTH / 2;
+    } else {
+        player_x += web_input_axis() * 5;
+    }
+    if (player_x < 0) {
+        player_x = 0;
+    }
+    if (player_x > SCREEN_WIDTH - PLAYER_WIDTH) {
+        player_x = SCREEN_WIDTH - PLAYER_WIDTH;
+    }
+    if (web_input_fire()) {
+        if (!tone_latched) {
+            web_play_tone(440 + score * 20, 100);
+            score += 1;
+            tone_latched = true;
+        }
+    } else {
+        tone_latched = false;
+    }
+    return 0;
+}
+
+function render(): i32 {
+    web_begin_frame(7, 17, 31);
+    web_draw_rect(0, 300, 640, 60, 11, 38, 61);
+    web_draw_rect(player_x, 270, PLAYER_WIDTH, 24, 83, 216, 251);
+    web_draw_text(18, 32, score);
+    return 0;
+}

--- a/samples/web_export_smoke/stasis.json
+++ b/samples/web_export_smoke/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "web_export_smoke",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}


### PR DESCRIPTION
## Summary

- add a real reachable Stasis HIR-to-WebAssembly backend and `stasis package --target web`
- match Windows/Android HostFrame, graphics command buffers, WebAudio, storage, clipboard, window requests, and three-word struct-view ABI
- preserve native SoA struct collections, internal array views, bounded access, and short-circuit boolean semantics
- emit `<game>/play/index.html` beside `<game>/assets/...`, plus a self-contained `<game_name>.html`
- retain and prepare only reachable release assets through the same pipeline used by Android/desktop
- keep release globals private and retain required function names in the export section
- run `wasm-opt -Oz` for release packages when available, with `STASIS_WASM_OPT` support and reported before/after sizes

## Browser acceptance

- hosted and one-file packages boot as WebAssembly with no current runtime error
- Canvas rendering and pointer interaction work through the native-shape host ABI
- WebAudio unlocks from a user gesture and receives game audio events
- responsive portrait sizing and window-mode requests work
- performance HUD remains under the 16 ms tick/render budget
- `wasm-opt -Oz` reduced the large-project Wasm test payload by 48.1% without changing browser behavior
- existing Windows render fixture packages PNG/SVG/TTF command-buffer rendering
- existing audio fixture packages MP3/WAV decoding and playback

## Validation

- `STASIS_WASM_OPT=... python tools/cargo_cache.py run -- cargo test -p stasis --bin stasis configured_wasm_opt_produces_a_valid_release_module`
- `python tools/cargo_cache.py run -- cargo test -p stasis_compiler backend::wasm::tests`
- `python tools/cargo_cache.py run -- cargo test -p stasis --test web_package`
- `python tools/cargo_cache.py run -- cargo test --workspace --all-targets -- --test-threads=1` (earlier slice)
- `node --check runtime/web/game.js`
- `cargo fmt --all -- --check`
- `git diff --check`

`tools/validate_repo.sh` still reaches two unrelated repository-baseline audits: five existing unsafe-boundary allowlist entries and an existing ignored environment test.
