### PR TITLE
fix: preserve full-image web sprite rendering

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -93,6 +93,8 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
         "function applyWindowRequest",
         "function sdlScancode",
         "const spriteStride = version >= 5 ? 8 : 4;",
+        "if (u0 === 0 && v0 === 0 && u1 === 1 && v1 === 1)",
+        "context.drawImage(image, -width / 2, -height / 2, width, height);",
         "context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight",
     ] {
         assert!(

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -429,7 +429,11 @@
       context.globalAlpha = Math.max(0, Math.min(1, i32[baseI + 2] / 255));
       context.translate(x + width / 2, y + height / 2);
       context.rotate(i32[baseI + 1] * Math.PI / 180);
-      context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight, -width / 2, -height / 2, width, height);
+      if (u0 === 0 && v0 === 0 && u1 === 1 && v1 === 1) {
+        context.drawImage(image, -width / 2, -height / 2, width, height);
+      } else {
+        context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight, -width / 2, -height / 2, width, height);
+      }
       context.restore();
     };
     const drawText = index => {


### PR DESCRIPTION
Release web packages using graphics command buffer V5 routed every sprite through the cropped nine-argument Canvas drawImage overload. Chromium renders ordinary SVG images incompletely through that path even when the UV rectangle is the full image. Use the established full-image overload for exact full UVs, while retaining source cropping for actual sprite-sheet cells. Verified with the focused web_package test and real Gambit Guard browser framebuffer captures at 360x720 and 1440x1000; the complete logo and rounded PLAY button are restored and the release HUD remains absent.