### PR TITLE
Simplify async asset API

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -5850,8 +5850,10 @@ mod tests {
         let runtime = strip_web_runtime_feature(WEB_RUNTIME_JS, "audio", false);
         assert!(runtime.contains("const assetTasks = new Map()"));
         assert!(runtime.contains("const requestSprite = pathId =>"));
+        assert!(runtime.contains("const releaseSprite = handle =>"));
         assert!(runtime.contains("stasis_jit_asset_request_sprite"));
         assert!(runtime.contains("stasis_jit_asset_task_poll"));
+        assert!(runtime.contains("stasis_jit_gfx_release_sprite"));
         assert!(!runtime.contains("const requestAudio = pathId =>"));
         assert!(!runtime.contains("stasis_jit_asset_request_audio"));
         assert!(!runtime.contains("let audioContext"));

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -2885,18 +2885,16 @@ mod tests {
         let source = sample
             .replace("import \"/vendor/stasis/src/stdlib/audio.stasis\";", "")
             .replace("import \"/vendor/stasis/src/stdlib/graphics.stasis\";", "");
+        let asset_tasks = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../src/stdlib/asset_tasks.stasis"
+        ));
+        let audio = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../src/stdlib/audio.stasis"
+        ))
+        .replace("import \"graphics.stasis\";", "");
         let declarations = r#"
-function @extern("stasis_jit_audio_init") audio_init(sample_rate: i32, channels: i32, latency: i32): bool;
-function @extern("stasis_jit_audio_is_available") audio_is_available(): bool;
-function @extern("stasis_jit_audio_get_sample_rate") audio_get_sample_rate(): i32;
-function @extern("stasis_jit_audio_get_channels") audio_get_channels(): i32;
-function @extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
-function @extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
-function @extern("stasis_jit_audio_play_music") audio_play_music(handle: i32, loop: bool, volume: f32): bool;
-function @extern("stasis_jit_audio_pause_music") audio_pause_music(handle: i32, paused: bool): void;
-function @extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(handle: i32, volume: f32): void;
-function @extern("stasis_jit_audio_stop_music") audio_stop_music(handle: i32): void;
-function @extern("stasis_jit_audio_play_effect") audio_play_effect(handle: i32, volume: f32): bool;
 function init_window(width: i32, height: i32, title: string): bool { return true; }
 function begin_frame(): void { return; }
 function clear(r: f32, g: f32, b: f32, a: f32): void { return; }
@@ -2905,7 +2903,7 @@ function end_frame(): void { return; }
         let mut process = AotProcess::new();
         process.upsert_file(
             "samples/audio_asset_playback/audio_asset_playback.stasis",
-            format!("{declarations}\n{source}"),
+            format!("{declarations}\n{asset_tasks}\n{audio}\n{source}"),
         );
         process.compile().expect("aot compile playback sample");
     }

--- a/crates/stasis_compiler/src/backend/emit.rs
+++ b/crates/stasis_compiler/src/backend/emit.rs
@@ -1674,10 +1674,16 @@ where
         .declare_function(symbol, Linkage::Export, &context.func.signature)
         .map_err(|error| format!("failed to declare function {symbol}: {error}"))?;
     let referenced_call_targets = collect_call_targets_from_hir(hir);
-    let uses_runtime_storage =
-        backend_mode == SharedCompileBackendMode::JitDirect || !global_path_types.is_empty();
-    let uses_collection_runtime =
-        backend_mode == SharedCompileBackendMode::JitDirect || !collection_infos.is_empty();
+    let has_struct_view_param = meta
+        .params
+        .iter()
+        .any(|type_id| is_struct_view_type(*type_id, named_struct_field_types));
+    let uses_runtime_storage = backend_mode == SharedCompileBackendMode::JitDirect
+        || !global_path_types.is_empty()
+        || has_struct_view_param;
+    let uses_collection_runtime = backend_mode == SharedCompileBackendMode::JitDirect
+        || !collection_infos.is_empty()
+        || has_struct_view_param;
     let runtime_call_imports = match backend_mode {
         SharedCompileBackendMode::JitDirect | SharedCompileBackendMode::AotDirect => {
             build_direct_runtime_call_import_ids(

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -5,9 +5,9 @@
 //! target-specific substitute implementation.
 
 use crate::backend::emit::{
-    build_compile_analysis_cache, compute_files_fingerprint, hash_global_path,
-    resolve_extern_call_signatures_with, AssignOp, AssignTarget, ComparisonOp, ConstantValue,
-    SimpleCondition, SimpleExpr, SimpleStmt,
+    are_call_argument_and_param_compatible, build_compile_analysis_cache,
+    compute_files_fingerprint, hash_global_path, resolve_extern_call_signatures_with, AssignOp,
+    AssignTarget, ComparisonOp, ConstantValue, SimpleCondition, SimpleExpr, SimpleStmt,
 };
 use crate::backend::program_snapshot::ProgramSnapshot;
 use crate::compiler::{CompileError, CompileReport, CompileResult, Compiler, FunctionMeta};
@@ -691,14 +691,6 @@ fn encode_module(
         {
             return Err(format!("unresolved web call target '{target}'"));
         }
-        if internal_by_name
-            .get(target)
-            .is_some_and(|candidates| candidates.len() > 1)
-        {
-            return Err(format!(
-                "web backend cannot yet resolve called overload family '{target}'"
-            ));
-        }
     }
 
     let mut signatures = imports
@@ -808,6 +800,19 @@ fn encode_module(
             }
         }
     }
+    let internal_overloads = internal_by_name
+        .iter()
+        .filter(|(_, candidates)| candidates.len() > 1)
+        .map(|(name, candidates)| {
+            (
+                name.clone(),
+                candidates
+                    .iter()
+                    .map(|index| (imports.len() + index) as u32)
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
 
     let mut module = b"\0asm\x01\0\0\0".to_vec();
 
@@ -945,6 +950,7 @@ fn encode_module(
             types,
             &import_indices,
             &internal_indices,
+            &internal_overloads,
             &signatures,
         )?;
         uleb(body.len() as u32, &mut code_section);
@@ -1212,6 +1218,7 @@ fn encode_function(
     types: &TypeTable,
     imports: &BTreeMap<String, u32>,
     internals: &BTreeMap<String, u32>,
+    internal_overloads: &BTreeMap<String, Vec<u32>>,
     signatures: &[Signature],
 ) -> Result<Vec<u8>, String> {
     let mut local_declarations = Vec::new();
@@ -1289,6 +1296,7 @@ fn encode_function(
         constants,
         imports,
         internals,
+        internal_overloads,
         signatures,
         scratch_index,
         return_type: function.return_type,
@@ -1413,6 +1421,7 @@ struct EncodeContext<'a> {
     constants: &'a BTreeMap<String, ConstantValue>,
     imports: &'a BTreeMap<String, u32>,
     internals: &'a BTreeMap<String, u32>,
+    internal_overloads: &'a BTreeMap<String, Vec<u32>>,
     signatures: &'a [Signature],
     scratch_index: u32,
     return_type: TypeId,
@@ -2251,11 +2260,6 @@ fn struct_field_binding<'a>(
                     .is_some_and(|field| field.type_id == field_type)
         })
         .collect::<Vec<_>>();
-    if candidates.is_empty() {
-        return Err(format!(
-            "web struct field {type_id}.{suffix} has no reachable SoA storage"
-        ));
-    }
     Ok(candidates)
 }
 
@@ -2314,6 +2318,21 @@ fn encode_struct_field_address(
     uleb(view.len, out);
     out.extend([0x4e, 0x04, 0x40, 0x00, 0x0b]);
     let candidates = struct_field_binding(context, binding.type_id, suffix)?;
+    if candidates.is_empty() {
+        let field_type = context.named_structs[&binding.type_id][suffix];
+        let width = storage_width(field_type, context.types, context.named_structs)?;
+        // A scalar-only struct receiver can never arrive with a collection index.
+        // Keep the unreachable collection arm valid without inventing storage.
+        out.push(0x00);
+        return Ok(MemoryBinding {
+            offset: 0,
+            type_id: field_type,
+            len: 0,
+            width,
+            stride: width,
+            scalar: false,
+        });
+    }
     let field = encode_selected_field_offset(binding.index, suffix, &candidates, out)?;
     out.push(0x20);
     uleb(view.index, out);
@@ -2575,6 +2594,168 @@ fn encode_expr(
     encode_expr_as(value, None, context, out)
 }
 
+fn encode_call_arguments(
+    target: &str,
+    args: &[SimpleExpr],
+    signature: &Signature,
+    context: &EncodeContext<'_>,
+) -> Result<Vec<u8>, String> {
+    if args.len() != signature.params.len() {
+        return Err(format!(
+            "web call '{target}' expected {} arguments, found {}",
+            signature.params.len(),
+            args.len()
+        ));
+    }
+    let mut encoded = Vec::new();
+    for (arg, param_type) in args.iter().zip(signature.params.iter()) {
+        if is_struct_view_type(*param_type, context.named_structs) {
+            let actual = encode_struct_view_expr(arg, context, &mut encoded)?;
+            require_same_struct_type(*param_type, actual, "call argument")?;
+        } else {
+            let actual = encode_expr_as(arg, Some(*param_type), context, &mut encoded)?;
+            if !are_call_argument_and_param_compatible(
+                actual,
+                *param_type,
+                context.types,
+                context.named_structs,
+            ) {
+                return Err(format!(
+                    "web call argument type mismatch: expected {param_type}, found {actual}"
+                ));
+            }
+        }
+    }
+    Ok(encoded)
+}
+
+fn resolve_call(
+    target: &str,
+    args: &[SimpleExpr],
+    expected: Option<TypeId>,
+    context: &EncodeContext<'_>,
+) -> Result<(u32, Vec<u8>), String> {
+    if let Some(index) = context
+        .imports
+        .get(target)
+        .or_else(|| context.internals.get(target))
+        .copied()
+    {
+        let signature = context
+            .signatures
+            .get(index as usize)
+            .ok_or_else(|| format!("missing web signature for '{target}'"))?;
+        return Ok((
+            index,
+            encode_call_arguments(target, args, signature, context)?,
+        ));
+    }
+    let Some(candidates) = context.internal_overloads.get(target) else {
+        return Err(format!("unknown web call '{target}'"));
+    };
+    let mut argument_types = Vec::with_capacity(args.len());
+    for argument in args {
+        if let Some(type_id) = infer_struct_view_type(argument, context) {
+            argument_types.push(type_id);
+            continue;
+        }
+        let type_id = if matches!(argument, SimpleExpr::StringLiteral(_)) {
+            context
+                .types
+                .string_literal_type_id()
+                .unwrap_or(TYPE_ID_I32)
+        } else {
+            encode_expr_as(argument, None, context, &mut Vec::new())?
+        };
+        argument_types.push(type_id);
+    }
+    let mut matches = Vec::new();
+    for index in candidates {
+        let Some(signature) = context.signatures.get(*index as usize) else {
+            continue;
+        };
+        if signature.params.len() != argument_types.len() {
+            continue;
+        }
+        if expected.is_some_and(|expected_type| {
+            !are_call_argument_and_param_compatible(
+                signature.result,
+                expected_type,
+                context.types,
+                context.named_structs,
+            )
+        }) {
+            continue;
+        }
+        if argument_types
+            .iter()
+            .zip(signature.params.iter())
+            .all(|(argument, parameter)| {
+                are_call_argument_and_param_compatible(
+                    *argument,
+                    *parameter,
+                    context.types,
+                    context.named_structs,
+                )
+            })
+        {
+            matches.push(*index);
+        }
+    }
+    match matches.len() {
+        1 => {
+            let index = matches.pop().expect("one web overload match");
+            let signature = context
+                .signatures
+                .get(index as usize)
+                .ok_or_else(|| format!("missing web signature for '{target}'"))?;
+            Ok((
+                index,
+                encode_call_arguments(target, args, signature, context)?,
+            ))
+        }
+        0 => Err(format!(
+            "web call '{target}' does not match any of {} overloads",
+            candidates.len()
+        )),
+        count => Err(format!(
+            "web call '{target}' is ambiguous across {count} overloads"
+        )),
+    }
+}
+
+fn infer_struct_view_type(value: &SimpleExpr, context: &EncodeContext<'_>) -> Option<TypeId> {
+    match value {
+        SimpleExpr::Identifier(name) => context
+            .locals
+            .get(name)
+            .filter(|binding| binding.struct_view.is_some())
+            .map(|binding| binding.type_id)
+            .or_else(|| {
+                context
+                    .foreach
+                    .get(name)
+                    .and_then(|binding| context.struct_collections.get(&binding.collection_path))
+                    .map(|binding| binding.type_id)
+            })
+            .or_else(|| {
+                context
+                    .struct_scalars
+                    .get(name)
+                    .map(|binding| binding.type_id)
+            }),
+        SimpleExpr::IndexedPath {
+            collection_path,
+            suffix,
+            ..
+        } if suffix.is_empty() => context
+            .struct_collections
+            .get(collection_path)
+            .map(|binding| binding.type_id),
+        _ => None,
+    }
+}
+
 fn encode_expr_as(
     value: &SimpleExpr,
     expected: Option<TypeId>,
@@ -2652,32 +2833,12 @@ fn encode_expr_as(
             if is_inline_intrinsic(target) {
                 return encode_inline_intrinsic(target, args, context, out);
             }
-            let index = context
-                .imports
-                .get(target)
-                .or_else(|| context.internals.get(target))
-                .copied()
-                .ok_or_else(|| format!("unknown web call '{target}'"))?;
+            let (index, encoded_args) = resolve_call(target, args, expected, context)?;
             let signature = context
                 .signatures
                 .get(index as usize)
                 .ok_or_else(|| format!("missing web signature for '{target}'"))?;
-            if args.len() != signature.params.len() {
-                return Err(format!(
-                    "web call '{target}' expected {} arguments, found {}",
-                    signature.params.len(),
-                    args.len()
-                ));
-            }
-            for (arg, param_type) in args.iter().zip(signature.params.iter()) {
-                if is_struct_view_type(*param_type, context.named_structs) {
-                    let actual = encode_struct_view_expr(arg, context, out)?;
-                    require_same_struct_type(*param_type, actual, "call argument")?;
-                } else {
-                    let actual = encode_expr_as(arg, Some(*param_type), context, out)?;
-                    require_same_type(*param_type, actual, "call argument")?;
-                }
-            }
+            out.extend(encoded_args);
             out.push(0x10);
             uleb(index, out);
             Ok(signature.result)
@@ -2916,14 +3077,9 @@ fn expression_returns_value(
     value: &SimpleExpr,
     context: &EncodeContext<'_>,
 ) -> Result<bool, String> {
-    if let SimpleExpr::Call { target, .. } = value {
-        let index = context
-            .imports
-            .get(target)
-            .or_else(|| context.internals.get(target))
-            .copied()
-            .ok_or_else(|| format!("unknown web call '{target}'"))? as usize;
-        return Ok(context.signatures[index].result != TYPE_ID_VOID);
+    if let SimpleExpr::Call { target, args } = value {
+        let (index, _) = resolve_call(target, args, None, context)?;
+        return Ok(context.signatures[index as usize].result != TYPE_ID_VOID);
     }
     Ok(true)
 }
@@ -3279,6 +3435,45 @@ mod tests {
         process.compile().expect("compile web struct views");
         assert_eq!(process.memory_layout()["items.value"].length, 4);
         assert!(process.module_bytes().starts_with(b"\0asm\x01\0\0\0"));
+    }
+
+    #[test]
+    fn resolves_internal_overloads_from_struct_receiver_types() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "overloads.stasis",
+            "struct ImageAsset { image_handle: i32; } struct AudioAsset { audio_handle: i32; } global image: ImageAsset; global audio: AudioAsset; function ready(self: ImageAsset): bool { return self.image_handle == 1; } function ready(self: AudioAsset): bool { return self.audio_handle == 2; } function main(): i32 { image.image_handle = 1; audio.audio_handle = 2; if (image.ready() && audio.ready()) { return 0; } return 1; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process
+            .compile()
+            .expect("compile receiver overloads for web");
+    }
+
+    #[test]
+    fn resolves_internal_overloads_from_enum_receiver_types() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "enum_overloads.stasis",
+            "enum ImageState { None, Ready } enum AudioState { None, Ready } global image: ImageState; global audio: AudioState; function ready(self: ImageState): bool { return self == ImageState.Ready; } function ready(self: AudioState): bool { return self == AudioState.Ready; } function main(): i32 { image = ImageState.Ready; audio = AudioState.Ready; if (image.ready() && audio.ready()) { return 0; } return 1; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process
+            .compile()
+            .expect("compile enum receiver overloads for web");
+    }
+
+    #[test]
+    fn resolves_internal_overloads_before_encoding_float_literals() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "float_overloads.stasis",
+            "function select(value: f32): i32 { return 1; } function select(value: f64): i32 { return 2; } function main(): i32 { return select(1.0); } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        process
+            .compile()
+            .expect("compile semantic float overload for web");
     }
 
     #[test]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -168,10 +168,17 @@ code.
 
 Asynchronous asset tasks use one bounded 64-entry queue and one host worker. File access, image
 rasterization, and audio decoding happen off the frame thread. `asset_task_poll` performs only the
-required main-thread publication step (texture upload or mixer-table insertion), and
-`asset_task_take_handle` transfers ownership to `ImageAsset`/`AudioAsset` or equivalent game state.
-Games should cancel failed, abandoned, or superseded requests so their bounded task slots can be
-reused. The web host maps the same states onto browser image and audio promises.
+required main-thread publication step (texture upload or mixer-table insertion). `ImageAsset` and
+`AudioAsset` expose this as `load_*()`, `ready()`, `failed()`, `play()`/`publish()`, and `release()`;
+their `AssetState` and opaque handles are driven by the host task. Games should release abandoned
+or superseded assets so their bounded task slots can be reused. The web host maps the same states
+onto browser image and audio promises.
+
+`LoadingProgress.advance(total_count, loaded_count, failed_count)` derives the real completed and
+in-progress counts and percentage for a loading screen. Failed work counts as finished so callers
+can decide whether to continue or retry. `displayed_percent` advances by at most one percentage
+point per tick, while `complete()` always uses the real counts. An empty batch reports 0% and is
+already complete.
 
 `play` and the native runner use HostFrame bulk snapshots for per-tick input/state now.
 Application code should read keyboard/pointer/quit state through the public wrappers in

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -112,6 +112,7 @@
     font.load().then(loaded => document.fonts.add(loaded)).catch(error => console.error(error));
     return handle;
   };
+  const releaseSprite = handle => { sprites.delete(handle); };
   const requestSprite = pathId => {
     const task = nextAssetTask++;
     const handle = nextHandle++;
@@ -280,7 +281,7 @@
     const entry = assetTasks.get(task);
     if (!entry) return;
     entry.state = 5;
-    if (entry.kind === "sprite") sprites.delete(entry.handle);
+    if (entry.kind === "sprite") releaseSprite(entry.handle);
     else audioAssets.delete(entry.handle);
     assetTasks.delete(task);
   };
@@ -316,6 +317,9 @@
     // @stasis-feature audio end
     gfx_load_sprite: pathId => loadSprite(pathId),
     stasis_gfx_load_sprite: pathId => loadSprite(pathId),
+    gfx_release_sprite: handle => releaseSprite(handle),
+    stasis_gfx_release_sprite: handle => releaseSprite(handle),
+    stasis_jit_gfx_release_sprite: handle => releaseSprite(handle),
     stasis_jit_asset_request_sprite: pathId => requestSprite(pathId),
     // @stasis-feature audio begin
     stasis_jit_asset_request_audio: pathId => requestAudio(pathId),

--- a/samples/audio_asset_playback/README.md
+++ b/samples/audio_asset_playback/README.md
@@ -1,9 +1,10 @@
 # Compressed audio asset playback
 
-This sample exercises MP3 music and PCM WAV effects through the same SDL-backed,
-Brickout-compatible helpers. It loops a quiet compressed tone, pauses and resumes
-it, changes its volume, overlaps a WAV effect, stops the music, and starts it again.
-MP3 bytes remain compressed on disk and decode into bounded host memory at load.
+This sample starts nonblocking MP3 and PCM WAV loads, checks `ready()` each tick,
+then plays through the asset values themselves. It loops a quiet compressed tone,
+pauses and resumes it, changes its volume, overlaps a WAV effect, stops the music,
+and starts it again. MP3 bytes remain compressed on disk and decode into bounded
+host memory on the host worker.
 
 Generate the checked-in fixture after deliberately changing its recipe:
 

--- a/samples/audio_asset_playback/audio_asset_playback.stasis
+++ b/samples/audio_asset_playback/audio_asset_playback.stasis
@@ -1,9 +1,10 @@
 import "/vendor/stasis/src/stdlib/audio.stasis";
 import "/vendor/stasis/src/stdlib/graphics.stasis";
 
-global music: i32;
-global effect: i32;
+global music: AudioAsset;
+global effect: AudioAsset;
 global ticks: i32;
+global playback_started: bool;
 
 function main(): i32 {
     init_window(480, 270, "Stasis Compressed Audio Playback");
@@ -13,35 +14,42 @@ function main(): i32 {
     if (!audio_is_available() || audio_get_sample_rate() != 48000 || audio_get_channels() != 2) {
         return 4;
     }
-    music = audio_load_music("assets/tone.mp3");
-    effect = audio_load_effect("assets/tone.wav");
-    if (music <= 0 || effect <= 0) {
+    if (!music.load_audio("assets/tone.mp3") || !effect.load_audio("assets/tone.wav")) {
         return 2;
-    }
-    if (!audio_play_music(music, true, 0.18)) {
-        return 3;
     }
     ticks = 0;
     return 0;
 }
 
 function tick(): i32 {
+    if (!playback_started) {
+        if (music.failed() || effect.failed()) {
+            return 2;
+        }
+        if (!music.ready() || !effect.ready()) {
+            return 0;
+        }
+        if (!music.play_music(true, 0.18)) {
+            return 3;
+        }
+        playback_started = true;
+    }
     ticks += 1;
     if (ticks == 120) {
-        audio_pause_music(music, true);
+        music.pause_music(true);
     }
     if (ticks == 180) {
-        audio_set_music_volume(music, 0.08);
-        audio_pause_music(music, false);
+        music.set_music_volume(0.08);
+        music.pause_music(false);
     }
     if (ticks == 240) {
-        audio_play_effect(effect, 0.25);
+        effect.play_effect(0.25);
     }
     if (ticks == 300) {
-        audio_stop_music(music);
+        music.stop_music();
     }
     if (ticks == 360) {
-        audio_play_music(music, true, 0.12);
+        music.play_music(true, 0.12);
     }
     return 0;
 }

--- a/src/stdlib/asset_tasks.stasis
+++ b/src/stdlib/asset_tasks.stasis
@@ -1,20 +1,191 @@
 @link("stasis_graphics");
 
-const ASSET_TASK_NONE: i32 = 0;
-const ASSET_TASK_PENDING: i32 = 1;
-const ASSET_TASK_LOADING: i32 = 2;
-const ASSET_TASK_LOADED: i32 = 3;
-const ASSET_TASK_FAILED: i32 = 4;
-const ASSET_TASK_CANCELLED: i32 = 5;
+enum AssetState {
+    None,
+    Pending,
+    Loading,
+    Loaded,
+    Failed,
+    Cancelled,
+}
 
-struct AssetTask {
-    request: i32;
+struct ImageAsset {
     handle: i32;
-    state: i32;
+    request: i32;
+    state: AssetState;
+    width: i32;
+    height: i32;
+}
+
+struct AudioAsset {
+    handle: i32;
+    request: i32;
+    state: AssetState;
+}
+
+struct LoadingProgress {
+    total_count: i32;
+    loaded_count: i32;
+    failed_count: i32;
+    in_progress_count: i32;
+    percent: i32;
+    displayed_percent: i32;
+}
+
+function reset(self: LoadingProgress): void {
+    self.total_count = 0;
+    self.loaded_count = 0;
+    self.failed_count = 0;
+    self.in_progress_count = 0;
+    self.percent = 0;
+    self.displayed_percent = 0;
+}
+
+function advance(self: LoadingProgress, total_count: i32, loaded_count: i32, failed_count: i32): i32 {
+    self.total_count = total_count;
+    if (self.total_count < 0) {
+        self.total_count = 0;
+    }
+
+    self.loaded_count = loaded_count;
+    if (self.loaded_count < 0) {
+        self.loaded_count = 0;
+    }
+
+    self.failed_count = failed_count;
+    if (self.failed_count < 0) {
+        self.failed_count = 0;
+    }
+
+    let completed_count: i32 = self.loaded_count + self.failed_count;
+    if (completed_count > self.total_count) {
+        completed_count = self.total_count;
+    }
+
+    self.in_progress_count = self.total_count - completed_count;
+    if (self.total_count == 0) {
+        self.percent = 0;
+    } else {
+        self.percent =(completed_count * 100) / self.total_count;
+    }
+
+    if (self.percent > self.displayed_percent) {
+        self.displayed_percent = self.displayed_percent + 1;
+    } else if (self.percent < self.displayed_percent) {
+        self.displayed_percent = self.percent;
+    }
+    return self.displayed_percent;
+}
+
+function complete(self: LoadingProgress): bool {
+    return self.total_count == 0 || self.loaded_count + self.failed_count >= self.total_count;
+}
+
+function successful(self: LoadingProgress): bool {
+    return self.complete() && self.failed_count == 0;
 }
 
 function @extern("stasis_jit_asset_request_sprite") asset_request_sprite(path: string, width: i32, height: i32): i32;
 function @extern("stasis_jit_asset_request_audio") asset_request_audio(path: string): i32;
-function @extern("stasis_jit_asset_task_poll") asset_task_poll(request: i32): i32;
+function @extern("stasis_jit_asset_task_poll") asset_task_state(request: i32): AssetState;
 function @extern("stasis_jit_asset_task_take_handle") asset_task_take_handle(request: i32): i32;
 function @extern("stasis_jit_asset_task_cancel") asset_task_cancel(request: i32): void;
+function @extern("stasis_jit_gfx_release_sprite") gfx_release_sprite(handle: i32): void;
+
+extern function audio_release(asset_handle: i32): void;
+
+function @asset_path(path) load_image(self: ImageAsset, path: string, width: i32, height: i32): bool {
+    self.release();
+    self.request = asset_request_sprite(path, width, height);
+    self.width = width;
+    self.height = height;
+    if (self.request <= 0) {
+        self.state = AssetState.Failed;
+        return false;
+    }
+    self.state = AssetState.Pending;
+    return true;
+}
+
+function @asset_path(path) load_audio(self: AudioAsset, path: string): bool {
+    self.release();
+    self.request = asset_request_audio(path);
+    if (self.request <= 0) {
+        self.state = AssetState.Failed;
+        return false;
+    }
+    self.state = AssetState.Pending;
+    return true;
+}
+
+function status(self: ImageAsset): AssetState {
+    if (self.request <= 0) {
+        return self.state;
+    }
+    self.state = asset_task_state(self.request);
+    if (self.state == AssetState.Loaded) {
+        self.handle = asset_task_take_handle(self.request);
+        self.request = 0;
+        if (self.handle <= 0) {
+            self.state = AssetState.Failed;
+        }
+    }
+    return self.state;
+}
+
+function status(self: AudioAsset): AssetState {
+    if (self.request <= 0) {
+        return self.state;
+    }
+    self.state = asset_task_state(self.request);
+    if (self.state == AssetState.Loaded) {
+        self.handle = asset_task_take_handle(self.request);
+        self.request = 0;
+        if (self.handle <= 0) {
+            self.state = AssetState.Failed;
+        }
+    }
+    return self.state;
+}
+
+function ready(self: ImageAsset): bool {
+    return self.status() == AssetState.Loaded;
+}
+
+function ready(self: AudioAsset): bool {
+    return self.status() == AssetState.Loaded;
+}
+
+function failed(self: ImageAsset): bool {
+    let current: AssetState = self.status();
+    return current == AssetState.Failed || current == AssetState.Cancelled;
+}
+
+function failed(self: AudioAsset): bool {
+    let current: AssetState = self.status();
+    return current == AssetState.Failed || current == AssetState.Cancelled;
+}
+
+function release(self: ImageAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle > 0) {
+        gfx_release_sprite(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}
+
+function release(self: AudioAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle > 0) {
+        audio_release(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}

--- a/src/stdlib/audio.stasis
+++ b/src/stdlib/audio.stasis
@@ -2,54 +2,43 @@
 
 import "graphics.stasis";
 
-struct AudioAsset {
-    handle: i32;
-    request: i32;
-    state: i32;
+function play(self: AudioAsset, loop: bool, volume: f32, pan: f32): i32 {
+    if (!self.ready()) {
+        return 0;
+    }
+    return audio_play(self.handle, loop, volume, pan);
 }
 
-function @asset_path(path) request_audio_load(self: AudioAsset, path: string): bool {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
-    if (self.handle > 0) {
-        audio_release(self.handle);
-    }
-    self.handle = 0;
-    self.request = asset_request_audio(path);
-    if (self.request <= 0) {
-        self.state = ASSET_TASK_FAILED;
+function play_effect(self: AudioAsset, volume: f32): bool {
+    if (!self.ready()) {
         return false;
     }
-    self.state = ASSET_TASK_PENDING;
-    return true;
+    return audio_play_effect(self.handle, volume);
 }
 
-function poll_audio_load(self: AudioAsset): i32 {
-    if (self.request <= 0) {
-        return self.state;
+function play_music(self: AudioAsset, loop: bool, volume: f32): bool {
+    if (!self.ready()) {
+        return false;
     }
-    self.state = asset_task_poll(self.request);
-    if (self.state == ASSET_TASK_LOADED) {
-        self.handle = asset_task_take_handle(self.request);
-        self.request = 0;
-        if (self.handle <= 0) {
-            self.state = ASSET_TASK_FAILED;
-        }
-    }
-    return self.state;
+    return audio_play_music(self.handle, loop, volume);
 }
 
-function release_audio(self: AudioAsset): void {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
+function stop_music(self: AudioAsset): void {
     if (self.handle > 0) {
-        audio_release(self.handle);
+        audio_stop_music(self.handle);
     }
-    self.request = 0;
-    self.handle = 0;
-    self.state = ASSET_TASK_NONE;
+}
+
+function pause_music(self: AudioAsset, paused: bool): void {
+    if (self.handle > 0) {
+        audio_pause_music(self.handle, paused);
+    }
+}
+
+function set_music_volume(self: AudioAsset, volume: f32): void {
+    if (self.handle > 0) {
+        audio_set_music_volume(self.handle, volume);
+    }
 }
 
 // Audio/runtime bindings (marker module).
@@ -68,7 +57,6 @@ extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i3
 // mono or stereo little-endian PCM16 WAV files. The music/effect helpers accept WAV or MP3.
 // Compressed input stays compressed on disk and is decoded into bounded host memory at load.
 extern function @asset_path(path) audio_load_wav(path: string): i32;
-extern function audio_release(asset_handle: i32): void;
 extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
 extern function audio_stop(voice_handle: i32): void;
 extern function audio_voice_is_playing(voice_handle: i32): bool;

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -37,14 +37,6 @@ struct Sprite {
     height: i32;
 }
 
-struct ImageAsset {
-    handle: i32;
-    request: i32;
-    state: i32;
-    width: i32;
-    height: i32;
-}
-
 struct TextRun {
     font: i32;
     handle: i32;
@@ -75,52 +67,22 @@ struct SpriteSheet {
 
 function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
 function @extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(self: SpriteSheet, path: string, width: i32, height: i32): bool;
-function @extern("stasis_jit_gfx_release_sprite") gfx_release_sprite(handle: i32): void;
 
-function @asset_path(path) request_image_load(self: ImageAsset, path: string, width: i32, height: i32): bool {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
-    if (self.handle > 0) {
-        gfx_release_sprite(self.handle);
-    }
-    self.handle = 0;
-    self.request = asset_request_sprite(path, width, height);
-    self.width = width;
-    self.height = height;
-    if (self.request <= 0) {
-        self.state = ASSET_TASK_FAILED;
+function publish(self: ImageAsset, target: Sprite): bool {
+    if (!self.ready()) {
         return false;
     }
-    self.state = ASSET_TASK_PENDING;
-    return true;
-}
-
-function poll_image_load(self: ImageAsset): i32 {
-    if (self.request <= 0) {
-        return self.state;
+    if (target.handle > 0 && target.handle != self.handle) {
+        gfx_release_sprite(target.handle);
     }
-    self.state = asset_task_poll(self.request);
-    if (self.state == ASSET_TASK_LOADED) {
-        self.handle = asset_task_take_handle(self.request);
-        self.request = 0;
-        if (self.handle <= 0) {
-            self.state = ASSET_TASK_FAILED;
-        }
-    }
-    return self.state;
-}
-
-function release_image(self: ImageAsset): void {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
-    if (self.handle > 0) {
-        gfx_release_sprite(self.handle);
-    }
-    self.request = 0;
+    target.handle = self.handle;
+    target.width = self.width;
+    target.height = self.height;
     self.handle = 0;
-    self.state = ASSET_TASK_NONE;
+    self.width = 0;
+    self.height = 0;
+    self.state = AssetState.None;
+    return true;
 }
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {

--- a/tests/stasis/asset_tasks.test.stasis
+++ b/tests/stasis/asset_tasks.test.stasis
@@ -1,0 +1,29 @@
+import "../../src/stdlib/asset_tasks.stasis";
+
+global progress: LoadingProgress;
+
+test `loading progress protects empty batches`(): bool {
+    progress.reset();
+    let displayed_percent: i32 = progress.advance(0, 0, 0);
+    return progress.percent == 0 && progress.displayed_percent == 0 && progress.in_progress_count == 0 && progress.complete() && progress.successful();
+}
+
+test `loading progress counts loaded and failed tasks as complete`(): bool {
+    progress.reset();
+    let displayed_percent: i32 = progress.advance(20, 2, 1);
+    if (progress.percent != 15 || progress.in_progress_count != 17) {
+        return false;
+    }
+    if (progress.displayed_percent != 1 || progress.complete() || progress.successful()) {
+        return false;
+    }
+
+    displayed_percent = progress.advance(20, 20, 0);
+    return progress.percent == 100 && progress.displayed_percent == 2 && progress.complete() && progress.successful();
+}
+
+test `loading progress completes failed batches without calling them successful`(): bool {
+    progress.reset();
+    let displayed_percent: i32 = progress.advance(3, 2, 1);
+    return progress.percent == 100 && progress.displayed_percent == 1 && progress.complete() && !progress.successful();
+}

--- a/tests/stasis/image_asset_publish.test.stasis
+++ b/tests/stasis/image_asset_publish.test.stasis
@@ -1,0 +1,20 @@
+import "../../src/stdlib/graphics.stasis";
+
+global asset: ImageAsset;
+global target: Sprite;
+
+test `publishing an image transfers its host handle and replaces the target`(): bool {
+    asset.handle = 22;
+    asset.state = AssetState.Loaded;
+    asset.width = 64;
+    asset.height = 48;
+
+    target.handle = 11;
+    target.width = 8;
+    target.height = 8;
+
+    if (!asset.publish(target)) {
+        return false;
+    }
+    return target.handle == 22 && target.width == 64 && target.height == 48 && asset.handle == 0 && asset.state == AssetState.None;
+}


### PR DESCRIPTION
## Summary
- expose AssetState as the host-reported enum shared by image and audio assets
- simplify public use to load_image/load_audio, status/ready/failed, publish/play, and elease
- keep opaque resource handles assigned and owned by the host
- add LoadingProgress.advance(total, loaded, failed) with zero-safe real progress and a one-point-per-tick displayed ramp
- teach the web backend to resolve receiver overloads and scalar-only struct receivers
- migrate the async audio sample to the simplified API

## Verification
- cargo fmt --all -- --check
- 15 focused WASM backend tests pass
- exact existing_audio_game_packages_wav_and_mp3_for_web_audio CI regression passes
- direct audio sample web package succeeds
- Gambit Guard: stasis check
- Gambit Guard: stasis test (168 passed)
