### PR TITLE
Keep web errors out of viewport layout

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -5934,7 +5934,13 @@ mod tests {
 
         let development = web_index_html("development-game", true);
         assert!(development.contains(r#"id="stasis-hud""#));
-        assert!(!development.contains("__STASIS_"));
+        for html in [&release, &development] {
+            assert!(!html.contains("__STASIS_"));
+            assert!(html.contains("#stasis-error { position: absolute;"));
+            assert!(html.contains("inset: 0; margin: 0;"));
+            assert!(html.contains("white-space: pre-wrap;"));
+            assert!(html.contains("#stasis-error:empty { display: none; }"));
+        }
     }
 
     #[test]

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -14,7 +14,8 @@
     #stasis-loading { position: absolute; inset: 0; display: grid; place-items: center; padding: 1rem; box-sizing: border-box; background: #07111f; color: #dff6ff; text-align: center; }
     #stasis-loading[data-hidden="true"] { display: none; }
     #stasis-loading[data-failed="true"] { color: #ff8f8f; }
-    #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
+    #stasis-error { position: absolute; inset: 0; margin: 0; padding: 1rem; box-sizing: border-box; overflow: auto; color: #ff8f8f; white-space: pre-wrap; pointer-events: none; }
+    #stasis-error:empty { display: none; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- overlay the web runtime error output instead of allowing an empty pre element to affect document layout
- hide the error element while empty
- preserve readable, scrollable failures when errors occur
- cover both development and release HTML generation

## Validation
- focused Rust test: release_web_index_omits_performance_hud
- node --test runtime/web/tests/loading_overlay.test.mjs
- git diff --check