### PR TITLE
Fix typed memory and struct copies in web runtime

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -296,6 +296,67 @@ function render(): i32 {
 }
 
 #[test]
+fn web_package_executes_scalar_struct_to_collection_copy() {
+    let root = repo_root();
+    let workspace = root
+        .join("build")
+        .join(format!("web-struct-copy-test-{}", stamp()));
+    fs::create_dir_all(workspace.join("src")).expect("create struct copy fixture");
+    fs::write(
+        workspace.join("stasis.json"),
+        r#"{"manifest_version":1,"name":"web_struct_copy","entry":"src/main.stasis","tests":"tests","output":"build"}"#,
+    )
+    .expect("write struct copy manifest");
+    fs::write(
+        workspace.join("src/main.stasis"),
+        r#"
+struct CopyState {
+    count: i32;
+    enabled: bool;
+}
+
+global source: CopyState;
+global destination: CopyState[2];
+
+function main(): i32 {
+    source.count = 40;
+    source.enabled = true;
+    destination[0] = source;
+    destination[1] = destination[0];
+    if (destination[1].enabled) {
+        return destination[1].count + 2;
+    }
+    return -1;
+}
+
+function tick(): i32 {
+    return 0;
+}
+
+function render(): i32 {
+    return 0;
+}
+"#,
+    )
+    .expect("write struct copy source");
+
+    let output = package(&workspace, Path::new("build/web-package"));
+    let execution = execute_web_main(&output.join("game.wasm"));
+    assert!(
+        execution.status.success(),
+        "scalar struct copy Wasm execution failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&execution.stdout),
+        String::from_utf8_lossy(&execution.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(execution.stdout).expect("UTF-8 result"),
+        "42"
+    );
+
+    fs::remove_dir_all(&workspace).expect("clean struct copy fixture");
+}
+
+#[test]
 fn web_package_instantiates_direct_measure_text_import() {
     let root = repo_root();
     let workspace = root
@@ -619,7 +680,13 @@ fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
     assert!(wasm.starts_with(b"\0asm\x01\0\0\0"));
     assert!(wasm.windows(6).any(|window| window == b"memory"));
     let runtime = fs::read_to_string(output.join("game.js")).expect("existing game runtime");
-    for expected in ["gfx_cmd_i32", "gfx_cmd_f32", "stasis_jit_gfx_cache_text"] {
+    for expected in [
+        "gfx_cmd_i32",
+        "gfx_cmd_f32",
+        "stasis_jit_gfx_cache_text",
+        "sys_memcpy_i32: sysMemcpyI32",
+        "sys_memcpy_f32: sysMemcpyF32",
+    ] {
         assert!(
             runtime.contains(expected),
             "missing web runtime data {expected}"
@@ -668,7 +735,13 @@ fn rooted_web_asset_paths_emit_package_relative_assets() {
     }
     let source = fs::read_to_string(workspace.join("main.stasis"))
         .expect("read rooted web fixture source")
-        .replace("\"assets/smoke.svg\"", &format!("\"{ROOTED_WEB_ASSET}\""));
+        .replace(
+            "extern function gfx_load_sprite",
+            &format!(
+                "const ROOTED_SMOKE_PATH: string = \"{ROOTED_WEB_ASSET}\";\n\nextern function gfx_load_sprite"
+            ),
+        )
+        .replace("\"assets/smoke.svg\"", "ROOTED_SMOKE_PATH");
     fs::write(workspace.join("main.stasis"), source).expect("write rooted web fixture source");
 
     let output = package(&workspace, Path::new("build/web-package"));

--- a/crates/stasis_compiler/src/backend/wasm.rs
+++ b/crates/stasis_compiler/src/backend/wasm.rs
@@ -145,7 +145,7 @@ impl WasmProcess {
             }
         }
 
-        self.string_literals = collect_string_literals(&lowered);
+        self.string_literals = collect_string_literals(&lowered, &analysis.constant_values);
         let (memory_bindings, _) =
             build_memory_bindings(&analysis, &types).map_err(CompileError::Backend)?;
         self.memory_layout = memory_bindings
@@ -2420,8 +2420,12 @@ fn encode_struct_collection_copy(
         out.push(0x41);
         sleb(target_field.stride as i32, out);
         out.extend([0x6c, 0x6a]);
-        let source_field = encode_struct_field_address(&source_binding, suffix, context, out)?;
-        encode_memory_load(source_field.type_id, out)?;
+        let source_field_type = encode_struct_field_load(&source_binding, suffix, context, out)?;
+        require_same_type(
+            target_field.type_id,
+            source_field_type,
+            "struct collection field assignment",
+        )?;
         encode_memory_store(target_field.type_id, out)?;
     }
     Ok(())
@@ -3627,8 +3631,15 @@ fn encode_zero(type_id: TypeId, out: &mut Vec<u8>) -> Result<(), String> {
     Ok(())
 }
 
-fn collect_string_literals(functions: &[(FunctionMeta, FunctionHIR)]) -> BTreeMap<i32, String> {
-    fn expression(value: &SimpleExpr, out: &mut BTreeMap<i32, String>) {
+fn collect_string_literals(
+    functions: &[(FunctionMeta, FunctionHIR)],
+    constants: &BTreeMap<String, ConstantValue>,
+) -> BTreeMap<i32, String> {
+    fn expression(
+        value: &SimpleExpr,
+        constants: &BTreeMap<String, ConstantValue>,
+        out: &mut BTreeMap<i32, String>,
+    ) {
         match value {
             SimpleExpr::StringLiteral(value) => {
                 out.insert(
@@ -3636,35 +3647,51 @@ fn collect_string_literals(functions: &[(FunctionMeta, FunctionHIR)]) -> BTreeMa
                     value.clone(),
                 );
             }
-            SimpleExpr::Condition(value) => condition(value, out),
-            SimpleExpr::IndexedPath { index, .. } => expression(index, out),
+            SimpleExpr::Identifier(name) => {
+                if let Some(ConstantValue::String { value, .. }) = constants.get(name) {
+                    out.insert(
+                        crate::backend::emit::hash_string_literal(value),
+                        value.clone(),
+                    );
+                }
+            }
+            SimpleExpr::Condition(value) => condition(value, constants, out),
+            SimpleExpr::IndexedPath { index, .. } => expression(index, constants, out),
             SimpleExpr::Call { args, .. } => {
                 for arg in args {
-                    expression(arg, out);
+                    expression(arg, constants, out);
                 }
             }
             SimpleExpr::Binary { lhs, rhs, .. } => {
-                expression(lhs, out);
-                expression(rhs, out);
+                expression(lhs, constants, out);
+                expression(rhs, constants, out);
             }
             _ => {}
         }
     }
-    fn condition(value: &SimpleCondition, out: &mut BTreeMap<i32, String>) {
+    fn condition(
+        value: &SimpleCondition,
+        constants: &BTreeMap<String, ConstantValue>,
+        out: &mut BTreeMap<i32, String>,
+    ) {
         match value {
             SimpleCondition::Comparison { lhs, rhs, .. } => {
-                expression(lhs, out);
-                expression(rhs, out);
+                expression(lhs, constants, out);
+                expression(rhs, constants, out);
             }
-            SimpleCondition::Expr(value) => expression(value, out),
+            SimpleCondition::Expr(value) => expression(value, constants, out),
             SimpleCondition::And(lhs, rhs) | SimpleCondition::Or(lhs, rhs) => {
-                condition(lhs, out);
-                condition(rhs, out);
+                condition(lhs, constants, out);
+                condition(rhs, constants, out);
             }
-            SimpleCondition::Not(value) => condition(value, out),
+            SimpleCondition::Not(value) => condition(value, constants, out),
         }
     }
-    fn statements(values: &[SimpleStmt], out: &mut BTreeMap<i32, String>) {
+    fn statements(
+        values: &[SimpleStmt],
+        constants: &BTreeMap<String, ConstantValue>,
+        out: &mut BTreeMap<i32, String>,
+    ) {
         for value in values {
             match value {
                 SimpleStmt::Let {
@@ -3674,17 +3701,17 @@ fn collect_string_literals(functions: &[(FunctionMeta, FunctionHIR)]) -> BTreeMa
                     expression: value, ..
                 }
                 | SimpleStmt::Expr(value)
-                | SimpleStmt::Return(value) => expression(value, out),
-                SimpleStmt::Convert { source, .. } => expression(source, out),
+                | SimpleStmt::Return(value) => expression(value, constants, out),
+                SimpleStmt::Convert { source, .. } => expression(source, constants, out),
                 SimpleStmt::If {
                     condition: value,
                     then_statements,
                     else_statements,
                 } => {
-                    condition(value, out);
-                    statements(then_statements, out);
+                    condition(value, constants, out);
+                    statements(then_statements, constants, out);
                     if let Some(values) = else_statements {
-                        statements(values, out);
+                        statements(values, constants, out);
                     }
                 }
                 SimpleStmt::For {
@@ -3693,21 +3720,21 @@ fn collect_string_literals(functions: &[(FunctionMeta, FunctionHIR)]) -> BTreeMa
                     step,
                     body_statements,
                 } => {
-                    statements(std::slice::from_ref(init), out);
-                    condition(value, out);
-                    statements(std::slice::from_ref(step), out);
-                    statements(body_statements, out);
+                    statements(std::slice::from_ref(init), constants, out);
+                    condition(value, constants, out);
+                    statements(std::slice::from_ref(step), constants, out);
+                    statements(body_statements, constants, out);
                 }
                 SimpleStmt::Foreach {
                     body_statements, ..
-                } => statements(body_statements, out),
+                } => statements(body_statements, constants, out),
                 SimpleStmt::Noop | SimpleStmt::Continue | SimpleStmt::ReturnVoid => {}
             }
         }
     }
     let mut out = BTreeMap::new();
     for (_, hir) in functions {
-        statements(&hir.statements, &mut out);
+        statements(&hir.statements, constants, &mut out);
     }
     out
 }
@@ -3863,6 +3890,37 @@ mod tests {
                 .windows(name.len())
                 .any(|window| window == name.as_bytes()));
         }
+    }
+
+    #[test]
+    fn collects_reachable_string_constants_and_inline_literals() {
+        let mut process = WasmProcess::new();
+        process.set_required_emit_roots(&["main".into(), "tick".into(), "render".into()]);
+        process.upsert_file(
+            "string_constants.stasis",
+            r#"
+const USED_PATH: string = "/assets/used.svg";
+const UNUSED_PATH: string = "/assets/unused.svg";
+extern function consume(path: string): i32;
+function main(): i32 { return consume(USED_PATH); }
+function tick(): i32 { return consume("direct literal"); }
+function render(): i32 { return 0; }
+"#,
+        );
+        process.compile().expect("compile string constants");
+
+        let strings = process.string_literals();
+        assert_eq!(
+            strings.get(&crate::backend::emit::hash_string_literal(
+                "/assets/used.svg"
+            )),
+            Some(&"/assets/used.svg".to_string())
+        );
+        assert_eq!(
+            strings.get(&crate::backend::emit::hash_string_literal("direct literal")),
+            Some(&"direct literal".to_string())
+        );
+        assert!(!strings.values().any(|value| value == "/assets/unused.svg"));
     }
 
     #[test]

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -149,6 +149,18 @@
     target.set(bytes);
     return bytes.length;
   };
+  const memoryLayouts = typeId => Object.values(game.memory || {})
+    .filter(layout => layout?.type_id === typeId
+      && Number.isSafeInteger(layout.hash));
+  const memoryLayoutsByHash = typeId => new Map(
+    memoryLayouts(typeId).map(layout => [layout.hash | 0, layout])
+  );
+  const memoryLayoutsByOffset = typeId => new Map(
+    Object.values(game.memory || {})
+      .filter(layout => layout?.type_id === typeId
+        && Number.isSafeInteger(layout.offset))
+      .map(layout => [layout.offset | 0, layout])
+  );
   const u8MemoryLayouts = new Map(
     Object.values(game.memory || {})
       .filter(layout => (layout?.byte_backed === true || layout?.type_id === 5)
@@ -202,6 +214,56 @@
     for (let offset = 0; offset < count; offset += 1) {
       writeU8(destination, dstIndex + offset, values[offset]);
     }
+  };
+  const typedMemoryLayouts = new Map([
+    [1, { byHash: memoryLayoutsByHash(1), byOffset: memoryLayoutsByOffset(1), width: 4 }],
+    [2, { byHash: memoryLayoutsByHash(2), byOffset: memoryLayoutsByOffset(2), width: 4 }],
+  ]);
+  const resolveTypedMemory = (reference, typeId) => {
+    const metadata = typedMemoryLayouts.get(typeId);
+    const layout = metadata?.byHash.get(reference | 0)
+      || metadata?.byOffset.get(reference | 0);
+    const memory = instance?.exports?.memory;
+    if (!layout || !(memory instanceof WebAssembly.Memory)) return null;
+    const { offset, stride, length } = layout;
+    if (![offset, stride, length].every(Number.isSafeInteger)
+      || offset < 0 || stride <= 0 || length < 0) return null;
+    const span = length === 0 ? 0 : (length - 1) * stride + metadata.width;
+    const end = offset + span;
+    if (!Number.isSafeInteger(span) || !Number.isSafeInteger(end)
+      || end > memory.buffer.byteLength) return null;
+    return { view: new DataView(memory.buffer), offset, stride, length };
+  };
+  const readTyped = (memory, index, typeId) => {
+    if (!memory || !Number.isInteger(index) || index < 0 || index >= memory.length) return 0;
+    const offset = memory.offset + index * memory.stride;
+    return typeId === 1
+      ? memory.view.getInt32(offset, true)
+      : memory.view.getFloat32(offset, true);
+  };
+  const writeTyped = (memory, index, value, typeId) => {
+    if (!memory || !Number.isInteger(index) || index < 0 || index >= memory.length) return;
+    const offset = memory.offset + index * memory.stride;
+    if (typeId === 1) memory.view.setInt32(offset, value, true);
+    else memory.view.setFloat32(offset, value, true);
+  };
+  const sysMemcpyTyped = (dst, dstIndex, src, srcIndex, count, typeId) => {
+    if (!Number.isInteger(count) || count <= 0) return;
+    const source = resolveTypedMemory(src, typeId);
+    const values = typeId === 1 ? new Int32Array(count) : new Float32Array(count);
+    for (let offset = 0; offset < count; offset += 1) {
+      values[offset] = readTyped(source, srcIndex + offset, typeId);
+    }
+    const destination = resolveTypedMemory(dst, typeId);
+    for (let offset = 0; offset < count; offset += 1) {
+      writeTyped(destination, dstIndex + offset, values[offset], typeId);
+    }
+  };
+  const sysMemcpyI32 = (dst, dstIndex, src, srcIndex, count) => {
+    sysMemcpyTyped(dst, dstIndex, src, srcIndex, count, 1);
+  };
+  const sysMemcpyF32 = (dst, dstIndex, src, srcIndex, count) => {
+    sysMemcpyTyped(dst, dstIndex, src, srcIndex, count, 2);
   };
   const setViewField = (base, index, field, value) => {
     const path = game.views?.[String(base)]?.[field];
@@ -572,6 +634,8 @@
     print_char: value => console.log(String.fromCodePoint(value)),
     print_string: value => console.log(stringValue(value)),
     sys_memcpy_u8: sysMemcpyU8,
+    sys_memcpy_i32: sysMemcpyI32,
+    sys_memcpy_f32: sysMemcpyF32,
     web_input_axis: () => (keys.has("ArrowRight") || keys.has("KeyD") ? 1 : 0) - (keys.has("ArrowLeft") || keys.has("KeyA") ? 1 : 0),
     web_input_fire: () => keys.has("Space") || pointer.down ? 1 : 0,
     web_pointer_x: () => pointer.x | 0,

--- a/runtime/web/tests/sys_memcpy_typed.test.mjs
+++ b/runtime/web/tests/sys_memcpy_typed.test.mjs
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
+
+async function loadRuntime(game, memory) {
+  const context2d = {
+    fillRect() {}, fillText() {}, save() {}, restore() {}, beginPath() {}, moveTo() {},
+    lineTo() {}, stroke() {}, drawImage() {}, translate() {}, rotate() {}
+  };
+  const canvas = {
+    width: 640,
+    height: 360,
+    style: {},
+    parentElement: { style: {} },
+    getContext: () => context2d,
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }),
+    addEventListener() {},
+    setPointerCapture() {},
+    focus() {},
+    requestFullscreen: async () => {},
+  };
+  const errorBox = { textContent: "" };
+  const document = {
+    body: { dataset: {} },
+    hidden: false,
+    fullscreenElement: null,
+    fonts: { ready: Promise.resolve(), add() {} },
+    hasFocus: () => true,
+    getElementById(id) {
+      if (id === "stasis-canvas") return canvas;
+      if (id === "stasis-hud") return { textContent: "" };
+      if (id === "stasis-audio") return { addEventListener() {}, disabled: false, textContent: "" };
+      if (id === "stasis-error") return errorBox;
+      return null;
+    },
+    addEventListener() {},
+  };
+  const instance = {
+    exports: {
+      memory,
+      main: () => 0,
+      tick: () => 0,
+      render: () => 0,
+    }
+  };
+  let env;
+  const webAssembly = {
+    Global: WebAssembly.Global,
+    Memory: WebAssembly.Memory,
+    instantiate: async (_bytes, imports) => {
+      env = imports.env;
+      return { instance };
+    },
+  };
+  const contextObject = {
+    document, screen: { width: 640, height: 360 }, devicePixelRatio: 1,
+    performance: { now: () => 0 }, WebAssembly: webAssembly,
+    fetch: async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }),
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame() {},
+    addEventListener() {},
+    console,
+    Image: class {},
+    FontFace: class { load() { return Promise.resolve(this); } },
+    AudioContext: class {
+      constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; }
+      close() {}
+      resume() {}
+    },
+    TextDecoder,
+    TextEncoder,
+    setTimeout,
+    clearTimeout,
+  };
+  contextObject.window = { STASIS_GAME: game, screen: contextObject.screen };
+  vm.runInNewContext(source, contextObject, { filename: "runtime/web/game.js" });
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(typeof env?.sys_memcpy_i32, "function", errorBox.textContent);
+  assert.equal(typeof env?.sys_memcpy_f32, "function", errorBox.textContent);
+  return env;
+}
+
+function typedGame() {
+  return {
+    memory: {
+      i32Source: { hash: 101, offset: 0, type_id: 1, length: 5, stride: 8 },
+      i32Destination: { hash: 202, offset: 64, type_id: 1, length: 5, stride: 8 },
+      f32Source: { hash: 303, offset: 128, type_id: 2, length: 4, stride: 12 },
+      f32Destination: { hash: 404, offset: 192, type_id: 2, length: 4, stride: 12 },
+      invalid: { hash: 505, offset: 65535, type_id: 1, length: 4, stride: 8 },
+    },
+    strings: {},
+    assets: {},
+  };
+}
+
+test("web typed memcpy imports copy strided i32/f32 values by hash", async () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const game = typedGame();
+  const view = new DataView(memory.buffer);
+  for (let index = 0; index < 5; index += 1) view.setInt32(index * 8, index * 11 - 7, true);
+  for (let index = 0; index < 4; index += 1) view.setFloat32(128 + index * 12, index + 0.25, true);
+  const env = await loadRuntime(game, memory);
+
+  env.sys_memcpy_i32(202, 1, 101, 0, 4);
+  assert.deepEqual(
+    Array.from({ length: 5 }, (_, index) => view.getInt32(64 + index * 8, true)),
+    [0, -7, 4, 15, 26]
+  );
+  env.sys_memcpy_f32(404, 0, 303, 0, 4);
+  assert.deepEqual(
+    Array.from({ length: 4 }, (_, index) => view.getFloat32(192 + index * 12, true)),
+    [0.25, 1.25, 2.25, 3.25]
+  );
+});
+
+test("web typed memcpy accepts linear-memory offsets and preserves overlap", async () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const game = typedGame();
+  const view = new DataView(memory.buffer);
+  for (let index = 0; index < 5; index += 1) view.setInt32(index * 8, index + 1, true);
+  for (let index = 0; index < 4; index += 1) view.setFloat32(128 + index * 12, index + 10.5, true);
+  const env = await loadRuntime(game, memory);
+
+  env.sys_memcpy_i32(0, 1, 0, 0, 4);
+  assert.deepEqual(
+    Array.from({ length: 5 }, (_, index) => view.getInt32(index * 8, true)),
+    [1, 1, 2, 3, 4]
+  );
+  env.sys_memcpy_f32(192, 0, 128, 1, 3);
+  assert.deepEqual(
+    Array.from({ length: 4 }, (_, index) => view.getFloat32(192 + index * 12, true)),
+    [11.5, 12.5, 13.5, 0]
+  );
+});
+
+test("web typed memcpy ignores invalid layouts and out-of-range elements", async () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const game = typedGame();
+  const view = new DataView(memory.buffer);
+  view.setInt32(0, 99, true);
+  view.setInt32(64, 77, true);
+  view.setFloat32(128, 6.5, true);
+  const env = await loadRuntime(game, memory);
+
+  env.sys_memcpy_i32(202, 4, 101, 4, 3);
+  assert.equal(view.getInt32(64 + 4 * 8, true), 0);
+  env.sys_memcpy_i32(505, 0, 101, 0, 2);
+  assert.equal(view.getInt32(64, true), 77);
+  env.sys_memcpy_i32(202, 0, 505, 0, 2);
+  assert.equal(view.getInt32(64, true), 0);
+  env.sys_memcpy_f32(404, 0, 303, -1, 2);
+  assert.equal(view.getFloat32(192, true), 0);
+  env.sys_memcpy_f32(404, 0, 303, 0, 0);
+  assert.equal(view.getFloat32(192, true), 0);
+});

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -25,6 +25,7 @@ python3 -m unittest tools.ci.test_verify_render_parity
 python3 tools/ci/verify_render_parity.py
 node --test runtime/web/tests/orientation_host_frame.test.mjs
 node --test runtime/web/tests/sys_memcpy_u8.test.mjs
+node --test runtime/web/tests/sys_memcpy_typed.test.mjs
 node --test runtime/web/tests/asset_paths.test.mjs
 node --test runtime/web/tests/audio_suspended_queue.test.mjs
 


### PR DESCRIPTION
## Summary
- provide `sys_memcpy_i32` and `sys_memcpy_f32` in the web host with hash/offset, stride, bounds, and overlap-safe behavior
- retain reachable string constants in WebAssembly runtime metadata so constant font and sprite paths resolve in packaged games
- make scalar-struct to struct-collection copies use the scalar-aware field loader instead of trapping on the scalar view sentinel
- add direct runtime and executable package regression coverage

## Validation
- `node --test runtime/web/tests/sys_memcpy_u8.test.mjs runtime/web/tests/sys_memcpy_typed.test.mjs runtime/web/tests/asset_paths.test.mjs` (11/11)
- focused WebAssembly reachable string-constant unit test passed
- executable scalar/collection struct-copy web package test passed and returned 42
- existing Windows graphics package and rooted constant-asset package tests passed
- `git diff --check`
- Sheep Herder release web package verified in a real browser: all three fonts loaded, Play transitions to gameplay, 229 commands/137 sprites, zero fresh warnings/errors