### PR TITLE
Remap Android follow-up workspace

### DIFF
--- a/tools/android_daily_followup.ps1
+++ b/tools/android_daily_followup.ps1
@@ -4,7 +4,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$repoRoot = "F:\StasisLang"
+$repoRoot = "D:\code\StasisLang"
 $codex = "C:\Users\Ben\AppData\Local\OpenAI\Codex\bin\codex.exe"
 $prompt = @"
 Continue the StasisLang Android Workshop branch work.


### PR DESCRIPTION
Remaps the disabled Android daily follow-up launcher from F:\StasisLang to D:\code\StasisLang. The task remains disabled. PowerShell parse, -DryRun, diff check, and pre-commit passed.