### PR TITLE
ci: parallelize Android emulator seams

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  generated-release-shell:
+  release-shell-seams:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -74,15 +74,6 @@ jobs:
             -no-boot-anim -camera-back none
           script: |
             pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1
-            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90
-
-      - name: Upload Android Workshop IT-025 evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-workshop-it025-seam
-          path: artifacts/android_workshop_seam/e
-          if-no-files-found: warn
 
       - name: Upload Android release-shell evidence
         if: always()
@@ -114,4 +105,78 @@ jobs:
         with:
           name: android-orientation-metrics-seam
           path: artifacts/android_orientation_metrics/e
+          if-no-files-found: warn
+
+  workshop-seams:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      CARGO_INCREMENTAL: "0"
+      CMAKE_BUILD_PARALLEL_LEVEL: "2"
+      STASIS_SDL3_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL
+      STASIS_SDL3_IMAGE_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL_image
+    steps:
+      - name: Checkout Stasis
+        uses: actions/checkout@v7
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.9"
+
+      - name: Checkout SDL3
+        uses: actions/checkout@v7
+        with:
+          repository: libsdl-org/SDL
+          ref: 8e37db5e797b6167f3a00d697d816a684bd259c7
+          path: target/android-link-deps/SDL
+
+      - name: Checkout SDL3_image
+        uses: actions/checkout@v7
+        with:
+          repository: libsdl-org/SDL_image
+          ref: bec9134a26c7d0f31b36d6083c25296e04cabff5
+          path: target/android-link-deps/SDL_image
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Android Rust targets
+        run: rustup target add aarch64-linux-android x86_64-linux-android
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Android Workshop seams
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_7
+          cores: 4
+          ram-size: 4096M
+          ndk: 27.0.12077973
+          cmake: 3.22.1
+          emulator-boot-timeout: 900
+          emulator-options: >-
+            -no-window -gpu swiftshader_indirect -no-snapshot -noaudio
+            -no-boot-anim -camera-back none
+          script: |
+            pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90
+
+      - name: Upload Android Workshop IT-025 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-workshop-it025-seam
+          path: artifacts/android_workshop_seam/e
           if-no-files-found: warn

--- a/docs/integration_seam_testing_strategy.md
+++ b/docs/integration_seam_testing_strategy.md
@@ -177,15 +177,18 @@ named for the injected failure, and leave the production path unchanged.
 |---|---|---:|---|
 | Fast contract | every PR and `tools/validate_repo.sh` | 2 min | descriptor parity, JIT HostFrame, buffer bounds, diagnostic schemas |
 | Native integration | nightly, platform-sharded | 15 min | desktop real runtime, linked AOT/C runtime, package link and symbol audit |
-| Android emulator | nightly | 15 min/test shard | Workshop JNI/JIT and generated release-shell behavior on a test-only x86_64 AOT build |
+| Android emulator | nightly | 15 min/test shard | Two concurrent isolated API35 x86_64 shards: generated release-shell IT-017-IT-020 and Workshop JNI/JIT IT-025-IT-027 |
 | Physical device | optional release candidate and scheduled farm | 15 min/test shard | Supplemental OEM driver, density, lifecycle, and representative rendering evidence |
 
 Tests should be promoted toward the faster lane when a deterministic lower
 adapter becomes available. The hosted x86_64 emulator is the CI and readiness
-gate. Physical-device tests supplement release confidence for OEM-specific
-surface, driver, and density behavior, but device availability does not block
-ordinary CI or task readiness. Production Android packaging remains ARM64; the
-x86_64 package target exists only for deterministic development/emulator tests.
+gate. Nightly runs provision one emulator per shard so release-shell and
+Workshop failures, timeouts, and evidence remain independently visible rather
+than sharing a sequential device. Physical-device tests supplement release
+confidence for OEM-specific surface, driver, and density behavior, but device
+availability does not block ordinary CI or task readiness. Production Android
+packaging remains ARM64; the x86_64 package target exists only for deterministic
+development/emulator tests.
 
 ## Proposed integration tests
 

--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -127,7 +127,7 @@ Run the blocking render end-to-end gate directly with:
 ```
 
 This builds the canonical `samples/render_parity` fixture in Workshop with the real x86_64 development JIT. It captures the OpenGL surface, normalizes the letterboxed 640x360 viewport, and checks Android regions for the background, procedural fallback, opaque/translucent/rotated SVG sprites, a filled rectangle, crossing lines, direct text, and cached text. Three spaced captures, at least 30 rendered frames, and a successful non-empty JIT compile are required. Release packages are checked separately by `build_release.ps1` and can be run on an arm64 device with `validate_device.ps1 -Release`.
-The gate also emits `artifacts/android_workshop_seam/e/workshop-workshop-seam.json` for IT-025 through IT-027. IT-025 binds one Java/JNI/dlopen call to the real Rust bridge version, Cranelift `CompileReady`, a guest JIT state checksum, the render command trace, and GLES presentation using the same direct-buffer frame token. IT-026 runs once after the acceptance compile and proves the canonical i32/f32/u8 direct buffers have exact native-order capacities and alignment; per-lane short, oversized, wrong-order, heap, null, and misaligned variants, plus swapped i32/f32 lanes, must fail before Rust and preserve every passed byte and guard canary. IT-027 dispatches exactly one Java `ACTION_DOWN`, `ACTION_MOVE`, and `ACTION_UP` through the preview, verifies the HostFrame logical/normalized/delta/edge lanes in guest JIT state, and waits for GLES to present the matching direct-buffer marker token. Its compact summary and ordered per-phase markers reject Java-only evidence, duplicate tokens, stale markers, and marker geometry or checksum mismatches. Missing structured ABI/touch evidence, versions, fallback/stub markers, or fatal diagnostics fail the gate. The API 35 nightly workflow runs this check after the release-shell seams on the already-running emulator and builds both real Rust bridge ABIs when the checkout has no ignored JNI artifacts.
+The gate also emits `artifacts/android_workshop_seam/e/workshop-workshop-seam.json` for IT-025 through IT-027. IT-025 binds one Java/JNI/dlopen call to the real Rust bridge version, Cranelift `CompileReady`, a guest JIT state checksum, the render command trace, and GLES presentation using the same direct-buffer frame token. IT-026 runs once after the acceptance compile and proves the canonical i32/f32/u8 direct buffers have exact native-order capacities and alignment; per-lane short, oversized, wrong-order, heap, null, and misaligned variants, plus swapped i32/f32 lanes, must fail before Rust and preserve every passed byte and guard canary. IT-027 dispatches exactly one Java `ACTION_DOWN`, `ACTION_MOVE`, and `ACTION_UP` through the preview, verifies the HostFrame logical/normalized/delta/edge lanes in guest JIT state, and waits for GLES to present the matching direct-buffer marker token. Its compact summary and ordered per-phase markers reject Java-only evidence, duplicate tokens, stale markers, and marker geometry or checksum mismatches. Missing structured ABI/touch evidence, versions, fallback/stub markers, or fatal diagnostics fail the gate. The API 35 nightly workflow runs this check on its own isolated emulator shard, concurrently with the release-shell shard, and builds both real Rust bridge ABIs when the checkout has no ignored JNI artifacts.
 
 Render-acceptance builds also emit one bounded performance sample after 60
 warm-up and 180 measured frames. Enforce the API 35 emulator thresholds with
@@ -138,13 +138,16 @@ of the hardware-normalized limits.
 
 ## Hosted release-shell emulator
 
-The `Android Emulator Seams` GitHub Actions workflow provisions an API 35
-`x86_64` AVD on an `ubuntu-latest` KVM runner. It runs IT-017, IT-018, and
-IT-019 through the test-only `android-x86_64` AOT package, so CI does not
+The `Android Emulator Seams` GitHub Actions workflow provisions two isolated
+API 35 `x86_64` AVDs on separate `ubuntu-latest` KVM runners. The release-shell
+shard runs IT-017 through IT-020 through the test-only `android-x86_64` AOT
+package, while the Workshop shard runs IT-025 through IT-027; the jobs start
+concurrently and report failures and artifacts independently. CI does not
 depend on an attached phone, a self-hosted runner, or a preinstalled local AVD.
 The workflow retains the lifecycle, touch, orientation, screenshot, and cleanup
-oracles and uploads one evidence artifact per seam. The public x86_64 target
-requires `--development-build`; production packages remain `android-arm64`.
+oracles and uploads the established evidence artifacts from each shard. The
+public x86_64 target requires `--development-build`; production packages remain
+`android-arm64`.
 
 Physical-device runs are optional supplemental release evidence for OEM GPU,
 surface, and density behavior. They are not a CI or task-readiness gate.

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -27,6 +27,14 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         cls.rust_bridge_script = read("mobile/android/build_rust_bridge.ps1")
         cls.provenance_script = read("mobile/android/rust_bridge_provenance.ps1")
 
+    def workflow_job_body(self, name: str) -> str:
+        match = re.search(
+            rf"(?ms)^  {re.escape(name)}:\n(?P<body>.*?)(?=^  [A-Za-z_][A-Za-z0-9_-]*:\n|\Z)",
+            self.workflow,
+        )
+        self.assertIsNotNone(match, name)
+        return match.group("body")
+
     def test_workflow_uses_hosted_x86_emulator(self):
         self.assertIn("runs-on: ubuntu-latest", self.workflow)
         self.assertNotIn("runs-on: macos-15", self.workflow)
@@ -106,23 +114,59 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertIn("  actions: read", self.nightly_workflow)
 
     def test_workflow_supplies_build_inputs_and_uploads_each_seam(self):
-        self.assertIn("gradle-version: \"8.9\"", self.workflow)
-        self.assertIn("ndk: 27.0.12077973", self.workflow)
-        self.assertIn("cmake: 3.22.1", self.workflow)
-        self.assertIn("8e37db5e797b6167f3a00d697d816a684bd259c7", self.workflow)
-        self.assertIn("bec9134a26c7d0f31b36d6083c25296e04cabff5", self.workflow)
-        self.assertLess(
-            self.workflow.index("- name: Setup Gradle"),
-            self.workflow.index("- name: Checkout SDL3"),
+        job_names = ("release-shell-seams", "workshop-seams")
+        job_bodies = {name: self.workflow_job_body(name) for name in job_names}
+        self.assertNotIn("generated-release-shell", self.workflow)
+        self.assertNotIn("needs:", self.workflow)
+        for body in job_bodies.values():
+            self.assertEqual(1, body.count("runs-on: ubuntu-latest"))
+            self.assertEqual(1, body.count("reactivecircus/android-emulator-runner@v2"))
+            for setup in (
+                "- name: Setup Gradle",
+                "- name: Checkout SDL3",
+                "- name: Checkout SDL3_image",
+                "- name: Install Rust",
+                "- name: Install Android Rust targets",
+                "- name: Setup Python",
+                "- name: Enable KVM",
+            ):
+                self.assertEqual(1, body.count(setup + "\n"), setup)
+            self.assertIn('gradle-version: "8.9"', body)
+            self.assertIn("ndk: 27.0.12077973", body)
+            self.assertIn("cmake: 3.22.1", body)
+            self.assertIn("api-level: 35", body)
+            self.assertIn("arch: x86_64", body)
+            self.assertIn("8e37db5e797b6167f3a00d697d816a684bd259c7", body)
+            self.assertIn("bec9134a26c7d0f31b36d6083c25296e04cabff5", body)
+            self.assertIn(
+                "rustup target add aarch64-linux-android x86_64-linux-android", body
+            )
+        release_body = job_bodies["release-shell-seams"]
+        workshop_body = job_bodies["workshop-seams"]
+        release_script = "pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1"
+        workshop_script = (
+            "pwsh -NoProfile -File ./mobile/android/test_render_emulator.ps1 "
+            "-Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90"
         )
-        for artifact in (
-            "android-workshop-it025-seam",
-            "android-resource-restore-seam",
-            "android-release-shell-seam",
-            "android-touch-roundtrip-seam",
-            "android-orientation-metrics-seam",
-        ):
-            self.assertIn(artifact, self.workflow)
+        self.assertEqual(1, release_body.count(release_script))
+        self.assertNotIn("test_render_emulator.ps1", release_body)
+        self.assertEqual(1, workshop_body.count(workshop_script))
+        self.assertNotIn("test_release_shell_emulator.ps1", workshop_body)
+        release_artifacts = re.findall(r"(?m)^\s+name: (android-[^\s]+)$", release_body)
+        workshop_artifacts = re.findall(r"(?m)^\s+name: (android-[^\s]+)$", workshop_body)
+        self.assertEqual(
+            sorted(
+                (
+                    "android-release-shell-seam",
+                    "android-resource-restore-seam",
+                    "android-touch-roundtrip-seam",
+                    "android-orientation-metrics-seam",
+                )
+            ),
+            sorted(release_artifacts),
+        )
+        self.assertEqual(["android-workshop-it025-seam"], workshop_artifacts)
+        self.assertEqual(5, self.workflow.count("          name: android-"))
         self.assertEqual(5, self.workflow.count("        if: always()"))
         self.assertNotIn("\n      if: always()", self.workflow)
 
@@ -152,7 +196,9 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
 
     def test_strategy_makes_emulator_the_readiness_gate(self):
         self.assertIn("hosted x86_64 emulator is the CI and readiness", self.strategy)
-        self.assertIn("Production Android packaging remains ARM64", self.strategy)
+        self.assertRegex(
+            self.strategy, r"Production Android\s+packaging remains ARM64"
+        )
         for test_id in ("IT-017", "IT-018", "IT-019"):
             row = next(line for line in self.strategy.splitlines() if f"| {test_id} |" in line)
             self.assertTrue(row.endswith("| Emulator |"), row)
@@ -165,11 +211,7 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         )
         self.assertGreaterEqual(inside_drag["duration_ms"], 2000)
 
-    def test_workshop_it025_runs_after_release_shells_on_the_same_emulator(self):
-        self.assertIn(
-            "test_render_emulator.ps1 -Headless -AvdName test -StepTimeoutSeconds 600 -RenderTimeoutSeconds 90",
-            self.workflow,
-        )
+    def test_workshop_it025_isolated_from_release_shells(self):
         self.assertIn("[int]$StepTimeoutSeconds = 300", self.workshop_script)
         self.assertIn("[math]::Min($StepTimeoutSeconds, $remainingSeconds)", self.workshop_script)
         self.assertIn("verify_android_workshop_seam.py", self.workshop_script)
@@ -186,8 +228,6 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
         self.assertIn("[System.IO.Path]::IsPathRooted", self.rust_bridge_script)
         self.assertNotIn('"app\\src\\workshop\\jniLibs\\$abi"', self.rust_bridge_script)
         self.assertNotIn('"$abi\\libstasis_android_bridge.so"', self.provenance_script)
-        self.assertIn("Install Android Rust targets", self.workflow)
-        self.assertIn("rustup target add aarch64-linux-android x86_64-linux-android", self.workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- split Android release-shell IT-017..020 and Workshop IT-025..027 into independent hosted emulator jobs
- keep toolchains, workspaces, emulators, failures, and artifacts isolated per shard
- strengthen workflow contract tests and document parallel nightly behavior

## Validation
- python -m unittest tools.ci.test_android_emulator_seams (9 passed)
- python -m py_compile tools/ci/test_android_emulator_seams.py
- python tools/ci/check_stasis_src_layout.py
- python -m unittest tools.ci.test_check_stasis_src_layout (1 passed)
- git diff --check
- independent review: clean

Maddox #269