### PR TITLE
Add cross-platform performance HUD metrics

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4315,6 +4315,10 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../runtime/stasis_render_contract.h"
     ));
+    const STASIS_PERFORMANCE_METRICS_HEADER: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../runtime/stasis_performance_metrics.h"
+    ));
     const BETWEEN_TICK_LAYOUT_V1: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../samples/between_tick_layout_migration/v1.stasis"
@@ -4348,21 +4352,30 @@ mod tests {
     }
 
     #[test]
-    fn windows_performance_hud_uses_frame_work_and_60_fps_budget() {
+    fn performance_hud_uses_additive_snapshot_and_excludes_present_wait() {
         for required in [
             "event.key.key == SDLK_F3",
             "stasis_host_performance_metrics_enabled",
             "stasis_host_set_performance_metrics",
             "g_perf_pending_guest_render_us",
-            "stasis_perf_elapsed_us(g_perf_render_started_counter, now)",
-            "budget@60fps=%d%%",
-            "const double total_ms = tick_ms + render_ms",
+            "stasis_host_get_latest_performance_metrics_v1",
+            "frame_work_us",
+            "present_wait_us",
+            "stasis_perf_finish_render_sample(stasis_perf_elapsed_us(",
+            "SDL_RenderDebugText",
+            "g_ios_three_finger_latched",
         ] {
             assert!(
                 STASIS_GRAPHICS_SOURCE.contains(required),
                 "Windows performance HUD contract should contain {required}"
             );
         }
+        assert!(STASIS_GRAPHICS_SOURCE.contains("host_started_counter"));
+        assert!(STASIS_GRAPHICS_SOURCE.contains("g_perf_render_started_counter, host_finished"));
+        assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("STASIS_PERF_UNAVAILABLE"));
+        assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("STASIS_PERF_METRICS_VERSION"));
+        assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("size"));
+        assert!(!STASIS_GRAPHICS_SOURCE.contains("N/A"));
         assert!(
             STASIS_RUNNER_SOURCE.contains("const int measure_hud = host_performance_metrics_enabled")
                 && STASIS_RUNNER_SOURCE.contains("if (measure_hud) QueryPerformanceCounter")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -63,6 +63,7 @@ const MOBILE_RUNTIME_FILES: &[&str] = &[
     "stasis_asset_path.h",
     "stasis_render_contract.h",
     "stasis_renderer_lifecycle.h",
+    "stasis_performance_metrics.h",
     "stasis_audio_assets.c",
     "stasis_audio_assets.h",
     "stasis_graphics.c",
@@ -7238,6 +7239,7 @@ mod tests {
         assert!(android
             .join("runtime/stasis_renderer_lifecycle.h")
             .is_file());
+        assert!(android.join("runtime/stasis_performance_metrics.h").is_file());
         assert!(android
             .join("android/app/src/main/assets/stasis_game/assets/manifest.json")
             .is_file());
@@ -7261,12 +7263,12 @@ mod tests {
         assert!(java.contains("nativeReadPerformanceMetrics"));
         assert!(java.contains("nativeSetPerformanceMetricsEnabled(show)"));
         assert!(java.contains("nativeReadRuntimeError"));
-        assert!(java.contains("hudText.append(\"tick=\")"));
-        assert!(java.contains("hudText.append(\"  render=\")"));
-        assert!(java.contains("hudText.append(\"  total=\")"));
-        assert!(java.contains("hudText.append(\" ms  budget@60fps=\")"));
+        assert!(java.contains("guest render"));
+        assert!(java.contains("host replay"));
+        assert!(java.contains("frame work"));
+        assert!(java.contains("appendWorkload"));
         assert!(!java.contains("percentile("));
-        assert!(java.contains("performanceHud.setSingleLine(true)"));
+        assert!(java.contains("performanceHud.setSingleLine(false)"));
         assert!(java.contains("verifyAssetManifest(staging)"));
         assert!(java.contains("manifestVersion != 1 && manifestVersion != 2"));
         assert!(java.contains("Asset verification failed before runtime startup"));
@@ -7280,6 +7282,7 @@ mod tests {
             jni.contains("Java_com_example_mobile_MainActivity_nativeSetPerformanceMetricsEnabled")
         );
         assert!(jni.contains("Java_com_example_mobile_MainActivity_nativeReadRuntimeError"));
+        assert!(jni.contains("stasis_host_get_latest_performance_metrics_v1"));
         assert!(!jni.contains("@STASIS_"));
         let runtime_source = fs::read_to_string(android.join("runtime/stasis_mobile_runtime.c"))
             .expect("read shared mobile runtime source");
@@ -7301,6 +7304,7 @@ mod tests {
         assert!(ios.join("runtime/stasis_asset_path.h").is_file());
         assert!(ios.join("runtime/stasis_render_contract.h").is_file());
         assert!(ios.join("runtime/stasis_renderer_lifecycle.h").is_file());
+        assert!(ios.join("runtime/stasis_performance_metrics.h").is_file());
         assert!(ios.join("runtime/stasis_platform_storage.c").is_file());
         assert!(ios.join("runtime/stasis_platform_storage.h").is_file());
         assert!(config.contains("@executable_path/Frameworks"));

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -470,8 +470,18 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
         "dataset.browserReplayMs",
         "dataset.frameWorkMs",
         "dataset.worstFrameWorkMs",
+        "dataset.backend",
+        "dataset.hostReplayMs",
+        "dataset.renderPrepMs",
+        "dataset.gpuSubmitMs",
+        "dataset.presentWaitMs",
+        "dataset.instances",
+        "dataset.uploadedBytes",
+        "PERF_ROLLING_CAPACITY",
+        "performanceWorstTimes",
         "RECT_BATCH_MIN",
         "drawArraysInstanced",
+        "Canvas2D + WebGL2",
         "\"host_i32\"",
         "\"host_f32\"",
         "audio_push_f32_interleaved",
@@ -491,6 +501,9 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
             "missing web runtime data {expected}"
         );
     }
+    assert!(!runtime.contains("render prep N/A"));
+    assert!(!runtime.contains("GPU submit N/A"));
+    assert!(!runtime.contains("present wait N/A"));
     assert!(!runtime.contains("STASIS_WASM_BASE64"));
     assert!(!runtime.contains("data:application/wasm;base64,"));
     assert!(output.join("index.html").is_file());
@@ -543,9 +556,16 @@ fn minimal_pong_and_standard_reference_omit_audio_and_input() {
         "dataset.browserReplayMs",
         "dataset.frameWorkMs",
         "dataset.worstFrameWorkMs",
+        "dataset.backend",
+        "dataset.hostReplayMs",
+        "dataset.renderPrepMs",
+        "dataset.gpuSubmitMs",
+        "dataset.presentWaitMs",
+        "PERF_ROLLING_CAPACITY",
     ] {
         assert!(runtime.contains(expected), "minimal runtime missing {expected}");
     }
+    assert!(!runtime.contains("N/A"));
     assert!(
         runtime.len() < 10_000,
         "minimal runtime was {} bytes",

--- a/docs/performance_hud.md
+++ b/docs/performance_hud.md
@@ -1,0 +1,35 @@
+# Stasis performance HUD contract
+
+The development performance HUD uses the same phase order on Web, desktop,
+Android, and iOS:
+
+1. **tick** — guest simulation/update code.
+2. **guest render** — guest code building the render command buffer.
+3. **host replay** — host validation, decoding, and interpretation of that
+   command buffer. A backend may include inseparable host-side draw work here.
+4. **render prep** — CPU batching, vertex/instance assembly, and buffer upload
+   when the backend can measure that boundary independently.
+5. **GPU submit** — CPU time issuing graphics API calls when measurable.
+6. **GPU execution** — nonblocking hardware timestamp timing. This is
+   unavailable
+   until a backend can read delayed queries without a per-frame fence.
+7. **frame work** — active CPU work: tick plus the available render phases.
+8. **present wait** — swap, vsync, compositor, or presentation duration;
+   it is never included in frame work or the 60 FPS budget verdict.
+
+Unavailable or unreliable measurements retain an explicit unavailable
+sentinel in the snapshot contract and are omitted from the rendered HUD,
+never substituted with zero. Canvas2D and SDL commonly omit render prep and
+GPU submit; WebGL2 reports rectangle instance, batch, and draw-call counts
+when its instanced path is active. Native sprite counts are sprites, not GPU
+instances, unless a backend actually performs instanced drawing.
+
+The budget verdict compares current active frame work with 16.67 ms. The
+displayed worst value is bounded to the most recent five seconds, so it can
+recover after a transient spike. Workload details (commands, lines,
+rectangles, sprites, text, instances, batches, draws, and uploaded bytes when
+available) explain why a phase is expensive.
+
+The desktop HUD is toggled with **F3**. Android keeps its three-finger toggle;
+iOS uses the same three-finger gesture in the shared SDL event path. Metrics
+collection is disabled while the HUD is hidden.

--- a/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
+++ b/mobile/shells/android/app/src/main/cpp/stasis_android_assets.c
@@ -2,8 +2,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "stasis_performance_metrics.h"
 
 void stasis_host_get_latest_performance_metrics(uint32_t *tick_us, uint32_t *render_us);
+int stasis_host_get_latest_performance_metrics_v1(
+    StasisPerformanceMetrics *output, size_t capacity);
 void stasis_host_set_performance_metrics_enabled(int enabled);
 int stasis_host_copy_runtime_error(char *output, size_t output_size);
 
@@ -59,14 +62,32 @@ Java_@STASIS_JNI_PACKAGE@_MainActivity_nativeReadPerformanceMetrics(
     jfloatArray output
 ) {
     (void)activity;
-    if (output == NULL || (*env)->GetArrayLength(env, output) < 2) {
+    if (output == NULL || (*env)->GetArrayLength(env, output) < 14) {
         return JNI_FALSE;
     }
-    uint32_t tick_us = 0;
-    uint32_t render_us = 0;
-    stasis_host_get_latest_performance_metrics(&tick_us, &render_us);
-    jfloat values[2] = {(jfloat)tick_us / 1000.0f, (jfloat)render_us / 1000.0f};
-    (*env)->SetFloatArrayRegion(env, output, 0, 2, values);
+    StasisPerformanceMetrics metrics;
+    if (!stasis_host_get_latest_performance_metrics_v1(&metrics, sizeof(metrics))) {
+        return JNI_FALSE;
+    }
+    const uint32_t values_us[] = {
+        metrics.tick_us, metrics.guest_render_us, metrics.host_replay_us,
+        metrics.render_prep_us, metrics.gpu_submit_us, metrics.gpu_execution_us,
+        metrics.frame_work_us, metrics.present_wait_us,
+    };
+    jfloat values[14];
+    for (int index = 0; index < 8; index++) {
+        values[index] = values_us[index] == STASIS_PERF_UNAVAILABLE
+            ? -1.0f : (jfloat)values_us[index] / 1000.0f;
+    }
+    const uint32_t counts[] = {
+        metrics.commands, metrics.lines, metrics.rectangles, metrics.sprites, metrics.text,
+    };
+    for (int index = 0; index < 5; index++) {
+        values[9 + index] = counts[index] == STASIS_PERF_UNAVAILABLE
+            ? -1.0f : (jfloat)counts[index];
+    }
+    values[8] = (jfloat)metrics.version;
+    (*env)->SetFloatArrayRegion(env, output, 0, 14, values);
     return JNI_TRUE;
 }
 

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -40,10 +40,13 @@ public final class MainActivity extends SDLActivity {
     private static native String nativeReadRuntimeError();
 
     private final Handler hudHandler = new Handler(Looper.getMainLooper());
-    private final float[] nativePerformance = new float[2];
-    private final RollingMetric tickMetric = new RollingMetric();
-    private final RollingMetric renderMetric = new RollingMetric();
-    private final StringBuilder hudText = new StringBuilder(96);
+    private final float[] nativePerformance = new float[14];
+    private final RollingMetric[] phaseMetrics = new RollingMetric[] {
+            new RollingMetric(), new RollingMetric(), new RollingMetric(), new RollingMetric(),
+            new RollingMetric(), new RollingMetric(), new RollingMetric(), new RollingMetric()
+    };
+    private final RollingMetric frameWorst = new RollingMetric();
+    private final StringBuilder hudText = new StringBuilder(420);
     private FrameLayout diagnosticLayer;
     private TextView performanceHud;
     private TextView runtimeError;
@@ -130,7 +133,7 @@ public final class MainActivity extends SDLActivity {
         performanceHud = new TextView(this);
         performanceHud.setTextColor(Color.WHITE);
         performanceHud.setTextSize(10.0f);
-        performanceHud.setSingleLine(true);
+        performanceHud.setSingleLine(false);
         performanceHud.setPadding(dp(6), dp(4), dp(6), dp(4));
         performanceHud.setBackgroundColor(Color.argb(150, 20, 28, 38));
         performanceHud.setContentDescription("Stasis performance timing overlay");
@@ -164,8 +167,8 @@ public final class MainActivity extends SDLActivity {
         nativeSetPerformanceMetricsEnabled(show);
         performanceHud.setVisibility(show ? View.VISIBLE : View.GONE);
         if (show) {
-            tickMetric.clear();
-            renderMetric.clear();
+            for (RollingMetric metric : phaseMetrics) metric.clear();
+            frameWorst.clear();
             updatePerformanceHud();
         }
     }
@@ -194,23 +197,46 @@ public final class MainActivity extends SDLActivity {
         if (performanceHud == null || performanceHud.getVisibility() != View.VISIBLE
                 || !nativeReadPerformanceMetrics(nativePerformance)) return;
         long now = System.nanoTime();
-        tickMetric.add(now, nativePerformance[0]);
-        renderMetric.add(now, nativePerformance[1]);
-        double tickAverage = tickMetric.average();
-        double renderAverage = renderMetric.average();
-        double totalAverage = tickAverage + renderAverage;
-        int budgetPercent = Math.max(0,
-                (int)((totalAverage * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
+        for (int index = 0; index < phaseMetrics.length; index++) {
+            if (nativePerformance[index] >= 0.0f) phaseMetrics[index].add(now, nativePerformance[index]);
+        }
+        if (nativePerformance[6] >= 0.0f) frameWorst.add(now, nativePerformance[6]);
+        int budgetPercent = nativePerformance[6] < 0.0f ? 0 : Math.max(0,
+                (int)((nativePerformance[6] * 100.0 / FRAME_BUDGET_MILLIS) + 0.5));
         hudText.setLength(0);
-        hudText.append("tick=");
-        appendMillis(hudText, tickAverage);
-        hudText.append("  render=");
-        appendMillis(hudText, renderAverage);
-        hudText.append("  total=");
-        appendMillis(hudText, totalAverage);
-        hudText.append(" ms  budget@60fps=").append(budgetPercent).append('%');
+        hudText.append("SDL · Android\n");
+        appendPhase(hudText, "tick", nativePerformance[0], phaseMetrics[0].worst());
+        appendPhase(hudText, "guest render", nativePerformance[1], phaseMetrics[1].worst());
+        appendPhase(hudText, "host replay", nativePerformance[2], phaseMetrics[2].worst());
+        appendPhase(hudText, "render prep", nativePerformance[3], phaseMetrics[3].worst());
+        appendPhase(hudText, "GPU submit", nativePerformance[4], phaseMetrics[4].worst());
+        appendPhase(hudText, "GPU execution", nativePerformance[5], phaseMetrics[5].worst());
+        appendPhase(hudText, "frame work", nativePerformance[6], frameWorst.worst());
+        appendPhase(hudText, "present wait", nativePerformance[7], phaseMetrics[7].worst());
+        if (nativePerformance[6] >= 0.0f) {
+            hudText.append(nativePerformance[6] <= FRAME_BUDGET_MILLIS ? "UNDER" : "OVER")
+                    .append(" 16.67 ms · ");
+        }
+        appendWorkload(hudText, "commands", nativePerformance[9], true);
+        appendWorkload(hudText, "lines", nativePerformance[10], false);
+        appendWorkload(hudText, "rects", nativePerformance[11], false);
+        appendWorkload(hudText, "sprites", nativePerformance[12], false);
+        appendWorkload(hudText, "text", nativePerformance[13], false);
         performanceHud.setTextColor(debugColorForBudget(budgetPercent));
         performanceHud.setText(hudText.toString());
+    }
+
+    private static void appendPhase(StringBuilder builder, String name, float current, double worst) {
+        if (current < 0.0f) return;
+        builder.append(name).append(' ');
+        appendMillis(builder, current); builder.append(" (worst "); appendMillis(builder, worst); builder.append(')');
+        builder.append('\n');
+    }
+
+    private static void appendWorkload(StringBuilder builder, String label, float value, boolean first) {
+        if (value < 0.0f) return;
+        builder.append(first ? "workload " : " · ").append(label).append(' ')
+                .append((int)(value + 0.5f));
     }
 
     private void updateRuntimeError() {
@@ -422,6 +448,15 @@ public final class MainActivity extends SDLActivity {
                 }
             }
             return samples == 0 ? 0.0 : total / samples;
+        }
+
+        double worst() {
+            long cutoff = System.nanoTime() - WINDOW_NANOS;
+            double result = -1.0;
+            for (int i = 0; i < count; i++) {
+                if (times[i] >= cutoff && values[i] > result) result = values[i];
+            }
+            return result < 0.0 ? 0.0 : result;
         }
     }
 }

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -195,6 +195,7 @@ if(STASIS_BUILD_MOBILE_RUNTIME)
     install(TARGETS stasis_mobile_runtime ARCHIVE DESTINATION lib)
     install(
         FILES stasis_asset_path.h stasis_mobile_runtime.h stasis_mobile_aot_runtime.h
+              stasis_performance_metrics.h
         DESTINATION include
     )
 endif()
@@ -236,6 +237,12 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
     )
     target_include_directories(stasis_renderer_lifecycle_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
     add_test(NAME stasis_renderer_lifecycle_contract COMMAND stasis_renderer_lifecycle_test)
+    add_executable(
+        stasis_performance_metrics_test
+        tests/stasis_performance_metrics_test.c
+    )
+    target_include_directories(stasis_performance_metrics_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_test(NAME stasis_performance_metrics_contract COMMAND stasis_performance_metrics_test)
     if(TARGET stasis_graphics_static)
         add_executable(
             stasis_asset_tasks_test

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -55,9 +55,11 @@ captures use the drawable resolution.
    cargo run -p stasis --release -- play samples\asteroids.stasis
    ```
 
-Press `F3` in a Windows play window to toggle the performance HUD. It reports
-five-second average tick, render, and total times plus total use of the 60 fps
-frame budget.
+Press `F3` in a Windows play window to toggle the performance HUD. It follows
+the shared ordered performance contract, showing the phases and workload
+details that the active backend can measure, plus a five-second rolling worst
+frame-work value. Unsupported fields are omitted from the rendered HUD. See
+`docs/performance_hud.md` for the contract.
 
 ## Android (NDK)
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -32,6 +32,7 @@
 #include "stasis_render_contract.h"
 #include "stasis_display_scale.h"
 #include "stasis_renderer_lifecycle.h"
+#include "stasis_performance_metrics.h"
 #if defined(_WIN32)
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -205,11 +206,10 @@ static float g_postfx_speed = 0.0f;
 static float g_postfx_color[3] = {0.05f, 0.85f, 0.78f};
 static bool g_postfx_force_disable = false;
 
-#define STASIS_PERF_SAMPLE_CAPACITY 360
+#define STASIS_PERF_SAMPLE_CAPACITY 1200
 typedef struct {
     uint64_t captured_counter;
-    uint64_t tick_us;
-    uint64_t render_us;
+    StasisPerformanceMetrics metrics;
 } StasisPerfSample;
 static StasisPerfSample g_perf_samples[STASIS_PERF_SAMPLE_CAPACITY];
 static int g_perf_sample_count = 0;
@@ -217,9 +217,13 @@ static int g_perf_sample_next = 0;
 static uint64_t g_perf_pending_tick_us = 0;
 static uint64_t g_perf_pending_guest_render_us = 0;
 static uint64_t g_perf_render_started_counter = 0;
-static SDL_AtomicInt g_perf_latest_tick_us;
-static SDL_AtomicInt g_perf_latest_render_us;
-static int g_perf_font_handle = -1;
+static SDL_SpinLock g_perf_metrics_lock;
+static StasisPerformanceMetrics g_perf_latest_metrics;
+static uint32_t g_perf_pending_lines = STASIS_PERF_UNAVAILABLE;
+static uint32_t g_perf_pending_rectangles = STASIS_PERF_UNAVAILABLE;
+static uint32_t g_perf_pending_sprites = STASIS_PERF_UNAVAILABLE;
+static uint32_t g_perf_pending_text = STASIS_PERF_UNAVAILABLE;
+static uint32_t g_perf_pending_commands = STASIS_PERF_UNAVAILABLE;
 static const char* g_restore_label[] = {
     "   01110 11111 01110 01110 11111 01110   ",
     "   10001 00100 10001 10001 00100 10001   ",
@@ -274,6 +278,9 @@ static float g_prev_x_px[STASIS_MAX_POINTERS];
 static float g_prev_y_px[STASIS_MAX_POINTERS];
 static SDL_FingerID g_finger_ids[STASIS_MAX_POINTERS - 1];
 static int g_finger_active[STASIS_MAX_POINTERS - 1];
+#if defined(__IPHONEOS__)
+static bool g_ios_three_finger_latched = false;
+#endif
 
 /* Forward decls for exported functions used before their definitions (MSVC C mode does not allow implicit declarations). */
 STASIS_EXPORT int stasis_get_time_ms(void);
@@ -310,7 +317,6 @@ static void setup_ortho(void);
 static void reset_line_program(void);
 static void reset_sprite_program(void);
 #endif
-static int stasis_perf_font(void);
 static uint64_t stasis_perf_elapsed_us(uint64_t started_counter, uint64_t finished_counter);
 
 /* Sprite atlas bookkeeping (paths + rasterized sprites). */
@@ -942,7 +948,6 @@ static void stasis_pump_events(void) {
                     g_perf_render_started_counter = 0;
                     stasis_host_set_performance_metrics_enabled(
                         g_force_debug_overlay ? 1 : 0);
-                    if (g_force_debug_overlay) (void)stasis_perf_font();
                     SDL_Log("performance HUD %s (F3 toggles)", g_force_debug_overlay ? "on" : "off");
                 }
                 break;
@@ -1026,6 +1031,21 @@ static void stasis_pump_events(void) {
                         event.tfinger.y * (float)g_native_window_height,
                         &logical_x, &logical_y);
                     stasis_set_pointer_pos_px(idx, logical_x, logical_y);
+#if defined(__IPHONEOS__)
+                    int active_fingers = 0;
+                    for (int finger = 0; finger < STASIS_MAX_POINTERS - 1; finger++) {
+                        if (g_finger_active[finger]) active_fingers++;
+                    }
+                    if (active_fingers >= 3 && !g_ios_three_finger_latched) {
+                        g_ios_three_finger_latched = true;
+                        g_force_debug_overlay = !g_force_debug_overlay;
+                        g_perf_sample_count = 0;
+                        g_perf_sample_next = 0;
+                        g_perf_render_started_counter = 0;
+                        stasis_host_set_performance_metrics_enabled(
+                            g_force_debug_overlay ? 1 : 0);
+                    }
+#endif
                 }
                 break;
             case SDL_EVENT_FINGER_MOTION:
@@ -1040,6 +1060,13 @@ static void stasis_pump_events(void) {
                         event.tfinger.y * (float)g_native_window_height,
                         &logical_x, &logical_y);
                     stasis_set_pointer_pos_px(idx, logical_x, logical_y);
+#if defined(__IPHONEOS__)
+                    int active_fingers = 0;
+                    for (int finger = 0; finger < STASIS_MAX_POINTERS - 1; finger++) {
+                        if (g_finger_active[finger]) active_fingers++;
+                    }
+                    if (active_fingers < 3) g_ios_three_finger_latched = false;
+#endif
                 }
                 break;
             case SDL_EVENT_FINGER_UP:
@@ -1242,8 +1269,31 @@ STASIS_EXPORT int stasis_host_performance_metrics_enabled(void)
 STASIS_EXPORT void stasis_host_set_performance_metrics_enabled(int enabled)
 {
     SDL_SetAtomicInt(&g_performance_metrics_requested, enabled != 0);
-    SDL_SetAtomicInt(&g_perf_latest_tick_us, 0);
-    SDL_SetAtomicInt(&g_perf_latest_render_us, 0);
+    SDL_LockSpinlock(&g_perf_metrics_lock);
+    memset(&g_perf_latest_metrics, 0, sizeof(g_perf_latest_metrics));
+    g_perf_latest_metrics.version = STASIS_PERF_METRICS_VERSION;
+    g_perf_latest_metrics.size = (uint32_t)sizeof(g_perf_latest_metrics);
+    g_perf_latest_metrics.tick_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.guest_render_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.host_replay_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.render_prep_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.gpu_submit_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.gpu_execution_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.frame_work_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.present_wait_us = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.commands = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.lines = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.rectangles = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.sprites = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.text = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.instances = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.batches = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.draw_calls = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.texture_switches = STASIS_PERF_UNAVAILABLE;
+    g_perf_latest_metrics.uploaded_bytes = STASIS_PERF_UNAVAILABLE;
+    snprintf(g_perf_latest_metrics.backend, sizeof(g_perf_latest_metrics.backend), "%s",
+        g_use_sdl_renderer ? "SDL" : "OpenGL");
+    SDL_UnlockSpinlock(&g_perf_metrics_lock);
 }
 
 STASIS_EXPORT void stasis_host_report_runtime_error(const char* message)
@@ -1278,12 +1328,30 @@ STASIS_EXPORT void stasis_host_get_latest_performance_metrics(
     uint32_t* tick_us,
     uint32_t* render_us)
 {
+    StasisPerformanceMetrics metrics;
+    SDL_LockSpinlock(&g_perf_metrics_lock);
+    metrics = g_perf_latest_metrics;
+    SDL_UnlockSpinlock(&g_perf_metrics_lock);
     if (tick_us) {
-        *tick_us = (uint32_t)SDL_GetAtomicInt(&g_perf_latest_tick_us);
+        *tick_us = metrics.tick_us;
     }
     if (render_us) {
-        *render_us = (uint32_t)SDL_GetAtomicInt(&g_perf_latest_render_us);
+        *render_us = metrics.host_replay_us == STASIS_PERF_UNAVAILABLE
+            ? metrics.guest_render_us
+            : metrics.guest_render_us + metrics.host_replay_us;
     }
+}
+
+/* Additive, capacity-checked snapshot API. The original two-value function above
+ * remains ABI-compatible for older shells and tools. */
+STASIS_EXPORT int stasis_host_get_latest_performance_metrics_v1(
+    StasisPerformanceMetrics* output, size_t capacity)
+{
+    if (!output || capacity < sizeof(StasisPerformanceMetrics)) return 0;
+    SDL_LockSpinlock(&g_perf_metrics_lock);
+    *output = g_perf_latest_metrics;
+    SDL_UnlockSpinlock(&g_perf_metrics_lock);
+    return 1;
 }
 
 typedef int (*stasis_tick_fn)(void);
@@ -4659,7 +4727,8 @@ STASIS_EXPORT uint64_t stasis_host_performance_elapsed_us(
     return stasis_perf_elapsed_us(started_counter, finished_counter);
 }
 
-static void stasis_perf_finish_render_sample(void) {
+static void stasis_perf_finish_render_sample(uint64_t host_replay_us,
+                                             uint64_t present_wait_us) {
     if (!stasis_host_performance_metrics_enabled()) {
         g_perf_render_started_counter = 0;
         return;
@@ -4667,11 +4736,33 @@ static void stasis_perf_finish_render_sample(void) {
     const uint64_t now = SDL_GetPerformanceCounter();
     StasisPerfSample* sample = &g_perf_samples[g_perf_sample_next];
     sample->captured_counter = now;
-    sample->tick_us = g_perf_pending_tick_us;
-    sample->render_us = g_perf_pending_guest_render_us
-        + stasis_perf_elapsed_us(g_perf_render_started_counter, now);
-    SDL_SetAtomicInt(&g_perf_latest_tick_us, (int)sample->tick_us);
-    SDL_SetAtomicInt(&g_perf_latest_render_us, (int)sample->render_us);
+    memset(&sample->metrics, 0, sizeof(sample->metrics));
+    sample->metrics.version = STASIS_PERF_METRICS_VERSION;
+    sample->metrics.size = (uint32_t)sizeof(sample->metrics);
+    sample->metrics.tick_us = (uint32_t)g_perf_pending_tick_us;
+    sample->metrics.guest_render_us = (uint32_t)g_perf_pending_guest_render_us;
+    sample->metrics.host_replay_us = (uint32_t)host_replay_us;
+    sample->metrics.render_prep_us = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.gpu_submit_us = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.gpu_execution_us = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.present_wait_us = (uint32_t)present_wait_us;
+    sample->metrics.frame_work_us = sample->metrics.tick_us
+        + sample->metrics.guest_render_us + sample->metrics.host_replay_us;
+    sample->metrics.commands = g_perf_pending_commands;
+    sample->metrics.lines = g_perf_pending_lines;
+    sample->metrics.rectangles = g_perf_pending_rectangles;
+    sample->metrics.sprites = g_perf_pending_sprites;
+    sample->metrics.text = g_perf_pending_text;
+    sample->metrics.instances = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.batches = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.draw_calls = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.texture_switches = STASIS_PERF_UNAVAILABLE;
+    sample->metrics.uploaded_bytes = STASIS_PERF_UNAVAILABLE;
+    snprintf(sample->metrics.backend, sizeof(sample->metrics.backend), "%s",
+        g_use_sdl_renderer ? "SDL" : "OpenGL");
+    SDL_LockSpinlock(&g_perf_metrics_lock);
+    g_perf_latest_metrics = sample->metrics;
+    SDL_UnlockSpinlock(&g_perf_metrics_lock);
     g_perf_sample_next = (g_perf_sample_next + 1) % STASIS_PERF_SAMPLE_CAPACITY;
     if (g_perf_sample_count < STASIS_PERF_SAMPLE_CAPACITY) {
         g_perf_sample_count++;
@@ -4679,72 +4770,166 @@ static void stasis_perf_finish_render_sample(void) {
     g_perf_render_started_counter = 0;
 }
 
-static void stasis_perf_averages(double* tick_ms, double* render_ms) {
+static void stasis_perf_latest_snapshot(StasisPerformanceMetrics* output,
+                                         uint32_t* worst_frame_work_us) {
+    if (!output) return;
+    SDL_LockSpinlock(&g_perf_metrics_lock);
+    *output = g_perf_latest_metrics;
+    SDL_UnlockSpinlock(&g_perf_metrics_lock);
+    uint32_t worst = output->frame_work_us;
     const uint64_t now = SDL_GetPerformanceCounter();
     const uint64_t frequency = SDL_GetPerformanceFrequency();
     const uint64_t window = frequency * 5u;
-    uint64_t tick_total = 0;
-    uint64_t render_total = 0;
-    int samples = 0;
-
     for (int i = 0; i < g_perf_sample_count; i++) {
         const StasisPerfSample* sample = &g_perf_samples[i];
-        if (sample->captured_counter == 0 || now < sample->captured_counter) continue;
-        if (now - sample->captured_counter > window) continue;
-        tick_total += sample->tick_us;
-        render_total += sample->render_us;
-        samples++;
+        if (sample->captured_counter == 0 || now < sample->captured_counter
+            || now - sample->captured_counter > window) continue;
+        if (sample->metrics.frame_work_us != STASIS_PERF_UNAVAILABLE
+            && sample->metrics.frame_work_us > worst) {
+            worst = sample->metrics.frame_work_us;
+        }
     }
-
-    if (samples == 0) {
-        *tick_ms = 0.0;
-        *render_ms = 0.0;
-        return;
-    }
-    *tick_ms = (double)tick_total / (double)samples / 1000.0;
-    *render_ms = (double)render_total / (double)samples / 1000.0;
+    if (worst_frame_work_us) *worst_frame_work_us = worst;
 }
 
-static int stasis_perf_font(void) {
-    if (g_perf_font_handle >= 0) return g_perf_font_handle;
-#if defined(_WIN32)
-    const char* windows_dir = getenv("WINDIR");
-    char path[1024];
-    if (windows_dir && *windows_dir) {
-        snprintf(path, sizeof(path), "%s/Fonts/segoeui.ttf", windows_dir);
+static void stasis_perf_append_value(char* output, size_t capacity, uint32_t us) {
+    if (us == STASIS_PERF_UNAVAILABLE) {
+        output[0] = '\0';
     } else {
-        snprintf(path, sizeof(path), "C:/Windows/Fonts/segoeui.ttf");
+        snprintf(output, capacity, "%.2f ms", (double)us / 1000.0);
     }
-    g_perf_font_handle = stasis_load_font(path, 15);
-#else
-    g_perf_font_handle = 0;
-#endif
-    return g_perf_font_handle;
 }
+
+static void stasis_perf_append_count(char* output, size_t capacity, uint32_t count) {
+    if (count == STASIS_PERF_UNAVAILABLE) output[0] = '\0';
+    else snprintf(output, capacity, "%u", (unsigned int)count);
+}
+
+#if !defined(STASIS_GRAPHICS_SDL_ONLY)
+/* Tiny runtime-owned fallback for OpenGL builds. It deliberately uses no font
+ * asset, allocation, or system API, so the diagnostic HUD remains visible on
+ * macOS/iOS/Linux even when a game has not loaded a font. */
+static uint8_t stasis_perf_glyph_row(char character, int row) {
+    static const uint8_t glyphs[36][7] = {
+        {0x0e,0x11,0x13,0x15,0x19,0x11,0x0e}, {0x04,0x0c,0x04,0x04,0x04,0x04,0x0e},
+        {0x0e,0x11,0x01,0x02,0x04,0x08,0x1f}, {0x1e,0x01,0x01,0x0e,0x01,0x01,0x1e},
+        {0x02,0x06,0x0a,0x12,0x1f,0x02,0x02}, {0x1f,0x10,0x10,0x1e,0x01,0x01,0x1e},
+        {0x06,0x08,0x10,0x1e,0x11,0x11,0x0e}, {0x1f,0x01,0x02,0x04,0x08,0x08,0x08},
+        {0x0e,0x11,0x11,0x0e,0x11,0x11,0x0e}, {0x0e,0x11,0x11,0x0f,0x01,0x02,0x1c},
+        {0x0e,0x11,0x11,0x1f,0x11,0x11,0x11}, {0x1e,0x11,0x11,0x1e,0x11,0x11,0x1e},
+        {0x0e,0x11,0x10,0x10,0x10,0x11,0x0e}, {0x1e,0x11,0x11,0x11,0x11,0x11,0x1e},
+        {0x1f,0x10,0x10,0x1e,0x10,0x10,0x1f}, {0x1f,0x10,0x10,0x1e,0x10,0x10,0x10},
+        {0x0e,0x11,0x10,0x17,0x11,0x11,0x0f}, {0x11,0x11,0x11,0x1f,0x11,0x11,0x11},
+        {0x0e,0x04,0x04,0x04,0x04,0x04,0x0e}, {0x01,0x01,0x01,0x01,0x11,0x11,0x0e},
+        {0x11,0x12,0x14,0x18,0x14,0x12,0x11}, {0x10,0x10,0x10,0x10,0x10,0x10,0x1f},
+        {0x11,0x1b,0x15,0x15,0x11,0x11,0x11}, {0x11,0x19,0x19,0x15,0x13,0x13,0x11},
+        {0x0e,0x11,0x11,0x11,0x11,0x11,0x0e}, {0x1e,0x11,0x11,0x1e,0x10,0x10,0x10},
+        {0x0e,0x11,0x11,0x11,0x15,0x12,0x0d}, {0x1e,0x11,0x11,0x1e,0x14,0x12,0x11},
+        {0x0f,0x10,0x10,0x0e,0x01,0x01,0x1e}, {0x1f,0x04,0x04,0x04,0x04,0x04,0x04},
+        {0x11,0x11,0x11,0x11,0x11,0x11,0x0e}, {0x11,0x11,0x11,0x11,0x11,0x0a,0x04},
+        {0x11,0x11,0x11,0x15,0x15,0x1b,0x11}, {0x11,0x11,0x0a,0x04,0x0a,0x11,0x11},
+        {0x11,0x11,0x0a,0x04,0x04,0x04,0x04}, {0x1f,0x01,0x02,0x04,0x08,0x10,0x1f}
+    };
+    const int upper = toupper((unsigned char)character);
+    if (upper >= '0' && upper <= '9') return glyphs[upper - '0'][row];
+    if (upper >= 'A' && upper <= 'Z') return glyphs[10 + upper - 'A'][row];
+    if (character == ':') return (row == 1 || row == 5) ? 0x04 : 0;
+    if (character == '.') return row == 6 ? 0x04 : 0;
+    if (character == '-') return row == 3 ? 0x1f : 0;
+    if (character == '%') return row == 1 ? 0x19 : (row == 5 ? 0x13 : 0);
+    if (character == '[' || character == ']') return (row == 0 || row == 6) ? 0x1e : 0x10;
+    return 0;
+}
+
+static void stasis_perf_draw_builtin_gl(const char* text, float x, float y,
+                                        float r, float g, float b) {
+    if (!text || !*text) return;
+    glDisable(GL_TEXTURE_2D);
+    glColor4f(r, g, b, 1.0f);
+    glBegin(GL_QUADS);
+    for (const char* cursor = text; *cursor; cursor++, x += 12.0f) {
+        for (int row = 0; row < 7; row++) {
+            const uint8_t bits = stasis_perf_glyph_row(*cursor, row);
+            for (int column = 0; column < 5; column++) {
+                if ((bits & (1u << (4 - column))) == 0) continue;
+                const float left = x + (float)column * 2.0f;
+                const float top = y + (float)row * 2.0f;
+                glVertex2f(left, top); glVertex2f(left + 2.0f, top);
+                glVertex2f(left + 2.0f, top + 2.0f); glVertex2f(left, top + 2.0f);
+            }
+        }
+    }
+    glEnd();
+}
+#endif
 
 static void stasis_perf_draw_overlay(void) {
     if (!g_force_debug_overlay) return;
-    const int font = stasis_perf_font();
-    if (font <= 0) return;
 
-    double tick_ms = 0.0;
-    double render_ms = 0.0;
-    stasis_perf_averages(&tick_ms, &render_ms);
-    const double total_ms = tick_ms + render_ms;
-    const int budget_percent = (int)(total_ms * 6.0 + 0.5);
-    char text[160];
-    snprintf(
-        text,
-        sizeof(text),
-        "tick=%.2f ms  render=%.2f ms  total=%.2f ms  budget@60fps=%d%%  [F3]",
-        tick_ms,
-        render_ms,
-        total_ms,
-        budget_percent);
+    StasisPerformanceMetrics metrics;
+    uint32_t worst_frame_work_us = STASIS_PERF_UNAVAILABLE;
+    stasis_perf_latest_snapshot(&metrics, &worst_frame_work_us);
+    const int under_budget = metrics.frame_work_us != STASIS_PERF_UNAVAILABLE
+        && metrics.frame_work_us <= 16667;
+    char tick[32], guest[32], host[32], frame[32], present[32];
+    char commands[16], lines[16], rectangles[16], sprites[16], text_count[16];
+    stasis_perf_append_value(tick, sizeof(tick), metrics.tick_us);
+    stasis_perf_append_value(guest, sizeof(guest), metrics.guest_render_us);
+    stasis_perf_append_value(host, sizeof(host), metrics.host_replay_us);
+    stasis_perf_append_value(frame, sizeof(frame), metrics.frame_work_us);
+    stasis_perf_append_value(present, sizeof(present), metrics.present_wait_us);
+    stasis_perf_append_count(commands, sizeof(commands), metrics.commands);
+    stasis_perf_append_count(lines, sizeof(lines), metrics.lines);
+    stasis_perf_append_count(rectangles, sizeof(rectangles), metrics.rectangles);
+    stasis_perf_append_count(sprites, sizeof(sprites), metrics.sprites);
+    stasis_perf_append_count(text_count, sizeof(text_count), metrics.text);
+    char text[5][220];
+    snprintf(text[0], sizeof(text[0]), "%s  [F3]", metrics.backend[0] ? metrics.backend : "native");
+    if (metrics.tick_us == STASIS_PERF_UNAVAILABLE && metrics.guest_render_us == STASIS_PERF_UNAVAILABLE) {
+        text[1][0] = '\0';
+    } else {
+        snprintf(text[1], sizeof(text[1]), "tick %s  guest render %s", tick, guest);
+    }
+    if (metrics.host_replay_us == STASIS_PERF_UNAVAILABLE) text[2][0] = '\0';
+    else snprintf(text[2], sizeof(text[2]), "host replay %s", host);
+    if (metrics.frame_work_us == STASIS_PERF_UNAVAILABLE) {
+        text[3][0] = '\0';
+    } else {
+        snprintf(text[3], sizeof(text[3]), "frame work %s (worst %.2f ms)  %s%s%s",
+            frame, worst_frame_work_us == STASIS_PERF_UNAVAILABLE ? 0.0 : (double)worst_frame_work_us / 1000.0,
+            under_budget ? "UNDER 16.67 ms" : "OVER 16.67 ms",
+            metrics.present_wait_us == STASIS_PERF_UNAVAILABLE ? "" : "  present wait ",
+            metrics.present_wait_us == STASIS_PERF_UNAVAILABLE ? "" : present);
+    }
+    if (metrics.commands == STASIS_PERF_UNAVAILABLE && metrics.lines == STASIS_PERF_UNAVAILABLE
+        && metrics.rectangles == STASIS_PERF_UNAVAILABLE && metrics.sprites == STASIS_PERF_UNAVAILABLE
+        && metrics.text == STASIS_PERF_UNAVAILABLE) {
+        text[4][0] = '\0';
+    } else {
+        size_t offset = 0;
+        text[4][0] = '\0';
+        if (metrics.commands != STASIS_PERF_UNAVAILABLE) {
+            offset += (size_t)snprintf(text[4] + offset, sizeof(text[4]) - offset, "commands %s", commands);
+        }
+        if (metrics.lines != STASIS_PERF_UNAVAILABLE && offset < sizeof(text[4])) {
+            offset += (size_t)snprintf(text[4] + offset, sizeof(text[4]) - offset, "%slines %s", offset ? "  " : "", lines);
+        }
+        if (metrics.rectangles != STASIS_PERF_UNAVAILABLE && offset < sizeof(text[4])) {
+            offset += (size_t)snprintf(text[4] + offset, sizeof(text[4]) - offset, "%srects %s", offset ? "  " : "", rectangles);
+        }
+        if (metrics.sprites != STASIS_PERF_UNAVAILABLE && offset < sizeof(text[4])) {
+            offset += (size_t)snprintf(text[4] + offset, sizeof(text[4]) - offset, "%ssprites %s", offset ? "  " : "", sprites);
+        }
+        if (metrics.text != STASIS_PERF_UNAVAILABLE && offset < sizeof(text[4])) {
+            (void)snprintf(text[4] + offset, sizeof(text[4]) - offset, "%stext %s", offset ? "  " : "", text_count);
+        }
+    }
 
     float r = 1.0f;
     float g = 1.0f;
     float b = 1.0f;
+    const int budget_percent = metrics.frame_work_us == STASIS_PERF_UNAVAILABLE
+        ? 0 : (int)(metrics.frame_work_us * 100u / 16667u);
     if (budget_percent >= 100) {
         r = 0.73f; g = 0.41f; b = 1.0f;
     } else if (budget_percent >= 80) {
@@ -4753,12 +4938,17 @@ static void stasis_perf_draw_overlay(void) {
         r = 1.0f; g = 0.84f; b = 0.40f;
     }
 
-    const int background_width = g_window_width > 690 ? 680 : g_window_width - 16;
+    const int background_width = g_window_width > 760 ? 750 : g_window_width - 16;
+    const float background_height = 18.0f + 18.0f * 5.0f;
     if (g_use_sdl_renderer) {
         SDL_SetRenderDrawBlendMode(g_renderer, SDL_BLENDMODE_BLEND);
         SDL_SetRenderDrawColor(g_renderer, 20, 28, 38, 170);
-        SDL_FRect background = { 8.0f, 8.0f, (float)background_width, 28.0f };
+        SDL_FRect background = { 8.0f, 8.0f, (float)background_width, background_height };
         if (background.w > 0) SDL_RenderFillRect(g_renderer, &background);
+        SDL_SetRenderDrawColor(g_renderer, (Uint8)(r * 255.0f), (Uint8)(g * 255.0f), (Uint8)(b * 255.0f), 255);
+        for (int line = 0; line < 5; line++) {
+            if (text[line][0]) SDL_RenderDebugText(g_renderer, 12.0f, 11.0f + (float)line * 18.0f, text[line]);
+        }
     } else {
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
         flush_lines();
@@ -4769,15 +4959,15 @@ static void stasis_perf_draw_overlay(void) {
             glBegin(GL_QUADS);
             glVertex2f(8.0f, 8.0f);
             glVertex2f(8.0f + (float)background_width, 8.0f);
-            glVertex2f(8.0f + (float)background_width, 36.0f);
-            glVertex2f(8.0f, 36.0f);
+            glVertex2f(8.0f + (float)background_width, 8.0f + background_height);
+            glVertex2f(8.0f, 8.0f + background_height);
             glEnd();
+        }
+        for (int line = 0; line < 5; line++) {
+            stasis_perf_draw_builtin_gl(text[line], 12.0f, 11.0f + (float)line * 18.0f, r, g, b);
         }
 #endif
     }
-
-    stasis_draw_text(font, text, 13.0f, 12.0f, 0.0f, 0.0f, 0.0f, 0.9f);
-    stasis_draw_text(font, text, 12.0f, 11.0f, r, g, b, 1.0f);
 }
 
 /*
@@ -4805,8 +4995,18 @@ STASIS_EXPORT void stasis_end_frame(void) {
 
         /* Capture before present so we read the current render target. */
         capture_scheduled_screenshot();
-        stasis_perf_finish_render_sample();
-        SDL_RenderPresent(g_renderer);
+        const int measure_frame = stasis_host_performance_metrics_enabled();
+        if (measure_frame) {
+            const uint64_t host_finished = SDL_GetPerformanceCounter();
+            const uint64_t present_started = SDL_GetPerformanceCounter();
+            SDL_RenderPresent(g_renderer);
+            const uint64_t present_finished = SDL_GetPerformanceCounter();
+            stasis_perf_finish_render_sample(stasis_perf_elapsed_us(
+                g_perf_render_started_counter, host_finished),
+                stasis_perf_elapsed_us(present_started, present_finished));
+        } else {
+            SDL_RenderPresent(g_renderer);
+        }
         g_line_count = 0;
     } else {
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
@@ -4818,8 +5018,18 @@ STASIS_EXPORT void stasis_end_frame(void) {
         }
         /* Capture after all draws (including postfx) but before swap. */
         capture_scheduled_screenshot();
-        stasis_perf_finish_render_sample();
-        SDL_GL_SwapWindow(g_window);
+        const int measure_frame = stasis_host_performance_metrics_enabled();
+        if (measure_frame) {
+            const uint64_t host_finished = SDL_GetPerformanceCounter();
+            const uint64_t present_started = SDL_GetPerformanceCounter();
+            SDL_GL_SwapWindow(g_window);
+            const uint64_t present_finished = SDL_GetPerformanceCounter();
+            stasis_perf_finish_render_sample(stasis_perf_elapsed_us(
+                g_perf_render_started_counter, host_finished),
+                stasis_perf_elapsed_us(present_started, present_finished));
+        } else {
+            SDL_GL_SwapWindow(g_window);
+        }
 #else
         /* STASIS_GRAPHICS_SDL_ONLY should never create a GL context. */
         g_line_count = 0;
@@ -5123,6 +5333,11 @@ static bool stasis_render_trace_is_enabled(void) {
 }
 
 static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const uint8_t* cmd_u8) {
+    /* Start before validation so a valid frame's host replay includes command
+     * validation and decoding. Rejected frames return before publishing a
+     * performance sample. */
+    const uint64_t host_started_counter = stasis_host_performance_metrics_enabled()
+        ? SDL_GetPerformanceCounter() : 0;
     StasisRenderValidation validation = stasis_render_validate(cmd_i32, cmd_f32);
     if (validation != STASIS_RENDER_VALID) {
         g_render_rejected_frames++;
@@ -5152,9 +5367,7 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
         cmd_i32[STASIS_RENDER_I_DISPLAY_GENERATION];
     g_render_last_density_generation =
         cmd_i32[STASIS_RENDER_I_DENSITY_GENERATION];
-    g_perf_render_started_counter = stasis_host_performance_metrics_enabled()
-        ? SDL_GetPerformanceCounter()
-        : 0;
+    g_perf_render_started_counter = host_started_counter;
 
     const int32_t flags = cmd_i32[STASIS_RENDER_I_FLAGS];
     const int32_t gfx_cmd_max_lines = STASIS_RENDER_MAX_LINES;
@@ -5177,6 +5390,12 @@ static void stasis_gfx_submit_v2(int32_t* cmd_i32, const float* cmd_f32, const u
     if (sprite_count > gfx_cmd_max_sprites) sprite_count = gfx_cmd_max_sprites;
     if (text_count > gfx_cmd_max_text) text_count = gfx_cmd_max_text;
     if (text_bytes_used > gfx_cmd_max_text_bytes) text_bytes_used = gfx_cmd_max_text_bytes;
+
+    g_perf_pending_lines = (uint32_t)line_count;
+    g_perf_pending_rectangles = (uint32_t)rect_count;
+    g_perf_pending_sprites = (uint32_t)sprite_count;
+    g_perf_pending_text = (uint32_t)text_count;
+    g_perf_pending_commands = (uint32_t)(line_count + rect_count + sprite_count + text_count);
 
     if (!g_render_contract_logged) {
         SDL_Log(

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -9,6 +9,8 @@ EXPORTS
     stasis_host_copy_runtime_error
     stasis_host_performance_metrics_enabled
     stasis_host_set_performance_metrics_enabled
+    stasis_host_get_latest_performance_metrics
+    stasis_host_get_latest_performance_metrics_v1
     stasis_init_window
     stasis_get_window_size
     stasis_get_display_metrics

--- a/runtime/stasis_performance_metrics.h
+++ b/runtime/stasis_performance_metrics.h
@@ -1,0 +1,36 @@
+#ifndef STASIS_PERFORMANCE_METRICS_H
+#define STASIS_PERFORMANCE_METRICS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define STASIS_PERF_METRICS_VERSION 1u
+#define STASIS_PERF_UNAVAILABLE UINT32_MAX
+#define STASIS_PERF_BACKEND_MAX 16
+
+/* Stable phase order shared by web, desktop, Android, and iOS HUDs. */
+typedef struct StasisPerformanceMetrics {
+    uint32_t version;
+    uint32_t size;
+    uint32_t tick_us;
+    uint32_t guest_render_us;
+    uint32_t host_replay_us;
+    uint32_t render_prep_us;
+    uint32_t gpu_submit_us;
+    uint32_t gpu_execution_us;
+    uint32_t frame_work_us;
+    uint32_t present_wait_us;
+    uint32_t commands;
+    uint32_t lines;
+    uint32_t rectangles;
+    uint32_t sprites;
+    uint32_t text;
+    uint32_t instances;
+    uint32_t batches;
+    uint32_t draw_calls;
+    uint32_t texture_switches;
+    uint32_t uploaded_bytes;
+    char backend[STASIS_PERF_BACKEND_MAX];
+} StasisPerformanceMetrics;
+
+#endif

--- a/runtime/tests/stasis_performance_metrics_test.c
+++ b/runtime/tests/stasis_performance_metrics_test.c
@@ -1,0 +1,21 @@
+#include "stasis_performance_metrics.h"
+
+#include <stddef.h>
+#include <stdio.h>
+
+int main(void) {
+    StasisPerformanceMetrics metrics = {0};
+    metrics.version = STASIS_PERF_METRICS_VERSION;
+    metrics.size = (uint32_t)sizeof(metrics);
+    metrics.render_prep_us = STASIS_PERF_UNAVAILABLE;
+    metrics.gpu_execution_us = STASIS_PERF_UNAVAILABLE;
+    if (metrics.version != 1u || metrics.size != sizeof(metrics)
+        || metrics.render_prep_us != UINT32_MAX
+        || metrics.gpu_execution_us != UINT32_MAX
+        || offsetof(StasisPerformanceMetrics, frame_work_us)
+            >= offsetof(StasisPerformanceMetrics, present_wait_us)) {
+        fputs("invalid performance metrics contract\n", stderr);
+        return 1;
+    }
+    return 0;
+}

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -51,6 +51,38 @@
   let worstWasmRender = 0;
   let worstBrowserReplay = 0;
   let worstFrameWork = 0;
+  const PERF_ROLLING_CAPACITY = 1200;
+  const performanceWorstTimes = new Float64Array(PERF_ROLLING_CAPACITY);
+  const performanceWorstValues = Array.from({ length: 5 }, () => new Float64Array(PERF_ROLLING_CAPACITY));
+  let performanceWorstNext = 0;
+  let performanceWorstCount = 0;
+  const recordPerformanceWorst = (now, tick, render, wasm, replay, frameWork) => {
+    performanceWorstTimes[performanceWorstNext] = now;
+    performanceWorstValues[0][performanceWorstNext] = tick;
+    performanceWorstValues[1][performanceWorstNext] = render;
+    performanceWorstValues[2][performanceWorstNext] = wasm;
+    performanceWorstValues[3][performanceWorstNext] = replay;
+    performanceWorstValues[4][performanceWorstNext] = frameWork;
+    performanceWorstNext = (performanceWorstNext + 1) % PERF_ROLLING_CAPACITY;
+    if (performanceWorstCount < PERF_ROLLING_CAPACITY) performanceWorstCount += 1;
+    const cutoff = now - 5000;
+    for (let metric = 0; metric < 5; metric += 1) {
+      let maximum = 0;
+      for (let sample = 0; sample < performanceWorstCount; sample += 1) {
+        if (performanceWorstTimes[sample] >= cutoff) maximum = Math.max(maximum, performanceWorstValues[metric][sample]);
+      }
+      if (metric === 0) worstTick = maximum;
+      else if (metric === 1) worstRender = maximum;
+      else if (metric === 2) worstWasmRender = maximum;
+      else if (metric === 3) worstBrowserReplay = maximum;
+      else worstFrameWork = maximum;
+    }
+  };
+  const performanceWorkload = {
+    commands: 0, lines: 0, rectangles: 0, sprites: 0, text: 0,
+    instances: 0, batches: 0, drawCalls: 0, uploadedBytes: 0
+  };
+  let performanceBackend = "Canvas2D";
   let rectBatcher;
   const RECT_BATCH_MIN = 64;
   const RECT_CAP = 10000;
@@ -753,6 +785,7 @@
     }
   }
   function executeCommands() {
+    performanceWorkload.commands += commands.length;
     context.globalAlpha = 1;
     context.globalCompositeOperation = "source-over";
     for (const command of commands) {
@@ -792,6 +825,8 @@
       context.restore();
     }
     const drawLine = index => {
+      performanceWorkload.lines += 1;
+      performanceWorkload.drawCalls += 1;
       const base = 4 + index * 8;
       context.save();
       context.globalAlpha = f32[base + 7];
@@ -809,7 +844,9 @@
       context.fillRect(f32[base], f32[base + 1], f32[base + 2], f32[base + 3]);
     };
     const drawRectRun = (start, count, ordered) => {
+      performanceWorkload.rectangles += count;
       if (count < RECT_BATCH_MIN) {
+        performanceWorkload.drawCalls += count;
         for (let offset = 0; offset < count; offset += 1) {
           const index = ordered ? i32[18464 + start + offset] % 16384 : start + offset;
           drawRect(index);
@@ -818,6 +855,7 @@
       }
       const batcher = getRectBatcher();
       if (!batcher) {
+        performanceWorkload.drawCalls += count;
         for (let offset = 0; offset < count; offset += 1) {
           const index = ordered ? i32[18464 + start + offset] % 16384 : start + offset;
           drawRect(index);
@@ -832,8 +870,14 @@
       }
       try {
         batcher.draw(rectScratch, count);
+        performanceWorkload.instances += count;
+        performanceWorkload.batches += 1;
+        performanceWorkload.drawCalls += 1;
+        performanceWorkload.uploadedBytes += count * 8 * Float32Array.BYTES_PER_ELEMENT;
+        performanceBackend = "Canvas2D + WebGL2";
       } catch (_) {
         rectBatcher = null;
+        performanceWorkload.drawCalls += count;
         for (let offset = 0; offset < count; offset += 1) {
           const index = ordered ? i32[18464 + start + offset] % 16384 : start + offset;
           drawRect(index);
@@ -841,6 +885,8 @@
       }
     };
     const drawSprite = index => {
+      performanceWorkload.sprites += 1;
+      performanceWorkload.drawCalls += 1;
       const baseI = 32 + index * 3;
       const baseF = 80004 + index * spriteStride;
       const image = sprites.get(i32[baseI]);
@@ -870,6 +916,8 @@
       context.restore();
     };
     const drawText = index => {
+      performanceWorkload.text += 1;
+      performanceWorkload.drawCalls += 1;
       const baseI = 12320 + index * 3;
       const baseF = textBase + index * 6;
       const offset = i32[baseI + 1];
@@ -895,6 +943,7 @@
     const textCount = Math.max(0, Math.min(i32[7], 2048));
     const rectCount = version >= 4 ? Math.max(0, Math.min(i32[24], 10000 - lineCount)) : 0;
     const orderCount = version >= 3 ? Math.max(0, Math.min(i32[22], 16144)) : 0;
+    performanceWorkload.commands += lineCount + rectCount + spriteCount + textCount;
     if (orderCount > 0) {
       for (let order = 0; order < orderCount; order += 1) {
         const encoded = i32[18464 + order];
@@ -1078,22 +1127,33 @@
     const wasmRenderStart = performance.now();
     instance.exports.render();
     const wasmRenderMs = performance.now() - wasmRenderStart;
+    performanceWorkload.commands = 0;
+    performanceWorkload.lines = 0;
+    performanceWorkload.rectangles = 0;
+    performanceWorkload.sprites = 0;
+    performanceWorkload.text = 0;
+    performanceWorkload.instances = 0;
+    performanceWorkload.batches = 0;
+    performanceWorkload.drawCalls = 0;
+    performanceWorkload.uploadedBytes = 0;
+    performanceBackend = rectBatcher ? "Canvas2D + WebGL2" : "Canvas2D";
     const replayStart = performance.now();
     executeCommands();
     const browserReplayMs = performance.now() - replayStart;
     const renderMs = wasmRenderMs + browserReplayMs;
     const frameWorkMs = tickMs + renderMs;
+    const renderPrepMs = -1;
+    const gpuSubmitMs = -1;
+    const gpuExecutionMs = -1;
+    const presentWaitMs = -1;
     frames += 1;
-    if (frames > 5) {
-      worstTick = Math.max(worstTick, tickMs);
-      worstRender = Math.max(worstRender, renderMs);
-      worstWasmRender = Math.max(worstWasmRender, wasmRenderMs);
-      worstBrowserReplay = Math.max(worstBrowserReplay, browserReplayMs);
-      worstFrameWork = Math.max(worstFrameWork, frameWorkMs);
-    }
-    const underBudget = worstFrameWork < 16;
+    recordPerformanceWorst(timestamp, tickMs, renderMs, wasmRenderMs, browserReplayMs, frameWorkMs);
+    const underBudget = frameWorkMs <= 16.67;
     if (hud) {
-      hud.textContent = `Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nwasm render ${wasmRenderMs.toFixed(3)} ms (worst ${worstWasmRender.toFixed(3)})\nbrowser replay ${browserReplayMs.toFixed(3)} ms (worst ${worstBrowserReplay.toFixed(3)})\nframe work ${frameWorkMs.toFixed(3)} ms (worst ${worstFrameWork.toFixed(3)})\n${underBudget ? "UNDER 16 ms" : "OVER BUDGET"}`;
+      const uploadText = performanceWorkload.uploadedBytes > 0 ? ` · uploaded ${performanceWorkload.uploadedBytes} B` : "";
+      const instanceText = performanceBackend.includes("WebGL2")
+        ? ` · instances ${performanceWorkload.instances} · batches ${performanceWorkload.batches}` : "";
+      hud.textContent = `${performanceBackend} · frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)}) · guest render ${wasmRenderMs.toFixed(3)} ms (worst ${worstWasmRender.toFixed(3)})\nhost replay ${browserReplayMs.toFixed(3)} ms (worst ${worstBrowserReplay.toFixed(3)})\nframe work ${frameWorkMs.toFixed(3)} ms (worst ${worstFrameWork.toFixed(3)}) · ${underBudget ? "UNDER 16.67 ms" : "OVER 16.67 ms"}\ncommands ${performanceWorkload.commands} · lines ${performanceWorkload.lines} · rects ${performanceWorkload.rectangles} · sprites ${performanceWorkload.sprites} · text ${performanceWorkload.text}\ndraws ${performanceWorkload.drawCalls}${instanceText}${uploadText}`;
     }
     document.body.dataset.frames = String(frames);
     document.body.dataset.tickMs = tickMs.toFixed(3);
@@ -1101,6 +1161,21 @@
     document.body.dataset.wasmRenderMs = wasmRenderMs.toFixed(3);
     document.body.dataset.browserReplayMs = browserReplayMs.toFixed(3);
     document.body.dataset.frameWorkMs = frameWorkMs.toFixed(3);
+    document.body.dataset.backend = performanceBackend;
+    document.body.dataset.hostReplayMs = browserReplayMs.toFixed(3);
+    document.body.dataset.renderPrepMs = String(renderPrepMs);
+    document.body.dataset.gpuSubmitMs = String(gpuSubmitMs);
+    document.body.dataset.gpuExecutionMs = String(gpuExecutionMs);
+    document.body.dataset.presentWaitMs = String(presentWaitMs);
+    document.body.dataset.commands = String(performanceWorkload.commands);
+    document.body.dataset.lines = String(performanceWorkload.lines);
+    document.body.dataset.rectangles = String(performanceWorkload.rectangles);
+    document.body.dataset.sprites = String(performanceWorkload.sprites);
+    document.body.dataset.text = String(performanceWorkload.text);
+    document.body.dataset.instances = performanceBackend.includes("WebGL2") ? String(performanceWorkload.instances) : "-1";
+    document.body.dataset.batches = performanceBackend.includes("WebGL2") ? String(performanceWorkload.batches) : "-1";
+    document.body.dataset.drawCalls = String(performanceWorkload.drawCalls);
+    document.body.dataset.uploadedBytes = String(performanceWorkload.uploadedBytes);
     document.body.dataset.worstTickMs = worstTick.toFixed(3);
     document.body.dataset.worstRenderMs = worstRender.toFixed(3);
     document.body.dataset.worstWasmRenderMs = worstWasmRender.toFixed(3);

--- a/runtime/web/game_minimal.js
+++ b/runtime/web/game_minimal.js
@@ -16,6 +16,17 @@ __STASIS_IMPORTS__
   let worstTick = 0;
   let worstRender = 0;
   let worstWasmRender=0,worstBrowserReplay=0,worstFrameWork=0;
+  const PERF_ROLLING_CAPACITY=1200;
+  const worstTimes=new Float64Array(PERF_ROLLING_CAPACITY);
+  const worstValues=Array.from({length:5},()=>new Float64Array(PERF_ROLLING_CAPACITY));
+  let worstNext=0,worstCount=0;
+  const recordWorst=(now,tick,render,wasm,replay,frameWork)=>{
+    worstTimes[worstNext]=now;worstValues[0][worstNext]=tick;worstValues[1][worstNext]=render;worstValues[2][worstNext]=wasm;worstValues[3][worstNext]=replay;worstValues[4][worstNext]=frameWork;
+    worstNext=(worstNext+1)%PERF_ROLLING_CAPACITY;if(worstCount<PERF_ROLLING_CAPACITY)worstCount+=1;
+    const cutoff=now-5000;let maxTick=0,maxRender=0,maxWasm=0,maxReplay=0,maxFrame=0;
+    for(let sample=0;sample<worstCount;sample+=1)if(worstTimes[sample]>=cutoff){maxTick=Math.max(maxTick,worstValues[0][sample]);maxRender=Math.max(maxRender,worstValues[1][sample]);maxWasm=Math.max(maxWasm,worstValues[2][sample]);maxReplay=Math.max(maxReplay,worstValues[3][sample]);maxFrame=Math.max(maxFrame,worstValues[4][sample]);}
+    worstTick=maxTick;worstRender=maxRender;worstWasmRender=maxWasm;worstBrowserReplay=maxReplay;worstFrameWork=maxFrame;
+  };
   const colorCache=new Map();
   const cachedColor=(r,g,b)=>{const key=((r&255)<<16)|((g&255)<<8)|(b&255);let value=colorCache.get(key);if(!value){value=color(r,g,b);colorCache.set(key,value);}return value;};
 
@@ -48,16 +59,31 @@ __STASIS_IMPORTS__
     const browserReplayMs=performance.now()-replayStart;
     const renderMs=wasmRenderMs+browserReplayMs;
     const frameWorkMs=tickMs+renderMs;
+    const renderPrepMs=-1,gpuSubmitMs=-1,gpuExecutionMs=-1,presentWaitMs=-1;
     frames += 1;
-    if (frames > 5) {
-      worstTick = Math.max(worstTick, tickMs);
-      worstRender=Math.max(worstRender,renderMs); worstWasmRender=Math.max(worstWasmRender,wasmRenderMs);worstBrowserReplay=Math.max(worstBrowserReplay,browserReplayMs);worstFrameWork=Math.max(worstFrameWork,frameWorkMs);
-    }
-    const underBudget=worstFrameWork<16;
-    if (hud) hud.textContent=`Wasm frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)})\nwasm render ${wasmRenderMs.toFixed(3)} ms (worst ${worstWasmRender.toFixed(3)})\nbrowser replay ${browserReplayMs.toFixed(3)} ms (worst ${worstBrowserReplay.toFixed(3)})\nframe work ${frameWorkMs.toFixed(3)} ms (worst ${worstFrameWork.toFixed(3)})\n${underBudget?"UNDER 16 ms":"OVER BUDGET"}`;
+    recordWorst(performance.now(),tickMs,renderMs,wasmRenderMs,browserReplayMs,frameWorkMs);
+    const underBudget=frameWorkMs<=16.67;
+    let lines=0,rectangles=0,text=0;
+    for(const command of commands){if(command[0]===1)rectangles+=1;else if(command[0]===2)text+=1;}
+    if (hud) hud.textContent=`Canvas2D · frame ${frames}\ntick ${tickMs.toFixed(3)} ms (worst ${worstTick.toFixed(3)}) · guest render ${wasmRenderMs.toFixed(3)} ms (worst ${worstWasmRender.toFixed(3)})\nhost replay ${browserReplayMs.toFixed(3)} ms (worst ${worstBrowserReplay.toFixed(3)})\nframe work ${frameWorkMs.toFixed(3)} ms (worst ${worstFrameWork.toFixed(3)}) · ${underBudget?"UNDER 16.67 ms":"OVER 16.67 ms"}\ncommands ${commands.length} · lines ${lines} · rects ${rectangles} · text ${text}\ndraws ${commands.length}`;
     document.body.dataset.frames = String(frames);
     document.body.dataset.tickMs=tickMs.toFixed(3);document.body.dataset.renderMs=renderMs.toFixed(3);document.body.dataset.wasmRenderMs=wasmRenderMs.toFixed(3);document.body.dataset.browserReplayMs=browserReplayMs.toFixed(3);document.body.dataset.frameWorkMs=frameWorkMs.toFixed(3);document.body.dataset.worstTickMs=worstTick.toFixed(3);document.body.dataset.worstRenderMs=worstRender.toFixed(3);document.body.dataset.worstWasmRenderMs=worstWasmRender.toFixed(3);document.body.dataset.worstBrowserReplayMs=worstBrowserReplay.toFixed(3);document.body.dataset.worstFrameWorkMs=worstFrameWork.toFixed(3);
     document.body.dataset.underBudget = String(underBudget);
+    document.body.dataset.backend="Canvas2D";
+    document.body.dataset.hostReplayMs=browserReplayMs.toFixed(3);
+    document.body.dataset.renderPrepMs=String(renderPrepMs);
+    document.body.dataset.gpuSubmitMs=String(gpuSubmitMs);
+    document.body.dataset.gpuExecutionMs=String(gpuExecutionMs);
+    document.body.dataset.presentWaitMs=String(presentWaitMs);
+    document.body.dataset.commands=String(commands.length);
+    document.body.dataset.lines=String(lines);
+    document.body.dataset.rectangles=String(rectangles);
+    document.body.dataset.sprites="-1";
+    document.body.dataset.text=String(text);
+    document.body.dataset.instances="-1";
+    document.body.dataset.batches="-1";
+    document.body.dataset.drawCalls=String(commands.length);
+    document.body.dataset.uploadedBytes="-1";
     requestAnimationFrame(frame);
   }
 

--- a/runtime/web/tests/render_pipeline.test.mjs
+++ b/runtime/web/tests/render_pipeline.test.mjs
@@ -144,7 +144,7 @@ test("runtime publishes split timing phases and HUD labels", async () => {
   assert.equal(runtime.body.dataset.frameWorkMs, "9.000");
   assert.equal(runtime.body.dataset.renderMs, "7.000");
   assert.equal(runtime.body.dataset.worstRenderMs, "7.000");
-  assert.match(runtime.hud.textContent, /wasm render/);
-  assert.match(runtime.hud.textContent, /browser replay/);
+  assert.match(runtime.hud.textContent, /guest render/);
+  assert.match(runtime.hud.textContent, /host replay/);
   assert.match(runtime.hud.textContent, /frame work/);
 });

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -1362,12 +1362,12 @@ def main() -> int:
     assert "event.getPointerCount() >= 3" in release_activity
     assert "nativeReadPerformanceMetrics" in release_activity
     assert "nativeReadRuntimeError" in release_activity
-    assert 'hudText.append("tick=")' in release_activity
-    assert 'hudText.append("  render=")' in release_activity
-    assert 'hudText.append("  total=")' in release_activity
-    assert 'hudText.append(" ms  budget@60fps=")' in release_activity
+    assert 'appendPhase(hudText, "guest render"' in release_activity
+    assert 'appendPhase(hudText, "host replay"' in release_activity
+    assert 'appendPhase(hudText, "frame work"' in release_activity
+    assert 'appendWorkload(hudText, "commands"' in release_activity
     assert "percentile(" not in release_activity
-    assert "performanceHud.setSingleLine(true)" in release_activity
+    assert "performanceHud.setSingleLine(false)" in release_activity
     assert "setOnApplyWindowInsetsListener" in release_activity
     assert "getDisplayCutout" in release_activity
     assert "verifyAssetManifest(staging)" in release_activity
@@ -1375,6 +1375,8 @@ def main() -> int:
     assert "MAX_MANIFEST_ASSETS = 4096" in release_activity
     assert "MAX_TOTAL_ASSET_BYTES" in release_activity
     assert "stasis_host_get_latest_performance_metrics" in release_bridge
+    assert "stasis_host_get_latest_performance_metrics_v1" in release_bridge
+    assert "stasis_performance_metrics.h" in release_bridge
     assert "stasis_host_copy_runtime_error" in release_bridge
     assert "drawSprites" in preview_renderer
     assert '"com.stasislang.pong"' in device_script

--- a/tools/generate_release_provenance.py
+++ b/tools/generate_release_provenance.py
@@ -28,6 +28,7 @@ RUNTIME_FILES = (
     "stasis_asset_path.h",
     "stasis_render_contract.h",
     "stasis_renderer_lifecycle.h",
+    "stasis_performance_metrics.h",
     "stasis_audio_assets.c",
     "stasis_audio_assets.h",
     "stasis_graphics.c",


### PR DESCRIPTION
## Summary

- add a versioned cross-platform performance metrics snapshot for web, desktop, Android, and iOS
- split guest render, host replay, active frame work, and present wait while omitting unavailable phases from rendered HUDs
- report workload and WebGL2 instancing counters where they are measurable
- use rolling five-second worst values and keep present/vsync wait outside the 60 FPS work budget
- document phase semantics and package the new metrics header for native/mobile consumers

## Validation

- `cargo test -p stasis --lib performance_hud_uses_additive_snapshot_and_excludes_present_wait`
- `cargo test -p stasis --bin stasis mobile_shells_are_platform_projects_over_one_shared_runtime`
- `cargo test -p stasis --test web_package` (8 passed)
- native MSVC/NMake build of `stasis_graphics_static`, `stasis_performance_metrics_test`, and `stasis_mobile_runtime_test`
- `ctest -R "stasis_(performance_metrics|mobile_runtime)"` (2 passed)
- `node --check runtime/web/game.js`
- `node --check runtime/web/game_minimal.js`
- `git diff --check`

The broad Android shell checker currently stops on its pre-existing `allowAiImageGeneration.setChecked(false)` assertion; the HUD-specific mobile packaging contract test passes.