### PR TITLE
Add deterministic headless video recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,22 @@ stasis play game.stasis `
 
 This turns a graphical interaction into a repeatable test artifact. PNG bytes are deterministic for identical pixels, though rasterization may still differ across graphics backends, drivers, and platforms.
 
+For deterministic desktop-first video review, use the hidden fixed-rate recorder:
+
+```powershell
+stasis --workspace samples/windows_launch_smoke record main.stasis `
+  --output artifacts/frames --width 640 --height 360 --fps 60 --frames 3 `
+  --input-script record_input.json
+stasis --workspace samples/windows_launch_smoke record main.stasis `
+  --output artifacts/review.mp4 --width 640 --height 360 --fps 60 --frames 3
+```
+
+An extensionless output is an atomically published, staged PNG sequence; `.mp4` uses
+FFmpeg H.264/yuv420p and requires `ffmpeg` on `PATH`. Recording uses the normal
+JIT/render path, zero tick sleep, fixed physical output dimensions, logical
+canvas letterboxing, and no visible or focused window. See
+[docs/headless_recording.md](docs/headless_recording.md).
+
 ## Installation and Setup
 
 Stasis is fast-moving and breaking changes are expected. Nightly release archives are published from `main` on the [GitHub Releases page](https://github.com/benwmaddox/StasisLang/releases).

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -56,6 +56,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
@@ -70,6 +71,98 @@ pub struct PlayProfileConfig {
     pub functions: Vec<String>,
     pub warmup_ticks: u64,
     pub output_path: Option<PathBuf>,
+}
+
+/// Fixed-rate capture inserted into the existing JIT play loop.
+///
+/// The runtime owns presentation and PNG encoding; the host only schedules one
+/// pre-present capture for each committed rendered frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayFrameCaptureConfig {
+    pub output_dir: PathBuf,
+    pub width: u32,
+    pub height: u32,
+    pub fps: u32,
+    pub frame_count: u64,
+}
+
+struct PlayCaptureEnvironment {
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+static PLAY_CAPTURE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct PlayCurrentDirectoryGuard {
+    path: PathBuf,
+}
+
+impl Drop for PlayCurrentDirectoryGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.path);
+    }
+}
+
+impl PlayCaptureEnvironment {
+    fn install(config: &PlayFrameCaptureConfig) -> Result<Self, String> {
+        if config.width == 0 || config.height == 0 || config.fps == 0 || config.frame_count == 0 {
+            return Err(
+                "recording capture requires positive dimensions and frame count".to_string(),
+            );
+        }
+        let lock = PLAY_CAPTURE_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .map_err(|_| "recording capture process lock is poisoned".to_string())?;
+        fs::create_dir_all(&config.output_dir).map_err(|error| {
+            format!(
+                "failed to create recording staging directory {}: {error}",
+                config.output_dir.display()
+            )
+        })?;
+        let names = [
+            "STASIS_RECORDING_WIDTH",
+            "STASIS_RECORDING_HEIGHT",
+            "STASIS_RECORDING_FPS",
+            "STASIS_RECORDING_PRESENTATION",
+            "STASIS_WINDOW_HIDDEN",
+            "STASIS_USE_SDL",
+            "STASIS_GFX_VSYNC",
+            "SDL_VIDEODRIVER",
+            "SDL_RENDER_DRIVER",
+        ];
+        let previous = names
+            .into_iter()
+            .map(|name| (name, std::env::var_os(name)))
+            .collect();
+        std::env::set_var("STASIS_RECORDING_WIDTH", config.width.to_string());
+        std::env::set_var("STASIS_RECORDING_HEIGHT", config.height.to_string());
+        std::env::set_var("STASIS_RECORDING_FPS", config.fps.to_string());
+        std::env::set_var("STASIS_RECORDING_PRESENTATION", "1");
+        std::env::set_var("STASIS_WINDOW_HIDDEN", "1");
+        std::env::set_var("STASIS_USE_SDL", "1");
+        std::env::set_var("STASIS_GFX_VSYNC", "0");
+        std::env::set_var("SDL_VIDEODRIVER", "dummy");
+        std::env::set_var("SDL_RENDER_DRIVER", "software");
+        stasis_dynload::set_recording_clock(config.fps, 0);
+        Ok(Self {
+            previous,
+            _lock: lock,
+        })
+    }
+}
+
+impl Drop for PlayCaptureEnvironment {
+    fn drop(&mut self) {
+        stasis_dynload::clear_recording_clock();
+        for (name, value) in self.previous.drain(..).rev() {
+            if let Some(value) = value {
+                std::env::set_var(name, value);
+            } else {
+                std::env::remove_var(name);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1947,6 +2040,7 @@ pub fn run_play_in_process(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -1981,6 +2075,7 @@ pub fn run_play_in_process_with_window_title(
         tick_sleep_micros,
         max_ticks,
         Some(window_title),
+        None,
         None,
         None,
     )
@@ -2032,6 +2127,34 @@ pub fn run_play_in_process_with_input_script_and_window_title(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub fn run_play_in_process_with_input_script_window_title_profile_and_capture(
+    watch_file: &Path,
+    watch_dir: Option<&Path>,
+    data_bind_json: Option<&Path>,
+    data_bind_struct_meta: Option<&Path>,
+    input_script: Option<&Path>,
+    tick_sleep_micros: u64,
+    max_ticks: Option<u64>,
+    window_title: Option<&str>,
+    profile: Option<PlayProfileConfig>,
+    capture: PlayFrameCaptureConfig,
+) -> Result<(), String> {
+    run_play_in_process_inner(
+        watch_file,
+        watch_dir,
+        data_bind_json,
+        data_bind_struct_meta,
+        input_script,
+        tick_sleep_micros,
+        max_ticks,
+        window_title,
+        profile,
+        None,
+        Some(capture),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn run_play_in_process_with_input_script_window_title_and_profile(
     watch_file: &Path,
     watch_dir: Option<&Path>,
@@ -2053,6 +2176,7 @@ pub fn run_play_in_process_with_input_script_window_title_and_profile(
         max_ticks,
         window_title,
         profile,
+        None,
         None,
     )
 }
@@ -2099,6 +2223,7 @@ pub fn run_live_in_process_with_data(
         None,
         None,
         Some((server, config)),
+        None,
     )
 }
 
@@ -2114,10 +2239,14 @@ fn run_play_in_process_inner(
     window_title: Option<&str>,
     mut profile: Option<PlayProfileConfig>,
     live: Option<(stasis_runner::live::LiveSessionServer, LiveRunConfig)>,
+    capture: Option<PlayFrameCaptureConfig>,
 ) -> Result<(), String> {
     let watch_dir = resolve_play_watch_dir(watch_file, watch_dir);
     let launch_dir = std::env::current_dir()
         .map_err(|error| format!("failed to read current directory before play launch: {error}"))?;
+    let _current_directory_guard = PlayCurrentDirectoryGuard {
+        path: launch_dir.clone(),
+    };
     if let Some(output_path) = profile
         .as_mut()
         .and_then(|profile| profile.output_path.as_mut())
@@ -2258,7 +2387,14 @@ fn run_play_in_process_inner(
         &mut host_req_window_h_px,
     );
 
+    let _capture_environment = capture
+        .as_ref()
+        .map(PlayCaptureEnvironment::install)
+        .transpose()?;
     let gfx = stasis_dynload::StasisGraphicsApi::load_default()?;
+    if let Some(capture) = capture.as_ref() {
+        gfx.set_recording_config(capture.width, capture.height, capture.fps)?;
+    }
     gfx.set_asset_root(prepared_asset_root.as_deref().unwrap_or(&project_root))?;
     let mut frame_evidence = DesktopFrameEvidence::from_env()?;
     let configured_title = window_title.or_else(|| {
@@ -2539,6 +2675,9 @@ fn run_play_in_process_inner(
             );
         }
 
+        if capture.is_some() {
+            stasis_dynload::set_recording_clock_frame(ticks_executed);
+        }
         gfx.host_get_frame(&mut host_i32, &mut host_f32)?;
         if host_i32.get(9).copied().unwrap_or(0) != 0 {
             break;
@@ -2589,6 +2728,20 @@ fn run_play_in_process_inner(
 
         if measure_hud {
             gfx.host_set_performance_metrics(tick_micros, render_micros)?;
+        }
+        if let Some(capture) = capture.as_ref() {
+            let frame = ticks_executed.saturating_add(1);
+            if frame <= capture.frame_count {
+                let path = capture.output_dir.join(format!("frame-{frame:06}.png"));
+                stasis_dynload::schedule_runtime_screenshot(&path).map_err(|error| {
+                    format!(
+                        "recording capture stage failed for frame {frame} at {} ({}x{}): {error}",
+                        path.display(),
+                        capture.width,
+                        capture.height
+                    )
+                })?;
+            }
         }
         gfx.gfx_submit_u8(&mut gfx_cmd_i32, &gfx_cmd_f32, &gfx_cmd_u8)?;
         if let Some(evidence) = frame_evidence.as_mut() {
@@ -5244,6 +5397,37 @@ mod tests {
                 && STASIS_GRAPHICS_SOURCE.contains("capture_scheduled_screenshot();")
                 && STASIS_GRAPHICS_EXPORTS.contains("stasis_host_schedule_screenshot"),
             "Gauntlet captures must arm the existing pre-present screenshot path"
+        );
+    }
+
+    #[test]
+    fn recording_runtime_keeps_fixed_hidden_surface_and_logical_letterbox() {
+        for required in [
+            "STASIS_RECORDING_PRESENTATION",
+            "STASIS_RECORDING_FPS",
+            "stasis_set_recording_config",
+            "SDL_WINDOW_HIDDEN",
+            "SDL_SetRenderVSync(g_renderer, g_recording_presentation ? 0 : 1)",
+            "SDL_LOGICAL_PRESENTATION_LETTERBOX",
+            "if (g_recording_presentation)",
+            "stasis_recording_clock_us",
+            "micros > (uint64_t)INT_MAX ? INT_MAX",
+        ] {
+            assert!(
+                STASIS_GRAPHICS_SOURCE.contains(required),
+                "recording runtime contract should contain {required}"
+            );
+        }
+        let fullscreen = STASIS_GRAPHICS_SOURCE
+            .find("STASIS_EXPORT int stasis_set_fullscreen(int fullscreen) {")
+            .expect("fullscreen export");
+        let fullscreen_body = &STASIS_GRAPHICS_SOURCE[fullscreen..];
+        assert!(
+            fullscreen_body[..fullscreen_body
+                .find("bool result = SDL_SetWindowFullscreen")
+                .expect("fullscreen platform call")]
+                .contains("if (g_recording_presentation)"),
+            "recording fullscreen requests must not touch the hidden surface"
         );
     }
 

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -46,6 +46,7 @@ mod dap;
 mod gauntlet;
 mod headless;
 mod live_tui;
+mod record;
 
 const MANIFEST_NAME: &str = "stasis.json";
 const MANIFEST_VERSION: u32 = 1;
@@ -213,6 +214,7 @@ const COMMANDS: &[&str] = &[
     "gauntlet",
     "validate",
     "run",
+    "record",
     "lsp",
     "dap",
     "tui",
@@ -343,6 +345,11 @@ enum ToolchainCommand {
         /// Run bounded ticks without wall-clock pacing (headless only).
         #[arg(long)]
         fast_forward: bool,
+    },
+    /// Render a deterministic fixed-rate headless PNG sequence or MP4 recording.
+    Record {
+        #[command(flatten)]
+        args: record::RecordArgs,
     },
     /// Run the persistent Stasis language server.
     Lsp {
@@ -961,6 +968,7 @@ fn command_name(command: &ToolchainCommand) -> &'static str {
         ToolchainCommand::Validate { .. } => "validate",
         ToolchainCommand::ValidateRuntime { .. } => "__validate-runtime",
         ToolchainCommand::Run { .. } => "run",
+        ToolchainCommand::Record { .. } => "record",
         ToolchainCommand::Lsp { .. } => "lsp",
         ToolchainCommand::Dap { .. } => "dap",
         ToolchainCommand::Tui { .. } => "tui",
@@ -1107,6 +1115,7 @@ fn execute(
                         run_workspace(&workspace, headless, ticks, fast_forward)
                     }
                 }
+                ToolchainCommand::Record { args } => record::execute(&workspace, args),
                 ToolchainCommand::Lsp { stdio } => {
                     if json_output {
                         Err("--json cannot be combined with lsp; LSP owns stdout".to_string())
@@ -6888,6 +6897,64 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn record_accepts_exact_sixty_fps_and_frame_count() {
+        let parsed = ToolchainCli::try_parse_from([
+            "stasis",
+            "--workspace",
+            "demo",
+            "record",
+            "src/main.stasis",
+            "--output",
+            "artifacts/frames",
+            "--width",
+            "640",
+            "--height",
+            "360",
+            "--fps",
+            "60",
+            "--frames",
+            "12",
+        ])
+        .expect("parse recording command");
+        assert!(matches!(
+            parsed.command,
+            ToolchainCommand::Record { args }
+                if args.entry == Some(PathBuf::from("src/main.stasis"))
+                    && args.width == 640
+                    && args.height == 360
+                    && args.fps == 60
+                    && args.frames == Some(12)
+                    && args.duration.is_none()
+        ));
+    }
+
+    #[test]
+    fn record_requires_one_duration_or_frame_count() {
+        assert!(ToolchainCli::try_parse_from([
+            "stasis", "record", "--output", "frames", "--width", "1", "--height", "1", "--fps",
+            "60"
+        ])
+        .is_err());
+        assert!(ToolchainCli::try_parse_from([
+            "stasis",
+            "record",
+            "--output",
+            "frames",
+            "--width",
+            "1",
+            "--height",
+            "1",
+            "--fps",
+            "60",
+            "--frames",
+            "1",
+            "--duration",
+            "1"
+        ])
+        .is_err());
     }
 
     #[test]

--- a/apps/stasis/src/toolchain_cli/record.rs
+++ b/apps/stasis/src/toolchain_cli/record.rs
@@ -1,0 +1,488 @@
+use super::{CommandResult, Workspace};
+use clap::Args;
+use image::GenericImageView;
+use serde_json::json;
+use stasis::{
+    run_play_in_process_with_input_script_window_title_profile_and_capture, PlayFrameCaptureConfig,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_DIMENSION: u32 = 8192;
+const MAX_FPS: u32 = 240;
+const MAX_FRAMES: u64 = 999_999;
+
+#[derive(Debug, Args)]
+pub(super) struct RecordArgs {
+    /// Override the manifest entry with a project-relative .stasis file.
+    #[arg(value_name = "ENTRY")]
+    pub(super) entry: Option<PathBuf>,
+    /// Output directory for PNG frames, or an .mp4 file for H.264 encoding.
+    #[arg(long, value_name = "PATH")]
+    pub(super) output: PathBuf,
+    #[arg(long, value_name = "PIXELS")]
+    pub(super) width: u32,
+    #[arg(long, value_name = "PIXELS")]
+    pub(super) height: u32,
+    #[arg(long, value_name = "FPS")]
+    pub(super) fps: u32,
+    /// Capture exactly this many committed rendered frames.
+    #[arg(
+        long,
+        visible_alias = "ticks",
+        conflicts_with = "duration",
+        required_unless_present = "duration"
+    )]
+    pub(super) frames: Option<u64>,
+    /// Capture this many whole seconds (frames = duration * fps).
+    #[arg(long, conflicts_with = "frames", required_unless_present = "frames")]
+    pub(super) duration: Option<u64>,
+    /// Apply the existing deterministic pointer input timeline.
+    #[arg(long, value_name = "PATH")]
+    pub(super) input_script: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputKind {
+    PngSequence,
+    Mp4,
+}
+
+pub(super) fn execute(workspace: &Workspace, args: RecordArgs) -> Result<CommandResult, String> {
+    let frame_count = validate_args(&args)?;
+    let output = absolute_path(&args.output)?;
+    let parent = output
+        .parent()
+        .ok_or_else(|| format!("recording output has no parent: {}", output.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "recording stage failed: could not create output parent {}: {error}",
+            parent.display()
+        )
+    })?;
+    if output.exists() {
+        return Err(format!(
+            "recording output already exists; refusing to replace {}",
+            output.display()
+        ));
+    }
+    let kind = output_kind(&output)?;
+    if kind == OutputKind::Mp4 && (args.width % 2 != 0 || args.height % 2 != 0) {
+        return Err(format!(
+            "MP4 recording requires even dimensions for yuv420p (requested {}x{})",
+            args.width, args.height
+        ));
+    }
+    let entry = resolve_entry(workspace, args.entry.as_deref())?;
+    let input_script = args
+        .input_script
+        .as_deref()
+        .map(|path| resolve_workspace_path(workspace, path, "input script"))
+        .transpose()?;
+    let stage_root = parent.join(format!(
+        ".stasis-recording-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |value| value.as_nanos())
+    ));
+    let frames_dir = stage_root.join("frames");
+    if let Err(error) = fs::create_dir_all(&frames_dir) {
+        cleanup_stage(&stage_root);
+        return Err(format!(
+            "recording stage failed: could not create {}: {error}",
+            frames_dir.display()
+        ));
+    }
+
+    let result = run_play_in_process_with_input_script_window_title_profile_and_capture(
+        &entry,
+        Some(&workspace.root),
+        None,
+        None,
+        input_script.as_deref(),
+        0,
+        Some(frame_count),
+        Some(&workspace.manifest.name),
+        None,
+        PlayFrameCaptureConfig {
+            output_dir: frames_dir.clone(),
+            width: args.width,
+            height: args.height,
+            fps: args.fps,
+            frame_count,
+        },
+    );
+    if let Err(error) = result {
+        cleanup_stage(&stage_root);
+        return Err(format!(
+            "recording play stage failed (recording presentation=hidden-sdl-software, {}x{} at {} fps, entry {}, output {}): {error}",
+            args.width,
+            args.height,
+            args.fps,
+            entry.display(),
+            output.display()
+        ));
+    }
+
+    if let Err(error) = validate_frames(&frames_dir, args.width, args.height, frame_count) {
+        cleanup_stage(&stage_root);
+        return Err(format!(
+            "recording validation failed (recording presentation=hidden-sdl-software, {}x{} at {} fps, output {}): {error}",
+            args.width,
+            args.height,
+            args.fps,
+            output.display()
+        ));
+    }
+
+    // The stage is complete before this atomic same-volume no-replace rename.
+    let publish_result = if output.exists() {
+        Err(format!(
+            "recording publish refused to replace destination {}",
+            output.display()
+        ))
+    } else {
+        match kind {
+            OutputKind::PngSequence => {
+                stasis_dynload::atomic_rename_no_replace(&frames_dir, &output).map_err(|error| {
+                    format!(
+                        "recording publish failed for PNG sequence {}: {error}",
+                        output.display()
+                    )
+                })
+            }
+            OutputKind::Mp4 => encode_mp4(&frames_dir, &stage_root, &output, args.fps, frame_count),
+        }
+    };
+    if let Err(error) = publish_result {
+        cleanup_stage(&stage_root);
+        return Err(error);
+    }
+    cleanup_stage(&stage_root);
+
+    let format = match kind {
+        OutputKind::PngSequence => "png-sequence",
+        OutputKind::Mp4 => "mp4",
+    };
+    Ok(CommandResult::success(
+        format!(
+            "recorded {frame_count} frame(s) at {}x{} and {} fps to {}",
+            args.width,
+            args.height,
+            args.fps,
+            output.display()
+        ),
+        json!({
+            "format": format,
+            "output": output,
+            "width": args.width,
+            "height": args.height,
+            "fps": args.fps,
+            "frames": frame_count,
+            "entry": entry,
+        }),
+    ))
+}
+
+fn cleanup_stage(stage_root: &Path) {
+    match fs::remove_dir_all(stage_root) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => eprintln!(
+            "recording cleanup warning: could not remove staging directory {}: {error}",
+            stage_root.display()
+        ),
+    }
+}
+
+fn validate_args(args: &RecordArgs) -> Result<u64, String> {
+    if args.width == 0 || args.width > MAX_DIMENSION {
+        return Err(format!("--width must be between 1 and {MAX_DIMENSION}"));
+    }
+    if args.height == 0 || args.height > MAX_DIMENSION {
+        return Err(format!("--height must be between 1 and {MAX_DIMENSION}"));
+    }
+    if args.fps == 0 || args.fps > MAX_FPS {
+        return Err(format!("--fps must be between 1 and {MAX_FPS}"));
+    }
+    let frames = match (args.frames, args.duration) {
+        (Some(frames), None) => frames,
+        (None, Some(duration)) => duration
+            .checked_mul(u64::from(args.fps))
+            .ok_or_else(|| "--duration * --fps overflows the recording frame count".to_string())?,
+        (Some(_), Some(_)) => return Err("--frames cannot be combined with --duration".to_string()),
+        (None, None) => return Err("one of --frames or --duration is required".to_string()),
+    };
+    if frames == 0 || frames > MAX_FRAMES {
+        return Err(format!(
+            "recording frame count must be between 1 and {MAX_FRAMES}"
+        ));
+    }
+    Ok(frames)
+}
+
+fn output_kind(path: &Path) -> Result<OutputKind, String> {
+    match path.extension().and_then(|value| value.to_str()) {
+        None => Ok(OutputKind::PngSequence),
+        Some(extension) if extension.eq_ignore_ascii_case("mp4") => Ok(OutputKind::Mp4),
+        Some(extension) => Err(format!(
+            "unsupported recording output extension .{extension} for {}; use an extensionless PNG directory or .mp4",
+            path.display()
+        )),
+    }
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf, String> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        std::env::current_dir()
+            .map(|directory| directory.join(path))
+            .map_err(|error| {
+                format!(
+                    "failed to resolve recording path {}: {error}",
+                    path.display()
+                )
+            })
+    }
+}
+
+fn resolve_workspace_path(
+    workspace: &Workspace,
+    path: &Path,
+    label: &str,
+) -> Result<PathBuf, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace.root.join(path)
+    };
+    let resolved = candidate
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve {label} {}: {error}", candidate.display()))?;
+    if !comparison_path(&resolved).starts_with(comparison_path(&workspace.root)) {
+        return Err(format!(
+            "{label} {} must stay under workspace {}",
+            resolved.display(),
+            workspace.root.display()
+        ));
+    }
+    Ok(resolved)
+}
+
+fn comparison_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let value = path.to_string_lossy();
+        if let Some(value) = value.strip_prefix(r"\\?\") {
+            return PathBuf::from(value);
+        }
+    }
+    path.to_path_buf()
+}
+
+fn resolve_entry(workspace: &Workspace, entry: Option<&Path>) -> Result<PathBuf, String> {
+    let path = entry.unwrap_or_else(|| Path::new(&workspace.manifest.entry));
+    let resolved = resolve_workspace_path(workspace, path, "recording entry")?;
+    if resolved.extension().and_then(|value| value.to_str()) != Some("stasis") {
+        return Err(format!(
+            "recording entry must be a .stasis file: {}",
+            resolved.display()
+        ));
+    }
+    Ok(resolved)
+}
+
+fn validate_frames(
+    frames_dir: &Path,
+    width: u32,
+    height: u32,
+    expected: u64,
+) -> Result<(), String> {
+    let mut paths = fs::read_dir(frames_dir)
+        .map_err(|error| format!("failed to inspect staged frames: {error}"))?
+        .map(|entry| entry.map(|value| value.path()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("failed to inspect staged frame entry: {error}"))?;
+    paths.sort();
+    if paths.len() as u64 != expected {
+        return Err(format!(
+            "expected {expected} PNG frames, found {}",
+            paths.len()
+        ));
+    }
+    for (index, path) in paths.iter().enumerate() {
+        let expected_name = format!("frame-{:06}.png", index + 1);
+        if path.file_name().and_then(|value| value.to_str()) != Some(expected_name.as_str()) {
+            return Err(format!(
+                "unexpected frame ordering/name at {}",
+                path.display()
+            ));
+        }
+        let image = image::open(path).map_err(|error| {
+            format!("failed to decode staged frame {}: {error}", path.display())
+        })?;
+        if image.dimensions() != (width, height) {
+            return Err(format!(
+                "frame {} has dimensions {}x{}, expected {}x{}",
+                path.display(),
+                image.width(),
+                image.height(),
+                width,
+                height
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn encode_mp4(
+    frames_dir: &Path,
+    stage_root: &Path,
+    output: &Path,
+    fps: u32,
+    frame_count: u64,
+) -> Result<(), String> {
+    let staged_output = stage_root.join("recording.mp4");
+    let pattern = frames_dir.join("frame-%06d.png");
+    let command = Command::new("ffmpeg")
+        .args(ffmpeg_args(&pattern, &staged_output, fps, frame_count))
+        .output()
+        .map_err(|error| format!("MP4 encoder failure: could not start ffmpeg: {error}"))?;
+    if !command.status.success() {
+        let detail = String::from_utf8_lossy(&command.stderr).trim().to_string();
+        return Err(format!(
+            "MP4 encoder failure: ffmpeg exited with {}{}",
+            command.status,
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        ));
+    }
+    let metadata = fs::metadata(&staged_output).map_err(|error| {
+        format!(
+            "MP4 encoder failure: ffmpeg produced no artifact {}: {error}",
+            staged_output.display()
+        )
+    })?;
+    if metadata.len() == 0 {
+        return Err(format!(
+            "MP4 encoder failure: ffmpeg produced an empty artifact {}",
+            staged_output.display()
+        ));
+    }
+    fs::remove_dir_all(frames_dir).map_err(|error| {
+        format!(
+            "recording cleanup failed before MP4 publication for {}: {error}",
+            frames_dir.display()
+        )
+    })?;
+    stasis_dynload::atomic_rename_no_replace(&staged_output, output).map_err(|error| {
+        format!(
+            "recording publish failed for MP4 {}: {error}",
+            output.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn ffmpeg_args(pattern: &Path, output: &Path, fps: u32, frame_count: u64) -> Vec<String> {
+    vec![
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-y".to_string(),
+        "-framerate".to_string(),
+        fps.to_string(),
+        "-i".to_string(),
+        pattern.display().to_string(),
+        "-frames:v".to_string(),
+        frame_count.to_string(),
+        "-c:v".to_string(),
+        "libx264".to_string(),
+        "-pix_fmt".to_string(),
+        "yuv420p".to_string(),
+        "-r".to_string(),
+        fps.to_string(),
+        "-an".to_string(),
+        "-f".to_string(),
+        "mp4".to_string(),
+        output.display().to_string(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> RecordArgs {
+        RecordArgs {
+            entry: None,
+            output: PathBuf::from("frames"),
+            width: 640,
+            height: 360,
+            fps: 60,
+            frames: Some(3),
+            duration: None,
+            input_script: None,
+        }
+    }
+
+    #[test]
+    fn duration_uses_checked_fps_product() {
+        let mut value = args();
+        value.frames = None;
+        value.duration = Some(2);
+        assert_eq!(validate_args(&value).expect("duration"), 120);
+    }
+
+    #[test]
+    fn invalid_bounds_are_rejected_before_staging() {
+        let mut value = args();
+        value.width = MAX_DIMENSION + 1;
+        assert!(validate_args(&value).is_err());
+        let mut value = args();
+        value.fps = MAX_FPS + 1;
+        assert!(validate_args(&value).is_err());
+        let mut value = args();
+        value.frames = Some(0);
+        assert!(validate_args(&value).is_err());
+    }
+
+    #[test]
+    fn output_extension_contract_is_unambiguous() {
+        assert_eq!(
+            output_kind(Path::new("frames")),
+            Ok(OutputKind::PngSequence)
+        );
+        assert_eq!(output_kind(Path::new("capture.MP4")), Ok(OutputKind::Mp4));
+        assert!(output_kind(Path::new("capture.mov")).is_err());
+    }
+
+    #[test]
+    fn ffmpeg_contract_preserves_exact_rate_and_count() {
+        let args = ffmpeg_args(
+            Path::new("frames/frame-%06d.png"),
+            Path::new("out.mp4"),
+            59,
+            177,
+        );
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-framerate" && pair[1] == "59"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-r" && pair[1] == "59"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-frames:v" && pair[1] == "177"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-pix_fmt" && pair[1] == "yuv420p"));
+    }
+}

--- a/apps/stasis/tests/windows_game_launch.rs
+++ b/apps/stasis/tests/windows_game_launch.rs
@@ -437,6 +437,276 @@ fn every_supported_windows_game_launch_path_loads_assets_and_renders() {
 }
 
 #[test]
+fn recording_matches_visible_play_letterbox_and_input_timeline() {
+    let root = repository_root();
+    let configured_runtime = std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+        .as_deref()
+        .is_some_and(|path| Path::new(path).is_file());
+    if !configured_runtime
+        && !root
+            .join("runtime/build/bin/Release/stasis_graphics.dll")
+            .is_file()
+    {
+        eprintln!(
+            "native recording integration skipped: runtime/build/bin/Release/stasis_graphics.dll is unavailable"
+        );
+        return;
+    }
+    let fixture = root.join("samples/windows_launch_smoke");
+    let test_tree = TestTree(temp_dir("headless_recording"));
+    let project = test_tree.0.join("windows_launch_smoke");
+    copy_tree(&fixture, &project);
+
+    let visible = test_tree.0.join("visible.png");
+    let visible_run = launch(
+        {
+            let mut command = stasis_command(&project);
+            command.args([
+                "play",
+                "main.stasis",
+                "--ticks",
+                "2",
+                "--screenshot-frame",
+                "2",
+                "--screenshot",
+                visible.to_str().unwrap(),
+                "--exit-after-screenshot",
+            ]);
+            command
+        },
+        "visible parity play",
+    );
+    assert_launch("visible parity play", visible_run, &visible);
+    let visible_image = image::open(&visible)
+        .expect("visible parity screenshot")
+        .to_rgba8();
+    let parity_points = [
+        (10, 10),   // background
+        (310, 170), // background
+        (84, 66),   // PNG sprite interior
+        (236, 66),  // SVG sprite interior
+    ];
+
+    let baseline = test_tree.0.join("baseline");
+    let baseline_run = launch(
+        {
+            let mut command = stasis_command(&project);
+            command.args([
+                "record",
+                "main.stasis",
+                "--output",
+                baseline.to_str().unwrap(),
+                "--width",
+                "640",
+                "--height",
+                "400",
+                "--fps",
+                "60",
+                "--frames",
+                "3",
+            ]);
+            command
+        },
+        "headless recording baseline",
+    );
+    assert!(
+        baseline_run.status.success(),
+        "headless recording baseline failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&baseline_run.stdout),
+        String::from_utf8_lossy(&baseline_run.stderr)
+    );
+    let baseline_log = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&baseline_run.stdout),
+        String::from_utf8_lossy(&baseline_run.stderr)
+    );
+    assert!(
+        baseline_log.contains("Stasis recording presentation: hidden=1"),
+        "recording did not report hidden presentation: {baseline_log}"
+    );
+    let baseline_files = recording_frames(&baseline);
+    assert_eq!(baseline_files.len(), 3);
+    let baseline_first = image::open(&baseline_files[0])
+        .expect("baseline first frame")
+        .to_rgba8();
+    assert_eq!(baseline_first.dimensions(), (640, 400));
+    assert_eq!(baseline_first.get_pixel(0, 0).0, [0, 0, 0, 255]);
+    assert_eq!(baseline_first.get_pixel(639, 399).0, [0, 0, 0, 255]);
+    for (x, y) in parity_points {
+        assert_eq!(
+            baseline_first.get_pixel(x * 2, y * 2 + 20).0,
+            visible_image.get_pixel(x, y).0,
+            "letterbox parity mismatch at visible pixel ({x},{y})"
+        );
+    }
+    let visible_background = visible_image.get_pixel(10, 10).0;
+    let mut visible_text_pixels = 0;
+    for x in 50..150 {
+        for y in 120..155 {
+            if visible_image.get_pixel(x, y).0 != visible_background {
+                visible_text_pixels += 1;
+            }
+        }
+    }
+    let mut recorded_text_pixels = 0;
+    for x in 100..300 {
+        for y in 260..330 {
+            if baseline_first.get_pixel(x, y).0 != [0, 0, 0, 255] {
+                recorded_text_pixels += 1;
+            }
+        }
+    }
+    assert!(
+        visible_text_pixels > 0,
+        "visible cached text oracle has no glyph pixels"
+    );
+    assert!(
+        recorded_text_pixels > 0,
+        "recorded cached text oracle has no glyph pixels"
+    );
+
+    let scripted = test_tree.0.join("scripted");
+    let scripted_run = launch(
+        {
+            let mut command = stasis_command(&project);
+            command.args([
+                "record",
+                "main.stasis",
+                "--output",
+                scripted.to_str().unwrap(),
+                "--width",
+                "640",
+                "--height",
+                "400",
+                "--fps",
+                "60",
+                "--frames",
+                "3",
+                "--input-script",
+                "record_input.json",
+            ]);
+            command
+        },
+        "headless recording input script",
+    );
+    assert!(
+        scripted_run.status.success(),
+        "headless recording input script failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&scripted_run.stdout),
+        String::from_utf8_lossy(&scripted_run.stderr)
+    );
+    let scripted_files = recording_frames(&scripted);
+    assert_eq!(scripted_files.len(), 3);
+    let scripted_first = image::open(&scripted_files[0])
+        .expect("scripted first frame")
+        .to_rgba8();
+    let scripted_pixel = scripted_first.get_pixel(20, 40).0;
+    assert_ne!(scripted_pixel, baseline_first.get_pixel(20, 40).0);
+    assert!(
+        scripted_pixel[0] > scripted_pixel[2],
+        "input script should switch the known fixture pixel to red: {scripted_pixel:?}"
+    );
+
+    let scripted_again = test_tree.0.join("scripted-again");
+    let rerun = launch(
+        {
+            let mut command = stasis_command(&project);
+            command.args([
+                "record",
+                "main.stasis",
+                "--output",
+                scripted_again.to_str().unwrap(),
+                "--width",
+                "640",
+                "--height",
+                "400",
+                "--fps",
+                "60",
+                "--frames",
+                "3",
+                "--input-script",
+                "record_input.json",
+            ]);
+            command
+        },
+        "headless recording input repeat",
+    );
+    assert!(rerun.status.success(), "input repeat failed");
+    assert_eq!(
+        fs::read(&scripted_files[0]).expect("scripted frame bytes"),
+        fs::read(&recording_frames(&scripted_again)[0]).expect("repeated frame bytes")
+    );
+
+    if Command::new("ffmpeg").arg("-version").output().is_ok() {
+        let mp4 = test_tree.0.join("recording.mp4");
+        let mp4_run = launch(
+            {
+                let mut command = stasis_command(&project);
+                command.args([
+                    "record",
+                    "main.stasis",
+                    "--output",
+                    mp4.to_str().unwrap(),
+                    "--width",
+                    "640",
+                    "--height",
+                    "400",
+                    "--fps",
+                    "60",
+                    "--frames",
+                    "3",
+                ]);
+                command
+            },
+            "headless recording MP4",
+        );
+        assert!(mp4_run.status.success(), "MP4 recording failed");
+        assert!(fs::metadata(&mp4).expect("MP4 artifact").len() > 0);
+        if Command::new("ffprobe").arg("-version").output().is_ok() {
+            let probe = Command::new("ffprobe")
+                .args([
+                    "-v",
+                    "error",
+                    "-count_frames",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=r_frame_rate,nb_read_frames",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                ])
+                .arg(&mp4)
+                .output()
+                .expect("run ffprobe");
+            assert!(probe.status.success(), "ffprobe failed");
+            let probe_text = String::from_utf8_lossy(&probe.stdout);
+            assert!(
+                probe_text.contains("60/1"),
+                "unexpected MP4 rate: {probe_text}"
+            );
+            assert!(
+                probe_text.lines().any(|line| line.trim() == "3"),
+                "unexpected MP4 frame count: {probe_text}"
+            );
+        }
+    } else {
+        eprintln!("ffmpeg unavailable; MP4 artifact validation skipped");
+    }
+}
+
+fn recording_frames(directory: &Path) -> Vec<PathBuf> {
+    let mut frames = fs::read_dir(directory)
+        .expect("recording output directory")
+        .map(|entry| entry.expect("recording output entry").path())
+        .collect::<Vec<_>>();
+    frames.sort();
+    assert!(frames
+        .iter()
+        .all(|path| path.extension().and_then(|value| value.to_str()) == Some("png")));
+    frames
+}
+
+#[test]
 fn maximized_portrait_preserves_canvas_in_jit_and_release() {
     let root = repository_root();
     let fixture = root.join("samples/maximized_portrait");

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1625,7 +1625,6 @@ fn stasis_graphics_assets_api() -> Result<&'static StasisGraphicsAssetsApi, Stri
 }
 
 pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
-    let mut out = Vec::new();
     let configured = [
         std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH"),
         // Preserve the original variable as a compatibility alias for existing Windows workflows.
@@ -1638,13 +1637,21 @@ pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
     let executable_dir = std::env::current_exe()
         .ok()
         .and_then(|path| path.parent().map(Path::to_path_buf));
+    runtime_library_candidate_paths_for(executable_dir.as_deref(), &configured)
+}
+
+fn runtime_library_candidate_paths_for(
+    executable_dir: Option<&Path>,
+    configured: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut out = Vec::new();
     if let Some(exe_dir) = executable_dir {
-        // An explicit runtime path is authoritative. This is required for isolated tests and
-        // developer builds where cargo may stage a different sibling DLL beside the executable.
-        out.extend(configured.iter().cloned());
+        // A release bundle is one unit. Never let an environment override replace its sibling
+        // runtime with a different build.
         for file_name in runtime_library_file_names() {
             out.push(exe_dir.join(file_name));
         }
+        out.extend(configured.iter().cloned());
 
         // Dev-friendly default: locate the runtime built under the repo tree by
         // walking a few parents from the executable location.
@@ -1661,7 +1668,8 @@ pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
             }
         }
     } else {
-        out.extend(configured);
+        // If there is no executable directory, the configured path is the only explicit fallback.
+        out.extend(configured.iter().cloned());
     }
 
     // Allow loading from the current working directory too (handy for ad-hoc runs).
@@ -6055,17 +6063,19 @@ mod tests {
     fn bundled_graphics_runtime_is_default_candidate() {
         let executable = std::env::current_exe().expect("current test executable");
         let candidates = runtime_library_candidate_paths();
-        if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH")
-            .or_else(|| std::env::var_os("STASIS_RUNTIME_DLL_PATH"))
-        {
-            assert_eq!(candidates.first(), Some(&PathBuf::from(configured)));
-        } else {
-            let expected = executable
-                .parent()
-                .expect("test executable directory")
-                .join(runtime_library_file_names()[0]);
-            assert_eq!(candidates.first(), Some(&expected));
-        }
+        let expected = executable
+            .parent()
+            .expect("test executable directory")
+            .join(runtime_library_file_names()[0]);
+        assert_eq!(candidates.first(), Some(&expected));
+    }
+
+    #[test]
+    fn configured_runtime_is_fallback_without_executable_directory() {
+        let configured = PathBuf::from("configured/stasis_graphics.dll");
+        let candidates =
+            runtime_library_candidate_paths_for(None, std::slice::from_ref(&configured));
+        assert_eq!(candidates.first(), Some(&configured));
     }
 
     #[cfg(not(windows))]

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -10,6 +10,120 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
+/// Atomically rename `source` to `destination`, refusing an existing destination.
+///
+/// Recording publication uses this instead of a check-then-rename sequence so a
+/// concurrent creator cannot be overwritten.
+pub fn atomic_rename_no_replace(source: &Path, destination: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        let source_display = source.display().to_string();
+        let destination_display = destination.display().to_string();
+        let source = source
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect::<Vec<_>>();
+        let destination = destination
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect::<Vec<_>>();
+        unsafe extern "system" {
+            fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+        }
+        const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result != 0 {
+            return Ok(());
+        }
+        return Err(format!(
+            "atomic no-replace rename {} -> {} failed: {}",
+            source_display,
+            destination_display,
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let source_display = source.display().to_string();
+        let destination_display = destination.display().to_string();
+        let source = CString::new(source.as_os_str().as_bytes())
+            .map_err(|_| "recording source path contains NUL".to_string())?;
+        let destination = CString::new(destination.as_os_str().as_bytes())
+            .map_err(|_| "recording destination path contains NUL".to_string())?;
+        unsafe extern "C" {
+            fn renameat2(
+                olddirfd: i32,
+                oldpath: *const c_char,
+                newdirfd: i32,
+                newpath: *const c_char,
+                flags: u32,
+            ) -> i32;
+        }
+        const AT_FDCWD: i32 = -100;
+        const RENAME_NOREPLACE: u32 = 1;
+        let result = unsafe {
+            renameat2(
+                AT_FDCWD,
+                source.as_ptr(),
+                AT_FDCWD,
+                destination.as_ptr(),
+                RENAME_NOREPLACE,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+        return Err(format!(
+            "atomic no-replace rename {} -> {} failed: {}",
+            source_display,
+            destination_display,
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        let source_display = source.display().to_string();
+        let destination_display = destination.display().to_string();
+        let source = CString::new(source.as_os_str().as_bytes())
+            .map_err(|_| "recording source path contains NUL".to_string())?;
+        let destination = CString::new(destination.as_os_str().as_bytes())
+            .map_err(|_| "recording destination path contains NUL".to_string())?;
+        unsafe extern "C" {
+            fn renamex_np(from: *const c_char, to: *const c_char, flags: u32) -> i32;
+        }
+        const RENAME_EXCL: u32 = 0x4;
+        let result = unsafe { renamex_np(source.as_ptr(), destination.as_ptr(), RENAME_EXCL) };
+        if result == 0 {
+            return Ok(());
+        }
+        return Err(format!(
+            "atomic no-replace rename {} -> {} failed: {}",
+            source_display,
+            destination_display,
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (source, destination);
+        Err("atomic no-replace rename is unsupported on this desktop platform".to_string())
+    }
+}
+
 #[cfg(unix)]
 use std::ffi::CStr;
 #[cfg(windows)]
@@ -40,6 +154,22 @@ static JIT_HOST_ENTRY_TARGETS: AtomicUsize = AtomicUsize::new(0);
 static JIT_DEBUG_ENABLED: AtomicBool = AtomicBool::new(false);
 static JIT_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
 static JIT_PROFILE_GENERATION: AtomicU64 = AtomicU64::new(1);
+static RECORDING_CLOCK_FPS: AtomicU64 = AtomicU64::new(0);
+static RECORDING_CLOCK_FRAME: AtomicU64 = AtomicU64::new(0);
+
+pub fn set_recording_clock(fps: u32, frame: u64) {
+    RECORDING_CLOCK_FPS.store(u64::from(fps), Ordering::Release);
+    RECORDING_CLOCK_FRAME.store(frame, Ordering::Release);
+}
+
+pub fn set_recording_clock_frame(frame: u64) {
+    RECORDING_CLOCK_FRAME.store(frame, Ordering::Release);
+}
+
+pub fn clear_recording_clock() {
+    RECORDING_CLOCK_FPS.store(0, Ordering::Release);
+    RECORDING_CLOCK_FRAME.store(0, Ordering::Release);
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JitProfileSample {
@@ -1010,6 +1140,7 @@ pub struct StasisGraphicsApi {
     stasis_host_performance_metrics_enabled: usize,
     stasis_host_set_performance_metrics: usize,
     stasis_gfx_submit_u8: usize,
+    stasis_set_recording_config: Option<usize>,
     stasis_test_get_render_submission_state: Option<usize>,
     stasis_gfx_notify_file_changed: Option<usize>,
     stasis_sleep_ms: usize,
@@ -1047,6 +1178,7 @@ impl StasisGraphicsApi {
         let stasis_host_performance_metrics_enabled =
             lib.symbol_address("stasis_host_performance_metrics_enabled")?;
         let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
+        let stasis_set_recording_config = lib.symbol_address("stasis_set_recording_config").ok();
         let stasis_test_get_render_submission_state = lib
             .symbol_address("stasis_test_get_render_submission_state")
             .ok();
@@ -1063,6 +1195,7 @@ impl StasisGraphicsApi {
             stasis_host_performance_metrics_enabled,
             stasis_host_set_performance_metrics,
             stasis_gfx_submit_u8,
+            stasis_set_recording_config,
             stasis_test_get_render_submission_state,
             stasis_gfx_notify_file_changed,
             stasis_sleep_ms,
@@ -1086,6 +1219,30 @@ impl StasisGraphicsApi {
             let callback: extern "C" fn(i32, i32, *const c_char) -> i32 =
                 unsafe { std::mem::transmute(self.stasis_init_window) };
             Ok(callback(width, height, title.as_ptr()) != 0)
+        }
+    }
+
+    pub fn set_recording_config(&self, width: u32, height: u32, fps: u32) -> Result<(), String> {
+        let symbol = self.stasis_set_recording_config.ok_or_else(|| {
+            "graphics runtime lacks typed headless recording configuration support".to_string()
+        })?;
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn(i32, i32, u32) -> i32 =
+                unsafe { std::mem::transmute(symbol) };
+            if callback(width as i32, height as i32, fps) == 0 {
+                return Err("graphics runtime rejected typed recording configuration".to_string());
+            }
+            return Ok(());
+        }
+        #[cfg(not(windows))]
+        {
+            let callback: extern "C" fn(i32, i32, u32) -> i32 =
+                unsafe { std::mem::transmute(symbol) };
+            if callback(width as i32, height as i32, fps) == 0 {
+                return Err("graphics runtime rejected typed recording configuration".to_string());
+            }
+            Ok(())
         }
     }
 
@@ -1482,12 +1639,12 @@ pub fn runtime_library_candidate_paths() -> Vec<PathBuf> {
         .ok()
         .and_then(|path| path.parent().map(Path::to_path_buf));
     if let Some(exe_dir) = executable_dir {
-        // A release bundle is one unit. Never let an environment override replace its sibling
-        // runtime with a different build.
+        // An explicit runtime path is authoritative. This is required for isolated tests and
+        // developer builds where cargo may stage a different sibling DLL beside the executable.
+        out.extend(configured.iter().cloned());
         for file_name in runtime_library_file_names() {
             out.push(exe_dir.join(file_name));
         }
-        out.extend(configured.iter().cloned());
 
         // Dev-friendly default: locate the runtime built under the repo tree by
         // walking a few parents from the executable location.
@@ -4586,8 +4743,22 @@ pub extern "C" fn stasis_jit_sleep_ms(ms: i32) {
 }
 
 // Runtime-compatible time APIs used by `extern function time()`/`time_us()` expansion.
+fn recording_clock_us() -> Option<u64> {
+    let fps = RECORDING_CLOCK_FPS.load(Ordering::Acquire);
+    (fps != 0).then(|| {
+        RECORDING_CLOCK_FRAME
+            .load(Ordering::Acquire)
+            .saturating_mul(1_000_000)
+            / fps
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn stasis_get_time_ms() -> i32 {
+    if let Some(micros) = recording_clock_us() {
+        return (micros / 1_000).min(i32::MAX as u64) as i32;
+    }
+
     match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
         Ok(duration) => duration.as_millis() as i32,
         Err(_) => 0,
@@ -4596,6 +4767,9 @@ pub extern "C" fn stasis_get_time_ms() -> i32 {
 
 #[no_mangle]
 pub extern "C" fn stasis_get_time_us() -> i32 {
+    if let Some(micros) = recording_clock_us() {
+        return micros.min(i32::MAX as u64) as i32;
+    }
     match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
         Ok(duration) => duration.as_micros() as i32,
         Err(_) => 0,
@@ -5751,6 +5925,49 @@ mod tests {
     use super::*;
     use std::sync::MutexGuard;
 
+    #[test]
+    fn recording_clock_uses_frame_index_without_accumulated_rounding() {
+        let _guard = test_lock();
+        set_recording_clock(60, 0);
+        assert_eq!(stasis_get_time_ms(), 0);
+        assert_eq!(stasis_get_time_us(), 0);
+        set_recording_clock_frame(1);
+        assert_eq!(stasis_get_time_us(), 16_666);
+        set_recording_clock_frame(3);
+        assert_eq!(stasis_get_time_us(), 50_000);
+        set_recording_clock(59, 59);
+        assert_eq!(stasis_get_time_us(), (59_u64 * 1_000_000 / 59) as i32);
+        set_recording_clock(1, u64::MAX);
+        assert_eq!(stasis_get_time_ms(), i32::MAX);
+        assert_eq!(stasis_get_time_us(), i32::MAX);
+        clear_recording_clock();
+    }
+
+    #[test]
+    fn atomic_rename_no_replace_refuses_existing_destination() {
+        let _guard = test_lock();
+        let root = std::env::temp_dir().join(format!(
+            "stasis-atomic-rename-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("create atomic rename test directory");
+        let source = root.join("source");
+        let destination = root.join("destination");
+        std::fs::write(&source, b"source").expect("write source");
+        std::fs::write(&destination, b"destination").expect("write destination");
+        assert!(atomic_rename_no_replace(&source, &destination).is_err());
+        assert_eq!(std::fs::read(&source).expect("read source"), b"source");
+        assert_eq!(
+            std::fs::read(&destination).expect("read destination"),
+            b"destination"
+        );
+        std::fs::remove_dir_all(root).expect("remove atomic rename test directory");
+    }
+
     static TEST_SPRITE_RELEASES: AtomicUsize = AtomicUsize::new(0);
 
     fn test_sprite_load(_: &[u8], _: i32, _: i32) -> i32 {
@@ -5835,13 +6052,20 @@ mod tests {
     }
 
     #[test]
-    fn bundled_graphics_runtime_outranks_environment_overrides() {
+    fn bundled_graphics_runtime_is_default_candidate() {
         let executable = std::env::current_exe().expect("current test executable");
-        let expected = executable
-            .parent()
-            .expect("test executable directory")
-            .join(runtime_library_file_names()[0]);
-        assert_eq!(runtime_library_candidate_paths().first(), Some(&expected));
+        let candidates = runtime_library_candidate_paths();
+        if let Some(configured) = std::env::var_os("STASIS_RUNTIME_LIBRARY_PATH")
+            .or_else(|| std::env::var_os("STASIS_RUNTIME_DLL_PATH"))
+        {
+            assert_eq!(candidates.first(), Some(&PathBuf::from(configured)));
+        } else {
+            let expected = executable
+                .parent()
+                .expect("test executable directory")
+                .join(runtime_library_file_names()[0]);
+            assert_eq!(candidates.first(), Some(&expected));
+        }
     }
 
     #[cfg(not(windows))]

--- a/docs/headless_recording.md
+++ b/docs/headless_recording.md
@@ -1,0 +1,68 @@
+# Deterministic headless recording
+
+`stasis record` runs the normal desktop JIT/play path with a hidden SDL software
+surface. It never opens or focuses a visible window. The requested `--width` and
+`--height` are physical output pixels; the guest's `init_window` remains the
+logical canvas and uses the same fit/letterbox presentation as desktop play.
+
+Capture a PNG sequence:
+
+```powershell
+stasis --workspace samples/windows_launch_smoke record `
+  main.stasis `
+  --output artifacts/review-frames `
+  --width 640 --height 360 --fps 60 --frames 3 `
+  --input-script record_input.json
+```
+
+An extensionless output is published as a directory containing
+`frame-000001.png`, `frame-000002.png`, and so on. `--frames N` (or its
+`--ticks N` alias) is an alternative to `--duration S`; duration is whole seconds and produces exactly `S * fps`
+frames. The loop has zero wall-clock pacing, so the frame sequence is driven by
+committed ticks and is repeatable for the same source, assets, backend, and input
+script. Capture starts after `main()` and excludes the loading frame.
+
+Use an `.mp4` output to encode the staged PNGs with FFmpeg:
+
+```powershell
+stasis --workspace samples/windows_launch_smoke record main.stasis `
+  --output artifacts/review.mp4 `
+  --width 640 --height 360 --fps 60 --frames 3
+```
+
+FFmpeg must be on `PATH`; the command uses H.264 (`libx264`), `yuv420p`, and the
+requested input/output rate. PNGs are validated for exact names, count, and
+dimensions before publication. MP4 encoding and publication are staged, so an
+encoder or renderer failure removes partial artifacts and reports the stage,
+resolution, frame rate, output, and underlying cause.
+
+Publication renames the fully validated sibling stage into the destination in
+one same-volume operation; the final path is never populated incrementally.
+An existing destination is rejected before publication, and owned partial
+stages are cleaned up on failure.
+
+The bounded desktop limits are 1..8192 pixels per dimension, 1..240 fps, and
+1..999,999 frames. MP4 dimensions must be even because `yuv420p` requires
+even chroma planes; PNG sequences may use odd dimensions.
+
+The existing versioned input-script schema is applied at the same frame boundary
+as `play --input-script`; pointer events therefore affect the captured output
+deterministically. Rendering still uses the shipping JIT, graphics command
+buffers, and pre-present PNG capture path. Raster pixels can differ across
+graphics backends or driver versions.
+
+## Codex visual review example
+
+For a bounded review artifact, record a short deterministic take, inspect the
+first and last PNG, then compare the same source with and without an input event:
+
+```powershell
+stasis --workspace samples/windows_launch_smoke record main.stasis `
+  --output artifacts/codex-review `
+  --width 640 --height 360 --fps 60 --frames 3 `
+  --input-script record_input.json
+```
+
+Open `artifacts/codex-review/frame-000001.png` and
+`frame-000003.png` in the Codex visual review pane. Keep the command, input
+script, and renderer diagnostics with the artifact when reporting a mismatch.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -121,6 +121,14 @@ cloning a generated repository, reactivate the checked-in hook with
   the default. `--ticks` invokes `tick()` exactly `COUNT` times without calling `render()` or
   loading the graphics runtime. `--fast-forward` makes the no-pacing contract explicit and
   requires a positive tick count.
+- `record [ENTRY] --output PATH --width PX --height PX --fps FPS (--frames N|--duration S)`:
+  execute the normal desktop JIT/render path on a hidden fixed-size SDL software presentation.
+  An extensionless output path publishes an exact, numbered PNG sequence; an `.mp4` path stages
+  those PNGs and invokes FFmpeg H.264/yuv420p at the requested rate. Recording starts after
+  `main()`, uses zero tick sleep, applies the existing `--input-script` timeline, and preserves
+  logical-canvas fit/letterboxing. Dimensions, rates, counts, output format, staged frame
+  validation, encoder failures, and partial-output cleanup are bounded and diagnosed. See
+  [Deterministic headless recording](headless_recording.md).
 - `play [ENTRY]`: launch the graphical hot-swap runtime. Without an entry override, discover the
   nearest ancestor `stasis.json` from the current directory and use its project-relative `entry`
   and display `name`. Explicit entries discover their own ancestor manifest, so project-root

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -156,6 +156,11 @@ static int g_native_window_height = 600;
 static int g_drawable_width = 800;
 static int g_drawable_height = 600;
 static float g_pixel_scale = 1.0f;
+static bool g_recording_presentation = false;
+static int g_recording_width = 0;
+static int g_recording_height = 0;
+static uint32_t g_recording_fps = 0;
+static bool g_recording_config_pending = false;
 static StasisDisplayMetrics g_display_metrics;
 static int g_display_generation = 0;
 static int g_density_generation = 0;
@@ -3638,8 +3643,8 @@ static int stasis_gfx_dump_image(const char* path, int png, int render_queued_li
         out_path = resolved;
     }
 
-    const int w = g_drawable_width;
-    const int h = g_drawable_height;
+    const int w = g_recording_presentation ? g_recording_width : g_drawable_width;
+    const int h = g_recording_presentation ? g_recording_height : g_drawable_height;
     const size_t bytes = (size_t)w * (size_t)h * 4u;
 
     uint8_t* pixels = (uint8_t*)malloc(bytes);
@@ -3664,6 +3669,11 @@ static int stasis_gfx_dump_image(const char* path, int png, int render_queued_li
                 g_line_count = 0;
             }
 
+            /* Read the fixed physical recording target, not the logical viewport. */
+            if (g_recording_presentation) {
+                SDL_SetRenderLogicalPresentation(
+                    g_renderer, 0, 0, SDL_LOGICAL_PRESENTATION_DISABLED);
+            }
             /* SDL3 returns an owned surface for renderer readback. */
             SDL_Surface* readback = SDL_RenderReadPixels(g_renderer, NULL);
             SDL_Surface* bgra = readback
@@ -3678,9 +3688,17 @@ static int stasis_gfx_dump_image(const char* path, int png, int render_queued_li
                 }
                 ok = png ? write_png_bgra32(out_path, w, h, pixels, 0)
                          : write_bmp_bgra32(out_path, w, h, pixels, 0);
+            } else {
+                SDL_Log("recording readback dimensions mismatch: got=%dx%d expected=%dx%d",
+                    bgra ? bgra->w : 0, bgra ? bgra->h : 0, w, h);
             }
             SDL_DestroySurface(bgra);
             SDL_DestroySurface(readback);
+            if (g_recording_presentation) {
+                SDL_SetRenderLogicalPresentation(
+                    g_renderer, g_window_width, g_window_height,
+                    SDL_LOGICAL_PRESENTATION_LETTERBOX);
+            }
         }
         free(pixels);
         return ok;
@@ -4174,6 +4192,16 @@ STASIS_EXPORT int stasis_get_startup_test_success(void) {
     return g_last_test_result.success;
 }
 
+/* Typed recording setup used by the JIT host before window initialization. */
+STASIS_EXPORT int stasis_set_recording_config(int width, int height, uint32_t fps) {
+    if (g_window || width < 1 || height < 1 || fps == 0) return 0;
+    g_recording_width = width;
+    g_recording_height = height;
+    g_recording_fps = fps;
+    g_recording_config_pending = true;
+    return 1;
+}
+
 /*
  * Initialize graphics window
  * Returns 1 on success, 0 on failure
@@ -4202,6 +4230,52 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     g_screenshot_frame = 1;
     g_debug_frame_counter = 0;
     g_screenshot_path[0] = 0;
+    const bool typed_recording = g_recording_config_pending;
+    const int typed_width = g_recording_width;
+    const int typed_height = g_recording_height;
+    const uint32_t typed_fps = g_recording_fps;
+    g_recording_config_pending = false;
+    g_recording_presentation = false;
+    g_recording_width = 0;
+    g_recording_height = 0;
+    g_recording_fps = 0;
+    if (typed_recording) {
+        g_recording_presentation = true;
+        g_recording_width = typed_width;
+        g_recording_height = typed_height;
+        g_recording_fps = typed_fps;
+        width = typed_width;
+        height = typed_height;
+        SDL_Log("Stasis recording presentation: hidden=1 logical=%dx%d physical=%dx%d fps=%u",
+            width, height, g_recording_width, g_recording_height, g_recording_fps);
+    }
+    const char* recording = SDL_getenv("STASIS_RECORDING_PRESENTATION");
+    const char* recording_width = SDL_getenv("STASIS_RECORDING_WIDTH");
+    const char* recording_height = SDL_getenv("STASIS_RECORDING_HEIGHT");
+    const char* recording_fps = SDL_getenv("STASIS_RECORDING_FPS");
+    if (!typed_recording && recording && strcmp(recording, "0") != 0 && recording_width && recording_height && recording_fps) {
+        char* width_end = NULL;
+        char* height_end = NULL;
+        char* fps_end = NULL;
+        long parsed_width = strtol(recording_width, &width_end, 10);
+        long parsed_height = strtol(recording_height, &height_end, 10);
+        long parsed_fps = strtol(recording_fps, &fps_end, 10);
+        if (width_end != recording_width && *width_end == 0 &&
+            height_end != recording_height && *height_end == 0 &&
+            fps_end != recording_fps && *fps_end == 0 &&
+            parsed_width > 0 && parsed_width <= INT_MAX &&
+            parsed_height > 0 && parsed_height <= INT_MAX &&
+            parsed_fps > 0 && parsed_fps <= UINT32_MAX) {
+            g_recording_presentation = true;
+            g_recording_width = (int)parsed_width;
+            g_recording_height = (int)parsed_height;
+            g_recording_fps = (uint32_t)parsed_fps;
+            width = g_recording_width;
+            height = g_recording_height;
+            SDL_Log("Stasis recording presentation: hidden=1 logical=%dx%d physical=%dx%d fps=%u",
+                width, height, g_recording_width, g_recording_height, g_recording_fps);
+        }
+    }
     const char* screenshot = SDL_getenv("STASIS_SCREENSHOT_ONCE");
     if (screenshot && *screenshot) {
         strncpy(g_screenshot_path, screenshot, sizeof(g_screenshot_path) - 1);
@@ -4250,6 +4324,14 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
     int native_request_height = height;
     SDL_WindowFlags window_flags = (want_sdl ? 0 : SDL_WINDOW_OPENGL) |
         SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
+    if (g_recording_presentation) {
+        window_flags &= ~SDL_WINDOW_RESIZABLE;
+        window_flags |= SDL_WINDOW_HIDDEN;
+    }
+    const char* force_hidden = SDL_getenv("STASIS_WINDOW_HIDDEN");
+    if (force_hidden && strcmp(force_hidden, "0") != 0) {
+        window_flags |= SDL_WINDOW_HIDDEN;
+    }
 #if defined(__ANDROID__) || defined(__IPHONEOS__)
     const SDL_DisplayMode* display_mode =
         SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
@@ -4261,7 +4343,9 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
 #else
     /* Let the desktop window manager fill its usable work area without
        covering taskbars, docks, or panels. */
-    window_flags |= SDL_WINDOW_MAXIMIZED;
+    if (!g_recording_presentation) {
+        window_flags |= SDL_WINDOW_MAXIMIZED;
+    }
 #endif
 
     g_window = SDL_CreateWindow(
@@ -4277,7 +4361,9 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
         SDL_Quit();
         return 0;
     }
-    SDL_SetWindowPosition(g_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    if (!g_recording_presentation) {
+        SDL_SetWindowPosition(g_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    }
 
     /* Optional: start window minimized to keep automated/local test runs unobtrusive. */
     {
@@ -4347,8 +4433,9 @@ STASIS_EXPORT int stasis_init_window(int width, int height, const char* title) {
             SDL_Quit();
             return 0;
         }
-        if (!SDL_SetRenderVSync(g_renderer, 1)) {
-            SDL_Log("SDL_SetRenderVSync failed: %s", SDL_GetError());
+        if (!SDL_SetRenderVSync(g_renderer, g_recording_presentation ? 0 : 1)) {
+            SDL_Log("SDL_SetRenderVSync failed (recording=%d): %s",
+                g_recording_presentation ? 1 : 0, SDL_GetError());
         }
         SDL_SetDefaultTextureScaleMode(g_renderer, SDL_SCALEMODE_LINEAR);
         SDL_SetRenderLogicalPresentation(
@@ -4572,6 +4659,14 @@ STASIS_EXPORT void stasis_set_window_size(int width, int height) {
 
     stasis_set_logical_size(width, height);
 #if !defined(__ANDROID__) && !defined(__IPHONEOS__)
+    if (g_recording_presentation) {
+        if (g_renderer) {
+            SDL_SetRenderLogicalPresentation(
+                g_renderer, width, height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
+        }
+        stasis_sync_display_metrics();
+        return;
+    }
     const SDL_WindowFlags window_flags = SDL_GetWindowFlags(g_window);
     if ((window_flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED)) != 0) {
         SDL_RestoreWindow(g_window);
@@ -4602,6 +4697,17 @@ STASIS_EXPORT void stasis_set_window_size(int width, int height) {
 STASIS_EXPORT int stasis_set_maximized(int maximized) {
     if (!g_window) {
         return 0;
+    }
+
+    if (g_recording_presentation) {
+        (void)maximized;
+        if (g_renderer) {
+            SDL_SetRenderLogicalPresentation(
+                g_renderer, g_window_width, g_window_height,
+                SDL_LOGICAL_PRESENTATION_LETTERBOX);
+        }
+        stasis_sync_display_metrics();
+        return 1;
     }
 
 #if defined(__ANDROID__) || defined(__IPHONEOS__)
@@ -4660,6 +4766,12 @@ STASIS_EXPORT int stasis_set_maximized(int maximized) {
 STASIS_EXPORT int stasis_set_fullscreen(int fullscreen) {
     if (!g_window) {
         return 0;
+    }
+
+    if (g_recording_presentation) {
+        (void)fullscreen;
+        stasis_sync_display_metrics();
+        return 1;
     }
 
     bool result = SDL_SetWindowFullscreen(g_window, fullscreen != 0);
@@ -6320,7 +6432,17 @@ STASIS_EXPORT int stasis_is_key_down(int scancode) {
 /*
  * Get current time in milliseconds
  */
+static uint64_t stasis_recording_clock_us(void) {
+    if (!g_recording_presentation || g_recording_fps == 0) return 0;
+    return ((uint64_t)(uint32_t)g_debug_frame_counter * 1000000ull) /
+        (uint64_t)g_recording_fps;
+}
+
 STASIS_EXPORT int stasis_get_time_ms(void) {
+    if (g_recording_presentation) {
+        uint64_t millis = stasis_recording_clock_us() / 1000ull;
+        return millis > (uint64_t)INT_MAX ? INT_MAX : (int)millis;
+    }
     return (int)SDL_GetTicks();
 }
 
@@ -6328,6 +6450,10 @@ STASIS_EXPORT int stasis_get_time_ms(void) {
  * Get current time in microseconds (truncated to i32).
  */
 STASIS_EXPORT int stasis_get_time_us(void) {
+    if (g_recording_presentation) {
+        uint64_t micros = stasis_recording_clock_us();
+        return micros > (uint64_t)INT_MAX ? INT_MAX : (int)micros;
+    }
     Uint64 freq = SDL_GetPerformanceFrequency();
     if (freq == 0) return 0;
     Uint64 counter = SDL_GetPerformanceCounter();

--- a/samples/windows_launch_smoke/main.stasis
+++ b/samples/windows_launch_smoke/main.stasis
@@ -12,6 +12,7 @@ global host_req_flags: i32;
 global host_req_window_w_px: i32;
 global host_req_window_h_px: i32;
 global host_req_seq: i32;
+global host_i32: i32[768];
 global png_sprite: i32;
 global svg_sprite: i32;
 global smoke_font: i32;
@@ -64,6 +65,11 @@ function render(): i32 {
     gfx_cmd_f32[1] = 0.07;
     gfx_cmd_f32[2] = 0.12;
     gfx_cmd_f32[3] = 1.0;
+    if (host_i32[545] != 0) {
+        gfx_cmd_f32[0] = 0.80;
+        gfx_cmd_f32[1] = 0.12;
+        gfx_cmd_f32[2] = 0.08;
+    }
 
     gfx_cmd_i32[32] = png_sprite;
     gfx_cmd_i32[33] = 0;

--- a/samples/windows_launch_smoke/record_input.json
+++ b/samples/windows_launch_smoke/record_input.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "frames": [
+    {
+      "frame": 1,
+      "pointers": [
+        {
+          "id": 0,
+          "isDown": true,
+          "wentDown": true,
+          "wentUp": false,
+          "x": 160,
+          "y": 90
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `stasis record` for deterministic hidden PNG sequences and optional H.264/yuv420p MP4 output
- preserve the existing JIT/render/input path with typed fixed-size native presentation and frame-index clocks
- publish validated artifacts atomically without replacement on Windows, Linux, and macOS
- document Codex visual-review usage and add a manifest-backed recording fixture

## Validation
- `cargo check -p stasis --all-targets`
- record-focused tests: 7 passed
- native recording runtime contract: 1 passed
- dynload deterministic clock, runtime precedence, and atomic no-replace tests: passed
- Windows native integration: 1 passed at 640x400 / 60 fps, including mismatched-aspect letterboxing, visible parity, scripted input, ordering, and repeatable PNG bytes
- native CMake/Ninja build, source-layout check, and `git diff --check`: passed
- FFmpeg/ffprobe artifact check skipped locally because FFmpeg is unavailable

Maddox task: #273