### PR TITLE
fix: update touch seam V5 traces

### DIFF
--- a/samples/android_touch_seam/android_seam_expectations.json
+++ b/samples/android_touch_seam/android_seam_expectations.json
@@ -3,13 +3,13 @@
   "test_id": "IT-018",
   "stable_frame": 30,
   "state_checksum": 2000,
-  "command_trace": 2065138741,
+  "command_trace": 1894625560,
   "logical_size": [360, 720],
   "touch": {
     "completion_sequence": 5,
     "coordinate_tolerance": 16.0,
     "safe_viewport": [0, 0, 360, 720],
-    "final_command_trace": 2551385997,
+    "final_command_trace": 3905660896,
     "gestures": [
       {
         "name": "outside_letterbox",


### PR DESCRIPTION
## Summary
- update IT-018's stable command trace for the V5 render contract
- update the deterministic post-touch command trace for the same V5 layout

## Verification
- derived the traces using the production stasis_render_trace byte-mixing contract
- cross-checked the derived stable value (1894625560) against nightly run 204's device observation
- python -m unittest tools.ci.test_android_emulator_seams tools.ci.test_run_android_release_shell_seam (21 tests)