### PR TITLE
fix: lower continue in web loops

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -1,7 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const CONTINUE_LOOP_PARITY: &str =
+    include_str!("../../../tests/stasis/seams/continue_loop_parity.stasis");
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -68,6 +71,48 @@ fn copy_tree(source: &Path, destination: &Path) {
             fs::copy(entry.path(), target).expect("copy fixture file");
         }
     }
+}
+
+fn execute_web_main(wasm: &Path) -> Output {
+    Command::new("node")
+        .arg("-e")
+        .arg(
+            "const fs = require('node:fs'); WebAssembly.instantiate(fs.readFileSync(process.argv[1]), {}).then(({ instance }) => process.stdout.write(String(instance.exports.main()))).catch((error) => { console.error(error); process.exit(1); });",
+        )
+        .arg(wasm)
+        .output()
+        .expect("execute packaged Wasm in Node")
+}
+
+#[test]
+fn web_continue_matches_native_for_and_foreach_loop_steps() {
+    let root = repo_root();
+    let workspace = root
+        .join("build")
+        .join(format!("web-continue-test-{}", stamp()));
+    fs::create_dir_all(workspace.join("src")).expect("create web continue fixture");
+    fs::write(
+        workspace.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"web_continue_parity","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("write web continue manifest");
+    fs::write(workspace.join("src/main.stasis"), CONTINUE_LOOP_PARITY)
+        .expect("write web continue source");
+
+    let output = package(&workspace, Path::new("build/web-package"));
+    let execution = execute_web_main(&output.join("game.wasm"));
+    assert!(
+        execution.status.success(),
+        "packaged Wasm execution failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&execution.stdout),
+        String::from_utf8_lossy(&execution.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(execution.stdout).expect("UTF-8 result"),
+        "434"
+    );
+
+    fs::remove_dir_all(&workspace).expect("clean web continue fixture");
 }
 
 #[test]

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -4814,17 +4814,17 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn jit_process_executes_continue_in_for_loop() {
+    fn jit_process_executes_continue_in_for_and_foreach_loops() {
         let mut process = JitProcess::new();
         process.upsert_file(
             "sample.stasis",
-            "function main(): i32 { let count: i32 = 0; for (let i: i32 = 0; i < 5; i += 1) { if (i == 2) { continue; } count += 1; } return count; }\n",
+            include_str!("../../../../tests/stasis/seams/continue_loop_parity.stasis"),
         );
         process.compile().expect("compile");
         let value = process
             .execute_i32_noarg_by_name("main")
             .expect("execute main");
-        assert_eq!(value, 4);
+        assert_eq!(value, 434);
     }
 
     #[cfg(windows)]

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -1306,6 +1306,7 @@ fn encode_function(
         scratch_f32,
         scratch_f64,
         foreach: BTreeMap::new(),
+        continue_depth: None,
     };
     encode_statements(&hir.statements, &context, &mut body)?;
     // Structured statements use void block types, so only a direct return proves that
@@ -1431,6 +1432,26 @@ struct EncodeContext<'a> {
     scratch_f32: u32,
     scratch_f64: u32,
     foreach: BTreeMap<String, WebForeachBinding>,
+    continue_depth: Option<u32>,
+}
+
+fn nested_control_context<'a>(context: &EncodeContext<'a>) -> Result<EncodeContext<'a>, String> {
+    let mut nested = context.clone();
+    nested.continue_depth = context
+        .continue_depth
+        .map(|depth| {
+            depth
+                .checked_add(1)
+                .ok_or_else(|| "web control-flow nesting exceeds branch depth limits".to_string())
+        })
+        .transpose()?;
+    Ok(nested)
+}
+
+fn loop_body_context<'a>(context: &EncodeContext<'a>) -> EncodeContext<'a> {
+    let mut nested = context.clone();
+    nested.continue_depth = Some(0);
+    nested
 }
 
 #[derive(Debug, Clone)]
@@ -1568,10 +1589,11 @@ fn encode_statements(
             } => {
                 encode_condition(condition, context, out)?;
                 out.extend([0x04, 0x40]);
-                encode_statements(then_statements, context, out)?;
+                let nested = nested_control_context(context)?;
+                encode_statements(then_statements, &nested, out)?;
                 if let Some(values) = else_statements {
                     out.push(0x05);
-                    encode_statements(values, context, out)?;
+                    encode_statements(values, &nested, out)?;
                 }
                 out.push(0x0b);
             }
@@ -1585,12 +1607,19 @@ fn encode_statements(
                 out.extend([0x02, 0x40, 0x03, 0x40]);
                 encode_condition(condition, context, out)?;
                 out.extend([0x45, 0x0d, 0x01]);
-                encode_statements(body_statements, context, out)?;
+                out.extend([0x02, 0x40]);
+                let nested = loop_body_context(context);
+                encode_statements(body_statements, &nested, out)?;
+                out.push(0x0b);
                 encode_statements(std::slice::from_ref(step), context, out)?;
                 out.extend([0x0c, 0x00, 0x0b, 0x0b]);
             }
             SimpleStmt::Continue => {
-                return Err("web scalar lane does not yet support continue".to_string())
+                let depth = context
+                    .continue_depth
+                    .ok_or_else(|| "continue statement is only valid inside loops".to_string())?;
+                out.push(0x0c);
+                uleb(depth, out);
             }
             SimpleStmt::Convert { target, source, .. } => {
                 let target_type = target_type(target, context)?;
@@ -1622,7 +1651,10 @@ fn encode_statements(
                         index_name: index_name.clone(),
                     },
                 );
+                nested.continue_depth = Some(0);
+                out.extend([0x02, 0x40]);
                 encode_statements(body_statements, &nested, out)?;
+                out.push(0x0b);
                 out.extend([0x20]);
                 uleb(index.index, out);
                 out.extend([0x41, 1, 0x6a, 0x21]);
@@ -3336,6 +3368,21 @@ mod tests {
                 .windows(name.len())
                 .any(|window| window == name.as_bytes()));
         }
+    }
+
+    #[test]
+    fn rejects_continue_outside_a_loop() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "invalid_continue.stasis",
+            "function main(): i32 { continue; return 0; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+        );
+        let error = process.compile().expect_err("reject continue outside loop");
+        assert!(
+            format!("{error:?}").contains("continue statement is only valid inside loops"),
+            "unexpected web continue diagnostic: {error:?}"
+        );
     }
 
     #[test]

--- a/tests/stasis/seams/continue_loop_parity.stasis
+++ b/tests/stasis/seams/continue_loop_parity.stasis
@@ -1,0 +1,54 @@
+global values: i32[4];
+
+function main(): i32 {
+    let for_count: i32 = 0;
+    let for_guard: i32 = 0;
+    for (let i: i32 = 0; i < 5; i += 1) {
+        for_guard += 1;
+        if (for_guard > 10) {
+            return 91;
+        }
+        if (i == 2) {
+            continue;
+        }
+        for_count += 1;
+    }
+
+    let foreach_count: i32 = 0;
+    let foreach_guard: i32 = 0;
+    foreach (let value, i in values) {
+        foreach_guard += 1;
+        if (foreach_guard > 10) {
+            return 92;
+        }
+        if (i == 2) {
+            continue;
+        }
+        foreach_count += 1;
+    }
+
+    let nested_count: i32 = 0;
+    let nested_guard: i32 = 0;
+    for (let outer: i32 = 0; outer < 2; outer += 1) {
+        for (let inner: i32 = 0; inner < 3; inner += 1) {
+            nested_guard += 1;
+            if (nested_guard > 20) {
+                return 93;
+            }
+            if (inner == 1) {
+                continue;
+            }
+            nested_count += 1;
+        }
+    }
+
+    return for_count * 100 + foreach_count * 10 + nested_count;
+}
+
+function tick(): i32 {
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}


### PR DESCRIPTION
## Summary

- lower `continue` in the web backend with structured Wasm branches
- preserve `for` step execution and `foreach` index increments
- adjust branch depth through nested conditionals and target the nearest nested loop
- share one parity fixture between native Cranelift and a Node-executed packaged web artifact

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- packaged web fixture executes in Node and returns `434`
- native Cranelift fixture executes and returns `434`
- all 5 `web_package` integration tests pass
- web diagnostic test rejects `continue` outside a loop
- full `stasis_compiler` run: 541/543 pass; the two failures reproduce independently and are unrelated local-environment baselines (missing Windows linker acceptance and production preview extern state)

This fixes the web/native compiler mismatch exposed by ChessTD's nightly build.