### PR TITLE
feat: enforce opt-in effect contracts

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -121,7 +121,26 @@ import "/vendor/stasis/stdlib/ui_axis_layout.stasis";
 import "/vendor/stasis/stdlib/ui_layout_audit.stasis";
 import "/vendor/stasis/stdlib/ui_button_9slice.stasis";
 
+struct GameState {
+    ticks: i32;
+}
+
+global state: GameState;
+
 function main(): i32 {
+    state.ticks = 0;
+    return 0;
+}
+
+function @effects(state) tick(): i32 {
+    state.ticks += 1;
+    return 0;
+}
+
+function @effects(graphics) render(): i32 {
+    begin_frame();
+    clear(0.05, 0.07, 0.10, 1.0);
+    end_frame();
     return 0;
 }
 "#;
@@ -5874,6 +5893,29 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generated_graphical_project_has_effect_boundaries_and_checks() {
+        let root = temp_dir("effect_template");
+        create_project(root.clone(), "effect_template".to_string()).expect("create project");
+        let source = fs::read_to_string(root.join("src/main.stasis")).expect("read source");
+        assert_eq!(
+            source
+                .matches("function @effects(state) tick(): i32")
+                .count(),
+            1
+        );
+        assert_eq!(
+            source
+                .matches("function @effects(graphics) render(): i32")
+                .count(),
+            1
+        );
+        assert!(!source.contains("function @effects(state, graphics)"));
+        let workspace = load_workspace(Some(&root)).expect("load generated workspace");
+        check_workspace(&workspace).expect("generated project checks");
+        remove_temp(&root);
+    }
     use stasis_ai::live_tool_specs;
     use stasis_compiler::frontend::types::TYPE_ID_U8;
     use std::collections::BTreeMap;

--- a/crates/stasis_compiler/src/backend/aot.rs
+++ b/crates/stasis_compiler/src/backend/aot.rs
@@ -1598,6 +1598,23 @@ fn build_engine_bundle_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn aot_enforces_the_same_effect_contracts_as_jit() {
+        let mut process = AotProcess::new();
+        process.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function helper(value: State): void { value.value += 1; } function @effects(state) tick(): i32 { helper(state); return state.value; } function main(): i32 { state.value = 4; return tick(); }",
+        );
+        process.compile().expect("compliant AOT contract");
+
+        process.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; global other: i32; function helper(): void { other += 1; } function @effects(state) tick(): i32 { helper(); return state.value; } function main(): i32 { return tick(); }",
+        );
+        let error = process.compile().expect_err("AOT contract violation");
+        assert!(format!("{error:?}").contains("tick -> helper"));
+    }
     use crate::backend::jit::JitProcess;
     use crate::backend::EngineEntrypoints;
     use object::{

--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -7580,6 +7580,70 @@ mod tests {
         assert_eq!(active.execute_i32_noarg_by_name("main").unwrap(), 2);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn effect_contract_rejects_staged_candidate_and_preserves_active_code() {
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function leaf(): void { return; } function @effects() render(): i32 { leaf(); return 7; } function main(): i32 { return render(); }",
+        );
+        active.compile().expect("compile compliant generation");
+        let revision = active
+            .generation_metadata()
+            .expect("active metadata")
+            .source_revision;
+        assert_eq!(active.execute_i32_noarg_by_name("main").unwrap(), 7);
+
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function leaf(): void { state.value += 1; } function @effects() render(): i32 { leaf(); return 9; } function main(): i32 { return render(); }",
+        );
+        let error = candidate
+            .compile()
+            .expect_err("candidate violates pure render boundary");
+        assert!(format!("{error:?}").contains("render -> leaf"));
+        assert_eq!(active.execute_i32_noarg_by_name("main").unwrap(), 7);
+        assert_eq!(
+            active.generation_metadata().unwrap().source_revision,
+            revision
+        );
+    }
+
+    #[test]
+    fn effect_contract_only_edit_reuses_emitted_machine_code() {
+        let mut active = JitProcess::new();
+        active.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function @effects(state) tick(): i32 { state.value += 1; return 0; }",
+        );
+        active.compile().expect("compile broad contract");
+        let pointer = active
+            .artifacts()
+            .iter()
+            .find(|artifact| artifact.function_key.name == "tick")
+            .expect("tick artifact")
+            .code_ptr;
+
+        let mut candidate = active.staged_candidate();
+        candidate.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function @effects(state.value) tick(): i32 { state.value += 1; return 0; }",
+        );
+        let report = candidate.compile().expect("validate narrower contract");
+        assert_eq!(report.emit.emitted_functions, 0);
+        assert_eq!(
+            candidate
+                .artifacts()
+                .iter()
+                .find(|artifact| artifact.function_key.name == "tick")
+                .unwrap()
+                .code_ptr,
+            pointer
+        );
+    }
+
     #[test]
     fn staged_candidate_applies_custom_roots_before_indexing_source_edits() {
         let mut active = JitProcess::new();

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -2427,6 +2427,26 @@ function @effects(allowed) tick(): void { write_second(); write_first(); }
     }
 
     #[test]
+    fn effect_contracts_propagate_generic_view_helper_writes() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+global allowed: ascii[8];
+global forbidden: ascii[8];
+function clear(value: ascii[]): void { value[0] = 0; }
+function @effects(allowed) tick(): void { clear(forbidden); }
+"#,
+        );
+        let error = compiler
+            .check()
+            .expect_err("generic view helper write must reach the boundary");
+        let message = compile_error_message(&error);
+        assert!(message.contains("forbidden[*]"), "{message}");
+        assert!(message.contains("tick -> clear"), "{message}");
+    }
+
+    #[test]
     fn effect_contracts_reject_unknown_externs_and_unknown_global_regions() {
         let mut compiler = Compiler::new();
         compiler.upsert_file(
@@ -2451,6 +2471,18 @@ function @effects(allowed) tick(): void { write_second(); write_first(); }
             "{}",
             compile_error_message(&error)
         );
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; extern function @effects(audio) collide(value: f32): void; function collide(value: i32): void { state.value += value; } function @effects(state) tick(): void { collide(missing()); }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("ambiguous same-name host effects must remain conservative");
+        let message = compile_error_message(&error);
+        assert!(message.contains("host effect 'audio'"), "{message}");
+        assert!(message.contains("from 'collide'"), "{message}");
 
         compiler = Compiler::new();
         compiler.upsert_file(

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -7,8 +7,8 @@ use crate::backend::emit::{
     SimpleStmt,
 };
 use crate::data_flow::{
-    build_function_data_flow_summaries, compiler_local_types, CompilerLocalType,
-    FunctionDataFlowSummary,
+    build_function_data_flow_summaries, compiler_local_types, validate_effect_contracts,
+    CompilerLocalType, FunctionDataFlowSummary,
 };
 use crate::frontend::indexer::{hash_text, index_file, IndexedCallDependency};
 use crate::frontend::module_graph::ModuleGraph;
@@ -46,6 +46,8 @@ pub struct FunctionMeta {
     pub return_type: TypeId,
     /// Requests body substitution at eligible call sites. The real function is still emitted.
     pub inline: bool,
+    /// Optional compile-time assertion over the function's reachable effects.
+    pub effect_contract: Option<Vec<String>>,
     pub dependencies: Vec<FunctionId>,
     pub dependents: Vec<FunctionId>,
     pub call_sites: Vec<FunctionCallSite>,
@@ -672,6 +674,7 @@ impl Compiler {
                     params: indexed_function.params,
                     return_type: indexed_function.return_type,
                     inline: indexed_function.inline,
+                    effect_contract: indexed_function.effect_contract,
                     dependencies: Vec::new(),
                     dependents: Vec::new(),
                     call_sites: Vec::new(),
@@ -880,6 +883,18 @@ impl Compiler {
             self.data_flow_summaries = summaries.into();
         }
         self.data_flow_context_fingerprint = context_fingerprint;
+        if let Err(violation) =
+            validate_effect_contracts(&self.files, &self.functions, &self.data_flow_summaries)
+        {
+            self.last_source_diagnostic = Some(crate::SourceDiagnostic::new(
+                violation.file,
+                violation.source_start as usize,
+                violation.source_end as usize,
+                violation.function,
+                violation.message.clone(),
+            ));
+            return Err(CompileError::Frontend(violation.message));
+        }
         Ok(())
     }
 
@@ -2184,6 +2199,13 @@ function tick(): i32 {
         );
         assert_eq!(tick.direct.host_calls, vec!["host_emit"]);
         assert_eq!(
+            tick.direct.host_effects,
+            vec![crate::data_flow::FunctionHostEffect {
+                function: "host_emit".to_string(),
+                capability: "unknown".to_string(),
+            }]
+        );
+        assert_eq!(
             tick.direct.reads,
             vec!["state.enemies[*].hp", "state.score"]
         );
@@ -2271,7 +2293,7 @@ global state: State;
 function touch(enemy: Enemy): void { enemy.hp += 1; }
 function touch(player: Player): void { player.score += 1; }
 
-function tick(): i32 {
+function @effects(state) tick(): i32 {
     touch(state.enemy);
     touch(state.player);
     return 0;
@@ -2289,6 +2311,273 @@ function tick(): i32 {
             tick.aggregate.writes,
             vec!["state.enemy.hp", "state.player.score"]
         );
+    }
+
+    #[test]
+    fn effect_contracts_follow_imported_calls() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "helper.stasis",
+            "function update(value: State): void { value.score += 1; }",
+        );
+        compiler.upsert_file(
+            "main.stasis",
+            "import \"helper.stasis\"; struct State { score: i32; } global state: State; function @effects(state) tick(): i32 { update(state); return state.score; }",
+        );
+        compiler.check().expect("imported alias write is contained");
+    }
+
+    #[test]
+    fn effect_contracts_enforce_transitive_alias_aware_global_regions() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+struct Enemy { hp: i32; }
+struct State { enemies: Enemy[2]; player: Enemy; score: i32; }
+global state: State;
+function damage(enemy: Enemy): void { enemy.hp -= 1; }
+function damage_enemies(): void { state.enemies.length = 2; state.enemies[0].damage(); }
+function @effects(state.enemies) tick(): void { damage_enemies(); }
+"#,
+        );
+        compiler.check().expect("contained alias write is allowed");
+
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+struct Enemy { hp: i32; }
+struct State { enemies: Enemy[2]; player: Enemy; score: i32; }
+global state: State;
+function damage(enemy: Enemy): void { enemy.hp -= 1; }
+function damage_enemies(): void { state.player.damage(); }
+function @effects(state.enemies) tick(): void { damage_enemies(); }
+"#,
+        );
+        let error = compiler.check().expect_err("neighboring region must fail");
+        let message = compile_error_message(&error);
+        assert!(message.contains("state.player.hp"), "{message}");
+        assert!(
+            message.contains("tick -> damage_enemies -> damage"),
+            "{message}"
+        );
+        let diagnostic = compiler.last_source_diagnostic().unwrap();
+        assert_eq!(diagnostic.symbol, "tick");
+        assert!(diagnostic.message.contains("originating operation"));
+    }
+
+    #[test]
+    fn effect_contracts_compose_regions_and_host_capabilities() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+struct State { enemies: i32[2]; projectiles: i32[2]; score: i32; }
+global state: State;
+extern function @effects(graphics) draw(value: i32): void;
+extern function @effects(audio) play(): void;
+function render_helpers(): void { draw(state.score); }
+function @effects(state.enemies, state.projectiles, graphics) simulate(): void {
+    state.enemies[0] += 1;
+    state.projectiles[1] += 1;
+    render_helpers();
+}
+"#,
+        );
+        compiler
+            .check()
+            .expect("declared regions and graphics pass");
+
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+struct State { score: i32; }
+global state: State;
+extern function @effects(graphics) draw(value: i32): void;
+extern function @effects(audio) play(): void;
+function helper(): void { play(); }
+function @effects(graphics) render(): void { draw(state.score); helper(); }
+"#,
+        );
+        let error = compiler.check().expect_err("audio is not graphics");
+        let message = compile_error_message(&error);
+        assert!(message.contains("host effect 'audio'"), "{message}");
+        assert!(message.contains("render -> helper"), "{message}");
+    }
+
+    #[test]
+    fn effect_contract_diagnostic_follows_the_rejected_effect_branch() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            r#"
+global allowed: i32;
+global first: i32;
+global second: i32;
+function write_second(): void { second += 1; }
+function write_first(): void { first += 1; }
+function @effects(allowed) tick(): void { write_second(); write_first(); }
+"#,
+        );
+        let error = compiler.check().expect_err("first is the sorted violation");
+        let message = compile_error_message(&error);
+        assert!(message.contains("rejects write 'first'"), "{message}");
+        assert!(message.contains("tick -> write_first"), "{message}");
+        assert!(!message.contains("write_second"), "{message}");
+    }
+
+    #[test]
+    fn effect_contracts_reject_unknown_externs_and_unknown_global_regions() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "extern function mystery(): void; function @effects(graphics) render(): void { mystery(); }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("unknown extern is conservative");
+        assert!(compile_error_message(&error).contains("host effect 'unknown'"));
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "extern function @effects(graphics) host(value: i32): void; extern function @effects(audio) host(value: f32): void; function @effects(graphics) render(): void { host(1); }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("same-name extern overload effects must not overwrite");
+        assert!(
+            compile_error_message(&error).contains("must declare identical @effects metadata"),
+            "{}",
+            compile_error_message(&error)
+        );
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "function @effects() render(): void { missing(); }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("unresolved calls cannot pass a restricted boundary");
+        let message = compile_error_message(&error);
+        assert!(message.contains("host effect 'unknown'"), "{message}");
+        assert!(message.contains("from 'missing'"), "{message}");
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "function @effects(state) tick(): void { return; }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("literal state global must exist");
+        assert!(compile_error_message(&error).contains("unknown global region 'state'"));
+
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { score: i32; } global state: State; function @effects(state.missing) tick(): void { return; }",
+        );
+        let error = compiler.check().expect_err("named region field must exist");
+        assert!(compile_error_message(&error).contains("state.missing"));
+
+        compiler.upsert_file(
+            "effects.stasis",
+            "global gfx_cmd_i32: i32[2]; function @effects(graphics) render(): void { gfx_cmd_i32[0] = 1; }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("application globals cannot impersonate command buffers");
+        assert!(compile_error_message(&error).contains("gfx_cmd_i32[*]"));
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "vendor/stasis/stdlib/internal/host_window_request.stasis",
+            "global host_req_flags: i32; function request_window(): void { host_req_flags = 1; }",
+        );
+        compiler.upsert_file(
+            "effects.stasis",
+            "import \"vendor/stasis/stdlib/internal/host_window_request.stasis\"; function @effects(platform) tick(): void { request_window(); }",
+        );
+        compiler
+            .check()
+            .expect("platform owns the stdlib window-request mailbox");
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "global host_req_flags: i32; function @effects(platform) tick(): void { host_req_flags = 1; }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("application globals cannot impersonate platform mailboxes");
+        assert!(compile_error_message(&error).contains("host_req_flags"));
+
+        compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function @effects(state) mutate(value: State): void { value.value += 1; }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("unbound parameter provenance is conservative");
+        assert!(compile_error_message(&error).contains("not proven"));
+    }
+
+    #[test]
+    fn effect_contract_rechecks_when_only_a_deep_callee_changes() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function leaf(): void { return; } function middle(): void { leaf(); } function @effects() render(): void { middle(); }",
+        );
+        compiler.check().expect("initial pure tree");
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function leaf(): void { state.value += 1; } function middle(): void { leaf(); } function @effects() render(): void { middle(); }",
+        );
+        let error = compiler
+            .check()
+            .expect_err("deep effect invalidates aggregate");
+        let message = compile_error_message(&error);
+        assert!(message.contains("state.value"), "{message}");
+        assert!(message.contains("render -> middle -> leaf"), "{message}");
+    }
+
+    #[test]
+    fn effect_contract_only_edit_reuses_statements_and_runtime_identity() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function @effects(state) tick(): void { state.value += 1; }",
+        );
+        compiler.index_pass().expect("initial allowed contract");
+        let signature = function_by_name(&compiler, "tick").signature_hash;
+        let parses = compiler.statement_parse_count;
+
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { value: i32; } global state: State; function @effects() tick(): void { state.value += 1; }",
+        );
+        compiler
+            .index_pass()
+            .expect_err("narrowed contract revalidates cached body");
+        assert_eq!(compiler.statement_parse_count, parses);
+        assert_eq!(
+            function_by_name(&compiler, "tick").signature_hash,
+            signature
+        );
+        assert!(!function_by_name(&compiler, "tick").dirty);
+    }
+
+    #[test]
+    fn on_code_swap_contract_names_state_and_rejection_capability() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "effects.stasis",
+            "struct State { swaps: i32; } global state: State; extern function @effects(code_swap) reject_code_swap(): void; function @effects(state, code_swap) on_code_swap(): void { state.swaps += 1; reject_code_swap(); }",
+        );
+        compiler.check().expect("explicit swap effects are allowed");
     }
 
     #[test]
@@ -2370,7 +2659,7 @@ struct State { left: i32; right: i32; }
 global state: State;
 function left(view: State): void { view.left += 1; right(view); }
 function right(view: State): void { view.right += 1; left(view); }
-function tick(): i32 { left(state); return 0; }
+function @effects(state) tick(): i32 { left(state); return 0; }
 "#,
         );
 

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -12,7 +12,16 @@ use crate::frontend::types::{
     TypeCategory, TypeId, TypeTable, TYPE_ID_BOOL, TYPE_ID_F32, TYPE_ID_F64, TYPE_ID_I32,
 };
 
-pub const FUNCTION_DATA_FLOW_SCHEMA_VERSION: u32 = 2;
+pub const FUNCTION_DATA_FLOW_SCHEMA_VERSION: u32 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EffectContractViolation {
+    pub file: String,
+    pub source_start: u32,
+    pub source_end: u32,
+    pub function: String,
+    pub message: String,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FunctionDataFlowEffects {
@@ -23,8 +32,16 @@ pub struct FunctionDataFlowEffects {
     pub calls: Vec<String>,
     pub host_calls: Vec<String>,
     #[serde(default)]
+    pub host_effects: Vec<FunctionHostEffect>,
+    #[serde(default)]
     pub host_call_costs: Vec<FunctionHostCallCost>,
     pub bounded_iterations: Vec<FunctionBoundedIteration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct FunctionHostEffect {
+    pub function: String,
+    pub capability: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
@@ -71,6 +88,12 @@ pub struct FunctionDataFlowSummary {
     internal_signature_hash: u64,
     #[serde(skip)]
     pub(crate) parameter_storage_kinds: Vec<ParameterStorageKind>,
+    #[serde(skip)]
+    internal_call_sites: Vec<CallSite>,
+    #[serde(skip)]
+    internal_direct_write_paths: Vec<String>,
+    #[serde(skip)]
+    internal_aggregate_write_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
@@ -98,6 +121,7 @@ struct EffectSets {
     parameter_writes: BTreeSet<String>,
     calls: BTreeSet<String>,
     host_calls: BTreeSet<String>,
+    host_effects: BTreeSet<FunctionHostEffect>,
     host_call_costs: BTreeMap<String, Option<u64>>,
     bounded_iterations: BTreeSet<FunctionBoundedIteration>,
     call_sites: Vec<CallSite>,
@@ -143,6 +167,7 @@ impl EffectSets {
             parameter_writes: public_parameter_paths(&self.parameter_writes, parameter_names),
             calls: self.calls.iter().cloned().collect(),
             host_calls: self.host_calls.iter().cloned().collect(),
+            host_effects: self.host_effects.iter().cloned().collect(),
             host_call_costs: self
                 .host_call_costs
                 .iter()
@@ -235,6 +260,7 @@ struct AnalysisContext<'a> {
     view_parameters_by_function: BTreeMap<u32, BTreeSet<usize>>,
     fixed_parameter_capacities: BTreeMap<u32, BTreeMap<usize, u64>>,
     extern_functions: BTreeSet<String>,
+    extern_effects: BTreeMap<String, Option<Vec<String>>>,
     collection_capacities: BTreeMap<String, u64>,
     path_types: BTreeMap<String, TypeId>,
     field_types: BTreeMap<TypeId, BTreeMap<String, TypeId>>,
@@ -439,6 +465,26 @@ pub(crate) fn build_function_data_flow_summaries(
             };
         let internal_syntax_fingerprint =
             effect_syntax_fingerprint(&statements_by_id[function.storage_index as usize]);
+        let internal_aggregate_write_paths = if let Some(aggregate_by_id) = &aggregate_by_id {
+            aggregate_by_id[function.storage_index as usize]
+                .writes
+                .iter()
+                .chain(
+                    aggregate_by_id[function.storage_index as usize]
+                        .parameter_writes
+                        .iter(),
+                )
+                .cloned()
+                .collect()
+        } else {
+            previous_by_key[&(
+                file.path.as_str(),
+                function.name.as_str(),
+                signature_hash.as_str(),
+            )]
+                .internal_aggregate_write_paths
+                .clone()
+        };
         out.push(FunctionDataFlowSummary {
             schema_version: FUNCTION_DATA_FLOW_SCHEMA_VERSION,
             function: function.name.clone(),
@@ -457,6 +503,20 @@ pub(crate) fn build_function_data_flow_summaries(
                 .get(function.storage_index as usize)
                 .cloned()
                 .unwrap_or_default(),
+            internal_call_sites: direct_by_id[function.storage_index as usize]
+                .call_sites
+                .clone(),
+            internal_direct_write_paths: direct_by_id[function.storage_index as usize]
+                .writes
+                .iter()
+                .chain(
+                    direct_by_id[function.storage_index as usize]
+                        .parameter_writes
+                        .iter(),
+                )
+                .cloned()
+                .collect(),
+            internal_aggregate_write_paths,
         });
     }
     out.sort_by(|left, right| {
@@ -794,6 +854,7 @@ fn build_context<'a>(
     let mut globals = BTreeSet::new();
     let mut constants = BTreeMap::new();
     let mut extern_functions = BTreeSet::new();
+    let mut extern_effects = BTreeMap::new();
     let mut resolved_externs = Vec::new();
     let mut structs = BTreeMap::new();
     let mut global_types = Vec::new();
@@ -824,6 +885,49 @@ fn build_context<'a>(
         if file.content.contains("extern") {
             for external in parse_top_level_extern_functions(&file.content)? {
                 extern_functions.insert(external.name.clone());
+                let mut effect_annotations = external
+                    .annotations
+                    .iter()
+                    .filter(|annotation| annotation.name == "effects");
+                let effect_annotation = effect_annotations.next();
+                if effect_annotations.next().is_some() {
+                    return Err(format!(
+                        "extern function '{}' may declare @effects only once",
+                        external.name
+                    ));
+                }
+                let capabilities = if let Some(annotation) = effect_annotation {
+                    Some(
+                        annotation
+                            .arguments
+                            .iter()
+                            .map(|argument| argument.text.trim().to_string())
+                            .collect::<Vec<_>>(),
+                    )
+                } else {
+                    None
+                };
+                if let Some(capabilities) = &capabilities {
+                    if let Some(invalid) = capabilities
+                        .iter()
+                        .find(|capability| !is_host_capability(capability))
+                    {
+                        return Err(format!(
+                            "extern function '{}' declares unknown host effect capability '{}'",
+                            external.name, invalid
+                        ));
+                    }
+                }
+                if let Some(previous) =
+                    extern_effects.insert(external.name.clone(), capabilities.clone())
+                {
+                    if previous != capabilities {
+                        return Err(format!(
+                            "extern overloads named '{}' must declare identical @effects metadata",
+                            external.name
+                        ));
+                    }
+                }
                 let params: Option<Vec<TypeId>> = external
                     .params
                     .iter()
@@ -912,7 +1016,7 @@ fn build_context<'a>(
         }
     }
     let mut fingerprint_hasher = DefaultHasher::new();
-    format!("{structs:?}|{global_types:?}|{constants:?}|{resolved_externs:?}")
+    format!("{structs:?}|{global_types:?}|{constants:?}|{resolved_externs:?}|{extern_effects:?}")
         .hash(&mut fingerprint_hasher);
     let fingerprint = fingerprint_hasher.finish();
     Ok(AnalysisContext {
@@ -921,6 +1025,7 @@ fn build_context<'a>(
         view_parameters_by_function,
         fixed_parameter_capacities,
         extern_functions,
+        extern_effects,
         collection_capacities,
         path_types,
         field_types,
@@ -1399,8 +1504,36 @@ fn analyze_expression(
                         .map(|argument| expression_effect_path(argument, context, locals, aliases))
                         .collect(),
                 );
+            } else if let Some(capability) = builtin_host_effect(target) {
+                effects.host_calls.insert(target.clone());
+                effects.host_effects.insert(FunctionHostEffect {
+                    function: target.clone(),
+                    capability: capability.to_string(),
+                });
+                effects.record_host_call(target);
             } else if context.extern_functions.contains(target) {
                 effects.host_calls.insert(target.clone());
+                let capabilities = context.extern_effects.get(target).and_then(Option::as_ref);
+                if capabilities.is_none() {
+                    effects.host_effects.insert(FunctionHostEffect {
+                        function: target.clone(),
+                        capability: "unknown".to_string(),
+                    });
+                } else if let Some(capabilities) = capabilities {
+                    effects
+                        .host_effects
+                        .extend(capabilities.iter().map(|capability| FunctionHostEffect {
+                            function: target.clone(),
+                            capability: capability.clone(),
+                        }));
+                }
+                effects.record_host_call(target);
+            } else if !is_pure_intrinsic(target) {
+                effects.host_calls.insert(target.clone());
+                effects.host_effects.insert(FunctionHostEffect {
+                    function: target.clone(),
+                    capability: "unknown".to_string(),
+                });
                 effects.record_host_call(target);
             }
             for (index, argument) in args.iter().enumerate() {
@@ -1419,6 +1552,365 @@ fn analyze_expression(
             analyze_expression(rhs, context, locals, local_types, aliases, effects);
         }
     }
+}
+
+pub(crate) fn is_host_capability(value: &str) -> bool {
+    matches!(
+        value,
+        "graphics"
+            | "audio"
+            | "storage"
+            | "network"
+            | "nondeterministic"
+            | "platform"
+            | "memory"
+            | "code_swap"
+    )
+}
+
+fn builtin_host_effect(target: &str) -> Option<&'static str> {
+    matches!(
+        target,
+        "print_i32" | "print_int" | "print_char" | "print_string"
+    )
+    .then_some("platform")
+}
+
+fn is_pure_intrinsic(target: &str) -> bool {
+    matches!(
+        target,
+        "fixed32_from_i32"
+            | "fixed32_to_i32"
+            | "fixed32_mul"
+            | "fixed32_div"
+            | "fixed32_from_ratio"
+            | "i32_to_f32"
+            | "f32_to_i32"
+            | "sin_fast"
+            | "cos_fast"
+    )
+}
+
+pub(crate) fn validate_effect_contracts(
+    files: &[SourceFile],
+    functions: &[FunctionMeta],
+    summaries: &[FunctionDataFlowSummary],
+) -> Result<(), EffectContractViolation> {
+    let mut capability_globals = BTreeMap::<&str, BTreeSet<String>>::new();
+    let mut structs = BTreeMap::new();
+    let mut layouts = Vec::new();
+    for file in files {
+        let Ok(layout) = parse_top_level_type_layout(&file.content) else {
+            continue;
+        };
+        structs.extend(
+            layout
+                .structs
+                .iter()
+                .map(|structure| (structure.name.clone(), structure.fields.clone())),
+        );
+        layouts.push((file, layout));
+    }
+    let mut declared_regions = BTreeSet::new();
+    for (file, layout) in layouts {
+        let normalized_path = file.path.replace('\\', "/");
+        let owned_capability = if normalized_path.ends_with("stdlib/internal/gfx_cmd.stasis") {
+            Some("graphics")
+        } else if normalized_path.ends_with("stdlib/internal/host_window_request.stasis") {
+            Some("platform")
+        } else {
+            None
+        };
+        if let Some(capability) = owned_capability {
+            capability_globals
+                .entry(capability)
+                .or_default()
+                .extend(layout.globals.iter().map(|global| global.name.clone()));
+        }
+        for global in layout.globals {
+            collect_declared_regions(
+                &global.name,
+                &global.type_name,
+                &structs,
+                &mut declared_regions,
+                &mut BTreeSet::new(),
+            );
+        }
+        for block in layout.global_blocks {
+            declared_regions.insert(block.name.clone());
+            for field in block.fields {
+                collect_declared_regions(
+                    &format!("{}.{}", block.name, field.name),
+                    &field.type_name,
+                    &structs,
+                    &mut declared_regions,
+                    &mut BTreeSet::new(),
+                );
+            }
+        }
+    }
+    let summary_by_id = summaries
+        .iter()
+        .map(|summary| (summary.internal_function_id, summary))
+        .collect::<BTreeMap<_, _>>();
+    for boundary in functions {
+        let Some(contract) = boundary.effect_contract.as_deref() else {
+            continue;
+        };
+        let Some(summary) = summary_by_id.get(&boundary.storage_index).copied() else {
+            continue;
+        };
+        for region in contract {
+            if !is_host_capability(region) && !declared_regions.contains(region) {
+                return Err(contract_violation(
+                    files,
+                    boundary,
+                    format!(
+                        "effect contract on '{}' names unknown global region '{}'",
+                        boundary.name, region
+                    ),
+                ));
+            }
+        }
+        let allowed_regions = contract
+            .iter()
+            .filter(|region| !is_host_capability(region))
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if let Some(path) =
+            summary.aggregate.writes.iter().find(|path| {
+                !write_is_allowed(path, &allowed_regions, contract, &capability_globals)
+            })
+        {
+            let chain = write_call_chain(
+                boundary.storage_index,
+                path,
+                &summary_by_id,
+                &mut BTreeSet::new(),
+            );
+            return Err(contract_violation(
+                files,
+                boundary,
+                format!(
+                    "effect contract on '{}' rejects write '{}'; originating operation is reachable through {}",
+                    boundary.name,
+                    path,
+                    display_call_chain(&chain, &summary_by_id)
+                ),
+            ));
+        }
+        if let Some(path) = summary.aggregate.parameter_writes.first() {
+            let chain = effect_call_chain(
+                boundary.storage_index,
+                &summary_by_id,
+                &mut BTreeSet::new(),
+                &|candidate| candidate.aggregate.parameter_writes.contains(path),
+                &|candidate| !candidate.direct.parameter_writes.is_empty(),
+            );
+            return Err(contract_violation(
+                files,
+                boundary,
+                format!(
+                    "effect contract on '{}' rejects write through parameter '{}': its global region is not proven; originating operation is reachable through {}",
+                    boundary.name,
+                    path,
+                    display_call_chain(&chain, &summary_by_id)
+                ),
+            ));
+        }
+        if let Some(effect) =
+            summary.aggregate.host_effects.iter().find(|effect| {
+                effect.capability == "unknown" || !contract.contains(&effect.capability)
+            })
+        {
+            let chain = effect_call_chain(
+                boundary.storage_index,
+                &summary_by_id,
+                &mut BTreeSet::new(),
+                &|candidate| candidate.aggregate.host_effects.contains(effect),
+                &|candidate| candidate.direct.host_effects.contains(effect),
+            );
+            return Err(contract_violation(
+                files,
+                boundary,
+                format!(
+                    "effect contract on '{}' rejects host effect '{}' from '{}'; originating operation is reachable through {}",
+                    boundary.name,
+                    effect.capability,
+                    effect.function,
+                    display_call_chain(&chain, &summary_by_id)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn collect_declared_regions(
+    path: &str,
+    type_name: &str,
+    structs: &BTreeMap<String, Vec<crate::frontend::parser::ParsedField>>,
+    regions: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
+) {
+    regions.insert(path.to_string());
+    let element_type = split_array_type(type_name)
+        .map(|(element, _)| element)
+        .unwrap_or(type_name);
+    if !visiting.insert(element_type.to_string()) {
+        return;
+    }
+    if let Some(fields) = structs.get(element_type) {
+        for field in fields {
+            collect_declared_regions(
+                &format!("{path}.{}", field.name),
+                &field.type_name,
+                structs,
+                regions,
+                visiting,
+            );
+        }
+    }
+    visiting.remove(element_type);
+}
+
+fn region_contains(region: &str, path: &str) -> bool {
+    path == region
+        || path
+            .strip_prefix(region)
+            .is_some_and(|suffix| suffix.starts_with('.') || suffix.starts_with('['))
+}
+
+fn write_is_allowed(
+    path: &str,
+    regions: &[&str],
+    contract: &[String],
+    capability_globals: &BTreeMap<&str, BTreeSet<String>>,
+) -> bool {
+    regions.iter().any(|region| region_contains(region, path))
+        || contract.iter().any(|capability| {
+            capability_globals
+                .get(capability.as_str())
+                .is_some_and(|globals| globals.contains(root_name(path)))
+        })
+}
+
+fn contract_violation(
+    files: &[SourceFile],
+    boundary: &FunctionMeta,
+    message: String,
+) -> EffectContractViolation {
+    EffectContractViolation {
+        file: files[boundary.file_id as usize].path.clone(),
+        source_start: boundary.signature_range.start,
+        source_end: boundary.signature_range.end,
+        function: boundary.name.clone(),
+        message,
+    }
+}
+
+fn effect_call_chain(
+    current: u32,
+    summaries: &BTreeMap<u32, &FunctionDataFlowSummary>,
+    visiting: &mut BTreeSet<u32>,
+    contains: &impl Fn(&FunctionDataFlowSummary) -> bool,
+    originates: &impl Fn(&FunctionDataFlowSummary) -> bool,
+) -> Vec<u32> {
+    if !visiting.insert(current) {
+        return vec![current];
+    }
+    let Some(summary) = summaries.get(&current).copied() else {
+        return vec![current];
+    };
+    if originates(summary) {
+        return vec![current];
+    }
+    for call_site in &summary.internal_call_sites {
+        let child = call_site.target_id;
+        let Some(child_summary) = summaries.get(&child).copied() else {
+            continue;
+        };
+        if !contains(child_summary) && !originates(child_summary) {
+            continue;
+        }
+        let mut branch = visiting.clone();
+        let chain = effect_call_chain(child, summaries, &mut branch, contains, originates);
+        if chain
+            .last()
+            .and_then(|id| summaries.get(id))
+            .is_some_and(|leaf| originates(leaf))
+        {
+            let mut out = vec![current];
+            out.extend(chain);
+            return out;
+        }
+    }
+    vec![current]
+}
+
+fn write_call_chain(
+    current: u32,
+    path: &str,
+    summaries: &BTreeMap<u32, &FunctionDataFlowSummary>,
+    visiting: &mut BTreeSet<(u32, String)>,
+) -> Vec<u32> {
+    if !visiting.insert((current, path.to_string())) {
+        return vec![current];
+    }
+    let Some(summary) = summaries.get(&current).copied() else {
+        return vec![current];
+    };
+    if summary
+        .internal_direct_write_paths
+        .iter()
+        .any(|candidate| candidate == path)
+    {
+        return vec![current];
+    }
+    for call_site in &summary.internal_call_sites {
+        let Some(child) = summaries.get(&call_site.target_id).copied() else {
+            continue;
+        };
+        let substitutions = call_site
+            .arguments
+            .iter()
+            .enumerate()
+            .filter_map(|(index, argument)| argument.clone().map(|argument| (index, argument)))
+            .collect::<BTreeMap<_, _>>();
+        let child_path = child
+            .internal_aggregate_write_paths
+            .iter()
+            .find(|candidate| {
+                substitute_path(candidate, &substitutions, false).as_deref() == Some(path)
+            });
+        let Some(child_path) = child_path else {
+            continue;
+        };
+        let mut branch = visiting.clone();
+        let chain = write_call_chain(call_site.target_id, child_path, summaries, &mut branch);
+        let reached_origin = chain.len() > 1
+            || child
+                .internal_direct_write_paths
+                .iter()
+                .any(|candidate| candidate == child_path);
+        if reached_origin {
+            let mut out = vec![current];
+            out.extend(chain);
+            return out;
+        }
+    }
+    vec![current]
+}
+
+fn display_call_chain(
+    chain: &[u32],
+    summaries: &BTreeMap<u32, &FunctionDataFlowSummary>,
+) -> String {
+    chain
+        .iter()
+        .filter_map(|id| summaries.get(id).map(|summary| summary.function.as_str()))
+        .collect::<Vec<_>>()
+        .join(" -> ")
 }
 
 fn analyze_view_argument(
@@ -1822,6 +2314,9 @@ fn merge_substituted_effects(
     aggregate
         .host_calls
         .extend(direct.host_calls.iter().cloned());
+    aggregate
+        .host_effects
+        .extend(direct.host_effects.iter().cloned());
     merge_host_call_costs(
         &mut aggregate.host_call_costs,
         &direct.host_call_costs,

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -259,6 +259,7 @@ struct AnalysisContext<'a> {
     constants: BTreeMap<String, i64>,
     view_parameters_by_function: BTreeMap<u32, BTreeSet<usize>>,
     fixed_parameter_capacities: BTreeMap<u32, BTreeMap<usize, u64>>,
+    internal_function_targets: BTreeMap<String, Vec<u32>>,
     extern_functions: BTreeSet<String>,
     extern_effects: BTreeMap<String, Option<Vec<String>>>,
     collection_capacities: BTreeMap<String, u64>,
@@ -1015,8 +1016,21 @@ fn build_context<'a>(
             }
         }
     }
+    let mut internal_function_targets = BTreeMap::<String, Vec<u32>>::new();
+    for function in functions {
+        internal_function_targets
+            .entry(function.name.clone())
+            .or_default()
+            .push(function.storage_index);
+        if !function.module_alias.is_empty() {
+            internal_function_targets
+                .entry(format!("{}.{}", function.module_alias, function.name))
+                .or_default()
+                .push(function.storage_index);
+        }
+    }
     let mut fingerprint_hasher = DefaultHasher::new();
-    format!("{structs:?}|{global_types:?}|{constants:?}|{resolved_externs:?}|{extern_effects:?}")
+    format!("{structs:?}|{global_types:?}|{constants:?}|{resolved_externs:?}|{extern_effects:?}|{internal_function_targets:?}")
         .hash(&mut fingerprint_hasher);
     let fingerprint = fingerprint_hasher.finish();
     Ok(AnalysisContext {
@@ -1024,6 +1038,7 @@ fn build_context<'a>(
         constants,
         view_parameters_by_function,
         fixed_parameter_capacities,
+        internal_function_targets,
         extern_functions,
         extern_effects,
         collection_capacities,
@@ -1504,37 +1519,59 @@ fn analyze_expression(
                         .map(|argument| expression_effect_path(argument, context, locals, aliases))
                         .collect(),
                 );
-            } else if let Some(capability) = builtin_host_effect(target) {
-                effects.host_calls.insert(target.clone());
-                effects.host_effects.insert(FunctionHostEffect {
-                    function: target.clone(),
-                    capability: capability.to_string(),
-                });
-                effects.record_host_call(target);
-            } else if context.extern_functions.contains(target) {
-                effects.host_calls.insert(target.clone());
-                let capabilities = context.extern_effects.get(target).and_then(Option::as_ref);
-                if capabilities.is_none() {
+            } else {
+                let mut handled = false;
+                let mut host_call = false;
+                if let Some(capability) = builtin_host_effect(target) {
+                    handled = true;
+                    host_call = true;
+                    effects.host_calls.insert(target.clone());
+                    effects.host_effects.insert(FunctionHostEffect {
+                        function: target.clone(),
+                        capability: capability.to_string(),
+                    });
+                }
+                if context.extern_functions.contains(target) {
+                    handled = true;
+                    host_call = true;
+                    effects.host_calls.insert(target.clone());
+                    let capabilities = context.extern_effects.get(target).and_then(Option::as_ref);
+                    if capabilities.is_none() {
+                        effects.host_effects.insert(FunctionHostEffect {
+                            function: target.clone(),
+                            capability: "unknown".to_string(),
+                        });
+                    } else if let Some(capabilities) = capabilities {
+                        effects
+                            .host_effects
+                            .extend(capabilities.iter().map(|capability| FunctionHostEffect {
+                                function: target.clone(),
+                                capability: capability.clone(),
+                            }));
+                    }
+                }
+                if host_call {
+                    effects.record_host_call(target);
+                }
+                if let Some(target_ids) = context.internal_function_targets.get(target) {
+                    handled = true;
+                    effects.calls.insert(target.clone());
+                    let arguments = args
+                        .iter()
+                        .map(|argument| expression_effect_path(argument, context, locals, aliases))
+                        .collect::<Vec<_>>();
+                    for target_id in target_ids {
+                        effects.record_call_site(*target_id, arguments.clone());
+                    }
+                }
+                if !handled && !is_pure_intrinsic(target) {
+                    effects.host_calls.insert(target.clone());
                     effects.host_effects.insert(FunctionHostEffect {
                         function: target.clone(),
                         capability: "unknown".to_string(),
                     });
-                } else if let Some(capabilities) = capabilities {
-                    effects
-                        .host_effects
-                        .extend(capabilities.iter().map(|capability| FunctionHostEffect {
-                            function: target.clone(),
-                            capability: capability.clone(),
-                        }));
+                    effects.record_host_call(target);
                 }
-                effects.record_host_call(target);
-            } else if !is_pure_intrinsic(target) {
-                effects.host_calls.insert(target.clone());
-                effects.host_effects.insert(FunctionHostEffect {
-                    function: target.clone(),
-                    capability: "unknown".to_string(),
-                });
-                effects.record_host_call(target);
             }
             for (index, argument) in args.iter().enumerate() {
                 let is_view = target_id

--- a/crates/stasis_compiler/src/frontend/formatter.rs
+++ b/crates/stasis_compiler/src/frontend/formatter.rs
@@ -1113,6 +1113,15 @@ mod tests {
     }
 
     #[test]
+    fn preserves_canonical_effect_attribute_placement_and_regions() {
+        let source = "function @effects(state.enemies,state.projectiles)tick():void{return;}";
+        let expected =
+            "function @effects(state.enemies, state.projectiles) tick(): void {\n    return;\n}\n";
+        assert_eq!(format_source(source).expect("format effects"), expected);
+        assert_eq!(format_source(expected).expect("reformat effects"), expected);
+    }
+
+    #[test]
     fn keeps_commented_imports_in_one_group() {
         let source = "import\"a.stasis\";// first\nimport \"b.stasis\";/* second */\nfunction main():i32{return 0;}";
         let expected = "import \"a.stasis\"; // first\nimport \"b.stasis\"; /* second */\n\nfunction main(): i32 {\n    return 0;\n}\n";

--- a/crates/stasis_compiler/src/frontend/indexer.rs
+++ b/crates/stasis_compiler/src/frontend/indexer.rs
@@ -17,6 +17,7 @@ pub struct IndexedFunction {
     pub param_type_names: Vec<String>,
     pub return_type: TypeId,
     pub inline: bool,
+    pub effect_contract: Option<Vec<String>>,
     pub dependencies: Vec<IndexedCallDependency>,
 }
 
@@ -70,6 +71,7 @@ pub fn index_file(source: &str, types: &mut TypeTable) -> Result<Vec<IndexedFunc
             .annotations
             .iter()
             .any(|annotation| annotation.name == "inline");
+        let effect_contract = parse_effect_contract(&function.annotations)?;
         let signature_hash = hash_signature(name_hash, &params, return_type, inline);
         let body_text = source
             .get(function.body_range.clone())
@@ -89,6 +91,7 @@ pub fn index_file(source: &str, types: &mut TypeTable) -> Result<Vec<IndexedFunc
             param_type_names,
             return_type,
             inline,
+            effect_contract,
             dependencies,
         });
     }
@@ -118,6 +121,51 @@ fn hash_signature(name_hash: u64, params: &[TypeId], return_type: TypeId, inline
         .wrapping_mul(1099511628211)
         .wrapping_add(u64::from(inline));
     hash
+}
+
+fn parse_effect_contract(
+    annotations: &[crate::frontend::parser::ParsedFunctionAnnotation],
+) -> Result<Option<Vec<String>>, String> {
+    let mut matches = annotations
+        .iter()
+        .filter(|annotation| annotation.name == "effects");
+    let Some(annotation) = matches.next() else {
+        return Ok(None);
+    };
+    if matches.next().is_some() {
+        return Err("a function may declare @effects only once".to_string());
+    }
+    if !annotation.has_parentheses {
+        return Err("@effects requires parentheses, for example @effects(graphics)".to_string());
+    }
+    let mut regions = Vec::with_capacity(annotation.arguments.len());
+    for argument in &annotation.arguments {
+        let region = argument.text.trim();
+        if region.contains('[') || region.contains(']') || region.contains('*') {
+            return Err(format!(
+                "@effects region '{region}' cannot use an index or wildcard; name the collection region instead"
+            ));
+        }
+        if region.is_empty()
+            || region.split('.').any(|segment| {
+                segment.is_empty()
+                    || !segment.bytes().enumerate().all(|(index, byte)| {
+                        byte == b'_'
+                            || byte.is_ascii_alphabetic()
+                            || (index > 0 && byte.is_ascii_digit())
+                    })
+            })
+        {
+            return Err(format!(
+                "@effects region '{region}' must be a statically named global path or host capability"
+            ));
+        }
+        if regions.iter().any(|existing| existing == region) {
+            return Err(format!("duplicate @effects region '{region}'"));
+        }
+        regions.push(region.to_string());
+    }
+    Ok(Some(regions))
 }
 
 fn collect_dependencies(body_text: &str) -> Result<Vec<IndexedCallDependency>, String> {
@@ -207,6 +255,43 @@ mod tests {
             types.resolve("i32").unwrap_or_default()
         );
         assert!(!indexed[0].inline);
+        assert_eq!(indexed[0].effect_contract, None);
+    }
+
+    #[test]
+    fn indexes_effect_contract_without_changing_runtime_identity() {
+        let mut types = TypeTable::new();
+        let plain = index_file("function render(): void { return; }", &mut types).unwrap();
+        let restricted = index_file(
+            "function @effects(graphics, state.ui) render(): void { return; }",
+            &mut types,
+        )
+        .unwrap();
+        assert_eq!(
+            restricted[0].effect_contract,
+            Some(vec!["graphics".to_string(), "state.ui".to_string()])
+        );
+        assert_eq!(plain[0].signature_hash, restricted[0].signature_hash);
+    }
+
+    #[test]
+    fn rejects_indexed_and_duplicate_effect_regions() {
+        let mut types = TypeTable::new();
+        let indexed = index_file(
+            "function @effects(state.enemies[0]) tick(): void { return; }",
+            &mut types,
+        )
+        .unwrap_err();
+        assert!(indexed.contains("name the collection region"), "{indexed}");
+        let duplicate = index_file(
+            "function @effects(state, state) tick(): void { return; }",
+            &mut types,
+        )
+        .unwrap_err();
+        assert!(
+            duplicate.contains("duplicate @effects region"),
+            "{duplicate}"
+        );
     }
 
     #[test]

--- a/crates/stasis_compiler/src/frontend/parser.rs
+++ b/crates/stasis_compiler/src/frontend/parser.rs
@@ -1114,6 +1114,19 @@ fn parse_function_annotations(
                 }
             }
             let next_cursor = skip_parenthesized_tokens(tokens, cursor)?;
+            if annotation_name == "effects" {
+                arguments = parse_effect_annotation_arguments(
+                    source,
+                    &tokens[cursor + 1..next_cursor - 1],
+                )?;
+                cursor = next_cursor;
+                annotations.push(ParsedFunctionAnnotation {
+                    name: annotation_name.to_string(),
+                    has_parentheses,
+                    arguments,
+                });
+                continue;
+            }
             let mut expects_argument = true;
             for token in &tokens[cursor + 1..next_cursor - 1] {
                 if token.kind == TokenKind::Comma {
@@ -1155,6 +1168,37 @@ fn parse_function_annotations(
         });
     }
     Ok((cursor, extern_symbol, annotations))
+}
+
+fn parse_effect_annotation_arguments(
+    source: &str,
+    tokens: &[Token],
+) -> Result<Vec<ParsedFunctionAnnotationArgument>, String> {
+    if tokens.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut arguments = Vec::new();
+    let mut start = 0usize;
+    for end in 0..=tokens.len() {
+        if end < tokens.len() && tokens[end].kind != TokenKind::Comma {
+            continue;
+        }
+        if start == end {
+            return Err("annotation '@effects' has an empty argument".to_string());
+        }
+        let first = tokens[start];
+        let last = tokens[end - 1];
+        arguments.push(ParsedFunctionAnnotationArgument {
+            kind: if start + 1 == end && first.kind == TokenKind::Identifier {
+                ParsedFunctionAnnotationArgumentKind::Identifier
+            } else {
+                ParsedFunctionAnnotationArgumentKind::Other
+            },
+            text: source[first.start..last.end].to_string(),
+        });
+        start = end + 1;
+    }
+    Ok(arguments)
 }
 
 fn parse_extern_symbol_annotation(

--- a/docs/function_data_flow.md
+++ b/docs/function_data_flow.md
@@ -11,7 +11,8 @@ Each summary contains deterministic source identity plus `direct` and `aggregate
 - `parameter_reads` and `parameter_writes` describe view/reference parameters by source name. When
   one function calls another, the aggregate summary substitutes those effects onto the caller's
   concrete state path for both receiver and function-form calls.
-- `calls` lists Stasis callees. `host_calls` lists extern or host-resolved calls.
+- `calls` lists Stasis callees. `host_calls` lists extern or host-resolved calls, while
+  `host_effects` pairs each call with its authoritative capability (or `unknown`).
 - `bounded_iterations` records `for` conditions and `foreach` collection bounds. A proven static
   maximum is included when the compiler can derive one; otherwise it is `null` rather than guessed.
 - `aggregate` includes effects from the transitive Stasis call graph and is cycle-safe.
@@ -19,6 +20,13 @@ Each summary contains deterministic source identity plus `direct` and `aggregate
 Function identity uses a project-relative file path in CLI output, body source offsets, and a
 lossless 16-digit hexadecimal signature hash. Structured statements are cached by function body and
 shared with lowering, so unchanged functions are not reparsed to produce summaries.
+
+The compiler enforces optional `function @effects(...)` assertions directly from these summaries.
+Global/parameter paths use the same alias substitution as tooling, and host metadata participates in
+the context fingerprint. Contract-only edits revalidate cached summaries without changing runtime
+identity or code generation. A deep callee, resolved overload, imported call edge, alias path, or
+extern metadata change rebuilds the affected aggregate before a JIT/AOT candidate can publish.
+Contract diagnostics reconstruct the resolved causal call chain; there is no second effect scanner.
 
 Language tooling can consume `Compiler::function_data_flow_summaries`. Runtime-backed tools can use
 `JitProcess::function_data_flow_summaries`. `stasis inspect --json` exposes the same values under

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -571,6 +571,47 @@ contracts. Ordinary internal functions may be added, removed, renamed, or change
 a live edit because the compiler rebuilds every reachable caller in the same candidate generation.
 The host must not retain any compiled entry address after the execution window that resolved it.
 
+### 7.7 Opt-in effect contracts
+
+`@effects(...)` is an optional compile-time assertion on a function boundary. It follows the
+existing function-attribute grammar:
+
+```stasis
+function @effects(state) tick(): i32 { update_game(); return 0; }
+function @effects(graphics) render(): i32 { draw_game(); return 0; }
+```
+
+Unannotated functions remain valid. Helpers called from an annotated boundary do not need their own
+annotations: the contract covers the complete resolved call tree, including imported and receiver-
+form calls, overloads, recursion, and mutually recursive groups. Reads and local mutation are always
+allowed. Successful compilation adds no runtime check.
+
+Named regions are literal global paths. `state` permits writes anywhere below the global named
+`state`; `state.enemies` permits assignment of that collection, its length and element storage, and
+nested element fields, while rejecting writes to `state.player` or another global. Multiple regions
+compose. Indexed and wildcard contracts such as `state.enemies[0]` and `state.enemies[*]` are invalid
+because the named collection region already covers every element.
+
+Host capabilities are `graphics`, `audio`, `storage`, `network`, `nondeterministic`, `platform`,
+`memory`, and `code_swap`. Standard-library extern declarations provide authoritative capability
+metadata. An extern without metadata is `unknown` and is rejected beneath every restricted
+boundary. `graphics` includes writes to the compiler-owned graphics command buffers, and `platform`
+includes writes to the compiler-owned window-request mailbox; neither capability permits an
+application global with the same name. Parameter-relative writes are substituted at each resolved call
+site; if the compiler cannot prove their global root, a restricted boundary rejects them.
+
+Diagnostics identify the annotated boundary, rejected path or host capability, originating host
+operation when applicable, and a causal function chain. Contract-only edits revalidate the existing
+summary without changing runtime function identity or forcing code generation. Resolved-call, alias,
+extern-metadata, and reachable-callee changes invalidate the aggregate before validation. JIT
+candidates are checked before publication, so rejection leaves the prior generation active; JIT
+and AOT use the same check.
+
+`on_code_swap` is unannotated by default because migration policy is application-specific. When it
+is annotated, it must explicitly name every state region and the `code_swap` capability needed to
+restore invariants or call `reject_code_swap`. A future read-only refinement may narrow reads, but
+reads require no annotation in this version.
+
 ## 8. Enums
 
 Enums are named types that lower to integer values.

--- a/samples/effect_contract/src/main.stasis
+++ b/samples/effect_contract/src/main.stasis
@@ -1,0 +1,24 @@
+struct GameState {
+    value: i32;
+}
+
+global state: GameState;
+
+function advance(value: GameState): void {
+    value.value += 1;
+}
+
+function @effects(state) tick(): i32 {
+    state.advance();
+    return 0;
+}
+
+function @effects(graphics) render(): i32 {
+    return state.value;
+}
+
+function main(): i32 {
+    state.value = 41;
+    tick();
+    return render();
+}

--- a/samples/effect_contract/stasis.json
+++ b/samples/effect_contract/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "effect_contract",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build"
+}

--- a/samples/effect_contract/tests/main.test.stasis
+++ b/samples/effect_contract/tests/main.test.stasis
@@ -1,0 +1,7 @@
+import "../src/main.stasis";
+
+test `state boundary updates through alias`(): bool {
+    state.value = 9;
+    tick();
+    return state.value == 10;
+}

--- a/src/stdlib/asset_tasks.stasis
+++ b/src/stdlib/asset_tasks.stasis
@@ -85,14 +85,14 @@ function successful(self: LoadingProgress): bool {
     return self.complete() && self.failed_count == 0;
 }
 
-function @extern("stasis_jit_asset_request_sprite") asset_request_sprite(path: string, width: i32, height: i32): i32;
-function @extern("stasis_jit_asset_request_audio") asset_request_audio(path: string): i32;
-function @extern("stasis_jit_asset_task_poll") asset_task_state(request: i32): AssetState;
-function @extern("stasis_jit_asset_task_take_handle") asset_task_take_handle(request: i32): i32;
-function @extern("stasis_jit_asset_task_cancel") asset_task_cancel(request: i32): void;
-function @extern("stasis_jit_gfx_release_sprite") gfx_release_sprite(handle: i32): void;
+function @effects(graphics)@extern("stasis_jit_asset_request_sprite") asset_request_sprite(path: string, width: i32, height: i32): i32;
+function @effects(audio)@extern("stasis_jit_asset_request_audio") asset_request_audio(path: string): i32;
+function @effects(platform)@extern("stasis_jit_asset_task_poll") asset_task_state(request: i32): AssetState;
+function @effects(platform)@extern("stasis_jit_asset_task_take_handle") asset_task_take_handle(request: i32): i32;
+function @effects(platform)@extern("stasis_jit_asset_task_cancel") asset_task_cancel(request: i32): void;
+function @effects(graphics)@extern("stasis_jit_gfx_release_sprite") gfx_release_sprite(handle: i32): void;
 
-extern function audio_release(asset_handle: i32): void;
+extern function @effects(audio) audio_release(asset_handle: i32): void;
 
 function @asset_path(path) load_image(self: ImageAsset, path: string, width: i32, height: i32): bool {
     self.release();

--- a/src/stdlib/audio.stasis
+++ b/src/stdlib/audio.stasis
@@ -44,30 +44,30 @@ function set_music_volume(self: AudioAsset, volume: f32): void {
 // Audio/runtime bindings (marker module).
 // From a generated project: import "/vendor/stasis/stdlib/audio.stasis";
 
-extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
-extern function audio_shutdown(): void;
-extern function audio_is_available(): bool;
-extern function audio_get_sample_rate(): i32;
-extern function audio_get_channels(): i32;
-extern function audio_get_queued_frames(): i32;
-extern function audio_get_underruns(): i32;
-extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
+extern function @effects(audio) audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
+extern function @effects(audio) audio_shutdown(): void;
+extern function @effects(audio) audio_is_available(): bool;
+extern function @effects(audio) audio_get_sample_rate(): i32;
+extern function @effects(audio) audio_get_channels(): i32;
+extern function @effects(audio) audio_get_queued_frames(): i32;
+extern function @effects(audio) audio_get_underruns(): i32;
+extern function @effects(audio) audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
 
 // Bounded audio assets are decoded outside deterministic Stasis state. audio_load_wav accepts
 // mono or stereo little-endian PCM16 WAV files. The music/effect helpers accept WAV or MP3.
 // Compressed input stays compressed on disk and is decoded into bounded host memory at load.
-extern function @asset_path(path) audio_load_wav(path: string): i32;
-extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
-extern function audio_stop(voice_handle: i32): void;
-extern function audio_voice_is_playing(voice_handle: i32): bool;
-extern function audio_voice_set_paused(voice_handle: i32, paused: bool): void;
-extern function audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
+extern function @effects(audio)@asset_path(path) audio_load_wav(path: string): i32;
+extern function @effects(audio) audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
+extern function @effects(audio) audio_stop(voice_handle: i32): void;
+extern function @effects(audio) audio_voice_is_playing(voice_handle: i32): bool;
+extern function @effects(audio) audio_voice_set_paused(voice_handle: i32, paused: bool): void;
+extern function @effects(audio) audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
 
 // Brickout-compatible category helpers backed by the same SDL host mixer.
-function @asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
-function @asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
-function @extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
-function @extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
-function @extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;
-function @extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(asset_handle: i32, volume: f32): void;
-function @extern("stasis_jit_audio_play_effect") audio_play_effect(asset_handle: i32, volume: f32): bool;
+function @effects(audio)@asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
+function @effects(audio)@asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
+function @effects(audio)@extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
+function @effects(audio)@extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
+function @effects(audio)@extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;
+function @effects(audio)@extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(asset_handle: i32, volume: f32): void;
+function @effects(audio)@extern("stasis_jit_audio_play_effect") audio_play_effect(asset_handle: i32, volume: f32): bool;

--- a/src/stdlib/clipboard.stasis
+++ b/src/stdlib/clipboard.stasis
@@ -1,7 +1,7 @@
 // Bounded printable-ASCII clipboard access for player-entered share codes.
 // Loading returns the byte length, or -1 when unavailable, invalid, or too large.
-function @extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
-function @extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
+function @effects(platform)@extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
+function @effects(platform)@extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
 
 function clipboard_load_ascii(out: ascii[]): i32 {
     out.length = 0;

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -13,7 +13,7 @@ import "internal/gfx_cmd.stasis";
 import "internal/host_window_request.stasis";
 import "asset_tasks.stasis";
 
-extern function sleep_ms(ms: i32): void;
+extern function @effects(nondeterministic) sleep_ms(ms: i32): void;
 
 // Hot-path reads are HostFrame snapshot-only (no host calls).
 function get_time_ms(): i32 {
@@ -25,11 +25,11 @@ function get_time_us(): i32 {
 }
 
 // Startup / assets (host calls; avoid in hot paths)
-extern function gfx_poll_reload(handle: i32): bool;
-extern function gfx_dump_bmp(path: string): i32;
-extern function gfx_dump_png(path: string): i32;
-extern function @asset_path(path) load_font(path: string, size: i32): i32;
-extern function measure_text(font: i32, text: string): f32;
+extern function @effects(graphics) gfx_poll_reload(handle: i32): bool;
+extern function @effects(graphics, storage) gfx_dump_bmp(path: string): i32;
+extern function @effects(graphics, storage) gfx_dump_png(path: string): i32;
+extern function @effects(graphics)@asset_path(path) load_font(path: string, size: i32): i32;
+extern function @effects(graphics) measure_text(font: i32, text: string): f32;
 
 struct Sprite {
     handle: i32;
@@ -65,8 +65,18 @@ struct SpriteSheet {
     cell_height: i32;
 }
 
-function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
-function @extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(self: SpriteSheet, path: string, width: i32, height: i32): bool;
+function @effects(graphics)@asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(
+    self: Sprite,
+    path: string,
+    width: i32,
+    height: i32
+): bool;
+function @effects(graphics)@extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(
+    self: SpriteSheet,
+    path: string,
+    width: i32,
+    height: i32
+): bool;
 
 function publish(self: ImageAsset, target: Sprite): bool {
     if (!self.ready()) {
@@ -202,7 +212,7 @@ function finished(self: AnimationClip, elapsed_ticks: i32): bool {
     return animation_finished(self.frame_count, self.ticks_per_frame, self.playback_mode, elapsed_ticks);
 }
 
-function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
+function @effects(graphics)@extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
 
 function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     if (self.font <= 0 || self.handle <= 0) {

--- a/src/stdlib/memory.stasis
+++ b/src/stdlib/memory.stasis
@@ -4,12 +4,12 @@
 // - explicit capacities for bounds checking
 // - clamped and/or checked variants
 
-extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
-extern function sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
-extern function sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
-extern function sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
-extern function sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
-extern function sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
 
 // Copy `count` bytes from src to dst, clamped to both buffers.
 // Returns bytes copied.

--- a/src/stdlib/stdlib.stasis
+++ b/src/stdlib/stdlib.stasis
@@ -6,7 +6,7 @@
 import "memory.stasis";
 
 // Abort the current hot swap after on_code_swap restores any application invariants it can.
-extern function reject_code_swap(): void;
+extern function @effects(code_swap) reject_code_swap(): void;
 
 // Bootstrap provides type-specific host functions behind one source-level overload family.
 function print(value: i32): void {

--- a/src/stdlib/storage.stasis
+++ b/src/stdlib/storage.stasis
@@ -1,13 +1,13 @@
 // Small durable integer preferences for game progression and settings.
 // Scope and key must be 1..63 ASCII letters, digits, underscores, or hyphens.
 // Missing, invalid, or corrupt values return the caller-provided fallback.
-extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
-extern function storage_save_i32(scope: string, key: string, value: i32): bool;
+extern function @effects(storage) storage_load_i32(scope: string, key: string, fallback: i32): i32;
+extern function @effects(storage) storage_save_i32(scope: string, key: string, value: i32): bool;
 
 // Bounded durable ASCII values for share codes and other small text payloads.
 // Returns the byte length, or -1 when the value is missing, invalid, or does not fit.
-function @extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
-function @extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
+function @effects(storage)@extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
+function @effects(storage)@extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
 
 function storage_load_ascii(scope: string, key: string, out: ascii[]): i32 {
     out.length = 0;


### PR DESCRIPTION
## Summary

- add opt-in `@effects(...)` contracts for named global regions and host capabilities
- enforce transitive alias-aware effects before JIT/AOT candidate publication
- annotate stdlib host boundaries and generate narrow `tick`/`render` contracts in `stasis new`
- add an executable effect-contract sample, docs, and deterministic parser/compiler/JIT/AOT tests

## Behavior

Unannotated functions remain compatible. Restricted functions may read any state but may write only declared regions and invoke only declared host capabilities. Diagnostics report the rejected effect and causal call chain. Contract-only edits revalidate cached analysis without changing runtime identity or forcing code generation.

The graphical template retains the existing lifecycle `i32` ABI; changing it to `void` is outside this compiler slice.

## Validation

- `cargo test -p stasis_compiler effect_contract`: 11 passed
- compiler library suite: 558 passed, 2 environment-dependent cases filtered (unavailable Windows linker; host audio availability)
- `cargo check --workspace --all-targets`: passed
- `stasis check --workspace samples/effect_contract`: passed
- `stasis test --workspace samples/effect_contract`: 1 passed
- release sample built and exited with code 42
- ChessTD migration checked successfully with `tick` and `render` contracts
- independent Luna max review: clean after overload and unresolved-call fixes

`tools/validate_repo.sh` could not start because this Windows Git Bash environment lacks its normal `dirname` and `python3` commands; the relevant wrapped Cargo and formatting checks were run directly.

Maddox task: #261
