### PR TITLE
Decouple synchronized controls from simulation and rendering

### DIFF
--- a/crates/stasis_compiler/src/backend/jit.rs
+++ b/crates/stasis_compiler/src/backend/jit.rs
@@ -2934,6 +2934,73 @@ fn builtin_host_symbol_address(symbol: &str) -> Option<usize> {
         "network_host_stop" | "stasis_network_host_stop" | "stasis_jit_network_host_stop" => {
             function_address(stasis_dynload::stasis_jit_network_host_stop as *const ())
         }
+        "realtime_start" | "stasis_realtime_start" | "stasis_jit_realtime_start" => {
+            function_address(stasis_dynload::stasis_jit_realtime_start as *const ())
+        }
+        "realtime_stop" | "stasis_realtime_stop" | "stasis_jit_realtime_stop" => {
+            function_address(stasis_dynload::stasis_jit_realtime_stop as *const ())
+        }
+        "realtime_submit_payload"
+        | "stasis_realtime_submit_payload"
+        | "stasis_jit_realtime_submit_payload" => {
+            function_address(stasis_dynload::stasis_jit_realtime_submit_payload as *const ())
+        }
+        "realtime_build_payload"
+        | "stasis_realtime_build_payload"
+        | "stasis_jit_realtime_build_payload" => {
+            function_address(stasis_dynload::stasis_jit_realtime_build_payload as *const ())
+        }
+        "realtime_resync_required"
+        | "stasis_realtime_resync_required"
+        | "stasis_jit_realtime_resync_required" => {
+            function_address(stasis_dynload::stasis_jit_realtime_resync_required as *const ())
+        }
+        "realtime_record_hash"
+        | "stasis_realtime_record_hash"
+        | "stasis_jit_realtime_record_hash" => {
+            function_address(stasis_dynload::stasis_jit_realtime_record_hash as *const ())
+        }
+        "realtime_apply_snapshot"
+        | "stasis_realtime_apply_snapshot"
+        | "stasis_jit_realtime_apply_snapshot" => {
+            function_address(stasis_dynload::stasis_jit_realtime_apply_snapshot as *const ())
+        }
+        "realtime_current_tick"
+        | "stasis_realtime_current_tick"
+        | "stasis_jit_realtime_current_tick" => {
+            function_address(stasis_dynload::stasis_jit_realtime_current_tick as *const ())
+        }
+        "realtime_current_epoch"
+        | "stasis_realtime_current_epoch"
+        | "stasis_jit_realtime_current_epoch" => {
+            function_address(stasis_dynload::stasis_jit_realtime_current_epoch as *const ())
+        }
+        "realtime_schedule" | "stasis_realtime_schedule" | "stasis_jit_realtime_schedule" => {
+            function_address(stasis_dynload::stasis_jit_realtime_schedule as *const ())
+        }
+        "realtime_advance" | "stasis_realtime_advance" | "stasis_jit_realtime_advance" => {
+            function_address(stasis_dynload::stasis_jit_realtime_advance as *const ())
+        }
+        "realtime_read_control"
+        | "stasis_realtime_read_control"
+        | "stasis_jit_realtime_read_control" => {
+            function_address(stasis_dynload::stasis_jit_realtime_read_control as *const ())
+        }
+        "realtime_disconnect" | "stasis_realtime_disconnect" | "stasis_jit_realtime_disconnect" => {
+            function_address(stasis_dynload::stasis_jit_realtime_disconnect as *const ())
+        }
+        "realtime_reconnect" | "stasis_realtime_reconnect" | "stasis_jit_realtime_reconnect" => {
+            function_address(stasis_dynload::stasis_jit_realtime_reconnect as *const ())
+        }
+        "realtime_pause" | "stasis_realtime_pause" | "stasis_jit_realtime_pause" => {
+            function_address(stasis_dynload::stasis_jit_realtime_pause as *const ())
+        }
+        "realtime_focus_lost" | "stasis_realtime_focus_lost" | "stasis_jit_realtime_focus_lost" => {
+            function_address(stasis_dynload::stasis_jit_realtime_focus_lost as *const ())
+        }
+        "realtime_rematch" | "stasis_realtime_rematch" | "stasis_jit_realtime_rematch" => {
+            function_address(stasis_dynload::stasis_jit_realtime_rematch as *const ())
+        }
         "storage_load_i32" | "stasis_storage_load_i32" | "stasis_jit_storage_load_i32" => {
             function_address(stasis_dynload::stasis_jit_storage_load_i32 as *const ())
         }

--- a/crates/stasis_compiler/tests/realtime_controls_jit_seam.rs
+++ b/crates/stasis_compiler/tests/realtime_controls_jit_seam.rs
@@ -1,0 +1,83 @@
+#![cfg(windows)]
+
+use object::{Object, ObjectSymbol};
+use stasis_compiler::backend::aot::AotProcess;
+use stasis_compiler::backend::jit::JitProcess;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const FIXTURE_PATH: &str = "tests/stasis/seams/realtime_controls_jit_probe.stasis";
+const FIXTURE: &str =
+    include_str!("../../../tests/stasis/seams/realtime_controls_jit_probe.stasis");
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical repository root")
+}
+
+#[test]
+fn stasis_guest_drives_the_realtime_control_contract_through_jit() {
+    let mut process = JitProcess::new();
+    process
+        .set_project_root(repository_root().to_string_lossy())
+        .expect("set JIT project root");
+    process.set_required_emit_roots(&["realtime_controls_jit_probe".to_string()]);
+    process.upsert_file(FIXTURE_PATH, FIXTURE);
+    process.compile().expect("compile realtime JIT fixture");
+
+    let result = process
+        .execute_i32_noarg_by_name("realtime_controls_jit_probe")
+        .expect("execute realtime JIT fixture");
+    assert_eq!(result, 0, "fixture failure code");
+}
+
+#[test]
+fn realtime_guest_aot_objects_import_the_stable_native_contract() {
+    let mut process = AotProcess::new();
+    process
+        .set_project_root(repository_root().to_string_lossy())
+        .expect("set AOT project root");
+    process.set_required_emit_roots(&["realtime_controls_jit_probe".to_string()]);
+    process.upsert_file(FIXTURE_PATH, FIXTURE);
+    process.compile().expect("compile realtime AOT fixture");
+
+    let output_dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repository_root().join("target"))
+        .join(format!("realtime-aot-symbols-{}", std::process::id()));
+    let objects = process
+        .write_object_files(&output_dir)
+        .expect("write realtime AOT objects");
+    let mut undefined = BTreeSet::new();
+    for (_, path) in objects.values() {
+        let bytes = fs::read(path).expect("read realtime AOT object");
+        let object = object::File::parse(bytes.as_slice()).expect("parse realtime AOT object");
+        undefined.extend(
+            object
+                .symbols()
+                .filter(|symbol| symbol.is_undefined())
+                .filter_map(|symbol| symbol.name().ok().map(str::to_string)),
+        );
+    }
+    fs::remove_dir_all(&output_dir).expect("remove AOT symbol evidence");
+
+    for symbol in [
+        "stasis_realtime_start",
+        "stasis_realtime_build_payload",
+        "stasis_realtime_submit_payload",
+        "stasis_realtime_current_epoch",
+        "stasis_realtime_advance",
+        "stasis_realtime_read_control",
+        "stasis_realtime_disconnect",
+        "stasis_realtime_reconnect",
+        "stasis_realtime_stop",
+    ] {
+        assert!(
+            undefined.contains(symbol),
+            "missing native AOT import {symbol}"
+        );
+    }
+}

--- a/crates/stasis_dynload/src/lib.rs
+++ b/crates/stasis_dynload/src/lib.rs
@@ -2379,6 +2379,36 @@ pub fn preflight_jit_i32_array_capacity(
     )
 }
 
+/// Returns the registered/owned capacity without growing or mutating a JIT
+/// collection. Realtime ABI wrappers use this before every bounded load/store.
+pub fn jit_i32_array_capacity(collection_hash: i32, field_hash: i32) -> Option<usize> {
+    if let Some((_, len)) = registered_i32_arrays()
+        .lock()
+        .expect("registered i32 array table mutex poisoned")
+        .get(&(collection_hash, field_hash))
+        .copied()
+    {
+        return Some(len);
+    }
+    if let Some(len) = owned_i32_arrays()
+        .lock()
+        .expect("owned i32 array table mutex poisoned")
+        .get(&(collection_hash, field_hash))
+        .map(Vec::len)
+    {
+        return Some(len);
+    }
+    let fallback = jit_i32_array_global_table()
+        .lock()
+        .expect("jit i32 array table mutex poisoned");
+    let max_index = fallback
+        .keys()
+        .filter(|(collection, field, _)| *collection == collection_hash && *field == field_hash)
+        .map(|(_, _, index)| *index)
+        .max()?;
+    usize::try_from(max_index).ok()?.checked_add(1)
+}
+
 pub fn preflight_jit_f32_array_capacity(
     collection_hash: i32,
     field_hash: i32,
@@ -4056,7 +4086,7 @@ pub extern "C" fn stasis_jit_network_host_send(
         for index in 0..payload_length {
             let value = stasis_jit_global_i32_array_load(payload_id, 0, index);
             let Ok(value) = u8::try_from(value) else {
-                return -1;
+                return -30 - index;
             };
             payload.push(value);
         }
@@ -4082,6 +4112,461 @@ pub extern "C" fn stasis_jit_network_host_stop() {
                 );
             }
         }
+    }
+}
+
+// Bounded realtime controls use the same Rust scheduler for native and JIT
+// guests.  These wrappers intentionally expose only scalar operations; game
+// state and rendering remain owned by the guest.
+fn stasis_network_payload_limit() -> usize {
+    #[cfg(feature = "network")]
+    {
+        stasis_network::REALTIME_NATIVE_MAX_PAYLOAD
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        0
+    }
+}
+
+const REALTIME_GUEST_MAX_TICK: u64 = i32::MAX as u64;
+const REALTIME_GUEST_MAX_EPOCH: i32 = i32::MAX;
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_start(
+    simulation_hz: i32,
+    presentation_hz: i32,
+    control_hz: i32,
+    input_delay_ticks: i32,
+    seats: i32,
+) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        if simulation_hz < 0
+            || presentation_hz < 0
+            || control_hz < 0
+            || input_delay_ticks < 0
+            || seats < 0
+        {
+            return -1;
+        }
+        return stasis_network::stasis_realtime_start(
+            simulation_hz,
+            presentation_hz,
+            control_hz,
+            input_delay_ticks,
+            seats,
+        );
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = (
+            simulation_hz,
+            presentation_hz,
+            control_hz,
+            input_delay_ticks,
+            seats,
+        );
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_stop() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_stop();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_submit_payload(payload_id: i32, payload_length: i32) -> i32 {
+    if payload_length < 0 || payload_length as usize > stasis_network_payload_limit() {
+        return -1;
+    }
+    if jit_i32_array_capacity(payload_id, 0)
+        .is_none_or(|capacity| capacity < payload_length as usize)
+    {
+        return -11;
+    }
+    #[cfg(feature = "network")]
+    {
+        let mut payload = Vec::with_capacity(payload_length as usize);
+        for index in 0..payload_length {
+            let value = stasis_jit_global_i32_array_load(payload_id, 0, index);
+            let Ok(value) = u8::try_from(value) else {
+                return -1;
+            };
+            payload.push(value);
+        }
+        return stasis_network::submit_realtime_payload_bytes(&payload);
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = payload_id;
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_build_payload(
+    out_payload_id: i32,
+    capacity: i32,
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32,
+) -> i32 {
+    if seat < 0
+        || seat >= 8
+        || epoch <= 0
+        || sequence <= 0
+        || apply_tick < 0
+        || apply_tick as u64 > REALTIME_GUEST_MAX_TICK
+        || epoch > REALTIME_GUEST_MAX_EPOCH
+        || buttons < 0
+        || buttons > i32::from(u16::MAX)
+        || !(-128..=127).contains(&axis_x)
+        || !(-128..=127).contains(&axis_y)
+        || capacity < 0
+        || capacity as usize > stasis_network_payload_limit()
+    {
+        return -1;
+    }
+    #[cfg(feature = "network")]
+    {
+        if jit_i32_array_capacity(out_payload_id, 0)
+            .is_none_or(|registered| registered < capacity as usize)
+        {
+            return -11;
+        }
+        let mut payload = vec![0_i32; capacity as usize];
+        let length = unsafe {
+            stasis_network::stasis_realtime_build_payload(
+                payload.as_mut_ptr(),
+                capacity,
+                seat,
+                epoch,
+                sequence,
+                apply_tick,
+                buttons,
+                axis_x,
+                axis_y,
+            )
+        };
+        if length < 0 {
+            return length;
+        }
+        for (index, value) in payload.into_iter().take(length as usize).enumerate() {
+            stasis_jit_global_i32_array_store(out_payload_id, 0, index as i32, value);
+        }
+        return length;
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = out_payload_id;
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_resync_required() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_resync_required();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_record_hash(tick: i32, hash_low: i32, hash_high: i32) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_record_hash(tick, hash_low, hash_high);
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = (tick, hash_low, hash_high);
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_apply_snapshot(
+    revision: i32,
+    tick: i32,
+    seat_count: i32,
+    buttons_id: i32,
+    axis_x_id: i32,
+    axis_y_id: i32,
+    sequences_id: i32,
+    epochs_id: i32,
+    active_id: i32,
+) -> i32 {
+    if revision <= 0 || tick < 0 || seat_count <= 0 || seat_count > 8 {
+        return -1;
+    }
+    let count = seat_count as usize;
+    for id in [
+        buttons_id,
+        axis_x_id,
+        axis_y_id,
+        sequences_id,
+        epochs_id,
+        active_id,
+    ] {
+        if jit_i32_array_capacity(id, 0).is_none_or(|capacity| capacity < count) {
+            return -11;
+        }
+    }
+    #[cfg(feature = "network")]
+    {
+        let mut buttons = Vec::<i32>::with_capacity(count);
+        let mut axis_x = Vec::<i32>::with_capacity(count);
+        let mut axis_y = Vec::<i32>::with_capacity(count);
+        let mut sequences = Vec::<i32>::with_capacity(count);
+        let mut epochs = Vec::<i32>::with_capacity(count);
+        let mut active = Vec::<i32>::with_capacity(count);
+        for index in 0..seat_count {
+            let button = stasis_jit_global_i32_array_load(buttons_id, 0, index);
+            let x = stasis_jit_global_i32_array_load(axis_x_id, 0, index);
+            let y = stasis_jit_global_i32_array_load(axis_y_id, 0, index);
+            let sequence = stasis_jit_global_i32_array_load(sequences_id, 0, index);
+            let epoch = stasis_jit_global_i32_array_load(epochs_id, 0, index);
+            let is_active = stasis_jit_global_i32_array_load(active_id, 0, index);
+            if button < 0
+                || button > i32::from(u16::MAX)
+                || !(-128..=127).contains(&x)
+                || !(-128..=127).contains(&y)
+                || sequence < 0
+                || epoch <= 0
+                || epoch > REALTIME_GUEST_MAX_EPOCH
+                || !matches!(is_active, 0 | 1)
+            {
+                return -1;
+            }
+            buttons.push(button);
+            axis_x.push(x);
+            axis_y.push(y);
+            sequences.push(sequence);
+            epochs.push(epoch);
+            active.push(is_active);
+        }
+        return unsafe {
+            stasis_network::stasis_realtime_apply_snapshot(
+                revision,
+                tick,
+                seat_count,
+                buttons.as_ptr(),
+                axis_x.as_ptr(),
+                axis_y.as_ptr(),
+                sequences.as_ptr(),
+                epochs.as_ptr(),
+                active.as_ptr(),
+            )
+        };
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = (
+            buttons_id,
+            axis_x_id,
+            axis_y_id,
+            sequences_id,
+            epochs_id,
+            active_id,
+        );
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_current_tick() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_current_tick();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_current_epoch(seat: i32) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return if seat < 0 {
+            -1
+        } else {
+            stasis_network::stasis_realtime_current_epoch(seat)
+        };
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = seat;
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_schedule(
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32,
+) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        if seat < 0 || epoch < 0 || sequence < 0 || buttons < 0 {
+            return -1;
+        }
+        return stasis_network::stasis_realtime_schedule(
+            seat, epoch, sequence, apply_tick, buttons, axis_x, axis_y,
+        );
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = (seat, epoch, sequence, apply_tick, buttons, axis_x, axis_y);
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_advance() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_advance();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_read_control(
+    seat: i32,
+    out_buttons_id: i32,
+    out_axis_x_id: i32,
+    out_axis_y_id: i32,
+) -> i32 {
+    if seat < 0 {
+        return -1;
+    }
+    if [out_buttons_id, out_axis_x_id, out_axis_y_id]
+        .into_iter()
+        .any(|id| jit_i32_array_capacity(id, 0).is_none_or(|capacity| capacity < 1))
+    {
+        return -11;
+    }
+    #[cfg(feature = "network")]
+    {
+        let mut buttons = 0_i32;
+        let mut axis_x = 0_i32;
+        let mut axis_y = 0_i32;
+        let result = unsafe {
+            stasis_network::stasis_realtime_read_control(
+                seat,
+                &mut buttons,
+                &mut axis_x,
+                &mut axis_y,
+            )
+        };
+        if result == 0 {
+            stasis_jit_global_i32_array_store(out_buttons_id, 0, 0, buttons as i32);
+            stasis_jit_global_i32_array_store(out_axis_x_id, 0, 0, axis_x);
+            stasis_jit_global_i32_array_store(out_axis_y_id, 0, 0, axis_y);
+        }
+        return result;
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = (out_buttons_id, out_axis_x_id, out_axis_y_id);
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_disconnect(seat: i32) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return if seat < 0 {
+            -1
+        } else {
+            stasis_network::stasis_realtime_disconnect(seat)
+        };
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = seat;
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_reconnect(seat: i32) -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return if seat < 0 {
+            -1
+        } else {
+            stasis_network::stasis_realtime_reconnect(seat)
+        };
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        let _ = seat;
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_pause() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_pause();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_focus_lost() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_focus_lost();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -4
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_jit_realtime_rematch() -> i32 {
+    #[cfg(feature = "network")]
+    {
+        return stasis_network::stasis_realtime_rematch();
+    }
+    #[cfg(not(feature = "network"))]
+    {
+        -4
     }
 }
 

--- a/crates/stasis_network/include/stasis_network.h
+++ b/crates/stasis_network/include/stasis_network.h
@@ -15,6 +15,31 @@ typedef struct stasis_network_event {
     unsigned char payload[STASIS_NETWORK_MAX_MESSAGE_BYTES];
 } stasis_network_event;
 
+int32_t stasis_realtime_start(int32_t simulation_hz, int32_t presentation_hz,
+    int32_t control_hz, int32_t input_delay_ticks, int32_t seats);
+int32_t stasis_realtime_stop(void);
+int32_t stasis_realtime_submit_payload(const int32_t *payload, int32_t length);
+int32_t stasis_realtime_build_payload(int32_t *out_payload, int32_t capacity,
+    int32_t seat, int32_t epoch, int32_t sequence, int32_t apply_tick,
+    int32_t buttons, int32_t axis_x, int32_t axis_y);
+int32_t stasis_realtime_resync_required(void);
+int32_t stasis_realtime_record_hash(int32_t tick, int32_t hash_low, int32_t hash_high);
+int32_t stasis_realtime_apply_snapshot(int32_t revision, int32_t tick, int32_t seat_count,
+    const int32_t *buttons, const int32_t *axis_x, const int32_t *axis_y,
+    const int32_t *sequences, const int32_t *epochs, const int32_t *active);
+int32_t stasis_realtime_current_tick(void);
+int32_t stasis_realtime_current_epoch(int32_t seat);
+int32_t stasis_realtime_schedule(int32_t seat, int32_t epoch, int32_t sequence,
+    int32_t apply_tick, int32_t buttons, int32_t axis_x, int32_t axis_y);
+int32_t stasis_realtime_advance(void);
+int32_t stasis_realtime_read_control(int32_t seat, int32_t *out_buttons,
+    int32_t *out_axis_x, int32_t *out_axis_y);
+int32_t stasis_realtime_disconnect(int32_t seat);
+int32_t stasis_realtime_reconnect(int32_t seat);
+int32_t stasis_realtime_pause(void);
+int32_t stasis_realtime_focus_lost(void);
+int32_t stasis_realtime_rematch(void);
+
 uint32_t stasis_network_abi_version(void);
 const char *stasis_network_release_id(void);
 int32_t stasis_network_supported(void);

--- a/crates/stasis_network/src/lib.rs
+++ b/crates/stasis_network/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(warnings)]
 
+pub mod realtime;
+
 use std::collections::{BTreeMap, HashMap};
 use std::io::{ErrorKind, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
@@ -7,7 +9,7 @@ use std::os::raw::{c_char, c_uchar};
 use std::str;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use thiserror::Error;
@@ -990,6 +992,534 @@ pub struct StasisNetworkEvent {
     pub length: u32,
     pub payload: [c_uchar; MAX_MESSAGE_BYTES],
 }
+
+static REALTIME_SESSION: OnceLock<Mutex<Option<realtime::RealtimeSession>>> = OnceLock::new();
+
+fn realtime_slot() -> &'static Mutex<Option<realtime::RealtimeSession>> {
+    REALTIME_SESSION.get_or_init(|| Mutex::new(None))
+}
+
+fn realtime_admission_code(outcome: realtime::AdmissionOutcome) -> i32 {
+    match outcome {
+        realtime::AdmissionOutcome::Accepted | realtime::AdmissionOutcome::AcceptedReordered => 0,
+        realtime::AdmissionOutcome::Duplicate => 1,
+        realtime::AdmissionOutcome::Inactive => -4,
+        realtime::AdmissionOutcome::ResyncRequired => -5,
+        realtime::AdmissionOutcome::Malformed => -1,
+        realtime::AdmissionOutcome::Conflict => -6,
+        realtime::AdmissionOutcome::Stale => -7,
+        realtime::AdmissionOutcome::Late => -8,
+        realtime::AdmissionOutcome::TooFar => -9,
+        realtime::AdmissionOutcome::Full => -10,
+    }
+}
+
+fn realtime_admission_precedence(outcome: realtime::AdmissionOutcome) -> u8 {
+    match outcome {
+        realtime::AdmissionOutcome::ResyncRequired => 100,
+        realtime::AdmissionOutcome::Conflict => 90,
+        realtime::AdmissionOutcome::Full => 80,
+        realtime::AdmissionOutcome::Malformed => 70,
+        realtime::AdmissionOutcome::Inactive => 60,
+        realtime::AdmissionOutcome::Stale => 50,
+        realtime::AdmissionOutcome::Late => 40,
+        realtime::AdmissionOutcome::TooFar => 30,
+        realtime::AdmissionOutcome::Duplicate => 20,
+        realtime::AdmissionOutcome::AcceptedReordered => 10,
+        realtime::AdmissionOutcome::Accepted => 0,
+    }
+}
+
+pub const REALTIME_NATIVE_MAX_PAYLOAD: usize = realtime::MAX_ENVELOPE_BYTES;
+
+pub fn submit_realtime_payload_bytes(bytes: &[u8]) -> i32 {
+    if bytes.len() > REALTIME_NATIVE_MAX_PAYLOAD {
+        return -1;
+    }
+    let Ok(envelope) = realtime::ControlEnvelope::decode(bytes) else {
+        return -1;
+    };
+    if envelope.transitions().iter().any(|transition| {
+        transition.seat as usize >= realtime::REALTIME_MAX_SEATS
+            || transition.epoch > realtime::GUEST_MAX_EPOCH
+            || transition.sequence > i32::MAX as u32
+            || transition.apply_tick > realtime::GUEST_MAX_TICK
+    }) {
+        return -1;
+    }
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -3;
+    };
+    let report = session.submit_envelope(&envelope);
+    report
+        .outcomes()
+        .iter()
+        .copied()
+        .max_by_key(|outcome| realtime_admission_precedence(*outcome))
+        .map(realtime_admission_code)
+        .unwrap_or(0)
+}
+
+#[no_mangle]
+/// Submits `length` RTC1 byte values stored as signed 32-bit ABI elements.
+///
+/// # Safety
+///
+/// `payload` must be non-null, correctly aligned, and valid for `length`
+/// contiguous `i32` reads.
+pub unsafe extern "C" fn stasis_realtime_submit_payload(payload: *const i32, length: i32) -> i32 {
+    if payload.is_null() || length < 0 || length as usize > REALTIME_NATIVE_MAX_PAYLOAD {
+        return -1;
+    }
+    let values = unsafe { std::slice::from_raw_parts(payload, length as usize) };
+    let Ok(bytes) = values
+        .iter()
+        .copied()
+        .map(u8::try_from)
+        .collect::<Result<Vec<_>, _>>()
+    else {
+        return -1;
+    };
+    submit_realtime_payload_bytes(&bytes)
+}
+
+#[no_mangle]
+/// Encodes one transition into caller-owned signed 32-bit ABI elements.
+///
+/// # Safety
+///
+/// `out_payload` must be valid for `capacity` contiguous `i32` writes.
+pub unsafe extern "C" fn stasis_realtime_build_payload(
+    out_payload: *mut i32,
+    capacity: i32,
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32,
+) -> i32 {
+    if out_payload.is_null()
+        || capacity < 0
+        || seat < 0
+        || seat as usize >= realtime::REALTIME_MAX_SEATS
+        || epoch <= 0
+        || epoch > realtime::GUEST_MAX_EPOCH as i32
+        || sequence <= 0
+        || apply_tick < 0
+    {
+        return -1;
+    }
+    let Ok(envelope) = realtime::ControlEnvelope::from_transition(realtime::ScheduledTransition {
+        seat: seat as u8,
+        epoch: epoch as u32,
+        sequence: sequence as u32,
+        apply_tick: apply_tick as u64,
+        state: realtime::ControlState::new(
+            match u16::try_from(buttons) {
+                Ok(value) => value,
+                Err(_) => return -1,
+            },
+            match i8::try_from(axis_x) {
+                Ok(value) => value,
+                Err(_) => return -1,
+            },
+            match i8::try_from(axis_y) {
+                Ok(value) => value,
+                Err(_) => return -1,
+            },
+        ),
+    }) else {
+        return -1;
+    };
+    let bytes = envelope.encode();
+    if (capacity as usize) < bytes.len() {
+        return -11;
+    }
+    unsafe {
+        for (index, byte) in bytes.iter().copied().enumerate() {
+            *out_payload.add(index) = i32::from(byte);
+        }
+    }
+    bytes.len() as i32
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_resync_required() -> i32 {
+    realtime_slot()
+        .lock()
+        .ok()
+        .and_then(|slot| slot.as_ref().map(|session| session.resync_required()))
+        .map(i32::from)
+        .unwrap_or(-1)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_record_hash(tick: i32, hash_low: i32, hash_high: i32) -> i32 {
+    if tick < 0 {
+        return -1;
+    }
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -3;
+    };
+    let hash = realtime_guest_hash(hash_low, hash_high);
+    match session.record_authoritative_hash(tick as u64, hash) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+fn realtime_guest_hash(hash_low: i32, hash_high: i32) -> u64 {
+    u64::from(hash_low as u32) | (u64::from(hash_high as u32) << 32)
+}
+
+#[no_mangle]
+/// Applies a bounded authoritative snapshot from caller-owned ABI arrays.
+///
+/// # Safety
+///
+/// Every array pointer must be non-null, correctly aligned, and valid for
+/// `seat_count` contiguous `i32` reads.
+pub unsafe extern "C" fn stasis_realtime_apply_snapshot(
+    revision: i32,
+    tick: i32,
+    seat_count: i32,
+    buttons: *const i32,
+    axis_x: *const i32,
+    axis_y: *const i32,
+    sequences: *const i32,
+    epochs: *const i32,
+    active: *const i32,
+) -> i32 {
+    if revision <= 0
+        || tick < 0
+        || seat_count <= 0
+        || seat_count as usize > realtime::REALTIME_MAX_SEATS
+        || buttons.is_null()
+        || axis_x.is_null()
+        || axis_y.is_null()
+        || sequences.is_null()
+        || epochs.is_null()
+        || active.is_null()
+    {
+        return -1;
+    }
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -3;
+    };
+    if seat_count as usize != session.seats() {
+        return -1;
+    }
+    let mut controls = [realtime::ControlState::neutral(); realtime::REALTIME_MAX_SEATS];
+    let mut sequence_floors = [0_u32; realtime::REALTIME_MAX_SEATS];
+    let mut seat_epochs = [1_u32; realtime::REALTIME_MAX_SEATS];
+    let mut active_seats = [false; realtime::REALTIME_MAX_SEATS];
+    for index in 0..seat_count as usize {
+        let button = unsafe { *buttons.add(index) };
+        let x = unsafe { *axis_x.add(index) };
+        let y = unsafe { *axis_y.add(index) };
+        let sequence = unsafe { *sequences.add(index) };
+        let epoch = unsafe { *epochs.add(index) };
+        let is_active = unsafe { *active.add(index) };
+        let (Ok(button), Ok(x), Ok(y), Ok(sequence), Ok(epoch)) = (
+            u16::try_from(button),
+            i8::try_from(x),
+            i8::try_from(y),
+            u32::try_from(sequence),
+            u32::try_from(epoch),
+        ) else {
+            return -1;
+        };
+        if sequence > i32::MAX as u32
+            || epoch > realtime::GUEST_MAX_EPOCH
+            || !matches!(is_active, 0 | 1)
+        {
+            return -1;
+        }
+        let state = realtime::ControlState::new(button, x, y);
+        controls[index] = state;
+        sequence_floors[index] = sequence;
+        seat_epochs[index] = epoch;
+        active_seats[index] = is_active != 0;
+    }
+    let snapshot = realtime::AuthoritativeSnapshot::new(
+        revision as u64,
+        tick as u64,
+        controls,
+        sequence_floors,
+        seat_epochs,
+        active_seats,
+    );
+    match session.apply_authoritative_snapshot(snapshot) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_start(
+    simulation_hz: i32,
+    presentation_hz: i32,
+    control_hz: i32,
+    input_delay_ticks: i32,
+    seats: i32,
+) -> i32 {
+    let (Ok(simulation_hz), Ok(presentation_hz), Ok(control_hz), Ok(input_delay_ticks), Ok(seats)) = (
+        u32::try_from(simulation_hz),
+        u32::try_from(presentation_hz),
+        u32::try_from(control_hz),
+        u32::try_from(input_delay_ticks),
+        usize::try_from(seats),
+    ) else {
+        return -1;
+    };
+    let Ok(config) = realtime::RealtimeConfig::new(
+        simulation_hz,
+        presentation_hz,
+        control_hz,
+        input_delay_ticks,
+    ) else {
+        return -1;
+    };
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    if slot.is_some() {
+        return -3;
+    }
+    let Ok(session) = realtime::RealtimeSession::new(config, seats) else {
+        return -1;
+    };
+    *slot = Some(session);
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_stop() -> i32 {
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    *slot = None;
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_current_tick() -> i32 {
+    realtime_slot()
+        .lock()
+        .ok()
+        .and_then(|slot| {
+            slot.as_ref()
+                .and_then(|session| i32::try_from(session.current_tick()).ok())
+        })
+        .unwrap_or(-1)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_current_epoch(seat: i32) -> i32 {
+    let Ok(seat) = usize::try_from(seat) else {
+        return -1;
+    };
+    realtime_slot()
+        .lock()
+        .ok()
+        .and_then(|slot| slot.as_ref().and_then(|session| session.epoch(seat)))
+        .and_then(|epoch| i32::try_from(epoch).ok())
+        .unwrap_or(-1)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_schedule(
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32,
+) -> i32 {
+    if seat < 0
+        || seat as usize >= realtime::REALTIME_MAX_SEATS
+        || epoch <= 0
+        || epoch > realtime::GUEST_MAX_EPOCH as i32
+        || sequence <= 0
+        || apply_tick < 0
+        || buttons < 0
+        || buttons > i32::from(u16::MAX)
+        || !(-128..=127).contains(&axis_x)
+        || !(-128..=127).contains(&axis_y)
+    {
+        return -1;
+    }
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -3;
+    };
+    let outcome = session.submit_transition(realtime::ScheduledTransition {
+        seat: seat as u8,
+        epoch: epoch as u32,
+        sequence: sequence as u32,
+        apply_tick: apply_tick as u64,
+        state: realtime::ControlState::new(buttons as u16, axis_x as i8, axis_y as i8),
+    });
+    realtime_admission_code(outcome)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_advance() -> i32 {
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if session.current_tick() >= realtime::GUEST_MAX_TICK {
+        return -4;
+    }
+    match session.advance_tick() {
+        Ok(_) => 0,
+        Err(realtime::TickError::Exhausted) => -3,
+    }
+}
+
+#[no_mangle]
+/// Writes the latest completed control state for `seat` to caller-owned outputs.
+///
+/// # Safety
+///
+/// Each output pointer must be non-null, correctly aligned, and valid for one
+/// write of its pointee type.
+pub unsafe extern "C" fn stasis_realtime_read_control(
+    seat: i32,
+    out_buttons: *mut i32,
+    out_axis_x: *mut i32,
+    out_axis_y: *mut i32,
+) -> i32 {
+    if seat < 0 || out_buttons.is_null() || out_axis_x.is_null() || out_axis_y.is_null() {
+        return -1;
+    }
+    let Ok(slot) = realtime_slot().lock() else {
+        return -2;
+    };
+    let Some(control) = slot
+        .as_ref()
+        .and_then(|session| session.control(seat as usize))
+    else {
+        return -3;
+    };
+    unsafe {
+        *out_buttons = i32::from(control.buttons);
+        *out_axis_x = i32::from(control.axis_x);
+        *out_axis_y = i32::from(control.axis_y);
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_disconnect(seat: i32) -> i32 {
+    let Ok(seat) = usize::try_from(seat) else {
+        return -3;
+    };
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if session
+        .epoch(seat)
+        .is_some_and(|epoch| epoch >= realtime::GUEST_MAX_EPOCH)
+    {
+        return -4;
+    }
+    session.disconnect(seat).map(|_| 0).unwrap_or(-3)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_reconnect(seat: i32) -> i32 {
+    let Ok(seat) = usize::try_from(seat) else {
+        return -3;
+    };
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if session
+        .epoch(seat)
+        .is_some_and(|epoch| epoch >= realtime::GUEST_MAX_EPOCH)
+    {
+        return -4;
+    }
+    session.reconnect(seat).map(|_| 0).unwrap_or(-3)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_pause() -> i32 {
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if (0..session.seats()).any(|seat| {
+        session
+            .epoch(seat)
+            .is_some_and(|epoch| epoch >= realtime::GUEST_MAX_EPOCH)
+    }) {
+        return -4;
+    }
+    session.pause().map(|_| 0).unwrap_or(-3)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_focus_lost() -> i32 {
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if (0..session.seats()).any(|seat| {
+        session
+            .epoch(seat)
+            .is_some_and(|epoch| epoch >= realtime::GUEST_MAX_EPOCH)
+    }) {
+        return -4;
+    }
+    session.focus_lost().map(|_| 0).unwrap_or(-3)
+}
+
+#[no_mangle]
+pub extern "C" fn stasis_realtime_rematch() -> i32 {
+    let Ok(mut slot) = realtime_slot().lock() else {
+        return -1;
+    };
+    let Some(session) = slot.as_mut() else {
+        return -2;
+    };
+    if (0..session.seats()).any(|seat| {
+        session
+            .epoch(seat)
+            .is_some_and(|epoch| epoch >= realtime::GUEST_MAX_EPOCH)
+    }) {
+        return -4;
+    }
+    session.rematch().map(|_| 0).unwrap_or(-3)
+}
 #[no_mangle]
 pub extern "C" fn stasis_network_abi_version() -> u32 {
     ABI_VERSION
@@ -1170,6 +1700,18 @@ mod tests {
     use std::time::{Duration, Instant};
     use tungstenite::client::IntoClientRequest;
     use tungstenite::connect;
+
+    #[test]
+    fn realtime_guest_abi_signatures_and_hash_lanes_are_exact() {
+        let _: unsafe extern "C" fn(*mut i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i32 =
+            stasis_realtime_build_payload;
+        let _: extern "C" fn(i32, i32, i32) -> i32 = stasis_realtime_record_hash;
+        let _: extern "C" fn(i32, i32, i32, i32, i32, i32, i32) -> i32 = stasis_realtime_schedule;
+        assert_eq!(
+            realtime_guest_hash(0x0123_4567, 0x89ab_cdef_u32 as i32),
+            0x89ab_cdef_0123_4567
+        );
+    }
 
     #[test]
     fn positive_seed_mapping_is_bounded_and_nonzero() {

--- a/crates/stasis_network/src/realtime.rs
+++ b/crates/stasis_network/src/realtime.rs
@@ -286,6 +286,7 @@ impl ControlEnvelope {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TickAdvance {
     pub tick: u64,
+    configured_seats: usize,
     controls: [ControlState; REALTIME_MAX_SEATS],
     applied: [ScheduledTransition; MAX_PENDING_TRANSITIONS],
     applied_count: usize,
@@ -303,7 +304,7 @@ impl TickAdvance {
     }
 
     pub fn control(&self, seat: usize) -> Option<ControlState> {
-        self.controls.get(seat).copied()
+        (seat < self.configured_seats).then(|| self.controls[seat])
     }
 
     pub fn applied_transitions(&self) -> &[ScheduledTransition] {
@@ -697,11 +698,11 @@ impl RealtimeSession {
     }
 
     pub fn epoch(&self, seat: usize) -> Option<u32> {
-        self.epochs.get(seat).copied()
+        (seat < self.seats).then(|| self.epochs[seat])
     }
 
     pub fn is_active(&self, seat: usize) -> Option<bool> {
-        self.active.get(seat).copied()
+        (seat < self.seats).then(|| self.active[seat])
     }
 
     pub const fn resync_required(&self) -> bool {
@@ -713,7 +714,7 @@ impl RealtimeSession {
     }
 
     pub fn control(&self, seat: usize) -> Option<ControlState> {
-        self.controls.get(seat).copied()
+        (seat < self.seats).then(|| self.controls[seat])
     }
 
     pub fn pending_len(&self) -> usize {
@@ -802,7 +803,7 @@ impl RealtimeSession {
             self.resync_required = true;
             return AdmissionOutcome::ResyncRequired;
         }
-        if self.pending_count == MAX_PENDING_TRANSITIONS || !self.replay.has_capacity() {
+        if self.pending_count == MAX_PENDING_TRANSITIONS {
             return AdmissionOutcome::Full;
         }
         let reordered = transition.sequence < self.highest_sequence[seat];
@@ -952,6 +953,7 @@ impl RealtimeSession {
         let applied_count = due_count;
         let advance = TickAdvance {
             tick: self.current_tick,
+            configured_seats: self.seats,
             controls: self.controls,
             applied,
             applied_count,
@@ -1115,12 +1117,6 @@ impl RealtimeSession {
         self.quarantined = [(0, 0, 0); MAX_PENDING_TRANSITIONS];
         self.quarantined_count = 0;
         self.resync_required = false;
-    }
-}
-
-impl ReplayLog {
-    fn has_capacity(&self) -> bool {
-        self.records.len() < self.limit
     }
 }
 

--- a/crates/stasis_network/src/realtime.rs
+++ b/crates/stasis_network/src/realtime.rs
@@ -1,0 +1,1207 @@
+//! Fixed-tick realtime control scheduling.
+//!
+//! This module owns the simulation-side contract only.  A transport may carry
+//! [`ControlEnvelope::encode`] bytes in its normal message envelope, but this
+//! module never reads a socket and never performs rendering work.
+
+use thiserror::Error;
+
+pub const REALTIME_MAX_SEATS: usize = 8;
+pub const MAX_ENVELOPE_TRANSITIONS: usize = 16;
+pub const MAX_PENDING_TRANSITIONS: usize = 128;
+pub const DEFAULT_REPLAY_RECORDS: usize = 65_536;
+pub const MAX_REPLAY_RECORDS: usize = 1_000_000;
+pub const MAX_DELAY_TICKS: u32 = 240;
+pub const MAX_FUTURE_TICKS: u64 = 240;
+pub const MAX_SNAPSHOT_TOKEN_BYTES: usize = 64;
+pub const MAX_RATE_HZ: u32 = 1_000;
+/// Native/JIT guests expose ticks and epochs as signed 32-bit values.
+pub const GUEST_MAX_TICK: u64 = i32::MAX as u64;
+pub const GUEST_MAX_EPOCH: u32 = i32::MAX as u32;
+pub const REALTIME_ENVELOPE_MAGIC: [u8; 4] = *b"RTC1";
+pub const REALTIME_ENVELOPE_VERSION: u16 = 1;
+pub const ENVELOPE_HEADER_BYTES: usize = 8;
+pub const TRANSITION_BYTES: usize = 21;
+pub const MAX_ENVELOPE_BYTES: usize =
+    ENVELOPE_HEADER_BYTES + MAX_ENVELOPE_TRANSITIONS * TRANSITION_BYTES;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ControlState {
+    pub buttons: u16,
+    pub axis_x: i8,
+    pub axis_y: i8,
+}
+
+impl ControlState {
+    pub const fn neutral() -> Self {
+        Self {
+            buttons: 0,
+            axis_x: 0,
+            axis_y: 0,
+        }
+    }
+
+    pub const fn new(buttons: u16, axis_x: i8, axis_y: i8) -> Self {
+        Self {
+            buttons,
+            axis_x,
+            axis_y,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ScheduledTransition {
+    pub seat: u8,
+    pub epoch: u32,
+    pub sequence: u32,
+    pub apply_tick: u64,
+    pub state: ControlState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealtimeConfig {
+    simulation_hz: u32,
+    presentation_hz: u32,
+    control_hz: u32,
+    input_delay_ticks: u32,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigError {
+    #[error("simulation, presentation, and control rates must be positive")]
+    ZeroRate,
+    #[error("rate exceeds the bounded realtime limit")]
+    RateTooHigh,
+    #[error("input delay must be positive")]
+    DelayZero,
+    #[error("input delay exceeds the bounded realtime limit")]
+    DelayTooHigh,
+}
+
+impl RealtimeConfig {
+    pub fn new(
+        simulation_hz: u32,
+        presentation_hz: u32,
+        control_hz: u32,
+        input_delay_ticks: u32,
+    ) -> Result<Self, ConfigError> {
+        if simulation_hz == 0 || presentation_hz == 0 || control_hz == 0 {
+            return Err(ConfigError::ZeroRate);
+        }
+        if simulation_hz > MAX_RATE_HZ || presentation_hz > MAX_RATE_HZ || control_hz > MAX_RATE_HZ
+        {
+            return Err(ConfigError::RateTooHigh);
+        }
+        if input_delay_ticks == 0 {
+            return Err(ConfigError::DelayZero);
+        }
+        if input_delay_ticks > MAX_DELAY_TICKS {
+            return Err(ConfigError::DelayTooHigh);
+        }
+        Ok(Self {
+            simulation_hz,
+            presentation_hz,
+            control_hz,
+            input_delay_ticks,
+        })
+    }
+
+    pub const fn simulation_hz(self) -> u32 {
+        self.simulation_hz
+    }
+
+    pub const fn presentation_hz(self) -> u32 {
+        self.presentation_hz
+    }
+
+    pub const fn control_hz(self) -> u32 {
+        self.control_hz
+    }
+
+    pub const fn input_delay_ticks(self) -> u32 {
+        self.input_delay_ticks
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionOutcome {
+    Accepted,
+    AcceptedReordered,
+    Inactive,
+    Duplicate,
+    Stale,
+    Conflict,
+    Late,
+    TooFar,
+    ResyncRequired,
+    Malformed,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdmissionReport {
+    outcomes: [AdmissionOutcome; MAX_ENVELOPE_TRANSITIONS],
+    count: usize,
+}
+
+impl AdmissionReport {
+    fn one(outcome: AdmissionOutcome) -> Self {
+        let mut report = Self {
+            outcomes: [AdmissionOutcome::Malformed; MAX_ENVELOPE_TRANSITIONS],
+            count: 1,
+        };
+        report.outcomes[0] = outcome;
+        report
+    }
+
+    pub fn len(self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.count == 0
+    }
+
+    pub fn outcomes(&self) -> &[AdmissionOutcome] {
+        &self.outcomes[..self.count]
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum EnvelopeError {
+    #[error("control envelope has an invalid transition")]
+    InvalidTransition,
+    #[error("control envelope is full")]
+    Full,
+    #[error("control envelope has a duplicate transition identity")]
+    Duplicate,
+    #[error("control envelope has a conflicting transition identity")]
+    Conflict,
+    #[error("control envelope is malformed")]
+    Malformed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ControlEnvelope {
+    count: usize,
+    transitions: [ScheduledTransition; MAX_ENVELOPE_TRANSITIONS],
+}
+
+impl Default for ControlEnvelope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ControlEnvelope {
+    pub const fn new() -> Self {
+        Self {
+            count: 0,
+            transitions: [ScheduledTransition {
+                seat: 0,
+                epoch: 0,
+                sequence: 0,
+                apply_tick: 0,
+                state: ControlState::neutral(),
+            }; MAX_ENVELOPE_TRANSITIONS],
+        }
+    }
+
+    pub fn from_transition(transition: ScheduledTransition) -> Result<Self, EnvelopeError> {
+        let mut envelope = Self::new();
+        envelope.push(transition)?;
+        Ok(envelope)
+    }
+
+    pub fn push(&mut self, transition: ScheduledTransition) -> Result<(), EnvelopeError> {
+        validate_transition(transition)?;
+        for existing in self.transitions.iter().take(self.count) {
+            if same_sequence(*existing, transition) {
+                if same_identity(*existing, transition) && *existing == transition {
+                    return Err(EnvelopeError::Duplicate);
+                }
+                return Err(EnvelopeError::Conflict);
+            }
+        }
+        if self.count == MAX_ENVELOPE_TRANSITIONS {
+            return Err(EnvelopeError::Full);
+        }
+        self.transitions[self.count] = transition;
+        self.count += 1;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    pub fn transitions(&self) -> &[ScheduledTransition] {
+        &self.transitions[..self.count]
+    }
+
+    /// Encode the bounded transport payload.  The production network layer
+    /// can pass these bytes through its existing message envelope unchanged.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(ENVELOPE_HEADER_BYTES + self.count * TRANSITION_BYTES);
+        bytes.extend_from_slice(&REALTIME_ENVELOPE_MAGIC);
+        bytes.extend_from_slice(&REALTIME_ENVELOPE_VERSION.to_be_bytes());
+        bytes.push(self.count as u8);
+        bytes.push(0);
+        for transition in self.transitions() {
+            encode_transition(*transition, &mut bytes);
+        }
+        bytes
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+        if bytes.len() < ENVELOPE_HEADER_BYTES || bytes.len() > MAX_ENVELOPE_BYTES {
+            return Err(EnvelopeError::Malformed);
+        }
+        if bytes[..4] != REALTIME_ENVELOPE_MAGIC
+            || u16::from_be_bytes([bytes[4], bytes[5]]) != REALTIME_ENVELOPE_VERSION
+            || bytes[7] != 0
+        {
+            return Err(EnvelopeError::Malformed);
+        }
+        let count = bytes[6] as usize;
+        if count > MAX_ENVELOPE_TRANSITIONS
+            || bytes.len() != ENVELOPE_HEADER_BYTES + count * TRANSITION_BYTES
+        {
+            return Err(EnvelopeError::Malformed);
+        }
+        let mut envelope = Self::new();
+        for index in 0..count {
+            let start = ENVELOPE_HEADER_BYTES + index * TRANSITION_BYTES;
+            envelope.push(decode_transition(&bytes[start..start + TRANSITION_BYTES])?)?;
+        }
+        Ok(envelope)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TickAdvance {
+    pub tick: u64,
+    controls: [ControlState; REALTIME_MAX_SEATS],
+    applied: [ScheduledTransition; MAX_PENDING_TRANSITIONS],
+    applied_count: usize,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum TickError {
+    #[error("authoritative simulation tick is exhausted")]
+    Exhausted,
+}
+
+impl TickAdvance {
+    pub fn controls(&self) -> &[ControlState; REALTIME_MAX_SEATS] {
+        &self.controls
+    }
+
+    pub fn control(&self, seat: usize) -> Option<ControlState> {
+        self.controls.get(seat).copied()
+    }
+
+    pub fn applied_transitions(&self) -> &[ScheduledTransition] {
+        &self.applied[..self.applied_count]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthoritativeSnapshot {
+    pub revision: u64,
+    pub tick: u64,
+    pub controls: [ControlState; REALTIME_MAX_SEATS],
+    pub sequences: [u32; REALTIME_MAX_SEATS],
+    pub epochs: [u32; REALTIME_MAX_SEATS],
+    pub active: [bool; REALTIME_MAX_SEATS],
+    pub game_token: [u8; MAX_SNAPSHOT_TOKEN_BYTES],
+    pub game_token_len: u8,
+}
+
+impl AuthoritativeSnapshot {
+    pub const fn new(
+        revision: u64,
+        tick: u64,
+        controls: [ControlState; REALTIME_MAX_SEATS],
+        sequences: [u32; REALTIME_MAX_SEATS],
+        epochs: [u32; REALTIME_MAX_SEATS],
+        active: [bool; REALTIME_MAX_SEATS],
+    ) -> Self {
+        Self {
+            revision,
+            tick,
+            controls,
+            sequences,
+            epochs,
+            active,
+            game_token: [0; MAX_SNAPSHOT_TOKEN_BYTES],
+            game_token_len: 0,
+        }
+    }
+
+    pub fn with_game_token(mut self, token: &[u8]) -> Result<Self, SnapshotError> {
+        if token.len() > MAX_SNAPSHOT_TOKEN_BYTES {
+            return Err(SnapshotError::TokenTooLarge);
+        }
+        self.game_token[..token.len()].copy_from_slice(token);
+        self.game_token_len = token.len() as u8;
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetReason {
+    Disconnect { seat: u8 },
+    Reconnect { seat: u8 },
+    Pause,
+    FocusLost,
+    Rematch,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleError {
+    #[error("seat is outside the configured seat count")]
+    InvalidSeat,
+    #[error("replay record limit is outside the bounded range")]
+    InvalidReplayLimit,
+    #[error("seat epoch is exhausted")]
+    EpochExhausted,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotError {
+    #[error("snapshot revision must be newer than the current revision")]
+    RevisionRegression,
+    #[error("snapshot tick does not leave room for bounded future scheduling")]
+    TickOutOfRange,
+    #[error("snapshot tick regresses within an unchanged seat epoch")]
+    TickRegression,
+    #[error("snapshot seat epoch regresses")]
+    EpochRegression,
+    #[error("snapshot seat epoch cannot be advanced safely")]
+    EpochExhausted,
+    #[error("snapshot sequence floor regresses within an unchanged seat epoch")]
+    SequenceRegression,
+    #[error("snapshot contains state for inactive seat {seat}")]
+    InactiveSeatState { seat: usize },
+    #[error("snapshot token is too large")]
+    TokenTooLarge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayRecord {
+    Scheduled(ScheduledTransition),
+    Tick {
+        tick: u64,
+        controls: [ControlState; REALTIME_MAX_SEATS],
+        authoritative_hash: Option<u64>,
+    },
+    Reset(ResetReason),
+    Snapshot(AuthoritativeSnapshot),
+    Quarantine {
+        seat: u8,
+        epoch: u32,
+        sequence: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayEvent {
+    Reset(ResetReason),
+    Snapshot(AuthoritativeSnapshot),
+    Quarantine { seat: u8, epoch: u32, sequence: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayLog {
+    records: Vec<ReplayRecord>,
+    limit: usize,
+    complete: bool,
+}
+
+impl Default for ReplayLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplayLog {
+    pub fn new() -> Self {
+        Self::with_limit(DEFAULT_REPLAY_RECORDS).expect("default replay limit is valid")
+    }
+
+    pub fn with_limit(limit: usize) -> Result<Self, LifecycleError> {
+        if limit == 0 || limit > MAX_REPLAY_RECORDS {
+            return Err(LifecycleError::InvalidReplayLimit);
+        }
+        Ok(Self {
+            records: Vec::new(),
+            limit,
+            complete: true,
+        })
+    }
+
+    fn push(&mut self, record: ReplayRecord) -> bool {
+        if self.records.len() == self.limit {
+            self.complete = false;
+            return false;
+        }
+        self.records.push(record);
+        true
+    }
+
+    fn record_hash(&mut self, tick: u64, hash: u64) -> Result<(), HashRecordError> {
+        let Some(ReplayRecord::Tick {
+            tick: latest_tick,
+            authoritative_hash,
+            ..
+        }) = self.records.last_mut()
+        else {
+            return Err(HashRecordError::NoUnfinishedTick);
+        };
+        if *latest_tick != tick {
+            return Err(HashRecordError::WrongTick {
+                expected: *latest_tick,
+                received: tick,
+            });
+        }
+        if authoritative_hash.is_some() {
+            return Err(HashRecordError::AlreadyRecorded);
+        }
+        *authoritative_hash = Some(hash);
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    pub fn records(&self) -> impl Iterator<Item = &ReplayRecord> {
+        self.records.iter()
+    }
+
+    /// Replay the control schedule and verify each caller-supplied hash.
+    /// Hashing remains the game's responsibility; the callback receives the
+    /// exact post-tick control snapshot used by the simulation.
+    pub fn replay<F>(
+        &self,
+        config: RealtimeConfig,
+        seats: usize,
+        hash: F,
+    ) -> Result<(), ReplayError>
+    where
+        F: FnMut(u64, &[ControlState; REALTIME_MAX_SEATS]) -> u64,
+    {
+        self.replay_with_events(config, seats, |_| {}, hash)
+    }
+
+    pub fn replay_with_events<E, F>(
+        &self,
+        config: RealtimeConfig,
+        seats: usize,
+        mut event: E,
+        mut hash: F,
+    ) -> Result<(), ReplayError>
+    where
+        E: FnMut(ReplayEvent),
+        F: FnMut(u64, &[ControlState; REALTIME_MAX_SEATS]) -> u64,
+    {
+        if !self.complete {
+            return Err(ReplayError::Incomplete);
+        }
+        let mut session =
+            RealtimeSession::new(config, seats).map_err(|_| ReplayError::InvalidSetup)?;
+        for (index, record) in self.records().enumerate() {
+            match *record {
+                ReplayRecord::Scheduled(transition) => {
+                    let outcome = session.submit_transition(transition);
+                    if !matches!(
+                        outcome,
+                        AdmissionOutcome::Accepted | AdmissionOutcome::AcceptedReordered
+                    ) {
+                        return Err(ReplayError::Admission { index, outcome });
+                    }
+                }
+                ReplayRecord::Tick {
+                    tick,
+                    controls,
+                    authoritative_hash,
+                } => {
+                    let advance = session
+                        .advance_tick()
+                        .map_err(|_| ReplayError::TickExhausted { index })?;
+                    if advance.tick != tick || advance.controls != controls {
+                        return Err(ReplayError::TickMismatch { index, tick });
+                    }
+                    let Some(expected) = authoritative_hash else {
+                        return Err(ReplayError::MissingHash { index, tick });
+                    };
+                    let observed = hash(tick, &controls);
+                    if observed != expected {
+                        return Err(ReplayError::HashMismatch {
+                            index,
+                            tick,
+                            expected,
+                            observed,
+                        });
+                    }
+                }
+                ReplayRecord::Reset(reason) => {
+                    event(ReplayEvent::Reset(reason));
+                    session.apply_reset(reason)?;
+                }
+                ReplayRecord::Snapshot(snapshot) => {
+                    event(ReplayEvent::Snapshot(snapshot));
+                    session.apply_snapshot(snapshot);
+                }
+                ReplayRecord::Quarantine {
+                    seat,
+                    epoch,
+                    sequence,
+                } => {
+                    event(ReplayEvent::Quarantine {
+                        seat,
+                        epoch,
+                        sequence,
+                    });
+                    if !session.quarantine_identity(seat, epoch, sequence) {
+                        return Err(ReplayError::InvalidSetup);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum HashRecordError {
+    #[error("there is no immediately preceding unfinished simulation tick")]
+    NoUnfinishedTick,
+    #[error("hash belongs to tick {expected}, not tick {received}")]
+    WrongTick { expected: u64, received: u64 },
+    #[error("the current simulation tick already has a hash")]
+    AlreadyRecorded,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayError {
+    #[error("replay log is incomplete")]
+    Incomplete,
+    #[error("replay setup is invalid")]
+    InvalidSetup,
+    #[error("replay admission failed at record {index}: {outcome:?}")]
+    Admission {
+        index: usize,
+        outcome: AdmissionOutcome,
+    },
+    #[error("replay tick {tick} differs at record {index}")]
+    TickMismatch { index: usize, tick: u64 },
+    #[error("replay tick could not advance at record {index}")]
+    TickExhausted { index: usize },
+    #[error("replay tick {tick} has no authoritative hash at record {index}")]
+    MissingHash { index: usize, tick: u64 },
+    #[error("replay hash differs at tick {tick}: expected {expected}, observed {observed}")]
+    HashMismatch {
+        index: usize,
+        tick: u64,
+        expected: u64,
+        observed: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealtimeSession {
+    config: RealtimeConfig,
+    seats: usize,
+    current_tick: u64,
+    snapshot_revision: u64,
+    controls: [ControlState; REALTIME_MAX_SEATS],
+    epochs: [u32; REALTIME_MAX_SEATS],
+    active: [bool; REALTIME_MAX_SEATS],
+    highest_applied_sequence: [u32; REALTIME_MAX_SEATS],
+    highest_sequence: [u32; REALTIME_MAX_SEATS],
+    quarantined: [(u8, u32, u32); MAX_PENDING_TRANSITIONS],
+    quarantined_count: usize,
+    resync_required: bool,
+    pending: [Option<ScheduledTransition>; MAX_PENDING_TRANSITIONS],
+    pending_count: usize,
+    recent: [Option<ScheduledTransition>; MAX_PENDING_TRANSITIONS],
+    recent_next: usize,
+    replay: ReplayLog,
+}
+
+impl RealtimeSession {
+    pub fn new(config: RealtimeConfig, seats: usize) -> Result<Self, LifecycleError> {
+        Self::new_with_replay_limit(config, seats, DEFAULT_REPLAY_RECORDS)
+    }
+
+    pub fn new_with_replay_limit(
+        config: RealtimeConfig,
+        seats: usize,
+        replay_limit: usize,
+    ) -> Result<Self, LifecycleError> {
+        if seats == 0 || seats > REALTIME_MAX_SEATS {
+            return Err(LifecycleError::InvalidSeat);
+        }
+        let mut session = Self {
+            config,
+            seats,
+            current_tick: 0,
+            snapshot_revision: 0,
+            controls: [ControlState::neutral(); REALTIME_MAX_SEATS],
+            epochs: [1; REALTIME_MAX_SEATS],
+            active: [false; REALTIME_MAX_SEATS],
+            highest_applied_sequence: [0; REALTIME_MAX_SEATS],
+            highest_sequence: [0; REALTIME_MAX_SEATS],
+            quarantined: [(0, 0, 0); MAX_PENDING_TRANSITIONS],
+            quarantined_count: 0,
+            resync_required: false,
+            pending: [None; MAX_PENDING_TRANSITIONS],
+            pending_count: 0,
+            recent: [None; MAX_PENDING_TRANSITIONS],
+            recent_next: 0,
+            replay: ReplayLog::with_limit(replay_limit)?,
+        };
+        session.active[..seats].fill(true);
+        Ok(session)
+    }
+
+    pub const fn config(&self) -> RealtimeConfig {
+        self.config
+    }
+
+    pub const fn seats(&self) -> usize {
+        self.seats
+    }
+
+    pub const fn current_tick(&self) -> u64 {
+        self.current_tick
+    }
+
+    pub const fn snapshot_revision(&self) -> u64 {
+        self.snapshot_revision
+    }
+
+    pub fn epoch(&self, seat: usize) -> Option<u32> {
+        self.epochs.get(seat).copied()
+    }
+
+    pub fn is_active(&self, seat: usize) -> Option<bool> {
+        self.active.get(seat).copied()
+    }
+
+    pub const fn resync_required(&self) -> bool {
+        self.resync_required
+    }
+
+    pub fn controls(&self) -> &[ControlState; REALTIME_MAX_SEATS] {
+        &self.controls
+    }
+
+    pub fn control(&self, seat: usize) -> Option<ControlState> {
+        self.controls.get(seat).copied()
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending_count
+    }
+
+    pub fn replay(&self) -> &ReplayLog {
+        &self.replay
+    }
+
+    pub fn earliest_apply_tick(&self) -> u64 {
+        self.current_tick
+            .saturating_add(u64::from(self.config.input_delay_ticks))
+    }
+
+    pub fn latest_apply_tick(&self) -> u64 {
+        self.current_tick.saturating_add(MAX_FUTURE_TICKS)
+    }
+
+    pub fn submit_transition(&mut self, transition: ScheduledTransition) -> AdmissionOutcome {
+        if validate_transition(transition).is_err() || transition.seat as usize >= self.seats {
+            return AdmissionOutcome::Malformed;
+        }
+        if self.resync_required {
+            return AdmissionOutcome::ResyncRequired;
+        }
+        let seat = transition.seat as usize;
+        if !self.active[seat] {
+            return AdmissionOutcome::Inactive;
+        }
+        if transition.epoch != self.epochs[seat] {
+            return AdmissionOutcome::Stale;
+        }
+        if transition.apply_tick < self.earliest_apply_tick() {
+            return AdmissionOutcome::Late;
+        }
+        if transition.apply_tick > self.latest_apply_tick() {
+            return AdmissionOutcome::TooFar;
+        }
+        if self
+            .quarantined
+            .iter()
+            .take(self.quarantined_count)
+            .any(|(seat, epoch, sequence)| {
+                *seat == transition.seat
+                    && *epoch == transition.epoch
+                    && *sequence == transition.sequence
+            })
+        {
+            return AdmissionOutcome::Conflict;
+        }
+        for existing in self.pending.iter().flatten() {
+            if same_sequence(*existing, transition) {
+                if same_identity(*existing, transition) && *existing == transition {
+                    return AdmissionOutcome::Duplicate;
+                }
+                if !self.quarantine_identity(transition.seat, transition.epoch, transition.sequence)
+                {
+                    self.resync_required = true;
+                    return AdmissionOutcome::ResyncRequired;
+                }
+                self.replay.push(ReplayRecord::Quarantine {
+                    seat: transition.seat,
+                    epoch: transition.epoch,
+                    sequence: transition.sequence,
+                });
+                return AdmissionOutcome::Conflict;
+            }
+        }
+        for existing in self.recent.iter().flatten() {
+            if same_sequence(*existing, transition) {
+                if same_identity(*existing, transition) && *existing == transition {
+                    return AdmissionOutcome::Duplicate;
+                }
+                return if transition.apply_tick <= self.current_tick {
+                    AdmissionOutcome::Late
+                } else {
+                    AdmissionOutcome::Stale
+                };
+            }
+        }
+        if transition.sequence <= self.highest_applied_sequence[seat] {
+            return AdmissionOutcome::Stale;
+        }
+        if self.quarantined_count == MAX_PENDING_TRANSITIONS {
+            self.resync_required = true;
+            return AdmissionOutcome::ResyncRequired;
+        }
+        if self.pending_count == MAX_PENDING_TRANSITIONS || !self.replay.has_capacity() {
+            return AdmissionOutcome::Full;
+        }
+        let reordered = transition.sequence < self.highest_sequence[seat];
+        let slot = self
+            .pending
+            .iter()
+            .position(Option::is_none)
+            .expect("pending_count and slots remain consistent");
+        self.pending[slot] = Some(transition);
+        self.pending_count += 1;
+        self.highest_sequence[seat] = self.highest_sequence[seat].max(transition.sequence);
+        self.replay.push(ReplayRecord::Scheduled(transition));
+        if reordered {
+            AdmissionOutcome::AcceptedReordered
+        } else {
+            AdmissionOutcome::Accepted
+        }
+    }
+
+    pub fn submit_envelope(&mut self, envelope: &ControlEnvelope) -> AdmissionReport {
+        let mut report = AdmissionReport {
+            outcomes: [AdmissionOutcome::Malformed; MAX_ENVELOPE_TRANSITIONS],
+            count: envelope.count,
+        };
+        for (index, transition) in envelope.transitions().iter().enumerate() {
+            report.outcomes[index] = self.submit_transition(*transition);
+        }
+        report
+    }
+
+    pub fn submit_payload(&mut self, payload: &[u8]) -> AdmissionReport {
+        match ControlEnvelope::decode(payload) {
+            Ok(envelope) => self.submit_envelope(&envelope),
+            Err(_) => AdmissionReport::one(AdmissionOutcome::Malformed),
+        }
+    }
+
+    /// Advance exactly one authoritative simulation tick.  No network read,
+    /// packet wait, or rendering operation occurs here.
+    pub fn advance_tick(&mut self) -> Result<TickAdvance, TickError> {
+        self.advance_tick_inner()
+    }
+
+    /// Attach a hash computed from the returned post-tick state to the
+    /// immediately preceding tick record.
+    pub fn record_authoritative_hash(
+        &mut self,
+        tick: u64,
+        authoritative_hash: u64,
+    ) -> Result<(), HashRecordError> {
+        self.replay.record_hash(tick, authoritative_hash)
+    }
+
+    pub fn disconnect(&mut self, seat: usize) -> Result<(), LifecycleError> {
+        self.lifecycle_epoch(seat, false, ResetReason::Disconnect { seat: seat as u8 })
+    }
+
+    pub fn reconnect(&mut self, seat: usize) -> Result<(), LifecycleError> {
+        self.lifecycle_epoch(seat, true, ResetReason::Reconnect { seat: seat as u8 })
+    }
+
+    pub fn pause(&mut self) -> Result<(), LifecycleError> {
+        self.reset_all(ResetReason::Pause)
+    }
+
+    pub fn focus_lost(&mut self) -> Result<(), LifecycleError> {
+        self.reset_all(ResetReason::FocusLost)
+    }
+
+    pub fn rematch(&mut self) -> Result<(), LifecycleError> {
+        self.reset_all(ResetReason::Rematch)
+    }
+
+    pub fn apply_authoritative_snapshot(
+        &mut self,
+        snapshot: AuthoritativeSnapshot,
+    ) -> Result<(), SnapshotError> {
+        if snapshot.revision == 0 || snapshot.revision <= self.snapshot_revision {
+            return Err(SnapshotError::RevisionRegression);
+        }
+        if snapshot.tick > u64::MAX - MAX_FUTURE_TICKS {
+            return Err(SnapshotError::TickOutOfRange);
+        }
+        for seat in 0..REALTIME_MAX_SEATS {
+            if (seat >= self.seats || !snapshot.active[seat])
+                && (snapshot.controls[seat] != ControlState::neutral()
+                    || snapshot.sequences[seat] != 0
+                    || snapshot.active[seat])
+            {
+                return Err(SnapshotError::InactiveSeatState { seat });
+            }
+        }
+        if snapshot.game_token_len as usize > MAX_SNAPSHOT_TOKEN_BYTES {
+            return Err(SnapshotError::TokenTooLarge);
+        }
+        for seat in 0..self.seats {
+            if snapshot.epochs[seat] == u32::MAX {
+                return Err(SnapshotError::EpochExhausted);
+            }
+            if snapshot.epochs[seat] < self.epochs[seat] {
+                return Err(SnapshotError::EpochRegression);
+            }
+            if snapshot.epochs[seat] == self.epochs[seat] {
+                if snapshot.tick < self.current_tick {
+                    return Err(SnapshotError::TickRegression);
+                }
+                if snapshot.sequences[seat] < self.highest_sequence[seat] {
+                    return Err(SnapshotError::SequenceRegression);
+                }
+            }
+        }
+        self.apply_snapshot(snapshot);
+        self.replay.push(ReplayRecord::Snapshot(snapshot));
+        Ok(())
+    }
+
+    fn advance_tick_inner(&mut self) -> Result<TickAdvance, TickError> {
+        self.current_tick = self
+            .current_tick
+            .checked_add(1)
+            .ok_or(TickError::Exhausted)?;
+        let mut due = [0usize; MAX_PENDING_TRANSITIONS];
+        let mut due_count = 0;
+        for (index, pending) in self.pending.iter().enumerate() {
+            if pending.is_some_and(|transition| transition.apply_tick == self.current_tick) {
+                due[due_count] = index;
+                due_count += 1;
+            }
+        }
+        due[..due_count].sort_by_key(|index| {
+            let transition = self.pending[*index].expect("due index is populated");
+            (transition.seat, transition.sequence, transition.apply_tick)
+        });
+        let mut applied = [ScheduledTransition::default(); MAX_PENDING_TRANSITIONS];
+        for (applied_index, index) in due.into_iter().take(due_count).enumerate() {
+            let transition = self.pending[index].take().expect("due index is populated");
+            self.pending_count -= 1;
+            self.controls[transition.seat as usize] = transition.state;
+            let seat = transition.seat as usize;
+            self.highest_applied_sequence[seat] =
+                self.highest_applied_sequence[seat].max(transition.sequence);
+            self.compact_quarantine(seat);
+            self.recent[self.recent_next] = Some(transition);
+            self.recent_next = (self.recent_next + 1) % MAX_PENDING_TRANSITIONS;
+            applied[applied_index] = transition;
+        }
+        let applied_count = due_count;
+        let advance = TickAdvance {
+            tick: self.current_tick,
+            controls: self.controls,
+            applied,
+            applied_count,
+        };
+        self.replay.push(ReplayRecord::Tick {
+            tick: advance.tick,
+            controls: advance.controls,
+            authoritative_hash: None,
+        });
+        Ok(advance)
+    }
+
+    fn lifecycle_epoch(
+        &mut self,
+        seat: usize,
+        active: bool,
+        reason: ResetReason,
+    ) -> Result<(), LifecycleError> {
+        if seat >= self.seats {
+            return Err(LifecycleError::InvalidSeat);
+        }
+        let next_epoch = self.next_epoch(seat)?;
+        self.epochs[seat] = next_epoch;
+        self.active[seat] = active;
+        self.controls[seat] = ControlState::neutral();
+        self.remove_pending_seat(seat);
+        self.highest_sequence[seat] = 0;
+        self.highest_applied_sequence[seat] = 0;
+        self.recent
+            .iter_mut()
+            .filter(|entry| entry.is_some_and(|t| t.seat as usize == seat))
+            .for_each(|entry| *entry = None);
+        let mut retained = [(0, 0, 0); MAX_PENDING_TRANSITIONS];
+        let mut retained_count = 0;
+        for entry in self.quarantined.iter().take(self.quarantined_count) {
+            if entry.0 as usize != seat {
+                retained[retained_count] = *entry;
+                retained_count += 1;
+            }
+        }
+        self.quarantined = retained;
+        self.quarantined_count = retained_count;
+        self.replay.push(ReplayRecord::Reset(reason));
+        Ok(())
+    }
+
+    fn reset_all(&mut self, reason: ResetReason) -> Result<(), LifecycleError> {
+        let mut next_epochs = self.epochs;
+        for (seat, next_epoch) in next_epochs.iter_mut().enumerate().take(self.seats) {
+            *next_epoch = self.next_epoch(seat)?;
+        }
+        self.epochs = next_epochs;
+        if reason == ResetReason::Rematch {
+            self.current_tick = 0;
+            self.active[..self.seats].fill(true);
+        }
+        self.controls = [ControlState::neutral(); REALTIME_MAX_SEATS];
+        self.pending = [None; MAX_PENDING_TRANSITIONS];
+        self.pending_count = 0;
+        for seat in 0..self.seats {
+            self.highest_sequence[seat] = 0;
+            self.highest_applied_sequence[seat] = 0;
+        }
+        self.quarantined = [(0, 0, 0); MAX_PENDING_TRANSITIONS];
+        self.quarantined_count = 0;
+        self.resync_required = false;
+        self.recent = [None; MAX_PENDING_TRANSITIONS];
+        self.recent_next = 0;
+        self.replay.push(ReplayRecord::Reset(reason));
+        Ok(())
+    }
+
+    fn remove_pending_seat(&mut self, seat: usize) {
+        for pending in &mut self.pending {
+            if pending.is_some_and(|transition| transition.seat as usize == seat) {
+                *pending = None;
+                self.pending_count -= 1;
+            }
+        }
+    }
+
+    fn apply_reset(&mut self, reason: ResetReason) -> Result<(), ReplayError> {
+        match reason {
+            ResetReason::Disconnect { seat } | ResetReason::Reconnect { seat } => self
+                .lifecycle_epoch(
+                    seat as usize,
+                    matches!(reason, ResetReason::Reconnect { .. }),
+                    reason,
+                )
+                .map_err(|_| ReplayError::InvalidSetup),
+            ResetReason::Pause | ResetReason::FocusLost | ResetReason::Rematch => self
+                .reset_all(reason)
+                .map_err(|_| ReplayError::InvalidSetup),
+        }
+    }
+
+    fn quarantine_identity(&mut self, seat: u8, epoch: u32, sequence: u32) -> bool {
+        self.remove_pending_sequence(seat, epoch, sequence);
+        if self
+            .quarantined
+            .iter()
+            .take(self.quarantined_count)
+            .any(|identity| *identity == (seat, epoch, sequence))
+        {
+            return true;
+        }
+        if self.quarantined_count < MAX_PENDING_TRANSITIONS {
+            self.quarantined[self.quarantined_count] = (seat, epoch, sequence);
+            self.quarantined_count += 1;
+            return true;
+        }
+        false
+    }
+
+    fn remove_pending_sequence(&mut self, seat: u8, epoch: u32, sequence: u32) {
+        for pending in &mut self.pending {
+            if pending.is_some_and(|transition| {
+                transition.seat == seat
+                    && transition.epoch == epoch
+                    && transition.sequence == sequence
+            }) {
+                *pending = None;
+                self.pending_count -= 1;
+            }
+        }
+    }
+
+    fn next_epoch(&self, seat: usize) -> Result<u32, LifecycleError> {
+        self.epochs[seat]
+            .checked_add(1)
+            .ok_or(LifecycleError::EpochExhausted)
+    }
+
+    fn compact_quarantine(&mut self, seat: usize) {
+        let floor = self.highest_applied_sequence[seat];
+        let epoch = self.epochs[seat];
+        let mut retained = [(0, 0, 0); MAX_PENDING_TRANSITIONS];
+        let mut retained_count = 0;
+        for identity in self.quarantined.iter().take(self.quarantined_count) {
+            if !(identity.0 as usize == seat && identity.1 == epoch && identity.2 <= floor) {
+                retained[retained_count] = *identity;
+                retained_count += 1;
+            }
+        }
+        self.quarantined = retained;
+        self.quarantined_count = retained_count;
+    }
+
+    fn apply_snapshot(&mut self, snapshot: AuthoritativeSnapshot) {
+        self.snapshot_revision = snapshot.revision;
+        self.current_tick = snapshot.tick;
+        self.controls = snapshot.controls;
+        self.highest_applied_sequence = snapshot.sequences;
+        self.highest_sequence = snapshot.sequences;
+        self.epochs = snapshot.epochs;
+        self.active = snapshot.active;
+        self.pending = [None; MAX_PENDING_TRANSITIONS];
+        self.pending_count = 0;
+        self.recent = [None; MAX_PENDING_TRANSITIONS];
+        self.recent_next = 0;
+        self.quarantined = [(0, 0, 0); MAX_PENDING_TRANSITIONS];
+        self.quarantined_count = 0;
+        self.resync_required = false;
+    }
+}
+
+impl ReplayLog {
+    fn has_capacity(&self) -> bool {
+        self.records.len() < self.limit
+    }
+}
+
+fn validate_transition(transition: ScheduledTransition) -> Result<(), EnvelopeError> {
+    if transition.seat as usize >= REALTIME_MAX_SEATS
+        || transition.epoch == 0
+        || transition.sequence == 0
+    {
+        return Err(EnvelopeError::InvalidTransition);
+    }
+    Ok(())
+}
+
+fn same_identity(left: ScheduledTransition, right: ScheduledTransition) -> bool {
+    left.seat == right.seat
+        && left.epoch == right.epoch
+        && left.sequence == right.sequence
+        && left.apply_tick == right.apply_tick
+}
+
+fn same_sequence(left: ScheduledTransition, right: ScheduledTransition) -> bool {
+    left.seat == right.seat && left.epoch == right.epoch && left.sequence == right.sequence
+}
+
+fn encode_transition(transition: ScheduledTransition, bytes: &mut Vec<u8>) {
+    bytes.push(transition.seat);
+    bytes.extend_from_slice(&transition.epoch.to_be_bytes());
+    bytes.extend_from_slice(&transition.sequence.to_be_bytes());
+    bytes.extend_from_slice(&transition.apply_tick.to_be_bytes());
+    bytes.extend_from_slice(&transition.state.buttons.to_be_bytes());
+    bytes.push(transition.state.axis_x as u8);
+    bytes.push(transition.state.axis_y as u8);
+}
+
+fn decode_transition(bytes: &[u8]) -> Result<ScheduledTransition, EnvelopeError> {
+    if bytes.len() != TRANSITION_BYTES {
+        return Err(EnvelopeError::Malformed);
+    }
+    let transition = ScheduledTransition {
+        seat: bytes[0],
+        epoch: u32::from_be_bytes(bytes[1..5].try_into().expect("fixed transition width")),
+        sequence: u32::from_be_bytes(bytes[5..9].try_into().expect("fixed transition width")),
+        apply_tick: u64::from_be_bytes(bytes[9..17].try_into().expect("fixed transition width")),
+        state: ControlState {
+            buttons: u16::from_be_bytes(bytes[17..19].try_into().expect("fixed transition width")),
+            axis_x: bytes[19] as i8,
+            axis_y: bytes[20] as i8,
+        },
+    };
+    validate_transition(transition)?;
+    Ok(transition)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_exhaustion_does_not_emit_duplicate_max_tick() {
+        let config = RealtimeConfig::new(60, 30, 120, 1).expect("config");
+        let mut session = RealtimeSession::new(config, 1).expect("session");
+        session.current_tick = u64::MAX - 1;
+        assert_eq!(session.advance_tick().expect("maximum tick").tick, u64::MAX);
+        assert_eq!(session.advance_tick(), Err(TickError::Exhausted));
+        assert_eq!(
+            session
+                .replay
+                .records()
+                .filter(|record| matches!(record, ReplayRecord::Tick { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn all_seat_reset_preflights_epoch_exhaustion() {
+        let config = RealtimeConfig::new(60, 60, 60, 1).expect("config");
+        let mut session = RealtimeSession::new(config, 2).expect("session");
+        session.epochs[1] = u32::MAX;
+        let before = session.clone();
+        assert_eq!(session.pause(), Err(LifecycleError::EpochExhausted));
+        assert_eq!(session, before);
+    }
+}

--- a/crates/stasis_network/tests/realtime_controls.rs
+++ b/crates/stasis_network/tests/realtime_controls.rs
@@ -1,0 +1,930 @@
+use stasis_network::realtime::{
+    AdmissionOutcome, AuthoritativeSnapshot, ConfigError, ControlEnvelope, ControlState,
+    HashRecordError, RealtimeConfig, RealtimeSession, ReplayError, ReplayEvent, ReplayRecord,
+    ScheduledTransition, SnapshotError, MAX_PENDING_TRANSITIONS, REALTIME_MAX_SEATS,
+};
+use stasis_network::{
+    stasis_realtime_advance, stasis_realtime_current_tick, stasis_realtime_read_control,
+    stasis_realtime_schedule, stasis_realtime_start, stasis_realtime_stop,
+    stasis_realtime_submit_payload, BundleFile, EventKind, NetworkHost, StaticBundle,
+};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+use tungstenite::client::IntoClientRequest;
+use tungstenite::{connect, Message};
+
+fn native_realtime_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("native realtime test lock")
+}
+
+fn transition(
+    seat: u8,
+    sequence: u32,
+    apply_tick: u64,
+    state: ControlState,
+) -> ScheduledTransition {
+    ScheduledTransition {
+        seat,
+        epoch: 1,
+        sequence,
+        apply_tick,
+        state,
+    }
+}
+
+fn transition_in_epoch(
+    seat: u8,
+    epoch: u32,
+    sequence: u32,
+    apply_tick: u64,
+    state: ControlState,
+) -> ScheduledTransition {
+    ScheduledTransition {
+        seat,
+        epoch,
+        sequence,
+        apply_tick,
+        state,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct World {
+    position: i32,
+    world_tick: u64,
+}
+
+fn simulate(world: &mut World, controls: &[ControlState; REALTIME_MAX_SEATS]) {
+    world.world_tick += 1;
+    world.position += i32::from(controls[0].axis_x);
+}
+
+fn world_hash(world: World, controls: &[ControlState; REALTIME_MAX_SEATS]) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in world
+        .position
+        .to_le_bytes()
+        .into_iter()
+        .chain(world.world_tick.to_le_bytes())
+    {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    for control in controls {
+        hash ^= u64::from(control.buttons);
+        hash = hash.wrapping_mul(0x100000001b3);
+        hash ^= control.axis_x as i64 as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+        hash ^= control.axis_y as i64 as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[test]
+fn rtc1_payload_crosses_the_existing_network_host_websocket_path() {
+    let bundle = StaticBundle::new(vec![BundleFile {
+        path: "index.html".into(),
+        mime: "text/html; charset=utf-8".into(),
+        bytes: b"<html/>".to_vec(),
+    }])
+    .expect("bundle");
+    let mut host = NetworkHost::bind(0, bundle).expect("host");
+    let mut request = format!("ws://{}/session", host.address())
+        .into_client_request()
+        .expect("request");
+    request.headers_mut().insert(
+        "Origin",
+        format!("http://{}", host.address())
+            .parse()
+            .expect("origin"),
+    );
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        format!(
+            "stasis-v1, {}, stasis-resume-v1.00112233445566778899aabbccddeeff",
+            hex(host.session_secret())
+        )
+        .parse()
+        .expect("protocol"),
+    );
+    let (mut socket, _) = connect(request).expect("websocket");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let connection = loop {
+        if let Some(event) = host.poll() {
+            if event.kind == EventKind::Connected {
+                break event.connection;
+            }
+        }
+        assert!(Instant::now() < deadline, "connection event timeout");
+        thread::sleep(Duration::from_millis(2));
+    };
+    let envelope =
+        ControlEnvelope::from_transition(transition(0, 1, 2, ControlState::new(1, 1, 0)))
+            .expect("envelope");
+    socket
+        .send(Message::Binary(envelope.encode().into()))
+        .expect("send RTC1");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let payload = loop {
+        if let Some(event) = host.poll() {
+            if event.kind == EventKind::Message && event.connection == connection {
+                break event.payload;
+            }
+        }
+        assert!(Instant::now() < deadline, "message event timeout");
+        thread::sleep(Duration::from_millis(2));
+    };
+    let config = RealtimeConfig::new(60, 60, 20, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("receiver");
+    assert_eq!(
+        session.submit_payload(&payload).outcomes(),
+        &[AdmissionOutcome::Accepted]
+    );
+    socket.close(None).expect("close");
+    host.stop().expect("stop");
+}
+
+#[test]
+fn networkhost_payload_reaches_the_same_native_realtime_session() {
+    let _guard = native_realtime_test_lock();
+    let bundle = StaticBundle::new(vec![BundleFile {
+        path: "index.html".into(),
+        mime: "text/html; charset=utf-8".into(),
+        bytes: b"<html/>".to_vec(),
+    }])
+    .expect("bundle");
+    let mut host = NetworkHost::bind(0, bundle).expect("host");
+    let mut request = format!("ws://{}/session", host.address())
+        .into_client_request()
+        .expect("request");
+    request.headers_mut().insert(
+        "Origin",
+        format!("http://{}", host.address())
+            .parse()
+            .expect("origin"),
+    );
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        format!(
+            "stasis-v1, {}, stasis-resume-v1.00112233445566778899aabbccddeeff",
+            hex(host.session_secret())
+        )
+        .parse()
+        .expect("protocol"),
+    );
+    let (mut socket, _) = connect(request).expect("websocket");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let connection = loop {
+        if let Some(event) = host.poll() {
+            if event.kind == EventKind::Connected {
+                break event.connection;
+            }
+        }
+        assert!(Instant::now() < deadline, "connection event timeout");
+        thread::sleep(Duration::from_millis(2));
+    };
+    let envelope =
+        ControlEnvelope::from_transition(transition(0, 1, 2, ControlState::new(7, 1, 0)))
+            .expect("envelope");
+    socket
+        .send(Message::Binary(envelope.encode().into()))
+        .expect("send RTC1");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let payload = loop {
+        if let Some(event) = host.poll() {
+            if event.kind == EventKind::Message && event.connection == connection {
+                break event.payload;
+            }
+        }
+        assert!(Instant::now() < deadline, "message event timeout");
+        thread::sleep(Duration::from_millis(2));
+    };
+    assert_eq!(stasis_realtime_stop(), 0);
+    assert_eq!(stasis_realtime_start(60, 120, 20, 1, 1), 0);
+    let guest_payload: Vec<i32> = payload.iter().copied().map(i32::from).collect();
+    assert_eq!(
+        unsafe {
+            stasis_realtime_submit_payload(guest_payload.as_ptr(), guest_payload.len() as i32)
+        },
+        0
+    );
+    assert_eq!(stasis_realtime_current_tick(), 0);
+    assert_eq!(stasis_realtime_advance(), 0);
+    assert_eq!(stasis_realtime_advance(), 0);
+    assert_eq!(stasis_realtime_current_tick(), 2);
+    assert_eq!(stasis_realtime_stop(), 0);
+    socket.close(None).expect("close");
+    host.stop().expect("stop");
+}
+
+#[test]
+fn native_guest_payload_bounds_and_mixed_outcomes_are_visible() {
+    let _guard = native_realtime_test_lock();
+    let encode = |envelope: &ControlEnvelope| {
+        envelope
+            .encode()
+            .into_iter()
+            .map(i32::from)
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(stasis_realtime_stop(), 0);
+    assert_eq!(stasis_realtime_start(60, 60, 60, 1, 1), 0);
+    let mut mixed = ControlEnvelope::new();
+    mixed
+        .push(transition_in_epoch(0, 1, 1, 1, ControlState::new(1, 1, 0)))
+        .expect("accepted transition");
+    mixed
+        .push(transition_in_epoch(0, 2, 2, 1, ControlState::neutral()))
+        .expect("stale transition");
+    let mixed = encode(&mixed);
+    assert_eq!(
+        unsafe { stasis_realtime_submit_payload(mixed.as_ptr(), mixed.len() as i32) },
+        -7,
+        "later stale outcome must not be hidden by the first acceptance"
+    );
+    assert_eq!(stasis_realtime_advance(), 0);
+    let (mut buttons, mut axis_x, mut axis_y) = (0, 0, 0);
+    assert_eq!(
+        unsafe { stasis_realtime_read_control(0, &mut buttons, &mut axis_x, &mut axis_y) },
+        0
+    );
+    assert_eq!((buttons, axis_x, axis_y), (1, 1, 0));
+    assert_eq!(stasis_realtime_stop(), 0);
+
+    assert_eq!(stasis_realtime_start(60, 60, 60, 1, 1), 0);
+    let hostile = ControlEnvelope::from_transition(transition_in_epoch(
+        0,
+        1,
+        i32::MAX as u32 + 1,
+        1,
+        ControlState::new(1, 1, 0),
+    ))
+    .expect("wire-valid hostile transition");
+    let hostile = encode(&hostile);
+    assert_eq!(
+        unsafe { stasis_realtime_submit_payload(hostile.as_ptr(), hostile.len() as i32) },
+        -1
+    );
+    assert_eq!(stasis_realtime_schedule(0, 1, 1, 1, 1, 1, 0), 0);
+    assert_eq!(stasis_realtime_stop(), 0);
+}
+
+#[test]
+fn rates_are_independent_and_delay_is_genuinely_future() {
+    let config = RealtimeConfig::new(60, 30, 120, 3).expect("independent rates");
+    assert_eq!(config.simulation_hz(), 60);
+    assert_eq!(config.presentation_hz(), 30);
+    assert_eq!(config.control_hz(), 120);
+    assert_eq!(config.input_delay_ticks(), 3);
+    assert_eq!(
+        RealtimeConfig::new(0, 60, 60, 3),
+        Err(ConfigError::ZeroRate)
+    );
+    assert_eq!(
+        RealtimeConfig::new(60, 60, 60, 0),
+        Err(ConfigError::DelayZero)
+    );
+    let session = RealtimeSession::new(config, 2).expect("session");
+    assert_eq!(session.earliest_apply_tick(), 3);
+    assert_eq!(session.latest_apply_tick(), 240);
+}
+
+#[test]
+fn two_devices_run_a_real_world_for_60_ticks_with_loss_recovery_and_read_only_presentation() {
+    let config = RealtimeConfig::new(60, 120, 20, 3).expect("realtime rates");
+    let press = transition(0, 1, 3, ControlState::new(1, 1, 0));
+    let change = transition(0, 2, 6, ControlState::new(1, -1, 0));
+    let release = transition(0, 3, 9, ControlState::neutral());
+    let mut device_a = RealtimeSession::new(config, 2).expect("device A");
+    let mut device_b = RealtimeSession::new(config, 2).expect("device B");
+    assert_eq!(
+        device_a.submit_transition(press),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        device_b.submit_transition(press),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        device_b.submit_transition(press),
+        AdmissionOutcome::Duplicate
+    );
+    assert_eq!(
+        device_a.submit_transition(release),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        device_b.submit_transition(release),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        device_a.submit_transition(change),
+        AdmissionOutcome::AcceptedReordered
+    );
+
+    let mut world_a = World::default();
+    let mut world_b = World::default();
+    let mut presentation_frames = 0_u64;
+    for tick in 1..=60 {
+        if tick == 3 {
+            // Device B's first copy of the direction change was lost. A
+            // retransmission arrives before its authoritative tick.
+            assert_eq!(
+                device_b.submit_transition(change),
+                AdmissionOutcome::AcceptedReordered
+            );
+        }
+        let advance_a = device_a.advance_tick().expect("tick A");
+        let advance_b = device_b.advance_tick().expect("tick B");
+        simulate(&mut world_a, advance_a.controls());
+        simulate(&mut world_b, advance_b.controls());
+        assert_eq!(advance_a.tick, tick);
+        assert_eq!(world_a, world_b);
+        assert_eq!(advance_a.controls(), advance_b.controls());
+        assert_eq!(
+            advance_a.applied_transitions().len(),
+            if [3, 6, 9].contains(&tick) { 1 } else { 0 }
+        );
+        let expected = match tick {
+            1 | 2 => ControlState::neutral(),
+            3..=5 => ControlState::new(1, 1, 0),
+            6..=8 => ControlState::new(1, -1, 0),
+            _ => ControlState::neutral(),
+        };
+        assert_eq!(advance_a.control(0), Some(expected));
+        let hash_a = world_hash(world_a, advance_a.controls());
+        let hash_b = world_hash(world_b, advance_b.controls());
+        assert_eq!(hash_a, hash_b);
+        device_a
+            .record_authoritative_hash(tick, hash_a)
+            .expect("hash A");
+        device_b
+            .record_authoritative_hash(tick, hash_b)
+            .expect("hash B");
+        for _ in 0..2 {
+            let before_tick = device_a.current_tick();
+            let before_controls = *device_a.controls();
+            let before_world = world_a;
+            presentation_frames += 1;
+            assert_eq!(device_a.current_tick(), before_tick);
+            assert_eq!(*device_a.controls(), before_controls);
+            assert_eq!(world_a, before_world);
+        }
+    }
+    assert_eq!(world_a.world_tick, 60);
+    assert_eq!(presentation_frames, 120);
+    assert_eq!(world_a.position, 0);
+    let mut replay_world = World::default();
+    device_a
+        .replay()
+        .replay(config, 2, |tick, controls| {
+            simulate(&mut replay_world, controls);
+            assert_eq!(replay_world.world_tick, tick);
+            world_hash(replay_world, controls)
+        })
+        .expect("replay reproduces world hashes");
+    assert_eq!(replay_world, world_a);
+}
+
+#[test]
+fn pending_conflicts_quarantine_both_arrival_orders_to_the_same_result() {
+    let config = RealtimeConfig::new(60, 60, 60, 1).expect("config");
+    let left = transition(0, 1, 3, ControlState::new(1, 1, 0));
+    let right = transition(0, 1, 3, ControlState::new(1, -1, 0));
+    let mut first_left = RealtimeSession::new(config, 1).expect("session");
+    let mut first_right = RealtimeSession::new(config, 1).expect("session");
+    assert_eq!(
+        first_left.submit_transition(left),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        first_left.submit_transition(right),
+        AdmissionOutcome::Conflict
+    );
+    assert_eq!(
+        first_right.submit_transition(right),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        first_right.submit_transition(left),
+        AdmissionOutcome::Conflict
+    );
+    for tick in 1..=3 {
+        let left_tick = first_left.advance_tick().expect("tick left");
+        let right_tick = first_right.advance_tick().expect("tick right");
+        assert_eq!(left_tick.controls(), right_tick.controls());
+        let hash = world_hash(
+            World {
+                world_tick: tick,
+                ..World::default()
+            },
+            left_tick.controls(),
+        );
+        first_left
+            .record_authoritative_hash(tick, hash)
+            .expect("hash");
+        first_right
+            .record_authoritative_hash(tick, hash)
+            .expect("hash");
+    }
+    assert_eq!(first_left.control(0), Some(ControlState::neutral()));
+    assert_eq!(first_left.submit_transition(right), AdmissionOutcome::Late);
+    assert!(first_left
+        .replay()
+        .records()
+        .any(|record| matches!(record, ReplayRecord::Quarantine { .. })));
+}
+
+#[test]
+fn envelope_and_future_bounds_are_bounded_and_malformed_inputs_are_stable() {
+    let scheduled = transition(1, 7, 10, ControlState::new(0x22, -3, 4));
+    let envelope = ControlEnvelope::from_transition(scheduled).expect("transition");
+    let bytes = envelope.encode();
+    assert_eq!(
+        ControlEnvelope::decode(&bytes)
+            .expect("round trip")
+            .transitions(),
+        &[scheduled]
+    );
+    assert_eq!(
+        ControlEnvelope::decode(&bytes)
+            .expect("epoch round trip")
+            .transitions()[0]
+            .epoch,
+        1
+    );
+    let mut malformed = bytes.clone();
+    malformed[0] = b'X';
+    assert!(ControlEnvelope::decode(&malformed).is_err());
+    let config = RealtimeConfig::new(60, 60, 30, 2).expect("config");
+    let mut session = RealtimeSession::new(config, 2).expect("session");
+    assert_eq!(
+        session.submit_payload(&malformed).outcomes(),
+        &[AdmissionOutcome::Malformed]
+    );
+    assert_eq!(
+        session.submit_transition(transition(2, 1, 3, ControlState::neutral())),
+        AdmissionOutcome::Malformed
+    );
+    assert_eq!(
+        session.submit_transition(transition(0, 0, 3, ControlState::neutral())),
+        AdmissionOutcome::Malformed
+    );
+    assert_eq!(
+        session.submit_transition(transition(0, 1, 1, ControlState::neutral())),
+        AdmissionOutcome::Late
+    );
+    assert_eq!(
+        session.submit_transition(transition(
+            0,
+            1,
+            session.latest_apply_tick() + 1,
+            ControlState::neutral()
+        )),
+        AdmissionOutcome::TooFar
+    );
+}
+
+#[test]
+fn lifecycle_and_snapshot_validation_preserve_sequence_floors() {
+    let config = RealtimeConfig::new(60, 60, 20, 2).expect("config");
+    let mut session = RealtimeSession::new(config, 2).expect("session");
+    assert_eq!(
+        session.submit_transition(transition(0, 1, 2, ControlState::new(1, 1, 0))),
+        AdmissionOutcome::Accepted
+    );
+    session.disconnect(0).expect("disconnect");
+    assert_eq!(session.pending_len(), 0);
+    assert_eq!(session.control(0), Some(ControlState::neutral()));
+    assert_eq!(
+        session.submit_transition(transition(0, 1, 2, ControlState::new(1, 1, 0))),
+        AdmissionOutcome::Inactive
+    );
+    session.reconnect(0).expect("reconnect");
+    assert_eq!(
+        session.submit_transition(transition(0, 99, 2, ControlState::new(1, 1, 0))),
+        AdmissionOutcome::Stale
+    );
+    session.pause().expect("pause");
+    session.focus_lost().expect("focus");
+    let mut controls = [ControlState::neutral(); REALTIME_MAX_SEATS];
+    controls[1] = ControlState::new(4, 0, -1);
+    let mut sequences = [0; REALTIME_MAX_SEATS];
+    sequences[0] = 9;
+    let snapshot = AuthoritativeSnapshot::new(
+        1,
+        40,
+        controls,
+        sequences,
+        [5, 3, 1, 1, 1, 1, 1, 1],
+        [true, true, false, false, false, false, false, false],
+    );
+    session
+        .apply_authoritative_snapshot(snapshot)
+        .expect("snapshot");
+    assert_eq!(session.current_tick(), 40);
+    assert_eq!(session.controls(), &controls);
+    assert_eq!(
+        session.submit_transition(transition(0, 8, 42, ControlState::neutral())),
+        AdmissionOutcome::Stale
+    );
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(
+            0,
+            5,
+            10,
+            42,
+            ControlState::new(2, 1, 0),
+        )),
+        AdmissionOutcome::Accepted
+    );
+    controls[2] = ControlState::new(1, 0, 0);
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            2,
+            41,
+            controls,
+            sequences,
+            [5, 1, 1, 1, 1, 1, 1, 1],
+            [true, true, false, false, false, false, false, false],
+        )),
+        Err(SnapshotError::InactiveSeatState { seat: 2 })
+    );
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            3,
+            u64::MAX,
+            [ControlState::neutral(); REALTIME_MAX_SEATS],
+            [0; REALTIME_MAX_SEATS],
+            [1; REALTIME_MAX_SEATS],
+            [true, true, false, false, false, false, false, false],
+        )),
+        Err(SnapshotError::TickOutOfRange)
+    );
+    let mut exhausted_epochs = [1; REALTIME_MAX_SEATS];
+    exhausted_epochs[0] = u32::MAX;
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            4,
+            40,
+            [ControlState::neutral(); REALTIME_MAX_SEATS],
+            [0; REALTIME_MAX_SEATS],
+            exhausted_epochs,
+            [true, true, false, false, false, false, false, false],
+        )),
+        Err(SnapshotError::EpochExhausted)
+    );
+    session.rematch().expect("rematch");
+    assert_eq!(session.current_tick(), 0);
+    assert_eq!(
+        session.controls(),
+        &[ControlState::neutral(); REALTIME_MAX_SEATS]
+    );
+}
+
+#[test]
+fn pause_and_focus_advance_all_epochs_and_reject_unseen_old_packets() {
+    let config = RealtimeConfig::new(60, 60, 20, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 2).expect("session");
+    let old_epoch = session.epoch(0).expect("epoch");
+    assert_eq!(
+        session.submit_transition(transition(0, 99, 1, ControlState::new(1, 0, 0))),
+        AdmissionOutcome::Accepted
+    );
+    session.pause().expect("pause");
+    assert_eq!(session.epoch(0), Some(old_epoch + 1));
+    assert_eq!(session.epoch(1), Some(2));
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(
+            0,
+            old_epoch,
+            100,
+            1,
+            ControlState::new(1, 0, 0)
+        )),
+        AdmissionOutcome::Stale
+    );
+    session.focus_lost().expect("focus");
+    assert_eq!(session.epoch(0), Some(old_epoch + 2));
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(
+            0,
+            old_epoch + 1,
+            1,
+            1,
+            ControlState::new(1, 0, 0)
+        )),
+        AdmissionOutcome::Stale
+    );
+}
+
+#[test]
+fn rematch_replay_reuses_epoch_reset_semantics() {
+    let config = RealtimeConfig::new(60, 60, 20, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("session");
+    session.rematch().expect("rematch");
+    let epoch = session.epoch(0).expect("epoch");
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(
+            0,
+            epoch,
+            1,
+            1,
+            ControlState::new(1, 1, 0)
+        )),
+        AdmissionOutcome::Accepted
+    );
+    session.advance_tick().expect("tick");
+    session.record_authoritative_hash(1, 42).expect("hash");
+    session
+        .replay()
+        .replay(config, 1, |_tick, _controls| 42)
+        .expect("rematch replay");
+}
+
+#[test]
+fn snapshots_are_monotonic_and_new_epochs_may_reset_floors() {
+    let config = RealtimeConfig::new(60, 60, 20, 2).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("session");
+    let controls = [ControlState::neutral(); REALTIME_MAX_SEATS];
+    let active = [true, false, false, false, false, false, false, false];
+    let epochs = [1, 1, 1, 1, 1, 1, 1, 1];
+    let mut sequences = [0; REALTIME_MAX_SEATS];
+    sequences[0] = 4;
+    session
+        .apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            1, 10, controls, sequences, epochs, active,
+        ))
+        .expect("first snapshot");
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            1, 11, controls, sequences, epochs, active,
+        )),
+        Err(SnapshotError::RevisionRegression)
+    );
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            2, 9, controls, sequences, epochs, active,
+        )),
+        Err(SnapshotError::TickRegression)
+    );
+    let mut lower_epochs = epochs;
+    lower_epochs[0] = 0;
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            3,
+            11,
+            controls,
+            sequences,
+            lower_epochs,
+            active,
+        )),
+        Err(SnapshotError::EpochRegression)
+    );
+    let mut lower_sequences = sequences;
+    lower_sequences[0] = 3;
+    assert_eq!(
+        session.apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            4,
+            11,
+            controls,
+            lower_sequences,
+            epochs,
+            active,
+        )),
+        Err(SnapshotError::SequenceRegression)
+    );
+    let mut new_epochs = epochs;
+    new_epochs[0] = 2;
+    session
+        .apply_authoritative_snapshot(AuthoritativeSnapshot::new(
+            5,
+            1,
+            controls,
+            [0; REALTIME_MAX_SEATS],
+            new_epochs,
+            active,
+        ))
+        .expect("new epoch reset");
+    assert_eq!(session.epoch(0), Some(2));
+    assert_eq!(session.current_tick(), 1);
+}
+
+#[test]
+fn quarantine_capacity_fails_closed_until_new_snapshot_or_rematch() {
+    let config = RealtimeConfig::new(60, 60, 60, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("session");
+    for sequence in 1..=(MAX_PENDING_TRANSITIONS as u32) {
+        let left = transition_in_epoch(
+            0,
+            1,
+            sequence,
+            sequence as u64 + 1,
+            ControlState::new(1, 1, 0),
+        );
+        let right = transition_in_epoch(
+            0,
+            1,
+            sequence,
+            sequence as u64 + 1,
+            ControlState::new(1, -1, 0),
+        );
+        assert_eq!(session.submit_transition(left), AdmissionOutcome::Accepted);
+        assert_eq!(session.submit_transition(right), AdmissionOutcome::Conflict);
+    }
+    assert!(!session.resync_required());
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(
+            0,
+            1,
+            (MAX_PENDING_TRANSITIONS + 1) as u32,
+            130,
+            ControlState::neutral(),
+        )),
+        AdmissionOutcome::ResyncRequired
+    );
+    assert!(session.resync_required());
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(0, 1, 999, 130, ControlState::neutral())),
+        AdmissionOutcome::ResyncRequired
+    );
+    let snapshot = AuthoritativeSnapshot::new(
+        1,
+        0,
+        [ControlState::neutral(); REALTIME_MAX_SEATS],
+        [0; REALTIME_MAX_SEATS],
+        [2; REALTIME_MAX_SEATS],
+        [true, false, false, false, false, false, false, false],
+    );
+    session
+        .apply_authoritative_snapshot(snapshot)
+        .expect("snapshot recovery");
+    assert!(!session.resync_required());
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(0, 2, 1, 1, ControlState::new(1, 1, 0),)),
+        AdmissionOutcome::Accepted
+    );
+}
+
+#[test]
+fn replay_notifies_game_of_reset_and_snapshot_before_later_hashes() {
+    use std::cell::RefCell;
+    let config = RealtimeConfig::new(60, 60, 20, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("session");
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(0, 1, 1, 2, ControlState::new(1, 1, 0),)),
+        AdmissionOutcome::Accepted
+    );
+    let first = session.advance_tick().expect("first tick");
+    let mut world = World::default();
+    simulate(&mut world, first.controls());
+    session
+        .record_authoritative_hash(1, world_hash(world, first.controls()))
+        .expect("first hash");
+    session.pause().expect("pause");
+    world = World::default();
+    let mut epochs = [1; REALTIME_MAX_SEATS];
+    epochs[0] = 3;
+    let snapshot = AuthoritativeSnapshot::new(
+        1,
+        0,
+        [ControlState::neutral(); REALTIME_MAX_SEATS],
+        [0; REALTIME_MAX_SEATS],
+        epochs,
+        [true, false, false, false, false, false, false, false],
+    )
+    .with_game_token(&[7])
+    .expect("token");
+    session
+        .apply_authoritative_snapshot(snapshot)
+        .expect("snapshot");
+    world.position = 7;
+    assert_eq!(
+        session.submit_transition(transition_in_epoch(0, 3, 1, 1, ControlState::new(1, 1, 0),)),
+        AdmissionOutcome::Accepted
+    );
+    for tick in 1..=2 {
+        let advance = session.advance_tick().expect("later tick");
+        simulate(&mut world, advance.controls());
+        session
+            .record_authoritative_hash(tick, world_hash(world, advance.controls()))
+            .expect("later hash");
+    }
+    let mut events = Vec::new();
+    let replay_world = RefCell::new(World::default());
+    session
+        .replay()
+        .replay_with_events(
+            config,
+            1,
+            |event| {
+                match event {
+                    ReplayEvent::Reset(_) => *replay_world.borrow_mut() = World::default(),
+                    ReplayEvent::Snapshot(snapshot) => {
+                        *replay_world.borrow_mut() = World {
+                            position: i32::from(snapshot.game_token[0]),
+                            ..World::default()
+                        };
+                    }
+                    ReplayEvent::Quarantine { .. } => {}
+                }
+                events.push(event);
+            },
+            |_tick, controls| {
+                let mut world = replay_world.borrow_mut();
+                simulate(&mut world, controls);
+                world_hash(*world, controls)
+            },
+        )
+        .expect("replay with lifecycle events");
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, ReplayEvent::Reset(_))));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ReplayEvent::Snapshot(snapshot)
+            if snapshot.game_token_len == 1 && snapshot.game_token[0] == 7
+    )));
+}
+
+#[test]
+fn queue_full_replay_overflow_and_hash_attachment_are_explicit() {
+    let config = RealtimeConfig::new(60, 60, 60, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 1).expect("session");
+    assert_eq!(
+        session.submit_transition(transition(0, 1, 1, ControlState::neutral())),
+        AdmissionOutcome::Accepted
+    );
+    assert_eq!(
+        session.submit_transition(transition(0, 1, 1, ControlState::new(1, 0, 0))),
+        AdmissionOutcome::Conflict
+    );
+    for sequence in 2..=((MAX_PENDING_TRANSITIONS + 1) as u32) {
+        assert_eq!(
+            session.submit_transition(transition(
+                0,
+                sequence,
+                sequence as u64,
+                ControlState::neutral()
+            )),
+            AdmissionOutcome::Accepted
+        );
+    }
+    assert_eq!(session.pending_len(), MAX_PENDING_TRANSITIONS);
+    assert_eq!(
+        session.submit_transition(transition(
+            0,
+            10_000,
+            session.latest_apply_tick(),
+            ControlState::neutral(),
+        )),
+        AdmissionOutcome::Full
+    );
+    let advance = session.advance_tick().expect("tick");
+    assert_eq!(
+        session.record_authoritative_hash(advance.tick + 1, 1),
+        Err(HashRecordError::WrongTick {
+            expected: advance.tick,
+            received: advance.tick + 1
+        })
+    );
+    assert_eq!(session.record_authoritative_hash(advance.tick, 1), Ok(()));
+    assert_eq!(
+        session.record_authoritative_hash(advance.tick, 2),
+        Err(HashRecordError::AlreadyRecorded)
+    );
+
+    let mut missing = RealtimeSession::new(config, 1).expect("missing hash session");
+    missing.advance_tick().expect("tick");
+    assert_eq!(
+        missing.replay().replay(config, 1, |_tick, _controls| 0),
+        Err(ReplayError::MissingHash { index: 0, tick: 1 })
+    );
+    let mut reset_hash = RealtimeSession::new(config, 1).expect("reset hash session");
+    reset_hash.advance_tick().expect("tick");
+    reset_hash.pause().expect("pause");
+    assert_eq!(
+        reset_hash.record_authoritative_hash(1, 1),
+        Err(HashRecordError::NoUnfinishedTick)
+    );
+    let mut overflow =
+        RealtimeSession::new_with_replay_limit(config, 1, 4).expect("overflow session");
+    for _ in 0..=4 {
+        overflow.advance_tick().expect("tick");
+    }
+    assert!(!overflow.replay().is_complete());
+    assert_eq!(
+        overflow.replay().replay(config, 1, |_tick, _controls| 0),
+        Err(ReplayError::Incomplete)
+    );
+}

--- a/crates/stasis_network/tests/realtime_controls.rs
+++ b/crates/stasis_network/tests/realtime_controls.rs
@@ -4,9 +4,10 @@ use stasis_network::realtime::{
     ScheduledTransition, SnapshotError, MAX_PENDING_TRANSITIONS, REALTIME_MAX_SEATS,
 };
 use stasis_network::{
-    stasis_realtime_advance, stasis_realtime_current_tick, stasis_realtime_read_control,
-    stasis_realtime_schedule, stasis_realtime_start, stasis_realtime_stop,
-    stasis_realtime_submit_payload, BundleFile, EventKind, NetworkHost, StaticBundle,
+    stasis_realtime_advance, stasis_realtime_current_epoch, stasis_realtime_current_tick,
+    stasis_realtime_read_control, stasis_realtime_schedule, stasis_realtime_start,
+    stasis_realtime_stop, stasis_realtime_submit_payload, BundleFile, EventKind, NetworkHost,
+    StaticBundle,
 };
 use std::sync::{Mutex, OnceLock};
 use std::thread;
@@ -239,6 +240,14 @@ fn native_guest_payload_bounds_and_mixed_outcomes_are_visible() {
 
     assert_eq!(stasis_realtime_stop(), 0);
     assert_eq!(stasis_realtime_start(60, 60, 60, 1, 1), 0);
+    assert_eq!(stasis_realtime_current_epoch(1), -1);
+    let (mut invalid_buttons, mut invalid_x, mut invalid_y) = (0, 0, 0);
+    assert_eq!(
+        unsafe {
+            stasis_realtime_read_control(1, &mut invalid_buttons, &mut invalid_x, &mut invalid_y)
+        },
+        -3
+    );
     let mut mixed = ControlEnvelope::new();
     mixed
         .push(transition_in_epoch(0, 1, 1, 1, ControlState::new(1, 1, 0)))
@@ -297,6 +306,26 @@ fn rates_are_independent_and_delay_is_genuinely_future() {
     let session = RealtimeSession::new(config, 2).expect("session");
     assert_eq!(session.earliest_apply_tick(), 3);
     assert_eq!(session.latest_apply_tick(), 240);
+}
+
+#[test]
+fn scalar_accessors_reject_fixed_array_seats_outside_configuration() {
+    let config = RealtimeConfig::new(60, 60, 60, 1).expect("config");
+    let mut session = RealtimeSession::new(config, 2).expect("session");
+    assert!(session.epoch(0).is_some());
+    assert!(session.is_active(1).is_some());
+    assert!(session.control(1).is_some());
+    assert_eq!(session.epoch(2), None);
+    assert_eq!(session.is_active(2), None);
+    assert_eq!(session.control(2), None);
+    assert_eq!(session.epoch(REALTIME_MAX_SEATS - 1), None);
+    assert_eq!(session.is_active(REALTIME_MAX_SEATS - 1), None);
+    assert_eq!(session.control(REALTIME_MAX_SEATS - 1), None);
+    let advance = session.advance_tick().expect("tick");
+    assert!(advance.control(0).is_some());
+    assert!(advance.control(1).is_some());
+    assert_eq!(advance.control(2), None);
+    assert_eq!(advance.control(REALTIME_MAX_SEATS - 1), None);
 }
 
 #[test]
@@ -927,4 +956,13 @@ fn queue_full_replay_overflow_and_hash_attachment_are_explicit() {
         overflow.replay().replay(config, 1, |_tick, _controls| 0),
         Err(ReplayError::Incomplete)
     );
+    assert_eq!(
+        overflow.submit_transition(transition(0, 1, 6, ControlState::new(3, 1, 0))),
+        AdmissionOutcome::Accepted
+    );
+    let advance = overflow
+        .advance_tick()
+        .expect("live tick after replay overflow");
+    assert_eq!(advance.control(0), Some(ControlState::new(3, 1, 0)));
+    assert!(!overflow.replay().is_complete());
 }

--- a/docs/build_checklist.md
+++ b/docs/build_checklist.md
@@ -1641,6 +1641,25 @@ Archived priority override (2026-02-13, historical):
 - Host-set misuse cannot produce partial state mutation or silent nondeterminism.
 - Status: `planned (post-S10b)`
 
+### RN1 - Realtime control scheduling and replay
+
+- Scope: Define one bounded, fixed-tick control contract over the existing
+  production network envelope for realtime games.
+- Deliverable: `stasis_network::realtime` validates rates, schedules and
+  deduplicates future transitions, applies held/neutral controls at exact
+  ticks without packet stalls, defines epoch-qualified lifecycle and monotonic
+  snapshot policy, and records replay transitions, lifecycle events, ticks,
+  and authoritative hashes. Stable native/JIT entrypoints expose bounded RTC1,
+  correction, hash, and lifecycle operations to `realtime_controls.stasis`;
+  replay callbacks remain host-owned. Turn-based networking remains unchanged.
+- Tests: Deterministic two-device 60 Hz simulation fixture with lower-rate
+  controls and measurable delay; loss/reorder/duplicate, lifecycle,
+  malformed/full bounds, matching hashes, replay reproduction, the production
+  WebSocket envelope, guest-domain/short-buffer/mixed-outcome rejection, an
+  executable Stasis JIT guest seam, and AOT object imports for the stable native
+  contract.
+- Status: `complete (2026-08-24)`.
+
 ### S17 - Immediate Axis Placement and Float Presentation Geometry
 
 - Source requirements: `docs/immediate_layout_prd.md`.

--- a/docs/project_architecture.md
+++ b/docs/project_architecture.md
@@ -421,3 +421,32 @@ Before merging a game change, answer:
 The structure can remain in one file or grow into focused systems. The useful
 part stays the same: bind input once, update explicit state in a visible order,
 and render the result without changing the game.
+
+## Realtime network controls
+
+Realtime games use the bounded contract in
+[`realtime_networking.md`](realtime_networking.md). Raw control changes are
+scheduled for future authoritative simulation ticks, submitted independently
+of the tick loop, and applied in stable order at their exact due tick. Held
+state persists and neutral release is explicit. Missing, delayed, duplicated,
+reordered, stale, conflicting, too-far, and malformed transitions have
+deterministic admission outcomes; a missing packet never stalls simulation or
+rendering. Conflicting pending variants quarantine their shared identity so
+arrival order cannot change the result.
+
+The production transport carries the module's versioned control payload inside
+its existing message envelope. Host-authoritative games correct clients with
+snapshots after due-time loss, while deterministic-peer games must recover a
+lost transition before due and require matching rates, integer state
+transitions, and replay hashes. Rendering may interpolate completed states
+only. Turn-based games keep their existing command path and do not use the
+realtime control API.
+
+Stasis guests import `src/stdlib/realtime_controls.stasis`. Its externs map to
+stable `stasis_realtime_*` native symbols for AOT and explicit JIT adapters in
+`stasis_dynload`; the host retains ownership of queues, clocks, snapshots, and
+replay storage. Guests can build/submit bounded RTC1 payloads, apply scalar-array
+snapshot corrections, attach authoritative hashes, and inspect resync state;
+game-token restoration and replay callbacks stay in Rust. Guest reads return
+the last completed control state and never advance simulation or presentation
+time. The guest ABI intentionally bounds ticks and epochs to `i32::MAX`.

--- a/docs/realtime_networking.md
+++ b/docs/realtime_networking.md
@@ -1,0 +1,102 @@
+# Realtime networking contract
+
+Realtime games use the Rust `stasis_network::realtime` contract. Turn-based
+games continue to use their existing command messages and are not routed
+through this module.
+
+## Rates and the transport boundary
+
+Each session declares independently bounded, positive simulation, presentation,
+and raw-control sampling rates plus a positive input delay in simulation ticks.
+A typical contract is 60 Hz simulation, 120 Hz presentation, 20 Hz control
+sampling, and a three tick authoritative delay; 60/30/120 is also valid.
+Presentation may interpolate between completed simulation states, but it never
+mutates simulation state and it cannot turn a late frame into a gameplay tick.
+
+`ControlEnvelope` is a versioned, bounded `RTC1` payload. It contains scheduled
+transitions with `(seat, epoch, sequence, apply_tick, state)` identity and can
+be sent as bytes through the existing production network message envelope.
+The transport remains responsible for delivery; the realtime session is
+responsible for validation, deduplication, ordering, and tick application.
+No new socket or game-specific transport is introduced. Stable native
+`stasis_realtime_*` entrypoints and `realtime_controls.stasis` let JIT and AOT
+guests build and submit RTC1 payloads, advance/read controls, apply corrections,
+attach hashes, inspect resync state, and drive lifecycle transitions. Snapshot
+tokens and replay callbacks remain Rust-host responsibilities.
+
+The guest ABI uses signed 32-bit integers. Guest-driven sessions therefore stop
+without mutation at tick `i32::MAX`, and guest-visible epochs are capped at
+`i32::MAX`. RTC1 bytes cross the guest ABI as bounded `i32` array elements in
+the range 0-255 so JIT and native AOT use an identical collection layout. JIT
+adapters reject undersized registered arrays before reading or writing them;
+native pointer callers must provide the declared capacity. Authoritative hashes
+use unsigned low/high `i32` lanes to preserve all 64 bits.
+
+## Tick and admission rules
+
+The caller submits controls separately from `advance_tick`. A transition must
+be at or after `earliest_apply_tick` and no later than `latest_apply_tick` (the
+bounded future horizon); its state is held until another accepted transition
+for that seat is applied. A neutral transition is an ordinary, first-class
+release and is applied at its exact scheduled tick.
+
+`advance_tick` increments exactly one simulation tick or reports tick-space
+exhaustion without mutation. It does not wait for a packet, a presentation
+frame, or another seat. Due transitions are applied in stable
+`(seat, epoch, sequence, apply_tick)` order. Missing controls keep their last
+state. Admission outcomes are deterministic: accepted, accepted
+reordered, duplicate, stale, conflict, late, too-far, malformed, or full.
+For a multi-transition guest payload, every transition is processed and the
+return code reports the highest-precedence outcome (resync, conflict, full,
+malformed, inactive, stale, late, too-far, duplicate, reordered, accepted).
+Sequence identity is retained through bounded recent history so retransmission
+is safe without making the queue unbounded. If two conflicting variants for a
+pending `(seat, epoch, sequence)` arrive, the session quarantines that identity and
+removes the pending transition; both arrival orders therefore converge to no
+control at that tick. A conflict discovered after application is reported as
+late/stale and never rewrites simulation history.
+
+## Lifecycle and authority
+
+Disconnect and reconnect neutralize that seat, advance its epoch, and discard
+its queued controls; disconnected seats reject input until reconnect. Pause
+and focus loss neutralize every seat, advance every epoch, and discard the
+pending queue. Rematch does the same and starts the simulation tick counter at
+zero. Epoch increments are preflighted before any lifecycle mutation. Sequence
+floors, recent identities, and quarantines reset with the new epoch; packets
+from the previous epoch remain stale regardless of their sequence. An
+authoritative snapshot replaces the tick, persistent controls,
+per-seat epochs/activity, and sequence floors, then discards pending, recent,
+and quarantined transitions. Monotonic snapshot revisions prevent an older
+snapshot from rewinding accepted authority.
+
+In host-authoritative mode, the host applies the contract and sends snapshots
+or corrections; clients may display a prediction but must converge to the
+authoritative snapshot. In deterministic-peer mode, every peer must use the
+same validated rates, delay, transition ordering, integer state rules, and
+lifecycle decisions. A lost transition must be recovered before its due tick;
+after due, deterministic peers cannot retroactively repair history and must
+restart/correct from authority. Host-authoritative mode uses a snapshot
+correction after due. A hash mismatch is a correction signal, not permission
+to stall the tick loop.
+
+Snapshots are accepted only when their tick leaves room for the future horizon,
+their revision and per-seat epochs do not regress or reach exhausted `u32::MAX`,
+and all inactive seats are neutral. Sequence floors are adopted exactly, so
+old packets remain stale after recovery.
+
+## Replay and rendering
+
+The bounded replay log records accepted scheduled transitions, quarantine
+decisions, every simulation tick, and caller-supplied post-tick authoritative
+hashes. Call `record_authoritative_hash(tick, hash)` exactly once immediately
+after the corresponding `advance_tick`; wrong-tick, duplicate, and
+cross-lifecycle attachment is rejected. `ReplayLog::replay` requires one hash
+for every tick and calls a game-owned hash function against each exact
+post-tick control snapshot. Overflow marks a log incomplete while simulation
+continues; incomplete logs cannot replay. Sessions use a bounded default replay
+capacity and may select an explicit capacity up to `MAX_REPLAY_RECORDS`.
+Lifecycle events and authoritative snapshot payloads are replayed through a
+game-owned callback so non-control world state can be restored deterministically.
+Rendering/interpolation is outside the log and outside state mutation; a render
+pass must only project the latest completed simulation state.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1044,6 +1044,46 @@ Rules:
 - Language semantics remain spec-driven from this document; compiler behavior must conform to it.
 - Tick-path runtime must remain free of parser/semantic/codegen work.
 
+### 17.2 Realtime Networking Contract
+
+Realtime control networking is a Rust host contract exposed to Stasis guests
+through the `realtime_controls.stasis` wrapper and stable native
+`stasis_realtime_*` ABI. `stasis_network::realtime` validates bounded simulation,
+presentation, control-sampling, and future-delay rates; carries fixed-size
+versioned control transitions through the existing production network message
+envelope; and applies persistent per-seat state at exact authoritative ticks.
+Submission and tick advancement are separate operations. `advance_tick`
+advances one tick without waiting for packets or fails without mutation when
+tick space is exhausted. Held controls persist, neutral
+release is an ordinary transition, and duplicate/reordered/stale/conflicting,
+late, too-far, malformed, and full cases have deterministic outcomes. Pending
+conflicts quarantine the shared seat/sequence identity, making opposite
+arrival orders converge; post-application conflicts are late/stale and never
+rewrite history.
+
+Disconnect, reconnect, pause, focus loss, snapshot recovery, and rematch have
+explicit neutral/reset behavior, per-seat connection epochs, and monotonic
+snapshot revisions. Host-authoritative sessions correct clients from snapshots.
+Deterministic-peer sessions require identical validated
+contracts, stable transition ordering, and matching replay hashes. Replays
+contain accepted scheduled transitions, quarantine decisions, simulation ticks,
+and exactly one caller-supplied authoritative hash per tick. Hashes are
+attached only by tick-qualified immediate completion; overflow makes a log
+incomplete while simulation continues. Rendering/interpolation remains
+presentation-only and cannot mutate simulation state. Deterministic peers must
+recover loss before due; host-authoritative clients use snapshot correction
+after due. Existing turn-based command networking is unchanged and does not
+use this API.
+
+The stable guest ABI exposes bounded RTC1 construction/submission, scalar-array
+snapshot correction, hash attachment, resync inspection, lifecycle operations,
+and completed-control reads. Rust retains replay callbacks and snapshot game
+tokens. Because Stasis integers are signed 32-bit values, guest-driven tick and
+epoch domains stop at `i32::MAX` without partial mutation; the Rust-only contract
+retains its wider internal tick domain. RTC1 buffers and snapshot arrays are
+capacity-checked at the JIT boundary, and authoritative hashes use two unsigned
+32-bit lanes so the guest ABI retains the complete 64-bit value.
+
 ## 18. Status Note
 
 This document defines the current direction.

--- a/src/stdlib/realtime_controls.stasis
+++ b/src/stdlib/realtime_controls.stasis
@@ -1,0 +1,164 @@
+// Host-owned bounded realtime scheduler.  The host/JIT bridge owns one
+// session; submitting a transition never advances the guest simulation.
+
+function @extern("stasis_realtime_start") realtime_start_raw(
+    simulation_hz: i32,
+    presentation_hz: i32,
+    control_hz: i32,
+    input_delay_ticks: i32,
+    seats: i32
+): i32;
+function @extern("stasis_realtime_stop") realtime_stop_raw(): i32;
+function @extern("stasis_realtime_submit_payload") realtime_submit_payload_raw(payload: i32[], length: i32): i32;
+function @extern("stasis_realtime_build_payload") realtime_build_payload_raw(
+    out_payload: i32[],
+    capacity: i32,
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32
+): i32;
+function @extern("stasis_realtime_resync_required") realtime_resync_required_raw(): i32;
+function @extern("stasis_realtime_record_hash") realtime_record_hash_raw(tick: i32, hash_low: i32, hash_high: i32): i32;
+function @extern("stasis_realtime_apply_snapshot") realtime_apply_snapshot_raw(
+    revision: i32,
+    tick: i32,
+    seat_count: i32,
+    buttons: i32[],
+    axis_x: i32[],
+    axis_y: i32[],
+    sequences: i32[],
+    epochs: i32[],
+    active: i32[]
+): i32;
+function @extern("stasis_realtime_current_tick") realtime_current_tick_raw(): i32;
+function @extern("stasis_realtime_current_epoch") realtime_current_epoch_raw(seat: i32): i32;
+function @extern("stasis_realtime_schedule") realtime_schedule_raw(
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32
+): i32;
+function @extern("stasis_realtime_advance") realtime_advance_raw(): i32;
+function @extern("stasis_realtime_read_control") realtime_read_control_raw(seat: i32, out_buttons: i32[], out_axis_x: i32[], out_axis_y: i32[]): i32;
+function @extern("stasis_realtime_disconnect") realtime_disconnect_raw(seat: i32): i32;
+function @extern("stasis_realtime_reconnect") realtime_reconnect_raw(seat: i32): i32;
+function @extern("stasis_realtime_pause") realtime_pause_raw(): i32;
+function @extern("stasis_realtime_focus_lost") realtime_focus_lost_raw(): i32;
+function @extern("stasis_realtime_rematch") realtime_rematch_raw(): i32;
+
+function realtime_start(simulation_hz: i32, presentation_hz: i32, control_hz: i32, input_delay_ticks: i32, seats: i32): i32 {
+    return realtime_start_raw(simulation_hz, presentation_hz, control_hz, input_delay_ticks, seats);
+}
+
+function realtime_stop(): i32 {
+    return realtime_stop_raw();
+}
+
+function realtime_submit_payload(payload: i32[], length: i32): i32 {
+    if (length < 0 || length > payload.max_length) {
+        return -11;
+    }
+    return realtime_submit_payload_raw(payload, length);
+}
+
+function realtime_build_payload(
+    out_payload: i32[],
+    capacity: i32,
+    seat: i32,
+    epoch: i32,
+    sequence: i32,
+    apply_tick: i32,
+    buttons: i32,
+    axis_x: i32,
+    axis_y: i32
+): i32 {
+    if (capacity < 0 || capacity > out_payload.max_length) {
+        return -11;
+    }
+    return realtime_build_payload_raw(out_payload, capacity, seat, epoch, sequence, apply_tick, buttons, axis_x, axis_y);
+}
+
+function realtime_resync_required(): i32 {
+    return realtime_resync_required_raw();
+}
+
+function realtime_record_hash(tick: i32, hash_low: i32, hash_high: i32): i32 {
+    return realtime_record_hash_raw(tick, hash_low, hash_high);
+}
+
+function realtime_apply_snapshot(
+    revision: i32,
+    tick: i32,
+    seat_count: i32,
+    buttons: i32[],
+    axis_x: i32[],
+    axis_y: i32[],
+    sequences: i32[],
+    epochs: i32[],
+    active: i32[]
+): i32 {
+    if (revision <= 0 || tick < 0 || seat_count <= 0 || seat_count > 8) {
+        return -1;
+    }
+    if (
+        buttons.max_length < seat_count
+        || axis_x.max_length < seat_count
+        || axis_y.max_length < seat_count
+        || sequences.max_length < seat_count
+        || epochs.max_length < seat_count
+        || active.max_length < seat_count
+    ) {
+        return -11;
+    }
+    return realtime_apply_snapshot_raw(revision, tick, seat_count, buttons, axis_x, axis_y, sequences, epochs, active);
+}
+
+function realtime_current_tick(): i32 {
+    return realtime_current_tick_raw();
+}
+
+function realtime_current_epoch(seat: i32): i32 {
+    return realtime_current_epoch_raw(seat);
+}
+
+function realtime_schedule(seat: i32, epoch: i32, sequence: i32, apply_tick: i32, buttons: i32, axis_x: i32, axis_y: i32): i32 {
+    return realtime_schedule_raw(seat, epoch, sequence, apply_tick, buttons, axis_x, axis_y);
+}
+
+function realtime_advance(): i32 {
+    return realtime_advance_raw();
+}
+
+function realtime_read_control(seat: i32, out_buttons: i32[], out_axis_x: i32[], out_axis_y: i32[]): i32 {
+    if (out_buttons.max_length < 1 || out_axis_x.max_length < 1 || out_axis_y.max_length < 1) {
+        return -11;
+    }
+    return realtime_read_control_raw(seat, out_buttons, out_axis_x, out_axis_y);
+}
+
+function realtime_disconnect(seat: i32): i32 {
+    return realtime_disconnect_raw(seat);
+}
+
+function realtime_reconnect(seat: i32): i32 {
+    return realtime_reconnect_raw(seat);
+}
+
+function realtime_pause(): i32 {
+    return realtime_pause_raw();
+}
+
+function realtime_focus_lost(): i32 {
+    return realtime_focus_lost_raw();
+}
+
+function realtime_rematch(): i32 {
+    return realtime_rematch_raw();
+}

--- a/tests/stasis/seams/realtime_controls_jit_probe.stasis
+++ b/tests/stasis/seams/realtime_controls_jit_probe.stasis
@@ -1,0 +1,145 @@
+import "../../../src/stdlib/realtime_controls.stasis";
+
+global realtime_probe_buttons: i32[1];
+global realtime_probe_axis_x: i32[1];
+global realtime_probe_axis_y: i32[1];
+global realtime_payload: i32[64];
+global realtime_short: i32[1];
+
+function realtime_controls_jit_probe(): i32 {
+    realtime_stop();
+    if (realtime_start(60, 120, 20, 2, 1) != 0) {
+        return 1;
+    }
+
+    let epoch: i32 = realtime_current_epoch(0);
+    if (epoch <= 0) {
+        return 2;
+    }
+    if (realtime_build_payload(realtime_short, 29, 0, epoch, 1, 2, 1, 1, 0) != -11) {
+        return 26;
+    }
+    if (realtime_submit_payload(realtime_short, 29) != -11) {
+        return 27;
+    }
+    if (realtime_apply_snapshot(1, 0, 2, realtime_short, realtime_short, realtime_short, realtime_short, realtime_short, realtime_short) != -11) {
+        return 28;
+    }
+    if (realtime_build_payload(realtime_payload, 64, 256, epoch, 1, 2, 1, 1, 0) != -1) {
+        return 29;
+    }
+    if (realtime_build_payload(realtime_payload, 64, 0, 0, 1, 2, 1, 1, 0) != -1) {
+        return 30;
+    }
+    if (realtime_build_payload(realtime_payload, 64, 0, epoch, 0, 2, 1, 1, 0) != -1) {
+        return 31;
+    }
+    if (realtime_build_payload(realtime_payload, 64, 0, epoch, 1, 2, 1, 128, 0) != -1) {
+        return 32;
+    }
+    if (realtime_build_payload(realtime_payload, 64, 0, epoch, 1, 2, 1, 1, 0) != 29) {
+        return 3;
+    }
+    if (realtime_payload[0] != 82) {
+        return 201;
+    }
+    if (realtime_payload[1] != 84) {
+        return 202;
+    }
+    if (realtime_payload[2] != 67) {
+        return 203;
+    }
+    if (realtime_payload[3] != 49) {
+        return 204;
+    }
+    if (realtime_payload[5] != 1 || realtime_payload[6] != 1) {
+        return 205;
+    }
+    if (realtime_payload[8] != 0 || realtime_payload[12] != epoch) {
+        return 206;
+    }
+    if (realtime_payload[16] != 1 || realtime_payload[24] != 2) {
+        return 207;
+    }
+    if (realtime_payload[26] != 1 || realtime_payload[27] != 1) {
+        return 208;
+    }
+    let submit_result: i32 = realtime_submit_payload(realtime_payload, 29);
+    if (submit_result != 0) {
+        return 100 - submit_result;
+    }
+    if (realtime_current_tick() != 0) {
+        return 4;
+    }
+
+    if (realtime_read_control(0, realtime_probe_buttons, realtime_probe_axis_x, realtime_probe_axis_y) != 0) {
+        return 5;
+    }
+    if (realtime_probe_buttons[0] != 0 || realtime_probe_axis_x[0] != 0) {
+        return 6;
+    }
+    if (realtime_advance() != 0 || realtime_current_tick() != 1) {
+        return 7;
+    }
+    if (realtime_record_hash(1, 19088743, -1985229329) != 0) {
+        return 33;
+    }
+    if (realtime_read_control(0, realtime_probe_buttons, realtime_probe_axis_x, realtime_probe_axis_y) != 0) {
+        return 8;
+    }
+    if (realtime_probe_buttons[0] != 0) {
+        return 9;
+    }
+
+    if (realtime_advance() != 0 || realtime_current_tick() != 2) {
+        return 10;
+    }
+    if (realtime_read_control(0, realtime_probe_buttons, realtime_probe_axis_x, realtime_probe_axis_y) != 0) {
+        return 11;
+    }
+    if (realtime_probe_buttons[0] != 1 || realtime_probe_axis_x[0] != 1) {
+        return 12;
+    }
+
+    if (realtime_schedule(0, epoch, 2, 4, 0, 0, 0) != 0) {
+        return 13;
+    }
+    if (realtime_advance() != 0) {
+        return 14;
+    }
+    if (realtime_read_control(0, realtime_probe_buttons, realtime_probe_axis_x, realtime_probe_axis_y) != 0) {
+        return 15;
+    }
+    if (realtime_probe_buttons[0] != 1) {
+        return 16;
+    }
+    if (realtime_advance() != 0) {
+        return 17;
+    }
+    if (realtime_read_control(0, realtime_probe_buttons, realtime_probe_axis_x, realtime_probe_axis_y) != 0) {
+        return 18;
+    }
+    if (realtime_probe_buttons[0] != 0 || realtime_probe_axis_x[0] != 0) {
+        return 19;
+    }
+    if (realtime_current_tick() != 4) {
+        return 20;
+    }
+
+    if (realtime_disconnect(0) != 0) {
+        return 21;
+    }
+    if (realtime_schedule(0, epoch, 3, 6, 1, 0, 0) != -4) {
+        return 22;
+    }
+    if (realtime_reconnect(0) != 0) {
+        return 23;
+    }
+    if (realtime_current_epoch(0) <= epoch) {
+        return 24;
+    }
+    if (realtime_stop() != 0) {
+        return 25;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a bounded deterministic realtime control scheduler with explicit simulation, presentation, and control rates
- add RTC1 packet admission, lifecycle epochs, snapshots, conflict quarantine/resync, replay, native ABI, JIT mappings, and Stasis wrappers
- add native, WebSocket, two-device, hostile-input, JIT/AOT seam, and ABI coverage plus architecture/spec documentation

## Validation
- cargo check -p stasis_network -p stasis_dynload -p stasis_compiler --all-targets: passed
- cargo fmt --all -- --check: passed
- focused stasis_network clippy with pre-existing unrelated lint allowances and -D warnings: passed
- stasis_network library test binary: 11/11 passed
- realtime_controls integration test binary: 14/14 passed
- pre-commit staged Stasis formatter test: 1/1 passed
- realtime_controls_jit_seam --no-run: compiled; its rebuilt executable was blocked at process launch by Windows Application Control (4551)
- full workspace check reached unrelated pre-existing AssetFormat::Sprite.layout errors / Windows Application Control; relevant package check passed

## Review
An independent gpt-5.6-sol medium review found no remaining actionable issues after the final buffer-capacity and ABI hardening pass.

Maddox Task #284