### PR TITLE
Fix Android landscape rotation artifacts

### DIFF
--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -4865,6 +4865,26 @@ mod tests {
     }
 
     #[test]
+    fn opengl_frame_start_clears_the_entire_drawable_before_viewport_content() {
+        let graphics_source = STASIS_GRAPHICS_SOURCE.replace("\r\n", "\n");
+        let clear_start = graphics_source
+            .find("static void stasis_gl_clear_drawable(void) {")
+            .expect("OpenGL frame-start clear helper");
+        let clear_body = graphics_source[clear_start..]
+            .split_once("\n}\n")
+            .map(|(body, _)| body)
+            .expect("complete OpenGL frame-start clear helper");
+        assert!(clear_body.contains("glDisable(GL_SCISSOR_TEST)"));
+        assert!(clear_body.contains("glClearColor(0.0f, 0.0f, 0.0f, 1.0f)"));
+        assert!(clear_body.contains("glClear(GL_COLOR_BUFFER_BIT)"));
+        assert!(
+            !clear_body.contains("glScissor"),
+            "frame-start clear must not depend on stale letterbox geometry"
+        );
+        assert!(graphics_source.contains("stasis_gl_clear_drawable();"));
+    }
+
+    #[test]
     fn windows_runtime_uses_physical_drawable_pixels_at_monitor_density() {
         assert!(
             STASIS_GRAPHICS_SOURCE.contains("SDL_WINDOW_HIGH_PIXEL_DENSITY")

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7197,6 +7197,14 @@ mod tests {
         let android_manifest =
             fs::read_to_string(android.join("android/app/src/main/AndroidManifest.xml"))
                 .expect("read Android manifest");
+        assert!(android_manifest.contains("android:appCategory=\"game\""));
+        assert!(android_manifest.contains(
+            "android:name=\"android.window.PROPERTY_COMPAT_ALLOW_ORIENTATION_OVERRIDE\""
+        ));
+        assert!(android_manifest.contains(
+            "android:name=\"android.window.PROPERTY_COMPAT_ALLOW_USER_ASPECT_RATIO_OVERRIDE\""
+        ));
+        assert!(android_manifest.matches("android:value=\"false\"").count() >= 2);
         assert!(android_manifest.contains("android:label=\"Mobile Smoke\""));
         assert!(android_manifest.contains("android:screenOrientation=\"fullSensor\""));
         let mobile_main = fs::read_to_string(android.join("common/stasis_mobile_main.c"))

--- a/mobile/shells/android/app/src/main/AndroidManifest.xml
+++ b/mobile/shells/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,15 @@
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
     <application
         android:allowBackup="false"
+        android:appCategory="game"
         android:label="@STASIS_APP_NAME@"
         android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen">
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_ORIENTATION_OVERRIDE"
+            android:value="false" />
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_USER_ASPECT_RATIO_OVERRIDE"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -666,26 +666,16 @@ static void stasis_sync_display_metrics(void) {
 }
 
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-static void stasis_gl_clear_rect(int x, int y, int width, int height) {
-    if (width <= 0 || height <= 0) return;
-    glScissor(x, y, width, height);
-    glClear(GL_COLOR_BUFFER_BIT);
-}
-
-static void stasis_gl_clear_letterbox_bars(void) {
-    const StasisDisplayViewport viewport = g_display_metrics.drawable_viewport;
-    const int left = (int)viewport.x;
-    const int bottom = stasis_display_bottom_origin_y(
-        g_drawable_height, viewport);
-    const int right = left + (int)viewport.w;
-    const int top = bottom + (int)viewport.h;
-    glEnable(GL_SCISSOR_TEST);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    stasis_gl_clear_rect(0, 0, left, g_drawable_height);
-    stasis_gl_clear_rect(right, 0, g_drawable_width - right, g_drawable_height);
-    stasis_gl_clear_rect(0, 0, g_drawable_width, bottom);
-    stasis_gl_clear_rect(0, top, g_drawable_width, g_drawable_height - top);
+static void stasis_gl_clear_drawable(void) {
+    /*
+     * Clear the complete drawable before the logical viewport is rendered.
+     * The viewport can be transiently stale while Android rotates or
+     * recreates its surface; clearing four bars from the previous metrics can
+     * leave newly exposed pixels uninitialized (or show old surface contents).
+     */
     glDisable(GL_SCISSOR_TEST);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
 }
 #endif
 
@@ -4702,7 +4692,7 @@ STASIS_EXPORT void stasis_begin_frame(void) {
         SDL_SetRenderClipRect(g_renderer, NULL);
     } else {
 #if !defined(STASIS_GRAPHICS_SDL_ONLY)
-        stasis_gl_clear_letterbox_bars();
+        stasis_gl_clear_drawable();
 #else
         (void)g_force_debug_overlay;
 #endif


### PR DESCRIPTION
## Summary
- classify packaged Android releases as games
- opt out of OEM/user orientation and aspect-ratio compatibility overrides
- clear the complete OpenGL drawable before rendering the logical viewport
- add focused packaging and renderer regression assertions

## Validation
- focused regression binaries passed directly
- release Stasis packager built successfully
- Sheep Herder arm64 debug APK built successfully from this branch
- final merged APK manifest inspected for sensorLandscape and both compatibility opt-outs

Theory gained: requested orientation and drawable geometry are separate contracts; Android may override the former, while a transient surface must still be fully initialized before viewport rendering.