### PR TITLE
Fix Web cached font parity with native

### DIFF
--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -447,11 +447,55 @@
     sprites.set(handle, image);
     return handle;
   };
+  const setCanvasFont = (font, size = font.renderSize) => {
+    context.font = `${size}px ${font.family}`;
+    context.textBaseline = "alphabetic";
+    if ("fontKerning" in context) context.fontKerning = "none";
+  };
+  const measureTextRun = (font, text) => {
+    context.save();
+    setCanvasFont(font);
+    const metrics = context.measureText(text);
+    context.restore();
+    const descent = Number.isFinite(metrics.actualBoundingBoxDescent)
+      ? Math.max(0, metrics.actualBoundingBoxDescent)
+      : Math.max(0, font.size - font.baseline);
+    return { width: metrics.width, height: font.baseline + descent };
+  };
+  const refreshTextRun = run => {
+    const font = fonts.get(run.font);
+    if (!font?.ready) return;
+    const metrics = measureTextRun(font, run.text);
+    setViewField(run.base, run.index, "width", metrics.width);
+    setViewField(run.base, run.index, "height", metrics.height);
+  };
+  const calibrateFont = font => {
+    context.save();
+    setCanvasFont(font, 1000);
+    const metrics = context.measureText("Mg");
+    context.restore();
+    const ascent = Number.isFinite(metrics.fontBoundingBoxAscent)
+      ? metrics.fontBoundingBoxAscent
+      : 1000;
+    const descent = Number.isFinite(metrics.fontBoundingBoxDescent)
+      ? metrics.fontBoundingBoxDescent
+      : 0;
+    const nativeHeight = ascent + descent;
+    const scale = nativeHeight > 0 ? font.size / nativeHeight : font.size / 1000;
+    font.renderSize = 1000 * scale;
+    font.baseline = ascent * scale;
+    font.ready = true;
+    font.pendingRuns.forEach(refreshTextRun);
+    font.pendingRuns.length = 0;
+  };
   const loadFont = (pathId, size) => {
     const handle = nextHandle++;
     const family = `stasis-font-${handle}`;
     const font = new FontFace(family, `url(${assetValue(pathId)})`);
-    fonts.set(handle, { family, size });
+    const fontInfo = {
+      family, size, renderSize: size, baseline: size, ready: false, pendingRuns: []
+    };
+    fonts.set(handle, fontInfo);
     const load = Promise.resolve()
       .then(() => font.load())
       .then(loaded => {
@@ -465,7 +509,7 @@
     const font = fonts.get(fontHandle);
     if (!font) return 0;
     context.save();
-    context.font = `${font.size}px ${font.family}`;
+    setCanvasFont(font);
     const width = context.measureText(stringValue(textId)).width;
     context.restore();
     return width;
@@ -855,10 +899,14 @@
       const text = stringValue(textId);
       cachedText.set(handle, { font, text });
       const fontInfo = fonts.get(font) || { size: 16 };
-      return setViewField(base, index, "font", font)
+      const run = { base, index, font, text };
+      const loaded = setViewField(base, index, "font", font)
         && setViewField(base, index, "handle", handle)
         && setViewField(base, index, "width", text.length * fontInfo.size * 0.6)
-        && setViewField(base, index, "height", fontInfo.size) ? 1 : 0;
+        && setViewField(base, index, "height", fontInfo.size);
+      if (loaded && fontInfo.ready) refreshTextRun(run);
+      else if (loaded && fontInfo.pendingRuns) fontInfo.pendingRuns.push(run);
+      return loaded ? 1 : 0;
     },
     storage_load_i32: (scope, key, fallback) => {
       const value = storageGet(storageKey(scope, key));
@@ -1156,7 +1204,9 @@
       const offset = i32[baseI + 1];
       const cached = offset < 0 ? cachedText.get(-offset) : null;
       const fontHandle = cached ? cached.font : i32[baseI];
-      const font = fonts.get(fontHandle) || { family: "ui-monospace", size: 18 };
+      const font = fonts.get(fontHandle) || {
+        family: "ui-monospace", size: 18, renderSize: 18, baseline: 18
+      };
       let text = cached ? cached.text : "";
       if (!cached && game.memory.gfx_cmd_u8) {
         const bytesLayout = game.memory.gfx_cmd_u8;
@@ -1166,9 +1216,8 @@
       context.save();
       context.globalAlpha = f32[baseF + 5];
       context.fillStyle = `rgb(${Math.round(f32[baseF + 2] * 255)} ${Math.round(f32[baseF + 3] * 255)} ${Math.round(f32[baseF + 4] * 255)})`;
-      context.font = `${font.size}px ${font.family}`;
-      context.textBaseline = "top";
-      context.fillText(text, f32[baseF], f32[baseF + 1]);
+      setCanvasFont(font);
+      context.fillText(text, f32[baseF], f32[baseF + 1] + font.baseline);
       context.restore();
     };
     const lineCount = Math.max(0, Math.min(i32[3], 10000));
@@ -1490,6 +1539,7 @@
       ]);
       await document.fonts.ready;
       setLoading("", "ready");
+      fonts.forEach(calibrateFont);
       document.body.dataset.ready = "true";
       document.body.dataset.runtime = "wasm";
       document.body.dataset.mainResult = String(mainResult);

--- a/runtime/web/tests/asset_paths.test.mjs
+++ b/runtime/web/tests/asset_paths.test.mjs
@@ -14,11 +14,15 @@ async function loadRuntime(game, options = {}) {
   let env;
   const memory = new WebAssembly.Memory({ initial: 1 });
   const context2d = {
+    fontKerning: "auto",
+    textBaseline: "alphabetic",
     fillRect() {}, fillText() {}, save() {}, restore() {}, beginPath() {}, moveTo() {},
     lineTo() {}, stroke() {}, drawImage() {}, translate() {}, rotate() {},
     measureText(value) {
       measurements.push({ font: this.font, value });
-      return { width: value.length * 7 };
+      return options.measureText?.({
+        font: this.font, fontKerning: this.fontKerning, textBaseline: this.textBaseline, value
+      }) || { width: value.length * 7 };
     }
   };
   const canvas = {
@@ -118,7 +122,7 @@ async function loadRuntime(game, options = {}) {
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(typeof env?.gfx_load_sprite, "function", errorBox.textContent);
   return {
-    env, imageSources, measurements, animationFrames, addedFonts, fontSources,
+    env, memory, imageSources, measurements, animationFrames, addedFonts, fontSources,
     document, errorBox, runtimePromise,
   };
 }
@@ -193,6 +197,50 @@ test("web measure_text uses the registered Canvas font and string handle", async
   assert.equal(typeof env.measure_text, "function");
   assert.equal(env.measure_text(font, 1), 42);
   assert.deepEqual(measurements, [{ font: "20px stasis-font-1", value: "marble" }]);
+});
+
+test("web cached text matches native pixel-height metrics before the first frame", async () => {
+  const game = {
+    memory: {
+      "run.font": { offset: 0, length: 1, stride: 4, type_id: 1 },
+      "run.handle": { offset: 4, length: 1, stride: 4, type_id: 1 },
+      "run.width": { offset: 8, length: 1, stride: 4, type_id: 2 },
+      "run.height": { offset: 12, length: 1, stride: 4, type_id: 2 },
+    },
+    views: {
+      "101": {
+        font: "run.font", handle: "run.handle", width: "run.width", height: "run.height",
+      },
+    },
+    strings: { "1": "assets/font.ttf", "2": "GAMBIT GUARD" },
+  };
+  let loadedFont = 0;
+  const result = await loadRuntime(game, {
+    main: env => {
+      loadedFont = env.load_font(1, 24);
+      assert.equal(env.stasis_jit_text_run_load_from(101, 0, 1, loadedFont, 2), 1);
+    },
+    measureText: metrics => {
+      assert.equal(metrics.textBaseline, "alphabetic");
+      assert.equal(metrics.fontKerning, "none");
+      if (metrics.font === "1000px stasis-font-1") {
+        return { width: 500, fontBoundingBoxAscent: 1011, fontBoundingBoxDescent: 353 };
+      }
+      assert.ok(Math.abs(Number.parseFloat(metrics.font) - 17.5953079) < 0.0001);
+      return { width: 139.25, actualBoundingBoxDescent: 0.25 };
+    },
+  });
+  await result.runtimePromise;
+
+  const view = new DataView(result.memory.buffer);
+  assert.equal(view.getInt32(0, true), loadedFont);
+  assert.ok(view.getInt32(4, true) > 0);
+  assert.equal(view.getFloat32(8, true), 139.25);
+  assert.ok(Math.abs(view.getFloat32(12, true) - 18.038856) < 0.0001);
+  assert.deepEqual(result.measurements.map(({ font, value }) => ({ font, value })), [
+    { font: "1000px stasis-font-1", value: "Mg" },
+    { font: "17.595307917888565px stasis-font-1", value: "GAMBIT GUARD" },
+  ]);
 });
 
 test("web startup fails visibly when a declared font cannot load", async () => {


### PR DESCRIPTION
## Behavior
- calibrate browser Canvas font sizes against loaded font ascent/descent so Stasis pixel-height requests match the native stb_truetype contract
- draw cached text from the calibrated alphabetic baseline
- replace the cached text width approximation with Canvas measurements before the first frame
- disable browser kerning when supported to track native glyph advance behavior

This removes the obsolete Web-only assumption that a requested Stasis pixel height is the same as a CSS em size.

## Verification
- node --test runtime/web/tests/*.test.mjs — 32/32 passed
- git diff --check — passed
- real Gambit Guard 360x720 framebuffer comparison:
  - shipped Web title: 191x17 px
  - native title: 139x11 px
  - fixed Web title: 140x12 px
- independent visual review: approved; no blocker or major defect, only 0–1 px rasterizer variation
- full local Cargo workspace run was attempted through tools/cargo_cache.py, but Windows Application Control blocked a cached build-script executable (OS error 4551) before project tests ran; CI remains the clean full-workspace gate

## Theory gained
Good: Stasis font size is a pixel-height contract, while CSS Canvas font size is an em-square contract; measuring the loaded face bridges those models without game-specific constants.

Bad: calibrating immediately after FontFace.load() can still measure fallback metrics before the browser font set is ready.

Adjustment: wait for document.fonts.ready, then calibrate and refresh all pending cached text runs before scheduling the first frame.