### PR TITLE
Capture deterministic game audio in MP4 recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,9 +362,12 @@ stasis --workspace samples/windows_launch_smoke record main.stasis `
 ```
 
 An extensionless output is an atomically published, staged PNG sequence; `.mp4` uses
-FFmpeg H.264/yuv420p and requires `ffmpeg` on `PATH`. Recording uses the normal
-JIT/render path, zero tick sleep, fixed physical output dimensions, logical
-canvas letterboxing, and no visible or focused window. See
+FFmpeg H.264/yuv420p plus AAC and requires `ffmpeg` on `PATH`. MP4 audio is the
+existing game mixer rendered offline as deterministic 48 kHz stereo PCM16; no
+physical device or microphone is used. Recording uses the normal JIT/render path,
+zero tick sleep, fixed physical output dimensions, logical canvas letterboxing,
+and no visible or focused window. PNG mode does not stage offline audio, although
+guest code may still request its normal audio API. See
 [docs/headless_recording.md](docs/headless_recording.md).
 
 ## Installation and Setup

--- a/apps/stasis/src/lib.rs
+++ b/apps/stasis/src/lib.rs
@@ -54,7 +54,7 @@ use stasis_runner::swap::contracts::{
 use stasis_runner::swap::pipeline::{CompilerBackend, DevHotSwapPipeline};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
@@ -84,6 +84,110 @@ pub struct PlayFrameCaptureConfig {
     pub height: u32,
     pub fps: u32,
     pub frame_count: u64,
+    pub audio_output: Option<PathBuf>,
+}
+
+const RECORDING_AUDIO_SAMPLE_RATE: u64 = 48_000;
+const RECORDING_AUDIO_CHANNELS: u16 = 2;
+
+fn recording_audio_target_samples(frame: u64, fps: u32) -> Result<u64, String> {
+    if fps == 0 {
+        return Err("recording audio stage requires a positive frame rate".to_string());
+    }
+    frame
+        .checked_mul(RECORDING_AUDIO_SAMPLE_RATE)
+        .ok_or_else(|| "recording audio stage sample schedule overflow".to_string())
+        .map(|samples| samples / u64::from(fps))
+}
+
+struct RecordingAudioSink {
+    file: fs::File,
+    frame_count: u64,
+}
+
+struct RecordingAudioTeardown<'a> {
+    gfx: &'a stasis_dynload::StasisGraphicsApi,
+}
+
+impl Drop for RecordingAudioTeardown<'_> {
+    fn drop(&mut self) {
+        let _ = self.gfx.set_recording_audio_config(false);
+    }
+}
+
+impl RecordingAudioSink {
+    fn create(path: &Path) -> Result<Self, String> {
+        let mut file = fs::File::create(path).map_err(|error| {
+            format!(
+                "recording audio stage failed to create {}: {error}",
+                path.display()
+            )
+        })?;
+        file.write_all(&[0u8; 44]).map_err(|error| {
+            format!(
+                "recording audio stage failed to reserve WAV header {}: {error}",
+                path.display()
+            )
+        })?;
+        Ok(Self {
+            file,
+            frame_count: 0,
+        })
+    }
+
+    fn append(&mut self, samples: &[f32]) -> Result<(), String> {
+        if samples.len() % usize::from(RECORDING_AUDIO_CHANNELS) != 0 {
+            return Err("recording audio mix returned non-stereo sample count".to_string());
+        }
+        let mut pcm = Vec::with_capacity(samples.len() * 2);
+        for sample in samples {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let value = if clamped <= -1.0 {
+                i16::MIN
+            } else {
+                (clamped * f32::from(i16::MAX)).round() as i16
+            };
+            pcm.extend_from_slice(&value.to_le_bytes());
+        }
+        self.file.write_all(&pcm).map_err(|error| {
+            format!("recording audio stage failed to write WAV samples: {error}")
+        })?;
+        self.frame_count = self
+            .frame_count
+            .saturating_add((samples.len() / usize::from(RECORDING_AUDIO_CHANNELS)) as u64);
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<(), String> {
+        let data_bytes = self
+            .frame_count
+            .checked_mul(u64::from(RECORDING_AUDIO_CHANNELS) * 2)
+            .ok_or_else(|| "recording audio WAV size overflow".to_string())?;
+        let riff_size = 36u64
+            .checked_add(data_bytes)
+            .ok_or_else(|| "recording audio WAV RIFF size overflow".to_string())?;
+        if data_bytes > u64::from(u32::MAX) || riff_size > u64::from(u32::MAX) {
+            return Err("recording audio WAV exceeds RIFF size limit".to_string());
+        }
+        let mut header = Vec::with_capacity(44);
+        header.extend_from_slice(b"RIFF");
+        header.extend_from_slice(&(riff_size as u32).to_le_bytes());
+        header.extend_from_slice(b"WAVEfmt ");
+        header.extend_from_slice(&16u32.to_le_bytes());
+        header.extend_from_slice(&1u16.to_le_bytes());
+        header.extend_from_slice(&RECORDING_AUDIO_CHANNELS.to_le_bytes());
+        header.extend_from_slice(&(RECORDING_AUDIO_SAMPLE_RATE as u32).to_le_bytes());
+        header.extend_from_slice(&(RECORDING_AUDIO_SAMPLE_RATE as u32 * 4).to_le_bytes());
+        header.extend_from_slice(&4u16.to_le_bytes());
+        header.extend_from_slice(&16u16.to_le_bytes());
+        header.extend_from_slice(b"data");
+        header.extend_from_slice(&(data_bytes as u32).to_le_bytes());
+        self.file
+            .seek(SeekFrom::Start(0))
+            .and_then(|_| self.file.write_all(&header))
+            .and_then(|_| self.file.flush())
+            .map_err(|error| format!("recording audio stage failed to finalize WAV: {error}"))
+    }
 }
 
 struct PlayCaptureEnvironment {
@@ -2395,6 +2499,19 @@ fn run_play_in_process_inner(
     if let Some(capture) = capture.as_ref() {
         gfx.set_recording_config(capture.width, capture.height, capture.fps)?;
     }
+    let _recording_audio_teardown = capture
+        .as_ref()
+        .filter(|capture| capture.audio_output.is_some())
+        .map(|_| {
+            gfx.set_recording_audio_config(true)?;
+            Ok::<_, String>(RecordingAudioTeardown { gfx: &gfx })
+        })
+        .transpose()?;
+    let mut recording_audio = capture
+        .as_ref()
+        .and_then(|capture| capture.audio_output.as_deref())
+        .map(RecordingAudioSink::create)
+        .transpose()?;
     gfx.set_asset_root(prepared_asset_root.as_deref().unwrap_or(&project_root))?;
     let mut frame_evidence = DesktopFrameEvidence::from_env()?;
     let configured_title = window_title.or_else(|| {
@@ -2744,6 +2861,24 @@ fn run_play_in_process_inner(
             }
         }
         gfx.gfx_submit_u8(&mut gfx_cmd_i32, &gfx_cmd_f32, &gfx_cmd_u8)?;
+        if let (Some(capture), Some(audio)) = (capture.as_ref(), recording_audio.as_mut()) {
+            let frame = ticks_executed.saturating_add(1);
+            let target_samples = recording_audio_target_samples(frame, capture.fps)?;
+            let delta = target_samples.saturating_sub(audio.frame_count);
+            let sample_count = delta
+                .checked_mul(u64::from(RECORDING_AUDIO_CHANNELS))
+                .ok_or_else(|| "recording audio stage buffer size overflow".to_string())?;
+            let sample_count = usize::try_from(sample_count)
+                .map_err(|_| "recording audio stage buffer is too large".to_string())?;
+            let mut samples = vec![0.0f32; sample_count];
+            gfx.pull_recording_audio_f32_interleaved(&mut samples)
+                .map_err(|error| {
+                    format!("recording audio mix stage failed at frame {frame}: {error}")
+                })?;
+            audio.append(&samples).map_err(|error| {
+                format!("recording audio WAV stage failed at frame {frame}: {error}")
+            })?;
+        }
         if let Some(evidence) = frame_evidence.as_mut() {
             let submission = gfx.test_render_submission_state()?.ok_or_else(|| {
                 format!(
@@ -2789,6 +2924,11 @@ fn run_play_in_process_inner(
     if let Some(profile) = profile.as_ref() {
         finish_play_profile(&jit, profile)?;
     }
+    let audio_finish = recording_audio
+        .take()
+        .map(RecordingAudioSink::finish)
+        .transpose();
+    audio_finish?;
 
     Ok(())
 }
@@ -4297,6 +4437,72 @@ mod tests {
     const WINDOW_REQUEST_MAILBOX_FIXTURE: &str =
         include_str!("../../../tests/stasis/seams/window_request_mailbox_probe.stasis");
 
+    #[test]
+    fn recording_audio_sample_schedule_has_no_fractional_drift() {
+        let targets = (0..60)
+            .map(|frame| recording_audio_target_samples(frame, 59).expect("sample target"))
+            .collect::<Vec<_>>();
+        assert_eq!(targets[0], 0);
+        assert_eq!(targets[1], 48_000 / 59);
+        assert_eq!(targets[59], 59 * 48_000 / 59);
+        assert_eq!(
+            recording_audio_target_samples(60, 59).unwrap(),
+            60 * 48_000 / 59
+        );
+        assert!(targets.windows(2).all(|pair| pair[1] >= pair[0]));
+    }
+
+    #[test]
+    fn recording_audio_sink_writes_pcm16_stereo_wav() {
+        let path = std::env::temp_dir().join(format!(
+            "stasis-recording-audio-{}-{}.wav",
+            std::process::id(),
+            UNIX_EPOCH.elapsed().unwrap_or_default().as_nanos()
+        ));
+        let mut sink = RecordingAudioSink::create(&path).expect("create WAV sink");
+        sink.append(&[0.5, -0.5, 0.0, 1.0])
+            .expect("write WAV samples");
+        sink.finish().expect("finish WAV sink");
+        let bytes = fs::read(&path).expect("read WAV sink");
+        assert_eq!(&bytes[0..4], b"RIFF");
+        assert_eq!(&bytes[8..12], b"WAVE");
+        assert_eq!(u16::from_le_bytes([bytes[22], bytes[23]]), 2);
+        assert_eq!(
+            u32::from_le_bytes([bytes[24], bytes[25], bytes[26], bytes[27]]),
+            48_000
+        );
+        assert_eq!(u16::from_le_bytes([bytes[34], bytes[35]]), 16);
+        assert_eq!(
+            u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]),
+            8
+        );
+        assert_eq!(bytes.len(), 52);
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn recording_audio_sink_uses_exact_cumulative_59fps_length() {
+        let path = std::env::temp_dir().join(format!(
+            "stasis-recording-audio-59fps-{}-{}.wav",
+            std::process::id(),
+            UNIX_EPOCH.elapsed().unwrap_or_default().as_nanos()
+        ));
+        let mut sink = RecordingAudioSink::create(&path).expect("create 59 fps WAV sink");
+        let mut written = 0u64;
+        for frame in 1..=60 {
+            let target = recording_audio_target_samples(frame, 59).unwrap();
+            let delta = target - written;
+            sink.append(&vec![0.0; delta as usize * 2])
+                .expect("write 59 fps samples");
+            written = target;
+        }
+        sink.finish().expect("finish 59 fps WAV sink");
+        let bytes = fs::metadata(&path).expect("stat 59 fps WAV").len();
+        assert_eq!(written, 60 * 48_000 / 59);
+        assert_eq!(bytes, 44 + written * 4);
+        fs::remove_file(path).ok();
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct AppliedWindowRequest {
         sequence: i32,
@@ -5406,6 +5612,8 @@ mod tests {
             "STASIS_RECORDING_PRESENTATION",
             "STASIS_RECORDING_FPS",
             "stasis_set_recording_config",
+            "stasis_set_recording_audio_config",
+            "stasis_recording_audio_pull_f32_interleaved",
             "SDL_WINDOW_HIDDEN",
             "SDL_SetRenderVSync(g_renderer, g_recording_presentation ? 0 : 1)",
             "SDL_LOGICAL_PRESENTATION_LETTERBOX",

--- a/apps/stasis/src/toolchain_cli/record.rs
+++ b/apps/stasis/src/toolchain_cli/record.rs
@@ -6,6 +6,7 @@ use stasis::{
     run_play_in_process_with_input_script_window_title_profile_and_capture, PlayFrameCaptureConfig,
 };
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -19,7 +20,7 @@ pub(super) struct RecordArgs {
     /// Override the manifest entry with a project-relative .stasis file.
     #[arg(value_name = "ENTRY")]
     pub(super) entry: Option<PathBuf>,
-    /// Output directory for PNG frames, or an .mp4 file for H.264 encoding.
+    /// Output directory for PNG frames, or an .mp4 file for H.264/AAC encoding.
     #[arg(long, value_name = "PATH")]
     pub(super) output: PathBuf,
     #[arg(long, value_name = "PIXELS")]
@@ -75,6 +76,18 @@ pub(super) fn execute(workspace: &Workspace, args: RecordArgs) -> Result<Command
             args.width, args.height
         ));
     }
+    if kind == OutputKind::Mp4 {
+        let audio_frames = frame_count
+            .checked_mul(48_000)
+            .ok_or_else(|| "MP4 recording audio sample schedule overflow".to_string())?
+            / u64::from(args.fps);
+        let audio_bytes = audio_frames
+            .checked_mul(4)
+            .ok_or_else(|| "MP4 recording WAV size overflow".to_string())?;
+        if audio_bytes > u64::from(u32::MAX) - 36 {
+            return Err("MP4 recording exceeds the bounded 4 GiB WAV staging limit".to_string());
+        }
+    }
     let entry = resolve_entry(workspace, args.entry.as_deref())?;
     let input_script = args
         .input_script
@@ -113,6 +126,7 @@ pub(super) fn execute(workspace: &Workspace, args: RecordArgs) -> Result<Command
             height: args.height,
             fps: args.fps,
             frame_count,
+            audio_output: (kind == OutputKind::Mp4).then(|| stage_root.join("audio.wav")),
         },
     );
     if let Err(error) = result {
@@ -136,6 +150,16 @@ pub(super) fn execute(workspace: &Workspace, args: RecordArgs) -> Result<Command
             args.fps,
             output.display()
         ));
+    }
+    if kind == OutputKind::Mp4 {
+        let audio_path = stage_root.join("audio.wav");
+        if let Err(error) = validate_wav(&audio_path, args.fps, frame_count) {
+            cleanup_stage(&stage_root);
+            return Err(format!(
+                "recording audio validation failed (48 kHz stereo PCM16, output {}): {error}",
+                output.display()
+            ));
+        }
     }
 
     // The stage is complete before this atomic same-volume no-replace rename.
@@ -339,6 +363,47 @@ fn validate_frames(
     Ok(())
 }
 
+fn validate_wav(path: &Path, fps: u32, frame_count: u64) -> Result<(), String> {
+    let mut file =
+        fs::File::open(path).map_err(|error| format!("failed to open staged WAV: {error}"))?;
+    let mut header = [0u8; 44];
+    file.read_exact(&mut header)
+        .map_err(|error| format!("failed to read staged WAV header: {error}"))?;
+    if &header[0..4] != b"RIFF" || &header[8..12] != b"WAVE" {
+        return Err("WAV header is missing RIFF/WAVE signatures".to_string());
+    }
+    if &header[12..16] != b"fmt " || u16::from_le_bytes([header[20], header[21]]) != 1 {
+        return Err("WAV is not uncompressed PCM".to_string());
+    }
+    let channels = u16::from_le_bytes([header[22], header[23]]);
+    let sample_rate = u32::from_le_bytes([header[24], header[25], header[26], header[27]]);
+    let bits = u16::from_le_bytes([header[34], header[35]]);
+    let data_size = u32::from_le_bytes([header[40], header[41], header[42], header[43]]) as u64;
+    let file_size = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect staged WAV: {error}"))?
+        .len();
+    let expected_frames = frame_count
+        .checked_mul(48_000)
+        .ok_or_else(|| "WAV sample schedule overflow".to_string())?
+        / u64::from(fps);
+    let expected_bytes = expected_frames
+        .checked_mul(4)
+        .ok_or_else(|| "WAV size overflow".to_string())?;
+    if channels != 2 || sample_rate != 48_000 || bits != 16 {
+        return Err(format!(
+            "expected PCM16 48 kHz stereo, got channels={channels} rate={sample_rate} bits={bits}"
+        ));
+    }
+    if data_size != expected_bytes || file_size != 44 + data_size {
+        return Err(format!(
+            "expected {expected_frames} audio frames ({expected_bytes} bytes), got {} bytes",
+            data_size
+        ));
+    }
+    Ok(())
+}
+
 fn encode_mp4(
     frames_dir: &Path,
     stage_root: &Path,
@@ -348,8 +413,15 @@ fn encode_mp4(
 ) -> Result<(), String> {
     let staged_output = stage_root.join("recording.mp4");
     let pattern = frames_dir.join("frame-%06d.png");
+    let audio = stage_root.join("audio.wav");
     let command = Command::new("ffmpeg")
-        .args(ffmpeg_args(&pattern, &staged_output, fps, frame_count))
+        .args(ffmpeg_args(
+            &pattern,
+            &audio,
+            &staged_output,
+            fps,
+            frame_count,
+        ))
         .output()
         .map_err(|error| format!("MP4 encoder failure: could not start ffmpeg: {error}"))?;
     if !command.status.success() {
@@ -391,7 +463,13 @@ fn encode_mp4(
     Ok(())
 }
 
-fn ffmpeg_args(pattern: &Path, output: &Path, fps: u32, frame_count: u64) -> Vec<String> {
+fn ffmpeg_args(
+    pattern: &Path,
+    audio: &Path,
+    output: &Path,
+    fps: u32,
+    frame_count: u64,
+) -> Vec<String> {
     vec![
         "-hide_banner".to_string(),
         "-loglevel".to_string(),
@@ -401,15 +479,27 @@ fn ffmpeg_args(pattern: &Path, output: &Path, fps: u32, frame_count: u64) -> Vec
         fps.to_string(),
         "-i".to_string(),
         pattern.display().to_string(),
+        "-i".to_string(),
+        audio.display().to_string(),
+        "-map".to_string(),
+        "0:v:0".to_string(),
+        "-map".to_string(),
+        "1:a:0".to_string(),
         "-frames:v".to_string(),
         frame_count.to_string(),
         "-c:v".to_string(),
         "libx264".to_string(),
         "-pix_fmt".to_string(),
         "yuv420p".to_string(),
+        "-c:a".to_string(),
+        "aac".to_string(),
+        "-ar".to_string(),
+        "48000".to_string(),
+        "-ac".to_string(),
+        "2".to_string(),
         "-r".to_string(),
         fps.to_string(),
-        "-an".to_string(),
+        "-shortest".to_string(),
         "-f".to_string(),
         "mp4".to_string(),
         output.display().to_string(),
@@ -468,6 +558,7 @@ mod tests {
     fn ffmpeg_contract_preserves_exact_rate_and_count() {
         let args = ffmpeg_args(
             Path::new("frames/frame-%06d.png"),
+            Path::new("audio.wav"),
             Path::new("out.mp4"),
             59,
             177,
@@ -484,5 +575,20 @@ mod tests {
         assert!(args
             .windows(2)
             .any(|pair| pair[0] == "-pix_fmt" && pair[1] == "yuv420p"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-map" && pair[1] == "0:v:0"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-map" && pair[1] == "1:a:0"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-c:a" && pair[1] == "aac"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-ar" && pair[1] == "48000"));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-ac" && pair[1] == "2"));
     }
 }

--- a/apps/stasis/tests/windows_game_launch.rs
+++ b/apps/stasis/tests/windows_game_launch.rs
@@ -120,6 +120,42 @@ fn configure_capture(command: &mut Command, screenshot: &Path, exit_after: bool)
     }
 }
 
+fn ffmpeg_directory(root: &Path) -> Option<PathBuf> {
+    let code_root = root.parent().and_then(Path::parent).unwrap_or(root);
+    for bundled in [
+        code_root.join("ffmpeg-9.0.1-essentials_build/bin"),
+        code_root.join("ffmpeg-9.0.1-essentials_build/ffmpeg-9.0.1-essentials_build/bin"),
+    ] {
+        if bundled.join("ffmpeg.exe").is_file() && bundled.join("ffprobe.exe").is_file() {
+            return Some(bundled);
+        }
+    }
+    let ffmpeg = Command::new("ffmpeg").arg("-version").output().ok();
+    let ffprobe = Command::new("ffprobe").arg("-version").output().ok();
+    if ffmpeg
+        .as_ref()
+        .is_some_and(|output| output.status.success())
+        && ffprobe
+            .as_ref()
+            .is_some_and(|output| output.status.success())
+    {
+        Some(PathBuf::from(""))
+    } else {
+        None
+    }
+}
+
+fn add_ffmpeg_path(command: &mut Command, directory: &Path) {
+    if !directory.as_os_str().is_empty() {
+        let current = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = std::env::split_paths(&current).collect::<Vec<_>>();
+        paths.insert(0, directory.to_path_buf());
+        if let Ok(path) = std::env::join_paths(paths) {
+            command.env("PATH", path);
+        }
+    }
+}
+
 fn assert_launch(description: &str, completed: CompletedProcess, screenshot: &Path) {
     let stdout = String::from_utf8_lossy(&completed.stdout);
     let stderr = String::from_utf8_lossy(&completed.stderr);
@@ -637,11 +673,12 @@ fn recording_matches_visible_play_letterbox_and_input_timeline() {
         fs::read(&recording_frames(&scripted_again)[0]).expect("repeated frame bytes")
     );
 
-    if Command::new("ffmpeg").arg("-version").output().is_ok() {
+    if let Some(ffmpeg_dir) = ffmpeg_directory(&root) {
         let mp4 = test_tree.0.join("recording.mp4");
         let mp4_run = launch(
             {
                 let mut command = stasis_command(&project);
+                add_ffmpeg_path(&mut command, &ffmpeg_dir);
                 command.args([
                     "record",
                     "main.stasis",
@@ -662,8 +699,13 @@ fn recording_matches_visible_play_letterbox_and_input_timeline() {
         );
         assert!(mp4_run.status.success(), "MP4 recording failed");
         assert!(fs::metadata(&mp4).expect("MP4 artifact").len() > 0);
-        if Command::new("ffprobe").arg("-version").output().is_ok() {
-            let probe = Command::new("ffprobe")
+        let ffprobe = if ffmpeg_dir.as_os_str().is_empty() {
+            PathBuf::from("ffprobe")
+        } else {
+            ffmpeg_dir.join("ffprobe.exe")
+        };
+        if Command::new(&ffprobe).arg("-version").output().is_ok() {
+            let probe = Command::new(&ffprobe)
                 .args([
                     "-v",
                     "error",
@@ -688,10 +730,199 @@ fn recording_matches_visible_play_letterbox_and_input_timeline() {
                 probe_text.lines().any(|line| line.trim() == "3"),
                 "unexpected MP4 frame count: {probe_text}"
             );
+            let audio_probe = Command::new(&ffprobe)
+                .args([
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "a:0",
+                    "-show_entries",
+                    "stream=codec_name,sample_rate,channels",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                ])
+                .arg(&mp4)
+                .output()
+                .expect("run audio ffprobe");
+            assert!(audio_probe.status.success(), "audio ffprobe failed");
+            let audio_text = String::from_utf8_lossy(&audio_probe.stdout);
+            assert!(
+                audio_text.contains("aac"),
+                "unexpected audio codec: {audio_text}"
+            );
+            assert!(
+                audio_text.contains("48000"),
+                "unexpected audio rate: {audio_text}"
+            );
+            assert!(
+                audio_text.lines().any(|line| line.trim() == "2"),
+                "unexpected audio channels: {audio_text}"
+            );
         }
     } else {
         eprintln!("ffmpeg unavailable; MP4 artifact validation skipped");
     }
+}
+
+#[test]
+fn recording_audio_asset_mp4_is_non_silent_repeatable_and_aligned() {
+    let root = repository_root();
+    let Some(ffmpeg_dir) = ffmpeg_directory(&root) else {
+        eprintln!("audio recording integration skipped: FFmpeg is unavailable");
+        return;
+    };
+    let runtime = std::env::var_os("STASIS_RUNTIME_DLL_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .or_else(|| {
+            let path = root.join("runtime/build/bin/Release/stasis_graphics.dll");
+            path.is_file().then_some(path)
+        });
+    let Some(runtime) = runtime else {
+        eprintln!("audio recording integration skipped: graphics runtime is unavailable");
+        return;
+    };
+    let fixture = root.join("samples/audio_asset_playback");
+    let test_tree = TestTree(temp_dir("audio_recording"));
+    let project = test_tree.0.join("audio_asset_playback");
+    copy_tree(&fixture, &project);
+    copy_tree(&root.join("src"), &project.join("vendor/stasis/src"));
+
+    let record = |output: &Path, label: &str| {
+        let mut command = stasis_command(&project);
+        command.env("STASIS_RUNTIME_DLL_PATH", &runtime);
+        add_ffmpeg_path(&mut command, &ffmpeg_dir);
+        command.args([
+            "record",
+            "audio_asset_playback.stasis",
+            "--output",
+            output.to_str().unwrap(),
+            "--width",
+            "480",
+            "--height",
+            "270",
+            "--fps",
+            "60",
+            "--frames",
+            "60",
+        ]);
+        let completed = launch(command, label);
+        assert!(
+            completed.status.success(),
+            "{label} failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&completed.stdout),
+            String::from_utf8_lossy(&completed.stderr)
+        );
+    };
+    let first = test_tree.0.join("audio-first.mp4");
+    let second = test_tree.0.join("audio-second.mp4");
+    record(&first, "audio recording first");
+    record(&second, "audio recording repeat");
+
+    let ffprobe = if ffmpeg_dir.as_os_str().is_empty() {
+        PathBuf::from("ffprobe")
+    } else {
+        ffmpeg_dir.join("ffprobe.exe")
+    };
+    let probe = |path: &Path, selector: &str, entries: &str| -> String {
+        let output = Command::new(&ffprobe)
+            .args([
+                "-v",
+                "error",
+                "-count_frames",
+                "-select_streams",
+                selector,
+                "-show_entries",
+                entries,
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+            ])
+            .arg(path)
+            .output()
+            .expect("run ffprobe");
+        assert!(
+            output.status.success(),
+            "ffprobe failed: {:?}",
+            output.status
+        );
+        String::from_utf8_lossy(&output.stdout).to_string()
+    };
+    let video = probe(
+        &first,
+        "v:0",
+        "stream=codec_name,r_frame_rate,nb_read_frames,start_time,duration",
+    );
+    assert!(video.contains("h264"), "unexpected video stream: {video}");
+    assert!(video.contains("60/1"), "unexpected video rate: {video}");
+    assert!(
+        video.lines().any(|line| line.trim() == "60"),
+        "unexpected video count: {video}"
+    );
+    assert!(
+        video.lines().any(|line| line.trim() == "0.000000"),
+        "unexpected video start: {video}"
+    );
+    let audio = probe(
+        &first,
+        "a:0",
+        "stream=codec_name,sample_rate,channels,start_time,duration",
+    );
+    assert!(audio.contains("aac"), "unexpected audio stream: {audio}");
+    assert!(audio.contains("48000"), "unexpected audio rate: {audio}");
+    assert!(
+        audio.lines().any(|line| line.trim() == "2"),
+        "unexpected audio channels: {audio}"
+    );
+    assert!(
+        audio.lines().any(|line| line.trim() == "0.000000"),
+        "unexpected audio start: {audio}"
+    );
+    let video_duration = video
+        .lines()
+        .last()
+        .expect("video duration")
+        .trim()
+        .parse::<f64>()
+        .expect("numeric video duration");
+    let audio_duration = audio
+        .lines()
+        .last()
+        .expect("audio duration")
+        .trim()
+        .parse::<f64>()
+        .expect("numeric audio duration");
+    assert!(
+        (video_duration - 1.0).abs() < 0.02,
+        "video duration {video_duration}"
+    );
+    assert!(
+        (audio_duration - video_duration).abs() <= 1024.0 / 48_000.0,
+        "A/V duration mismatch: {audio_duration} vs {video_duration}"
+    );
+
+    let decode = |path: &Path| {
+        let output = Command::new(if ffmpeg_dir.as_os_str().is_empty() {
+            PathBuf::from("ffmpeg")
+        } else {
+            ffmpeg_dir.join("ffmpeg.exe")
+        })
+        .args(["-v", "error", "-i"])
+        .arg(path)
+        .args(["-map", "0:a:0", "-f", "s16le", "-acodec", "pcm_s16le", "-"])
+        .output()
+        .expect("decode audio");
+        assert!(output.status.success(), "audio decode failed");
+        output.stdout
+    };
+    let first_pcm = decode(&first);
+    let second_pcm = decode(&second);
+    assert!(
+        !first_pcm.is_empty()
+            && first_pcm
+                .chunks_exact(2)
+                .any(|sample| i16::from_le_bytes([sample[0], sample[1]]) != 0)
+    );
+    assert_eq!(first_pcm, second_pcm, "recorded PCM must be repeatable");
 }
 
 fn recording_frames(directory: &Path) -> Vec<PathBuf> {

--- a/apps/stasis/tests/windows_game_launch.rs
+++ b/apps/stasis/tests/windows_game_launch.rs
@@ -824,7 +824,7 @@ fn recording_audio_asset_mp4_is_non_silent_repeatable_and_aligned() {
     } else {
         ffmpeg_dir.join("ffprobe.exe")
     };
-    let probe = |path: &Path, selector: &str, entries: &str| -> String {
+    let probe = |path: &Path, selector: &str, entries: &str| -> serde_json::Value {
         let output = Command::new(&ffprobe)
             .args([
                 "-v",
@@ -835,7 +835,7 @@ fn recording_audio_asset_mp4_is_non_silent_repeatable_and_aligned() {
                 "-show_entries",
                 entries,
                 "-of",
-                "default=noprint_wrappers=1:nokey=1",
+                "json",
             ])
             .arg(path)
             .output()
@@ -845,50 +845,40 @@ fn recording_audio_asset_mp4_is_non_silent_repeatable_and_aligned() {
             "ffprobe failed: {:?}",
             output.status
         );
-        String::from_utf8_lossy(&output.stdout).to_string()
+        let payload: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("parse ffprobe JSON");
+        payload["streams"]
+            .as_array()
+            .and_then(|streams| streams.first())
+            .cloned()
+            .expect("ffprobe stream")
     };
     let video = probe(
         &first,
         "v:0",
         "stream=codec_name,r_frame_rate,nb_read_frames,start_time,duration",
     );
-    assert!(video.contains("h264"), "unexpected video stream: {video}");
-    assert!(video.contains("60/1"), "unexpected video rate: {video}");
-    assert!(
-        video.lines().any(|line| line.trim() == "60"),
-        "unexpected video count: {video}"
-    );
-    assert!(
-        video.lines().any(|line| line.trim() == "0.000000"),
-        "unexpected video start: {video}"
-    );
+    assert_eq!(video["codec_name"], "h264", "unexpected video stream");
+    assert_eq!(video["r_frame_rate"], "60/1", "unexpected video rate");
+    assert_eq!(video["nb_read_frames"], "60", "unexpected video count");
+    assert_eq!(video["start_time"], "0.000000", "unexpected video start");
     let audio = probe(
         &first,
         "a:0",
         "stream=codec_name,sample_rate,channels,start_time,duration",
     );
-    assert!(audio.contains("aac"), "unexpected audio stream: {audio}");
-    assert!(audio.contains("48000"), "unexpected audio rate: {audio}");
-    assert!(
-        audio.lines().any(|line| line.trim() == "2"),
-        "unexpected audio channels: {audio}"
-    );
-    assert!(
-        audio.lines().any(|line| line.trim() == "0.000000"),
-        "unexpected audio start: {audio}"
-    );
-    let video_duration = video
-        .lines()
-        .last()
+    assert_eq!(audio["codec_name"], "aac", "unexpected audio stream");
+    assert_eq!(audio["sample_rate"], "48000", "unexpected audio rate");
+    assert_eq!(audio["channels"], 2, "unexpected audio channels");
+    assert_eq!(audio["start_time"], "0.000000", "unexpected audio start");
+    let video_duration = video["duration"]
+        .as_str()
         .expect("video duration")
-        .trim()
         .parse::<f64>()
         .expect("numeric video duration");
-    let audio_duration = audio
-        .lines()
-        .last()
+    let audio_duration = audio["duration"]
+        .as_str()
         .expect("audio duration")
-        .trim()
         .parse::<f64>()
         .expect("numeric audio duration");
     assert!(

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -1141,6 +1141,8 @@ pub struct StasisGraphicsApi {
     stasis_host_set_performance_metrics: usize,
     stasis_gfx_submit_u8: usize,
     stasis_set_recording_config: Option<usize>,
+    stasis_set_recording_audio_config: Option<usize>,
+    stasis_recording_audio_pull_f32_interleaved: Option<usize>,
     stasis_test_get_render_submission_state: Option<usize>,
     stasis_gfx_notify_file_changed: Option<usize>,
     stasis_sleep_ms: usize,
@@ -1179,6 +1181,11 @@ impl StasisGraphicsApi {
             lib.symbol_address("stasis_host_performance_metrics_enabled")?;
         let stasis_gfx_submit_u8 = lib.symbol_address("stasis_gfx_submit_u8")?;
         let stasis_set_recording_config = lib.symbol_address("stasis_set_recording_config").ok();
+        let stasis_set_recording_audio_config =
+            lib.symbol_address("stasis_set_recording_audio_config").ok();
+        let stasis_recording_audio_pull_f32_interleaved = lib
+            .symbol_address("stasis_recording_audio_pull_f32_interleaved")
+            .ok();
         let stasis_test_get_render_submission_state = lib
             .symbol_address("stasis_test_get_render_submission_state")
             .ok();
@@ -1196,6 +1203,8 @@ impl StasisGraphicsApi {
             stasis_host_set_performance_metrics,
             stasis_gfx_submit_u8,
             stasis_set_recording_config,
+            stasis_set_recording_audio_config,
+            stasis_recording_audio_pull_f32_interleaved,
             stasis_test_get_render_submission_state,
             stasis_gfx_notify_file_changed,
             stasis_sleep_ms,
@@ -1244,6 +1253,62 @@ impl StasisGraphicsApi {
             }
             Ok(())
         }
+    }
+
+    pub fn set_recording_audio_config(&self, enabled: bool) -> Result<(), String> {
+        let symbol = self.stasis_set_recording_audio_config.ok_or_else(|| {
+            "graphics runtime lacks offline recording audio configuration support".to_string()
+        })?;
+        #[cfg(windows)]
+        {
+            let callback: extern "system" fn(i32) -> i32 = unsafe { std::mem::transmute(symbol) };
+            if callback(if enabled { 1 } else { 0 }) == 0 {
+                return Err(
+                    "graphics runtime rejected offline recording audio configuration".to_string(),
+                );
+            }
+            return Ok(());
+        }
+        #[cfg(not(windows))]
+        {
+            let callback: extern "C" fn(i32) -> i32 = unsafe { std::mem::transmute(symbol) };
+            if callback(if enabled { 1 } else { 0 }) == 0 {
+                return Err(
+                    "graphics runtime rejected offline recording audio configuration".to_string(),
+                );
+            }
+            Ok(())
+        }
+    }
+
+    pub fn pull_recording_audio_f32_interleaved(
+        &self,
+        output: &mut [f32],
+    ) -> Result<usize, String> {
+        if output.len() % 2 != 0 {
+            return Err("recording audio output must contain stereo samples".to_string());
+        }
+        let symbol = self
+            .stasis_recording_audio_pull_f32_interleaved
+            .ok_or_else(|| {
+                "graphics runtime lacks offline recording audio pull support".to_string()
+            })?;
+        let frame_count = output.len() / 2;
+        if frame_count > i32::MAX as usize {
+            return Err("recording audio pull exceeds runtime frame-count bound".to_string());
+        }
+        #[cfg(windows)]
+        let callback: extern "system" fn(*mut f32, i32) -> i32 =
+            unsafe { std::mem::transmute(symbol) };
+        #[cfg(not(windows))]
+        let callback: extern "C" fn(*mut f32, i32) -> i32 = unsafe { std::mem::transmute(symbol) };
+        let accepted = callback(output.as_mut_ptr(), frame_count as i32);
+        if accepted < 0 || accepted as usize != frame_count {
+            return Err(format!(
+                "graphics runtime returned {accepted} recording audio frames, expected {frame_count}"
+            ));
+        }
+        Ok(accepted as usize)
     }
 
     pub fn set_asset_root(&self, path: &Path) -> Result<(), String> {

--- a/docs/headless_recording.md
+++ b/docs/headless_recording.md
@@ -30,11 +30,29 @@ stasis --workspace samples/windows_launch_smoke record main.stasis `
   --width 640 --height 360 --fps 60 --frames 3
 ```
 
-FFmpeg must be on `PATH`; the command uses H.264 (`libx264`), `yuv420p`, and the
-requested input/output rate. PNGs are validated for exact names, count, and
-dimensions before publication. MP4 encoding and publication are staged, so an
-encoder or renderer failure removes partial artifacts and reports the stage,
-resolution, frame rate, output, and underlying cause.
+FFmpeg must be on `PATH`; the command uses H.264 (`libx264`), `yuv420p`, AAC,
+and the requested input/output rate. MP4 recording also runs the existing game
+mixer offline at 48 kHz, stereo, PCM16 before muxing it as AAC. Audio samples
+for frame `n` are exactly `floor(n * 48000 / fps)`, so fractional rates do not
+accumulate rounding drift and no physical audio device is opened. This captures
+game-generated asset voices and `audio_push_f32_interleaved` samples only; it
+does not capture a microphone or system audio. PNG mode does not stage offline
+audio; guest code may still initialize and use the normal interactive audio API
+when that path is requested.
+
+For a checked-in audio example:
+
+```powershell
+stasis --workspace samples/audio_asset_playback record `
+  audio_asset_playback.stasis `
+  --output artifacts/audio-review.mp4 `
+  --width 480 --height 270 --fps 60 --frames 60
+```
+
+PNG frames and the staged WAV are validated for exact count, dimensions,
+format, and sample count before publication. MP4 encoding and publication are
+staged, so an encoder, mixer, or renderer failure removes partial artifacts and
+reports the stage, resolution, frame rate, output, and underlying cause.
 
 Publication renames the fully validated sibling stage into the destination in
 one same-volume operation; the final path is never populated incrementally.

--- a/docs/toolchain_cli.md
+++ b/docs/toolchain_cli.md
@@ -124,10 +124,13 @@ cloning a generated repository, reactivate the checked-in hook with
 - `record [ENTRY] --output PATH --width PX --height PX --fps FPS (--frames N|--duration S)`:
   execute the normal desktop JIT/render path on a hidden fixed-size SDL software presentation.
   An extensionless output path publishes an exact, numbered PNG sequence; an `.mp4` path stages
-  those PNGs and invokes FFmpeg H.264/yuv420p at the requested rate. Recording starts after
-  `main()`, uses zero tick sleep, applies the existing `--input-script` timeline, and preserves
-  logical-canvas fit/letterboxing. Dimensions, rates, counts, output format, staged frame
-  validation, encoder failures, and partial-output cleanup are bounded and diagnosed. See
+  those PNGs and the existing mixed game audio, then invokes FFmpeg H.264/yuv420p plus AAC at
+  the requested rate. Audio is rendered offline as deterministic 48 kHz stereo PCM16 using
+  cumulative `floor(frame * 48000 / fps)` sample boundaries; no physical device, microphone, or
+  system audio is used. Recording starts after `main()`, uses zero tick sleep, applies the existing
+  `--input-script` timeline, and preserves logical-canvas fit/letterboxing. Dimensions, rates,
+  counts, output format, staged frame/WAV validation, encoder failures, and partial-output cleanup
+  are bounded and diagnosed. See
   [Deterministic headless recording](headless_recording.md).
 - `play [ENTRY]`: launch the graphical hot-swap runtime. Without an entry override, discover the
   nearest ancestor `stasis.json` from the current directory and use its project-relative `entry`

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -261,6 +261,16 @@ if(STASIS_MOBILE_RUNTIME_BUILD_TESTS)
             PROPERTIES ENVIRONMENT "SDL_VIDEODRIVER=dummy;SDL_RENDER_DRIVER=software;SDL_AUDIODRIVER=dummy"
         )
         add_executable(
+            stasis_recording_audio_test
+            tests/stasis_recording_audio_test.c
+        )
+        target_link_libraries(stasis_recording_audio_test PRIVATE stasis_graphics_static)
+        target_compile_definitions(
+            stasis_recording_audio_test
+            PRIVATE STASIS_TEST_AUDIO_PATH="${CMAKE_SOURCE_DIR}/../samples/audio_asset_playback/assets/tone.wav"
+        )
+        add_test(NAME stasis_recording_audio_contract COMMAND stasis_recording_audio_test)
+        add_executable(
             stasis_font_cache_test
             tests/stasis_font_cache_test.c
         )

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -1513,6 +1513,7 @@ static int g_audio_underruns = 0;
 static int g_audio_channels = 2;
 static int g_audio_sample_rate = 48000;
 static int g_audio_target_latency_frames = 2048;
+#define STASIS_AUDIO_MAX_TARGET_LATENCY_FRAMES (1 << 20)
 static float* g_audio_ring = NULL;
 static int g_audio_ring_capacity_frames = 0;
 static int g_audio_ring_capacity_samples = 0;
@@ -1520,6 +1521,7 @@ static int g_audio_read_sample = 0;
 static int g_audio_write_sample = 0;
 static int g_audio_queued_samples = 0;
 static int64_t g_audio_running_frame_index = 0;
+static int g_recording_audio_enabled = 0;
 
 static StasisAudioAssetStore g_audio_assets;
 
@@ -1532,6 +1534,53 @@ static int stasis_audio_has_active_voice(void) {
 static int stasis_audio_maxi(int a, int b) { return a > b ? a : b; }
 static int stasis_audio_mini(int a, int b) { return a < b ? a : b; }
 
+static int stasis_audio_ensure_ring_init(void) {
+    if (g_audio_assets.next_asset_handle <= 0 || g_audio_assets.next_voice_handle <= 0) {
+        stasis_audio_assets_reset(&g_audio_assets);
+    }
+    if (g_audio_ring) return 1;
+
+    g_audio_channels = 2;
+    g_audio_target_latency_frames = stasis_audio_maxi(512, g_audio_target_latency_frames);
+    g_audio_ring_capacity_frames = stasis_audio_maxi(8192, g_audio_target_latency_frames * 4);
+    g_audio_ring_capacity_samples = g_audio_ring_capacity_frames * g_audio_channels;
+    g_audio_ring = (float*)malloc((size_t)g_audio_ring_capacity_samples * sizeof(float));
+    if (!g_audio_ring) {
+        g_audio_ring_capacity_frames = 0;
+        g_audio_ring_capacity_samples = 0;
+        return 0;
+    }
+    SDL_memset(g_audio_ring, 0, (size_t)g_audio_ring_capacity_samples * sizeof(float));
+    g_audio_read_sample = 0;
+    g_audio_write_sample = 0;
+    g_audio_queued_samples = 0;
+    g_audio_underruns = 0;
+    g_audio_running_frame_index = 0;
+    return 1;
+}
+
+static int stasis_audio_mix_output(float* output, int frame_count) {
+    if (!output || frame_count <= 0 || g_audio_channels <= 0 ||
+        !stasis_audio_ensure_ring_init()) return 0;
+    const int sample_count = frame_count * g_audio_channels;
+    SDL_memset(output, 0, (size_t)sample_count * sizeof(float));
+    const int available = stasis_audio_mini(sample_count, g_audio_queued_samples);
+    int copied = 0;
+    while (copied < available) {
+        int contiguous = g_audio_ring_capacity_samples - g_audio_read_sample;
+        int part = stasis_audio_mini(available - copied, contiguous);
+        SDL_memcpy(
+            &output[copied], &g_audio_ring[g_audio_read_sample],
+            (size_t)part * sizeof(float));
+        copied += part;
+        g_audio_read_sample = (g_audio_read_sample + part) % g_audio_ring_capacity_samples;
+        g_audio_queued_samples -= part;
+    }
+    stasis_audio_assets_mix(&g_audio_assets, output, frame_count, g_audio_sample_rate);
+    g_audio_running_frame_index += frame_count;
+    return frame_count;
+}
+
 static void SDLCALL stasis_audio_callback(
     void* userdata,
     SDL_AudioStream* stream,
@@ -1542,38 +1591,21 @@ static void SDLCALL stasis_audio_callback(
     (void)total_amount;
     if (!stream || additional_amount <= 0 || g_audio_channels <= 0) return;
 
-    int remaining_samples = additional_amount / (int)sizeof(float);
-    if (g_audio_queued_samples < remaining_samples && !stasis_audio_has_active_voice()) {
+    int remaining_frames = additional_amount / (int)sizeof(float) / g_audio_channels;
+    if (g_audio_queued_samples < remaining_frames * g_audio_channels &&
+        !stasis_audio_has_active_voice()) {
         g_audio_underruns++;
     }
 
     float output[1024];
-    while (remaining_samples > 0) {
-        int chunk = stasis_audio_mini(remaining_samples, (int)(sizeof(output) / sizeof(output[0])));
-        int available = stasis_audio_mini(chunk, g_audio_queued_samples);
-        int copied = 0;
-        while (copied < available) {
-            int contiguous = g_audio_ring_capacity_samples - g_audio_read_sample;
-            int part = stasis_audio_mini(available - copied, contiguous);
-            SDL_memcpy(
-                &output[copied], &g_audio_ring[g_audio_read_sample],
-                (size_t)part * sizeof(float));
-            copied += part;
-            g_audio_read_sample =
-                (g_audio_read_sample + part) % g_audio_ring_capacity_samples;
-            g_audio_queued_samples -= part;
-        }
-        if (copied < chunk) {
-            SDL_memset(&output[copied], 0, (size_t)(chunk - copied) * sizeof(float));
-        }
-        stasis_audio_assets_mix(
-            &g_audio_assets, output, chunk / g_audio_channels, g_audio_sample_rate);
-        if (!SDL_PutAudioStreamData(stream, output, chunk * (int)sizeof(float))) return;
-        remaining_samples -= chunk;
+    const int max_frames = (int)(sizeof(output) / sizeof(output[0])) / g_audio_channels;
+    while (remaining_frames > 0) {
+        int chunk = stasis_audio_mini(remaining_frames, max_frames);
+        if (stasis_audio_mix_output(output, chunk) != chunk) return;
+        if (!SDL_PutAudioStreamData(
+                stream, output, chunk * g_audio_channels * (int)sizeof(float))) return;
+        remaining_frames -= chunk;
     }
-
-    g_audio_running_frame_index +=
-        (additional_amount / (int)sizeof(float)) / g_audio_channels;
 }
 
 static void stasis_audio_shutdown_internal(void) {
@@ -1608,9 +1640,7 @@ static int stasis_audio_ensure_init(void) {
     if (stasis_audio_disabled()) {
         return 0;
     }
-    if (g_audio_assets.next_asset_handle <= 0 || g_audio_assets.next_voice_handle <= 0) {
-        stasis_audio_assets_reset(&g_audio_assets);
-    }
+    if (g_recording_audio_enabled) return stasis_audio_ensure_ring_init();
     if (g_audio_initialized && g_audio_stream) {
         return 1;
     }
@@ -1648,23 +1678,11 @@ static int stasis_audio_ensure_init(void) {
     g_audio_stream = stream;
     g_audio_channels = 2;
 
-    g_audio_target_latency_frames = stasis_audio_maxi(512, g_audio_target_latency_frames);
-    g_audio_ring_capacity_frames = stasis_audio_maxi(8192, g_audio_target_latency_frames * 4);
-    g_audio_ring_capacity_samples = g_audio_ring_capacity_frames * g_audio_channels;
-
-    g_audio_ring = (float*)malloc((size_t)g_audio_ring_capacity_samples * sizeof(float));
-    if (!g_audio_ring) {
+    if (!stasis_audio_ensure_ring_init()) {
         SDL_DestroyAudioStream(g_audio_stream);
         g_audio_stream = NULL;
         return 0;
     }
-    SDL_memset(g_audio_ring, 0, (size_t)g_audio_ring_capacity_samples * sizeof(float));
-
-    g_audio_read_sample = 0;
-    g_audio_write_sample = 0;
-    g_audio_queued_samples = 0;
-    g_audio_underruns = 0;
-    g_audio_running_frame_index = 0;
     g_audio_initialized = 1;
 
     if (!SDL_ResumeAudioStreamDevice(g_audio_stream)) {
@@ -3357,11 +3375,24 @@ static int stasis_asset_task_worker(void* unused) {
     }
 }
 
-static int stasis_asset_tasks_ensure_started(void) {
-    if (g_asset_task_thread) return 1;
+static int stasis_asset_tasks_ensure_storage(void) {
+    if (g_asset_task_mutex && g_asset_task_condition) return 1;
     g_asset_task_mutex = SDL_CreateMutex();
     g_asset_task_condition = SDL_CreateCondition();
     if (!g_asset_task_mutex || !g_asset_task_condition) goto fail;
+    return 1;
+
+fail:
+    if (g_asset_task_condition) SDL_DestroyCondition(g_asset_task_condition);
+    if (g_asset_task_mutex) SDL_DestroyMutex(g_asset_task_mutex);
+    g_asset_task_condition = NULL;
+    g_asset_task_mutex = NULL;
+    return 0;
+}
+
+static int stasis_asset_tasks_ensure_started(void) {
+    if (g_asset_task_thread) return 1;
+    if (!stasis_asset_tasks_ensure_storage()) return 0;
     g_asset_task_stop = 0;
     g_asset_task_thread = SDL_CreateThread(stasis_asset_task_worker, "stasis-assets", NULL);
     if (!g_asset_task_thread) goto fail;
@@ -3374,6 +3405,8 @@ fail:
     g_asset_task_mutex = NULL;
     return 0;
 }
+
+static StasisAssetTask* stasis_asset_task_find_locked(int task_id);
 
 static int stasis_asset_task_request(
     int kind,
@@ -3388,7 +3421,13 @@ static int stasis_asset_task_request(
     } else if (kind == STASIS_ASSET_KIND_AUDIO && !stasis_audio_ensure_init()) {
         return 0;
     }
-    if (!stasis_asset_tasks_ensure_started()) return 0;
+    const int synchronous_audio =
+        kind == STASIS_ASSET_KIND_AUDIO && g_recording_audio_enabled;
+    if (synchronous_audio) {
+        if (!stasis_asset_tasks_ensure_storage()) return 0;
+    } else if (!stasis_asset_tasks_ensure_started()) {
+        return 0;
+    }
 
     SDL_LockMutex(g_asset_task_mutex);
     int slot = -1;
@@ -3407,7 +3446,7 @@ static int stasis_asset_task_request(
     task->id = g_asset_task_next_id++;
     if (g_asset_task_next_id <= 0) g_asset_task_next_id = 1;
     task->kind = kind;
-    task->state = STASIS_ASSET_TASK_PENDING;
+    task->state = synchronous_audio ? STASIS_ASSET_TASK_LOADING : STASIS_ASSET_TASK_PENDING;
     task->max_w = max_w;
     task->max_h = max_h;
     task->raster_w = kind == STASIS_ASSET_KIND_SPRITE
@@ -3416,8 +3455,30 @@ static int stasis_asset_task_request(
         ? stasis_display_scaled_extent(max_h, g_pixel_scale) : 0;
     memcpy(task->path, resolved, strlen(resolved) + 1);
     int id = task->id;
-    SDL_SignalCondition(g_asset_task_condition);
     SDL_UnlockMutex(g_asset_task_mutex);
+    if (synchronous_audio) {
+        StasisDecodedAudio audio;
+        memset(&audio, 0, sizeof(audio));
+        const int ok = stasis_audio_decode(resolved, &audio);
+        SDL_LockMutex(g_asset_task_mutex);
+        task = stasis_asset_task_find_locked(id);
+        if (!task || task->release_requested || task->state == STASIS_ASSET_TASK_CANCELLED) {
+            stasis_audio_decoded_free(&audio);
+            if (task) stasis_asset_task_clear(task);
+        } else if (!ok) {
+            task->state = STASIS_ASSET_TASK_FAILED;
+            stasis_audio_decoded_free(&audio);
+        } else {
+            task->audio = audio;
+            task->state = STASIS_ASSET_TASK_DECODED;
+        }
+        SDL_UnlockMutex(g_asset_task_mutex);
+    } else {
+        SDL_LockMutex(g_asset_task_mutex);
+        task = stasis_asset_task_find_locked(id);
+        if (task) SDL_SignalCondition(g_asset_task_condition);
+        SDL_UnlockMutex(g_asset_task_mutex);
+    }
     return id;
 }
 
@@ -6132,10 +6193,10 @@ STASIS_EXPORT int stasis_asset_task_poll(int task_id) {
     int handle = 0;
     if (kind == STASIS_ASSET_KIND_SPRITE) {
         handle = stasis_gfx_publish_sprite_task(task);
-    } else if (kind == STASIS_ASSET_KIND_AUDIO && g_audio_stream) {
-        SDL_LockAudioStream(g_audio_stream);
+    } else if (kind == STASIS_ASSET_KIND_AUDIO && (g_audio_stream || g_recording_audio_enabled)) {
+        if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
         handle = stasis_audio_assets_store_decoded(&g_audio_assets, &task->audio);
-        SDL_UnlockAudioStream(g_audio_stream);
+        if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     }
 
     SDL_LockMutex(g_asset_task_mutex);
@@ -6696,9 +6757,9 @@ STASIS_EXPORT int stasis_audio_load_wav(const char* path) {
         return 0;
     }
     if (!stasis_audio_ensure_init()) goto fail;
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     int handle = stasis_audio_assets_load_wav(&g_audio_assets, resolved);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     if (handle == 0) {
         stasis_report_runtime_errorf("Audio failed to load: %s", path);
     }
@@ -6715,9 +6776,9 @@ static int stasis_audio_load_asset(const char* path) {
         return 0;
     }
     if (!stasis_audio_ensure_init()) return 0;
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     int handle = stasis_audio_assets_load(&g_audio_assets, resolved);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     if (handle == 0) {
         stasis_report_runtime_errorf("Audio failed to load: %s", path);
     }
@@ -6725,10 +6786,10 @@ static int stasis_audio_load_asset(const char* path) {
 }
 
 STASIS_EXPORT void stasis_audio_release(int asset_handle) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_release(&g_audio_assets, asset_handle);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT int stasis_audio_play(int asset_handle, int loop, float volume, float pan) {
@@ -6737,43 +6798,43 @@ STASIS_EXPORT int stasis_audio_play(int asset_handle, int loop, float volume, fl
     if (volume > 1.0f) volume = 1.0f;
     if (pan < -1.0f) pan = -1.0f;
     if (pan > 1.0f) pan = 1.0f;
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     int voice_handle = stasis_audio_assets_play(&g_audio_assets, asset_handle, loop, volume, pan);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     return voice_handle;
 }
 
 STASIS_EXPORT void stasis_audio_stop(int voice_handle) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_stop_voice(&g_audio_assets, voice_handle);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT int stasis_audio_voice_is_playing(int voice_handle) {
-    if (!g_audio_stream) return 0;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return 0;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     int playing = stasis_audio_assets_voice_is_playing(&g_audio_assets, voice_handle);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     return playing;
 }
 
 STASIS_EXPORT void stasis_audio_voice_set_paused(int voice_handle, int paused) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_voice_set_paused(&g_audio_assets, voice_handle, paused);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT void stasis_audio_voice_set_volume_pan(int voice_handle, float volume, float pan) {
-    if (!g_audio_stream) return;
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
     if (volume < 0.0f) volume = 0.0f;
     if (volume > 1.0f) volume = 1.0f;
     if (pan < -1.0f) pan = -1.0f;
     if (pan > 1.0f) pan = 1.0f;
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_voice_set_volume_pan(&g_audio_assets, voice_handle, volume, pan);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 /* Brickout-compatible convenience API. Both categories use the same bounded WAV/MP3 asset
@@ -6787,34 +6848,34 @@ STASIS_EXPORT int stasis_audio_load_effect(const char* path) {
 }
 
 STASIS_EXPORT int stasis_audio_play_music(int asset_handle, int loop, float volume) {
-    if (!g_audio_stream) {
+    if (!g_audio_stream && !g_recording_audio_enabled) {
         return stasis_audio_play(asset_handle, loop, volume, 0.0f) > 0;
     }
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_stop_asset(&g_audio_assets, asset_handle);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
     return stasis_audio_play(asset_handle, loop, volume, 0.0f) > 0;
 }
 
 STASIS_EXPORT void stasis_audio_stop_music(int asset_handle) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_stop_asset(&g_audio_assets, asset_handle);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT void stasis_audio_pause_music(int asset_handle, int paused) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_set_asset_paused(&g_audio_assets, asset_handle, paused);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT void stasis_audio_set_music_volume(int asset_handle, float volume) {
-    if (!g_audio_stream) return;
-    SDL_LockAudioStream(g_audio_stream);
+    if (!g_audio_stream && !g_recording_audio_enabled) return;
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     stasis_audio_assets_set_asset_volume(&g_audio_assets, asset_handle, volume);
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 }
 
 STASIS_EXPORT int stasis_audio_play_effect(int asset_handle, float volume) {
@@ -6822,11 +6883,16 @@ STASIS_EXPORT int stasis_audio_play_effect(int asset_handle, float volume) {
 }
 
 STASIS_EXPORT int stasis_audio_init(int sample_rate, int channels, int target_latency_frames) {
-    if (sample_rate > 0) g_audio_sample_rate = sample_rate;
     if (channels != 0 && channels != 2) return 0;
+    if (target_latency_frames > STASIS_AUDIO_MAX_TARGET_LATENCY_FRAMES) return 0;
+    if (g_recording_audio_enabled && sample_rate > 0 && sample_rate != 48000) return 0;
+    if (sample_rate > 0) g_audio_sample_rate = sample_rate;
     g_audio_channels = 2;
     if (target_latency_frames > 0) g_audio_target_latency_frames = target_latency_frames;
 
+    if (g_recording_audio_enabled) {
+        return stasis_audio_ensure_ring_init();
+    }
     if (g_audio_stream) {
         stasis_audio_shutdown_internal();
     }
@@ -6839,20 +6905,27 @@ STASIS_EXPORT void stasis_audio_shutdown(void) {
 }
 
 STASIS_EXPORT int stasis_audio_is_available(void) {
+    if (g_recording_audio_enabled) return stasis_audio_ensure_ring_init();
     return stasis_audio_ensure_init();
 }
 
 STASIS_EXPORT int stasis_audio_get_sample_rate(void) {
+    if (g_recording_audio_enabled) return g_audio_sample_rate;
     if (!stasis_audio_ensure_init()) return 0;
     return g_audio_sample_rate;
 }
 
 STASIS_EXPORT int stasis_audio_get_channels(void) {
+    if (g_recording_audio_enabled) return g_audio_channels;
     if (!stasis_audio_ensure_init()) return 0;
     return g_audio_channels;
 }
 
 STASIS_EXPORT int stasis_audio_get_queued_frames(void) {
+    if (g_recording_audio_enabled) {
+        if (!stasis_audio_ensure_ring_init() || g_audio_channels <= 0) return 0;
+        return g_audio_queued_samples / g_audio_channels;
+    }
     if (!stasis_audio_ensure_init()) return 0;
 
     int queued = 0;
@@ -6865,6 +6938,7 @@ STASIS_EXPORT int stasis_audio_get_queued_frames(void) {
 }
 
 STASIS_EXPORT int stasis_audio_get_underruns(void) {
+    if (g_recording_audio_enabled) return 0;
     if (!stasis_audio_ensure_init()) return 0;
 
     int underruns = 0;
@@ -6876,12 +6950,16 @@ STASIS_EXPORT int stasis_audio_get_underruns(void) {
 
 STASIS_EXPORT int stasis_audio_push_f32_interleaved(const float* interleaved_lr, int frame_count) {
     if (!interleaved_lr || frame_count <= 0) return 0;
-    if (!stasis_audio_ensure_init()) return 0;
+    if (g_recording_audio_enabled) {
+        if (!stasis_audio_ensure_ring_init()) return 0;
+    } else if (!stasis_audio_ensure_init()) {
+        return 0;
+    }
 
     int accepted_samples = 0;
     const int requested_samples = frame_count * g_audio_channels;
 
-    SDL_LockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_LockAudioStream(g_audio_stream);
     int free_samples = g_audio_ring_capacity_samples - g_audio_queued_samples;
     int to_write = stasis_audio_mini(requested_samples, free_samples);
 
@@ -6894,10 +6972,32 @@ STASIS_EXPORT int stasis_audio_push_f32_interleaved(const float* interleaved_lr,
         accepted_samples += chunk;
         to_write -= chunk;
     }
-    SDL_UnlockAudioStream(g_audio_stream);
+    if (g_audio_stream) SDL_UnlockAudioStream(g_audio_stream);
 
     if (g_audio_channels <= 0) return 0;
     return accepted_samples / g_audio_channels;
+}
+
+STASIS_EXPORT int stasis_set_recording_audio_config(int enabled) {
+    if (g_audio_stream || g_audio_initialized) return 0;
+    if (!enabled && g_recording_audio_enabled) {
+        stasis_asset_tasks_shutdown();
+        stasis_audio_shutdown_internal();
+    }
+    g_recording_audio_enabled = enabled != 0;
+    if (g_recording_audio_enabled) {
+        g_audio_sample_rate = 48000;
+        g_audio_channels = 2;
+    }
+    return 1;
+}
+
+STASIS_EXPORT int stasis_recording_audio_pull_f32_interleaved(
+    float* output_stereo,
+    int frame_count
+) {
+    if (!g_recording_audio_enabled || !output_stereo || frame_count <= 0) return 0;
+    return stasis_audio_mix_output(output_stereo, frame_count);
 }
 
 /*

--- a/runtime/stasis_graphics.def
+++ b/runtime/stasis_graphics.def
@@ -42,6 +42,8 @@ EXPORTS
     stasis_audio_get_queued_frames
     stasis_audio_get_underruns
     stasis_audio_push_f32_interleaved
+    stasis_set_recording_audio_config
+    stasis_recording_audio_pull_f32_interleaved
     stasis_audio_load_wav
     stasis_audio_release
     stasis_audio_play

--- a/runtime/tests/stasis_recording_audio_test.c
+++ b/runtime/tests/stasis_recording_audio_test.c
@@ -1,0 +1,90 @@
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+extern int stasis_set_recording_audio_config(int enabled);
+extern int stasis_audio_init(int sample_rate, int channels, int target_latency_frames);
+extern int stasis_audio_is_available(void);
+extern int stasis_audio_get_sample_rate(void);
+extern int stasis_audio_get_channels(void);
+extern int stasis_audio_push_f32_interleaved(const float* samples, int frame_count);
+extern int stasis_recording_audio_pull_f32_interleaved(float* output, int frame_count);
+extern int stasis_audio_play(int asset_handle, int loop, float volume, float pan);
+extern int stasis_audio_voice_is_playing(int voice_handle);
+extern void stasis_audio_voice_set_volume_pan(int voice_handle, float volume, float pan);
+extern int stasis_asset_request_audio(const char* path);
+extern int stasis_asset_task_poll(int task_id);
+extern int stasis_asset_task_take_handle(int task_id);
+extern void stasis_audio_shutdown(void);
+
+#ifndef STASIS_TEST_AUDIO_PATH
+#error STASIS_TEST_AUDIO_PATH is required
+#endif
+
+#define STASIS_ASSET_TASK_LOADED 3
+
+static int near(float actual, float expected) {
+    return fabsf(actual - expected) < 0.0001f;
+}
+
+int main(void) {
+    if (!stasis_set_recording_audio_config(1)) return 1;
+    if (stasis_audio_init(44100, 2, 1024) != 0) return 2;
+    if (stasis_audio_get_sample_rate() != 48000) return 3;
+    if (stasis_audio_init(48000, 2, (1 << 20) + 1) != 0) return 4;
+    if (!stasis_audio_init(48000, 2, 1024)) return 2;
+    if (!stasis_audio_is_available() || stasis_audio_get_sample_rate() != 48000 ||
+        stasis_audio_get_channels() != 2) return 5;
+
+    const float pushed[] = { 0.25f, -0.25f, 0.5f, -0.5f };
+    if (stasis_audio_push_f32_interleaved(pushed, 2) != 2) return 6;
+    float output[8];
+    memset(output, 0, sizeof(output));
+    if (stasis_recording_audio_pull_f32_interleaved(output, 2) != 2) return 7;
+    if (!near(output[0], pushed[0]) || !near(output[1], pushed[1]) ||
+        !near(output[2], pushed[2]) || !near(output[3], pushed[3])) return 8;
+    memset(output, 0, sizeof(output));
+    if (stasis_recording_audio_pull_f32_interleaved(output, 2) != 2) return 9;
+    for (int i = 0; i < 4; i++) if (!near(output[i], 0.0f)) return 10;
+
+    int task = stasis_asset_request_audio(STASIS_TEST_AUDIO_PATH);
+    if (task <= 0) {
+        fprintf(stderr, "audio task request failed\n");
+        return 11;
+    }
+    int state = stasis_asset_task_poll(task);
+    if (state != STASIS_ASSET_TASK_LOADED) {
+        fprintf(stderr, "audio task state=%d expected immediate loaded\n", state);
+        return 12;
+    }
+    int asset = stasis_asset_task_take_handle(task);
+    if (asset <= 0) return 13;
+    int voice = stasis_audio_play(asset, 1, 0.5f, 0.0f);
+    if (voice <= 0) return 14;
+    float mixed[4096 * 2];
+    memset(mixed, 0, sizeof(mixed));
+    if (stasis_recording_audio_pull_f32_interleaved(mixed, 4096) != 4096) return 15;
+    int non_silent = 0;
+    for (int i = 0; i < 4096 * 2; i++) {
+        if (fabsf(mixed[i]) > 0.0001f) non_silent = 1;
+    }
+    if (!non_silent || !stasis_audio_voice_is_playing(voice)) return 16;
+    stasis_audio_voice_set_volume_pan(voice, 0.25f, 1.0f);
+    memset(mixed, 0, sizeof(mixed));
+    if (stasis_recording_audio_pull_f32_interleaved(mixed, 4096) != 4096) return 17;
+    for (int i = 0; i < 4096; i++) {
+        if (!near(mixed[i * 2], 0.0f) && fabsf(mixed[i * 2]) > 0.0001f) return 18;
+    }
+
+    stasis_audio_shutdown();
+    if (!stasis_set_recording_audio_config(0)) return 19;
+    if (!stasis_set_recording_audio_config(1)) return 20;
+    if (!stasis_audio_init(48000, 2, 1024)) return 21;
+    memset(output, 0, sizeof(output));
+    if (stasis_recording_audio_pull_f32_interleaved(output, 2) != 2) return 22;
+    for (int i = 0; i < 4; i++) if (!near(output[i], 0.0f)) return 23;
+    stasis_audio_shutdown();
+    if (!stasis_set_recording_audio_config(0)) return 24;
+    puts("stasis recording audio offline mixer contract passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- render the existing Stasis audio mixer offline at deterministic 48 kHz stereo frame boundaries
- stage exact PCM16 WAV audio and mux H.264 video with AAC while preserving PNG-only behavior
- make recording audio asset decode simulation-deterministic and add native, Rust, Windows, and documentation coverage

## Validation
- native CMake/Ninja build: passed
- ctest -R stasis_recording_audio_contract: 1/1 passed
- cargo check -p stasis --all-targets: passed
- cargo check -p stasis_dynload: passed
- targeted rustfmt, source-layout, cached diff, and pre-commit checks: passed
- independent review: clean after fixed-rate, decode-timing, teardown, offline pan, bounds, and WAV validation corrections
- real mixer artifact: H.264/AAC, 640x400, 60 fps, 720 frames, 48 kHz stereo, A/V start 0, duration 12.000s

Maddox #275