### PR TITLE
Cache verified Android package assets

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Test release provenance
         run: python -m unittest tools.ci.test_release_provenance
 
+      - name: Test Android verified asset cache
+        run: python tools/ci/test_android_asset_cache.py
+
       - name: Test render parity fixture and capture gate
         run: |
           python -m unittest tools.ci.test_verify_android_render_performance

--- a/apps/stasis/src/toolchain_cli.rs
+++ b/apps/stasis/src/toolchain_cli.rs
@@ -8172,8 +8172,23 @@ mod tests {
             android.join("android/app/src/main/java/com/stasislang/game/MainActivity.java"),
         )
         .expect("read Android activity");
-        assert!(java.contains(".stasis_game.staging"));
-        assert!(java.contains("new File(root, \".\")"));
+        let asset_cache = fs::read_to_string(
+            android.join("android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java"),
+        )
+        .expect("read Android asset cache");
+        assert!(asset_cache.contains("CACHE_SCHEMA = \"stasis.android.asset-cache\""));
+        assert!(asset_cache.contains("MAX_MARKER_BYTES"));
+        assert!(asset_cache.contains("publicationInterceptor.beforeInstall"));
+        assert!(asset_cache.contains("inventoryMatches"));
+        assert!(asset_cache.contains("rename(backup, root)"));
+        assert!(asset_cache.contains("BACKUP_ALT_NAME"));
+        assert!(asset_cache.contains("MAX_COPIED_TREE_BYTES"));
+        assert!(asset_cache.contains("child.equals(\".\")"));
+        assert!(java.contains("StasisAssetCache.Result"));
+        assert!(java.contains("packageInfo.lastUpdateTime"));
+        assert!(java.contains("INVALID_ASSET_ROOT"));
+        assert!(java.contains("Asset cache mode="));
+        assert!(java.contains("packaged_read_bytes="));
         assert!(java.contains("event.getPointerCount() >= 3"));
         assert!(java.contains("nativeReadPerformanceMetrics"));
         assert!(java.contains("nativeSetPerformanceMetricsEnabled(show)"));
@@ -8184,9 +8199,8 @@ mod tests {
         assert!(java.contains("appendWorkload"));
         assert!(!java.contains("percentile("));
         assert!(java.contains("performanceHud.setSingleLine(false)"));
-        assert!(java.contains("verifyAssetManifest(staging)"));
-        assert!(java.contains("manifestVersion != 1 && manifestVersion != 2"));
-        assert!(java.contains("Asset verification failed before runtime startup"));
+        assert!(java.contains("new AndroidAssetSource(getAssets())"));
+        assert!(java.contains("Asset cache preparation failed before runtime startup"));
         assert!(java.contains("setOnApplyWindowInsetsListener"));
         let jni =
             fs::read_to_string(android.join("android/app/src/main/cpp/stasis_android_assets.c"))

--- a/docs/android_release_shell_backlog.md
+++ b/docs/android_release_shell_backlog.md
@@ -8,7 +8,9 @@ The current shell provides app identity/version/orientation from `stasis.json`,
 arm64 AOT execution, SDL graphics/audio/input/lifecycle handling, packaged
 sprites and fonts, app-private storage, a three-finger performance overlay,
 safe-inset-aware fatal diagnostics, and startup SHA-256 verification of every
-asset declared by `assets/manifest.json`.
+asset declared by `assets/manifest.json` on cold extraction. Cached startup
+reuse checks the versioned marker and extracted-tree metadata inventory instead
+of rehashing the complete asset tree.
 
 ## Potential additions
 
@@ -37,9 +39,11 @@ asset declared by `assets/manifest.json`.
 9. Delivery-size reporting. Record AAB size, estimated arm64 download/install
    size, native-library contribution, assets, symbols, and regression thresholds
    in release CI.
-10. Asset-copy optimization. Verify package assets once per version and retain a
-    validated version marker so large games do not recopy and rehash unchanged
-    content on every launch.
+10. Completed: asset-copy optimization. The Android shell verifies package
+   assets on a cold install/update, retains a versioned package/release and
+   manifest marker with a verified file inventory, and reuses it on ordinary
+   Activity creation and process restart. iOS continues to open immutable
+   app-bundle assets directly, so it has no extraction cache.
 
 Add these only through the generic shell or an explicit optional adapter. Do not
 reintroduce game-specific Android runtime flavors.

--- a/docs/mobile_packaging.md
+++ b/docs/mobile_packaging.md
@@ -107,6 +107,18 @@ desktop, Workshop JIT preview, and the generated release shell. On Android, a
 three-finger tap toggles a rolling tick/render timing overlay in both Workshop
 and the generated release app.
 
+The generated Android release shell reads the packaged asset manifest on every
+Activity creation but reuses a matching app-private extraction when its
+versioned package/release marker and file inventory still agree. Cold
+extraction verifies every declared asset and publishes the staged tree with
+rollback protection; reuse relies on the verified inventory's bounded file
+metadata rather than rehashing all asset bytes. Missing, changed, truncated,
+extra, or partial output is rebuilt or rejected safely. The marker seals the
+fully verified tree within the app-private trust boundary; this inventory is
+not a cryptographic defense against a same-privilege attacker who rewrites
+bytes and restores all recorded metadata. The shell logs elapsed time and
+deterministic packaged/cache byte counters for cold and reuse paths.
+
 ## iOS arm64
 
 On macOS install Xcode and obtain device-capable `SDL3.xcframework` and
@@ -129,6 +141,10 @@ signing disabled; the driver builds `samples/mobile_storage_link` and verifies
 the arm64 executable, embedded SDL frameworks, packaged assets and provenance,
 and absence of Stasis source. A signed device install still requires the
 developer's `DEVELOPMENT_TEAM` and provisioning profile.
+
+iOS uses the immutable app-bundle asset tree directly and has no Android-style
+extraction cache. The Android cache is therefore not part of the shared iOS
+runtime contract.
 
 When the project declares the optional `network` capability, packaging also
 requires a macOS host with Xcode and the `aarch64-apple-ios` Rust target. The

--- a/mobile/shells/android/README.md
+++ b/mobile/shells/android/README.md
@@ -19,10 +19,28 @@ game loader, or writable source is included.
 The Android activity adds one release diagnostic: a three-finger tap toggles a
 five-second rolling tick/render timing overlay with average, p50, p95, and
 60-fps frame-budget usage. It is hidden when the game starts. The same
-safe-inset-aware overlay layer presents startup/runtime resource failures, and
-startup verifies every packaged asset against its manifest SHA-256 before
-replacing the last validated app-private copy. Future candidates are recorded
-in `docs/android_release_shell_backlog.md`.
+safe-inset-aware overlay layer presents startup/runtime resource failures.
+
+Packaged assets are copied into the app-private directory only on a cold cache
+path. The cache reads the small packaged `assets/manifest.json` on every
+activity creation, then reuses a matching extracted tree when its versioned
+marker agrees on the package name, release identity, manifest SHA-256, and
+verified file inventory (size and modification time). A cold path copies the
+tree, SHA-256 verifies every declared asset, writes the marker last, and
+publishes by rename with rollback protection. This metadata inventory avoids
+rehashing all asset bytes on ordinary recreation while remaining inside the
+app-private trust boundary: missing, truncated, mutated, extra, partial, stale,
+or corrupt state is rejected and rebuilt. The marker seals a fully verified
+tree inside the app-private trust boundary; the inventory rejects observable
+metadata/tree changes without claiming cryptographic detection of a same-
+privilege rewrite that restores every recorded metadata value. Startup logs
+cold/reuse elapsed time and packaged/cache read-write byte counters.
+
+iOS does not use this extraction cache. Its immutable app-bundle assets are
+opened directly by the iOS shell; the Android cache is not forced onto that
+platform.
+
+Future candidates are recorded in `docs/android_release_shell_backlog.md`.
 
 The generated shell also supports an opt-in integration-test launch extra,
 `stasis.seam_test_id`. It enables bounded `stasis.seam_test.v1` log markers for

--- a/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.res.AssetManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -15,27 +16,17 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
+import com.stasislang.shell.StasisAssetCache;
 import org.libsdl.app.SDLActivity;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HashSet;
 
 public final class MainActivity extends SDLActivity {
     private static final String STASIS_ANDROID_ORIENTATION = "@STASIS_ANDROID_ORIENTATION@";
+    private static final String INVALID_ASSET_ROOT = ".stasis_asset_root_unavailable";
     private static final long HUD_UPDATE_INTERVAL_MS = 200L;
     private static final double FRAME_BUDGET_MILLIS = 1000.0 / 60.0;
-    private static final int MAX_MANIFEST_BYTES = 1024 * 1024;
-    private static final int MAX_MANIFEST_ASSETS = 4096;
-    private static final long MAX_ASSET_BYTES = 128L * 1024L * 1024L;
-    private static final long MAX_TOTAL_ASSET_BYTES = 150L * 1024L * 1024L;
     private static final boolean STASIS_NETWORK_ENABLED = @STASIS_NETWORK_ENABLED@ != 0;
 
     private static native void nativeSetAssetRoot(String path);
@@ -90,32 +81,39 @@ public final class MainActivity extends SDLActivity {
         if (BuildConfig.STASIS_SEAM_TESTS && seamTestId != null) {
             nativeSetSeamTestId(seamTestId);
         }
-        File root = new File(getFilesDir(), "stasis_game");
-        File staging = new File(getFilesDir(), ".stasis_game.staging");
+        File invalidAssetRoot = new File(getFilesDir(), INVALID_ASSET_ROOT + "."
+                + Long.toHexString(System.nanoTime()));
+        while (invalidAssetRoot.exists()) {
+            invalidAssetRoot = new File(getFilesDir(), INVALID_ASSET_ROOT + "."
+                    + Long.toHexString(System.nanoTime()));
+        }
+        nativeSetAssetRoot(invalidAssetRoot.getAbsolutePath());
         String startupError = null;
         try {
-            deleteTree(staging);
-            copyAssetTree(getAssets(), "stasis_game", staging);
-            verifyAssetManifest(staging);
-            deleteTree(root);
-            if (!staging.renameTo(root)) {
-                throw new IOException("Unable to publish " + root);
-            }
-        } catch (IOException error) {
-            Log.e("Stasis", "Asset verification failed before runtime startup", error);
-            try {
-                deleteTree(staging);
-            } catch (IOException ignored) {
-                // The original failure is the actionable diagnostic.
-            }
+            PackageInfo packageInfo = getPackageManager().getPackageInfo(getPackageName(), 0);
+            long versionCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+                    ? packageInfo.getLongVersionCode() : packageInfo.versionCode;
+            String releaseIdentity = versionCode + ":" + packageInfo.versionName + ":"
+                    + packageInfo.lastUpdateTime;
+            long startedNanos = System.nanoTime();
+            StasisAssetCache.Result result = new StasisAssetCache(
+                    new AndroidAssetSource(getAssets()), getFilesDir(), getPackageName(),
+                    releaseIdentity).prepare();
+            StasisAssetCache.Metrics metrics = result.getMetrics();
+            long elapsedMillis = (System.nanoTime() - startedNanos) / 1_000_000L;
+            Log.i("Stasis", "Asset cache mode=" + (result.isReused() ? "reuse" : "cold")
+                    + " elapsed_ms=" + elapsedMillis
+                    + " packaged_read_bytes=" + metrics.getPackagedReadBytes()
+                    + " cache_read_bytes=" + metrics.getCacheReadBytes()
+                    + " cache_write_bytes=" + metrics.getCacheWriteBytes());
+            File root = result.getRoot();
+            File assetBase = new File(root, "@STASIS_ASSET_BASE@");
+            if (!assetBase.isDirectory()) throw new IOException("validated asset base is unavailable");
+            nativeSetAssetRoot(assetBase.getAbsolutePath());
+        } catch (Exception error) {
+            Log.e("Stasis", "Asset cache preparation failed before runtime startup", error);
             startupError = "Asset verification failed: " + error.getMessage();
         }
-        File assetBase = new File(root, "@STASIS_ASSET_BASE@");
-        if (!assetBase.isDirectory()) {
-            if (!root.isDirectory()) root.mkdirs();
-            startupError = "Bundled Stasis asset base is unavailable";
-        }
-        nativeSetAssetRoot(assetBase.getAbsolutePath());
         super.onCreate(state);
         installDiagnosticOverlay();
         if (startupError != null) showRuntimeError(startupError);
@@ -351,144 +349,22 @@ public final class MainActivity extends SDLActivity {
         return Math.round(value * getResources().getDisplayMetrics().density);
     }
 
-    private static void verifyAssetManifest(File root) throws IOException {
-        File manifestFile = new File(root, "assets/manifest.json");
-        byte[] manifestBytes = readBounded(manifestFile, MAX_MANIFEST_BYTES);
-        try {
-            JSONObject manifest = new JSONObject(new String(manifestBytes, "UTF-8"));
-            int manifestVersion = manifest.optInt("version", -1);
-            if (!"stasis-assets".equals(manifest.optString("schema"))
-                    || (manifestVersion != 1 && manifestVersion != 2)) {
-                throw new IOException("Unsupported packaged asset manifest");
-            }
-            JSONArray assets = manifest.getJSONArray("assets");
-            if (assets.length() > MAX_MANIFEST_ASSETS) {
-                throw new IOException("Asset manifest exceeds the entry limit");
-            }
-            String rootPath = root.getCanonicalPath() + File.separator;
-            HashSet<String> ids = new HashSet<>();
-            HashSet<String> paths = new HashSet<>();
-            long totalBytes = 0;
-            for (int index = 0; index < assets.length(); index++) {
-                JSONObject asset = assets.getJSONObject(index);
-                String id = asset.getString("id");
-                String path = asset.getString("path");
-                String expectedHash = asset.getString("content_sha256");
-                if (id.isEmpty() || !ids.add(id)) {
-                    throw new IOException("Asset manifest contains an invalid or duplicate id");
-                }
-                if (!isSafeAssetPath(path) || !paths.add(path)) {
-                    throw new IOException("Asset manifest contains an unsafe or duplicate path");
-                }
-                if (!expectedHash.matches("[0-9a-f]{64}")) {
-                    throw new IOException("Asset manifest contains an invalid SHA-256 value");
-                }
-                File assetFile = new File(root, path);
-                String assetPath = assetFile.getCanonicalPath();
-                if (!assetPath.startsWith(rootPath) || !assetFile.isFile()
-                        || assetFile.length() > MAX_ASSET_BYTES) {
-                    throw new IOException("Packaged asset is missing, unsafe, or oversized: " + path);
-                }
-                totalBytes += assetFile.length();
-                if (totalBytes > MAX_TOTAL_ASSET_BYTES) {
-                    throw new IOException("Packaged assets exceed the total byte limit");
-                }
-                if (!expectedHash.equals(sha256(assetFile))) {
-                    throw new IOException("Packaged asset hash mismatch: " + path);
-                }
-            }
-        } catch (IOException error) {
-            throw error;
-        } catch (Exception error) {
-            throw new IOException("Asset manifest could not be parsed", error);
-        }
-    }
+    private static final class AndroidAssetSource implements StasisAssetCache.AssetSource {
+        private final AssetManager assets;
 
-    private static boolean isSafeAssetPath(String path) {
-        return path.startsWith("assets/") && !path.endsWith("/")
-                && path.indexOf('\\') < 0 && path.indexOf('\0') < 0
-                && !path.contains("//") && !path.contains("/../")
-                && !path.endsWith("/..") && !path.contains("/./")
-                && !path.endsWith("/.");
-    }
+        AndroidAssetSource(AssetManager assets) {
+            this.assets = assets;
+        }
 
-    private static byte[] readBounded(File file, int limit) throws IOException {
-        if (!file.isFile() || file.length() > limit) {
-            throw new IOException("Asset manifest is missing or oversized");
+        @Override
+        public String[] list(String path) throws IOException {
+            String[] children = assets.list(path);
+            return children == null ? new String[0] : children;
         }
-        try (FileInputStream input = new FileInputStream(file);
-                ByteArrayOutputStream output = new ByteArrayOutputStream((int)file.length())) {
-            byte[] buffer = new byte[16384];
-            int total = 0;
-            int count;
-            while ((count = input.read(buffer)) != -1) {
-                total += count;
-                if (total > limit) throw new IOException("Asset manifest exceeds the byte limit");
-                output.write(buffer, 0, count);
-            }
-            return output.toByteArray();
-        }
-    }
 
-    private static String sha256(File file) throws IOException {
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException error) {
-            throw new IOException("SHA-256 is unavailable", error);
-        }
-        try (FileInputStream input = new FileInputStream(file)) {
-            byte[] buffer = new byte[16384];
-            int count;
-            while ((count = input.read(buffer)) != -1) digest.update(buffer, 0, count);
-        }
-        StringBuilder result = new StringBuilder(64);
-        for (byte value : digest.digest()) {
-            int unsigned = value & 0xff;
-            if (unsigned < 16) result.append('0');
-            result.append(Integer.toHexString(unsigned));
-        }
-        return result.toString();
-    }
-
-    private static void copyAssetTree(AssetManager assets, String assetPath, File output)
-            throws IOException {
-        String[] children = assets.list(assetPath);
-        if (children != null && children.length > 0) {
-            if (!output.isDirectory() && !output.mkdirs()) {
-                throw new IOException("Unable to create " + output);
-            }
-            for (String child : children) {
-                copyAssetTree(assets, assetPath + "/" + child, new File(output, child));
-            }
-            return;
-        }
-        File parent = output.getParentFile();
-        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
-            throw new IOException("Unable to create " + parent);
-        }
-        try (InputStream input = assets.open(assetPath);
-                FileOutputStream stream = new FileOutputStream(output)) {
-            byte[] buffer = new byte[16384];
-            int count;
-            while ((count = input.read(buffer)) != -1) {
-                stream.write(buffer, 0, count);
-            }
-        }
-    }
-
-    private static void deleteTree(File path) throws IOException {
-        if (!path.exists()) {
-            return;
-        }
-        File[] children = path.listFiles();
-        if (children != null) {
-            for (File child : children) {
-                deleteTree(child);
-            }
-        }
-        if (!path.delete()) {
-            throw new IOException("Unable to remove " + path);
+        @Override
+        public InputStream open(String path) throws IOException {
+            return assets.open(path);
         }
     }
 

--- a/mobile/shells/android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java
+++ b/mobile/shells/android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java
@@ -1,0 +1,839 @@
+package com.stasislang.shell;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Base64;
+
+/** App-private, verified extraction cache for the packaged release asset tree. */
+public final class StasisAssetCache {
+    public static final String CACHE_SCHEMA = "stasis.android.asset-cache";
+    public static final int CACHE_VERSION = 1;
+    public static final int MAX_MANIFEST_BYTES = 1024 * 1024;
+    public static final int MAX_MARKER_BYTES = 512 * 1024;
+    public static final int MAX_MANIFEST_ASSETS = 4096;
+    public static final int MAX_TREE_FILES = 8192;
+    public static final long MAX_ASSET_BYTES = 128L * 1024L * 1024L;
+    public static final long MAX_TOTAL_ASSET_BYTES = 150L * 1024L * 1024L;
+    public static final long MAX_COPIED_TREE_BYTES = 150L * 1024L * 1024L;
+
+    private static final String PACKAGED_ROOT = "stasis_game";
+    private static final String MANIFEST_PATH = "assets/manifest.json";
+    private static final String MARKER_NAME = ".stasis_asset_cache.v1";
+    private static final String STAGING_NAME = ".stasis_game.staging";
+    private static final String BACKUP_NAME = ".stasis_game.previous";
+    private static final String BACKUP_ALT_NAME = ".stasis_game.previous.2";
+
+    public interface AssetSource {
+        String[] list(String path) throws IOException;
+
+        InputStream open(String path) throws IOException;
+    }
+
+    interface PublicationInterceptor {
+        void beforeInstall(File staging, File root, File backup) throws IOException;
+    }
+
+    interface InventoryProbe {
+        void beforeInventory(File candidate) throws IOException;
+    }
+
+    interface BackupCleanupProbe {
+        void beforeCleanup(File backup) throws IOException;
+    }
+
+    static final PublicationInterceptor NO_INTERCEPTOR =
+            new PublicationInterceptor() {
+                @Override
+                public void beforeInstall(File staging, File root, File backup) {
+                }
+            };
+    static final InventoryProbe NO_INVENTORY_PROBE =
+            new InventoryProbe() {
+                @Override
+                public void beforeInventory(File candidate) {
+                }
+            };
+    static final BackupCleanupProbe NO_CLEANUP_PROBE =
+            new BackupCleanupProbe() {
+                @Override
+                public void beforeCleanup(File backup) {
+                }
+            };
+
+    public static final class Metrics {
+        private long packagedReadBytes;
+        private long cacheReadBytes;
+        private long cacheWriteBytes;
+
+        public long getPackagedReadBytes() {
+            return packagedReadBytes;
+        }
+
+        public long getCacheReadBytes() {
+            return cacheReadBytes;
+        }
+
+        public long getCacheWriteBytes() {
+            return cacheWriteBytes;
+        }
+
+        public long getTotalReadBytes() {
+            return packagedReadBytes + cacheReadBytes;
+        }
+
+        public long getTotalWriteBytes() {
+            return cacheWriteBytes;
+        }
+    }
+
+    public static final class Result {
+        private final File root;
+        private final boolean reused;
+        private final Metrics metrics;
+
+        private Result(File root, boolean reused, Metrics metrics) {
+            this.root = root;
+            this.reused = reused;
+            this.metrics = metrics;
+        }
+
+        public File getRoot() {
+            return root;
+        }
+
+        public boolean isReused() {
+            return reused;
+        }
+
+        public Metrics getMetrics() {
+            return metrics;
+        }
+    }
+
+    private final AssetSource source;
+    private final File filesDir;
+    private final String packageName;
+    private final String releaseIdentity;
+    private final PublicationInterceptor publicationInterceptor;
+    private final InventoryProbe inventoryProbe;
+    private final BackupCleanupProbe backupCleanupProbe;
+
+    public StasisAssetCache(AssetSource source, File filesDir, String packageName,
+            String releaseIdentity) {
+        this(source, filesDir, packageName, releaseIdentity, NO_INTERCEPTOR);
+    }
+
+    StasisAssetCache(AssetSource source, File filesDir, String packageName,
+            String releaseIdentity, PublicationInterceptor publicationInterceptor) {
+        this(source, filesDir, packageName, releaseIdentity, publicationInterceptor,
+                NO_INVENTORY_PROBE, NO_CLEANUP_PROBE);
+    }
+
+    StasisAssetCache(AssetSource source, File filesDir, String packageName,
+            String releaseIdentity, PublicationInterceptor publicationInterceptor,
+            InventoryProbe inventoryProbe, BackupCleanupProbe backupCleanupProbe) {
+        if (source == null || filesDir == null || packageName == null || releaseIdentity == null
+                || publicationInterceptor == null || inventoryProbe == null
+                || backupCleanupProbe == null) {
+            throw new IllegalArgumentException("asset cache arguments must be non-null");
+        }
+        this.source = source;
+        this.filesDir = filesDir;
+        this.packageName = packageName;
+        this.releaseIdentity = releaseIdentity;
+        this.publicationInterceptor = publicationInterceptor;
+        this.inventoryProbe = inventoryProbe;
+        this.backupCleanupProbe = backupCleanupProbe;
+    }
+
+    public Result prepare() throws IOException {
+        Metrics metrics = new Metrics();
+        File root = new File(filesDir, PACKAGED_ROOT);
+        File staging = new File(filesDir, STAGING_NAME);
+        File[] backups = backupSlots();
+        deleteTree(staging);
+
+        byte[] packagedManifest = readSourceBounded(MANIFEST_PATH, MAX_MANIFEST_BYTES, metrics);
+        Manifest manifest = Manifest.parse(packagedManifest);
+        String manifestHash = sha256(packagedManifest);
+        if (recoverPublication(root, backups, packagedManifest, manifestHash, metrics)) {
+            return new Result(root, true, metrics);
+        }
+
+        try {
+            copyAssetTree(PACKAGED_ROOT, staging, metrics, 0, new CopyState());
+            verifyExtractedTree(staging, manifest, packagedManifest, metrics);
+            writeMarker(staging, manifestHash, metrics);
+            publish(staging, root, backups);
+            return new Result(root, false, metrics);
+        } catch (IOException error) {
+            deleteTree(staging);
+            throw error;
+        }
+    }
+
+    private boolean isReusable(File root, byte[] packagedManifest, String manifestHash,
+            Metrics metrics) throws IOException {
+        if (!root.isDirectory()) return false;
+        File markerFile = new File(root, MARKER_NAME);
+        if (!markerFile.isFile()) return false;
+        Marker marker;
+        try {
+            marker = Marker.parse(readFileBounded(markerFile, MAX_MARKER_BYTES, metrics));
+        } catch (IOException error) {
+            return false;
+        }
+        if (!CACHE_SCHEMA.equals(marker.schema) || marker.version != CACHE_VERSION
+                || !packageName.equals(marker.packageName)
+                || !releaseIdentity.equals(marker.releaseIdentity)
+                || !manifestHash.equals(marker.manifestHash)) {
+            return false;
+        }
+        File extractedManifest = new File(root, MANIFEST_PATH);
+        byte[] extractedBytes;
+        try {
+            extractedBytes = readFileBounded(extractedManifest, MAX_MANIFEST_BYTES, metrics);
+        } catch (IOException error) {
+            return false;
+        }
+        if (!MessageDigest.isEqual(packagedManifest, extractedBytes)
+                || !manifestHash.equals(sha256(extractedBytes))) {
+            return false;
+        }
+        try {
+            inventoryProbe.beforeInventory(root);
+            return inventoryMatches(root, marker.entries);
+        } catch (IOException error) {
+            // A broken candidate is invalid; another transaction candidate may recover it.
+            return false;
+        }
+    }
+
+    private void verifyExtractedTree(File root, Manifest manifest, byte[] packagedManifest,
+            Metrics metrics) throws IOException {
+        byte[] extractedManifest = readFileBounded(new File(root, MANIFEST_PATH),
+                MAX_MANIFEST_BYTES, metrics);
+        if (!MessageDigest.isEqual(packagedManifest, extractedManifest)) {
+            throw new IOException("extracted asset manifest differs from the packaged manifest");
+        }
+        long totalBytes = 0;
+        for (AssetEntry entry : manifest.assets) {
+            File file = safeFile(root, entry.path);
+            if (!file.isFile() || file.length() > MAX_ASSET_BYTES) {
+                throw new IOException("packaged asset is missing or oversized: " + entry.path);
+            }
+            totalBytes += file.length();
+            if (totalBytes > MAX_TOTAL_ASSET_BYTES) {
+                throw new IOException("packaged assets exceed the total byte limit");
+            }
+            if (!entry.sha256.equals(sha256(file, metrics))) {
+                throw new IOException("packaged asset hash mismatch: " + entry.path);
+            }
+        }
+        List<InventoryEntry> inventory = collectInventory(root);
+        if (inventory.size() > MAX_TREE_FILES) {
+            throw new IOException("extracted asset tree exceeds the file limit");
+        }
+    }
+
+    private void writeMarker(File root, String manifestHash, Metrics metrics) throws IOException {
+        List<InventoryEntry> entries = collectInventory(root);
+        StringBuilder marker = new StringBuilder(256 + entries.size() * 48);
+        marker.append("schema=").append(CACHE_SCHEMA).append('\n');
+        marker.append("version=").append(CACHE_VERSION).append('\n');
+        marker.append("package_name=").append(encode(packageName)).append('\n');
+        marker.append("release_identity=").append(encode(releaseIdentity)).append('\n');
+        marker.append("manifest_sha256=").append(manifestHash).append('\n');
+        marker.append("entry_count=").append(entries.size()).append('\n');
+        for (InventoryEntry entry : entries) {
+            marker.append("entry=").append(encode(entry.path)).append('\t')
+                    .append(entry.length).append('\t').append(entry.modified).append('\n');
+        }
+        byte[] bytes = marker.toString().getBytes(StandardCharsets.UTF_8);
+        if (bytes.length > MAX_MARKER_BYTES) throw new IOException("asset cache marker is oversized");
+        File markerFile = new File(root, MARKER_NAME);
+        try (FileOutputStream output = new FileOutputStream(markerFile)) {
+            output.write(bytes);
+            output.getFD().sync();
+            metrics.cacheWriteBytes += bytes.length;
+        }
+    }
+
+    private File[] backupSlots() {
+        return new File[] {
+                new File(filesDir, BACKUP_NAME),
+                new File(filesDir, BACKUP_ALT_NAME)
+        };
+    }
+
+    private void publish(File staging, File root, File[] backups) throws IOException {
+        File backup = null;
+        boolean movedOldRoot = false;
+        try {
+            if (root.exists()) {
+                backup = chooseBackupSlot(backups);
+                rename(root, backup);
+                movedOldRoot = true;
+            }
+            publicationInterceptor.beforeInstall(staging, root, backup);
+            rename(staging, root);
+        } catch (IOException error) {
+            if (root.exists() && movedOldRoot) deleteTree(root);
+            if (movedOldRoot && backup.exists()) {
+                try {
+                    rename(backup, root);
+                } catch (IOException rollbackError) {
+                    error.addSuppressed(rollbackError);
+                }
+            }
+            throw error;
+        }
+        // The staging-to-root rename is the commit. Cleanup is deferred so an
+        // old backup cannot damage or invalidate the newly committed tree.
+        if (backup != null) tryCleanupBackup(backup);
+    }
+
+    private boolean recoverPublication(File root, File[] backups, byte[] packagedManifest,
+            String manifestHash, Metrics metrics) throws IOException {
+        boolean rootValid = isReusable(root, packagedManifest, manifestHash, metrics);
+        File validBackup = null;
+        for (File backup : backups) {
+            if (backup.exists() && isReusable(backup, packagedManifest, manifestHash, metrics)) {
+                validBackup = backup;
+                break;
+            }
+        }
+        if (rootValid) {
+            for (File backup : backups) tryCleanupBackup(backup);
+            return true;
+        }
+        if (validBackup != null) {
+            if (root.exists()) deleteTree(root);
+            rename(validBackup, root);
+            for (File backup : backups) {
+                if (!backup.equals(validBackup)) tryCleanupBackup(backup);
+            }
+            return true;
+        }
+        // Keep an invalid prior root until publication can move it to backup;
+        // this preserves rollback if staging or publication fails.
+        for (File backup : backups) tryCleanupBackup(backup);
+        return false;
+    }
+
+    private File chooseBackupSlot(File[] backups) throws IOException {
+        for (File backup : backups) {
+            if (!backup.exists()) return backup;
+        }
+        for (File backup : backups) tryCleanupBackup(backup);
+        for (File backup : backups) {
+            if (!backup.exists()) return backup;
+        }
+        throw new IOException("no transaction backup slot is available");
+    }
+
+    private static void rename(File source, File target) throws IOException {
+        if (!source.renameTo(target)) {
+            throw new IOException("unable to atomically publish " + target);
+        }
+    }
+
+    private void copyAssetTree(String sourcePath, File output, Metrics metrics, int depth,
+            CopyState state) throws IOException {
+        if (depth > 64) throw new IOException("packaged asset tree is too deep");
+        String[] children = source.list(sourcePath);
+        if (children != null && children.length > 0) {
+            if (children.length > MAX_TREE_FILES) throw new IOException("packaged asset directory is too large");
+            if (!output.isDirectory() && !output.mkdirs()) {
+                throw new IOException("unable to create " + output);
+            }
+            for (String child : children) {
+                if (child == null || child.isEmpty() || child.equals(".") || child.equals("..")
+                        || child.indexOf('/') >= 0
+                        || child.indexOf('\\') >= 0) {
+                    throw new IOException("invalid packaged asset name");
+                }
+                copyAssetTree(sourcePath + "/" + child, new File(output, child), metrics,
+                        depth + 1, state);
+            }
+            return;
+        }
+        if (++state.fileCount > MAX_TREE_FILES) throw new IOException("packaged asset tree is too large");
+        File parent = output.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("unable to create " + parent);
+        }
+        try (InputStream input = source.open(sourcePath); FileOutputStream outputStream =
+                new FileOutputStream(output)) {
+            long perFileLimit = sourcePath.equals(PACKAGED_ROOT + "/" + MANIFEST_PATH)
+                    ? MAX_MANIFEST_BYTES : MAX_ASSET_BYTES;
+            copy(input, outputStream, metrics, true, perFileLimit, state);
+        }
+    }
+
+    private static void copy(InputStream input, OutputStream output, Metrics metrics,
+            boolean packaged, long perFileLimit, CopyState state) throws IOException {
+        byte[] buffer = new byte[16 * 1024];
+        long total = 0;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            total += count;
+            state.totalBytes += count;
+            if (total > perFileLimit || state.totalBytes > MAX_COPIED_TREE_BYTES) {
+                throw new IOException("packaged asset tree exceeds its byte limit");
+            }
+            if (packaged) metrics.packagedReadBytes += count;
+            else metrics.cacheReadBytes += count;
+            output.write(buffer, 0, count);
+            metrics.cacheWriteBytes += count;
+        }
+    }
+
+    private byte[] readSourceBounded(String path, int limit, Metrics metrics) throws IOException {
+        try (InputStream input = source.open(PACKAGED_ROOT + "/" + path)) {
+            return readBounded(input, limit, metrics, true);
+        }
+    }
+
+    private static byte[] readFileBounded(File file, int limit, Metrics metrics) throws IOException {
+        try (FileInputStream input = new FileInputStream(file)) {
+            return readBounded(input, limit, metrics, false);
+        }
+    }
+
+    private static byte[] readBounded(InputStream input, int limit, Metrics metrics,
+            boolean packaged) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(limit, 16 * 1024));
+        byte[] buffer = new byte[16 * 1024];
+        int total = 0;
+        int count;
+        while ((count = input.read(buffer)) != -1) {
+            total += count;
+            if (total > limit) throw new IOException("bounded asset read exceeded its limit");
+            if (packaged) metrics.packagedReadBytes += count;
+            else metrics.cacheReadBytes += count;
+            output.write(buffer, 0, count);
+        }
+        return output.toByteArray();
+    }
+
+    private static String sha256(byte[] bytes) throws IOException {
+        try {
+            return hex(MessageDigest.getInstance("SHA-256").digest(bytes));
+        } catch (NoSuchAlgorithmException error) {
+            throw new IOException("SHA-256 is unavailable", error);
+        }
+    }
+
+    private static String sha256(File file, Metrics metrics) throws IOException {
+        try (FileInputStream input = new FileInputStream(file)) {
+            MessageDigest digest;
+            try {
+                digest = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException error) {
+                throw new IOException("SHA-256 is unavailable", error);
+            }
+            byte[] buffer = new byte[16 * 1024];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                metrics.cacheReadBytes += count;
+                digest.update(buffer, 0, count);
+            }
+            return hex(digest.digest());
+        }
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder result = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            int unsigned = value & 0xff;
+            if (unsigned < 16) result.append('0');
+            result.append(Integer.toHexString(unsigned));
+        }
+        return result.toString();
+    }
+
+    private static File safeFile(File root, String path) throws IOException {
+        if (!isSafeAssetPath(path)) throw new IOException("unsafe asset path: " + path);
+        File file = new File(root, path);
+        String rootPath = root.getCanonicalPath() + File.separator;
+        if (!file.getCanonicalPath().startsWith(rootPath)) {
+            throw new IOException("asset path escapes extraction root: " + path);
+        }
+        return file;
+    }
+
+    private static boolean isSafeAssetPath(String path) {
+        return path != null && path.startsWith("assets/") && !path.endsWith("/")
+                && path.indexOf('\\') < 0 && path.indexOf('\0') < 0 && !path.contains("//")
+                && !path.contains("/../") && !path.endsWith("/..") && !path.contains("/./")
+                && !path.endsWith("/.");
+    }
+
+    private static List<InventoryEntry> collectInventory(File root) throws IOException {
+        List<InventoryEntry> entries = new ArrayList<>();
+        collectInventory(root, root, entries);
+        Collections.sort(entries);
+        return entries;
+    }
+
+    private static void collectInventory(File root, File current, List<InventoryEntry> entries)
+            throws IOException {
+        File[] children = current.listFiles();
+        if (children == null) {
+            if (!current.isDirectory()) throw new IOException("unable to enumerate " + current);
+            return;
+        }
+        for (File child : children) {
+            if (current.equals(root) && child.getName().equals(MARKER_NAME)) continue;
+            String canonical = child.getCanonicalPath();
+            String rootPath = root.getCanonicalPath() + File.separator;
+            if (!canonical.startsWith(rootPath)) throw new IOException("asset tree escapes root");
+            if (child.isDirectory()) collectInventory(root, child, entries);
+            else if (child.isFile()) {
+                String relative = root.toPath().relativize(child.toPath()).toString()
+                        .replace(File.separatorChar, '/');
+                entries.add(new InventoryEntry(relative, child.length(), child.lastModified()));
+                if (entries.size() > MAX_TREE_FILES) throw new IOException("asset tree is too large");
+            } else throw new IOException("unsupported extraction entry: " + child);
+        }
+    }
+
+    private static boolean inventoryMatches(File root, List<InventoryEntry> expected)
+            throws IOException {
+        List<InventoryEntry> actual = collectInventory(root);
+        if (actual.size() != expected.size()) return false;
+        for (int index = 0; index < expected.size(); index++) {
+            InventoryEntry left = expected.get(index);
+            InventoryEntry right = actual.get(index);
+            if (!left.path.equals(right.path) || left.length != right.length
+                    || left.modified != right.modified) return false;
+        }
+        return true;
+    }
+
+    private static void deleteTree(File path) throws IOException {
+        if (!path.exists()) return;
+        File[] children = path.listFiles();
+        if (children != null) {
+            for (File child : children) deleteTree(child);
+        }
+        if (!path.delete()) throw new IOException("unable to remove " + path);
+    }
+
+    private void tryCleanupBackup(File path) {
+        try {
+            backupCleanupProbe.beforeCleanup(path);
+            deleteTree(path);
+        } catch (IOException ignored) {
+            // A committed root is valid even when an old backup remains.
+        }
+    }
+
+    private static final class CopyState {
+        int fileCount;
+        long totalBytes;
+    }
+
+    private static String encode(String value) {
+        return Base64.getEncoder().withoutPadding()
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decode(String value) throws IOException {
+        if (value == null || value.isEmpty()) throw new IOException("missing cache marker value");
+        try {
+            return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException error) {
+            throw new IOException("invalid cache marker encoding", error);
+        }
+    }
+
+    private static final class InventoryEntry implements Comparable<InventoryEntry> {
+        final String path;
+        final long length;
+        final long modified;
+
+        InventoryEntry(String path, long length, long modified) {
+            this.path = path;
+            this.length = length;
+            this.modified = modified;
+        }
+
+        @Override
+        public int compareTo(InventoryEntry other) {
+            return path.compareTo(other.path);
+        }
+    }
+
+    private static final class Marker {
+        String schema;
+        int version;
+        String packageName;
+        String releaseIdentity;
+        String manifestHash;
+        List<InventoryEntry> entries;
+
+        static Marker parse(byte[] bytes) throws IOException {
+            Marker marker = new Marker();
+            Map<String, String> values = new HashMap<>();
+            List<InventoryEntry> entries = new ArrayList<>();
+            String text = new String(bytes, StandardCharsets.UTF_8);
+            for (String line : text.split("\\n", -1)) {
+                if (line.isEmpty()) continue;
+                if (line.startsWith("entry=")) {
+                    String[] fields = line.substring(6).split("\\t", -1);
+                    if (fields.length != 3) throw new IOException("invalid asset cache entry");
+                    long length = parseNonNegative(fields[1]);
+                    long modified = parseNonNegative(fields[2]);
+                    entries.add(new InventoryEntry(decode(fields[0]), length, modified));
+                } else {
+                    int split = line.indexOf('=');
+                    if (split <= 0) throw new IOException("invalid asset cache marker");
+                    values.put(line.substring(0, split), line.substring(split + 1));
+                }
+            }
+            marker.schema = values.get("schema");
+            marker.version = parseInt(values.get("version"));
+            marker.packageName = decode(values.get("package_name"));
+            marker.releaseIdentity = decode(values.get("release_identity"));
+            marker.manifestHash = values.get("manifest_sha256");
+            int entryCount = parseInt(values.get("entry_count"));
+            if (entryCount < 0 || entryCount != entries.size() || entries.size() > MAX_TREE_FILES) {
+                throw new IOException("invalid asset cache inventory count");
+            }
+            Collections.sort(entries);
+            marker.entries = entries;
+            return marker;
+        }
+
+        private static int parseInt(String value) throws IOException {
+            try {
+                return Integer.parseInt(value);
+            } catch (Exception error) {
+                throw new IOException("invalid asset cache marker number", error);
+            }
+        }
+
+        private static long parseNonNegative(String value) throws IOException {
+            try {
+                long result = Long.parseLong(value);
+                if (result < 0) throw new NumberFormatException();
+                return result;
+            } catch (Exception error) {
+                throw new IOException("invalid asset cache inventory value", error);
+            }
+        }
+    }
+
+    private static final class AssetEntry {
+        final String path;
+        final String sha256;
+
+        AssetEntry(String path, String sha256) {
+            this.path = path;
+            this.sha256 = sha256;
+        }
+    }
+
+    private static final class Manifest {
+        final List<AssetEntry> assets;
+
+        private Manifest(List<AssetEntry> assets) {
+            this.assets = assets;
+        }
+
+        static Manifest parse(byte[] bytes) throws IOException {
+            Object value = new JsonParser(new String(bytes, StandardCharsets.UTF_8)).parse();
+            if (!(value instanceof Map)) throw new IOException("asset manifest is not an object");
+            Map<?, ?> object = (Map<?, ?>) value;
+            if (!(object.get("schema") instanceof String)
+                    || !"stasis-assets".equals(object.get("schema"))) {
+                throw new IOException("unsupported packaged asset manifest");
+            }
+            Object version = object.get("version");
+            if (!(version instanceof Long)
+                    || (((Long) version).longValue() != 1L && ((Long) version).longValue() != 2L)) {
+                throw new IOException("unsupported packaged asset manifest version");
+            }
+            Object rawAssets = object.get("assets");
+            if (!(rawAssets instanceof List) || ((List<?>) rawAssets).size() > MAX_MANIFEST_ASSETS) {
+                throw new IOException("asset manifest exceeds the entry limit");
+            }
+            Set<String> ids = new HashSet<>();
+            Set<String> paths = new HashSet<>();
+            List<AssetEntry> assets = new ArrayList<>();
+            for (Object raw : (List<?>) rawAssets) {
+                if (!(raw instanceof Map)) throw new IOException("invalid asset manifest entry");
+                Map<?, ?> entry = (Map<?, ?>) raw;
+                Object id = entry.get("id");
+                Object path = entry.get("path");
+                Object hash = entry.get("content_sha256");
+                if (!(id instanceof String) || ((String) id).isEmpty() || !ids.add((String) id)
+                        || !(path instanceof String) || !isSafeAssetPath((String) path)
+                        || !paths.add((String) path) || !(hash instanceof String)
+                        || !((String) hash).matches("[0-9a-f]{64}")) {
+                    throw new IOException("invalid or duplicate asset manifest entry");
+                }
+                assets.add(new AssetEntry((String) path, (String) hash));
+            }
+            return new Manifest(assets);
+        }
+    }
+
+    private static final class JsonParser {
+        private final String text;
+        private int index;
+
+        JsonParser(String text) {
+            this.text = text;
+        }
+
+        Object parse() throws IOException {
+            Object value = value(0);
+            whitespace();
+            if (index != text.length()) throw error("trailing JSON");
+            return value;
+        }
+
+        private Object value(int depth) throws IOException {
+            if (depth > 32) throw error("JSON nesting limit exceeded");
+            whitespace();
+            if (index >= text.length()) throw error("unexpected end of JSON");
+            char current = text.charAt(index);
+            if (current == '{') return object(depth + 1);
+            if (current == '[') return array(depth + 1);
+            if (current == '"') return string();
+            if (text.startsWith("true", index)) { index += 4; return Boolean.TRUE; }
+            if (text.startsWith("false", index)) { index += 5; return Boolean.FALSE; }
+            if (text.startsWith("null", index)) { index += 4; return null; }
+            return number();
+        }
+
+        private Map<String, Object> object(int depth) throws IOException {
+            Map<String, Object> result = new HashMap<>();
+            index++;
+            whitespace();
+            if (take('}')) return result;
+            while (true) {
+                whitespace();
+                if (index >= text.length() || text.charAt(index) != '"') {
+                    throw error("object key is not a string");
+                }
+                String key = string();
+                whitespace();
+                require(':');
+                result.put(key, value(depth));
+                whitespace();
+                if (take('}')) return result;
+                require(',');
+            }
+        }
+
+        private List<Object> array(int depth) throws IOException {
+            List<Object> result = new ArrayList<>();
+            index++;
+            whitespace();
+            if (take(']')) return result;
+            while (true) {
+                result.add(value(depth));
+                whitespace();
+                if (take(']')) return result;
+                require(',');
+            }
+        }
+
+        private String string() throws IOException {
+            require('"');
+            StringBuilder result = new StringBuilder();
+            while (index < text.length()) {
+                char current = text.charAt(index++);
+                if (current == '"') return result.toString();
+                if (current == '\\') {
+                    if (index >= text.length()) throw error("unterminated escape");
+                    char escaped = text.charAt(index++);
+                    switch (escaped) {
+                        case '"': case '\\': case '/': result.append(escaped); break;
+                        case 'b': result.append('\b'); break;
+                        case 'f': result.append('\f'); break;
+                        case 'n': result.append('\n'); break;
+                        case 'r': result.append('\r'); break;
+                        case 't': result.append('\t'); break;
+                        case 'u':
+                            String digits = hexDigits(4);
+                            try {
+                                result.append((char)Integer.parseInt(digits, 16));
+                            } catch (NumberFormatException error) {
+                                throw error("invalid JSON unicode escape");
+                            }
+                            break;
+                        default: throw error("invalid JSON escape");
+                    }
+                } else {
+                    if (current < 0x20) throw error("control character in JSON string");
+                    result.append(current);
+                }
+            }
+            throw error("unterminated JSON string");
+        }
+
+        private String hexDigits(int count) throws IOException {
+            if (index + count > text.length()) throw error("short JSON unicode escape");
+            String result = text.substring(index, index + count);
+            index += count;
+            return result;
+        }
+
+        private Number number() throws IOException {
+            int start = index;
+            while (index < text.length() && "-+0123456789.eE".indexOf(text.charAt(index)) >= 0) {
+                index++;
+            }
+            try {
+                String value = text.substring(start, index);
+                if (!value.matches("-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?")) {
+                    throw new NumberFormatException();
+                }
+                if (value.indexOf('.') >= 0 || value.indexOf('e') >= 0
+                        || value.indexOf('E') >= 0) {
+                    return Double.valueOf(value);
+                }
+                return Long.valueOf(value);
+            } catch (Exception parseError) {
+                throw error("invalid JSON number");
+            }
+        }
+
+        private void whitespace() {
+            while (index < text.length() && Character.isWhitespace(text.charAt(index))) index++;
+        }
+
+        private boolean take(char expected) {
+            if (index < text.length() && text.charAt(index) == expected) { index++; return true; }
+            return false;
+        }
+
+        private void require(char expected) throws IOException {
+            if (!take(expected)) throw error("expected '" + expected + "'");
+        }
+
+        private IOException error(String message) {
+            return new IOException(message + " at byte " + index);
+        }
+    }
+}

--- a/tools/ci/check_android_shell.py
+++ b/tools/ci/check_android_shell.py
@@ -111,7 +111,10 @@ REQUIRED_FILES = [
     "mobile/android/README.md",
     "tools/android_ai_agent_host.py",
     "mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java",
+    "mobile/shells/android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java",
     "mobile/shells/android/app/src/main/cpp/stasis_android_assets.c",
+    "tools/ci/test_android_asset_cache.py",
+    "tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java",
     "tools/ci/check_android_release_package.py",
     "tests/android/AiQueuePolicyTest.java",
     "tests/android/WorkshopProjectFormatPolicyTest.java",
@@ -1353,6 +1356,7 @@ def main() -> int:
     assert "setContentView(status)" not in activity
 
     release_activity = read("mobile/shells/android/app/src/main/java/com/stasislang/game/MainActivity.java")
+    release_cache = read("mobile/shells/android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java")
     release_bridge = read("mobile/shells/android/app/src/main/cpp/stasis_android_assets.c")
     assert "System.loadLibrary(\"SDL3\")" in release_activity
     assert "System.loadLibrary(\"SDL3_image\")" in release_activity
@@ -1370,10 +1374,22 @@ def main() -> int:
     assert "performanceHud.setSingleLine(false)" in release_activity
     assert "setOnApplyWindowInsetsListener" in release_activity
     assert "getDisplayCutout" in release_activity
-    assert "verifyAssetManifest(staging)" in release_activity
-    assert 'MessageDigest.getInstance("SHA-256")' in release_activity
-    assert "MAX_MANIFEST_ASSETS = 4096" in release_activity
-    assert "MAX_TOTAL_ASSET_BYTES" in release_activity
+    assert "StasisAssetCache.Result" in release_activity
+    assert "new AndroidAssetSource(getAssets())" in release_activity
+    assert "packageInfo.lastUpdateTime" in release_activity
+    assert "INVALID_ASSET_ROOT" in release_activity
+    assert "nativeSetAssetRoot(invalidAssetRoot.getAbsolutePath())" in release_activity
+    assert "Asset cache mode=" in release_activity
+    assert "packaged_read_bytes=" in release_activity
+    assert "CACHE_SCHEMA = \"stasis.android.asset-cache\"" in release_cache
+    assert "MAX_MARKER_BYTES" in release_cache
+    assert "inventoryMatches" in release_cache
+    assert "publicationInterceptor.beforeInstall" in release_cache
+    assert "rename(backup, root)" in release_cache
+    assert "BACKUP_ALT_NAME" in release_cache
+    assert "MAX_COPIED_TREE_BYTES" in release_cache
+    assert 'child.equals(".")' in release_cache
+    assert "stasis asset cache JVM scenarios" in read("tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java")
     assert "stasis_host_get_latest_performance_metrics" in release_bridge
     assert "stasis_host_get_latest_performance_metrics_v1" in release_bridge
     assert "stasis_performance_metrics.h" in release_bridge

--- a/tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java
+++ b/tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java
@@ -292,7 +292,7 @@ public final class StasisAssetCacheTest {
                 }
             }
         } else {
-            Files.copy(source, destination);
+            Files.copy(source, destination, java.nio.file.StandardCopyOption.COPY_ATTRIBUTES);
         }
     }
 

--- a/tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java
+++ b/tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java
@@ -1,0 +1,336 @@
+package com.stasislang.shell;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+
+public final class StasisAssetCacheTest {
+    private static final String PACKAGE = "com.example.cache";
+    private static final String RELEASE = "7:1.0:100";
+
+    public static void main(String[] args) throws Exception {
+        Path temp = Files.createTempDirectory("stasis-asset-cache-test");
+        try {
+            Path packaged = temp.resolve("packaged");
+            Path files = temp.resolve("files");
+            Files.createDirectories(packaged.resolve("stasis_game/assets"));
+            Files.write(packaged.resolve("stasis_game/assets/token.txt"), bytes("original"));
+            Files.write(packaged.resolve("stasis_game/assets/.stasis_asset_cache.v1"),
+                    bytes("nested packaged marker basename"));
+            writeManifest(packaged, "token.txt");
+            CountingSource source = new CountingSource(packaged.toFile());
+
+            StasisAssetCache.Result cold = cache(source, files.toFile(), RELEASE).prepare();
+            check(!cold.isReused(), "first install is cold");
+            check(cold.getMetrics().getCacheWriteBytes() > 0, "cold path writes bytes");
+            Path root = files.resolve("stasis_game");
+            Path marker = root.resolve(".stasis_asset_cache.v1");
+            check(Files.isRegularFile(marker), "cold path writes marker last");
+            check(text(root.resolve("assets/.stasis_asset_cache.v1")).contains("nested packaged"),
+                    "nested marker basename is retained");
+
+            CountingSource restartedSource = new CountingSource(packaged.toFile());
+            StasisAssetCache.Result recreation = cache(restartedSource, files.toFile(), RELEASE).prepare();
+            check(recreation.isReused(), "ordinary recreation reuses");
+            check(restartedSource.openCount == 1, "fresh source reads only packaged manifest");
+            check(recreation.getMetrics().getPackagedReadBytes()
+                    == Files.size(packaged.resolve("stasis_game/assets/manifest.json")),
+                    "reuse packaged bytes are manifest-only");
+            check(recreation.getMetrics().getCacheReadBytes()
+                    == Files.size(marker) + Files.size(root.resolve("assets/manifest.json")),
+                    "reuse cache bytes are marker and manifest only");
+            check(recreation.getMetrics().getCacheWriteBytes() == 0, "reuse does not write assets");
+
+            Path updateFiles = temp.resolve("update-time-files");
+            check(!cache(source, updateFiles.toFile(), RELEASE).prepare().isReused(),
+                    "same-version baseline installs");
+            check(!cache(source, updateFiles.toFile(), "7:1.0:200").prepare().isReused(),
+                    "same-version package update time rebuilds");
+
+            boolean invalidName = false;
+            try {
+                cache(new InvalidChildSource(packaged.toFile()),
+                        temp.resolve("invalid-child-files").toFile(), RELEASE).prepare();
+            } catch (IOException expected) {
+                invalidName = true;
+            }
+            check(invalidName, "dot child names are rejected before output resolution");
+
+            Path token = root.resolve("assets/token.txt");
+            long originalModified = Files.getLastModifiedTime(token).toMillis();
+            Files.write(token, bytes("tampered"));
+            if (Files.getLastModifiedTime(token).toMillis() == originalModified) {
+                check(token.toFile().setLastModified(originalModified + 2000L),
+                        "stabilize mutation timestamp");
+            }
+            StasisAssetCache.Result mutation = cache(source, files.toFile(), RELEASE).prepare();
+            check(!mutation.isReused(), "ordinary mutation invalidates inventory");
+            check(text(root.resolve("assets/token.txt")).equals("original"), "mutation rebuilds");
+
+            Files.write(root.resolve("assets/token.txt"), bytes("x"));
+            StasisAssetCache.Result truncation = cache(source, files.toFile(), RELEASE).prepare();
+            check(!truncation.isReused(), "truncation invalidates inventory");
+            check(text(root.resolve("assets/token.txt")).equals("original"), "truncation rebuilds");
+
+            Files.delete(marker);
+            check(!cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "missing marker rebuilds");
+            Files.write(marker, bytes("corrupt marker\n"));
+            check(!cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "corrupt marker rebuilds");
+
+            Files.createDirectories(files.resolve(".stasis_game.staging"));
+            Files.write(files.resolve(".stasis_game.staging/partial"), bytes("partial"));
+            check(cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "partial staging is discarded before safe reuse");
+            check(!Files.exists(files.resolve(".stasis_game.staging")), "staging is cleaned");
+
+            check(!cache(source, files.toFile(), "8:2.0").prepare().isReused(),
+                    "package release update rebuilds");
+
+            Files.write(packaged.resolve("stasis_game/assets/token.txt"), bytes("updated"));
+            writeManifest(packaged, "token.txt");
+            check(!cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "packaged manifest change rebuilds");
+            check(text(root.resolve("assets/token.txt")).equals("updated"), "manifest update publishes");
+
+            Path backup = files.resolve(".stasis_game.previous");
+            Path backupAlt = files.resolve(".stasis_game.previous.2");
+            copyTree(root, backup);
+            Files.write(backup.resolve(".stasis_asset_cache.v1"), bytes("stale backup"));
+            check(cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "valid root wins over stale backup");
+            check(!Files.exists(backup), "stale backup cleanup is deferred but retried safely");
+
+            copyTree(root, backup);
+            copyTree(root, backupAlt);
+            Files.write(backup.resolve(".stasis_asset_cache.v1"), bytes("malformed candidate"));
+            Files.write(root.resolve("assets/token.txt"), bytes("broken"));
+            check(cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "valid backup replaces invalid root");
+            check(text(root.resolve("assets/token.txt")).equals("updated"),
+                    "backup recovery restores the validated tree");
+            check(!Files.exists(backup), "recovered backup is no longer selected");
+            check(!Files.exists(backupAlt), "alternate backup is consumed by recovery");
+
+            copyTree(root, backup);
+            check(cache(source, files.toFile(), RELEASE, StasisAssetCache.NO_INTERCEPTOR,
+                    new StasisAssetCache.InventoryProbe() {
+                        @Override
+                        public void beforeInventory(File candidate) throws IOException {
+                            if (candidate.getName().equals("stasis_game")) {
+                                throw new IOException("injected malformed root inventory");
+                            }
+                        }
+                    }, StasisAssetCache.NO_CLEANUP_PROBE).prepare().isReused(),
+                    "inventory failure falls back to valid backup");
+
+            copyTree(root, backup);
+            check(cache(source, files.toFile(), RELEASE, StasisAssetCache.NO_INTERCEPTOR,
+                    new StasisAssetCache.InventoryProbe() {
+                        @Override
+                        public void beforeInventory(File candidate) throws IOException {
+                            if (candidate.getName().equals(".stasis_game.previous")) {
+                                throw new IOException("injected malformed backup inventory");
+                            }
+                        }
+                    }, StasisAssetCache.NO_CLEANUP_PROBE).prepare().isReused(),
+                    "valid root survives malformed backup inventory");
+
+            copyTree(root, backup);
+            Files.write(backup.resolve(".stasis_asset_cache.v1"), bytes("stale leftover"));
+            Files.write(packaged.resolve("stasis_game/assets/token.txt"), bytes("slot-update"));
+            writeManifest(packaged, "token.txt");
+            check(!cache(source, files.toFile(), RELEASE, StasisAssetCache.NO_INTERCEPTOR,
+                    StasisAssetCache.NO_INVENTORY_PROBE, new StasisAssetCache.BackupCleanupProbe() {
+                        @Override
+                        public void beforeCleanup(File candidate) throws IOException {
+                            if (candidate.getName().equals(".stasis_game.previous")) {
+                                throw new IOException("injected stale backup cleanup failure");
+                            }
+                        }
+                    }).prepare().isReused(),
+                    "update uses alternate transaction backup when stale cleanup fails");
+            check(text(root.resolve("assets/token.txt")).equals("slot-update"),
+                    "alternate backup update publishes");
+            check(Files.exists(backup), "failed stale cleanup leaves bounded leftover");
+            check(!Files.exists(backupAlt), "alternate transaction backup is cleaned");
+
+            Files.write(root.resolve("assets/unexpected.txt"), bytes("tamper"));
+            check(!cache(source, files.toFile(), RELEASE).prepare().isReused(),
+                    "unexpected extracted file invalidates inventory");
+
+            Files.write(packaged.resolve("stasis_game/assets/token.txt"), bytes("newer"));
+            writeManifest(packaged, "token.txt");
+            String oldRoot = text(root.resolve("assets/token.txt"));
+            boolean failed = false;
+            try {
+                cache(source, files.toFile(), RELEASE, new StasisAssetCache.PublicationInterceptor() {
+                    @Override
+                    public void beforeInstall(File staging, File destination, File backup)
+                            throws IOException {
+                        throw new IOException("injected publication failure");
+                    }
+                }).prepare();
+            } catch (IOException expected) {
+                failed = true;
+            }
+            check(failed, "publication failure is surfaced");
+            check(text(root.resolve("assets/token.txt")).equals(oldRoot),
+                    "publication failure preserves prior root");
+            check(!Files.exists(files.resolve(".stasis_game.staging")),
+                    "publication failure leaves no staging root");
+
+            Path firstInstallWithStaleSlots = temp.resolve("first-install-stale-slots");
+            Files.createDirectories(firstInstallWithStaleSlots);
+            copyTree(root, firstInstallWithStaleSlots.resolve(".stasis_game.previous"));
+            copyTree(root, firstInstallWithStaleSlots.resolve(".stasis_game.previous.2"));
+            StasisAssetCache.Result firstInstall = cache(source,
+                    firstInstallWithStaleSlots.toFile(), RELEASE,
+                    StasisAssetCache.NO_INTERCEPTOR, StasisAssetCache.NO_INVENTORY_PROBE,
+                    new StasisAssetCache.BackupCleanupProbe() {
+                        @Override
+                        public void beforeCleanup(File candidate) throws IOException {
+                            throw new IOException("injected unavailable stale backup");
+                        }
+                    }).prepare();
+            check(!firstInstall.isReused(),
+                    "first install needs no rollback slot when no root exists");
+            check(text(firstInstallWithStaleSlots.resolve("stasis_game/assets/token.txt"))
+                            .equals("newer"),
+                    "first install publishes despite unavailable stale slots");
+
+            String malformedUnicode = Character.toString((char)92) + "uZZZZ";
+            String tokenHash = hex(MessageDigest.getInstance("SHA-256").digest(
+                    Files.readAllBytes(packaged.resolve("stasis_game/assets/token.txt"))));
+            Files.write(packaged.resolve("stasis_game/assets/manifest.json"), bytes(
+                    "{\"schema\":\"stasis-assets\",\"version\":1,\"assets\":["
+                            + "{\"id\":\"" + malformedUnicode
+                            + "\",\"path\":\"assets/token.txt\","
+                            + "\"content_sha256\":\"" + tokenHash + "\"}]}"));
+            boolean malformed = false;
+            try {
+                cache(source, temp.resolve("malformed-files").toFile(), RELEASE).prepare();
+            } catch (IOException expected) {
+                malformed = true;
+            }
+            check(malformed, "malformed unicode is reported as IOException");
+
+            System.out.println("stasis asset cache JVM scenarios ok");
+        } finally {
+            delete(temp.toFile());
+        }
+    }
+
+    private static StasisAssetCache cache(CountingSource source, File files, String release) {
+        return cache(source, files, release, StasisAssetCache.NO_INTERCEPTOR);
+    }
+
+    private static StasisAssetCache cache(CountingSource source, File files, String release,
+            StasisAssetCache.PublicationInterceptor interceptor) {
+        return new StasisAssetCache(source, files, PACKAGE, release, interceptor);
+    }
+
+    private static StasisAssetCache cache(CountingSource source, File files, String release,
+            StasisAssetCache.PublicationInterceptor publication,
+            StasisAssetCache.InventoryProbe inventory,
+            StasisAssetCache.BackupCleanupProbe cleanup) {
+        return new StasisAssetCache(source, files, PACKAGE, release, publication,
+                inventory, cleanup);
+    }
+
+    private static void writeManifest(Path packaged, String fileName) throws Exception {
+        byte[] file = Files.readAllBytes(packaged.resolve("stasis_game/assets/" + fileName));
+        String hash = hex(MessageDigest.getInstance("SHA-256").digest(file));
+        String manifest = "{\"schema\":\"stasis-assets\",\"version\":1,\"assets\":["
+                + "{\"id\":\"token\",\"path\":\"assets/" + fileName
+                + "\",\"content_sha256\":\"" + hash + "\"}]}";
+        Files.write(packaged.resolve("stasis_game/assets/manifest.json"),
+                manifest.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String hex(byte[] bytes) {
+        StringBuilder result = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            int unsigned = value & 0xff;
+            if (unsigned < 16) result.append('0');
+            result.append(Integer.toHexString(unsigned));
+        }
+        return result.toString();
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String text(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static void check(boolean condition, String message) {
+        if (!condition) throw new AssertionError(message);
+    }
+
+    private static void delete(File file) throws IOException {
+        if (!file.exists()) return;
+        File[] children = file.listFiles();
+        if (children != null) for (File child : children) delete(child);
+        if (!file.delete()) throw new IOException("unable to delete " + file);
+    }
+
+    private static void copyTree(Path source, Path destination) throws IOException {
+        if (Files.isDirectory(source)) {
+            Files.createDirectories(destination);
+            try (java.nio.file.DirectoryStream<Path> children = Files.newDirectoryStream(source)) {
+                for (Path child : children) {
+                    copyTree(child, destination.resolve(child.getFileName().toString()));
+                }
+            }
+        } else {
+            Files.copy(source, destination);
+        }
+    }
+
+    private static class CountingSource implements StasisAssetCache.AssetSource {
+        protected final File root;
+        int openCount;
+
+        CountingSource(File root) {
+            this.root = root;
+        }
+
+        void reset() {
+            openCount = 0;
+        }
+
+        @Override
+        public String[] list(String path) {
+            File directory = new File(root, path);
+            String[] children = directory.list();
+            return children == null ? new String[0] : children;
+        }
+
+        @Override
+        public InputStream open(String path) throws IOException {
+            openCount++;
+            return new FileInputStream(new File(root, path));
+        }
+    }
+
+    private static final class InvalidChildSource extends CountingSource {
+        InvalidChildSource(File root) {
+            super(root);
+        }
+
+        @Override
+        public String[] list(String path) {
+            if (path.equals("stasis_game")) return new String[] {"."};
+            return super.list(path);
+        }
+    }
+}

--- a/tools/ci/test_android_asset_cache.py
+++ b/tools/ci/test_android_asset_cache.py
@@ -1,0 +1,31 @@
+"""Compile and run the platform-neutral Android release asset cache scenarios."""
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CACHE = ROOT / "mobile/shells/android/app/src/main/java/com/stasislang/shell/StasisAssetCache.java"
+TEST = ROOT / "tools/ci/java/com/stasislang/shell/StasisAssetCacheTest.java"
+
+
+def main() -> int:
+    javac = shutil.which("javac")
+    java = shutil.which("java")
+    if not javac or not java:
+        raise RuntimeError("JDK 8+ is required for the direct Android asset-cache runner")
+    with tempfile.TemporaryDirectory(prefix="stasis-android-asset-cache-") as directory:
+        output = Path(directory) / "classes"
+        output.mkdir()
+        subprocess.run([javac, "-encoding", "UTF-8", "-d", str(output), str(CACHE), str(TEST)],
+                       cwd=ROOT, check=True)
+        subprocess.run([java, "-cp", str(output), "com.stasislang.shell.StasisAssetCacheTest"],
+                       cwd=ROOT, check=True)
+    print("android asset cache JVM runner ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- cache verified Android release assets by package/update identity and packaged manifest SHA-256
- reuse an app-private sealed inventory without recopying or rehashing all asset bytes on Activity recreation
- publish cold extractions with bounded verification, marker-last commit, two-slot rollback recovery, and startup I/O/timing metrics
- add deterministic direct JVM scenarios and run them in PR CI
- document why iOS keeps using its immutable app-bundle assets directly

## Tests
- `python tools/ci/test_android_asset_cache.py`
- generated `toolchain_cli::tests::mobile_shells_are_platform_projects_over_one_shared_runtime` (1 passed)
- `python tools/cargo_cache.py run -- cargo test -p stasis mobile_shells_are_platform_projects_over_one_shared_runtime --no-run`
- `python tools/ci/check_stasis_src_layout.py`
- `python tools/ci/check_sdl3_migration.py`
- `python tools/cargo_cache.py run -- cargo fmt --all -- --check`
- `git diff --check`

## Local limitations
- normal Cargo test execution is blocked by the local signing runner's missing certificate; the compiled test executable passes when invoked directly
- Android package build is unavailable locally because Android SDK/SDL source variables are unset
- broad `check_android_shell.py` stops at the pre-existing Workshop AI-toggle assertion at line 320 before the release-shell section

Maddox #202