### PR TITLE
fix: omit web HUD from release packages

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3807,7 +3807,7 @@ fn web_index_html(title: &str, development_build: bool) -> String {
     let (hud_style, hud) = if development_build {
         (
             "#stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }",
-            r#"<div id="stasis-hud" role="status">Starting Wasm…</div>"#,
+            r#"<div id="stasis-hud" role="status">Starting Wasm...</div>"#,
         )
     } else {
         ("", "")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3756,7 +3756,7 @@ fn package_web_workspace(
             .map_err(|error| format!("failed to write web runtime: {error}"))?;
         fs::write(
             staging_root.join("index.html"),
-            WEB_INDEX_HTML.replace("__STASIS_GAME_TITLE__", &workspace.manifest.name),
+            web_index_html(&workspace.manifest.name, development_build),
         )
         .map_err(|error| format!("failed to write web index: {error}"))?;
 
@@ -3801,6 +3801,21 @@ fn package_web_workspace(
             "development_build": provenance["development_build"],
         }),
     ))
+}
+
+fn web_index_html(title: &str, development_build: bool) -> String {
+    let (hud_style, hud) = if development_build {
+        (
+            "#stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }",
+            r#"<div id="stasis-hud" role="status">Starting Wasm…</div>"#,
+        )
+    } else {
+        ("", "")
+    };
+    WEB_INDEX_HTML
+        .replace("__STASIS_GAME_TITLE__", title)
+        .replace("__STASIS_PERFORMANCE_HUD_STYLE__", hud_style)
+        .replace("__STASIS_PERFORMANCE_HUD__", hud)
 }
 
 fn web_runtime_config(workspace: &Workspace, process: &WasmProcess) -> Value {
@@ -5574,6 +5589,17 @@ mod tests {
     use super::*;
     use stasis_ai::live_tool_specs;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn release_web_index_omits_performance_hud() {
+        let release = web_index_html("release-game", false);
+        assert!(!release.contains("stasis-hud"));
+        assert!(!release.contains("__STASIS_"));
+
+        let development = web_index_html("development-game", true);
+        assert!(development.contains(r#"id="stasis-hud""#));
+        assert!(!development.contains("__STASIS_"));
+    }
 
     #[test]
     fn successful_live_runner_allows_terminal_acknowledgement_to_finish() {

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -101,6 +101,9 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
     assert!(!runtime.contains("STASIS_WASM_BASE64"));
     assert!(!runtime.contains("data:application/wasm;base64,"));
     assert!(output.join("index.html").is_file());
+    let index = fs::read_to_string(output.join("index.html")).expect("index.html");
+    assert!(index.contains(r#"id="stasis-hud""#));
+    assert!(!index.contains("__STASIS_"));
     assert!(!output.join("play").exists());
     assert!(output.join("stasis_provenance.json").is_file());
     assert!(!output.join("web_export_smoke.html").exists());

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -35,8 +35,9 @@ The browser populates the canonical HostFrame arrays and consumes the existing g
 buffers, matching Android/Windows. Browser policy (fullscreen gestures, Clipboard API, local
 storage, and WebAudio unlocking) remains in JavaScript.
 
-The HUD reports current and worst observed `tick` and `render` time separately. Both must remain
-below 16 ms. Browser audio is unlocked by the **Enable sound** user gesture; subsequent
+Development packages show a HUD with current and worst observed `tick` and `render` time; both must
+remain below 16 ms. Release packages omit the performance HUD. Browser audio is unlocked by the
+**Enable sound** user gesture; subsequent
 `web_play_tone` calls originate in Stasis game logic.
 
 ## Current compiler and host lane

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -583,7 +583,9 @@
       worstRender = Math.max(worstRender, renderMs);
     }
     const underBudget = worstTick < 16 && worstRender < 16;
-    hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nrender ${renderMs.toFixed(3)} ms (worst ${worstRender.toFixed(3)})\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
+    if (hud) {
+      hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nrender ${renderMs.toFixed(3)} ms (worst ${worstRender.toFixed(3)})\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
+    }
     document.body.dataset.frames = String(frames);
     document.body.dataset.tickMs = tickMs.toFixed(3);
     document.body.dataset.renderMs = renderMs.toFixed(3);

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -10,7 +10,7 @@
     body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; color: #dff6ff; }
     main { position: relative; width: min(960px, 100vw); }
     canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
-    #stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }
+    __STASIS_PERFORMANCE_HUD_STYLE__
     #stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }
     #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
   </style>
@@ -18,7 +18,7 @@
 <body>
   <main>
     <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
-    <div id="stasis-hud" role="status">Starting Wasm…</div>
+    __STASIS_PERFORMANCE_HUD__
     <button id="stasis-audio" type="button">Enable sound</button>
     <pre id="stasis-error"></pre>
   </main>


### PR DESCRIPTION
## Summary

- render performance HUD markup and CSS only for `--development-build` web packages
- omit the HUD entirely from release `index.html`
- keep internal timing datasets and frame-budget measurement available without a visible HUD
- make the browser runtime tolerate the intentionally absent release HUD element

## Validation

- `python tools/cargo_cache.py run -- cargo test -p stasis release_web_index_omits_performance_hud`
- `python tools/cargo_cache.py run -- cargo test -p stasis --test web_package`
- `cargo fmt --all -- --check`
- `git diff --check`
- browser acceptance with release DOM shape: zero HUD elements, Wasm frames advanced, keyboard input moved the player, WebAudio entered `running`, timing remained under budget internally, and no console warnings/errors

## Theory gained

Performance measurement belongs to the shared browser runtime, while its visual presentation is package-profile policy. Release can therefore omit the HUD without splitting the execution path or losing diagnostic timing data.