### PR TITLE
ci: prefer waiting on Android ANR dialogs

### DIFF
--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -532,7 +532,9 @@ def dismiss_system_dialog_action(adb: Path, serial: str | None) -> bool:
         node.attrib.get("text", ""): node.attrib.get("bounds", "")
         for node in root.iter("node")
     }
-    for label in ("Close app", "Wait"):
+    # Keep the system component alive when Android offers the non-destructive
+    # action. Closing Pixel Launcher can leave the emulator compositor black.
+    for label in ("Wait", "Close app"):
         bounds = actions.get(label, "")
         match = re.fullmatch(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]", bounds)
         if match is None:

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -209,6 +209,34 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             calls,
         )
 
+    def test_foreground_check_prefers_wait_over_closing_system_component(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("shell", "dumpsys", "window", "windows"):
+                return "mCurrentFocus=Window{456 u0 android/.AppNotRespondingDialog}"
+            if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
+                return (
+                    "<?xml version='1.0' encoding='UTF-8'?><hierarchy>"
+                    "<node text=\"Close app\" bounds=\"[120,600][420,720]\" />"
+                    "<node text=\"Wait\" bounds=\"[120,720][420,840]\" />"
+                    "</hierarchy>"
+                )
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            changed = seam.ensure_test_activity_foreground(
+                Path("adb"),
+                "device",
+                "com.example.seam",
+                "com.example.seam/.MainActivity",
+            )
+
+        self.assertTrue(changed)
+        self.assertIn(("shell", "input", "tap", "270", "780"), calls)
+        self.assertNotIn(("shell", "input", "tap", "270", "660"), calls)
+
     def test_foreground_check_dismisses_layered_anr_over_focused_activity(self):
         calls = []
 


### PR DESCRIPTION
Nightly 209 successfully dismissed Pixel Launcher's ANR dialog but selected Close app, after which the captured compositor stayed black despite an earlier stable seam frame. Prefer Android's non-destructive Wait action and retain Close app as a fallback when Wait is unavailable. Adds an explicit both-action regression. Verified: 17 seam unit tests pass.