### PR TITLE
Fix nightly slow-seam CI gating

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -11,6 +11,12 @@ on:
       - synchronize
       - ready_for_review
   workflow_dispatch:
+    inputs:
+      run_slow_seams:
+        description: Run platform integration and packaging seams.
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       run_slow_seams:
@@ -96,7 +102,7 @@ jobs:
         run: cargo test --workspace --all-targets -- --test-threads=1
 
   bootstrap-smoke-windows:
-    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
+    if: ${{ inputs.run_slow_seams }}
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -197,7 +203,7 @@ jobs:
         run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture
 
   vscode-extension-e2e:
-    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
+    if: ${{ inputs.run_slow_seams }}
     name: VS Code E2E (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -308,7 +314,7 @@ jobs:
             vscode-stasis/.vsix/stasislang.stasis.vsix
 
   android-package-link:
-    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
+    if: ${{ inputs.run_slow_seams }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Stasis
@@ -369,7 +375,7 @@ jobs:
           path: target/android-native-link-evidence.json
 
   ios-package-link:
-    if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}
+    if: ${{ inputs.run_slow_seams }}
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/apps/stasis/tests/desktop_input_frame_seam.rs
+++ b/apps/stasis/tests/desktop_input_frame_seam.rs
@@ -121,7 +121,7 @@ fn run_guest_frame(
     assert_close(scalar_f32("seam_pointer_x"), x, "guest pointer x");
     assert_close(scalar_f32("seam_pointer_y"), y, "guest pointer y");
 
-    assert_eq!(&gfx_i32[0..4], &[1196967473, 4, 3, 0]);
+    assert_eq!(&gfx_i32[0..4], &[1196967473, 5, 3, 0]);
     assert_eq!(gfx_i32[22], 1, "render order count");
     assert_eq!(gfx_i32[24], 1, "render rectangle count");
     for (index, expected) in clear.iter().enumerate() {
@@ -274,7 +274,7 @@ fn desktop_sdl_input_changes_jit_state_and_submitted_frame_on_the_intended_tick(
     assert_eq!(&host_i32[548..552], &[1, 0, 0, 1]);
     assert_eq!(
         [down_trace, move_trace, up_trace],
-        [-1596497517, 610004423, -1115252597],
+        [1530966022, 413668306, -939500466],
         "guest state markers must produce the locked native frame traces"
     );
 

--- a/apps/stasis/tests/desktop_manifest_assets_seam.rs
+++ b/apps/stasis/tests/desktop_manifest_assets_seam.rs
@@ -19,7 +19,7 @@ const PNG_SHA256: &str = "98d61197c8db539121336207a1cc722093a0d3e0acd5ef5196c1ed
 const FONT_SHA256: &str = "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47";
 const PNG_MANIFEST_HANDLE: i32 = 1_221_991_035;
 const FONT_MANIFEST_HANDLE: i32 = 623_275_877;
-const RENDER_TRACE: i32 = -2_088_676_722;
+const RENDER_TRACE: i32 = 1_202_089_527;
 
 type SetAssetRoot = extern "system" fn(*const std::ffi::c_char) -> i32;
 type ScheduleScreenshot = extern "system" fn(*const std::ffi::c_char) -> i32;

--- a/tests/stasis/seams/desktop_manifest_assets_probe.stasis
+++ b/tests/stasis/seams/desktop_manifest_assets_probe.stasis
@@ -3,6 +3,7 @@
 extern function gfx_load_sprite(path: string, max_w: i32, max_h: i32): i32;
 extern function load_font(path: string, size: i32): i32;
 extern function measure_text(font: i32, text: string): f32;
+
 function @extern("stasis_jit_gfx_cache_text") gfx_cache_text(font: i32, text: string): i32;
 function @extern("stasis_jit_gfx_measure_text_cached") gfx_measure_text_cached(handle: i32): f32;
 
@@ -42,7 +43,7 @@ function tick(): i32 {
 
 function render(): i32 {
     gfx_cmd_i32[0] = 1196967473;
-    gfx_cmd_i32[1] = 4;
+    gfx_cmd_i32[1] = 5;
     gfx_cmd_i32[2] = 3;
     gfx_cmd_i32[3] = 0;
     gfx_cmd_i32[4] = 1;
@@ -67,26 +68,30 @@ function render(): i32 {
     gfx_cmd_f32[80005] = 28.0;
     gfx_cmd_f32[80006] = 64.0;
     gfx_cmd_f32[80007] = 64.0;
+    gfx_cmd_f32[80008] = 0.0;
+    gfx_cmd_f32[80009] = 0.0;
+    gfx_cmd_f32[80010] = 1.0;
+    gfx_cmd_f32[80011] = 1.0;
 
     gfx_cmd_i32[12320] = seam_font_handle;
     gfx_cmd_i32[12321] = 0;
     gfx_cmd_i32[12322] = 6;
-    gfx_cmd_f32[96388] = 30.0;
-    gfx_cmd_f32[96389] = 112.0;
-    gfx_cmd_f32[96390] = 1.0;
-    gfx_cmd_f32[96391] = 0.8;
-    gfx_cmd_f32[96392] = 0.1;
-    gfx_cmd_f32[96393] = 1.0;
+    gfx_cmd_f32[112772] = 30.0;
+    gfx_cmd_f32[112773] = 112.0;
+    gfx_cmd_f32[112774] = 1.0;
+    gfx_cmd_f32[112775] = 0.8;
+    gfx_cmd_f32[112776] = 0.1;
+    gfx_cmd_f32[112777] = 1.0;
 
     gfx_cmd_i32[12323] = seam_font_handle;
     gfx_cmd_i32[12324] = 0 - seam_cached_handle;
     gfx_cmd_i32[12325] = 0;
-    gfx_cmd_f32[96394] = 175.0;
-    gfx_cmd_f32[96395] = 112.0;
-    gfx_cmd_f32[96396] = 0.1;
-    gfx_cmd_f32[96397] = 0.9;
-    gfx_cmd_f32[96398] = 1.0;
-    gfx_cmd_f32[96399] = 1.0;
+    gfx_cmd_f32[112778] = 175.0;
+    gfx_cmd_f32[112779] = 112.0;
+    gfx_cmd_f32[112780] = 0.1;
+    gfx_cmd_f32[112781] = 0.9;
+    gfx_cmd_f32[112782] = 1.0;
+    gfx_cmd_f32[112783] = 1.0;
 
     gfx_cmd_u8[0] = 68;
     gfx_cmd_u8[1] = 73;

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import re
 import unittest
 
 
@@ -42,17 +43,59 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
             "needs: [detect, build, vscode_extension, integration_seams, android_device_seams]",
             self.nightly_workflow,
         )
-        self.assertIn("uses: ./.github/workflows/pr-ci.yml", self.nightly_workflow)
-        self.assertIn("run_slow_seams: true", self.nightly_workflow)
-        self.assertEqual(
-            4,
-            self.pr_workflow.count(
-                "if: ${{ github.event_name == 'workflow_call' && inputs.run_slow_seams }}"
-            ),
+        self.assertIn(
+            "uses: ./.github/workflows/pr-ci.yml\n"
+            "    with:\n"
+            "      run_slow_seams: true",
+            self.nightly_workflow,
         )
         self.assertNotIn("self-hosted", self.workflow)
         self.assertNotIn("runs-on: [self-hosted, Windows, android-device]", self.workflow)
         self.assertNotIn("ANDROID_SERIAL", self.workflow)
+
+    def test_pr_ci_slow_seams_are_boolean_input_gated(self):
+        input_declaration = (
+            "    inputs:\n"
+            "      run_slow_seams:\n"
+            "        description: Run platform integration and packaging seams.\n"
+            "        required: false\n"
+            "        default: false\n"
+            "        type: boolean\n"
+        )
+        for event in ("workflow_dispatch", "workflow_call"):
+            match = re.search(
+                rf"(?ms)^  {event}:\n(?P<body>.*?)(?=^  [A-Za-z_][A-Za-z0-9_-]*:|\Z)",
+                self.pr_workflow,
+            )
+            self.assertIsNotNone(match, event)
+            self.assertIn(input_declaration, match.group("body"))
+
+        self.assertNotIn(
+            "github.event_name == 'workflow_call' && inputs.run_slow_seams",
+            self.pr_workflow,
+        )
+        slow_jobs = (
+            "bootstrap-smoke-windows",
+            "vscode-extension-e2e",
+            "android-package-link",
+            "ios-package-link",
+        )
+        slow_gate = "if: ${{ inputs.run_slow_seams }}"
+        self.assertEqual(4, self.pr_workflow.count(slow_gate))
+        for job in slow_jobs:
+            match = re.search(
+                rf"(?ms)^  {re.escape(job)}:\n(?P<body>.*?)(?=^  [A-Za-z_][A-Za-z0-9_-]*:|\Z)",
+                self.pr_workflow,
+            )
+            self.assertIsNotNone(match, job)
+            self.assertEqual(1, match.group("body").count(slow_gate))
+            if job == "bootstrap-smoke-windows":
+                self.assertEqual(
+                    1,
+                    match.group("body").count(
+                        "run: cargo test -p stasis_compiler -- --test-threads=1 --nocapture"
+                    ),
+                )
 
     def test_nightly_grants_reusable_ci_read_permissions(self):
         self.assertIn("  contents: write", self.nightly_workflow)


### PR DESCRIPTION
## Summary

- restore nightly execution of Windows bootstrap, VS Code E2E, Android package/link, and iOS package/link seams
- add an explicit boolean manual-dispatch input so a task branch can run the same full gate without publishing a nightly release
- preserve the serialized Windows compiler suite that protects process-global compiler/JIT state
- add deterministic workflow contract coverage that pins the slow jobs and the Windows compiler command to their intended scopes
- migrate two stale Windows-only gfx seam fixtures to the current v5 render layout, exposed once the slow lane ran again

## Root cause

PR #445 fixed the original intermittent nested-struct linked-AOT result by serializing the Windows compiler suite. A later CI refactor gated reusable-workflow jobs on `github.event_name == 'workflow_call'`, but a called workflow's `github` context belongs to its caller. Nightly `schedule` and `workflow_dispatch` callers therefore skipped every slow job even while passing `run_slow_seams: true`.

## Validation

- `python -m unittest tools.ci.test_android_emulator_seams` (8 passed)
- `python tools/ci/check_stasis_src_layout.py` (passed)
- `python tools/ci/check_windows_vs_generator.py` (passed)
- `cargo test -p stasis --test desktop_manifest_assets_seam -- --nocapture` with configured runtime (1 passed)
- repository staged-source formatter gate (1 passed)
- `git diff --check` (passed)
- actionlint (no diagnostics)
- independent implementation review and final re-review (clean)
- nightly-equivalent full slow run 32186496251 on exact head `ea13e736`: all six jobs passed; Windows passed every desktop seam and the serialized compiler suite (561 passed), including the nested-struct linked-AOT regression test