### PR TITLE
ci: run slow seams only in nightly

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -1,32 +1,11 @@
 name: Android Emulator Seams
 
 on:
-  workflow_dispatch:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    paths:
-      - ".github/workflows/android-device-seams.yml"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "apps/stasis/**"
-      - "crates/**"
-      - "mobile/android/**"
-      - "mobile/shells/**"
-      - "runtime/**"
-      - "samples/android_aot_seam/**"
-      - "samples/android_touch_seam/**"
-      - "samples/android_orientation_seam/**"
-      - "src/**"
-      - "tools/cargo_cache.py"
-      - "tools/ci/run_android_release_shell_seam.py"
+  workflow_call:
 
 concurrency:
-  group: android-emulator-seams-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: android-emulator-seams-nightly
+  cancel-in-progress: false
 
 jobs:
   generated-release-shell:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,6 +16,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  integration_seams:
+    uses: ./.github/workflows/pr-ci.yml
+    with:
+      run_slow_seams: true
+
+  android_device_seams:
+    uses: ./.github/workflows/android-device-seams.yml
+
   detect:
     runs-on: ubuntu-latest
     outputs:
@@ -441,7 +449,7 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: [detect, build, vscode_extension]
+    needs: [detect, build, vscode_extension, integration_seams, android_device_seams]
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,6 +11,13 @@ on:
       - synchronize
       - ready_for_review
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      run_slow_seams:
+        description: Run platform integration and packaging seams.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -18,7 +25,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: pr-ci-${{ github.event.pull_request.number || github.ref }}
+  group: pr-ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -81,7 +88,7 @@ jobs:
         run: cargo test --workspace --all-targets -- --test-threads=1
 
   bootstrap-smoke-windows:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -183,7 +190,7 @@ jobs:
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture
 
   vscode-extension-e2e:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
     name: VS Code E2E (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -295,7 +302,7 @@ jobs:
             vscode-stasis/.vsix/stasislang.stasis.vsix
 
   android-package-link:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Stasis
@@ -356,7 +363,7 @@ jobs:
           path: target/android-native-link-evidence.json
 
   ios-package-link:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/docs/integration_seam_testing_strategy.md
+++ b/docs/integration_seam_testing_strategy.md
@@ -176,8 +176,8 @@ named for the injected failure, and leave the production path unchanged.
 | Lane | Trigger | Budget | Contents |
 |---|---|---:|---|
 | Fast contract | every PR and `tools/validate_repo.sh` | 2 min | descriptor parity, JIT HostFrame, buffer bounds, diagnostic schemas |
-| Native integration | every PR, platform-sharded | 10 min | desktop real runtime, linked AOT/C runtime, package link and symbol audit |
-| Android emulator | merge/nightly and affected PRs | 15 min/test shard | Workshop JNI/JIT and generated release-shell behavior on a test-only x86_64 AOT build |
+| Native integration | nightly, platform-sharded | 15 min | desktop real runtime, linked AOT/C runtime, package link and symbol audit |
+| Android emulator | nightly | 15 min/test shard | Workshop JNI/JIT and generated release-shell behavior on a test-only x86_64 AOT build |
 | Physical device | optional release candidate and scheduled farm | 15 min/test shard | Supplemental OEM driver, density, lifecycle, and representative rendering evidence |
 
 Tests should be promoted toward the faster lane when a deterministic lower

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -14,6 +14,8 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.workflow = read(".github/workflows/android-device-seams.yml")
+        cls.nightly_workflow = read(".github/workflows/nightly-release.yml")
+        cls.pr_workflow = read(".github/workflows/pr-ci.yml")
         cls.release_script = read("mobile/android/test_release_shell.ps1")
         cls.emulator_script = read("mobile/android/test_release_shell_emulator.ps1")
         cls.strategy = read("docs/integration_seam_testing_strategy.md")
@@ -28,13 +30,26 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertIn("api-level: 35", self.workflow)
         self.assertIn("arch: x86_64", self.workflow)
         self.assertIn("Enable KVM", self.workflow)
-        self.assertIn("pull_request:", self.workflow)
+        self.assertIn("workflow_call:", self.workflow)
+        self.assertNotIn("pull_request:", self.workflow)
+        self.assertNotIn("workflow_dispatch:", self.workflow)
         self.assertIn('uses: actions/setup-python@v5', self.workflow)
         self.assertIn('python-version: "3.12"', self.workflow)
-        self.assertIn("group: android-emulator-seams-", self.workflow)
-        self.assertIn("cancel-in-progress: true", self.workflow)
-        for dependency_path in ('"Cargo.lock"', '"Cargo.toml"', '"crates/**"', '"src/**"'):
-            self.assertIn(dependency_path, self.workflow)
+        self.assertIn("group: android-emulator-seams-nightly", self.workflow)
+        self.assertIn("cancel-in-progress: false", self.workflow)
+        self.assertIn("uses: ./.github/workflows/android-device-seams.yml", self.nightly_workflow)
+        self.assertIn(
+            "needs: [detect, build, vscode_extension, integration_seams, android_device_seams]",
+            self.nightly_workflow,
+        )
+        self.assertIn("uses: ./.github/workflows/pr-ci.yml", self.nightly_workflow)
+        self.assertIn("run_slow_seams: true", self.nightly_workflow)
+        self.assertEqual(
+            4,
+            self.pr_workflow.count(
+                "if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}"
+            ),
+        )
         self.assertNotIn("self-hosted", self.workflow)
         self.assertNotIn("runs-on: [self-hosted, Windows, android-device]", self.workflow)
         self.assertNotIn("ANDROID_SERIAL", self.workflow)


### PR DESCRIPTION
## Summary
- make Android emulator seams reusable-only instead of PR/manual-triggered
- make native platform integration jobs reusable-only and skip them on ordinary PR CI
- invoke both slow seam suites from Nightly Release
- require both seam suites before publishing a nightly release
- keep fast contract/unit checks on every PR

## Expected cadence
- scheduled nightly: slow native and emulator seams run once per day
- manual Nightly Release: same complete gate
- pull requests / standalone PR CI dispatch: fast checks only

## Validation
- python -m unittest tools.ci.test_android_emulator_seams tools.ci.test_run_android_release_shell_seam tools.ci.test_cargo_cache (27 passed)
- python tools/ci/check_stasis_src_layout.py
- git diff --check
- main currently has no protected required-check contexts that would be stranded by skipped slow job names