### PR TITLE
Fix macOS release smoke executable

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -246,7 +246,11 @@ jobs:
           ./bin/stasis --workspace cli-smoke check
           ./bin/stasis --workspace cli-smoke test
           ./bin/stasis --workspace cli-smoke build --mode release
-          ./cli-smoke/build/ci_smoke
+          smoke_executable="./cli-smoke/build/ci_smoke"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            smoke_executable="./cli-smoke/build/ci_smoke.app/Contents/MacOS/ci_smoke"
+          fi
+          "${smoke_executable}"
           printf '%s\n' \
             'function main(): i32 { return 0; }' \
             'function tick(): i32 { return 0; }' \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -314,7 +314,11 @@ jobs:
           ./bin/stasis --workspace cli-smoke check
           ./bin/stasis --workspace cli-smoke test
           ./bin/stasis --workspace cli-smoke build --mode release
-          ./cli-smoke/build/ci_smoke
+          smoke_executable="./cli-smoke/build/ci_smoke"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            smoke_executable="./cli-smoke/build/ci_smoke.app/Contents/MacOS/ci_smoke"
+          fi
+          "${smoke_executable}"
           printf '%s\n' \
             'function main(): i32 { return 0; }' \
             'function tick(): i32 { return 0; }' \

--- a/tools/ci/test_release_provenance.py
+++ b/tools/ci/test_release_provenance.py
@@ -65,6 +65,37 @@ class ReleaseProvenanceTests(unittest.TestCase):
                     f"{filename} missing from Windows assembly in {workflow_name}",
                 )
 
+    def test_release_workflows_select_platform_smoke_executable(self):
+        for workflow_name in (
+            ".github/workflows/nightly-release.yml",
+            ".github/workflows/bootstrap-artifacts.yml",
+        ):
+            workflow = (ROOT / workflow_name).read_text(encoding="utf-8")
+            smoke_start = workflow.index("      - name: Smoke test bundled CLI (unix)")
+            next_step = workflow.find("\n      - name:", smoke_start + 1)
+            smoke_block = workflow[smoke_start:next_step if next_step != -1 else None]
+            self.assertIn(
+                'smoke_executable="./cli-smoke/build/ci_smoke"',
+                smoke_block,
+                workflow_name,
+            )
+            self.assertIn(
+                'if [[ "${{ runner.os }}" == "macOS" ]]; then',
+                smoke_block,
+                workflow_name,
+            )
+            self.assertIn(
+                'smoke_executable="./cli-smoke/build/ci_smoke.app/Contents/MacOS/ci_smoke"',
+                smoke_block,
+                workflow_name,
+            )
+            self.assertIn('"${smoke_executable}"', smoke_block, workflow_name)
+            self.assertNotRegex(
+                smoke_block,
+                r"(?m)^\s+\./cli-smoke/build/ci_smoke\s*$",
+                workflow_name,
+            )
+
     def test_package_verifier_detects_runtime_substitution(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)


### PR DESCRIPTION
## Summary
- run packaged CLI smoke tests from the macOS app bundle executable
- retain the direct executable path on Linux
- add regression coverage for both release workflows

## Validation
- python -m unittest tools.ci.test_release_provenance
- ctionlint .github/workflows/nightly-release.yml .github/workflows/bootstrap-artifacts.yml
- git diff --check

## Theory gained
Release smoke execution must follow the platform-specific artifact shape: a macOS app bundle versus a direct Linux executable.