### PR TITLE
test: add standard JavaScript Pong comparison

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -139,7 +139,7 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
 }
 
 #[test]
-fn minimal_pong_omits_unreachable_audio_and_input_from_wasm_and_js() {
+fn minimal_pong_and_standard_reference_omit_audio_and_input() {
     let workspace = repo_root().join("samples/pong_web_minimal");
     let relative_output = PathBuf::from(format!("build/web-package-test-{}", stamp()));
     let output = package(&workspace, &relative_output);
@@ -177,6 +177,34 @@ fn minimal_pong_omits_unreachable_audio_and_input_from_wasm_and_js() {
         "minimal runtime was {} bytes",
         runtime.len()
     );
+
+    let standard = repo_root().join("samples/pong_web_standard");
+    let standard_runtime =
+        fs::read_to_string(standard.join("game.js")).expect("standard Pong runtime");
+    let standard_index =
+        fs::read_to_string(standard.join("index.html")).expect("standard Pong index");
+    for omitted in ["AudioContext", "keydown", "pointerdown"] {
+        assert!(
+            !standard_runtime.contains(omitted),
+            "standard JS retained {omitted}"
+        );
+        assert!(
+            !standard_index.contains(omitted),
+            "standard HTML retained {omitted}"
+        );
+    }
+    for expected in [
+        "requestAnimationFrame(frame)",
+        "context.fillRect",
+        "context.fillText",
+        "SCREEN_WIDTH = 640",
+        "SCREEN_HEIGHT = 360",
+    ] {
+        assert!(
+            standard_runtime.contains(expected),
+            "standard JS missing {expected}"
+        );
+    }
 
     fs::remove_dir_all(&output).expect("clean minimal Pong package");
 }

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -95,6 +95,10 @@ game drawn only with canvas rectangles and text. It intentionally declares unrea
 keyboard helpers; package tests require those helpers and host functions to be absent from both
 `game.wasm` and `game.js`, and require the sound UI to be absent from `index.html`.
 
+`samples/pong_web_standard` is an idiomatic, plain HTML and JavaScript implementation of the same
+gameplay and presentation. It provides a direct size and behavior comparison for the Stasis web
+package without adding audio, input, image, font, or framework dependencies.
+
 The existing `samples/windows_launch_smoke` and `samples/audio_asset_playback` fixtures are also web
 package gates. Together they cover the shared graphics command buffers, PNG/SVG/font assets, and
 decoded WAV/MP3 WebAudio playback.

--- a/samples/pong_web_standard/README.md
+++ b/samples/pong_web_standard/README.md
@@ -1,0 +1,8 @@
+# Standard JavaScript Pong
+
+This is the plain HTML and JavaScript counterpart to `samples/pong_web_minimal`.
+It intentionally matches that sample's 640x360 canvas, autonomous paddles, ball
+movement, collision rules, scores, colors, and vector-only rendering. It has no
+audio, keyboard, pointer, image, or font dependencies.
+
+Serve this directory over HTTP and open `index.html` in a browser.

--- a/samples/pong_web_standard/game.js
+++ b/samples/pong_web_standard/game.js
@@ -1,0 +1,104 @@
+const SCREEN_WIDTH = 640;
+const SCREEN_HEIGHT = 360;
+const PADDLE_WIDTH = 12;
+const PADDLE_HEIGHT = 72;
+const BALL_SIZE = 12;
+
+const canvas = document.querySelector("#pong");
+const context = canvas.getContext("2d", { alpha: false });
+
+const game = {
+  leftY: 144,
+  rightY: 144,
+  ballX: 0,
+  ballY: 0,
+  ballDX: 0,
+  ballDY: 0,
+  leftScore: 0,
+  rightScore: 0,
+};
+
+function resetBall(direction) {
+  game.ballX = SCREEN_WIDTH / 2 - BALL_SIZE / 2;
+  game.ballY = SCREEN_HEIGHT / 2 - BALL_SIZE / 2;
+  game.ballDX = direction * 4;
+  game.ballDY = 3;
+}
+
+function followBall(y) {
+  const center = y + PADDLE_HEIGHT / 2;
+  if (center < game.ballY) {
+    y += 3;
+  } else if (center > game.ballY + BALL_SIZE) {
+    y -= 3;
+  }
+  return Math.max(0, Math.min(y, SCREEN_HEIGHT - PADDLE_HEIGHT));
+}
+
+function update() {
+  game.leftY = followBall(game.leftY);
+  game.rightY = followBall(game.rightY);
+  game.ballX += game.ballDX;
+  game.ballY += game.ballDY;
+
+  if (game.ballY <= 0 || game.ballY >= SCREEN_HEIGHT - BALL_SIZE) {
+    game.ballDY = -game.ballDY;
+  }
+  if (
+    game.ballX >= 20 &&
+    game.ballX <= 32 &&
+    game.ballY + BALL_SIZE >= game.leftY &&
+    game.ballY <= game.leftY + PADDLE_HEIGHT
+  ) {
+    game.ballDX = 4;
+  }
+  if (
+    game.ballX + BALL_SIZE >= 608 &&
+    game.ballX <= 620 &&
+    game.ballY + BALL_SIZE >= game.rightY &&
+    game.ballY <= game.rightY + PADDLE_HEIGHT
+  ) {
+    game.ballDX = -4;
+  }
+  if (game.ballX < 0) {
+    game.rightScore += 1;
+    resetBall(1);
+  }
+  if (game.ballX > SCREEN_WIDTH) {
+    game.leftScore += 1;
+    resetBall(-1);
+  }
+}
+
+function rectangle(x, y, width, height, color) {
+  context.fillStyle = color;
+  context.fillRect(x, y, width, height);
+}
+
+function render() {
+  rectangle(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, "rgb(5 12 24)");
+  rectangle(20, game.leftY, PADDLE_WIDTH, PADDLE_HEIGHT, "rgb(83 216 251)");
+  rectangle(608, game.rightY, PADDLE_WIDTH, PADDLE_HEIGHT, "rgb(251 180 83)");
+  rectangle(game.ballX, game.ballY, BALL_SIZE, BALL_SIZE, "rgb(245 248 255)");
+  rectangle(318, 0, 4, SCREEN_HEIGHT, "rgb(42 76 102)");
+
+  context.fillStyle = "#dff6ff";
+  context.font = "18px ui-monospace, Consolas, monospace";
+  context.fillText(`score ${game.leftScore}`, 250, 30);
+  context.fillText(`score ${game.rightScore}`, 370, 30);
+}
+
+let frames = 0;
+
+function frame() {
+  update();
+  render();
+  frames += 1;
+  document.body.dataset.frames = String(frames);
+  requestAnimationFrame(frame);
+}
+
+resetBall(1);
+document.body.dataset.ready = "true";
+document.body.dataset.runtime = "javascript";
+requestAnimationFrame(frame);

--- a/samples/pong_web_standard/index.html
+++ b/samples/pong_web_standard/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
+  <title>Standard JavaScript Pong</title>
+  <style>
+    :root { color-scheme: dark; font-family: ui-monospace, Consolas, monospace; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; }
+    main { width: min(960px, 100vw); }
+    canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #050c18; }
+  </style>
+</head>
+<body>
+  <main>
+    <canvas id="pong" width="640" height="360" aria-label="Autonomous Pong game"></canvas>
+  </main>
+  <script type="module" src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an idiomatic plain HTML/JavaScript counterpart to the autonomous vector Pong sample
- match the Stasis gameplay, dimensions, colors, scores, and no-input/no-audio feature set
- extend the web package regression to keep the comparison free of audio and input dependencies

## Size comparison
| Playable files | Raw | Gzip |
|---|---:|---:|
| Stasis HTML + JS + Wasm | 5,126 B | 2,366 B |
| Standard HTML + JS | 3,301 B | 1,355 B |

The standard version is 35.6% smaller raw and 42.7% smaller gzipped. Stasis build provenance is excluded from playable totals; including it makes the generated Stasis directory 9,839 B raw and 4,667 B gzipped for this run.

## Verification
- focused Rust web-package regression: 1 passed
- cargo fmt --all -- --check
- node --check samples/pong_web_standard/game.js
- Chromium: 3,293 frames, rendered canvas, zero console errors/warnings