### PR TITLE
feat: link web runtime by reachable imports

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -3593,6 +3593,7 @@ fn package_workspace(
 
 const WEB_INDEX_HTML: &str = include_str!("../../../runtime/web/index.html");
 const WEB_RUNTIME_JS: &str = include_str!("../../../runtime/web/game.js");
+const WEB_MINIMAL_RUNTIME_JS: &str = include_str!("../../../runtime/web/game_minimal.js");
 
 struct WebWasmArtifact {
     bytes: Vec<u8>,
@@ -3755,7 +3756,11 @@ fn package_web_workspace(
         let runtime_json = serde_json::to_string(&runtime_config)
             .map_err(|error| format!("failed to encode static web runtime metadata: {error}"))?
             .replace("</", "<\\/");
-        let runtime_bundle = format!("window.STASIS_GAME = {runtime_json};\n{WEB_RUNTIME_JS}");
+        let audio_enabled = process.imported_symbols().iter().any(|symbol| {
+            symbol.starts_with("audio_") || symbol.contains("_audio_") || symbol == "web_play_tone"
+        });
+        let linked_runtime = link_web_runtime(&process, audio_enabled);
+        let runtime_bundle = format!("window.STASIS_GAME = {runtime_json};\n{linked_runtime}");
         let wasm_path = staging_root.join("game.wasm");
         fs::write(&wasm_path, &wasm.bytes)
             .map_err(|error| format!("failed to write {}: {error}", wasm_path.display()))?;
@@ -3763,7 +3768,7 @@ fn package_web_workspace(
             .map_err(|error| format!("failed to write web runtime: {error}"))?;
         fs::write(
             staging_root.join("index.html"),
-            web_index_html(&workspace.manifest.name, development_build),
+            web_index_html(&workspace.manifest.name, development_build, audio_enabled),
         )
         .map_err(|error| format!("failed to write web index: {error}"))?;
 
@@ -3810,7 +3815,7 @@ fn package_web_workspace(
     ))
 }
 
-fn web_index_html(title: &str, development_build: bool) -> String {
+fn web_index_html(title: &str, development_build: bool, audio_enabled: bool) -> String {
     let (hud_style, hud) = if development_build {
         (
             "#stasis-hud { position: absolute; top: 10px; left: 10px; padding: 8px 10px; background: #000b; border: 1px solid #53d8fb88; line-height: 1.4; pointer-events: none; }",
@@ -3823,6 +3828,69 @@ fn web_index_html(title: &str, development_build: bool) -> String {
         .replace("__STASIS_GAME_TITLE__", title)
         .replace("__STASIS_PERFORMANCE_HUD_STYLE__", hud_style)
         .replace("__STASIS_PERFORMANCE_HUD__", hud)
+        .replace(
+            "__STASIS_AUDIO_BUTTON_STYLE__",
+            if audio_enabled { "#stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }" } else { "" },
+        )
+        .replace(
+            "__STASIS_AUDIO_BUTTON__",
+            if audio_enabled { r#"<button id="stasis-audio" type="button">Enable sound</button>"# } else { "" },
+        )
+}
+
+fn lean_web_runtime(process: &WasmProcess) -> Option<String> {
+    if WEB_RUNTIME_BUFFERS
+        .iter()
+        .any(|path| process.memory_layout().contains_key(*path))
+    {
+        return None;
+    }
+    let snippets = BTreeMap::from([
+        ("cos_fast", "    cos_fast: value => Math.cos(value),"),
+        ("print_char", "    print_char: value => console.log(String.fromCodePoint(value)),"),
+        ("print_i32", "    print_i32: value => console.log(value),"),
+        ("print_int", "    print_int: value => console.log(value),"),
+        ("print_string", "    print_string: value => console.log(stringValue(value)),"),
+        ("sin_fast", "    sin_fast: value => Math.sin(value),"),
+        ("web_begin_frame", "    web_begin_frame: (r, g, b) => { commands.length = 0; commands.push([0, r, g, b]); },"),
+        ("web_draw_rect", "    web_draw_rect: (x, y, width, height, r, g, b) => commands.push([1, x, y, width, height, r, g, b]),"),
+        ("web_draw_text", "    web_draw_text: (x, y, value) => commands.push([2, x, y, value]),"),
+    ]);
+    let imports = process
+        .imported_symbols()
+        .iter()
+        .map(|symbol| snippets.get(symbol.as_str()).copied())
+        .collect::<Option<Vec<_>>>()?;
+    Some(WEB_MINIMAL_RUNTIME_JS.replace("__STASIS_IMPORTS__", &imports.join("\n")))
+}
+
+fn link_web_runtime(process: &WasmProcess, audio_enabled: bool) -> String {
+    if let Some(runtime) = lean_web_runtime(process) {
+        return runtime;
+    }
+    strip_web_runtime_feature(WEB_RUNTIME_JS, "audio", audio_enabled)
+}
+
+fn strip_web_runtime_feature(source: &str, feature: &str, enabled: bool) -> String {
+    let begin = format!("// @stasis-feature {feature} begin");
+    let end = format!("// @stasis-feature {feature} end");
+    let mut inside = false;
+    source
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed == begin {
+                inside = true;
+                return None;
+            }
+            if trimmed == end {
+                inside = false;
+                return None;
+            }
+            (enabled || !inside).then_some(line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 // Keep these aligned with the metadata reads in runtime/web/game.js. Development
@@ -5656,12 +5724,14 @@ mod tests {
 
     #[test]
     fn release_web_index_omits_performance_hud() {
-        let release = web_index_html("release-game", false);
+        let release = web_index_html("release-game", false, false);
         assert!(!release.contains("stasis-hud"));
+        assert!(!release.contains("stasis-audio"));
         assert!(!release.contains("__STASIS_"));
 
-        let development = web_index_html("development-game", true);
+        let development = web_index_html("development-game", true, true);
         assert!(development.contains(r#"id="stasis-hud""#));
+        assert!(development.contains(r#"id="stasis-audio""#));
         assert!(!development.contains("__STASIS_"));
     }
 

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -114,6 +114,49 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
 }
 
 #[test]
+fn minimal_pong_omits_unreachable_audio_and_input_from_wasm_and_js() {
+    let workspace = repo_root().join("samples/pong_web_minimal");
+    let relative_output = PathBuf::from(format!("build/web-package-test-{}", stamp()));
+    let output = package(&workspace, &relative_output);
+
+    let wasm = fs::read(output.join("game.wasm")).expect("minimal Pong Wasm");
+    let runtime = fs::read_to_string(output.join("game.js")).expect("minimal Pong runtime");
+    let index = fs::read_to_string(output.join("index.html")).expect("minimal Pong index");
+    for reachable in ["reset_ball", "follow_ball", "web_draw_rect"] {
+        assert!(
+            wasm.windows(reachable.len())
+                .any(|window| window == reachable.as_bytes()),
+            "missing reachable Pong dependency {reachable}"
+        );
+    }
+    for omitted in [
+        "unused_audio_feature",
+        "unused_keyboard_feature",
+        "web_play_tone",
+        "web_input_axis",
+    ] {
+        assert!(
+            !wasm
+                .windows(omitted.len())
+                .any(|window| window == omitted.as_bytes()),
+            "Wasm retained unreachable dependency {omitted}"
+        );
+        assert!(!runtime.contains(omitted), "JS retained {omitted}");
+    }
+    assert!(!runtime.contains("AudioContext"));
+    assert!(!runtime.contains("keydown"));
+    assert!(!runtime.contains("pointerdown"));
+    assert!(!index.contains("Enable sound"));
+    assert!(
+        runtime.len() < 10_000,
+        "minimal runtime was {} bytes",
+        runtime.len()
+    );
+
+    fs::remove_dir_all(&output).expect("clean minimal Pong package");
+}
+
+#[test]
 fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
     let workspace = repo_root().join("samples/windows_launch_smoke");
     let relative_output = PathBuf::from(format!("build/web-package-test-{}", stamp()));
@@ -129,6 +172,10 @@ fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
             "missing web runtime data {expected}"
         );
     }
+    assert!(!runtime.contains("AudioContext"));
+    assert!(!runtime.contains("audio_init"));
+    let index = fs::read_to_string(output.join("index.html")).expect("existing game index");
+    assert!(!index.contains("Enable sound"));
     assert!(runtime.contains(r#""assets":{}"#));
     assert!(!runtime.contains("../assets/"));
     for expected in [

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -147,7 +147,7 @@ fn minimal_pong_omits_unreachable_audio_and_input_from_wasm_and_js() {
     let wasm = fs::read(output.join("game.wasm")).expect("minimal Pong Wasm");
     let runtime = fs::read_to_string(output.join("game.js")).expect("minimal Pong runtime");
     let index = fs::read_to_string(output.join("index.html")).expect("minimal Pong index");
-    for reachable in ["reset_ball", "follow_ball", "web_draw_rect"] {
+    for reachable in ["main", "tick", "render", "web_draw_rect"] {
         assert!(
             wasm.windows(reachable.len())
                 .any(|window| window == reachable.as_bytes()),

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -36,6 +36,7 @@ pub struct WasmProcess {
     struct_views: BTreeMap<i32, BTreeMap<String, String>>,
     debug_symbols: bool,
     global_types: BTreeMap<String, TypeId>,
+    imported_symbols: BTreeSet<String>,
     program_snapshot: Option<ProgramSnapshot>,
 }
 
@@ -79,6 +80,10 @@ impl WasmProcess {
 
     pub fn global_types(&self) -> &BTreeMap<String, TypeId> {
         &self.global_types
+    }
+
+    pub fn imported_symbols(&self) -> &BTreeSet<String> {
+        &self.imported_symbols
     }
 
     pub fn program_snapshot(&self) -> Option<&ProgramSnapshot> {
@@ -181,8 +186,9 @@ impl WasmProcess {
                 );
             }
         }
-        self.module = encode_module(&lowered, &analysis, &types, self.debug_symbols)
-            .map_err(CompileError::Backend)?;
+        (self.module, self.imported_symbols) =
+            encode_module(&lowered, &analysis, &types, self.debug_symbols)
+                .map_err(CompileError::Backend)?;
         self.program_snapshot = Some(
             ProgramSnapshot::build(
                 source_revision,
@@ -205,6 +211,8 @@ struct Signature {
     params: Vec<TypeId>,
     result: TypeId,
 }
+
+type WasmImport = (String, String, Signature);
 
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 struct WasmSignature {
@@ -513,24 +521,10 @@ fn build_struct_collections(
     Ok(out)
 }
 
-fn encode_module(
+fn collect_imports(
     functions: &[(FunctionMeta, FunctionHIR)],
     analysis: &crate::backend::emit::CompileAnalysisCache,
-    types: &TypeTable,
-    debug_symbols: bool,
-) -> Result<Vec<u8>, String> {
-    let mut internal_by_name: BTreeMap<String, Vec<usize>> = BTreeMap::new();
-    for (index, (function, _)) in functions.iter().enumerate() {
-        internal_by_name
-            .entry(function.name.clone())
-            .or_default()
-            .push(index);
-        internal_by_name
-            .entry(format!("{}.{}", function.module_alias, function.name))
-            .or_default()
-            .push(index);
-    }
-
+) -> Result<(BTreeSet<String>, Vec<WasmImport>), String> {
     let mut called = BTreeSet::new();
     for (_, hir) in functions {
         collect_calls(&hir.statements, &mut called);
@@ -572,6 +566,28 @@ fn encode_module(
         }
     }
     imports.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok((called, imports))
+}
+
+fn encode_module(
+    functions: &[(FunctionMeta, FunctionHIR)],
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+    types: &TypeTable,
+    debug_symbols: bool,
+) -> Result<(Vec<u8>, BTreeSet<String>), String> {
+    let mut internal_by_name: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (index, (function, _)) in functions.iter().enumerate() {
+        internal_by_name
+            .entry(function.name.clone())
+            .or_default()
+            .push(index);
+        internal_by_name
+            .entry(format!("{}.{}", function.module_alias, function.name))
+            .or_default()
+            .push(index);
+    }
+
+    let (called, imports) = collect_imports(functions, analysis)?;
 
     let imported_names = imports
         .iter()
@@ -732,7 +748,6 @@ fn encode_module(
         }
         section(2, import_section, &mut module);
     }
-
     let mut function_section = Vec::new();
     uleb(functions.len() as u32 + 4, &mut function_section);
     for index in 0..functions.len() {
@@ -881,7 +896,8 @@ fn encode_module(
             .collect()
     };
     append_name_section(&function_names, &mut module);
-    Ok(module)
+    let imported_symbols = imports.into_iter().map(|(_, symbol, _)| symbol).collect();
+    Ok((module, imported_symbols))
 }
 
 fn encode_global_accessor(
@@ -2960,6 +2976,25 @@ mod tests {
                 .windows(name.len())
                 .any(|window| window == name.as_bytes()));
         }
+    }
+
+    #[test]
+    fn reports_only_imports_called_by_reachable_functions() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "imports.stasis",
+            "extern function live(): i32; extern function dead(): i32; function main(): i32 { return live(); } function tick(): i32 { return 0; } function render(): i32 { return 0; } function unused(): i32 { return dead(); }",
+        );
+        process.compile().expect("compile reachable web imports");
+        assert_eq!(
+            process.imported_symbols(),
+            &BTreeSet::from(["live".to_string()])
+        );
+        assert!(!process
+            .module_bytes()
+            .windows("dead".len())
+            .any(|window| window == b"dead"));
     }
 
     #[test]

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -728,6 +728,7 @@ Archived priority override (2026-02-13, historical):
 - local `foreach` over fixed-size local array bindings
 - `for` headers require `init`, `condition`, and `step` segments (no missing-segment forms such as `for (; cond; step)`).
 - Reachability-gated emission now compiles roots (`main`, `tick`, `render`, `on_code_swap`) plus reachable callees; same-name overload siblings are included to preserve receiver overload behavior.
+- Web packages now carry the reachable Wasm import set into JavaScript host linking: direct scalar/vector games receive an exact small host, audio support/UI is omitted without reachable audio imports, and `samples/pong_web_minimal` verifies unreachable audio/input dependencies are absent from both outputs.
 - Non-engine JIT contract assembly now consumes only emitted symbol code pointers (unemitted, unreachable functions are excluded from override patch emission).
 - Host memory intrinsics used by stdlib/gfx paths are now real externs with Rust-native bindings:
 - `sys_memcpy_u8/i32/f32`

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -61,9 +61,21 @@ release export names remain in the Wasm export section while `wasm-opt` may disc
 custom name section. Called overload families that cannot be selected from HIR identity still fail
 with deterministic diagnostics.
 
+Web packaging carries the reachable Wasm import set into host linking. Scalar games that use only
+the direct canvas/math/print bridge receive a small generated JavaScript host containing exactly
+those imported functions. Games using the shared graphics buffers retain the full renderer, while
+audio declarations, helpers, imports, and the sound-unlock UI are removed unless a reachable
+function imports audio. JIT and AOT continue to use the same function-reachability closure before
+backend emission, so unreachable Stasis functions are excluded consistently across targets.
+
 `samples/web_export_smoke` is the end-to-end acceptance project. It verifies compiled movement,
 keyboard and pointer input, Canvas rendering, a Stasis-triggered WebAudio tone, the performance HUD,
 and the static package layout.
+
+`samples/pong_web_minimal` is the dependency-linking acceptance project. It is an autonomous Pong
+game drawn only with canvas rectangles and text. It intentionally declares unreachable audio and
+keyboard helpers; package tests require those helpers and host functions to be absent from both
+`game.wasm` and `game.js`, and require the sound UI to be absent from `index.html`.
 
 The existing `samples/windows_launch_smoke` and `samples/audio_asset_playback` fixtures are also web
 package gates. Together they cover the shared graphics command buffers, PNG/SVG/font assets, and
@@ -106,3 +118,17 @@ Emitter cleanup reflection:
 Theory gained: for a nonnegative collection length, `index >=u length` is exactly the union of
 `index < 0` and `index >=s length`. Together with grouped local declarations and proven terminal
 returns, this reduces the guest before Binaryen without creating a second semantic pipeline.
+
+Function-level host-linking reflection (2026-08-15):
+
+- Good: reusing the Wasm emitter's reachable import set made browser host selection a direct linker
+  decision instead of a second source scanner.
+- Bad: the original static browser host mixed optional audio policy with mandatory frame/render
+  policy, so dead guest functions were removed while their JavaScript support remained.
+- Adjustment: optional browser capability blocks must be keyed from reachable imports, with an
+  end-to-end sample that contains deliberately unreachable feature calls.
+
+Theory gained: a target package is only as dependency-aware as both sides of its ABI. Reachable HIR
+selects guest functions and imports; carrying that same import set into host linking removes unused
+browser policy without inventing target-specific reachability. An adjacent prediction is that
+storage, clipboard, and sprite/font support can move behind the same import-keyed host blocks.

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -3,7 +3,9 @@
   const canvas = document.getElementById("stasis-canvas");
   const context = canvas.getContext("2d", { alpha: false });
   const hud = document.getElementById("stasis-hud");
+  // @stasis-feature audio begin
   const audioButton = document.getElementById("stasis-audio");
+  // @stasis-feature audio end
   const errorBox = document.getElementById("stasis-error");
   const keys = new Set();
   const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, down: false, wentDown: false, wentUp: false };
@@ -14,6 +16,7 @@
   const cachedText = new Map();
   let nextHandle = 1;
   let instance;
+  // @stasis-feature audio begin
   let audioContext;
   let audioEvents = 0;
   let audioSampleRate = 48000;
@@ -23,6 +26,7 @@
   const audioAssets = new Map();
   const audioVoices = new Map();
   const pendingAudio = [];
+  // @stasis-feature audio end
   const volatileStorage = new Map();
   let clipboardText = "";
   let frames = 0;
@@ -107,6 +111,7 @@
     font.load().then(loaded => document.fonts.add(loaded)).catch(error => console.error(error));
     return handle;
   };
+  // @stasis-feature audio begin
   const ensureAudio = () => {
     audioContext ||= new AudioContext();
     return audioContext;
@@ -180,6 +185,7 @@
     else void start();
     return frameCount;
   };
+  // @stasis-feature audio end
   const imports = { env: {
     sin_fast: value => Math.sin(value),
     cos_fast: value => Math.cos(value),
@@ -194,6 +200,7 @@
     web_begin_frame: (r, g, b) => { commands.length = 0; commands.push([0, r, g, b]); },
     web_draw_rect: (x, y, width, height, r, g, b) => commands.push([1, x, y, width, height, r, g, b]),
     web_draw_text: (x, y, value) => commands.push([2, x, y, value]),
+    // @stasis-feature audio begin
     web_play_tone: (frequency, durationMs) => {
       if (!audioContext || audioContext.state !== "running") return;
       const oscillator = audioContext.createOscillator();
@@ -208,6 +215,7 @@
       audioEvents += 1;
       document.body.dataset.audioEvents = String(audioEvents);
     },
+    // @stasis-feature audio end
     gfx_load_sprite: pathId => loadSprite(pathId),
     stasis_gfx_load_sprite: pathId => loadSprite(pathId),
     load_font: (pathId, size) => loadFont(pathId, size),
@@ -253,6 +261,7 @@
       if (navigator.clipboard?.writeText) void navigator.clipboard.writeText(clipboardText).catch(() => {});
       return 1;
     },
+    // @stasis-feature audio begin
     audio_init: (sampleRate, channels) => {
       audioSampleRate = Math.max(8000, Math.min(sampleRate || 48000, 192000));
       audioChannels = Math.max(1, Math.min(channels || 2, 2));
@@ -302,7 +311,8 @@
     stasis_jit_audio_set_music_volume: (handle, volume) => {
       const voice = audioVoices.get(handle);
       if (voice) voice.gain.gain.value = Math.max(0, Math.min(1, volume));
-    }
+    },
+    // @stasis-feature audio end
   }};
 
   document.addEventListener("paste", event => {
@@ -643,6 +653,7 @@
   canvas.addEventListener("pointercancel", () => { pointer.down = false; pointer.wentUp = true; });
   addEventListener("resize", () => { resized = true; displayGeneration += 1; });
   document.addEventListener("fullscreenchange", () => { resized = true; displayGeneration += 1; });
+  // @stasis-feature audio begin
   audioButton.addEventListener("click", async () => {
     await applyFullscreenGesture();
     audioContext ||= new AudioContext();
@@ -653,6 +664,7 @@
     document.body.dataset.audioState = audioContext.state;
     canvas.focus();
   });
+  // @stasis-feature audio end
 
   async function wasmBytes() {
     const response = await fetch("game.wasm");

--- a/runtime/web/game_minimal.js
+++ b/runtime/web/game_minimal.js
@@ -1,0 +1,71 @@
+(() => {
+  "use strict";
+  const canvas = document.getElementById("stasis-canvas");
+  const context = canvas.getContext("2d", { alpha: false });
+  const hud = document.getElementById("stasis-hud");
+  const errorBox = document.getElementById("stasis-error");
+  const game = window.STASIS_GAME || { strings: {} };
+  const commands = [];
+  const stringValue = id => game.strings[String(id)] || "";
+  const color = (r, g, b) => `rgb(${r & 255} ${g & 255} ${b & 255})`;
+  const imports = { env: {
+__STASIS_IMPORTS__
+  }};
+  let instance;
+  let frames = 0;
+  let worstTick = 0;
+  let worstRender = 0;
+
+  function executeCommands() {
+    for (const command of commands) {
+      if (command[0] === 0) {
+        context.fillStyle = color(command[1], command[2], command[3]);
+        context.fillRect(0, 0, canvas.width, canvas.height);
+      } else if (command[0] === 1) {
+        context.fillStyle = color(command[5], command[6], command[7]);
+        context.fillRect(command[1], command[2], command[3], command[4]);
+      }
+      else if (command[0] === 2) {
+        context.fillStyle = "#dff6ff";
+        context.font = "18px ui-monospace, Consolas, monospace";
+        context.fillText(`score ${command[3]}`, command[1], command[2]);
+      }
+    }
+  }
+
+  function frame() {
+    const tickStart = performance.now();
+    instance.exports.tick();
+    const tickMs = performance.now() - tickStart;
+    const renderStart = performance.now();
+    instance.exports.render();
+    executeCommands();
+    const renderMs = performance.now() - renderStart;
+    frames += 1;
+    if (frames > 5) {
+      worstTick = Math.max(worstTick, tickMs);
+      worstRender = Math.max(worstRender, renderMs);
+    }
+    const underBudget = worstTick < 16 && worstRender < 16;
+    if (hud) hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms\nrender ${renderMs.toFixed(3)} ms\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
+    document.body.dataset.frames = String(frames);
+    document.body.dataset.underBudget = String(underBudget);
+    requestAnimationFrame(frame);
+  }
+
+  (async () => {
+    try {
+      const response = await fetch("game.wasm");
+      if (!response.ok) throw new Error(`failed to load game.wasm: ${response.status}`);
+      instance = (await WebAssembly.instantiate(await response.arrayBuffer(), imports)).instance;
+      document.body.dataset.mainResult = String(instance.exports.main());
+      document.body.dataset.ready = "true";
+      document.body.dataset.runtime = "wasm";
+      requestAnimationFrame(frame);
+    } catch (error) {
+      document.body.dataset.ready = "false";
+      errorBox.textContent = String(error && error.stack || error);
+      throw error;
+    }
+  })();
+})();

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -11,7 +11,7 @@
     main { position: relative; width: min(960px, 100vw); }
     canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
     __STASIS_PERFORMANCE_HUD_STYLE__
-    #stasis-audio { position: absolute; top: 10px; right: 10px; border: 1px solid #53d8fb; background: #0b263d; color: white; padding: 8px 12px; cursor: pointer; }
+    __STASIS_AUDIO_BUTTON_STYLE__
     #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
   </style>
 </head>
@@ -19,7 +19,7 @@
   <main>
     <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
     __STASIS_PERFORMANCE_HUD__
-    <button id="stasis-audio" type="button">Enable sound</button>
+    __STASIS_AUDIO_BUTTON__
     <pre id="stasis-error"></pre>
   </main>
   <script src="game.js"></script>

--- a/samples/pong_web_minimal/src/main.stasis
+++ b/samples/pong_web_minimal/src/main.stasis
@@ -1,0 +1,99 @@
+const SCREEN_WIDTH: i32 = 640;
+const SCREEN_HEIGHT: i32 = 360;
+const PADDLE_WIDTH: i32 = 12;
+const PADDLE_HEIGHT: i32 = 72;
+const BALL_SIZE: i32 = 12;
+
+global left_y: i32;
+global right_y: i32;
+global ball_x: i32;
+global ball_y: i32;
+global ball_dx: i32;
+global ball_dy: i32;
+global left_score: i32;
+global right_score: i32;
+
+function @extern("web_begin_frame") web_begin_frame(red: i32, green: i32, blue: i32): void;
+function @extern("web_draw_rect") web_draw_rect(x: i32, y: i32, width: i32, height: i32, red: i32, green: i32, blue: i32): void;
+function @extern("web_draw_text") web_draw_text(x: i32, y: i32, value: i32): void;
+function @extern("web_play_tone") web_play_tone(frequency: i32, duration_ms: i32): void;
+function @extern("web_input_axis") web_input_axis(): i32;
+
+function reset_ball(direction: i32): void {
+    ball_x = SCREEN_WIDTH / 2 - BALL_SIZE / 2;
+    ball_y = SCREEN_HEIGHT / 2 - BALL_SIZE / 2;
+    ball_dx = direction * 4;
+    ball_dy = 3;
+}
+
+function follow_ball(y: i32): i32 {
+    let center: i32 = y + PADDLE_HEIGHT / 2;
+    if (center < ball_y) {
+        y += 3;
+    } else {
+        if (center > ball_y + BALL_SIZE) {
+            y -= 3;
+        }
+    }
+    if (y < 0) {
+        return 0;
+    }
+    if (y > SCREEN_HEIGHT - PADDLE_HEIGHT) {
+        return SCREEN_HEIGHT - PADDLE_HEIGHT;
+    }
+    return y;
+}
+
+function main(): i32 {
+    left_y = 144;
+    right_y = 144;
+    left_score = 0;
+    right_score = 0;
+    reset_ball(1);
+    return 0;
+}
+
+function tick(): i32 {
+    left_y = follow_ball(left_y);
+    right_y = follow_ball(right_y);
+    ball_x += ball_dx;
+    ball_y += ball_dy;
+    if (ball_y <= 0 || ball_y >= SCREEN_HEIGHT - BALL_SIZE) {
+        ball_dy = 0 - ball_dy;
+    }
+    if (ball_x <= 32 && ball_x >= 20 && ball_y + BALL_SIZE >= left_y && ball_y <= left_y + PADDLE_HEIGHT) {
+        ball_dx = 4;
+    }
+    if (ball_x + BALL_SIZE >= 608 && ball_x <= 620 && ball_y + BALL_SIZE >= right_y && ball_y <= right_y + PADDLE_HEIGHT) {
+        ball_dx = -4;
+    }
+    if (ball_x < 0) {
+        right_score += 1;
+        reset_ball(1);
+    }
+    if (ball_x > SCREEN_WIDTH) {
+        left_score += 1;
+        reset_ball(-1);
+    }
+    return 0;
+}
+
+function render(): i32 {
+    web_begin_frame(5, 12, 24);
+    web_draw_rect(20, left_y, PADDLE_WIDTH, PADDLE_HEIGHT, 83, 216, 251);
+    web_draw_rect(608, right_y, PADDLE_WIDTH, PADDLE_HEIGHT, 251, 180, 83);
+    web_draw_rect(ball_x, ball_y, BALL_SIZE, BALL_SIZE, 245, 248, 255);
+    web_draw_rect(318, 0, 4, SCREEN_HEIGHT, 42, 76, 102);
+    web_draw_text(250, 30, left_score);
+    web_draw_text(370, 30, right_score);
+    return 0;
+}
+
+// These functions intentionally prove that unreachable feature dependencies are not linked.
+function unused_audio_feature(): void {
+    web_play_tone(440, 100);
+}
+
+function unused_keyboard_feature(): i32 {
+    return web_input_axis();
+}

--- a/samples/pong_web_minimal/stasis.json
+++ b/samples/pong_web_minimal/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "pong_web_minimal",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}


### PR DESCRIPTION
## Summary

- preserve the reachable Wasm import set as compiler output and use it to link browser host support
- emit a compact JS host for scalar/vector games and omit audio code/UI when no reachable audio import exists
- add an autonomous vector Pong sample with deliberately unreachable audio and keyboard functions
- document the cross-target reachability contract and web host-linking extension point

## Impact

The Pong acceptance package drops the JS payload from the previous always-full 30,515-byte runtime to a 3,393-byte linked bundle, an 88.9% reduction (27,122 bytes). Its development Wasm module is 1,331 bytes. Neither output contains the unreachable audio or keyboard dependencies.

A real-browser run reached `ready=true`, rendered 436 frames without errors, and stayed under the 16 ms frame budget.

## Validation

- `cargo test -p stasis_compiler backend::wasm::tests::reports_only_imports_called_by_reachable_functions`
- `cargo test -p stasis --test web_package`
- `cargo test --workspace --all-targets -- --test-threads=1`
- `cargo fmt --all -- --check`
- `node --check runtime/web/game.js`
- `node --check runtime/web/game_minimal.js`
- real-browser local package acceptance

`tools/validate_repo.sh` currently stops before tests on an existing render ABI fixture mismatch (`gfx_cmd_f32.length` expects 125060 while checked-in consumers use 108676). This change does not touch that ABI; the full workspace test command above passes.