### PR TITLE
Support adaptive large native font atlases

### DIFF
--- a/runtime/stasis_display_scale.h
+++ b/runtime/stasis_display_scale.h
@@ -175,10 +175,29 @@ static int stasis_display_scaled_extent(int logical_extent, float pixel_scale) {
     return (int)scaled;
 }
 
+#define STASIS_DISPLAY_FONT_ATLAS_MIN_EXTENT 512
+#define STASIS_DISPLAY_FONT_ATLAS_MAX_EXTENT 4096
+
 static int stasis_display_font_atlas_extent(float pixel_scale) {
-    if (pixel_scale <= 1.0f) return 512;
+    if (pixel_scale <= 1.0f) return STASIS_DISPLAY_FONT_ATLAS_MIN_EXTENT;
     if (pixel_scale <= 4.0f) return 1024;
     return 2048;
+}
+
+/* Return the next bounded power-of-two atlas size, or zero at the cap. */
+static int stasis_display_font_atlas_next_extent(int atlas_extent) {
+    if (atlas_extent < STASIS_DISPLAY_FONT_ATLAS_MIN_EXTENT) {
+        return STASIS_DISPLAY_FONT_ATLAS_MIN_EXTENT;
+    }
+    if (atlas_extent >= STASIS_DISPLAY_FONT_ATLAS_MAX_EXTENT) return 0;
+    int next_extent = STASIS_DISPLAY_FONT_ATLAS_MIN_EXTENT;
+    while (next_extent <= atlas_extent) {
+        if (next_extent > STASIS_DISPLAY_FONT_ATLAS_MAX_EXTENT / 2) {
+            return STASIS_DISPLAY_FONT_ATLAS_MAX_EXTENT;
+        }
+        next_extent *= 2;
+    }
+    return next_extent;
 }
 
 #endif

--- a/runtime/stasis_graphics.c
+++ b/runtime/stasis_graphics.c
@@ -7431,27 +7431,48 @@ static uint32_t fnv1a_u32(const unsigned char* data, int len) {
     return h;
 }
 
+static int stasis_font_atlas_pixels(int atlas_size, size_t* pixels_out) {
+    if (atlas_size <= 0 || !pixels_out) return 0;
+    const size_t extent = (size_t)atlas_size;
+    if (extent > SIZE_MAX / extent) return 0;
+    *pixels_out = extent * extent;
+    return 1;
+}
+
 static int stasis_build_font_atlas(StasisFont* font) {
     if (!font || !font->ttf_buffer || font->font_size <= 0) return 0;
 
     const float pixel_scale = g_pixel_scale < 1.0f ? 1.0f : g_pixel_scale;
     const int raster_size = stasis_display_scaled_extent(font->font_size, pixel_scale);
-    const int atlas_size = stasis_display_font_atlas_extent(pixel_scale);
-    const size_t atlas_pixels = (size_t)atlas_size * (size_t)atlas_size;
-    unsigned char* atlas_bitmap = (unsigned char*)malloc(atlas_pixels);
-    if (!atlas_bitmap) return 0;
-
+    int atlas_size = stasis_display_font_atlas_extent(pixel_scale);
+    size_t atlas_pixels = 0;
+    unsigned char* atlas_bitmap = NULL;
     stbtt_bakedchar baked_chars[FONT_NUM_CHARS];
-    int result = stbtt_BakeFontBitmap(font->ttf_buffer, 0, (float)raster_size,
-        atlas_bitmap, atlas_size, atlas_size, FONT_FIRST_CHAR, FONT_NUM_CHARS, baked_chars);
-    if (result <= 0) {
+    int result = 0;
+    for (;;) {
+        if (!stasis_font_atlas_pixels(atlas_size, &atlas_pixels)) return 0;
+        atlas_bitmap = (unsigned char*)malloc(atlas_pixels);
+        if (!atlas_bitmap) return 0;
+        result = stbtt_BakeFontBitmap(font->ttf_buffer, 0, (float)raster_size,
+            atlas_bitmap, atlas_size, atlas_size, FONT_FIRST_CHAR, FONT_NUM_CHARS, baked_chars);
+        if (result > 0) break;
+
         free(atlas_bitmap);
-        SDL_Log("stasis_load_font: BakeFontBitmap failed size=%d atlas=%d", raster_size, atlas_size);
-        return 0;
+        atlas_bitmap = NULL;
+        const int next_atlas_size = stasis_display_font_atlas_next_extent(atlas_size);
+        if (next_atlas_size == 0) {
+            SDL_Log("stasis_load_font: BakeFontBitmap failed size=%d atlas=%d", raster_size, atlas_size);
+            return 0;
+        }
+        atlas_size = next_atlas_size;
     }
 
     if (g_use_sdl_renderer) {
         if (!g_renderer) {
+            free(atlas_bitmap);
+            return 0;
+        }
+        if (atlas_pixels > SIZE_MAX / 4u) {
             free(atlas_bitmap);
             return 0;
         }

--- a/runtime/tests/stasis_display_scale_test.c
+++ b/runtime/tests/stasis_display_scale_test.c
@@ -148,6 +148,16 @@ static void test_extreme_density_and_extent_are_bounded(void) {
     CHECK(stasis_display_font_atlas_extent(metrics.raster_scale) == 2048);
 }
 
+static void test_font_atlas_growth_is_bounded_and_deterministic(void) {
+    CHECK(stasis_display_font_atlas_next_extent(512) == 1024);
+    CHECK(stasis_display_font_atlas_next_extent(1024) == 2048);
+    CHECK(stasis_display_font_atlas_next_extent(2048) == 4096);
+    CHECK(stasis_display_font_atlas_next_extent(4096) == 0);
+    CHECK(stasis_display_font_atlas_next_extent(8192) == 0);
+    CHECK(stasis_display_font_atlas_next_extent(0) == 512);
+    CHECK(stasis_display_font_atlas_next_extent(513) == 1024);
+}
+
 int main(void) {
     test_phone_scale_preserves_logical_canvas();
     test_pointer_mapping_round_trips_through_letterbox();
@@ -157,5 +167,6 @@ int main(void) {
     test_safe_native_area_maps_to_logical_viewport();
     test_maximized_portrait_pointer_mapping();
     test_extreme_density_and_extent_are_bounded();
+    test_font_atlas_growth_is_bounded_and_deterministic();
     return 0;
 }

--- a/runtime/tests/stasis_font_cache_test.c
+++ b/runtime/tests/stasis_font_cache_test.c
@@ -99,6 +99,10 @@ int main(void) {
     CHECK(second_size > 0);
     CHECK(second_size != first);
 
+    int large = stasis_load_font(STASIS_TEST_FONT_PATH, 100);
+    CHECK(large > 0);
+    CHECK(stasis_load_font(STASIS_TEST_FONT_PATH, 100) == large);
+
     size_t identity_size = 0;
     unsigned char* identity_bytes = read_file(STASIS_TEST_FONT_PATH, &identity_size);
     char identity_names[10][64];


### PR DESCRIPTION
## Summary
- grow native stb font atlases through deterministic bounded 512/1024/2048/4096 retries
- make 100px wordmarks render instead of silently failing at the fixed 512px atlas
- preserve logical metrics, texture replacement, cache handles, and reraster behavior
- cover atlas growth/cap behavior and large-font cache reuse

## Validation
- stasis_display_scale_test passes with adaptive growth coverage
- Sheep Herder headless desktop and 900x405 captures load Cinzel at 100px successfully and visually match Menu B hierarchy
- git diff --check passes
- stasis_font_cache_test passed during implementation; a later rerun of the rebuilt executable was blocked by host Application Control policy
