### PR TITLE
Improve sample input and asset loading

### DIFF
--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -4,6 +4,13 @@
   const context = canvas.getContext("2d", { alpha: false });
   const hud = document.getElementById("stasis-hud");
   const errorBox = document.getElementById("stasis-error");
+  const loadingBox = document.getElementById("stasis-loading");
+  const setLoading = (message, state = "loading") => {
+    if (!loadingBox) return;
+    loadingBox.textContent = message;
+    loadingBox.dataset.failed = state === "failed" ? "true" : "false";
+    loadingBox.dataset.hidden = state === "ready" ? "true" : "false";
+  };
   const keys = new Set();
   const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, down: false, wentDown: false, wentUp: false };
   const commands = [];
@@ -1238,6 +1245,7 @@
 
   window.STASIS_RUNTIME_PROMISE = (async () => {
     try {
+      setLoading("Loading Stasis runtime…", "loading");
       const result = await WebAssembly.instantiate(await wasmBytes(), imports);
       instance = result.instance;
       writeHostFrame(performance.now());
@@ -1249,12 +1257,14 @@
         ...fontLoads.values()
       ]);
       await document.fonts.ready;
+      setLoading("", "ready");
       document.body.dataset.ready = "true";
       document.body.dataset.runtime = "wasm";
       document.body.dataset.mainResult = String(mainResult);
       requestAnimationFrame(frame);
     } catch (error) {
       document.body.dataset.ready = "false";
+      setLoading(`Unable to start this game. ${String(error && error.message || error)}`, "failed");
       if (instance) {
         for (const [label, name] of [
           ["debugPhaseCount", "state.active_run_definition.phase_count"],

--- a/runtime/web/game_minimal.js
+++ b/runtime/web/game_minimal.js
@@ -4,6 +4,13 @@
   const context = canvas.getContext("2d", { alpha: false });
   const hud = document.getElementById("stasis-hud");
   const errorBox = document.getElementById("stasis-error");
+  const loadingBox = document.getElementById("stasis-loading");
+  const setLoading = (message, state = "loading") => {
+    if (!loadingBox) return;
+    loadingBox.textContent = message;
+    loadingBox.dataset.failed = state === "failed" ? "true" : "false";
+    loadingBox.dataset.hidden = state === "ready" ? "true" : "false";
+  };
   const game = window.STASIS_GAME || { strings: {} };
   const commands = [];
   const stringValue = id => game.strings[String(id)] || "";
@@ -89,15 +96,18 @@ __STASIS_IMPORTS__
 
   (async () => {
     try {
+      setLoading("Loading Stasis runtime…", "loading");
       const response = await fetch("game.wasm");
       if (!response.ok) throw new Error(`failed to load game.wasm: ${response.status}`);
       instance = (await WebAssembly.instantiate(await response.arrayBuffer(), imports)).instance;
       document.body.dataset.mainResult = String(instance.exports.main());
       document.body.dataset.ready = "true";
+      setLoading("", "ready");
       document.body.dataset.runtime = "wasm";
       requestAnimationFrame(frame);
     } catch (error) {
       document.body.dataset.ready = "false";
+      setLoading(`Unable to start this game. ${String(error && error.message || error)}`, "failed");
       errorBox.textContent = String(error && error.stack || error);
       throw error;
     }

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -11,12 +11,16 @@
     main { position: relative; width: min(960px, 100vw); }
     canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
     __STASIS_PERFORMANCE_HUD_STYLE__
+    #stasis-loading { position: absolute; inset: 0; display: grid; place-items: center; padding: 1rem; box-sizing: border-box; background: #07111f; color: #dff6ff; text-align: center; }
+    #stasis-loading[data-hidden="true"] { display: none; }
+    #stasis-loading[data-failed="true"] { color: #ff8f8f; }
     #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
   </style>
 </head>
 <body>
   <main>
     <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
+    <div id="stasis-loading" role="status" aria-live="polite">Loading Stasis runtime…</div>
     __STASIS_PERFORMANCE_HUD__
     <pre id="stasis-error"></pre>
   </main>

--- a/runtime/web/tests/loading_overlay.test.mjs
+++ b/runtime/web/tests/loading_overlay.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const root = new URL("../", import.meta.url);
+const read = name => fs.readFileSync(new URL(name, root), "utf8");
+
+test("web package template exposes an immediate accessible loading status", () => {
+  const html = read("index.html");
+  assert.match(html, /id="stasis-loading"/);
+  assert.match(html, /role="status"/);
+  assert.match(html, /aria-live="polite"/);
+  assert.match(html, /data-hidden="true"/);
+});
+
+test("web runtimes keep loading visible, hide only when ready, and retain failure", () => {
+  for (const name of ["game.js", "game_minimal.js"]) {
+    const source = read(name);
+    assert.match(source, /setLoading\("Loading Stasis runtime…", "loading"\)/);
+    assert.match(source, /dataset\.hidden = state === "ready" \? "true" : "false"/);
+    assert.match(source, /dataset\.failed = state === "failed" \? "true" : "false"/);
+    assert.match(source, /setLoading\("", "ready"\)/);
+    assert.match(source, /setLoading\(`Unable to start this game\./);
+    assert.match(source, /, "failed"\)/);
+  }
+});

--- a/samples/asset_breakout/src/main.stasis
+++ b/samples/asset_breakout/src/main.stasis
@@ -9,6 +9,7 @@ const PADDLE_W: f32 = 96.0;
 const PADDLE_H: f32 = 14.0;
 const BALL_SIZE: f32 = 12.0;
 const PADDLE_Y: f32 = 326.0;
+const ASSET_TOTAL: i32 = 4;
 
 struct Brick {
     x: f32;
@@ -23,8 +24,16 @@ struct Assets {
     ball: Sprite;
 }
 
+struct AssetLoader {
+    current: ImageAsset;
+    step: i32;
+    assets_ready: bool;
+    failed: bool;
+}
+
 global bricks: Brick[35];
 global assets: Assets;
+global loader: AssetLoader;
 global paddle_x: f32;
 global ball_x: f32;
 global ball_y: f32;
@@ -34,6 +43,24 @@ global bricks_left: i32;
 global ball_active: bool;
 global round_done: bool;
 global presentation_variant: i32;
+
+function loading_completed_count(step: i32): i32 {
+    if (step < 0) {
+        return 0;
+    }
+    if (step > ASSET_TOTAL) {
+        return ASSET_TOTAL;
+    }
+    return step;
+}
+
+function loading_percent(step: i32): i32 {
+    return loading_completed_count(step) * 100 / ASSET_TOTAL;
+}
+
+function loading_is_blocking(): bool {
+    return !loader.assets_ready && !loader.failed;
+}
 
 function clamp_paddle(value: f32): f32 {
     if (value < 0.0) {
@@ -157,30 +184,85 @@ function update_ball(): void {
     }
 }
 
+function request_current_asset(): void {
+    if (loader.step == 0) {
+        loader.current.load_image("assets/arena_background.png", 640, 360);
+    } else if (loader.step == 1) {
+        loader.current.load_image("assets/brick.svg", 78, 22);
+    } else if (loader.step == 2) {
+        loader.current.load_image("assets/paddle.svg", 96, 14);
+    } else if (loader.step == 3) {
+        loader.current.load_image("assets/ball.svg", 12, 12);
+    }
+}
+
+function publish_current_asset(): bool {
+    if (loader.step == 0) {
+        return loader.current.publish(assets.background);
+    }
+    if (loader.step == 1) {
+        return loader.current.publish(assets.brick);
+    }
+    if (loader.step == 2) {
+        return loader.current.publish(assets.paddle);
+    }
+    return loader.current.publish(assets.ball);
+}
+
+function poll_asset_loading(): void {
+    if (loader.assets_ready || loader.failed) {
+        return;
+    }
+    if (loader.step >= ASSET_TOTAL) {
+        loader.assets_ready = assets.background.handle > 0 && assets.brick.handle > 0 && assets.paddle.handle > 0 && assets.ball.handle > 0;
+        if (loader.assets_ready) {
+            reset_round();
+        } else {
+            loader.failed = true;
+        }
+        return;
+    }
+    if (loader.current.state == AssetState.None) {
+        request_current_asset();
+        if (loader.current.state == AssetState.Failed) {
+            loader.failed = true;
+        }
+        return;
+    }
+    if (loader.current.failed()) {
+        loader.failed = true;
+        return;
+    }
+    if (loader.current.ready()) {
+        if (!publish_current_asset()) {
+            loader.failed = true;
+            return;
+        }
+        loader.step += 1;
+    }
+}
+
 function main(): i32 {
     if (!init_window(640, 360, "Neon Breakout")) {
         return 1;
     }
-    if (!assets.background.load_sprite_from("assets/arena_background.png", 640, 360)) {
-        return 1;
-    }
-    if (!assets.brick.load_sprite_from("assets/brick.svg", 78, 22)) {
-        return 1;
-    }
-    if (!assets.paddle.load_sprite_from("assets/paddle.svg", 96, 14)) {
-        return 1;
-    }
-    if (!assets.ball.load_sprite_from("assets/ball.svg", 12, 12)) {
-        return 1;
-    }
+    loader.step = 0;
+    loader.assets_ready = false;
+    loader.failed = false;
     presentation_variant = 0;
-    reset_round();
     return 0;
 }
 
 function tick(): i32 {
     if (should_quit()) {
         return 1;
+    }
+    poll_asset_loading();
+    if (loading_is_blocking()) {
+        return 0;
+    }
+    if (loader.failed) {
+        return 0;
     }
     update_pointer();
     update_ball();
@@ -190,6 +272,22 @@ function tick(): i32 {
 function render(): i32 {
     begin_frame();
     clear(0.02, 0.02, 0.08, 1.0);
+    if (loader.failed) {
+        fill_rect(96.0, 140.0, 448.0, 5.0, 0.45, 0.10, 0.16, 1.0);
+        fill_rect(96.0, 140.0, 448.0, 5.0, 0.95, 0.30, 0.35, 1.0);
+        fill_rect(220.0, 180.0, 200.0, 8.0, 0.95, 0.30, 0.35, 1.0);
+        end_frame();
+        return 0;
+    }
+    if (!loader.assets_ready) {
+        let progress_width: f32 = 448.0 * i32_to_f32(loading_percent(loader.step)) / 100.0;
+        fill_rect(96.0, 140.0, 448.0, 5.0, 0.10, 0.18, 0.30, 1.0);
+        fill_rect(96.0, 140.0, progress_width, 5.0, 0.20, 0.85, 0.98, 1.0);
+        fill_rect(220.0, 180.0, 200.0, 8.0, 0.10, 0.18, 0.30, 1.0);
+        fill_rect(220.0, 180.0, 2.0 * i32_to_f32(loading_percent(loader.step)), 8.0, 0.20, 0.85, 0.98, 1.0);
+        end_frame();
+        return 0;
+    }
     assets.background.draw(0.0, 0.0, 235, 0);
     foreach (let brick, i in bricks) {
         if (brick.alive) {

--- a/samples/asset_breakout/stasis.json
+++ b/samples/asset_breakout/stasis.json
@@ -7,7 +7,7 @@
   "vendor": {
     "stasis": {
       "release_id": "development",
-      "sha256": "ae83fa61f536b13463ecded28234ba60ba49084ab2805f997074b6e61803cf72"
+      "sha256": "f2c2ec98515477c382ec55234905e5f629d9d55ef01752288f7b1429a11a6afc"
     }
   },
   "android": {

--- a/samples/asset_breakout/tests/asset_breakout.test.stasis
+++ b/samples/asset_breakout/tests/asset_breakout.test.stasis
@@ -61,3 +61,28 @@ test `hot swap preserves active round`(): bool {
     on_code_swap();
     return presentation_variant == 1 && ball_active && ball_x == 123.0 && ball_y == 87.0 && bricks_left == 12;
 }
+
+test `asset loading progress is bounded`(): bool {
+    if (loading_percent(-1) != 0 || loading_percent(0) != 0) {
+        return false;
+    }
+    if (loading_percent(2) != 50 || loading_percent(ASSET_TOTAL) != 100) {
+        return false;
+    }
+    return loading_percent(ASSET_TOTAL + 1) == 100;
+}
+
+test `simulation stays gated until assets are ready`(): bool {
+    loader.assets_ready = false;
+    loader.failed = false;
+    if (!loading_is_blocking()) {
+        return false;
+    }
+    loader.assets_ready = true;
+    if (loading_is_blocking()) {
+        return false;
+    }
+    loader.assets_ready = false;
+    loader.failed = true;
+    return !loading_is_blocking();
+}

--- a/samples/asset_breakout/vendor/stasis/docs/README.md
+++ b/samples/asset_breakout/vendor/stasis/docs/README.md
@@ -1,0 +1,38 @@
+# Stasis knowledge library
+
+Small, executable lessons for Stasis developers. The language specification
+and compiler diagnostics remain authoritative for syntax and semantics.
+
+## A Little Stasis
+
+Read these in order. Each lesson adds one idea and uses snippets backed by the
+compiled example project.
+
+1. [Three entry points](a-little-stasis/01-three-entry-points.md)
+2. [State has owners](a-little-stasis/02-state-has-owners.md)
+3. [A tick is an ordered recipe](a-little-stasis/03-a-tick-is-an-ordered-recipe.md)
+4. [Input crosses a boundary](a-little-stasis/04-input-crosses-a-boundary.md)
+5. [Bounded storage is policy](a-little-stasis/05-bounded-storage-is-policy.md)
+6. [Query, materialize, commit](a-little-stasis/06-query-materialize-commit.md)
+7. [Test systems, not balance numbers](a-little-stasis/07-test-systems-not-balance-numbers.md)
+8. [Projection is not authority](a-little-stasis/08-projection-is-not-authority.md)
+
+## Practical examples
+
+Each page solves one system problem for one style of game.
+
+- [Pong: score after the ball crosses the goal](practical-examples/pong-score-after-the-ball-crosses-the-goal.md)
+- [Breakout: remove one brick on a vertical hit](practical-examples/breakout-remove-one-brick-per-collision.md)
+- [Platformer: land in the crossing tick](practical-examples/platformer-land-in-the-crossing-tick.md)
+- [Snake: reject a reverse turn](practical-examples/snake-reject-a-reverse-turn.md)
+
+## Focused references
+
+- [Geometry and collision](geometry-and-collision.md)
+- [Semantic edit and validation](semantic-edit-and-validation.md)
+
+## Executable backing
+
+The Stasis snippets come from the source and test files under `examples/`.
+Run `stasis format --check`, `stasis check`, and `stasis test` from
+`examples/` after changing a snippet or its backing behavior.

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/01-three-entry-points.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/01-three-entry-points.md
@@ -1,0 +1,22 @@
+# 01. Three entry points
+
+What are the smallest roles in a Stasis game?
+
+The Stasis host recognizes `main`, `tick`, and `render` as lifecycle roots.
+The project decides what each boundary delegates to. Here, `main` establishes
+state, `tick` advances one logical transition, and `render` builds
+presentation data.
+
+```stasis
+function main(): i32 {
+    reset_simulation();
+    configure_example_wave();
+    return 0;
+}
+```
+
+Later nuggets define the state owners, show the recipe directly inside `tick`,
+and build the projection inside `render`.
+
+**Keep:** Stasis owns the lifecycle boundary; project code gives each root one
+clear responsibility.

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/02-state-has-owners.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/02-state-has-owners.md
@@ -1,0 +1,59 @@
+# 02. State has owners
+
+Which code is allowed to change each value?
+
+Give each kind of state its own record. Live rules and pending requests may contain the same fields, but they have different owners and different times at which they may change.
+
+```stasis
+struct TowerRules {
+    damage: i32;
+    range_end: i32;
+    cooldown_ticks: i32;
+}
+
+struct TowerRuleInput {
+    damage: i32;
+    range_end: i32;
+    cooldown_ticks: i32;
+}
+```
+
+Simulation progression and presentation data have different owners as well. The render record is a copy for display, not another authority over an enemy slot.
+
+```stasis
+struct RenderEnemy {
+    visible: bool;
+    stable_id: i32;
+    path_position: i32;
+    health: i32;
+}
+
+struct SimulationState {
+    tick_index: i32;
+    wave_count: i32;
+    wave_cursor: i32;
+    cooldown_ticks: i32;
+    capacity_blocked: bool;
+    spawned_count: i32;
+    defeated_count: i32;
+}
+```
+
+Queueing an input must not silently update live rules. This small test stops before application so that ownership, not the fixture values, is the assertion.
+
+```stasis
+test `queued input does not mutate live rules`(): bool {
+    reset_simulation();
+    let damage_before: i32 = tower_rules.damage;
+    let range_before: i32 = tower_rules.range_end;
+    let cooldown_before: i32 = tower_rules.cooldown_ticks;
+
+    if (!submit_tower_rules(4, 6, 3)) {
+        return false;
+    }
+
+    return pending_input_count == 1 && tower_rules.damage == damage_before && tower_rules.range_end == range_before && tower_rules.cooldown_ticks == cooldown_before;
+}
+```
+
+**Keep:** a value crosses from input to live state only through the owner of that transition.

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/03-a-tick-is-an-ordered-recipe.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/03-a-tick-is-an-ordered-recipe.md
@@ -1,0 +1,46 @@
+# 03. A tick is an ordered recipe
+
+If each system works alone, can the game still be wrong?
+
+Yes. The order in which systems observe and change state is part of the rule. Write that order in one small recipe:
+
+```stasis
+function tick(): i32 {
+    apply_pending_inputs();
+    advance_cooldown();
+    spawn_due_events();
+    move_enemies();
+    materialize_attack();
+    commit_attack();
+    remove_defeated();
+    state.tick_index += 1;
+    return 0;
+}
+```
+
+This test observes two dependencies after one public tick: the queued range is
+live before targeting, and movement also runs before targeting. The recipe
+states the finer ordering between input and movement.
+
+```stasis
+test `public tick applies input and movement before targeting`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    let health_before: i32 = enemies[target_id].health;
+    let position_before: i32 = enemies[target_id].path_position;
+    submit_tower_rules(4, 0, 3);
+
+    tick();
+
+    if (state.tick_index != 1 || pending_input_count != 0 || tower_rules.range_end != 0) {
+        return false;
+    }
+    return enemies[target_id].path_position == position_before + 1 && enemies[target_id].health == health_before && !pending_attack.valid;
+}
+```
+
+The unchanged health is a fixture consequence of the no-target path. The
+durable assertions are the observable dependencies, not an ordering the test
+cannot distinguish.
+
+**Keep:** system order is behavior, so test interactions at the tick boundary.

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/04-input-crosses-a-boundary.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/04-input-crosses-a-boundary.md
@@ -1,0 +1,70 @@
+# 04. Input Crosses a Boundary
+
+How does a request become part of the next tick without changing live rules early?
+
+An input has two owners in sequence: the boundary validates and queues it, then the simulation applies and consumes it.
+
+## Validate, then enqueue
+
+Invalid values and a full queue return `false` before storage. The count owns the next write position.
+
+```stasis
+function submit_tower_rules(damage: i32, range_end: i32, cooldown_ticks: i32): bool {
+    if (damage <= 0 || range_end < 0 || cooldown_ticks < 0) {
+        return false;
+    }
+    if (pending_input_count >= INPUT_CAPACITY) {
+        return false;
+    }
+    let input_index: i32 = pending_input_count;
+    pending_inputs[input_index].damage = damage;
+    pending_inputs[input_index].range_end = range_end;
+    pending_inputs[input_index].cooldown_ticks = cooldown_ticks;
+    pending_input_count += 1;
+    return true;
+}
+```
+
+## Apply, then consume
+
+Accepted entries apply in order. Clearing the count makes the queue empty; old array cells are no longer owned by it.
+
+```stasis
+function apply_pending_inputs(): void {
+    for (let input_index: i32 = 0; input_index < pending_input_count; input_index += 1) {
+        tower_rules.damage = pending_inputs[input_index].damage;
+        tower_rules.range_end = pending_inputs[input_index].range_end;
+        tower_rules.cooldown_ticks = pending_inputs[input_index].cooldown_ticks;
+    }
+    pending_input_count = 0;
+}
+```
+
+## Test the boundary
+
+The values are fixtures. These tests protect rejection and once-only consumption.
+
+```stasis
+test `invalid input never enters the queue`(): bool {
+    reset_simulation();
+
+    return !submit_tower_rules(3, -1, 2) && pending_input_count == 0;
+}
+```
+
+```stasis
+test `applied input is consumed once`(): bool {
+    reset_simulation();
+    submit_tower_rules(3, 7, 1);
+    apply_pending_inputs();
+    let applied_damage: i32 = tower_rules.damage;
+    pending_inputs[0].damage = applied_damage + 1;
+
+    apply_pending_inputs();
+
+    return pending_input_count == 0 && tower_rules.damage == applied_damage;
+}
+```
+
+**Keep:** input becomes live only through validation, queue ownership, and one ordered consume.
+

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/05-bounded-storage-is-policy.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/05-bounded-storage-is-policy.md
@@ -1,0 +1,45 @@
+# 05. Bounded Storage Is Policy
+
+What does a fixed slot decide when storage fills and an old occupant leaves?
+
+A bounded array makes capacity, allocation order, and reuse visible to the simulation. An inactive slot is available; an active slot has one current owner.
+
+## Allocate by stable slot order
+
+The first free slot wins. A full scan returns `-1`, so the caller must handle capacity explicitly.
+
+```stasis
+function allocate_enemy(health: i32): i32 {
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (!enemies[slot_id].active) {
+            enemies[slot_id].active = true;
+            enemies[slot_id].health = health;
+            enemies[slot_id].path_position = 0;
+            state.spawned_count += 1;
+            return slot_id;
+        }
+    }
+    return -1;
+}
+```
+
+## Reuse is an ownership transition
+
+Removal releases a slot. The next allocation may reuse its ID, while a survivor keeps its own state.
+
+```stasis
+test `allocation reuses the lowest released slot`(): bool {
+    reset_simulation();
+    let released_id: i32 = allocate_enemy(1);
+    let survivor_id: i32 = allocate_enemy(4);
+    enemies[released_id].health = 0;
+    remove_defeated();
+
+    let reused_id: i32 = allocate_enemy(6);
+
+    return reused_id == released_id && enemies[survivor_id].active;
+}
+```
+
+**Keep:** capacity and slot reuse are state transitions, not hidden collection behavior.
+

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/06-query-materialize-commit.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/06-query-materialize-commit.md
@@ -1,0 +1,72 @@
+# 06. Query, Materialize, Commit
+
+How can a system decide an action without mutating the world while it is still deciding?
+
+A query selects a stable ID. Materialization records an intent. Commit validates that intent and owns the state change.
+
+## Query and materialize
+
+`select_target()` reads active slots and applies a deterministic priority. The materializer clears stale intent before recording the selected action.
+
+```stasis
+function materialize_attack(): void {
+    pending_attack.valid = false;
+    pending_attack.target_id = -1;
+    pending_attack.damage = 0;
+    if (state.cooldown_ticks != 0) {
+        return;
+    }
+    let target_id: i32 = select_target();
+    if (target_id >= 0) {
+        pending_attack.valid = true;
+        pending_attack.target_id = target_id;
+        pending_attack.damage = tower_rules.damage;
+    }
+}
+```
+
+## Commit once
+
+Commit rechecks the slot, changes health, starts the cooldown, and consumes the intent. A rejected or repeated commit changes nothing.
+
+```stasis
+function commit_attack(): bool {
+    if (!pending_attack.valid) {
+        return false;
+    }
+    let target_id: i32 = pending_attack.target_id;
+    if (target_id < 0 || target_id >= ENEMY_CAPACITY || !enemies[target_id].active) {
+        pending_attack.valid = false;
+        return false;
+    }
+    enemies[target_id].health -= pending_attack.damage;
+    state.cooldown_ticks = tower_rules.cooldown_ticks;
+    pending_attack.valid = false;
+    return true;
+}
+```
+
+## Test the transition
+
+The values are fixtures. This test protects commit ownership and once-only consumption.
+
+```stasis
+test `attack commit consumes one intent once`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    pending_attack.valid = true;
+    pending_attack.target_id = target_id;
+    pending_attack.damage = 3;
+    let health_before: i32 = enemies[target_id].health;
+    let damage: i32 = pending_attack.damage;
+
+    let first_commit: bool = commit_attack();
+    let health_after: i32 = enemies[target_id].health;
+    let second_commit: bool = commit_attack();
+
+    return first_commit && !second_commit && health_after == health_before - damage && enemies[target_id].health == health_after;
+}
+```
+
+**Keep:** query what may happen, materialize one intent, and let one commit own the transition.
+

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/07-test-systems-not-balance-numbers.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/07-test-systems-not-balance-numbers.md
@@ -1,0 +1,80 @@
+# 07. Test systems, not balance numbers
+
+How do you find the first wrong system when a fixture value changes?
+
+Use a short testing ladder. Start with one query, then one direct action, then the public tick boundary, and finally a short trace. Assert ownership, ordering, gates, and interactions. Health and damage values are fixtures; a relational change can still prove that an attack happened.
+
+First, isolate a query. This test protects the targeting tie-break without testing combat balance.
+
+```stasis
+test `target ties choose the lower stable slot id`(): bool {
+    reset_simulation();
+    let first_id: i32 = allocate_enemy(5);
+    let second_id: i32 = allocate_enemy(5);
+    enemies[first_id].path_position = 4;
+    enemies[second_id].path_position = enemies[first_id].path_position;
+
+    return first_id < second_id && select_target() == first_id;
+}
+```
+
+Next, test one gate directly. The cooldown blocks materialization until the
+system advances it to ready.
+
+```stasis
+test `cooldown gates attack materialization until ready`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    state.cooldown_ticks = 1;
+
+    materialize_attack();
+    let blocked: bool = !pending_attack.valid;
+    advance_cooldown();
+    materialize_attack();
+
+    return blocked && pending_attack.valid && pending_attack.target_id == target_id;
+}
+```
+
+Then cross the public boundary with the interaction test from
+[A tick is an ordered recipe](03-a-tick-is-an-ordered-recipe.md). Do not repeat
+it here; add the next layer.
+
+Finally, checkpoint a few ticks. Stop at the first failed checkpoint: the earliest difference narrows the search to the systems before that observation.
+
+```stasis
+test `short tick trace reveals the first divergent system`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(9);
+    submit_tower_rules(2, 8, 2);
+    let damage: i32 = pending_inputs[0].damage;
+    let cooldown: i32 = pending_inputs[0].cooldown_ticks;
+    let initial_health: i32 = enemies[target_id].health;
+
+    tick();
+    if (
+        state.tick_index != 1
+        || enemies[target_id].path_position != 1
+        || enemies[target_id].health != initial_health - damage
+        || state.cooldown_ticks != cooldown
+    ) {
+        return false;
+    }
+
+    let health_after_attack: i32 = enemies[target_id].health;
+    tick();
+    if (
+        state.tick_index != 2
+        || enemies[target_id].path_position != 2
+        || enemies[target_id].health != health_after_attack
+        || state.cooldown_ticks != cooldown - 1
+    ) {
+        return false;
+    }
+
+    tick();
+    return state.tick_index == 3 && enemies[target_id].path_position == 3 && enemies[target_id].health == health_after_attack - damage && state.cooldown_ticks == cooldown;
+}
+```
+
+**Keep:** Assert system contracts and interactions; do not turn current balance numbers into permanent rules.

--- a/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/08-projection-is-not-authority.md
+++ b/samples/asset_breakout/vendor/stasis/docs/a-little-stasis/08-projection-is-not-authority.md
@@ -1,0 +1,63 @@
+# 08. Projection is not authority
+
+What may rendering change, and what must remain untouched?
+
+Rendering copies authoritative records into its own bounded projection. It may rebuild presentation data, but it must not advance the tick or mutate gameplay state.
+
+```stasis
+function render(): i32 {
+    render_enemy_count = 0;
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        render_enemies[slot_id].visible = false;
+        if (enemies[slot_id].active) {
+            let command_index: i32 = render_enemy_count;
+            render_enemies[command_index].visible = true;
+            render_enemies[command_index].stable_id = slot_id;
+            render_enemies[command_index].path_position = enemies[slot_id].path_position;
+            render_enemies[command_index].health = enemies[slot_id].health;
+            render_enemy_count += 1;
+        }
+    }
+    return 0;
+}
+```
+
+Test the authority boundary separately. Rendering must preserve the simulation values it reads.
+
+```stasis
+test `render preserves authoritative gameplay state`(): bool {
+    reset_simulation();
+    let enemy_id: i32 = allocate_enemy(5);
+    enemies[enemy_id].path_position = 3;
+    let tick_before: i32 = state.tick_index;
+    let health_before: i32 = enemies[enemy_id].health;
+    let position_before: i32 = enemies[enemy_id].path_position;
+
+    render();
+
+    return state.tick_index == tick_before && enemies[enemy_id].health == health_before && enemies[enemy_id].path_position == position_before && enemies[enemy_id].active;
+}
+```
+
+Then test the projection itself. Stable slot order and copied fields are the contract here, not a particular health value.
+
+```stasis
+test `render projects active slots in stable order`(): bool {
+    reset_simulation();
+    let first_id: i32 = allocate_enemy(5);
+    let second_id: i32 = allocate_enemy(7);
+    enemies[first_id].path_position = 2;
+    enemies[second_id].path_position = 6;
+
+    render();
+
+    if (render_enemy_count != 2) {
+        return false;
+    }
+    let first_matches: bool = render_enemies[0].stable_id == first_id && render_enemies[0].path_position == enemies[first_id].path_position;
+    let second_matches: bool = render_enemies[1].stable_id == second_id && render_enemies[1].path_position == enemies[second_id].path_position;
+    return first_matches && second_matches;
+}
+```
+
+**Keep:** Rendering is a repeatable projection of gameplay state, never an owner of gameplay state.

--- a/samples/asset_breakout/vendor/stasis/docs/examples/src/breakout_brick.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/src/breakout_brick.stasis
@@ -1,0 +1,64 @@
+const BRICK_CAPACITY: i32 = 2;
+
+struct Brick {
+    active: bool;
+    left: i32;
+    right: i32;
+    top: i32;
+    bottom: i32;
+}
+
+struct BreakoutState {
+    ball_x: i32;
+    ball_y: i32;
+    ball_dx: i32;
+    ball_dy: i32;
+}
+
+global breakout: BreakoutState;
+global bricks: Brick[2];
+
+function reset_breakout(): void {
+    breakout.ball_x = 0;
+    breakout.ball_y = 0;
+    breakout.ball_dx = 0;
+    breakout.ball_dy = 1;
+    for (let brick_id: i32 = 0; brick_id < BRICK_CAPACITY; brick_id += 1) {
+        bricks[brick_id].active = false;
+    }
+}
+
+function first_brick_at(x: i32, y: i32): i32 {
+    for (let brick_id: i32 = 0; brick_id < BRICK_CAPACITY; brick_id += 1) {
+        if (
+            bricks[brick_id].active
+            && x >= bricks[brick_id].left
+            && x <= bricks[brick_id].right
+            && y >= bricks[brick_id].top
+            && y <= bricks[brick_id].bottom
+        ) {
+            return brick_id;
+        }
+    }
+    return -1;
+}
+
+function main(): i32 {
+    reset_breakout();
+    return 0;
+}
+
+function tick(): i32 {
+    breakout.ball_x += breakout.ball_dx;
+    breakout.ball_y += breakout.ball_dy;
+    let hit_id: i32 = first_brick_at(breakout.ball_x, breakout.ball_y);
+    if (hit_id >= 0) {
+        bricks[hit_id].active = false;
+        breakout.ball_dy = -breakout.ball_dy;
+    }
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/src/game_patterns.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/src/game_patterns.stasis
@@ -1,0 +1,286 @@
+const ENEMY_CAPACITY: i32 = 4;
+const WAVE_CAPACITY: i32 = 6;
+const MAX_SPAWNS_PER_STEP: i32 = 2;
+const INPUT_CAPACITY: i32 = 2;
+
+struct EnemySlot {
+    active: bool;
+    health: i32;
+    path_position: i32;
+}
+
+struct WaveEvent {
+    spawn_tick: i32;
+    health: i32;
+}
+
+struct TowerRules {
+    damage: i32;
+    range_end: i32;
+    cooldown_ticks: i32;
+}
+
+struct TowerRuleInput {
+    damage: i32;
+    range_end: i32;
+    cooldown_ticks: i32;
+}
+
+struct AttackIntent {
+    valid: bool;
+    target_id: i32;
+    damage: i32;
+}
+
+struct RenderEnemy {
+    visible: bool;
+    stable_id: i32;
+    path_position: i32;
+    health: i32;
+}
+
+struct SimulationState {
+    tick_index: i32;
+    wave_count: i32;
+    wave_cursor: i32;
+    cooldown_ticks: i32;
+    capacity_blocked: bool;
+    spawned_count: i32;
+    defeated_count: i32;
+}
+
+global state: SimulationState;
+global enemies: EnemySlot[4];
+global wave_events: WaveEvent[6];
+global tower_rules: TowerRules;
+global pending_inputs: TowerRuleInput[2];
+global pending_input_count: i32;
+global pending_attack: AttackIntent;
+global render_enemies: RenderEnemy[4];
+global render_enemy_count: i32;
+
+function reset_simulation(): void {
+    state.tick_index = 0;
+    state.wave_count = 0;
+    state.wave_cursor = 0;
+    state.cooldown_ticks = 0;
+    state.capacity_blocked = false;
+    state.spawned_count = 0;
+    state.defeated_count = 0;
+    tower_rules.damage = 2;
+    tower_rules.range_end = 8;
+    tower_rules.cooldown_ticks = 2;
+    pending_input_count = 0;
+    pending_attack.valid = false;
+    pending_attack.target_id = -1;
+    pending_attack.damage = 0;
+    render_enemy_count = 0;
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        enemies[slot_id].active = false;
+        enemies[slot_id].health = 0;
+        enemies[slot_id].path_position = 0;
+        render_enemies[slot_id].visible = false;
+    }
+}
+
+function submit_tower_rules(damage: i32, range_end: i32, cooldown_ticks: i32): bool {
+    if (damage <= 0 || range_end < 0 || cooldown_ticks < 0) {
+        return false;
+    }
+    if (pending_input_count >= INPUT_CAPACITY) {
+        return false;
+    }
+    let input_index: i32 = pending_input_count;
+    pending_inputs[input_index].damage = damage;
+    pending_inputs[input_index].range_end = range_end;
+    pending_inputs[input_index].cooldown_ticks = cooldown_ticks;
+    pending_input_count += 1;
+    return true;
+}
+
+function apply_pending_inputs(): void {
+    for (let input_index: i32 = 0; input_index < pending_input_count; input_index += 1) {
+        tower_rules.damage = pending_inputs[input_index].damage;
+        tower_rules.range_end = pending_inputs[input_index].range_end;
+        tower_rules.cooldown_ticks = pending_inputs[input_index].cooldown_ticks;
+    }
+    pending_input_count = 0;
+}
+
+function set_wave_event(index: i32, spawn_tick: i32, health: i32): void {
+    wave_events[index].spawn_tick = spawn_tick;
+    wave_events[index].health = health;
+}
+
+function wave_is_valid(count: i32): bool {
+    if (count < 0 || count > WAVE_CAPACITY) {
+        return false;
+    }
+    for (let index: i32 = 0; index < count; index += 1) {
+        if (wave_events[index].spawn_tick < 0 || wave_events[index].health <= 0) {
+            return false;
+        }
+        if (index > 0 && wave_events[index].spawn_tick < wave_events[index - 1].spawn_tick) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function activate_wave(count: i32): bool {
+    if (!wave_is_valid(count)) {
+        return false;
+    }
+    state.wave_count = count;
+    state.wave_cursor = 0;
+    state.capacity_blocked = false;
+    return true;
+}
+
+function configure_example_wave(): bool {
+    set_wave_event(0, 0, 3);
+    set_wave_event(1, 0, 4);
+    set_wave_event(2, 2, 5);
+    set_wave_event(3, 4, 6);
+    return activate_wave(4);
+}
+
+function allocate_enemy(health: i32): i32 {
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (!enemies[slot_id].active) {
+            enemies[slot_id].active = true;
+            enemies[slot_id].health = health;
+            enemies[slot_id].path_position = 0;
+            state.spawned_count += 1;
+            return slot_id;
+        }
+    }
+    return -1;
+}
+
+function spawn_due_events(): void {
+    state.capacity_blocked = false;
+    let attempts: i32 = 0;
+    for (attempts = 0; attempts < MAX_SPAWNS_PER_STEP && state.wave_cursor < state.wave_count; attempts += 1) {
+        let event_index: i32 = state.wave_cursor;
+        if (wave_events[event_index].spawn_tick > state.tick_index) {
+            return;
+        }
+        if (allocate_enemy(wave_events[event_index].health) < 0) {
+            state.capacity_blocked = true;
+            return;
+        }
+        state.wave_cursor += 1;
+    }
+}
+
+function advance_cooldown(): void {
+    if (state.cooldown_ticks > 0) {
+        state.cooldown_ticks -= 1;
+    }
+}
+
+function move_enemies(): void {
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (enemies[slot_id].active) {
+            enemies[slot_id].path_position += 1;
+        }
+    }
+}
+
+function select_target(): i32 {
+    let selected_id: i32 = -1;
+    let selected_position: i32 = -1;
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (enemies[slot_id].active && enemies[slot_id].path_position <= tower_rules.range_end) {
+            if (enemies[slot_id].path_position > selected_position) {
+                selected_id = slot_id;
+                selected_position = enemies[slot_id].path_position;
+            }
+        }
+    }
+    return selected_id;
+}
+
+function materialize_attack(): void {
+    pending_attack.valid = false;
+    pending_attack.target_id = -1;
+    pending_attack.damage = 0;
+    if (state.cooldown_ticks != 0) {
+        return;
+    }
+    let target_id: i32 = select_target();
+    if (target_id >= 0) {
+        pending_attack.valid = true;
+        pending_attack.target_id = target_id;
+        pending_attack.damage = tower_rules.damage;
+    }
+}
+
+function commit_attack(): bool {
+    if (!pending_attack.valid) {
+        return false;
+    }
+    let target_id: i32 = pending_attack.target_id;
+    if (target_id < 0 || target_id >= ENEMY_CAPACITY || !enemies[target_id].active) {
+        pending_attack.valid = false;
+        return false;
+    }
+    enemies[target_id].health -= pending_attack.damage;
+    state.cooldown_ticks = tower_rules.cooldown_ticks;
+    pending_attack.valid = false;
+    return true;
+}
+
+function remove_defeated(): void {
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (enemies[slot_id].active && enemies[slot_id].health <= 0) {
+            enemies[slot_id].active = false;
+            state.defeated_count += 1;
+        }
+    }
+}
+
+function active_enemy_count(): i32 {
+    let count: i32 = 0;
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        if (enemies[slot_id].active) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+function main(): i32 {
+    reset_simulation();
+    configure_example_wave();
+    return 0;
+}
+
+function tick(): i32 {
+    apply_pending_inputs();
+    advance_cooldown();
+    spawn_due_events();
+    move_enemies();
+    materialize_attack();
+    commit_attack();
+    remove_defeated();
+    state.tick_index += 1;
+    return 0;
+}
+
+function render(): i32 {
+    render_enemy_count = 0;
+    for (let slot_id: i32 = 0; slot_id < ENEMY_CAPACITY; slot_id += 1) {
+        render_enemies[slot_id].visible = false;
+        if (enemies[slot_id].active) {
+            let command_index: i32 = render_enemy_count;
+            render_enemies[command_index].visible = true;
+            render_enemies[command_index].stable_id = slot_id;
+            render_enemies[command_index].path_position = enemies[slot_id].path_position;
+            render_enemies[command_index].health = enemies[slot_id].health;
+            render_enemy_count += 1;
+        }
+    }
+    return 0;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/src/platformer_landing.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/src/platformer_landing.stasis
@@ -1,0 +1,36 @@
+struct PlatformerState {
+    player_y: i32;
+    player_vy: i32;
+    floor_y: i32;
+    grounded: bool;
+}
+
+global platformer: PlatformerState;
+
+function reset_platformer(): void {
+    platformer.player_y = 0;
+    platformer.player_vy = 0;
+    platformer.floor_y = 10;
+    platformer.grounded = false;
+}
+
+function main(): i32 {
+    reset_platformer();
+    return 0;
+}
+
+function tick(): i32 {
+    platformer.player_vy += 1;
+    platformer.player_y += platformer.player_vy;
+    platformer.grounded = false;
+    if (platformer.player_y >= platformer.floor_y) {
+        platformer.player_y = platformer.floor_y;
+        platformer.player_vy = 0;
+        platformer.grounded = true;
+    }
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/src/pong_goal.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/src/pong_goal.stasis
@@ -1,0 +1,42 @@
+const COURT_LEFT: i32 = 0;
+const COURT_RIGHT: i32 = 100;
+const COURT_CENTER: i32 = 50;
+
+struct PongState {
+    ball_x: i32;
+    ball_dx: i32;
+    left_score: i32;
+    right_score: i32;
+}
+
+global pong: PongState;
+
+function reset_pong(): void {
+    pong.ball_x = COURT_CENTER;
+    pong.ball_dx = 1;
+    pong.left_score = 0;
+    pong.right_score = 0;
+}
+
+function main(): i32 {
+    reset_pong();
+    return 0;
+}
+
+function tick(): i32 {
+    pong.ball_x += pong.ball_dx;
+    if (pong.ball_x < COURT_LEFT) {
+        pong.right_score += 1;
+        pong.ball_x = COURT_CENTER;
+        pong.ball_dx = 1;
+    } else if (pong.ball_x > COURT_RIGHT) {
+        pong.left_score += 1;
+        pong.ball_x = COURT_CENTER;
+        pong.ball_dx = -1;
+    }
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/src/snake_turn.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/src/snake_turn.stasis
@@ -1,0 +1,57 @@
+struct SnakeState {
+    head_x: i32;
+    head_y: i32;
+    direction_x: i32;
+    direction_y: i32;
+    queued_x: i32;
+    queued_y: i32;
+    has_queued_turn: bool;
+}
+
+global snake: SnakeState;
+
+function reset_snake(): void {
+    snake.head_x = 4;
+    snake.head_y = 4;
+    snake.direction_x = 1;
+    snake.direction_y = 0;
+    snake.queued_x = 0;
+    snake.queued_y = 0;
+    snake.has_queued_turn = false;
+}
+
+function queue_turn(x: i32, y: i32): bool {
+    let horizontal: bool =(x == -1 || x == 1) && y == 0;
+    let vertical: bool = x == 0 &&(y == -1 || y == 1);
+    if (!horizontal && !vertical) {
+        return false;
+    }
+    snake.queued_x = x;
+    snake.queued_y = y;
+    snake.has_queued_turn = true;
+    return true;
+}
+
+function main(): i32 {
+    reset_snake();
+    return 0;
+}
+
+function tick(): i32 {
+    if (snake.has_queued_turn) {
+        let reverses_x: bool = snake.queued_x == -snake.direction_x;
+        let reverses_y: bool = snake.queued_y == -snake.direction_y;
+        if (!reverses_x && !reverses_y) {
+            snake.direction_x = snake.queued_x;
+            snake.direction_y = snake.queued_y;
+        }
+        snake.has_queued_turn = false;
+    }
+    snake.head_x += snake.direction_x;
+    snake.head_y += snake.direction_y;
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/stasis.json
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/stasis.json
@@ -1,0 +1,7 @@
+{
+  "manifest_version": 1,
+  "name": "Knowledge Library Examples",
+  "entry": "src/game_patterns.stasis",
+  "tests": "tests",
+  "output": "build"
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/tests/breakout_brick.test.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/tests/breakout_brick.test.stasis
@@ -1,0 +1,19 @@
+import "../src/breakout_brick.stasis";
+
+test `one tick removes one overlapping brick and reflects once`(): bool {
+    reset_breakout();
+    for (let brick_id: i32 = 0; brick_id < BRICK_CAPACITY; brick_id += 1) {
+        bricks[brick_id].active = true;
+        bricks[brick_id].left = 4;
+        bricks[brick_id].right = 6;
+        bricks[brick_id].top = 4;
+        bricks[brick_id].bottom = 6;
+    }
+    breakout.ball_x = 5;
+    breakout.ball_y = 3;
+    breakout.ball_dy = 1;
+
+    tick();
+
+    return !bricks[0].active && bricks[1].active && breakout.ball_dy == -1;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/tests/game_patterns.test.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/tests/game_patterns.test.stasis
@@ -1,0 +1,266 @@
+import "../src/game_patterns.stasis";
+
+test `invalid wave metadata does not activate a wave`(): bool {
+    reset_simulation();
+    set_wave_event(0, 3, 2);
+    set_wave_event(1, 2, 2);
+    let count_before: i32 = state.wave_count;
+    let cursor_before: i32 = state.wave_cursor;
+
+    return !activate_wave(2) && state.wave_count == count_before && state.wave_cursor == cursor_before;
+}
+
+test `target ties choose the lower stable slot id`(): bool {
+    reset_simulation();
+    let first_id: i32 = allocate_enemy(5);
+    let second_id: i32 = allocate_enemy(5);
+    enemies[first_id].path_position = 4;
+    enemies[second_id].path_position = enemies[first_id].path_position;
+
+    return first_id < second_id && select_target() == first_id;
+}
+
+test `invalid input never enters the queue`(): bool {
+    reset_simulation();
+
+    return !submit_tower_rules(3, -1, 2) && pending_input_count == 0;
+}
+
+test `queued input does not mutate live rules`(): bool {
+    reset_simulation();
+    let damage_before: i32 = tower_rules.damage;
+    let range_before: i32 = tower_rules.range_end;
+    let cooldown_before: i32 = tower_rules.cooldown_ticks;
+
+    if (!submit_tower_rules(4, 6, 3)) {
+        return false;
+    }
+
+    return pending_input_count == 1 && tower_rules.damage == damage_before && tower_rules.range_end == range_before && tower_rules.cooldown_ticks == cooldown_before;
+}
+
+test `accepted inputs apply in queue order`(): bool {
+    reset_simulation();
+    submit_tower_rules(3, 7, 1);
+    submit_tower_rules(5, 4, 2);
+    let last_damage: i32 = pending_inputs[1].damage;
+    let last_range: i32 = pending_inputs[1].range_end;
+    let last_cooldown: i32 = pending_inputs[1].cooldown_ticks;
+
+    apply_pending_inputs();
+
+    return tower_rules.damage == last_damage && tower_rules.range_end == last_range && tower_rules.cooldown_ticks == last_cooldown;
+}
+
+test `a full input queue preserves accepted entries`(): bool {
+    reset_simulation();
+    submit_tower_rules(3, 7, 1);
+    submit_tower_rules(5, 4, 2);
+    let accepted_damage: i32 = pending_inputs[1].damage;
+
+    let accepted: bool = submit_tower_rules(9, 9, 9);
+
+    return !accepted && pending_input_count == INPUT_CAPACITY && pending_inputs[1].damage == accepted_damage;
+}
+
+test `applied input is consumed once`(): bool {
+    reset_simulation();
+    submit_tower_rules(3, 7, 1);
+    apply_pending_inputs();
+    let applied_damage: i32 = tower_rules.damage;
+    pending_inputs[0].damage = applied_damage + 1;
+
+    apply_pending_inputs();
+
+    return pending_input_count == 0 && tower_rules.damage == applied_damage;
+}
+
+test `cooldown gates attack materialization until ready`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    state.cooldown_ticks = 1;
+
+    materialize_attack();
+    let blocked: bool = !pending_attack.valid;
+    advance_cooldown();
+    materialize_attack();
+
+    return blocked && pending_attack.valid && pending_attack.target_id == target_id;
+}
+
+test `spawn work stops at its per-step allowance`(): bool {
+    reset_simulation();
+    set_wave_event(0, 0, 2);
+    set_wave_event(1, 0, 3);
+    set_wave_event(2, 0, 4);
+    activate_wave(3);
+    let cursor_before: i32 = state.wave_cursor;
+    let active_before: i32 = active_enemy_count();
+
+    spawn_due_events();
+
+    return state.wave_cursor - cursor_before == MAX_SPAWNS_PER_STEP && active_enemy_count() - active_before == MAX_SPAWNS_PER_STEP && state.wave_cursor < state.wave_count;
+}
+
+test `capacity leaves an unprocessed spawn event pending`(): bool {
+    reset_simulation();
+    for (let index: i32 = 0; index < ENEMY_CAPACITY; index += 1) {
+        allocate_enemy(1);
+    }
+    set_wave_event(0, 0, 3);
+    activate_wave(1);
+    let cursor_before: i32 = state.wave_cursor;
+
+    spawn_due_events();
+
+    return state.capacity_blocked && state.wave_cursor == cursor_before && active_enemy_count() == ENEMY_CAPACITY;
+}
+
+test `movement changes active slots only`(): bool {
+    reset_simulation();
+    let active_id: i32 = allocate_enemy(5);
+    let inactive_id: i32 = 1;
+    enemies[active_id].path_position = 3;
+    enemies[inactive_id].path_position = 9;
+    let active_before: i32 = enemies[active_id].path_position;
+    let inactive_before: i32 = enemies[inactive_id].path_position;
+
+    move_enemies();
+
+    return enemies[active_id].path_position == active_before + 1 && enemies[inactive_id].path_position == inactive_before && !enemies[inactive_id].active;
+}
+
+test `attack materialization does not mutate gameplay state`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    enemies[target_id].path_position = 3;
+    let health_before: i32 = enemies[target_id].health;
+    let active_before: i32 = active_enemy_count();
+    let cooldown_before: i32 = state.cooldown_ticks;
+
+    materialize_attack();
+
+    if (!pending_attack.valid || pending_attack.target_id != target_id) {
+        return false;
+    }
+    return enemies[target_id].health == health_before && active_enemy_count() == active_before && state.cooldown_ticks == cooldown_before;
+}
+
+test `attack commit consumes one intent once`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    pending_attack.valid = true;
+    pending_attack.target_id = target_id;
+    pending_attack.damage = 3;
+    let health_before: i32 = enemies[target_id].health;
+    let damage: i32 = pending_attack.damage;
+
+    let first_commit: bool = commit_attack();
+    let health_after: i32 = enemies[target_id].health;
+    let second_commit: bool = commit_attack();
+
+    return first_commit && !second_commit && health_after == health_before - damage && enemies[target_id].health == health_after;
+}
+
+test `removal releases defeated slots and preserves survivors`(): bool {
+    reset_simulation();
+    let removed_id: i32 = allocate_enemy(1);
+    let survivor_id: i32 = allocate_enemy(4);
+    let survivor_health: i32 = enemies[survivor_id].health;
+    let defeated_before: i32 = state.defeated_count;
+    enemies[removed_id].health = 0;
+
+    remove_defeated();
+
+    return !enemies[removed_id].active && enemies[survivor_id].active && enemies[survivor_id].health == survivor_health && state.defeated_count == defeated_before + 1;
+}
+
+test `allocation reuses the lowest released slot`(): bool {
+    reset_simulation();
+    let released_id: i32 = allocate_enemy(1);
+    let survivor_id: i32 = allocate_enemy(4);
+    enemies[released_id].health = 0;
+    remove_defeated();
+
+    let reused_id: i32 = allocate_enemy(6);
+
+    return reused_id == released_id && enemies[survivor_id].active;
+}
+
+test `render projects active slots in stable order`(): bool {
+    reset_simulation();
+    let first_id: i32 = allocate_enemy(5);
+    let second_id: i32 = allocate_enemy(7);
+    enemies[first_id].path_position = 2;
+    enemies[second_id].path_position = 6;
+
+    render();
+
+    if (render_enemy_count != 2) {
+        return false;
+    }
+    let first_matches: bool = render_enemies[0].stable_id == first_id && render_enemies[0].path_position == enemies[first_id].path_position;
+    let second_matches: bool = render_enemies[1].stable_id == second_id && render_enemies[1].path_position == enemies[second_id].path_position;
+    return first_matches && second_matches;
+}
+
+test `render preserves authoritative gameplay state`(): bool {
+    reset_simulation();
+    let enemy_id: i32 = allocate_enemy(5);
+    enemies[enemy_id].path_position = 3;
+    let tick_before: i32 = state.tick_index;
+    let health_before: i32 = enemies[enemy_id].health;
+    let position_before: i32 = enemies[enemy_id].path_position;
+
+    render();
+
+    return state.tick_index == tick_before && enemies[enemy_id].health == health_before && enemies[enemy_id].path_position == position_before && enemies[enemy_id].active;
+}
+
+test `public tick applies input and movement before targeting`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(5);
+    let health_before: i32 = enemies[target_id].health;
+    let position_before: i32 = enemies[target_id].path_position;
+    submit_tower_rules(4, 0, 3);
+
+    tick();
+
+    if (state.tick_index != 1 || pending_input_count != 0 || tower_rules.range_end != 0) {
+        return false;
+    }
+    return enemies[target_id].path_position == position_before + 1 && enemies[target_id].health == health_before && !pending_attack.valid;
+}
+
+test `short tick trace reveals the first divergent system`(): bool {
+    reset_simulation();
+    let target_id: i32 = allocate_enemy(9);
+    submit_tower_rules(2, 8, 2);
+    let damage: i32 = pending_inputs[0].damage;
+    let cooldown: i32 = pending_inputs[0].cooldown_ticks;
+    let initial_health: i32 = enemies[target_id].health;
+
+    tick();
+    if (
+        state.tick_index != 1
+        || enemies[target_id].path_position != 1
+        || enemies[target_id].health != initial_health - damage
+        || state.cooldown_ticks != cooldown
+    ) {
+        return false;
+    }
+
+    let health_after_attack: i32 = enemies[target_id].health;
+    tick();
+    if (
+        state.tick_index != 2
+        || enemies[target_id].path_position != 2
+        || enemies[target_id].health != health_after_attack
+        || state.cooldown_ticks != cooldown - 1
+    ) {
+        return false;
+    }
+
+    tick();
+    return state.tick_index == 3 && enemies[target_id].path_position == 3 && enemies[target_id].health == health_after_attack - damage && state.cooldown_ticks == cooldown;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/tests/platformer_landing.test.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/tests/platformer_landing.test.stasis
@@ -1,0 +1,11 @@
+import "../src/platformer_landing.stasis";
+
+test `falling through the floor boundary lands in the same tick`(): bool {
+    reset_platformer();
+    platformer.player_y = 8;
+    platformer.player_vy = 2;
+
+    tick();
+
+    return platformer.player_y == platformer.floor_y && platformer.player_vy == 0 && platformer.grounded;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/tests/pong_goal.test.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/tests/pong_goal.test.stasis
@@ -1,0 +1,18 @@
+import "../src/pong_goal.stasis";
+
+test `crossing the right goal scores once and resets play`(): bool {
+    reset_pong();
+    pong.left_score = 4;
+    pong.right_score = 7;
+    pong.ball_x = COURT_RIGHT;
+    pong.ball_dx = 1;
+
+    tick();
+    if (pong.left_score != 5 || pong.right_score != 7 || pong.ball_x != COURT_CENTER || pong.ball_dx != -1) {
+        return false;
+    }
+
+    tick();
+
+    return pong.left_score == 5 && pong.right_score == 7 && pong.ball_x == COURT_CENTER - 1 && pong.ball_dx == -1;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/examples/tests/snake_turn.test.stasis
+++ b/samples/asset_breakout/vendor/stasis/docs/examples/tests/snake_turn.test.stasis
@@ -1,0 +1,13 @@
+import "../src/snake_turn.stasis";
+
+test `a reverse turn is consumed without reversing movement`(): bool {
+    reset_snake();
+    let x_before: i32 = snake.head_x;
+    if (!queue_turn(-1, 0)) {
+        return false;
+    }
+
+    tick();
+
+    return snake.head_x == x_before + 1 && snake.direction_x == 1 && !snake.has_queued_turn;
+}

--- a/samples/asset_breakout/vendor/stasis/docs/geometry-and-collision.md
+++ b/samples/asset_breakout/vendor/stasis/docs/geometry-and-collision.md
@@ -1,0 +1,116 @@
+# Geometry and collision
+
+<!-- tags: 2d, geometry, collision, shapes, contact, deterministic-order -->
+
+Geometry is authoritative data plus an explicit collision policy. Rendering may
+show a sprite, tile, or primitive, but collision should read the simulation's
+position and shape data directly.
+
+Stasis does not prescribe one collision API. The bundled example demonstrates
+stable IDs and query/materialize/commit with attacks; the geometric policies on
+this page are general design guidance rather than claims about example code.
+
+## Coordinate and shape contract
+
+Declare one coordinate contract for the simulation:
+
+- origin and positive-axis directions;
+- units and permitted numeric range;
+- whether positions identify a center, corner, or cell;
+- whether a rectangle is represented by edges or by position plus extent;
+- whether coordinates are integer cells or fixed-point values.
+
+Keep position separate from collision shape. A moving object can have a visual
+position, a collision center, and one or more collision volumes without making
+the renderer part of the collision query. A shape may be smaller than the
+visible art, and a multi-part object may need several volumes. Name that choice
+in the game rules.
+
+Normalize shape data before testing. For an axis-aligned rectangle, keep
+`left <= right` and `top <= bottom`. Reject or repair invalid authored shapes
+at the data boundary; do not let every collision caller invent its own repair.
+
+## Contact versus overlap
+
+Choose equality deliberately and use the policy that matches the game rule.
+
+| Policy | Boundary condition | Typical use |
+| --- | --- | --- |
+| Inclusive contact | Equal edges count as a hit | Solid walls, support surfaces, blocking volumes |
+| Strict overlap | Positive area or penetration is required | Damage areas, trigger regions, non-solid proximity |
+| Cell occupancy | The same canonical cell is occupied | Grid movement, placement, board rules |
+
+Do not mix policies accidentally between walls, units, projectiles, and
+triggers. Give a predicate a policy-specific name and test equality plus the
+nearest value on both sides of the boundary.
+
+Separate detection from response. A contact can block movement, apply damage,
+open a trigger, bounce an object, or do nothing. The shape test should identify
+the geometric fact; a pair policy should choose the gameplay consequence.
+
+## Pair policy data
+
+For systems with several object kinds, express pair behavior as data or as a
+small set of explicit policy branches:
+
+| Pair | Query rule | Commit rule |
+| --- | --- | --- |
+| mover / wall | Test the mover volume against the wall volume | Clamp or separate, then constrain movement |
+| projectile / target | Test the projectile volume against the target volume | Apply one damage event and retire the projectile if required |
+| unit / trigger | Test the unit volume against the trigger volume | Emit one bounded trigger event |
+| unit / unit | Use the declared contact policy | Block, overlap, or ignore according to the rule table |
+
+The policy table should state whether a pair is symmetric, which side owns the
+response, and whether repeated contact in one tick is one event or many. Do
+not infer these answers from declaration order or render order.
+
+## Query, materialize, commit
+
+Use three visible phases when collision can mutate state:
+
+1. Query active positions and shapes in a bounded, deterministic order.
+2. Materialize a bounded list of contact or attack intents containing stable
+   object IDs and the data needed for the decision.
+3. Commit intents in the declared order. Recheck that referenced objects are
+   still active before applying damage, separation, scoring, or removal.
+
+Queries must not change health, cooldowns, occupancy, or lifecycle flags.
+Materialized intents make the decision inspectable and prevent a later
+mutation from silently changing which pair was selected. Commit code owns
+mutation and may invalidate later intents explicitly.
+
+## Stable order and removal
+
+Use stable numeric IDs for bounded slots. Scan slots in ascending ID order, or
+define another total order in the rules. When candidates tie on range,
+priority, path position, or contact side, apply the documented tie-breaker
+instead of relying on container or pointer order.
+
+Do not compact an array while a later loop still depends on its indexes unless
+the compaction rule is part of the contract. An active flag with deterministic
+first-free allocation preserves surviving IDs and makes reuse testable. If
+removal is committed during a pass, decide whether later queries see the
+removed object and keep that decision consistent across systems.
+
+## Verification checklist
+
+- Test separated, touching, slight-overlap, containment, and corner cases.
+- Test negative movement and each world boundary.
+- Test a pair with no response and a pair with a response.
+- Test equal-priority candidates and verify the stable tie-breaker.
+- Test one contact that defeats an object and verify no later system acts on it.
+- Test that query/materialize does not mutate authoritative state.
+- Test that render projection may write presentation data without changing
+  authoritative gameplay state.
+
+These are design influences, not additional Stasis semantics:
+
+- [Handmade Hero Day 26: Introduction to Game Architecture](https://guide.handmadehero.org/code/day026/)
+- [Handmade Hero Day 54: Removing the Dormant Entity Concept](https://guide.handmadehero.org/code/day054/)
+- [Handmade Hero Day 63: Simulation Regions](https://guide.handmadehero.org/code/day063/)
+- [Handmade Hero Day 64: Mapping Entity Indexes to Pointers](https://guide.handmadehero.org/code/day064/)
+- [Handmade Hero Day 69: Pairwise Collision Rules](https://guide.handmadehero.org/code/day069/)
+- [Handmade Hero Day 78: Multiple Collision Volumes](https://guide.handmadehero.org/code/day078/)
+- [Mike Acton, Data-Oriented C++](https://www.youtube.com/watch?v=rX0ItVEVjHc)
+- [Richard Fabian, Data-Oriented Design](https://dataorienteddesign.com/dodbook.pdf)
+- [Data Locality](https://gameprogrammingpatterns.com/data-locality.html)

--- a/samples/asset_breakout/vendor/stasis/docs/practical-examples/breakout-remove-one-brick-per-collision.md
+++ b/samples/asset_breakout/vendor/stasis/docs/practical-examples/breakout-remove-one-brick-per-collision.md
@@ -1,0 +1,58 @@
+# Breakout: Remove One Brick on a Vertical Hit
+
+**Goal:** when a moving ball point enters overlapping bricks vertically, remove one deterministic brick and reflect once.
+
+Move the ball, query the first active point hit by stable slot order, then commit one result in `tick()`.
+
+```stasis
+function first_brick_at(x: i32, y: i32): i32 {
+    for (let brick_id: i32 = 0; brick_id < BRICK_CAPACITY; brick_id += 1) {
+        if (
+            bricks[brick_id].active
+            && x >= bricks[brick_id].left
+            && x <= bricks[brick_id].right
+            && y >= bricks[brick_id].top
+            && y <= bricks[brick_id].bottom
+        ) {
+            return brick_id;
+        }
+    }
+    return -1;
+}
+```
+
+```stasis
+function tick(): i32 {
+    breakout.ball_x += breakout.ball_dx;
+    breakout.ball_y += breakout.ball_dy;
+    let hit_id: i32 = first_brick_at(breakout.ball_x, breakout.ball_y);
+    if (hit_id >= 0) {
+        bricks[hit_id].active = false;
+        breakout.ball_dy = -breakout.ball_dy;
+    }
+    return 0;
+}
+```
+
+```stasis
+test `one tick removes one overlapping brick and reflects once`(): bool {
+    reset_breakout();
+    for (let brick_id: i32 = 0; brick_id < BRICK_CAPACITY; brick_id += 1) {
+        bricks[brick_id].active = true;
+        bricks[brick_id].left = 4;
+        bricks[brick_id].right = 6;
+        bricks[brick_id].top = 4;
+        bricks[brick_id].bottom = 6;
+    }
+    breakout.ball_x = 5;
+    breakout.ball_y = 3;
+    breakout.ball_dy = 1;
+
+    tick();
+
+    return !bricks[0].active && bricks[1].active && breakout.ball_dy == -1;
+}
+```
+
+Full source: [breakout_brick.stasis](../examples/src/breakout_brick.stasis)
+

--- a/samples/asset_breakout/vendor/stasis/docs/practical-examples/platformer-land-in-the-crossing-tick.md
+++ b/samples/asset_breakout/vendor/stasis/docs/practical-examples/platformer-land-in-the-crossing-tick.md
@@ -1,0 +1,34 @@
+# Platformer: Land in the Crossing Tick
+
+**Goal:** if gravity moves the player through the floor boundary, finish the same tick on the floor and grounded.
+
+Apply gravity, move, then resolve the boundary. Landing owns position, velocity, and grounded state together.
+
+```stasis
+function tick(): i32 {
+    platformer.player_vy += 1;
+    platformer.player_y += platformer.player_vy;
+    platformer.grounded = false;
+    if (platformer.player_y >= platformer.floor_y) {
+        platformer.player_y = platformer.floor_y;
+        platformer.player_vy = 0;
+        platformer.grounded = true;
+    }
+    return 0;
+}
+```
+
+```stasis
+test `falling through the floor boundary lands in the same tick`(): bool {
+    reset_platformer();
+    platformer.player_y = 8;
+    platformer.player_vy = 2;
+
+    tick();
+
+    return platformer.player_y == platformer.floor_y && platformer.player_vy == 0 && platformer.grounded;
+}
+```
+
+Full source: [platformer_landing.stasis](../examples/src/platformer_landing.stasis)
+

--- a/samples/asset_breakout/vendor/stasis/docs/practical-examples/pong-score-after-the-ball-crosses-the-goal.md
+++ b/samples/asset_breakout/vendor/stasis/docs/practical-examples/pong-score-after-the-ball-crosses-the-goal.md
@@ -1,0 +1,45 @@
+# Pong: Score After the Ball Crosses the Goal
+
+**Goal:** award one point, reset the ball, and send it back into play.
+
+Move first. Resolve either goal once. Keep scoring and reset in the same `tick()`.
+
+```stasis
+function tick(): i32 {
+    pong.ball_x += pong.ball_dx;
+    if (pong.ball_x < COURT_LEFT) {
+        pong.right_score += 1;
+        pong.ball_x = COURT_CENTER;
+        pong.ball_dx = 1;
+    } else if (pong.ball_x > COURT_RIGHT) {
+        pong.left_score += 1;
+        pong.ball_x = COURT_CENTER;
+        pong.ball_dx = -1;
+    }
+    return 0;
+}
+```
+
+Test the whole transition, not the chosen court dimensions.
+
+```stasis
+test `crossing the right goal scores once and resets play`(): bool {
+    reset_pong();
+    pong.left_score = 4;
+    pong.right_score = 7;
+    pong.ball_x = COURT_RIGHT;
+    pong.ball_dx = 1;
+
+    tick();
+    if (pong.left_score != 5 || pong.right_score != 7 || pong.ball_x != COURT_CENTER || pong.ball_dx != -1) {
+        return false;
+    }
+
+    tick();
+
+    return pong.left_score == 5 && pong.right_score == 7 && pong.ball_x == COURT_CENTER - 1 && pong.ball_dx == -1;
+}
+```
+
+Full source: [pong_goal.stasis](../examples/src/pong_goal.stasis)
+

--- a/samples/asset_breakout/vendor/stasis/docs/practical-examples/snake-reject-a-reverse-turn.md
+++ b/samples/asset_breakout/vendor/stasis/docs/practical-examples/snake-reject-a-reverse-turn.md
@@ -1,0 +1,39 @@
+# Snake: Reject a Reverse Turn
+
+**Goal:** consume a queued turn without allowing a 180-degree direction change.
+
+Compare the queued direction with the current direction at the start of `tick()`. Move only after the direction is settled.
+
+```stasis
+function tick(): i32 {
+    if (snake.has_queued_turn) {
+        let reverses_x: bool = snake.queued_x == -snake.direction_x;
+        let reverses_y: bool = snake.queued_y == -snake.direction_y;
+        if (!reverses_x && !reverses_y) {
+            snake.direction_x = snake.queued_x;
+            snake.direction_y = snake.queued_y;
+        }
+        snake.has_queued_turn = false;
+    }
+    snake.head_x += snake.direction_x;
+    snake.head_y += snake.direction_y;
+    return 0;
+}
+```
+
+```stasis
+test `a reverse turn is consumed without reversing movement`(): bool {
+    reset_snake();
+    let x_before: i32 = snake.head_x;
+    if (!queue_turn(-1, 0)) {
+        return false;
+    }
+
+    tick();
+
+    return snake.head_x == x_before + 1 && snake.direction_x == 1 && !snake.has_queued_turn;
+}
+```
+
+Full source: [snake_turn.stasis](../examples/src/snake_turn.stasis)
+

--- a/samples/asset_breakout/vendor/stasis/docs/semantic-edit-and-validation.md
+++ b/samples/asset_breakout/vendor/stasis/docs/semantic-edit-and-validation.md
@@ -1,0 +1,108 @@
+# Semantic edit and validation
+
+<!-- tags: symbols, references, source-hash, atomic-apply, compiler, tests, runtime -->
+
+Stasis edits operate on compiler-discovered source items. The unit of change
+is an import group, globals group, struct, function, or test declaration, not a
+guessed text range. The semantic tooling owns source spans, declaration
+replacement, import handling, candidate compilation, receipts, and rollback.
+
+## Discover before editing
+
+Start with a scoped symbol inventory using `stasis --json symbol list`. Narrow
+it with `--file`, `--kind`, `--owner`, `--query`, and paging options. Use
+`symbol find` when several declarations may share a name; use `symbol read`
+when one exact item is required.
+
+Before changing behavior, run `stasis --json symbol references SYMBOL` for the
+relevant function, struct, global field, or qualified field path. Inspect the
+definitions, reads, writes, and calls. A name match is not enough evidence
+that the target is the correct boundary.
+
+`symbol list` returns compact metadata. `symbol find` adds `source_hash`, and
+`symbol read` returns the complete source item, including `symbol_id`, source
+spans, source, and source hash. These fields have different roles:
+
+| Field | Meaning |
+| --- | --- |
+| `symbol_id` | Canonical semantic identity; required by schema-version 2 batch selectors |
+| `kind` | `imports`, `globals`, `struct`, `function`, or `test` |
+| `file` | Project-relative source or test file |
+| `name` | Semantic declaration name |
+| `owner` | Optional containing type or scope |
+| `signature` | Normalized declaration signature; optional in a selector |
+| `source_hash` | Hash of the current item source used for optimistic concurrency |
+
+For direct CLI selection, add `kind`, `file`, `owner`, and `signature` as needed
+to disambiguate the name. For a schema-version 2 `symbol apply` request, use the
+`symbol_id` returned by `symbol read`. Keep that read's `source_hash` as the
+expected hash for an update or delete.
+
+## Plan a semantic operation
+
+Choose `add`, `update`, `delete`, or a related `apply` batch. For an update,
+provide the complete replacement declaration and the expected source hash.
+Do not reconstruct a partial declaration from a line offset. For related
+changes, put all edits in one versioned request so the compiler can validate
+their relationships together.
+
+Use a dry run when the target, import ownership, or changed-file set is
+uncertain. A dry run compiler-validates the candidate without writing files or
+running tests. The response reports successful validation, and its plan records:
+
+- the normalized edits;
+- each changed file's complete before and after source plus hashes;
+- the expected reload classification.
+
+Embedded imports in replacement source are merged, and unused imports in
+touched files are pruned. Inspect the plan's after-source when import changes
+matter.
+
+## Apply atomically
+
+`stasis symbol apply --request REQUEST.json` plans the complete batch in memory,
+handles imports, and compiler-validates the resulting workspace before writing.
+A normal apply then writes the batch and runs the project tests. Candidate
+compilation failure leaves source files untouched. A write, test, or receipt
+failure triggers rollback of touched source files; an error reports separately
+if rollback is incomplete. A successful operation writes a receipt that records
+the reversible change.
+
+Use `--no-tests` only when the surrounding workflow explicitly owns an
+equivalent test gate. It weakens the normal behavior guarantee and should be
+visible in the edit record.
+
+After a successful apply, retain the receipt and the post-edit source hashes.
+Revert through the semantic receipt; the revert operation verifies the expected
+post-edit state before restoring the prior source.
+
+## Validate behavior
+
+Validation has distinct layers:
+
+1. Run `stasis fmt --check` to catch formatting drift without mutating files.
+2. Run `stasis check` for project compilation and diagnostics.
+3. Run `stasis test` for deterministic state-transition and regression tests.
+4. Use fresh `stasis validate PATH OP VALUE --frames N` evidence for observable
+   runtime state.
+5. Inspect the final changed-file list and the receipt before reporting success.
+
+Passing compilation proves that the source is valid. Passing tests proves only
+the behavior covered by those tests. Fresh runtime validation proves the
+observable path selected by that validation. Keep all three claims separate.
+
+## Failure and recovery
+
+| Failure | First check | Correct response |
+| --- | --- | --- |
+| No symbol or several symbols match | Scope, kind, file, owner, signature | Refine discovery; do not guess a text location |
+| Source hash is stale | Current `symbol read` result | Re-read references and re-plan from the current source |
+| Reference set is broader than expected | Reads, writes, callers, and import map | Include the affected declarations or narrow the intended change |
+| Batch does not compile | First compiler diagnostic in the changed item | Correct the smallest semantic unit and rerun the dry run |
+| Tests reject the batch | Failing invariant and first divergent tick | Repair behavior, preserve the regression, and reapply |
+| Runtime evidence disagrees | Fresh validation setup and projection boundary | Inspect authoritative state and render projection separately |
+| Apply fails after multiple edits | Error plus current source hashes | Confirm rollback restored every touched file before retrying |
+
+Do not call an edit successful because source bytes changed. The success record
+should include the semantic target, expected hash, changed files, compiler/test
+result, runtime evidence when observable behavior changed, and the receipt path.

--- a/samples/asset_breakout/vendor/stasis/stdlib/asset_tasks.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/asset_tasks.stasis
@@ -1,0 +1,220 @@
+@link("stasis_graphics");
+
+enum AssetState {
+    None,
+    Pending,
+    Loading,
+    Loaded,
+    Failed,
+    Cancelled,
+}
+
+struct ImageAsset {
+    handle: i32;
+    request: i32;
+    state: AssetState;
+    width: i32;
+    height: i32;
+}
+
+struct AudioAsset {
+    handle: i32;
+    request: i32;
+    state: AssetState;
+}
+
+struct LoadingProgress {
+    total_count: i32;
+    loaded_count: i32;
+    failed_count: i32;
+    in_progress_count: i32;
+    percent: i32;
+    displayed_percent: i32;
+}
+
+function reset(self: LoadingProgress): void {
+    self.total_count = 0;
+    self.loaded_count = 0;
+    self.failed_count = 0;
+    self.in_progress_count = 0;
+    self.percent = 0;
+    self.displayed_percent = 0;
+}
+
+function advance(self: LoadingProgress, total_count: i32, loaded_count: i32, failed_count: i32): i32 {
+    self.total_count = total_count;
+    if (self.total_count < 0) {
+        self.total_count = 0;
+    }
+
+    self.loaded_count = loaded_count;
+    if (self.loaded_count < 0) {
+        self.loaded_count = 0;
+    }
+
+    self.failed_count = failed_count;
+    if (self.failed_count < 0) {
+        self.failed_count = 0;
+    }
+
+    let completed_count: i32 = self.loaded_count + self.failed_count;
+    if (completed_count > self.total_count) {
+        completed_count = self.total_count;
+    }
+
+    self.in_progress_count = self.total_count - completed_count;
+    if (self.total_count == 0) {
+        self.percent = 0;
+    } else {
+        self.percent =(completed_count * 100) / self.total_count;
+    }
+
+    if (self.percent > self.displayed_percent) {
+        self.displayed_percent = self.displayed_percent + 1;
+    } else if (self.percent < self.displayed_percent) {
+        self.displayed_percent = self.percent;
+    }
+    return self.displayed_percent;
+}
+
+function complete(self: LoadingProgress): bool {
+    return self.total_count == 0 || self.loaded_count + self.failed_count >= self.total_count;
+}
+
+function successful(self: LoadingProgress): bool {
+    return self.complete() && self.failed_count == 0;
+}
+
+function @effects(graphics)@extern("stasis_jit_asset_request_sprite") asset_request_sprite(path: string, width: i32, height: i32): i32;
+function @effects(audio)@extern("stasis_jit_asset_request_audio") asset_request_audio(path: string): i32;
+function @effects(platform)@extern("stasis_jit_asset_task_poll") asset_task_state(request: i32): AssetState;
+function @effects(platform)@extern("stasis_jit_asset_task_take_handle") asset_task_take_handle(request: i32): i32;
+function @effects(platform)@extern("stasis_jit_asset_task_cancel") asset_task_cancel(request: i32): void;
+function @effects(graphics)@extern("stasis_jit_gfx_release_sprite") gfx_release_sprite(handle: i32): void;
+
+extern function @effects(audio) audio_release(asset_handle: i32): void;
+
+function reset_image(self: ImageAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle != 0) {
+        gfx_release_sprite(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}
+
+// Sprite ownership lives beside the asset release overloads so callers that
+// import graphics get one unambiguous receiver-method module, while direct
+// asset_tasks imports keep the existing ImageAsset/AudioAsset release API.
+struct Sprite {
+    handle: i32;
+    width: i32;
+    height: i32;
+}
+
+function reset_audio(self: AudioAsset): void {
+    if (self.request > 0) {
+        asset_task_cancel(self.request);
+    }
+    if (self.handle != 0) {
+        audio_release(self.handle);
+    }
+    self.request = 0;
+    self.handle = 0;
+    self.state = AssetState.None;
+}
+
+function release(self: ImageAsset): void {
+    reset_image(self);
+}
+
+function release(self: AudioAsset): void {
+    reset_audio(self);
+}
+
+// Release is safe to call repeatedly. A Sprite is an owning value only when
+// it was populated by load_sprite_from; copied integer handles do not acquire
+// another native reference.
+function release(self: Sprite): void {
+    if (self.handle != 0) {
+        gfx_release_sprite(self.handle);
+    }
+    self.handle = 0;
+    self.width = 0;
+    self.height = 0;
+}
+
+function @asset_path(path) load_image(self: ImageAsset, path: string, width: i32, height: i32): bool {
+    reset_image(self);
+    self.request = asset_request_sprite(path, width, height);
+    self.width = width;
+    self.height = height;
+    if (self.request <= 0) {
+        self.state = AssetState.Failed;
+        return false;
+    }
+    self.state = AssetState.Pending;
+    return true;
+}
+
+function @asset_path(path) load_audio(self: AudioAsset, path: string): bool {
+    reset_audio(self);
+    self.request = asset_request_audio(path);
+    if (self.request <= 0) {
+        self.state = AssetState.Failed;
+        return false;
+    }
+    self.state = AssetState.Pending;
+    return true;
+}
+
+function status(self: ImageAsset): AssetState {
+    if (self.request <= 0) {
+        return self.state;
+    }
+    self.state = asset_task_state(self.request);
+    if (self.state == AssetState.Loaded) {
+        self.handle = asset_task_take_handle(self.request);
+        self.request = 0;
+        if (self.handle == 0) {
+            self.state = AssetState.Failed;
+        }
+    }
+    return self.state;
+}
+
+function status(self: AudioAsset): AssetState {
+    if (self.request <= 0) {
+        return self.state;
+    }
+    self.state = asset_task_state(self.request);
+    if (self.state == AssetState.Loaded) {
+        self.handle = asset_task_take_handle(self.request);
+        self.request = 0;
+        if (self.handle == 0) {
+            self.state = AssetState.Failed;
+        }
+    }
+    return self.state;
+}
+
+function ready(self: ImageAsset): bool {
+    return self.status() == AssetState.Loaded;
+}
+
+function ready(self: AudioAsset): bool {
+    return self.status() == AssetState.Loaded;
+}
+
+function failed(self: ImageAsset): bool {
+    let current: AssetState = self.status();
+    return current == AssetState.Failed || current == AssetState.Cancelled;
+}
+
+function failed(self: AudioAsset): bool {
+    let current: AssetState = self.status();
+    return current == AssetState.Failed || current == AssetState.Cancelled;
+}

--- a/samples/asset_breakout/vendor/stasis/stdlib/audio.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/audio.stasis
@@ -1,33 +1,73 @@
 @link("stasis_graphics");
 
+import "graphics.stasis";
+
+function play(self: AudioAsset, loop: bool, volume: f32, pan: f32): i32 {
+    if (!self.ready()) {
+        return 0;
+    }
+    return audio_play(self.handle, loop, volume, pan);
+}
+
+function play_effect(self: AudioAsset, volume: f32): bool {
+    if (!self.ready()) {
+        return false;
+    }
+    return audio_play_effect(self.handle, volume);
+}
+
+function play_music(self: AudioAsset, loop: bool, volume: f32): bool {
+    if (!self.ready()) {
+        return false;
+    }
+    return audio_play_music(self.handle, loop, volume);
+}
+
+function stop_music(self: AudioAsset): void {
+    if (self.handle > 0) {
+        audio_stop_music(self.handle);
+    }
+}
+
+function pause_music(self: AudioAsset, paused: bool): void {
+    if (self.handle > 0) {
+        audio_pause_music(self.handle, paused);
+    }
+}
+
+function set_music_volume(self: AudioAsset, volume: f32): void {
+    if (self.handle > 0) {
+        audio_set_music_volume(self.handle, volume);
+    }
+}
+
 // Audio/runtime bindings (marker module).
 // From a generated project: import "/vendor/stasis/stdlib/audio.stasis";
 
-extern function audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
-extern function audio_shutdown(): void;
-extern function audio_is_available(): bool;
-extern function audio_get_sample_rate(): i32;
-extern function audio_get_channels(): i32;
-extern function audio_get_queued_frames(): i32;
-extern function audio_get_underruns(): i32;
-extern function audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
+extern function @effects(audio) audio_init(sample_rate: i32, channels: i32, target_latency_frames: i32): bool;
+extern function @effects(audio) audio_shutdown(): void;
+extern function @effects(audio) audio_is_available(): bool;
+extern function @effects(audio) audio_get_sample_rate(): i32;
+extern function @effects(audio) audio_get_channels(): i32;
+extern function @effects(audio) audio_get_queued_frames(): i32;
+extern function @effects(audio) audio_get_underruns(): i32;
+extern function @effects(audio) audio_push_f32_interleaved(samples: f32[], frame_count: i32): i32;
 
 // Bounded audio assets are decoded outside deterministic Stasis state. audio_load_wav accepts
 // mono or stereo little-endian PCM16 WAV files. The music/effect helpers accept WAV or MP3.
 // Compressed input stays compressed on disk and is decoded into bounded host memory at load.
-extern function @asset_path(path) audio_load_wav(path: string): i32;
-extern function audio_release(asset_handle: i32): void;
-extern function audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
-extern function audio_stop(voice_handle: i32): void;
-extern function audio_voice_is_playing(voice_handle: i32): bool;
-extern function audio_voice_set_paused(voice_handle: i32, paused: bool): void;
-extern function audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
+extern function @effects(audio)@asset_path(path) audio_load_wav(path: string): i32;
+extern function @effects(audio) audio_play(asset_handle: i32, loop: bool, volume: f32, pan: f32): i32;
+extern function @effects(audio) audio_stop(voice_handle: i32): void;
+extern function @effects(audio) audio_voice_is_playing(voice_handle: i32): bool;
+extern function @effects(audio) audio_voice_set_paused(voice_handle: i32, paused: bool): void;
+extern function @effects(audio) audio_voice_set_volume_pan(voice_handle: i32, volume: f32, pan: f32): void;
 
 // Brickout-compatible category helpers backed by the same SDL host mixer.
-function @asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
-function @asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
-function @extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
-function @extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
-function @extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;
-function @extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(asset_handle: i32, volume: f32): void;
-function @extern("stasis_jit_audio_play_effect") audio_play_effect(asset_handle: i32, volume: f32): bool;
+function @effects(audio)@asset_path(path)@extern("stasis_jit_audio_load_music") audio_load_music(path: string): i32;
+function @effects(audio)@asset_path(path)@extern("stasis_jit_audio_load_effect") audio_load_effect(path: string): i32;
+function @effects(audio)@extern("stasis_jit_audio_play_music") audio_play_music(asset_handle: i32, loop: bool, volume: f32): bool;
+function @effects(audio)@extern("stasis_jit_audio_stop_music") audio_stop_music(asset_handle: i32): void;
+function @effects(audio)@extern("stasis_jit_audio_pause_music") audio_pause_music(asset_handle: i32, paused: bool): void;
+function @effects(audio)@extern("stasis_jit_audio_set_music_volume") audio_set_music_volume(asset_handle: i32, volume: f32): void;
+function @effects(audio)@extern("stasis_jit_audio_play_effect") audio_play_effect(asset_handle: i32, volume: f32): bool;

--- a/samples/asset_breakout/vendor/stasis/stdlib/clipboard.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/clipboard.stasis
@@ -1,7 +1,7 @@
 // Bounded printable-ASCII clipboard access for player-entered share codes.
 // Loading returns the byte length, or -1 when unavailable, invalid, or too large.
-function @extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
-function @extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
+function @effects(platform)@extern("stasis_jit_clipboard_load_ascii") clipboard_load_ascii_raw(out: ascii[], capacity: i32): i32;
+function @effects(platform)@extern("stasis_jit_clipboard_save_ascii") clipboard_save_ascii_raw(value: ascii[], length: i32): i32;
 
 function clipboard_load_ascii(out: ascii[]): i32 {
     out.length = 0;

--- a/samples/asset_breakout/vendor/stasis/stdlib/graphics.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/graphics.stasis
@@ -11,8 +11,9 @@
 import "internal/host_frame.stasis";
 import "internal/gfx_cmd.stasis";
 import "internal/host_window_request.stasis";
+import "asset_tasks.stasis";
 
-extern function sleep_ms(ms: i32): void;
+extern function @effects(nondeterministic) sleep_ms(ms: i32): void;
 
 // Hot-path reads are HostFrame snapshot-only (no host calls).
 function get_time_ms(): i32 {
@@ -24,17 +25,11 @@ function get_time_us(): i32 {
 }
 
 // Startup / assets (host calls; avoid in hot paths)
-extern function gfx_poll_reload(handle: i32): bool;
-extern function gfx_dump_bmp(path: string): i32;
-extern function gfx_dump_png(path: string): i32;
-extern function @asset_path(path) load_font(path: string, size: i32): i32;
-extern function measure_text(font: i32, text: string): f32;
-
-struct Sprite {
-    handle: i32;
-    width: i32;
-    height: i32;
-}
+extern function @effects(graphics) gfx_poll_reload(handle: i32): bool;
+extern function @effects(graphics, storage) gfx_dump_bmp(path: string): i32;
+extern function @effects(graphics, storage) gfx_dump_png(path: string): i32;
+extern function @effects(graphics)@asset_path(path) load_font(path: string, size: i32): i32;
+extern function @effects(graphics) measure_text(font: i32, text: string): f32;
 
 struct TextRun {
     font: i32;
@@ -64,11 +59,38 @@ struct SpriteSheet {
     cell_height: i32;
 }
 
-function @asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(self: Sprite, path: string, width: i32, height: i32): bool;
-function @extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(self: SpriteSheet, path: string, width: i32, height: i32): bool;
+function @effects(graphics)@asset_path(path)@extern("stasis_jit_sprite_load_from") load_sprite_from(
+    self: Sprite,
+    path: string,
+    width: i32,
+    height: i32
+): bool;
+function @effects(graphics)@extern("stasis_jit_sprite_load_from") load_sprite_sheet_asset_from(
+    self: SpriteSheet,
+    path: string,
+    width: i32,
+    height: i32
+): bool;
+
+function publish(self: ImageAsset, target: Sprite): bool {
+    if (!self.ready()) {
+        return false;
+    }
+    if (target.handle != 0) {
+        gfx_release_sprite(target.handle);
+    }
+    target.handle = self.handle;
+    target.width = self.width;
+    target.height = self.height;
+    self.handle = 0;
+    self.width = 0;
+    self.height = 0;
+    self.state = AssetState.None;
+    return true;
+}
 
 function draw(self: Sprite, x: f32, y: f32, alpha: i32, rotation: i32): void {
-    if (self.handle <= 0 || self.width <= 0 || self.height <= 0) {
+    if (self.handle == 0 || self.width <= 0 || self.height <= 0) {
         return;
     }
     let width: f32 = 0.0;
@@ -101,7 +123,7 @@ function load_sprite_sheet_from(self: SpriteSheet, path: string, columns: i32, r
 }
 
 function draw_frame(self: SpriteSheet, frame: i32, x: f32, y: f32, alpha: i32, rotation: i32): void {
-    if (self.handle <= 0 || self.columns <= 0 || self.rows <= 0 || self.cell_width <= 0 || self.cell_height <= 0) {
+    if (self.handle == 0 || self.columns <= 0 || self.rows <= 0 || self.cell_width <= 0 || self.cell_height <= 0) {
         return;
     }
     if (self.columns > 2147483647 / self.rows) {
@@ -184,7 +206,7 @@ function finished(self: AnimationClip, elapsed_ticks: i32): bool {
     return animation_finished(self.frame_count, self.ticks_per_frame, self.playback_mode, elapsed_ticks);
 }
 
-function @extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
+function @effects(graphics)@extern("stasis_jit_text_run_load_from") load_text_from(self: TextRun, font: i32, text: string): bool;
 
 function draw(self: TextRun, x: f32, y: f32, r: f32, g: f32, b: f32, a: f32): void {
     if (self.font <= 0 || self.handle <= 0) {
@@ -214,6 +236,11 @@ function set_fullscreen(enabled: i32): i32 {
 
 function set_maximized(enabled: i32): i32 {
     host_request_maximized(enabled);
+    return 0;
+}
+
+function set_maximized_canvas(width: i32, height: i32): i32 {
+    host_request_maximized_canvas(width, height);
     return 0;
 }
 

--- a/samples/asset_breakout/vendor/stasis/stdlib/internal/host_window_request.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/internal/host_window_request.stasis
@@ -40,3 +40,10 @@ function host_request_maximized(enabled: i32): void {
     }
     host_req_seq = host_req_seq + 1;
 }
+
+function host_request_maximized_canvas(width: i32, height: i32): void {
+    host_req_flags = HOST_REQ_FLAG_MAXIMIZED;
+    host_req_window_w_px = width;
+    host_req_window_h_px = height;
+    host_req_seq = host_req_seq + 1;
+}

--- a/samples/asset_breakout/vendor/stasis/stdlib/memory.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/memory.stasis
@@ -4,12 +4,12 @@
 // - explicit capacities for bounds checking
 // - clamped and/or checked variants
 
-extern function sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
-extern function sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
-extern function sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
-extern function sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
-extern function sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
-extern function sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memcpy_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_u8(dst: u8[], dst_index: i32, src: u8[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_i32(dst: i32[], dst_index: i32, src: i32[], src_index: i32, count: i32): void;
+extern function @effects(memory) sys_memmove_f32(dst: f32[], dst_index: i32, src: f32[], src_index: i32, count: i32): void;
 
 // Copy `count` bytes from src to dst, clamped to both buffers.
 // Returns bytes copied.

--- a/samples/asset_breakout/vendor/stasis/stdlib/stdlib.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/stdlib.stasis
@@ -6,7 +6,7 @@
 import "memory.stasis";
 
 // Abort the current hot swap after on_code_swap restores any application invariants it can.
-extern function reject_code_swap(): void;
+extern function @effects(code_swap) reject_code_swap(): void;
 
 // Bootstrap provides type-specific host functions behind one source-level overload family.
 function print(value: i32): void {

--- a/samples/asset_breakout/vendor/stasis/stdlib/storage.stasis
+++ b/samples/asset_breakout/vendor/stasis/stdlib/storage.stasis
@@ -1,13 +1,13 @@
 // Small durable integer preferences for game progression and settings.
 // Scope and key must be 1..63 ASCII letters, digits, underscores, or hyphens.
 // Missing, invalid, or corrupt values return the caller-provided fallback.
-extern function storage_load_i32(scope: string, key: string, fallback: i32): i32;
-extern function storage_save_i32(scope: string, key: string, value: i32): bool;
+extern function @effects(storage) storage_load_i32(scope: string, key: string, fallback: i32): i32;
+extern function @effects(storage) storage_save_i32(scope: string, key: string, value: i32): bool;
 
 // Bounded durable ASCII values for share codes and other small text payloads.
 // Returns the byte length, or -1 when the value is missing, invalid, or does not fit.
-function @extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
-function @extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
+function @effects(storage)@extern("stasis_jit_storage_load_ascii") storage_load_ascii_raw(scope: string, key: string, out: ascii[], capacity: i32): i32;
+function @effects(storage)@extern("stasis_jit_storage_save_ascii") storage_save_ascii_raw(scope: string, key: string, value: ascii[], length: i32): i32;
 
 function storage_load_ascii(scope: string, key: string, out: ascii[]): i32 {
     out.length = 0;

--- a/samples/pointer_pong/main.stasis
+++ b/samples/pointer_pong/main.stasis
@@ -100,6 +100,10 @@ function paddle_from_pointer(y: f32): f32 {
     return clamp_paddle(y - PADDLE_H / 2.0);
 }
 
+function pointer_controls_paddle(pointer_count: i32): bool {
+    return pointer_count > 0;
+}
+
 function reset_ball(direction: f32): void {
     state.ball_x = SCREEN_W / 2.0 - BALL_SIZE / 2.0;
     state.ball_y = SCREEN_H / 2.0 - BALL_SIZE / 2.0;
@@ -108,7 +112,10 @@ function reset_ball(direction: f32): void {
 }
 
 function update_player(): void {
-    if (input_pointer_count() > 0 && input_pointer_is_down(0)) {
+    // Pointer position is continuously available for mouse hover and touch.
+    // A press is not required; keyboard movement remains the fallback when no
+    // pointer has entered the game canvas yet.
+    if (pointer_controls_paddle(input_pointer_count())) {
         state.left_y = paddle_from_pointer(input_pointer_y_logical(0));
         return;
     }

--- a/samples/pointer_pong/tests/pointer_pong.test.stasis
+++ b/samples/pointer_pong/tests/pointer_pong.test.stasis
@@ -8,6 +8,16 @@ test `paddle target centers on pointer`(): bool {
     return true;
 }
 
+test `pointer movement does not require a press`(): bool {
+    if (!pointer_controls_paddle(1)) {
+        return false;
+    }
+    if (pointer_controls_paddle(0)) {
+        return false;
+    }
+    return true;
+}
+
 test `paddle clamp stays inside screen`(): bool {
     if (clamp_paddle(-4.0) != 0.0) {
         return false;


### PR DESCRIPTION
## What changed
- make Pointer Pong follow mouse hover without requiring a press while retaining touch and keyboard fallbacks
- add an immediate web runtime loading overlay with distinct loading, ready, and failure states
- give Neon Breakout a staged `ImageAsset` loading process that gates simulation and displays progress/failure without external assets
- update focused sample and runtime tests

## Validation
- Pointer Pong: format, check, 4 tests passed
- Neon Breakout: format, check, 8 tests passed
- web loading overlay: 2 focused tests passed
- browser package smoke tests passed after rebuilding