### PR TITLE
Fix desktop frame double pacing

### DIFF
--- a/apps/stasis/src/frame_pacer.rs
+++ b/apps/stasis/src/frame_pacer.rs
@@ -1,0 +1,114 @@
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub(crate) struct FramePacer {
+    interval: Duration,
+    next_deadline: Instant,
+}
+
+impl FramePacer {
+    pub(crate) fn from_micros(interval_micros: u64, now: Instant) -> Result<Option<Self>, String> {
+        if interval_micros == 0 {
+            return Ok(None);
+        }
+        let interval = Duration::from_micros(interval_micros);
+        let next_deadline = now
+            .checked_add(interval)
+            .ok_or_else(|| "tick interval exceeds the host monotonic clock range".to_string())?;
+        Ok(Some(Self {
+            interval,
+            next_deadline,
+        }))
+    }
+
+    pub(crate) fn wait(&mut self) {
+        let delay = self.delay_at(Instant::now());
+        if !delay.is_zero() {
+            thread::sleep(delay);
+        }
+    }
+
+    fn delay_at(&mut self, now: Instant) -> Duration {
+        let deadline = self.next_deadline;
+        if now < deadline {
+            self.next_deadline = deadline.checked_add(self.interval).unwrap_or(now);
+            return deadline.duration_since(now);
+        }
+
+        if now.duration_since(deadline) >= self.interval {
+            self.next_deadline = now.checked_add(self.interval).unwrap_or(now);
+        } else {
+            self.next_deadline = deadline.checked_add(self.interval).unwrap_or(now);
+        }
+        Duration::ZERO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pacer(interval_micros: u64, base: Instant) -> FramePacer {
+        FramePacer::from_micros(interval_micros, base)
+            .expect("valid interval")
+            .expect("enabled pacer")
+    }
+
+    #[test]
+    fn fast_present_waits_only_for_remaining_frame_budget() {
+        let base = Instant::now();
+        let mut pacer = pacer(16_000, base);
+
+        assert_eq!(
+            pacer.delay_at(base + Duration::from_micros(4_000)),
+            Duration::from_micros(12_000)
+        );
+        assert_eq!(pacer.next_deadline, base + Duration::from_micros(32_000));
+    }
+
+    #[test]
+    fn vsynced_present_consuming_the_interval_adds_no_delay() {
+        let base = Instant::now();
+        let mut pacer = pacer(16_000, base);
+
+        assert_eq!(
+            pacer.delay_at(base + Duration::from_micros(16_000)),
+            Duration::ZERO
+        );
+        assert_eq!(pacer.next_deadline, base + Duration::from_micros(32_000));
+    }
+
+    #[test]
+    fn short_overrun_does_not_add_delay_or_move_the_cadence() {
+        let base = Instant::now();
+        let mut pacer = pacer(16_000, base);
+
+        assert_eq!(
+            pacer.delay_at(base + Duration::from_micros(20_000)),
+            Duration::ZERO
+        );
+        assert_eq!(pacer.next_deadline, base + Duration::from_micros(32_000));
+    }
+
+    #[test]
+    fn long_pause_resets_without_a_catch_up_burst() {
+        let base = Instant::now();
+        let mut pacer = pacer(16_000, base);
+        let resumed = base + Duration::from_secs(2);
+
+        assert_eq!(pacer.delay_at(resumed), Duration::ZERO);
+        assert_eq!(pacer.next_deadline, resumed + Duration::from_micros(16_000));
+        assert_eq!(
+            pacer.delay_at(resumed + Duration::from_micros(1_000)),
+            Duration::from_micros(15_000)
+        );
+    }
+
+    #[test]
+    fn zero_interval_disables_pacing() {
+        assert!(FramePacer::from_micros(0, Instant::now())
+            .expect("zero is valid")
+            .is_none());
+    }
+}

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod compiler_backend;
 mod events;
+mod frame_pacer;
 mod host_set_registry;
 mod live_workspace;
 mod mobile_aot_bindings;
@@ -29,6 +30,7 @@ pub use stasis_test_runner::{
 pub use window_config::WindowConfig;
 
 use compiler_backend::{IncrementalCompilerBackend, PreparedJitSwap};
+use frame_pacer::FramePacer;
 use live_workspace::LiveWorkspace;
 use runtime_exec::RuntimeLauncher;
 use serde::{Deserialize, Serialize};
@@ -2329,6 +2331,7 @@ fn run_play_in_process_inner(
         .transpose()?;
 
     let mut ticks_executed: u64 = 0;
+    let mut frame_pacer = FramePacer::from_micros(tick_sleep_micros, Instant::now())?;
     loop {
         if let Some(live) = live.as_mut() {
             live.process_boundary(
@@ -2598,13 +2601,9 @@ fn run_play_in_process_inner(
                 .ok_or_else(|| "desktop frame has no published JIT entry table".to_string())?;
             evidence.record(ticks_executed.saturating_add(1), entry_revision, submission)?;
         }
-        if tick_sleep_micros > 0 {
-            let ms = (tick_sleep_micros / 1000) as i32;
-            if ms > 0 {
-                gfx.sleep_ms(ms)?;
-            }
+        if let Some(frame_pacer) = frame_pacer.as_mut() {
+            frame_pacer.wait();
         }
-
         if let Some(live) = live.as_mut() {
             if run_tick {
                 ticks_executed = ticks_executed.saturating_add(1);

--- a/docs/shared_renderer_process.md
+++ b/docs/shared_renderer_process.md
@@ -80,3 +80,19 @@ shipping renderer. It performs no per-command JNI calls and adds no additional
 full-frame copy. The old desktop GL adapter is available only when CMake is
 explicitly configured with `STASIS_GRAPHICS_SDL_ONLY=OFF`; it is not packaged or
 exercised as the canonical process.
+
+## Frame pacing
+
+Rendering and presentation do not define simulation time. Desktop `stasis play`
+paces the tick boundary against an absolute monotonic deadline. Work performed by
+input collection, `tick`, `render`, and `stasis_gfx_submit_u8`--including a
+blocking vsynced present--counts toward the configured interval. The host waits
+only for the remaining budget, adds no delay after an overrun, and resets its
+deadline after a whole-interval pause so suspended or stalled sessions do not
+run a catch-up burst.
+
+The Android and iOS shell applies the same deadline invariant through the shared
+mobile frame pacer. Display synchronization can contribute to pacing on every
+platform, but it never authorizes an extra simulation step. Physical-display
+verification at 60, 90, and 120 Hz remains part of platform acceptance because
+drivers can differ in whether and how long presentation blocks.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -125,6 +125,10 @@ cloning a generated repository, reactivate the checked-in hook with
   nearest ancestor `stasis.json` from the current directory and use its project-relative `entry`
   and display `name`. Explicit entries discover their own ancestor manifest, so project-root
   imports and asset preparation remain anchored to the project even when play starts in `src/`.
+  The desktop loop uses `--tick-sleep-us` as an absolute tick interval: input, simulation,
+  rendering, and a potentially vsynced present consume that interval, and the host sleeps only for
+  the remaining budget. An overrun adds no delay, while a pause of at least one whole interval
+  resets the deadline instead of producing a catch-up burst. Passing zero disables this pacing.
 - `run --watch`: launch the existing graphical runner and hot-swap pipeline for game projects.
   The window title uses the manifest project name. Because it is an unbounded graphical session,
   watch mode rejects `--json` and `--headless`.


### PR DESCRIPTION
## Summary
- replace the unconditional post-present desktop sleep with one absolute monotonic frame deadline
- count input, tick, render, and potentially blocking vsynced present work against the configured interval
- reset after long stalls without catch-up bursts and document the shared desktop/mobile invariant

## Tests
- `python tools/cargo_cache.py run -- cargo test -p stasis frame_pacer -- --test-threads=1` (5 passed)
- `python tools/cargo_cache.py run -- cargo test -p stasis --lib -- --test-threads=1` (275 passed, 2 existing Brickout JIT symbol-resolution failures reproduced identically on unmodified main)
- `python tools/cargo_cache.py run -- cargo check -p stasis --all-targets`
- `python tools/ci/check_stasis_src_layout.py`
- `python tools/cargo_cache.py run -- cargo fmt --all -- --check`
- `git diff --check`
- canonical validator passed layout, SDL3, JIT generation, and 293 ABI comparisons, then stopped at the unchanged audited-unsafe-boundary baseline

## Review
- independent `gpt-5.6-luna` maximum-reasoning review: CLEAN
- simplicity/cruft review: one deadline state, no alternate loop, shim, or obsolete fixed desktop sleep

Maddox #196