### PR TITLE
Add Swarm Field stress sample

### DIFF
--- a/samples/swarm_field/src/main.stasis
+++ b/samples/swarm_field/src/main.stasis
@@ -1,0 +1,213 @@
+import "/vendor/stasis/stdlib/graphics.stasis";
+
+const SCREEN_W: f32 = 640.0;
+const SCREEN_H: f32 = 360.0;
+const AGENT_COUNT: i32 = 8192;
+const AGENT_SIZE: f32 = 1.8;
+const MAX_SPEED: f32 = 2.8;
+
+struct Agent {
+    x: f32;
+    y: f32;
+    vx: f32;
+    vy: f32;
+    band: i32;
+}
+
+// Fixed-size state: no entity allocation or iteration-count changes at runtime.
+global agents: Agent[8192];
+global field_x: f32;
+global field_y: f32;
+global field_mode: i32;
+global presentation_variant: i32;
+
+function abs_f32(value: f32): f32 {
+    if (value < 0.0) {
+        return 0.0 - value;
+    }
+    return value;
+}
+
+function clamp_speed(value: f32): f32 {
+    if (value < 0.0 - MAX_SPEED) {
+        return 0.0 - MAX_SPEED;
+    }
+    if (value > MAX_SPEED) {
+        return MAX_SPEED;
+    }
+    return value;
+}
+
+function wrap_x(value: f32): f32 {
+    if (value < 0.0) {
+        return value + SCREEN_W;
+    }
+    if (value >= SCREEN_W) {
+        return value - SCREEN_W;
+    }
+    return value;
+}
+
+function wrap_y(value: f32): f32 {
+    if (value < 0.0) {
+        return value + SCREEN_H;
+    }
+    if (value >= SCREEN_H) {
+        return value - SCREEN_H;
+    }
+    return value;
+}
+
+function initialize_agents(): void {
+    // 128 columns x 64 rows gives a stable, dense starting lattice.
+    for (let i: i32 = 0; i < AGENT_COUNT; i += 1) {
+        let column: i32 = i % 128;
+        let row: i32 = i / 128;
+        agents[i].x = i32_to_f32(column) * 5.0 + 2.0;
+        agents[i].y = i32_to_f32(row) * 5.0 + 2.0;
+        agents[i].vx = i32_to_f32((i % 5) - 2) * 0.22;
+        agents[i].vy = i32_to_f32(((i / 5) % 5) - 2) * 0.18;
+        agents[i].band = i % 6;
+    }
+}
+
+function toggle_field_mode(): void {
+    if (field_mode == 0) {
+        field_mode = 1;
+    } else {
+        field_mode = 0;
+    }
+}
+
+function update_field_from_pointer(): void {
+    if (input_pointer_count() <= 0) {
+        return;
+    }
+    field_x = input_pointer_x_logical(0);
+    field_y = input_pointer_y_logical(0);
+    if (input_pointer_went_down(0)) {
+        toggle_field_mode();
+    }
+}
+
+function update_agent(index: i32): void {
+    let column: i32 = index % 128;
+    let row: i32 = index / 128;
+    let home_x: f32 = i32_to_f32(column) * 5.0 + 2.0;
+    let home_y: f32 = i32_to_f32(row) * 5.0 + 2.0;
+    let dx: f32 = field_x - agents[index].x;
+    let dy: f32 = field_y - agents[index].y;
+    let home_dx: f32 = home_x - agents[index].x;
+    let home_dy: f32 = home_y - agents[index].y;
+
+    // A spring keeps the lattice distributed while the pointer adds a local orbit.
+    let in_core: bool = abs_f32(dx) < 70.0 && abs_f32(dy) < 70.0;
+    let radial_sign: f32 = 1.0;
+    if (field_mode == 1 || in_core) {
+        radial_sign = -1.0;
+    }
+    let ax: f32 = home_dx * 0.004 + dx * 0.00055 * radial_sign - dy * 0.00035;
+    let ay: f32 = home_dy * 0.004 + dy * 0.00055 * radial_sign + dx * 0.00035;
+    if (ax > 0.18) {
+        ax = 0.18;
+    }
+    if (ax < -0.18) {
+        ax = -0.18;
+    }
+    if (ay > 0.18) {
+        ay = 0.18;
+    }
+    if (ay < -0.18) {
+        ay = -0.18;
+    }
+    agents[index].vx = clamp_speed(agents[index].vx * 0.992 + ax);
+    agents[index].vy = clamp_speed(agents[index].vy * 0.992 + ay);
+    agents[index].x = wrap_x(agents[index].x + agents[index].vx);
+    agents[index].y = wrap_y(agents[index].y + agents[index].vy);
+}
+
+function update_agents(): void {
+    for (let i: i32 = 0; i < AGENT_COUNT; i += 1) {
+        update_agent(i);
+    }
+}
+
+function main(): i32 {
+    init_window(640, 360, "Stasis Swarm Field");
+    field_x = SCREEN_W / 2.0;
+    field_y = SCREEN_H / 2.0;
+    field_mode = 0;
+    presentation_variant = 0;
+    initialize_agents();
+    return 0;
+}
+
+function tick(): i32 {
+    if (should_quit()) {
+        return 1;
+    }
+    update_field_from_pointer();
+    update_agents();
+    return 0;
+}
+
+function render(): i32 {
+    begin_frame();
+    clear(0.015, 0.025, 0.055, 1.0);
+    fill_rect(0.0, 0.0, SCREEN_W, 1.0, 0.16, 0.28, 0.42, 1.0);
+    fill_rect(0.0, SCREEN_H - 1.0, SCREEN_W, 1.0, 0.16, 0.28, 0.42, 1.0);
+
+    // One rectangle per agent: 8,192 commands, below the 10,000 command cap.
+    for (let i: i32 = 0; i < AGENT_COUNT; i += 1) {
+        let red: f32 = 0.22;
+        let green: f32 = 0.78;
+        let blue: f32 = 0.98;
+        if (agents[i].band == 1) {
+            red = 0.98;
+            green = 0.72;
+            blue = 0.28;
+        } else if (agents[i].band == 2) {
+            red = 0.42;
+            green = 0.96;
+            blue = 0.54;
+        } else if (agents[i].band == 3) {
+            red = 0.92;
+            green = 0.38;
+            blue = 0.76;
+        } else if (agents[i].band == 4) {
+            red = 0.98;
+            green = 0.42;
+            blue = 0.30;
+        } else if (agents[i].band == 5) {
+            red = 0.64;
+            green = 0.50;
+            blue = 0.98;
+        }
+        if (presentation_variant == 1) {
+            let swap: f32 = red;
+            red = blue;
+            blue = swap;
+        }
+        fill_rect(agents[i].x, agents[i].y, AGENT_SIZE, AGENT_SIZE, red, green, blue, 0.94);
+    }
+
+    let field_red: f32 = 0.30;
+    let field_blue: f32 = 0.96;
+    if (field_mode == 1) {
+        field_red = 0.98;
+        field_blue = 0.32;
+    }
+    fill_rect(field_x - 8.0, field_y - 1.0, 16.0, 2.0, field_red, 0.92, field_blue, 1.0);
+    fill_rect(field_x - 1.0, field_y - 8.0, 2.0, 16.0, field_red, 0.92, field_blue, 1.0);
+    end_frame();
+    return 0;
+}
+
+// Compatible swaps keep agents moving and only change the color presentation.
+function on_code_swap(): void {
+    if (presentation_variant == 0) {
+        presentation_variant = 1;
+    } else {
+        presentation_variant = 0;
+    }
+}

--- a/samples/swarm_field/stasis.json
+++ b/samples/swarm_field/stasis.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 1,
+  "name": "swarm_field",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build",
+  "vendor": {
+    "stasis": {
+      "release_id": "development",
+      "sha256": "ae83fa61f536b13463ecded28234ba60ba49084ab2805f997074b6e61803cf72"
+    }
+  },
+  "android": {
+    "application_id": "com.stasislang.sample.swarmfield",
+    "label": "Stasis Swarm Field",
+    "orientation": "sensorLandscape",
+    "version_code": 1,
+    "version_name": "1.0.0"
+  }
+}

--- a/samples/swarm_field/tests/swarm_field.test.stasis
+++ b/samples/swarm_field/tests/swarm_field.test.stasis
@@ -1,0 +1,87 @@
+import "../src/main.stasis";
+
+test `agent lattice initialization is deterministic`(): bool {
+    initialize_agents();
+    if (agents[0].x != 2.0 || agents[0].y != 2.0) {
+        return false;
+    }
+    if (agents[8191].x != 637.0 || agents[8191].y != 317.0) {
+        return false;
+    }
+    if (agents[8191].band != 1) {
+        return false;
+    }
+    return true;
+}
+
+test `field mode toggles between attract and repel`(): bool {
+    field_mode = 0;
+    toggle_field_mode();
+    if (field_mode != 1) {
+        return false;
+    }
+    toggle_field_mode();
+    return field_mode == 0;
+}
+
+test `agent update wraps and clamps speed`(): bool {
+    field_x = 0.0;
+    field_y = 0.0;
+    field_mode = 1;
+    agents[0].x = 0.1;
+    agents[0].y = 0.1;
+    agents[0].vx = -2.8;
+    agents[0].vy = -2.8;
+    update_agent(0);
+    if (agents[0].x < 0.0 || agents[0].x >= SCREEN_W) {
+        return false;
+    }
+    if (agents[0].y < 0.0 || agents[0].y >= SCREEN_H) {
+        return false;
+    }
+    if (agents[0].vx < 0.0 - MAX_SPEED || agents[0].vx > MAX_SPEED) {
+        return false;
+    }
+    if (agents[0].vy < 0.0 - MAX_SPEED || agents[0].vy > MAX_SPEED) {
+        return false;
+    }
+    return true;
+}
+
+test `soft core repels attract mode`(): bool {
+    field_x = 321.0;
+    field_y = 2.0;
+    field_mode = 0;
+    agents[64].x = 322.0;
+    agents[64].y = 2.0;
+    agents[64].vx = 0.0;
+    agents[64].vy = 0.0;
+    update_agent(64);
+    return agents[64].vx > 0.0;
+}
+
+test `home springs preserve broad coverage`(): bool {
+    initialize_agents();
+    field_x = 320.0;
+    field_y = 180.0;
+    field_mode = 0;
+    for (let tick: i32 = 0; tick < 9000; tick += 1) {
+        update_agent(0);
+        update_agent(8191);
+    }
+    if (agents[0].x > 180.0 || agents[8191].x < 460.0) {
+        return false;
+    }
+    return agents[0].y < 180.0 && agents[8191].y > 180.0;
+}
+
+test `hot swap changes presentation without resetting agents`(): bool {
+    agents[3].x = 123.0;
+    agents[3].y = 45.0;
+    presentation_variant = 0;
+    on_code_swap();
+    if (presentation_variant != 1) {
+        return false;
+    }
+    return agents[3].x == 123.0 && agents[3].y == 45.0;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/audio.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/audio.stasis
@@ -1,0 +1,33 @@
+@link("stasis_graphics");
+
+// Audio/runtime bindings (marker module).
+// From a generated project: import "/vendor/stasis/stdlib/audio.stasis";
+
+extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
+extern function audio_shutdown(): void;
+extern function audio_is_available(): bool;
+extern function audio_get_sample_rate(): i32;
+extern function audio_get_channels(): i32;
+extern function audio_get_queued_frames(): i32;
+extern function audio_get_underruns(): i32;
+extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
+
+// Bounded audio assets are decoded outside deterministic Stasis state. audio_load_wav accepts
+// mono or stereo little-endian PCM16 WAV files. The music/effect helpers accept WAV or MP3.
+// Compressed input stays compressed on disk and is decoded into bounded host memory at load.
+extern function @asset_path(path) audio_load_wav(path: string): i32;
+extern function audio_release(asset_handle: i32): void;
+extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
+extern function audio_stop(voice_handle: i32): void;
+extern function audio_voice_is_playing(voice_handle: i32): bool;
+extern function audio_voice_set_paused(voice_handle: i32, paused: bool): void;
+extern function audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
+
+// Brickout-compatible category helpers backed by the same SDL host mixer.
+function @asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
+function @asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
+function @extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
+function @extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
+function @extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;
+function @extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(asset_handle: i32, volume: f32): void;
+function @extern("stasis_jit_audio_play_effect") audio_play_effect(asset_handle: i32, volume: f32): bool;

--- a/samples/swarm_field/vendor/stasis/stdlib/clipboard.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/clipboard.stasis
@@ -1,0 +1,27 @@
+// Bounded printable-ASCII clipboard access for player-entered share codes.
+// Loading returns the byte length, or -1 when unavailable, invalid, or too large.
+function @extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
+function @extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
+
+function clipboard_load_ascii(out: ascii[]): i32 {
+    out.length = 0;
+    let capacity: i32 = out.max_length;
+    if (capacity <= 0) {
+        return -1;
+    }
+    let loaded: i32 = clipboard_load_ascii_raw(out, capacity);
+    if (loaded < 0 || loaded > capacity) {
+        out.length = 0;
+        return -1;
+    }
+    out.length = loaded;
+    return loaded;
+}
+
+function clipboard_save_ascii(value: ascii[]): bool {
+    let count: i32 = value.length;
+    if (count < 0 || count > value.max_length) {
+        return false;
+    }
+    return clipboard_save_ascii_raw(value, count) != 0;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/collision.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/collision.stasis
@@ -1,0 +1,55 @@
+// Collision predicates accept scalar components so callers do not need temporary shape structs.
+
+function @inline aabb_intersects(
+    minimum_x: f32,
+    minimum_y: f32,
+    maximum_x: f32,
+    maximum_y: f32,
+    other_minimum_x: f32,
+    other_minimum_y: f32,
+    other_maximum_x: f32,
+    other_maximum_y: f32
+): bool {
+    if (maximum_x < other_minimum_x) {
+        return false;
+    }
+    if (minimum_x > other_maximum_x) {
+        return false;
+    }
+    if (maximum_y < other_minimum_y) {
+        return false;
+    }
+    if (minimum_y > other_maximum_y) {
+        return false;
+    }
+    return true;
+}
+
+function @inline aabb_contains_point(minimum_x: f32, minimum_y: f32, maximum_x: f32, maximum_y: f32, point_x: f32, point_y: f32): bool {
+    if (point_x < minimum_x) {
+        return false;
+    }
+    if (point_x > maximum_x) {
+        return false;
+    }
+    if (point_y < minimum_y) {
+        return false;
+    }
+    if (point_y > maximum_y) {
+        return false;
+    }
+    return true;
+}
+
+function @inline circle_intersects(x: f32, y: f32, radius: f32, other_x: f32, other_y: f32, other_radius: f32): bool {
+    let delta_x: f32 = x - other_x;
+    let delta_y: f32 = y - other_y;
+    let radius_sum: f32 = radius + other_radius;
+    return delta_x * delta_x + delta_y * delta_y <= radius_sum * radius_sum;
+}
+
+function @inline circle_contains_point(x: f32, y: f32, radius: f32, point_x: f32, point_y: f32): bool {
+    let delta_x: f32 = point_x - x;
+    let delta_y: f32 = point_y - y;
+    return delta_x * delta_x + delta_y * delta_y <= radius * radius;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/flex_layout.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/flex_layout.stasis
@@ -1,0 +1,219 @@
+// Flex-style layout helpers for simple UI composition.
+// From a generated project: import "/vendor/stasis/stdlib/flex_layout.stasis";
+//
+// Uses plain f32 arrays for portability across backends.
+// Rect layout: [x, y, w, h]
+
+import "stdlib.stasis";
+import "graphics.stasis";
+
+const FLEX_RECT_STRIDE: i32 = 4;
+const FLEX_RECT_X: i32 = 0;
+const FLEX_RECT_Y: i32 = 1;
+const FLEX_RECT_W: i32 = 2;
+const FLEX_RECT_H: i32 = 3;
+const FLEX_JUSTIFY_START: i32 = 0;
+const FLEX_JUSTIFY_CENTER: i32 = 1;
+const FLEX_JUSTIFY_END: i32 = 2;
+const FLEX_JUSTIFY_SPACE_BETWEEN: i32 = 3;
+const FLEX_ALIGN_START: i32 = 0;
+const FLEX_ALIGN_CENTER: i32 = 1;
+const FLEX_ALIGN_END: i32 = 2;
+const FLEX_ALIGN_STRETCH: i32 = 3;
+
+function flex_max_f32(a: f32, b: f32): f32 {
+    if (a > b) {
+        return a;
+    }
+    return b;
+}
+
+function flex_min_i32(a: i32, b: i32): i32 {
+    if (a < b) {
+        return a;
+    }
+    return b;
+}
+
+function flex_rect_set(rect: f32[], x: f32, y: f32, w: f32, h: f32): void {
+    rect[FLEX_RECT_X] = x;
+    rect[FLEX_RECT_Y] = y;
+    rect[FLEX_RECT_W] = w;
+    rect[FLEX_RECT_H] = h;
+}
+
+function flex_rect_set_at(rects: f32[], index: i32, x: f32, y: f32, w: f32, h: f32): void {
+    let base: i32 = index * FLEX_RECT_STRIDE;
+    rects[base + FLEX_RECT_X] = x;
+    rects[base + FLEX_RECT_Y] = y;
+    rects[base + FLEX_RECT_W] = w;
+    rects[base + FLEX_RECT_H] = h;
+}
+
+function flex_rect_x(rects: f32[], index: i32): f32 {
+    return rects[index * FLEX_RECT_STRIDE + FLEX_RECT_X];
+}
+
+function flex_rect_y(rects: f32[], index: i32): f32 {
+    return rects[index * FLEX_RECT_STRIDE + FLEX_RECT_Y];
+}
+
+function flex_rect_w(rects: f32[], index: i32): f32 {
+    return rects[index * FLEX_RECT_STRIDE + FLEX_RECT_W];
+}
+
+function flex_rect_h(rects: f32[], index: i32): f32 {
+    return rects[index * FLEX_RECT_STRIDE + FLEX_RECT_H];
+}
+
+function flex_measure_box(out_size: f32[], inner_w: f32, inner_h: f32, pad_x: f32, pad_y: f32): void {
+    out_size[0] = inner_w + pad_x * 2.0;
+    out_size[1] = inner_h + pad_y * 2.0;
+}
+
+function flex_measure_text_box(out_size: f32[], font: i32, text: string, line_h: f32, pad_x: f32, pad_y: f32): void {
+    let text_w: f32 = measure_text(font, text);
+    flex_measure_box(out_size, text_w, line_h, pad_x, pad_y);
+}
+
+function flex_measure_text_run_box(out_size: f32[], run: TextRun, line_h: f32, pad_x: f32, pad_y: f32): void {
+    flex_measure_box(out_size, run.width, line_h, pad_x, pad_y);
+}
+
+function flex_main_total(item_main: f32[], count: i32, gap: f32): f32 {
+    let total: f32 = 0.0;
+    let i: i32 = 0;
+    for (i = 0; i < count; i = i + 1) {
+        total = total + item_main[i];
+    }
+    if (count > 1) {
+        total = total + i32_to_f32(count - 1) * gap;
+    }
+    return total;
+}
+
+function flex_row(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[], count: i32, gap: f32, justify: i32, align: i32): void {
+    let sum_w: f32 = 0.0;
+    let i: i32 = 0;
+    for (i = 0; i < count; i = i + 1) {
+        sum_w = sum_w + item_w[i];
+    }
+
+    let actual_gap: f32 = gap;
+    if (justify == FLEX_JUSTIFY_SPACE_BETWEEN && count > 1) {
+        actual_gap =(parent[FLEX_RECT_W] - sum_w) / i32_to_f32(count - 1);
+        if (actual_gap < 0.0) {
+            actual_gap = 0.0;
+        }
+    }
+
+    let total_w: f32 = sum_w;
+    if (count > 1) {
+        total_w = total_w + i32_to_f32(count - 1) * actual_gap;
+    }
+
+    let cursor_x: f32 = parent[FLEX_RECT_X];
+    if (justify == FLEX_JUSTIFY_CENTER) {
+        cursor_x = parent[FLEX_RECT_X] +(parent[FLEX_RECT_W] - total_w) * 0.5;
+    }
+    if (justify == FLEX_JUSTIFY_END) {
+        cursor_x = parent[FLEX_RECT_X] + parent[FLEX_RECT_W] - total_w;
+    }
+
+    for (i = 0; i < count; i = i + 1) {
+        let y: f32 = parent[FLEX_RECT_Y];
+        let h: f32 = item_h[i];
+        if (align == FLEX_ALIGN_CENTER) {
+            y = parent[FLEX_RECT_Y] +(parent[FLEX_RECT_H] - h) * 0.5;
+        }
+        if (align == FLEX_ALIGN_END) {
+            y = parent[FLEX_RECT_Y] + parent[FLEX_RECT_H] - h;
+        }
+        if (align == FLEX_ALIGN_STRETCH) {
+            y = parent[FLEX_RECT_Y];
+            h = parent[FLEX_RECT_H];
+        }
+        flex_rect_set_at(out_rects, i, cursor_x, y, item_w[i], h);
+        cursor_x = cursor_x + item_w[i] + actual_gap;
+    }
+}
+
+function flex_column(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[], count: i32, gap: f32, justify: i32, align: i32): void {
+    let sum_h: f32 = 0.0;
+    let i: i32 = 0;
+    for (i = 0; i < count; i = i + 1) {
+        sum_h = sum_h + item_h[i];
+    }
+
+    let actual_gap: f32 = gap;
+    if (justify == FLEX_JUSTIFY_SPACE_BETWEEN && count > 1) {
+        actual_gap =(parent[FLEX_RECT_H] - sum_h) / i32_to_f32(count - 1);
+        if (actual_gap < 0.0) {
+            actual_gap = 0.0;
+        }
+    }
+
+    let total_h: f32 = sum_h;
+    if (count > 1) {
+        total_h = total_h + i32_to_f32(count - 1) * actual_gap;
+    }
+
+    let cursor_y: f32 = parent[FLEX_RECT_Y];
+    if (justify == FLEX_JUSTIFY_CENTER) {
+        cursor_y = parent[FLEX_RECT_Y] +(parent[FLEX_RECT_H] - total_h) * 0.5;
+    }
+    if (justify == FLEX_JUSTIFY_END) {
+        cursor_y = parent[FLEX_RECT_Y] + parent[FLEX_RECT_H] - total_h;
+    }
+
+    for (i = 0; i < count; i = i + 1) {
+        let x: f32 = parent[FLEX_RECT_X];
+        let w: f32 = item_w[i];
+        if (align == FLEX_ALIGN_CENTER) {
+            x = parent[FLEX_RECT_X] +(parent[FLEX_RECT_W] - w) * 0.5;
+        }
+        if (align == FLEX_ALIGN_END) {
+            x = parent[FLEX_RECT_X] + parent[FLEX_RECT_W] - w;
+        }
+        if (align == FLEX_ALIGN_STRETCH) {
+            x = parent[FLEX_RECT_X];
+            w = parent[FLEX_RECT_W];
+        }
+        flex_rect_set_at(out_rects, i, x, cursor_y, w, item_h[i]);
+        cursor_y = cursor_y + item_h[i] + actual_gap;
+    }
+}
+
+function flex_grid(out_rects: f32[], parent: f32[], item_w: f32[], item_h: f32[], count: i32, columns: i32, col_gap: f32, row_gap: f32): void {
+    if (count <= 0 || columns <= 0) {
+        return;
+    }
+
+    let row_start: i32 = 0;
+    let row_y: f32 = parent[FLEX_RECT_Y];
+
+    for (row_start = 0; row_start < count; row_start = row_start + columns) {
+        let row_count: i32 = flex_min_i32(columns, count - row_start);
+        let row_width: f32 = 0.0;
+        let row_height: f32 = 0.0;
+        let col: i32 = 0;
+
+        for (col = 0; col < row_count; col = col + 1) {
+            let idx: i32 = row_start + col;
+            row_width = row_width + item_w[idx];
+            row_height = flex_max_f32(row_height, item_h[idx]);
+        }
+
+        let cursor_x: f32 = parent[FLEX_RECT_X];
+
+        for (col = 0; col < row_count; col = col + 1) {
+            let idx: i32 = row_start + col;
+            let y: f32 = row_y;
+            let h: f32 = item_h[idx];
+            flex_rect_set_at(out_rects, idx, cursor_x, y, item_w[idx], h);
+            cursor_x = cursor_x + item_w[idx] + col_gap;
+        }
+
+        row_y = row_y + row_height + row_gap;
+    }
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/frame_timer.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/frame_timer.stasis
@@ -1,0 +1,65 @@
+// Frame timing utilities (not loaded by default).
+//
+// Intended usage:
+// - Store a FrameTimer inside your game state.
+// - Call frame_timer_init(...) once (or on restart).
+// - Each frame, push measured work time via frame_timer_push(...).
+
+const FRAME_TIMER_SAMPLES: i32 = 120;
+
+struct FrameTimer {
+    samples_ms: i32[120];
+    sample_index: i32;
+}
+
+function frame_timer_reset_index(): i32 {
+    return 0;
+}
+
+function frame_timer_init(samples_ms: i32[120]): void {
+    foreach (let v, i in samples_ms) {
+        if (i < FRAME_TIMER_SAMPLES) {
+            samples_ms[i] = 1;
+        }
+    }
+}
+
+function frame_timer_push(samples_ms: i32[120], sample_index: i32, value_ms: i32): i32 {
+    let idx: i32 = sample_index;
+    if (idx < 0) {
+        idx = 0;
+    }
+    if (idx >(FRAME_TIMER_SAMPLES - 1)) {
+        idx = 0;
+    }
+
+    samples_ms[idx] = value_ms;
+    idx = idx + 1;
+    if (idx >(FRAME_TIMER_SAMPLES - 1)) {
+        idx = 0;
+    }
+    return idx;
+}
+
+function frame_timer_avg_tenths(samples_ms: i32[120]): i32 {
+    // Fixed-point average in 0.1ms units to avoid f32->i32 cast issues in some backends.
+    let sum: i32 = 0;
+    let i: i32 = 0;
+    for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
+        sum = sum + samples_ms[i];
+    }
+    return(sum * 10) / FRAME_TIMER_SAMPLES;
+}
+
+function frame_timer_max(samples_ms: i32[120]): i32 {
+    // Returns the max sample value across the full sample window.
+    let max_v: i32 = 0;
+    let i: i32 = 0;
+    for (i = 0; i < FRAME_TIMER_SAMPLES; i = i + 1) {
+        let v: i32 = samples_ms[i];
+        if (v > max_v) {
+            max_v = v;
+        }
+    }
+    return max_v;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/graphics.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/graphics.stasis
@@ -1,0 +1,364 @@
+@link("stasis_graphics");
+
+// Graphics/runtime bindings.
+//
+// Policy: Stasis does not call into the host on hot paths.
+// - Inputs/state are read from private HostFrame globals written by the host once per tick.
+// - Rendering is written into private command buffers read by the host after `tick()`.
+//
+// The remaining `extern` functions are intended for startup/asset loading (not per-tick).
+
+import "internal/host_frame.stasis";
+import "internal/gfx_cmd.stasis";
+import "internal/host_window_request.stasis";
+
+extern function sleep_ms(ms: i32): void;
+
+// Hot-path reads are HostFrame snapshot-only (no host calls).
+function get_time_ms(): i32 {
+    return host_time_ms();
+}
+
+function get_time_us(): i32 {
+    return host_time_us();
+}
+
+// Startup / assets (host calls; avoid in hot paths)
+extern function gfx_poll_reload(handle: i32): bool;
+extern function gfx_dump_bmp(path: string): i32;
+extern function gfx_dump_png(path: string): i32;
+extern function @asset_path(path) load_font(path: string, size: i32): i32;
+extern function measure_text(font: i32, text: string): f32;
+
+struct Sprite {
+    handle: i32;
+    width: i32;
+    height: i32;
+}
+
+struct TextRun {
+    font: i32;
+    handle: i32;
+    width: f32;
+    height: f32;
+}
+
+const ANIMATION_PLAYBACK_ONCE: i32 = 0;
+const ANIMATION_PLAYBACK_LOOP: i32 = 1;
+const ANIMATION_PLAYBACK_PING_PONG: i32 = 2;
+
+struct AnimationClip {
+    first_frame: i32;
+    frame_count: i32;
+    ticks_per_frame: i32;
+    playback_mode: i32;
+}
+
+struct SpriteSheet {
+    handle: i32;
+    width: i32;
+    height: i32;
+    columns: i32;
+    rows: i32;
+    cell_width: i32;
+    cell_height: i32;
+}
+
+function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
+function @extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(self: SpriteSheet, path: string, width: i32, height: i32): bool;
+
+function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
+    if (self.handle <= 0 || self.width <= 0 || self.height <= 0) {
+        return;
+    }
+    let width: f32 = 0.0;
+    let height: f32 = 0.0;
+    width.from_i32(self.width);
+    height.from_i32(self.height);
+    gfx_cmd_sprite(self.handle, x, y, width, height, rotation, alpha);
+}
+
+function load_sprite_sheet_from(self: SpriteSheet, path: string, columns: i32, rows: i32, cell_width: i32, cell_height: i32): bool {
+    if (columns <= 0 || rows <= 0 || cell_width <= 0 || cell_height <= 0) {
+        return false;
+    }
+    if (columns > 2147483647 / rows || columns > 2147483647 / cell_width || rows > 2147483647 / cell_height) {
+        return false;
+    }
+    let total_width: i32 = columns * cell_width;
+    let total_height: i32 = rows * cell_height;
+    if (total_width <= 0 || total_height <= 0) {
+        return false;
+    }
+    if (!self.load_sprite_sheet_asset_from(path, total_width, total_height)) {
+        return false;
+    }
+    self.columns = columns;
+    self.rows = rows;
+    self.cell_width = cell_width;
+    self.cell_height = cell_height;
+    return true;
+}
+
+function draw_frame(self: SpriteSheet, frame: i32, x: f32, y: f32, alpha: i32, rotation: i32): void {
+    if (self.handle <= 0 || self.columns <= 0 || self.rows <= 0 || self.cell_width <= 0 || self.cell_height <= 0) {
+        return;
+    }
+    if (self.columns > 2147483647 / self.rows) {
+        return;
+    }
+    let frame_total: i32 = self.columns * self.rows;
+    if (frame < 0 || frame >= frame_total) {
+        return;
+    }
+    let column: i32 = frame % self.columns;
+    let row: i32 = frame / self.columns;
+    let inv_columns: f32 = 1.0;
+    let inv_rows: f32 = 1.0;
+    inv_columns = inv_columns / self.columns;
+    inv_rows = inv_rows / self.rows;
+    let u0: f32 = 0.0;
+    let v0: f32 = 0.0;
+    let u1: f32 = 0.0;
+    let v1: f32 = 0.0;
+    u0 = i32_to_f32(column) * inv_columns;
+    v0 = i32_to_f32(row) * inv_rows;
+    u1 = i32_to_f32(column + 1) * inv_columns;
+    v1 = i32_to_f32(row + 1) * inv_rows;
+    let width: f32 = 0.0;
+    let height: f32 = 0.0;
+    width.from_i32(self.cell_width);
+    height.from_i32(self.cell_height);
+    gfx_cmd_sprite(self.handle, x, y, width, height, rotation, alpha);
+    gfx_cmd_set_last_sprite_uv(u0, v0, u1, v1);
+}
+
+function animation_frame_at(first_frame: i32, frame_count: i32, ticks_per_frame: i32, playback_mode: i32, elapsed_ticks: i32): i32 {
+    let frame: i32 = first_frame;
+    if (first_frame < 0 || frame_count <= 0 || ticks_per_frame <= 0) {
+        return frame;
+    }
+    if (first_frame > 2147483647 -(frame_count - 1)) {
+        return frame;
+    }
+    let elapsed: i32 = elapsed_ticks;
+    if (elapsed < 0) {
+        elapsed = 0;
+    }
+    let step: i32 = elapsed / ticks_per_frame;
+    if (playback_mode == 0) {
+        if (step >= frame_count) {
+            step = frame_count - 1;
+        }
+    } else if (playback_mode == 1) {
+        step = step % frame_count;
+    } else if (frame_count <= 1) {
+        step = 0;
+    } else {
+        if (frame_count > 1073741824) {
+            return first_frame;
+        }
+        let period: i32 = frame_count * 2 - 2;
+        let phase: i32 = step % period;
+        if (phase >= frame_count) {
+            step = period - phase;
+        } else {
+            step = phase;
+        }
+    }
+    return first_frame + step;
+}
+
+function animation_finished(frame_count: i32, ticks_per_frame: i32, playback_mode: i32, elapsed_ticks: i32): bool {
+    if (frame_count <= 0 || ticks_per_frame <= 0) {
+        return true;
+    }
+    return playback_mode == 0 && elapsed_ticks >= 0 && elapsed_ticks / ticks_per_frame >= frame_count;
+}
+
+function frame_at(self: AnimationClip, elapsed_ticks: i32): i32 {
+    return animation_frame_at(self.first_frame, self.frame_count, self.ticks_per_frame, self.playback_mode, elapsed_ticks);
+}
+
+function finished(self: AnimationClip, elapsed_ticks: i32): bool {
+    return animation_finished(self.frame_count, self.ticks_per_frame, self.playback_mode, elapsed_ticks);
+}
+
+function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
+
+function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
+    if (self.font <= 0 || self.handle <= 0) {
+        return;
+    }
+    gfx_cmd_text_cached(self.font, self.handle, x, y, r, g, b, a);
+}
+
+function get_desktop_size(out_w: i32[], out_h: i32[]): void {
+    out_w[0] = host_screen_w_px();
+    out_h[0] = host_screen_h_px();
+}
+
+function init_window(width: i32, height: i32, title: string): bool {
+    host_request_windowed(width, height);
+    return true;
+}
+
+function set_window_size(width: i32, height: i32): void {
+    host_request_windowed(width, height);
+}
+
+function set_fullscreen(enabled: i32): i32 {
+    host_request_fullscreen(enabled);
+    return 0;
+}
+
+function set_maximized(enabled: i32): i32 {
+    host_request_maximized(enabled);
+    return 0;
+}
+
+// Legacy-ish names retained as pure wrappers (no host calls).
+function begin_frame(): void {
+    gfx_cmd_begin();
+}
+
+function end_frame(): void {
+    gfx_cmd_mark_present();
+}
+
+function clear(r: f32, g: f32, b: f32, a: f32): void {
+    gfx_cmd_clear(r, g, b, a);
+}
+
+function draw_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32): void {
+    gfx_cmd_line(x1, y1, x2, y2, r, g, b, a);
+}
+
+function fill_rect(x: f32, y: f32, w: f32, h: f32, r: f32, g: f32, b: f32, a: f32): void {
+    gfx_cmd_rect(x, y, w, h, r, g, b, a);
+}
+
+function draw_lines(lines: f32[], count: i32): void {
+    gfx_cmd_lines_from(lines, count);
+}
+
+function gfx_draw_sprites(cmd_i32: i32[], cmd_f32: f32[], count: i32): void {
+    gfx_cmd_sprites_from(cmd_i32, cmd_f32, count);
+}
+
+function gfx_window_resized(): bool {
+    return host_resized();
+}
+
+function gfx_logical_width(): f32 {
+    return host_logical_width();
+}
+
+function gfx_logical_height(): f32 {
+    return host_logical_height();
+}
+
+function gfx_native_width_px(): i32 {
+    return host_native_w_px();
+}
+
+function gfx_native_height_px(): i32 {
+    return host_native_h_px();
+}
+
+function gfx_drawable_width_px(): i32 {
+    return host_drawable_w_px();
+}
+
+function gfx_drawable_height_px(): i32 {
+    return host_drawable_h_px();
+}
+
+function gfx_safe_viewport_x(): f32 {
+    return host_safe_x();
+}
+
+function gfx_safe_viewport_y(): f32 {
+    return host_safe_y();
+}
+
+function gfx_safe_viewport_width(): f32 {
+    return host_safe_width();
+}
+
+function gfx_safe_viewport_height(): f32 {
+    return host_safe_height();
+}
+
+function gfx_content_scale(): f32 {
+    return host_content_scale();
+}
+
+function gfx_raster_scale(): f32 {
+    return host_raster_scale();
+}
+
+function gfx_display_generation(): i32 {
+    return host_display_generation();
+}
+
+function gfx_density_generation(): i32 {
+    return host_density_generation();
+}
+
+function is_key_down(scancode: i32): bool {
+    return host_key_down(scancode);
+}
+
+function should_quit(): bool {
+    return host_quit_requested();
+}
+
+// Pointer/query wrappers over HostFrame
+function input_pointer_count(): i32 {
+    return host_pointer_count();
+}
+
+function input_pointer_id(index: i32): i32 {
+    return host_pointer_id(index);
+}
+
+function input_pointer_is_down(index: i32): bool {
+    return host_pointer_is_down(index);
+}
+
+function input_pointer_went_down(index: i32): bool {
+    return host_pointer_went_down(index);
+}
+
+function input_pointer_went_up(index: i32): bool {
+    return host_pointer_went_up(index);
+}
+
+function input_pointer_x_logical(index: i32): f32 {
+    return host_pointer_x_logical(index);
+}
+
+function input_pointer_y_logical(index: i32): f32 {
+    return host_pointer_y_logical(index);
+}
+
+function input_pointer_dx_logical(index: i32): f32 {
+    return host_pointer_dx_logical(index);
+}
+
+function input_pointer_dy_logical(index: i32): f32 {
+    return host_pointer_dy_logical(index);
+}
+
+function input_pointer_x_n(index: i32): f32 {
+    return host_pointer_x_n(index);
+}
+
+function input_pointer_y_n(index: i32): f32 {
+    return host_pointer_y_n(index);
+}
+
+function input_dropped_pointers(): i32 {
+    return host_dropped_pointers();
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/hud_table.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/hud_table.stasis
@@ -1,0 +1,133 @@
+// HUD layout helpers for reusable "tables" (rows/columns) over arrays of data.
+// From a generated project: import "/vendor/stasis/stdlib/hud_table.stasis";
+//
+// Cranelift note:
+// - The Cranelift backend does not currently support arbitrary struct member access.
+// - This module uses f32[4] rects (x,y,w,h) to stay portable across backends.
+//
+// Rect layout: [x, y, w, h]
+const HUD_RECT_X: i32 = 0;
+const HUD_RECT_Y: i32 = 1;
+const HUD_RECT_W: i32 = 2;
+const HUD_RECT_H: i32 = 3;
+
+// Clamp utility (avoid extra imports).
+function hud_clamp(value: i32, minimum: i32, maximum: i32): i32 {
+    if (value < minimum) {
+        return minimum;
+    }
+    if (value > maximum) {
+        return maximum;
+    }
+    return value;
+}
+
+function hud_rect_set(out_r: f32[], x: f32, y: f32, w: f32, h: f32): void {
+    out_r[HUD_RECT_X] = x;
+    out_r[HUD_RECT_Y] = y;
+    out_r[HUD_RECT_W] = w;
+    out_r[HUD_RECT_H] = h;
+}
+
+// Compute the total width of a table given column widths and gaps.
+function hud_table_width(col_w: f32[], col_count: i32, col_gap: f32): f32 {
+    let n: i32 = col_count;
+    if (n < 0) {
+        n = 0;
+    }
+    let sum: f32 = 0.0;
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        sum = sum + col_w[i];
+    }
+    if (n > 1) {
+        sum = sum + i32_to_f32(n - 1) * col_gap;
+    }
+    return sum;
+}
+
+// Compute the total height of a table given row height and gaps.
+function hud_table_height(row_count: i32, row_h: f32, row_gap: f32): f32 {
+    let n: i32 = row_count;
+    if (n < 0) {
+        n = 0;
+    }
+    let h: f32 = i32_to_f32(n) * row_h;
+    if (n > 1) {
+        h = h + i32_to_f32(n - 1) * row_gap;
+    }
+    return h;
+}
+
+// Place a table anchored within a parent rect.
+// anchor:
+// 0=top-left, 1=top-right, 2=bottom-left, 3=bottom-right, 4=top-center, 5=bottom-center
+function hud_table_place(out_table: f32[], parent: f32[], table_w: f32, table_h: f32, anchor: i32, pad_x: f32, pad_y: f32): void {
+    let x: f32 = parent[HUD_RECT_X] + pad_x;
+    let y: f32 = parent[HUD_RECT_Y] + pad_y;
+
+    if (anchor == 1) {
+        x = parent[HUD_RECT_X] + parent[HUD_RECT_W] - pad_x - table_w;
+    }
+    if (anchor == 2) {
+        y = parent[HUD_RECT_Y] + parent[HUD_RECT_H] - pad_y - table_h;
+    }
+    if (anchor == 3) {
+        x = parent[HUD_RECT_X] + parent[HUD_RECT_W] - pad_x - table_w;
+        y = parent[HUD_RECT_Y] + parent[HUD_RECT_H] - pad_y - table_h;
+    }
+    if (anchor == 4) {
+        x = parent[HUD_RECT_X] +(parent[HUD_RECT_W] - table_w) * 0.5;
+    }
+    if (anchor == 5) {
+        x = parent[HUD_RECT_X] +(parent[HUD_RECT_W] - table_w) * 0.5;
+        y = parent[HUD_RECT_Y] + parent[HUD_RECT_H] - pad_y - table_h;
+    }
+
+    hud_rect_set(out_table, x, y, table_w, table_h);
+}
+
+function hud_table_cell_x(table: f32[], col_w: f32[], col_count: i32, col_gap: f32, col: i32): f32 {
+    let c: i32 = hud_clamp(col, 0, col_count - 1);
+    let x: f32 = table[HUD_RECT_X];
+    let i: i32 = 0;
+    for (i = 0; i < c; i = i + 1) {
+        x = x + col_w[i] + col_gap;
+    }
+    return x;
+}
+
+function hud_table_cell_w(col_w: f32[], col_count: i32, col: i32): f32 {
+    let c: i32 = hud_clamp(col, 0, col_count - 1);
+    return col_w[c];
+}
+
+function hud_table_cell_y(table: f32[], row_h: f32, row_gap: f32, row: i32): f32 {
+    let r: i32 = row;
+    if (r < 0) {
+        r = 0;
+    }
+    return table[HUD_RECT_Y] + i32_to_f32(r) *(row_h + row_gap);
+}
+
+function hud_table_cell_h(row_h: f32): f32 {
+    return row_h;
+}
+
+function hud_table_cell_rect(
+    out_cell: f32[],
+    table: f32[],
+    col_w: f32[],
+    col_count: i32,
+    col_gap: f32,
+    row_h: f32,
+    row_gap: f32,
+    col: i32,
+    row: i32
+): void {
+    let x: f32 = hud_table_cell_x(table, col_w, col_count, col_gap, col);
+    let y: f32 = hud_table_cell_y(table, row_h, row_gap, row);
+    let w: f32 = hud_table_cell_w(col_w, col_count, col);
+    let h: f32 = hud_table_cell_h(row_h);
+    hud_rect_set(out_cell, x, y, w, h);
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/internal/gfx_cmd.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/internal/gfx_cmd.stasis
@@ -1,0 +1,547 @@
+import "../stdlib.stasis";
+
+// Graphics command buffer (v5)
+//
+// Policy:
+// - Ordering: line, rectangle, sprite, and text calls append to one bounded order stream.
+// - Geometry: lines grow forward and rectangles grow backward in one fixed arena.
+// - Compatibility: an empty order stream uses lines -> rectangles -> sprites -> text order.
+// - Coordinates: logical top-left pixels from the HostFrame display contract.
+
+const GFX_CMD_MAGIC: i32 = 1196967473; // 0x47584631 ('GXF1')
+
+const GFX_CMD_VERSION: i32 = 5;
+
+// i32 header indices
+const GFX_I_MAGIC: i32 = 0;
+const GFX_I_VERSION: i32 = 1;
+const GFX_I_FLAGS: i32 = 2;
+const GFX_I_LINE_COUNT: i32 = 3;
+const GFX_I_SPRITE_COUNT: i32 = 4;
+const GFX_I_DROPPED_LINES: i32 = 5;
+const GFX_I_DROPPED_SPRITES: i32 = 6;
+const GFX_I_TEXT_COUNT: i32 = 7;
+const GFX_I_DROPPED_TEXT: i32 = 8;
+const GFX_I_TEXT_BYTES_USED: i32 = 9;
+
+// Host-populated display metadata. Guest frame construction leaves these
+// reserved slots untouched; they are not part of the command trace.
+const GFX_I_LOGICAL_W: i32 = 10;
+const GFX_I_LOGICAL_H: i32 = 11;
+const GFX_I_NATIVE_W: i32 = 12;
+const GFX_I_NATIVE_H: i32 = 13;
+const GFX_I_DRAWABLE_W: i32 = 14;
+const GFX_I_DRAWABLE_H: i32 = 15;
+const GFX_I_SAFE_X: i32 = 16;
+const GFX_I_SAFE_Y: i32 = 17;
+const GFX_I_SAFE_W: i32 = 18;
+const GFX_I_SAFE_H: i32 = 19;
+const GFX_I_DISPLAY_GENERATION: i32 = 20;
+const GFX_I_DENSITY_GENERATION: i32 = 21;
+const GFX_I_ORDER_COUNT: i32 = 22;
+const GFX_I_DROPPED_ORDER: i32 = 23;
+const GFX_I_RECT_COUNT: i32 = 24;
+const GFX_I_DROPPED_RECTS: i32 = 25;
+const GFX_I_SPRITE_BASE: i32 = 32;
+const GFX_I_ORDER_BASE: i32 = 18464;
+
+// flags
+const GFX_FLAG_CLEAR: i32 = 1;
+const GFX_FLAG_PRESENT: i32 = 2;
+
+// capacities (must match runtime clamp in `stasis_gfx_submit`)
+const GFX_MAX_GEOMETRY: i32 = 10000;
+const GFX_GEOMETRY_STRIDE_F32: i32 = 8;
+const GFX_MAX_LINES: i32 = 10000;
+const GFX_LINE_STRIDE_F32: i32 = 8;
+const GFX_MAX_SPRITES: i32 = 4096;
+const GFX_SPRITE_STRIDE_I32: i32 = 3; // handle,rot_deg,a
+
+// x,y,w,h,u0,v0,u1,v1. UVs are normalized source coordinates.
+const GFX_SPRITE_STRIDE_F32: i32 = 8;
+const GFX_MAX_TEXT: i32 = 2048;
+const GFX_TEXT_STRIDE_I32: i32 = 3; // font, byte_offset, byte_len
+
+const GFX_TEXT_STRIDE_F32: i32 = 6; // x,y,r,g,b,a
+
+const GFX_TEXT_MAX_BYTES: i32 = 65536;
+const GFX_MAX_ORDER: i32 = 16144;
+const GFX_ORDER_KIND_SCALE: i32 = 16384;
+const GFX_ORDER_LINE: i32 = 1;
+const GFX_ORDER_SPRITE: i32 = 2;
+const GFX_ORDER_TEXT: i32 = 3;
+const GFX_ORDER_RECT: i32 = 4;
+
+// f32 layout
+const GFX_F_CLEAR_R: i32 = 0;
+const GFX_F_CLEAR_G: i32 = 1;
+const GFX_F_CLEAR_B: i32 = 2;
+const GFX_F_CLEAR_A: i32 = 3;
+const GFX_F_LINE_BASE: i32 = 4;
+const GFX_F_SPRITE_BASE: i32 = 80004;
+const GFX_F_RECT_REVERSE_BASE: i32 = 79996;
+const GFX_F_TEXT_BASE: i32 = 112772;
+
+// NOTE: Array sizes must be integer literals in Stasis today.
+// Keep these in sync with the constants above:
+// - i32 count = 32 + (4096*3) + (2048*3) + 16144 = 34608
+// - f32 count = 4 + (10000*8) + (4096*8) + (2048*6) = 125060
+const GFX_I_TEXT_BASE: i32 = 12320;
+
+global gfx_cmd_i32: i32[34608];
+global gfx_cmd_f32: f32[125060];
+global gfx_cmd_u8: u8[65536];
+
+// Begin a new frame, resetting all counts (typical immediate-mode usage).
+function @inline gfx_cmd_begin(): void {
+    gfx_cmd_i32[GFX_I_MAGIC] = GFX_CMD_MAGIC;
+    gfx_cmd_i32[GFX_I_VERSION] = GFX_CMD_VERSION;
+    gfx_cmd_i32[GFX_I_FLAGS] = 0;
+    gfx_cmd_i32[GFX_I_LINE_COUNT] = 0;
+    gfx_cmd_i32[GFX_I_SPRITE_COUNT] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_LINES] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = 0;
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_TEXT] = 0;
+    gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = 0;
+    gfx_cmd_i32[GFX_I_ORDER_COUNT] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_ORDER] = 0;
+    gfx_cmd_i32[GFX_I_RECT_COUNT] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_RECTS] = 0;
+}
+
+// Begin a new frame without clearing counts/streams (persistent-mode usage).
+//
+// Intended usage:
+// - Prebuild streams once (set counts + write entries).
+// - Each tick call `gfx_cmd_begin_persistent()`, patch only changed entries, and `gfx_cmd_mark_present()`.
+function @inline gfx_cmd_begin_persistent(): void {
+    gfx_cmd_i32[GFX_I_MAGIC] = GFX_CMD_MAGIC;
+    gfx_cmd_i32[GFX_I_VERSION] = GFX_CMD_VERSION;
+    gfx_cmd_i32[GFX_I_FLAGS] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_LINES] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_TEXT] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_ORDER] = 0;
+    gfx_cmd_i32[GFX_I_DROPPED_RECTS] = 0;
+}
+
+function @inline gfx_cmd_append_order(kind: i32, index: i32): bool {
+    let order_index: i32 = gfx_cmd_i32[GFX_I_ORDER_COUNT];
+    if (order_index < 0 || order_index >= GFX_MAX_ORDER) {
+        gfx_cmd_i32[GFX_I_DROPPED_ORDER] = gfx_cmd_i32[GFX_I_DROPPED_ORDER] + 1;
+        return false;
+    }
+    gfx_cmd_i32[GFX_I_ORDER_BASE + order_index] = kind * GFX_ORDER_KIND_SCALE + index;
+    gfx_cmd_i32[GFX_I_ORDER_COUNT] = order_index + 1;
+    return true;
+}
+
+function @inline gfx_cmd_clear(r: f32, g: f32, b: f32, a: f32): void {
+    gfx_cmd_i32[GFX_I_FLAGS] = GFX_FLAG_CLEAR;
+    gfx_cmd_f32[GFX_F_CLEAR_R] = r;
+    gfx_cmd_f32[GFX_F_CLEAR_G] = g;
+    gfx_cmd_f32[GFX_F_CLEAR_B] = b;
+    gfx_cmd_f32[GFX_F_CLEAR_A] = a;
+}
+
+function gfx_cmd_line(x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_LINE_COUNT];
+    let rect_count: i32 = gfx_cmd_i32[GFX_I_RECT_COUNT];
+    if (i < 0 || rect_count < 0 || rect_count > GFX_MAX_GEOMETRY || i >= GFX_MAX_GEOMETRY - rect_count) {
+        gfx_cmd_i32[GFX_I_DROPPED_LINES] = gfx_cmd_i32[GFX_I_DROPPED_LINES] + 1;
+        return;
+    }
+    if (!gfx_cmd_append_order(GFX_ORDER_LINE, i)) {
+        gfx_cmd_i32[GFX_I_DROPPED_LINES] = gfx_cmd_i32[GFX_I_DROPPED_LINES] + 1;
+        return;
+    }
+
+    let base: i32 = GFX_F_LINE_BASE + i * GFX_LINE_STRIDE_F32;
+    gfx_cmd_f32[base + 0] = x1;
+    gfx_cmd_f32[base + 1] = y1;
+    gfx_cmd_f32[base + 2] = x2;
+    gfx_cmd_f32[base + 3] = y2;
+    gfx_cmd_f32[base + 4] = r;
+    gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b;
+    gfx_cmd_f32[base + 7] = a;
+
+    gfx_cmd_i32[GFX_I_LINE_COUNT] = i + 1;
+}
+
+function gfx_cmd_rect(x: f32, y: f32, w: f32, h: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_RECT_COUNT];
+    let line_count: i32 = gfx_cmd_i32[GFX_I_LINE_COUNT];
+    if (i < 0 || line_count < 0 || line_count > GFX_MAX_GEOMETRY || i >= GFX_MAX_GEOMETRY - line_count) {
+        gfx_cmd_i32[GFX_I_DROPPED_RECTS] = gfx_cmd_i32[GFX_I_DROPPED_RECTS] + 1;
+        return;
+    }
+    if (!gfx_cmd_append_order(GFX_ORDER_RECT, i)) {
+        gfx_cmd_i32[GFX_I_DROPPED_RECTS] = gfx_cmd_i32[GFX_I_DROPPED_RECTS] + 1;
+        return;
+    }
+
+    let base: i32 = GFX_F_RECT_REVERSE_BASE - i * GFX_GEOMETRY_STRIDE_F32;
+    gfx_cmd_f32[base + 0] = x;
+    gfx_cmd_f32[base + 1] = y;
+    gfx_cmd_f32[base + 2] = w;
+    gfx_cmd_f32[base + 3] = h;
+    gfx_cmd_f32[base + 4] = r;
+    gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b;
+    gfx_cmd_f32[base + 7] = a;
+
+    gfx_cmd_i32[GFX_I_RECT_COUNT] = i + 1;
+}
+
+function gfx_cmd_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
+    if (i >= GFX_MAX_SPRITES || !gfx_cmd_append_order(GFX_ORDER_SPRITE, i)) {
+        gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = gfx_cmd_i32[GFX_I_DROPPED_SPRITES] + 1;
+        return;
+    }
+    let base_i: i32 = GFX_I_SPRITE_BASE + i * GFX_SPRITE_STRIDE_I32;
+    let base_f: i32 = GFX_F_SPRITE_BASE + i * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_i32[base_i + 0] = handle;
+    gfx_cmd_i32[base_i + 1] = rot_deg;
+    gfx_cmd_i32[base_i + 2] = a;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = w;
+    gfx_cmd_f32[base_f + 3] = h;
+    gfx_cmd_f32[base_f + 4] = 0.0;
+    gfx_cmd_f32[base_f + 5] = 0.0;
+    gfx_cmd_f32[base_f + 6] = 1.0;
+    gfx_cmd_f32[base_f + 7] = 1.0;
+    gfx_cmd_i32[GFX_I_SPRITE_COUNT] = i + 1;
+}
+
+function gfx_cmd_set_last_sprite_uv(u0: f32, v0: f32, u1: f32, v1: f32): void {
+    if (u0 < 0.0 || v0 < 0.0 || u1 > 1.0 || v1 > 1.0 || u0 >= u1 || v0 >= v1) {
+        return;
+    }
+    let count: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
+    if (count <= 0 || count > GFX_MAX_SPRITES) {
+        return;
+    }
+    let base_f: i32 = GFX_F_SPRITE_BASE +(count - 1) * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_f32[base_f + 4] = u0;
+    gfx_cmd_f32[base_f + 5] = v0;
+    gfx_cmd_f32[base_f + 6] = u1;
+    gfx_cmd_f32[base_f + 7] = v1;
+}
+
+function gfx_cmd_set_sprite_at(index: i32, handle: i32, x: f32, y: f32, w: f32, h: f32, rot_deg: i32, a: i32): void {
+    if (index < 0 || index >= GFX_MAX_SPRITES) {
+        return;
+    }
+    let base_i: i32 = GFX_I_SPRITE_BASE + index * GFX_SPRITE_STRIDE_I32;
+    let base_f: i32 = GFX_F_SPRITE_BASE + index * GFX_SPRITE_STRIDE_F32;
+    gfx_cmd_i32[base_i + 0] = handle;
+    gfx_cmd_i32[base_i + 1] = rot_deg;
+    gfx_cmd_i32[base_i + 2] = a;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = w;
+    gfx_cmd_f32[base_f + 3] = h;
+    gfx_cmd_f32[base_f + 4] = 0.0;
+    gfx_cmd_f32[base_f + 5] = 0.0;
+    gfx_cmd_f32[base_f + 6] = 1.0;
+    gfx_cmd_f32[base_f + 7] = 1.0;
+}
+
+function gfx_cmd_lines_from(lines: f32[], count: i32): void {
+    if (count <= 0) {
+        return;
+    }
+
+    let start: i32 = gfx_cmd_i32[GFX_I_LINE_COUNT];
+    let rect_count: i32 = gfx_cmd_i32[GFX_I_RECT_COUNT];
+    if (start < 0 || rect_count < 0 || rect_count > GFX_MAX_GEOMETRY || start > GFX_MAX_GEOMETRY - rect_count) {
+        gfx_cmd_i32[GFX_I_DROPPED_LINES] = gfx_cmd_i32[GFX_I_DROPPED_LINES] + count;
+        return;
+    }
+    let avail: i32 = GFX_MAX_GEOMETRY - rect_count - start;
+    let n: i32 = count;
+    if (n > avail) {
+        n = avail;
+        gfx_cmd_i32[GFX_I_DROPPED_LINES] = gfx_cmd_i32[GFX_I_DROPPED_LINES] +(count - n);
+    }
+    if (n <= 0) {
+        return;
+    }
+
+    let dst: i32 = GFX_F_LINE_BASE + start * GFX_LINE_STRIDE_F32;
+    let total: i32 = n * GFX_LINE_STRIDE_F32;
+    sys_memcpy_f32(gfx_cmd_f32, dst, lines, 0, total);
+    let order_i: i32 = 0;
+    for (order_i = 0; order_i < n; order_i = order_i + 1) {
+        if (!gfx_cmd_append_order(GFX_ORDER_LINE, start + order_i)) {
+            gfx_cmd_i32[GFX_I_DROPPED_LINES] = gfx_cmd_i32[GFX_I_DROPPED_LINES] +(n - order_i);
+            n = order_i;
+        }
+    }
+    gfx_cmd_i32[GFX_I_LINE_COUNT] = start + n;
+}
+
+function gfx_cmd_sprites_from(cmd_i32: i32[], cmd_f32: f32[], count: i32): void {
+    if (count <= 0) {
+        return;
+    }
+
+    let start: i32 = gfx_cmd_i32[GFX_I_SPRITE_COUNT];
+    let avail: i32 = GFX_MAX_SPRITES - start;
+    let n: i32 = count;
+    if (n > avail) {
+        n = avail;
+        gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = gfx_cmd_i32[GFX_I_DROPPED_SPRITES] +(count - n);
+    }
+    if (n <= 0) {
+        return;
+    }
+
+    let dst_i: i32 = GFX_I_SPRITE_BASE + start * GFX_SPRITE_STRIDE_I32;
+    let total_i: i32 = n * GFX_SPRITE_STRIDE_I32;
+    sys_memcpy_i32(gfx_cmd_i32, dst_i, cmd_i32, 0, total_i);
+    let dst_f: i32 = GFX_F_SPRITE_BASE + start * GFX_SPRITE_STRIDE_F32;
+    let total_f: i32 = n * GFX_SPRITE_STRIDE_F32;
+    sys_memcpy_f32(gfx_cmd_f32, dst_f, cmd_f32, 0, total_f);
+    let order_i: i32 = 0;
+    for (order_i = 0; order_i < n; order_i = order_i + 1) {
+        if (!gfx_cmd_append_order(GFX_ORDER_SPRITE, start + order_i)) {
+            gfx_cmd_i32[GFX_I_DROPPED_SPRITES] = gfx_cmd_i32[GFX_I_DROPPED_SPRITES] +(n - order_i);
+            n = order_i;
+        }
+    }
+    gfx_cmd_i32[GFX_I_SPRITE_COUNT] = start + n;
+}
+
+function gfx_cmd_set_line_at(index: i32, x1: f32, y1: f32, x2: f32, y2: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let rect_count: i32 = gfx_cmd_i32[GFX_I_RECT_COUNT];
+    if (index < 0 || rect_count < 0 || rect_count > GFX_MAX_GEOMETRY || index >= GFX_MAX_GEOMETRY - rect_count) {
+        return;
+    }
+
+    let base: i32 = GFX_F_LINE_BASE + index * GFX_LINE_STRIDE_F32;
+    gfx_cmd_f32[base + 0] = x1;
+    gfx_cmd_f32[base + 1] = y1;
+    gfx_cmd_f32[base + 2] = x2;
+    gfx_cmd_f32[base + 3] = y2;
+    gfx_cmd_f32[base + 4] = r;
+    gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b;
+    gfx_cmd_f32[base + 7] = a;
+}
+
+function gfx_cmd_set_rect_at(index: i32, x: f32, y: f32, w: f32, h: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let line_count: i32 = gfx_cmd_i32[GFX_I_LINE_COUNT];
+    if (index < 0 || line_count < 0 || line_count > GFX_MAX_GEOMETRY || index >= GFX_MAX_GEOMETRY - line_count) {
+        return;
+    }
+
+    let base: i32 = GFX_F_RECT_REVERSE_BASE - index * GFX_GEOMETRY_STRIDE_F32;
+    gfx_cmd_f32[base + 0] = x;
+    gfx_cmd_f32[base + 1] = y;
+    gfx_cmd_f32[base + 2] = w;
+    gfx_cmd_f32[base + 3] = h;
+    gfx_cmd_f32[base + 4] = r;
+    gfx_cmd_f32[base + 5] = g;
+    gfx_cmd_f32[base + 6] = b;
+    gfx_cmd_f32[base + 7] = a;
+}
+
+function gfx_cmd_text(font: i32, text: utf8[], x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_TEXT_COUNT];
+    if (i >= GFX_MAX_TEXT) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+
+    let byte_len: i32 = length_bytes(text);
+    if (byte_len < 0) {
+        byte_len = 0;
+    }
+    if (byte_len > 1024) {
+        byte_len = 1024;
+    } // hard cap per command to keep worst-case bounded
+
+    let used: i32 = gfx_cmd_i32[GFX_I_TEXT_BYTES_USED];
+    if (used < 0) {
+        used = 0;
+    }
+    if (used + byte_len + 1 > GFX_TEXT_MAX_BYTES) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+    if (!gfx_cmd_append_order(GFX_ORDER_TEXT, i)) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+
+    sys_memcpy_u8(gfx_cmd_u8, used, text, 0, byte_len);
+    gfx_cmd_u8[used + byte_len] = 0;
+
+    let base_i: i32 = GFX_I_TEXT_BASE + i * GFX_TEXT_STRIDE_I32;
+    gfx_cmd_i32[base_i + 0] = font;
+    gfx_cmd_i32[base_i + 1] = used;
+    gfx_cmd_i32[base_i + 2] = byte_len;
+
+    let base_f: i32 = GFX_F_TEXT_BASE + i * GFX_TEXT_STRIDE_F32;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = r;
+    gfx_cmd_f32[base_f + 3] = g;
+    gfx_cmd_f32[base_f + 4] = b;
+    gfx_cmd_f32[base_f + 5] = a;
+
+    gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = used + byte_len + 1;
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = i + 1;
+}
+
+// Write a text draw referencing a cached glyph run (no per-frame UTF-8 bytes copied).
+// The runtime interprets `byte_offset < 0` as a cached text handle.
+function gfx_cmd_text_cached(font: i32, run_handle: i32, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
+    let i: i32 = gfx_cmd_i32[GFX_I_TEXT_COUNT];
+    if (i >= GFX_MAX_TEXT) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+    if (run_handle <= 0) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+    if (!gfx_cmd_append_order(GFX_ORDER_TEXT, i)) {
+        gfx_cmd_i32[GFX_I_DROPPED_TEXT] = gfx_cmd_i32[GFX_I_DROPPED_TEXT] + 1;
+        return;
+    }
+
+    let base_i: i32 = GFX_I_TEXT_BASE + i * GFX_TEXT_STRIDE_I32;
+    gfx_cmd_i32[base_i + 0] = font;
+    gfx_cmd_i32[base_i + 1] = 0 - run_handle; // negative => cached run handle
+    gfx_cmd_i32[base_i + 2] = 0;
+
+    let base_f: i32 = GFX_F_TEXT_BASE + i * GFX_TEXT_STRIDE_F32;
+    gfx_cmd_f32[base_f + 0] = x;
+    gfx_cmd_f32[base_f + 1] = y;
+    gfx_cmd_f32[base_f + 2] = r;
+    gfx_cmd_f32[base_f + 3] = g;
+    gfx_cmd_f32[base_f + 4] = b;
+    gfx_cmd_f32[base_f + 5] = a;
+
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = i + 1;
+}
+
+function gfx_cmd_set_line_count(count: i32): void {
+    if (count < 0) {
+        count = 0;
+    }
+    let maximum: i32 = GFX_MAX_GEOMETRY - gfx_cmd_i32[GFX_I_RECT_COUNT];
+    if (maximum < 0) {
+        maximum = 0;
+    }
+    if (count > maximum) {
+        count = maximum;
+    }
+    gfx_cmd_i32[GFX_I_LINE_COUNT] = count;
+}
+
+function gfx_cmd_set_rect_count(count: i32): void {
+    if (count < 0) {
+        count = 0;
+    }
+    let maximum: i32 = GFX_MAX_GEOMETRY - gfx_cmd_i32[GFX_I_LINE_COUNT];
+    if (maximum < 0) {
+        maximum = 0;
+    }
+    if (count > maximum) {
+        count = maximum;
+    }
+    gfx_cmd_i32[GFX_I_RECT_COUNT] = count;
+}
+
+function gfx_cmd_set_sprite_count(count: i32): void {
+    if (count < 0) {
+        count = 0;
+    }
+    if (count > GFX_MAX_SPRITES) {
+        count = GFX_MAX_SPRITES;
+    }
+    gfx_cmd_i32[GFX_I_SPRITE_COUNT] = count;
+}
+
+function gfx_cmd_set_text_count(count: i32): void {
+    if (count < 0) {
+        count = 0;
+    }
+    if (count > GFX_MAX_TEXT) {
+        count = GFX_MAX_TEXT;
+    }
+    gfx_cmd_i32[GFX_I_TEXT_COUNT] = count;
+}
+
+function gfx_cmd_set_text_bytes_used(bytes_used: i32): void {
+    if (bytes_used < 0) {
+        bytes_used = 0;
+    }
+    if (bytes_used > GFX_TEXT_MAX_BYTES) {
+        bytes_used = GFX_TEXT_MAX_BYTES;
+    }
+    gfx_cmd_i32[GFX_I_TEXT_BYTES_USED] = bytes_used;
+}
+
+function @inline gfx_cmd_submit(): void {
+    gfx_cmd_i32[GFX_I_FLAGS] = gfx_cmd_i32[GFX_I_FLAGS] + GFX_FLAG_PRESENT;
+}
+
+function @inline gfx_cmd_submit_no_present(): void {
+    return;
+}
+
+function @inline gfx_cmd_mark_present(): void {
+    gfx_cmd_i32[GFX_I_FLAGS] = gfx_cmd_i32[GFX_I_FLAGS] + GFX_FLAG_PRESENT;
+}
+
+function @inline gfx_cmd_line_count(): i32 {
+    return gfx_cmd_i32[GFX_I_LINE_COUNT];
+}
+
+function @inline gfx_cmd_sprite_count(): i32 {
+    return gfx_cmd_i32[GFX_I_SPRITE_COUNT];
+}
+
+function @inline gfx_cmd_rect_count(): i32 {
+    return gfx_cmd_i32[GFX_I_RECT_COUNT];
+}
+
+function @inline gfx_cmd_text_count(): i32 {
+    return gfx_cmd_i32[GFX_I_TEXT_COUNT];
+}
+
+function @inline gfx_cmd_order_count(): i32 {
+    return gfx_cmd_i32[GFX_I_ORDER_COUNT];
+}
+
+function @inline gfx_cmd_dropped_lines(): i32 {
+    return gfx_cmd_i32[GFX_I_DROPPED_LINES];
+}
+
+function @inline gfx_cmd_dropped_sprites(): i32 {
+    return gfx_cmd_i32[GFX_I_DROPPED_SPRITES];
+}
+
+function @inline gfx_cmd_dropped_rects(): i32 {
+    return gfx_cmd_i32[GFX_I_DROPPED_RECTS];
+}
+
+function @inline gfx_cmd_dropped_text(): i32 {
+    return gfx_cmd_i32[GFX_I_DROPPED_TEXT];
+}
+
+function @inline gfx_cmd_dropped_order(): i32 {
+    return gfx_cmd_i32[GFX_I_DROPPED_ORDER];
+}
+
+function @inline gfx_cmd_text_bytes_used(): i32 {
+    return gfx_cmd_i32[GFX_I_TEXT_BYTES_USED];
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/internal/host_frame.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/internal/host_frame.stasis
@@ -1,0 +1,230 @@
+// Host frame snapshot ABI.
+//
+// Practical hybrid approach:
+// - Reads: host writes a single deterministic snapshot once per tick via bulk host mode.
+//
+// Usage:
+// - Read everything from `host_i32[]` / `host_f32[]` accessors below for the rest of the tick.
+//
+// NOTE: This is a prototype layout. Treat all unused indices as reserved.
+
+const HOST_MAX_POINTERS: i32 = 8;
+
+// i32 layout
+const HOST_I_TIME_MS: i32 = 0;
+
+// 1..6 removed with pre-1.0 window/viewport compatibility aliases.
+const HOST_I_POINTER_COUNT: i32 = 7;
+const HOST_I_DROPPED_POINTERS: i32 = 8;
+const HOST_I_QUIT_REQUESTED: i32 = 9;
+const HOST_I_TICK_INDEX: i32 = 10;
+const HOST_I_RESIZED: i32 = 11;
+const HOST_I_SCREEN_W_PX: i32 = 12;
+const HOST_I_SCREEN_H_PX: i32 = 13;
+
+// vNext header
+const HOST_I_VERSION: i32 = 14;
+const HOST_I_FLAGS: i32 = 15;
+const HOST_I_TICK_HZ: i32 = 16; // 0 if unknown / not provided
+
+// Convenience mirrors (avoid bitwise ops in Stasis source).
+const HOST_I_WINDOW_FOCUSED: i32 = 17;
+const HOST_I_WINDOW_MINIMIZED: i32 = 18;
+const HOST_I_TIME_US: i32 = 19;
+
+// Physical display metrics. Logical and safe geometry live in the f32 lane.
+const HOST_I_NATIVE_W_PX: i32 = 22;
+const HOST_I_NATIVE_H_PX: i32 = 23;
+const HOST_I_DRAWABLE_W_PX: i32 = 24;
+const HOST_I_DRAWABLE_H_PX: i32 = 25;
+
+// 20,21 and 26..29 removed with integer presentation geometry.
+const HOST_I_DISPLAY_GENERATION: i32 = 30;
+const HOST_I_DENSITY_GENERATION: i32 = 31;
+
+// Keyboard state (SDL scancodes), one i32 per scancode (0/1).
+const HOST_I_KEY_BASE: i32 = 32;
+const HOST_I_KEY_COUNT: i32 = 512;
+
+// Reserve space for future fields before pointers.
+const HOST_I_POINTER_BASE: i32 = 544; // HOST_I_KEY_BASE + HOST_I_KEY_COUNT
+
+const HOST_I_POINTER_STRIDE: i32 = 4; // id, is_down, went_down, went_up
+
+const HOST_I32_COUNT: i32 = 768;
+
+// f32 layout
+const HOST_F_POINTER_BASE: i32 = 0;
+const HOST_F_POINTER_STRIDE: i32 = 6; // x_px, y_px, dx_px, dy_px, x_n, y_n
+
+const HOST_F_CONTENT_SCALE: i32 = 48;
+const HOST_F_RASTER_SCALE: i32 = 49;
+const HOST_F_LOGICAL_W: i32 = 50;
+const HOST_F_LOGICAL_H: i32 = 51;
+const HOST_F_SAFE_X: i32 = 52;
+const HOST_F_SAFE_Y: i32 = 53;
+const HOST_F_SAFE_W: i32 = 54;
+const HOST_F_SAFE_H: i32 = 55;
+const HOST_F32_COUNT: i32 = 64;
+
+global host_i32: i32[768];
+global host_f32: f32[64];
+
+function host_tick_index(): i32 {
+    return host_i32[HOST_I_TICK_INDEX];
+}
+
+function host_time_ms(): i32 {
+    return host_i32[HOST_I_TIME_MS];
+}
+
+function host_pointer_count(): i32 {
+    return host_i32[HOST_I_POINTER_COUNT];
+}
+
+function host_dropped_pointers(): i32 {
+    return host_i32[HOST_I_DROPPED_POINTERS];
+}
+
+function host_quit_requested(): bool {
+    return host_i32[HOST_I_QUIT_REQUESTED] != 0;
+}
+
+function host_resized(): bool {
+    return host_i32[HOST_I_RESIZED] != 0;
+}
+
+function host_screen_w_px(): i32 {
+    return host_i32[HOST_I_SCREEN_W_PX];
+}
+
+function host_screen_h_px(): i32 {
+    return host_i32[HOST_I_SCREEN_H_PX];
+}
+
+function host_version(): i32 {
+    return host_i32[HOST_I_VERSION];
+}
+
+function host_flags(): i32 {
+    return host_i32[HOST_I_FLAGS];
+}
+
+function host_tick_hz(): i32 {
+    return host_i32[HOST_I_TICK_HZ];
+}
+
+function host_window_focused(): bool {
+    return host_i32[HOST_I_WINDOW_FOCUSED] != 0;
+}
+
+function host_window_minimized(): bool {
+    return host_i32[HOST_I_WINDOW_MINIMIZED] != 0;
+}
+
+function host_time_us(): i32 {
+    return host_i32[HOST_I_TIME_US];
+}
+
+function host_logical_width(): f32 {
+    return host_f32[HOST_F_LOGICAL_W];
+}
+
+function host_logical_height(): f32 {
+    return host_f32[HOST_F_LOGICAL_H];
+}
+
+function host_native_w_px(): i32 {
+    return host_i32[HOST_I_NATIVE_W_PX];
+}
+
+function host_native_h_px(): i32 {
+    return host_i32[HOST_I_NATIVE_H_PX];
+}
+
+function host_drawable_w_px(): i32 {
+    return host_i32[HOST_I_DRAWABLE_W_PX];
+}
+
+function host_drawable_h_px(): i32 {
+    return host_i32[HOST_I_DRAWABLE_H_PX];
+}
+
+function host_safe_x(): f32 {
+    return host_f32[HOST_F_SAFE_X];
+}
+
+function host_safe_y(): f32 {
+    return host_f32[HOST_F_SAFE_Y];
+}
+
+function host_safe_width(): f32 {
+    return host_f32[HOST_F_SAFE_W];
+}
+
+function host_safe_height(): f32 {
+    return host_f32[HOST_F_SAFE_H];
+}
+
+function host_display_generation(): i32 {
+    return host_i32[HOST_I_DISPLAY_GENERATION];
+}
+
+function host_density_generation(): i32 {
+    return host_i32[HOST_I_DENSITY_GENERATION];
+}
+
+function host_content_scale(): f32 {
+    return host_f32[HOST_F_CONTENT_SCALE];
+}
+
+function host_raster_scale(): f32 {
+    return host_f32[HOST_F_RASTER_SCALE];
+}
+
+function host_key_down(scancode: i32): bool {
+    if (scancode < 0 || scancode >= 512) {
+        return false;
+    }
+    return host_i32[HOST_I_KEY_BASE + scancode] != 0;
+}
+
+function host_pointer_id(index: i32): i32 {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 0];
+}
+
+function host_pointer_is_down(index: i32): bool {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 1] != 0;
+}
+
+function host_pointer_went_down(index: i32): bool {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 2] != 0;
+}
+
+function host_pointer_went_up(index: i32): bool {
+    return host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3] != 0;
+}
+
+function host_pointer_x_logical(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0];
+}
+
+function host_pointer_y_logical(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1];
+}
+
+function host_pointer_dx_logical(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 2];
+}
+
+function host_pointer_dy_logical(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 3];
+}
+
+function host_pointer_x_n(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4];
+}
+
+function host_pointer_y_n(index: i32): f32 {
+    return host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5];
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/internal/host_window_request.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/internal/host_window_request.stasis
@@ -1,0 +1,42 @@
+// Guest-to-host window request ABI.
+//
+// The host polls these globals once per tick (or at least once after `main()`),
+// and applies any requested mode/size changes.
+//
+// Ordering: ABI order is the order of fields/globals declared here.
+
+const HOST_REQ_FLAG_WINDOWED: i32 = 1;
+const HOST_REQ_FLAG_FULLSCREEN: i32 = 2;
+const HOST_REQ_FLAG_MAXIMIZED: i32 = 4;
+
+global host_req_seq: i32;
+global host_req_flags: i32;
+global host_req_window_w_px: i32;
+global host_req_window_h_px: i32;
+
+// Publish window requests by updating the payload before advancing the sequence.
+// The host observes the sequence change as the commit point for the mailbox.
+function host_request_windowed(width: i32, height: i32): void {
+    host_req_flags = HOST_REQ_FLAG_WINDOWED;
+    host_req_window_w_px = width;
+    host_req_window_h_px = height;
+    host_req_seq = host_req_seq + 1;
+}
+
+function host_request_fullscreen(enabled: i32): void {
+    if (enabled != 0) {
+        host_req_flags = HOST_REQ_FLAG_FULLSCREEN;
+    } else {
+        host_req_flags = HOST_REQ_FLAG_WINDOWED;
+    }
+    host_req_seq = host_req_seq + 1;
+}
+
+function host_request_maximized(enabled: i32): void {
+    if (enabled != 0) {
+        host_req_flags = HOST_REQ_FLAG_MAXIMIZED;
+    } else {
+        host_req_flags = HOST_REQ_FLAG_WINDOWED;
+    }
+    host_req_seq = host_req_seq + 1;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/memory.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/memory.stasis
@@ -1,0 +1,224 @@
+// Memory utilities.
+//
+// These wrappers are intended to be safer than calling the raw `sys_*` bulk ops:
+// - explicit capacities for bounds checking
+// - clamped and/or checked variants
+
+extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+extern function sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+
+// Copy `count` bytes from src to dst, clamped to both buffers.
+// Returns bytes copied.
+function mem_copy_u8(dst: u8[], dst_cap: i32, dst_index: i32, src: u8[], src_cap: i32, src_index: i32, count: i32): i32 {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
+
+    let dst_rem: i32 = dst_cap - dst_index;
+    let src_rem: i32 = src_cap - src_index;
+    let n: i32 = count;
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+
+    sys_memmove_u8(dst, dst_index, src, src_index, n);
+    return n;
+}
+
+// Copy `count` bytes from src to dst; fails if any bound would be exceeded.
+function mem_copy_u8_checked(dst: u8[], dst_cap: i32, dst_index: i32, src: u8[], src_cap: i32, src_index: i32, count: i32): bool {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
+    sys_memmove_u8(dst, dst_index, src, src_index, count);
+    return true;
+}
+
+// Set `count` bytes to `value`, clamped to the buffer. Returns bytes written.
+function mem_set_u8(dst: u8[], dst_cap: i32, dst_index: i32, value: u8, count: i32): i32 {
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
+    let rem: i32 = dst_cap - dst_index;
+    let n: i32 = count;
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
+    return n;
+}
+
+function mem_zero_u8(dst: u8[], dst_cap: i32, dst_index: i32, count: i32): i32 {
+    return mem_set_u8(dst, dst_cap, dst_index, 0, count);
+}
+
+// Copy `count` elements from src to dst, clamped to both buffers.
+// Returns elements copied.
+function mem_copy_i32(dst: i32[], dst_cap: i32, dst_index: i32, src: i32[], src_cap: i32, src_index: i32, count: i32): i32 {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
+
+    let dst_rem: i32 = dst_cap - dst_index;
+    let src_rem: i32 = src_cap - src_index;
+    let n: i32 = count;
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+
+    sys_memmove_i32(dst, dst_index, src, src_index, n);
+    return n;
+}
+
+function mem_copy_i32_checked(dst: i32[], dst_cap: i32, dst_index: i32, src: i32[], src_cap: i32, src_index: i32, count: i32): bool {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
+    sys_memmove_i32(dst, dst_index, src, src_index, count);
+    return true;
+}
+
+function mem_set_i32(dst: i32[], dst_cap: i32, dst_index: i32, value: i32, count: i32): i32 {
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
+    let rem: i32 = dst_cap - dst_index;
+    let n: i32 = count;
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
+    return n;
+}
+
+function mem_zero_i32(dst: i32[], dst_cap: i32, dst_index: i32, count: i32): i32 {
+    return mem_set_i32(dst, dst_cap, dst_index, 0, count);
+}
+
+// Copy `count` elements from src to dst, clamped to both buffers.
+// Returns elements copied.
+function mem_copy_f32(dst: f32[], dst_cap: i32, dst_index: i32, src: f32[], src_cap: i32, src_index: i32, count: i32): i32 {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap || src_index >= src_cap) {
+        return 0;
+    }
+
+    let dst_rem: i32 = dst_cap - dst_index;
+    let src_rem: i32 = src_cap - src_index;
+    let n: i32 = count;
+    if (n > dst_rem) {
+        n = dst_rem;
+    }
+    if (n > src_rem) {
+        n = src_rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+
+    sys_memmove_f32(dst, dst_index, src, src_index, n);
+    return n;
+}
+
+function mem_copy_f32_checked(dst: f32[], dst_cap: i32, dst_index: i32, src: f32[], src_cap: i32, src_index: i32, count: i32): bool {
+    if (dst_cap < 0 || src_cap < 0 || dst_index < 0 || src_index < 0 || count < 0) {
+        return false;
+    }
+    if (dst_index + count > dst_cap) {
+        return false;
+    }
+    if (src_index + count > src_cap) {
+        return false;
+    }
+    if (count == 0) {
+        return true;
+    }
+    sys_memmove_f32(dst, dst_index, src, src_index, count);
+    return true;
+}
+
+function mem_set_f32(dst: f32[], dst_cap: i32, dst_index: i32, value: f32, count: i32): i32 {
+    if (dst_cap < 0 || dst_index < 0 || count <= 0) {
+        return 0;
+    }
+    if (dst_index >= dst_cap) {
+        return 0;
+    }
+    let rem: i32 = dst_cap - dst_index;
+    let n: i32 = count;
+    if (n > rem) {
+        n = rem;
+    }
+    if (n <= 0) {
+        return 0;
+    }
+    let i: i32 = 0;
+    for (i = 0; i < n; i = i + 1) {
+        dst[dst_index + i] = value;
+    }
+    return n;
+}
+
+function mem_zero_f32(dst: f32[], dst_cap: i32, dst_index: i32, count: i32): i32 {
+    return mem_set_f32(dst, dst_cap, dst_index, 0, count);
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/sdl_scancodes.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/sdl_scancodes.stasis
@@ -1,0 +1,15 @@
+// SDL scancodes used by samples.
+// Values match SDL_SCANCODE_* (keyboard scancodes, not keycodes).
+
+enum Scancode {
+    A = 4,
+    D = 7,
+    W = 26,
+    Return = 40,
+    Escape = 41,
+    Space = 44,
+    Right = 79,
+    Left = 80,
+    Down = 81,
+    Up = 82,
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/stdlib.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/stdlib.stasis
@@ -1,0 +1,536 @@
+// Stasis standard library (stub).
+// From a generated project: import "/vendor/stasis/stdlib/stdlib.stasis";
+// For host-backed APIs, import "/vendor/stasis/stdlib/graphics.stasis" and/or
+// "/vendor/stasis/stdlib/audio.stasis".
+
+import "memory.stasis";
+
+// Abort the current hot swap after on_code_swap restores any application invariants it can.
+extern function reject_code_swap(): void;
+
+// Bootstrap provides type-specific host functions behind one source-level overload family.
+function print(value: i32): void {
+    print_int(value);
+}
+
+function print(value: string): void {
+    print_string(value);
+}
+
+function to_i32(value: u8): i32 {
+    return value;
+}
+
+function to_u8_trunc(value: i32): u8 {
+    let out: i32 = value % 256;
+    if (out < 0) {
+        out += 256;
+    }
+    return out;
+}
+
+function char_is_digit(b: u8): bool {
+    return b >= 48 && b <= 57;
+}
+
+function char_is_upper(b: u8): bool {
+    return b >= 65 && b <= 90;
+}
+
+function char_is_lower(b: u8): bool {
+    return b >= 97 && b <= 122;
+}
+
+function char_is_alpha(b: u8): bool {
+    return char_is_upper(b) || char_is_lower(b);
+}
+
+function char_is_alnum(b: u8): bool {
+    return char_is_alpha(b) || char_is_digit(b);
+}
+
+function char_is_space(b: u8): bool {
+    return b == 32 || b == 9 || b == 10 || b == 13;
+}
+
+function char_is_hex(b: u8): bool {
+    if (char_is_digit(b)) {
+        return true;
+    }
+    if (b >= 65 && b <= 70) {
+        return true;
+    }
+    return b >= 97 && b <= 102;
+}
+
+function char_is_print(b: u8): bool {
+    return b >= 32 && b <= 126;
+}
+
+function char_is_ascii(b: u8): bool {
+    return b < 128;
+}
+
+function char_to_upper(b: u8): u8 {
+    if (char_is_lower(b)) {
+        return b - 32;
+    }
+    return b;
+}
+
+function char_to_lower(b: u8): u8 {
+    if (char_is_upper(b)) {
+        return b + 32;
+    }
+    return b;
+}
+
+function char_to_digit(b: u8): i32 {
+    if (!char_is_digit(b)) {
+        return -1;
+    }
+    return b - 48;
+}
+
+function char_from_digit(d: i32): u8 {
+    if (d < 0 || d > 9) {
+        return 48;
+    }
+    return 48 + d;
+}
+
+function char_to_hex(b: u8): i32 {
+    if (char_is_digit(b)) {
+        return b - 48;
+    }
+    if (b >= 65 && b <= 70) {
+        return 10 +(b - 65);
+    }
+    if (b >= 97 && b <= 102) {
+        return 10 +(b - 97);
+    }
+    return -1;
+}
+
+function char_from_hex(d: i32): u8 {
+    if (d < 0 || d > 15) {
+        return 48;
+    }
+    if (d < 10) {
+        return 48 + d;
+    }
+    return 65 +(d - 10);
+}
+
+function length(s: ascii[]): i32 {
+    let value: i32 = s.length;
+    if (value < 0) {
+        return 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        return max_len;
+    }
+    return value;
+}
+
+function ascii_max_length(s: ascii[]): i32 {
+    let value: i32 = s.max_length;
+    if (value < 0) {
+        return 0;
+    }
+    return value;
+}
+
+function ascii_scan_limit(s: ascii[]): i32 {
+    let max_len: i32 = ascii_max_length(s);
+    if (max_len > 0) {
+        return max_len;
+    }
+    let known_len: i32 = length(s);
+    if (known_len < 0) {
+        return 0;
+    }
+    return known_len + 1;
+}
+
+function ascii_set_len(s: ascii[], len: i32) {
+    let value: i32 = len;
+    if (value < 0) {
+        value = 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        value = max_len;
+    }
+    s.length = value;
+}
+
+function ascii_is_empty(s: ascii[]): bool {
+    return length(s) == 0;
+}
+
+function ascii_get(s: ascii[], index: i32): u8 {
+    return s[index];
+}
+
+function ascii_set(s: ascii[], index: i32, b: u8) {
+    s[index] = b;
+    if (b == 0) {
+        ascii_set_len(s, index);
+        return;
+    }
+    if (index >= length(s)) {
+        ascii_set_len(s, index + 1);
+    }
+}
+
+function ascii_recount(s: ascii[]): i32 {
+    let i: i32 = 0;
+    let limit: i32 = ascii_scan_limit(s);
+    for (i = 0; i < limit; i = i + 1) {
+        if (s[i] == 0) {
+            ascii_set_len(s, i);
+            return i;
+        }
+    }
+    ascii_set_len(s, limit);
+    return limit;
+}
+
+function ascii_clear(s: ascii[]) {
+    s[0] = 0;
+    ascii_set_len(s, 0);
+}
+
+function ascii_copy(dst: ascii[], src: ascii[]): i32 {
+    let i: i32 = 0;
+    let dst_limit: i32 = ascii_scan_limit(dst);
+    let src_limit: i32 = ascii_scan_limit(src);
+    let limit: i32 = src_limit;
+    if (dst_limit < limit) {
+        limit = dst_limit;
+    }
+    for (i = 0; i < limit; i = i + 1) {
+        let b: u8 = src[i];
+        dst[i] = b;
+        if (b == 0) {
+            ascii_set_len(dst, i);
+            return i;
+        }
+    }
+    if (dst_limit > 0 && limit >= dst_limit) {
+        dst[dst_limit - 1] = 0;
+        ascii_set_len(dst, dst_limit - 1);
+        return dst_limit - 1;
+    }
+    if (limit < dst_limit) {
+        dst[limit] = 0;
+        ascii_set_len(dst, limit);
+        return limit;
+    }
+    return 0;
+}
+
+function ascii_append(dst: ascii[], src: ascii[]): i32 {
+    let base: i32 = length(dst);
+    let i: i32 = 0;
+    let dst_limit: i32 = ascii_scan_limit(dst);
+    if (base < 0) {
+        base = 0;
+    }
+    if (dst_limit <= 0 || base >= dst_limit) {
+        return base;
+    }
+    let src_limit: i32 = ascii_scan_limit(src);
+    let write_limit: i32 = dst_limit - base - 1;
+    if (write_limit <= 0) {
+        dst[base] = 0;
+        ascii_set_len(dst, base);
+        return base;
+    }
+    for (i = 0; i < write_limit && i < src_limit; i = i + 1) {
+        let b: u8 = src[i];
+        if (b == 0) {
+            dst[base + i] = 0;
+            ascii_set_len(dst, base + i);
+            return base + i;
+        }
+        dst[base + i] = b;
+    }
+    dst[base + i] = 0;
+    ascii_set_len(dst, base + i);
+    return base + i;
+}
+
+function ascii_push(dst: ascii[], b: u8): i32 {
+    let base: i32 = length(dst);
+    dst[base] = b;
+    if (b == 0) {
+        ascii_set_len(dst, base);
+        return base;
+    }
+    dst[base + 1] = 0;
+    ascii_set_len(dst, base + 1);
+    return base + 1;
+}
+
+function ascii_push_i32(dst: ascii[], value: i32): void {
+    let v: i32 = value;
+    if (v == 0) {
+        ascii_push(dst, 48);
+        return;
+    }
+
+    if (v < 0) {
+        ascii_push(dst, 45);
+        v = 0 - v;
+    }
+
+    // Find the highest power-of-10 divisor.
+    let pow10: i32 = 1;
+    let i: i32 = 0;
+    for (i = 0; pow10 <= v / 10; i = i + 1) {
+        pow10 = pow10 * 10;
+    }
+
+    // Emit digits.
+    for (i = 0; pow10 > 0; i = i + 1) {
+        let digit: i32 =(v / pow10) % 10;
+        ascii_push(dst, to_u8_trunc(48 + digit));
+        pow10 = pow10 / 10;
+    }
+}
+
+function ascii_cmp(a: ascii[], b: ascii[]): i32 {
+    let i: i32 = 0;
+    let a_limit: i32 = ascii_scan_limit(a);
+    let b_limit: i32 = ascii_scan_limit(b);
+    let limit: i32 = a_limit;
+    if (b_limit < limit) {
+        limit = b_limit;
+    }
+    for (i = 0; i < limit; i = i + 1) {
+        let av: i32 = to_i32(a[i]);
+        let bv: i32 = to_i32(b[i]);
+        if (av < bv) {
+            return -1;
+        }
+        if (av > bv) {
+            return 1;
+        }
+        if (av == 0) {
+            return 0;
+        }
+    }
+    if (a_limit == b_limit) {
+        return 0;
+    }
+    if (a_limit < b_limit) {
+        return -1;
+    }
+    return 1;
+}
+
+function ascii_eq(a: ascii[], b: ascii[]): bool {
+    return ascii_cmp(a, b) == 0;
+}
+
+function ascii_find_byte(s: ascii[], b: u8): i32 {
+    let i: i32 = 0;
+    let limit: i32 = ascii_scan_limit(s);
+    for (i = 0; i < limit; i = i + 1) {
+        let cur: u8 = s[i];
+        if (cur == b) {
+            return i;
+        }
+        if (cur == 0) {
+            return -1;
+        }
+    }
+    return -1;
+}
+
+function ascii_find_last_byte(s: ascii[], b: u8): i32 {
+    let i: i32 = 0;
+    let last: i32 = -1;
+    let limit: i32 = ascii_scan_limit(s);
+    for (i = 0; i < limit; i = i + 1) {
+        let cur: u8 = s[i];
+        if (cur == b) {
+            last = i;
+        }
+        if (cur == 0) {
+            return last;
+        }
+    }
+    return last;
+}
+
+function ascii_starts_with(s: ascii[], prefix: ascii[]): bool {
+    let i: i32 = 0;
+    let limit: i32 = ascii_scan_limit(prefix);
+    for (i = 0; i < limit; i = i + 1) {
+        let p: u8 = prefix[i];
+        if (p == 0) {
+            return true;
+        }
+        let v: u8 = s[i];
+        if (v == 0) {
+            return false;
+        }
+        if (v != p) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function ascii_ends_with(s: ascii[], suffix: ascii[]): bool {
+    let len_s: i32 = length(s);
+    let len_suf: i32 = length(suffix);
+    if (len_suf > len_s) {
+        return false;
+    }
+    let start: i32 = len_s - len_suf;
+    let i: i32 = 0;
+    for (i = 0; i < len_suf; i = i + 1) {
+        if (s[start + i] != suffix[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function ascii_find(s: ascii[], needle: ascii[]): i32 {
+    let len_s: i32 = length(s);
+    let len_n: i32 = length(needle);
+    if (len_n == 0) {
+        return 0;
+    }
+    if (len_n > len_s) {
+        return -1;
+    }
+    let i: i32 = 0;
+    let j: i32 = 0;
+    let match: bool = true;
+    for (i = 0; i <(len_s - len_n + 1); i = i + 1) {
+        match = true;
+        for (j = 0; j < len_n; j = j + 1) {
+            if (s[i + j] != needle[j]) {
+                match = false;
+                j = len_n;
+            }
+        }
+        if (match) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+function ascii_contains(s: ascii[], needle: ascii[]): bool {
+    return ascii_find(s, needle) >= 0;
+}
+
+// UTF-8 string buffer helpers.
+//
+// Layout (see `docs/spec.md`):
+// - `utf8[N]`: [byte_length: i32][max_length: i32][char_length: i32][data: u8[N]]
+//
+// Note: `utf8_set_len_ascii` assumes the payload contains only ASCII bytes, so
+// `char_length == byte_length`.
+
+function utf8_max_length(s: utf8[]): i32 {
+    let value: i32 = s.max_length;
+    if (value < 0) {
+        return 0;
+    }
+    return value;
+}
+
+function length_bytes(s: utf8[]): i32 {
+    let value: i32 = s.length;
+    if (value < 0) {
+        return 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        return max_len;
+    }
+    return value;
+}
+
+function length_chars(s: utf8[]): i32 {
+    let value: i32 = s.char_length;
+    if (value < 0) {
+        return 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        return max_len;
+    }
+    return value;
+}
+
+function utf8_set_byte_len(s: utf8[], len: i32): void {
+    let value: i32 = len;
+    if (value < 0) {
+        value = 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        value = max_len;
+    }
+    s.length = value;
+}
+
+function utf8_set_char_len(s: utf8[], len: i32): void {
+    let value: i32 = len;
+    if (value < 0) {
+        value = 0;
+    }
+    let max_len: i32 = s.max_length;
+    if (max_len > 0 && value > max_len) {
+        value = max_len;
+    }
+    s.char_length = value;
+}
+
+function utf8_set_len_ascii(s: utf8[], len: i32): void {
+    utf8_set_byte_len(s, len);
+    utf8_set_char_len(s, len);
+}
+
+function utf8_clear_ascii(s: utf8[]): void {
+    s[0] = 0;
+    utf8_set_len_ascii(s, 0);
+}
+
+function utf8_from_ascii(dst: utf8[], src: ascii[], dst_max: i32): i32 {
+    let bound: i32 = dst_max;
+    let cap: i32 = utf8_max_length(dst);
+    if (cap > 0 && bound > cap) {
+        bound = cap;
+    }
+    if (bound <= 0) {
+        return 0;
+    }
+
+    let i: i32 = 0;
+    let limit: i32 = bound - 1;
+    let src_limit: i32 = ascii_scan_limit(src);
+    for (i = 0; i < limit && i < src_limit; i = i + 1) {
+        let b: u8 = src[i];
+        if (b == 0) {
+            dst[i] = 0;
+            utf8_set_len_ascii(dst, i);
+            return i;
+        }
+        dst[i] = b;
+    }
+
+    dst[i] = 0;
+    utf8_set_len_ascii(dst, i);
+    return i;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/storage.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/storage.stasis
@@ -1,0 +1,33 @@
+// Small durable integer preferences for game progression and settings.
+// Scope and key must be 1..63 ASCII letters, digits, underscores, or hyphens.
+// Missing, invalid, or corrupt values return the caller-provided fallback.
+extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
+extern function storage_save_i32(scope: string, key: string, value: i32): bool;
+
+// Bounded durable ASCII values for share codes and other small text payloads.
+// Returns the byte length, or -1 when the value is missing, invalid, or does not fit.
+function @extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
+function @extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
+
+function storage_load_ascii(scope: string, key: string, out: ascii[]): i32 {
+    out.length = 0;
+    let capacity: i32 = out.max_length;
+    if (capacity <= 0) {
+        return -1;
+    }
+    let loaded: i32 = storage_load_ascii_raw(scope, key, out, capacity);
+    if (loaded < 0 || loaded > capacity) {
+        out.length = 0;
+        return -1;
+    }
+    out.length = loaded;
+    return loaded;
+}
+
+function storage_save_ascii(scope: string, key: string, value: ascii[]): bool {
+    let count: i32 = value.length;
+    if (count < 0 || count > value.max_length) {
+        return false;
+    }
+    return storage_save_ascii_raw(scope, key, value, count) != 0;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/testing/input_testkit.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/testing/input_testkit.stasis
@@ -1,0 +1,101 @@
+import "../internal/host_frame.stasis";
+
+function input_testkit_reset(): void {
+    let i: i32 = 0;
+    for (i = 0; i < HOST_I32_COUNT; i = i + 1) {
+        host_i32[i] = 0;
+    }
+    for (i = 0; i < HOST_F32_COUNT; i = i + 1) {
+        host_f32[i] = 0.0;
+    }
+}
+
+function input_testkit_set_quit_requested(value: bool): void {
+    if (value) {
+        host_i32[HOST_I_QUIT_REQUESTED] = 1;
+    } else {
+        host_i32[HOST_I_QUIT_REQUESTED] = 0;
+    }
+}
+
+function input_testkit_set_key_down(scancode: i32, value: bool): void {
+    if (scancode < 0 || scancode >= HOST_I_KEY_COUNT) {
+        return;
+    }
+    if (value) {
+        host_i32[HOST_I_KEY_BASE + scancode] = 1;
+    } else {
+        host_i32[HOST_I_KEY_BASE + scancode] = 0;
+    }
+}
+
+function input_testkit_set_pointer_count(count: i32): void {
+    if (count < 0) {
+        count = 0;
+    }
+    if (count > HOST_MAX_POINTERS) {
+        count = HOST_MAX_POINTERS;
+    }
+    host_i32[HOST_I_POINTER_COUNT] = count;
+}
+
+function input_testkit_set_pointer_count_raw(count: i32): void {
+    host_i32[HOST_I_POINTER_COUNT] = count;
+}
+
+function input_testkit_set_display_snapshot_with_logical(native_w_px: i32, native_h_px: i32, logical_w_px: i32, logical_h_px: i32, generation: i32): void {
+    host_i32[HOST_I_NATIVE_W_PX] = native_w_px;
+    host_i32[HOST_I_NATIVE_H_PX] = native_h_px;
+    host_i32[HOST_I_DRAWABLE_W_PX] = native_w_px;
+    host_i32[HOST_I_DRAWABLE_H_PX] = native_h_px;
+    host_i32[HOST_I_DISPLAY_GENERATION] = generation;
+    host_i32[HOST_I_DENSITY_GENERATION] = generation;
+    host_f32[HOST_F_CONTENT_SCALE] = 1.0;
+    host_f32[HOST_F_RASTER_SCALE] = 1.0;
+    host_f32[HOST_F_LOGICAL_W] = i32_to_f32(logical_w_px);
+    host_f32[HOST_F_LOGICAL_H] = i32_to_f32(logical_h_px);
+    host_f32[HOST_F_SAFE_X] = 0.0;
+    host_f32[HOST_F_SAFE_Y] = 0.0;
+    host_f32[HOST_F_SAFE_W] = i32_to_f32(logical_w_px);
+    host_f32[HOST_F_SAFE_H] = i32_to_f32(logical_h_px);
+}
+
+function input_testkit_set_display_snapshot(width_px: i32, height_px: i32, generation: i32): void {
+    input_testkit_set_display_snapshot_with_logical(width_px, height_px, width_px, height_px, generation);
+}
+
+function input_testkit_set_pointer(index: i32, id: i32, is_down: bool, went_down: bool, went_up: bool, x_px: f32, y_px: f32): void {
+    let logical_w: f32 = host_f32[HOST_F_LOGICAL_W];
+    let logical_h: f32 = host_f32[HOST_F_LOGICAL_H];
+    if (index < 0 || index >= HOST_MAX_POINTERS) {
+        return;
+    }
+    host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 0] = id;
+    if (is_down) {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 1] = 1;
+    } else {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 1] = 0;
+    }
+    if (went_down) {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 2] = 1;
+    } else {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 2] = 0;
+    }
+    if (went_up) {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3] = 1;
+    } else {
+        host_i32[HOST_I_POINTER_BASE + index * HOST_I_POINTER_STRIDE + 3] = 0;
+    }
+    host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 0] = x_px;
+    host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 1] = y_px;
+    if (logical_w > 0.0) {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4] = x_px / logical_w;
+    } else {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 4] = 0.0;
+    }
+    if (logical_h > 0.0) {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5] = y_px / logical_h;
+    } else {
+        host_f32[HOST_F_POINTER_BASE + index * HOST_F_POINTER_STRIDE + 5] = 0.0;
+    }
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/ui_axis_layout.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/ui_axis_layout.stasis
@@ -1,0 +1,33 @@
+// Immediate one-axis placement for scalar UI geometry.
+
+enum UiHorizontal {
+    Left,
+    Center,
+    Right,
+}
+
+enum UiVertical {
+    Top,
+    Center,
+    Bottom,
+}
+
+function @inline ui_place_x(parent_x: f32, parent_width: f32, child_width: f32, horizontal: UiHorizontal): f32 {
+    if (horizontal == UiHorizontal.Center) {
+        return parent_x +(parent_width - child_width) * 0.5;
+    }
+    if (horizontal == UiHorizontal.Right) {
+        return parent_x + parent_width - child_width;
+    }
+    return parent_x;
+}
+
+function @inline ui_place_y(parent_y: f32, parent_height: f32, child_height: f32, vertical: UiVertical): f32 {
+    if (vertical == UiVertical.Center) {
+        return parent_y +(parent_height - child_height) * 0.5;
+    }
+    if (vertical == UiVertical.Bottom) {
+        return parent_y + parent_height - child_height;
+    }
+    return parent_y;
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/ui_button_9slice.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/ui_button_9slice.stasis
@@ -1,0 +1,133 @@
+import "graphics.stasis";
+
+// Shared 9-slice button helpers for sprite-based UI.
+// Background uses 9 sprites (3x3 grid). Icons are sprites; text uses the command buffer.
+
+function ui_draw_sprite(handle: i32, x: f32, y: f32, w: f32, h: f32, a: i32): void {
+    gfx_cmd_sprite(handle, x, y, w, h, 0, a);
+}
+
+function ui_row_button_width(available_w: f32, count: i32, gap: f32): f32 {
+    let safe_count: i32 = count;
+    if (safe_count < 1) {
+        safe_count = 1;
+    }
+    let gaps: f32 = gap * i32_to_f32(safe_count - 1);
+    let button_w: f32 =(available_w - gaps) / i32_to_f32(safe_count);
+    if (button_w < 0.0) {
+        button_w = 0.0;
+    }
+    return button_w;
+}
+
+function ui_row_button_x(start_x: f32, index: i32, button_w: f32, gap: f32): f32 {
+    let idx: i32 = index;
+    if (idx < 0) {
+        idx = 0;
+    }
+    return start_x + i32_to_f32(idx) *(button_w + gap);
+}
+
+function ui_draw_9slice(
+    top_left: i32,
+    top: i32,
+    top_right: i32,
+    left: i32,
+    center: i32,
+    right: i32,
+    bottom_left: i32,
+    bottom: i32,
+    bottom_right: i32,
+    slice_w: f32,
+    slice_h: f32,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32
+): void {
+    let sw: f32 = slice_w;
+    let sh: f32 = slice_h;
+    let mid_w: f32 = w - sw * 2.0;
+    let mid_h: f32 = h - sh * 2.0;
+    if (mid_w < 0.0) {
+        mid_w = 0.0;
+    }
+    if (mid_h < 0.0) {
+        mid_h = 0.0;
+    }
+
+    // Top row
+    ui_draw_sprite(top_left, x, y, sw, sh, 255);
+    ui_draw_sprite(top, x + sw, y, mid_w, sh, 255);
+    ui_draw_sprite(top_right, x + sw + mid_w, y, sw, sh, 255);
+
+    // Middle row
+    ui_draw_sprite(left, x, y + sh, sw, mid_h, 255);
+    ui_draw_sprite(center, x + sw, y + sh, mid_w, mid_h, 255);
+    ui_draw_sprite(right, x + sw + mid_w, y + sh, sw, mid_h, 255);
+
+    // Bottom row
+    ui_draw_sprite(bottom_left, x, y + sh + mid_h, sw, sh, 255);
+    ui_draw_sprite(bottom, x + sw, y + sh + mid_h, mid_w, sh, 255);
+    ui_draw_sprite(bottom_right, x + sw + mid_w, y + sh + mid_h, sw, sh, 255);
+}
+
+function ui_draw_button_9slice(
+    top_left: i32,
+    top: i32,
+    top_right: i32,
+    left: i32,
+    center: i32,
+    right: i32,
+    bottom_left: i32,
+    bottom: i32,
+    bottom_right: i32,
+    slice_w: f32,
+    slice_h: f32,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    label: string,
+    font_handle: i32,
+    text_r: f32,
+    text_g: f32,
+    text_b: f32,
+    text_a: f32,
+    icon_handle: i32,
+    icon_aspect: f32,
+    icon_pad: f32,
+    text_pad: f32
+): void {
+    ui_draw_9slice(top_left, top, top_right, left, center, right, bottom_left, bottom, bottom_right, slice_w, slice_h, x, y, w, h);
+
+    let content_x: f32 = x + text_pad;
+    let content_w: f32 = w - text_pad * 2.0;
+    if (content_w < 0.0) {
+        content_w = 0.0;
+    }
+
+    if (icon_handle != 0) {
+        let icon_h: f32 = h * 0.6;
+        let icon_w: f32 = icon_h * icon_aspect;
+        let icon_x: f32 = x + icon_pad;
+        let icon_y: f32 = y +(h - icon_h) * 0.5;
+        ui_draw_sprite(icon_handle, icon_x, icon_y, icon_w, icon_h, 255);
+
+        let used_w: f32 =(icon_x - x) + icon_w + icon_pad;
+        content_x = x + used_w;
+        content_w = w - used_w - text_pad;
+        if (content_w < 0.0) {
+            content_w = 0.0;
+        }
+    }
+
+    if (font_handle == 0) {
+        return;
+    }
+
+    let text_w: f32 = measure_text(font_handle, label);
+    let text_x: f32 = content_x +(content_w - text_w) * 0.5;
+    let text_y: f32 = y +(h * 0.55);
+    gfx_cmd_text(font_handle, label, text_x, text_y, text_r, text_g, text_b, text_a);
+}

--- a/samples/swarm_field/vendor/stasis/stdlib/ui_layout_audit.stasis
+++ b/samples/swarm_field/vendor/stasis/stdlib/ui_layout_audit.stasis
@@ -1,0 +1,231 @@
+// Allocation-free geometry checks and machine-readable UI layout reporting.
+// Values are emitted as signed thousandths of one logical layout unit.
+
+function ui_audit_abs(value: f32): f32 {
+    if (value < 0.0) {
+        return 0.0 - value;
+    }
+    return value;
+}
+
+function ui_audit_center_delta_x(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32): f32 {
+    return(child_x + child_width * 0.5) -(parent_x + parent_width * 0.5);
+}
+
+function ui_audit_center_delta_y(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32): f32 {
+    return(child_y + child_height * 0.5) -(parent_y + parent_height * 0.5);
+}
+
+function ui_audit_left_gap(parent_x: f32, child_x: f32): f32 {
+    return child_x - parent_x;
+}
+
+function ui_audit_right_gap(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32): f32 {
+    return parent_x + parent_width -(child_x + child_width);
+}
+
+function ui_audit_top_gap(parent_y: f32, child_y: f32): f32 {
+    return child_y - parent_y;
+}
+
+function ui_audit_bottom_gap(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32): f32 {
+    return parent_y + parent_height -(child_y + child_height);
+}
+
+function ui_audit_equal(a: f32, b: f32, tolerance: f32): bool {
+    return ui_audit_abs(a - b) <= tolerance;
+}
+
+function ui_audit_centered_x(parent_x: f32, parent_width: f32, child_x: f32, child_width: f32, tolerance: f32): bool {
+    return ui_audit_abs(ui_audit_center_delta_x(parent_x, parent_width, child_x, child_width)) <= tolerance;
+}
+
+function ui_audit_centered_y(parent_y: f32, parent_height: f32, child_y: f32, child_height: f32, tolerance: f32): bool {
+    return ui_audit_abs(ui_audit_center_delta_y(parent_y, parent_height, child_y, child_height)) <= tolerance;
+}
+
+function ui_audit_contains_axis(parent_start: f32, parent_length: f32, child_start: f32, child_length: f32, tolerance: f32): bool {
+    return child_start >= parent_start - tolerance && child_start + child_length <= parent_start + parent_length + tolerance;
+}
+
+function ui_audit_overlap_x(first_x: f32, first_width: f32, second_x: f32, second_width: f32): f32 {
+    let start: f32 = first_x;
+    if (second_x > start) {
+        start = second_x;
+    }
+    let end: f32 = first_x + first_width;
+    if (second_x + second_width < end) {
+        end = second_x + second_width;
+    }
+    if (end <= start) {
+        return 0.0;
+    }
+    return end - start;
+}
+
+function ui_audit_overlap_y(first_y: f32, first_height: f32, second_y: f32, second_height: f32): f32 {
+    let start: f32 = first_y;
+    if (second_y > start) {
+        start = second_y;
+    }
+    let end: f32 = first_y + first_height;
+    if (second_y + second_height < end) {
+        end = second_y + second_height;
+    }
+    if (end <= start) {
+        return 0.0;
+    }
+    return end - start;
+}
+
+function ui_audit_rects_overlap(
+    first_x: f32,
+    first_y: f32,
+    first_width: f32,
+    first_height: f32,
+    second_x: f32,
+    second_y: f32,
+    second_width: f32,
+    second_height: f32
+): bool {
+    return ui_audit_overlap_x(first_x, first_width, second_x, second_width) > 0.0 && ui_audit_overlap_y(first_y, first_height, second_y, second_height) > 0.0;
+}
+
+function ui_audit_milli(value: f32): i32 {
+    let result: i32 = 0;
+    if (value < 0.0) {
+        result.from_f32(value * 1000.0 - 0.5);
+    } else {
+        result.from_f32(value * 1000.0 + 0.5);
+    }
+    return result;
+}
+
+function ui_audit_print_bool(value: bool): void {
+    if (value) {
+        print_int(1);
+    } else {
+        print_int(0);
+    }
+}
+
+function ui_audit_rect(id: string, role: string, x: f32, y: f32, width: f32, height: f32): void {
+    print_string("UI_LAYOUT|rect|id=");
+    print_string(id);
+    print_string("|role=");
+    print_string(role);
+    print_string("|x_milli=");
+    print_int(ui_audit_milli(x));
+    print_string("|y_milli=");
+    print_int(ui_audit_milli(y));
+    print_string("|w_milli=");
+    print_int(ui_audit_milli(width));
+    print_string("|h_milli=");
+    print_int(ui_audit_milli(height));
+    print_string("\n");
+}
+
+function ui_audit_text(id: string, x: f32, y: f32, width: f32, height: f32, font_size: i32): void {
+    print_string("UI_LAYOUT|text|id=");
+    print_string(id);
+    print_string("|x_milli=");
+    print_int(ui_audit_milli(x));
+    print_string("|y_milli=");
+    print_int(ui_audit_milli(y));
+    print_string("|w_milli=");
+    print_int(ui_audit_milli(width));
+    print_string("|h_milli=");
+    print_int(ui_audit_milli(height));
+    print_string("|font_size=");
+    print_int(font_size);
+    print_string("\n");
+}
+
+function ui_audit_baseline_check(first_id: string, second_id: string, first_y: f32, second_y: f32, tolerance: f32): void {
+    let delta: f32 = second_y - first_y;
+    let passes: bool = ui_audit_abs(delta) <= tolerance;
+    print_string("UI_LAYOUT|check|kind=baseline|first=");
+    print_string(first_id);
+    print_string("|second=");
+    print_string(second_id);
+    print_string("|delta_milli=");
+    print_int(ui_audit_milli(delta));
+    print_string("|tolerance_milli=");
+    print_int(ui_audit_milli(tolerance));
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}
+
+function ui_audit_center_check(axis: string, child_id: string, parent_id: string, delta: f32, tolerance: f32): void {
+    let passes: bool = ui_audit_abs(delta) <= tolerance;
+    print_string("UI_LAYOUT|check|kind=center_");
+    print_string(axis);
+    print_string("|child=");
+    print_string(child_id);
+    print_string("|parent=");
+    print_string(parent_id);
+    print_string("|delta_milli=");
+    print_int(ui_audit_milli(delta));
+    print_string("|tolerance_milli=");
+    print_int(ui_audit_milli(tolerance));
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}
+
+function ui_audit_padding_axis(
+    axis: string,
+    id: string,
+    parent_id: string,
+    parent_start: f32,
+    parent_length: f32,
+    child_start: f32,
+    child_length: f32,
+    tolerance: f32
+): void {
+    let contained: bool = ui_audit_contains_axis(parent_start, parent_length, child_start, child_length, tolerance);
+    print_string("UI_LAYOUT|padding|axis=");
+    print_string(axis);
+    print_string("|id=");
+    print_string(id);
+    print_string("|parent=");
+    print_string(parent_id);
+    print_string("|start_milli=");
+    print_int(ui_audit_milli(child_start - parent_start));
+    print_string("|end_milli=");
+    print_int(ui_audit_milli(parent_start + parent_length -(child_start + child_length)));
+    print_string("|contained=");
+    ui_audit_print_bool(contained);
+    print_string("\n");
+}
+
+function ui_audit_overlap_axis(
+    axis: string,
+    first_id: string,
+    second_id: string,
+    first_start: f32,
+    first_length: f32,
+    second_start: f32,
+    second_length: f32,
+    overlap_expected: bool
+): void {
+    let overlap: f32 = ui_audit_overlap_x(first_start, first_length, second_start, second_length);
+    let passes: bool = overlap <= 0.0;
+    if (overlap_expected) {
+        passes = overlap > 0.0;
+    }
+    print_string("UI_LAYOUT|check|kind=overlap|axis=");
+    print_string(axis);
+    print_string("|first=");
+    print_string(first_id);
+    print_string("|second=");
+    print_string(second_id);
+    print_string("|overlap_milli=");
+    print_int(ui_audit_milli(overlap));
+    print_string("|expected=");
+    ui_audit_print_bool(overlap_expected);
+    print_string("|pass=");
+    ui_audit_print_bool(passes);
+    print_string("\n");
+}


### PR DESCRIPTION
## What changed

- adds the public Swarm Field sample with 8,192 deterministic agents
- uses fixed bounded state, ordered ticks, and no per-frame allocation
- keeps the field distributed with a spring-to-lattice model while pointer/touch attraction and repel remain interactive
- includes the full vendored project and six deterministic tests, including a 9,000-tick anti-collapse case
- demonstrates compatible hot swap through `on_code_swap` without resetting simulation state

## Why

This gives Stasis a flagship sample that visibly stresses fixed state and rendering while showing the language/runtime advantages directly.

## Validation

- `stasis check`
- `stasis test` — 6/6 passed
- release web package — 5,230 bytes raw; 1,909 bytes gzip level 9
- mobile browser sustained run — 0.1 ms tick, 6.1 ms render, 10.8 ms worst render