### PR TITLE
Fix string literal text in mobile AOT

### DIFF
--- a/runtime/stasis_mobile_aot_runtime.c
+++ b/runtime/stasis_mobile_aot_runtime.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdatomic.h>
 #include <stdio.h>
@@ -989,9 +990,66 @@ static int32_t collection_meta_hash(int32_t hash, int32_t kind) {
     return (int32_t)value;
 }
 
+static int utf8_continuation(unsigned char value) {
+    return value >= 0x80 && value <= 0xbf;
+}
+
+static size_t utf8_sequence_length(const unsigned char *cursor, size_t remaining) {
+    const unsigned char first = cursor[0];
+    if (first <= 0x7f) return 1;
+    if (remaining >= 2 && first >= 0xc2 && first <= 0xdf &&
+        utf8_continuation(cursor[1])) return 2;
+    if (remaining >= 3 && first == 0xe0 && cursor[1] >= 0xa0 && cursor[1] <= 0xbf &&
+        utf8_continuation(cursor[2])) return 3;
+    if (remaining >= 3 && first >= 0xe1 && first <= 0xec && utf8_continuation(cursor[1]) &&
+        utf8_continuation(cursor[2])) return 3;
+    if (remaining >= 3 && first == 0xed && cursor[1] >= 0x80 && cursor[1] <= 0x9f &&
+        utf8_continuation(cursor[2])) return 3;
+    if (remaining >= 3 && first >= 0xee && first <= 0xef && utf8_continuation(cursor[1]) &&
+        utf8_continuation(cursor[2])) return 3;
+    if (remaining >= 4 && first == 0xf0 && cursor[1] >= 0x90 && cursor[1] <= 0xbf &&
+        utf8_continuation(cursor[2]) && utf8_continuation(cursor[3])) return 4;
+    if (remaining >= 4 && first >= 0xf1 && first <= 0xf3 && utf8_continuation(cursor[1]) &&
+        utf8_continuation(cursor[2]) && utf8_continuation(cursor[3])) return 4;
+    if (remaining >= 4 && first == 0xf4 && cursor[1] >= 0x80 && cursor[1] <= 0x8f &&
+        utf8_continuation(cursor[2]) && utf8_continuation(cursor[3])) return 4;
+    return 1;
+}
+
+static int32_t utf8_char_length(const char *text) {
+    const unsigned char *cursor = (const unsigned char *)text;
+    const size_t byte_length = strlen(text);
+    size_t offset = 0;
+    size_t count = 0;
+    while (offset < byte_length) {
+        const size_t remaining = byte_length - offset;
+        const size_t sequence_length = utf8_sequence_length(cursor, remaining);
+        if (count >= (size_t)INT32_MAX) return INT32_MAX;
+        count += 1;
+        cursor += sequence_length;
+        offset += sequence_length;
+    }
+    return (int32_t)count;
+}
+
+static int32_t saturated_i32_length(size_t length) {
+    return length > (size_t)INT32_MAX ? INT32_MAX : (int32_t)length;
+}
+
 int32_t stasis_jit_collection_i32_load(int32_t hash, int32_t kind) {
     int32_t derived = collection_meta_hash(hash, kind);
-    return derived == 0 ? 0 : stasis_jit_global_i32_load(derived);
+    StasisScalar *metadata;
+    const char *literal;
+
+    if (derived == 0) return 0;
+    metadata = find_scalar(derived, STASIS_VALUE_I32, 0);
+    if (metadata != NULL) return stasis_jit_global_i32_load(derived);
+
+    literal = find_string(hash);
+    if (literal == NULL) return 0;
+    if (kind == 1 || kind == 2) return saturated_i32_length(strlen(literal));
+    if (kind == 3) return utf8_char_length(literal);
+    return 0;
 }
 void stasis_jit_collection_i32_store(int32_t hash, int32_t kind, int32_t value) {
     int32_t derived = collection_meta_hash(hash, kind);
@@ -1023,6 +1081,53 @@ static void copy_i32_values(int32_t dst, int32_t di, int32_t src, int32_t si, in
     }
 }
 
+static int mobile_text_array_is_registered(int32_t collection_hash) {
+    return find_array(collection_hash, 0, STASIS_VALUE_U8, 0) != NULL ||
+        find_array(collection_hash, 0, STASIS_VALUE_I32, 0) != NULL;
+}
+
+static int32_t saturating_index_add(int32_t base, int32_t offset) {
+    int64_t value = (int64_t)base + (int64_t)offset;
+    if (value > INT32_MAX) return INT32_MAX;
+    if (value < INT32_MIN) return INT32_MIN;
+    return (int32_t)value;
+}
+
+static void copy_u8_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
+    int32_t *values;
+    int32_t offset;
+    const char *literal = NULL;
+
+    if (count <= 0) return;
+    if (!mobile_text_array_is_registered(src)) literal = find_string(src);
+    if (literal != NULL) {
+        const size_t byte_length = strlen(literal);
+        for (offset = 0; offset < count; offset += 1) {
+            const int32_t source_index = saturating_index_add(si, offset);
+            const int32_t destination_index = saturating_index_add(di, offset);
+            int32_t value = 0;
+            if (source_index >= 0 && (size_t)source_index < byte_length) {
+                value = (unsigned char)literal[source_index];
+            }
+            stasis_jit_global_i32_array_store(dst, 0, destination_index, value);
+        }
+        return;
+    }
+
+    if ((size_t)count > SIZE_MAX / sizeof(*values)) return;
+    values = (int32_t *)malloc((size_t)count * sizeof(*values));
+    if (values == NULL) return;
+    for (offset = 0; offset < count; offset += 1) {
+        values[offset] = stasis_jit_global_i32_array_load(
+            src, 0, saturating_index_add(si, offset));
+    }
+    for (offset = 0; offset < count; offset += 1) {
+        stasis_jit_global_i32_array_store(
+            dst, 0, saturating_index_add(di, offset), values[offset]);
+    }
+    free(values);
+}
+
 static void copy_f32_values(int32_t dst, int32_t di, int32_t src, int32_t si, int32_t count) {
     int32_t index;
     if (count <= 0 || di < 0 || si < 0) return;
@@ -1039,12 +1144,12 @@ static void copy_f32_values(int32_t dst, int32_t di, int32_t src, int32_t si, in
     }
 }
 
-void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memcpy_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_u8_values(d, di, s, si, n); }
 void stasis_jit_sys_memcpy_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memcpy_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }
 
 /* Mobile AOT has no live swap coordinator; retain the shared import contract as a no-op. */
 void stasis_jit_reject_code_swap(void) {}
-void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
+void stasis_jit_sys_memmove_u8(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_u8_values(d, di, s, si, n); }
 void stasis_jit_sys_memmove_i32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_i32_values(d, di, s, si, n); }
 void stasis_jit_sys_memmove_f32(int32_t d, int32_t di, int32_t s, int32_t si, int32_t n) { copy_f32_values(d, di, s, si, n); }

--- a/runtime/tests/stasis_mobile_aot_runtime_test.c
+++ b/runtime/tests/stasis_mobile_aot_runtime_test.c
@@ -167,6 +167,9 @@ int main(void) {
     uint8_t dynamic_path[] = "sprite.bmp";
     uint8_t ascii_value[] = "GG1-test";
     uint8_t ascii_out[32] = {0};
+    uint8_t literal_out[8] = {0};
+    uint8_t utf8_out[16] = {0};
+    uint8_t raw_out[4] = {0};
     int32_t sprite_handle[1] = {0};
     int32_t sprite_width[1] = {0};
     int32_t sprite_height[1] = {0};
@@ -205,8 +208,16 @@ int main(void) {
     CHECK(stasis_jit_global_i32_array_load(22, 0, 1) == 2);
     stasis_jit_sys_memcpy_u8(22, 2, 22, 0, 2);
     CHECK(external_u8[2] == 1 && external_u8[3] == 2);
+    stasis_jit_upsert_string_literal(22, "literal-must-not-win");
+    stasis_jit_register_global_u8_array(54, 0, raw_out, sizeof(raw_out));
+    stasis_jit_sys_memcpy_u8(54, 0, 22, 0, 4);
+    CHECK(memcmp(raw_out, external_u8, sizeof(raw_out)) == 0);
 
     stasis_jit_register_global_i32_array(24, 0, overlapping_i32, 5);
+    stasis_jit_upsert_string_literal(24, "i32-array-must-win");
+    memset(raw_out, 0, sizeof(raw_out));
+    stasis_jit_sys_memcpy_u8(54, 0, 24, 0, 4);
+    CHECK(memcmp(raw_out, "\1\2\3\4", sizeof(raw_out)) == 0);
     stasis_jit_sys_memmove_i32(24, 1, 24, 0, 4);
     CHECK(overlapping_i32[0] == 1 && overlapping_i32[1] == 1 &&
             overlapping_i32[2] == 2 && overlapping_i32[3] == 3 && overlapping_i32[4] == 4);
@@ -245,6 +256,41 @@ int main(void) {
 
     stasis_jit_upsert_string_literal(40, "sample_game");
     stasis_jit_upsert_string_literal(41, "unlocked_tier");
+    CHECK(stasis_jit_collection_i32_load(40, 1) == 11);
+    CHECK(stasis_jit_collection_i32_load(40, 2) == 11);
+    CHECK(stasis_jit_collection_i32_load(40, 3) == 11);
+    {
+        const char utf8_literal[] = {
+            'h', (char)0xc3, (char)0xa9, 'l', 'l', 'o', ' ',
+            (char)0xf0, (char)0x9f, (char)0x8c, (char)0x8d, 0};
+        stasis_jit_upsert_string_literal(45, utf8_literal);
+        CHECK(stasis_jit_collection_i32_load(45, 1) == 11);
+        CHECK(stasis_jit_collection_i32_load(45, 2) == 11);
+        CHECK(stasis_jit_collection_i32_load(45, 3) == 7);
+        stasis_jit_register_global_u8_array(53, 0, utf8_out, sizeof(utf8_out));
+        stasis_jit_sys_memcpy_u8(53, 0, 45, 0, 11);
+        CHECK(memcmp(utf8_out, utf8_literal, 11) == 0);
+    }
+    stasis_jit_upsert_string_literal(50, "field");
+    stasis_jit_register_global_u8_array(52, 0, literal_out, sizeof(literal_out));
+    stasis_jit_sys_memcpy_u8(52, 1, 50, 1, 3);
+    CHECK(memcmp(literal_out, "\0iel\0\0\0\0", sizeof(literal_out)) == 0);
+    stasis_jit_sys_memmove_u8(52, 0, 50, 0, 5);
+    CHECK(memcmp(literal_out, "field", 5) == 0);
+    memset(literal_out, 0x7f, sizeof(literal_out));
+    stasis_jit_sys_memcpy_u8(52, 0, 50, 99, 2);
+    CHECK(literal_out[0] == 0 && literal_out[1] == 0);
+    {
+        const char truncated_literal[] = {'x', (char)0xc3, 0};
+        stasis_jit_upsert_string_literal(46, truncated_literal);
+        CHECK(stasis_jit_collection_i32_load(46, 1) == 2);
+        CHECK(stasis_jit_collection_i32_load(46, 3) == 2);
+    }
+    CHECK(stasis_jit_collection_i32_load(404, 1) == 0);
+    CHECK(stasis_jit_collection_i32_load(40, 0) == 0);
+    CHECK(stasis_jit_collection_i32_load(40, 4) == 0);
+    stasis_jit_collection_i32_store(45, 1, 23);
+    CHECK(stasis_jit_collection_i32_load(45, 1) == 23);
     CHECK(stasis_jit_storage_load_i32(40, 41, 1) == 1);
     CHECK(stasis_jit_storage_save_i32(40, 41, 4) == 1);
     CHECK(stasis_jit_storage_load_i32(40, 41, 1) == 4);


### PR DESCRIPTION
Mobile AOT now matches the desktop runtime for string-literal collection metadata and UTF-8 byte copying. Mutable collection storage keeps precedence, literal lengths and character counts are bounds-safe, and byte copies preserve overlap semantics. Tests cover ASCII, multibyte and truncated UTF-8, bounds, mutable precedence, raw arrays, memcpy, and memmove. Validated with the Android-native runtime contract test plus real arm64 APKs for Sheep Herder and Maddox Marble Run; text renders visibly in both.