### PR TITLE
fix: dismiss Android system dialog actions

### DIFF
--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -9,6 +9,7 @@ import re
 import struct
 import subprocess
 import time
+import xml.etree.ElementTree as ET
 import zlib
 from pathlib import Path
 
@@ -509,6 +510,48 @@ def validate_regions(capture: Path, expectations: dict) -> list[dict]:
     return observed
 
 
+def dismiss_system_dialog_action(adb: Path, serial: str | None) -> bool:
+    hierarchy = _run(
+        adb,
+        serial,
+        "shell",
+        "uiautomator",
+        "dump",
+        "/dev/tty",
+        required=False,
+    )
+    start = hierarchy.find("<?xml")
+    end = hierarchy.rfind("</hierarchy>")
+    if start < 0 or end < start:
+        return False
+    try:
+        root = ET.fromstring(hierarchy[start : end + len("</hierarchy>")])
+    except ET.ParseError:
+        return False
+    actions = {
+        node.attrib.get("text", ""): node.attrib.get("bounds", "")
+        for node in root.iter("node")
+    }
+    for label in ("Close app", "Wait"):
+        bounds = actions.get(label, "")
+        match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds)
+        if match is None:
+            continue
+        left, top, right, bottom = (int(value) for value in match.groups())
+        _run(
+            adb,
+            serial,
+            "shell",
+            "input",
+            "tap",
+            str((left + right) // 2),
+            str((top + bottom) // 2),
+            required=False,
+        )
+        return True
+    return False
+
+
 def ensure_test_activity_foreground(
     adb: Path,
     serial: str | None,
@@ -530,7 +573,8 @@ def ensure_test_activity_foreground(
     )
     if package_id in current_focus:
         return False
-    if current_focus:
+    dismissed = dismiss_system_dialog_action(adb, serial) if current_focus else False
+    if current_focus and not dismissed:
         _run(
             adb,
             serial,

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -170,6 +170,44 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             ("shell", "input", "keyevent", "KEYCODE_BACK"),
             calls,
         )
+
+    def test_foreground_check_taps_system_dialog_action_before_restarting(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("shell", "dumpsys", "window", "windows"):
+                return "mCurrentFocus=Window{456 u0 android/.AppNotRespondingDialog}"
+            if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
+                return (
+                    "UI hierarchy dumped\n<?xml version='1.0' encoding='UTF-8' "
+                    "standalone='yes'?><hierarchy><node text=\"Close app\" "
+                    "bounds=\"[120,600][420,720]\" /></hierarchy>"
+                )
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            changed = seam.ensure_test_activity_foreground(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                "com.example.seam/.MainActivity",
+            )
+
+        self.assertTrue(changed)
+        self.assertIn(("shell", "input", "tap", "270", "660"), calls)
+        self.assertNotIn(("shell", "input", "keyevent", "KEYCODE_BACK"), calls)
+        self.assertIn(
+            (
+                "shell",
+                "am",
+                "start",
+                "-W",
+                "-n",
+                "com.example.seam/.MainActivity",
+            ),
+            calls,
+        )
         self.assertIn(
             (
                 "shell",


### PR DESCRIPTION
## Summary
- inspect Android's UI hierarchy when a non-test window owns focus
- tap the concrete Close app (or Wait fallback) action for ANR dialogs before restarting the test activity
- retain KEYCODE_BACK as the fallback for other system windows

## Verification
- python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_android_emulator_seams (22 tests)
- git diff --check

## Nightly evidence
Run 31794908616 captured Pixel Launcher isn't responding over a correctly rendered IT-017 frame. The existing KEYCODE_BACK retry left the ANR modal composited; observed left_red was the dialog's [241,240,247] instead of the expected [230,31,41].