### PR TITLE
Polish title-aware web loading shell

### DIFF
--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -5940,9 +5940,13 @@ mod tests {
         let release = web_index_html("release-game", false);
         assert!(!release.contains("stasis-hud"));
         assert!(!release.contains("__STASIS_"));
+        assert!(release.contains(r#"<h1 id="stasis-loading-title">release-game</h1>"#));
+        assert!(release.contains(r#"id="stasis-loading-status">Preparing…</div>"#));
+        assert!(release.contains(r#"id="stasis-loading" role="status" aria-live="polite""#));
 
         let development = web_index_html("development-game", true);
         assert!(development.contains(r#"id="stasis-hud""#));
+        assert!(development.contains(r#"<h1 id="stasis-loading-title">development-game</h1>"#));
         for html in [&release, &development] {
             assert!(!html.contains("__STASIS_"));
             assert!(html.contains("#stasis-error { position: absolute;"));

--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -522,6 +522,9 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
     );
     let runtime = fs::read_to_string(output.join("game.js")).expect("game.js");
     let index = fs::read_to_string(output.join("index.html")).expect("index.html");
+    assert!(index.contains(r#"<title>web_export_smoke</title>"#));
+    assert!(index.contains(r#"<h1 id="stasis-loading-title">web_export_smoke</h1>"#));
+    assert!(index.contains(r#"id="stasis-loading-status">Preparing…</div>"#));
     assert!(!index.contains("stasis-audio"));
     assert!(!index.contains("Enable sound"));
     for expected in [
@@ -625,7 +628,8 @@ fn minimal_pong_and_standard_reference_omit_audio_and_input() {
         "dataset.gpuSubmitMs",
         "dataset.presentWaitMs",
         "PERF_ROLLING_CAPACITY",
-        "if (hud) {\n      recordWorst(",
+        "if (hud)",
+        "recordWorst(",
     ] {
         assert!(
             runtime.contains(expected),

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -53,6 +53,15 @@ The browser populates the canonical HostFrame arrays and consumes the existing g
 buffers, matching Android/Windows. Browser policy (fullscreen gestures, Clipboard API, local
 storage, and WebAudio unlocking) remains in JavaScript.
 
+Before the Wasm module and game assets are ready, `index.html` displays a static, title-aware
+loading shell. The package generator substitutes the manifest game name into
+`#stasis-loading-title`; the separate `#stasis-loading-status` line is the live status target
+updated by both browser runtimes. The shell uses only inline HTML/CSS so it remains available on
+slow or offline starts. `setLoading` keeps the title and decorative structure intact while it
+updates that status, hides the shell after readiness, and leaves it visible with a readable error
+status when startup fails. The `stasis-loading` element retains `role="status"` and
+`aria-live="polite"` for assistive technology.
+
 Development packages show a HUD with current and warmup-excluded worst observed `tick`, `wasm
 render`, `browser replay`, and total `frame work` time. Tick is guest simulation, wasm render is
 guest command-buffer generation, browser replay is host execution/compositing, and frame work is

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -5,9 +5,11 @@
   const hud = document.getElementById("stasis-hud");
   const errorBox = document.getElementById("stasis-error");
   const loadingBox = document.getElementById("stasis-loading");
+  const loadingStatus = document.getElementById("stasis-loading-status");
   const setLoading = (message, state = "loading") => {
     if (!loadingBox) return;
-    loadingBox.textContent = message;
+    if (loadingStatus) loadingStatus.textContent = message;
+    else loadingBox.textContent = message;
     loadingBox.dataset.failed = state === "failed" ? "true" : "false";
     loadingBox.dataset.hidden = state === "ready" ? "true" : "false";
   };
@@ -1315,7 +1317,7 @@
 
   window.STASIS_RUNTIME_PROMISE = (async () => {
     try {
-      setLoading("Loading Stasis runtime…", "loading");
+      setLoading("Preparing…", "loading");
       const result = await WebAssembly.instantiate(await wasmBytes(), imports);
       instance = result.instance;
       writeHostFrame(performance.now());

--- a/runtime/web/game_minimal.js
+++ b/runtime/web/game_minimal.js
@@ -5,9 +5,11 @@
   const hud = document.getElementById("stasis-hud");
   const errorBox = document.getElementById("stasis-error");
   const loadingBox = document.getElementById("stasis-loading");
+  const loadingStatus = document.getElementById("stasis-loading-status");
   const setLoading = (message, state = "loading") => {
     if (!loadingBox) return;
-    loadingBox.textContent = message;
+    if (loadingStatus) loadingStatus.textContent = message;
+    else loadingBox.textContent = message;
     loadingBox.dataset.failed = state === "failed" ? "true" : "false";
     loadingBox.dataset.hidden = state === "ready" ? "true" : "false";
   };
@@ -98,7 +100,7 @@ __STASIS_IMPORTS__
 
   (async () => {
     try {
-      setLoading("Loading Stasis runtime…", "loading");
+      setLoading("Preparing…", "loading");
       const response = await fetch("game.wasm");
       if (!response.ok) throw new Error(`failed to load game.wasm: ${response.status}`);
       instance = (await WebAssembly.instantiate(await response.arrayBuffer(), imports)).instance;

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -6,14 +6,23 @@
   <link rel="icon" href="data:,">
   <title>__STASIS_GAME_TITLE__</title>
   <style>
-    :root { color-scheme: dark; font-family: ui-monospace, Consolas, monospace; }
-    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #07111f; color: #dff6ff; }
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #081613; color: #f3eee1; }
     main { position: relative; width: min(960px, 100vw); }
     canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
     __STASIS_PERFORMANCE_HUD_STYLE__
-    #stasis-loading { position: absolute; inset: 0; display: grid; place-items: center; padding: 1rem; box-sizing: border-box; background: #07111f; color: #dff6ff; text-align: center; }
+    #stasis-loading { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: clamp(1.5rem, 7vw, 5rem); box-sizing: border-box; overflow: hidden; isolation: isolate; background: linear-gradient(145deg, #102a24 0%, #0b1d1a 48%, #07131d 100%); color: #f3eee1; text-align: center; }
+    #stasis-loading::before, #stasis-loading::after { position: absolute; z-index: -1; display: block; content: ""; pointer-events: none; }
+    #stasis-loading::before { width: min(86vw, 56rem); height: min(86vw, 56rem); border: 1px solid #bca66b22; border-radius: 50%; background: radial-gradient(circle, #c6a96b0d 0%, transparent 67%); transform: translate(22%, -25%); }
+    #stasis-loading::after { inset: 0; background: linear-gradient(90deg, transparent 0 49.95%, #bca66b10 50%, transparent 50.05%); opacity: .65; }
+    .stasis-loading-card { width: min(100%, 58rem); display: grid; justify-items: center; gap: clamp(.85rem, 2.5vw, 1.45rem); }
+    .stasis-loading-rule { position: relative; width: min(100%, 32rem); height: 7px; }
+    .stasis-loading-rule::before { position: absolute; top: 3px; right: 0; left: 0; height: 1px; content: ""; background: linear-gradient(90deg, transparent, #c7b47b99 18%, #c7b47b99 82%, transparent); }
+    .stasis-loading-rule-marked::after { position: absolute; top: 0; left: 50%; width: 7px; height: 7px; box-sizing: border-box; content: ""; border: 1px solid #c7b47bcc; background: #0c211d; transform: translateX(-50%) rotate(45deg); }
+    #stasis-loading-title { max-width: 100%; margin: 0; color: #d8ba70; font-family: Georgia, "Times New Roman", serif; font-size: clamp(2.15rem, 6.2vw, 5.4rem); font-weight: 400; letter-spacing: .055em; line-height: .95; text-shadow: 0 2px 18px #0008; text-transform: uppercase; text-wrap: balance; }
+    #stasis-loading-status { min-height: 1.2em; color: #b9c2b5; font-size: clamp(.72rem, 1.6vw, .86rem); letter-spacing: .1em; line-height: 1.4; text-transform: uppercase; }
     #stasis-loading[data-hidden="true"] { display: none; }
-    #stasis-loading[data-failed="true"] { color: #ff8f8f; }
+    #stasis-loading[data-failed="true"] #stasis-loading-status { color: #f1a09a; }
     #stasis-error { position: absolute; inset: 0; margin: 0; padding: 1rem; box-sizing: border-box; overflow: auto; color: #ff8f8f; white-space: pre-wrap; pointer-events: none; }
     #stasis-error:empty { display: none; }
   </style>
@@ -21,7 +30,14 @@
 <body>
   <main>
     <canvas id="stasis-canvas" width="640" height="360" aria-label="__STASIS_GAME_TITLE__ game canvas" tabindex="0"></canvas>
-    <div id="stasis-loading" role="status" aria-live="polite">Loading Stasis runtime…</div>
+    <div id="stasis-loading" role="status" aria-live="polite">
+      <div class="stasis-loading-card">
+        <div class="stasis-loading-rule" aria-hidden="true"></div>
+        <h1 id="stasis-loading-title">__STASIS_GAME_TITLE__</h1>
+        <div class="stasis-loading-rule stasis-loading-rule-marked" aria-hidden="true"></div>
+        <div id="stasis-loading-status">Preparing…</div>
+      </div>
+    </div>
     __STASIS_PERFORMANCE_HUD__
     <pre id="stasis-error"></pre>
   </main>

--- a/runtime/web/tests/loading_overlay.test.mjs
+++ b/runtime/web/tests/loading_overlay.test.mjs
@@ -10,13 +10,20 @@ test("web package template exposes an immediate accessible loading status", () =
   assert.match(html, /id="stasis-loading"/);
   assert.match(html, /role="status"/);
   assert.match(html, /aria-live="polite"/);
+  assert.match(html, /id="stasis-loading-title">__STASIS_GAME_TITLE__<\/h1>/);
+  assert.match(html, /id="stasis-loading-status">Preparing…<\/div>/);
+  assert.match(html, /position: fixed; inset: 0;/);
+  assert.match(html, /body \{[^}]*overflow: hidden;/);
   assert.match(html, /data-hidden="true"/);
 });
 
 test("web runtimes keep loading visible, hide only when ready, and retain failure", () => {
   for (const name of ["game.js", "game_minimal.js"]) {
     const source = read(name);
-    assert.match(source, /setLoading\("Loading Stasis runtime…", "loading"\)/);
+    assert.match(source, /const loadingStatus = document\.getElementById\("stasis-loading-status"\)/);
+    assert.match(source, /if \(loadingStatus\) loadingStatus\.textContent = message;/);
+    assert.match(source, /else loadingBox\.textContent = message;/);
+    assert.match(source, /setLoading\("Preparing…", "loading"\)/);
     assert.match(source, /dataset\.hidden = state === "ready" \? "true" : "false"/);
     assert.match(source, /dataset\.failed = state === "failed" \? "true" : "false"/);
     assert.match(source, /setLoading\("", "ready"\)/);


### PR DESCRIPTION
## Summary
- replace the generic pre-Wasm message with a responsive, title-aware full-viewport shell
- preserve the game title and ornament structure while both web runtimes update loading/error status
- prevent document scrollbars during short 20:9 landscape startup
- cover generated packages, full/minimal runtimes, and document the contract

## Validation
- node --test runtime/web/tests/loading_overlay.test.mjs
- cargo test -p stasis --bin stasis release_web_index_omits_performance_hud
- cargo test -p stasis --test web_package web_package_contains_runnable_static_bundle_without_standalone_html
- cargo test -p stasis --test web_package minimal_pong_and_standard_reference_omit_audio_and_input
- visual QA at 1600x720 and 900x405, including failure and loader-to-menu transition