### PR TITLE
StasisLang: generation-safe sprite release lifecycle

### DIFF
--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -783,6 +783,8 @@ pub fn run_android_workshop_tick(
 
 const MAX_EMBEDDED_FONTS: usize = 64;
 const MAX_EMBEDDED_TEXT_RUNS: usize = 4096;
+const MAX_EMBEDDED_SPRITES: usize = 4096;
+const MAX_PENDING_SPRITE_RELEASES: usize = 256;
 
 #[derive(Clone)]
 struct EmbeddedFont {
@@ -800,11 +802,20 @@ struct EmbeddedTextRun {
     measured_height: f32,
 }
 
+#[derive(Clone)]
+struct EmbeddedSpriteRef {
+    handle: i32,
+    refs: usize,
+}
+
 struct EmbeddedResourceCatalog {
     project_root: PathBuf,
     assets: ResolvedAssetManifest,
     fonts: Vec<EmbeddedFont>,
     text_runs: Vec<EmbeddedTextRun>,
+    sprite_refs: Vec<EmbeddedSpriteRef>,
+    pending_sprite_releases: Vec<i32>,
+    pending_sprite_release_cancellations: Vec<i32>,
     error: Option<String>,
 }
 
@@ -820,7 +831,7 @@ fn install_embedded_resource_host(project_root: &Path) -> Result<(), String> {
         .map_err(|_| "embedded resource catalog mutex poisoned")? = Some(catalog);
     stasis_dynload::set_embedded_graphics_host(Some(stasis_dynload::EmbeddedGraphicsHost {
         load_sprite: embedded_load_sprite,
-        release_sprite: |_| {},
+        release_sprite: embedded_release_sprite,
         load_font: embedded_load_font,
         measure_text: embedded_measure_text,
         cache_text: embedded_cache_text,
@@ -848,23 +859,43 @@ fn prepare_embedded_resource_catalog(
             assets: Vec::new(),
         }
     };
-    let (fonts, text_runs) = if preserve_loaded_resources {
+    let (
+        fonts,
+        text_runs,
+        sprite_refs,
+        pending_sprite_releases,
+        pending_sprite_release_cancellations,
+    ) = if preserve_loaded_resources {
         let slot = embedded_resource_catalog()
             .lock()
             .map_err(|_| "embedded resource catalog mutex poisoned")?;
         slot.as_ref()
             .filter(|catalog| catalog.project_root == project_root)
-            .map(|catalog| (catalog.fonts.clone(), catalog.text_runs.clone()))
+            .map(|catalog| {
+                (
+                    catalog.fonts.clone(),
+                    catalog.text_runs.clone(),
+                    catalog.sprite_refs.clone(),
+                    catalog.pending_sprite_releases.clone(),
+                    catalog.pending_sprite_release_cancellations.clone(),
+                )
+            })
             .unwrap_or_else(|| {
                 (
                     Vec::with_capacity(MAX_EMBEDDED_FONTS),
                     Vec::with_capacity(MAX_EMBEDDED_TEXT_RUNS),
+                    Vec::with_capacity(MAX_EMBEDDED_SPRITES),
+                    Vec::with_capacity(MAX_PENDING_SPRITE_RELEASES),
+                    Vec::with_capacity(MAX_EMBEDDED_SPRITES),
                 )
             })
     } else {
         (
             Vec::with_capacity(MAX_EMBEDDED_FONTS),
             Vec::with_capacity(MAX_EMBEDDED_TEXT_RUNS),
+            Vec::with_capacity(MAX_EMBEDDED_SPRITES),
+            Vec::with_capacity(MAX_PENDING_SPRITE_RELEASES),
+            Vec::with_capacity(MAX_EMBEDDED_SPRITES),
         )
     };
     Ok(EmbeddedResourceCatalog {
@@ -872,6 +903,9 @@ fn prepare_embedded_resource_catalog(
         assets,
         fonts,
         text_runs,
+        sprite_refs,
+        pending_sprite_releases,
+        pending_sprite_release_cancellations,
         error: None,
     })
 }
@@ -939,8 +973,146 @@ fn embedded_load_sprite(path: &[u8], _max_w: i32, _max_h: i32) -> i32 {
             catalog,
             format!("sprite is not declared in the asset manifest: {display_path}"),
         );
+    } else if !embedded_acquire_sprite(catalog, handle) {
+        return 0;
     }
     handle
+}
+
+fn embedded_acquire_sprite(catalog: &mut EmbeddedResourceCatalog, handle: i32) -> bool {
+    if let Some(index) = catalog
+        .sprite_refs
+        .iter()
+        .position(|entry| entry.handle == handle)
+    {
+        let Some(next_refs) = catalog.sprite_refs[index].refs.checked_add(1) else {
+            set_embedded_resource_error(catalog, "sprite reference count overflow".to_string());
+            return false;
+        };
+        let cancellation_queued = catalog
+            .pending_sprite_release_cancellations
+            .contains(&handle);
+        if !cancellation_queued
+            && catalog.pending_sprite_release_cancellations.len() >= MAX_EMBEDDED_SPRITES
+        {
+            set_embedded_resource_error(
+                catalog,
+                "pending sprite release cancellation queue is full".to_string(),
+            );
+            return false;
+        }
+        catalog.sprite_refs[index].refs = next_refs;
+        catalog
+            .pending_sprite_releases
+            .retain(|queued| *queued != handle);
+        if !cancellation_queued {
+            catalog.pending_sprite_release_cancellations.push(handle);
+        }
+        return true;
+    }
+
+    let cancellation_queued = catalog
+        .pending_sprite_release_cancellations
+        .contains(&handle);
+    if !cancellation_queued
+        && catalog.pending_sprite_release_cancellations.len() >= MAX_EMBEDDED_SPRITES
+    {
+        set_embedded_resource_error(
+            catalog,
+            "pending sprite release cancellation queue is full".to_string(),
+        );
+        return false;
+    }
+    if catalog.sprite_refs.len() >= MAX_EMBEDDED_SPRITES {
+        set_embedded_resource_error(catalog, "sprite registry is full".to_string());
+        return false;
+    }
+    if !cancellation_queued {
+        catalog.pending_sprite_release_cancellations.push(handle);
+    }
+    catalog
+        .sprite_refs
+        .push(EmbeddedSpriteRef { handle, refs: 1 });
+    true
+}
+
+fn embedded_release_sprite(handle: i32) {
+    if handle == 0 {
+        return;
+    }
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return;
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return;
+    };
+    let Some(index) = catalog
+        .sprite_refs
+        .iter()
+        .position(|entry| entry.handle == handle)
+    else {
+        // Handles supplied directly by raw code were never acquired by this
+        // typed ownership table and are deliberately ignored.
+        return;
+    };
+    if catalog.sprite_refs[index].refs == 0 {
+        return;
+    }
+    catalog.sprite_refs[index].refs -= 1;
+    if catalog.sprite_refs[index].refs != 0 {
+        return;
+    }
+    if catalog.pending_sprite_releases.contains(&handle) {
+        return;
+    }
+    if catalog.pending_sprite_releases.len() >= MAX_EMBEDDED_SPRITES {
+        set_embedded_resource_error(catalog, "pending sprite release queue is full".to_string());
+        return;
+    }
+    catalog
+        .pending_sprite_release_cancellations
+        .retain(|queued| *queued != handle);
+    catalog.pending_sprite_releases.push(handle);
+}
+
+fn take_embedded_sprite_releases() -> Vec<i32> {
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return Vec::new();
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return Vec::new();
+    };
+    let count = catalog
+        .pending_sprite_releases
+        .len()
+        .min(MAX_PENDING_SPRITE_RELEASES);
+    let releases = catalog
+        .pending_sprite_releases
+        .drain(..count)
+        .collect::<Vec<_>>();
+    for handle in &releases {
+        catalog
+            .sprite_refs
+            .retain(|entry| entry.handle != *handle || entry.refs != 0);
+    }
+    releases
+}
+
+fn take_embedded_sprite_release_cancellations() -> Vec<i32> {
+    let Ok(mut slot) = embedded_resource_catalog().lock() else {
+        return Vec::new();
+    };
+    let Some(catalog) = slot.as_mut() else {
+        return Vec::new();
+    };
+    let count = catalog
+        .pending_sprite_release_cancellations
+        .len()
+        .min(MAX_PENDING_SPRITE_RELEASES);
+    catalog
+        .pending_sprite_release_cancellations
+        .drain(..count)
+        .collect()
 }
 
 fn embedded_load_font(path: &[u8], size: i32) -> i32 {
@@ -2631,6 +2803,27 @@ pub extern "C" fn stasis_android_bridge_resolve_sprite_asset(
         .into_raw()
 }
 
+/// Drain typed sprite releases produced by the Android JIT. The stable
+/// manifest handles are returned as a bounded JSON array and are consumed by
+/// the Workshop GL thread; an empty array is a successful no-op.
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_drain_sprite_releases() -> *mut c_char {
+    let releases = take_embedded_sprite_releases();
+    CString::new(serde_json::json!({ "status": "ok", "handles": releases }).to_string())
+        .unwrap_or_else(|_| CString::new("{\"status\":\"ok\",\"handles\":[]}").unwrap())
+        .into_raw()
+}
+
+/// Drain typed sprite release cancellations produced after a stable handle was
+/// reacquired before its previously delivered GL release was applied.
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_poll_sprite_release_cancellations() -> *mut c_char {
+    let handles = take_embedded_sprite_release_cancellations();
+    CString::new(serde_json::json!({ "status": "ok", "handles": handles }).to_string())
+        .unwrap_or_else(|_| CString::new("{\"status\":\"ok\",\"handles\":[]}").unwrap())
+        .into_raw()
+}
+
 #[no_mangle]
 pub extern "C" fn stasis_android_bridge_resolve_cached_text(
     project_root: *const c_char,
@@ -2711,6 +2904,142 @@ pub extern "C" fn stasis_android_bridge_free_string(value: *mut c_char) {
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn typed_sprite_release_refcounts_and_cancels_pending_event_on_reacquire() {
+        let root = std::env::temp_dir().join("stasis_android_sprite_release_refs");
+        let catalog = EmbeddedResourceCatalog {
+            project_root: root,
+            assets: ResolvedAssetManifest {
+                manifest_path: PathBuf::new(),
+                dynamic_assets: Default::default(),
+                assets: Vec::new(),
+            },
+            fonts: Vec::new(),
+            text_runs: Vec::new(),
+            sprite_refs: vec![EmbeddedSpriteRef {
+                handle: 17,
+                refs: 2,
+            }],
+            pending_sprite_releases: Vec::new(),
+            pending_sprite_release_cancellations: Vec::new(),
+            error: None,
+        };
+        *embedded_resource_catalog().lock().unwrap() = Some(catalog);
+        embedded_release_sprite(17);
+        assert!(take_embedded_sprite_releases().is_empty());
+        embedded_release_sprite(17);
+        // A zero-reference handle queues exactly once, and a reacquisition
+        // removes that event before it can reach the GL thread.
+        let mut slot = embedded_resource_catalog().lock().unwrap();
+        let catalog = slot.as_mut().unwrap();
+        assert!(embedded_acquire_sprite(catalog, 17));
+        drop(slot);
+        assert!(take_embedded_sprite_releases().is_empty());
+        embedded_release_sprite(17);
+        assert_eq!(take_embedded_sprite_releases(), vec![17]);
+        let mut slot = embedded_resource_catalog().lock().unwrap();
+        let catalog = slot.as_mut().unwrap();
+        assert!(embedded_acquire_sprite(catalog, 17));
+        drop(slot);
+        assert_eq!(take_embedded_sprite_release_cancellations(), vec![17]);
+        embedded_release_sprite(17);
+        assert_eq!(take_embedded_sprite_releases(), vec![17]);
+    }
+
+    #[test]
+    fn typed_sprite_release_refcount_overflow_is_a_resource_error() {
+        let mut catalog = EmbeddedResourceCatalog {
+            project_root: PathBuf::new(),
+            assets: ResolvedAssetManifest {
+                manifest_path: PathBuf::new(),
+                dynamic_assets: Default::default(),
+                assets: Vec::new(),
+            },
+            fonts: Vec::new(),
+            text_runs: Vec::new(),
+            sprite_refs: vec![EmbeddedSpriteRef {
+                handle: 31,
+                refs: usize::MAX,
+            }],
+            pending_sprite_releases: Vec::new(),
+            pending_sprite_release_cancellations: Vec::new(),
+            error: None,
+        };
+        assert!(!embedded_acquire_sprite(&mut catalog, 31));
+        assert_eq!(
+            catalog.error.as_deref(),
+            Some("sprite reference count overflow")
+        );
+    }
+
+    #[test]
+    fn typed_sprite_release_delivery_batches_without_loss() {
+        let _guard = bridge_runtime_test_guard();
+        let catalog = EmbeddedResourceCatalog {
+            project_root: PathBuf::new(),
+            assets: ResolvedAssetManifest {
+                manifest_path: PathBuf::new(),
+                dynamic_assets: Default::default(),
+                assets: Vec::new(),
+            },
+            fonts: Vec::new(),
+            text_runs: Vec::new(),
+            sprite_refs: (1..=300)
+                .map(|handle| EmbeddedSpriteRef { handle, refs: 1 })
+                .collect(),
+            pending_sprite_releases: Vec::new(),
+            pending_sprite_release_cancellations: Vec::new(),
+            error: None,
+        };
+        *embedded_resource_catalog().lock().unwrap() = Some(catalog);
+        for handle in 1..=300 {
+            embedded_release_sprite(handle);
+        }
+        let first = take_embedded_sprite_releases();
+        let second = take_embedded_sprite_releases();
+        assert_eq!(first.len(), MAX_PENDING_SPRITE_RELEASES);
+        assert_eq!(first, (1..=256).collect::<Vec<_>>());
+        assert_eq!(second, (257..=300).collect::<Vec<_>>());
+        assert!(take_embedded_sprite_releases().is_empty());
+        *embedded_resource_catalog().lock().unwrap() = None;
+    }
+
+    #[test]
+    fn typed_sprite_release_registry_reuses_slots_after_delivery() {
+        let _guard = bridge_runtime_test_guard();
+        let catalog = EmbeddedResourceCatalog {
+            project_root: PathBuf::new(),
+            assets: ResolvedAssetManifest {
+                manifest_path: PathBuf::new(),
+                dynamic_assets: Default::default(),
+                assets: Vec::new(),
+            },
+            fonts: Vec::new(),
+            text_runs: Vec::new(),
+            sprite_refs: Vec::new(),
+            pending_sprite_releases: Vec::new(),
+            pending_sprite_release_cancellations: Vec::new(),
+            error: None,
+        };
+        *embedded_resource_catalog().lock().unwrap() = Some(catalog);
+        for _ in 0..5000 {
+            let mut slot = embedded_resource_catalog().lock().unwrap();
+            assert!(embedded_acquire_sprite(slot.as_mut().unwrap(), 17));
+            drop(slot);
+            assert_eq!(take_embedded_sprite_release_cancellations(), vec![17]);
+            embedded_release_sprite(17);
+            assert_eq!(take_embedded_sprite_releases(), vec![17]);
+        }
+        assert!(embedded_resource_catalog()
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .sprite_refs
+            .is_empty());
+        *embedded_resource_catalog().lock().unwrap() = None;
+    }
 
     #[test]
     fn android_display_metrics_preserve_logical_canvas_and_round_trip_letterbox() {
@@ -3311,6 +3640,303 @@ mod tests {
         clear_runtime_session_for_test();
     }
 
+    #[test]
+    fn android_jit_typed_sprite_release_reaches_bridge_and_draws_signed_handle() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let source = r#"
+import "/vendor/stasis/stdlib/graphics.stasis";
+
+struct State {
+    sprite: Sprite;
+    loaded: i32;
+    initial_handle: i32;
+    initial_width: i32;
+    initial_height: i32;
+    draw_count: i32;
+    draw_asset: i32;
+    phase: i32;
+}
+
+global state: State;
+
+function main(): void {
+    if (state.sprite.load_sprite_from("assets/ball.svg", 32, 32)) {
+        state.loaded = 1;
+        state.initial_handle = state.sprite.handle;
+        state.initial_width = state.sprite.width;
+        state.initial_height = state.sprite.height;
+    }
+}
+
+function tick(): void {
+    gfx_cmd_begin();
+    state.sprite.draw(4.0, 5.0, 200, 7);
+    state.draw_count = gfx_cmd_sprite_count();
+    state.draw_asset = gfx_cmd_i32[GFX_I_SPRITE_BASE];
+    gfx_cmd_mark_present();
+    if (state.phase == 0) {
+        state.sprite.release();
+        state.phase = 1;
+    } else {
+        state.sprite.release();
+        state.phase = 2;
+    }
+}
+"#;
+        let (root, handle) = write_typed_sprite_project("typed_release", source);
+
+        let _first =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("run typed sprite release tick");
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.draw_count"
+            )
+            .expect("read draw count"),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.draw_asset"
+            )
+            .expect("read draw asset"),
+            handle
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "state.loaded")
+                .expect("read loaded flag"),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.initial_handle",
+            )
+            .expect("read initial handle"),
+            handle
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.initial_width",
+            )
+            .expect("read initial width"),
+            32
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.initial_height",
+            )
+            .expect("read initial height"),
+            32
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.sprite.handle"
+            )
+            .expect("read released handle"),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.sprite.width"
+            )
+            .expect("read released width"),
+            0
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.sprite.height",
+            )
+            .expect("read released height"),
+            0
+        );
+        assert_eq!(
+            ffi_json(stasis_android_bridge_drain_sprite_releases())["handles"],
+            serde_json::json!([handle])
+        );
+
+        let _duplicate =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("run duplicate release tick");
+        assert_eq!(
+            ffi_json(stasis_android_bridge_drain_sprite_releases())["handles"],
+            serde_json::json!([])
+        );
+
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
+    fn android_jit_typed_sprite_release_reacquire_cancels_pending_event() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let source = r#"
+import "/vendor/stasis/stdlib/graphics.stasis";
+
+struct State {
+    sprite: Sprite;
+    loaded: i32;
+    reloaded: i32;
+    reload_handle: i32;
+    reload_width: i32;
+    reload_height: i32;
+    draw_count: i32;
+    draw_asset: i32;
+    phase: i32;
+}
+
+global state: State;
+
+function main(): void {
+    state.phase = 0;
+    if (state.sprite.load_sprite_from("assets/ball.svg", 32, 32)) {
+        state.loaded = 1;
+    }
+}
+
+function tick(): void {
+    gfx_cmd_begin();
+    if (state.phase == 0) {
+        state.sprite.release();
+        if (state.sprite.load_sprite_from("assets/ball.svg", 32, 32)) {
+            state.reloaded = 1;
+            state.reload_handle = state.sprite.handle;
+            state.reload_width = state.sprite.width;
+            state.reload_height = state.sprite.height;
+        }
+        state.sprite.draw(6.0, 7.0, 255, 0);
+        state.draw_count = gfx_cmd_sprite_count();
+        state.draw_asset = gfx_cmd_i32[GFX_I_SPRITE_BASE];
+        state.phase = 1;
+    } else {
+        state.sprite.release();
+        state.phase = 2;
+    }
+    gfx_cmd_mark_present();
+}
+"#;
+        let (root, handle) = write_typed_sprite_project("typed_reacquire", source);
+
+        let _reacquired =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("run same-tick release and reacquire");
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.draw_count"
+            )
+            .expect("read draw count"),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.draw_asset"
+            )
+            .expect("read draw asset"),
+            handle
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "state.loaded")
+                .expect("read loaded flag"),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(&root, Path::new("src/main.stasis"), "state.reloaded")
+                .expect("read reloaded flag"),
+            1
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.reload_handle"
+            )
+            .expect("read reload handle"),
+            handle
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.reload_width"
+            )
+            .expect("read reload width"),
+            32
+        );
+        assert_eq!(
+            get_android_workshop_i32_global(
+                &root,
+                Path::new("src/main.stasis"),
+                "state.reload_height",
+            )
+            .expect("read reload height"),
+            32
+        );
+        assert_eq!(
+            ffi_json(stasis_android_bridge_drain_sprite_releases())["handles"],
+            serde_json::json!([])
+        );
+
+        let _final_release =
+            run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+                .expect("run final release");
+        assert_eq!(
+            ffi_json(stasis_android_bridge_drain_sprite_releases())["handles"],
+            serde_json::json!([handle])
+        );
+        assert_eq!(
+            ffi_json(stasis_android_bridge_drain_sprite_releases())["handles"],
+            serde_json::json!([])
+        );
+
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
+    #[test]
+    fn android_jit_direct_asset_tasks_release_overloads_compile() {
+        let _guard = bridge_runtime_test_guard();
+        clear_runtime_session_for_test();
+        let source = r#"
+import "/vendor/stasis/stdlib/asset_tasks.stasis";
+
+global image: ImageAsset;
+global audio: AudioAsset;
+
+function main(): void {
+    image.release();
+    audio.release();
+}
+
+function tick(): void {}
+"#;
+        let (root, _) = write_typed_sprite_project("direct_asset_tasks_release", source);
+        run_android_workshop_tick(&root, Path::new("src/main.stasis"), default_tick_input())
+            .expect("compile and run direct asset_tasks release overloads");
+        fs::remove_dir_all(&root).ok();
+        clear_runtime_session_for_test();
+    }
+
     fn temp_project(name: &str) -> PathBuf {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -3319,6 +3945,48 @@ mod tests {
         let root = std::env::temp_dir().join(format!("stasis_android_bridge_{name}_{stamp}"));
         fs::create_dir_all(root.join("src")).expect("create project");
         root
+    }
+
+    fn write_typed_sprite_project(name: &str, source: &str) -> (PathBuf, i32) {
+        let root = temp_project(name);
+        let stdlib_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src/stdlib");
+        for (relative, destination) in [
+            ("stdlib.stasis", "stdlib.stasis"),
+            ("memory.stasis", "memory.stasis"),
+            ("graphics.stasis", "graphics.stasis"),
+            ("asset_tasks.stasis", "asset_tasks.stasis"),
+            ("internal/host_frame.stasis", "internal/host_frame.stasis"),
+            ("internal/gfx_cmd.stasis", "internal/gfx_cmd.stasis"),
+            (
+                "internal/host_window_request.stasis",
+                "internal/host_window_request.stasis",
+            ),
+        ] {
+            let target = root.join("vendor/stasis/stdlib").join(destination);
+            fs::create_dir_all(target.parent().expect("stdlib target parent"))
+                .expect("create vendored stdlib directory");
+            fs::copy(stdlib_root.join(relative), target).expect("vendor stdlib source");
+        }
+        fs::create_dir_all(root.join("assets")).expect("create sprite assets");
+        let sprite = include_bytes!(
+            "../../../mobile/android/app/src/main/assets/workshop_sample/assets/ball.svg"
+        );
+        fs::write(root.join("assets/ball.svg"), sprite).expect("write sprite asset");
+        let hash = stasis_assets::sha256_bytes(sprite);
+        fs::write(
+            root.join(stasis_assets::DEFAULT_ASSET_MANIFEST_PATH),
+            format!(r#"{{"schema":"stasis-assets","version":1,"assets":[{{"id":"ball","path":"assets/ball.svg","content_sha256":"{hash}","format":{{"kind":"sprite","encoding":"svg","width":32,"height":32}},"dependencies":[]}}]}}"#),
+        )
+        .expect("write sprite manifest");
+        fs::write(root.join("src/main.stasis"), source).expect("write typed sprite source");
+        let manifest = load_android_workshop_asset_manifest(&root).expect("load sprite manifest");
+        let handle = manifest
+            .by_id("ball")
+            .expect("manifest sprite")
+            .handle
+            .as_i32();
+        assert!(handle < 0, "fixture must exercise signed stable handle");
+        (root, handle)
     }
 
     #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -4506,7 +4506,7 @@ pub extern "C" fn stasis_jit_sprite_load_from(
     struct_view_i32_store(base, index, len, "handle", loaded_handle);
     struct_view_i32_store(base, index, len, "width", width);
     struct_view_i32_store(base, index, len, "height", height);
-    if old_handle != 0 && old_handle != loaded_handle {
+    if old_handle != 0 {
         stasis_jit_gfx_release_sprite(old_handle);
     }
     1
@@ -5719,11 +5719,87 @@ mod tests {
     use super::*;
     use std::sync::MutexGuard;
 
+    static TEST_SPRITE_RELEASES: AtomicUsize = AtomicUsize::new(0);
+
+    fn test_sprite_load(_: &[u8], _: i32, _: i32) -> i32 {
+        77
+    }
+
+    fn test_sprite_release(handle: i32) {
+        if handle == 77 {
+            TEST_SPRITE_RELEASES.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn test_font_load(_: &[u8], _: i32) -> i32 {
+        1
+    }
+
+    fn test_measure_text(_: i32, _: &[u8]) -> f32 {
+        1.0
+    }
+
+    fn test_cache_text(_: i32, _: &[u8]) -> i32 {
+        1
+    }
+
+    fn test_measure_cached(_: i32) -> f32 {
+        1.0
+    }
+
+    fn test_poll_reload(_: i32) -> i32 {
+        0
+    }
+
     fn test_lock() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .expect("dynload test lock mutex poisoned")
+    }
+
+    struct EmbeddedHostReset;
+
+    impl Drop for EmbeddedHostReset {
+        fn drop(&mut self) {
+            set_embedded_graphics_host(None);
+        }
+    }
+
+    #[test]
+    fn jit_sprite_same_handle_replacement_releases_prior_acquisition() {
+        let _guard = test_lock();
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_i32_array_global_table();
+        clear_jit_string_literal_table();
+        TEST_SPRITE_RELEASES.store(0, Ordering::SeqCst);
+        let _host_reset = EmbeddedHostReset;
+        set_embedded_graphics_host(Some(EmbeddedGraphicsHost {
+            load_sprite: test_sprite_load,
+            release_sprite: test_sprite_release,
+            load_font: test_font_load,
+            measure_text: test_measure_text,
+            cache_text: test_cache_text,
+            measure_text_cached: test_measure_cached,
+            measure_text_cached_height: test_measure_cached,
+            poll_reload: test_poll_reload,
+        }));
+        let mut handles = [0_i32];
+        let mut widths = [0_i32];
+        let mut heights = [0_i32];
+        register_global_i32_array(100, global_path_hash("handle"), handles.as_mut_ptr(), 1);
+        register_global_i32_array(100, global_path_hash("width"), widths.as_mut_ptr(), 1);
+        register_global_i32_array(100, global_path_hash("height"), heights.as_mut_ptr(), 1);
+        upsert_jit_string_literal(55, "assets/sprite.svg");
+        assert_eq!(stasis_jit_sprite_load_from(100, 0, 1, 55, 32, 24), 1);
+        assert_eq!(stasis_jit_sprite_load_from(100, 0, 1, 55, 32, 24), 1);
+        assert_eq!(handles[0], 77);
+        assert_eq!(TEST_SPRITE_RELEASES.load(Ordering::SeqCst), 1);
+        clear_registered_global_memory();
+        clear_jit_i32_global_table();
+        clear_jit_i32_array_global_table();
+        clear_jit_string_literal_table();
     }
 
     #[test]

--- a/docs/typed_draw_resources.md
+++ b/docs/typed_draw_resources.md
@@ -51,6 +51,7 @@ Stasis receiver-form functions are the primary API. They mutate an existing glob
 ```stasis
 function load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void;
+function release(self: Sprite): void;
 
 function load_text_from(self: TextRun, font: i32, text: string): bool;
 function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void;
@@ -98,6 +99,31 @@ Receiver-scoped resolution distinguishes the two `draw` functions by parameter 0
 
 Replacing an already valid sprite releases the old handle only after its replacement loads successfully. Failed replacement preserves the old valid resource. Prepared text remains owned by the host cache, which currently has no individual run-release operation; this API does not invent a second ownership policy.
 
+`Sprite.release()` is idempotent. It calls the native release bridge only when the
+receiver has a nonzero handle, then clears `handle`, `width`, and `height` even
+when the handle is stale or already released. A copied `Sprite` value is not an
+extra host acquisition: manually copying its integer fields and releasing both
+copies is invalid ownership. Code that needs two owners must load the resource
+twice (the host may return the same native handle and balances both references).
+
+Native desktop and mobile-AOT handles contain a slot generation. Release makes
+the old generation invalid, and a later slot reuse receives a different
+generation; stale handles are omitted from renderer restoration. The JIT and
+mobile AOT replacement paths publish the newly acquired receiver state before
+releasing the previous ownership, including when both acquisitions return the
+same handle.
+
+Android Workshop uses stable manifest handles as content identities, not GPU
+allocation IDs. Typed loads maintain a bounded per-project reference table. A
+zero-reference release is queued for the GL thread and is canceled if the same
+stable handle is acquired before the queue is drained. Workshop may map several
+manifest handles to one decoded texture by content hash; the GLES texture is
+deleted only after its last mapping is removed. The queue and table retain
+bounded deterministic limits, and overflow is surfaced as a resource error.
+Raw/direct manifest handles that were never acquired through typed loading are
+not owned by this release table. Surface restoration rebuilds only live entries;
+released entries and pending canceled releases cannot reappear.
+
 ## Drawing invariants
 
 `Sprite.draw` reads width and height from the receiver and emits the existing sprite command at exactly those logical dimensions. It rejects or ignores an invalid receiver according to the existing graphics-command failure policy; it never substitutes caller-provided dimensions.
@@ -125,6 +151,7 @@ The first implementation slice must cover:
 - receiver-form mutation of a global `Sprite` and `TextRun`;
 - successful load metadata assignment;
 - atomic clearing on invalid dimensions or native load failure;
+- idempotent `Sprite.release()` clearing all receiver metadata;
 - canonical sprite command width and height sourced from the receiver;
 - cached-text drawing through the receiver;
 - JIT and AOT lowering for the representative program where applicable;
@@ -174,6 +201,13 @@ The receiver is a mutable view into global-backed state, matching Stasis's exist
 ## Extension point
 
 Future work may add explicit downscale, fit, or intentionally upscaled operations. Those APIs must remain distinct from canonical `draw` and must validate against the resource's logical painted envelope. Asset-manifest IDs may eventually supply the logical size so paths and dimensions also have one declaration.
+
+TextRun and font ownership intentionally remain unchanged in this slice. The
+existing host text cache retains font bytes and prepared runs through surface
+restore; a future text/font release extension must define cache ownership
+separately rather than reusing sprite release semantics.
+`SpriteSheet` ownership is likewise unchanged; adding its explicit release
+operation remains a separate API extension from this `Sprite.release()` slice.
 
 Theory gained: a drawable's logical painted envelope belongs to the loaded resource, not to each draw command. The existing graphics path proves that physical raster density is already a host concern while Stasis draw commands still duplicate logical size. This predicts that receiver-owned logical dimensions can remove silent enlargement from ordinary drawing without changing the renderer or command-buffer architecture.
 

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -24,6 +24,8 @@ typedef char *(*stasis_android_bridge_inspect_runtime_state_fn)(const char *proj
 typedef char *(*stasis_android_bridge_set_i32_global_fn)(const char *project_root, const char *entry_file, const char *path, int value);
 typedef char *(*stasis_android_bridge_get_i32_global_fn)(const char *project_root, const char *entry_file, const char *path);
 typedef char *(*stasis_android_bridge_resolve_sprite_asset_fn)(const char *project_root, int handle);
+typedef char *(*stasis_android_bridge_drain_sprite_releases_fn)(void);
+typedef char *(*stasis_android_bridge_poll_sprite_release_cancellations_fn)(void);
 typedef char *(*stasis_android_bridge_resolve_cached_text_fn)(const char *project_root, int handle);
 typedef char *(*stasis_android_bridge_resolve_font_fn)(const char *project_root, int handle);
 typedef char *(*stasis_android_bridge_source_items_fn)(const char *project_root, const char *entry_file);
@@ -49,6 +51,8 @@ typedef struct RustBridgeApi {
     stasis_android_bridge_set_i32_global_fn set_i32_global;
     stasis_android_bridge_get_i32_global_fn get_i32_global;
     stasis_android_bridge_resolve_sprite_asset_fn resolve_sprite_asset;
+    stasis_android_bridge_drain_sprite_releases_fn drain_sprite_releases;
+    stasis_android_bridge_poll_sprite_release_cancellations_fn poll_sprite_release_cancellations;
     stasis_android_bridge_resolve_cached_text_fn resolve_cached_text;
     stasis_android_bridge_resolve_font_fn resolve_font;
     stasis_android_bridge_source_items_fn source_items;
@@ -184,6 +188,11 @@ static RustBridgeApi *load_rust_bridge_api(void) {
             (stasis_android_bridge_get_i32_global_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_get_i32_global");
     rust_bridge_api.resolve_sprite_asset =
             (stasis_android_bridge_resolve_sprite_asset_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_sprite_asset");
+    rust_bridge_api.drain_sprite_releases =
+            (stasis_android_bridge_drain_sprite_releases_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_drain_sprite_releases");
+    rust_bridge_api.poll_sprite_release_cancellations =
+            (stasis_android_bridge_poll_sprite_release_cancellations_fn)dlsym(
+                    rust_bridge_api.handle, "stasis_android_bridge_poll_sprite_release_cancellations");
     rust_bridge_api.resolve_cached_text =
             (stasis_android_bridge_resolve_cached_text_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_resolve_cached_text");
     rust_bridge_api.resolve_font =
@@ -522,6 +531,41 @@ Java_com_stasislang_workshop_MainActivity_nativeResolveSpriteAsset(
     if (message == NULL) {
         return (*env)->NewStringUTF(env,
                 "{\"status\":\"error\",\"error\":\"shared sprite resolver returned no result\"}");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativeDrainSpriteReleases(
+        JNIEnv *env, jclass activity_class) {
+    (void)activity_class;
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->drain_sprite_releases == NULL || bridge->free_string == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"ok\",\"handles\":[]}");
+    }
+    char *message = bridge->drain_sprite_releases();
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"ok\",\"handles\":[]}");
+    }
+    jstring result = (*env)->NewStringUTF(env, message);
+    bridge->free_string(message);
+    return result;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_stasislang_workshop_MainActivity_nativePollSpriteReleaseCancellations(
+        JNIEnv *env, jclass activity_class) {
+    (void)activity_class;
+    RustBridgeApi *bridge = load_rust_bridge_api();
+    if (bridge == NULL || bridge->poll_sprite_release_cancellations == NULL
+            || bridge->free_string == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"ok\",\"handles\":[]}");
+    }
+    char *message = bridge->poll_sprite_release_cancellations();
+    if (message == NULL) {
+        return (*env)->NewStringUTF(env, "{\"status\":\"ok\",\"handles\":[]}");
     }
     jstring result = (*env)->NewStringUTF(env, message);
     bridge->free_string(message);

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -10,6 +10,10 @@ import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.Arrays;
+import java.util.ArrayDeque;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private static final String LOG_TAG = "StasisRenderer";
@@ -125,6 +129,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         default void onDisplayMetricsChanged(float rasterScale, int densityGeneration) {}
 
         int textureFor(int handle);
+
+        default void releaseSprite(int handle) {}
 
         default int fallbackTexture() {
             return 0;
@@ -277,6 +283,8 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     private final TextureProvider textures;
     private final TimingListener timing;
     private final RendererResourceLifecycle resourceLifecycle = new RendererResourceLifecycle();
+    static final int MAX_PENDING_SPRITE_RELEASES = 256;
+    private final ArrayDeque<Integer> pendingSpriteReleases = new ArrayDeque<>();
     private final FramePerformanceSamples performanceSamples = BuildConfig.STASIS_RENDER_ACCEPTANCE
             ? new FramePerformanceSamples(PERFORMANCE_WARMUP_FRAMES, PERFORMANCE_SAMPLE_FRAMES)
             : null;
@@ -319,6 +327,59 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     StasisPreviewRenderer(TextureProvider textures, TimingListener timing) {
         this.textures = textures;
         this.timing = timing;
+    }
+
+    synchronized boolean enqueuePendingSpriteReleases(String message) {
+        if (message == null || message.isEmpty()) return false;
+        try {
+            JSONObject response = new JSONObject(message);
+            JSONArray handles = response.optJSONArray("handles");
+            if (handles == null || handles.length() == 0) return false;
+            if (handles.length() > MAX_PENDING_SPRITE_RELEASES - pendingSpriteReleases.size()) {
+                return false;
+            }
+            boolean enqueued = false;
+            for (int index = 0; index < handles.length(); index += 1) {
+                int handle = handles.optInt(index, 0);
+                if (handle != 0) {
+                    pendingSpriteReleases.addLast(handle);
+                    enqueued = true;
+                }
+            }
+            return enqueued;
+        } catch (Exception error) {
+            return false;
+        }
+    }
+
+    synchronized boolean hasPendingSpriteReleases() {
+        return !pendingSpriteReleases.isEmpty();
+    }
+
+    synchronized boolean cancelPendingSpriteReleases(String message) {
+        if (message == null || message.isEmpty()) return false;
+        try {
+            JSONArray handles = new JSONObject(message).optJSONArray("handles");
+            if (handles == null) return false;
+            boolean canceled = false;
+            for (int index = 0; index < handles.length(); index += 1) {
+                int handle = handles.optInt(index, 0);
+                if (handle == 0) continue;
+                while (pendingSpriteReleases.removeFirstOccurrence(handle)) {
+                    canceled = true;
+                }
+            }
+            return canceled;
+        } catch (Exception error) {
+            return false;
+        }
+    }
+
+    // Package-private so queue behavior can be tested without constructing a GLES surface.
+    synchronized void applyPendingSpriteReleases() {
+        while (!pendingSpriteReleases.isEmpty()) {
+            textures.releaseSprite(pendingSpriteReleases.removeFirst());
+        }
     }
 
     // Callers fill these only while synchronized on this renderer. Native code writes
@@ -415,6 +476,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         int orderCount = 0;
         boolean presented = false;
         synchronized (this) {
+            applyPendingSpriteReleases();
             if (restorePlaceholderPending
                     && System.nanoTime() < restorePlaceholderUntilNanos) {
                 drawRestorePlaceholder();

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -476,7 +476,6 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
         int orderCount = 0;
         boolean presented = false;
         synchronized (this) {
-            applyPendingSpriteReleases();
             if (restorePlaceholderPending
                     && System.nanoTime() < restorePlaceholderUntilNanos) {
                 drawRestorePlaceholder();
@@ -549,6 +548,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                     }
                 }
             }
+            finishPendingSpriteReleases(hasFrame, presented);
             capture = pendingCapture;
             pendingCapture = null;
             capturedFrame = capture == null ? null : captureLogicalFrame();
@@ -561,6 +561,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
             if (report != null) Log.i(LOG_TAG, report);
         }
         timing.onRendered(totalNanos);
+    }
+
+    // Releases must wait until the command buffer has consumed its sprite textures. A
+    // frame blocked by restore/resource failure is retried later, so retain its queue.
+    synchronized void finishPendingSpriteReleases(boolean hasFrame, boolean presented) {
+        if (!hasFrame || presented) applyPendingSpriteReleases();
     }
 
     private void drawRestorePlaceholder() {

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertTrue;
 import java.nio.IntBuffer;
 import java.nio.FloatBuffer;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -57,6 +59,79 @@ public final class StasisPreviewRendererSchemaTest {
         assertTrue(diagnostic.contains("logical=24x16 raster=72x48 backend=gles"));
         assertTrue(diagnostic.contains("surface_generation=3 renderer_generation=4"));
         assertTrue(diagnostic.contains("reason=surface_changed failure=upload_failed"));
+    }
+
+    @Test
+    public void spriteReleaseQueueIsOrderedBoundedAndAppliedThroughProvider() {
+        List<Integer> released = new ArrayList<>();
+        StasisPreviewRenderer.TextureProvider provider =
+                new StasisPreviewRenderer.TextureProvider() {
+                    @Override public void onResourceGenerationChanged(
+                            int surfaceGeneration, int rendererGeneration,
+                            boolean discardGpuHandles, String transitionReason) {}
+                    @Override public int textureFor(int handle) { return 0; }
+                    @Override public void releaseSprite(int handle) { released.add(handle); }
+                };
+        StasisPreviewRenderer renderer = new StasisPreviewRenderer(provider, ignored -> {});
+
+        assertTrue(renderer.enqueuePendingSpriteReleases(
+                "{\"status\":\"ok\",\"handles\":[-7,11,-13]}"));
+        assertTrue(renderer.hasPendingSpriteReleases());
+        renderer.applyPendingSpriteReleases();
+        assertEquals(java.util.Arrays.asList(-7, 11, -13), released);
+        assertFalse(renderer.hasPendingSpriteReleases());
+
+        String tooLarge = releaseBatchJson(StasisPreviewRenderer.MAX_PENDING_SPRITE_RELEASES + 1);
+        assertFalse(renderer.enqueuePendingSpriteReleases(tooLarge));
+        assertFalse(renderer.hasPendingSpriteReleases());
+
+        String full = releaseBatchJson(StasisPreviewRenderer.MAX_PENDING_SPRITE_RELEASES);
+        assertTrue(renderer.enqueuePendingSpriteReleases(full));
+        assertFalse(renderer.enqueuePendingSpriteReleases("{\"handles\":[99]}"));
+        assertTrue(renderer.hasPendingSpriteReleases());
+        renderer.applyPendingSpriteReleases();
+        assertFalse(renderer.hasPendingSpriteReleases());
+        assertEquals(3 + StasisPreviewRenderer.MAX_PENDING_SPRITE_RELEASES, released.size());
+        assertEquals(-1, released.get(3).intValue());
+        assertEquals(-StasisPreviewRenderer.MAX_PENDING_SPRITE_RELEASES,
+                released.get(released.size() - 1).intValue());
+    }
+
+    @Test
+    public void queuedReleaseIsCanceledBeforeGlApplicationWhenHandleReacquires() {
+        List<Integer> released = new ArrayList<>();
+        StasisPreviewRenderer.TextureProvider provider =
+                new StasisPreviewRenderer.TextureProvider() {
+                    @Override public void onResourceGenerationChanged(
+                            int surfaceGeneration, int rendererGeneration,
+                            boolean discardGpuHandles, String transitionReason) {}
+                    @Override public int textureFor(int handle) { return 0; }
+                    @Override public void releaseSprite(int handle) { released.add(handle); }
+                };
+        StasisPreviewRenderer renderer = new StasisPreviewRenderer(provider, ignored -> {});
+
+        assertTrue(renderer.enqueuePendingSpriteReleases(
+                "{\"handles\":[-17,23]}"));
+        assertTrue(renderer.cancelPendingSpriteReleases(
+                "{\"handles\":[-17]}"));
+        assertTrue(renderer.hasPendingSpriteReleases());
+        renderer.applyPendingSpriteReleases();
+        assertEquals(java.util.Arrays.asList(23), released);
+        assertFalse(renderer.hasPendingSpriteReleases());
+        assertFalse(renderer.cancelPendingSpriteReleases(
+                "{\"handles\":[-17]}"));
+        assertTrue(renderer.enqueuePendingSpriteReleases("{\"handles\":[-17]}"));
+        renderer.applyPendingSpriteReleases();
+        assertEquals(java.util.Arrays.asList(23, -17), released);
+    }
+
+    private static String releaseBatchJson(int count) {
+        StringBuilder json = new StringBuilder("{\"handles\":[");
+        for (int index = 0; index < count; index += 1) {
+            if (index != 0) json.append(',');
+            json.append(-(index + 1));
+        }
+        return json.append("]}").toString();
     }
 
     @Test

--- a/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
+++ b/mobile/android/app/src/test/java/com/stasislang/workshop/StasisPreviewRendererSchemaTest.java
@@ -125,6 +125,33 @@ public final class StasisPreviewRendererSchemaTest {
         assertEquals(java.util.Arrays.asList(23, -17), released);
     }
 
+    @Test
+    public void spriteReleasesWaitForPresentationButCanCleanUpWithoutAFrame() {
+        List<Integer> released = new ArrayList<>();
+        StasisPreviewRenderer.TextureProvider provider =
+                new StasisPreviewRenderer.TextureProvider() {
+                    @Override public void onResourceGenerationChanged(
+                            int surfaceGeneration, int rendererGeneration,
+                            boolean discardGpuHandles, String transitionReason) {}
+                    @Override public int textureFor(int handle) { return 0; }
+                    @Override public void releaseSprite(int handle) { released.add(handle); }
+                };
+        StasisPreviewRenderer renderer = new StasisPreviewRenderer(provider, ignored -> {});
+
+        assertTrue(renderer.enqueuePendingSpriteReleases("{\"handles\":[-31]}"));
+        renderer.finishPendingSpriteReleases(true, false);
+        assertTrue(renderer.hasPendingSpriteReleases());
+        assertTrue(released.isEmpty());
+        renderer.finishPendingSpriteReleases(true, true);
+        assertFalse(renderer.hasPendingSpriteReleases());
+        assertEquals(java.util.Arrays.asList(-31), released);
+
+        assertTrue(renderer.enqueuePendingSpriteReleases("{\"handles\":[47]}"));
+        renderer.finishPendingSpriteReleases(false, false);
+        assertFalse(renderer.hasPendingSpriteReleases());
+        assertEquals(java.util.Arrays.asList(-31, 47), released);
+    }
+
     private static String releaseBatchJson(int count) {
         StringBuilder json = new StringBuilder("{\"handles\":[");
         for (int index = 0; index < count; index += 1) {

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/MainActivity.java
@@ -351,6 +351,8 @@ public final class MainActivity extends Activity {
     private static native int nativeRunFrameInto(String projectRoot, int touchX, int touchY,
             int touchActive, int screenWidth, int screenHeight, ByteBuffer frameI32,
             ByteBuffer frameF32, ByteBuffer frameU8);
+    private static native String nativeDrainSpriteReleases();
+    private static native String nativePollSpriteReleaseCancellations();
     private static native String nativeLastFrameError();
     private static native String nativeInspectRuntimeState(String projectRoot);
     private static native String nativeSetRuntimeI32(String projectRoot, String path, int value);
@@ -11787,17 +11789,29 @@ public final class MainActivity extends Activity {
         int runNativeFrame(String projectRoot, int inputX, int inputY, int inputActive,
                 int screenWidth, int screenHeight, int[] header) {
             int status;
+            boolean releaseBatchEnqueued = false;
+            boolean releaseCancellationApplied = false;
             long requested = System.nanoTime();
             synchronized (renderer) {
                 long started = System.nanoTime();
                 lastRendererSyncWaitNanos = started - requested;
+                boolean drainReleases = !renderer.hasPendingSpriteReleases();
                 status = nativeRunFrameInto(projectRoot, inputX, inputY, inputActive,
                         screenWidth, screenHeight, renderer.frameI32Bytes(),
                         renderer.frameF32Bytes(), renderer.frameU8Bytes());
+                releaseCancellationApplied = renderer.cancelPendingSpriteReleases(
+                        nativePollSpriteReleaseCancellations());
+                if (!drainReleases && releaseCancellationApplied) {
+                    drainReleases = !renderer.hasPendingSpriteReleases();
+                }
+                if (drainReleases) {
+                    releaseBatchEnqueued = renderer.enqueuePendingSpriteReleases(
+                            nativeDrainSpriteReleases());
+                }
                 lastNativeFrameDurationNanos = System.nanoTime() - started;
                 renderer.copyFrameHeaderInto(header);
             }
-            if (status == 0) requestRender();
+            if (status == 0 || releaseBatchEnqueued || releaseCancellationApplied) requestRender();
             return status;
         }
 

--- a/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
+++ b/mobile/android/app/src/workshop/java/com/stasislang/workshop/WorkshopTextureProvider.java
@@ -203,6 +203,14 @@ final class WorkshopTextureProvider implements StasisPreviewRenderer.TextureProv
         }
     }
 
+    @Override
+    public void releaseSprite(int handle) {
+        SpriteTexture cached = textures.get(handle);
+        if (cached == null) return;
+        textures.remove(handle);
+        releaseSpriteIfUnreferenced(cached);
+    }
+
     static boolean usesFallbackSprite(int handle) {
         return handle == 0;
     }

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -287,6 +287,7 @@ STASIS_EXPORT void stasis_gfx_release_sprite(int handle);
 STASIS_EXPORT void stasis_audio_release(int asset_handle);
 STASIS_EXPORT void stasis_gfx_submit_u8(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8);
 STASIS_EXPORT int stasis_test_get_render_submission_state(int32_t* out_i32, int32_t capacity);
+STASIS_EXPORT int stasis_test_get_sprite_state(int32_t handle, int32_t* out_i32, int32_t capacity);
 STASIS_EXPORT void stasis_draw_text(int font_handle, const char* text, float x, float y, float r, float g, float b, float a);
 
 /* Forward decls for internal helpers used before their definitions. */
@@ -5275,6 +5276,19 @@ STASIS_EXPORT int stasis_test_get_render_submission_state(int32_t* out_i32, int3
         out_i32[5] = g_render_last_display_generation;
         out_i32[6] = g_render_last_density_generation;
     }
+    return 1;
+}
+
+STASIS_EXPORT int stasis_test_get_sprite_state(int32_t handle, int32_t* out_i32, int32_t capacity) {
+    const char* enabled = SDL_getenv("STASIS_ENABLE_TEST_INPUT");
+    if (!out_i32 || capacity < 4 || !enabled || enabled[0] != '1' || enabled[1] != '\0') {
+        return 0;
+    }
+    SpriteEntry* entry = sprite_get(handle);
+    out_i32[0] = entry != NULL ? 1 : 0;
+    out_i32[1] = entry != NULL ? entry->ref_count : 0;
+    out_i32[2] = entry != NULL ? (int32_t)entry->generation : 0;
+    out_i32[3] = g_sprite_count;
     return 1;
 }
 

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -73,6 +73,7 @@ EXPORTS
     stasis_test_push_input_event
     stasis_test_push_display_event
     stasis_test_get_render_submission_state
+    stasis_test_get_sprite_state
     stasis_gfx_notify_file_changed
     stasis_gfx_load_sprite
     stasis_asset_request_sprite

--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -775,7 +775,7 @@ int stasis_jit_sprite_load_from(int32_t base, int32_t index, int32_t len, int32_
     stasis_struct_i32_store(base, index, len, "handle", loaded_handle);
     stasis_struct_i32_store(base, index, len, "width", width);
     stasis_struct_i32_store(base, index, len, "height", height);
-    if (old_handle != 0 && old_handle != loaded_handle) stasis_jit_gfx_release_sprite(old_handle);
+    if (old_handle != 0) stasis_jit_gfx_release_sprite(old_handle);
     return 1;
 }
 

--- a/runtime/tests/stasis_asset_tasks_test.c
+++ b/runtime/tests/stasis_asset_tasks_test.c
@@ -1,5 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 int stasis_init_window(int width, int height, const char* title);
 void stasis_shutdown(void);
@@ -9,6 +16,21 @@ int stasis_asset_task_poll(int task);
 int stasis_asset_task_take_handle(int task);
 void stasis_asset_task_cancel(int task);
 void stasis_gfx_release_sprite(int handle);
+int stasis_test_get_sprite_state(int handle, int* out_i32, int capacity);
+int stasis_test_push_display_event(
+    int kind,
+    int logical_w,
+    int logical_h,
+    int native_w,
+    int native_h,
+    int drawable_w,
+    int drawable_h,
+    int safe_x,
+    int safe_y,
+    int safe_w,
+    int safe_h);
+int stasis_mobile_poll_events(void);
+void stasis_host_get_frame(int32_t* out_i32, float* out_f32);
 void stasis_audio_release(int handle);
 void stasis_sleep_ms(int ms);
 
@@ -30,6 +52,11 @@ static int wait_for_task(int task) {
 }
 
 int main(void) {
+#if defined(_WIN32)
+    _putenv_s("STASIS_ENABLE_TEST_INPUT", "1");
+#else
+    setenv("STASIS_ENABLE_TEST_INPUT", "1", 1);
+#endif
     CHECK(stasis_init_window(64, 64, "stasis_asset_tasks_test"));
 
     int sprite_task = stasis_asset_request_sprite(STASIS_TEST_SPRITE_PATH, 32, 32);
@@ -46,10 +73,54 @@ int main(void) {
     CHECK(stasis_asset_task_poll(sprite_task) == 0);
     CHECK(stasis_asset_task_poll(audio_task) == 0);
 
+    int sprite_state[4] = {0};
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 1 && sprite_state[1] == 1 && sprite_state[3] >= 1);
+
+    int shared_task = stasis_asset_request_sprite(STASIS_TEST_SPRITE_PATH, 32, 32);
+    CHECK(shared_task > 0);
+    CHECK(wait_for_task(shared_task) == 3);
+    int shared_sprite = stasis_asset_task_take_handle(shared_task);
+    CHECK(shared_sprite == sprite);
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 1 && sprite_state[1] == 2 && sprite_state[3] == 1);
+
     int cancelled = stasis_asset_request_audio(STASIS_TEST_AUDIO_PATH);
     CHECK(cancelled > 0);
     stasis_asset_task_cancel(cancelled);
     CHECK(stasis_asset_task_poll(cancelled) == 0 || stasis_asset_task_poll(cancelled) == 5);
+
+    stasis_gfx_release_sprite(sprite);
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 1 && sprite_state[1] == 1 && sprite_state[3] == 1);
+    stasis_gfx_release_sprite(shared_sprite);
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 0 && sprite_state[1] == 0);
+
+    int reused_task = stasis_asset_request_sprite(STASIS_TEST_SPRITE_PATH, 32, 32);
+    CHECK(reused_task > 0);
+    CHECK(wait_for_task(reused_task) == 3);
+    int reused_sprite = stasis_asset_task_take_handle(reused_task);
+    CHECK(reused_sprite > 0 && reused_sprite != sprite);
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 0 && sprite_state[1] == 0 && sprite_state[3] == 1);
+    stasis_gfx_release_sprite(reused_sprite);
+    CHECK(stasis_test_get_sprite_state(reused_sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 0 && sprite_state[1] == 0 && sprite_state[3] == 0);
+
+    /* A display lifecycle round-trip must not restore a released generation. */
+    int32_t host_i32[768] = {0};
+    float host_f32[64] = {0};
+    CHECK(stasis_test_push_display_event(2, 64, 64, 64, 64, 64, 64, 0, 0, 64, 64) == 1);
+    CHECK(stasis_mobile_poll_events() == 0);
+    stasis_host_get_frame(host_i32, host_f32);
+    CHECK(host_i32[18] == 1);
+    CHECK(stasis_test_push_display_event(3, 64, 64, 64, 64, 64, 64, 0, 0, 64, 64) == 1);
+    CHECK(stasis_mobile_poll_events() == 0);
+    stasis_host_get_frame(host_i32, host_f32);
+    CHECK(host_i32[18] == 0);
+    CHECK(stasis_test_get_sprite_state(sprite, sprite_state, 4) == 1);
+    CHECK(sprite_state[0] == 0 && sprite_state[1] == 0 && sprite_state[3] == 0);
 
     stasis_gfx_release_sprite(sprite);
     stasis_audio_release(audio);

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -29,6 +29,7 @@ static int32_t hash_text(const char *text) {
 static char last_sprite_path[64];
 static int sprite_handle_to_load = 1;
 static int released_sprite_handle;
+static int released_sprite_count;
 static char saved_scope[64];
 static char saved_key[64];
 static int saved_value;
@@ -99,7 +100,10 @@ int stasis_asset_request_audio(const char *path) { return path ? 32 : 0; }
 int stasis_asset_task_poll(int task) { return task > 0 ? 3 : 0; }
 int stasis_asset_task_take_handle(int task) { return task > 0 ? 33 : 0; }
 void stasis_asset_task_cancel(int task) { (void)task; }
-void stasis_gfx_release_sprite(int handle) { released_sprite_handle = handle; }
+void stasis_gfx_release_sprite(int handle) {
+    released_sprite_handle = handle;
+    released_sprite_count += 1;
+}
 int stasis_gfx_dump_bmp(const char *path) { return path != NULL; }
 int stasis_gfx_dump_png(const char *path) { return path != NULL; }
 int stasis_gfx_cache_text(int font, const char *text) { return font + (text != NULL); }
@@ -222,10 +226,14 @@ int main(void) {
     stasis_jit_register_global_i32_array(100, hash_text("height"), sprite_height, 1);
     CHECK(stasis_jit_sprite_load_from(100, 0, 1, 23, 48, 24) == 1);
     CHECK(sprite_handle[0] == 1 && sprite_width[0] == 48 && sprite_height[0] == 24);
+    sprite_handle_to_load = 1;
+    CHECK(stasis_jit_sprite_load_from(100, 0, 1, 23, 56, 28) == 1);
+    CHECK(sprite_handle[0] == 1 && sprite_width[0] == 56 && sprite_height[0] == 28);
+    CHECK(released_sprite_count == 1 && released_sprite_handle == 1);
     sprite_handle_to_load = -1520461853;
     CHECK(stasis_jit_sprite_load_from(100, 0, 1, 23, 64, 32) == 1);
     CHECK(sprite_handle[0] == -1520461853 && sprite_width[0] == 64 && sprite_height[0] == 32);
-    CHECK(released_sprite_handle == 1);
+    CHECK(released_sprite_count == 2 && released_sprite_handle == 1);
 
     stasis_jit_register_global_i32_array(101, hash_text("font"), text_font, 1);
     stasis_jit_register_global_i32_array(101, hash_text("handle"), text_handle, 1);

--- a/samples/typed_sprite/main.stasis
+++ b/samples/typed_sprite/main.stasis
@@ -41,6 +41,14 @@ function main(): i32 {
     state.sprite.width = 136;
     state.sprite.height = 92;
 
+    state.sprite.release();
+    if (state.sprite.handle != 0 || state.sprite.width != 0 || state.sprite.height != 0) {
+        return 7;
+    }
+    state.sprite.handle = 41;
+    state.sprite.width = 136;
+    state.sprite.height = 92;
+
     gfx_cmd_begin();
     state.sprite.draw(12.5, 23.5, 211, 17);
 
@@ -51,49 +59,49 @@ function main(): i32 {
     state.text.draw(31.0, 42.0, 0.9, 0.8, 0.7, 0.6);
 
     if (gfx_cmd_sprite_count() != 1) {
-        return 7;
-    }
-    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 0] != 41) {
         return 8;
     }
-    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 1] != 17) {
+    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 0] != 41) {
         return 9;
     }
-    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 2] != 211) {
+    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 1] != 17) {
         return 10;
     }
-    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 0] != 12.5) {
+    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 2] != 211) {
         return 11;
     }
-    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 1] != 23.5) {
+    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 0] != 12.5) {
         return 12;
     }
-    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 2] != 136.0) {
+    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 1] != 23.5) {
         return 13;
     }
-    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 3] != 92.0) {
+    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 2] != 136.0) {
         return 14;
     }
-    if (gfx_cmd_text_count() != 1) {
+    if (gfx_cmd_f32[GFX_F_SPRITE_BASE + 3] != 92.0) {
         return 15;
     }
-    if (gfx_cmd_i32[GFX_I_TEXT_BASE + 0] != 3) {
+    if (gfx_cmd_text_count() != 1) {
         return 16;
     }
-    if (gfx_cmd_i32[GFX_I_TEXT_BASE + 1] != 0 - 8) {
+    if (gfx_cmd_i32[GFX_I_TEXT_BASE + 0] != 3) {
         return 17;
     }
-    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 0] != 31.0) {
+    if (gfx_cmd_i32[GFX_I_TEXT_BASE + 1] != 0 - 8) {
         return 18;
     }
-    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 1] != 42.0) {
+    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 0] != 31.0) {
         return 19;
     }
-    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 2] != 0.9) {
+    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 1] != 42.0) {
         return 20;
     }
-    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 5] != 0.6) {
+    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 2] != 0.9) {
         return 21;
+    }
+    if (gfx_cmd_f32[GFX_F_TEXT_BASE + 5] != 0.6) {
+        return 22;
     }
     return 0;
 }

--- a/samples/typed_sprite/tests/typed_sprite.test.stasis
+++ b/samples/typed_sprite/tests/typed_sprite.test.stasis
@@ -13,8 +13,28 @@ test `invalid sprite replacement preserves receiver atomically`(): bool {
     return tested_sprite.handle == 23 && tested_sprite.width == 16 && tested_sprite.height == 16;
 }
 
+test `sprite release clears live receiver and is idempotent`(): bool {
+    tested_sprite.handle = 0 - 23;
+    tested_sprite.width = 16;
+    tested_sprite.height = 16;
+    tested_sprite.release();
+    if (tested_sprite.handle != 0 || tested_sprite.width != 0 || tested_sprite.height != 0) {
+        return false;
+    }
+    tested_sprite.release();
+    return tested_sprite.handle == 0 && tested_sprite.width == 0 && tested_sprite.height == 0;
+}
+
+test `zero sprite release remains zero`(): bool {
+    tested_sprite.handle = 0;
+    tested_sprite.width = 0;
+    tested_sprite.height = 0;
+    tested_sprite.release();
+    return tested_sprite.handle == 0 && tested_sprite.width == 0 && tested_sprite.height == 0;
+}
+
 test `draw uses sprite logical dimensions`(): bool {
-    tested_sprite.handle = 7;
+    tested_sprite.handle = 0 - 7;
     tested_sprite.width = 80;
     tested_sprite.height = 48;
 
@@ -24,7 +44,7 @@ test `draw uses sprite logical dimensions`(): bool {
     if (gfx_cmd_sprite_count() != 1) {
         return false;
     }
-    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 0] != 7) {
+    if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 0] != 0 - 7) {
         return false;
     }
     if (gfx_cmd_i32[GFX_I_SPRITE_BASE + 1] != 9) {

--- a/src/stdlib/asset_tasks.stasis
+++ b/src/stdlib/asset_tasks.stasis
@@ -94,8 +94,61 @@ function @effects(graphics)@extern("stasis_jit_gfx_release_sprite") gfx_release_
 
 extern function @effects(audio) audio_release(asset_handle: i32): void;
 
+function reset_image(self: ImageAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle != 0) {
+        gfx_release_sprite(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}
+
+// Sprite ownership lives beside the asset release overloads so callers that
+// import graphics get one unambiguous receiver-method module, while direct
+// asset_tasks imports keep the existing ImageAsset/AudioAsset release API.
+struct Sprite {
+    handle: i32;
+    width: i32;
+    height: i32;
+}
+
+function reset_audio(self: AudioAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle != 0) {
+        audio_release(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}
+
+function release(self: ImageAsset): void {
+    reset_image(self);
+}
+
+function release(self: AudioAsset): void {
+    reset_audio(self);
+}
+
+// Release is safe to call repeatedly. A Sprite is an owning value only when
+// it was populated by load_sprite_from; copied integer handles do not acquire
+// another native reference.
+function release(self: Sprite): void {
+    if (self.handle != 0) {
+        gfx_release_sprite(self.handle);
+    }
+    self.handle = 0;
+    self.width = 0;
+    self.height = 0;
+}
+
 function @asset_path(path) load_image(self: ImageAsset, path: string, width: i32, height: i32): bool {
-    self.release();
+    reset_image(self);
     self.request = asset_request_sprite(path, width, height);
     self.width = width;
     self.height = height;
@@ -108,7 +161,7 @@ function @asset_path(path) load_image(self: ImageAsset, path: string, width: i32
 }
 
 function @asset_path(path) load_audio(self: AudioAsset, path: string): bool {
-    self.release();
+    reset_audio(self);
     self.request = asset_request_audio(path);
     if (self.request <= 0) {
         self.state = AssetState.Failed;
@@ -126,7 +179,7 @@ function status(self: ImageAsset): AssetState {
     if (self.state == AssetState.Loaded) {
         self.handle = asset_task_take_handle(self.request);
         self.request = 0;
-        if (self.handle <= 0) {
+        if (self.handle == 0) {
             self.state = AssetState.Failed;
         }
     }
@@ -141,7 +194,7 @@ function status(self: AudioAsset): AssetState {
     if (self.state == AssetState.Loaded) {
         self.handle = asset_task_take_handle(self.request);
         self.request = 0;
-        if (self.handle <= 0) {
+        if (self.handle == 0) {
             self.state = AssetState.Failed;
         }
     }
@@ -164,28 +217,4 @@ function failed(self: ImageAsset): bool {
 function failed(self: AudioAsset): bool {
     let current: AssetState = self.status();
     return current == AssetState.Failed || current == AssetState.Cancelled;
-}
-
-function release(self: ImageAsset): void {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
-    if (self.handle > 0) {
-        gfx_release_sprite(self.handle);
-    }
-    self.request = 0;
-    self.handle = 0;
-    self.state = AssetState.None;
-}
-
-function release(self: AudioAsset): void {
-    if (self.request > 0) {
-        asset_task_cancel(self.request);
-    }
-    if (self.handle > 0) {
-        audio_release(self.handle);
-    }
-    self.request = 0;
-    self.handle = 0;
-    self.state = AssetState.None;
 }

--- a/src/stdlib/graphics.stasis
+++ b/src/stdlib/graphics.stasis
@@ -31,12 +31,6 @@ extern function @effects(graphics, storage) gfx_dump_png(path: string): i32;
 extern function @effects(graphics)@asset_path(path) load_font(path: string, size: i32): i32;
 extern function @effects(graphics) measure_text(font: i32, text: string): f32;
 
-struct Sprite {
-    handle: i32;
-    width: i32;
-    height: i32;
-}
-
 struct TextRun {
     font: i32;
     handle: i32;
@@ -82,7 +76,7 @@ function publish(self: ImageAsset, target: Sprite): bool {
     if (!self.ready()) {
         return false;
     }
-    if (target.handle > 0 && target.handle != self.handle) {
+    if (target.handle != 0) {
         gfx_release_sprite(target.handle);
     }
     target.handle = self.handle;
@@ -96,7 +90,7 @@ function publish(self: ImageAsset, target: Sprite): bool {
 }
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
-    if (self.handle <= 0 || self.width <= 0 || self.height <= 0) {
+    if (self.handle == 0 || self.width <= 0 || self.height <= 0) {
         return;
     }
     let width: f32 = 0.0;
@@ -129,7 +123,7 @@ function load_sprite_sheet_from(self: SpriteSheet, path: string, columns: i32, r
 }
 
 function draw_frame(self: SpriteSheet, frame: i32, x: f32, y: f32, alpha: i32, rotation: i32): void {
-    if (self.handle <= 0 || self.columns <= 0 || self.rows <= 0 || self.cell_width <= 0 || self.cell_height <= 0) {
+    if (self.handle == 0 || self.columns <= 0 || self.rows <= 0 || self.cell_width <= 0 || self.cell_height <= 0) {
         return;
     }
     if (self.columns > 2147483647 / self.rows) {


### PR DESCRIPTION
Implements Maddox #200. Adds idempotent typed Sprite.release, balanced replacement refcounts, generation/stale-handle native coverage, and bounded Android Workshop release/cancellation delivery to the GL thread. Integration coverage compiles and runs real Stasis Sprite.load/draw/release programs, including duplicate release, cross-tick reacquire cancellation, batching, registry reuse, direct asset_tasks compatibility, native C lifecycle, and Android JVM queue behavior. Validation: Android bridge 59/59; dynload 25/25; Workshop JVM 148/148; native CTest 2/2; typed drawable verifier 7/7; workspace all-target check; format/diff/pre-commit checks.