### PR TITLE
ci: bound Android seam CPU contention

### DIFF
--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 75
     env:
       CARGO_INCREMENTAL: "0"
+      CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
       STASIS_SDL3_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL
       STASIS_SDL3_IMAGE_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL_image
@@ -61,10 +62,10 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: default
+          target: google_apis
           arch: x86_64
           profile: pixel_7
-          cores: 4
+          cores: 2
           ram-size: 4096M
           ndk: 27.0.12077973
           cmake: 3.22.1
@@ -112,6 +113,7 @@ jobs:
     timeout-minutes: 75
     env:
       CARGO_INCREMENTAL: "0"
+      CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
       STASIS_SDL3_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL
       STASIS_SDL3_IMAGE_SOURCE: ${{ github.workspace }}/target/android-link-deps/SDL_image
@@ -159,10 +161,10 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: default
+          target: google_apis
           arch: x86_64
           profile: pixel_7
-          cores: 4
+          cores: 2
           ram-size: 4096M
           ndk: 27.0.12077973
           cmake: 3.22.1

--- a/.github/workflows/android-device-seams.yml
+++ b/.github/workflows/android-device-seams.yml
@@ -61,7 +61,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           profile: pixel_7
           cores: 4
@@ -159,7 +159,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
-          target: google_apis
+          target: default
           arch: x86_64
           profile: pixel_7
           cores: 4

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -135,12 +135,15 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
             self.assertIn("ndk: 27.0.12077973", body)
             self.assertIn("cmake: 3.22.1", body)
             self.assertIn("api-level: 35", body)
+            self.assertIn("target: default", body)
             self.assertIn("arch: x86_64", body)
             self.assertIn("8e37db5e797b6167f3a00d697d816a684bd259c7", body)
             self.assertIn("bec9134a26c7d0f31b36d6083c25296e04cabff5", body)
             self.assertIn(
                 "rustup target add aarch64-linux-android x86_64-linux-android", body
             )
+        self.assertEqual(2, self.workflow.count("target: default"))
+        self.assertNotIn("target: google_apis", self.workflow)
         release_body = job_bodies["release-shell-seams"]
         workshop_body = job_bodies["workshop-seams"]
         release_script = "pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1"

--- a/tools/ci/test_android_emulator_seams.py
+++ b/tools/ci/test_android_emulator_seams.py
@@ -135,15 +135,17 @@ class AndroidEmulatorSeamContractTests(unittest.TestCase):
             self.assertIn("ndk: 27.0.12077973", body)
             self.assertIn("cmake: 3.22.1", body)
             self.assertIn("api-level: 35", body)
-            self.assertIn("target: default", body)
+            self.assertIn("target: google_apis", body)
             self.assertIn("arch: x86_64", body)
+            self.assertIn('CARGO_BUILD_JOBS: "2"', body)
+            self.assertIn("cores: 2", body)
             self.assertIn("8e37db5e797b6167f3a00d697d816a684bd259c7", body)
             self.assertIn("bec9134a26c7d0f31b36d6083c25296e04cabff5", body)
             self.assertIn(
                 "rustup target add aarch64-linux-android x86_64-linux-android", body
             )
-        self.assertEqual(2, self.workflow.count("target: default"))
-        self.assertNotIn("target: google_apis", self.workflow)
+        self.assertEqual(2, self.workflow.count('CARGO_BUILD_JOBS: "2"'))
+        self.assertEqual(2, self.workflow.count("cores: 2"))
         release_body = job_bodies["release-shell-seams"]
         workshop_body = job_bodies["workshop-seams"]
         release_script = "pwsh -NoProfile -File ./mobile/android/test_release_shell_emulator.ps1"


### PR DESCRIPTION
## Summary
- limit Android emulator seam guests to two CPU cores
- cap Cargo build parallelism at two jobs
- enforce both limits in the workflow contract tests

## Validation
- full Android Emulator Seams workflow passed: https://github.com/benwmaddox/StasisLang/actions/runs/32574456779
- python -m unittest tools.ci.test_android_emulator_seams tools.ci.test_run_android_release_shell_seam (33 tests passed)

The CPU caps prevent host saturation that was causing Pixel Launcher and Quickstep ANR dialogs during acceptance runs.