### PR TITLE
fix: stop web audio when pages exit

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -161,6 +161,16 @@ fn existing_audio_game_packages_wav_and_mp3_for_web_audio() {
         "stasis_jit_audio_load_music",
         "stasis_jit_audio_load_effect",
         "decodeAudioData",
+        "document.addEventListener(\"visibilitychange\"",
+        "addEventListener(\"pagehide\"",
+        "addEventListener(\"pageshow\"",
+        "if (event.persisted) suspendWebAudio()",
+        "else shutdownWebAudio()",
+        "pendingAudio.length = 0",
+        "audioContext.suspend()",
+        "resumingContext.resume()",
+        "resumingContext.suspend()",
+        "closingContext.close()",
     ] {
         assert!(
             runtime.contains(expected),

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -20,6 +20,7 @@
   let audioChannels = 2;
   let audioNextStart = 0;
   let audioUnderruns = 0;
+  let audioSuspendedByLifecycle = false;
   const audioAssets = new Map();
   const audioVoices = new Map();
   const pendingAudio = [];
@@ -152,6 +153,40 @@
     if (voice) voice.source.stop();
     audioVoices.delete(handle);
   };
+  const updateAudioState = () => {
+    document.body.dataset.audioState = audioContext?.state || "closed";
+  };
+  const suspendWebAudio = () => {
+    if (!audioContext) return;
+    audioSuspendedByLifecycle = true;
+    if (audioContext.state === "running") {
+      void audioContext.suspend().then(updateAudioState).catch(() => {});
+    }
+  };
+  const resumeWebAudio = () => {
+    if (!audioSuspendedByLifecycle || !audioContext || audioContext.state === "closed") return;
+    audioSuspendedByLifecycle = false;
+    const resumingContext = audioContext;
+    void resumingContext.resume().then(() => {
+      if (audioSuspendedByLifecycle && resumingContext === audioContext) {
+        void resumingContext.suspend().then(updateAudioState).catch(() => {});
+      } else {
+        updateAudioState();
+      }
+    }).catch(() => {
+      if (resumingContext === audioContext) audioSuspendedByLifecycle = true;
+    });
+  };
+  const shutdownWebAudio = () => {
+    audioSuspendedByLifecycle = false;
+    pendingAudio.length = 0;
+    for (const handle of Array.from(audioVoices.keys())) stopAudio(handle);
+    const closingContext = audioContext;
+    audioContext = undefined;
+    audioNextStart = 0;
+    if (closingContext && closingContext.state !== "closed") void closingContext.close();
+    updateAudioState();
+  };
   const pushAudio = (byteOffset, frameCount) => {
     if (!instance?.exports.memory || frameCount <= 0) return 0;
     const sampleCount = frameCount * audioChannels;
@@ -260,10 +295,7 @@
       return 1;
     },
     audio_shutdown: () => {
-      for (const handle of Array.from(audioVoices.keys())) stopAudio(handle);
-      if (audioContext) void audioContext.close();
-      audioContext = undefined;
-      audioNextStart = 0;
+      shutdownWebAudio();
     },
     audio_is_available: () => 1,
     audio_get_sample_rate: () => audioSampleRate,
@@ -307,6 +339,17 @@
 
   document.addEventListener("paste", event => {
     clipboardText = event.clipboardData?.getData("text/plain") || clipboardText;
+  });
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) suspendWebAudio();
+    else resumeWebAudio();
+  });
+  addEventListener("pagehide", event => {
+    if (event.persisted) suspendWebAudio();
+    else shutdownWebAudio();
+  });
+  addEventListener("pageshow", event => {
+    if (event.persisted && !document.hidden) resumeWebAudio();
   });
 
   function executeCommands() {
@@ -637,7 +680,7 @@
     for (const start of pendingAudio.splice(0)) await start();
     audioButton.textContent = "Sound enabled";
     audioButton.disabled = true;
-    document.body.dataset.audioState = audioContext.state;
+    updateAudioState();
     canvas.focus();
   });
 


### PR DESCRIPTION
## Summary

- suspend the Web Audio context when a browser document becomes hidden
- preserve suspended audio across back/forward-cache page transitions and resume it when the cached page returns
- stop active voices, discard queued starts, and close the audio context when a page exits permanently
- guard the asynchronous resume path so a tab hidden during resume is immediately suspended again
- extend the web audio packaging regression test to require the lifecycle hooks and cleanup behavior

## Root cause

The generated web host owned a persistent `AudioContext` but did not connect it to browser page lifecycle events. On Android browsers such as DuckDuckGo, closing or hiding a tab can stop rendering without immediately destroying its page, allowing previously started MP3 sources to keep playing.

## Impact

Web games no longer continue music, effects, or narration after their page exits. Cached pages retain their audio state without enabling sound unless the player had already enabled it.

## Validation

- `node --check runtime/web/game.js`
- `cargo fmt --all -- --check`
- `cargo test -p stasis --test web_package` — 3 passed
- focused `existing_audio_game_packages_wav_and_mp3_for_web_audio` rerun — passed

Physical DuckDuckGo-on-Android verification remains outstanding.