### PR TITLE
fix: unblock nightly release validation

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,8 @@ env:
 
 permissions:
   contents: write
+  pull-requests: read
+  actions: read
 
 on:
   schedule:

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -4184,7 +4184,7 @@ global host_f32: f32[64];
 global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 function main(): void { host_req_window_w_px = 360; host_req_window_h_px = 720; }
 function tick(): void {}
@@ -4273,7 +4273,7 @@ function render(): void {
 global host_i32: i32[768];
 global host_f32: f32[64];
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 function main(): void { gfx_load_sprite(\"../assets/missing.svg\", 32, 32); }
 function tick(): void {}

--- a/mobile/android/app/src/main/assets/exploration_sample/src/host_runtime.stasis
+++ b/mobile/android/app/src/main/assets/exploration_sample/src/host_runtime.stasis
@@ -27,7 +27,7 @@ const GFX_F_LINE_BASE: i32 = 4;
 const GFX_F_SPRITE_BASE: i32 = 80004;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 
 struct Sprite {

--- a/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
+++ b/mobile/android/app/src/main/assets/workshop_sample/src/preview_adapter.stasis
@@ -3,7 +3,7 @@
 global host_i32: i32[768];
 global host_f32: f32[64];
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 
 struct Sprite {

--- a/samples/render_parity/main.stasis
+++ b/samples/render_parity/main.stasis
@@ -21,7 +21,7 @@ function @extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, p
 function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global host_i32: i32[768];
 global host_f32: f32[64];

--- a/samples/render_parity/trace.stasis
+++ b/samples/render_parity/trace.stasis
@@ -8,7 +8,7 @@ function @extern("stasis_jit_render_v2_trace") native_render_trace(
 ): i32;
 
 global cmd_i32: i32[34608];
-global cmd_f32: f32[108676];
+global cmd_f32: f32[125060];
 global cmd_u8: u8[65536];
 
 function main(): i32 {
@@ -28,10 +28,10 @@ function main(): i32 {
 
     build_parity_frame(cmd_i32, cmd_f32, cmd_u8, 3, 1, 2, 1, 1);
 
-    let historical_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 108676, cmd_u8, 65536);
+    let historical_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 125060, cmd_u8, 65536);
     cmd_i32[18464] = 16384;
     cmd_i32[18466] = 32768;
-    let sprite_first_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 108676, cmd_u8, 65536);
+    let sprite_first_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 125060, cmd_u8, 65536);
     if (historical_order == sprite_first_order) {
         return 0;
     }

--- a/samples/render_parity/trace.stasis
+++ b/samples/render_parity/trace.stasis
@@ -8,7 +8,7 @@ function @extern("stasis_jit_render_v2_trace") native_render_trace(
 ): i32;
 
 global cmd_i32: i32[34608];
-global cmd_f32: f32[125060];
+global cmd_f32: f32[108676];
 global cmd_u8: u8[65536];
 
 function main(): i32 {
@@ -28,10 +28,10 @@ function main(): i32 {
 
     build_parity_frame(cmd_i32, cmd_f32, cmd_u8, 3, 1, 2, 1, 1);
 
-    let historical_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 125060, cmd_u8, 65536);
+    let historical_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 108676, cmd_u8, 65536);
     cmd_i32[18464] = 16384;
     cmd_i32[18466] = 32768;
-    let sprite_first_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 125060, cmd_u8, 65536);
+    let sprite_first_order: i32 = native_render_trace(cmd_i32, 34608, cmd_f32, 108676, cmd_u8, 65536);
     if (historical_order == sprite_first_order) {
         return 0;
     }

--- a/samples/windows_launch_smoke/main.stasis
+++ b/samples/windows_launch_smoke/main.stasis
@@ -6,7 +6,7 @@ extern function load_font(path: string, size: i32): i32;
 function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global host_req_flags: i32;
 global host_req_window_w_px: i32;

--- a/tests/stasis/seams/desktop_hot_swap_generation_invalid.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_invalid.stasis
@@ -1,5 +1,5 @@
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global tick_generation: i32;
 

--- a/tests/stasis/seams/desktop_hot_swap_generation_reject.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_reject.stasis
@@ -1,7 +1,7 @@
 extern function reject_code_swap(): void;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global tick_generation: i32;
 

--- a/tests/stasis/seams/desktop_hot_swap_generation_v1.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_v1.stasis
@@ -1,5 +1,5 @@
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global tick_generation: i32;
 

--- a/tests/stasis/seams/desktop_hot_swap_generation_v2.stasis
+++ b/tests/stasis/seams/desktop_hot_swap_generation_v2.stasis
@@ -1,5 +1,5 @@
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global tick_generation: i32;
 

--- a/tests/stasis/seams/desktop_manifest_assets_probe.stasis
+++ b/tests/stasis/seams/desktop_manifest_assets_probe.stasis
@@ -7,7 +7,7 @@ function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: st
 function @extern("stasis_jit_gfx_measure_text_cached") gfx_measure_text_cached(handle: i32): f32;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global seam_sprite_handle: i32;
 global seam_font_handle: i32;

--- a/tests/stasis/seams/generated_mobile_aot_probe.stasis
+++ b/tests/stasis/seams/generated_mobile_aot_probe.stasis
@@ -1,7 +1,7 @@
 global host_i32: i32[768];
 global host_f32: f32[64];
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global host_req_seq: i32;
 global host_req_flags: i32;

--- a/tests/stasis/seams/jit_aot_host_replay_probe.stasis
+++ b/tests/stasis/seams/jit_aot_host_replay_probe.stasis
@@ -155,7 +155,7 @@ function render(): i32 {
         gfx_cmd_i32,
         34608,
         gfx_cmd_f32,
-        108676,
+        125060,
         gfx_cmd_u8,
         65536
     );

--- a/tests/stasis/seams/mobile_packaged_assets_probe.stasis
+++ b/tests/stasis/seams/mobile_packaged_assets_probe.stasis
@@ -9,7 +9,7 @@ extern function audio_load_wav(path: string): i32;
 extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global seam_sprite_handle: i32;
 global seam_font_handle: i32;

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -54,6 +54,11 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertNotIn("runs-on: [self-hosted, Windows, android-device]", self.workflow)
         self.assertNotIn("ANDROID_SERIAL", self.workflow)
 
+    def test_nightly_grants_reusable_ci_read_permissions(self):
+        self.assertIn("  contents: write", self.nightly_workflow)
+        self.assertIn("  pull-requests: read", self.nightly_workflow)
+        self.assertIn("  actions: read", self.nightly_workflow)
+
     def test_workflow_supplies_build_inputs_and_uploads_each_seam(self):
         self.assertIn("gradle-version: \"8.9\"", self.workflow)
         self.assertIn("ndk: 27.0.12077973", self.workflow)

--- a/tools/ci/test_runtime_abi_contract.py
+++ b/tools/ci/test_runtime_abi_contract.py
@@ -41,8 +41,8 @@ class RuntimeAbiContractTests(unittest.TestCase):
     def test_java_version_drift_is_rejected(self):
         failures, _ = self.run_with(
             contract.JAVA_RENDERER,
-            "static final int RENDER_VERSION = 4;",
             "static final int RENDER_VERSION = 5;",
+            "static final int RENDER_VERSION = 6;",
         )
         self.assertTrue(any(failure.field == "STASIS_RENDER_CURRENT_VERSION" for failure in failures))
 
@@ -65,8 +65,8 @@ class RuntimeAbiContractTests(unittest.TestCase):
     def test_generated_aot_registration_drift_is_rejected(self):
         failures, _ = self.run_with(
             contract.AOT,
-            "gfx_cmd_f32, 108676);",
-            "gfx_cmd_f32, 108675);",
+            "gfx_cmd_f32, 125060);",
+            "gfx_cmd_f32, 125059);",
         )
         self.assertTrue(any(failure.field == "gfx_cmd_f32.registration_length" for failure in failures))
 

--- a/vscode-stasis/test/fixture/src/main.stasis
+++ b/vscode-stasis/test/fixture/src/main.stasis
@@ -1,7 +1,7 @@
 import "../.stasis_cache/toolchain/src/stdlib/graphics.stasis";
 
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[108676];
+global gfx_cmd_f32: f32[125060];
 global gfx_cmd_u8: u8[65536];
 global score: i32;
 


### PR DESCRIPTION
## Summary
- grant the nightly caller the read permissions required by the reusable PR CI workflow
- synchronize render ABI fixtures and probes with the sprite-sheet frame capacity/version now on main
- cover the workflow permission and ABI drift contracts

## Validation
- python tools/ci/check_runtime_abi_contract.py (293 comparisons)
- python -m unittest tools.ci.test_runtime_abi_contract tools.ci.test_android_emulator_seams (14 tests)
- git diff --check

Fixes the zero-job startup failure seen in nightly runs 200 and 201 and the independent main-branch ABI failure that would otherwise block the rerun.