### PR TITLE
Support responsive mobile canvases

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4803,7 +4803,12 @@ mod tests {
             STASIS_WINDOW_REQUEST_STDLIB.contains("const HOST_REQ_FLAG_MAXIMIZED: i32 = 4;")
                 && STASIS_WINDOW_REQUEST_STDLIB
                     .contains("function host_request_maximized(enabled: i32): void")
-                && STASIS_GRAPHICS_STDLIB.contains("function set_maximized(enabled: i32): i32"),
+                && STASIS_WINDOW_REQUEST_STDLIB.contains(
+                    "function host_request_maximized_canvas(width: i32, height: i32): void"
+                )
+                && STASIS_GRAPHICS_STDLIB.contains("function set_maximized(enabled: i32): i32")
+                && STASIS_GRAPHICS_STDLIB
+                    .contains("function set_maximized_canvas(width: i32, height: i32): i32"),
             "stdlib should expose a first-class maximized presentation request"
         );
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -713,10 +713,10 @@ impl ProjectManifest {
             }
             if !matches!(
                 android.orientation.as_str(),
-                "unspecified" | "sensorLandscape" | "sensorPortrait"
+                "unspecified" | "sensorLandscape" | "sensorPortrait" | "fullSensor"
             ) {
                 return Err(
-                    "android orientation must be unspecified, sensorLandscape, or sensorPortrait"
+                    "android orientation must be unspecified, sensorLandscape, sensorPortrait, or fullSensor"
                         .to_string(),
                 );
             }
@@ -6992,7 +6992,7 @@ mod tests {
                 android: Some(AndroidProjectManifest {
                     application_id: "com.example.mobile".to_string(),
                     label: "Mobile Smoke".to_string(),
-                    orientation: "sensorPortrait".to_string(),
+                    orientation: "fullSensor".to_string(),
                     version_code: 7,
                     version_name: "2.1.0".to_string(),
                 }),
@@ -7029,7 +7029,7 @@ mod tests {
             fs::read_to_string(android.join("android/app/src/main/AndroidManifest.xml"))
                 .expect("read Android manifest");
         assert!(android_manifest.contains("android:label=\"Mobile Smoke\""));
-        assert!(android_manifest.contains("android:screenOrientation=\"sensorPortrait\""));
+        assert!(android_manifest.contains("android:screenOrientation=\"fullSensor\""));
         let mobile_main = fs::read_to_string(android.join("common/stasis_mobile_main.c"))
             .expect("read shared mobile main");
         assert!(mobile_main.contains("stasis_mobile_runtime_last_entry_result"));
@@ -7222,6 +7222,21 @@ mod tests {
             ..ProjectManifest::new("example_game".to_string())
         };
         assert!(valid.validate().is_ok());
+
+        for orientation in [
+            "unspecified",
+            "sensorLandscape",
+            "sensorPortrait",
+            "fullSensor",
+        ] {
+            let mut oriented = valid.clone();
+            oriented.android.as_mut().unwrap().orientation = orientation.to_string();
+            assert!(oriented.validate().is_ok(), "rejected {orientation}");
+        }
+
+        let mut invalid_orientation = valid.clone();
+        invalid_orientation.android.as_mut().unwrap().orientation = "sensor".to_string();
+        assert!(invalid_orientation.validate().is_err());
 
         for application_id in ["game", "com.example.bad-name", "com.1game"] {
             let mut invalid = valid.clone();

--- a/docs/display_metrics.md
+++ b/docs/display_metrics.md
@@ -75,6 +75,9 @@ Desktop presentation is explicit and independent from the logical canvas:
 - `set_maximized(1)` fills the window-manager usable work area while preserving
   taskbars, docks, panels, and normal window chrome. It does not change the
   logical size last requested by `init_window` or `set_window_size`.
+- `set_maximized_canvas(width, height)` changes the logical canvas and keeps the
+  native presentation maximized. SDL aspect-fits that canvas with letterbox or
+  pillarbox buffers when its aspect ratio differs from the native surface.
 - `set_maximized(0)` restores a windowed presentation using the retained logical
   dimensions.
 - `set_fullscreen(1)` remains borderless desktop fullscreen and is not an alias
@@ -91,6 +94,16 @@ boundary in both JIT and packaged AOT runners. A common portrait setup is:
 init_window(360, 720, "Portrait Game");
 set_maximized(1);
 ```
+
+A responsive game can switch between purpose-built logical canvases without
+restoring or resizing the desktop window:
+
+```stasis
+set_maximized_canvas(720, 360);
+```
+
+On Android and iOS the native surface remains platform-owned fullscreen while
+the requested logical canvas changes through the same between-tick mailbox.
 
 The title argument remains a compatibility parameter for guest source. The
 native title is owned by the project/CLI launch configuration because the

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -32,6 +32,10 @@ not publish a partial app project.
 }
 ```
 
+`orientation` accepts `unspecified`, `sensorLandscape`, `sensorPortrait`, or
+Android's `fullSensor`. Use `fullSensor` when the app owns responsive logical
+canvases for all four physical device rotations.
+
 Each output contains the same pieces:
 
 - `aot/`: target-native game objects, generated entry bindings, ABI metadata

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -217,6 +217,11 @@ function set_maximized(enabled: i32): i32 {
     return 0;
 }
 
+function set_maximized_canvas(width: i32, height: i32): i32 {
+    host_request_maximized_canvas(width, height);
+    return 0;
+}
+
 // Legacy-ish names retained as pure wrappers (no host calls).
 function begin_frame(): void {
     gfx_cmd_begin();

--- a/src/stdlib/internal/host_window_request.stasis
+++ b/src/stdlib/internal/host_window_request.stasis
@@ -40,3 +40,10 @@ function host_request_maximized(enabled: i32): void {
     }
     host_req_seq = host_req_seq + 1;
 }
+
+function host_request_maximized_canvas(width: i32, height: i32): void {
+    host_req_flags = HOST_REQ_FLAG_MAXIMIZED;
+    host_req_window_w_px = width;
+    host_req_window_h_px = height;
+    host_req_seq = host_req_seq + 1;
+}


### PR DESCRIPTION
## Summary
- accept Android fullSensor orientation in package configuration
- add set_maximized_canvas(width, height) so apps can change logical presentation without restoring desktop windows
- document responsive logical canvases and mobile letterboxing

## Verification
- python tools/cargo_cache.py run -- cargo fmt --all
- focused manifest, mobile-shell, and maximized-canvas source-contract tests
- python tools/cargo_cache.py run -- cargo test -p stasis

Theory gained: the existing host request mailbox already separates logical canvas dimensions from native presentation; exposing the maximized form lets one responsive policy work on desktop and mobile without a second renderer path.