### PR TITLE
docs: require PNG and MP4 validation evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@
 - Cover parser/semantics/lowering/JIT boundaries and hot-swap safety behavior.
 - Keep each test command bounded to 15 minutes max (900 seconds); split/shard runs when needed, and treat overruns as stability regressions.
 - After each edit/test step, check for lingering test processes (for example `target/debug/deps/*.exe`) and clean them up before the next step.
+- Validate user-visible graphical work with reviewable media in addition to automated assertions: use PNG for a representative still state and MP4 when motion, timing, input, animation, or a multi-step interaction matters. Inspect the captured artifact itself; a successful capture command is not proof that the pixels or sequence are correct. These artifacts are especially useful for independent AI review.
+- Every AI-authored work summary must include a `Visual evidence:` line. List the inspected PNG and/or MP4 paths and what each proves, or state `not applicable` for work with no user-visible behavior. If relevant media could not be captured, state that limitation rather than implying visual validation passed.
 - For incremental compilation:
 - Validate file-level invalidation correctness.
 - Validate per-function gating behavior.

--- a/README.md
+++ b/README.md
@@ -351,6 +351,14 @@ stasis play game.stasis `
 
 This turns a graphical interaction into a repeatable test artifact. PNG bytes are deterministic for identical pixels, though rasterization may still differ across graphics backends, drivers, and platforms.
 
+Use PNG evidence for a representative still state. Use an MP4 recording when validation
+depends on motion, timing, animation, input, state transitions, or a multi-step interaction. Review
+the artifact itself after capture; the command succeeding does not prove that the rendered result is
+correct. These formats are intentionally easy to hand to human and multimodal AI reviewers. AI work
+summaries should include a `Visual evidence:` line with the inspected PNG/MP4 paths and what they
+prove, use `not applicable` for non-visual work, or state clearly when relevant capture was not
+available.
+
 For deterministic desktop-first video review, use the hidden fixed-rate recorder:
 
 ```powershell

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -78,6 +78,11 @@ rolls every touched file back on failure. Do not use `--no-tests` unless the use
   isolated runtime, so it is suitable for an integration-style red/green check without depending
   on a currently running game's state. Do not report an observable change complete without a
   passing fresh validation or an equivalent focused integration test.
+- For user-visible graphical behavior, supplement assertions with media that a human or AI reviewer
+  can inspect. Capture PNG for a representative still state. Capture MP4 when the claim depends on
+  motion, timing, animation, input, state transitions, or a multi-step interaction. Inspect the
+  resulting pixels or recording; merely producing the file does not validate the behavior. Prefer
+  deterministic `stasis record` output when available; see `docs/headless_recording.md`.
 - Finish with `stasis fmt --check`, `stasis check`, and `stasis test`. Semantic symbol edits already
   preserve untouched formatting; do not run mutating whole-project formatting as routine cleanup.
 - Keep the generated `.githooks/pre-commit` active. `stasis new` configures it automatically; after
@@ -88,3 +93,8 @@ rolls every touched file back on failure. Do not use `--no-tests` unless the use
 
 Use `stasis ai "PROMPT"` only when the user explicitly wants Stasis's subscription-backed nested
 AI turn. An agent already performing the task should use the commands above directly.
+
+Every AI-authored work summary must include a `Visual evidence:` line. Name each inspected PNG
+and/or MP4 and state what it proves, or write `Visual evidence: not applicable` when the work has no
+user-visible behavior. If relevant capture was not possible, report that limitation and do not imply
+that visual validation passed.

--- a/docs/contributor_workflow.md
+++ b/docs/contributor_workflow.md
@@ -56,8 +56,10 @@ To smoke-test the installed Codex provider and shared response schema, run `carg
 
 1. Update any docs that would prevent repeating the same mistake.
 2. If the task came from PR review feedback, reply on GitHub when appropriate with the fix, clarification, or follow-up question.
-3. Commit with a message that explains what changed, why, how it was verified, and any residual risks.
-4. Append a concise entry to `docs/night_shift_report.md`.
+3. For user-visible graphical work, capture and inspect reviewable evidence in addition to automated checks. Use PNG for a representative still state; use MP4 for motion, timing, animation, input, or multi-step interaction. Keep captures focused on the behavior under review and exclude unrelated windows, notifications, secrets, and personal data.
+4. Every AI-authored work summary must include `Visual evidence:` followed by the inspected PNG/MP4 paths and what they prove. Use `Visual evidence: not applicable` when the change has no user-visible behavior. If capture was relevant but unavailable, say so explicitly and record the remaining validation gap.
+5. Commit with a message that explains what changed, why, how it was verified, and any residual risks.
+6. Append a concise entry to `docs/night_shift_report.md`.
 
 ## Stop Conditions
 

--- a/docs/headless_recording.md
+++ b/docs/headless_recording.md
@@ -89,3 +89,14 @@ stasis --workspace samples/windows_launch_smoke record main.stasis `
 Open `artifacts/codex-review/frame-000001.png` and
 `frame-000003.png` in the Codex visual review pane. Keep the command, input
 script, and renderer diagnostics with the artifact when reporting a mismatch.
+
+Use PNG when one or a few representative states prove the visual claim. Use
+MP4 when correctness depends on motion, timing, animation, audio, input, state
+transitions, or a multi-step interaction. AI review should inspect the MP4 and,
+when useful, selected PNG frames from the same deterministic take rather than
+treating successful encoding as proof of correct behavior.
+
+Every AI-authored work summary must include a `Visual evidence:` line naming
+the inspected PNG and/or MP4 paths and the behavior they prove. Use
+`Visual evidence: not applicable` for work with no user-visible behavior. If
+capture was relevant but unavailable, report the remaining validation gap.

--- a/docs/live_tui_recording.md
+++ b/docs/live_tui_recording.md
@@ -47,3 +47,7 @@ Narrate each hypothesis before its action. The displayed duration is an end-to-e
 - Copy the accepted MP4 to a phone-share directory and verify it with the same LAN URL used by the viewer.
 
 For a fully scripted take, keep the action and narration scripts beside the captured artifact, record the exact command sequence and model disclosure, and retain rejected takes only as local QA evidence.
+
+In an AI-authored work summary, include `Visual evidence:` with the accepted MP4 path, any sampled
+PNG frame paths, and the specific behavior each artifact proves. If the recording could not be made
+or inspected, report that validation gap explicitly.


### PR DESCRIPTION
Summary:
- document PNG stills and MP4 recordings as visual validation artifacts
- require AI-authored summaries to report inspected visual evidence or an explicit limitation
- connect the guidance to deterministic stasis record output

Validation:
- git diff --check
- repository pre-commit checks

Visual evidence: not applicable - documentation-only change with no user-visible runtime behavior.