### PR TITLE
fix: provide web text measurement host

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -84,6 +84,17 @@ fn execute_web_main(wasm: &Path) -> Output {
         .expect("execute packaged Wasm in Node")
 }
 
+fn execute_web_main_with_measure_text(wasm: &Path) -> Output {
+    Command::new("node")
+        .arg("-e")
+        .arg(
+            "const fs = require('node:fs'); const bytes = fs.readFileSync(process.argv[1]); const imports = WebAssembly.Module.imports(new WebAssembly.Module(bytes)); if (!imports.some(({ module, name }) => module === 'env' && name === 'measure_text')) throw new Error('package did not retain env.measure_text'); WebAssembly.instantiate(bytes, { env: { measure_text: () => 12.5 } }).then(({ instance }) => process.stdout.write(String(instance.exports.main()))).catch((error) => { console.error(error); process.exit(1); });",
+        )
+        .arg(wasm)
+        .output()
+        .expect("execute packaged Wasm with measure_text import")
+}
+
 #[test]
 fn web_continue_matches_native_for_and_foreach_loop_steps() {
     let root = repo_root();
@@ -242,6 +253,63 @@ function render(): i32 {
     );
 
     fs::remove_dir_all(&workspace).expect("clean nested text fixture");
+}
+
+#[test]
+fn web_package_instantiates_direct_measure_text_import() {
+    let root = repo_root();
+    let workspace = root
+        .join("build")
+        .join(format!("web-measure-text-test-{}", stamp()));
+    fs::create_dir_all(workspace.join("src")).expect("create measure_text fixture");
+    fs::write(
+        workspace.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"web_measure_text","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("write measure_text manifest");
+    fs::write(
+        workspace.join("src/main.stasis"),
+        r#"
+extern function measure_text(font: i32, text: string): f32;
+
+function main(): i32 {
+    let width: f32 = measure_text(2, "abc");
+    if (width == 12.5) {
+        return 0;
+    }
+    return 1;
+}
+
+function tick(): i32 {
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}
+"#,
+    )
+    .expect("write measure_text source");
+
+    let output = package(&workspace, Path::new("build/web-package"));
+    let runtime = fs::read_to_string(output.join("game.js")).expect("measure_text web runtime");
+    assert!(
+        runtime.contains("measure_text:"),
+        "web host omitted the direct measure_text import"
+    );
+    let execution = execute_web_main_with_measure_text(&output.join("game.wasm"));
+    assert!(
+        execution.status.success(),
+        "measure_text Wasm instantiation failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&execution.stdout),
+        String::from_utf8_lossy(&execution.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(execution.stdout).expect("UTF-8 result"),
+        "0"
+    );
+
+    fs::remove_dir_all(&workspace).expect("clean measure_text fixture");
 }
 
 #[test]

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -160,6 +160,15 @@
     font.load().then(loaded => document.fonts.add(loaded)).catch(error => console.error(error));
     return handle;
   };
+  const measureText = (fontHandle, textId) => {
+    const font = fonts.get(fontHandle);
+    if (!font) return 0;
+    context.save();
+    context.font = `${font.size}px ${font.family}`;
+    const width = context.measureText(stringValue(textId)).width;
+    context.restore();
+    return width;
+  };
   const releaseSprite = handle => { sprites.delete(handle); };
   const requestSprite = pathId => {
     const task = nextAssetTask++;
@@ -383,6 +392,9 @@
     stasis_jit_asset_task_cancel: task => cancelAssetTask(task),
     load_font: (pathId, size) => loadFont(pathId, size),
     stasis_load_font: (pathId, size) => loadFont(pathId, size),
+    measure_text: (font, textId) => measureText(font, textId),
+    stasis_measure_text: (font, textId) => measureText(font, textId),
+    stasis_jit_measure_text: (font, textId) => measureText(font, textId),
     stasis_jit_sprite_load_from: (base, index, _len, pathId, width, height) => {
       const handle = loadSprite(pathId);
       return setViewField(base, index, "handle", handle)

--- a/runtime/web/tests/asset_paths.test.mjs
+++ b/runtime/web/tests/asset_paths.test.mjs
@@ -7,11 +7,16 @@ const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
 
 async function loadRuntime(game) {
   const imageSources = [];
+  const measurements = [];
   let env;
   const memory = new WebAssembly.Memory({ initial: 1 });
   const context2d = {
     fillRect() {}, fillText() {}, save() {}, restore() {}, beginPath() {}, moveTo() {},
-    lineTo() {}, stroke() {}, drawImage() {}, translate() {}, rotate() {}
+    lineTo() {}, stroke() {}, drawImage() {}, translate() {}, rotate() {},
+    measureText(value) {
+      measurements.push({ font: this.font, value });
+      return { width: value.length * 7 };
+    }
   };
   const canvas = {
     width: 640,
@@ -93,7 +98,7 @@ async function loadRuntime(game) {
   await new Promise(resolve => setImmediate(resolve));
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(typeof env?.gfx_load_sprite, "function", errorBox.textContent);
-  return { env, imageSources };
+  return { env, imageSources, measurements };
 }
 
 test("web asset paths normalize fallback values and preserve explicit overrides", async () => {
@@ -124,4 +129,17 @@ test("web asset paths normalize fallback values and preserve explicit overrides"
     "assets/packed/override-123.png",
     "",
   ]);
+});
+
+test("web measure_text uses the registered Canvas font and string handle", async () => {
+  const game = {
+    memory: {},
+    strings: { "1": "marble" },
+  };
+  const { env, measurements } = await loadRuntime(game);
+
+  const font = env.load_font(7, 20);
+  assert.equal(typeof env.measure_text, "function");
+  assert.equal(env.measure_text(font, 1), 42);
+  assert.deepEqual(measurements, [{ font: "20px stasis-font-1", value: "marble" }]);
 });


### PR DESCRIPTION
## Summary

- provide Canvas-backed `measure_text` in the generated Web host
- expose direct, `stasis_`, and compiler-lowered `stasis_jit_` aliases
- test registered-font measurement in the runtime
- compile and instantiate a Web package that imports `env.measure_text`

## Root cause

The compiler correctly retained the direct `measure_text` WebAssembly import, but `runtime/web/game.js` did not provide the matching `env` function, so browser instantiation failed before the game could start.

## Validation

- all 7 Web package tests passed
- all 5 Web runtime Node tests passed
- the current Maddox Marble Run package instantiated successfully with `env.measure_text`; `main()` returned `0`

The local pre-commit hook could not run because its external `F:\Tools\Stasis\sign-stasis-local.cmd` signer is absent; the focused runtime and package suites were run directly before committing.
