### PR TITLE
fix: scope test data bindings to imports

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -1444,6 +1444,21 @@ pub fn load_and_apply_play_data_bindings(
     paths: &[(PathBuf, PathBuf)],
     jit: Option<&JitProcess>,
 ) -> Result<(), String> {
+    load_and_apply_play_data_bindings_with_scope(paths, jit, false)
+}
+
+pub fn load_and_apply_play_data_bindings_for_test(
+    paths: &[(PathBuf, PathBuf)],
+    jit: &JitProcess,
+) -> Result<(), String> {
+    load_and_apply_play_data_bindings_with_scope(paths, Some(jit), true)
+}
+
+fn load_and_apply_play_data_bindings_with_scope(
+    paths: &[(PathBuf, PathBuf)],
+    jit: Option<&JitProcess>,
+    skip_missing_global_roots: bool,
+) -> Result<(), String> {
     let mut loaded = Vec::new();
     for (data_path, meta_path) in paths {
         let meta_source = fs::read_to_string(meta_path).map_err(|error| {
@@ -1508,10 +1523,18 @@ pub fn load_and_apply_play_data_bindings(
     for (_, data_root, metadata) in &loaded {
         validate_play_binding_source(data_root, metadata)?;
         if let Some(jit) = jit {
+            if skip_missing_global_roots && !jit.has_global_path(&metadata.global_name) {
+                continue;
+            }
             validate_play_binding_targets(metadata, jit)?;
         }
     }
     for (_, json_root, metadata) in loaded {
+        if skip_missing_global_roots
+            && jit.is_some_and(|jit| !jit.has_global_path(&metadata.global_name))
+        {
+            continue;
+        }
         apply_play_data_binding_value(&json_root, &metadata)?;
     }
     Ok(())

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use stasis::{
-    load_and_apply_play_data_bindings, resolve_play_data_binding_paths, run_live_in_process,
-    run_live_in_process_with_data, run_play_in_process_with_window_title,
+    load_and_apply_play_data_bindings_for_test, resolve_play_data_binding_paths,
+    run_live_in_process, run_live_in_process_with_data, run_play_in_process_with_window_title,
     run_self_host_aot_cli_with_options, LiveRunConfig, StasisTestRunSession,
 };
 use stasis_assets::{
@@ -2172,7 +2172,7 @@ fn test_workspace(workspace: &Workspace, path: Option<&Path>) -> Result<CommandR
                 snapshot,
                 manifest.as_ref(),
             )?;
-            load_and_apply_play_data_bindings(&data_binding_paths, Some(jit))
+            load_and_apply_play_data_bindings_for_test(&data_binding_paths, jit)
         },
     )?;
     let scenarios = headless::run_scenarios(workspace, &directory)?;
@@ -6315,6 +6315,26 @@ mod tests {
         );
         let workspace = load_workspace(Some(&root)).expect("workspace");
         test_workspace(&workspace, None).expect("bound test project");
+        remove_temp(&root);
+    }
+
+    #[test]
+    fn workspace_tests_skip_project_bindings_outside_the_test_import_graph() {
+        let root = temp_dir("test_data_binding_scoped_imports");
+        write_data_binding_test_project(
+            &root,
+            Some(r#"{"config":{"loaded":true,"scalar":17,"values":[4,9]}}"#),
+            Some(DATA_BINDING_META),
+        );
+        fs::write(
+            root.join("tests/independent.test.stasis"),
+            "global independent_value: i32;\ntest `independent test omits project globals`(): bool { return independent_value == 0; }\n",
+        )
+        .expect("write independent test");
+        let workspace = load_workspace(Some(&root)).expect("workspace");
+        let result = test_workspace(&workspace, None).expect("scoped binding test project");
+        assert_eq!(result.data["tests_run"], 2);
+        assert_eq!(result.data["tests_passed"], 2);
         remove_temp(&root);
     }
 


### PR DESCRIPTION
## Summary
- apply project data bindings only to independently compiled tests whose import graph contains the binding's root global
- keep source, field, type, and capacity validation strict when that global is present
- cover a project with one bound test and one independent test file

## Verification
- cache-aware cargo fmt --all -- --check
- cache-aware cargo test -p stasis workspace_tests_

## Release evidence
Gambit Guard production run 31793860288 reproduced the regression on nightly-20260814-205: stasis test rejected live_balance_data.piece_max_hp in an independently compiled test that does not import that global.