### PR TITLE
Recover Android seam captures from hidden system dialogs

### DIFF
--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -626,6 +626,23 @@ def capture_until_regions_match(
             return validate_regions(capture, expectations)
         except SeamError as error:
             last_error = error
+            # Android 15 may layer a launcher ANR above the focused test
+            # activity without reporting AppNotRespondingDialog through
+            # dumpsys window. Only inspect the UI hierarchy after a capture
+            # mismatch, then dismiss a known system action and restore the
+            # test activity before trying the framebuffer again.
+            if dismiss_system_dialog_action(adb, serial):
+                _run(
+                    adb,
+                    serial,
+                    "shell",
+                    "am",
+                    "start",
+                    "-W",
+                    "-n",
+                    component,
+                    required=False,
+                )
             time.sleep(0.25)
     if last_error is not None:
         raise last_error

--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -528,6 +528,17 @@ def dismiss_system_dialog_action(adb: Path, serial: str | None) -> bool:
         root = ET.fromstring(hierarchy[start : end + len("</hierarchy>")])
     except ET.ParseError:
         return False
+    system_anr_titles = {
+        "Pixel Launcher isn't responding",
+        "System UI isn't responding",
+    }
+    alert_titles = {
+        node.attrib.get("text", "")
+        for node in root.iter("node")
+        if node.attrib.get("resource-id", "") == "android:id/alertTitle"
+    }
+    if system_anr_titles.isdisjoint(alert_titles):
+        return False
     actions = {
         node.attrib.get("text", ""): node.attrib.get("bounds", "")
         for node in root.iter("node")
@@ -629,8 +640,8 @@ def capture_until_regions_match(
             # Android 15 may layer a launcher ANR above the focused test
             # activity without reporting AppNotRespondingDialog through
             # dumpsys window. Only inspect the UI hierarchy after a capture
-            # mismatch, then dismiss a known system action and restore the
-            # test activity before trying the framebuffer again.
+            # mismatch, then dismiss a verified launcher/System UI ANR and
+            # restore the test activity before trying the framebuffer again.
             if dismiss_system_dialog_action(adb, serial):
                 _run(
                     adb,

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -288,6 +288,55 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             calls,
         )
 
+    def test_capture_mismatch_dismisses_undetected_system_dialog(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("exec-out", "screencap", "-p"):
+                return b"capture"
+            return ""
+
+        with tempfile.TemporaryDirectory() as temporary:
+            capture = Path(temporary) / "frame.png"
+            with (
+                mock.patch.object(seam, "_run", side_effect=fake_run),
+                mock.patch.object(
+                    seam, "ensure_test_activity_foreground", return_value=False
+                ),
+                mock.patch.object(
+                    seam, "validate_regions",
+                    side_effect=[seam.SeamError("covered"), [{"name": "red"}]],
+                ),
+                mock.patch.object(
+                    seam, "dismiss_system_dialog_action", return_value=True
+                ) as dismiss,
+                mock.patch.object(seam.time, "sleep"),
+            ):
+                observed = seam.capture_until_regions_match(
+                    Path("adb"),
+                    "device",
+                    capture,
+                    {"logical_size": [640, 360], "regions": []},
+                    seam.time.monotonic() + 5,
+                    "com.example.seam",
+                    "com.example.seam/.MainActivity",
+                )
+
+        self.assertEqual(observed, [{"name": "red"}])
+        dismiss.assert_called_once_with(Path("adb"), "device")
+        self.assertIn(
+            (
+                "shell",
+                "am",
+                "start",
+                "-W",
+                "-n",
+                "com.example.seam/.MainActivity",
+            ),
+            calls,
+        )
+
     def test_selects_real_letterbox_for_each_surface_orientation(self):
         self.assertEqual(
             seam.outside_letterbox_point([360, 720], (1080, 2400)),

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -181,7 +181,10 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
                 return (
                     "UI hierarchy dumped\n<?xml version='1.0' encoding='UTF-8' "
-                    "standalone='yes'?><hierarchy><node text=\"Close app\" "
+                    "standalone='yes'?><hierarchy><node "
+                    "resource-id=\"android:id/alertTitle\" "
+                    "text=\"Pixel Launcher isn't responding\" />"
+                    "<node text=\"Close app\" "
                     "bounds=\"[120,600][420,720]\" /></hierarchy>"
                 )
             return ""
@@ -219,6 +222,8 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
                 return (
                     "<?xml version='1.0' encoding='UTF-8'?><hierarchy>"
+                    "<node resource-id=\"android:id/alertTitle\" "
+                    "text=\"System UI isn't responding\" />"
                     "<node text=\"Close app\" bounds=\"[120,600][420,720]\" />"
                     "<node text=\"Wait\" bounds=\"[120,720][420,840]\" />"
                     "</hierarchy>"
@@ -250,6 +255,8 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
                 return (
                     "<?xml version='1.0' encoding='UTF-8'?><hierarchy>"
+                    "<node resource-id=\"android:id/alertTitle\" "
+                    "text=\"Pixel Launcher isn't responding\" />"
                     "<node text=\"Close app\" bounds=\"[120,600][420,720]\" />"
                     "</hierarchy>"
                 )
@@ -287,6 +294,27 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
             ),
             calls,
         )
+
+    def test_dialog_action_does_not_hide_product_anr(self):
+        calls = []
+
+        def fake_run(_adb, _serial, *arguments, **_options):
+            calls.append(arguments)
+            if arguments == ("shell", "uiautomator", "dump", "/dev/tty"):
+                return (
+                    "<?xml version='1.0' encoding='UTF-8'?><hierarchy>"
+                    "<node resource-id=\"android:id/alertTitle\" "
+                    "text=\"Stasis Android Seam isn't responding\" />"
+                    "<node text=\"Wait\" bounds=\"[120,720][420,840]\" />"
+                    "</hierarchy>"
+                )
+            return ""
+
+        with mock.patch.object(seam, "_run", side_effect=fake_run):
+            dismissed = seam.dismiss_system_dialog_action(Path("adb"), "device")
+
+        self.assertFalse(dismissed)
+        self.assertNotIn(("shell", "input", "tap", "270", "780"), calls)
 
     def test_capture_mismatch_dismisses_undetected_system_dialog(self):
         calls = []


### PR DESCRIPTION
## Summary
- inspect the UI hierarchy after a framebuffer mismatch so Android 15 launcher ANRs hidden from dumpsys cannot cover release evidence
- prefer the non-destructive Wait action, restore the test activity, and retry capture
- cover the undetected-dialog recovery path with a focused unit regression

## Verification
- python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_android_emulator_seams (25 passed)
- git diff --check

## Failure evidence
Nightly run 31905371831 failed twice because Pixel Launcher’s ANR dialog covered a correctly rendering IT-017 sample. The uploaded stable-frame evidence showed the red/cyan sample behind the modal.