### PR TITLE
Fix packaged quick fixes with lexical shadowing

### DIFF
--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -3037,6 +3037,39 @@ function @effects(state) tick(): i32 { left(state); return 0; }
     }
 
     #[test]
+    fn local_and_parameter_types_shadow_same_named_globals_in_data_flow_validation() {
+        let mut compiler = Compiler::new();
+        compiler.upsert_file(
+            "shadowing.stasis",
+            r#"
+global value: i32;
+
+function parameter_value(value: f32): f32 {
+    return value + 1.0;
+}
+
+function local_value(): f32 {
+    let value: f32[2];
+    value[0] = 1.0;
+    return value[0];
+}
+
+function global_value(): i32 {
+    return value;
+}
+
+function main(): i32 {
+    return global_value() + f32_to_i32(parameter_value(2.0) + local_value());
+}
+"#,
+        );
+
+        compiler
+            .check()
+            .expect("locals and parameters must shadow same-named globals");
+    }
+
+    #[test]
     fn data_flow_resolves_overloads_with_nested_intrinsic_arguments() {
         let mut compiler = Compiler::new();
         compiler.upsert_file(

--- a/crates/stasis_compiler/src/compiler.rs
+++ b/crates/stasis_compiler/src/compiler.rs
@@ -3042,10 +3042,12 @@ function @effects(state) tick(): i32 { left(state); return 0; }
         compiler.upsert_file(
             "shadowing.stasis",
             r#"
-global value: i32;
+global value: i32[2];
+global float_values: f32[2];
 
-function parameter_value(value: f32): f32 {
-    return value + 1.0;
+function parameter_value(value: f32[2]): f32 {
+    value[0] = 1.0;
+    return value[0] + 1.0;
 }
 
 function local_value(): f32 {
@@ -3055,11 +3057,11 @@ function local_value(): f32 {
 }
 
 function global_value(): i32 {
-    return value;
+    return value[0];
 }
 
 function main(): i32 {
-    return global_value() + f32_to_i32(parameter_value(2.0) + local_value());
+    return global_value() + f32_to_i32(parameter_value(float_values) + local_value());
 }
 "#,
         );

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -2489,11 +2489,18 @@ fn expression_type(
             suffix,
             ..
         } => {
-            if let Some(type_id) = context
-                .path_types
-                .get(&indexed_state_path(collection_path, suffix))
-            {
-                return Some(*type_id);
+            // Indexed wildcard paths are compiler-global metadata.  A local
+            // or parameter with the same root must be resolved first, or an
+            // unrelated global array can override its element type.
+            let root = root_name(collection_path);
+            let has_lexical_root = local_types.contains_key(root) || aliases.contains_key(root);
+            if !has_lexical_root {
+                if let Some(type_id) = context
+                    .path_types
+                    .get(&indexed_state_path(collection_path, suffix))
+                {
+                    return Some(*type_id);
+                }
             }
             let collection = path_type(collection_path, context, local_types, aliases)?;
             let element = context.types.indexed_element_type_id(collection)?;

--- a/crates/stasis_compiler/src/data_flow.rs
+++ b/crates/stasis_compiler/src/data_flow.rs
@@ -2539,17 +2539,21 @@ fn path_type(
     local_types: &BTreeMap<String, TypeId>,
     aliases: &BTreeMap<String, String>,
 ) -> Option<TypeId> {
-    if let Some(type_id) = context.path_types.get(path) {
-        return Some(*type_id);
-    }
     let root = root_name(path);
-    let root_type = local_types.get(root).copied().or_else(|| {
-        aliases
-            .get(root)
-            .and_then(|alias| context.path_types.get(alias).copied())
-    })?;
     let suffix = path.strip_prefix(root)?.trim_start_matches('.');
-    field_suffix_type(root_type, suffix, &context.field_types)
+
+    // A local or parameter shadows a global with the same path root.  Resolve
+    // the complete local path before falling back to the compiler's global
+    // path table; otherwise a workspace file can make a local f32 look like
+    // an unrelated global i32 during semantic validation.
+    if let Some(root_type) = local_types.get(root).copied() {
+        return field_suffix_type(root_type, suffix, &context.field_types);
+    }
+    if let Some(alias) = aliases.get(root) {
+        let root_type = context.path_types.get(alias).copied()?;
+        return field_suffix_type(root_type, suffix, &context.field_types);
+    }
+    context.path_types.get(path).copied()
 }
 
 fn field_suffix_type(

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -3357,6 +3357,13 @@ mod tests {
         let unused_path = root.join("src/unused.stasis");
         let unused_source = include_str!("../../../vscode-stasis/test/fixture/src/unused.stasis");
         fs::write(&unused_path, unused_source).expect("fixture unused source");
+        // The VS Code formatter opens a workspace-root document before asking
+        // for the import quick fix.  Keep the same unrelated global here: it
+        // must not shadow the f32 locals/parameters in the materialized stdlib.
+        let format_path = root.join(format!("format-input-{}.stasis", std::process::id()));
+        let format_path_text = format_path.to_string_lossy().replace('\\', "/");
+        let format_source = "global value: i32;\n";
+        fs::write(&format_path, format_source).expect("fixture formatter source");
         let toolchain_source = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src");
         let mut toolchain_documents = Vec::new();
         for directory in ["", "internal", "testing"] {
@@ -3392,6 +3399,7 @@ mod tests {
             unused_path.to_string_lossy().replace('\\', "/"),
             unused_source,
         );
+        service.set_disk_document(format_path_text, format_source);
         for (path, source) in toolchain_documents {
             service.set_disk_document(path, source);
         }

--- a/crates/stasis_language_service/src/lib.rs
+++ b/crates/stasis_language_service/src/lib.rs
@@ -3335,6 +3335,18 @@ mod tests {
         ));
         fs::remove_dir_all(&root).ok();
         fs::create_dir_all(root.join("src")).expect("fixture source directory");
+        fs::write(
+            root.join("stasis.json"),
+            r#"{
+  "manifest_version": 1,
+  "name": "vscode_e2e",
+  "entry": "src/main.stasis",
+  "tests": "tests",
+  "output": "build",
+  "stdlib": "toolchain"
+}"#,
+        )
+        .expect("fixture manifest");
         let path = root.join("src/main.stasis");
         let path_text = path.to_string_lossy().replace('\\', "/");
         let source = include_str!("../../../vscode-stasis/test/fixture/src/main.stasis");
@@ -3346,6 +3358,7 @@ mod tests {
         let unused_source = include_str!("../../../vscode-stasis/test/fixture/src/unused.stasis");
         fs::write(&unused_path, unused_source).expect("fixture unused source");
         let toolchain_source = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../src");
+        let mut toolchain_documents = Vec::new();
         for directory in ["", "internal", "testing"] {
             let source_directory = toolchain_source.join("stdlib").join(directory);
             let cached_directory = root
@@ -3357,10 +3370,18 @@ mod tests {
                 if entry.path().extension().and_then(|value| value.to_str()) != Some("stasis") {
                     continue;
                 }
-                fs::copy(entry.path(), cached_directory.join(entry.file_name()))
-                    .expect("cached toolchain source");
+                let cached_path = cached_directory.join(entry.file_name());
+                fs::copy(entry.path(), &cached_path).expect("cached toolchain source");
+                toolchain_documents.push((
+                    cached_path.to_string_lossy().replace('\\', "/"),
+                    fs::read_to_string(entry.path()).expect("toolchain source text"),
+                ));
             }
         }
+        assert!(toolchain_documents.iter().any(|(path, source)| {
+            path.ends_with("/stdlib/memory.stasis")
+                && source.contains("mem_set_f32(dst, dst_cap, dst_index, 0.0, count)")
+        }));
         let mut service = LanguageService::new(root.to_string_lossy()).expect("language service");
         service.set_disk_document(path_text.clone(), source);
         service.set_disk_document(
@@ -3371,6 +3392,9 @@ mod tests {
             unused_path.to_string_lossy().replace('\\', "/"),
             unused_source,
         );
+        for (path, source) in toolchain_documents {
+            service.set_disk_document(path, source);
+        }
 
         let report = service.diagnostics();
         assert!(
@@ -3417,6 +3441,23 @@ mod tests {
             Some(path_text.as_str())
         );
         assert_eq!(actions[0].edits[0].path, path_text);
+
+        let memory_source = "import \"../.stasis_cache/toolchain/src/stdlib/memory.stasis\";\n\
+import \"missing.stasis\";\n\
+global memory_probe: f32[1];\n\
+function main(): i32 { return mem_zero_f32(memory_probe, 1, 0, 1); }\n";
+        service.open_document(path_text.clone(), 3, memory_source);
+        let memory_missing = service.diagnostics();
+        assert_eq!(memory_missing.diagnostics.len(), 1);
+        assert_eq!(memory_missing.diagnostics[0].code, "stasis.missingModule");
+        let memory_actions = service
+            .code_actions(&path_text, &["quickfix".to_string()])
+            .expect("memory-backed missing-import quick fix");
+        assert_eq!(memory_actions.len(), 1);
+        assert_eq!(
+            memory_actions[0].title,
+            "Remove unresolved import 'missing'"
+        );
         fs::remove_dir_all(root).ok();
     }
 

--- a/src/stdlib/memory.stasis
+++ b/src/stdlib/memory.stasis
@@ -220,5 +220,5 @@ function mem_set_f32(dst: f32[], dst_cap: i32, dst_index: i32, value: f32, count
 }
 
 function mem_zero_f32(dst: f32[], dst_cap: i32, dst_index: i32, count: i32): i32 {
-    return mem_set_f32(dst, dst_cap, dst_index, 0, count);
+    return mem_set_f32(dst, dst_cap, dst_index, 0.0, count);
 }


### PR DESCRIPTION
Fixes the installed VSIX structured import quick fix failure without weakening compiler validation. The shipped f32 zero helper now uses 0.0, and compiler semantic path resolution gives lexical locals, parameters, and aliases precedence over unrelated workspace globals. Adds compiler and manifest-backed language-service regressions reproducing the VS Code formatter scratch-file collision. Validation: language service 33/33, compiler regression, fresh minimal toolchain packaging, and installed VS Code 1.96 E2E exit 0. Full compiler test execution reached 545 passes; six host AOT/runtime cases were blocked locally by Device Guard and remain covered by PR CI.