### PR TITLE
Bound graphical release smoke tests

### DIFF
--- a/.github/workflows/bootstrap-artifacts.yml
+++ b/.github/workflows/bootstrap-artifacts.yml
@@ -205,7 +205,21 @@ jobs:
           .\stasis.exe --workspace cli-smoke check
           .\stasis.exe --workspace cli-smoke test
           .\stasis.exe --workspace cli-smoke build --mode release
-          .\cli-smoke\build\ci_smoke.exe
+          $smokeProcess = Start-Process -FilePath ".\cli-smoke\build\ci_smoke.exe" -PassThru
+          try {
+            if ($smokeProcess.WaitForExit(5000)) {
+              if ($smokeProcess.ExitCode -ne 0) { throw "ci_smoke exited early with code $($smokeProcess.ExitCode)" }
+            } else {
+              Stop-Process -Id $smokeProcess.Id -Force -ErrorAction SilentlyContinue
+              $smokeProcess.WaitForExit()
+            }
+          } finally {
+            if (-not $smokeProcess.HasExited) {
+              Stop-Process -Id $smokeProcess.Id -Force -ErrorAction SilentlyContinue
+              $smokeProcess.WaitForExit()
+            }
+            $smokeProcess.Dispose()
+          }
           Set-Content -Path "cli-smoke/src/main.stasis" -Encoding ASCII -Value @(
             "function main(): i32 { return 0; }",
             "function tick(): i32 { return 0; }",
@@ -250,7 +264,24 @@ jobs:
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             smoke_executable="./cli-smoke/build/ci_smoke.app/Contents/MacOS/ci_smoke"
           fi
-          "${smoke_executable}"
+          python3 - "${smoke_executable}" <<'PY'
+          import subprocess
+          import sys
+
+          process = subprocess.Popen([sys.argv[1]])
+          try:
+              return_code = process.wait(timeout=5)
+          except subprocess.TimeoutExpired:
+              process.terminate()
+              try:
+                  process.wait(timeout=5)
+              except subprocess.TimeoutExpired:
+                  process.kill()
+                  process.wait()
+          else:
+              if return_code != 0:
+                  raise SystemExit(f"ci_smoke exited early with code {return_code}")
+          PY
           printf '%s\n' \
             'function main(): i32 { return 0; }' \
             'function tick(): i32 { return 0; }' \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -283,7 +283,21 @@ jobs:
           .\stasis.exe --workspace cli-smoke check
           .\stasis.exe --workspace cli-smoke test
           .\stasis.exe --workspace cli-smoke build --mode release
-          .\cli-smoke\build\ci_smoke.exe
+          $smokeProcess = Start-Process -FilePath ".\cli-smoke\build\ci_smoke.exe" -PassThru
+          try {
+            if ($smokeProcess.WaitForExit(5000)) {
+              if ($smokeProcess.ExitCode -ne 0) { throw "ci_smoke exited early with code $($smokeProcess.ExitCode)" }
+            } else {
+              Stop-Process -Id $smokeProcess.Id -Force -ErrorAction SilentlyContinue
+              $smokeProcess.WaitForExit()
+            }
+          } finally {
+            if (-not $smokeProcess.HasExited) {
+              Stop-Process -Id $smokeProcess.Id -Force -ErrorAction SilentlyContinue
+              $smokeProcess.WaitForExit()
+            }
+            $smokeProcess.Dispose()
+          }
           Set-Content -Path "cli-smoke/src/main.stasis" -Encoding ASCII -Value @(
             "function main(): i32 { return 0; }",
             "function tick(): i32 { return 0; }",
@@ -318,7 +332,24 @@ jobs:
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             smoke_executable="./cli-smoke/build/ci_smoke.app/Contents/MacOS/ci_smoke"
           fi
-          "${smoke_executable}"
+          python3 - "${smoke_executable}" <<'PY'
+          import subprocess
+          import sys
+
+          process = subprocess.Popen([sys.argv[1]])
+          try:
+              return_code = process.wait(timeout=5)
+          except subprocess.TimeoutExpired:
+              process.terminate()
+              try:
+                  process.wait(timeout=5)
+              except subprocess.TimeoutExpired:
+                  process.kill()
+                  process.wait()
+          else:
+              if return_code != 0:
+                  raise SystemExit(f"ci_smoke exited early with code {return_code}")
+          PY
           printf '%s\n' \
             'function main(): i32 { return 0; }' \
             'function tick(): i32 { return 0; }' \

--- a/tools/ci/test_release_provenance.py
+++ b/tools/ci/test_release_provenance.py
@@ -96,6 +96,50 @@ class ReleaseProvenanceTests(unittest.TestCase):
                 workflow_name,
             )
 
+    def test_release_workflows_bound_graphical_smoke_processes(self):
+        for workflow_name in (
+            ".github/workflows/nightly-release.yml",
+            ".github/workflows/bootstrap-artifacts.yml",
+        ):
+            workflow = (ROOT / workflow_name).read_text(encoding="utf-8")
+            windows_start = workflow.index(
+                "      - name: Smoke test bundled graphics runtime (windows)"
+            )
+            unix_start = workflow.index(
+                "      - name: Smoke test bundled CLI (unix)"
+            )
+            windows_block = workflow[windows_start:unix_start]
+            unix_end = workflow.find("\n      - name:", unix_start + 1)
+            unix_block = workflow[unix_start:unix_end if unix_end != -1 else None]
+
+            self.assertIn(
+                'Start-Process -FilePath ".\\cli-smoke\\build\\ci_smoke.exe" -PassThru',
+                windows_block,
+                workflow_name,
+            )
+            self.assertIn("WaitForExit(5000)", windows_block, workflow_name)
+            self.assertIn("$smokeProcess.ExitCode -ne 0", windows_block, workflow_name)
+            self.assertIn("Stop-Process -Id $smokeProcess.Id -Force", windows_block, workflow_name)
+            self.assertIn("$smokeProcess.WaitForExit()", windows_block, workflow_name)
+            self.assertNotRegex(
+                windows_block,
+                r"(?m)^\s+\.\\cli-smoke\\build\\ci_smoke\.exe\s*$",
+                workflow_name,
+            )
+
+            self.assertIn('python3 - "${smoke_executable}" <<\'PY\'', unix_block, workflow_name)
+            self.assertIn("process = subprocess.Popen([sys.argv[1]])", unix_block, workflow_name)
+            self.assertIn("process.wait(timeout=5)", unix_block, workflow_name)
+            self.assertIn("if return_code != 0:", unix_block, workflow_name)
+            self.assertIn("process.terminate()", unix_block, workflow_name)
+            self.assertIn("process.kill()", unix_block, workflow_name)
+            self.assertIn("process.wait()", unix_block, workflow_name)
+            self.assertNotRegex(
+                unix_block,
+                r"(?m)^\s+\./cli-smoke/build/ci_smoke\s*$",
+                workflow_name,
+            )
+
     def test_package_verifier_detects_runtime_substitution(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)


### PR DESCRIPTION
## Summary
- treat a healthy long-running graphical smoke app as a successful startup
- bound Windows, Linux, and macOS smoke lifetimes to five seconds with deterministic cleanup
- retain early nonzero-exit failure handling and add regression coverage to both release workflows

## Validation
- python -m unittest tools.ci.test_release_provenance
- ctionlint .github/workflows/nightly-release.yml .github/workflows/bootstrap-artifacts.yml
- git diff --check

## Theory gained
Graphical smoke tests validate successful startup, not natural process exit; their process lifetime must be explicitly bounded and cleaned up on every platform.