### PR TITLE
Publish idle web hover pointers

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -5934,7 +5934,13 @@ mod tests {
 
         let development = web_index_html("development-game", true);
         assert!(development.contains(r#"id="stasis-hud""#));
-        assert!(!development.contains("__STASIS_"));
+        for html in [&release, &development] {
+            assert!(!html.contains("__STASIS_"));
+            assert!(html.contains("#stasis-error { position: absolute;"));
+            assert!(html.contains("inset: 0; margin: 0;"));
+            assert!(html.contains("white-space: pre-wrap;"));
+            assert!(html.contains("#stasis-error:empty { display: none; }"));
+        }
     }
 
     #[test]

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -686,6 +686,13 @@ fn existing_windows_game_packages_command_buffers_sprites_and_font_for_web() {
         "stasis_jit_gfx_cache_text",
         "sys_memcpy_i32: sysMemcpyI32",
         "sys_memcpy_f32: sysMemcpyF32",
+        "const pointerCount = pointer.hover || pointer.down || pointer.wentDown || pointer.wentUp ? 1 : 0;",
+        "const inside = event.clientX >= bounds.left && event.clientX <= bounds.right",
+        "&& event.clientY >= bounds.top && event.clientY <= bounds.bottom;",
+        "pointer.hover = event.pointerType !== \"touch\" && inside;",
+        "canvas.addEventListener(\"pointerleave\", () => { pointer.hover = false; });",
+        "canvas.addEventListener(\"pointerup\", event => {\n    updatePointer(event);\n    pointer.down = false;\n    pointer.wentUp = true;\n  });",
+        "canvas.addEventListener(\"pointercancel\", () => { pointer.hover = false; pointer.down = false; pointer.wentUp = true; });",
     ] {
         assert!(
             runtime.contains(expected),

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -12,7 +12,7 @@
     loadingBox.dataset.hidden = state === "ready" ? "true" : "false";
   };
   const keys = new Set();
-  const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, down: false, wentDown: false, wentUp: false };
+  const pointer = { id: 0, x: 0, y: 0, dx: 0, dy: 0, hover: false, down: false, wentDown: false, wentUp: false };
   const commands = [];
   const game = window.STASIS_GAME || { strings: {}, memory: {}, assets: {} };
   const sprites = new Map();
@@ -1079,7 +1079,7 @@
     const bounds = canvas.getBoundingClientRect();
     const ratio = devicePixelRatio || 1;
     const focused = document.hasFocus() ? 1 : 0;
-    const pointerCount = pointer.down || pointer.wentDown || pointer.wentUp ? 1 : 0;
+    const pointerCount = pointer.hover || pointer.down || pointer.wentDown || pointer.wentUp ? 1 : 0;
     i32[0] = Math.floor(elapsedMs) | 0;
     i32[7] = pointerCount;
     i32[8] = 0;
@@ -1268,11 +1268,14 @@
     const bounds = canvas.getBoundingClientRect();
     const x = Math.round((event.clientX - bounds.left) * canvas.width / bounds.width);
     const y = Math.round((event.clientY - bounds.top) * canvas.height / bounds.height);
+    const inside = event.clientX >= bounds.left && event.clientX <= bounds.right
+      && event.clientY >= bounds.top && event.clientY <= bounds.bottom;
     pointer.dx += x - pointer.x;
     pointer.dy += y - pointer.y;
     pointer.x = x;
     pointer.y = y;
     pointer.id = event.pointerId | 0;
+    pointer.hover = event.pointerType !== "touch" && inside;
   }
   addEventListener("keydown", event => {
     keys.add(event.code);
@@ -1295,12 +1298,13 @@
     canvas.focus();
     void applyFullscreenGesture();
   });
+  canvas.addEventListener("pointerleave", () => { pointer.hover = false; });
   canvas.addEventListener("pointerup", event => {
     updatePointer(event);
     pointer.down = false;
     pointer.wentUp = true;
   });
-  canvas.addEventListener("pointercancel", () => { pointer.down = false; pointer.wentUp = true; });
+  canvas.addEventListener("pointercancel", () => { pointer.hover = false; pointer.down = false; pointer.wentUp = true; });
   addEventListener("resize", () => { resized = true; displayGeneration += 1; });
   document.addEventListener("fullscreenchange", () => { resized = true; displayGeneration += 1; });
   // @stasis-feature audio begin

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -14,7 +14,8 @@
     #stasis-loading { position: absolute; inset: 0; display: grid; place-items: center; padding: 1rem; box-sizing: border-box; background: #07111f; color: #dff6ff; text-align: center; }
     #stasis-loading[data-hidden="true"] { display: none; }
     #stasis-loading[data-failed="true"] { color: #ff8f8f; }
-    #stasis-error { color: #ff8f8f; white-space: pre-wrap; }
+    #stasis-error { position: absolute; inset: 0; margin: 0; padding: 1rem; box-sizing: border-box; overflow: auto; color: #ff8f8f; white-space: pre-wrap; pointer-events: none; }
+    #stasis-error:empty { display: none; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- keep non-touch pointers present while hovering the canvas
- clear hover state on leave/cancel while preserving release edges
- add web package contract coverage

## Validation
- node --check runtime/web/game.js
- rustfmt --check apps/stasis/tests/web_package.rs
- python tools/cargo_cache.py run -- cargo test -p stasis --test web_package -- --skip minimal_pong_and_standard_reference_omit_audio_and_input
- Sheep Herder: 117 tests passed
- visually verified title and course-card hover at 1600x720