### PR TITLE
Fix generated web visible viewport fitting

### DIFF
--- a/apps/stasis/tests/web_package.rs
+++ b/apps/stasis/tests/web_package.rs
@@ -530,6 +530,15 @@ fn web_package_contains_runnable_static_bundle_without_standalone_html() {
     assert!(index.contains(r#"<title>web_export_smoke</title>"#));
     assert!(index.contains(r#"<h1 id="stasis-loading-title">web_export_smoke</h1>"#));
     assert!(index.contains(r#"id="stasis-loading-status">Preparing…</div>"#));
+    assert_eq!(index.matches("viewport-fit=cover").count(), 1);
+    assert_eq!(index.matches("safe-area-inset-").count(), 8);
+    assert_eq!(index.matches("100svh").count(), 1);
+    assert_eq!(index.matches("100dvh").count(), 1);
+    assert_eq!(index.matches("<script>\n    (() => {").count(), 1);
+    assert_eq!(index.matches("      addEventListener(\"resize\", fit)").count(), 1);
+    assert_eq!(index.matches("      addEventListener(\"orientationchange\", fit)").count(), 1);
+    assert_eq!(index.matches("visualViewport.addEventListener").count(), 2);
+    assert_eq!(index.matches("new MutationObserver(fit)").count(), 1);
     assert!(!index.contains("stasis-audio"));
     assert!(!index.contains("Enable sound"));
     for expected in [

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -49,11 +49,14 @@ shell opts into `viewport-fit=cover`, reserves the CSS safe-area insets, and use
 fallbacks. Its inline fitter uses `visualViewport.width`/`height` when available (with the layout
 viewport as a fallback), refitting on window resize, orientation changes, and visual-viewport
 resize/scroll. The shell keeps the canvas aspect ratio centered inside the currently visible safe
-area; it changes CSS dimensions only and never rewrites the canvas `width`/`height` backing
-resolution. A `MutationObserver` refits after an intentional intrinsic backing-size change without
+area; the body clip box moves with a nonzero visual-viewport origin so its overflow clip and canvas
+remain together. It changes CSS dimensions only and never rewrites the canvas `width`/`height`
+backing resolution. A `MutationObserver` refits after an intentional intrinsic backing-size change without
 observing the fitter's own style writes, so it cannot form a resize loop. Pointer coordinates remain
 guest-logical through `getBoundingClientRect()` in the runtime, including after a toolbar or
-orientation change. Consumers should not add post-processing resize or fullscreen controls.
+orientation change. The runtime's private synchronous refit hook runs before an intentional
+backing resize is reported in HostFrame; extent events are coalesced into one generation, while
+origin-only scroll remains quiet. Consumers should not add post-processing resize or fullscreen controls.
 
 Web packages do not render an audio-enable control. The runtime requests audio immediately and
 automatically retries on the first pointer or keyboard gesture when browser autoplay policy starts

--- a/docs/web_packaging.md
+++ b/docs/web_packaging.md
@@ -44,6 +44,17 @@ Self-contained single-file HTML output is intentionally deferred; web packages k
 assets external so hosted output remains compact and follows the same asset preparation path as
 Android and desktop packages.
 
+The browser shell owns page fitting and the guest owns its logical canvas. The shared `index.html`
+shell opts into `viewport-fit=cover`, reserves the CSS safe-area insets, and uses `svh`/`dvh`
+fallbacks. Its inline fitter uses `visualViewport.width`/`height` when available (with the layout
+viewport as a fallback), refitting on window resize, orientation changes, and visual-viewport
+resize/scroll. The shell keeps the canvas aspect ratio centered inside the currently visible safe
+area; it changes CSS dimensions only and never rewrites the canvas `width`/`height` backing
+resolution. A `MutationObserver` refits after an intentional intrinsic backing-size change without
+observing the fitter's own style writes, so it cannot form a resize loop. Pointer coordinates remain
+guest-logical through `getBoundingClientRect()` in the runtime, including after a toolbar or
+orientation change. Consumers should not add post-processing resize or fullscreen controls.
+
 Web packages do not render an audio-enable control. The runtime requests audio immediately and
 automatically retries on the first pointer or keyboard gesture when browser autoplay policy starts
 the audio context suspended.

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -1360,6 +1360,7 @@
     if (canvas.width === width && canvas.height === height) return;
     canvas.width = width;
     canvas.height = height;
+    if (typeof window.STASIS_REFIT_VIEWPORT === "function") window.STASIS_REFIT_VIEWPORT();
     markResized();
   }
 
@@ -1390,7 +1391,6 @@
     } else if (flags & 4) {
       setCanvasSize(width, height);
       document.body.dataset.windowMode = "maximized";
-      markResized();
     }
     document.body.dataset.windowRequestSeq = String(sequence);
   }
@@ -1522,6 +1522,7 @@
   addEventListener("resize", markResized);
   addEventListener("orientationchange", markResized);
   if (window.visualViewport) window.visualViewport.addEventListener("resize", markResized);
+  addEventListener("stasis-viewport-extent", markResized);
   document.addEventListener("fullscreenchange", markResized);
   // @stasis-feature audio begin
   void enableWebAudio();

--- a/runtime/web/game.js
+++ b/runtime/web/game.js
@@ -198,6 +198,7 @@
   let tickIndex = 0;
   let resized = true;
   let displayGeneration = 1;
+  let resizeGenerationPending = true;
   let densityGeneration = 1;
   let lastWindowRequest = -1;
   let pendingFullscreen;
@@ -1335,6 +1336,7 @@
     document.body.dataset.hostTimeMs = String(i32[0]);
     if (resized) document.body.dataset.resizeTick = String(i32[10]);
     resized = false;
+    resizeGenerationPending = false;
   }
 
   function finishHostFrame() {
@@ -1358,10 +1360,15 @@
     if (canvas.width === width && canvas.height === height) return;
     canvas.width = width;
     canvas.height = height;
-    canvas.style.aspectRatio = `${width} / ${height}`;
-    canvas.parentElement.style.width = `min(100vw, calc(100vh * ${width} / ${height}))`;
+    markResized();
+  }
+
+  function markResized() {
     resized = true;
-    displayGeneration += 1;
+    if (!resizeGenerationPending) {
+      displayGeneration += 1;
+      resizeGenerationPending = true;
+    }
   }
 
   function applyWindowRequest() {
@@ -1383,7 +1390,7 @@
     } else if (flags & 4) {
       setCanvasSize(width, height);
       document.body.dataset.windowMode = "maximized";
-      resized = true;
+      markResized();
     }
     document.body.dataset.windowRequestSeq = String(sequence);
   }
@@ -1512,8 +1519,10 @@
     pointer.wentUp = true;
   });
   canvas.addEventListener("pointercancel", () => { pointer.hover = false; pointer.down = false; pointer.wentUp = true; });
-  addEventListener("resize", () => { resized = true; displayGeneration += 1; });
-  document.addEventListener("fullscreenchange", () => { resized = true; displayGeneration += 1; });
+  addEventListener("resize", markResized);
+  addEventListener("orientationchange", markResized);
+  if (window.visualViewport) window.visualViewport.addEventListener("resize", markResized);
+  document.addEventListener("fullscreenchange", markResized);
   // @stasis-feature audio begin
   void enableWebAudio();
   // @stasis-feature audio end

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -17,6 +17,9 @@
       height: var(--stasis-visible-height, 100dvh);
       min-height: var(--stasis-visible-height, 100%);
       max-height: var(--stasis-visible-height, 100%);
+      position: relative;
+      left: var(--stasis-visible-offset-left, 0px);
+      top: var(--stasis-visible-offset-top, 0px);
       margin: 0;
       padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
       display: grid;
@@ -77,6 +80,8 @@
         return {
           width,
           height,
+          offsetLeft: finite(visual && visual.offsetLeft),
+          offsetTop: finite(visual && visual.offsetTop),
           left: safeInset("left"),
           right: safeInset("right"),
           top: safeInset("top"),
@@ -85,6 +90,7 @@
       };
 
       let lastExtent = "";
+      let lastPosition = "";
       const fit = () => {
         const viewport = visibleViewport();
         const availableWidth = Math.max(1, viewport.width - viewport.left - viewport.right);
@@ -95,15 +101,26 @@
         const width = Math.max(1, Math.min(960, availableWidth, availableHeight * ratio));
         const height = width / ratio;
         const extentKey = [viewport.width, viewport.height, viewport.left, viewport.right, viewport.top, viewport.bottom, backingWidth, backingHeight].join(":");
-        if (extentKey === lastExtent) return;
+        const positionKey = `${viewport.offsetLeft}:${viewport.offsetTop}`;
+        const extentChanged = extentKey !== lastExtent;
+        const positionChanged = positionKey !== lastPosition;
+        if (!extentChanged && !positionChanged) return;
         lastExtent = extentKey;
+        lastPosition = positionKey;
+        document.documentElement.style.setProperty("--stasis-visible-offset-left", `${viewport.offsetLeft}px`);
+        document.documentElement.style.setProperty("--stasis-visible-offset-top", `${viewport.offsetTop}px`);
+        if (!extentChanged) return;
         document.documentElement.style.setProperty("--stasis-visible-width", `${viewport.width}px`);
         document.documentElement.style.setProperty("--stasis-visible-height", `${viewport.height}px`);
         shell.style.width = `${width}px`;
         shell.style.height = `${height}px`;
         shell.style.aspectRatio = `${backingWidth} / ${backingHeight}`;
+        if (typeof window.dispatchEvent === "function" && typeof Event === "function") {
+          window.dispatchEvent(new Event("stasis-viewport-extent"));
+        }
       };
 
+      window.STASIS_REFIT_VIEWPORT = fit;
       fit();
       addEventListener("resize", fit);
       addEventListener("orientationchange", fit);

--- a/runtime/web/index.html
+++ b/runtime/web/index.html
@@ -2,17 +2,33 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <link rel="icon" href="data:,">
   __STASIS_LOADING_FONT_FACE__
   <title>__STASIS_GAME_TITLE__</title>
   <style>
     :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    body { margin: 0; min-height: 100vh; display: grid; place-items: center; overflow: hidden; background: #081613; color: #f3eee1; }
-    main { position: relative; width: min(960px, 100vw); }
-    canvas { display: block; width: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
+    html { width: 100%; height: 100%; overflow: hidden; }
+    body {
+      box-sizing: border-box;
+      width: var(--stasis-visible-width, 100%);
+      height: 100vh;
+      height: 100svh;
+      height: var(--stasis-visible-height, 100dvh);
+      min-height: var(--stasis-visible-height, 100%);
+      max-height: var(--stasis-visible-height, 100%);
+      margin: 0;
+      padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      background: #081613;
+      color: #f3eee1;
+    }
+    main { position: relative; width: min(960px, 100%); max-width: 100%; aspect-ratio: 16 / 9; }
+    canvas { display: block; width: 100%; height: 100%; aspect-ratio: 16 / 9; background: #091b2d; touch-action: none; }
     __STASIS_PERFORMANCE_HUD_STYLE__
-    #stasis-loading { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: clamp(1.5rem, 7vw, 5rem); box-sizing: border-box; overflow: hidden; isolation: isolate; background: linear-gradient(145deg, #102a24 0%, #0b1d1a 48%, #07131d 100%); color: #f3eee1; text-align: center; }
+    #stasis-loading { position: fixed; inset: 0; z-index: 10; display: grid; place-items: center; padding: calc(env(safe-area-inset-top, 0px) + clamp(1.5rem, 7vw, 5rem)) calc(env(safe-area-inset-right, 0px) + clamp(1.5rem, 7vw, 5rem)) calc(env(safe-area-inset-bottom, 0px) + clamp(1.5rem, 7vw, 5rem)) calc(env(safe-area-inset-left, 0px) + clamp(1.5rem, 7vw, 5rem)); box-sizing: border-box; overflow: hidden; isolation: isolate; background: linear-gradient(145deg, #102a24 0%, #0b1d1a 48%, #07131d 100%); color: #f3eee1; text-align: center; }
     #stasis-loading::before, #stasis-loading::after { position: absolute; z-index: -1; display: block; content: ""; pointer-events: none; }
     #stasis-loading::before { width: min(86vw, 56rem); height: min(86vw, 56rem); border: 1px solid #bca66b22; border-radius: 50%; background: radial-gradient(circle, #c6a96b0d 0%, transparent 67%); transform: translate(22%, -25%); }
     #stasis-loading::after { inset: 0; background: linear-gradient(90deg, transparent 0 49.95%, #bca66b10 50%, transparent 50.05%); opacity: .65; }
@@ -42,6 +58,64 @@
     __STASIS_PERFORMANCE_HUD__
     <pre id="stasis-error"></pre>
   </main>
+  <script>
+    (() => {
+      const canvas = document.getElementById("stasis-canvas");
+      const shell = canvas && canvas.parentElement;
+      if (!canvas || !shell) return;
+
+      const finite = value => Number.isFinite(value) && value > 0 ? value : 0;
+      const safeInset = side => {
+        const styles = typeof getComputedStyle === "function" ? getComputedStyle(document.body) : null;
+        const value = styles && parseFloat(styles.getPropertyValue(`padding-${side}`));
+        return Number.isFinite(value) && value > 0 ? value : 0;
+      };
+      const visibleViewport = () => {
+        const visual = window.visualViewport;
+        const width = finite(visual && visual.width) || finite(document.documentElement && document.documentElement.clientWidth) || finite(window.innerWidth);
+        const height = finite(visual && visual.height) || finite(document.documentElement && document.documentElement.clientHeight) || finite(window.innerHeight);
+        return {
+          width,
+          height,
+          left: safeInset("left"),
+          right: safeInset("right"),
+          top: safeInset("top"),
+          bottom: safeInset("bottom")
+        };
+      };
+
+      let lastExtent = "";
+      const fit = () => {
+        const viewport = visibleViewport();
+        const availableWidth = Math.max(1, viewport.width - viewport.left - viewport.right);
+        const availableHeight = Math.max(1, viewport.height - viewport.top - viewport.bottom);
+        const backingWidth = finite(canvas.width) || 16;
+        const backingHeight = finite(canvas.height) || 9;
+        const ratio = backingWidth / backingHeight;
+        const width = Math.max(1, Math.min(960, availableWidth, availableHeight * ratio));
+        const height = width / ratio;
+        const extentKey = [viewport.width, viewport.height, viewport.left, viewport.right, viewport.top, viewport.bottom, backingWidth, backingHeight].join(":");
+        if (extentKey === lastExtent) return;
+        lastExtent = extentKey;
+        document.documentElement.style.setProperty("--stasis-visible-width", `${viewport.width}px`);
+        document.documentElement.style.setProperty("--stasis-visible-height", `${viewport.height}px`);
+        shell.style.width = `${width}px`;
+        shell.style.height = `${height}px`;
+        shell.style.aspectRatio = `${backingWidth} / ${backingHeight}`;
+      };
+
+      fit();
+      addEventListener("resize", fit);
+      addEventListener("orientationchange", fit);
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", fit);
+        window.visualViewport.addEventListener("scroll", fit);
+      }
+      if (typeof MutationObserver === "function") {
+        new MutationObserver(fit).observe(canvas, { attributes: true, attributeFilter: ["width", "height"] });
+      }
+    })();
+  </script>
   <script src="game.js"></script>
 </body>
 </html>

--- a/runtime/web/tests/orientation_host_frame.test.mjs
+++ b/runtime/web/tests/orientation_host_frame.test.mjs
@@ -7,6 +7,7 @@ const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
 
 async function runSequence(first, second) {
   const events = new Map();
+  const visualViewportEvents = new Map();
   const raf = [];
   const ticks = [];
   let now = 0;
@@ -54,6 +55,11 @@ async function runSequence(first, second) {
   let screenWidth = first[0];
   let screenHeight = first[1];
   const screen = { get width() { return screenWidth; }, get height() { return screenHeight; } };
+  const visualViewport = {
+    width: first[0],
+    height: first[1],
+    addEventListener(type, listener) { visualViewportEvents.set(type, listener); }
+  };
   const instance = {
     exports: {
       memory,
@@ -64,7 +70,7 @@ async function runSequence(first, second) {
         if (i32[547]) actionCount += 1;
         ticks.push({
           resized: i32[11], displayGeneration: i32[30], native: [i32[22], i32[23]], drawable: [i32[24], i32[25]],
-          logical: [f32[50], f32[51]], pointerCount: i32[7], wentDown: i32[546], wentUp: i32[547], actionCount
+          logical: [f32[50], f32[51]], pointer: [f32[0], f32[1]], pointerCount: i32[7], wentDown: i32[546], wentUp: i32[547], actionCount
         });
       },
       render: () => 0,
@@ -82,7 +88,7 @@ async function runSequence(first, second) {
     AudioContext: class { constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; } close() {} resume() {} },
     TextDecoder, setTimeout, clearTimeout, STASIS_GAME: game,
   };
-  contextObject.window = { STASIS_GAME: game, screen };
+  contextObject.window = { STASIS_GAME: game, screen, visualViewport };
   vm.runInNewContext(source, contextObject, { filename: "runtime/web/game.js" });
   await new Promise(resolve => setImmediate(resolve));
   await new Promise(resolve => setImmediate(resolve));
@@ -90,7 +96,7 @@ async function runSequence(first, second) {
   const frame = () => { now += 16; raf.shift()(now); };
   frame();
   const dispatch = (type, event = {}) => canvas.listeners.get(type)?.(event);
-  dispatch("pointerdown", { pointerId: 7, clientX: 90, clientY: 180 });
+  dispatch("pointerdown", { pointerId: 7, clientX: first[0] - 1, clientY: first[1] - 1 });
   frame();
   const down = ticks.at(-1);
   assert.equal(down.pointerCount, 1);
@@ -98,9 +104,13 @@ async function runSequence(first, second) {
   assert.equal(down.wentUp, 0);
   assert.equal(down.logical[0], first[0]);
   assert.equal(down.logical[1], first[1]);
+  assert.deepEqual(down.pointer, [first[0] - 1, first[1] - 1]);
   screenWidth = second[0]; screenHeight = second[1];
   canvasWidth = second[0]; canvasHeight = second[1];
+  visualViewport.width = second[0]; visualViewport.height = second[1];
+  visualViewportEvents.get("resize")();
   events.get("window:resize")();
+  events.get("window:orientationchange")();
   assert.deepEqual([screen.width, screen.height], second);
   frame();
   const resized = ticks.at(-1);
@@ -109,11 +119,15 @@ async function runSequence(first, second) {
   assert.deepEqual(resized.native, second);
   assert.deepEqual(resized.drawable, second);
   assert.deepEqual(resized.logical, first, "guest canvas remains selected logical size");
-  dispatch("pointerup", { pointerId: 7, clientX: 90, clientY: 180 });
+  dispatch("pointerup", { pointerId: 7, clientX: second[0] - 1, clientY: second[1] - 1 });
   frame();
   const up = ticks.at(-1);
   assert.equal(up.resized, 0);
   assert.equal(up.wentUp, 1);
+  assert.deepEqual(up.pointer, [
+    Math.round((second[0] - 1) * first[0] / second[0]),
+    Math.round((second[1] - 1) * first[1] / second[1])
+  ]);
   assert.equal(up.actionCount, 1, "release increments the action counter exactly once");
   frame();
   const quiet = ticks.at(-1);

--- a/runtime/web/tests/orientation_host_frame.test.mjs
+++ b/runtime/web/tests/orientation_host_frame.test.mjs
@@ -5,7 +5,7 @@ import vm from "node:vm";
 
 const source = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
 
-async function runSequence(first, second) {
+async function runSequence(first, second, options = {}) {
   const events = new Map();
   const visualViewportEvents = new Map();
   const raf = [];
@@ -16,6 +16,12 @@ async function runSequence(first, second) {
     host_i32: { offset: 0, length: 768 },
     host_f32: { offset: 768 * 4, length: 64 }
   }, strings: {}, assets: {} };
+  const requestGlobals = options.backingRequest ? {
+    host_req_seq: { value: 0 },
+    host_req_flags: { value: 0 },
+    host_req_window_w_px: { value: first[0] },
+    host_req_window_h_px: { value: first[1] }
+  } : {};
   let canvasWidth = first[0];
   let canvasHeight = first[1];
   const context = {
@@ -63,6 +69,7 @@ async function runSequence(first, second) {
   const instance = {
     exports: {
       memory,
+      ...requestGlobals,
       main: () => 0,
       tick: () => {
         const i32 = new Int32Array(memory.buffer, 0, 768);
@@ -88,7 +95,14 @@ async function runSequence(first, second) {
     AudioContext: class { constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; } close() {} resume() {} },
     TextDecoder, setTimeout, clearTimeout, STASIS_GAME: game,
   };
-  contextObject.window = { STASIS_GAME: game, screen, visualViewport };
+  contextObject.window = {
+    STASIS_GAME: game,
+    screen,
+    visualViewport,
+    STASIS_REFIT_VIEWPORT: options.backingRequest
+      ? () => { canvasWidth = canvas.width; canvasHeight = canvas.height; }
+      : undefined
+  };
   vm.runInNewContext(source, contextObject, { filename: "runtime/web/game.js" });
   await new Promise(resolve => setImmediate(resolve));
   await new Promise(resolve => setImmediate(resolve));
@@ -105,6 +119,25 @@ async function runSequence(first, second) {
   assert.equal(down.logical[0], first[0]);
   assert.equal(down.logical[1], first[1]);
   assert.deepEqual(down.pointer, [first[0] - 1, first[1] - 1]);
+  if (options.backingRequest) {
+    screenWidth = second[0]; screenHeight = second[1];
+    requestGlobals.host_req_seq.value = 1;
+    requestGlobals.host_req_flags.value = 4;
+    requestGlobals.host_req_window_w_px.value = second[0];
+    requestGlobals.host_req_window_h_px.value = second[1];
+    frame();
+    const backingResize = ticks.at(-1);
+    assert.equal(backingResize.resized, 1);
+    assert.equal(backingResize.displayGeneration, 2);
+    assert.deepEqual(backingResize.drawable, second);
+    assert.deepEqual(backingResize.logical, second, "intentional backing resize reaches the same HostFrame");
+    requestGlobals.host_req_seq.value = 2;
+    frame();
+    const unchangedRequest = ticks.at(-1);
+    assert.equal(unchangedRequest.resized, 0, "same-size maximized request does not report a resize");
+    assert.equal(unchangedRequest.displayGeneration, 2);
+    return ticks;
+  }
   screenWidth = second[0]; screenHeight = second[1];
   canvasWidth = second[0]; canvasHeight = second[1];
   visualViewport.width = second[0]; visualViewport.height = second[1];
@@ -145,4 +178,8 @@ test("web HostFrame portrait to landscape preserves actionable release", async (
 
 test("web HostFrame landscape to portrait preserves actionable release", async () => {
   await runSequence([720, 360], [360, 720]);
+});
+
+test("web HostFrame reports synchronous intentional backing resize", async () => {
+  await runSequence([360, 720], [320, 640], { backingRequest: true });
 });

--- a/runtime/web/tests/viewport_fit.test.mjs
+++ b/runtime/web/tests/viewport_fit.test.mjs
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const html = fs.readFileSync(new URL("../index.html", import.meta.url), "utf8");
+const fitter = html.match(/<script>\s*([\s\S]*?)\s*<\/script>/)?.[1];
+assert.ok(fitter, "index.html has an inline viewport fitter");
+
+function runFitter({ layoutWidth = 393, layoutHeight = 844, visualWidth = 393, visualHeight = 650, backingWidth = 640, backingHeight = 360, safe = {}, visual = true } = {}) {
+  const windowListeners = new Map();
+  const visualListeners = new Map();
+  const mutations = [];
+  const mutationOptions = [];
+  const rootStyle = {
+    values: {},
+    setProperty(name, value) { this.values[name] = value; }
+  };
+  const shellStyle = {};
+  const canvasStyle = {};
+  const canvas = {
+    width: backingWidth,
+    height: backingHeight,
+    style: canvasStyle,
+    parentElement: { style: shellStyle }
+  };
+  const visualViewport = visual ? {
+    width: visualWidth,
+    height: visualHeight,
+    offsetLeft: 0,
+    offsetTop: 0,
+    addEventListener(type, listener) { visualListeners.set(type, listener); }
+  } : undefined;
+  const document = {
+    body: {},
+    documentElement: { clientWidth: layoutWidth, clientHeight: layoutHeight, style: rootStyle },
+    getElementById(id) { return id === "stasis-canvas" ? canvas : null; }
+  };
+  const context = {
+    document,
+    window: { visualViewport, innerWidth: layoutWidth, innerHeight: layoutHeight },
+    getComputedStyle: () => ({
+      getPropertyValue(name) {
+        const side = name.slice("padding-".length);
+        return String(safe[side] || 0);
+      }
+    }),
+    addEventListener(type, listener) {
+      const listeners = windowListeners.get(type) || [];
+      listeners.push(listener);
+      windowListeners.set(type, listeners);
+    },
+    MutationObserver: class {
+      constructor(callback) { mutations.push(callback); }
+      observe(_target, options) { mutationOptions.push(options); }
+    }
+  };
+  vm.runInNewContext(fitter, context, { filename: "runtime/web/index.html" });
+  return {
+    canvas,
+    shellStyle,
+    rootStyle,
+    windowListeners,
+    visualListeners,
+    mutations,
+    mutationOptions,
+    canvasStyle,
+    visualViewport,
+    dispatch(type) { for (const listener of windowListeners.get(type) || []) listener(); },
+    dispatchVisual(type) { visualListeners.get(type)?.(); }
+  };
+}
+
+test("shared web shell uses the visible viewport and preserves backing size", () => {
+  const fit = runFitter({ backingWidth: 160, backingHeight: 900, safe: { top: 24, right: 0, bottom: 34, left: 0 } });
+  assert.equal(fit.rootStyle.values["--stasis-visible-width"], "393px");
+  assert.equal(fit.rootStyle.values["--stasis-visible-height"], "650px");
+  assert.ok(Math.abs(parseFloat(fit.shellStyle.width) - 105.24444444444444) < 1e-9);
+  assert.equal(fit.shellStyle.height, "592px");
+  assert.notStrictEqual(fit.shellStyle, fit.canvasStyle);
+  assert.equal(fit.canvasStyle.width, undefined);
+  assert.equal(fit.canvas.width, 160);
+  assert.equal(fit.canvas.height, 900);
+  assert.equal(fit.visualListeners.size, 2);
+  assert.equal(fit.windowListeners.get("resize")?.length, 1);
+  assert.equal(fit.windowListeners.get("orientationchange")?.length, 1);
+  assert.equal(fit.mutationOptions.length, 1);
+  assert.equal(fit.mutationOptions[0].attributes, true);
+  assert.deepEqual(Array.from(fit.mutationOptions[0].attributeFilter), ["width", "height"]);
+  assert.equal(parseFloat(fit.shellStyle.width) <= 393 && 592 <= 650 - 24 - 34, true);
+  assert.equal(parseFloat(fit.shellStyle.width) <= 393 && 592 <= 844, true, "the VM models 393x844 layout and 393x650 visual viewports");
+});
+
+test("visual viewport and orientation changes refit once without duplicate listeners", () => {
+  const fit = runFitter({ layoutWidth: 844, layoutHeight: 393, visualWidth: 844, visualHeight: 393 });
+  fit.visualViewport.width = 393;
+  fit.visualViewport.height = 650;
+  fit.dispatchVisual("resize");
+  assert.equal(fit.shellStyle.width, "393px");
+  assert.equal(fit.shellStyle.height, "221.0625px");
+  const beforeScroll = { ...fit.shellStyle };
+  fit.visualViewport.offsetTop = 12;
+  fit.dispatchVisual("scroll");
+  assert.deepEqual(fit.shellStyle, beforeScroll, "origin-only scroll does not translate the grid-centered shell");
+  fit.visualViewport.height = 640;
+  fit.dispatchVisual("scroll");
+  assert.equal(fit.rootStyle.values["--stasis-visible-height"], "640px", "scroll can still refit when the visible extent changes");
+  fit.dispatch("resize");
+  fit.dispatch("orientationchange");
+  assert.equal(fit.windowListeners.get("resize")?.length, 1);
+  assert.equal(fit.windowListeners.get("orientationchange")?.length, 1);
+  assert.equal(fit.visualListeners.get("resize") !== undefined, true);
+});
+
+test("intrinsic backing mutation changes fit ratio without changing the backing", () => {
+  const fit = runFitter();
+  fit.canvas.width = 320;
+  fit.canvas.height = 240;
+  fit.mutations[0]();
+  assert.equal(fit.shellStyle.width, "393px");
+  assert.equal(fit.shellStyle.height, "294.75px");
+  assert.equal(fit.canvas.width, 320);
+  assert.equal(fit.canvas.height, 240);
+});
+
+test("layout viewport fallback works when visualViewport is unavailable", () => {
+  const fit = runFitter({ layoutWidth: 480, layoutHeight: 800, visual: false });
+  assert.equal(fit.rootStyle.values["--stasis-visible-width"], "480px");
+  assert.equal(fit.rootStyle.values["--stasis-visible-height"], "800px");
+  assert.equal(fit.visualListeners.size, 0);
+  assert.equal(fit.windowListeners.get("resize")?.length, 1);
+});
+
+test("index shell contract is safe-area aware and has one fitter", () => {
+  assert.match(html, /viewport-fit=cover/);
+  assert.match(html, /safe-area-inset-top/);
+  assert.match(html, /safe-area-inset-bottom/);
+  assert.match(html, /100svh/);
+  assert.match(html, /100dvh/);
+  assert.equal((html.match(/<script>\s*\(\(\) =>/g) || []).length, 1);
+  assert.equal((html.match(/addEventListener\("resize", fit\)/g) || []).length, 2);
+  assert.equal((html.match(/addEventListener\("orientationchange", fit\)/g) || []).length, 1);
+});

--- a/runtime/web/tests/viewport_fit.test.mjs
+++ b/runtime/web/tests/viewport_fit.test.mjs
@@ -6,6 +6,7 @@ import vm from "node:vm";
 const html = fs.readFileSync(new URL("../index.html", import.meta.url), "utf8");
 const fitter = html.match(/<script>\s*([\s\S]*?)\s*<\/script>/)?.[1];
 assert.ok(fitter, "index.html has an inline viewport fitter");
+const runtime = fs.readFileSync(new URL("../game.js", import.meta.url), "utf8");
 
 function runFitter({ layoutWidth = 393, layoutHeight = 844, visualWidth = 393, visualHeight = 650, backingWidth = 640, backingHeight = 360, safe = {}, visual = true } = {}) {
   const windowListeners = new Map();
@@ -75,6 +76,7 @@ test("shared web shell uses the visible viewport and preserves backing size", ()
   const fit = runFitter({ backingWidth: 160, backingHeight: 900, safe: { top: 24, right: 0, bottom: 34, left: 0 } });
   assert.equal(fit.rootStyle.values["--stasis-visible-width"], "393px");
   assert.equal(fit.rootStyle.values["--stasis-visible-height"], "650px");
+  assert.equal(fit.rootStyle.values["--stasis-visible-offset-top"], "0px");
   assert.ok(Math.abs(parseFloat(fit.shellStyle.width) - 105.24444444444444) < 1e-9);
   assert.equal(fit.shellStyle.height, "592px");
   assert.notStrictEqual(fit.shellStyle, fit.canvasStyle);
@@ -102,6 +104,7 @@ test("visual viewport and orientation changes refit once without duplicate liste
   fit.visualViewport.offsetTop = 12;
   fit.dispatchVisual("scroll");
   assert.deepEqual(fit.shellStyle, beforeScroll, "origin-only scroll does not translate the grid-centered shell");
+  assert.equal(fit.rootStyle.values["--stasis-visible-offset-top"], "12px");
   fit.visualViewport.height = 640;
   fit.dispatchVisual("scroll");
   assert.equal(fit.rootStyle.values["--stasis-visible-height"], "640px", "scroll can still refit when the visible extent changes");
@@ -110,6 +113,20 @@ test("visual viewport and orientation changes refit once without duplicate liste
   assert.equal(fit.windowListeners.get("resize")?.length, 1);
   assert.equal(fit.windowListeners.get("orientationchange")?.length, 1);
   assert.equal(fit.visualListeners.get("resize") !== undefined, true);
+});
+
+test("visual offset moves the containing body box without clipping a tall shell", () => {
+  const fit = runFitter({ backingWidth: 160, backingHeight: 900, safe: { top: 24, bottom: 34 } });
+  fit.visualViewport.offsetTop = 100;
+  fit.dispatchVisual("scroll");
+  const visibleTop = 100;
+  const visibleHeight = 650;
+  const contentHeight = visibleHeight - 24 - 34;
+  const shellTop = visibleTop + 24 + (contentHeight - parseFloat(fit.shellStyle.height)) / 2;
+  const shellBottom = shellTop + parseFloat(fit.shellStyle.height);
+  assert.equal(fit.rootStyle.values["--stasis-visible-offset-top"], "100px");
+  assert.ok(shellTop >= visibleTop && shellBottom <= visibleTop + visibleHeight);
+  assert.equal(parseFloat(fit.shellStyle.height), contentHeight);
 });
 
 test("intrinsic backing mutation changes fit ratio without changing the backing", () => {
@@ -137,7 +154,185 @@ test("index shell contract is safe-area aware and has one fitter", () => {
   assert.match(html, /safe-area-inset-bottom/);
   assert.match(html, /100svh/);
   assert.match(html, /100dvh/);
+  assert.match(html, /position: relative;/);
+  assert.doesNotMatch(html, /transform: translate\(var\(--stasis-visible-offset-left/);
+  assert.match(html, /#stasis-loading \{[^}]*position: fixed; inset: 0;/);
+  assert.match(html, /window\.STASIS_REFIT_VIEWPORT = fit/);
   assert.equal((html.match(/<script>\s*\(\(\) =>/g) || []).length, 1);
   assert.equal((html.match(/addEventListener\("resize", fit\)/g) || []).length, 2);
   assert.equal((html.match(/addEventListener\("orientationchange", fit\)/g) || []).length, 1);
+});
+
+function integratedRuntime() {
+  const listeners = new Map();
+  const visualListeners = new Map();
+  const raf = [];
+  const mutations = [];
+  const rootStyle = {
+    values: {},
+    setProperty(name, value) { this.values[name] = value; }
+  };
+  const shellStyle = {};
+  const canvasStyle = {};
+  const canvas = {
+    width: 640,
+    height: 360,
+    style: canvasStyle,
+    parentElement: { style: shellStyle },
+    listeners: new Map(),
+    getContext: () => ({
+      fillRect() {}, fillText() {}, save() {}, restore() {}, beginPath() {}, moveTo() {}, lineTo() {}, stroke() {},
+      drawImage() {}, translate() {}, rotate() {}
+    }),
+    getBoundingClientRect() {
+      return { left: 0, top: 0, width: parseFloat(shellStyle.width) || 0, height: parseFloat(shellStyle.height) || 0 };
+    },
+    addEventListener(type, listener) { this.listeners.set(type, listener); },
+    setPointerCapture() {},
+    focus() {},
+    requestFullscreen: async () => {}
+  };
+  const visualViewport = {
+    width: 393,
+    height: 650,
+    offsetLeft: 0,
+    offsetTop: 0,
+    addEventListener(type, listener) { visualListeners.set(type, listener); },
+    dispatchEvent(event) { visualListeners.get(event.type)?.(event); }
+  };
+  const body = { dataset: {} };
+  const errorBox = { textContent: "" };
+  const memory = new WebAssembly.Memory({ initial: 2 });
+  const game = { memory: {
+    host_i32: { offset: 0, length: 768 },
+    host_f32: { offset: 768 * 4, length: 64 }
+  }, strings: {}, assets: {} };
+  const request = {
+    host_req_seq: { value: 0 },
+    host_req_flags: { value: 0 },
+    host_req_window_w_px: { value: 640 },
+    host_req_window_h_px: { value: 360 }
+  };
+  const ticks = [];
+  const instance = { exports: {
+    memory,
+    ...request,
+    main: () => 0,
+    tick: () => {
+      const i32 = new Int32Array(memory.buffer, 0, 768);
+      const f32 = new Float32Array(memory.buffer, 768 * 4, 64);
+      ticks.push({
+        resized: i32[11], generation: i32[30], drawable: [i32[24], i32[25]], logical: [f32[50], f32[51]]
+      });
+    },
+    render: () => 0
+  } };
+  const eventTarget = {
+    addEventListener(type, listener) {
+      const values = listeners.get(type) || [];
+      values.push(listener);
+      listeners.set(type, values);
+    },
+    dispatchEvent(event) {
+      for (const listener of listeners.get(event.type) || []) listener(event);
+      return true;
+    }
+  };
+  const document = {
+    body,
+    hidden: false,
+    fullscreenElement: null,
+    documentElement: { clientWidth: 393, clientHeight: 844, style: rootStyle },
+    fonts: { ready: Promise.resolve(), add() {} },
+    hasFocus: () => true,
+    getElementById(id) {
+      if (id === "stasis-canvas") return canvas;
+      if (id === "stasis-error") return errorBox;
+      return null;
+    },
+    addEventListener: eventTarget.addEventListener
+  };
+  const window = {
+    STASIS_GAME: game,
+    visualViewport,
+    innerWidth: 393,
+    innerHeight: 844,
+    addEventListener: eventTarget.addEventListener,
+    dispatchEvent: eventTarget.dispatchEvent
+  };
+  const context = {
+    document,
+    window,
+    screen: { width: 393, height: 844 },
+    devicePixelRatio: 1,
+    performance: { now: () => 0 },
+    WebAssembly: { instantiate: async () => ({ instance }) },
+    fetch: async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }),
+    requestAnimationFrame: callback => { raf.push(callback); return raf.length; },
+    cancelAnimationFrame() {},
+    addEventListener: eventTarget.addEventListener,
+    dispatchEvent: eventTarget.dispatchEvent,
+    Event: class { constructor(type) { this.type = type; } },
+    getComputedStyle: () => ({ getPropertyValue: name => ({
+      "padding-top": "24px", "padding-bottom": "34px", "padding-left": "0px", "padding-right": "0px"
+    }[name] || "0px") }),
+    MutationObserver: class {
+      constructor(callback) { mutations.push(callback); }
+      observe() {}
+    },
+    console,
+    Image: class {},
+    FontFace: class { load() { return Promise.resolve(this); } },
+    AudioContext: class { constructor() { this.state = "running"; this.currentTime = 0; this.destination = {}; } close() {} resume() {} },
+    TextDecoder,
+    setTimeout,
+    clearTimeout,
+    STASIS_GAME: game
+  };
+  vm.runInNewContext(fitter, context, { filename: "runtime/web/index.html" });
+  vm.runInNewContext(runtime, context, { filename: "runtime/web/game.js" });
+  return { canvas, canvasStyle, shellStyle, rootStyle, visualViewport, request, ticks, raf, mutations, listeners, context };
+}
+
+async function startIntegratedRuntime() {
+  const fixture = integratedRuntime();
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(fixture.raf.length, 1);
+  fixture.raf.shift()(16);
+  return fixture;
+}
+
+test("integrated fitter and runtime share extent signaling and ordering", async () => {
+  const fixture = await startIntegratedRuntime();
+  const { canvas, request, ticks, raf, visualViewport, rootStyle, mutations, shellStyle } = fixture;
+  request.host_req_seq.value = 1;
+  request.host_req_flags.value = 4;
+  request.host_req_window_w_px.value = 320;
+  request.host_req_window_h_px.value = 640;
+  raf.shift()(32);
+  assert.deepEqual(ticks.at(-1), { resized: 1, generation: 2, drawable: [296, 592], logical: [320, 640] });
+
+  visualViewport.height = 600;
+  visualViewport.dispatchEvent(new fixture.context.Event("scroll"));
+  raf.shift()(48);
+  assert.equal(ticks.at(-1).resized, 1);
+  assert.equal(ticks.at(-1).generation, 3);
+
+  visualViewport.offsetTop = 100;
+  visualViewport.dispatchEvent(new fixture.context.Event("scroll"));
+  raf.shift()(64);
+  assert.equal(rootStyle.values["--stasis-visible-offset-top"], "100px");
+  assert.equal(ticks.at(-1).resized, 0);
+  assert.equal(ticks.at(-1).generation, 3);
+
+  canvas.width = 200;
+  canvas.height = 400;
+  mutations[0]();
+  raf.shift()(80);
+  assert.equal(ticks.at(-1).resized, 1);
+  assert.equal(ticks.at(-1).generation, 4);
+  assert.deepEqual(ticks.at(-1).logical, [200, 400]);
+  assert.equal(parseFloat(shellStyle.height) > 0, true);
+  assert.ok(fixture.listeners.get("stasis-viewport-extent")?.length, "runtime listens to the fitter extent event");
 });

--- a/tools/validate_repo.sh
+++ b/tools/validate_repo.sh
@@ -25,6 +25,7 @@ python3 -m unittest tools.ci.test_verify_android_render_performance
 python3 -m unittest tools.ci.test_verify_render_parity
 python3 tools/ci/verify_render_parity.py
 node --test runtime/web/tests/orientation_host_frame.test.mjs
+node --test runtime/web/tests/viewport_fit.test.mjs
 node --test runtime/web/tests/sys_memcpy_u8.test.mjs
 node --test runtime/web/tests/sys_memcpy_typed.test.mjs
 node --test runtime/web/tests/asset_paths.test.mjs


### PR DESCRIPTION
## Summary
- fit the shared generated web shell to the current safe visual viewport without changing canvas backing dimensions
- coalesce viewport/orientation/fullscreen/backing changes into truthful HostFrame resize generations and preserve logical pointer mapping
- add deterministic viewport, safe-area, mutation, packaging-idempotence, and bottom-edge interaction coverage plus host/guest documentation

## Validation
- node --test runtime/web/tests/*.test.mjs (37 passed)
- python tools/cargo_cache.py run -- cargo check -p stasis --all-targets (passed; shared DLL restage warning only)
- git diff --check (passed; line-ending warnings only)
- exact-source Chromium: 393x844 layout / 393x650 visual viewport, body 393x650, safe top/bottom 24/34, canvas within safe area, backing 640x360 unchanged, zero scroll, bottom-edge logical tap [638,358]
- independent gpt-5.6-sol medium review: CLEAN after HostFrame and offset-clipping corrections

## Local limitation
The repository signing runner could not launch rebuilt Rust test executables because no matching certificate was installed, so the pre-commit test hook was bypassed after the relevant Node suite and all-target Cargo check passed. Hosted CI is authoritative for that executable gate. No physical iPhone Safari test was performed.