### PR TITLE
Load stress Stasis asset handling

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -55,6 +55,7 @@ jobs:
           python tools/ci/check_runtime_abi_contract.py
           python -m unittest tools.ci.test_cargo_cache
           python -m unittest tools.ci.test_android_emulator_seams
+          python -m unittest tools.ci.test_generate_asset_load_fixture
           python -m unittest tools.ci.test_runtime_abi_contract
           python -m unittest tools.ci.test_run_android_release_shell_seam
           python -m unittest tools.ci.test_verify_android_native_library
@@ -169,6 +170,12 @@ jobs:
         run: |
           $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
           cargo test -p stasis --test desktop_manifest_assets_seam -- --test-threads=1 --nocapture
+
+      - name: Test desktop asset load stress
+        shell: pwsh
+        run: |
+          $env:STASIS_RUNTIME_DLL_PATH = (Resolve-Path "target/render-parity-runtime/bin/Release/stasis_graphics.dll")
+          python tools/cargo_cache.py run -- cargo test -p stasis --test desktop_asset_load_stress -- --test-threads=1 --nocapture
 
       - name: Test malformed render buffer recovery seam
         shell: pwsh

--- a/apps/stasis/tests/desktop_asset_load_stress.rs
+++ b/apps/stasis/tests/desktop_asset_load_stress.rs
@@ -1,0 +1,236 @@
+#![cfg(windows)]
+
+use serde_json::json;
+use stasis_assets::{load_project_asset_manifest, AssetFormat, AssetLimits};
+use stasis_dynload::Library;
+use std::collections::HashSet;
+use std::ffi::{c_char, CString};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+const FONT_COUNT: usize = 10;
+const SPRITE_COUNT: usize = 536;
+const PHRASE_COUNT: usize = 600;
+
+type InitWindow = extern "system" fn(i32, i32, *const c_char) -> i32;
+type Shutdown = extern "system" fn();
+type SetAssetRoot = extern "system" fn(*const c_char) -> i32;
+type LoadSprite = extern "system" fn(*const c_char, i32, i32) -> i32;
+type LoadFont = extern "system" fn(*const c_char, i32) -> i32;
+type MeasureText = extern "system" fn(i32, *const c_char) -> f32;
+type CacheText = extern "system" fn(i32, *const c_char) -> i32;
+
+struct ShutdownGuard(Option<Shutdown>);
+
+impl Drop for ShutdownGuard {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.0.take() {
+            shutdown();
+        }
+    }
+}
+
+struct FixtureGuard {
+    path: PathBuf,
+    parent: PathBuf,
+}
+
+impl Drop for FixtureGuard {
+    fn drop(&mut self) {
+        debug_assert!(self.path.starts_with(&self.parent));
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repository root")
+}
+
+fn fixture_root(repository: &Path) -> FixtureGuard {
+    let parent = std::env::temp_dir();
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("read system clock")
+        .as_nanos();
+    let root = (0..100)
+        .map(|attempt| {
+            parent.join(format!(
+                "stasis_asset_load_stress_{}_{}_{}",
+                std::process::id(),
+                timestamp,
+                attempt
+            ))
+        })
+        .find(|candidate| fs::create_dir(candidate).is_ok())
+        .expect("create unique asset-load fixture directory");
+    assert!(root.starts_with(&parent));
+    let guard = FixtureGuard { path: root, parent };
+    let generator = repository.join("tools/ci/generate_asset_load_fixture.py");
+    let output = Command::new("python")
+        .arg(generator)
+        .arg(&guard.path)
+        .output()
+        .expect("run deterministic asset fixture generator");
+    assert!(
+        output.status.success(),
+        "fixture generator failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    guard
+}
+
+fn evidence_path(repository: &Path) -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository.join("target"));
+    target.join("seam-tests/it-asset-load-stress.json")
+}
+
+unsafe fn symbol<T>(library: &Library, name: &str) -> T {
+    let address = library
+        .symbol_address(name)
+        .unwrap_or_else(|error| panic!("resolve native symbol {name}: {error}"));
+    assert_eq!(
+        std::mem::size_of::<T>(),
+        std::mem::size_of::<usize>(),
+        "native symbol pointer size"
+    );
+    std::mem::transmute_copy(&address)
+}
+
+#[test]
+fn desktop_asset_load_stress_loads_bounded_fixture() {
+    std::env::set_var("STASIS_USE_SDL", "1");
+    let repository = repository_root();
+    let fixture = fixture_root(&repository);
+    let manifest = load_project_asset_manifest(&fixture.path, AssetLimits::default())
+        .expect("validate generated v2 asset manifest");
+    assert_eq!(manifest.assets.len(), 546);
+    let sprites = manifest
+        .assets
+        .iter()
+        .filter(|asset| matches!(asset.entry.format, AssetFormat::Sprite { .. }))
+        .collect::<Vec<_>>();
+    let fonts = manifest
+        .assets
+        .iter()
+        .filter(|asset| matches!(asset.entry.format, AssetFormat::Font { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(sprites.len(), SPRITE_COUNT);
+    assert_eq!(fonts.len(), FONT_COUNT);
+
+    let runtime_path = PathBuf::from(
+        std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+            .expect("STASIS_RUNTIME_DLL_PATH must name the CI-built SDL runtime"),
+    );
+    let library = Library::load(&runtime_path).expect("load SDL graphics runtime");
+    let init_window: InitWindow = unsafe { symbol(&library, "stasis_init_window") };
+    let shutdown: Shutdown = unsafe { symbol(&library, "stasis_shutdown") };
+    let set_asset_root: SetAssetRoot = unsafe { symbol(&library, "stasis_set_asset_root") };
+    let load_sprite: LoadSprite = unsafe { symbol(&library, "stasis_gfx_load_sprite") };
+    let load_font: LoadFont = unsafe { symbol(&library, "stasis_load_font") };
+    let measure_text: MeasureText = unsafe { symbol(&library, "stasis_measure_text") };
+    let cache_text: CacheText = unsafe { symbol(&library, "stasis_gfx_cache_text") };
+    let title = CString::new("Stasis asset load stress").unwrap();
+    assert_ne!(
+        init_window(320, 180, title.as_ptr()),
+        0,
+        "initialize SDL runtime"
+    );
+    let _shutdown = ShutdownGuard(Some(shutdown));
+    let root = CString::new(fixture.path.to_string_lossy().as_bytes()).unwrap();
+    assert_eq!(set_asset_root(root.as_ptr()), 1, "set generated asset root");
+
+    let started = Instant::now();
+    let mut sprite_handles = Vec::with_capacity(sprites.len());
+    let mut unique_sprite_handles = HashSet::with_capacity(sprites.len());
+    for asset in &sprites {
+        let (width, height) = match asset.entry.format {
+            AssetFormat::Sprite { width, height, .. } => (width as i32, height as i32),
+            _ => unreachable!(),
+        };
+        let path = CString::new(asset.entry.path.as_bytes()).unwrap();
+        let handle = load_sprite(path.as_ptr(), width, height);
+        assert!(handle > 0, "sprite failed to load: {}", asset.entry.id);
+        assert!(
+            unique_sprite_handles.insert(handle),
+            "duplicate sprite handle"
+        );
+        sprite_handles.push(handle);
+    }
+
+    let mut font_handles = Vec::with_capacity(fonts.len());
+    for asset in &fonts {
+        let path = CString::new(asset.entry.path.as_bytes()).unwrap();
+        let handle = load_font(path.as_ptr(), 18);
+        assert!(handle > 0, "font failed to load: {}", asset.entry.id);
+        assert!(!font_handles.contains(&handle), "duplicate font handle");
+        font_handles.push(handle);
+    }
+    assert_eq!(font_handles.len(), FONT_COUNT);
+    let repeated_font = CString::new(fonts[0].entry.path.as_bytes()).unwrap();
+    assert_eq!(
+        load_font(repeated_font.as_ptr(), 18),
+        font_handles[0],
+        "duplicate font load reuses the cache handle"
+    );
+
+    let phrases: serde_json::Value = serde_json::from_slice(
+        &fs::read(fixture.path.join("phrases.json")).expect("read generated phrases"),
+    )
+    .expect("parse generated phrases");
+    let phrases = phrases["phrases"].as_array().expect("phrase array");
+    assert_eq!(phrases.len(), PHRASE_COUNT);
+    let mut cached_handles = Vec::with_capacity(phrases.len());
+    for phrase in phrases {
+        let text = CString::new(phrase.as_str().expect("phrase text")).unwrap();
+        let width = measure_text(font_handles[0], text.as_ptr());
+        assert!(width > 0.0, "phrase measured zero width");
+        let cached = cache_text(font_handles[0], text.as_ptr());
+        assert!(cached > 0, "phrase cache returned zero");
+        cached_handles.push(cached);
+    }
+    assert_eq!(
+        cached_handles.iter().collect::<HashSet<_>>().len(),
+        PHRASE_COUNT,
+        "distinct phrases receive distinct cache handles"
+    );
+    let repeated = CString::new("deterministic asset-load phrase 000").unwrap();
+    assert_eq!(
+        cache_text(font_handles[0], repeated.as_ptr()),
+        cached_handles[0],
+        "cached phrase handle is stable"
+    );
+
+    let evidence = evidence_path(&repository);
+    if let Some(parent) = evidence.parent() {
+        fs::create_dir_all(parent).expect("create persistent asset-load evidence directory");
+    }
+    fs::write(
+        evidence,
+        serde_json::to_vec_pretty(&json!({
+            "schema": "stasis-asset-load-stress",
+            "test_id": "desktop_asset_load_stress",
+            "status": "passed",
+            "sprites": sprite_handles.len(),
+            "fonts": font_handles.len(),
+            "phrases": cached_handles.len(),
+            "elapsed_ms": started.elapsed().as_millis(),
+        }))
+        .unwrap(),
+    )
+    .expect("write asset load evidence");
+    eprintln!(
+        "desktop asset load stress: sprites={} fonts={} phrases={} elapsed_ms={}",
+        sprite_handles.len(),
+        font_handles.len(),
+        cached_handles.len(),
+        started.elapsed().as_millis()
+    );
+}

--- a/docs/asset_load_stress.md
+++ b/docs/asset_load_stress.md
@@ -1,0 +1,28 @@
+# Asset-load stress fixture
+
+The Windows slow CI lane generates an ephemeral asset project with
+`tools/ci/generate_asset_load_fixture.py`. The fixture contains 10 distinct
+font paths (copies of the canonical test font), 256 small PNG sprites, 256 SVG
+sprites, 24 larger PNG sprites, and 600 deterministic text phrases. Its v2
+manifest has 546 entries and is removed by the test guard; no generated files
+belong in source control.
+
+`apps/stasis/tests/desktop_asset_load_stress.rs` validates the manifest with
+the default `stasis_assets::AssetLimits`, loads all 536 sprites and 10 fonts
+through the native SDL runtime, measures and caches all 600 phrases, checks
+positive unique handles and cache reuse, and writes bounded count/timing
+evidence to `CARGO_TARGET_DIR/seam-tests/it-asset-load-stress.json` before
+cleanup. Reproduce on Windows after building the runtime by
+setting `STASIS_RUNTIME_DLL_PATH` and running:
+
+```text
+python -m unittest tools.ci.test_generate_asset_load_fixture
+python tools/cargo_cache.py run -- cargo test -p stasis --test desktop_asset_load_stress -- --nocapture
+```
+
+The load test fixed the former eight-font capacity failure by making the
+runtime font table explicitly bounded at 32 entries. Other explicit runtime
+bounds remain: 4096 manifest entries, 1024 cached text runs, 256 KiB cached
+text bytes, 65,536 cached text quads, and 4096 submitted sprites. The test does not
+claim coverage for mobile/web packaging, physical GPU texture limits, or
+platform-specific font rasterizer behavior.

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -391,7 +391,7 @@ static int g_asset_task_stop;
 static int g_asset_task_next_id = 1;
 
 /* Font rendering with stb_truetype. */
-#define MAX_FONTS 8
+#define MAX_FONTS 32
 #define FONT_FIRST_CHAR 32
 #define FONT_NUM_CHARS 95
 

--- a/runtime/tests/stasis_font_cache_test.c
+++ b/runtime/tests/stasis_font_cache_test.c
@@ -1,16 +1,41 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/stat.h>
 #if defined(_WIN32)
+#include <direct.h>
+#include <process.h>
 #include <sys/utime.h>
 #else
+#include <sys/types.h>
+#include <unistd.h>
 #include <utime.h>
 #endif
 
 int stasis_init_window(int width, int height, const char* title);
 void stasis_shutdown(void);
+int stasis_set_asset_root(const char* path);
 int stasis_load_font(const char* path, int font_size);
+
+static char g_temp_dir[512];
+static char g_identity_paths[10][768];
+static char g_replacement_path[768];
+static int g_temp_dir_created;
+
+static void cleanup_font_cache_temp_files(void) {
+    if (!g_temp_dir_created) return;
+    for (int i = 0; i < 10; i++) {
+        if (g_identity_paths[i][0] != '\0') remove(g_identity_paths[i]);
+    }
+    if (g_replacement_path[0] != '\0') remove(g_replacement_path);
+#if defined(_WIN32)
+    _rmdir(g_temp_dir);
+#else
+    rmdir(g_temp_dir);
+#endif
+    g_temp_dir_created = 0;
+}
 
 #define CHECK(condition) do { \
     if (!(condition)) { \
@@ -41,6 +66,26 @@ static void write_file(const char* path, const unsigned char* bytes, size_t size
     CHECK(fclose(file) == 0);
 }
 
+static int create_unique_temp_directory(const char* parent, char* out, size_t out_size) {
+#if defined(_WIN32)
+    long process_id = (long)_getpid();
+#else
+    long process_id = (long)getpid();
+#endif
+    for (unsigned int attempt = 0; attempt < 100; attempt++) {
+        int written = snprintf(out, out_size, "%s/stasis_font_cache_test_%ld_%u",
+            parent, process_id, attempt);
+        if (written <= 0 || (size_t)written >= out_size) return 0;
+#if defined(_WIN32)
+        if (_mkdir(out) == 0) return 1;
+#else
+        if (mkdir(out, 0700) == 0) return 1;
+#endif
+        if (errno != EEXIST) return 0;
+    }
+    return 0;
+}
+
 int main(void) {
     CHECK(stasis_init_window(64, 64, "stasis_font_cache_test"));
 
@@ -54,33 +99,67 @@ int main(void) {
     CHECK(second_size > 0);
     CHECK(second_size != first);
 
-    const char* replacement_path = "stasis_font_cache_test_replacement.ttf";
-    remove(replacement_path);
+    size_t identity_size = 0;
+    unsigned char* identity_bytes = read_file(STASIS_TEST_FONT_PATH, &identity_size);
+    char identity_names[10][64];
+    int identity_handles[10];
+    const char* temp_parent = getenv("TEMP");
+#if !defined(_WIN32)
+    if (!temp_parent || !*temp_parent) temp_parent = getenv("TMPDIR");
+#endif
+    if (!temp_parent || !*temp_parent) temp_parent = ".";
+    CHECK(create_unique_temp_directory(temp_parent, g_temp_dir, sizeof(g_temp_dir)));
+    g_temp_dir_created = 1;
+    CHECK(atexit(cleanup_font_cache_temp_files) == 0);
+    CHECK(strlen(g_temp_dir) < 512);
+    for (int i = 0; i < 10; i++) {
+        int name_written = snprintf(identity_names[i], sizeof(identity_names[i]),
+            "stasis_font_cache_test_identity_%02d.ttf", i);
+        CHECK(name_written > 0 && (size_t)name_written < sizeof(identity_names[i]));
+        int written = snprintf(g_identity_paths[i], sizeof(g_identity_paths[i]),
+            "%s/%s", g_temp_dir, identity_names[i]);
+        CHECK(written > 0 && (size_t)written < sizeof(g_identity_paths[i]));
+        write_file(g_identity_paths[i], identity_bytes, identity_size);
+    }
+    CHECK(stasis_set_asset_root(g_temp_dir));
+    for (int i = 0; i < 10; i++) {
+        identity_handles[i] = stasis_load_font(identity_names[i], 18);
+        CHECK(identity_handles[i] > 0);
+        for (int prior = 0; prior < i; prior++) {
+            CHECK(identity_handles[i] != identity_handles[prior]);
+        }
+        CHECK(stasis_load_font(identity_names[i], 18) == identity_handles[i]);
+    }
+    free(identity_bytes);
+
+    const char* replacement_name = "stasis_font_cache_test_replacement.ttf";
+    int replacement_written = snprintf(g_replacement_path, sizeof(g_replacement_path),
+        "%s/%s", g_temp_dir, replacement_name);
+    CHECK(replacement_written > 0 && (size_t)replacement_written < sizeof(g_replacement_path));
     size_t replacement_size = 0;
     unsigned char* replacement = read_file(STASIS_TEST_FONT_PATH, &replacement_size);
-    write_file(replacement_path, replacement, replacement_size);
+    write_file(g_replacement_path, replacement, replacement_size);
 #if defined(_WIN32)
     struct _stat replacement_stat;
-    CHECK(_stat(replacement_path, &replacement_stat) == 0);
+    CHECK(_stat(g_replacement_path, &replacement_stat) == 0);
 #else
     struct stat replacement_stat;
-    CHECK(stat(replacement_path, &replacement_stat) == 0);
+    CHECK(stat(g_replacement_path, &replacement_stat) == 0);
 #endif
-    int replacement_handle = stasis_load_font(replacement_path, 22);
+    int replacement_handle = stasis_load_font(replacement_name, 22);
     CHECK(replacement_handle > 0);
 
     memset(replacement, 0, replacement_size);
-    write_file(replacement_path, replacement, replacement_size);
+    write_file(g_replacement_path, replacement, replacement_size);
 #if defined(_WIN32)
     struct _utimbuf original_times = {replacement_stat.st_atime, replacement_stat.st_mtime};
-    CHECK(_utime(replacement_path, &original_times) == 0);
+    CHECK(_utime(g_replacement_path, &original_times) == 0);
 #else
     struct utimbuf original_times = {replacement_stat.st_atime, replacement_stat.st_mtime};
-    CHECK(utime(replacement_path, &original_times) == 0);
+    CHECK(utime(g_replacement_path, &original_times) == 0);
 #endif
-    CHECK(stasis_load_font(replacement_path, 22) == 0);
+    CHECK(stasis_load_font(replacement_name, 22) == 0);
     free(replacement);
-    CHECK(remove(replacement_path) == 0);
 
     stasis_shutdown();
     puts("stasis_font_cache_test: ok");

--- a/tools/ci/generate_asset_load_fixture.py
+++ b/tools/ci/generate_asset_load_fixture.py
@@ -1,0 +1,158 @@
+"""Generate the deterministic asset-load stress fixture.
+
+The fixture is intentionally ephemeral: callers provide an empty output
+directory, and the generator writes only beneath that directory. The generated
+manifest is the same v2 manifest consumed by ``stasis_assets``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import struct
+import zlib
+from pathlib import Path
+
+
+SMALL_PNG_COUNT = 256
+SVG_COUNT = 256
+LARGE_PNG_COUNT = 24
+FONT_COUNT = 10
+PHRASE_COUNT = 600
+MANIFEST_ENTRY_COUNT = FONT_COUNT + SMALL_PNG_COUNT + SVG_COUNT + LARGE_PNG_COUNT
+
+
+def _png(width: int, height: int, seed: int) -> bytes:
+    """Return a tiny deterministic RGBA PNG without a third-party dependency."""
+
+    rows = bytearray()
+    for y in range(height):
+        rows.append(0)  # filter byte
+        for x in range(width):
+            value = (seed * 29 + x * 17 + y * 31) & 0xFF
+            rows.extend((value, (value + seed) & 0xFF, (value + x + y) & 0xFF, 255))
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + kind
+            + payload
+            + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(rows), level=9))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _write(path: Path, data: bytes) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return hashlib.sha256(data).hexdigest()
+
+
+def _entry(asset_id: str, path: str, digest: str, fmt: dict) -> dict:
+    return {"id": asset_id, "path": path, "content_sha256": digest, "format": fmt}
+
+
+def generate_fixture(output: Path, font_source: Path | None = None) -> Path:
+    """Create the fixture at *output* and return its project root."""
+
+    output = output.resolve()
+    if output.exists():
+        if any(output.iterdir()):
+            raise ValueError(f"output directory must be empty: {output}")
+    else:
+        output.mkdir(parents=True)
+
+    source = font_source or Path(__file__).resolve().parents[2] / "apps/stasis/assets/gauntlet-font/Basic-Regular.ttf"
+    if not source.is_file():
+        raise FileNotFoundError(f"canonical test font not found: {source}")
+
+    entries: list[dict] = []
+    assets = output / "assets"
+    for index in range(FONT_COUNT):
+        relative = f"fonts/font_{index:03d}.ttf"
+        target = assets / relative.removeprefix("assets/")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        entries.append(
+            _entry(
+                f"font_{index:03d}",
+                f"assets/{relative}",
+                hashlib.sha256(target.read_bytes()).hexdigest(),
+                {"kind": "font", "encoding": "ttf"},
+            )
+        )
+
+    for index in range(SMALL_PNG_COUNT):
+        relative = f"sprites/small_{index:03d}.png"
+        digest = _write(assets / relative, _png(8, 8, index))
+        entries.append(
+            _entry(
+                f"small_{index:03d}",
+                f"assets/{relative}",
+                digest,
+                {"kind": "sprite", "encoding": "png", "width": 8, "height": 8},
+            )
+        )
+
+    for index in range(SVG_COUNT):
+        relative = f"sprites/vector_{index:03d}.svg"
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" '
+            f'viewBox="0 0 16 16"><rect width="16" height="16" fill="#{index:06x}"/>'
+            f'<circle cx="{index % 16}" cy="{(index // 16) % 16}" r="2" fill="#ffffff"/></svg>\n'
+        ).encode("ascii")
+        digest = _write(assets / relative, svg)
+        entries.append(
+            _entry(
+                f"vector_{index:03d}",
+                f"assets/{relative}",
+                digest,
+                {"kind": "sprite", "encoding": "svg", "width": 16, "height": 16},
+            )
+        )
+
+    for index in range(LARGE_PNG_COUNT):
+        relative = f"sprites/large_{index:03d}.png"
+        digest = _write(assets / relative, _png(256, 256, 1000 + index))
+        entries.append(
+            _entry(
+                f"large_{index:03d}",
+                f"assets/{relative}",
+                digest,
+                {"kind": "sprite", "encoding": "png", "width": 256, "height": 256},
+            )
+        )
+
+    phrases = [f"deterministic asset-load phrase {index:03d}" for index in range(PHRASE_COUNT)]
+    (output / "phrases.json").write_text(
+        json.dumps({"version": 1, "phrases": phrases}, indent=2) + "\n", encoding="utf-8"
+    )
+    manifest = {"schema": "stasis-assets", "version": 2, "assets": entries}
+    if len(entries) != MANIFEST_ENTRY_COUNT:
+        raise AssertionError(f"generated {len(entries)} entries, expected {MANIFEST_ENTRY_COUNT}")
+    (assets / "manifest.json").parent.mkdir(parents=True, exist_ok=True)
+    (assets / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path, help="empty directory to populate")
+    parser.add_argument("--font", type=Path, help="override canonical test font")
+    args = parser.parse_args()
+    generate_fixture(args.output, args.font)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/test_generate_asset_load_fixture.py
+++ b/tools/ci/test_generate_asset_load_fixture.py
@@ -1,0 +1,65 @@
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.ci.generate_asset_load_fixture import (
+    FONT_COUNT,
+    LARGE_PNG_COUNT,
+    MANIFEST_ENTRY_COUNT,
+    PHRASE_COUNT,
+    SMALL_PNG_COUNT,
+    SVG_COUNT,
+    generate_fixture,
+)
+
+
+class AssetLoadFixtureTests(unittest.TestCase):
+    def test_counts_hashes_and_repeatability(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first"
+            second = root / "second"
+            generate_fixture(first)
+            generate_fixture(second)
+            manifest = json.loads((first / "assets/manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["schema"], "stasis-assets")
+            self.assertEqual(manifest["version"], 2)
+            self.assertEqual(len(manifest["assets"]), MANIFEST_ENTRY_COUNT)
+            self.assertEqual(len(list((first / "assets/fonts").glob("*.ttf"))), FONT_COUNT)
+            self.assertEqual(len(list((first / "assets/sprites").glob("small_*.png"))), SMALL_PNG_COUNT)
+            self.assertEqual(len(list((first / "assets/sprites").glob("vector_*.svg"))), SVG_COUNT)
+            self.assertEqual(len(list((first / "assets/sprites").glob("large_*.png"))), LARGE_PNG_COUNT)
+            phrases = json.loads((first / "phrases.json").read_text(encoding="utf-8"))["phrases"]
+            self.assertEqual(len(phrases), PHRASE_COUNT)
+            for entry in manifest["assets"]:
+                path = first / entry["path"]
+                self.assertEqual(hashlib.sha256(path.read_bytes()).hexdigest(), entry["content_sha256"])
+                kind = entry["format"]["kind"]
+                if kind == "font":
+                    self.assertEqual(entry["format"]["encoding"], "ttf")
+                else:
+                    self.assertEqual(kind, "sprite")
+                    self.assertIn(entry["format"]["encoding"], {"png", "svg"})
+                    self.assertGreater(entry["format"]["width"], 0)
+                    self.assertGreater(entry["format"]["height"], 0)
+            first_files = sorted(path.relative_to(first) for path in first.rglob("*"))
+            second_files = sorted(path.relative_to(second) for path in second.rglob("*"))
+            self.assertEqual(first_files, second_files)
+            for relative in first_files:
+                if (first / relative).is_file():
+                    self.assertEqual((first / relative).read_bytes(), (second / relative).read_bytes())
+
+    def test_requires_empty_output_and_isolated_cleanup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "fixture"
+            generate_fixture(root)
+            with self.assertRaises(ValueError):
+                generate_fixture(root)
+            self.assertFalse((root / "assets/manifest.json").is_symlink())
+        self.assertFalse(root.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a deterministic ephemeral stress fixture with 10 fonts, 536 sprites, and 600 cached phrases
- raise the bounded desktop font capacity from 8 to 32 after reproducing the ninth-font failure
- exercise the real Windows SDL runtime in the existing slow CI lane and preserve structured evidence
- document explicit remaining manifest, text-cache, render, and platform bounds

## Validation

- `python -m unittest tools.ci.test_generate_asset_load_fixture tools.ci.test_android_emulator_seams` (10 passed)
- `python tools/ci/check_stasis_src_layout.py` (passed)
- `python tools/cargo_cache.py run -- cargo test -p stasis --test desktop_asset_load_stress --no-run` (passed)
- `cargo fmt --all --check` (passed)
- `git diff --check` (passed)
- staged Stasis formatter gate (1 passed)
- independent Luna/max review after temp-path and failure-cleanup corrections (clean)

The available local graphics DLL predates this branch and reproduces the expected old ninth-font failure. The hosted slow Windows job builds this branch's runtime and is the authoritative executable stress result.