### PR TITLE
Preserve packaged Android orientation through SDL startup

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -7224,6 +7224,49 @@ mod tests {
         assert!(android_activity.contains("stasis.seam_test_id"));
         assert!(android_activity.contains("BuildConfig.STASIS_SEAM_TESTS"));
         assert!(android_activity.contains("nativeSetSeamTestId"));
+        assert!(android_activity
+            .contains("private static final String STASIS_ANDROID_ORIENTATION = \"fullSensor\";"));
+        assert!(!android_activity.contains("@STASIS_ANDROID_ORIENTATION@"));
+        assert!(android_activity.contains("public void setOrientationBis"));
+        assert!(android_activity.contains("ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE"));
+        assert!(android_activity.contains("ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT"));
+        assert!(android_activity.contains("ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR"));
+        assert!(
+            android_activity.contains("super.setOrientationBis(width, height, resizable, hint);")
+        );
+
+        let mut landscape_workspace = workspace.clone();
+        landscape_workspace
+            .manifest
+            .android
+            .as_mut()
+            .expect("Android manifest")
+            .orientation = "sensorLandscape".to_string();
+        let android_landscape = root.join("android-landscape-package");
+        fs::create_dir_all(&android_landscape).expect("create landscape Android staging");
+        assemble_mobile_shell(
+            &landscape_workspace,
+            PackageTarget::AndroidArm64,
+            &aot,
+            &android_landscape,
+            &provenance,
+        )
+        .expect("assemble landscape Android shell");
+        let landscape_activity = fs::read_to_string(
+            android_landscape
+                .join("android/app/src/main/java/com/stasislang/game/MainActivity.java"),
+        )
+        .expect("read landscape Android activity");
+        assert!(landscape_activity.contains(
+            "private static final String STASIS_ANDROID_ORIENTATION = \"sensorLandscape\";"
+        ));
+        assert!(!landscape_activity.contains("@STASIS_ANDROID_ORIENTATION@"));
+        let landscape_manifest = fs::read_to_string(
+            android_landscape.join("android/app/src/main/AndroidManifest.xml"),
+        )
+        .expect("read landscape Android manifest");
+        assert!(landscape_manifest.contains("android:screenOrientation=\"sensorLandscape\""));
+
         let android_jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))
                 .expect("read Android JNI bridge");

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -1,6 +1,7 @@
 package @STASIS_PACKAGE_ID@;
 
 import android.content.res.AssetManager;
+import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -26,6 +27,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 
 public final class MainActivity extends SDLActivity {
+    private static final String STASIS_ANDROID_ORIENTATION = "@STASIS_ANDROID_ORIENTATION@";
     private static final long HUD_UPDATE_INTERVAL_MS = 200L;
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
     private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
@@ -52,6 +54,26 @@ public final class MainActivity extends SDLActivity {
     private TextView runtimeError;
     private Runnable hudUpdater;
     private String displayedRuntimeError;
+
+    @Override
+    public void setOrientationBis(int width, int height, boolean resizable, String hint) {
+        int requestedOrientation;
+        switch (STASIS_ANDROID_ORIENTATION) {
+            case "sensorLandscape":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+                break;
+            case "sensorPortrait":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
+                break;
+            case "fullSensor":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+                break;
+            default:
+                super.setOrientationBis(width, height, resizable, hint);
+                return;
+        }
+        setRequestedOrientation(requestedOrientation);
+    }
 
     @Override
     protected void onCreate(Bundle state) {


### PR DESCRIPTION
## Root cause
SDL3 recalculates Android orientation after window creation. Stasis marks its SDL window resizable, so an unset SDL orientation hint becomes `SCREEN_ORIENTATION_FULL_USER`, overwriting a packaged `sensorLandscape` manifest policy and allowing a portrait surface.

## Fix
- generate the package orientation into the release activity
- override SDLActivity.setOrientationBis for sensorLandscape, sensorPortrait, and fullSensor
- delegate unspecified policies to SDL so adaptive orientation seams still work
- add focused generated-shell assertions

## Validation
- cargo check passed
- focused mobile-shell packaging test passed
- arm64 and x86_64 Android Java/native builds passed
- API 35 emulator was locked to portrait (1080x2400); Sheep Herder remained resumed in landscape at 2400x1080
- compositor screenshot showed a clean full-frame render without the static strip

Theory gained: the package manifest is only the initial policy; SDL's post-window callback is the last writer and must preserve explicit package intent.