### PR TITLE
Remove developer-local path dependencies

### DIFF
--- a/.cargo/stasis-sign-and-run.cmd
+++ b/.cargo/stasis-sign-and-run.cmd
@@ -18,6 +18,15 @@ goto collect_args
 
 set "SIGN_TOOL=%STASIS_AOT_SIGN_TOOL%"
 if not "%SIGN_TOOL%"=="" (
+  where "%SIGN_TOOL%" >nul 2>nul
+  if errorlevel 1 if not exist "%SIGN_TOOL%" (
+    if "%STASIS_REQUIRE_SIGNED_EXECUTION%"=="1" (
+      echo [stasis-sign-runner] configured signer does not exist: %SIGN_TOOL%>&2
+      exit /b 5
+    )
+    echo [stasis-sign-runner] ignoring unavailable optional signer: %SIGN_TOOL%>&2
+    goto run_unsigned
+  )
   if not exist "%TARGET%" (
     echo [stasis-sign-runner] target does not exist: %TARGET%>&2
     exit /b 3
@@ -34,5 +43,6 @@ if not "%SIGN_TOOL%"=="" (
   )
 )
 
+:run_unsigned
 "%TARGET%" %FORWARD_ARGS%
 exit /b %ERRORLEVEL%

--- a/apps/stasis/src/compiler_backend.rs
+++ b/apps/stasis/src/compiler_backend.rs
@@ -7974,6 +7974,58 @@ echo "signed" > "$1.signed"
     }
 
     #[test]
+    fn missing_optional_signer_does_not_block_unsigned_local_artifacts() {
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+        let _guard = SIGN_ENV_LOCK.lock().expect("lock signer env");
+        let old_signer = std::env::var_os("STASIS_AOT_SIGN_TOOL");
+        let old_required = std::env::var_os("STASIS_REQUIRE_SIGNED_EXECUTION");
+        let missing_signer = std::env::temp_dir().join("stasis-missing-sign-tool");
+        std::env::set_var("STASIS_AOT_SIGN_TOOL", &missing_signer);
+        std::env::remove_var("STASIS_REQUIRE_SIGNED_EXECUTION");
+
+        let result = maybe_sign_output_artifact(Path::new("local-artifact.exe"));
+
+        if let Some(value) = old_signer {
+            std::env::set_var("STASIS_AOT_SIGN_TOOL", value);
+        } else {
+            std::env::remove_var("STASIS_AOT_SIGN_TOOL");
+        }
+        if let Some(value) = old_required {
+            std::env::set_var("STASIS_REQUIRE_SIGNED_EXECUTION", value);
+        } else {
+            std::env::remove_var("STASIS_REQUIRE_SIGNED_EXECUTION");
+        }
+        result.expect("an unavailable optional signer should permit unsigned local output");
+    }
+
+    #[test]
+    fn missing_required_signer_fails_before_artifact_execution() {
+        let _process_env_guard = stasis_process_env_lock().lock().expect("lock process env");
+        let _guard = SIGN_ENV_LOCK.lock().expect("lock signer env");
+        let old_signer = std::env::var_os("STASIS_AOT_SIGN_TOOL");
+        let old_required = std::env::var_os("STASIS_REQUIRE_SIGNED_EXECUTION");
+        let missing_signer = std::env::temp_dir().join("stasis-missing-required-sign-tool");
+        std::env::set_var("STASIS_AOT_SIGN_TOOL", &missing_signer);
+        std::env::set_var("STASIS_REQUIRE_SIGNED_EXECUTION", "1");
+
+        let result = maybe_sign_output_artifact(Path::new("local-artifact.exe"));
+
+        if let Some(value) = old_signer {
+            std::env::set_var("STASIS_AOT_SIGN_TOOL", value);
+        } else {
+            std::env::remove_var("STASIS_AOT_SIGN_TOOL");
+        }
+        if let Some(value) = old_required {
+            std::env::set_var("STASIS_REQUIRE_SIGNED_EXECUTION", value);
+        } else {
+            std::env::remove_var("STASIS_REQUIRE_SIGNED_EXECUTION");
+        }
+        assert!(result
+            .expect_err("required signing must reject an unavailable signer")
+            .contains("does not exist"));
+    }
+
+    #[test]
     fn self_host_aot_cli_writes_default_summary_sidecar() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -8427,19 +8479,52 @@ pub fn run_self_host_aot_cli(
 }
 
 fn maybe_sign_output_artifact(artifact_path: &Path) -> Result<(), String> {
-    let Some(sign_tool) = std::env::var_os("STASIS_AOT_SIGN_TOOL") else {
-        return Ok(());
+    let sign_tool = std::env::var_os("STASIS_AOT_SIGN_TOOL").filter(|tool| !tool.is_empty());
+    let signing_required =
+        std::env::var_os("STASIS_REQUIRE_SIGNED_EXECUTION").is_some_and(|value| value == "1");
+    let Some(sign_tool) = sign_tool else {
+        return if signing_required {
+            Err("STASIS_REQUIRE_SIGNED_EXECUTION=1 but STASIS_AOT_SIGN_TOOL is not set".to_string())
+        } else {
+            Ok(())
+        };
     };
-    let status = std::process::Command::new(&sign_tool)
+    let sign_tool_path = Path::new(&sign_tool);
+    if (sign_tool_path.is_absolute() || sign_tool_path.components().count() > 1)
+        && !sign_tool_path.is_file()
+    {
+        if signing_required {
+            return Err(format!(
+                "configured signer tool {:?} does not exist",
+                sign_tool
+            ));
+        }
+        eprintln!(
+            "warning: ignoring unavailable optional signer tool {:?}",
+            sign_tool
+        );
+        return Ok(());
+    }
+    let status = match std::process::Command::new(&sign_tool)
         .arg(artifact_path)
         .status()
-        .map_err(|error| {
-            format!(
+    {
+        Ok(status) => status,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && !signing_required => {
+            eprintln!(
+                "warning: ignoring unavailable optional signer tool {:?}",
+                sign_tool
+            );
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(format!(
                 "failed to launch signer tool {:?} for {}: {error}",
                 sign_tool,
                 artifact_path.display()
-            )
-        })?;
+            ));
+        }
+    };
     if !status.success() {
         return Err(format!(
             "signer tool {:?} failed for {} with status {:?}",

--- a/docs/aot_brickout_quality_gate.md
+++ b/docs/aot_brickout_quality_gate.md
@@ -6,7 +6,8 @@ compiled, linked into a DLL, and executed headlessly for more than one tick.
 ## Command
 
 ```powershell
-cd F:\StasisLang
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
 $env:STASIS_AOT_QUALITY_GATE = "1"
 cargo test -p stasis aot_brickout_revenge_v1_engine_bundle_executes_two_ticks -- --nocapture
 ```

--- a/docs/cargo_cache_policy.md
+++ b/docs/cargo_cache_policy.md
@@ -50,13 +50,13 @@ python tools/cargo_cache.py measure --json
 Preview removal of one stale worktree's entire Cargo target:
 
 ```text
-python tools/cargo_cache.py clean --worktree F:\StasisLang\.worktrees\old-task
+python tools/cargo_cache.py clean --worktree "C:\src\StasisLang\.worktrees\old-task"
 ```
 
 Remove only that target's incremental directories after reviewing the exact paths:
 
 ```text
-python tools/cargo_cache.py clean --worktree F:\StasisLang\.worktrees\old-task --incremental-only --apply
+python tools/cargo_cache.py clean --worktree "C:\src\StasisLang\.worktrees\old-task" --incremental-only --apply
 ```
 
 Preview or remove the shared automation cache:

--- a/docs/windows-app-control.md
+++ b/docs/windows-app-control.md
@@ -32,8 +32,9 @@ $env:STASIS_AOT_SIGN_TOOL = "C:\tools\sign-stasis.cmd"
 3. If your environment allows Defender exclusions, add:
 
 ```powershell
-Add-MpPreference -ExclusionPath "F:\StasisLang\.stasis_cache\tmp"
-Add-MpPreference -ExclusionPath "F:\StasisLang\target\release"
+$repoRoot = (Resolve-Path .).Path
+Add-MpPreference -ExclusionPath (Join-Path $repoRoot ".stasis_cache\tmp")
+Add-MpPreference -ExclusionPath (Join-Path $repoRoot "target\release")
 ```
 
 Note: this requires elevated/admin PowerShell and does not override WDAC/AppLocker policy.
@@ -43,7 +44,7 @@ Note: this requires elevated/admin PowerShell and does not override WDAC/AppLock
 - `STASIS_AOT_SIGN_TOOL` signs AOT-produced executables.
 - `STASIS_COMPILER_ANALYSIS_SIGN_TOOL` signs blocked compiler-analysis artifacts (for example `.stasis_cache\run\*.dll`) and retries once automatically.
 - Cargo execution in this repo now runs through `.cargo\stasis-sign-and-run.cmd` on Windows and will sign each launched executable first when `STASIS_AOT_SIGN_TOOL` is set.
-- Set `STASIS_REQUIRE_SIGNED_EXECUTION=1` to fail fast if the signer tool is missing.
+- An unavailable optional signer is reported and local execution continues unsigned. Set `STASIS_REQUIRE_SIGNED_EXECUTION=1` to fail fast when signing is required or the configured tool is unavailable.
 
 Example (PowerShell):
 
@@ -62,8 +63,8 @@ If Defender exclusions are insufficient, ask IT/security to allow one of:
 - Publisher rule for your local signing certificate.
 - Hash rule for built binaries.
 - Path rule for:
-- `F:\StasisLang\.stasis_cache\tmp`
-- `F:\StasisLang\target\release`
+- `<repo>\.stasis_cache\tmp`
+- `<repo>\target\release`
 
 Publisher rules are preferred to reduce churn when binaries change.
 

--- a/scripts/build_local_editor_release.ps1
+++ b/scripts/build_local_editor_release.ps1
@@ -83,11 +83,21 @@ if (-not $SkipBuild) {
       if ($LASTEXITCODE -ne 0) { throw "Signing failed for $signedFile." }
     }
   } elseif ($env:STASIS_AOT_SIGN_TOOL) {
-    @("stasis.exe", "stasis_graphics.dll") | ForEach-Object {
-      $signedFile = Join-Path $toolchainRoot $_
-      & $env:STASIS_AOT_SIGN_TOOL $signedFile
-      if ($LASTEXITCODE -ne 0) { throw "Configured local signer failed for $signedFile." }
+    $signTool = Get-Command $env:STASIS_AOT_SIGN_TOOL -CommandType Application -ErrorAction SilentlyContinue
+    if (-not $signTool) {
+      if ($env:STASIS_REQUIRE_SIGNED_EXECUTION -eq "1") {
+        throw "Configured signing tool was not found: $env:STASIS_AOT_SIGN_TOOL"
+      }
+      Write-Warning "Ignoring unavailable optional signing tool: $env:STASIS_AOT_SIGN_TOOL"
+    } else {
+      @("stasis.exe", "stasis_graphics.dll") | ForEach-Object {
+        $signedFile = Join-Path $toolchainRoot $_
+        & $signTool.Source $signedFile
+        if ($LASTEXITCODE -ne 0) { throw "Configured local signer failed for $signedFile." }
+      }
     }
+  } elseif ($env:STASIS_REQUIRE_SIGNED_EXECUTION -eq "1") {
+    throw "STASIS_REQUIRE_SIGNED_EXECUTION=1 but STASIS_AOT_SIGN_TOOL is not set."
   }
 
   & (Join-Path $toolchainRoot "stasis.exe") --json editor-info

--- a/tools/android_daily_followup.ps1
+++ b/tools/android_daily_followup.ps1
@@ -1,11 +1,18 @@
 param(
-    [switch]$DryRun
+    [switch]$DryRun,
+    [string]$CodexPath = ""
 )
 
 $ErrorActionPreference = "Stop"
 
-$repoRoot = "D:\code\StasisLang"
-$codex = "C:\Users\Ben\AppData\Local\OpenAI\Codex\bin\codex.exe"
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+if ($CodexPath) {
+    $codex = Get-Command $CodexPath -CommandType Application -ErrorAction Stop |
+        Select-Object -First 1 -ExpandProperty Source
+} else {
+    $codex = Get-Command codex -CommandType Application -ErrorAction Stop |
+        Select-Object -First 1 -ExpandProperty Source
+}
 $prompt = @"
 Continue the StasisLang Android Workshop branch work.
 
@@ -23,10 +30,6 @@ Leave unrelated local dirty files alone unless explicitly instructed otherwise.
 
 if (!(Test-Path -LiteralPath $repoRoot)) {
     throw "Repo root not found: $repoRoot"
-}
-
-if (!(Test-Path -LiteralPath $codex)) {
-    throw "Codex CLI not found: $codex"
 }
 
 $args = @("--cd", $repoRoot, $prompt)


### PR DESCRIPTION
## Summary
- derive Android follow-up repo root from the script and resolve Codex from PATH or an explicit option
- make stale optional signer paths warn and continue unsigned for local builds
- preserve strict signing failure through STASIS_REQUIRE_SIGNED_EXECUTION=1
- apply the same policy to Cargo execution, AOT/package artifacts, and editor release builds
- replace checkout-specific F: documentation examples

## Validation
- cargo fmt --check
- cargo check -p stasis
- focused optional/required signer tests
- pre-commit test
- PowerShell parse and Android dry run
- batch optional/strict behavior
- web runtime tests 12/12
- git diff --check

Full validation is limited on this Windows host by unavailable Bash and pre-existing stale generated-cache ABI failures; focused source-owned checks pass.