### PR TITLE
Fix rooted assets across live and web runtimes

### DIFF
--- a/apps/stasis/build.rs
+++ b/apps/stasis/build.rs
@@ -73,18 +73,31 @@ fn runtime_library_candidate_paths() -> Vec<PathBuf> {
         .canonicalize()
         .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join(".."));
 
-    let mut candidates = Vec::new();
-    if let Some(configured) = env::var_os("STASIS_RUNTIME_LIBRARY_PATH") {
-        candidates.push(PathBuf::from(configured));
-    }
-    if let Some(configured) = env::var_os("STASIS_RUNTIME_DLL_PATH") {
-        candidates.push(PathBuf::from(configured));
-    }
-    for file_name in runtime_library_file_names() {
-        candidates.push(repo_root.join(file_name));
-        candidates.push(repo_root.join("build").join(file_name));
-        for build_dir in ["build", "build_ci"] {
-            for configuration in [None, Some("Release"), Some("Debug")] {
+    let configured = [
+        env::var_os("STASIS_RUNTIME_LIBRARY_PATH"),
+        env::var_os("STASIS_RUNTIME_DLL_PATH"),
+    ]
+    .into_iter()
+    .flatten()
+    .map(PathBuf::from);
+    runtime_library_candidate_paths_for(&repo_root, configured, runtime_library_file_names())
+}
+
+/// Build staging prefers runtime binaries from the current checkout over legacy copies.
+///
+/// Keep explicit environment paths first: they are an intentional override for CI and
+/// platform-specific workflows. The runtime build outputs follow in release, unconfigured
+/// (the native build's bin root), and debug order for both regular and CI build trees. Copies
+/// beside the repository root or in its legacy `build` directory are last-resort fallbacks.
+pub fn runtime_library_candidate_paths_for(
+    repo_root: &Path,
+    configured: impl IntoIterator<Item = PathBuf>,
+    file_names: &[&str],
+) -> Vec<PathBuf> {
+    let mut candidates = configured.into_iter().collect::<Vec<_>>();
+    for build_dir in ["build", "build_ci"] {
+        for configuration in [Some("Release"), None, Some("Debug")] {
+            for file_name in file_names {
                 let mut candidate = repo_root.join("runtime").join(build_dir).join("bin");
                 if let Some(configuration) = configuration {
                     candidate.push(configuration);
@@ -93,6 +106,10 @@ fn runtime_library_candidate_paths() -> Vec<PathBuf> {
                 candidates.push(candidate);
             }
         }
+    }
+    for file_name in file_names {
+        candidates.push(repo_root.join(file_name));
+        candidates.push(repo_root.join("build").join(file_name));
     }
     candidates
 }

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -2259,6 +2259,7 @@ fn run_play_in_process_inner(
     );
 
     let gfx = stasis_dynload::StasisGraphicsApi::load_default()?;
+    gfx.set_asset_root(prepared_asset_root.as_deref().unwrap_or(&project_root))?;
     let mut frame_evidence = DesktopFrameEvidence::from_env()?;
     let configured_title = window_title.or_else(|| {
         live.as_ref()

--- a/apps/stasis/tests/runtime_library_candidates.rs
+++ b/apps/stasis/tests/runtime_library_candidates.rs
@@ -1,0 +1,60 @@
+#[allow(dead_code)]
+#[path = "../build.rs"]
+mod build_script;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write_fixture(path: &Path) {
+    fs::create_dir_all(path.parent().expect("fixture parent"))
+        .expect("create runtime fixture parent");
+    fs::write(path, b"runtime").expect("write runtime fixture");
+}
+
+#[test]
+fn fresh_runtime_build_precedes_legacy_copies_but_explicit_override_wins() {
+    let root = std::env::temp_dir().join(format!(
+        "stasis_runtime_library_candidates_{}_{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    let _ = fs::remove_dir_all(&root);
+
+    let fresh = root
+        .join("runtime")
+        .join("build")
+        .join("bin")
+        .join("Release")
+        .join("stasis_graphics.dll");
+    let stale_root = root.join("stasis_graphics.dll");
+    let stale_build = root.join("build").join("stasis_graphics.dll");
+    write_fixture(&fresh);
+    write_fixture(&stale_root);
+    write_fixture(&stale_build);
+
+    let candidates = build_script::runtime_library_candidate_paths_for(
+        &root,
+        std::iter::empty::<PathBuf>(),
+        &["stasis_graphics.dll"],
+    );
+    let selected = candidates
+        .iter()
+        .find(|candidate| candidate.is_file())
+        .expect("select a runtime candidate");
+    assert_eq!(selected, &fresh);
+
+    let explicit = root.join("explicit").join("stasis_graphics.dll");
+    write_fixture(&explicit);
+    let candidates = build_script::runtime_library_candidate_paths_for(
+        &root,
+        [explicit.clone()],
+        &["stasis_graphics.dll"],
+    );
+    let selected = candidates
+        .iter()
+        .find(|candidate| candidate.is_file())
+        .expect("select an explicitly configured runtime candidate");
+    assert_eq!(selected, &explicit);
+
+    fs::remove_dir_all(root).expect("remove runtime candidate fixture");
+}

--- a/apps/stasis/tests/toolchain_cli.rs
+++ b/apps/stasis/tests/toolchain_cli.rs
@@ -2711,10 +2711,10 @@ fn tui_discovers_entry_workspace_and_anchors_source_relative_assets() {
     fs::create_dir_all(project.join("assets")).expect("create asset directory");
 
     let sample = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../samples/render_parity");
-    let main_source = fs::read_to_string(sample.join("main.stasis"))
-        .expect("read render parity entry")
-        .replace("\"assets/", "\"../assets/");
-    fs::write(project.join("src/main.stasis"), main_source).expect("write nested entry");
+    let main_source =
+        fs::read_to_string(sample.join("main.stasis")).expect("read render parity entry");
+    let rooted_source = main_source.replace("\"assets/", "\"/assets/");
+    fs::write(project.join("src/main.stasis"), rooted_source).expect("write rooted entry");
     fs::copy(
         sample.join("frame.stasis"),
         project.join("src/frame.stasis"),
@@ -2739,6 +2739,28 @@ fn tui_discovers_entry_workspace_and_anchors_source_relative_assets() {
     .expect("write manifest");
     fs::write(project.join("live.commands"), ":quit\n").expect("write live script");
 
+    let rooted_output = stasis(
+        &[
+            "tui",
+            "demo/src/main.stasis",
+            "--live-script",
+            "live.commands",
+            "--live-json",
+        ],
+        &parent,
+    );
+    assert_eq!(
+        rooted_output.status.code(),
+        Some(0),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&rooted_output.stdout),
+        String::from_utf8_lossy(&rooted_output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&rooted_output.stdout).contains("\"kind\":\"quitting\""));
+    assert!(!String::from_utf8_lossy(&rooted_output.stderr).contains("failed to open"));
+
+    let legacy_source = main_source.replace("\"assets/", "\"../assets/");
+    fs::write(project.join("src/main.stasis"), legacy_source).expect("write legacy entry");
     let output = stasis(
         &[
             "tui",

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const CONTINUE_LOOP_PARITY: &str =
     include_str!("../../../tests/stasis/seams/continue_loop_parity.stasis");
+const ROOTED_WEB_ASSET: &str = "/assets/smoke.svg";
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -645,6 +646,48 @@ fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
     assert!(output.join("assets/smoke.ttf").is_file());
 
     fs::remove_dir_all(&output).expect("clean existing game web package");
+}
+
+#[test]
+fn rooted_web_asset_paths_emit_package_relative_assets() {
+    let root = repo_root();
+    let source_workspace = root.join("samples/windows_launch_smoke");
+    let workspace = root
+        .join("build")
+        .join(format!("web-rooted-assets-test-{}", stamp()));
+    fs::create_dir_all(workspace.join("assets")).expect("create rooted web fixture");
+    for file in ["stasis.json", "main.stasis"] {
+        fs::copy(source_workspace.join(file), workspace.join(file)).expect("copy web fixture");
+    }
+    for file in ["manifest.json", "smoke.png", "smoke.svg", "smoke.ttf"] {
+        fs::copy(
+            source_workspace.join("assets").join(file),
+            workspace.join("assets").join(file),
+        )
+        .expect("copy web fixture asset");
+    }
+    let source = fs::read_to_string(workspace.join("main.stasis"))
+        .expect("read rooted web fixture source")
+        .replace("\"assets/smoke.svg\"", &format!("\"{ROOTED_WEB_ASSET}\""));
+    fs::write(workspace.join("main.stasis"), source).expect("write rooted web fixture source");
+
+    let output = package(&workspace, Path::new("build/web-package"));
+    assert!(
+        output.join("assets/smoke.svg").is_file(),
+        "rooted asset was not emitted at its package-relative key"
+    );
+    let runtime = fs::read_to_string(output.join("game.js")).expect("rooted web runtime");
+    assert!(
+        runtime.contains(&format!("\"{ROOTED_WEB_ASSET}\"")),
+        "rooted asset literal was not retained in runtime metadata"
+    );
+    assert!(
+        runtime.contains("value.startsWith(\"/assets/\")")
+            && runtime.contains("return value.slice(1)"),
+        "web runtime is missing the rooted-to-package-relative asset mapping"
+    );
+
+    fs::remove_dir_all(&workspace).expect("clean rooted web fixture");
 }
 
 #[test]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1003,6 +1003,7 @@ pub fn graphics_runtime_release_id(path: &Path) -> Result<String, String> {
 pub struct StasisGraphicsApi {
     _lib: Library,
     stasis_init_window: usize,
+    stasis_set_asset_root: usize,
     stasis_host_get_frame: usize,
     stasis_host_bulk_init: usize,
     stasis_host_bulk_apply_requests: usize,
@@ -1036,6 +1037,7 @@ impl StasisGraphicsApi {
         let lib = Library::load(path)?;
         verify_graphics_runtime_abi(&lib, path)?;
         let stasis_init_window = lib.symbol_address("stasis_init_window")?;
+        let stasis_set_asset_root = lib.symbol_address("stasis_set_asset_root")?;
         let stasis_host_get_frame = lib.symbol_address("stasis_host_get_frame")?;
         let stasis_host_bulk_init = lib.symbol_address("stasis_host_bulk_init")?;
         let stasis_host_bulk_apply_requests =
@@ -1054,6 +1056,7 @@ impl StasisGraphicsApi {
         Ok(Self {
             _lib: lib,
             stasis_init_window,
+            stasis_set_asset_root,
             stasis_host_get_frame,
             stasis_host_bulk_init,
             stasis_host_bulk_apply_requests,
@@ -1083,6 +1086,35 @@ impl StasisGraphicsApi {
             let callback: extern "C" fn(i32, i32, *const c_char) -> i32 =
                 unsafe { std::mem::transmute(self.stasis_init_window) };
             Ok(callback(width, height, title.as_ptr()) != 0)
+        }
+    }
+
+    pub fn set_asset_root(&self, path: &Path) -> Result<(), String> {
+        let path = CString::new(path.to_string_lossy().as_bytes())
+            .map_err(|_| "asset root contains an interior NUL byte".to_string())?;
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn(*const c_char) -> i32 =
+                unsafe { std::mem::transmute(self.stasis_set_asset_root) };
+            if callback(path.as_ptr()) == 0 {
+                return Err(format!(
+                    "graphics runtime rejected asset root {}",
+                    path.to_string_lossy()
+                ));
+            }
+            return Ok(());
+        }
+        #[cfg(not(windows))]
+        {
+            let callback: extern "C" fn(*const c_char) -> i32 =
+                unsafe { std::mem::transmute(self.stasis_set_asset_root) };
+            if callback(path.as_ptr()) == 0 {
+                return Err(format!(
+                    "graphics runtime rejected asset root {}",
+                    path.to_string_lossy()
+                ));
+            }
+            Ok(())
         }
     }
 

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -115,7 +115,11 @@
     Math.max(0, Math.min(255, Math.round(b * 255)))
   );
   const stringValue = id => game.strings[String(id)] || "";
-  const assetKey = value => value.replace(/^(?:\.\.\/|\.\/)+/, "");
+  const assetKey = value => {
+    if (value === "/assets") return "assets";
+    if (value.startsWith("/assets/")) return value.slice(1);
+    return value.replace(/^(?:\.\.\/|\.\/)+/, "");
+  };
   const assetValue = id => {
     const value = stringValue(id);
     const key = assetKey(value);

--- a/runtime/web/tests/asset_paths.test.mjs
+++ b/runtime/web/tests/asset_paths.test.mjs
@@ -10,6 +10,7 @@ async function loadRuntime(game, options = {}) {
   const measurements = [];
   const animationFrames = [];
   const addedFonts = [];
+  const fontSources = [];
   let env;
   const memory = new WebAssembly.Memory({ initial: 1 });
   const context2d = {
@@ -92,6 +93,11 @@ async function loadRuntime(game, options = {}) {
       get src() { return this.value; }
     },
     FontFace: class {
+      constructor(family, source) {
+        this.family = family;
+        this.source = source;
+        fontSources.push(source);
+      }
       load() { return options.fontLoad ? options.fontLoad(this) : Promise.resolve(this); }
     },
     AudioContext: class {
@@ -111,7 +117,10 @@ async function loadRuntime(game, options = {}) {
   await new Promise(resolve => setImmediate(resolve));
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(typeof env?.gfx_load_sprite, "function", errorBox.textContent);
-  return { env, imageSources, measurements, animationFrames, addedFonts, document, errorBox, runtimePromise };
+  return {
+    env, imageSources, measurements, animationFrames, addedFonts, fontSources,
+    document, errorBox, runtimePromise,
+  };
 }
 
 test("web asset paths normalize fallback values and preserve explicit overrides", async () => {
@@ -142,6 +151,35 @@ test("web asset paths normalize fallback values and preserve explicit overrides"
     "assets/packed/override-123.png",
     "",
   ]);
+});
+
+test("web rooted sprite and font paths use package-relative asset keys", async () => {
+  const game = {
+    memory: {},
+    strings: {
+      "1": "/assets/rooted-fallback.png",
+      "2": "/assets/rooted.png",
+      "3": "/assets/rooted.ttf",
+      "4": "/textures/absolute.png",
+    },
+    assets: {
+      "assets/rooted.png": "assets/packed/rooted-123.png",
+      "assets/rooted.ttf": "assets/packed/rooted-456.ttf",
+    },
+  };
+  const { env, imageSources, fontSources } = await loadRuntime(game);
+
+  env.gfx_load_sprite(1);
+  env.gfx_load_sprite(2);
+  env.load_font(3, 20);
+  env.gfx_load_sprite(4);
+
+  assert.deepEqual(imageSources, [
+    "assets/rooted-fallback.png",
+    "assets/packed/rooted-123.png",
+    "/textures/absolute.png",
+  ]);
+  assert.deepEqual(fontSources, ["url(assets/packed/rooted-456.ttf)"]);
 });
 
 test("web measure_text uses the registered Canvas font and string handle", async () => {


### PR DESCRIPTION
## Summary
- anchor live graphics assets at the prepared package root or project root before guest startup
- prefer freshly built graphics runtimes over stale legacy DLL copies
- normalize rooted /assets paths to package-relative keys in the web runtime
- add compile/runtime/package regression coverage for native live mode and web assets

## Verification
- cargo check -p stasis_dynload -p stasis
- cargo test -p stasis_compiler validation_resolves_declaring_module_and_reports_every_path_contract
- cargo test -p stasis --test runtime_library_candidates
- cargo test -p stasis --test toolchain_cli tui_discovers_entry_workspace_and_anchors_source_relative_assets
- cargo test -p stasis --test web_package rooted_web_asset_paths_emit_package_relative_assets
- node --test runtime/web/tests/asset_paths.test.mjs
- rustfmt --edition 2021 --check on changed Rust files
- Sheep Herder no-override native captures: 18/24/42px fonts loaded, render contract text=3
- Sheep Herder web and Android packages contain byte-identical sheep_font.ttf assets