### PR TITLE
Accept allowlisted emulator ANR titles without node IDs

### DIFF
--- a/tools/ci/run_android_release_shell_seam.py
+++ b/tools/ci/run_android_release_shell_seam.py
@@ -535,7 +535,6 @@ def dismiss_system_dialog_action(adb: Path, serial: str | None) -> bool:
     alert_titles = {
         node.attrib.get("text", "")
         for node in root.iter("node")
-        if node.attrib.get("resource-id", "") == "android:id/alertTitle"
     }
     if system_anr_titles.isdisjoint(alert_titles):
         return False

--- a/tools/ci/test_run_android_release_shell_seam.py
+++ b/tools/ci/test_run_android_release_shell_seam.py
@@ -182,7 +182,6 @@ class AndroidReleaseShellSeamTests(unittest.TestCase):
                 return (
                     "UI hierarchy dumped\n<?xml version='1.0' encoding='UTF-8' "
                     "standalone='yes'?><hierarchy><node "
-                    "resource-id=\"android:id/alertTitle\" "
                     "text=\"Pixel Launcher isn't responding\" />"
                     "<node text=\"Close app\" "
                     "bounds=\"[120,600][420,720]\" /></hierarchy>"


### PR DESCRIPTION
## Summary
- recognize the exact allowlisted Pixel Launcher/System UI ANR titles even when Android 15 omits android:id/alertTitle from the UI hierarchy
- retain exact-title gating so Stasis product ANRs remain release failures
- exercise the no-resource-id hierarchy observed in nightly evidence

## Verification
- python -m unittest tools.ci.test_run_android_release_shell_seam tools.ci.test_android_emulator_seams (26 passed)
- git diff --check

## Evidence
Required nightly 31906834481 again captured the correctly rendering IT-017 sample behind the Pixel Launcher not responding dialog; the title node did not satisfy the resource-ID-specific recovery merged in #511.