### PR TITLE
test(android): prove Workshop JNI JIT GLES seam

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -74,7 +74,7 @@ jobs:
             -no-boot-anim -camera-back none
           script: |
             pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
-            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless
+            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -StepTimeoutSeconds 600
 
       - name: Upload Android Workshop IT-025 evidence
         if: always()

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -74,7 +74,7 @@ jobs:
             -no-boot-anim -camera-back none
           script: |
             pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
-            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -StepTimeoutSeconds 600
+            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600
 
       - name: Upload Android Workshop IT-025 evidence
         if: always()

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -74,7 +74,7 @@ jobs:
             -no-boot-anim -camera-back none
           script: |
             pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
-            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600
+            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90
 
       - name: Upload Android Workshop IT-025 evidence
         if: always()

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Android Rust targets
+        run: rustup target add aarch64-linux-android x86_64-linux-android
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -69,7 +72,17 @@ jobs:
           emulator-options: >-
             -no-window -gpu swiftshader_indirect -no-snapshot -noaudio
             -no-boot-anim -camera-back none
-          script: pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
+          script: |
+            pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
+            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless
+
+      - name: Upload Android Workshop IT-025 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-workshop-it025-seam
+          path: artifacts/android_workshop_seam/e
+          if-no-files-found: warn
 
       - name: Upload Android release-shell evidence
         if: always()

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           python -m unittest tools.ci.test_verify_android_render_performance
           python -m unittest tools.ci.test_verify_render_parity
+          python -m unittest tools.ci.test_verify_android_workshop_seam
           python tools/ci/verify_render_parity.py
 
       - name: Test web runtime seams

--- a/crates/stasis_android_bridge/src/lib.rs
+++ b/crates/stasis_android_bridge/src/lib.rs
@@ -37,6 +37,14 @@ pub const ANDROID_RENDER_FRAME_I32_CAPACITY: usize = ANDROID_RENDER_FRAME_HEADER
 pub const ANDROID_RENDER_GFX_I32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_I32_COUNT;
 pub const ANDROID_RENDER_GFX_F32_CAPACITY: usize = stasis_dynload::STASIS_RENDER_F32_COUNT;
 pub const ANDROID_RENDER_GFX_U8_CAPACITY: usize = stasis_dynload::STASIS_RENDER_U8_COUNT;
+pub const ANDROID_RENDER_I_FRAME_TOKEN: usize = 26;
+
+/// Stable identity for the real Rust bridge loaded by the Workshop JNI shim.
+/// The pointer is backed by a static NUL-terminated package-version literal.
+#[no_mangle]
+pub extern "C" fn stasis_android_bridge_version() -> *const c_char {
+    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr().cast()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndroidBridgeTickInput {
@@ -1509,20 +1517,22 @@ fn write_production_host_frame(
 }
 
 fn write_android_display_metadata(out: &mut [i32]) -> Result<(), String> {
-    if out.len() < 22 {
+    if out.len() <= ANDROID_RENDER_I_FRAME_TOKEN {
         return Err("render header is too small for display metadata".to_string());
     }
-    let (metrics, display_generation, density_generation) = RUNTIME_SESSION.with(|slot| {
-        let slot = slot.borrow();
-        let session = slot
-            .as_ref()
-            .ok_or_else(|| "Android runtime session was not initialized".to_string())?;
-        Ok::<_, String>((
-            session.display_metrics,
-            session.display_generation,
-            session.density_generation,
-        ))
-    })?;
+    let (metrics, display_generation, density_generation, frame_token) =
+        RUNTIME_SESSION.with(|slot| {
+            let slot = slot.borrow();
+            let session = slot
+                .as_ref()
+                .ok_or_else(|| "Android runtime session was not initialized".to_string())?;
+            Ok::<_, String>((
+                session.display_metrics,
+                session.display_generation,
+                session.density_generation,
+                session.tick_count,
+            ))
+        })?;
     out[10] = metrics.logical_w;
     out[11] = metrics.logical_h;
     out[12] = metrics.native_w;
@@ -1535,6 +1545,7 @@ fn write_android_display_metadata(out: &mut [i32]) -> Result<(), String> {
     out[19] = metrics.logical_h;
     out[20] = display_generation;
     out[21] = density_generation;
+    out[ANDROID_RENDER_I_FRAME_TOKEN] = frame_token;
     Ok(())
 }
 
@@ -2902,6 +2913,16 @@ pub extern "C" fn stasis_android_bridge_free_string(value: *mut c_char) {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CStr;
+
+    #[test]
+    fn exports_the_real_bridge_package_version() {
+        let version = unsafe { CStr::from_ptr(super::stasis_android_bridge_version()) };
+        assert_eq!(
+            version.to_str().expect("bridge version is UTF-8"),
+            env!("CARGO_PKG_VERSION")
+        );
+    }
     use super::*;
     use std::collections::BTreeSet;
 

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -127,6 +127,7 @@ Run the blocking render end-to-end gate directly with:
 ```
 
 This builds the canonical `samples/render_parity` fixture in Workshop with the real x86_64 development JIT. It captures the OpenGL surface, normalizes the letterboxed 640x360 viewport, and checks Android regions for the background, procedural fallback, opaque/translucent/rotated SVG sprites, a filled rectangle, crossing lines, direct text, and cached text. Three spaced captures, at least 30 rendered frames, and a successful non-empty JIT compile are required. Release packages are checked separately by `build_release.ps1` and can be run on an arm64 device with `validate_device.ps1 -Release`.
+The gate also emits `artifacts/android_workshop_seam/e/workshop-workshop-seam.json` for IT-025. It binds one Java/JNI/dlopen call to the real Rust bridge version, Cranelift `CompileReady`, a guest JIT state checksum, the render command trace, and GLES presentation using the same direct-buffer frame token; missing versions, fallback/stub markers, or fatal diagnostics fail the gate. The API 35 nightly workflow runs this check after the release-shell seams on the already-running emulator and builds both real Rust bridge ABIs when the checkout has no ignored JNI artifacts.
 
 Render-acceptance builds also emit one bounded performance sample after 60
 warm-up and 180 measured frames. Enforce the API 35 emulator thresholds with

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -9,6 +9,7 @@ def allowDebugWorkshopRustBridge = (project.findProperty('stasis.allowDebugRustB
         .toString().toBoolean()
 def renderAcceptance = (project.findProperty('stasis.renderAcceptance') ?: 'false')
         .toString().toBoolean()
+def powershellExecutable = System.getProperty('os.name').toLowerCase().contains('windows') ? 'powershell' : 'pwsh'
 android {
     namespace 'com.stasislang.workshop'
     compileSdk = (project.findProperty('stasis.compileSdk') ?: '35').toString().toInteger()
@@ -24,6 +25,7 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DSTASIS_ANDROID_SMOKE_ONLY=ON'
+                arguments "-DSTASIS_RENDER_ACCEPTANCE=${renderAcceptance ? 'ON' : 'OFF'}"
             }
         }
     }
@@ -88,7 +90,7 @@ tasks.register('verifyWorkshopRustBridge', Exec) {
     inputs.files('src/workshop/jniLibs/arm64-v8a/libstasis_android_bridge.so',
             'src/workshop/jniLibs/x86_64/libstasis_android_bridge.so')
     def expectedProfile = allowDebugWorkshopRustBridge ? 'debug' : 'release'
-    commandLine 'powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
+    commandLine powershellExecutable, '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
             rootProject.file('rust_bridge_provenance.ps1').absolutePath,
             '-Mode', 'Verify', '-Profile', expectedProfile
 }

--- a/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -2,11 +2,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(stasis_mobile_smoke C)
 
 option(STASIS_ANDROID_SMOKE_ONLY "Build the standalone Android native smoke entrypoint" ON)
+option(STASIS_RENDER_ACCEPTANCE "Emit render-acceptance-only Workshop seam evidence" OFF)
 
 add_library(stasis_mobile_smoke SHARED
     stasis_mobile_smoke.c
     stasis_android_sprite.c
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime/stasis_platform_storage.c")
+if(STASIS_RENDER_ACCEPTANCE)
+    target_compile_definitions(stasis_mobile_smoke PRIVATE STASIS_RENDER_ACCEPTANCE=1)
+endif()
 target_include_directories(stasis_mobile_smoke PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../runtime")
 
 find_library(log_lib log)

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -465,6 +465,15 @@ static void log_workshop_it025_marker(JNIEnv *env, const char *bridge_version,
             (*env)->GetVersion(env), bridge_version, render_version,
             state_checksum, command_trace, frame_token);
 }
+
+static uint32_t workshop_it025_command_trace(int32_t *values_i32,
+        const float *values_f32, const uint8_t *values_u8) {
+    int32_t frame_token = values_i32[STASIS_RENDER_I_FRAME_TOKEN];
+    values_i32[STASIS_RENDER_I_FRAME_TOKEN] = 0;
+    uint32_t trace = stasis_render_trace(values_i32, values_f32, values_u8);
+    values_i32[STASIS_RENDER_I_FRAME_TOKEN] = frame_token;
+    return trace;
+}
 #endif
 static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
     RustBridgeApi *bridge = load_rust_bridge_api();
@@ -905,7 +914,7 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
                 return -1;
             }
             log_workshop_it025_marker(env, it025_bridge_version, it025_state_checksum,
-                    stasis_render_trace(values_i32, values_f32, values_u8),
+                    workshop_it025_command_trace(values_i32, values_f32, values_u8),
                     values_i32[STASIS_RENDER_I_VERSION],
                     values_i32[STASIS_RENDER_I_FRAME_TOKEN]);
         }

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -466,14 +466,6 @@ static void log_workshop_it025_marker(JNIEnv *env, const char *bridge_version,
             state_checksum, command_trace, frame_token);
 }
 
-static uint32_t workshop_it025_command_trace(int32_t *values_i32,
-        const float *values_f32, const uint8_t *values_u8) {
-    int32_t frame_token = values_i32[STASIS_RENDER_I_FRAME_TOKEN];
-    values_i32[STASIS_RENDER_I_FRAME_TOKEN] = 0;
-    uint32_t trace = stasis_render_trace(values_i32, values_f32, values_u8);
-    values_i32[STASIS_RENDER_I_FRAME_TOKEN] = frame_token;
-    return trace;
-}
 #endif
 static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
     RustBridgeApi *bridge = load_rust_bridge_api();
@@ -914,7 +906,7 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
                 return -1;
             }
             log_workshop_it025_marker(env, it025_bridge_version, it025_state_checksum,
-                    workshop_it025_command_trace(values_i32, values_f32, values_u8),
+                    stasis_render_trace(values_i32, values_f32, values_u8),
                     values_i32[STASIS_RENDER_I_VERSION],
                     values_i32[STASIS_RENDER_I_FRAME_TOKEN]);
         }

--- a/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
+++ b/mobile/android/app/src/main/cpp/stasis_mobile_smoke.c
@@ -15,7 +15,11 @@
 
 #define STASIS_ANDROID_LOG_TAG "StasisWorkshop"
 #define STASIS_RUNTIME_STATE_RELATIVE_PATH "build/runtime_state.txt"
+#ifndef STASIS_RENDER_ACCEPTANCE
+#define STASIS_RENDER_ACCEPTANCE 0
+#endif
 typedef char *(*stasis_android_bridge_compile_project_fn)(const char *project_root, const char *entry_file);
+typedef const char *(*stasis_android_bridge_version_fn)(void);
 typedef char *(*stasis_android_bridge_run_tests_fn)(const char *project_root);
 typedef char *(*stasis_android_bridge_run_tick_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h);
 typedef int (*stasis_android_bridge_run_tick_frame_fn)(const char *project_root, const char *entry_file, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len);
@@ -42,6 +46,7 @@ typedef int (*stasis_codex_android_initialize_fn)(void *env, void *context);
 typedef void (*stasis_codex_android_free_string_fn)(char *value);
 typedef struct RustBridgeApi {
     void *handle;
+    stasis_android_bridge_version_fn version;
     stasis_android_bridge_compile_project_fn compile_project;
     stasis_android_bridge_run_tests_fn run_tests;
     stasis_android_bridge_run_tick_fn run_tick;
@@ -170,6 +175,8 @@ static RustBridgeApi *load_rust_bridge_api(void) {
         return NULL;
     }
 
+    rust_bridge_api.version =
+            (stasis_android_bridge_version_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_version");
     rust_bridge_api.compile_project =
             (stasis_android_bridge_compile_project_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_compile_project");
     rust_bridge_api.run_tests =
@@ -207,7 +214,8 @@ static RustBridgeApi *load_rust_bridge_api(void) {
             (stasis_android_bridge_set_storage_root_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_set_storage_root");
     rust_bridge_api.free_string =
             (stasis_android_bridge_free_string_fn)dlsym(rust_bridge_api.handle, "stasis_android_bridge_free_string");
-    if (rust_bridge_api.compile_project == NULL ||
+    if (rust_bridge_api.version == NULL ||
+        rust_bridge_api.compile_project == NULL ||
         rust_bridge_api.run_tick == NULL ||
         rust_bridge_api.free_string == NULL) {
         __android_log_print(ANDROID_LOG_WARN, STASIS_ANDROID_LOG_TAG, "Rust Android bridge missing required symbols");
@@ -440,6 +448,24 @@ static int try_rust_bridge_get_i32_global(const char *project_root, const char *
     bridge->free_string(bridge_message);
     return 1;
 }
+
+static int parse_state_value(const char *message, int *value) {
+    return strstr(message, "StateGet:") != NULL && parse_manifest_i32(message, "value=", value);
+}
+
+#if STASIS_RENDER_ACCEPTANCE
+static void log_workshop_it025_marker(JNIEnv *env, const char *bridge_version,
+        int state_checksum, uint32_t command_trace, int render_version, int frame_token) {
+    __android_log_print(ANDROID_LOG_INFO, STASIS_ANDROID_LOG_TAG,
+            "Stasis Workshop IT-025: {\"schema\":\"stasis.workshop_seam.v1\","
+            "\"test_id\":\"IT-025\",\"event\":\"frame\","
+            "\"jni_version\":%d,\"rust_bridge_version\":\"%s\","
+            "\"render_version\":%d,\"state_checksum\":%d,"
+            "\"command_trace\":%u,\"frame_token\":%d,\"fallback\":0,\"stub\":0}",
+            (*env)->GetVersion(env), bridge_version, render_version,
+            state_checksum, command_trace, frame_token);
+}
+#endif
 static int try_rust_bridge_run_tick_frame(const char *project_root, int touch_x, int touch_y, int touch_active, int screen_w, int screen_h, int32_t *out_i32, uintptr_t out_i32_len, float *out_f32, uintptr_t out_f32_len, uint8_t *out_u8, uintptr_t out_u8_len) {
     RustBridgeApi *bridge = load_rust_bridge_api();
     if (bridge == NULL || bridge->run_tick_frame == NULL) {
@@ -817,7 +843,6 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
             root, (int)touch_x, (int)touch_y, (int)touch_active, (int)screen_w, (int)screen_h,
             values_i32, STASIS_RENDER_I32_COUNT, values_f32, STASIS_RENDER_F32_COUNT,
             values_u8, STASIS_RENDER_U8_COUNT);
-    (*env)->ReleaseStringUTFChars(env, project_root, root);
     if (status != 0) {
         values_i32[0] = -1;
     } else {
@@ -849,7 +874,44 @@ Java_com_stasislang_workshop_MainActivity_nativeRunFrameInto(JNIEnv *env, jclass
             last_display_generation = values_i32[STASIS_RENDER_I_DISPLAY_GENERATION];
             last_density_generation = values_i32[STASIS_RENDER_I_DENSITY_GENERATION];
         }
+#if STASIS_RENDER_ACCEPTANCE
+        {
+            static int it025_state_ready = 0;
+            static int it025_state_checksum;
+            static const char *it025_bridge_version;
+            RustBridgeApi *bridge = load_rust_bridge_api();
+            char state_message[256];
+            if (!it025_state_ready) {
+                it025_bridge_version = bridge == NULL || bridge->version == NULL
+                        ? NULL : bridge->version();
+                if (it025_bridge_version == NULL || it025_bridge_version[0] == '\0' ||
+                        !try_rust_bridge_get_i32_global(root, "seam_state_checksum",
+                                state_message, sizeof(state_message)) ||
+                        !parse_state_value(state_message, &it025_state_checksum) ||
+                        it025_state_checksum <= 0) {
+                    __android_log_print(ANDROID_LOG_ERROR, STASIS_ANDROID_LOG_TAG,
+                            "IT-025 state checksum was unavailable from the live Rust JIT global bridge");
+                    (*env)->ReleaseStringUTFChars(env, project_root, root);
+                    values_i32[0] = -1;
+                    return -1;
+                }
+                it025_state_ready = 1;
+            }
+            if (it025_bridge_version == NULL) {
+                __android_log_print(ANDROID_LOG_ERROR, STASIS_ANDROID_LOG_TAG,
+                        "IT-025 Rust bridge version was unavailable after initialization");
+                (*env)->ReleaseStringUTFChars(env, project_root, root);
+                values_i32[0] = -1;
+                return -1;
+            }
+            log_workshop_it025_marker(env, it025_bridge_version, it025_state_checksum,
+                    stasis_render_trace(values_i32, values_f32, values_u8),
+                    values_i32[STASIS_RENDER_I_VERSION],
+                    values_i32[STASIS_RENDER_I_FRAME_TOKEN]);
+        }
+#endif
     }
+    (*env)->ReleaseStringUTFChars(env, project_root, root);
     return (jint)status;
 }
 

--- a/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
+++ b/mobile/android/app/src/main/java/com/stasislang/workshop/StasisPreviewRenderer.java
@@ -51,6 +51,7 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
     static final int I_DROPPED_ORDER = 23;
     static final int I_RECT_COUNT = 24;
     static final int I_DROPPED_RECTS = 25;
+    static final int I_FRAME_TOKEN = 26;
     static final int I_SPRITE_BASE = 32;
     static final int F_LINE_BASE = 4;
     static final int MAX_GEOMETRY = 10_000;
@@ -544,7 +545,12 @@ final class StasisPreviewRenderer implements GLSurfaceView.Renderer {
                 if (BuildConfig.STASIS_RENDER_ACCEPTANCE) {
                     renderAcceptanceFrameCount += 1;
                     if (renderAcceptanceFrameCount == 1 || renderAcceptanceFrameCount % 30 == 0) {
-                        Log.i(LOG_TAG, "RenderAcceptanceFrame: count=" + renderAcceptanceFrameCount);
+                        Log.i(LOG_TAG, "RenderAcceptanceFrame: count=" + renderAcceptanceFrameCount
+                                + " frame_token=" + frameI32.get(I_FRAME_TOKEN));
+                        Log.i(LOG_TAG, "Stasis Workshop IT-025 GLES: {\"schema\":\"stasis.workshop_seam.v1\","
+                                + "\"test_id\":\"IT-025\",\"event\":\"present\",\"count\":"
+                                + renderAcceptanceFrameCount + ","
+                                + "\"frame_token\":" + frameI32.get(I_FRAME_TOKEN) + "}");
                     }
                 }
             }

--- a/mobile/android/build_debug.ps1
+++ b/mobile/android/build_debug.ps1
@@ -14,7 +14,8 @@ $ErrorActionPreference = "Stop"
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Push-Location $scriptRoot
 try {
-    $gradle = Join-Path $scriptRoot "gradlew.bat"
+    $gradleName = if ([System.IO.Path]::DirectorySeparatorChar -eq [char]'\') { "gradlew.bat" } else { "gradlew" }
+    $gradle = Join-Path $scriptRoot $gradleName
     if ($GradlePath) {
         if (-not (Test-Path $GradlePath)) { throw "Gradle was not found: $GradlePath" }
         $gradleCmd = $GradlePath

--- a/mobile/android/build_rust_bridge.ps1
+++ b/mobile/android/build_rust_bridge.ps1
@@ -11,6 +11,8 @@ $ErrorActionPreference = "Stop"
 
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$runningOnWindows = [System.IO.Path]::DirectorySeparatorChar -eq [char]'\'
+$executableSuffix = if ($runningOnWindows) { ".exe" } else { "" }
 
 if (-not $AndroidHome) {
     if ($env:ANDROID_HOME) {
@@ -18,12 +20,16 @@ if (-not $AndroidHome) {
     } elseif ($env:ANDROID_SDK_ROOT) {
         $AndroidHome = $env:ANDROID_SDK_ROOT
     } else {
-        $AndroidHome = "C:\Android\Sdk"
+        $AndroidHome = if ($runningOnWindows) {
+            "C:\Android\Sdk"
+        } else {
+            Join-Path ([Environment]::GetFolderPath("UserProfile")) "Android/sdk"
+        }
     }
 }
 
 $ndkRoot = if ($NdkVersion) {
-    Join-Path $AndroidHome "ndk\$NdkVersion"
+    Join-Path (Join-Path $AndroidHome "ndk") $NdkVersion
 } else {
     $ndkParent = Join-Path $AndroidHome "ndk"
     $ndks = Get-ChildItem -Directory $ndkParent -ErrorAction SilentlyContinue | Sort-Object Name -Descending
@@ -33,7 +39,9 @@ $ndkRoot = if ($NdkVersion) {
     $ndks[0].FullName
 }
 
-$prebuilt = Join-Path $ndkRoot "toolchains\llvm\prebuilt\windows-x86_64"
+$prebuiltName = if ($runningOnWindows) { "windows-x86_64" } else { "linux-x86_64" }
+$prebuilt = Join-Path (Join-Path (Join-Path $ndkRoot "toolchains") "llvm") (Join-Path "prebuilt" $prebuiltName)
+$linkerSuffix = if ($runningOnWindows) { ".cmd" } else { "" }
 $installedTargets = & rustup target list --installed
 if ($LASTEXITCODE -ne 0) { throw "rustup target discovery failed with exit code $LASTEXITCODE" }
 $env:CARGO_INCREMENTAL = "0"
@@ -66,7 +74,7 @@ foreach ($abi in $Abis) {
     $target = $targets[$abi]
     if (-not $target) { throw "Unsupported Android ABI: $abi" }
     $rustTarget = $target.Rust
-    $linker = Join-Path $prebuilt "bin\$($target.Clang)$MinSdk-clang.cmd"
+    $linker = Join-Path (Join-Path $prebuilt "bin") "$($target.Clang)$MinSdk-clang$linkerSuffix"
     if (-not (Test-Path $linker)) { throw "Android linker not found: $linker" }
     if ($installedTargets -notcontains $rustTarget) {
         throw "Rust target $rustTarget is not installed. Run: rustup target add $rustTarget"
@@ -76,19 +84,33 @@ foreach ($abi in $Abis) {
     $linkerVariable = "CARGO_TARGET_$($rustTarget.ToUpperInvariant().Replace('-', '_'))_LINKER"
     Set-Item -Path "Env:$linkerVariable" -Value $linker
     Set-Item -Path "Env:CC_$targetEnvName" -Value $linker
-    Set-Item -Path "Env:AR_$targetEnvName" -Value (Join-Path $prebuilt "bin\llvm-ar.exe")
+    Set-Item -Path "Env:AR_$targetEnvName" -Value (Join-Path (Join-Path $prebuilt "bin") "llvm-ar$executableSuffix")
 
     Push-Location $repoRoot
     try {
-        cargo build -p stasis_android_bridge --target $rustTarget @profileArgs
+        $cargoCache = Join-Path (Join-Path $repoRoot "tools") "cargo_cache.py"
+        & python $cargoCache run -- cargo build -p stasis_android_bridge --target $rustTarget @profileArgs
         if ($LASTEXITCODE -ne 0) { throw "Rust Android bridge build failed with exit code $LASTEXITCODE" }
     } finally {
         Pop-Location
     }
 
-    $source = Join-Path $repoRoot "target\$rustTarget\$profileDir\libstasis_android_bridge.so"
+    $targetRoot = if ($env:CARGO_TARGET_DIR) {
+        if ([System.IO.Path]::IsPathRooted($env:CARGO_TARGET_DIR)) {
+            [System.IO.Path]::GetFullPath($env:CARGO_TARGET_DIR)
+        } else {
+            [System.IO.Path]::GetFullPath((Join-Path $repoRoot $env:CARGO_TARGET_DIR))
+        }
+    } else {
+        $commonGitDir = (& git -C $repoRoot rev-parse --path-format=absolute --git-common-dir).Trim()
+        Join-Path (Split-Path $commonGitDir -Parent) (Join-Path "build" "codex-cargo-target")
+    }
+    $source = Join-Path (Join-Path (Join-Path $targetRoot $rustTarget) $profileDir) "libstasis_android_bridge.so"
+    if (-not (Test-Path $source)) {
+        $source = Join-Path (Join-Path (Join-Path $repoRoot "target") $rustTarget) (Join-Path $profileDir "libstasis_android_bridge.so")
+    }
     if (-not (Test-Path $source)) { throw "Rust bridge output was not produced: $source" }
-    $destDir = Join-Path $scriptRoot "app\src\workshop\jniLibs\$abi"
+    $destDir = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $scriptRoot "app") "src") "workshop") "jniLibs") $abi
     New-Item -ItemType Directory -Force $destDir | Out-Null
     $dest = Join-Path $destDir "libstasis_android_bridge.so"
     Copy-Item -Force $source $dest

--- a/mobile/android/rust_bridge_provenance.ps1
+++ b/mobile/android/rust_bridge_provenance.ps1
@@ -9,7 +9,7 @@ $ErrorActionPreference = "Stop"
 
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
-$jniRoot = Join-Path $scriptRoot "app\src\workshop\jniLibs"
+$jniRoot = Join-Path (Join-Path (Join-Path (Join-Path $scriptRoot "app") "src") "workshop") "jniLibs"
 $manifestPath = Join-Path $jniRoot "stasis-rust-bridge.json"
 $requiredTargets = [ordered]@{
     "arm64-v8a" = "aarch64-linux-android"
@@ -44,7 +44,7 @@ function Get-BridgeEntries([string]$ExpectedProfile) {
     $entries = @()
     foreach ($pair in $requiredTargets.GetEnumerator()) {
         $abi = $pair.Key
-        $bridge = Join-Path $jniRoot "$abi\libstasis_android_bridge.so"
+        $bridge = Join-Path (Join-Path $jniRoot $abi) "libstasis_android_bridge.so"
         if (-not (Test-Path -LiteralPath $bridge)) {
             throw "Workshop Rust bridge is missing ABI $abi."
         }
@@ -101,7 +101,7 @@ foreach ($pair in $requiredTargets.GetEnumerator()) {
             $entry[0].file -ne $expectedFile -or $entry[0].profile -ne $Profile) {
         throw "Workshop Rust bridge provenance is invalid for ABI $abi."
     }
-    $bridge = Join-Path $jniRoot "$abi\libstasis_android_bridge.so"
+    $bridge = Join-Path (Join-Path $jniRoot $abi) "libstasis_android_bridge.so"
     if (-not (Test-Path -LiteralPath $bridge)) {
         throw "Workshop Rust bridge is missing ABI $abi."
     }

--- a/mobile/android/test_render_emulator.ps1
+++ b/mobile/android/test_render_emulator.ps1
@@ -18,22 +18,29 @@ $serial = "emulator-$Port"
 $startedEmulator = $false
 $packages = @("com.stasislang.workshop")
 
+$runningOnWindows = [System.IO.Path]::DirectorySeparatorChar -eq [char]'\'
 $androidHome = if ($env:ANDROID_HOME) {
     $env:ANDROID_HOME
 } elseif ($env:ANDROID_SDK_ROOT) {
     $env:ANDROID_SDK_ROOT
 } else {
-    "C:\Android\Sdk"
+    if ($runningOnWindows) { "C:\Android\Sdk" } else {
+        Join-Path ([Environment]::GetFolderPath("UserProfile")) "Android/sdk"
+    }
 }
-$adb = Join-Path $androidHome "platform-tools\adb.exe"
-if (-not (Test-Path $adb)) { throw "adb.exe was not found: $adb" }
+$adbExecutableSuffix = if ($runningOnWindows) { ".exe" } else { "" }
+$adb = Join-Path (Join-Path $androidHome "platform-tools") "adb$adbExecutableSuffix"
+if (-not (Test-Path $adb)) { throw "adb was not found: $adb" }
 
 $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
 if (-not $OutputPath) {
-    $OutputPath = Join-Path $repoRoot "artifacts\android_render_e2e\$stamp"
+    $OutputPath = Join-Path (Join-Path (Join-Path $repoRoot "artifacts") "android_workshop_seam") "e"
 }
 $artifactRoot = [System.IO.Path]::GetFullPath($OutputPath)
 New-Item -ItemType Directory -Force -Path $artifactRoot | Out-Null
+$toolsCiRoot = Join-Path (Join-Path $repoRoot "tools") "ci"
+$renderParityManifest = Join-Path (Join-Path (Join-Path $repoRoot "samples") "render_parity") "capture_manifest.json"
+$workshopApk = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $scriptRoot "app") "build") "outputs") "apk") "workshop") (Join-Path "debug" "app-workshop-debug.apk")
 
 function Assert-In-Time([string]$Step) {
     if ($startedAt.Elapsed.TotalSeconds -gt $TotalTimeoutSeconds) {
@@ -66,7 +73,11 @@ function Invoke-BoundedScript([string]$Path, [string[]]$Arguments, [string]$Phas
     $errorTask = $process.StandardError.ReadToEndAsync()
     $timedOut = -not $process.WaitForExit($stepSeconds * 1000)
     if ($timedOut) {
-        & taskkill.exe /PID $process.Id /T /F 2>$null | Out-Null
+        if ($process.PSObject.Methods.Name -contains "Kill") {
+            $process.Kill($true)
+        } elseif ($runningOnWindows) {
+            & taskkill.exe /PID $process.Id /T /F 2>$null | Out-Null
+        }
     }
     $process.WaitForExit()
     $outputTask.Result | Set-Content -LiteralPath $stdout -Encoding UTF8
@@ -112,10 +123,11 @@ function Find-PackageProcessId([string]$Package) {
 }
 
 function Resolve-Gradle {
-    $wrapper = Join-Path $scriptRoot "gradlew.bat"
+    $wrapperName = if ($runningOnWindows) { "gradlew.bat" } else { "gradlew" }
+    $wrapper = Join-Path $scriptRoot $wrapperName
     if (Test-Path $wrapper) { return $wrapper }
     if ($env:ChocolateyInstall) {
-        $installed = Get-ChildItem (Join-Path $env:ChocolateyInstall "lib\gradle\tools") `
+        $installed = Get-ChildItem (Join-Path (Join-Path (Join-Path $env:ChocolateyInstall "lib") "gradle") "tools") `
             -Recurse -Filter gradle.bat -ErrorAction SilentlyContinue |
             Sort-Object FullName -Descending | Select-Object -First 1
         if ($installed) { return $installed.FullName }
@@ -331,7 +343,7 @@ function Assert-RenderedVariant(
                 }
                 Write-Host "$Name viewport=$viewportArg"
                 Save-Screenshot $capture
-                & python (Join-Path $repoRoot "tools\ci\verify_render_parity.py") `
+                & python (Join-Path $toolsCiRoot "verify_render_parity.py") `
                     --capture $capture --capture-only --profile android_emulator `
                     "--viewport=$viewportArg"
                 if ($LASTEXITCODE -eq 0) {
@@ -404,7 +416,7 @@ function Assert-RenderedVariant(
         android_sdk = [int]$observedSdk
     } | ConvertTo-Json | Set-Content -LiteralPath $metadataPath -Encoding UTF8
     $performanceArguments = @(
-        (Join-Path $repoRoot "tools\ci\verify_android_render_performance.py"),
+        (Join-Path $toolsCiRoot "verify_android_render_performance.py"),
         "--log", $logFile,
         "--metadata", $metadataPath,
         "--evidence", (Join-Path $artifactRoot "$Name-performance.json")
@@ -422,6 +434,10 @@ function Assert-RenderedVariant(
     if (-not $renderPassed) {
         throw "$Name render acceptance timed out: $lastFailure; see $artifactRoot"
     }
+    & python (Join-Path $toolsCiRoot "verify_android_workshop_seam.py") `
+        --log $logFile --capture $capture --manifest $renderParityManifest `
+        --apk $Apk --metadata $metadataPath --evidence (Join-Path $artifactRoot "$Name-workshop-seam.json")
+    if ($LASTEXITCODE -ne 0) { throw "$Name IT-025 Workshop seam verification failed; see $logFile" }
     Write-Output "$Name render acceptance passed: $capture"
 }
 
@@ -430,23 +446,27 @@ try {
         $_ -match "^$([regex]::Escape($serial))\s+device(?:\s|$)"
     }
     $startedEmulator = -not [bool]$runningBefore
-    $emulatorArguments = @("-AvdName", $AvdName, "-Port", "$Port")
-    if ($Headless) { $emulatorArguments += "-Headless" }
-    $serial = Invoke-BoundedScript (Join-Path $scriptRoot "start_emulator.ps1") `
-        $emulatorArguments "start-emulator"
-    $serial = @($serial) | Select-Object -Last 1
+    if ($startedEmulator) {
+        $emulatorArguments = @("-AvdName", $AvdName, "-Port", "$Port")
+        if ($Headless) { $emulatorArguments += "-Headless" }
+        $serial = Invoke-BoundedScript (Join-Path $scriptRoot "start_emulator.ps1") `
+            $emulatorArguments "start-emulator"
+        $serial = @($serial) | Select-Object -Last 1
+    } else {
+        Write-Host "Reusing ready Android emulator $serial"
+    }
 
     if (-not $SkipBuild) {
         $gradle = Resolve-Gradle
         Invoke-BoundedScript (Join-Path $scriptRoot "build_debug.ps1") @(
-            "-RenderAcceptance", "-SkipCodexNative", "-SkipRustBridgeBuild",
+            "-RenderAcceptance", "-SkipCodexNative",
             "-NoGradleDaemon", "-GradlePath", $gradle
         ) "build-workshop" | Out-Null
         Assert-In-Time "Workshop build"
     }
 
     Assert-RenderedVariant "workshop" "com.stasislang.workshop" `
-        (Join-Path $scriptRoot "app\build\outputs\apk\workshop\debug\app-workshop-debug.apk") `
+        $workshopApk `
         "Interactive Stasis game preview. Touch the game to control it." $true
     Assert-In-Time "render acceptance"
 

--- a/mobile/android/test_render_emulator.ps1
+++ b/mobile/android/test_render_emulator.ps1
@@ -74,10 +74,13 @@ function Invoke-BoundedScript([string]$Path, [string[]]$Arguments, [string]$Phas
     $errorTask = $process.StandardError.ReadToEndAsync()
     $timedOut = -not $process.WaitForExit($stepSeconds * 1000)
     if ($timedOut) {
-        if ($process.PSObject.Methods.Name -contains "Kill") {
+        $killWithTree = $process.GetType().GetMethod("Kill", [Type[]]@([bool]))
+        if ($null -ne $killWithTree) {
             $process.Kill($true)
         } elseif ($runningOnWindows) {
             & taskkill.exe /PID $process.Id /T /F 2>$null | Out-Null
+        } else {
+            $process.Kill()
         }
     }
     $process.WaitForExit()

--- a/mobile/android/test_render_emulator.ps1
+++ b/mobile/android/test_render_emulator.ps1
@@ -4,6 +4,7 @@ param(
     [switch]$Headless,
     [switch]$SkipBuild,
     [int]$RenderTimeoutSeconds = 45,
+    [int]$StepTimeoutSeconds = 300,
     [int]$TotalTimeoutSeconds = 900,
     [double]$MaxRenderP50Millis = 0,
     [double]$MaxRenderP95Millis = 0,
@@ -50,7 +51,7 @@ function Assert-In-Time([string]$Step) {
 
 function Invoke-BoundedScript([string]$Path, [string[]]$Arguments, [string]$Phase) {
     $remainingSeconds = [math]::Floor($TotalTimeoutSeconds - $startedAt.Elapsed.TotalSeconds)
-    $stepSeconds = [math]::Min(300, $remainingSeconds)
+    $stepSeconds = [math]::Min($StepTimeoutSeconds, $remainingSeconds)
     if ($stepSeconds -le 0) { throw "Android render E2E exceeded ${TotalTimeoutSeconds}s before $Phase" }
     $stdout = Join-Path $artifactRoot "$Phase-stdout.log"
     $stderr = Join-Path $artifactRoot "$Phase-stderr.log"

--- a/runtime/stasis_render_contract.h
+++ b/runtime/stasis_render_contract.h
@@ -47,6 +47,8 @@
 #define STASIS_RENDER_I_DROPPED_ORDER 23
 #define STASIS_RENDER_I_RECT_COUNT 24
 #define STASIS_RENDER_I_DROPPED_RECTS 25
+/* Reserved header slot carrying the monotonically increasing Android frame token. */
+#define STASIS_RENDER_I_FRAME_TOKEN 26
 #define STASIS_RENDER_I_SPRITE_BASE 32
 
 #define STASIS_RENDER_F_CLEAR_BASE 0

--- a/samples/render_parity/capture_manifest.json
+++ b/samples/render_parity/capture_manifest.json
@@ -3,6 +3,7 @@
   "fixture": "samples/render_parity/main.stasis",
   "trace_fixture": "samples/render_parity/trace.stasis",
   "command_trace": 1390729377,
+  "workshop_command_trace": 3939026311,
   "state_checksum": 2500,
   "render_contract_version": 5,
   "font_sha256": "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47",

--- a/samples/render_parity/capture_manifest.json
+++ b/samples/render_parity/capture_manifest.json
@@ -3,6 +3,8 @@
   "fixture": "samples/render_parity/main.stasis",
   "trace_fixture": "samples/render_parity/trace.stasis",
   "command_trace": 1390729377,
+  "state_checksum": 2500,
+  "render_contract_version": 5,
   "font_sha256": "17ec668bd0cd62e934f97563287ed72a4a8599ae716d20c1a93c82f1876dde47",
   "logical_size": [640, 360],
   "required_commands": {

--- a/samples/render_parity/main.stasis
+++ b/samples/render_parity/main.stasis
@@ -33,6 +33,10 @@ global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
 global host_req_seq: i32;
 
+// IT-025 reads this guest-owned value through the live JIT global bridge.  It
+// is deliberately independent of host display metadata.
+global seam_state_checksum: i32;
+
 struct ParityState {
     opaque: Sprite;
     translucent: Sprite;
@@ -46,6 +50,7 @@ struct ParityState {
 global state: ParityState;
 
 function main(): i32 {
+    seam_state_checksum = 2500;
     host_req_flags = 1;
     host_req_window_w_px = PARITY_WINDOW_W;
     host_req_window_h_px = PARITY_WINDOW_H;

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -1434,8 +1434,6 @@ def main() -> int:
     assert "CompileReady: backend=cranelift-jit" in bridge
     assert "Stasis Workshop IT-025" in native
     assert "STASIS_RENDER_ACCEPTANCE" in native
-    assert "workshop_it025_command_trace" in native
-    assert "values_i32[STASIS_RENDER_I_FRAME_TOKEN] = 0" in native
     assert "STASIS_RENDER_I_FRAME_TOKEN" in native
     assert "IT-025 GLES" in preview_renderer
     assert "I_FRAME_TOKEN" in preview_renderer

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -1434,6 +1434,8 @@ def main() -> int:
     assert "CompileReady: backend=cranelift-jit" in bridge
     assert "Stasis Workshop IT-025" in native
     assert "STASIS_RENDER_ACCEPTANCE" in native
+    assert "workshop_it025_command_trace" in native
+    assert "values_i32[STASIS_RENDER_I_FRAME_TOKEN] = 0" in native
     assert "STASIS_RENDER_I_FRAME_TOKEN" in native
     assert "IT-025 GLES" in preview_renderer
     assert "I_FRAME_TOKEN" in preview_renderer

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -165,8 +165,11 @@ def main() -> int:
     assert "stale for the current Rust/Cargo inputs" in rust_bridge_provenance
     assert "aarch64-linux-android" in rust_bridge_script
     assert "x86_64-linux-android" in rust_bridge_script
+    assert "linux-x86_64" in rust_bridge_script
+    assert "[System.IO.Path]::IsPathRooted" in rust_bridge_script
     assert "libstasis_android_bridge.so" in rust_bridge_script
-    assert '"app\\src\\workshop\\jniLibs\\$abi"' in rust_bridge_script
+    assert 'Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $scriptRoot "app") "src") "workshop") "jniLibs") $abi' in rust_bridge_script
+    assert "cargo_cache.py" in rust_bridge_script
     assert 'build_rust_bridge.ps1") -Release' in debug_script
     assert ":app:assembleWorkshopDebug" in debug_script
     assert "package-mobile" in release_script
@@ -1392,6 +1395,7 @@ def main() -> int:
     assert "required Rust Android compiler bridge is unavailable" in native
     assert "dlopen(\"libstasis_android_bridge.so\"" in native
     assert "stasis_android_bridge_compile_project" in native
+    assert "stasis_android_bridge_version" in native
     assert "stasis_android_bridge_set_i32_global" in native
     assert "stasis_android_bridge_get_i32_global" in native
     assert "Java_com_stasislang_workshop_MainActivity_nativeSetRuntimeI32" in native
@@ -1428,6 +1432,11 @@ def main() -> int:
     assert "WorkshopReload::FastReload" in bridge
     assert "WorkshopReload::ResetRequired" in bridge
     assert "CompileReady: backend=cranelift-jit" in bridge
+    assert "Stasis Workshop IT-025" in native
+    assert "STASIS_RENDER_ACCEPTANCE" in native
+    assert "STASIS_RENDER_I_FRAME_TOKEN" in native
+    assert "IT-025 GLES" in preview_renderer
+    assert "I_FRAME_TOKEN" in preview_renderer
     assert "Stasis Android native smoke loaded" in native
 
     cmake = read("mobile/android/app/src/main/cpp/CMakeLists.txt")
@@ -1439,6 +1448,7 @@ def main() -> int:
     assert "STASIS_ANDROID_PUBLISHED_AOT" not in cmake
     assert "published_aot_objects.cmake" not in cmake
     assert "find_library(dl_lib dl)" in cmake
+    assert "STASIS_RENDER_ACCEPTANCE" in cmake
     assert "${dl_lib}" in cmake
 
     for sample in STASIS_SAMPLE_FILES:

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -167,7 +167,7 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
 
     def test_workshop_it025_runs_after_release_shells_on_the_same_emulator(self):
         self.assertIn(
-            "test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600",
+            "test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90",
             self.workflow,
         )
         self.assertIn("[int]$StepTimeoutSeconds = 300", self.workshop_script)

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -166,7 +166,12 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertGreaterEqual(inside_drag["duration_ms"], 2000)
 
     def test_workshop_it025_runs_after_release_shells_on_the_same_emulator(self):
-        self.assertIn("test_render_emulator.ps1 -Headless", self.workflow)
+        self.assertIn(
+            "test_render_emulator.ps1 -Headless -StepTimeoutSeconds 600",
+            self.workflow,
+        )
+        self.assertIn("[int]$StepTimeoutSeconds = 300", self.workshop_script)
+        self.assertIn("[math]::Min($StepTimeoutSeconds, $remainingSeconds)", self.workshop_script)
         self.assertIn("verify_android_workshop_seam.py", self.workshop_script)
         self.assertIn('Join-Path (Join-Path (Join-Path $repoRoot "artifacts") "android_workshop_seam") "e"', self.workshop_script)
         self.assertIn("Reusing ready Android emulator", self.workshop_script)

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -167,7 +167,7 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
 
     def test_workshop_it025_runs_after_release_shells_on_the_same_emulator(self):
         self.assertIn(
-            "test_render_emulator.ps1 -Headless -StepTimeoutSeconds 600",
+            "test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600",
             self.workflow,
         )
         self.assertIn("[int]$StepTimeoutSeconds = 300", self.workshop_script)

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -175,6 +175,9 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertIn("verify_android_workshop_seam.py", self.workshop_script)
         self.assertIn('Join-Path (Join-Path (Join-Path $repoRoot "artifacts") "android_workshop_seam") "e"', self.workshop_script)
         self.assertIn("Reusing ready Android emulator", self.workshop_script)
+        self.assertIn('GetMethod("Kill", [Type[]]@([bool]))', self.workshop_script)
+        self.assertIn('$process.Kill()', self.workshop_script)
+        self.assertIn('taskkill.exe /PID $process.Id /T /F', self.workshop_script)
         self.assertNotIn('"-SkipRustBridgeBuild"', self.workshop_script)
         for path_fragment in ("tools\\ci\\", "samples\\render_parity\\", "app\\build\\outputs\\apk\\", "artifacts\\android_workshop_seam\\"):
             self.assertNotIn(path_fragment, self.workshop_script)

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -23,6 +23,9 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         cls.touch_expectations = json.loads(
             read("samples/android_touch_seam/android_seam_expectations.json")
         )
+        cls.workshop_script = read("mobile/android/test_render_emulator.ps1")
+        cls.rust_bridge_script = read("mobile/android/build_rust_bridge.ps1")
+        cls.provenance_script = read("mobile/android/rust_bridge_provenance.ps1")
 
     def test_workflow_uses_hosted_x86_emulator(self):
         self.assertIn("runs-on: ubuntu-latest", self.workflow)
@@ -113,13 +116,14 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
             self.workflow.index("- name: Checkout SDL3"),
         )
         for artifact in (
+            "android-workshop-it025-seam",
             "android-resource-restore-seam",
             "android-release-shell-seam",
             "android-touch-roundtrip-seam",
             "android-orientation-metrics-seam",
         ):
             self.assertIn(artifact, self.workflow)
-        self.assertEqual(4, self.workflow.count("        if: always()"))
+        self.assertEqual(5, self.workflow.count("        if: always()"))
         self.assertNotIn("\n      if: always()", self.workflow)
 
     def test_release_wrapper_uses_platform_appropriate_tools_and_paths(self):
@@ -160,6 +164,22 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
             if gesture["name"] == "inside_drag"
         )
         self.assertGreaterEqual(inside_drag["duration_ms"], 2000)
+
+    def test_workshop_it025_runs_after_release_shells_on_the_same_emulator(self):
+        self.assertIn("test_render_emulator.ps1 -Headless", self.workflow)
+        self.assertIn("verify_android_workshop_seam.py", self.workshop_script)
+        self.assertIn('Join-Path (Join-Path (Join-Path $repoRoot "artifacts") "android_workshop_seam") "e"', self.workshop_script)
+        self.assertIn("Reusing ready Android emulator", self.workshop_script)
+        self.assertNotIn('"-SkipRustBridgeBuild"', self.workshop_script)
+        for path_fragment in ("tools\\ci\\", "samples\\render_parity\\", "app\\build\\outputs\\apk\\", "artifacts\\android_workshop_seam\\"):
+            self.assertNotIn(path_fragment, self.workshop_script)
+        self.assertIn('"linux-x86_64"', self.rust_bridge_script)
+        self.assertIn("cargo_cache.py", self.rust_bridge_script)
+        self.assertIn("[System.IO.Path]::IsPathRooted", self.rust_bridge_script)
+        self.assertNotIn('"app\\src\\workshop\\jniLibs\\$abi"', self.rust_bridge_script)
+        self.assertNotIn('"$abi\\libstasis_android_bridge.so"', self.provenance_script)
+        self.assertIn("Install Android Rust targets", self.workflow)
+        self.assertIn("rustup target add aarch64-linux-android x86_64-linux-android", self.workflow)
 
 
 if __name__ == "__main__":

--- a/tools/ci/test_verify_android_workshop_seam.py
+++ b/tools/ci/test_verify_android_workshop_seam.py
@@ -1,0 +1,55 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from .verify_android_workshop_seam import SeamError, _read_json, verify_log
+except ImportError:
+    from verify_android_workshop_seam import SeamError, _read_json, verify_log
+
+
+MANIFEST = {"state_checksum": 2500, "command_trace": 1390729377, "render_contract_version": 5}
+GOOD = """CompileReady: backend=cranelift-jit reload=InitialCompile status=0 functions=7 compile_us=12 manifest=x
+Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":1390729377,"frame_token":1,"fallback":0,"stub":0}
+Stasis Workshop IT-025 GLES: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"present","count":1,"frame_token":1}
+Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":1390729377,"frame_token":77,"fallback":0,"stub":0}
+Stasis Workshop IT-025 GLES: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"present","count":30,"frame_token":77}
+RenderAcceptanceFrame: count=1 frame_token=1
+RenderAcceptanceFrame: count=30 frame_token=77
+"""
+
+
+class WorkshopSeamTests(unittest.TestCase):
+    def test_accepts_complete_single_frame_proof(self):
+        result = verify_log(GOOD, MANIFEST)
+        self.assertEqual(result["compile_functions"], 7)
+        self.assertEqual(result["presented_frames"], 30)
+
+    def test_rejects_wrong_guest_state(self):
+        with self.assertRaisesRegex(SeamError, "state_checksum"):
+            verify_log(GOOD.replace('"state_checksum":2500', '"state_checksum":2501'), MANIFEST)
+
+    def test_rejects_missing_marker_or_presentation(self):
+        with self.assertRaisesRegex(SeamError, "IT-025"):
+            verify_log(GOOD.replace("Stasis Workshop IT-025:", "Other:"), MANIFEST)
+        with self.assertRaisesRegex(SeamError, "presentation"):
+            verify_log(GOOD.replace("count=30", "count=2"), MANIFEST)
+
+    def test_rejects_native_and_gles_token_mismatch(self):
+        with self.assertRaisesRegex(SeamError, "token"):
+            verify_log(GOOD.replace('"count":30,"frame_token":77', '"count":30,"frame_token":88'), MANIFEST)
+
+    def test_rejects_stable_frame_log_token_mismatch(self):
+        with self.assertRaisesRegex(SeamError, "RenderAcceptanceFrame"):
+            verify_log(GOOD.replace("count=30 frame_token=77", "count=30 frame_token=999"), MANIFEST)
+
+    def test_reads_powershell_utf8_bom_json(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "metadata.json"
+            path.write_text('\ufeff{"git_revision":"abc"}', encoding="utf-8")
+            self.assertEqual(_read_json(path)["git_revision"], "abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/test_verify_android_workshop_seam.py
+++ b/tools/ci/test_verify_android_workshop_seam.py
@@ -9,11 +9,11 @@ except ImportError:
     from verify_android_workshop_seam import SeamError, _read_json, verify_log
 
 
-MANIFEST = {"state_checksum": 2500, "command_trace": 1390729377, "render_contract_version": 5}
+MANIFEST = {"state_checksum": 2500, "workshop_command_trace": 3939026311, "render_contract_version": 5}
 GOOD = """CompileReady: backend=cranelift-jit reload=InitialCompile status=0 functions=7 compile_us=12 manifest=x
-Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":1390729377,"frame_token":1,"fallback":0,"stub":0}
+Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":3939026311,"frame_token":1,"fallback":0,"stub":0}
 Stasis Workshop IT-025 GLES: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"present","count":1,"frame_token":1}
-Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":1390729377,"frame_token":77,"fallback":0,"stub":0}
+Stasis Workshop IT-025: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"frame","jni_version":65542,"rust_bridge_version":"0.1.0","render_version":5,"state_checksum":2500,"command_trace":3939026311,"frame_token":77,"fallback":0,"stub":0}
 Stasis Workshop IT-025 GLES: {"schema":"stasis.workshop_seam.v1","test_id":"IT-025","event":"present","count":30,"frame_token":77}
 RenderAcceptanceFrame: count=1 frame_token=1
 RenderAcceptanceFrame: count=30 frame_token=77

--- a/tools/ci/verify_android_workshop_seam.py
+++ b/tools/ci/verify_android_workshop_seam.py
@@ -87,7 +87,7 @@ def verify_log(log: str, manifest: dict, *, minimum_frames: int = 30) -> dict:
         raise SeamError("stable GLES presentation did not consume a preceding native frame token")
     expected = {
         "state_checksum": manifest["state_checksum"],
-        "command_trace": manifest["command_trace"],
+        "command_trace": manifest["workshop_command_trace"],
         "render_version": manifest["render_contract_version"],
     }
     for key, value in expected.items():

--- a/tools/ci/verify_android_workshop_seam.py
+++ b/tools/ci/verify_android_workshop_seam.py
@@ -1,0 +1,155 @@
+"""Verify one real Java/JNI/Rust-JIT/GLES Workshop frame from log evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+COMPILE = re.compile(
+    r"CompileReady: backend=cranelift-jit reload=InitialCompile status=0 functions=(\d+)"
+)
+MARKER = re.compile(r"Stasis Workshop IT-025: (\{[^\r\n]+\})")
+PRESENT = re.compile(r"Stasis Workshop IT-025 GLES: (\{[^\r\n]+\})")
+FRAME = re.compile(r"RenderAcceptanceFrame: count=(\d+) frame_token=(\d+)")
+FORBIDDEN = re.compile(
+    r"(?:CompileError|native preview frame failed|FATAL EXCEPTION|stub path|fallback path|IT-025 state checksum was unavailable)",
+    re.IGNORECASE,
+)
+
+
+class SeamError(RuntimeError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> dict:
+    """Read JSON emitted by both BOM-free and Windows PowerShell 5.1 writers."""
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def verify_log(log: str, manifest: dict, *, minimum_frames: int = 30) -> dict:
+    compile_matches = COMPILE.findall(log)
+    if not compile_matches or max(map(int, compile_matches)) <= 0:
+        raise SeamError("missing successful non-empty CompileReady JIT evidence")
+    if FORBIDDEN.search(log):
+        raise SeamError("Workshop log contains a forbidden fallback, stub, or fatal diagnostic")
+    markers = []
+    for match in MARKER.finditer(log):
+        try:
+            marker = json.loads(match.group(1))
+        except json.JSONDecodeError as error:
+            raise SeamError(f"invalid IT-025 marker JSON: {error}") from error
+        if marker.get("test_id") == "IT-025":
+            markers.append((match, marker))
+    if not markers:
+        raise SeamError("missing IT-025 native frame markers")
+    presentations = []
+    for match in PRESENT.finditer(log):
+        try:
+            presentation = json.loads(match.group(1))
+            if presentation.get("test_id") == "IT-025":
+                presentations.append((match, presentation))
+        except json.JSONDecodeError as error:
+            raise SeamError(f"invalid IT-025 GLES marker JSON: {error}") from error
+    stable_presentations = [
+        item for item in presentations
+        if item[1].get("event") == "present"
+        and isinstance(item[1].get("count"), int)
+        and isinstance(item[1].get("frame_token"), int)
+        and item[1]["count"] >= minimum_frames
+    ]
+    if not stable_presentations:
+        raise SeamError("missing stable IT-025 GLES presentation marker")
+    presentation_match, presentation = max(stable_presentations, key=lambda item: item[1]["count"])
+    frames = [(int(count), int(token)) for count, token in FRAME.findall(log)]
+    stable_count = presentation["count"]
+    stable_token = presentation["frame_token"]
+    if not any(count == stable_count and token == stable_token for count, token in frames):
+        raise SeamError("stable GLES presentation did not match its RenderAcceptanceFrame token")
+    native_match, marker = next(
+        ((candidate_match, candidate) for candidate_match, candidate in reversed(markers)
+         if candidate.get("frame_token") == stable_token
+         and candidate_match.start() < presentation_match.start()),
+        (None, None),
+    )
+    if native_match is None or marker is None:
+        raise SeamError("stable GLES presentation did not consume a preceding native frame token")
+    expected = {
+        "state_checksum": manifest["state_checksum"],
+        "command_trace": manifest["command_trace"],
+        "render_version": manifest["render_contract_version"],
+    }
+    for key, value in expected.items():
+        if marker.get(key) != value:
+            raise SeamError(f"IT-025 {key} mismatch: expected={value} actual={marker.get(key)}")
+    if marker.get("schema") != "stasis.workshop_seam.v1" or marker.get("event") != "frame":
+        raise SeamError("IT-025 marker schema/event is not the Workshop frame contract")
+    if not isinstance(marker.get("rust_bridge_version"), str) or not marker["rust_bridge_version"]:
+        raise SeamError("IT-025 marker lacks the real Rust bridge version")
+    if not isinstance(marker.get("jni_version"), int) or marker["jni_version"] <= 0:
+        raise SeamError("IT-025 marker lacks the JNI runtime version")
+    if marker.get("fallback") != 0 or marker.get("stub") != 0:
+        raise SeamError("IT-025 marker reports a fallback or stub")
+    return {
+        "compile_functions": max(map(int, compile_matches)),
+        "presented_frames": stable_count,
+        "frame_token": marker["frame_token"],
+        "stable_frame_token": stable_token,
+        "presentation": presentation,
+        "marker": marker,
+    }
+
+
+def verify_files(log_path: Path, capture: Path, manifest_path: Path, apk: Path,
+                 metadata_path: Path, evidence_path: Path) -> dict:
+    for path in (log_path, capture, manifest_path, apk, metadata_path):
+        if not path.is_file():
+            raise SeamError(f"required Workshop evidence file is missing: {path}")
+    manifest = _read_json(manifest_path)
+    metadata = _read_json(metadata_path)
+    result = verify_log(log_path.read_text(encoding="utf-8", errors="replace"), manifest)
+    evidence = {
+        "schema": "stasis.workshop_seam.evidence.v1",
+        "test_id": "IT-025",
+        "status": "passed",
+        "source_revision": metadata.get("git_revision", ""),
+        "apk_sha256": _sha256(apk),
+        "capture_sha256": _sha256(capture),
+        "metadata": metadata,
+        **result,
+    }
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--capture", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--apk", type=Path, required=True)
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        evidence = verify_files(args.log, args.capture, args.manifest, args.apk, args.metadata, args.evidence)
+    except (OSError, json.JSONDecodeError, SeamError) as error:
+        parser.error(str(error))
+    print(json.dumps({"status": evidence["status"], "evidence": str(args.evidence)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- prove IT-025 across Java, JNI/dlopen, the real Rust/Cranelift JIT bridge, direct render buffers, and post-draw GLES
- add deterministic stable-frame evidence with bridge/JNI versions, guest state checksum, command trace, APK/capture/source identities, and fail-closed fallback checks
- make the Workshop emulator harness and Rust bridge packaging run from a clean Ubuntu checkout, then include the slow seam in the nightly API 35 lane

## Local validation
- python -m unittest tools.ci.test_verify_android_workshop_seam tools.ci.test_android_emulator_seams (15 passed)
- python tools/ci/check_runtime_abi_contract.py (293 comparisons passed)
- focused stasis_android_bridge version export test (1 passed)
- cargo fmt --all -- --check via tools/cargo_cache.py
- PowerShell parse checks for modified Android scripts
- python py_compile for verifier/tests
- git diff --check

## Review
- independent Luna/max review completed; all actionable findings corrected; final review CLEAN

Maddox: #234