### PR TITLE
Address performance HUD review feedback

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4372,6 +4372,32 @@ mod tests {
         }
         assert!(STASIS_GRAPHICS_SOURCE.contains("host_started_counter"));
         assert!(STASIS_GRAPHICS_SOURCE.contains("g_perf_render_started_counter, host_finished"));
+        let finger_up = STASIS_GRAPHICS_SOURCE
+            .split_once("case SDL_EVENT_FINGER_UP:")
+            .and_then(|(_, source)| source.split_once("default:").map(|(section, _)| section))
+            .expect("finger-up event source section");
+        let release_offset = finger_up
+            .find("stasis_release_finger_slot(event.tfinger.fingerID)")
+            .expect("finger-up should release its slot");
+        let reset_offset = finger_up
+            .find("stasis_ios_active_finger_count() < 3")
+            .expect("finger-up should reset the iOS three-finger latch below three active fingers");
+        assert!(
+            release_offset < reset_offset,
+            "finger-up must release its slot before checking the active-finger latch reset"
+        );
+        assert!(
+            STASIS_GRAPHICS_SOURCE.contains(
+                "if (stasis_ios_active_finger_count() >= 3 && !g_ios_three_finger_latched)"
+            ),
+            "iOS three-finger latch should use the shared active-finger count helper"
+        );
+        assert!(
+            !STASIS_GRAPHICS_SOURCE.contains(
+                "case SDL_EVENT_FINGER_MOTION:\n                {\n                    int active_fingers"
+            ),
+            "iOS three-finger latch should not reset from motion events"
+        );
         assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("STASIS_PERF_UNAVAILABLE"));
         assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("STASIS_PERF_METRICS_VERSION"));
         assert!(STASIS_PERFORMANCE_METRICS_HEADER.contains("size"));

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -479,6 +479,7 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
         "dataset.uploadedBytes",
         "PERF_ROLLING_CAPACITY",
         "performanceWorstTimes",
+        "if (hud) {\n      recordPerformanceWorst(",
         "RECT_BATCH_MIN",
         "drawArraysInstanced",
         "Canvas2D + WebGL2",
@@ -562,8 +563,12 @@ fn minimal_pong_and_standard_reference_omit_audio_and_input() {
         "dataset.gpuSubmitMs",
         "dataset.presentWaitMs",
         "PERF_ROLLING_CAPACITY",
+        "if (hud) {\n      recordWorst(",
     ] {
-        assert!(runtime.contains(expected), "minimal runtime missing {expected}");
+        assert!(
+            runtime.contains(expected),
+            "minimal runtime missing {expected}"
+        );
     }
     assert!(!runtime.contains("N/A"));
     assert!(

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -903,6 +903,16 @@ static void stasis_release_finger_slot(SDL_FingerID fingerId) {
     }
 }
 
+#if defined(__IPHONEOS__)
+static int stasis_ios_active_finger_count(void) {
+    int active_fingers = 0;
+    for (int finger = 0; finger < STASIS_MAX_POINTERS - 1; finger++) {
+        if (g_finger_active[finger]) active_fingers++;
+    }
+    return active_fingers;
+}
+#endif
+
 static void stasis_pump_events(void) {
     if (!g_window) return;
     stasis_sync_display_metrics();
@@ -1032,11 +1042,7 @@ static void stasis_pump_events(void) {
                         &logical_x, &logical_y);
                     stasis_set_pointer_pos_px(idx, logical_x, logical_y);
 #if defined(__IPHONEOS__)
-                    int active_fingers = 0;
-                    for (int finger = 0; finger < STASIS_MAX_POINTERS - 1; finger++) {
-                        if (g_finger_active[finger]) active_fingers++;
-                    }
-                    if (active_fingers >= 3 && !g_ios_three_finger_latched) {
+                    if (stasis_ios_active_finger_count() >= 3 && !g_ios_three_finger_latched) {
                         g_ios_three_finger_latched = true;
                         g_force_debug_overlay = !g_force_debug_overlay;
                         g_perf_sample_count = 0;
@@ -1060,13 +1066,6 @@ static void stasis_pump_events(void) {
                         event.tfinger.y * (float)g_native_window_height,
                         &logical_x, &logical_y);
                     stasis_set_pointer_pos_px(idx, logical_x, logical_y);
-#if defined(__IPHONEOS__)
-                    int active_fingers = 0;
-                    for (int finger = 0; finger < STASIS_MAX_POINTERS - 1; finger++) {
-                        if (g_finger_active[finger]) active_fingers++;
-                    }
-                    if (active_fingers < 3) g_ios_three_finger_latched = false;
-#endif
                 }
                 break;
             case SDL_EVENT_FINGER_UP:
@@ -1077,6 +1076,9 @@ static void stasis_pump_events(void) {
                     g_input_frame.pointers[idx].is_down = 0;
                     g_input_frame.pointers[idx].went_up = 1;
                     stasis_release_finger_slot(event.tfinger.fingerID);
+#if defined(__IPHONEOS__)
+                    if (stasis_ios_active_finger_count() < 3) g_ios_three_finger_latched = false;
+#endif
                     float logical_x = 0.0f;
                     float logical_y = 0.0f;
                     stasis_window_to_logical(

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -1154,7 +1154,9 @@
     const gpuExecutionMs = -1;
     const presentWaitMs = -1;
     frames += 1;
-    recordPerformanceWorst(timestamp, tickMs, renderMs, wasmRenderMs, browserReplayMs, frameWorkMs);
+    if (hud) {
+      recordPerformanceWorst(timestamp, tickMs, renderMs, wasmRenderMs, browserReplayMs, frameWorkMs);
+    }
     const underBudget = frameWorkMs <= 16.67;
     if (hud) {
       const uploadText = performanceWorkload.uploadedBytes > 0 ? ` · uploaded ${performanceWorkload.uploadedBytes} B` : "";

--- a/runtime/web/game_minimal.js
+++ b/runtime/web/game_minimal.js
@@ -68,7 +68,9 @@ __STASIS_IMPORTS__
     const frameWorkMs=tickMs+renderMs;
     const renderPrepMs=-1,gpuSubmitMs=-1,gpuExecutionMs=-1,presentWaitMs=-1;
     frames += 1;
-    recordWorst(performance.now(),tickMs,renderMs,wasmRenderMs,browserReplayMs,frameWorkMs);
+    if (hud) {
+      recordWorst(performance.now(),tickMs,renderMs,wasmRenderMs,browserReplayMs,frameWorkMs);
+    }
     const underBudget=frameWorkMs<=16.67;
     let lines=0,rectangles=0,text=0;
     for(const command of commands){if(command[0]===1)rectangles+=1;else if(command[0]===2)text+=1;}


### PR DESCRIPTION
## Summary

- gate rolling worst-window collection in both web runtimes on the presence of the development HUD
- reset the iOS three-finger HUD latch after finger-up only when fewer than three touches remain active
- add regression coverage for both findings raised after #541 was reviewed

## Root cause and impact

PR #541 was merged while two P2 review threads were still unresolved. Release web packages omit the HUD element, but still paid for full rolling-window scans every frame. On iOS, the gesture latch was reset during motion instead of after touch release, so a normal three-finger gesture could leave the HUD toggle permanently latched.

The fixes remove the hidden production overhead and make repeated iOS HUD toggles work while preserving correct behavior when three or more touches remain active.

## Validation

- `cargo test -p stasis --lib performance_hud_uses_additive_snapshot_and_excludes_present_wait`
- `cargo test -p stasis --test web_package web_package_contains_runnable_static_bundle_without_standalone_html -- --exact`
- `cargo test -p stasis --test web_package minimal_pong_and_standard_reference_omit_audio_and_input -- --exact`
- `node --check runtime/web/game.js`
- `node --check runtime/web/game_minimal.js`
- `rustfmt --edition 2021 --check apps/stasis/src/lib.rs apps/stasis/tests/web_package.rs`
- `git diff --check`