### PR TITLE
fix: retain methods called on complex receivers

### DIFF
--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -2686,6 +2686,33 @@ function tick(): i32 { choose(fixed32_mul(1, 2)); return 0; }
     }
 
     #[test]
+    fn indexed_receiver_call_keeps_imported_method_reachable() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "main.stasis",
+            "import \"assets.stasis\"; struct State { assets: Asset[2]; } global state: State; function main(): i32 { return state.assets[1].poll(); }",
+        );
+        compiler.upsert_file(
+            "assets.stasis",
+            "struct Asset { state: i32; } function poll(self: Asset): i32 { return self.state; }",
+        );
+        compiler
+            .index_pass()
+            .expect("indexed receiver dependency resolution");
+        let main = compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("main function");
+        let poll = compiler
+            .functions()
+            .iter()
+            .find(|function| function.name == "poll")
+            .expect("poll method");
+        assert_eq!(main.dependencies, vec![poll.id]);
+    }
+
+    #[test]
     fn importer_can_call_directly_imported_child() {
         let mut compiler = Compiler::new();
         compiler.upsert_file(

--- a/crates/stasis_compiler/src/frontend/indexer.rs
+++ b/crates/stasis_compiler/src/frontend/indexer.rs
@@ -153,6 +153,21 @@ fn collect_dependencies(body_text: &str) -> Result<Vec<IndexedCallDependency>, S
         if tokens.get(index.wrapping_sub(1)).is_some_and(|previous| {
             previous.kind == TokenKind::Other && &body_text[previous.start..previous.end] == "."
         }) {
+            let receiver_method_already_collected = tokens
+                .get(index.wrapping_sub(2))
+                .is_some_and(|receiver| receiver.kind == TokenKind::Identifier);
+            if !receiver_method_already_collected
+                && tokens
+                    .get(index + 1)
+                    .is_some_and(|next| next.kind == TokenKind::LParen)
+            {
+                dependencies.push(IndexedCallDependency {
+                    qualifier: None,
+                    qualifier_span: None,
+                    name: identifier.to_string(),
+                    name_span: token.start as u32..token.end as u32,
+                });
+            }
             continue;
         }
         if tokens
@@ -238,5 +253,29 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn collects_method_dependencies_from_indexed_and_chained_receivers() {
+        let mut types = TypeTable::new();
+        let source = concat!(
+            "function main(index: i32): i32 { ",
+            "return state.assets[index].poll() + state.current.release(); ",
+            "}\n"
+        );
+        let indexed = index_file(source, &mut types).expect("index");
+        let main = indexed
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("main function");
+        assert_eq!(
+            main.dependencies
+                .iter()
+                .map(|dependency| dependency.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["poll", "release"]
+        );
+        assert_eq!(main.dependencies[0].qualifier, None);
+        assert_eq!(main.dependencies[1].qualifier.as_deref(), Some("current"));
     }
 }


### PR DESCRIPTION
## Summary
- retain imported method dependencies called through indexed and chained receivers
- add focused indexer and compiler reachability regressions
- prevent JIT unresolved-symbol failures for calls such as image_loading.images[index].poll_image_load()

## Verification
- cargo fmt --all -- --check
- cargo test -p stasis_compiler
- release stasis.exe built with two workers
- patched release CLI successfully ran stasis check against the ChessTD async-loading integration