### PR TITLE
Fix packaged web text rendering

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -16,7 +16,6 @@ use stasis_compiler::backend::program_snapshot::ProgramSnapshot;
 use stasis_compiler::backend::state_migration::MAX_STATE_SNAPSHOT_BYTES;
 use stasis_compiler::backend::wasm::WasmProcess;
 use stasis_compiler::frontend::formatter::format_source;
-use stasis_compiler::frontend::types::TYPE_ID_U8;
 use stasis_compiler::frontend::workshop::{
     find_workshop_references, find_workshop_symbols, load_workshop_edit_workspace,
     plan_workshop_semantic_edits, workshop_direct_import_files, workshop_reachable_files,
@@ -4057,6 +4056,7 @@ fn web_runtime_config(
                     "type_id": layout.type_id,
                     "length": layout.length,
                     "stride": layout.stride,
+                    "byte_backed": layout.byte_backed,
                 }),
             )
         })
@@ -4115,7 +4115,7 @@ fn prune_release_web_runtime_config(config: &mut Value, imported_symbols: &BTree
             retained_paths.contains(path.as_str())
                 || WEB_RUNTIME_BUFFERS.contains(&path.as_str())
                 || (imported_symbols.contains("sys_memcpy_u8")
-                    && layout["type_id"].as_u64() == Some(u64::from(TYPE_ID_U8)))
+                    && layout["byte_backed"].as_bool() == Some(true))
         });
     config["globals"]
         .as_object_mut()
@@ -5875,6 +5875,7 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
 mod tests {
     use super::*;
     use stasis_ai::live_tool_specs;
+    use stasis_compiler::frontend::types::TYPE_ID_U8;
     use std::collections::BTreeMap;
 
     #[test]
@@ -6001,7 +6002,7 @@ mod tests {
         ]);
         process.upsert_file(
             "memcpy.stasis",
-            "extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void; global source: u8[4]; global destination: u8[4]; global scratch: u8[2]; global unrelated: i32[4]; function main(): i32 { source[0] = 65; sys_memcpy_u8(destination, 0, source, 0, 4); return destination[0]; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
+            "extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void; global source: u8[4]; global destination: u8[4]; global source_utf8: utf8[4]; global destination_ascii: ascii[4]; global scratch: u8[2]; global unrelated: i32[4]; function main(): i32 { source[0] = 65; source_utf8[0] = 66; sys_memcpy_u8(destination, 0, source, 0, 4); sys_memcpy_u8(destination_ascii, 0, source_utf8, 0, 1); return destination[0]; } function tick(): i32 { return 0; } function render(): i32 { return 0; }",
         );
         process.compile().expect("compile web memcpy fixture");
         assert!(process.imported_symbols().contains("sys_memcpy_u8"));
@@ -6013,6 +6014,16 @@ mod tests {
                 .get(path)
                 .unwrap_or_else(|| panic!("release omitted u8 layout {path}"));
             assert_eq!(layout["type_id"], json!(TYPE_ID_U8));
+            assert_eq!(
+                layout["hash"],
+                json!(stasis_compiler::backend::wasm::wasm_global_hash(path))
+            );
+        }
+        for path in ["source_utf8", "destination_ascii"] {
+            let layout = memory
+                .get(path)
+                .unwrap_or_else(|| panic!("release omitted byte-backed layout {path}"));
+            assert_eq!(layout["byte_backed"], json!(true));
             assert_eq!(
                 layout["hash"],
                 json!(stasis_compiler::backend::wasm::wasm_global_hash(path))

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -95,6 +95,45 @@ fn execute_web_main_with_measure_text(wasm: &Path) -> Output {
         .expect("execute packaged Wasm with measure_text import")
 }
 
+fn execute_web_main_with_byte_memcpy(package: &Path) -> Output {
+    Command::new("node")
+        .arg("-e")
+        .arg(
+            r#"const fs = require('node:fs');
+const root = process.argv[1];
+const source = fs.readFileSync(`${root}/game.js`, 'utf8');
+const game = JSON.parse(source.slice('window.STASIS_GAME = '.length, source.indexOf(';', 'window.STASIS_GAME = '.length)));
+const layoutsByHash = new Map(Object.values(game.memory || {})
+  .filter(layout => layout?.byte_backed === true && Number.isSafeInteger(layout.hash))
+  .map(layout => [layout.hash | 0, layout]));
+const layoutsByOffset = new Map(Object.values(game.memory || {})
+  .filter(layout => layout?.byte_backed === true && Number.isSafeInteger(layout.offset))
+  .map(layout => [layout.offset | 0, layout]));
+const layoutFor = reference => layoutsByHash.get(reference | 0) || layoutsByOffset.get(reference | 0);
+let instance;
+function copy_u8(destinationHash, destinationIndex, sourceHash, sourceIndex, count) {
+  const destination = layoutFor(destinationHash);
+  const sourceLayout = layoutFor(sourceHash);
+  if (!destination || !sourceLayout || !instance?.exports?.memory || count <= 0) return;
+  const bytes = new Uint8Array(instance.exports.memory.buffer);
+  const values = [];
+  for (let offset = 0; offset < count; offset += 1) {
+    values.push(bytes[sourceLayout.offset + (sourceIndex + offset) * sourceLayout.stride]);
+  }
+  values.forEach((value, offset) => {
+    bytes[destination.offset + (destinationIndex + offset) * destination.stride] = value;
+  });
+}
+const bytes = fs.readFileSync(`${root}/game.wasm`);
+WebAssembly.instantiate(bytes, { env: { sys_memcpy_u8: copy_u8 } })
+  .then(({ instance: value }) => { instance = value; process.stdout.write(String(instance.exports.main())); })
+  .catch(error => { console.error(error); process.exit(1); });"#,
+        )
+        .arg(package)
+        .output()
+        .expect("execute packaged Wasm with byte memcpy import")
+}
+
 #[test]
 fn web_continue_matches_native_for_and_foreach_loop_steps() {
     let root = repo_root();
@@ -310,6 +349,85 @@ function render(): i32 {
     );
 
     fs::remove_dir_all(&workspace).expect("clean measure_text fixture");
+}
+
+#[test]
+fn web_package_retains_byte_backed_text_layouts_for_memcpy_import() {
+    let root = repo_root();
+    let workspace = root
+        .join("build")
+        .join(format!("web-byte-memcpy-test-{}", stamp()));
+    fs::create_dir_all(workspace.join("src")).expect("create byte memcpy fixture");
+    fs::write(
+        workspace.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"web_byte_memcpy","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("write byte memcpy manifest");
+    fs::write(
+        workspace.join("src/main.stasis"),
+        r#"
+extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+
+global source: utf8[4];
+global destination: ascii[4];
+
+function seed_source(value: utf8[]): void {
+    value[0] = 65;
+    value[1] = 66;
+}
+
+function read_destination(value: ascii[]): i32 {
+    return value[0] * 100 + value[1];
+}
+
+function main(): i32 {
+    seed_source(source);
+    sys_memcpy_u8(destination, 0, source, 0, 2);
+    return read_destination(destination);
+}
+
+function tick(): i32 {
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}
+"#,
+    )
+    .expect("write byte memcpy source");
+
+    let output = package(&workspace, Path::new("build/web-package"));
+    let runtime = fs::read_to_string(output.join("game.js")).expect("byte memcpy runtime");
+    let game = runtime
+        .strip_prefix("window.STASIS_GAME = ")
+        .and_then(|source| source.split_once(';').map(|(json, _)| json))
+        .map(|json| {
+            serde_json::from_str::<serde_json::Value>(json).expect("parse runtime metadata")
+        })
+        .expect("runtime metadata prefix");
+    for path in ["source", "destination"] {
+        assert_eq!(
+            game["memory"][path]["byte_backed"],
+            serde_json::json!(true),
+            "release metadata omitted byte-backed marker for {path}"
+        );
+    }
+    assert!(runtime.contains("sys_memcpy_u8: sysMemcpyU8"));
+
+    let execution = execute_web_main_with_byte_memcpy(&output);
+    assert!(
+        execution.status.success(),
+        "byte memcpy Wasm execution failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&execution.stdout),
+        String::from_utf8_lossy(&execution.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(execution.stdout).expect("UTF-8 result"),
+        "6566"
+    );
+
+    fs::remove_dir_all(&workspace).expect("clean byte memcpy fixture");
 }
 
 #[test]

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -151,6 +151,8 @@ impl WasmProcess {
         self.memory_layout = memory_bindings
             .into_iter()
             .map(|(path, binding)| {
+                let byte_backed =
+                    is_byte_backed_memory_path(&path, binding.type_id, &analysis, &types);
                 (
                     path,
                     WasmMemoryLayout {
@@ -158,6 +160,7 @@ impl WasmProcess {
                         type_id: binding.type_id,
                         length: binding.len,
                         stride: binding.stride,
+                        byte_backed,
                     },
                 )
             })
@@ -389,6 +392,35 @@ pub struct WasmMemoryLayout {
     pub type_id: TypeId,
     pub length: i32,
     pub stride: u32,
+    pub byte_backed: bool,
+}
+
+fn is_byte_backed_type(type_id: TypeId, types: &TypeTable) -> bool {
+    if type_id == TYPE_ID_U8 {
+        return true;
+    }
+    matches!(
+        types.type_info(type_id).map(|info| info.category),
+        Some(
+            TypeCategory::AsciiFixed
+                | TypeCategory::AsciiView
+                | TypeCategory::Utf8Fixed
+                | TypeCategory::Utf8View
+        )
+    )
+}
+
+fn is_byte_backed_memory_path(
+    path: &str,
+    type_id: TypeId,
+    analysis: &crate::backend::emit::CompileAnalysisCache,
+    types: &TypeTable,
+) -> bool {
+    is_byte_backed_type(type_id, types)
+        || analysis
+            .collection_infos
+            .get(path)
+            .is_some_and(|collection| matches!(collection.element_shape.as_str(), "ascii" | "utf8"))
 }
 
 fn storage_width(

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -10,6 +10,7 @@
   const game = window.STASIS_GAME || { strings: {}, memory: {}, assets: {} };
   const sprites = new Map();
   const fonts = new Map();
+  const fontLoads = new Map();
   const cachedText = new Map();
   let nextHandle = 1;
   let instance;
@@ -75,11 +76,20 @@
   };
   const u8MemoryLayouts = new Map(
     Object.values(game.memory || {})
-      .filter(layout => layout?.type_id === 5 && Number.isSafeInteger(layout.hash))
+      .filter(layout => (layout?.byte_backed === true || layout?.type_id === 5)
+        && Number.isSafeInteger(layout.hash))
       .map(layout => [layout.hash | 0, layout])
   );
+  const u8MemoryLayoutsByOffset = new Map(
+    Object.values(game.memory || {})
+      .filter(layout => (layout?.byte_backed === true || layout?.type_id === 5)
+        && Number.isSafeInteger(layout.offset))
+      .map(layout => [layout.offset | 0, layout])
+  );
+  const hasU8MemoryReference = reference => u8MemoryLayouts.has(reference | 0)
+    || u8MemoryLayoutsByOffset.has(reference | 0);
   const resolveU8Memory = hash => {
-    const layout = u8MemoryLayouts.get(hash | 0);
+    const layout = u8MemoryLayouts.get(hash | 0) || u8MemoryLayoutsByOffset.get(hash | 0);
     const memory = instance?.exports?.memory;
     if (!layout || !(memory instanceof WebAssembly.Memory)) return null;
     const { offset, stride, length } = layout;
@@ -101,8 +111,8 @@
   };
   const sysMemcpyU8 = (dst, dstIndex, src, srcIndex, count) => {
     if (!Number.isInteger(count) || count <= 0) return;
-    const sourceRegistered = u8MemoryLayouts.has(src | 0);
     const source = resolveU8Memory(src);
+    const sourceRegistered = hasU8MemoryReference(src);
     const literal = sourceRegistered
       ? null
       : new TextEncoder().encode(stringValue(src));
@@ -157,7 +167,13 @@
     const family = `stasis-font-${handle}`;
     const font = new FontFace(family, `url(${assetValue(pathId)})`);
     fonts.set(handle, { family, size });
-    font.load().then(loaded => document.fonts.add(loaded)).catch(error => console.error(error));
+    const load = Promise.resolve()
+      .then(() => font.load())
+      .then(loaded => {
+        document.fonts.add(loaded);
+        return loaded;
+      });
+    fontLoads.set(handle, load);
     return handle;
   };
   const measureText = (fontHandle, textId) => {
@@ -858,7 +874,7 @@
     return response.arrayBuffer();
   }
 
-  (async () => {
+  window.STASIS_RUNTIME_PROMISE = (async () => {
     try {
       const result = await WebAssembly.instantiate(await wasmBytes(), imports);
       instance = result.instance;
@@ -868,8 +884,9 @@
       applyWindowRequest();
       await Promise.all([
         ...Array.from(sprites.values(), image => image.decode().catch(() => undefined)),
-        document.fonts.ready
+        ...fontLoads.values()
       ]);
+      await document.fonts.ready;
       document.body.dataset.ready = "true";
       document.body.dataset.runtime = "wasm";
       document.body.dataset.mainResult = String(mainResult);

--- a/runtime/web/tests/asset_paths.test.mjs
+++ b/runtime/web/tests/asset_paths.test.mjs
@@ -5,9 +5,11 @@ import vm from "node:vm";
 
 const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
 
-async function loadRuntime(game) {
+async function loadRuntime(game, options = {}) {
   const imageSources = [];
   const measurements = [];
+  const animationFrames = [];
+  const addedFonts = [];
   let env;
   const memory = new WebAssembly.Memory({ initial: 1 });
   const context2d = {
@@ -35,7 +37,10 @@ async function loadRuntime(game) {
     body: { dataset: {} },
     hidden: false,
     fullscreenElement: null,
-    fonts: { ready: Promise.resolve(), add() {} },
+    fonts: {
+      ready: options.fontsReady || Promise.resolve(),
+      add(font) { addedFonts.push(font); },
+    },
     hasFocus: () => true,
     getElementById(id) {
       if (id === "stasis-canvas") return canvas;
@@ -49,7 +54,7 @@ async function loadRuntime(game) {
   const instance = {
     exports: {
       memory,
-      main: () => 0,
+      main: () => { options.main?.(env); return 0; },
       tick: () => 0,
       render: () => 0,
     }
@@ -69,7 +74,11 @@ async function loadRuntime(game) {
       },
     },
     fetch: async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }),
-    requestAnimationFrame: () => 1,
+    requestAnimationFrame: () => {
+      animationFrames.push(true);
+      options.onFrame?.();
+      return 1;
+    },
     cancelAnimationFrame() {},
     addEventListener() {},
     console,
@@ -82,7 +91,9 @@ async function loadRuntime(game) {
       }
       get src() { return this.value; }
     },
-    FontFace: class { load() { return Promise.resolve(this); } },
+    FontFace: class {
+      load() { return options.fontLoad ? options.fontLoad(this) : Promise.resolve(this); }
+    },
     AudioContext: class {
       constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; }
       close() {}
@@ -95,10 +106,12 @@ async function loadRuntime(game) {
   };
   contextObject.window = { STASIS_GAME: game, screen };
   vm.runInNewContext(source, contextObject, { filename: "runtime/web/game.js" });
+  const runtimePromise = contextObject.window.STASIS_RUNTIME_PROMISE;
+  runtimePromise?.catch(() => {});
   await new Promise(resolve => setImmediate(resolve));
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(typeof env?.gfx_load_sprite, "function", errorBox.textContent);
-  return { env, imageSources, measurements };
+  return { env, imageSources, measurements, animationFrames, addedFonts, document, errorBox, runtimePromise };
 }
 
 test("web asset paths normalize fallback values and preserve explicit overrides", async () => {
@@ -142,4 +155,48 @@ test("web measure_text uses the registered Canvas font and string handle", async
   assert.equal(typeof env.measure_text, "function");
   assert.equal(env.measure_text(font, 1), 42);
   assert.deepEqual(measurements, [{ font: "20px stasis-font-1", value: "marble" }]);
+});
+
+test("web startup fails visibly when a declared font cannot load", async () => {
+  const result = await loadRuntime({
+    memory: {},
+    strings: { "7": "assets/missing.ttf" },
+  }, {
+    main: env => env.load_font(7, 20),
+    fontLoad: () => Promise.reject(new Error("font fetch failed")),
+  });
+  await assert.rejects(result.runtimePromise, /font fetch failed/);
+
+  const { document, errorBox, animationFrames } = result;
+  assert.equal(document.body.dataset.ready, "false");
+  assert.match(errorBox.textContent, /font fetch failed/);
+  assert.deepEqual(animationFrames, []);
+});
+
+test("web startup waits for every FontFace load before the fonts-ready signal", async () => {
+  const releases = [];
+  let fontsReadyResolved = false;
+  let frameCount = 0;
+  const runtime = loadRuntime({
+    memory: {},
+    strings: { "7": "assets/first.ttf", "8": "assets/second.ttf" },
+  }, {
+    main: env => {
+      env.load_font(7, 20);
+      env.load_font(8, 24);
+    },
+    fontLoad: font => new Promise(resolve => releases.push(() => resolve(font))),
+    fontsReady: Promise.resolve().then(() => { fontsReadyResolved = true; }),
+    onFrame: () => { frameCount += 1; },
+  });
+
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(releases.length, 2);
+  assert.equal(fontsReadyResolved, true);
+  assert.equal(frameCount, 0);
+
+  releases.forEach(release => release());
+  const afterFontsResolve = await runtime;
+  assert.equal(frameCount, 1);
+  assert.equal(afterFontsResolve.addedFonts.length, 2);
 });

--- a/runtime/web/tests/sys_memcpy_u8.test.mjs
+++ b/runtime/web/tests/sys_memcpy_u8.test.mjs
@@ -126,3 +126,45 @@ test("web sys_memcpy_u8 matches native registered-buffer and literal semantics",
   copy(202, 0, 505, 0, 0);
   assert.deepEqual(Array.from(bytes.slice(16, 24)), [0, 0, 9, 9, 9, 9, 9, 0xc3]);
 });
+
+test("web sys_memcpy_u8 copies byte-backed ascii and utf8 layouts with their declared stride", async () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const game = {
+    memory: {
+      source_utf8: { hash: 101, offset: 0, type_id: 69, length: 4, stride: 4, byte_backed: true },
+      destination_ascii: { hash: 202, offset: 64, type_id: 70, length: 4, stride: 4, byte_backed: true },
+    },
+    strings: {},
+    assets: {},
+  };
+  const bytes = new Uint8Array(memory.buffer);
+  bytes[0] = 0xc3;
+  bytes[4] = 0xa9;
+  const copy = await loadRuntime(game, memory);
+
+  copy(202, 0, 101, 0, 2);
+
+  assert.equal(bytes[64], 0xc3);
+  assert.equal(bytes[68], 0xa9);
+});
+
+test("web sys_memcpy_u8 accepts Wasm linear-memory offsets for registered layouts", async () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const game = {
+    memory: {
+      source: { hash: 101, offset: 0, type_id: 69, length: 4, stride: 4, byte_backed: true },
+      destination: { hash: 202, offset: 64, type_id: 70, length: 4, stride: 4, byte_backed: true },
+    },
+    strings: {},
+    assets: {},
+  };
+  const bytes = new Uint8Array(memory.buffer);
+  bytes[0] = 65;
+  bytes[4] = 66;
+  const copy = await loadRuntime(game, memory);
+
+  copy(64, 0, 0, 0, 2);
+
+  assert.equal(bytes[64], 65);
+  assert.equal(bytes[68], 66);
+});


### PR DESCRIPTION
Retain packaged Wasm ASCII/UTF-8 byte layouts and resolve linear-memory offsets; await every FontFace load and hard-fail startup on font errors. Validated with 9/9 web runtime tests, 8/8 web package integration tests, cargo fmt/check, and real-game browser rendering.