### PR TITLE
Preserve diagnostic provenance for packaged quick fixes

### DIFF
--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -576,11 +576,18 @@ pub struct RenamePlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageDiagnosticOrigin {
+    pub path: String,
+    pub range: Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LanguageCodeAction {
     pub title: String,
     pub kind: String,
     pub preferred: bool,
     pub diagnostic_code: Option<String>,
+    pub diagnostic_origin: Option<LanguageDiagnosticOrigin>,
     pub edits: Vec<RenameEdit>,
 }
 
@@ -1522,6 +1529,7 @@ impl LanguageService {
             kind: "source.organizeImports".to_string(),
             preferred: true,
             diagnostic_code: None,
+            diagnostic_origin: None,
             edits: vec![RenameEdit {
                 path: absolute_source_path(&project_root, &change.file),
                 range: 0..change.before_source.len(),
@@ -1767,6 +1775,10 @@ impl LanguageService {
                 kind: "quickfix".to_string(),
                 preferred: true,
                 diagnostic_code: Some(diagnostic.code.as_str().to_string()),
+                diagnostic_origin: Some(LanguageDiagnosticOrigin {
+                    path: published.path.clone(),
+                    range: diagnostic.start..diagnostic.end,
+                }),
                 edits: fix
                     .edits
                     .into_iter()
@@ -3637,6 +3649,7 @@ function main(): i32 {
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].kind, "source.organizeImports");
         assert!(actions[0].preferred);
+        assert!(actions[0].diagnostic_origin.is_none());
         assert_eq!(actions[0].edits[0].range, 0..source.len());
         assert_eq!(
             actions[0].edits[0].new_text,
@@ -3674,6 +3687,13 @@ function main(): i32 {
         assert_eq!(
             actions[0].diagnostic_code.as_deref(),
             Some("stasis.missingModule")
+        );
+        assert_eq!(
+            actions[0].diagnostic_origin,
+            Some(LanguageDiagnosticOrigin {
+                path: main_text.clone(),
+                range: 7..23,
+            })
         );
         assert_eq!(
             &source[actions[0].edits[0].range.clone()],

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -3336,8 +3336,15 @@ mod tests {
         fs::remove_dir_all(&root).ok();
         fs::create_dir_all(root.join("src")).expect("fixture source directory");
         let path = root.join("src/main.stasis");
+        let path_text = path.to_string_lossy().replace('\\', "/");
         let source = include_str!("../../../vscode-stasis/test/fixture/src/main.stasis");
         fs::write(&path, source).expect("fixture source");
+        let helper_path = root.join("src/helper.stasis");
+        let helper_source = include_str!("../../../vscode-stasis/test/fixture/src/helper.stasis");
+        fs::write(&helper_path, helper_source).expect("fixture helper source");
+        let unused_path = root.join("src/unused.stasis");
+        let unused_source = include_str!("../../../vscode-stasis/test/fixture/src/unused.stasis");
+        fs::write(&unused_path, unused_source).expect("fixture unused source");
         let toolchain_source = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src");
         for directory in ["", "internal", "testing"] {
             let source_directory = toolchain_source.join("stdlib").join(directory);
@@ -3355,7 +3362,15 @@ mod tests {
             }
         }
         let mut service = LanguageService::new(root.to_string_lossy()).expect("language service");
-        service.set_disk_document(path.to_string_lossy(), source);
+        service.set_disk_document(path_text.clone(), source);
+        service.set_disk_document(
+            helper_path.to_string_lossy().replace('\\', "/"),
+            helper_source,
+        );
+        service.set_disk_document(
+            unused_path.to_string_lossy().replace('\\', "/"),
+            unused_source,
+        );
 
         let report = service.diagnostics();
         assert!(
@@ -3365,7 +3380,7 @@ mod tests {
         );
 
         service.open_document(
-            path.to_string_lossy(),
+            path_text.clone(),
             1,
             format!(
                 "{source}\nfunction lsp_diagnostic_probe(): i32 {{ while (true) {{ return 1; }} }}\n"
@@ -3380,6 +3395,28 @@ mod tests {
             "dirty fixture diagnostics: {:?}",
             dirty.diagnostics
         );
+
+        service.open_document(
+            path_text.clone(),
+            2,
+            format!("import \"missing.stasis\";\n{source}"),
+        );
+        let missing = service.diagnostics();
+        assert_eq!(missing.diagnostics.len(), 1);
+        assert_eq!(missing.diagnostics[0].code, "stasis.missingModule");
+        let actions = service
+            .code_actions(&path_text, &["quickfix".to_string()])
+            .expect("fixture missing-import quick fix");
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Remove unresolved import 'missing'");
+        assert_eq!(
+            actions[0]
+                .diagnostic_origin
+                .as_ref()
+                .map(|origin| origin.path.as_str()),
+            Some(path_text.as_str())
+        );
+        assert_eq!(actions[0].edits[0].path, path_text);
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/stasis_lsp/src/lib.rs
+++ b/crates/stasis_lsp/src/lib.rs
@@ -2190,6 +2190,123 @@ mod tests {
     }
 
     #[test]
+    fn packaged_nested_project_open_sequence_returns_missing_import_quick_fix() {
+        let (mut server, uri, main_path) = test_server("packaged-nested-missing-import");
+        let (server_connection, client_connection) = Connection::memory();
+        let root = Path::new(&main_path)
+            .parent()
+            .expect("source directory")
+            .to_path_buf();
+        let helper_path = path_text(&root.join("helper.stasis"));
+        let unused_path = path_text(&root.join("unused.stasis"));
+        let source = "import \"helper.stasis\";\nimport \"unused.stasis\";\nfunction main(): i32 { return helper(); }\n";
+        server.service.set_disk_document(&main_path, source);
+        server
+            .service
+            .set_disk_document(&helper_path, "function helper(): i32 { return 1; }\n");
+        server.service.set_disk_document(
+            &unused_path,
+            "function unused_helper(): i32 { return 2; }\n",
+        );
+        server
+            .handle_notification(
+                &server_connection,
+                Notification::new(
+                    DidOpenTextDocument::METHOD.to_string(),
+                    serde_json::json!({
+                        "textDocument": {
+                            "uri": uri,
+                            "languageId": "stasis",
+                            "version": 1,
+                            "text": source
+                        }
+                    }),
+                ),
+            )
+            .expect("packaged didOpen");
+
+        let missing_import = "import \"missing.stasis\";\n";
+        server
+            .handle_notification(
+                &server_connection,
+                Notification::new(
+                    DidChangeTextDocument::METHOD.to_string(),
+                    serde_json::json!({
+                        "textDocument": {"uri": uri, "version": 2},
+                        "contentChanges": [{
+                            "range": {
+                                "start": {"line": 0, "character": 0},
+                                "end": {"line": 0, "character": 0}
+                            },
+                            "rangeLength": 0,
+                            "text": missing_import
+                        }]
+                    }),
+                ),
+            )
+            .expect("packaged didChange");
+        let Message::Notification(notification) = client_connection
+            .receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("didChange diagnostics")
+        else {
+            panic!("expected didChange diagnostics");
+        };
+        let published: PublishDiagnosticsParams =
+            serde_json::from_value(notification.params).expect("published diagnostics");
+        assert_eq!(
+            published.diagnostics[0].code,
+            Some(NumberOrString::String("stasis.missingModule".to_string()))
+        );
+
+        let service_actions = server
+            .service
+            .code_actions(&main_path, &["quickfix".to_string()])
+            .expect("packaged quick fixes");
+        assert_eq!(service_actions.len(), 1);
+        assert_eq!(
+            service_actions[0]
+                .diagnostic_origin
+                .as_ref()
+                .map(|origin| origin.path.as_str()),
+            Some(main_path.as_str())
+        );
+        assert_eq!(service_actions[0].edits[0].path, main_path);
+
+        server
+            .handle_request(
+                &server_connection,
+                Request::new(
+                    RequestId::from(97),
+                    CodeActionRequest::METHOD.to_string(),
+                    serde_json::json!({
+                        "textDocument": {"uri": uri},
+                        "range": {
+                            "start": {"line": 0, "character": 0},
+                            "end": {"line": 0, "character": missing_import.len() - 1}
+                        },
+                        "context": {
+                            "diagnostics": [],
+                            "only": ["quickfix"]
+                        }
+                    }),
+                ),
+            )
+            .expect("packaged quick-fix request");
+        let actions: Option<Vec<CodeActionOrCommand>> = serde_json::from_value(
+            receive_response(&client_connection, 97)
+                .response_result
+                .expect("code-action result"),
+        )
+        .expect("code-action response");
+        let CodeActionOrCommand::CodeAction(action) = &actions.expect("actions")[0] else {
+            panic!("expected code action");
+        };
+        assert_eq!(action.title, "Remove unresolved import 'missing'");
+        assert!(action.diagnostics.is_none());
+    }
+
+    #[test]
     fn standard_quick_fix_is_available_without_request_diagnostics() {
         let (mut server, uri, main_path) = test_server("missing-import-quick-fix-empty-context");
         let (server_connection, client_connection) = Connection::memory();

--- a/crates/stasis_lsp/src/lib.rs
+++ b/crates/stasis_lsp/src/lib.rs
@@ -54,8 +54,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use stasis_language_service::{
     CompletionResolveData, DiagnosticSeverity, Document, HoverInfo, LanguageCompletionItem,
-    LanguageHierarchyItem, LanguageHierarchyKind, LanguageInlayHintKind, LanguageLocation,
-    LanguageService, LanguageSymbol, LanguageSymbolKind, Position,
+    LanguageDiagnosticOrigin, LanguageHierarchyItem, LanguageHierarchyKind, LanguageInlayHintKind,
+    LanguageLocation, LanguageService, LanguageSymbol, LanguageSymbolKind, Position,
     SignatureHelp as SharedSignatureHelp, TextChange, WorkspaceRevision,
 };
 use url::Url;
@@ -1145,10 +1145,13 @@ impl LanguageServer {
                 let diagnostics = if let Some(code) = action.diagnostic_code.as_ref() {
                     if request_diagnostics.is_empty() {
                         // VS Code may omit the diagnostics it is requesting actions for.
-                        // Keep an action only when its current-document edit is relevant to
-                        // the requested range, but do not claim an association we cannot
-                        // establish from the request context.
+                        // Keep an action only when its originating diagnostic is relevant to
+                        // the requested document/range, but do not claim an association we
+                        // cannot establish from the request context.
                         let action_touches_request = {
+                            let Some(origin) = action.diagnostic_origin.as_ref() else {
+                                return Ok(None);
+                            };
                             let snapshot = self.service.snapshot();
                             let document = snapshot.document(&path).ok_or_else(|| {
                                 format!("code-action document is not indexed: '{path}'")
@@ -1167,9 +1170,10 @@ impl LanguageServer {
                                         .map(|end| start..end)
                                 })
                                 .map_err(|error| error.to_string())?;
-                            action.edits.iter().any(|edit| {
-                                edit.path == path && ranges_touch(&edit.range, &requested)
-                            })
+                            // Do not infer provenance from edit targets: a valid fix may
+                            // edit multiple documents, and an unrelated file-wide edit must
+                            // not make it eligible for this request.
+                            diagnostic_origin_touches_request(origin, &path, &requested)
                         };
                         if !action_touches_request {
                             return Ok(None);
@@ -1797,6 +1801,14 @@ fn ranges_touch(left: &std::ops::Range<usize>, right: &std::ops::Range<usize>) -
         && right.start <= left.end
 }
 
+fn diagnostic_origin_touches_request(
+    origin: &LanguageDiagnosticOrigin,
+    path: &str,
+    requested: &std::ops::Range<usize>,
+) -> bool {
+    origin.path == path && ranges_touch(&origin.range, requested)
+}
+
 fn lsp_selection_range(
     document: &Document,
     ranges: Vec<std::ops::Range<usize>>,
@@ -2225,6 +2237,25 @@ mod tests {
         assert_eq!(action.title, "Remove unresolved import 'missing'");
         assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
         assert!(action.diagnostics.is_none());
+    }
+
+    #[test]
+    fn diagnostic_origin_filter_requires_requested_document_not_edit_target() {
+        let requested = 7..23;
+        let origin = LanguageDiagnosticOrigin {
+            path: "project/src/main.stasis".to_string(),
+            range: 7..23,
+        };
+        assert!(diagnostic_origin_touches_request(
+            &origin,
+            "project/src/main.stasis",
+            &requested
+        ));
+        assert!(!diagnostic_origin_touches_request(
+            &origin,
+            "project/src/helper.stasis",
+            &requested
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- carry source diagnostic provenance into language-service quick fixes
- use diagnostic origin, not edit targets, when VS Code omits request diagnostics
- reproduce the packaged nested-project didOpen/didChange/code-action sequence

## Validation
- cargo fmt --all -- --check
- cargo test -p stasis_language_service (33 passed)
- cargo test -p stasis_lsp (23 passed)
- git diff --check
- pre-commit checks

Theory gained: packaged VS Code may send an empty code-action diagnostic context; relevance must come from the current compiler diagnostic's document and range, because edit targets are not reliable diagnostic provenance.