### PR TITLE
Upload only nightly release artifact files

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -516,7 +516,12 @@ jobs:
             notes="$(printf 'Automated nightly build.\n\nFirst nightly tag in this repository.')"
           fi
 
-          gh release create "${NIGHTLY_TAG}" dist/* \
+          mapfile -d '' -t release_assets < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+          if ((${#release_assets[@]} == 0)); then
+            echo "No regular release assets found directly under dist" >&2
+            exit 1
+          fi
+          gh release create "${NIGHTLY_TAG}" "${release_assets[@]}" \
             --repo "${GITHUB_REPOSITORY}" \
             --title "Nightly ${NIGHTLY_TAG}" \
             --notes "${notes}" \

--- a/tools/ci/test_release_provenance.py
+++ b/tools/ci/test_release_provenance.py
@@ -140,6 +140,30 @@ class ReleaseProvenanceTests(unittest.TestCase):
                 workflow_name,
             )
 
+    def test_nightly_release_filters_top_level_regular_assets(self):
+        workflow = (ROOT / ".github/workflows/nightly-release.yml").read_text(
+            encoding="utf-8"
+        )
+        release_start = workflow.index("      - name: Create GitHub prerelease")
+        release_block = workflow[release_start:]
+        self.assertIn(
+            "mapfile -d '' -t release_assets < <(find dist -maxdepth 1 -type f -print0 | sort -z)",
+            release_block,
+        )
+        self.assertIn("if ((${#release_assets[@]} == 0)); then", release_block)
+        self.assertIn(
+            'echo "No regular release assets found directly under dist" >&2',
+            release_block,
+        )
+        self.assertIn(
+            'gh release create "${NIGHTLY_TAG}" "${release_assets[@]}"',
+            release_block,
+        )
+        self.assertNotRegex(
+            release_block,
+            r'gh release create .*dist/\*',
+        )
+
     def test_package_verifier_detects_runtime_substitution(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary)


### PR DESCRIPTION
## Summary
- filter nightly download output to top-level regular files before publication
- exclude evidence directories from gh release create
- fail clearly when no release files exist and add regression coverage

## Validation
- python -m unittest tools.ci.test_release_provenance
- ctionlint .github/workflows/nightly-release.yml
- git diff --check

## Theory gained
Downloaded evidence directories can coexist under dist; release publication must derive an explicit regular-file set instead of globbing all entries.