### PR TITLE
feat: improve local release packaging

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -40,7 +40,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod dap;
 mod gauntlet;
@@ -134,6 +134,26 @@ if ! git diff --quiet -- ':(glob)**/*.stasis'; then
     exit 1
 fi
 "#;
+const TARGET_BUILD_HELP: &str = r#"Build targets:
+  Windows, Linux, or macOS (current host)
+    stasis build --mode release
+    stasis package --target desktop
+
+  Web (WebAssembly browser bundle)
+    stasis package --target web
+
+  Android devices (64-bit ARM app project)
+    stasis package-mobile --target android-arm64
+
+  Android emulator (x86-64 test app project)
+    stasis package-mobile --target android-x86_64 --development-build
+
+  iPhone and iPad (64-bit ARM app project)
+    stasis package-mobile --target ios-arm64
+
+Desktop builds target the operating system running stasis. Web output is a static bundle to
+serve over HTTP. Mobile commands create Gradle or Xcode projects for final SDK builds; source
+toolchains create local release packages when official provenance is absent."#;
 const COMMANDS: &[&str] = &[
     "new",
     "init",
@@ -168,7 +188,8 @@ const COMMANDS: &[&str] = &[
     name = "stasis",
     version,
     about = "The batteries-included Stasis toolchain",
-    long_about = "Create, format, check, test, run, live-edit, build, inspect, and package Stasis projects without invoking Cargo."
+    long_about = "Create, format, check, test, run, live-edit, build, inspect, and package Stasis projects without invoking Cargo.",
+    after_help = TARGET_BUILD_HELP
 )]
 struct ToolchainCli {
     #[arg(
@@ -325,7 +346,7 @@ enum ToolchainCommand {
         target: PackageTarget,
         #[arg(long, value_name = "PATH")]
         out: Option<PathBuf>,
-        /// Permit a visibly labeled package from a local/source toolchain.
+        /// Force a visibly labeled development package.
         #[arg(long)]
         development_build: bool,
     },
@@ -337,7 +358,7 @@ enum ToolchainCommand {
         entry: Option<PathBuf>,
         #[arg(long, value_name = "PATH")]
         out: Option<PathBuf>,
-        /// Permit a visibly labeled package from a local/source toolchain.
+        /// Force a visibly labeled development package.
         #[arg(long)]
         development_build: bool,
         /// Select named Stasis functions for bounded mobile AOT profiling.
@@ -796,8 +817,19 @@ pub(super) fn try_run() -> Option<i32> {
     };
     let command_name = command_name(&parsed.command);
     let raw_output = matches!(&parsed.command, ToolchainCommand::Fmt { stdin: true, .. });
+    let started_at = (!parsed.json
+        && matches!(
+            &parsed.command,
+            ToolchainCommand::Build { .. }
+                | ToolchainCommand::Package { .. }
+                | ToolchainCommand::PackageMobile { .. }
+        ))
+    .then(Instant::now);
     match execute(parsed.command, parsed.workspace, parsed.json) {
-        Ok(result) => {
+        Ok(mut result) => {
+            if let Some(started_at) = started_at {
+                append_elapsed_confirmation(&mut result.human, started_at.elapsed());
+            }
             if parsed.json {
                 println!(
                     "{}",
@@ -837,6 +869,22 @@ pub(super) fn try_run() -> Option<i32> {
             }
             Some(1)
         }
+    }
+}
+
+fn append_elapsed_confirmation(output: &mut String, elapsed: Duration) {
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    output.push_str("Completed in ");
+    if elapsed.as_secs() >= 60 {
+        let minutes = elapsed.as_secs() / 60;
+        let seconds = elapsed.as_secs_f64() - minutes as f64 * 60.0;
+        output.push_str(&format!("{minutes}m {seconds:.1}s."));
+    } else if elapsed.as_secs() >= 1 {
+        output.push_str(&format!("{:.2}s.", elapsed.as_secs_f64()));
+    } else {
+        output.push_str(&format!("{}ms.", elapsed.as_millis()));
     }
 }
 
@@ -3700,6 +3748,7 @@ fn package_web_workspace(
         ));
     }
     let provenance = resolve_package_provenance(development_build)?;
+    let development_build = provenance["development_build"].as_bool() == Some(true);
     fs::create_dir_all(&staging_root)
         .map_err(|error| format!("failed to create {}: {error}", staging_root.display()))?;
 
@@ -4358,21 +4407,16 @@ fn content_hashes(root: &Path, prefix: &str) -> Result<serde_json::Map<String, V
     Ok(output)
 }
 
-fn release_provenance_path() -> Result<PathBuf, String> {
+fn release_provenance_path() -> Result<Option<PathBuf>, String> {
     let executable = env::current_exe()
         .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
     let directory = executable.parent().unwrap_or(Path::new("."));
-    for candidate in [
+    Ok([
         directory.join(RELEASE_PROVENANCE_NAME),
         directory.join("..").join(RELEASE_PROVENANCE_NAME),
-    ] {
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-    }
-    Err(format!(
-        "installed toolchain is missing {RELEASE_PROVENANCE_NAME}; reinstall an official release or pass --development-build for a visibly labeled local package"
-    ))
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file()))
 }
 
 fn provenance_string_field<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
@@ -4491,7 +4535,7 @@ fn git_text(args: &[&str]) -> Option<String> {
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn development_provenance() -> Result<Value, String> {
+fn local_provenance(development_build: bool) -> Result<Value, String> {
     let executable = env::current_exe()
         .map_err(|error| format!("failed to locate stasis executable: {error}"))?;
     let runtime = bundled_mobile_runtime_dir()?;
@@ -4503,12 +4547,20 @@ fn development_provenance() -> Result<Value, String> {
             Value::String(sha256_file(&runtime.join(name))?),
         );
     }
+    let dirty_state = git_text(&["status", "--porcelain", "--untracked-files=no"])
+        .map_or(true, |status| !status.is_empty());
+    let build_class = if development_build {
+        "development"
+    } else {
+        "local_release"
+    };
     Ok(json!({
         "schema": "stasis.release_provenance.v1",
+        "build_class": build_class,
         "release_tag": Value::Null,
         "source_commit": git_text(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_string()),
-        "dirty_state": true,
-        "development_build": true,
+        "dirty_state": dirty_state,
+        "development_build": development_build,
         "compiler": {
             "path": executable.file_name().unwrap_or_default().to_string_lossy(),
             "sha256": sha256_file(&executable)?,
@@ -4520,7 +4572,7 @@ fn development_provenance() -> Result<Value, String> {
         "features": ["aot", "jit", "mobile-aot", "shared-renderer"],
         "dependencies": {
             "stasis": env!("CARGO_PKG_VERSION"),
-            "toolchain": "development",
+            "toolchain": build_class,
             "sdl3": "3.4.10-static",
             "sdl3_image": "3.4.4-static",
         },
@@ -4529,9 +4581,11 @@ fn development_provenance() -> Result<Value, String> {
 
 fn resolve_package_provenance(development_build: bool) -> Result<Value, String> {
     if development_build {
-        development_provenance()
+        local_provenance(true)
+    } else if let Some(path) = release_provenance_path()? {
+        verify_release_provenance(&path)
     } else {
-        verify_release_provenance(&release_provenance_path()?)
+        local_provenance(false)
     }
 }
 
@@ -4545,6 +4599,8 @@ fn write_mobile_provenance_header(destination: &Path, provenance: &Value) -> Res
     let commit = provenance["source_commit"].as_str().unwrap_or("unknown");
     let label = if provenance["development_build"].as_bool() == Some(true) {
         "non-release development build"
+    } else if provenance["build_class"] == "local_release" {
+        "local release"
     } else {
         "official release"
     };
@@ -6107,6 +6163,22 @@ mod tests {
     }
     use std::sync::atomic::{AtomicU64, Ordering};
 
+    #[test]
+    fn elapsed_confirmation_uses_readable_units() {
+        for (elapsed, expected) in [
+            (Duration::from_millis(482), "built\nCompleted in 482ms."),
+            (Duration::from_millis(1_250), "built\nCompleted in 1.25s."),
+            (
+                Duration::from_millis(301_500),
+                "built\nCompleted in 5m 1.5s.",
+            ),
+        ] {
+            let mut output = "built".to_string();
+            append_elapsed_confirmation(&mut output, elapsed);
+            assert_eq!(output, expected);
+        }
+    }
+
     static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
 
     fn temp_dir(name: &str) -> PathBuf {
@@ -6632,6 +6704,23 @@ mod tests {
     }
 
     #[test]
+    fn local_release_provenance_keeps_release_behavior_without_claiming_official_status() {
+        let provenance = local_provenance(false).expect("local release provenance");
+        assert_eq!(provenance["build_class"], "local_release");
+        assert_eq!(provenance["development_build"], false);
+        assert!(provenance["release_tag"].is_null());
+        assert!(provenance["compiler"]["sha256"].as_str().is_some());
+
+        let root = temp_dir("local_release_provenance");
+        fs::create_dir_all(&root).expect("local release header directory");
+        write_mobile_provenance_header(&root, &provenance).expect("local release header");
+        assert!(fs::read_to_string(root.join("stasis_package_provenance.h"))
+            .expect("read local release header")
+            .contains("local release"));
+        remove_temp(&root);
+    }
+
+    #[test]
     fn release_provenance_rejects_substituted_renderer_sources() {
         let root = temp_dir("release_provenance_mismatch");
         let runtime = root.join("runtime");
@@ -6781,7 +6870,7 @@ mod tests {
 
         let android = root.join("android-package");
         fs::create_dir_all(&android).expect("create Android staging");
-        let provenance = development_provenance().expect("development provenance");
+        let provenance = local_provenance(true).expect("development provenance");
         assemble_mobile_shell(
             &workspace,
             PackageTarget::AndroidArm64,

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -4547,8 +4547,9 @@ fn local_provenance(development_build: bool) -> Result<Value, String> {
             Value::String(sha256_file(&runtime.join(name))?),
         );
     }
-    let dirty_state = git_text(&["status", "--porcelain", "--untracked-files=no"])
-        .map_or(true, |status| !status.is_empty());
+    let dirty_state = development_build
+        || git_text(&["status", "--porcelain", "--untracked-files=no"])
+            .map_or(true, |status| !status.is_empty());
     let build_class = if development_build {
         "development"
     } else {
@@ -6718,6 +6719,14 @@ mod tests {
             .expect("read local release header")
             .contains("local release"));
         remove_temp(&root);
+    }
+
+    #[test]
+    fn development_provenance_is_always_marked_dirty() {
+        let provenance = local_provenance(true).expect("development provenance");
+        assert_eq!(provenance["build_class"], "development");
+        assert_eq!(provenance["development_build"], true);
+        assert_eq!(provenance["dirty_state"], true);
     }
 
     #[test]

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -94,6 +94,63 @@ fn json_stderr(output: &Output) -> Value {
 }
 
 #[test]
+fn help_explains_how_to_build_each_supported_target() {
+    let output = stasis(&["help"], Path::new(env!("CARGO_MANIFEST_DIR")));
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let help = String::from_utf8(output.stdout).expect("UTF-8 help output");
+
+    for expected in [
+        "Build targets:",
+        "Windows, Linux, or macOS (current host)",
+        "stasis build --mode release",
+        "stasis package --target desktop",
+        "stasis package --target web",
+        "stasis package-mobile --target android-arm64",
+        "stasis package-mobile --target android-x86_64 --development-build",
+        "stasis package-mobile --target ios-arm64",
+        "Mobile commands create Gradle or Xcode projects",
+    ] {
+        assert!(help.contains(expected), "missing help text: {expected}");
+    }
+}
+
+#[test]
+fn build_confirmation_reports_elapsed_time() {
+    let project = temp_dir("build_elapsed");
+    fs::create_dir_all(project.join("src")).expect("source directory");
+    fs::write(
+        project.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"build_elapsed","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("workspace manifest");
+    fs::write(
+        project.join("src/main.stasis"),
+        "function main(): i32 { return 0; }\n",
+    )
+    .expect("entry source");
+
+    let output = stasis(&["build", "--mode", "dev"], &project);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 build output");
+    let confirmation = stdout.lines().last().expect("elapsed confirmation");
+    assert!(confirmation.starts_with("Completed in "), "{stdout}");
+    assert!(confirmation.ends_with('.'), "{stdout}");
+
+    let json_output = stasis(&["--json", "build", "--mode", "dev"], &project);
+    let json = json_stdout(&json_output);
+    assert_eq!(json["command"], "build");
+    assert!(json["result"].get("elapsed_ms").is_none());
+
+    fs::remove_dir_all(project).ok();
+}
+
+#[test]
 fn check_reports_structured_asset_diagnostics_and_build_is_atomic() {
     let project = temp_dir("asset_validation");
     fs::create_dir_all(project.join("src")).expect("source directory");
@@ -1621,6 +1678,11 @@ fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
             "stdout={} stderr={}",
             String::from_utf8_lossy(&packaged.stdout),
             String::from_utf8_lossy(&packaged.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&packaged.stdout).contains("\nCompleted in "),
+            "stdout={}",
+            String::from_utf8_lossy(&packaged.stdout)
         );
         assert!(project
             .join(output)

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -79,13 +79,19 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
 
     let wasm = fs::read(output.join("game.wasm")).expect("game.wasm");
     assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
-    for export in ["main", "tick", "render", "player_x"] {
+    for export in ["main", "tick", "render"] {
         assert!(
             wasm.windows(export.len())
                 .any(|window| window == export.as_bytes()),
             "missing Wasm export {export}"
         );
     }
+    assert!(
+        !wasm
+            .windows("player_x".len())
+            .any(|window| window == b"player_x"),
+        "local release retained development-only Wasm symbols"
+    );
     let runtime = fs::read_to_string(output.join("game.js")).expect("game.js");
     let index = fs::read_to_string(output.join("index.html")).expect("index.html");
     assert!(!index.contains("stasis-audio"));
@@ -117,7 +123,7 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
     assert!(!runtime.contains("data:application/wasm;base64,"));
     assert!(output.join("index.html").is_file());
     let index = fs::read_to_string(output.join("index.html")).expect("index.html");
-    assert!(index.contains(r#"id="stasis-hud""#));
+    assert!(!index.contains(r#"id="stasis-hud""#));
     assert!(!index.contains("__STASIS_"));
     assert!(!output.join("play").exists());
     assert!(output.join("stasis_provenance.json").is_file());

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -26,7 +26,6 @@ fn package(workspace: &Path, relative_output: &Path) -> PathBuf {
         .arg(workspace)
         .arg("--target")
         .arg("web")
-        .arg("--development-build")
         .arg("--out")
         .arg(relative_output)
         .arg("--json")
@@ -39,10 +38,16 @@ fn package(workspace: &Path, relative_output: &Path) -> PathBuf {
         String::from_utf8_lossy(&result.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&result.stdout).contains("\"wasm_optimized\":false"),
-        "development package unexpectedly optimized Wasm: {}",
+        String::from_utf8_lossy(&result.stdout).contains("\"development_build\":false"),
+        "source-built package did not select local release provenance: {}",
         String::from_utf8_lossy(&result.stdout)
     );
+    let provenance: serde_json::Value = serde_json::from_slice(
+        &fs::read(output.join("stasis_provenance.json")).expect("read web provenance"),
+    )
+    .expect("parse web provenance");
+    assert_eq!(provenance["build_class"], "local_release");
+    assert_eq!(provenance["development_build"], false);
     output
 }
 
@@ -82,6 +87,9 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
         );
     }
     let runtime = fs::read_to_string(output.join("game.js")).expect("game.js");
+    let index = fs::read_to_string(output.join("index.html")).expect("index.html");
+    assert!(!index.contains("stasis-audio"));
+    assert!(!index.contains("Enable sound"));
     for expected in [
         "requestAnimationFrame(frame)",
         "web_play_tone",
@@ -91,6 +99,9 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
         "audio_push_f32_interleaved",
         "function writeHostFrame",
         "function applyWindowRequest",
+        "const enableWebAudio = () =>",
+        "addEventListener(\"pointerdown\", () => { void enableWebAudio(); }",
+        "void enableWebAudio();",
         "function sdlScancode",
         "const spriteStride = version >= 5 ? 8 : 4;",
         "if (u0 === 0 && v0 === 0 && u1 === 1 && v1 === 1)",
@@ -187,6 +198,7 @@ fn existing_audio_game_packages_wav_and_mp3_for_web_audio() {
             "web runtime embedded {expected}"
         );
     }
+    assert!(!runtime.contains("audioButton"));
     assert!(runtime.contains(r#""assets":{}"#));
     assert!(!runtime.contains("../assets/"));
     assert!(output.join("assets/tone.mp3").is_file());

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -9,8 +9,9 @@ stasis --workspace path/to/game package-mobile --target ios-arm64
 ```
 
 Official release archives verify their compiler and runtime sources against
-`stasis_release_provenance.json` before packaging. A source checkout must add
-`--development-build`; that output is explicitly labeled non-release. See
+`stasis_release_provenance.json` before packaging. When that manifest is absent,
+a source-built toolchain automatically emits content-addressed local-release provenance and keeps
+optimized release behavior. `--development-build` explicitly selects development output. See
 `release_provenance.md` for the manifest and repinning contract.
 
 `stasis.json` supplies the entry source. Its optional Android object supplies

--- a/docs/release_provenance.md
+++ b/docs/release_provenance.md
@@ -24,13 +24,18 @@ sidecar manifest from the resolved runtime payload directory during initializati
 embedded manifest and exposes the release/development classification to build
 audit tools.
 
-## Development builds
+## Local release and development builds
 
 A source checkout has no authority to claim an official release. Local proof
-packages therefore require the explicit `--development-build` flag. Their
-manifest sets `development_build` and `dirty_state` to `true`, uses a null
-release tag, and logs `non-release development build` at runtime. This flag
-permits local iteration; it never disables asset or compiler validation.
+packages therefore use `build_class: "local_release"` when the installed
+toolchain has no `stasis_release_provenance.json`. They still use optimized release behavior and
+set `development_build` to `false`, while recording the real source commit, dirty state, compiler
+hash, and runtime/template hashes. Their release tag remains null and mobile runtimes label them
+`local release`, so they cannot be confused with a verified official archive.
+
+`--development-build` explicitly selects development behavior and provenance. Those packages use
+`build_class: "development"`, set `development_build` to `true`, and log
+`non-release development build` at runtime. The flag never disables asset or compiler validation.
 Manually dispatched bootstrap artifacts use the same development classification;
 only a published `v*` release or generated `nightly-*` release is official.
 
@@ -38,7 +43,8 @@ only a published `v*` release or generated `nightly-*` release is official.
 
 - A source-proof build demonstrates behavior from a named commit but is not a
   distributable release.
-- A local proof package uses `--development-build` and is visibly non-release.
+- A local release package is optimized release output with content-addressed local provenance.
+- A local development package uses `--development-build` and is visibly non-release.
 - An official artifact comes from the release workflow and must pass manifest
   hash verification when it regenerates its Android and iOS smoke packages.
 

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -151,6 +151,10 @@ cloning a generated repository, reactivate the checked-in hook with
   shared AOT output, SDL-only runtime, bundled assets, verified provenance, and thin Gradle or
   Xcode app shell.
 - `package --target android-arm64|ios-arm64`: compatibility spelling that uses the manifest entry.
+- Successful human-readable `build`, `package`, and `package-mobile` commands end with a
+  `Completed in ...` line. Durations use milliseconds for sub-second work, seconds for work under
+  one minute, and minutes plus seconds for longer builds. JSON output remains deterministic and
+  does not include wall-clock timing.
 - `inspect [--capacity PATH=COUNT] [--mobile-budget-bytes N]`: compile the manifest entry and
   report the canonical direct-storage model: bytes and alignment by state path/field, struct
   rollups, capacity versus active count, snapshot size, the eight largest pools, recognized
@@ -212,8 +216,9 @@ scenario-path digest so distinct files cannot overwrite each other. General inpu
 See `samples/headless_scenario` for an executable fixture.
 
 Official packaging fails if the installed compiler or renderer sources differ from the release
-manifest. When working from a source checkout, pass `--development-build` to `package` or
-`package-mobile`; the resulting package is permanently labeled non-release. See
+manifest. Without an installed release manifest, source-built toolchains generate optimized local
+releases with `build_class: "local_release"` and content-addressed provenance. Pass
+`--development-build` to explicitly request visibly labeled development output. See
 [Release and package provenance](release_provenance.md).
 
 Add `--json` to receive one stable JSON result object. Usage errors exit 2, command/compile/test

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -27,6 +27,10 @@ Self-contained single-file HTML output is intentionally deferred; web packages k
 assets external so hosted output remains compact and follows the same asset preparation path as
 Android and desktop packages.
 
+Web packages do not render an audio-enable control. The runtime requests audio immediately and
+automatically retries on the first pointer or keyboard gesture when browser autoplay policy starts
+the audio context suspended.
+
 ## Runtime contract
 
 The browser owns `requestAnimationFrame`, input collection, Canvas 2D command execution, WebAudio,

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -3,7 +3,6 @@
   const canvas = document.getElementById("stasis-canvas");
   const context = canvas.getContext("2d", { alpha: false });
   const hud = document.getElementById("stasis-hud");
-  const audioButton = document.getElementById("stasis-audio");
   const errorBox = document.getElementById("stasis-error");
   const keys = new Set();
   const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, down: false, wentDown: false, wentUp: false };
@@ -15,6 +14,7 @@
   let nextHandle = 1;
   let instance;
   let audioContext;
+  let audioEnablePromise;
   let audioEvents = 0;
   let audioSampleRate = 48000;
   let audioChannels = 2;
@@ -156,6 +156,31 @@
   const updateAudioState = () => {
     document.body.dataset.audioState = audioContext?.state || "closed";
   };
+  const enableWebAudio = () => {
+    const audio = ensureAudio();
+    if (audio.state === "running") {
+      for (const start of pendingAudio.splice(0)) void start();
+      updateAudioState();
+      return Promise.resolve(true);
+    }
+    if (audioEnablePromise) return audioEnablePromise;
+    const attempt = audio.resume().then(() => {
+      if (audio === audioContext && audio.state === "running") {
+        for (const start of pendingAudio.splice(0)) void start();
+        updateAudioState();
+        return true;
+      }
+      updateAudioState();
+      return false;
+    }).catch(() => {
+      updateAudioState();
+      return false;
+    }).finally(() => {
+      if (audioEnablePromise === attempt) audioEnablePromise = undefined;
+    });
+    audioEnablePromise = attempt;
+    return attempt;
+  };
   const suspendWebAudio = () => {
     if (!audioContext) return;
     audioSuspendedByLifecycle = true;
@@ -183,6 +208,7 @@
     for (const handle of Array.from(audioVoices.keys())) stopAudio(handle);
     const closingContext = audioContext;
     audioContext = undefined;
+    audioEnablePromise = undefined;
     audioNextStart = 0;
     if (closingContext && closingContext.state !== "closed") void closingContext.close();
     updateAudioState();
@@ -669,11 +695,13 @@
   }
   addEventListener("keydown", event => {
     keys.add(event.code);
+    void enableWebAudio();
     void applyFullscreenGesture();
     if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Space"].includes(event.code)) event.preventDefault();
   });
   addEventListener("keyup", event => { keys.delete(event.code); void applyFullscreenGesture(); });
   canvas.addEventListener("pointermove", updatePointer);
+  addEventListener("pointerdown", () => { void enableWebAudio(); }, { passive: true });
   canvas.addEventListener("pointerdown", event => {
     updatePointer(event);
     pointer.down = true;
@@ -690,16 +718,7 @@
   canvas.addEventListener("pointercancel", () => { pointer.down = false; pointer.wentUp = true; });
   addEventListener("resize", () => { resized = true; displayGeneration += 1; });
   document.addEventListener("fullscreenchange", () => { resized = true; displayGeneration += 1; });
-  audioButton.addEventListener("click", async () => {
-    await applyFullscreenGesture();
-    audioContext ||= new AudioContext();
-    await audioContext.resume();
-    for (const start of pendingAudio.splice(0)) await start();
-    audioButton.textContent = "Sound enabled";
-    audioButton.disabled = true;
-    updateAudioState();
-    canvas.focus();
-  });
+  void enableWebAudio();
 
   async function wasmBytes() {
     const response = await fetch("game.wasm");

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -11,7 +11,6 @@
     main { position: relative; width: min(960px, 100vw); }
     canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
     __STASIS_PERFORMANCE_HUD_STYLE__
-    #stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }
     #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
   </style>
 </head>
@@ -19,7 +18,6 @@
   <main>
     <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
     __STASIS_PERFORMANCE_HUD__
-    <button id="stasis-audio" type="button">Enable sound</button>
     <pre id="stasis-error"></pre>
   </main>
   <script src="game.js"></script>


### PR DESCRIPTION
## Summary

- add a target-oriented build guide to `stasis help`
- print readable elapsed-time confirmations after successful human-readable build and package commands
- default source-built toolchains to optimized, content-addressed `local_release` provenance when no official release manifest is installed
- remove the web audio-enable button and transparently arm audio immediately or on the first browser gesture

## Why

The CLI exposed packaging targets only through command-specific flags, successful long builds did not report their duration, and source-built installations required an unnecessary `--development-build` opt-in even when users wanted release behavior. Web packages also surfaced an audio control that should not be part of the game UI.

## Impact

`stasis package --target web` now works from a complete source-built toolchain without extra flags and produces optimized local-release output that remains distinct from verified official releases. Human build/package output ends with `Completed in ...`; JSON stays deterministic. Web audio has no visible button and retries automatically after a browser-permitted user gesture.

## Root cause

Packaging treated missing official provenance as a fatal condition instead of a separate local-release class, and web audio activation was coupled to a dedicated DOM button rather than the page's normal input gestures.

## Validation

- `python tools/cargo_cache.py run -- cargo fmt --all -- --check`
- `node --check runtime/web/game.js`
- focused CLI help, elapsed-output, and local-release provenance tests
- all three `apps/stasis/tests/web_package.rs` integration tests
- optimized `cargo build -p stasis --release`
- PATH-installed no-flag web package smoke test verifying `local_release`, elapsed output, automatic audio arming, and no audio button
