### PR TITLE
Support portable rooted asset paths

### DIFF
--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -1743,13 +1743,14 @@ fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
     assert_eq!(created.status.code(), Some(0));
     fs::write(
         project.join("src/main.stasis"),
-        "import \"/vendor/stasis/stdlib/graphics.stasis\";\nfunction main(): i32 { return 0; }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
+        "import \"/vendor/stasis/stdlib/graphics.stasis\";\nfunction main(): i32 { return load_font(\"/assets/fonts/ui.ttf\", 16); }\nfunction tick(): i32 { return 0; }\nfunction render(): i32 { return 0; }\n",
     )
     .expect("write mobile entry");
-    fs::create_dir_all(project.join("assets")).expect("create assets");
+    fs::create_dir_all(project.join("assets/fonts")).expect("create assets");
+    fs::write(project.join("assets/fonts/ui.ttf"), b"font").expect("write font asset");
     fs::write(
         project.join("assets/manifest.json"),
-        "{\n  \"schema\": \"stasis-assets\",\n  \"version\": 1,\n  \"assets\": []\n}\n",
+        "{\n  \"schema\": \"stasis-assets\",\n  \"version\": 1,\n  \"assets\": [\n    {\"id\":\"ui_font\",\"path\":\"assets/fonts/ui.ttf\",\"content_sha256\":\"795ea3efa43d0872b63bf0067be97553b46983e4f075097669391e9d15388ecc\",\"format\":{\"kind\":\"font\",\"encoding\":\"ttf\"},\"dependencies\":[]}\n  ]\n}\n",
     )
     .expect("write asset manifest");
 
@@ -1887,6 +1888,9 @@ fn package_mobile_builds_android_and_ios_projects_from_one_entry() {
     assert!(android_cmake.contains("set(SDLIMAGE_PNG_LIBPNG OFF CACHE BOOL \"\" FORCE)"));
     assert!(project
         .join("android/android/app/src/main/assets/stasis_game/assets/manifest.json")
+        .is_file());
+    assert!(project
+        .join("android/android/app/src/main/assets/stasis_game/assets/fonts/ui.ttf")
         .is_file());
     let arm64_gradle = fs::read_to_string(project.join("android/android/app/build.gradle"))
         .expect("read arm64 Gradle");

--- a/crates/stasis_compiler/src/backend/assets.rs
+++ b/crates/stasis_compiler/src/backend/assets.rs
@@ -626,15 +626,27 @@ fn resolve_one(
     manifest_paths: Option<&BTreeSet<String>>,
     result: &mut AssetValidationResult,
 ) {
-    if looks_absolute_or_uri(logical_path) {
+    if logical_path.contains('\\') {
+        result.diagnostics.push(diagnostic(
+            reference,
+            "asset_path_nonportable_separator",
+            vec![logical_path.to_string()],
+            "asset paths must use forward slashes; backslash separators are not portable"
+                .to_string(),
+        ));
+        return;
+    }
+    if looks_absolute_or_uri(logical_path) && !is_virtual_asset_path(logical_path) {
         result.diagnostics.push(diagnostic(
             reference,
             "asset_path_absolute_or_uri",
             vec![logical_path.to_string()],
-            "asset paths must be relative filesystem paths".to_string(),
+            "asset paths must be relative filesystem paths or use the /assets/... project-root spelling".to_string(),
         ));
         return;
     }
+    let rooted_project_path = is_virtual_asset_path(logical_path)
+        .then(|| logical_path.strip_prefix('/').unwrap_or(logical_path));
     let source = PathBuf::from(&reference.source_path);
     let declaring_dir = if source.is_absolute() {
         source
@@ -650,23 +662,29 @@ fn resolve_one(
             .to_path_buf()
     };
     let mut candidates = Vec::new();
-    for source_base_dir in source_base_dirs {
-        let source_base_dir = if source_base_dir.is_absolute() {
-            source_base_dir.clone()
-        } else {
-            project_root.join(source_base_dir)
-        };
-        let candidate = source_base_dir.join(logical_path);
-        if !candidates.contains(&candidate) {
-            candidates.push(candidate);
+    if let Some(rooted_project_path) = rooted_project_path {
+        // `/assets/...` is a virtual project-root spelling. It must not depend on
+        // the declaring source module or any caller-provided source base.
+        candidates.push(project_root.join(rooted_project_path));
+    } else {
+        for source_base_dir in source_base_dirs {
+            let source_base_dir = if source_base_dir.is_absolute() {
+                source_base_dir.clone()
+            } else {
+                project_root.join(source_base_dir)
+            };
+            let candidate = source_base_dir.join(logical_path);
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
         }
-    }
-    for candidate in [
-        declaring_dir.join(logical_path),
-        project_root.join(logical_path),
-    ] {
-        if !candidates.contains(&candidate) {
-            candidates.push(candidate);
+        for candidate in [
+            declaring_dir.join(logical_path),
+            project_root.join(logical_path),
+        ] {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
         }
     }
     let attempted = candidates
@@ -753,6 +771,10 @@ fn looks_absolute_or_uri(path: &str) -> bool {
         || path.starts_with('/')
         || path.starts_with('\\')
         || path.as_bytes().get(1).is_some_and(|byte| *byte == b':')
+}
+
+fn is_virtual_asset_path(path: &str) -> bool {
+    path == "/assets" || path.starts_with("/assets/")
 }
 
 fn normalize_path(path: &Path) -> Option<PathBuf> {
@@ -1099,10 +1121,11 @@ function main(): i32 {
         let references = vec![
             reference(0, "../../assets/svg/hero.svg"),
             reference(10, "assets/svg/hero.svg"),
-            reference(20, "../../outside.svg"),
-            reference(30, "assets/svg/missing.svg"),
-            reference(40, "https://example.com/hero.svg"),
-            reference(50, "C:/assets/hero.svg"),
+            reference(20, "/assets/svg/hero.svg"),
+            reference(30, "../../outside.svg"),
+            reference(40, "assets/svg/missing.svg"),
+            reference(50, "https://example.com/hero.svg"),
+            reference(60, "C:/assets/hero.svg"),
         ];
         let result = validate_asset_references(
             &root,
@@ -1111,7 +1134,7 @@ function main(): i32 {
             Some(&BTreeSet::from(["assets/svg/hero.svg".to_string()])),
             &BTreeSet::new(),
         );
-        assert_eq!(result.references.len(), 2);
+        assert_eq!(result.references.len(), 3);
         assert_eq!(
             result.resolved_paths,
             BTreeSet::from(["assets/svg/hero.svg".to_string()])
@@ -1133,11 +1156,61 @@ function main(): i32 {
         let undeclared = validate_asset_references(
             &root,
             &[],
-            &[reference(60, "assets/svg/hero.svg")],
+            &[reference(70, "assets/svg/hero.svg")],
             Some(&BTreeSet::new()),
             &BTreeSet::new(),
         );
         assert_eq!(undeclared.diagnostics[0].code, "asset_not_declared");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn validation_rejects_nonportable_asset_path_spellings() {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("stasis_asset_portability_{stamp}"));
+        fs::create_dir_all(root.join("assets/fonts")).expect("asset dir");
+        fs::write(root.join("assets/fonts/ui.ttf"), "font").expect("asset fixture");
+        let source_path = root.join("main.stasis").to_string_lossy().into_owned();
+        let reference = |start, logical_path: &str| AssetReference {
+            api: "load_font".into(),
+            source_path: source_path.clone(),
+            start,
+            end: start + logical_path.len(),
+            logical_path: Some(logical_path.into()),
+        };
+        let result = validate_asset_references(
+            &root,
+            &[],
+            &[
+                reference(0, "/assets/fonts/ui.ttf"),
+                reference(1, "/tmp/ui.ttf"),
+                reference(2, "C:/assets/fonts/ui.ttf"),
+                reference(3, "assets\\fonts\\ui.ttf"),
+                reference(4, "\\\\server\\share\\ui.ttf"),
+                reference(5, "https://example.com/ui.ttf"),
+            ],
+            None,
+            &BTreeSet::new(),
+        );
+        assert_eq!(result.references.len(), 1);
+        assert_eq!(result.references[0].project_path, "assets/fonts/ui.ttf");
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "asset_path_absolute_or_uri",
+                "asset_path_absolute_or_uri",
+                "asset_path_nonportable_separator",
+                "asset_path_nonportable_separator",
+                "asset_path_absolute_or_uri",
+            ]
+        );
         fs::remove_dir_all(root).ok();
     }
 }

--- a/docs/asset_manifest.md
+++ b/docs/asset_manifest.md
@@ -67,7 +67,7 @@ Preparation writes only beneath the build output; project masters and the source
 
 `stasis play` prepares the same bundle beneath `.stasis_cache/play-assets` before guest startup and mirrors the source directory's position relative to the project root. Existing source-relative paths such as `../assets/images/hero.png` therefore resolve to prepared output without source rewriting. Resized cache hits do not decode the master again. Development builds stage the complete declared manifest so iterative and optional paths remain available.
 
-Static `@asset_path` validation uses the active program entry's source directory as that same runtime boundary, including when the annotated loader call lives in a nested imported module. The declaring module and project root remain compatibility fallbacks, but they do not replace the entry boundary used by play and packaging.
+Static `@asset_path` validation uses the active program entry's source directory as that same runtime boundary, including when the annotated loader call lives in a nested imported module. The declaring module and project root remain compatibility fallbacks, but they do not replace the entry boundary used by play and packaging. A leading `/assets/...` is a portable virtual project-root spelling: it is treated exactly like the canonical `assets/...` path and never as a host filesystem root. It is resolved only against the project's canonical `assets/` directory, including when the annotated call lives in a nested module.
 
 `stasis check`, tests, development builds, release builds, and mobile/desktop packages
 consume one compiler-owned asset-reference result. Asset loader declarations mark their path
@@ -76,8 +76,9 @@ metadata, and supported legacy loader names remain compatible. Arbitrary string 
 treated as assets.
 
 Static references in the entry module's reachable graph are validated before output publication.
-Each path resolves first relative to its declaring source module and then from the project root,
-must remain beneath `assets/`, must name a regular file with exact disk casing on every host, and,
+Each relative path resolves first relative to its declaring source module and then from the project root;
+each `/assets/...` path resolves from the project root only. Every path must remain beneath `assets/`,
+must name a regular file with exact disk casing on every host, and,
 when a manifest exists, must name a declared entry. Release outputs retain only those validated
 paths plus transitive manifest dependencies. Test roots use the same rules; test-only and
 unreachable production modules do not enlarge a release package.
@@ -95,7 +96,7 @@ The package contains only the selected display envelope's output, not multiple r
 
 - IDs are 1-128 ASCII letters, digits, `.`, `_`, or `-` and are unique within a project.
 - Runtime handles are the nonzero FNV-1a 32-bit hash of `<kind>:<id>`. Load fails if two entries collide; platforms must not repair or renumber collisions independently.
-- Paths use forward slashes, start with `assets/`, contain only normal path components, and must resolve to a regular file under the canonical project `assets/` directory.
+- Manifest paths use forward slashes, start with `assets/`, contain only normal path components, and must resolve to a regular file under the canonical project `assets/` directory. Source `@asset_path` literals may additionally use the rooted `/assets/...` spelling. URI paths, drive paths, UNC paths, any embedded backslash separator, and leading slash paths other than `/assets/...` are compile errors; dynamic manifest paths remain canonical `assets/...` paths.
 - SHA-256 is checked against the complete bounded file before the asset is accepted.
 - Declared encodings must match file extensions. Sprite dimensions, audio metadata, font encoding, display dimensions, manifest size, entry count, and individual file size are bounded by the shared resolver.
 - Sprite preparation requires a version 2 manifest and top-level `display` metadata.

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -48,8 +48,11 @@ Each output contains the same pieces:
 Mobile packaging follows the selected entry module's import graph and the same
 compiler-owned `@asset_path` validation used by `stasis check` and desktop builds. It includes
 only validated manifest assets from reachable production calls plus transitive dependencies.
-Relative literals use the declaring module directory, project-root `assets/...` paths are also
-accepted, and casing is checked identically on Windows and Unix. Bounded dynamic loaders must use
+Relative literals use the declaring module directory. Both canonical `assets/...` and rooted
+`/assets/...` project paths are accepted; the latter is a virtual root spelling and is staged as
+`assets/...` beneath `stasis_game` on every target. Casing is checked identically on Windows and Unix.
+URI, drive, UNC, embedded-backslash, and other host-rooted spellings fail compilation before
+publishing a package. Bounded dynamic loaders must use
 the manifest's `dynamic_assets` declaration; otherwise packaging fails before publishing output.
 Android and iOS use the identical result.
 
@@ -61,7 +64,8 @@ Potential Android release-shell additions are tracked in
 `android_release_shell_backlog.md`; they must remain generic or opt-in adapters.
 
 The runtime asset root is always the packaged `stasis_game` project root.
-Canonical game paths therefore start with `assets/`. For compatibility with
+Canonical game paths therefore start with `assets/`; source-rooted `/assets/...` paths are
+normalized to that same canonical form before runtime lookup. For compatibility with
 older source-relative literals such as `../assets/foo.svg`, an explicit
 packaged asset root normalizes `.` and leading parent segments without allowing
 the resolved path to escape `stasis_game`.

--- a/runtime/stasis_asset_path.h
+++ b/runtime/stasis_asset_path.h
@@ -4,6 +4,11 @@
 #include <stddef.h>
 #include <string.h>
 
+static int stasis_asset_path_is_virtual_root(const char *path) {
+    return path != NULL &&
+        (strcmp(path, "/assets") == 0 || strncmp(path, "/assets/", 8) == 0);
+}
+
 static int stasis_asset_normalize_relative_path(
     const char *path,
     char *out,
@@ -12,12 +17,16 @@ static int stasis_asset_normalize_relative_path(
     const char *cursor = path;
     size_t used = 0;
     if (path == NULL || out == NULL || out_size < 2) return 0;
-    if (path[0] == '/' || path[0] == '\\') return 0;
+    int rooted = stasis_asset_path_is_virtual_root(path);
+    if (path[0] == '/' && !rooted) return 0;
+    if (path[0] == '\\') return 0;
     if (((path[0] >= 'A' && path[0] <= 'Z') ||
          (path[0] >= 'a' && path[0] <= 'z')) &&
-        path[1] == ':' && (path[2] == '/' || path[2] == '\\')) {
+        path[1] == ':') {
         return 0;
     }
+    if (strstr(path, "://") != NULL) return 0;
+    if (rooted) cursor = path + 1;
 
     while (*cursor != '\0') {
         while (*cursor == '/' || *cursor == '\\') cursor += 1;
@@ -42,6 +51,9 @@ static int stasis_asset_normalize_relative_path(
 
     if (used == 0) return 0;
     out[used] = '\0';
+    if (rooted && strcmp(out, "assets") != 0 && strncmp(out, "assets/", 7) != 0) {
+        return 0;
+    }
     return 1;
 }
 

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -1956,7 +1956,14 @@ static int is_absolute_path(const char* path) {
 static int resolve_asset_path(const char* path, char* out, size_t out_size) {
     if (!out || out_size < 2 || !path || !*path) return 0;
     ensure_asset_base();
-    if (is_absolute_path(path)) {
+    if (stasis_asset_path_is_virtual_root(path)) {
+        char normalized[1024];
+        if (!stasis_asset_normalize_relative_path(path, normalized, sizeof(normalized))) {
+            return 0;
+        }
+        snprintf(out, out_size, "%s/%s", g_asset_base, normalized);
+        out[out_size - 1] = 0;
+    } else if (is_absolute_path(path)) {
         if (g_asset_env[0] != 0) return 0;
         strncpy(out, path, out_size - 1);
         out[out_size - 1] = 0;
@@ -2220,7 +2227,7 @@ static GLuint link_program(GLuint vs, GLuint fs) {
 static uint64_t get_file_mtime(const char* path) {
     char resolved[1024];
     const char* probe = path;
-    if (!is_absolute_path(path)) {
+    if (!is_absolute_path(path) || stasis_asset_path_is_virtual_root(path)) {
         if (!resolve_asset_path(path, resolved, sizeof(resolved))) {
             return 0;
         }

--- a/runtime/tests/stasis_asset_path_test.c
+++ b/runtime/tests/stasis_asset_path_test.c
@@ -19,6 +19,8 @@ int main(void) {
     CHECK_PATH("../../assets/sprites/unit.svg", "assets/sprites/unit.svg");
     CHECK_PATH("src/../assets/ball.svg", "assets/ball.svg");
     CHECK_PATH("./assets\\ball.svg", "assets/ball.svg");
+    CHECK_PATH("/assets/ball.svg", "assets/ball.svg");
+    CHECK_PATH("/assets/fonts/../ball.svg", "assets/ball.svg");
 
     char too_small[4] = {0};
     if (stasis_asset_normalize_relative_path("assets/ball.svg", too_small, sizeof(too_small))) {
@@ -28,6 +30,8 @@ int main(void) {
     char absolute[128] = {0};
     if (stasis_asset_normalize_relative_path("/tmp/ball.svg", absolute, sizeof(absolute)) ||
         stasis_asset_normalize_relative_path("C:\\tmp\\ball.svg", absolute, sizeof(absolute)) ||
+        stasis_asset_normalize_relative_path("C:tmp\\ball.svg", absolute, sizeof(absolute)) ||
+        stasis_asset_normalize_relative_path("/assets/../../tmp/ball.svg", absolute, sizeof(absolute)) ||
         stasis_asset_normalize_relative_path("\\\\server\\share\\ball.svg", absolute, sizeof(absolute))) {
         fprintf(stderr, "absolute asset path unexpectedly accepted\n");
         return 1;


### PR DESCRIPTION
## Summary
- define `/assets/...` as portable Stasis project-root syntax across desktop and mobile packages
- reject host-specific asset spellings such as drive paths, UNC/backslash paths, URIs, and arbitrary filesystem roots at compile time
- normalize rooted paths through the shared runtime and add compiler, runtime, mobile packaging, and documentation coverage

## Validation
- targeted `rustfmt --check` passed for changed Rust files
- `git diff --check` passed
- the repository pre-commit hook compiled and ran the staged Stasis compiler checks successfully
- direct Cargo test execution remains blocked by stale Cranelift references to `F:\StasisLang`; fresh targets are blocked by local Windows Application Control
- direct C runtime test execution was unavailable because no C compiler is on PATH
