### PR TITLE
Test input across orientation changes

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Check Stasis src layout
         run: |
           python tools/ci/check_stasis_src_layout.py
@@ -61,6 +66,9 @@ jobs:
           python -m unittest tools.ci.test_verify_android_render_performance
           python -m unittest tools.ci.test_verify_render_parity
           python tools/ci/verify_render_parity.py
+
+      - name: Test web orientation HostFrame seam
+        run: node --test runtime/web/tests/orientation_host_frame.test.mjs
 
       - name: Test native render contract and lifecycle matrix
         run: |
@@ -93,7 +101,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Check Stasis src layout
         run: python tools/ci/check_stasis_src_layout.py
 
@@ -215,7 +222,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/apps/stasis/tests/desktop_display_metrics_seam.rs
+++ b/apps/stasis/tests/desktop_display_metrics_seam.rs
@@ -16,10 +16,18 @@ const WINDOW_MINIMIZED: i32 = 2;
 const WINDOW_RESTORED: i32 = 3;
 const POINTER_DOWN: i32 = 3;
 const POINTER_MOVE: i32 = 4;
+const POINTER_UP: i32 = 5;
 const TOUCH_ID: i32 = 91;
-const ODD_TRACE: i32 = -873_412_109;
-const MINIMIZED_TRACE: i32 = 1_700_295_147;
-const RESTORED_TRACE: i32 = -683_859_671;
+const POINTER_SLOT_ID: i32 = 1;
+const ODD_TRACE: i32 = 896_184_146;
+const MINIMIZED_TRACE: i32 = -1_273_339_326;
+const RESTORED_TRACE: i32 = -1_200_835_344;
+const PORTRAIT_RELEASE_TRACE: i32 = 1_386_315_686;
+const PORTRAIT_DOWN_TRACE: i32 = 569_769_344;
+const LANDSCAPE_DOWN_TRACE: i32 = 569_769_344;
+const LANDSCAPE_RELEASE_TRACE: i32 = 569_769_344;
+const RESTORED_PORTRAIT_TRACE: i32 = 773_912_317;
+const QUIET_TRACE: i32 = 773_912_317;
 
 #[derive(Clone, Copy)]
 struct DisplaySample {
@@ -48,6 +56,44 @@ const ODD_FRACTIONAL: DisplaySample = DisplaySample {
     density_generation: 2,
 };
 
+const ORIENTATION_PORTRAIT: DisplaySample = DisplaySample {
+    logical: [360, 720],
+    native: [360, 720],
+    drawable: [360, 720],
+    safe_native: [0, 0, 360, 720],
+    safe_logical: [0.0, 0.0, 360.0, 720.0],
+    safe_rounded: [0, 0, 360, 720],
+    content_scale: 1.0,
+    raster_scale: 1.0,
+    display_generation: 4,
+    density_generation: 4,
+};
+
+const ORIENTATION_LANDSCAPE: DisplaySample = DisplaySample {
+    logical: [360, 720],
+    native: [720, 360],
+    drawable: [720, 360],
+    safe_native: [0, 0, 720, 360],
+    safe_logical: [0.0, 0.0, 360.0, 720.0],
+    safe_rounded: [0, 0, 360, 720],
+    content_scale: 0.5,
+    raster_scale: 1.0,
+    display_generation: 5,
+    density_generation: 4,
+};
+
+const RESTORED_PORTRAIT: DisplaySample = DisplaySample {
+    logical: [360, 720],
+    native: [360, 720],
+    drawable: [360, 720],
+    safe_native: [0, 0, 360, 720],
+    safe_logical: [0.0, 0.0, 360.0, 720.0],
+    safe_rounded: [0, 0, 360, 720],
+    content_scale: 1.0,
+    raster_scale: 1.0,
+    display_generation: 6,
+    density_generation: 4,
+};
 const RESTORED_SCALE: DisplaySample = DisplaySample {
     logical: [400, 300],
     native: [801, 601],
@@ -157,6 +203,56 @@ fn assert_close(actual: f32, expected: f32, field: &str) {
         (actual - expected).abs() <= 0.002,
         "{field} mismatch: expected={expected} actual={actual}"
     );
+}
+
+fn assert_pointer_release(
+    host_i32: &[i32],
+    host_f32: &[f32],
+    expected_x: f32,
+    expected_y: f32,
+    expected_x_n: f32,
+    expected_y_n: f32,
+    expected_actions: i32,
+) {
+    assert_eq!(
+        host_i32[7], 2,
+        "touch release keeps slot 1 visible for this frame"
+    );
+    assert_eq!(&host_i32[548..552], &[POINTER_SLOT_ID, 0, 0, 1]);
+    assert_close(host_f32[6], expected_x, "touch release logical x");
+    assert_close(host_f32[7], expected_y, "touch release logical y");
+    assert_close(host_f32[10], expected_x_n, "touch release normalized x");
+    assert_close(host_f32[11], expected_y_n, "touch release normalized y");
+    assert_eq!(scalar_i32("metric_pointer_id"), POINTER_SLOT_ID);
+    assert_eq!(scalar_i32("metric_pointer_count"), 2);
+    assert_eq!(scalar_i32("metric_pointer_is_down"), 0);
+    assert_eq!(scalar_i32("metric_pointer_went_up"), 1);
+    assert_eq!(scalar_i32("metric_release_actions"), expected_actions);
+}
+fn assert_pointer_down(
+    host_i32: &[i32],
+    host_f32: &[f32],
+    expected_x: f32,
+    expected_y: f32,
+    expected_x_n: f32,
+    expected_y_n: f32,
+    expected_actions: i32,
+) {
+    assert_eq!(
+        host_i32[7], 2,
+        "touch down keeps slot 1 visible for this frame"
+    );
+    assert_eq!(&host_i32[548..552], &[POINTER_SLOT_ID, 1, 1, 0]);
+    assert_close(host_f32[6], expected_x, "touch down logical x");
+    assert_close(host_f32[7], expected_y, "touch down logical y");
+    assert_close(host_f32[10], expected_x_n, "touch down normalized x");
+    assert_close(host_f32[11], expected_y_n, "touch down normalized y");
+    assert_eq!(scalar_i32("metric_pointer_id"), POINTER_SLOT_ID);
+    assert_eq!(scalar_i32("metric_pointer_count"), 2);
+    assert_eq!(scalar_i32("metric_pointer_is_down"), 1);
+    assert_eq!(scalar_i32("metric_pointer_went_down"), 1);
+    assert_eq!(scalar_i32("metric_pointer_went_up"), 0);
+    assert_eq!(scalar_i32("metric_release_actions"), expected_actions);
 }
 
 fn assert_metrics(
@@ -438,6 +534,132 @@ fn desktop_surface_metrics_reach_stasis_and_renderer_in_one_generation() {
     assert_eq!(restored_trace, RESTORED_TRACE);
     assert_eq!(duplicate_trace, RESTORED_TRACE);
 
+    native.display(DISPLAY_CHANGED, ORIENTATION_PORTRAIT);
+    native.pointer(POINTER_UP, 200.0, 150.0);
+    let portrait_release_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        ORIENTATION_PORTRAIT,
+        false,
+        true,
+    );
+    assert_pointer_release(
+        &host_i32,
+        &host_f32,
+        200.0,
+        150.0,
+        200.0 / 360.0,
+        150.0 / 720.0,
+        1,
+    );
+    assert_eq!(portrait_release_trace, PORTRAIT_RELEASE_TRACE);
+
+    native.pointer(POINTER_DOWN, 270.0, 540.0);
+    let portrait_down_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        ORIENTATION_PORTRAIT,
+        false,
+        false,
+    );
+    assert_pointer_down(&host_i32, &host_f32, 270.0, 540.0, 0.75, 0.75, 1);
+    assert_eq!(portrait_down_trace, PORTRAIT_DOWN_TRACE);
+
+    native.display(DISPLAY_CHANGED, ORIENTATION_LANDSCAPE);
+    let landscape_down_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        ORIENTATION_LANDSCAPE,
+        false,
+        true,
+    );
+    assert_eq!(scalar_i32("metric_display_generation"), 5);
+    assert_eq!(scalar_i32("metric_density_generation"), 4);
+    assert_eq!(&host_i32[548..552], &[POINTER_SLOT_ID, 1, 0, 0]);
+    assert_eq!(scalar_i32("metric_pointer_is_down"), 1);
+    assert_eq!(scalar_i32("metric_pointer_went_down"), 0);
+    assert_eq!(scalar_i32("metric_pointer_went_up"), 0);
+    assert_eq!(landscape_down_trace, LANDSCAPE_DOWN_TRACE);
+
+    native.pointer(POINTER_UP, 270.0, 540.0);
+    let landscape_release_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        ORIENTATION_LANDSCAPE,
+        false,
+        false,
+    );
+    assert_pointer_release(&host_i32, &host_f32, 270.0, 540.0, 0.75, 0.75, 2);
+    assert_eq!(landscape_release_trace, LANDSCAPE_RELEASE_TRACE);
+
+    native.display(DISPLAY_CHANGED, RESTORED_PORTRAIT);
+    let restored_portrait_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        RESTORED_PORTRAIT,
+        false,
+        true,
+    );
+    assert_eq!(host_i32[7], 1, "restored frame has idle mouse only");
+    assert_eq!(host_i32[11], 1, "restored portrait reports resize once");
+    assert_eq!(
+        host_i32[548..552],
+        [POINTER_SLOT_ID, 0, 0, 0],
+        "restored frame clears absent touch slot"
+    );
+    assert_eq!(scalar_i32("metric_pointer_id"), 0);
+    assert_eq!(scalar_i32("metric_pointer_count"), 1);
+    assert_eq!(scalar_i32("metric_pointer_is_down"), 0);
+    assert_eq!(scalar_i32("metric_pointer_went_down"), 0);
+    assert_eq!(scalar_i32("metric_pointer_went_up"), 0);
+    assert_eq!(scalar_i32("metric_release_actions"), 2);
+    assert_eq!(restored_portrait_trace, RESTORED_PORTRAIT_TRACE);
+
+    let quiet_trace = run_frame(
+        &gfx,
+        &mut jit,
+        &mut host_i32,
+        &mut host_f32,
+        &mut gfx_i32,
+        &gfx_f32,
+        &gfx_u8,
+        RESTORED_PORTRAIT,
+        false,
+        false,
+    );
+    assert_eq!(host_i32[7], 1);
+    assert_eq!(host_i32[11], 0, "next quiet frame clears resized");
+    assert_eq!(host_i32[30], 6);
+    assert_eq!(host_i32[31], 4);
+    assert_eq!(scalar_i32("metric_pointer_went_up"), 0);
+    assert_eq!(scalar_i32("metric_release_actions"), 2);
+    assert_eq!(quiet_trace, QUIET_TRACE);
+
     let evidence = json!({
         "schema": "stasis.seam_test.v1",
         "test_id": "IT-007",
@@ -447,9 +669,15 @@ fn desktop_surface_metrics_reach_stasis_and_renderer_in_one_generation() {
             {"stage": "odd_fractional", "logical": ODD_FRACTIONAL.logical, "native": ODD_FRACTIONAL.native, "drawable": ODD_FRACTIONAL.drawable, "safe": ODD_FRACTIONAL.safe_logical, "display_generation": 2, "density_generation": 2, "trace": odd_trace},
             {"stage": "minimized", "display_generation": 2, "density_generation": 2, "trace": minimized_trace},
             {"stage": "restored_scale", "logical": RESTORED_SCALE.logical, "native": RESTORED_SCALE.native, "drawable": RESTORED_SCALE.drawable, "display_generation": 3, "density_generation": 3, "trace": restored_trace},
-            {"stage": "duplicate_restore", "display_generation": 3, "density_generation": 3, "trace": duplicate_trace}
+            {"stage": "duplicate_restore", "display_generation": 3, "density_generation": 3, "trace": duplicate_trace},
+            {"stage": "portrait_release", "logical": ORIENTATION_PORTRAIT.logical, "native": ORIENTATION_PORTRAIT.native, "drawable": ORIENTATION_PORTRAIT.drawable, "display_generation": 4, "density_generation": 4, "pointer_went_up": 1, "release_actions": 1, "trace": portrait_release_trace},
+            {"stage": "portrait_down", "logical": ORIENTATION_PORTRAIT.logical, "native": ORIENTATION_PORTRAIT.native, "drawable": ORIENTATION_PORTRAIT.drawable, "display_generation": 4, "density_generation": 4, "pointer_went_down": 1, "pointer_went_up": 0, "release_actions": 1, "trace": portrait_down_trace},
+            {"stage": "landscape_down", "logical": ORIENTATION_LANDSCAPE.logical, "native": ORIENTATION_LANDSCAPE.native, "drawable": ORIENTATION_LANDSCAPE.drawable, "display_generation": 5, "density_generation": 4, "pointer_went_down": 0, "pointer_went_up": 0, "release_actions": 1, "trace": landscape_down_trace},
+            {"stage": "landscape_release", "logical": ORIENTATION_LANDSCAPE.logical, "native": ORIENTATION_LANDSCAPE.native, "drawable": ORIENTATION_LANDSCAPE.drawable, "display_generation": 5, "density_generation": 4, "pointer_went_up": 1, "release_actions": 2, "trace": landscape_release_trace},
+            {"stage": "restored_portrait", "logical": RESTORED_PORTRAIT.logical, "native": RESTORED_PORTRAIT.native, "drawable": RESTORED_PORTRAIT.drawable, "display_generation": 6, "density_generation": 4, "pointer_went_up": 0, "release_actions": 2, "trace": restored_portrait_trace},
+            {"stage": "quiet", "logical": RESTORED_PORTRAIT.logical, "native": RESTORED_PORTRAIT.native, "drawable": RESTORED_PORTRAIT.drawable, "display_generation": 6, "density_generation": 4, "pointer_went_up": 0, "release_actions": 2, "trace": quiet_trace}
         ],
-        "oracle": {"renderer_lifecycle": initial_lifecycle, "restoration_generation_advances": 1, "pointer_round_trip_tolerance": 0.002}
+        "oracle": {"renderer_lifecycle": initial_lifecycle, "restoration_generation_advances": 1, "pointer_round_trip_tolerance": 0.002, "orientation_release_actions": 2}
     });
     let evidence_path = std::env::var_os("CARGO_TARGET_DIR")
         .map(PathBuf::from)

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -2788,6 +2788,393 @@ mod tests {
     }
 
     #[test]
+    fn android_workshop_host_frame_preserves_edges_across_orientation_changes() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let root = temp_project("orientation_host_frame");
+        let source = format!(
+            "{}\n\
+             global observed_release_actions: i32;\n\
+             global observed_resized: i32;\n\
+             global observed_native_w: i32;\n\
+             global observed_native_h: i32;\n\
+             global observed_drawable_w: i32;\n\
+             global observed_drawable_h: i32;\n\
+             global observed_display_generation: i32;\n\
+             global observed_density_generation: i32;\n\
+             global observed_pointer_count: i32;\n\
+             global observed_pointer_id: i32;\n\
+             global observed_is_down: i32;\n\
+             global observed_went_down: i32;\n\
+             global observed_went_up: i32;\n\
+             global observed_logical_ok: i32;\n\
+             global observed_normalized_ok: i32;\n\
+             global host_req_window_w_px: i32;\n\
+             global host_req_window_h_px: i32;\n\
+             function main(): void {{ observed_release_actions = 0; host_req_window_w_px = 360; host_req_window_h_px = 720; }}\n\
+             function tick(): void {{\n\
+                 observed_native_w = host_native_w_px();\n\
+                 observed_native_h = host_native_h_px();\n\
+                 observed_drawable_w = host_drawable_w_px();\n\
+                 observed_drawable_h = host_drawable_h_px();\n\
+                 observed_display_generation = host_display_generation();\n\
+                 observed_density_generation = host_density_generation();\n\
+                 observed_resized = 0;\n\
+                 if (host_resized()) {{ observed_resized = 1; }}\n\
+                 observed_pointer_count = host_pointer_count();\n\
+                 observed_pointer_id = host_pointer_id(0);\n\
+                 observed_is_down = 0;\n\
+                 if (host_pointer_is_down(0)) {{ observed_is_down = 1; }}\n\
+                 observed_went_down = 0;\n\
+                 if (host_pointer_went_down(0)) {{ observed_went_down = 1; }}\n\
+                 observed_went_up = 0;\n\
+                 if (host_pointer_went_up(0)) {{\n\
+                     observed_went_up = 1;\n\
+                     observed_release_actions += 1;\n\
+                 }}\n\
+                 observed_logical_ok = 0;\n\
+                 if (host_logical_width() == 360.0 && host_logical_height() == 720.0) {{ observed_logical_ok = 1; }}\n\
+                 observed_normalized_ok = 0;\n\
+                 if (host_pointer_x_n(0) == 0.5 && host_pointer_y_n(0) == 0.5) {{ observed_normalized_ok = 1; }}\n\
+             }}\n",
+            include_str!("../../../src/stdlib/internal/host_frame.stasis")
+        );
+        fs::write(root.join("src/main.stasis"), source).expect("write orientation fixture");
+        let entry = Path::new("src/main.stasis");
+        let frame = |touch_active: i32, screen_w: i32, screen_h: i32| {
+            run_android_workshop_tick(
+                &root,
+                entry,
+                AndroidBridgeTickInput {
+                    touch_x: screen_w / 2,
+                    touch_y: screen_h / 2,
+                    touch_active,
+                    screen_w,
+                    screen_h,
+                },
+            )
+            .expect("run orientation frame")
+        };
+
+        let portrait_down = frame(1, 360, 720);
+        assert_eq!(portrait_down.tick_count, 1);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_w").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_h").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_w").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_h").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_id").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+
+        frame(0, 360, 720);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+
+        frame(1, 720, 360);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_w").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_h").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_w").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_h").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_id").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+
+        frame(0, 720, 360);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+
+        let restored = frame(0, 360, 720);
+        assert_eq!(restored.tick_count, 5);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            3
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_w").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_native_h").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_w").unwrap(),
+            360
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_drawable_h").unwrap(),
+            720
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+
+        let quiet = frame(0, 360, 720);
+        assert_eq!(quiet.tick_count, 6);
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_display_generation").unwrap(),
+            3
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_density_generation").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_resized").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_pointer_count").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_is_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_down").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_went_up").unwrap(),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_release_actions").unwrap(),
+            2
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_logical_ok").unwrap(),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, entry, "observed_normalized_ok").unwrap(),
+            1
+        );
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
     fn android_bridge_uses_shared_asset_manifest_resolver() {
         let root = temp_project("shared_assets");
         fs::create_dir_all(root.join("assets")).expect("create assets");
@@ -4184,7 +4571,7 @@ global host_f32: f32[64];
 global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[125060];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 function main(): void { host_req_window_w_px = 360; host_req_window_h_px = 720; }
 function tick(): void {}
@@ -4273,7 +4660,7 @@ function render(): void {
 global host_i32: i32[768];
 global host_f32: f32[64];
 global gfx_cmd_i32: i32[34608];
-global gfx_cmd_f32: f32[125060];
+global gfx_cmd_f32: f32[108676];
 global gfx_cmd_u8: u8[65536];
 function main(): void { gfx_load_sprite(\"../assets/missing.svg\", 32, 32); }
 function tick(): void {}

--- a/mobile/android/validate_device.ps1
+++ b/mobile/android/validate_device.ps1
@@ -71,6 +71,105 @@ function Invoke-Adb([string[]]$Arguments) {
     return $result
 }
 
+function Invoke-AdbBestEffort([string[]]$Arguments) {
+    $previousPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $result = @(& $adb -s $serial @Arguments 2>$null)
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousPreference
+    }
+    if ($exitCode -ne 0) { return @() }
+    return $result
+}
+
+function Read-ObservedRotation {
+    $sources = @(
+        (Invoke-AdbBestEffort @("shell", "dumpsys", "window", "displays")),
+        (Invoke-AdbBestEffort @("shell", "dumpsys", "display")),
+        (Invoke-AdbBestEffort @("shell", "dumpsys", "input"))
+    )
+    foreach ($source in $sources) {
+        $match = [regex]::Match(($source -join "`n"), '(?m)\bmRotation=(\d+)\b')
+        if ($match.Success) { return [int]$match.Groups[1].Value }
+        $match = [regex]::Match(($source -join "`n"), '(?m)\bdisplay_rotation=(\d+)\b')
+        if ($match.Success) { return [int]$match.Groups[1].Value }
+    }
+    return -1
+}
+
+function Set-ObservedRotation([int]$Rotation) {
+    Invoke-AdbBestEffort @("shell", "settings", "put", "system", "accelerometer_rotation", "0") | Out-Null
+    Invoke-AdbBestEffort @("shell", "settings", "put", "system", "user_rotation", "$Rotation") | Out-Null
+    Invoke-AdbBestEffort @("shell", "cmd", "window", "user-rotation", "lock", "$Rotation") | Out-Null
+}
+
+function Wait-ObservedRotation([int]$Expected, [int]$TimeoutSeconds = 20) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $observed = Read-ObservedRotation
+        if ($observed -eq $Expected) { return $observed }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+    throw "Android rotation did not reach $Expected; observed $observed"
+}
+
+function Read-PreviewFrames {
+    $lines = Invoke-AdbBestEffort @("logcat", "-d", "-s", "StasisWorkshop:I", "*:S")
+    $pattern = 'logical=(\d+)x(\d+)\s+native=(\d+)x(\d+)\s+drawable=(\d+)x(\d+)\s+display_gen=(\d+)\s+density_gen=(\d+)'
+    foreach ($line in $lines) {
+        $match = [regex]::Match($line.ToString(), $pattern)
+        if (-not $match.Success) { continue }
+        [pscustomobject]@{
+            line = $line.ToString()
+            logical_w = [int]$match.Groups[1].Value
+            logical_h = [int]$match.Groups[2].Value
+            native_w = [int]$match.Groups[3].Value
+            native_h = [int]$match.Groups[4].Value
+            drawable_w = [int]$match.Groups[5].Value
+            drawable_h = [int]$match.Groups[6].Value
+            display_gen = [int]$match.Groups[7].Value
+            density_gen = [int]$match.Groups[8].Value
+        }
+    }
+}
+
+function Wait-PreviewFrame([int]$PreviousDisplayGeneration, [bool]$Landscape, [int]$LogicalWidth = 0, [int]$LogicalHeight = 0, [int]$TimeoutSeconds = 25) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $frames = @(Read-PreviewFrames)
+        $frame = $frames | Where-Object {
+            $matchesLogical = $LogicalWidth -le 0 -or ($_.logical_w -eq $LogicalWidth -and $_.logical_h -eq $LogicalHeight)
+            $matchesOrientation = if ($Landscape) { $_.native_w -gt $_.native_h } else { $_.native_h -gt $_.native_w }
+            $matchesLogical -and $_.display_gen -gt $PreviousDisplayGeneration -and $matchesOrientation
+        } | Sort-Object display_gen | Select-Object -Last 1
+        if ($frame) { return $frame }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+    throw "Workshop preview did not emit a newer $($(if($Landscape){'landscape'}else{'portrait'})) gfx_cmd frame after display_gen=$PreviousDisplayGeneration"
+}
+
+function Save-AndroidScreenshot([string]$Path) {
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $adb
+    $startInfo.Arguments = "-s $serial exec-out screencap -p"
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) { throw "Android screenshot capture could not start" }
+    $errorTask = $process.StandardError.ReadToEndAsync()
+    $stream = [IO.File]::Create($Path)
+    try { $process.StandardOutput.BaseStream.CopyTo($stream) } finally { $stream.Dispose() }
+    $process.WaitForExit()
+    $errorTask.Result | Set-Content -LiteralPath "$Path.stderr" -Encoding UTF8
+    if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $Path) -or (Get-Item -LiteralPath $Path).Length -eq 0) {
+        throw "Android screenshot capture failed: $Path"
+    }
+}
 $originalAutoRotation = $null
 $originalRotation = $null
 try {
@@ -95,24 +194,60 @@ try {
     $versionName = ($packageInfo | Select-String -Pattern 'versionName=' | Select-Object -First 1).Line.Trim()
 
     $lifecycleLog = @()
+    $previewFrames = @()
+    $capturePaths = @()
     $restoreCount = 0
     if ($Lifecycle) {
         $originalAutoRotation = (Invoke-Adb @("shell", "settings", "get", "system", "accelerometer_rotation") | Select-Object -First 1).Trim()
         $originalRotation = (Invoke-Adb @("shell", "settings", "get", "system", "user_rotation") | Select-Object -First 1).Trim()
-        Invoke-Adb @("shell", "settings", "put", "system", "accelerometer_rotation", "0") | Out-Null
-        Invoke-Adb @("shell", "settings", "put", "system", "user_rotation", "1") | Out-Null
-        Start-Sleep -Seconds 2
+
+        # Re-launch into a known portrait frame, then exercise the live Workshop surface.
+        Set-ObservedRotation 0
+        Invoke-Adb @("shell", "am", "force-stop", $package) | Out-Null
+        Invoke-Adb @("shell", "am", "start", "-S", "-W", "-n", "$package/$activity") | Out-Null
+        Start-Sleep -Seconds 1
+        $appPid = (Invoke-Adb @("shell", "pidof", $package) | Select-Object -First 1).Trim()
+        if (-not $appPid) { throw "Android package did not start for Workshop orientation acceptance: $package" }
+        Wait-ObservedRotation 0 | Out-Null
+        $beforeFrame = Wait-PreviewFrame -PreviousDisplayGeneration -1 -Landscape $false
+        $previewFrames += $beforeFrame
+        $beforeCapture = Join-Path $outputDirectory "before.png"
+        Save-AndroidScreenshot $beforeCapture
+        $capturePaths += $beforeCapture
+
+        Set-ObservedRotation 1
+        Wait-ObservedRotation 1 | Out-Null
+        $landscapeFrame = Wait-PreviewFrame -PreviousDisplayGeneration $beforeFrame.display_gen -Landscape $true -LogicalWidth $beforeFrame.logical_w -LogicalHeight $beforeFrame.logical_h
+        $previewFrames += $landscapeFrame
+        $landscapeCapture = Join-Path $outputDirectory "landscape.png"
+        Save-AndroidScreenshot $landscapeCapture
+        $capturePaths += $landscapeCapture
+        $tapX = [math]::Floor($landscapeFrame.native_w / 2)
+        $tapY = [math]::Floor($landscapeFrame.native_h / 2)
+        Invoke-Adb @("shell", "input", "tap", "$tapX", "$tapY") | Out-Null
+        Start-Sleep -Milliseconds 500
+        $appPid = (Invoke-Adb @("shell", "pidof", $package) | Select-Object -First 1).Trim()
+        if (-not $appPid) { throw "Android package died after the landscape Workshop preview tap" }
+
+        Set-ObservedRotation 0
+        Wait-ObservedRotation 0 | Out-Null
+        $afterFrame = Wait-PreviewFrame -PreviousDisplayGeneration $landscapeFrame.display_gen -Landscape $false -LogicalWidth $beforeFrame.logical_w -LogicalHeight $beforeFrame.logical_h
+        $previewFrames += $afterFrame
+        $afterCapture = Join-Path $outputDirectory "after.png"
+        Save-AndroidScreenshot $afterCapture
+        $capturePaths += $afterCapture
+        $appPid = (Invoke-Adb @("shell", "pidof", $package) | Select-Object -First 1).Trim()
+        if (-not $appPid) { throw "Android package did not survive the restored portrait Workshop preview" }
+
+        # Keep the existing renderer lifecycle proof in the same run.
         Invoke-Adb @("shell", "input", "keyevent", "KEYCODE_HOME") | Out-Null
         Start-Sleep -Seconds 1
-        Invoke-Adb @("shell", "am", "start", "-W", "-n", "$package/$activity") | Out-Null
-        Start-Sleep -Seconds 2
-        Invoke-Adb @("shell", "settings", "put", "system", "user_rotation", "0") | Out-Null
-        Start-Sleep -Seconds 2
         Invoke-Adb @("shell", "am", "start", "-S", "-W", "-n", "$package/$activity") | Out-Null
         Start-Sleep -Seconds 2
         $appPid = (Invoke-Adb @("shell", "pidof", $package) | Select-Object -First 1).Trim()
-        if (-not $appPid) { throw "Android package did not survive lifecycle acceptance: $package" }
-        $lifecycleLog = @(Invoke-Adb @("logcat", "-d", "-s", "StasisRenderer:I", "*:S"))
+        if (-not $appPid) { throw "Android package did not survive renderer lifecycle acceptance: $package" }
+
+        $lifecycleLog = @(Invoke-Adb @("logcat", "-d", "-s", "StasisRenderer:I", "StasisWorkshop:I", "*:S"))
         $restoreCount = @($lifecycleLog | Select-String -SimpleMatch "resources restored").Count
         if ($restoreCount -lt 2) {
             throw "renderer lifecycle emitted only $restoreCount successful restoration markers"
@@ -121,7 +256,6 @@ try {
             throw "renderer lifecycle reported a restoration failure"
         }
     }
-
     Write-Report @{
         status = "passed"
         installed = [bool]$Install
@@ -133,8 +267,10 @@ try {
         version = $versionName
         launch = @($launchOutput)
         lifecycle = [bool]$Lifecycle
-        restoration_markers = $restoreCount
         lifecycle_log = $lifecycleLog
+        restoration_markers = $restoreCount
+        preview_frames = $previewFrames
+        captures = $capturePaths
     }
 } catch {
     Write-Report @{
@@ -145,6 +281,7 @@ try {
     }
     exit 1
 } finally {
+        & $adb -s $serial shell cmd window user-rotation free 2>$null | Out-Null
     if ($serial) {
         if ($null -ne $originalAutoRotation) {
             & $adb -s $serial shell settings put system accelerometer_rotation $originalAutoRotation | Out-Null

--- a/runtime/web/tests/orientation_host_frame.test.mjs
+++ b/runtime/web/tests/orientation_host_frame.test.mjs
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
+
+async function runSequence(first, second) {
+  const events = new Map();
+  const raf = [];
+  const ticks = [];
+  let now = 0;
+  const memory = new WebAssembly.Memory({ initial: 2 });
+  const game = { memory: {
+    host_i32: { offset: 0, length: 768 },
+    host_f32: { offset: 768 * 4, length: 64 }
+  }, strings: {}, assets: {} };
+  let canvasWidth = first[0];
+  let canvasHeight = first[1];
+  const context = {
+    fillRect() {}, fillText() {}, save() {}, restore() {}, beginPath() {}, moveTo() {}, lineTo() {}, stroke() {},
+    drawImage() {}, translate() {}, rotate() {}
+  };
+  const canvas = {
+    width: canvasWidth,
+    height: canvasHeight,
+    style: {},
+    parentElement: { style: {} },
+    listeners: new Map(),
+    getContext: () => context,
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: canvasWidth, height: canvasHeight }),
+    addEventListener(type, listener) { this.listeners.set(type, listener); },
+    setPointerCapture() {},
+    focus() {},
+    requestFullscreen: async () => {},
+  };
+  const body = { dataset: {} };
+  const errorBox = { textContent: "" };
+  const document = {
+    body,
+    hidden: false,
+    fullscreenElement: null,
+    fonts: { ready: Promise.resolve(), add() {} },
+    hasFocus: () => true,
+    getElementById(id) {
+      if (id === "stasis-canvas") return canvas;
+      if (id === "stasis-hud") return { textContent: "" };
+      if (id === "stasis-audio") return { addEventListener() {}, disabled: false, textContent: "" };
+      if (id === "stasis-error") return errorBox;
+      return null;
+    },
+    addEventListener(type, listener) { events.set(`document:${type}`, listener); },
+  };
+  let screenWidth = first[0];
+  let screenHeight = first[1];
+  const screen = { get width() { return screenWidth; }, get height() { return screenHeight; } };
+  const instance = {
+    exports: {
+      memory,
+      main: () => 0,
+      tick: () => {
+        const i32 = new Int32Array(memory.buffer, 0, 768);
+        const f32 = new Float32Array(memory.buffer, 768 * 4, 64);
+        if (i32[547]) actionCount += 1;
+        ticks.push({
+          resized: i32[11], displayGeneration: i32[30], native: [i32[22], i32[23]], drawable: [i32[24], i32[25]],
+          logical: [f32[50], f32[51]], pointerCount: i32[7], wentDown: i32[546], wentUp: i32[547], actionCount
+        });
+      },
+      render: () => 0,
+    }
+  };
+  let actionCount = 0;
+  const contextObject = {
+    document, screen, devicePixelRatio: 1, performance: { now: () => now },
+    WebAssembly: { instantiate: async () => ({ instance }) },
+    fetch: async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }),
+    requestAnimationFrame: callback => { raf.push(callback); return raf.length; },
+    cancelAnimationFrame() {},
+    addEventListener(type, listener) { events.set(`window:${type}`, listener); },
+    console, Image: class {}, FontFace: class { load() { return Promise.resolve(this); } },
+    AudioContext: class { constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; } close() {} resume() {} },
+    TextDecoder, setTimeout, clearTimeout, STASIS_GAME: game,
+  };
+  contextObject.window = { STASIS_GAME: game, screen };
+  vm.runInNewContext(source, contextObject, { filename: "runtime/web/game.js" });
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(raf.length, 1, `runtime schedules its first RAF: ${errorBox.textContent}`);
+  const frame = () => { now += 16; raf.shift()(now); };
+  frame();
+  const dispatch = (type, event = {}) => canvas.listeners.get(type)?.(event);
+  dispatch("pointerdown", { pointerId: 7, clientX: 90, clientY: 180 });
+  frame();
+  const down = ticks.at(-1);
+  assert.equal(down.pointerCount, 1);
+  assert.equal(down.wentDown, 1);
+  assert.equal(down.wentUp, 0);
+  assert.equal(down.logical[0], first[0]);
+  assert.equal(down.logical[1], first[1]);
+  screenWidth = second[0]; screenHeight = second[1];
+  canvasWidth = second[0]; canvasHeight = second[1];
+  events.get("window:resize")();
+  assert.deepEqual([screen.width, screen.height], second);
+  frame();
+  const resized = ticks.at(-1);
+  assert.equal(resized.resized, 1);
+  assert.equal(resized.displayGeneration, 2);
+  assert.deepEqual(resized.native, second);
+  assert.deepEqual(resized.drawable, second);
+  assert.deepEqual(resized.logical, first, "guest canvas remains selected logical size");
+  dispatch("pointerup", { pointerId: 7, clientX: 90, clientY: 180 });
+  frame();
+  const up = ticks.at(-1);
+  assert.equal(up.resized, 0);
+  assert.equal(up.wentUp, 1);
+  assert.equal(up.actionCount, 1, "release increments the action counter exactly once");
+  frame();
+  const quiet = ticks.at(-1);
+  assert.equal(quiet.resized, 0);
+  assert.equal(quiet.displayGeneration, 2);
+  assert.equal(quiet.pointerCount, 0);
+  assert.equal(quiet.wentUp, 0);
+  assert.equal(quiet.actionCount, 1, "quiet frames do not repeat the action");
+  return ticks;
+}
+
+test("web HostFrame portrait to landscape preserves actionable release", async () => {
+  await runSequence([360, 720], [720, 360]);
+});
+
+test("web HostFrame landscape to portrait preserves actionable release", async () => {
+  await runSequence([720, 360], [360, 720]);
+});

--- a/samples/android_orientation_seam/main.stasis
+++ b/samples/android_orientation_seam/main.stasis
@@ -1,4 +1,4 @@
-import "/vendor/stasis/src/stdlib/graphics.stasis";
+import ".stasis_cache/toolchain/src/stdlib/graphics.stasis";
 
 global seam_state_checksum: i32;
 global seam_probe_sequence: i32;

--- a/samples/android_orientation_seam/stasis.json
+++ b/samples/android_orientation_seam/stasis.json
@@ -4,6 +4,7 @@
   "entry": "main.stasis",
   "tests": "tests",
   "output": "build",
+  "stdlib": "toolchain",
   "android": {
     "application_id": "com.stasislang.seam.it019",
     "label": "Stasis Android Orientation Seam",

--- a/samples/android_orientation_seam/tests/android_orientation_seam.test.stasis
+++ b/samples/android_orientation_seam/tests/android_orientation_seam.test.stasis
@@ -1,0 +1,71 @@
+import "../.stasis_cache/toolchain/src/stdlib/testing/input_testkit.stasis";
+import "../main.stasis";
+
+function reset_orientation_seam(): void {
+    input_testkit_reset();
+    seam_state_checksum = 4000;
+    seam_probe_sequence = 0;
+    seam_probe_kind = 0;
+    seam_probe_tick = 0;
+    seam_pointer_id = 0;
+    seam_pointer_count = 0;
+    seam_pointer_is_down = 0;
+    seam_pointer_went_down = 0;
+    seam_pointer_went_up = 0;
+    seam_pointer_x = 0.0;
+    seam_pointer_y = 0.0;
+    seam_pointer_x_n = 0.0;
+    seam_pointer_y_n = 0.0;
+    seam_safe_x = 0.0;
+    seam_safe_y = 0.0;
+    seam_safe_w = 0.0;
+    seam_safe_h = 0.0;
+    seam_logical_w = 0.0;
+    seam_logical_h = 0.0;
+    seam_native_w = 0;
+    seam_native_h = 0;
+    seam_drawable_w = 0;
+    seam_drawable_h = 0;
+    seam_display_generation = 0;
+    seam_density_generation = 0;
+    seam_content_scale = 0.0;
+    seam_raster_scale = 0.0;
+    seam_pending_generation = 0;
+    seam_last_generation = 0;
+}
+
+function set_stage(width_px: i32, height_px: i32, generation: i32, is_down: bool, went_down: bool, went_up: bool): void {
+    input_testkit_set_display_snapshot_with_logical(width_px, height_px, 360, 720, generation);
+    input_testkit_set_pointer_count(2);
+    input_testkit_set_pointer(0, 0, false, false, false, 0.0, 0.0);
+    input_testkit_set_pointer(1, 77, is_down, went_down, went_up, 270.0, 540.0);
+    tick();
+}
+
+test `android orientation seam portrait to landscape release is actionable`(): bool {
+    reset_orientation_seam();
+    set_stage(360, 720, 1, true, true, false);
+    let portrait_down: bool = seam_probe_sequence == 0 && seam_state_checksum == 4000;
+    set_stage(360, 720, 1, false, false, true);
+    let portrait_up: bool = seam_probe_sequence == 1 && seam_probe_kind == 1 && seam_display_generation == 1 && seam_pointer_id == 77 && seam_pointer_went_up == 1 && seam_pointer_x == 270.0 && seam_pointer_y == 540.0;
+    set_stage(720, 360, 2, true, true, false);
+    let landscape_down: bool = seam_probe_sequence == 1 && seam_state_checksum == 4111;
+    set_stage(720, 360, 2, false, false, true);
+    let landscape_up: bool = seam_probe_sequence == 2 && seam_probe_kind == 2 && seam_display_generation == 2 && seam_pointer_id == 77 && seam_pointer_went_up == 1 && seam_pointer_x_n == 0.75 && seam_pointer_y_n == 0.75;
+    return portrait_down && portrait_up && landscape_down && landscape_up;
+}
+
+test `android orientation seam landscape to portrait release is actionable`(): bool {
+    reset_orientation_seam();
+    set_stage(720, 360, 1, true, true, false);
+    let landscape_down: bool = seam_probe_sequence == 0 && seam_state_checksum == 4000;
+    set_stage(720, 360, 1, false, false, true);
+    let landscape_up: bool = seam_probe_sequence == 1 && seam_probe_kind == 2 && seam_display_generation == 1 && seam_logical_w == 360.0 && seam_logical_h == 720.0 && seam_native_w == 720 && seam_native_h == 360 && seam_pointer_id == 77 && seam_pointer_went_up == 1;
+    set_stage(360, 720, 2, true, true, false);
+    let portrait_down: bool = seam_probe_sequence == 1 && seam_state_checksum == 4121;
+    set_stage(360, 720, 2, false, false, true);
+    let portrait_up: bool = seam_probe_sequence == 2 && seam_probe_kind == 1 && seam_display_generation == 2 && seam_logical_w == 360.0 && seam_logical_h == 720.0 && seam_native_w == 360 && seam_native_h == 720 && seam_pointer_id == 77 && seam_pointer_went_up == 1 && seam_pointer_x_n == 0.75 && seam_pointer_y_n == 0.75;
+    set_stage(360, 720, 2, false, false, false);
+    let quiet: bool = seam_probe_sequence == 2 && seam_state_checksum == 4212 && seam_pointer_went_up == 1;
+    return landscape_down && landscape_up && portrait_down && portrait_up && quiet;
+}

--- a/src/stdlib/testing/input_testkit.stasis
+++ b/src/stdlib/testing/input_testkit.stasis
@@ -43,7 +43,30 @@ function input_testkit_set_pointer_count_raw(count: i32): void {
     host_i32[HOST_I_POINTER_COUNT] = count;
 }
 
+function input_testkit_set_display_snapshot_with_logical(native_w_px: i32, native_h_px: i32, logical_w_px: i32, logical_h_px: i32, generation: i32): void {
+    host_i32[HOST_I_NATIVE_W_PX] = native_w_px;
+    host_i32[HOST_I_NATIVE_H_PX] = native_h_px;
+    host_i32[HOST_I_DRAWABLE_W_PX] = native_w_px;
+    host_i32[HOST_I_DRAWABLE_H_PX] = native_h_px;
+    host_i32[HOST_I_DISPLAY_GENERATION] = generation;
+    host_i32[HOST_I_DENSITY_GENERATION] = generation;
+    host_f32[HOST_F_CONTENT_SCALE] = 1.0;
+    host_f32[HOST_F_RASTER_SCALE] = 1.0;
+    host_f32[HOST_F_LOGICAL_W] = i32_to_f32(logical_w_px);
+    host_f32[HOST_F_LOGICAL_H] = i32_to_f32(logical_h_px);
+    host_f32[HOST_F_SAFE_X] = 0.0;
+    host_f32[HOST_F_SAFE_Y] = 0.0;
+    host_f32[HOST_F_SAFE_W] = i32_to_f32(logical_w_px);
+    host_f32[HOST_F_SAFE_H] = i32_to_f32(logical_h_px);
+}
+
+function input_testkit_set_display_snapshot(width_px: i32, height_px: i32, generation: i32): void {
+    input_testkit_set_display_snapshot_with_logical(width_px, height_px, width_px, height_px, generation);
+}
+
 function input_testkit_set_pointer(index: i32, id: i32, is_down: bool, went_down: bool, went_up: bool, x_px: f32, y_px: f32): void {
+    let logical_w: f32 = host_f32[HOST_F_LOGICAL_W];
+    let logical_h: f32 = host_f32[HOST_F_LOGICAL_H];
     if (index < 0 || index >= HOST_MAX_POINTERS) {
         return;
     }
@@ -65,4 +88,14 @@ function input_testkit_set_pointer(index: i32, id: i32, is_down: bool, went_down
     }
     host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0] = x_px;
     host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1] = y_px;
+    if (logical_w > 0.0) {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4] = x_px / logical_w;
+    } else {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4] = 0.0;
+    }
+    if (logical_h > 0.0) {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5] = y_px / logical_h;
+    } else {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5] = 0.0;
+    }
 }

--- a/tests/stasis/seams/desktop_display_metrics_probe.stasis
+++ b/tests/stasis/seams/desktop_display_metrics_probe.stasis
@@ -22,9 +22,16 @@ global metric_pointer_x: f32;
 global metric_pointer_y: f32;
 global metric_pointer_x_n: f32;
 global metric_pointer_y_n: f32;
+global metric_pointer_id: i32;
+global metric_pointer_count: i32;
+global metric_pointer_is_down: i32;
+global metric_pointer_went_down: i32;
+global metric_pointer_went_up: i32;
+global metric_release_actions: i32;
 
 function main(): i32 {
     metric_tick = 0;
+    metric_release_actions = 0;
     return 0;
 }
 
@@ -46,11 +53,35 @@ function tick(): i32 {
     metric_safe_h = host_safe_height();
     metric_content_scale = host_content_scale();
     metric_raster_scale = host_raster_scale();
+    metric_pointer_count = host_pointer_count();
     if (host_pointer_count() > 1) {
+        metric_pointer_id = host_pointer_id(1);
+        metric_pointer_is_down = 0;
+        if (host_pointer_is_down(1)) {
+            metric_pointer_is_down = 1;
+        }
+        metric_pointer_went_down = 0;
+        if (host_pointer_went_down(1)) {
+            metric_pointer_went_down = 1;
+        }
+        metric_pointer_went_up = 0;
+        if (host_pointer_went_up(1)) {
+            metric_pointer_went_up = 1;
+            metric_release_actions += 1;
+        }
         metric_pointer_x = host_pointer_x_logical(1);
         metric_pointer_y = host_pointer_y_logical(1);
         metric_pointer_x_n = host_pointer_x_n(1);
         metric_pointer_y_n = host_pointer_y_n(1);
+    } else {
+        metric_pointer_id = 0;
+        metric_pointer_is_down = 0;
+        metric_pointer_went_down = 0;
+        metric_pointer_went_up = 0;
+        metric_pointer_x = 0.0;
+        metric_pointer_y = 0.0;
+        metric_pointer_x_n = 0.0;
+        metric_pointer_y_n = 0.0;
     }
     return 0;
 }

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -23,6 +23,7 @@ python3 -m unittest tools.ci.test_sdl3_migration
 python3 -m unittest tools.ci.test_verify_android_render_performance
 python3 -m unittest tools.ci.test_verify_render_parity
 python3 tools/ci/verify_render_parity.py
+node --test runtime/web/tests/orientation_host_frame.test.mjs
 
 set +e
 ignored_tests="$(rg -n -U --pcre2 '#\s*\[\s*(?:ignore\b|cfg_attr\s*\([^\]]*\bignore\b)' apps crates mobile tests -g '*.rs' 2>&1)"


### PR DESCRIPTION
Adds bidirectional orientation/input transition coverage across StasisLang's distinct HostFrame producers: shared Stasis tests, native SDL desktop, web, and Android Workshop. The tests preserve the guest logical canvas while native dimensions and display generations change, and verify pointer releases remain actionable after rotation. CI now runs the web seam, and Android lifecycle acceptance rotates, taps, restores, and records evidence. Validation: web 2/2, shared Stasis 2/2, Android bridge 1/1, desktop SDL 1/1, PowerShell parse and diff checks passed, plus the previously completed live Workshop emulator acceptance.