### PR TITLE
fix: dismiss system dialogs before Android captures

### DIFF
--- a/samples/android_aot_seam/android_seam_expectations.json
+++ b/samples/android_aot_seam/android_seam_expectations.json
@@ -3,7 +3,7 @@
   "test_id": "IT-017",
   "stable_frame": 30,
   "state_checksum": 1210,
-  "command_trace": 1947640508,
+  "command_trace": 1582127377,
   "logical_size": [640, 360],
   "regions": [
     {"name": "left_red", "center": [160, 180], "rgb": [230, 31, 41], "tolerance": 30},

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -509,16 +509,65 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     return observed
 
 
+def ensure_test_activity_foreground(
+    adb: Path,
+    serial: str | None,
+    package_id: str,
+    component: str,
+) -> bool:
+    windows = _run(
+        adb,
+        serial,
+        "shell",
+        "dumpsys",
+        "window",
+        "windows",
+        required=False,
+    )
+    current_focus = next(
+        (line for line in windows.splitlines() if "mCurrentFocus=" in line),
+        "",
+    )
+    if package_id in current_focus:
+        return False
+    if current_focus:
+        _run(
+            adb,
+            serial,
+            "shell",
+            "input",
+            "keyevent",
+            "KEYCODE_BACK",
+            required=False,
+        )
+    _run(
+        adb,
+        serial,
+        "shell",
+        "am",
+        "start",
+        "-W",
+        "-n",
+        component,
+        required=False,
+    )
+    return True
+
+
 def capture_until_regions_match(
     adb: Path,
     serial: str | None,
     capture: Path,
     expectations: dict,
     deadline: float,
+    package_id: str,
+    component: str,
 ) -> list[dict]:
     """Wait for the stable marker's frame to reach Android's compositor."""
     last_error: SeamError | None = None
     while time.monotonic() < deadline:
+        if ensure_test_activity_foreground(adb, serial, package_id, component):
+            time.sleep(0.25)
         capture.write_bytes(
             _run(adb, serial, "exec-out", "screencap", "-p", text=False)
         )
@@ -979,6 +1028,8 @@ def main() -> int:
                     stage_capture_path,
                     stage_expectations,
                     min(deadline, time.monotonic() + 10),
+                    package_id,
+                    component,
                 )
                 orientation_evidence.append(
                     {
@@ -1000,6 +1051,8 @@ def main() -> int:
             capture_path,
             expectations,
             min(deadline, time.monotonic() + 10),
+            package_id,
+            component,
         )
         time.sleep(1)
         second_pid = _run(

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -127,6 +127,61 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             )
             self.assertEqual([item["name"] for item in observed], ["red", "teal"])
 
+    def test_foreground_check_leaves_test_activity_untouched(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            return "mCurrentFocus=Window{123 u0 com.example.seam/.MainActivity}"
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            changed = seam.ensure_test_activity_foreground(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                "com.example.seam/.MainActivity",
+            )
+
+        self.assertFalse(changed)
+        self.assertEqual(
+            calls,
+            [("shell", "dumpsys", "window", "windows")],
+        )
+
+    def test_foreground_check_dismisses_system_dialog_and_restarts(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("shell", "dumpsys", "window", "windows"):
+                return "mCurrentFocus=Window{456 u0 android/.AppNotRespondingDialog}"
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            changed = seam.ensure_test_activity_foreground(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                "com.example.seam/.MainActivity",
+            )
+
+        self.assertTrue(changed)
+        self.assertIn(
+            ("shell", "input", "keyevent", "KEYCODE_BACK"),
+            calls,
+        )
+        self.assertIn(
+            (
+                "shell",
+                "am",
+                "start",
+                "-W",
+                "-n",
+                "com.example.seam/.MainActivity",
+            ),
+            calls,
+        )
+
     def test_selects_real_letterbox_for_each_surface_orientation(self):
         self.assertEqual(
             seam.outside_letterbox_point([360, 720], (1080, 2400)),


### PR DESCRIPTION
## Summary
- inspect Android's current focused window before release-shell screenshots
- leave the test activity untouched when it already owns focus
- dismiss a blocking system dialog and relaunch the exact test component before retrying capture

## Evidence
- nightly 203 reached 30 accepted/presented IT-017 frames with the expected V5 trace, but stable-frame.png was covered by a Pixel Launcher ANR dialog

## Validation
- python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_android_emulator_seams (21 tests)
- git diff --check