### PR TITLE
ci: dismiss layered Android ANR dialogs

### DIFF
--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -571,10 +571,15 @@ def ensure_test_activity_foreground(
         (line for line in windows.splitlines() if "mCurrentFocus=" in line),
         "",
     )
-    if package_id in current_focus:
+    system_dialog_present = "AppNotRespondingDialog" in windows
+    if package_id in current_focus and not system_dialog_present:
         return False
-    dismissed = dismiss_system_dialog_action(adb, serial) if current_focus else False
-    if current_focus and not dismissed:
+    dismissed = (
+        dismiss_system_dialog_action(adb, serial)
+        if current_focus or system_dialog_present
+        else False
+    )
+    if (current_focus or system_dialog_present) and not dismissed:
         _run(
             adb,
             serial,

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -208,6 +208,46 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             ),
             calls,
         )
+
+    def test_foreground_check_dismisses_layered_anr_over_focused_activity(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("shell", "dumpsys", "window", "windows"):
+                return (
+                    "mCurrentFocus=Window{123 u0 com.example.seam/.MainActivity}\n"
+                    "Window #2 Window{456 u0 android/.AppNotRespondingDialog}"
+                )
+            if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
+                return (
+                    "<?xml version='1.0' encoding='UTF-8'?><hierarchy>"
+                    "<node text=\"Close app\" bounds=\"[120,600][420,720]\" />"
+                    "</hierarchy>"
+                )
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            changed = seam.ensure_test_activity_foreground(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                "com.example.seam/.MainActivity",
+            )
+
+        self.assertTrue(changed)
+        self.assertIn(("shell", "input", "tap", "270", "660"), calls)
+        self.assertIn(
+            (
+                "shell",
+                "am",
+                "start",
+                "-W",
+                "-n",
+                "com.example.seam/.MainActivity",
+            ),
+            calls,
+        )
         self.assertIn(
             (
                 "shell",


### PR DESCRIPTION
Nightly 208 captured Pixel Launcher's ANR dialog over IT-017 even though the test activity could remain reported as the focused window. Detect AppNotRespondingDialog anywhere in the full window dump, then use the existing hierarchy action tap and restart path before framebuffer capture. Adds a regression for an ANR window layered over a focused test activity. Verified: 16 seam unit tests pass.